### PR TITLE
(NAV): goto symbol and class

### DIFF
--- a/src/main/kotlin/org/rust/ide/navigation/goto/RustClassNavigationContributor.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RustClassNavigationContributor.kt
@@ -1,5 +1,9 @@
 package org.rust.ide.navigation.goto
 
 import com.intellij.ide.util.gotoByName.DefaultClassNavigationContributor
+import org.rust.lang.core.psi.RustItem
+import org.rust.lang.core.stubs.index.RustStructOrEnumIndex
 
-public class RustClassNavigationContributor : DefaultClassNavigationContributor()
+public class RustClassNavigationContributor
+    : RustNavigationContributorBase<RustItem>(RustStructOrEnumIndex.KEY, RustItem::class.java)
+

--- a/src/main/kotlin/org/rust/ide/navigation/goto/RustNavigationContributorBase.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RustNavigationContributorBase.kt
@@ -1,0 +1,43 @@
+package org.rust.ide.navigation.goto
+
+import com.intellij.navigation.ChooseByNameContributor
+import com.intellij.navigation.GotoClassContributor
+import com.intellij.navigation.NavigationItem
+import com.intellij.openapi.project.Project
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.stubs.StubIndex
+import com.intellij.psi.stubs.StubIndexKey
+import org.rust.lang.core.psi.RustNamedElement
+
+abstract class RustNavigationContributorBase<T> protected constructor(
+        private val indexKey: StubIndexKey<String, T>,
+        private val clazz: Class<T>
+    ) : ChooseByNameContributor
+      , GotoClassContributor
+    where T: NavigationItem, T: RustNamedElement {
+
+    override fun getNames(project: Project?, includeNonProjectItems: Boolean): Array<out String> {
+        project ?: return emptyArray()
+        return StubIndex.getInstance().getAllKeys(indexKey, project).toTypedArray()
+    }
+
+    override fun getItemsByName(name: String?,
+                                pattern: String?,
+                                project: Project?,
+                                includeNonProjectItems: Boolean): Array<out NavigationItem> {
+
+        if (project == null || name == null) {
+            return emptyArray()
+        }
+        val scope = if (includeNonProjectItems)
+            GlobalSearchScope.allScope(project)
+        else
+            GlobalSearchScope.projectScope(project)
+
+        return StubIndex.getElements(indexKey, name, project, scope, clazz).toTypedArray<NavigationItem>()
+    }
+
+    override fun getQualifiedName(item: NavigationItem?): String? = null
+
+    override fun getQualifiedNameSeparator(): String = "::"
+}

--- a/src/main/kotlin/org/rust/ide/navigation/goto/RustSymbolNavigationContributor.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RustSymbolNavigationContributor.kt
@@ -1,6 +1,7 @@
 package org.rust.ide.navigation.goto
 
-import com.intellij.ide.util.gotoByName.DefaultSymbolNavigationContributor
+import org.rust.lang.core.psi.RustItem
+import org.rust.lang.core.stubs.index.RustItemIndex
 
-public class RustSymbolNavigationContributor : DefaultSymbolNavigationContributor()
-
+class RustSymbolNavigationContributor
+    : RustNavigationContributorBase<RustItem>(RustItemIndex.KEY, RustItem::class.java)

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustItemImplMixin.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustItemImplMixin.kt
@@ -1,12 +1,13 @@
 package org.rust.lang.core.psi.impl.mixin
 
 import com.intellij.lang.ASTNode
+import com.intellij.navigation.ItemPresentation
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.lang.core.psi.RustItem
 import org.rust.lang.core.psi.RustNamedElement
-import org.rust.lang.core.psi.impl.RustNamedElementImpl
 import org.rust.lang.core.psi.impl.RustStubbedNamedElementImpl
 import org.rust.lang.core.stubs.RustItemStub
+import javax.swing.Icon
 
 public abstract class RustItemImplMixin : RustStubbedNamedElementImpl<RustItemStub>
                                         , RustItem {
@@ -18,5 +19,13 @@ public abstract class RustItemImplMixin : RustStubbedNamedElementImpl<RustItemSt
 
     override fun getBoundElements(): Collection<RustNamedElement> =
         listOf(this)
+
+    override fun getPresentation(): ItemPresentation = object : ItemPresentation {
+        override fun getLocationString(): String? = "(in ${containingFile.name})"
+
+        override fun getIcon(unused: Boolean): Icon? = this@RustItemImplMixin.getIcon(0)
+
+        override fun getPresentableText(): String? = name
+    }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RustItemIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RustItemIndex.kt
@@ -1,0 +1,15 @@
+package org.rust.lang.core.stubs.index
+
+import com.intellij.psi.stubs.StringStubIndexExtension
+import com.intellij.psi.stubs.StubIndexKey
+import org.rust.lang.core.psi.RustItem
+
+class RustItemIndex : StringStubIndexExtension<RustItem>() {
+    companion object {
+        val KEY: StubIndexKey<String, RustItem> = StubIndexKey.createIndexKey("rust.items")
+    }
+
+    override fun getVersion(): Int = 0
+
+    override fun getKey(): StubIndexKey<String, RustItem> = KEY
+}

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RustStructOrEnumIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RustStructOrEnumIndex.kt
@@ -1,0 +1,15 @@
+package org.rust.lang.core.stubs.index
+
+import com.intellij.psi.stubs.StringStubIndexExtension
+import com.intellij.psi.stubs.StubIndexKey
+import org.rust.lang.core.psi.RustItem
+
+class RustStructOrEnumIndex : StringStubIndexExtension<RustItem>() {
+    companion object {
+        val KEY: StubIndexKey<String, RustItem> = StubIndexKey.createIndexKey("rust.structOrEnum")
+    }
+
+    override fun getVersion(): Int = 0
+
+    override fun getKey(): StubIndexKey<String, RustItem> = KEY
+}

--- a/src/main/kotlin/org/rust/lang/core/stubs/types/RustEnumItemStubElementType.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/types/RustEnumItemStubElementType.kt
@@ -1,9 +1,11 @@
 package org.rust.lang.core.stubs.types
 
-import org.rust.lang.core.psi.RustConstItem
+import com.intellij.psi.stubs.StubIndexKey
 import org.rust.lang.core.psi.RustEnumItem
+import org.rust.lang.core.psi.RustItem
 import org.rust.lang.core.psi.impl.RustEnumItemImpl
 import org.rust.lang.core.stubs.RustItemStub
+import org.rust.lang.core.stubs.index.RustStructOrEnumIndex
 
 class RustEnumItemStubElementType(debugName: String)
     : RustItemStubElementType<RustEnumItem>(debugName) {
@@ -11,4 +13,6 @@ class RustEnumItemStubElementType(debugName: String)
     override fun createPsi(stub: RustItemStub): RustEnumItem =
         RustEnumItemImpl(stub, this)
 
+    override val additionalIndexKeys: Array<StubIndexKey<String, RustItem>>
+        get() = arrayOf(RustStructOrEnumIndex.KEY)
 }

--- a/src/main/kotlin/org/rust/lang/core/stubs/types/RustItemStubElementType.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/types/RustItemStubElementType.kt
@@ -1,10 +1,9 @@
 package org.rust.lang.core.stubs.types
 
-import com.intellij.psi.stubs.StubElement
-import com.intellij.psi.stubs.StubInputStream
-import com.intellij.psi.stubs.StubOutputStream
+import com.intellij.psi.stubs.*
 import org.rust.lang.core.psi.RustItem
 import org.rust.lang.core.stubs.RustItemStub
+import org.rust.lang.core.stubs.index.RustItemIndex
 
 abstract class RustItemStubElementType<PsiT: RustItem>(debugName: String)
     : RustStubElementType<RustItemStub, PsiT>(debugName) {
@@ -18,4 +17,17 @@ abstract class RustItemStubElementType<PsiT: RustItem>(debugName: String)
     override fun createStub(psi: PsiT, parentStub: StubElement<*>?): RustItemStub =
         RustItemStub(parentStub, this, psi.name ?: "")
 
+    final override fun indexStub(stub: RustItemStub, sink: IndexSink) {
+        super.indexStub(stub, sink)
+        val indexName = stub.name
+        if (indexName != null && !indexName.isBlank()) {
+            sink.occurrence(RustItemIndex.KEY, indexName)
+            for (key in additionalIndexKeys) {
+                sink.occurrence(key, indexName)
+            }
+        }
+    }
+
+    open val additionalIndexKeys: Array<StubIndexKey<String, RustItem>>
+        get() = emptyArray()
 }

--- a/src/main/kotlin/org/rust/lang/core/stubs/types/RustStructItemStubElementType.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/types/RustStructItemStubElementType.kt
@@ -1,13 +1,19 @@
 package org.rust.lang.core.stubs.types
 
+import com.intellij.psi.stubs.StubIndexKey
+import org.rust.lang.core.psi.RustItem
 import org.rust.lang.core.psi.RustStructItem
 import org.rust.lang.core.psi.impl.RustStructItemImpl
 import org.rust.lang.core.stubs.RustItemStub
+import org.rust.lang.core.stubs.index.RustStructOrEnumIndex
 
 class RustStructItemStubElementType(debugName: String)
     : RustItemStubElementType<RustStructItem>(debugName) {
 
     override fun createPsi(stub: RustItemStub): RustStructItem =
         RustStructItemImpl(stub, this)
+
+    override val additionalIndexKeys: Array<StubIndexKey<String, RustItem>>
+        get() = arrayOf(RustStructOrEnumIndex.KEY)
 }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -176,6 +176,9 @@
         <!-- Indices -->
 
         <fileBasedIndex implementation="org.rust.lang.core.resolve.indexes.RustModulesIndexExtension"/>
+        <stubIndex implementation="org.rust.lang.core.stubs.index.RustItemIndex"/>
+        <stubIndex implementation="org.rust.lang.core.stubs.index.RustStructOrEnumIndex"/>
+
 
     </extensions>
 


### PR DESCRIPTION
This adds goto symbol (any item) and goto class (struct or enum). I faild to find tests for this functions in go/erlang plugin, hence there is no tests. 

@alexeykudinkin please review