### PR TITLE
(CARGO): introduce CargoModuleTargetsService

### DIFF
--- a/src/main/kotlin/org/rust/cargo/CargoConstants.kt
+++ b/src/main/kotlin/org/rust/cargo/CargoConstants.kt
@@ -1,5 +1,6 @@
 package org.rust.cargo
 
+import com.intellij.openapi.externalSystem.model.Key
 import com.intellij.openapi.externalSystem.model.ProjectSystemId
 
 object CargoConstants {
@@ -12,4 +13,8 @@ object CargoConstants {
     val PROJECT_SYSTEM_ID = ProjectSystemId(ID)
 
     const val CARGO_EXECUTABLE_NAME: String = "cargo"
+
+    object KEYS {
+        val TARGET = Key.create(CargoProjectDescription.Target::class.java, 0)
+    }
 }

--- a/src/main/kotlin/org/rust/cargo/CargoProjectDescription.kt
+++ b/src/main/kotlin/org/rust/cargo/CargoProjectDescription.kt
@@ -3,6 +3,7 @@ package org.rust.cargo
 import com.intellij.util.PathUtil
 import org.rust.cargo.commands.impl.CargoMetadata
 import java.io.File
+import java.io.Serializable
 import java.util.*
 
 class CargoProjectDescription private constructor(
@@ -34,14 +35,13 @@ class CargoProjectDescription private constructor(
         }
     }
 
-    class Target(
+    data class Target(
         /**
          * Path to the crate root file, relative to the directory with Cargo.toml
          */
         val path: String,
         val kind: TargetKind
-    ) {
-
+    ) : Serializable {
         init {
             require(!File(path).isAbsolute)
         }

--- a/src/main/kotlin/org/rust/cargo/project/CargoProjectResolver.kt
+++ b/src/main/kotlin/org/rust/cargo/project/CargoProjectResolver.kt
@@ -116,22 +116,9 @@ class CargoProjectResolver : ExternalSystemProjectResolver<CargoExecutionSetting
 
         val moduleNode = projectNode.createChild(ProjectKeys.MODULE, modData)
 
-        // Publish source-/test-/resources- roots
-        val content = ContentRootData(CargoProjectSystem.ID, module.contentRoot.absolutePath)
+        moduleNode.addRoots(module)
+        moduleNode.addTargets(module)
 
-        // Standard cargo layout
-        // http://doc.crates.io/manifest.html#the-project-layout
-        for (src in listOf("src", "examples")) {
-            content.storePath(ExternalSystemSourceType.SOURCE, File(module.contentRoot, src).absolutePath)
-        }
-
-        for (test in listOf("tests", "benches")) {
-            content.storePath(ExternalSystemSourceType.TEST, File(module.contentRoot, test).absolutePath)
-        }
-
-        content.storePath(ExternalSystemSourceType.EXCLUDED, File(module.contentRoot, "target").absolutePath)
-
-        moduleNode.createChild(ProjectKeys.CONTENT_ROOT, content)
         return moduleNode
     }
 
@@ -140,5 +127,29 @@ class CargoProjectResolver : ExternalSystemProjectResolver<CargoExecutionSetting
         libData.addPath(LibraryPathType.SOURCE, lib.contentRoot.absolutePath)
         val libNode = projectNode.createChild(ProjectKeys.LIBRARY, libData)
         return libNode
+    }
+}
+
+private fun DataNode<ModuleData>.addRoots(module: CargoProjectDescription.Module) {
+    val content = ContentRootData(CargoProjectSystem.ID, module.contentRoot.absolutePath)
+
+    // Standard cargo layout
+    // http://doc.crates.io/manifest.html#the-project-layout
+    for (src in listOf("src", "examples")) {
+        content.storePath(ExternalSystemSourceType.SOURCE, File(module.contentRoot, src).absolutePath)
+    }
+
+    for (test in listOf("tests", "benches")) {
+        content.storePath(ExternalSystemSourceType.TEST, File(module.contentRoot, test).absolutePath)
+    }
+
+    content.storePath(ExternalSystemSourceType.EXCLUDED, File(module.contentRoot, "target").absolutePath)
+
+    createChild(ProjectKeys.CONTENT_ROOT, content)
+}
+
+private fun DataNode<ModuleData>.addTargets(module: CargoProjectDescription.Module) {
+    for (target in module.targets) {
+        createChild(CargoConstants.KEYS.TARGET, target)
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/module/RustModuleType.kt
+++ b/src/main/kotlin/org/rust/cargo/project/module/RustModuleType.kt
@@ -1,11 +1,21 @@
 package org.rust.cargo.project.module
 
 import com.intellij.icons.AllIcons
+import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleType
 import com.intellij.openapi.module.ModuleTypeManager
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.VirtualFile
+import org.rust.cargo.project.module.persistence.impl.CargoModuleTargetsServiceImpl
 import org.rust.ide.icons.RustIcons
 import javax.swing.Icon
 
+/**
+ * Type of a Rust module.
+ *
+ * Rust modules are generally imported from Cargo, correspond to a single `Cargo.toml` file
+ * and are required to have exactly one content root.
+ */
 class RustModuleType : ModuleType<RustModuleBuilder>(MODULE_TYPE_ID) {
 
     override fun createModuleBuilder(): RustModuleBuilder = RustModuleBuilder(INSTANCE)

--- a/src/main/kotlin/org/rust/cargo/project/module/persistence/CargoModuleTargetsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/module/persistence/CargoModuleTargetsService.kt
@@ -1,0 +1,25 @@
+package org.rust.cargo.project.module.persistence
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleServiceManager
+import org.rust.cargo.CargoProjectDescription
+
+/**
+ * Stores information about crate roots (aka targets) of the module
+ *
+ * See [CargoProjectDataService] for how this is populated
+ */
+interface CargoModuleTargetsService {
+    /**
+     * Provides a set of targets for the corresponding module.
+     *
+     * You should prefer `Module.targets` extensions instead
+     */
+    val targets: Collection<CargoProjectDescription.Target>
+
+    /**
+     * Persists new set of targets. This is done automatically on external project
+     * refresh
+     */
+    fun saveTargets(targets: Collection<CargoProjectDescription.Target>)
+}

--- a/src/main/kotlin/org/rust/cargo/project/module/persistence/CargoProjectDataService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/module/persistence/CargoProjectDataService.kt
@@ -1,0 +1,33 @@
+package org.rust.cargo.project.module.persistence
+
+import com.intellij.openapi.externalSystem.model.DataNode
+import com.intellij.openapi.externalSystem.model.Key
+import com.intellij.openapi.externalSystem.model.ProjectKeys
+import com.intellij.openapi.externalSystem.model.project.ProjectData
+import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider
+import com.intellij.openapi.externalSystem.service.project.manage.AbstractProjectDataService
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import org.rust.cargo.CargoConstants
+import org.rust.cargo.CargoProjectDescription
+import org.rust.cargo.util.getService
+
+/**
+ * Populates [CargoModuleTargetsService] on project import
+ */
+class CargoProjectDataService : AbstractProjectDataService<CargoProjectDescription.Target, Module>() {
+    override fun getTargetDataKey(): Key<CargoProjectDescription.Target> = CargoConstants.KEYS.TARGET
+
+    override fun postProcess(toImport: Collection<DataNode<CargoProjectDescription.Target>>,
+                             projectData: ProjectData?,
+                             project: Project,
+                             modelsProvider: IdeModifiableModelsProvider) {
+        val targetsByModule = toImport.groupBy { it.getData(ProjectKeys.MODULE)?.internalName }
+
+        for ((moduleName, targets) in targetsByModule) {
+            val module = modelsProvider.modules.find { it.name == moduleName } ?: continue
+            val service = module.getService<CargoModuleTargetsService>()
+            service.saveTargets(targets.map { it.data })
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/project/module/persistence/impl/CargoModuleTargetsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/module/persistence/impl/CargoModuleTargetsServiceImpl.kt
@@ -1,0 +1,61 @@
+package org.rust.cargo.project.module.persistence.impl
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.StoragePathMacros
+import com.intellij.util.xmlb.XmlSerializerUtil
+import com.intellij.util.xmlb.annotations.AbstractCollection
+import org.rust.cargo.CargoProjectDescription
+import org.rust.cargo.project.module.persistence.CargoModuleTargetsService
+import java.util.*
+
+@State(
+    name = "CargoModuleTargets",
+    storages = arrayOf(Storage(file = StoragePathMacros.MODULE_FILE))
+)
+class CargoModuleTargetsServiceImpl : PersistentStateComponent<CargoModuleTargetsServiceImpl>
+                                    , CargoModuleTargetsService {
+
+    @AbstractCollection
+    private var myTargets: MutableCollection<SerializableTarget> = ArrayList()
+
+    override fun loadState(state: CargoModuleTargetsServiceImpl) {
+        XmlSerializerUtil.copyBean(state, this)
+    }
+
+    override fun getState(): CargoModuleTargetsServiceImpl = this
+
+    override val targets: Collection<CargoProjectDescription.Target>
+        get() = myTargets.mapNotNull { it.intoTarget() }
+
+    override fun saveTargets(targets: Collection<CargoProjectDescription.Target>) {
+        myTargets = targets.map { SerializableTarget.fromTarget(it) }.toMutableList()
+    }
+
+}
+
+// IDEA serializer requires objects to have default constructors,
+// nullable fields and mutable collections, so we have to introduce
+// an evil nullable twin of [CargoProjectDescription.Target]
+//
+// `null`s in fields signal serialization failure, so we can't `!!` here safely.
+//
+// Ideally this should be private, but alas this also breaks serialization
+data class SerializableTarget(
+    var path: String? = null,
+    var kind: CargoProjectDescription.TargetKind? = null
+) {
+    fun intoTarget(): CargoProjectDescription.Target? {
+        return CargoProjectDescription.Target(
+            path ?: return null,
+            kind ?: return null
+        )
+    }
+
+    companion object {
+        fun fromTarget(target: CargoProjectDescription.Target): SerializableTarget =
+            SerializableTarget(target.path, target.kind)
+    }
+}
+

--- a/src/main/kotlin/org/rust/cargo/util/PlatformUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/PlatformUtil.kt
@@ -1,5 +1,7 @@
 package org.rust.cargo.util
 
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleServiceManager
 import com.intellij.openapi.util.SystemInfo
 
 object PlatformUtil {
@@ -12,3 +14,6 @@ object PlatformUtil {
     }
 
 }
+
+inline fun<reified T: Any> Module.getService(): T =
+        ModuleServiceManager.getService(this, T::class.java)!!

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -149,6 +149,10 @@
         <projectService serviceImplementation="org.rust.cargo.project.settings.CargoSettings"/>
         <projectService serviceImplementation="org.rust.cargo.project.settings.CargoLocalSettings"/>
         <projectService serviceImplementation="org.rust.cargo.project.settings.CargoProjectSettings"/>
+        <externalProjectDataService implementation="org.rust.cargo.project.module.persistence.CargoProjectDataService"/>
+
+        <moduleService serviceInterface="org.rust.cargo.project.module.persistence.CargoModuleTargetsService"
+                       serviceImplementation="org.rust.cargo.project.module.persistence.impl.CargoModuleTargetsServiceImpl"/>
 
         <projectImportProvider implementation="org.rust.cargo.project.CargoProjectImportProvider"/>
         <projectImportBuilder implementation="org.rust.cargo.project.CargoProjectImportBuilder"/>

--- a/src/test/kotlin/org/rust/lang/core/resolve/RustMultifileResolveTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RustMultifileResolveTestCaseBase.kt
@@ -2,14 +2,17 @@ package org.rust.lang.core.resolve
 
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleType
-import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ContentEntry
+import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.testFramework.LightProjectDescriptor
 import com.intellij.testFramework.fixtures.DefaultLightProjectDescriptor
 import org.assertj.core.api.Assertions.assertThat
+import org.rust.cargo.CargoProjectDescription
 import org.rust.cargo.project.module.RustModuleType
+import org.rust.cargo.project.module.persistence.CargoModuleTargetsService
+import org.rust.cargo.util.getService
 import org.rust.lang.core.psi.RustNamedElement
 import org.rust.lang.core.resolve.ref.RustReference
-import java.io.File
 
 
 abstract class RustMultiFileResolveTestCaseBase : RustResolveTestCaseBase() {
@@ -18,6 +21,13 @@ abstract class RustMultiFileResolveTestCaseBase : RustResolveTestCaseBase() {
         return object : DefaultLightProjectDescriptor() {
 
             override fun getModuleType(): ModuleType<*> = RustModuleType.INSTANCE
+
+            override fun configureModule(module: Module, model: ModifiableRootModel, contentEntry: ContentEntry) {
+                super.configureModule(module, model, contentEntry)
+                module.getService<CargoModuleTargetsService>().saveTargets(listOf(
+                    binTarget("main.rs"), libTarget("lib.rs")
+                ))
+            }
         }
     }
 
@@ -51,4 +61,10 @@ abstract class RustMultiFileResolveTestCaseBase : RustResolveTestCaseBase() {
 
         return usage.resolve()
     }
+
+    private fun binTarget(path: String): CargoProjectDescription.Target =
+        CargoProjectDescription.Target(path, CargoProjectDescription.TargetKind.BIN)
+
+    private fun libTarget(path: String): CargoProjectDescription.Target =
+        CargoProjectDescription.Target(path, CargoProjectDescription.TargetKind.LIB)
 }


### PR DESCRIPTION
This PR adds exact information about modules crate roots. 

The info is available via `CargoModuleTargetsService`, which is a persistent module level service. 

The information is populated after the import from external system via `CargoProjectDataService`. 

The user visible change is that crates with non default layout (like cargo itself) start to resolve.

@alexeykudinkin I may do some tweaks to it tomorrow, but it is generally ready for a review. 