### PR TITLE
(RUNCONFIG) Show env vars dialog, and run cargo with env vars

### DIFF
--- a/src/main/kotlin/org/rust/cargo/commands/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/commands/Cargo.kt
@@ -45,7 +45,7 @@ class Cargo(
         return CargoProjectDescription.fromCargoMetadata(data)
     }
 
-    fun generalCommand(command: String, additionalArguments: List<String> = emptyList(), environmentVariables: Map<String, String>? = null): GeneralCommandLine =
+    fun generalCommand(command: String, additionalArguments: List<String> = emptyList(), environmentVariables: Map<String, String> = emptyMap()): GeneralCommandLine =
         GeneralCommandLine(pathToCargoExecutable)
             .withWorkDirectory(projectDirectory)
             .withParameters(command)

--- a/src/main/kotlin/org/rust/cargo/commands/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/commands/Cargo.kt
@@ -45,11 +45,12 @@ class Cargo(
         return CargoProjectDescription.fromCargoMetadata(data)
     }
 
-    fun generalCommand(command: String, additionalArguments: List<String> = emptyList()): GeneralCommandLine =
+    fun generalCommand(command: String, additionalArguments: List<String> = emptyList(), environmentVariables: Map<String, String>? = null): GeneralCommandLine =
         GeneralCommandLine(pathToCargoExecutable)
             .withWorkDirectory(projectDirectory)
             .withParameters(command)
             .withParameters(additionalArguments)
+            .withEnvironment(environmentVariables)
 
     private val metadataCommandline: GeneralCommandLine get() = generalCommand("metadata", emptyList())
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandConfiguration.kt
@@ -25,6 +25,7 @@ class CargoCommandConfiguration(project: Project,
 
     var command: String = "run"
     var additionalArguments: String = ""
+    var environmentVariables: Map<String, String>? = null
 
     init {
         configurationModule.module = project.getModules().firstOrNull()
@@ -49,7 +50,7 @@ class CargoCommandConfiguration(project: Project,
         val pathToCargo = module.pathToCargo ?: return null
         val moduleDirectory = PathUtil.getParentPath(module.moduleFilePath)
         val args = ParametersListUtil.parse(additionalArguments)
-        return CargoRunState(environment, pathToCargo, moduleDirectory, command, args)
+        return CargoRunState(environment, pathToCargo, moduleDirectory, command, args, environmentVariables)
     }
 
     override fun writeExternal(element: Element) {

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandConfiguration.kt
@@ -25,7 +25,7 @@ class CargoCommandConfiguration(project: Project,
 
     var command: String = "run"
     var additionalArguments: String = ""
-    var environmentVariables: Map<String, String>? = null
+    var environmentVariables: Map<String, String> = mutableMapOf()
 
     init {
         configurationModule.module = project.getModules().firstOrNull()

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
@@ -10,10 +10,11 @@ class CargoRunState(environment: ExecutionEnvironment,
                     private val pathToCargo: String,
                     private val moduleDirectory: String,
                     private val command: String,
-                    private val additionalArguments: List<String>) : CommandLineState(environment) {
+                    private val additionalArguments: List<String>,
+                    private val environmentVariables: Map<String, String>?) : CommandLineState(environment) {
 
     override fun startProcess(): ProcessHandler {
-        val cmd = Cargo(pathToCargo, moduleDirectory).generalCommand(command, additionalArguments)
+        val cmd = Cargo(pathToCargo, moduleDirectory).generalCommand(command, additionalArguments, environmentVariables)
         return OSProcessHandler(cmd)
     }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
@@ -11,7 +11,7 @@ class CargoRunState(environment: ExecutionEnvironment,
                     private val moduleDirectory: String,
                     private val command: String,
                     private val additionalArguments: List<String>,
-                    private val environmentVariables: Map<String, String>?) : CommandLineState(environment) {
+                    private val environmentVariables: Map<String, String>) : CommandLineState(environment) {
 
     override fun startProcess(): ProcessHandler {
         val cmd = Cargo(pathToCargo, moduleDirectory).generalCommand(command, additionalArguments, environmentVariables)

--- a/src/main/kotlin/org/rust/cargo/runconfig/forms/CargoRunConfigurationEditorForm.form
+++ b/src/main/kotlin/org/rust/cargo/runconfig/forms/CargoRunConfigurationEditorForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.rust.cargo.runconfig.forms.CargoRunConfigurationEditorForm">
-  <grid id="27dc6" binding="root" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="root" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -52,6 +52,22 @@
         </constraints>
         <properties>
           <dialogCaption value="Cargo arguments"/>
+        </properties>
+      </component>
+      <component id="bc403" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Environment variables:"/>
+        </properties>
+      </component>
+      <component id="af781" class="com.intellij.execution.configuration.EnvironmentVariablesComponent" binding="environmentVariables">
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value=""/>
         </properties>
       </component>
     </children>

--- a/src/main/kotlin/org/rust/cargo/runconfig/forms/CargoRunConfigurationEditorForm.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/forms/CargoRunConfigurationEditorForm.kt
@@ -1,6 +1,7 @@
 package org.rust.cargo.runconfig.forms
 
 import com.intellij.application.options.ModulesComboBox
+import com.intellij.execution.configuration.EnvironmentVariablesComponent
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.ui.RawCommandLineEditor
@@ -16,6 +17,7 @@ class CargoRunConfigurationEditorForm : SettingsEditor<CargoCommandConfiguration
     private lateinit var command: JTextField
     private lateinit var comboModules: ModulesComboBox
     private lateinit var additionalArguments: RawCommandLineEditor
+    private lateinit var environmentVariables: EnvironmentVariablesComponent
 
     override fun resetEditorFrom(configuration: CargoCommandConfiguration) {
         command.text = configuration.command
@@ -24,6 +26,9 @@ class CargoRunConfigurationEditorForm : SettingsEditor<CargoCommandConfiguration
         comboModules.selectedModule = configuration.configurationModule.module
 
         additionalArguments.text = configuration.additionalArguments
+        configuration.environmentVariables?.let {
+            environmentVariables.envs = it
+        }
     }
 
     @Throws(ConfigurationException::class)
@@ -31,6 +36,7 @@ class CargoRunConfigurationEditorForm : SettingsEditor<CargoCommandConfiguration
         configuration.command = command.text
         configuration.setModule(comboModules.selectedModule)
         configuration.additionalArguments = additionalArguments.text
+        configuration.environmentVariables = environmentVariables.envs
     }
 
     override fun createEditor(): JComponent = root

--- a/src/main/kotlin/org/rust/cargo/runconfig/forms/CargoRunConfigurationEditorForm.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/forms/CargoRunConfigurationEditorForm.kt
@@ -26,9 +26,7 @@ class CargoRunConfigurationEditorForm : SettingsEditor<CargoCommandConfiguration
         comboModules.selectedModule = configuration.configurationModule.module
 
         additionalArguments.text = configuration.additionalArguments
-        configuration.environmentVariables?.let {
-            environmentVariables.envs = it
-        }
+        environmentVariables.envs = configuration.environmentVariables
     }
 
     @Throws(ConfigurationException::class)


### PR DESCRIPTION
This PR is to run cargo with environment variables, ex. `RUST_LOG` for `env_logger`.

It adds two ui components:

 - `Environment variables` field on the run config dialog
 - `Environment Variables` dialog on clicking a `...` button

![screen shot 2016-04-04 at 1 16 51 pm](https://cloud.githubusercontent.com/assets/5753792/14238159/7265f182-fa68-11e5-8c9a-ec599c4ae609.png)

![screen shot 2016-04-04 at 1 17 00 pm](https://cloud.githubusercontent.com/assets/5753792/14238163/7951eb90-fa68-11e5-961e-fa5bdaf309d2.png)
