### PR TITLE
(PSI): add missing accessors for tokens created by collapsing

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/grammar/rust.bnf
+++ b/src/main/kotlin/org/rust/lang/core/grammar/rust.bnf
@@ -254,6 +254,13 @@
     implements  ("use_glob") = "org.rust.lang.core.psi.RustNamedElement"
     mixin       ("use_glob") = "org.rust.lang.core.psi.impl.mixin.RustUseGlobImplMixin"
 
+    // HACK(jajakobyly): Grammar-Kit is unable to simply generate accesors for tokens
+    //                   created by external rules. We need to work around this limitation.
+    //                   Fortunately, all "external" tokens are only used inside binary
+    //                   expressions, so we can inject accessors for them using mixins.
+    implements  ("binary_expr") = "org.rust.lang.core.psi.impl.RustBinaryExprExternalTokens"
+    mixin       ("binary_expr") = "org.rust.lang.core.psi.impl.mixin.RustBinaryExprImplMixin"
+
     elementType(".*_bin_expr")   = binary_expr
     elementType(".*_range_expr") = range_expr
 
@@ -1100,12 +1107,12 @@ private stmt_ ::= expr_stmt
 // Utils
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-external gtgteq ::= collapse GTGTEQ GT GT EQ
-external gtgt   ::= collapse GTGT GT GT
-external gteq   ::= collapse GTEQ GT EQ
-external ltlteq ::= collapse LTLTEQ LT LT EQ
-external ltlt   ::= collapse LTLT LT LT
-external lteq   ::= collapse LTEQ LT EQ
+external gtgteq ::= collapse GTGTEQ GT GT EQ  { name = ">>=" }
+external gtgt   ::= collapse GTGT GT GT       { name = ">>" }
+external gteq   ::= collapse GTEQ GT EQ       { name = ">=" }
+external ltlteq ::= collapse LTLTEQ LT LT EQ  { name = "<<=" }
+external ltlt   ::= collapse LTLT LT LT       { name = "<<" }
+external lteq   ::= collapse LTEQ LT EQ       { name = "<=" }
 
 // Trailing commas are allowed
 private meta comma_separated_list ::= <<param>> ( ',' <<param>> ) * ','?

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/RustBinaryExprExternalTokens.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/RustBinaryExprExternalTokens.kt
@@ -1,0 +1,13 @@
+package org.rust.lang.core.psi.impl
+
+import com.intellij.psi.PsiElement
+
+// The only use of this interface is to be extended by RustBinaryExpr
+internal interface RustBinaryExprExternalTokens {
+    fun getGtgteq(): PsiElement?
+    fun getGtgt(): PsiElement?
+    fun getGteq(): PsiElement?
+    fun getLtlteq(): PsiElement?
+    fun getLtlt(): PsiElement?
+    fun getLteq(): PsiElement?
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustBinaryExprImplMixin.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustBinaryExprImplMixin.kt
@@ -1,0 +1,15 @@
+package org.rust.lang.core.psi.impl.mixin
+
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RustBinaryExpr
+import org.rust.lang.core.psi.impl.RustExprImpl
+
+abstract class RustBinaryExprImplMixin(node: ASTNode) : RustExprImpl(node), RustBinaryExpr {
+    override fun getGtgteq(): PsiElement? = findChildByType(GTGTEQ)
+    override fun getGtgt(): PsiElement? = findChildByType(GTGT)
+    override fun getGteq(): PsiElement? = findChildByType(GTEQ)
+    override fun getLtlteq(): PsiElement? = findChildByType(LTLTEQ)
+    override fun getLtlt(): PsiElement? = findChildByType(LTLT)
+    override fun getLteq(): PsiElement? = findChildByType(LTEQ)
+}


### PR DESCRIPTION
These accessors disappeared in #325. Now they're back