### PR TITLE
(RES): fix resolve of submodules in libraries

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/module/util/RustCrateUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/project/module/util/RustCrateUtil.kt
@@ -11,7 +11,6 @@ import org.rust.cargo.CargoProjectDescription
 import org.rust.cargo.project.module.persistence.CargoModuleService
 import org.rust.cargo.util.getService
 import org.rust.lang.core.psi.RustModItem
-import org.rust.lang.core.psi.impl.RustFile
 import org.rust.lang.core.psi.impl.rustMod
 import java.io.File
 
@@ -39,7 +38,7 @@ fun Module.relativise(f: VirtualFile): String? =
 val Module.crateRootFiles: Collection<VirtualFile>
     get() = targets.mapNotNull { target ->
         contentRoot.findFileByRelativePath(target.path)
-    }
+    } + externCrates.mapNotNull { it.virtualFile }
 
 val Module.targets: Collection<CargoProjectDescription.Target> get() =
     getService<CargoModuleService>().targets
@@ -53,6 +52,8 @@ data class ExternCrate(
     /**
      * Root module file (typically `src/lib.rs`)
      */
+    val virtualFile: VirtualFile,
+
     val psiFile: Lazy<PsiFile?>
 )
 
@@ -71,6 +72,7 @@ val Module.externCrates: Collection<ExternCrate> get() =
         vFile?.let { vFile ->
             ExternCrate(
                 crate.name,
+                vFile,
                 lazy {
                     PsiManager.getInstance(project).findFile(vFile)
                 }

--- a/src/main/kotlin/org/rust/lang/core/psi/util/RustPsiExtensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/util/RustPsiExtensions.kt
@@ -1,7 +1,7 @@
 package org.rust.lang.core.psi.util
 
 import com.intellij.openapi.module.Module
-import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
@@ -49,8 +49,18 @@ fun PsiElement.isAfter(other: PsiElement): Boolean = other.textOffset < textOffs
 fun PsiElement.isBefore(anchor: Int): Boolean = textOffset < anchor
 
 
-fun PsiElement.getModule(): Module? =
-    ModuleUtilCore.findModuleForPsiElement(this)
+/**
+ * Returns module for this PsiElement.
+ *
+ * If the element is in a library, returns the module which depends on
+ * the library.
+ */
+fun PsiElement.getModule(): Module? {
+    val vFile = this.containingFile.virtualFile ?: return null
+    return ProjectRootManager.getInstance(project).fileIndex
+        .getOrderEntriesForFile(vFile)
+        .firstOrNull()?.ownerModule
+}
 
 
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RustModulesIndexExtension.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RustModulesIndexExtension.kt
@@ -19,7 +19,7 @@ import java.io.DataOutput
 
 class RustModulesIndexExtension : FileBasedIndexExtension<RustModulePath, RustQualifiedName>() {
 
-    override fun getVersion(): Int = 1
+    override fun getVersion(): Int = 2
 
     override fun dependsOnFileContent(): Boolean = true
 

--- a/src/test/kotlin/org/rust/cargo/project/CargoLibrariesResolveTestCase.kt
+++ b/src/test/kotlin/org/rust/cargo/project/CargoLibrariesResolveTestCase.kt
@@ -1,0 +1,43 @@
+package org.rust.cargo.project
+
+import com.intellij.psi.PsiManager
+import com.intellij.util.indexing.FileBasedIndex
+import org.assertj.core.api.Assertions.*
+import org.rust.lang.core.resolve.indexes.RustModulesIndex
+
+class CargoLibrariesResolveTestCase: CargoImportTestCaseBase() {
+
+    fun testResolve() {
+        var main = """
+            extern crate rand;
+
+            use rand::distributions;
+
+            mod foo;
+
+            fn main() {
+                let _ = distributions::nor<ref>mal::Normal::new(0.0, 1.0);
+            }
+        """
+
+        val referenceOffset = main.indexOf("<ref>")
+        check(referenceOffset > 0)
+        main = main.replace("<ref>", "")
+
+        val mainFile = createProjectSubFile("src/main.rs", main)
+        createProjectSubFile("src/foo.rs", "")
+        importProject("""
+            [package]
+            name = "hello"
+            version = "0.1.0"
+            authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
+
+            [dependencies]
+            rand = "=0.3.14"
+        """)
+
+        val psiFile = PsiManager.getInstance(myProject).findFile(mainFile)
+        val reference = psiFile?.findReferenceAt(referenceOffset)!!
+        assertThat(reference.resolve()).isNotNull()
+    }
+}


### PR DESCRIPTION
This resolves #271 and #272 by changing `getModule` implementation to return non null value even for elements from libraries.

The test here is very integrated. It literally launches cargo, downloads `rand` from crates.io`, imports project and resolves a reference. 

@alexeykudinkin please review.