### PR TITLE
(PLUGIN) remove redundent tags

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,6 @@
 <idea-plugin version="2">
     <id>org.rust.lang</id>
     <name>Rust</name>
-    <version>0.0.1</version>
 
     <vendor url="https://github.com/intellij-rust/intellij-rust"/>
 


### PR DESCRIPTION
Fix #232 

* gradle aleardy handle the classpath to kotlin external jars, so there is no need to maintain kotlin jars in two place.
* and the version tag here is also redundent. if we now use gradle and gradle-idea-plugin, version here https://github.com/intellij-rust/intellij-rust/blob/master/gradle.properties#L11 will override the version tag in `plugin.xml`, reference to https://github.com/ignatov/intellij-erlang/blob/master/plugin/resources/META-INF/plugin.xml#L21, this is also tested use my tiny plugins.