### PR TITLE
(T): add tests for cargo import

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/settings/CargoProjectSettings.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/CargoProjectSettings.kt
@@ -2,7 +2,7 @@ package org.rust.cargo.project.settings
 
 import com.intellij.openapi.externalSystem.settings.ExternalProjectSettings
 
-class CargoProjectSettings : ExternalProjectSettings() {
+class CargoProjectSettings(var cargoHome: String? = null) : ExternalProjectSettings() {
 
     protected fun copyTo(receiver: CargoProjectSettings) {
         receiver.cargoHome = cargoHome
@@ -14,6 +14,4 @@ class CargoProjectSettings : ExternalProjectSettings() {
         copyTo(result)
         return result
     }
-
-    var cargoHome: String? = null
 }

--- a/src/test/java/com/intellij/openapi/externalSystem/test/AbstractExternalSystemTest.groovy
+++ b/src/test/java/com/intellij/openapi/externalSystem/test/AbstractExternalSystemTest.groovy
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.externalSystem.test
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.extensions.ExtensionPoint
+import com.intellij.openapi.extensions.Extensions
+import com.intellij.openapi.externalSystem.ExternalSystemManager
+import com.intellij.openapi.externalSystem.model.DataNode
+import com.intellij.openapi.externalSystem.model.project.ProjectData
+import com.intellij.openapi.externalSystem.service.project.manage.ProjectDataManager
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.testFramework.SkipInHeadlessEnvironment
+import com.intellij.testFramework.UsefulTestCase
+import com.intellij.testFramework.fixtures.IdeaProjectTestFixture
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory
+import com.intellij.util.ui.UIUtil
+import org.jetbrains.annotations.NotNull
+import org.jetbrains.annotations.Nullable
+
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
+/**
+ * @author Denis Zhdanov
+ * @since 8/7/13 2:04 PM
+ */
+@SkipInHeadlessEnvironment
+abstract class AbstractExternalSystemTest extends UsefulTestCase {
+
+  static File tmpDir
+
+  IdeaProjectTestFixture testFixture
+  Project project
+  File projectDir
+
+  TestExternalSystemManager externalSystemManager
+  ExtensionPoint externalSystemManagerEP
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp()
+
+    ensureTempDirCreated()
+
+    testFixture = IdeaTestFixtureFactory.fixtureFactory.createFixtureBuilder(name).fixture
+    testFixture.setUp()
+    project = testFixture.project
+
+    projectDir = new File(tmpDir, getTestName(false));
+    projectDir.mkdirs();
+
+    externalSystemManager = new TestExternalSystemManager(project)
+    def area = Extensions.getArea(null)
+    externalSystemManagerEP = area.getExtensionPoint(ExternalSystemManager.EP_NAME)
+    externalSystemManagerEP.registerExtension(externalSystemManager)
+  }
+
+  private static void ensureTempDirCreated() {
+    if (tmpDir != null) {
+      return
+    }
+
+    tmpDir = new File(FileUtil.tempDirectory, "externalSystemTests")
+    FileUtil.delete(tmpDir)
+    tmpDir.mkdirs()
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    try {
+      project = null
+      UIUtil.invokeAndWaitIfNeeded {
+        try {
+          externalSystemManagerEP.unregisterExtension(externalSystemManager)
+          testFixture.tearDown();
+          testFixture = null;
+        }
+        catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+      if (!FileUtil.delete(projectDir) && projectDir.exists()) {
+        System.err.println("Cannot delete " + projectDir);
+        //printDirectoryContent(myDir);
+        projectDir.deleteOnExit();
+      }
+    }
+    finally {
+      super.tearDown();
+      resetClassFields(getClass());
+    }
+  }
+
+  private void resetClassFields(@Nullable Class<?> aClass) {
+    if (aClass == null) {
+      return
+    }
+
+    for (Field field : aClass.declaredFields) {
+      final int modifiers = field.modifiers;
+      if ((modifiers & Modifier.FINAL) == 0 && (modifiers & Modifier.STATIC) == 0 && !field.getType().isPrimitive()) {
+        field.setAccessible(true);
+        try {
+          field.set(this, null);
+        }
+        catch (IllegalAccessException e) {
+          e.printStackTrace();
+        }
+      }
+    }
+
+    if (aClass != AbstractExternalSystemTest.class) {
+      resetClassFields(aClass.getSuperclass());
+    }
+  }
+
+  public void setupExternalProject(@NotNull Closure c) {
+    DataNode<ProjectData> node = buildExternalProjectInfo(c)
+    applyProjectState([node])
+  }
+
+  @NotNull
+  public <T> DataNode<T> buildExternalProjectInfo(@NotNull Closure c) {
+    ExternalProjectBuilder builder = new ExternalProjectBuilder(projectDir: projectDir)
+    c.delegate = builder
+    c.call()
+  }
+
+  protected void applyProjectState(@NotNull List<DataNode<ProjectData>> states) {
+    def dataManager = ServiceManager.getService(ProjectDataManager.class)
+    def settingsInitialized = false
+    for (DataNode<ProjectData> node : states) {
+      if (!settingsInitialized) {
+        settingsInitialized = true
+        def settings = ExternalSystemApiUtil.getSettings(project, ExternalSystemTestUtil.TEST_EXTERNAL_SYSTEM_ID)
+        settings.linkedProjectsSettings = [new TestExternalProjectSettings(externalProjectPath: node.data.linkedExternalProjectPath)]
+      }
+
+      final Project myProject = project
+      dataManager.importData(node, myProject, true)
+    }
+  }
+}

--- a/src/test/java/com/intellij/openapi/externalSystem/test/ExternalProjectBuilder.groovy
+++ b/src/test/java/com/intellij/openapi/externalSystem/test/ExternalProjectBuilder.groovy
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.externalSystem.test
+
+import com.intellij.externalSystem.JavaProjectData
+import com.intellij.openapi.externalSystem.model.DataNode
+import com.intellij.openapi.externalSystem.model.ProjectKeys
+import com.intellij.openapi.externalSystem.model.ProjectSystemId
+import com.intellij.openapi.externalSystem.model.project.*
+import com.intellij.openapi.externalSystem.model.task.TaskData
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
+import com.intellij.openapi.module.ModuleTypeId
+import com.intellij.openapi.roots.DependencyScope
+import com.intellij.util.BooleanFunction
+import org.jetbrains.annotations.NotNull
+
+import static com.intellij.openapi.externalSystem.test.ExternalSystemTestUtil.TEST_EXTERNAL_SYSTEM_ID
+/**
+ * @author Denis Zhdanov
+ * @since 8/8/13 12:42 PM
+ */
+class ExternalProjectBuilder extends BuilderSupport {
+  
+  File projectDir
+  DataNode<ProjectData> projectNode;
+  
+  @Override
+  protected void setParent(Object parent, Object child) {
+  }
+
+  @Override
+  protected Object createNode(Object name) {
+    createNode(name, [:])
+  }
+
+  @Override
+  protected Object createNode(Object name, Object value) {
+    createNode(name, [name: value])
+  }
+
+  @Override
+  protected Object createNode(Object name, Map attributes, Object value) {
+    createNode(name, [name: value] + attributes)
+  }
+
+  @Override
+  protected Object createNode(Object name, Map attributes) {
+    def projectPath = ExternalSystemApiUtil.normalizePath(projectDir.path)
+    switch (name) {
+      case 'project':
+        ProjectSystemId projectSystemId = attributes.projectSystemId ?: TEST_EXTERNAL_SYSTEM_ID
+        ProjectData projectData = new ProjectData(projectSystemId, attributes.name ?: 'project', projectPath, projectPath)
+        projectNode = new DataNode<ProjectData>(ProjectKeys.PROJECT, projectData, null)
+        return projectNode
+      case 'javaProject':
+        ProjectSystemId projectSystemId = attributes.projectSystemId ?: TEST_EXTERNAL_SYSTEM_ID
+        String jdk = attributes.jdk ?: ""
+        String languageLevel = attributes.languageLevel ?: ""
+        JavaProjectData javaProjectData = new JavaProjectData(projectSystemId, "")
+        javaProjectData.setJdkVersion(jdk)
+        javaProjectData.setLanguageLevel(languageLevel)
+        return (current as DataNode).createChild(JavaProjectData.KEY, javaProjectData)
+      case 'module':
+        ProjectSystemId projectSystemId = attributes.projectSystemId ?: TEST_EXTERNAL_SYSTEM_ID
+        String moduleFilePath = attributes.moduleFilePath ?: projectPath
+        String externalConfigPath = attributes.externalConfigPath ?: projectPath
+        ModuleData moduleData = new ModuleData(attributes.name ?: name as String,
+                                               projectSystemId,
+                                               ModuleTypeId.JAVA_MODULE,
+                                               attributes.name ?: name as String,
+                                               moduleFilePath,
+                                               externalConfigPath)
+        return (current as DataNode).createChild(ProjectKeys.MODULE, moduleData)
+      case 'lib':
+        DataNode<ModuleData> parentNode = current as DataNode
+        LibraryDependencyData data = new LibraryDependencyData(parentNode.data,
+                                                               getLibrary(attributes.name, attributes),
+                                                               getLevel(attributes))
+        data.scope = getScope(attributes)
+        return parentNode.createChild(ProjectKeys.LIBRARY_DEPENDENCY, data)
+      case 'extraModel':
+        DataNode<ModuleData> parentNode = current as DataNode
+        return parentNode.createChild(attributes.key, attributes.model)
+      case 'task':
+        DataNode<ExternalConfigPathAware> parentNode = current as DataNode
+        ProjectSystemId projectSystemId = attributes.projectSystemId ?: TEST_EXTERNAL_SYSTEM_ID
+        TaskData data = new TaskData(projectSystemId, attributes.name, parentNode.data.linkedExternalProjectPath, null)
+        return parentNode.createChild(ProjectKeys.TASK, data)
+      case 'contentRoot':
+        DataNode<ModuleData> parentNode = current as DataNode
+        ContentRootData data = new ContentRootData(TEST_EXTERNAL_SYSTEM_ID, attributes.name)
+        return parentNode.createChild(ProjectKeys.CONTENT_ROOT, data)
+      case 'folder':
+        DataNode<ContentRootData> parentNode = current as DataNode
+        ContentRootData data = parentNode.data;
+        data.storePath(attributes.type, attributes.path)
+        return null
+        
+      default: throw new IllegalArgumentException("Unexpected entry: $name");
+    }
+  }
+
+  @NotNull
+  private LibraryData getLibrary(@NotNull String name, @NotNull Map attributes) {
+    DataNode<LibraryData> existing = ExternalSystemApiUtil.find(projectNode, ProjectKeys.LIBRARY, {
+      DataNode<LibraryData> node -> node.data.externalName == name
+    } as BooleanFunction)
+    if (existing != null) {
+      return existing.data
+    }
+    LibraryData result = new LibraryData(TEST_EXTERNAL_SYSTEM_ID, name, attributes.unresolved as boolean)
+    ['bin': LibraryPathType.BINARY, 'src': LibraryPathType.SOURCE, 'doc': LibraryPathType.DOC].each {
+      key, type -> attributes[key]?.each { result.addPath(type, it as String) }
+    }
+    if (attributes.level != 'module') {
+      projectNode.createChild(ProjectKeys.LIBRARY, result)
+    }
+    result
+  }
+
+  @NotNull
+  private static LibraryLevel getLevel(@NotNull Map attributes) {
+    try {
+      return LibraryLevel.valueOf(attributes.level.toUpperCase())
+    }
+    catch (Exception ignored) {
+      return LibraryLevel.PROJECT
+    }
+  }
+  
+  @NotNull
+  private static DependencyScope getScope(@NotNull Map attributes) {
+    try {
+      return DependencyScope.valueOf(attributes.scope.toUpperCase())
+    }
+    catch (Exception ignored) {
+      return DependencyScope.COMPILE
+    }
+  }
+}

--- a/src/test/java/com/intellij/openapi/externalSystem/test/ExternalSystemImportingTestCase.java
+++ b/src/test/java/com/intellij/openapi/externalSystem/test/ExternalSystemImportingTestCase.java
@@ -1,0 +1,554 @@
+/*
+ * Copyright 2000-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.externalSystem.test;
+
+import com.intellij.openapi.application.AccessToken;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.externalSystem.importing.ImportSpecBuilder;
+import com.intellij.openapi.externalSystem.model.DataNode;
+import com.intellij.openapi.externalSystem.model.ExternalProjectInfo;
+import com.intellij.openapi.externalSystem.model.ProjectSystemId;
+import com.intellij.openapi.externalSystem.model.project.ProjectData;
+import com.intellij.openapi.externalSystem.service.execution.ProgressExecutionMode;
+import com.intellij.openapi.externalSystem.service.project.ExternalProjectRefreshCallback;
+import com.intellij.openapi.externalSystem.service.project.manage.ProjectDataManager;
+import com.intellij.openapi.externalSystem.settings.AbstractExternalSystemSettings;
+import com.intellij.openapi.externalSystem.settings.ExternalProjectSettings;
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
+import com.intellij.openapi.externalSystem.util.ExternalSystemUtil;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl;
+import com.intellij.openapi.roots.*;
+import com.intellij.openapi.roots.impl.libraries.ProjectLibraryTable;
+import com.intellij.openapi.roots.libraries.Library;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.ui.TestDialog;
+import com.intellij.openapi.util.Couple;
+import com.intellij.openapi.util.Ref;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.packaging.artifacts.Artifact;
+import com.intellij.packaging.artifacts.ArtifactManager;
+import com.intellij.testFramework.IdeaTestUtil;
+import com.intellij.util.BooleanFunction;
+import com.intellij.util.Consumer;
+import com.intellij.util.Function;
+import com.intellij.util.PathUtil;
+import com.intellij.util.containers.ContainerUtil;
+import com.intellij.util.containers.ContainerUtilRt;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.jps.model.java.JavaResourceRootType;
+import org.jetbrains.jps.model.java.JavaSourceRootProperties;
+import org.jetbrains.jps.model.java.JavaSourceRootType;
+import org.jetbrains.jps.model.module.JpsModuleSourceRootType;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Vladislav.Soroka
+ * @since 6/30/2014
+ */
+public abstract class ExternalSystemImportingTestCase extends ExternalSystemTestCase {
+
+  @Override
+  protected void setUpInWriteAction() throws Exception {
+    super.setUpInWriteAction();
+  }
+
+  protected void assertModules(String... expectedNames) {
+    Module[] actual = ModuleManager.getInstance(myProject).getModules();
+    List<String> actualNames = new ArrayList<String>();
+
+    for (Module m : actual) {
+      actualNames.add(m.getName());
+    }
+
+    assertUnorderedElementsAreEqual(actualNames, expectedNames);
+  }
+
+  protected void assertContentRoots(String moduleName, String... expectedRoots) {
+    List<String> actual = new ArrayList<String>();
+    for (ContentEntry e : getContentRoots(moduleName)) {
+      actual.add(e.getUrl());
+    }
+
+    for (int i = 0; i < expectedRoots.length; i++) {
+      expectedRoots[i] = VfsUtilCore.pathToUrl(expectedRoots[i]);
+    }
+
+    assertUnorderedPathsAreEqual(actual, Arrays.asList(expectedRoots));
+  }
+
+  protected void assertSources(String moduleName, String... expectedSources) {
+    doAssertContentFolders(moduleName, JavaSourceRootType.SOURCE, expectedSources);
+  }
+
+  protected void assertGeneratedSources(String moduleName, String... expectedSources) {
+    assertGeneratedSources(moduleName, JavaSourceRootType.SOURCE, expectedSources);
+  }
+
+  protected void assertGeneratedTestSources(String moduleName, String... expectedSources) {
+    assertGeneratedSources(moduleName, JavaSourceRootType.TEST_SOURCE, expectedSources);
+  }
+
+  private void assertGeneratedSources(String moduleName, JavaSourceRootType type, String... expectedSources) {
+    final ContentEntry[] contentRoots = getContentRoots(moduleName);
+    final String rootUrl = contentRoots.length > 1 ? ExternalSystemApiUtil.getExternalProjectPath(getModule(moduleName)) : null;
+    List<SourceFolder> folders = doAssertContentFolders(rootUrl, contentRoots, type, expectedSources);
+    for (SourceFolder folder : folders) {
+      JavaSourceRootProperties properties = folder.getJpsElement().getProperties(type);
+      assertNotNull(properties);
+      assertTrue("Not a generated folder: " + folder, properties.isForGeneratedSources());
+    }
+  }
+
+  protected void assertResources(String moduleName, String... expectedSources) {
+    doAssertContentFolders(moduleName, JavaResourceRootType.RESOURCE, expectedSources);
+  }
+
+  protected void assertTestSources(String moduleName, String... expectedSources) {
+    doAssertContentFolders(moduleName, JavaSourceRootType.TEST_SOURCE, expectedSources);
+  }
+
+  protected void assertTestResources(String moduleName, String... expectedSources) {
+    doAssertContentFolders(moduleName, JavaResourceRootType.TEST_RESOURCE, expectedSources);
+  }
+
+  protected void assertExcludes(String moduleName, String... expectedExcludes) {
+    ContentEntry contentRoot = getContentRoot(moduleName);
+    doAssertContentFolders(contentRoot, Arrays.asList(contentRoot.getExcludeFolders()), expectedExcludes);
+  }
+
+  protected void assertContentRootExcludes(String moduleName, String contentRoot, String... expectedExcudes) {
+    ContentEntry root = getContentRoot(moduleName, contentRoot);
+    doAssertContentFolders(root, Arrays.asList(root.getExcludeFolders()), expectedExcudes);
+  }
+
+  private void doAssertContentFolders(String moduleName, @NotNull JpsModuleSourceRootType<?> rootType, String... expected) {
+    final ContentEntry[] contentRoots = getContentRoots(moduleName);
+    final String rootUrl = contentRoots.length > 1 ? ExternalSystemApiUtil.getExternalProjectPath(getModule(moduleName)) : null;
+    doAssertContentFolders(rootUrl, contentRoots, rootType, expected);
+  }
+
+  private static List<SourceFolder> doAssertContentFolders(@Nullable String rootUrl,
+                                                           ContentEntry[] contentRoots,
+                                                           @NotNull JpsModuleSourceRootType<?> rootType,
+                                                           String... expected) {
+    List<SourceFolder> result = new ArrayList<SourceFolder>();
+    List<String> actual = new ArrayList<String>();
+    for (ContentEntry contentRoot : contentRoots) {
+      for (SourceFolder f : contentRoot.getSourceFolders(rootType)) {
+        rootUrl = rootUrl == null ? VirtualFileManager.extractPath(contentRoot.getUrl()) : VirtualFileManager.extractPath(rootUrl);
+        String folderUrl = VirtualFileManager.extractPath(f.getUrl());
+        if (folderUrl.startsWith(rootUrl)) {
+          int length = rootUrl.length() + 1;
+          folderUrl = folderUrl.substring(Math.min(length, folderUrl.length()));
+        }
+
+        actual.add(folderUrl);
+        result.add(f);
+      }
+    }
+
+    assertOrderedElementsAreEqual(actual, Arrays.asList(expected));
+    return result;
+  }
+
+  private static void doAssertContentFolders(ContentEntry e, final List<? extends ContentFolder> folders, String... expected) {
+    List<String> actual = new ArrayList<String>();
+    for (ContentFolder f : folders) {
+      String rootUrl = e.getUrl();
+      String folderUrl = f.getUrl();
+
+      if (folderUrl.startsWith(rootUrl)) {
+        int length = rootUrl.length() + 1;
+        folderUrl = folderUrl.substring(Math.min(length, folderUrl.length()));
+      }
+
+      actual.add(folderUrl);
+    }
+
+    assertOrderedElementsAreEqual(actual, Arrays.asList(expected));
+  }
+
+  protected void assertModuleOutput(String moduleName, String output, String testOutput) {
+    CompilerModuleExtension e = getCompilerExtension(moduleName);
+
+    assertFalse(e.isCompilerOutputPathInherited());
+    assertEquals(output, getAbsolutePath(e.getCompilerOutputUrl()));
+    assertEquals(testOutput, getAbsolutePath(e.getCompilerOutputUrlForTests()));
+  }
+
+  protected void assertModuleInheritedOutput(String moduleName) {
+    CompilerModuleExtension e = getCompilerExtension(moduleName);
+    assertTrue(e.isCompilerOutputPathInherited());
+  }
+
+  private static String getAbsolutePath(String path) {
+    path = VfsUtil.urlToPath(path);
+    path = PathUtil.getCanonicalPath(path);
+    return FileUtil.toSystemIndependentName(path);
+  }
+
+  protected void assertProjectOutput(String module) {
+    assertTrue(getCompilerExtension(module).isCompilerOutputPathInherited());
+  }
+
+  protected CompilerModuleExtension getCompilerExtension(String module) {
+    return CompilerModuleExtension.getInstance(getModule(module));
+  }
+
+  protected void assertModuleLibDep(String moduleName, String depName) {
+    assertModuleLibDep(moduleName, depName, null);
+  }
+
+  protected void assertModuleLibDep(String moduleName, String depName, String classesPath) {
+    assertModuleLibDep(moduleName, depName, classesPath, null, null);
+  }
+
+  protected void assertModuleLibDep(String moduleName, String depName, String classesPath, String sourcePath, String javadocPath) {
+    LibraryOrderEntry lib = ContainerUtil.getFirstItem(getModuleLibDeps(moduleName, depName));
+
+    assertModuleLibDepPath(lib, OrderRootType.CLASSES, classesPath == null ? null : Collections.singletonList(classesPath));
+    assertModuleLibDepPath(lib, OrderRootType.SOURCES, sourcePath == null ? null : Collections.singletonList(sourcePath));
+    assertModuleLibDepPath(lib, JavadocOrderRootType.getInstance(), javadocPath == null ? null : Collections.singletonList(javadocPath));
+  }
+
+  protected void assertModuleLibDep(String moduleName,
+                                    String depName,
+                                    List<String> classesPaths,
+                                    List<String> sourcePaths,
+                                    List<String> javadocPaths) {
+    LibraryOrderEntry lib = ContainerUtil.getFirstItem(getModuleLibDeps(moduleName, depName));
+
+    assertModuleLibDepPath(lib, OrderRootType.CLASSES, classesPaths);
+    assertModuleLibDepPath(lib, OrderRootType.SOURCES, sourcePaths);
+    assertModuleLibDepPath(lib, JavadocOrderRootType.getInstance(), javadocPaths);
+  }
+
+  private static void assertModuleLibDepPath(LibraryOrderEntry lib, OrderRootType type, List<String> paths) {
+    assertNotNull(lib);
+    if (paths == null) return;
+    assertUnorderedPathsAreEqual(Arrays.asList(lib.getRootUrls(type)), paths);
+    // also check the library because it may contain slight different set of urls (e.g. with duplicates)
+    final Library library = lib.getLibrary();
+    assertNotNull(library);
+    assertUnorderedPathsAreEqual(Arrays.asList(library.getUrls(type)), paths);
+  }
+
+  protected void assertModuleLibDepScope(String moduleName, String depName, DependencyScope scopes) {
+    List<LibraryOrderEntry> deps = getModuleLibDeps(moduleName, depName);
+    assertUnorderedElementsAreEqual(ContainerUtil.map2Array(deps, new Function<LibraryOrderEntry, Object>() {
+      @Override
+      public Object fun(LibraryOrderEntry entry) {
+        return entry.getScope();
+      }
+    }), scopes);
+  }
+
+  protected List<LibraryOrderEntry> getModuleLibDeps(String moduleName, String depName) {
+    return getModuleDep(moduleName, depName, LibraryOrderEntry.class);
+  }
+
+  protected void assertModuleLibDeps(String moduleName, String... expectedDeps) {
+    assertModuleDeps(moduleName, LibraryOrderEntry.class, expectedDeps);
+  }
+
+  protected void assertExportedDeps(String moduleName, String... expectedDeps) {
+    final List<String> actual = new ArrayList<String>();
+
+    getRootManager(moduleName).orderEntries().withoutSdk().withoutModuleSourceEntries().exportedOnly().process(new RootPolicy<Object>() {
+      @Override
+      public Object visitModuleOrderEntry(ModuleOrderEntry e, Object value) {
+        actual.add(e.getModuleName());
+        return null;
+      }
+
+      @Override
+      public Object visitLibraryOrderEntry(LibraryOrderEntry e, Object value) {
+        actual.add(e.getLibraryName());
+        return null;
+      }
+    }, null);
+
+    assertOrderedElementsAreEqual(actual, expectedDeps);
+  }
+
+  protected void assertModuleModuleDeps(String moduleName, String... expectedDeps) {
+    assertModuleDeps(moduleName, ModuleOrderEntry.class, expectedDeps);
+  }
+
+  private void assertModuleDeps(String moduleName, Class clazz, String... expectedDeps) {
+    assertOrderedElementsAreEqual(collectModuleDepsNames(moduleName, clazz), expectedDeps);
+  }
+
+  protected void assertModuleModuleDepScope(String moduleName, String depName, DependencyScope... scopes) {
+    List<ModuleOrderEntry> deps = getModuleModuleDeps(moduleName, depName);
+    assertUnorderedElementsAreEqual(ContainerUtil.map2Array(deps, new Function<ModuleOrderEntry, Object>() {
+      @Override
+      public Object fun(ModuleOrderEntry entry) {
+        return entry.getScope();
+      }
+    }), scopes);
+  }
+
+  @NotNull
+  private List<ModuleOrderEntry> getModuleModuleDeps(@NotNull String moduleName, @NotNull String depName) {
+    return getModuleDep(moduleName, depName, ModuleOrderEntry.class);
+  }
+
+  private List<String> collectModuleDepsNames(String moduleName, Class clazz) {
+    List<String> actual = new ArrayList<String>();
+
+    for (OrderEntry e : getRootManager(moduleName).getOrderEntries()) {
+      if (clazz.isInstance(e)) {
+        actual.add(e.getPresentableName());
+      }
+    }
+    return actual;
+  }
+
+  @NotNull
+  private <T> List<T> getModuleDep(@NotNull String moduleName, @NotNull String depName, @NotNull Class<T> clazz) {
+    List<T> deps = ContainerUtil.newArrayList();
+
+    for (OrderEntry e : getRootManager(moduleName).getOrderEntries()) {
+      if (clazz.isInstance(e) && e.getPresentableName().equals(depName)) {
+        deps.add((T)e);
+      }
+    }
+    assertNotNull("Dependency not found: " + depName + "\namong: " + collectModuleDepsNames(moduleName, clazz), deps);
+    return deps;
+  }
+
+  public void assertProjectLibraries(String... expectedNames) {
+    List<String> actualNames = new ArrayList<String>();
+    for (Library each : ProjectLibraryTable.getInstance(myProject).getLibraries()) {
+      String name = each.getName();
+      actualNames.add(name == null ? "<unnamed>" : name);
+    }
+    assertUnorderedElementsAreEqual(actualNames, expectedNames);
+  }
+
+  protected void assertModuleGroupPath(String moduleName, String... expected) {
+    String[] path = ModuleManager.getInstance(myProject).getModuleGroupPath(getModule(moduleName));
+
+    if (expected.length == 0) {
+      assertNull(path);
+    }
+    else {
+      assertNotNull(path);
+      assertOrderedElementsAreEqual(Arrays.asList(path), expected);
+    }
+  }
+
+  protected void assertArtifacts(String... expectedNames) {
+    final List<String> actualNames = ContainerUtil.map(
+      ArtifactManager.getInstance(myProject).getAllArtifactsIncludingInvalid(), new Function<Artifact, String>() {
+        @Override
+        public String fun(Artifact artifact) {
+          return artifact.getName();
+        }
+      });
+
+    assertUnorderedElementsAreEqual(actualNames, expectedNames);
+  }
+
+  protected Module getModule(final String name) {
+    AccessToken accessToken = ApplicationManager.getApplication().acquireReadActionLock();
+    try {
+      Module m = ModuleManager.getInstance(myProject).findModuleByName(name);
+      assertNotNull("Module " + name + " not found", m);
+      return m;
+    }
+    finally {
+      accessToken.finish();
+    }
+  }
+
+  private ContentEntry getContentRoot(String moduleName) {
+    ContentEntry[] ee = getContentRoots(moduleName);
+    List<String> roots = new ArrayList<String>();
+    for (ContentEntry e : ee) {
+      roots.add(e.getUrl());
+    }
+
+    String message = "Several content roots found: [" + StringUtil.join(roots, ", ") + "]";
+    assertEquals(message, 1, ee.length);
+
+    return ee[0];
+  }
+
+  private ContentEntry getContentRoot(String moduleName, String path) {
+    for (ContentEntry e : getContentRoots(moduleName)) {
+      if (e.getUrl().equals(VfsUtilCore.pathToUrl(path))) return e;
+    }
+    throw new AssertionError("content root not found");
+  }
+
+  public ContentEntry[] getContentRoots(String moduleName) {
+    return getRootManager(moduleName).getContentEntries();
+  }
+
+  private ModuleRootManager getRootManager(String module) {
+    return ModuleRootManager.getInstance(getModule(module));
+  }
+
+  protected void ignoreData(BooleanFunction<DataNode<?>> booleanFunction, final boolean ignored) {
+    final ExternalProjectInfo externalProjectInfo = ProjectDataManager.getInstance().getExternalProjectData(
+      myProject, getExternalSystemId(), getCurrentExternalProjectSettings().getExternalProjectPath());
+    assertNotNull(externalProjectInfo);
+
+    final DataNode<ProjectData> projectDataNode = externalProjectInfo.getExternalProjectStructure();
+    assertNotNull(projectDataNode);
+
+    final Collection<DataNode<?>> nodes = ExternalSystemApiUtil.findAllRecursively(projectDataNode, booleanFunction);
+    for (DataNode<?> node : nodes) {
+      ExternalSystemApiUtil.visit(node, new Consumer<DataNode<?>>() {
+        @Override
+        public void consume(DataNode dataNode) {
+          dataNode.setIgnored(ignored);
+        }
+      });
+    }
+    ServiceManager.getService(ProjectDataManager.class).importData(projectDataNode, myProject, true);
+  }
+
+  protected void importProject(@NonNls String config) throws IOException {
+    createProjectConfig(config);
+    importProject();
+  }
+
+  protected void importProject() {
+    doImportProject();
+  }
+
+  private void doImportProject() {
+    AbstractExternalSystemSettings systemSettings = ExternalSystemApiUtil.getSettings(myProject, getExternalSystemId());
+    final ExternalProjectSettings projectSettings = getCurrentExternalProjectSettings();
+    projectSettings.setExternalProjectPath(getProjectPath());
+    Set<ExternalProjectSettings> projects = ContainerUtilRt.newHashSet(systemSettings.getLinkedProjectsSettings());
+    projects.remove(projectSettings);
+    projects.add(projectSettings);
+    systemSettings.setLinkedProjectsSettings(projects);
+
+    final Ref<Couple<String>> error = Ref.create();
+    ExternalSystemUtil.refreshProjects(
+      new ImportSpecBuilder(myProject, getExternalSystemId())
+        .use(ProgressExecutionMode.MODAL_SYNC)
+        .callback(new ExternalProjectRefreshCallback() {
+          @Override
+          public void onSuccess(@Nullable final DataNode<ProjectData> externalProject) {
+            if (externalProject == null) {
+              System.err.println("Got null External project after import");
+              return;
+            }
+            ServiceManager.getService(ProjectDataManager.class).importData(externalProject, myProject, true);
+            System.out.println("External project was successfully imported");
+          }
+
+          @Override
+          public void onFailure(@NotNull String errorMessage, @Nullable String errorDetails) {
+            error.set(Couple.of(errorMessage, errorDetails));
+          }
+        })
+    );
+
+    if (!error.isNull()) {
+      String failureMsg = "Import failed: " + error.get().first;
+      if (StringUtil.isNotEmpty(error.get().second)) {
+        failureMsg += "\nError details: \n" + error.get().second;
+      }
+      fail(failureMsg);
+    }
+  }
+
+  protected abstract ExternalProjectSettings getCurrentExternalProjectSettings();
+
+  protected abstract ProjectSystemId getExternalSystemId();
+
+  protected void setupJdkForModules(String... moduleNames) {
+    for (String each : moduleNames) {
+      setupJdkForModule(each);
+    }
+  }
+
+  protected Sdk setupJdkForModule(final String moduleName) {
+    final Sdk sdk = true ? JavaAwareProjectJdkTableImpl.getInstanceEx().getInternalJdk() : createJdk("Java 1.5");
+    ModuleRootModificationUtil.setModuleSdk(getModule(moduleName), sdk);
+    return sdk;
+  }
+
+  protected static Sdk createJdk(String versionName) {
+    return IdeaTestUtil.getMockJdk17(versionName);
+  }
+
+  protected static AtomicInteger configConfirmationForYesAnswer() {
+    final AtomicInteger counter = new AtomicInteger();
+    Messages.setTestDialog(new TestDialog() {
+      @Override
+      public int show(String message) {
+        counter.set(counter.get() + 1);
+        return 0;
+      }
+    });
+    return counter;
+  }
+
+  protected static AtomicInteger configConfirmationForNoAnswer() {
+    final AtomicInteger counter = new AtomicInteger();
+    Messages.setTestDialog(new TestDialog() {
+      @Override
+      public int show(String message) {
+        counter.set(counter.get() + 1);
+        return 1;
+      }
+    });
+    return counter;
+  }
+
+  //protected void assertProblems(String... expectedProblems) {
+  //  final List<String> actualProblems = new ArrayList<String>();
+  //  UIUtil.invokeAndWaitIfNeeded(new Runnable() {
+  //    @Override
+  //    public void run() {
+  //      final NewErrorTreeViewPanel messagesView = ExternalSystemNotificationManager.getInstance(myProject)
+  //        .prepareMessagesView(getExternalSystemId(), NotificationSource.PROJECT_SYNC, false);
+  //      final ErrorViewStructure treeStructure = messagesView.getErrorViewStructure();
+  //
+  //      ErrorTreeElement[] elements = treeStructure.getChildElements(treeStructure.getRootElement());
+  //      for (ErrorTreeElement element : elements) {
+  //        if (element.getKind() == ErrorTreeElementKind.ERROR ||
+  //            element.getKind() == ErrorTreeElementKind.WARNING) {
+  //          actualProblems.add(StringUtil.join(element.getText(), "\n"));
+  //        }
+  //      }
+  //    }
+  //  });
+  //
+  //  assertOrderedElementsAreEqual(actualProblems, expectedProblems);
+  //}
+}

--- a/src/test/java/com/intellij/openapi/externalSystem/test/ExternalSystemTestCase.java
+++ b/src/test/java/com/intellij/openapi/externalSystem/test/ExternalSystemTestCase.java
@@ -1,0 +1,557 @@
+/*
+ * Copyright 2000-2015 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.externalSystem.test;
+
+import com.intellij.compiler.CompilerTestUtil;
+import com.intellij.compiler.impl.ModuleCompileScope;
+import com.intellij.openapi.application.AccessToken;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.Result;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.compiler.CompileScope;
+import com.intellij.openapi.compiler.CompilerMessage;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.module.ModuleType;
+import com.intellij.openapi.module.StdModuleTypes;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl;
+import com.intellij.openapi.roots.ModuleRootModificationUtil;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.io.ByteSequence;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.io.FileUtilRt;
+import com.intellij.openapi.vfs.*;
+import com.intellij.testFramework.*;
+import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory;
+import com.intellij.util.Processor;
+import com.intellij.util.ThrowableRunnable;
+import com.intellij.util.containers.ContainerUtil;
+import gnu.trove.THashSet;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Before;
+
+import java.awt.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.List;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+/**
+ * @author Vladislav.Soroka
+ * @since 6/30/2014
+ */
+public abstract class ExternalSystemTestCase extends UsefulTestCase {
+  private File ourTempDir;
+
+  protected IdeaProjectTestFixture myTestFixture;
+
+  protected Project myProject;
+
+  protected File myTestDir;
+  protected VirtualFile myProjectRoot;
+  protected VirtualFile myProjectConfig;
+  protected List<VirtualFile> myAllConfigs = new ArrayList<VirtualFile>();
+
+  private List<String> myAllowedRoots = new ArrayList<String>();
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    ensureTempDirCreated();
+
+    myTestDir = new File(ourTempDir, getTestName(false));
+    FileUtil.ensureExists(myTestDir);
+
+    setUpFixtures();
+    myProject = myTestFixture.getProject();
+
+    edt(new Runnable() {
+      @Override
+      public void run() {
+        ApplicationManager.getApplication().runWriteAction(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              setUpInWriteAction();
+            }
+            catch (Throwable e) {
+              try {
+                tearDown();
+              }
+              catch (Exception e1) {
+                e1.printStackTrace();
+              }
+              throw new RuntimeException(e);
+            }
+          }
+        });
+      }
+    });
+
+    List<String> allowedRoots = new ArrayList<String>();
+    collectAllowedRoots(allowedRoots);
+
+    CompilerTestUtil.enableExternalCompiler();
+  }
+
+  protected void collectAllowedRoots(List<String> roots) throws IOException {
+  }
+
+  public static Collection<String> collectRootsInside(String root) {
+    final List<String> roots = ContainerUtil.newSmartList();
+    roots.add(root);
+    FileUtil.processFilesRecursively(new File(root), new Processor<File>() {
+      @Override
+      public boolean process(File file) {
+        try {
+          String path = file.getCanonicalPath();
+          if (!FileUtil.isAncestor(path, path, false)) {
+            roots.add(path);
+          }
+        }
+        catch (IOException ignore) {
+        }
+        return true;
+      }
+    });
+
+    return roots;
+  }
+
+  private void ensureTempDirCreated() throws IOException {
+    if (ourTempDir != null) return;
+
+    ourTempDir = new File(FileUtil.getTempDirectory(), getTestsTempDir());
+    FileUtil.delete(ourTempDir);
+    FileUtil.ensureExists(ourTempDir);
+  }
+
+  protected abstract String getTestsTempDir();
+
+  protected void setUpFixtures() throws Exception {
+    myTestFixture = IdeaTestFixtureFactory.getFixtureFactory().createFixtureBuilder(getName()).getFixture();
+    myTestFixture.setUp();
+  }
+
+  protected void setUpInWriteAction() throws Exception {
+    File projectDir = new File(myTestDir, "project");
+    FileUtil.ensureExists(projectDir);
+    myProjectRoot = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(projectDir);
+  }
+
+  @After
+  @Override
+  public void tearDown() throws Exception {
+    try {
+      EdtTestUtil.runInEdtAndWait(new ThrowableRunnable<Throwable>() {
+        @Override
+        public void run() throws Throwable {
+          CompilerTestUtil.disableExternalCompiler(myProject);
+          tearDownFixtures();
+        }
+      });
+      myProject = null;
+      if (!FileUtil.delete(myTestDir) && myTestDir.exists()) {
+        System.err.println("Cannot delete " + myTestDir);
+        //printDirectoryContent(myDir);
+        myTestDir.deleteOnExit();
+      }
+    }
+    finally {
+      super.tearDown();
+      resetClassFields(getClass());
+    }
+  }
+
+  private static void printDirectoryContent(File dir) {
+    File[] files = dir.listFiles();
+    if (files == null) return;
+
+    for (File file : files) {
+      System.out.println(file.getAbsolutePath());
+
+      if (file.isDirectory()) {
+        printDirectoryContent(file);
+      }
+    }
+  }
+
+  protected void tearDownFixtures() throws Exception {
+    myTestFixture.tearDown();
+    myTestFixture = null;
+  }
+
+  private void resetClassFields(final Class<?> aClass) {
+    if (aClass == null) return;
+
+    final Field[] fields = aClass.getDeclaredFields();
+    for (Field field : fields) {
+      final int modifiers = field.getModifiers();
+      if ((modifiers & Modifier.FINAL) == 0
+          && (modifiers & Modifier.STATIC) == 0
+          && !field.getType().isPrimitive()) {
+        field.setAccessible(true);
+        try {
+          field.set(this, null);
+        }
+        catch (IllegalAccessException e) {
+          e.printStackTrace();
+        }
+      }
+    }
+
+    if (aClass == ExternalSystemTestCase.class) return;
+    resetClassFields(aClass.getSuperclass());
+  }
+
+  @Override
+  protected void runTest() throws Throwable {
+    try {
+      if (runInWriteAction()) {
+        new WriteAction() {
+          @Override
+          protected void run(@NotNull Result result) throws Throwable {
+            ExternalSystemTestCase.super.runTest();
+          }
+        }.executeSilently().throwException();
+      }
+      else {
+        ExternalSystemTestCase.super.runTest();
+      }
+    }
+    catch (Exception throwable) {
+      Throwable each = throwable;
+      do {
+        if (each instanceof HeadlessException) {
+          printIgnoredMessage("Doesn't work in Headless environment");
+          return;
+        }
+      }
+      while ((each = each.getCause()) != null);
+      throw throwable;
+    }
+  }
+
+  @Override
+  protected void invokeTestRunnable(@NotNull Runnable runnable) throws Exception {
+    runnable.run();
+  }
+
+  protected boolean runInWriteAction() {
+    return false;
+  }
+
+  protected static String getRoot() {
+    if (SystemInfo.isWindows) return "c:";
+    return "";
+  }
+
+  protected static String getEnvVar() {
+    if (SystemInfo.isWindows) return "TEMP";
+    else if (SystemInfo.isLinux) return "HOME";
+    return "TMPDIR";
+  }
+
+  protected String getProjectPath() {
+    return myProjectRoot.getPath();
+  }
+
+  protected String getParentPath() {
+    return myProjectRoot.getParent().getPath();
+  }
+
+  protected String pathFromBasedir(String relPath) {
+    return pathFromBasedir(myProjectRoot, relPath);
+  }
+
+  protected static String pathFromBasedir(VirtualFile root, String relPath) {
+    return FileUtil.toSystemIndependentName(root.getPath() + "/" + relPath);
+  }
+
+  protected Module createModule(String name) throws IOException {
+    return createModule(name, StdModuleTypes.JAVA);
+  }
+
+  protected Module createModule(final String name, final ModuleType type) throws IOException {
+    return new WriteCommandAction<Module>(myProject) {
+      @Override
+      protected void run(@NotNull Result<Module> moduleResult) throws Throwable {
+        VirtualFile f = createProjectSubFile(name + "/" + name + ".iml");
+        Module module = ModuleManager.getInstance(myProject).newModule(f.getPath(), type.getId());
+        PsiTestUtil.addContentRoot(module, f.getParent());
+        moduleResult.setResult(module);
+      }
+    }.execute().getResultObject();
+  }
+
+  protected VirtualFile createProjectConfig(@NonNls String config) throws IOException {
+    return myProjectConfig = createConfigFile(myProjectRoot, config);
+  }
+
+  protected VirtualFile createConfigFile(final VirtualFile dir, String config) throws IOException {
+    final String configFileName = getExternalSystemConfigFileName();
+    VirtualFile f = dir.findChild(configFileName);
+    if (f == null) {
+      f = new WriteAction<VirtualFile>() {
+        @Override
+        protected void run(@NotNull Result<VirtualFile> result) throws Throwable {
+          VirtualFile res = dir.createChildData(null, configFileName);
+          result.setResult(res);
+        }
+      }.execute().getResultObject();
+      myAllConfigs.add(f);
+    }
+    setFileContent(f, config, true);
+    return f;
+  }
+
+  protected abstract String getExternalSystemConfigFileName();
+
+  protected void createStdProjectFolders() throws IOException {
+    createProjectSubDirs("src/main/java",
+                         "src/main/resources",
+                         "src/test/java",
+                         "src/test/resources");
+  }
+
+  protected void createProjectSubDirs(String... relativePaths) throws IOException {
+    for (String path : relativePaths) {
+      createProjectSubDir(path);
+    }
+  }
+
+  protected VirtualFile createProjectSubDir(String relativePath) throws IOException {
+    File f = new File(getProjectPath(), relativePath);
+    FileUtil.ensureExists(f);
+    return LocalFileSystem.getInstance().refreshAndFindFileByIoFile(f);
+  }
+
+  protected VirtualFile createProjectSubFile(String relativePath) throws IOException {
+    File f = new File(getProjectPath(), relativePath);
+    FileUtil.ensureExists(f.getParentFile());
+    FileUtil.ensureCanCreateFile(f);
+    final boolean created = f.createNewFile();
+    if(!created) {
+      throw new AssertionError("Unable to create the project sub file: " + f.getAbsolutePath());
+    }
+    return LocalFileSystem.getInstance().refreshAndFindFileByIoFile(f);
+  }
+
+  private static void addJarEntry(byte[] bytes, String path, JarOutputStream target) throws IOException {
+    JarEntry entry = new JarEntry(path.replace("\\", "/"));
+    target.putNextEntry(entry);
+    target.write(bytes);
+    target.close();
+  }
+
+  protected VirtualFile createProjectSubFile(String relativePath, String content) throws IOException {
+    VirtualFile file = createProjectSubFile(relativePath);
+    setFileContent(file, content, false);
+    return file;
+  }
+
+
+  protected void compileModules(final String... moduleNames) {
+    compile(createModulesCompileScope(moduleNames));
+  }
+
+  private void compile(final CompileScope scope) {
+    try {
+      CompilerTester tester = new CompilerTester(myProject, Arrays.asList(scope.getAffectedModules()));
+      try {
+        List<CompilerMessage> messages = tester.make(scope);
+        for (CompilerMessage message : messages) {
+          switch (message.getCategory()) {
+            case ERROR:
+              fail("Compilation failed with error: " + message.getMessage());
+              break;
+            case WARNING:
+              System.out.println("Compilation warning: " + message.getMessage());
+              break;
+            case INFORMATION:
+              break;
+            case STATISTICS:
+              break;
+          }
+        }
+      }
+      finally {
+        tester.tearDown();
+      }
+    }
+    catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+
+  private CompileScope createModulesCompileScope(final String[] moduleNames) {
+    final List<Module> modules = new ArrayList<Module>();
+    for (String name : moduleNames) {
+      modules.add(getModule(name));
+    }
+    return new ModuleCompileScope(myProject, modules.toArray(new Module[modules.size()]), false);
+  }
+
+  protected Sdk setupJdkForModule(final String moduleName) {
+    final Sdk sdk = true ? JavaAwareProjectJdkTableImpl.getInstanceEx().getInternalJdk() : createJdk("Java 1.5");
+    ModuleRootModificationUtil.setModuleSdk(getModule(moduleName), sdk);
+    return sdk;
+  }
+
+  protected static Sdk createJdk(String versionName) {
+    return IdeaTestUtil.getMockJdk17(versionName);
+  }
+
+  protected Module getModule(final String name) {
+    AccessToken accessToken = ApplicationManager.getApplication().acquireReadActionLock();
+    try {
+      Module m = ModuleManager.getInstance(myProject).findModuleByName(name);
+      assertNotNull("Module " + name + " not found", m);
+      return m;
+    }
+    finally {
+      accessToken.finish();
+    }
+  }
+
+  private static void setFileContent(final VirtualFile file, final String content, final boolean advanceStamps) throws IOException {
+    new WriteAction<VirtualFile>() {
+      @Override
+      protected void run(@NotNull Result<VirtualFile> result) throws Throwable {
+        if (advanceStamps) {
+          file.setBinaryContent(content.getBytes(CharsetToolkit.UTF8_CHARSET), -1, file.getTimeStamp() + 4000);
+        }
+        else {
+          file.setBinaryContent(content.getBytes(CharsetToolkit.UTF8_CHARSET), file.getModificationStamp(), file.getTimeStamp());
+        }
+      }
+    }.execute().getResultObject();
+  }
+
+  protected static <T, U> void assertOrderedElementsAreEqual(Collection<U> actual, Collection<T> expected) {
+    assertOrderedElementsAreEqual(actual, expected.toArray());
+  }
+
+  protected static <T> void assertUnorderedElementsAreEqual(Collection<T> actual, Collection<T> expected) {
+    assertEquals(new HashSet<T>(expected), new HashSet<T>(actual));
+  }
+  protected static void assertUnorderedPathsAreEqual(Collection<String> actual, Collection<String> expected) {
+    assertEquals(new SetWithToString<String>(new THashSet<String>(expected, FileUtil.PATH_HASHING_STRATEGY)),
+                 new SetWithToString<String>(new THashSet<String>(actual, FileUtil.PATH_HASHING_STRATEGY)));
+  }
+
+  protected static <T> void assertUnorderedElementsAreEqual(T[] actual, T... expected) {
+    assertUnorderedElementsAreEqual(Arrays.asList(actual), expected);
+  }
+
+  protected static <T> void assertUnorderedElementsAreEqual(Collection<T> actual, T... expected) {
+    assertUnorderedElementsAreEqual(actual, Arrays.asList(expected));
+  }
+
+  protected static <T, U> void assertOrderedElementsAreEqual(Collection<U> actual, T... expected) {
+    String s = "\nexpected: " + Arrays.asList(expected) + "\nactual: " + new ArrayList<U>(actual);
+    assertEquals(s, expected.length, actual.size());
+
+    java.util.List<U> actualList = new ArrayList<U>(actual);
+    for (int i = 0; i < expected.length; i++) {
+      T expectedElement = expected[i];
+      U actualElement = actualList.get(i);
+      assertEquals(s, expectedElement, actualElement);
+    }
+  }
+
+  protected static <T> void assertContain(java.util.List<? extends T> actual, T... expected) {
+    java.util.List<T> expectedList = Arrays.asList(expected);
+    assertTrue("expected: " + expectedList + "\n" + "actual: " + actual.toString(), actual.containsAll(expectedList));
+  }
+
+  protected static <T> void assertDoNotContain(java.util.List<T> actual, T... expected) {
+    java.util.List<T> actualCopy = new ArrayList<T>(actual);
+    actualCopy.removeAll(Arrays.asList(expected));
+    assertEquals(actual.toString(), actualCopy.size(), actual.size());
+  }
+
+  protected boolean ignore() {
+    printIgnoredMessage(null);
+    return true;
+  }
+
+  private void printIgnoredMessage(String message) {
+    String toPrint = "Ignored";
+    if (message != null) {
+      toPrint += ", because " + message;
+    }
+    toPrint += ": " + getClass().getSimpleName() + "." + getName();
+    System.out.println(toPrint);
+  }
+
+  private static class SetWithToString<T> extends AbstractSet<T> {
+
+    private final Set<T> myDelegate;
+
+    public SetWithToString(@NotNull Set<T> delegate) {
+      myDelegate = delegate;
+    }
+
+    @Override
+    public int size() {
+      return myDelegate.size();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+      return myDelegate.contains(o);
+    }
+
+    @NotNull
+    @Override
+    public Iterator<T> iterator() {
+      return myDelegate.iterator();
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+      return myDelegate.containsAll(c);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return myDelegate.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+      return myDelegate.hashCode();
+    }
+  }
+
+}

--- a/src/test/java/com/intellij/openapi/externalSystem/test/ExternalSystemTestUtil.java
+++ b/src/test/java/com/intellij/openapi/externalSystem/test/ExternalSystemTestUtil.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.externalSystem.test;
+
+import com.intellij.openapi.externalSystem.model.ProjectSystemId;
+import com.intellij.util.containers.ContainerUtilRt;
+import com.intellij.util.messages.Topic;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+
+import java.util.Map;
+
+/**
+ * @author Denis Zhdanov
+ * @since 8/8/13 12:50 PM
+ */
+public class ExternalSystemTestUtil {
+
+  public static final ProjectSystemId TEST_EXTERNAL_SYSTEM_ID = new ProjectSystemId("TEST_EXTERNAL_SYSTEM_ID");
+
+  public static final Topic<TestExternalSystemSettingsListener> SETTINGS_TOPIC = Topic.create(
+    "TEST_EXTERNAL_SYSTEM_SETTINGS", TestExternalSystemSettingsListener.class
+  );
+
+  private ExternalSystemTestUtil() {
+  }
+
+  public static void assertMapsEqual(@NotNull Map<?, ?> expected, @NotNull Map<?, ?> actual) {
+    Map<?, ?> local = ContainerUtilRt.newHashMap(expected);
+    for (Map.Entry<?, ?> entry : actual.entrySet()) {
+      Object expectedValue = local.remove(entry.getKey());
+      if (expectedValue == null) {
+        Assert.fail(String.format("Expected to find '%s' -> '%s' mapping but it doesn't exist", entry.getKey(), entry.getValue()));
+      }
+      if (!expectedValue.equals(entry.getValue())) {
+        Assert.fail(
+          String.format("Expected to find '%s' value for the key '%s' but got '%s'", expectedValue, entry.getKey(), entry.getValue())
+        );
+      }
+    }
+    if (!local.isEmpty()) {
+      Assert.fail("No mappings found for the following keys: " + local.keySet());
+    }
+  }
+}

--- a/src/test/java/com/intellij/openapi/externalSystem/test/README.txt
+++ b/src/test/java/com/intellij/openapi/externalSystem/test/README.txt
@@ -1,0 +1,3 @@
+This classes are copy pasted from intellij-community, because they are not included in openapi yet.
+
+ExternalSystemTestCase is modified not to depend on com.intellij.packaging.artifacts.Artifact.

--- a/src/test/java/com/intellij/openapi/externalSystem/test/TestExternalProjectSettings.java
+++ b/src/test/java/com/intellij/openapi/externalSystem/test/TestExternalProjectSettings.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.externalSystem.test;
+
+import com.intellij.openapi.externalSystem.settings.ExternalProjectSettings;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author Denis Zhdanov
+ * @since 8/8/13 5:12 PM
+ */
+public class TestExternalProjectSettings extends ExternalProjectSettings {
+
+  @NotNull
+  @Override
+  public ExternalProjectSettings clone() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/test/java/com/intellij/openapi/externalSystem/test/TestExternalSystemExecutionSettings.groovy
+++ b/src/test/java/com/intellij/openapi/externalSystem/test/TestExternalSystemExecutionSettings.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.externalSystem.test
+
+import com.intellij.openapi.externalSystem.model.settings.ExternalSystemExecutionSettings
+
+/**
+ * @author Denis Zhdanov
+ * @since 8/8/13 5:22 PM
+ */
+class TestExternalSystemExecutionSettings extends ExternalSystemExecutionSettings {
+}

--- a/src/test/java/com/intellij/openapi/externalSystem/test/TestExternalSystemLocalSettings.groovy
+++ b/src/test/java/com/intellij/openapi/externalSystem/test/TestExternalSystemLocalSettings.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.externalSystem.test
+
+import com.intellij.openapi.externalSystem.settings.AbstractExternalSystemLocalSettings
+import com.intellij.openapi.project.Project
+import org.jetbrains.annotations.NotNull
+
+/**
+ * @author Denis Zhdanov
+ * @since 8/8/13 5:21 PM
+ */
+class TestExternalSystemLocalSettings extends AbstractExternalSystemLocalSettings {
+
+  TestExternalSystemLocalSettings(@NotNull Project project) {
+    super(ExternalSystemTestUtil.TEST_EXTERNAL_SYSTEM_ID, project)
+  }
+}

--- a/src/test/java/com/intellij/openapi/externalSystem/test/TestExternalSystemManager.groovy
+++ b/src/test/java/com/intellij/openapi/externalSystem/test/TestExternalSystemManager.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.externalSystem.test
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.SimpleJavaParameters
+import com.intellij.openapi.externalSystem.ExternalSystemManager
+import com.intellij.openapi.externalSystem.model.ProjectSystemId
+import com.intellij.openapi.externalSystem.service.project.ExternalSystemProjectResolver
+import com.intellij.openapi.externalSystem.task.ExternalSystemTaskManager
+import com.intellij.openapi.fileChooser.FileChooserDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Pair
+import com.intellij.util.Function
+import org.jetbrains.annotations.NotNull
+/**
+ * @author Denis Zhdanov
+ * @since 8/8/13 5:20 PM
+ */
+class TestExternalSystemManager implements ExternalSystemManager<
+TestExternalProjectSettings,
+TestExternalSystemSettingsListener,
+TestExternalSystemSettings,
+TestExternalSystemLocalSettings,
+TestExternalSystemExecutionSettings>
+{
+
+  TestExternalSystemSettings systemSettings
+  TestExternalSystemLocalSettings localSettings
+  TestExternalSystemExecutionSettings executionSettings
+
+  TestExternalSystemManager(@NotNull Project project) {
+    systemSettings = new TestExternalSystemSettings(project)
+    localSettings = new TestExternalSystemLocalSettings(project)
+    executionSettings = new TestExternalSystemExecutionSettings()
+  }
+
+  @NotNull
+  @Override
+  ProjectSystemId getSystemId() {
+    ExternalSystemTestUtil.TEST_EXTERNAL_SYSTEM_ID
+  }
+
+  @NotNull
+  @Override
+  Function<Project, TestExternalSystemSettings> getSettingsProvider() { { project -> systemSettings } as Function }
+
+  @NotNull
+  @Override
+  Function<Project, TestExternalSystemLocalSettings> getLocalSettingsProvider() { { project -> localSettings } as Function }
+
+  @NotNull
+  @Override
+  Function<Pair<Project, String>, TestExternalSystemExecutionSettings> getExecutionSettingsProvider() {
+    { project -> executionSettings } as Function
+  }
+
+  @NotNull
+  @Override
+  Class<? extends ExternalSystemProjectResolver<TestExternalSystemExecutionSettings>> getProjectResolverClass() {
+    throw new UnsupportedOperationException()
+  }
+
+  @Override
+  Class<? extends ExternalSystemTaskManager<TestExternalSystemExecutionSettings>> getTaskManagerClass() {
+    throw new UnsupportedOperationException()
+  }
+
+  @NotNull
+  @Override
+  FileChooserDescriptor getExternalProjectDescriptor() {
+    throw new UnsupportedOperationException()
+  }
+
+  @Override
+  void enhanceRemoteProcessing(@NotNull SimpleJavaParameters parameters) throws ExecutionException {
+  }
+
+  @Override
+  void enhanceLocalProcessing(@NotNull List<URL> urls) {
+  }
+}

--- a/src/test/java/com/intellij/openapi/externalSystem/test/TestExternalSystemSettings.groovy
+++ b/src/test/java/com/intellij/openapi/externalSystem/test/TestExternalSystemSettings.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.externalSystem.test
+
+import com.intellij.openapi.externalSystem.settings.AbstractExternalSystemSettings
+import com.intellij.openapi.externalSystem.settings.ExternalSystemSettingsListener
+import com.intellij.openapi.project.Project
+import org.jetbrains.annotations.NotNull
+/**
+ * @author Denis Zhdanov
+ * @since 8/8/13 4:04 PM
+ */
+class TestExternalSystemSettings extends AbstractExternalSystemSettings<
+TestExternalSystemSettings,
+TestExternalProjectSettings,
+TestExternalSystemSettingsListener>
+{
+
+  TestExternalSystemSettings(Project project) {
+    super(ExternalSystemTestUtil.SETTINGS_TOPIC, project)
+  }
+
+  @Override
+  void subscribe(@NotNull ExternalSystemSettingsListener<TestExternalProjectSettings> listener) {
+    throw new UnsupportedOperationException()
+  }
+
+  @Override
+  protected void copyExtraSettingsFrom(@NotNull TestExternalSystemSettings settings) {
+    throw new UnsupportedOperationException() 
+  }
+
+  @Override
+  protected void checkSettings(@NotNull TestExternalProjectSettings old, @NotNull TestExternalProjectSettings current) {
+    throw new UnsupportedOperationException() 
+  }
+}

--- a/src/test/java/com/intellij/openapi/externalSystem/test/TestExternalSystemSettingsListener.java
+++ b/src/test/java/com/intellij/openapi/externalSystem/test/TestExternalSystemSettingsListener.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.openapi.externalSystem.test;
+
+import com.intellij.openapi.externalSystem.settings.ExternalSystemSettingsListener;
+
+/**
+ * @author Denis Zhdanov
+ * @since 8/8/13 5:11 PM
+ */
+public interface TestExternalSystemSettingsListener extends ExternalSystemSettingsListener<TestExternalProjectSettings> {
+}

--- a/src/test/kotlin/org/rust/cargo/project/CargoImportTestCase.kt
+++ b/src/test/kotlin/org/rust/cargo/project/CargoImportTestCase.kt
@@ -1,0 +1,22 @@
+package org.rust.cargo.project
+
+class CargoImportTestCase : CargoImportTestCaseBase() {
+    fun testModuleStructure() {
+        createProjectSubFile("src/main.rs", "fn main() {}")
+        createProjectSubFile("src/lib.rs", "")
+        importProject("""
+            [package]
+            name = "hello"
+            version = "0.1.0"
+            authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
+
+            [dependencies]
+            libc = "0.2.7"
+        """)
+
+        assertModules("hello")
+        assertModuleLibDep("hello", "Cargo: libc 0.2.7")
+
+        assertTargets("src/main.rs", "src/lib.rs")
+    }
+}

--- a/src/test/kotlin/org/rust/cargo/project/CargoImportTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/cargo/project/CargoImportTestCaseBase.kt
@@ -1,0 +1,39 @@
+package org.rust.cargo.project
+
+import com.intellij.openapi.externalSystem.model.ProjectSystemId
+import com.intellij.openapi.externalSystem.test.ExternalSystemImportingTestCase
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.roots.ModuleRootManager
+import org.rust.cargo.CargoConstants
+import org.rust.cargo.project.module.util.targets
+import org.rust.cargo.project.settings.CargoProjectSettings
+import org.assertj.core.api.Assertions.*
+
+abstract class CargoImportTestCaseBase : ExternalSystemImportingTestCase() {
+    override fun getTestsTempDir(): String = "cargoImportTests"
+
+    override fun getExternalSystemConfigFileName(): String = "Cargo.toml"
+
+    override fun getCurrentExternalProjectSettings(): CargoProjectSettings? =
+        RustSdkType.INSTANCE.suggestHomePath()?.let {
+            CargoProjectSettings(it)
+        }
+
+    override fun getExternalSystemId(): ProjectSystemId = CargoConstants.PROJECT_SYSTEM_ID
+
+    override fun runTest() {
+        if (currentExternalProjectSettings == null) {
+            System.err?.println("SKIP $name: no Rust sdk found")
+            return
+        }
+        super.runTest()
+    }
+
+    final protected fun assertTargets(vararg paths: String) {
+        val module = ModuleManager.getInstance(myProject).modules.single()
+        assertThat(module.targets.map { it.path })
+            .containsOnly(*paths)
+    }
+
+}
+


### PR DESCRIPTION
This finally adds tests for importing a Cargo project. 

TestCase class is [copy-pasted](https://upsource.jetbrains.com/idea-ce/file/idea-ce-90d7fa536950e73b47d19aef3c978dfbb89b4d7c/platform/external-system-impl/testSrc/com/intellij/openapi/externalSystem/test/ExternalSystemImportingTestCase.java?nav=0:0:focused), because it is not included in any published IDEA jars :(

The test itself [is a breeze](https://github.com/intellij-rust/intellij-rust/blob/0a3d9c618a4cd3ba462541b8cbb6680ae49bc83b/src/test/kotlin/org/rust/cargo/project/CargoImportTestCase.kt).

It also tests previously untested bits of #259 .

@alexeykudinkin please review.  