### PR TITLE
(INSPECTIONS): warn if SDK is not configured

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/module/util/RustCrateUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/project/module/util/RustCrateUtil.kt
@@ -98,7 +98,7 @@ private val Module.sdkCrates: Collection<ExternCrate> get() {
     }
 }
 
-private fun Module.locateRustSources(): VirtualFile? {
+fun Module.locateRustSources(): VirtualFile? {
     val sourceRoot = ModuleRootManager.getInstance(this)
         .orderEntries()
         .sdkOnly()

--- a/src/main/kotlin/org/rust/ide/inspections/WrongSdkConfigurationNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/WrongSdkConfigurationNotificationProvider.kt
@@ -1,0 +1,55 @@
+package org.rust.ide.inspections
+
+import com.intellij.ProjectTopics
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectBundle
+import com.intellij.openapi.roots.ModuleRootAdapter
+import com.intellij.openapi.roots.ModuleRootEvent
+import com.intellij.openapi.roots.ui.configuration.ProjectSettingsService
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.EditorNotificationPanel
+import com.intellij.ui.EditorNotifications
+import org.rust.cargo.project.rustSdk
+import org.rust.lang.core.psi.impl.isNotRustFile
+
+class WrongSdkConfigurationNotificationProvider(
+    private val project: Project,
+    private val notifications: EditorNotifications
+) : EditorNotifications.Provider<EditorNotificationPanel>() {
+
+    init {
+        project.messageBus.connect(project).subscribe(ProjectTopics.PROJECT_ROOTS,
+            object : ModuleRootAdapter() {
+                override fun rootsChanged(event: ModuleRootEvent?) {
+                    notifications.updateAllNotifications()
+                }
+            })
+    }
+
+    override fun getKey(): Key<EditorNotificationPanel> = KEY
+
+    override fun createNotificationPanel(file: VirtualFile, editor: FileEditor): EditorNotificationPanel? {
+        if (file.isNotRustFile) return null
+        val module = ModuleUtilCore.findModuleForFile(file, project) ?: return null
+        if (module.rustSdk == null) {
+            return createMissingSdkPanel()
+        }
+
+        return null
+    }
+
+    private fun createMissingSdkPanel(): EditorNotificationPanel =
+        EditorNotificationPanel().apply {
+            setText(ProjectBundle.message("project.sdk.not.defined"))
+            createActionLabel(ProjectBundle.message("project.sdk.setup"), {
+                ProjectSettingsService.getInstance(project).chooseAndSetSdk()
+            })
+        }
+
+    companion object {
+        private val KEY: Key<EditorNotificationPanel> = Key.create("Setup Rust SDK")
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/WrongSdkConfigurationNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/WrongSdkConfigurationNotificationProvider.kt
@@ -3,22 +3,39 @@ package org.rust.ide.inspections
 import com.intellij.ProjectTopics
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectBundle
+import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.roots.ModuleRootAdapter
 import com.intellij.openapi.roots.ModuleRootEvent
+import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.roots.ui.configuration.ProjectSettingsService
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.component1
+import com.intellij.openapi.util.component2
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.EditorNotificationPanel
 import com.intellij.ui.EditorNotifications
+import com.intellij.util.download.DownloadableFileService
+import org.rust.cargo.project.RustcVersion
+import org.rust.cargo.project.module.util.locateRustSources
 import org.rust.cargo.project.rustSdk
 import org.rust.lang.core.psi.impl.isNotRustFile
 
+/*
+ * Warn user if no rust sdk is found for the current module or if the sdk lacks standard library sources.
+ */
 class WrongSdkConfigurationNotificationProvider(
     private val project: Project,
     private val notifications: EditorNotifications
-) : EditorNotifications.Provider<EditorNotificationPanel>() {
+) : EditorNotifications.Provider<EditorNotificationPanel>()
+
+// Indexing begins as soon as rust sources are downloaded. If this is not `DumbAware` then
+// notification panel will stay until the indexing ends. Let's make this `DumbAware` to make the panel
+// go away immediately and avoid user confusion.
+  , DumbAware
+{
 
     init {
         project.messageBus.connect(project).subscribe(ProjectTopics.PROJECT_ROOTS,
@@ -34,8 +51,11 @@ class WrongSdkConfigurationNotificationProvider(
     override fun createNotificationPanel(file: VirtualFile, editor: FileEditor): EditorNotificationPanel? {
         if (file.isNotRustFile) return null
         val module = ModuleUtilCore.findModuleForFile(file, project) ?: return null
-        if (module.rustSdk == null) {
-            return createMissingSdkPanel()
+        val sdk = module.rustSdk ?: return createMissingSdkPanel()
+        val homePath = sdk.homePath ?: return createMissingSdkPanel()
+
+        if (module.locateRustSources() == null) {
+            return createAttachSourcesPanel(sdk, homePath)
         }
 
         return null
@@ -48,6 +68,40 @@ class WrongSdkConfigurationNotificationProvider(
                 ProjectSettingsService.getInstance(project).chooseAndSetSdk()
             })
         }
+
+    private fun createAttachSourcesPanel(sdk: Sdk, sdkHomePath: String): EditorNotificationPanel {
+        val panel = EditorNotificationPanel()
+        panel.setText("Standard library sources are not found. Some features will not work.")
+
+        panel.createActionLabel("Download and attach sources", {
+            // XXX: this queries external process and then fetches a file from a network.
+            // Everything can go wrong here.
+            val version = RustcVersion.queryFromRustc(sdkHomePath) ?: return@createActionLabel
+            val src = downloadSources(panel, version) ?: return@createActionLabel
+
+            sdk.sdkModificator.apply {
+                removeRoots(OrderRootType.CLASSES)
+                addRoot(src, OrderRootType.CLASSES)
+                commitChanges()
+            }
+        })
+
+        return panel
+    }
+
+    private fun downloadSources(panel: EditorNotificationPanel, version: RustcVersion): VirtualFile? {
+        val url = version.sourcesArchiveUrl
+        val downloadService = DownloadableFileService.getInstance()
+        val fileDescription = downloadService.createFileDescription(url, "rust-${version.release}-src.zip")
+        val downloader = downloadService.createDownloader(listOf(fileDescription), "rust")
+
+        // Ask user where to download the archive with source code.
+        val downloadTo = null
+        val (file, @Suppress("UNUSED_VARIABLE") description) =
+            downloader.downloadWithProgress(downloadTo, project, panel)?.singleOrNull() ?: return null
+
+        return file
+    }
 
     companion object {
         private val KEY: Key<EditorNotificationPanel> = Key.create("Setup Rust SDK")

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/RustFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/RustFile.kt
@@ -3,12 +3,12 @@ package org.rust.lang.core.psi.impl
 import com.intellij.extapi.psi.PsiFileBase
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.FileViewProvider
 import com.intellij.psi.PsiFile
 import org.rust.lang.RustFileType
 import org.rust.lang.RustLanguage
 import org.rust.lang.core.psi.RustFileModItem
-import org.rust.lang.core.psi.RustModItem
 import org.rust.lang.core.psi.util.RustModules
 import org.rust.lang.core.resolve.indexes.RustModulePath
 
@@ -25,6 +25,8 @@ class RustFile(fileViewProvider: FileViewProvider) : PsiFileBase(fileViewProvide
 val PsiFile.modulePath: RustModulePath?
     get() = RustModulePath.devise(this)
 
+val VirtualFile.isRustFile: Boolean get() = fileType == RustFileType
+val VirtualFile.isNotRustFile: Boolean get() = !isRustFile
 
 /**
  * Prepends directory name to this file, if it is `mod.rs`

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -179,6 +179,10 @@
         <stubIndex implementation="org.rust.lang.core.stubs.index.RustStructOrEnumIndex"/>
 
 
+        <!-- Notification Providers -->
+
+        <editorNotificationProvider implementation="org.rust.ide.inspections.WrongSdkConfigurationNotificationProvider" />
+
     </extensions>
 
     <application-components>


### PR DESCRIPTION
This warns user is SDK is not configured:

![sdk](https://cloud.githubusercontent.com/assets/1711539/14176517/0befdab4-f75a-11e5-9d2f-e7a66b2957e2.png)

By itself this is pretty useless after #253 has been merged. But I want to expand this and add a warning/quick fix for attaching SDK sources (in this or in a separate PR).

@alexeykudinkin please review. 