### PR TITLE
(PSI): simplify `getModule`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/util/RustPsiExtensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/util/RustPsiExtensions.kt
@@ -1,7 +1,7 @@
 package org.rust.lang.core.psi.util
 
 import com.intellij.openapi.module.Module
-import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
@@ -59,10 +59,10 @@ fun PsiElement.isBefore(anchor: Int): Boolean = textOffset < anchor
  * the library.
  */
 fun PsiElement.getModule(): Module? {
-    val vFile = this.containingFile.originalFile.virtualFile ?: return null
-    return ProjectRootManager.getInstance(project).fileIndex
-        .getOrderEntriesForFile(vFile)
-        .firstOrNull()?.ownerModule
+    // It's important to look the module for `containingFile` file
+    // and not the element itself. Otherwise this will break for
+    // elements in libraries.
+    return ModuleUtilCore.findModuleForPsiElement(containingFile)
 }
 
 


### PR DESCRIPTION
Stolen from https://github.com/go-lang-plugin-org/go-lang-idea-plugin/blob/58a85af0be6652f1882ba5725588d691af7cd27d/src/com/goide/appengine/GoAppEngineExtension.java#L30.

@alexeykudinkin this will conflict with #323, but it may help you with `ModuleIndex`.