### PR TITLE
(BUILD): upgrade Kotlin to beta3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ repositories {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-runtime:$kotlinVersion"
 
     gen 'de.jflex:jflex:1.6.0'
     gen files('lib/gk/grammar-kit-patched.jar')

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ name = "intellij-rust"
 ideaVersion = 15.0
 
 javaVersion = 1.8
-kotlinVersion = 1.0.0-beta-1103
+kotlinVersion = 1.0.0-beta-3595
 
 version = 0.0.1
 


### PR DESCRIPTION
Ok, I figured out why I was getting `NoSuchMethodError`. Here is the story

IDEA uses a separate class loader for each plugin ([ref](http://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_class_loaders.html?search=Class)) which loads classes from plugin's lib directory. So in theory it is possible to write a plugin which won't depend on the host IDEA Kotlin version. 

In practice, our plugin distribution does include `kotlin-stdlib` and `kotlin-runtime` jars in the lib directory, so we **are independent** from the Kotlin version bundled with user's IDEA. The user can even uninstall the Kotlin plugin and it won't affect the Rust plugin.

It's all rainbows and unicorns, but why the tests were failing :) ? 

Turns out, the `kotlin-runtime` dependency was not used during the tests, so an older version from idea-sdk was picked up. Hence I've added it to `dependencies.compile` which according to [Gradle docs](https://docs.gradle.org/current/userguide/artifact_dependencies_tutorial.html#configurations) should also activate it for `runtime` and `testRuntime` scenarios. Don't forget to reimport gradle project after the change.

@alexeykudinkin @atsky please correct me if I misunderstood something. 