### PR TITLE
(T): download rust sources for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ out
 classes
 lib
 gen
+src/test/resources/rustc-nightly/

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
 
 plugins {
     id 'org.jetbrains.intellij' version "0.0.42"
+    id 'de.undercouch.download' version "2.1.0"
 }
 
 
@@ -27,6 +28,7 @@ allprojects {
     // IntelliJ plugin configuration
 
     apply plugin: 'org.jetbrains.intellij'
+    apply plugin: 'de.undercouch.download'
 
     intellij {
         pluginName 'intellij-rust'
@@ -152,6 +154,19 @@ task generateLexers {
 task generateParsers {
     dependsOn generateRustPsiAndParser
 }
+
+task downloadRustSources(type: de.undercouch.gradle.tasks.download.Download) {
+    overwrite false
+    src 'https://static.rust-lang.org/dist/rustc-nightly-src.tar.gz'
+    dest new File(buildDir, "rustc-nightly-src.tar.gz")
+}
+
+task downloadAndUntarRustSources(dependsOn: downloadRustSources, type: Copy) {
+    from  tarTree(downloadRustSources.dest)
+    into "src/test/resources"
+}
+
+test.dependsOn downloadAndUntarRustSources
 
 apply from: "shared.gradle"
 

--- a/src/test/kotlin/org/rust/RustWithSdkTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/RustWithSdkTestCaseBase.kt
@@ -1,0 +1,29 @@
+package org.rust
+
+import com.intellij.openapi.module.ModuleType
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.testFramework.LightProjectDescriptor
+import org.rust.cargo.project.RustSdkType
+import org.rust.cargo.project.module.RustModuleType
+import org.rust.lang.RustTestCase
+import org.rust.lang.RustTestCaseBase
+
+abstract class RustWithSdkTestCaseBase : RustTestCaseBase() {
+    final override fun getProjectDescriptor(): LightProjectDescriptor = object : LightProjectDescriptor() {
+        override fun getSdk(): Sdk? {
+            val sdk = ProjectJdkImpl("RustTest", RustSdkType.INSTANCE)
+            val sdkModificator = sdk.sdkModificator
+
+            val sdkSrc = "${RustTestCase.testResourcesPath}/rustc-nightly/src"
+            val sdkSrcFile = LocalFileSystem.getInstance().findFileByPath(sdkSrc)
+            sdkModificator.addRoot(sdkSrcFile, OrderRootType.CLASSES)
+            sdkModificator.commitChanges()
+            return sdk
+        }
+
+        override fun getModuleType(): ModuleType<*> = RustModuleType.INSTANCE
+    }
+}

--- a/src/test/kotlin/org/rust/lang/core/resolve/RustStdlibResolveTestCase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RustStdlibResolveTestCase.kt
@@ -1,0 +1,14 @@
+package org.rust.lang.core.resolve
+
+import com.intellij.openapi.roots.ModuleRootManager
+import org.assertj.core.api.Assertions.assertThat
+import org.rust.RustWithSdkTestCaseBase
+
+class RustStdlibResolveTestCase : RustWithSdkTestCaseBase() {
+    override val dataPath = "org/rust/lang/core/resolve/fixtures"
+
+    fun testSdkHasSources() {
+        assertThat(ModuleRootManager.getInstance(myModule).orderEntries().sdkOnly().classesRoots)
+            .hasSize(1)
+    }
+}


### PR DESCRIPTION
This adds a gradle task to download latest rust sources from rust-lang.org and an sdk aware base test case. 

Rust sources are downloaded only once, when the `test` task is executed for the first time. Their size is 20 mb, so I think we can just always download them.

@alexeykudinkin please review