### PR TITLE
Adds LiveTemplate for assert! and assert_eq!

### DIFF
--- a/src/main/resources/org/rust/ide/liveTemplates/Rust.xml
+++ b/src/main/resources/org/rust/ide/liveTemplates/Rust.xml
@@ -24,4 +24,19 @@
             <option name="RUST_FILE" value="true"/>
         </context>
     </template>
+
+    <template name="a" value="assert!($END$);" description="assert" toReformat="true" toShortenFQNames="true">
+        <context>
+            <option name="RUST_FILE" value="true" />
+        </context>
+    </template>
+    
+    <template name="ae" value="assert_eq!($LEFT$, $RIGHT$);" description="assert equals" toReformat="true" toShortenFQNames="true">
+        <variable name="LEFT" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="RIGHT" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="RUST_FILE" value="true" />
+        </context>
+    </template>
+
 </templateSet>


### PR DESCRIPTION
I found this template helpful, using `a` and `ae` live templates for testing. 

If this makes sense for upstream, I might also do another PR for the `debug_` equivalents.