### PR TITLE
(RES): refactor RustResolveEngine

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/scope/RustResolveScope.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/scope/RustResolveScope.kt
@@ -9,11 +9,3 @@ public interface RustResolveScope : RustCompositeElement {
     fun getDeclarations(): Collection<RustDeclaringElement>
 }
 
-//
-// Extension points
-//
-
-internal fun RustResolveScope.resolveWith(v: RustResolveEngine.ResolveScopeVisitor): RustNamedElement? {
-    this.accept(v)
-    return v.matched
-}


### PR DESCRIPTION
The main part is that instead of threading `visited` set through all of the resolve function, we use a statefull object (`Resolver`).

`RustResolveEngine` now contains only public interface, the implementation is provided via top level private items in the file.

@alexeykudinkin please review

