### PR TITLE
Update RustColorSettingsPage to match annotator changes

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RustHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RustHighlightingAnnotator.kt
@@ -9,6 +9,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.impl.mixin.isMut
 import org.rust.lang.core.psi.impl.mixin.isStatic
 
+// Highlighting logic here should be kept in sync with tags in RustColorSettingsPage
 class RustHighlightingAnnotator : Annotator {
     override fun annotate(element: PsiElement, holder: AnnotationHolder) = element.accept(object : RustVisitor() {
         override fun visitAttr(o: RustAttr) {

--- a/src/main/kotlin/org/rust/ide/colorscheme/RustColorSettingsPage.kt
+++ b/src/main/kotlin/org/rust/ide/colorscheme/RustColorSettingsPage.kt
@@ -10,6 +10,9 @@ import com.intellij.openapi.options.colors.AttributesDescriptor as d
 class RustColorSettingsPage : ColorSettingsPage {
     private val ATTRS = arrayOf(
         d("Identifier", RustColors.IDENTIFIER),
+        d("Function declaration", RustColors.FUNCTION_DECLARATION),
+        d("Instance method declaration", RustColors.INSTANCE_METHOD),
+        d("Static method declaration", RustColors.STATIC_METHOD),
         d("Lifetime", RustColors.LIFETIME),
         d("Char", RustColors.CHAR),
         d("String", RustColors.STRING),
@@ -32,12 +35,15 @@ class RustColorSettingsPage : ColorSettingsPage {
         d("Valid escape sequence", RustColors.VALID_STRING_ESCAPE),
         d("Invalid escape sequence", RustColors.INVALID_STRING_ESCAPE)
     )
-    // This tags should be kept in sync with RustAnnotator highlighting logic
+    // This tags should be kept in sync with RustHighlightingAnnotator highlighting logic
     private val ANNOTATOR_TAGS = mapOf(
         "attribute" to RustColors.ATTRIBUTE,
         "macro" to RustColors.MACRO,
         "type-parameter" to RustColors.TYPE_PARAMETER,
-        "mut-binding" to RustColors.MUT_BINDING
+        "mut-binding" to RustColors.MUT_BINDING,
+        "function-decl" to RustColors.FUNCTION_DECLARATION,
+        "instance-method-decl" to RustColors.INSTANCE_METHOD,
+        "static-method-decl" to RustColors.STATIC_METHOD
     )
     private val DEMO_TEXT by lazy {
         loadCodeSampleResource("org/rust/ide/colorscheme/highlighterDemoText.rs")

--- a/src/main/resources/org/rust/ide/colorscheme/highlighterDemoText.rs
+++ b/src/main/resources/org/rust/ide/colorscheme/highlighterDemoText.rs
@@ -1,5 +1,5 @@
 /* Block comment */
-fn main() {
+fn <function-decl>main</function-decl>() {
     // A simple integer calculator:
     // `+` or `-` means add or subtract by 1
     // `*` or `/` means multiply or divide by 2
@@ -23,7 +23,7 @@ fn main() {
 
 /// Some documentation
 <attribute>#[cfg(target_os="linux")]</attribute>
-unsafe fn a_function<<type-parameter>T</type-parameter>: 'lifetime>() {
+unsafe fn <function-decl>a_function</function-decl><<type-parameter>T</type-parameter>: 'lifetime>() {
     'label: loop {
         println!("Hello\x20W\u{f3}rld!\u{abcdef}");
     }


### PR DESCRIPTION
Annotator was updated in 14fe4c4.
I'm not sure about names of the new color settings. Only the identifier is highlighted, and only in the declarations, not on every use.