### PR TITLE
(GRAM): force accessor generation

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/grammar/rust.bnf
+++ b/src/main/kotlin/org/rust/lang/core/grammar/rust.bnf
@@ -833,8 +833,9 @@ restricted_expr ::= ret_expr
 }
 
 // https://github.com/rust-lang/rfcs/blob/master/text/0092-struct-grammar.md
-private no_struct_lit_expr  ::= << withoutStructLiterals restricted_expr >>
-private any_expr            ::= << withStructLiterals restricted_expr >>
+private no_struct_lit_expr  ::= << withoutStructLiterals restricted_expr >> | never restricted_expr
+private any_expr            ::= << withStructLiterals restricted_expr >>    | never restricted_expr
+private never ::= !()
 
 
 block_expr ::= while_expr


### PR DESCRIPTION
This forces grammar kit to generate proper accessors for expresisons.

Before:

```Java

public interface RustIfExpr extends RustExpr {

  @NotNull
  List<RustBlock> getBlockList();

  @Nullable
  RustExpr getExpr(); // this is the `then` branch, condition is missing

  @Nullable
  PsiElement getElse(); 

  @NotNull
  PsiElement getIf();

}

public interface RustParenExpr extends RustExpr {

  @NotNull
  PsiElement getLparen();

  @NotNull
  PsiElement getRparen();

}
```


After:

```Java
public interface RustIfExpr extends RustExpr {

  @NotNull
  List<RustBlock> getBlockList();

  @NotNull
  List<RustExpr> getExprList();

  @Nullable
  PsiElement getElse();

  @NotNull
  PsiElement getIf();

}

public interface RustParenExpr extends RustExpr {

  @Nullable
  RustExpr getExpr();

  @NotNull
  PsiElement getLparen();

  @NotNull
  PsiElement getRparen();

}
```

@alexeykudinkin @jajakobyly what do you think?

It's a horrible hack, but the tests pass.