### PR TITLE
Fix NPE in RustEnterInLineCommentHandler

### DIFF
--- a/src/main/kotlin/org/rust/ide/typing/RustEnterInLineCommentHandler.kt
+++ b/src/main/kotlin/org/rust/ide/typing/RustEnterInLineCommentHandler.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.actionSystem.EditorActionHandler
 import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiFile
+import com.intellij.psi.TokenType.WHITE_SPACE
 import com.intellij.util.text.CharArrayUtil
 import org.rust.lang.core.lexer.RustTokenElementTypes.INNER_DOC_COMMENT
 import org.rust.lang.core.lexer.RustTokenElementTypes.OUTER_DOC_COMMENT
@@ -35,9 +36,9 @@ class RustEnterInLineCommentHandler : EnterHandlerDelegateAdapter() {
 
         // find the PsiElement at the caret
         var elementAtCaret = file.findElementAt(caret) ?: return Result.Continue
-        if (isEOL) {
+        if (isEOL && elementAtCaret.node?.elementType == WHITE_SPACE) {
             // ... or the previous one if this is end-of-line whitespace
-            elementAtCaret = elementAtCaret.prevSibling
+            elementAtCaret = elementAtCaret.prevSibling ?: return Result.Continue
         }
 
         // check if the element at the caret is a line comment

--- a/src/test/kotlin/org/rust/ide/typing/RustEnterHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/RustEnterHandlerTest.kt
@@ -23,4 +23,7 @@ class RustEnterHandlerTest : RustTestCaseBase() {
 
     fun testDirectlyAfterToken() = doTest()
     fun testInsideToken() = doTest()
+
+    fun testAtFileBeginning() = doTest()
+    fun testInsideStringLiteral() = doTest()
 }

--- a/src/test/resources/org/rust/ide/typing/fixtures/at_file_beginning.rs
+++ b/src/test/resources/org/rust/ide/typing/fixtures/at_file_beginning.rs
@@ -1,0 +1,2 @@
+<caret>
+// Some comment

--- a/src/test/resources/org/rust/ide/typing/fixtures/at_file_beginning_after.rs
+++ b/src/test/resources/org/rust/ide/typing/fixtures/at_file_beginning_after.rs
@@ -1,0 +1,3 @@
+
+<caret>
+// Some comment

--- a/src/test/resources/org/rust/ide/typing/fixtures/inside_string_literal.rs
+++ b/src/test/resources/org/rust/ide/typing/fixtures/inside_string_literal.rs
@@ -1,0 +1,16 @@
+// Taken from issue #185
+
+fn read_manifest_output() -> String {
+    "\
+{\
+    \"name\":\"foo\",\
+    \"version\":\"0.5.0\",\
+    \"dependencies\":[],\
+    \"targets\":[{\
+        \"kind\":[\"bin\"],\
+        \"name\":\"foo\",\
+        \"src_path\":\"src[..]foo.rs\"\
+    }],\<caret>
+    \"manifest_path\":\"[..]Cargo.toml\"\
+}".into()
+}

--- a/src/test/resources/org/rust/ide/typing/fixtures/inside_string_literal_after.rs
+++ b/src/test/resources/org/rust/ide/typing/fixtures/inside_string_literal_after.rs
@@ -1,0 +1,17 @@
+// Taken from issue #185
+
+fn read_manifest_output() -> String {
+    "\
+{\
+    \"name\":\"foo\",\
+    \"version\":\"0.5.0\",\
+    \"dependencies\":[],\
+    \"targets\":[{\
+        \"kind\":[\"bin\"],\
+        \"name\":\"foo\",\
+        \"src_path\":\"src[..]foo.rs\"\
+    }],\
+    <caret>
+    \"manifest_path\":\"[..]Cargo.toml\"\
+}".into()
+}


### PR DESCRIPTION
Check whether an end-of-line at caret is actually a whitespace
before moving to a previous element, and do not fail on
whitespace at the beginning of file.

Fixes #185.
