### PR TITLE
formatter: Use parameterized test case

### DIFF
--- a/src/test/kotlin/org/rust/lang/formatter/RustFormatterTestCase.kt
+++ b/src/test/kotlin/org/rust/lang/formatter/RustFormatterTestCase.kt
@@ -1,24 +1,43 @@
 package org.rust.lang.formatter
 
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.psi.formatter.FormatterTestCase
-import org.rust.lang.RustTestCaseBase
+import com.intellij.testFramework.LightPlatformTestCase
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.io.File
 
-class RustFormatterTestCase : FormatterTestCase() {
-    override fun getTestDataPath() = "src/test/resources"
+@RunWith(Parameterized::class)
+class RustFormatterTestCase(val fileName: String) : FormatterTestCase() {
 
-    override fun getBasePath() = "org/rust/lang/formatter/fixtures"
-
+    override fun getTestDataPath() = TEST_DATA_PATH
+    override fun getBasePath() = BASE_PATH
     override fun getFileExtension() = "rs"
 
-    override fun getTestName(lowercaseFirstLetter: Boolean): String? {
-        val camelCase = super.getTestName(lowercaseFirstLetter)
-        return RustTestCaseBase.camelToSnake(camelCase)
-    }
+    override fun getTestName(lowercaseFirstLetter: Boolean) = fileName
 
-    fun testBlocks() = doTest()
-    fun testItems() = doTest()
-    fun testExpressions() = doTest()
-    fun testArgumentAlignment() = doTest()
-    fun testArgumentIndent() = doTest()
-    fun testTraits() = doTest()
+    @Before
+    fun before() = invokeTestRunnable { setUp() }
+
+    @Test
+    fun test() = WriteCommandAction.runWriteCommandAction(LightPlatformTestCase.getProject(), {
+        doTest(fileName, fileName + "_after")
+    })
+
+    @After
+    fun after() = invokeTestRunnable { tearDown() }
+
+    companion object {
+        val TEST_DATA_PATH = "src/test/resources"
+        val BASE_PATH = "org/rust/lang/formatter/fixtures"
+
+        @JvmStatic @Parameterized.Parameters(name = "{0}")
+        fun params() = File(FileUtil.toSystemDependentName("$TEST_DATA_PATH/$BASE_PATH"))
+            .listFiles { !it.nameWithoutExtension.endsWith("_after") }!!
+            .map { arrayOf(it.nameWithoutExtension) }
+    }
 }

--- a/src/test/kotlin/org/rust/lang/formatter/RustFormatterTestCase.kt
+++ b/src/test/kotlin/org/rust/lang/formatter/RustFormatterTestCase.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.psi.formatter.FormatterTestCase
 import com.intellij.testFramework.LightPlatformTestCase
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -37,7 +38,8 @@ class RustFormatterTestCase(val fileName: String) : FormatterTestCase() {
 
         @JvmStatic @Parameterized.Parameters(name = "{0}")
         fun params() = File(FileUtil.toSystemDependentName("$TEST_DATA_PATH/$BASE_PATH"))
-            .listFiles { !it.nameWithoutExtension.endsWith("_after") }!!
-            .map { arrayOf(it.nameWithoutExtension) }
+            .listFiles { !it.nameWithoutExtension.endsWith("_after") }
+            ?.map { arrayOf(it.nameWithoutExtension) }
+            .apply { assertThat(this).overridingErrorMessage("No test files found").isNotEmpty() }
     }
 }


### PR DESCRIPTION
It is annoying to always manually have to add another test method for each test file pair that was added to the fixtures folder. This PR makes it easier by automatically detecting the test files and generating test cases for each one.