### PR TITLE
Unescaping

### DIFF
--- a/src/main/kotlin/org/rust/ide/spellchecker/StringLiteralTokenizer.kt
+++ b/src/main/kotlin/org/rust/ide/spellchecker/StringLiteralTokenizer.kt
@@ -1,10 +1,10 @@
 package org.rust.ide.spellchecker
 
-import com.intellij.codeInsight.CodeInsightUtilCore
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.spellchecker.inspections.PlainTextSplitter
 import com.intellij.spellchecker.tokenizer.EscapeSequenceTokenizer
 import com.intellij.spellchecker.tokenizer.TokenConsumer
+import org.rust.lang.utils.parseRustStringCharacters
 
 class StringLiteralTokenizer : EscapeSequenceTokenizer<LeafPsiElement>() {
 
@@ -22,9 +22,8 @@ class StringLiteralTokenizer : EscapeSequenceTokenizer<LeafPsiElement>() {
         fun processTextWithEscapeSequences(element: LeafPsiElement, text: String, consumer: TokenConsumer) {
             val unescapedText = StringBuilder()
             val offsets = IntArray(text.length + 1)
-            CodeInsightUtilCore.parseStringCharacters(text, unescapedText, offsets)
-
-            processTextWithOffsets(element, consumer, unescapedText, offsets, 1)
+            parseRustStringCharacters(text, unescapedText, offsets)
+            processTextWithOffsets(element, consumer, unescapedText, offsets, 0)
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/lexer/RustLexerUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/lexer/RustLexerUtil.kt
@@ -1,17 +1,29 @@
 package org.rust.lang.core.lexer
 
+import com.intellij.lexer.Lexer
+import com.intellij.psi.tree.IElementType
+
+fun CharSequence.tokenize(lexer: Lexer): Sequence<Pair<IElementType, String>> =
+    generateSequence({
+        lexer.start(this)
+        lexer.tokenType?.to(lexer.tokenText)
+    }, {
+        lexer.advance()
+        lexer.tokenType?.to(lexer.tokenText)
+    })
+
 //
 // String extensions
 //
 
-fun String.isEOL() : Boolean {
+fun String.isEOL(): Boolean {
     // TODO(kudinkin): Sync with flex
     return equals("\r")
         || equals("\n")
         || equals("\r\n")
 }
 
-fun String.containsEOL() : Boolean {
+fun String.containsEOL(): Boolean {
     // TODO(kudinkin): Sync with flex
     return contains("\r")
         || contains("\n")

--- a/src/main/kotlin/org/rust/lang/utils/RustEscapesUtils.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RustEscapesUtils.kt
@@ -1,0 +1,43 @@
+package org.rust.lang.utils
+
+import com.intellij.psi.StringEscapesTokenTypes.VALID_STRING_ESCAPE_TOKEN
+import org.rust.lang.core.lexer.RustEscapesLexer
+import org.rust.lang.core.psi.RustTokenElementTypes.STRING_LITERAL
+
+/**
+ * Unescape string escaped using Rust escaping rules.
+ */
+fun String.unescapeRust(unicode: Boolean = true, eol: Boolean = true): String {
+    val sb = StringBuilder(length)
+    val lexer = RustEscapesLexer(STRING_LITERAL, unicode, eol)
+    lexer.start(this)
+    while (lexer.tokenType != null) {
+        sb.append(when (lexer.tokenType) {
+            VALID_STRING_ESCAPE_TOKEN -> decodeEscape(lexer.tokenText)
+            else                      -> lexer.tokenText
+        })
+        lexer.advance()
+    }
+    return sb.toString()
+}
+
+private fun decodeEscape(esc: String): String = when (esc) {
+    "\\n"  -> "\n"
+    "\\r"  -> "\r"
+    "\\t"  -> "\t"
+    "\\0"  -> "\u0000"
+    "\\\\" -> "\\"
+    "\\'"  -> "\'"
+    "\\\"" -> "\""
+
+    else   -> {
+        assert(esc.length >= 2)
+        assert(esc[0] == '\\')
+        when (esc[1]) {
+            'x'        -> Integer.parseUnsignedInt(esc.substring(2), 16).toChar().toString()
+            'u'        -> Integer.parseUnsignedInt(esc.substring(3, esc.length - 1), 16).toChar().toString()
+            '\r', '\n' -> ""
+            else       -> error("unreachable")
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/ide/spellchecker/RustSpellCheckerTest.kt
+++ b/src/test/kotlin/org/rust/ide/spellchecker/RustSpellCheckerTest.kt
@@ -20,4 +20,5 @@ class RustSpellCheckerTest : RustTestCaseBase() {
     fun testStringLiterals() = doTest()
     fun testCommentsSuppressed() = doTest(processComments = false)
     fun testStringLiteralsSuppressed() = doTest(processLiterals = false)
+    fun testStringLiteralsWithEscapes() = doTest()
 }

--- a/src/test/kotlin/org/rust/lang/core/lexer/RustEscapesLexingTestCase.kt
+++ b/src/test/kotlin/org/rust/lang/core/lexer/RustEscapesLexingTestCase.kt
@@ -22,18 +22,10 @@ class RustEscapesLexingTestCase : RustLexingTestCaseBase() {
 
     fun testFuzzy() {
         val lexers = ESCAPABLE_LITERALS_TOKEN_SET.types.map { RustEscapesLexer.of(it) }
-
         for (lexer in lexers) {
             repeat(10000) {
-                execute(lexer, randomLiteral())
+                randomLiteral().tokenize(lexer).forEach { }
             }
-        }
-    }
-
-    private fun execute(lexer: RustEscapesLexer, input: CharSequence) {
-        lexer.start(input)
-        while (lexer.tokenType != null) {
-            lexer.advance()
         }
     }
 

--- a/src/test/kotlin/org/rust/lang/utils/RustEscapesUtilsTest.kt
+++ b/src/test/kotlin/org/rust/lang/utils/RustEscapesUtilsTest.kt
@@ -1,0 +1,51 @@
+package org.rust.lang.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class UnescapeRustTest(private val input: String,
+                       private val expected: String,
+                       private val unicode: Boolean,
+                       private val eol: Boolean) {
+    @Test
+    fun test() = assertEquals(expected, input.unescapeRust(unicode, eol))
+
+    companion object {
+        @Parameterized.Parameters(name = "{index}: \"{0}\" → \"{1}\" U:{2} E:{3}")
+        @JvmStatic fun data(): Collection<Array<Any>> = listOf(
+            arrayOf("aaa", "aaa", true, true),
+            arrayOf("aaa", "aaa", false, false),
+            arrayOf("a\\na", "a\na", true, true),
+            arrayOf("a\\ra", "a\ra", true, true),
+            arrayOf("a\\ta", "a\ta", true, true),
+            arrayOf("a\\0a", "a\u0000a", true, true),
+            arrayOf("a\\'a", "a'a", true, true),
+            arrayOf("a\\\"a", "a\"a", true, true),
+            arrayOf("a\\\\a", "a\\a", true, true),
+            arrayOf("a\\x20a", "a a", true, true),
+            arrayOf("a\\x0aa", "a\na", true, true),
+            arrayOf("a\\x0Aa", "a\na", true, true),
+            arrayOf("foo\\\n    bar", "foobar", true, true),
+            arrayOf("foo\\\r\n    bar", "foobar", true, true),
+            arrayOf("foo\\\r\n    bar", "foo\\\r\n    bar", true, false),
+            arrayOf("foo\\r\\nbar", "foo\r\nbar", true, true),
+            arrayOf("\\u{0119}dw\\u{0105}rd", "\u0119dw\u0105rd", true, true),
+            arrayOf("\\u{0119}dw\\u{0105}rd", "\\u{0119}dw\\u{0105}rd", false, true),
+            arrayOf("\\u{0}", "\u0000", true, true),
+            arrayOf("\\u{00}", "\u0000", true, true),
+            arrayOf("\\u{000}", "\u0000", true, true),
+            arrayOf("\\u{0000}", "\u0000", true, true),
+            arrayOf("\\u{00000}", "\u0000", true, true),
+            arrayOf("\\u{000000}", "\u0000", true, true),
+            arrayOf("\\u{0000000}", "\\u{0000000}", true, true),
+            arrayOf("\\u{00000000}", "\\u{00000000}", true, true),
+            arrayOf("\\u{}", "\\u{}", true, true),
+            arrayOf("\\u{", "\\u{", true, true),
+            arrayOf("\\u", "\\u", true, true),
+            arrayOf("\\u{zzzz}", "\\u{zzzz}", true, true)
+        )
+    }
+}

--- a/src/test/resources/org/rust/ide/spellchecker/fixtures/string_literals_with_escapes.rs
+++ b/src/test/resources/org/rust/ide/spellchecker/fixtures/string_literals_with_escapes.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let s = "Hello, <TYPO descr="Typo: In word 'Wodlr'">W\u{6F}dlr</TYPO>!";
+    let s = "Hello, <TYPO descr="Typo: In word 'Wodlr'">W\x6Fdlr</TYPO>!";
+}


### PR DESCRIPTION
This PR ports `unescapeRust` extension method from #244. Also, as @matklad suggested, wires it with the spellchecker code, to support Rust-style escape sequences.