### PR TITLE
(MISC): update kotlin to 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 }
 
 plugins {
-    id 'org.jetbrains.intellij' version "0.0.41"
+    id 'org.jetbrains.intellij' version "0.0.42"
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ name = "intellij-rust"
 ideaVersion = 143.2167.2
 
 javaVersion = 1.6
-kotlinVersion = 1.0.0-rc-1036
+kotlinVersion = 1.0.0
 
 version = 0.0.1
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -27,7 +27,7 @@
 
         <!-- Rust -->
 
-        <compileServer.plugin classpath="jps.jar;kotlin-runtime-1.0.0-rc-1036.jar;kotlin-stdlib-1.0.0-rc-1036.jar"/>
+        <compileServer.plugin classpath="jps.jar;kotlin-runtime-1.0.0.jar;kotlin-stdlib-1.0.0.jar"/>
 
         <!-- Modules -->
 


### PR DESCRIPTION
WIP

This does not work yet

* we need to wait until gralde intellij plugin 0.0.41, which will include https://github.com/JetBrains/gradle-intellij-plugin/commit/ab9507d99e06b9965c0f0304ac8daf8c0fda1290

* for [some obscure reason](https://gist.github.com/matklad/9353e40bbc51fb3dd753), it does not work for IDEA 15.0.3. I guess it's better just to wait until 15.0.4