### PR TITLE
(T): use rust sources to test parser performance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,10 @@ The test suite can be run by launching:
 
     ./gradlew test
 
+To launch parser performance tests, use
+
+    ./gradlew performanceTest
+
 # Plugin architecture
 
 We use Kotlin language for the plugin. If you can program in Java or Rust, you

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ allprojects {
     }
 
     test {
+        useJUnit {
+            excludeCategories 'org.rust.Performance'
+        }
         testLogging {
             events "passed", "skipped", "failed"
             exceptionFormat = 'full'
@@ -165,6 +168,22 @@ task downloadRustSources(type: de.undercouch.gradle.tasks.download.Download) {
 }
 
 test.dependsOn downloadRustSources
+
+task performanceTest(type: Test, group: 'Verification', dependsOn: [classes, testClasses, downloadRustSources]) {
+    useJUnit {
+        includeCategories 'org.rust.Performance'
+        reports.html.destination = "$buildDir/reports/performanceTests"
+    }
+
+    testLogging {
+        events "passed", "skipped", "failed"
+        showStandardStreams = true
+        exceptionFormat = 'full'
+    }
+
+    outputs.upToDateWhen { false } // always execute task, even if already executed.
+}
+check.dependsOn performanceTest
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Misc

--- a/src/test/kotlin/org/rust/Performance.kt
+++ b/src/test/kotlin/org/rust/Performance.kt
@@ -1,0 +1,6 @@
+package org.rust
+
+/**
+ * Marker interface for tests category
+ */
+interface Performance

--- a/src/test/kotlin/org/rust/lang/RustTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/lang/RustTestCaseBase.kt
@@ -61,14 +61,6 @@ abstract class RustTestCaseBase : LightPlatformCodeInsightFixtureTestCase(), Rus
     protected fun getVirtualFileByName(path: String): VirtualFile? =
         LocalFileSystem.getInstance().findFileByPath(path)
 
-    companion object {
-        @JvmStatic
-        fun camelToSnake(camelCaseName: String): String =
-            camelCaseName.split("(?=[A-Z])".toRegex())
-                .map { it.toLowerCase() }
-                .joinToString("_")
-    }
-
     open class RustProjectDescriptor : LightProjectDescriptor() {
 
         final override fun configureModule(module: Module, model: ModifiableRootModel, contentEntry: ContentEntry) {
@@ -102,17 +94,14 @@ abstract class RustTestCaseBase : LightPlatformCodeInsightFixtureTestCase(), Rus
             ),
             source = null
         )
+
     }
 
     class WithStdlibRustProjectDescriptor : RustProjectDescriptor() {
-        override fun testCargoProject(module: Module, contentRoot: String): CargoProjectDescription {
-            val sourcesArchive = checkNotNull(LocalFileSystem.getInstance()
-                .findFileByPath("${RustTestCase.testResourcesPath}/rustc-src.zip")) {
-               "Rust sources archive not found. Run `./gradlew test` to download the archive."
-            }
 
-            checkNotNull(StandardLibraryRoots.fromFile(sourcesArchive)) {
-                "Invalid Rust source: $sourcesArchive"
+        override fun testCargoProject(module: Module, contentRoot: String): CargoProjectDescription {
+            checkNotNull(StandardLibraryRoots.fromFile(rustSourcesArchive())) {
+                "Corrupted invalid Rust sources"
             }.attachTo(module)
 
             val packages = listOf(testCargoPackage(contentRoot))
@@ -122,4 +111,20 @@ abstract class RustTestCaseBase : LightPlatformCodeInsightFixtureTestCase(), Rus
             }
         }
     }
+
+    companion object {
+        @JvmStatic
+        fun camelToSnake(camelCaseName: String): String =
+            camelCaseName.split("(?=[A-Z])".toRegex())
+                .map { it.toLowerCase() }
+                .joinToString("_")
+
+        @JvmStatic
+        fun rustSourcesArchive(): VirtualFile =
+            checkNotNull(LocalFileSystem.getInstance()
+                .findFileByPath("${RustTestCase.testResourcesPath}/rustc-src.zip")) {
+                "Rust sources archive not found. Run `./gradlew test` to download the archive."
+            }
+    }
 }
+

--- a/src/test/kotlin/org/rust/lang/core/parser/RustParserPerformanceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/parser/RustParserPerformanceTest.kt
@@ -1,0 +1,94 @@
+package org.rust.lang.core.parser
+
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.JarFileSystem
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileVisitor
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.impl.DebugUtil
+import org.junit.experimental.categories.Category
+import org.rust.Performance
+import org.rust.lang.RustFileType
+import org.rust.lang.RustTestCaseBase
+import java.util.*
+import kotlin.system.measureTimeMillis
+
+@Category(Performance::class)
+class RustParserPerformanceTest : RustTestCaseBase() {
+    override val dataPath: String = ""
+
+    fun testParsingCompilerSources() {
+        val sources = rustSrcDir()
+        parseRustFiles(
+            sources,
+            ignored = setOf("test", "doc", "etc", "grammar"),
+            expectedNumberOfFiles = 800,
+            checkForErrors = true
+        )
+    }
+
+    fun testParsingCompilerTests() {
+        val testDir = rustSrcDir().findFileByRelativePath("test")!!
+        parseRustFiles(
+            testDir,
+            ignored = emptyList(),
+            expectedNumberOfFiles = 4000,
+            checkForErrors = false
+        )
+    }
+
+    private data class FileStats(
+        val path: String,
+        val time: Long,
+        val fileLength: Int
+    )
+
+    private fun parseRustFiles(directory: VirtualFile,
+                               ignored: Collection<String>,
+                               expectedNumberOfFiles: Int,
+                               checkForErrors: Boolean) {
+        val processed = ArrayList<FileStats>()
+        val totalTime = measureTimeMillis {
+            VfsUtilCore.visitChildrenRecursively(directory, object : VirtualFileVisitor<Void>() {
+                override fun visitFileEx(file: VirtualFile): Result {
+                    if (file.isDirectory && file.name in ignored) return SKIP_CHILDREN
+                    if (file.fileType != RustFileType) return CONTINUE
+                    val fileContent = String(file.contentsToByteArray())
+
+                    val time = measureTimeMillis {
+                        val psi = PsiFileFactory.getInstance(project).createFileFromText(file.name, file.fileType, fileContent)
+                        val psiString = DebugUtil.psiToString(psi, /* skipWhitespace = */ true)
+
+                        if (checkForErrors) {
+                            check("PsiErrorElement" !in psiString) {
+                                "Failed to parse ${file.path}\n\n$fileContent\n\n$psiString\n\n${file.path}"
+                            }
+                        }
+                    }
+
+                    val relPath = FileUtil.getRelativePath(directory.path, file.path, '/')!!
+                    processed += FileStats(relPath, time, fileContent.length)
+                    return CONTINUE
+                }
+            })
+        }
+        check(processed.size > expectedNumberOfFiles)
+
+        println("\n$name " +
+            "\nTotal: ${totalTime}ms" +
+            "\nFiles: ${processed.size}")
+        val slowest = processed.sortedByDescending { it.time }.take(5)
+        println("\nSlowest files")
+        for (stats in slowest) {
+            println("${"%3d".format(stats.time)}ms ${"%3d".format(stats.fileLength / 1024)}kb: ${stats.path}")
+        }
+        println()
+    }
+
+    private fun rustSrcDir(): VirtualFile =
+        JarFileSystem.getInstance().getJarRootForLocalFile(rustSourcesArchive())
+            ?.children?.singleOrNull()
+            ?.findChild("src")!!
+}
+


### PR DESCRIPTION
This adds the first performance test. The test simply executes the parser on the compiler's source code. 