### PR TITLE
Changed Github links to use the organization namespace. 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Clone
 
 ```
-git clone --recursive https://github.com/alexeykudinkin/intellij-rust.git
+git clone --recursive https://github.com/intellij-rust/intellij-rust.git
 cd intellij-rust
 ```
 
@@ -42,7 +42,7 @@ sources`, and select `build.gradle` from the root directory of the plugin.
 To contribute to the code of the project check out the the latest version and follow instructions on how to build & run it.
 
 If you feel yourself new to the field or don't know what you should start coping with check out issue-tracker for the 
-[up-for-grab](https://github.com/alexeykudinkin/intellij-rust/labels/up%20for%20grab) tasks as these may be greatest entry points to the project source code.
+[up-for-grab](https://github.com/intellij-rust/intellij-rust/labels/up%20for%20grab) tasks as these may be greatest entry points to the project source code.
 
 If you want to contribute to the project in any of the numerous other ways, first of all consider joining our [Gitter](https://gitter.im/alexeykudinkin/intellij-rust?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) therefore
 being on par with the current development efforts.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ brave enough and want to use the plugin, you have to build it from source. Note 
 Building:
 
 ```
-$ git clone https://github.com/alexeykudinkin/intellij-rust
+$ git clone https://github.com/intellij-rust/intellij-rust
 $ cd intellij-rust
 $ ./gradlew buildPlugin
 ```
@@ -28,10 +28,6 @@ This creates a zip archive in `build/distributions` which you can install with
 
 See the [usage docs](doc/Usage.md).
 
-## FAQ
-
-Here would be a list of the most frequent asked questions: [FAQ](https://github.com/alexeykudinkin/intellij-rust/wiki/FAQ)
- 
 ## Bugs
 
 Current high-volatility state entails no support just yet, so be patient, please, and save your anger until it hits stability milestone (at least)


### PR DESCRIPTION
I checked the links which I changed, they all work.
I intentionally did not change the travis and gitter links, as I didn't know, if this would brake something.

Further, I removed the FAQ section from README.md as the link pointed to the Github-Wiki for this repository and this seems to be disabled right now.