### PR TITLE
`CargoProjectWorkspace` refactoring

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -50,7 +50,7 @@ class RustProjectSettingsServiceImpl(
 
                 if (value != null) {
                     for (module in project.getModules()) {
-                        module.getServiceOrThrow<CargoProjectWorkspace>().scheduleUpdate(value)
+                        module.getServiceOrThrow<CargoProjectWorkspace>().requestUpdate(value)
                     }
                 }
 

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -10,6 +10,7 @@ import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.workspace.CargoProjectWorkspace
 import org.rust.cargo.project.configurable.RustProjectConfigurable
 import org.rust.cargo.toolchain.RustToolchain
+import org.rust.cargo.util.getComponentOrThrow
 import org.rust.cargo.util.getModules
 import org.rust.cargo.util.getServiceOrThrow
 
@@ -50,7 +51,7 @@ class RustProjectSettingsServiceImpl(
 
                 if (value != null) {
                     for (module in project.getModules()) {
-                        module.getServiceOrThrow<CargoProjectWorkspace>().requestUpdateUsing(value)
+                        module.getComponentOrThrow<CargoProjectWorkspace>().requestUpdateUsing(value)
                     }
                 }
 

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -50,7 +50,7 @@ class RustProjectSettingsServiceImpl(
 
                 if (value != null) {
                     for (module in project.getModules()) {
-                        module.getServiceOrThrow<CargoProjectWorkspace>().requestUpdate(value)
+                        module.getServiceOrThrow<CargoProjectWorkspace>().requestUpdateUsing(value)
                     }
                 }
 

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
@@ -11,7 +11,7 @@ interface CargoProjectWorkspace {
     /**
      * Updates Rust libraries asynchronously. Consecutive requests are coalesced.
      */
-    fun requestUpdate(toolchain: RustToolchain, immediately: Boolean = false)
+    fun requestUpdateUsing(toolchain: RustToolchain, immediately: Boolean = false)
 
     /**
      * Latest version of the Cargo's project-description obtained

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
@@ -23,15 +23,7 @@ interface CargoProjectWorkspace {
 
     /**
      * Latest version of the Cargo's project-description obtained
-     *
-     * NOTA BENE: In the current implementation it's SYNCHRONOUS
      */
     val projectDescription: CargoProjectDescription?
-
-    /**
-     * Subscribes given listener to the supplied topic on the [CargoProjectWorkspace]'s private
-     * message-bus
-     */
-    fun <L: Any> subscribeTo(t: Topic<L>, listener: L, disposer: Disposable? = null)
 
 }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
@@ -1,5 +1,8 @@
 package org.rust.cargo.project.workspace
 
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.util.Disposer
+import com.intellij.util.messages.Topic
 import org.rust.cargo.project.CargoProjectDescription
 import org.rust.cargo.toolchain.RustToolchain
 
@@ -24,5 +27,10 @@ interface CargoProjectWorkspace {
      * NOTA BENE: In the current implementation it's SYNCHRONOUS
      */
     val projectDescription: CargoProjectDescription?
+
+    /**
+     * Subscribes given listener to the supplied topic
+     */
+    fun <L> subscribeTo(t: Topic<L>, listener: L, disposer: Disposable? = null)
 
 }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
@@ -1,5 +1,6 @@
 package org.rust.cargo.project.workspace
 
+import com.intellij.util.messages.Topic
 import org.rust.cargo.project.CargoProjectDescription
 import org.rust.cargo.toolchain.RustToolchain
 
@@ -7,17 +8,21 @@ import org.rust.cargo.toolchain.RustToolchain
  * Uses `cargo metadata` command to update IDEA libraries and Cargo project model.
  */
 interface CargoProjectWorkspace {
-    /**
-     * Updates Rust libraries asynchronously. Consecutive updates are coalesced.
-     */
-    fun scheduleUpdate(toolchain: RustToolchain)
 
     /**
-     * Immediately schedules an update. Shows balloon upon completion.
+     * Updates Rust libraries asynchronously. Consecutive requests are coalesced.
+     */
+    fun requestUpdate(toolchain: RustToolchain, immediately: Boolean = false)
+
+    /**
+     * Latest version of the Cargo's project-description obtained
      *
-     * Update is still asynchronous.
+     * NOTA BENE: In the current implementation it's SYNCHRONOUS
      */
-    fun updateNow(toolchain: RustToolchain)
+    val projectDescription: CargoProjectDescription
 
-    val projectDescription: CargoProjectDescription?
+    companion object {
+        val UPDATES = Topic("org.rust.CargoProjectUpdatesTopic", CargoProjectWorkspaceListener::class.java)
+    }
+
 }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
@@ -4,7 +4,12 @@ import org.rust.cargo.project.CargoProjectDescription
 import org.rust.cargo.toolchain.RustToolchain
 
 /**
- * Uses `cargo metadata` command to update IDEA libraries and Cargo project model.
+ * Cargo based project's workspace abstraction insulating inter-op with the `cargo` & `Cargo.toml`
+ * itself. Uses `cargo metadata` sub-command to update IDEA module's & project's model.
+ *
+ * Quite low-level in its nature & follows a soft-fail policy, i.e. provides access
+ * for latest obtained instance of the [CargoProjectDescription], though doesn't assure that this
+ * one could be obtained (consider the case with invalid, or missing `Cargo.toml`)
  */
 interface CargoProjectWorkspace {
 

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
@@ -29,7 +29,8 @@ interface CargoProjectWorkspace {
     val projectDescription: CargoProjectDescription?
 
     /**
-     * Subscribes given listener to the supplied topic
+     * Subscribes given listener to the supplied topic on the [CargoProjectWorkspace]'s private
+     * message-bus
      */
     fun <L: Any> subscribeTo(t: Topic<L>, listener: L, disposer: Disposable? = null)
 

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
@@ -31,6 +31,6 @@ interface CargoProjectWorkspace {
     /**
      * Subscribes given listener to the supplied topic
      */
-    fun <L> subscribeTo(t: Topic<L>, listener: L, disposer: Disposable? = null)
+    fun <L: Any> subscribeTo(t: Topic<L>, listener: L, disposer: Disposable? = null)
 
 }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
@@ -1,6 +1,5 @@
 package org.rust.cargo.project.workspace
 
-import com.intellij.util.messages.Topic
 import org.rust.cargo.project.CargoProjectDescription
 import org.rust.cargo.toolchain.RustToolchain
 
@@ -19,10 +18,6 @@ interface CargoProjectWorkspace {
      *
      * NOTA BENE: In the current implementation it's SYNCHRONOUS
      */
-    val projectDescription: CargoProjectDescription
-
-    companion object {
-        val UPDATES = Topic("org.rust.CargoProjectUpdatesTopic", CargoProjectWorkspaceListener::class.java)
-    }
+    val projectDescription: CargoProjectDescription?
 
 }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspaceListener.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspaceListener.kt
@@ -13,7 +13,7 @@ interface CargoProjectWorkspaceListener {
      * Called every time Cargo's project gets description updated, no
      * matter whether did it actually changed from the previous update or not
      */
-    fun onProjectUpdated(r: UpdateResult)
+    fun onWorkspaceUpdateCompleted(r: UpdateResult)
 
     sealed class UpdateResult {
         class Ok(val projectDescription: CargoProjectDescription) : UpdateResult()

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspaceListener.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspaceListener.kt
@@ -1,0 +1,16 @@
+package org.rust.cargo.project.workspace
+
+import org.rust.cargo.project.CargoProjectDescription
+
+/**
+ * Interface to subscribe for the Cargo-backed project updates. That's a rather low-level API
+ */
+interface CargoProjectWorkspaceListener {
+
+    /**
+     * Called every time Cargo's project gets description updated, no
+     * matter whether did it actually changed from the previous update or not
+     */
+    fun onProjectUpdated(projectDescription: CargoProjectDescription)
+
+}

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspaceListener.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspaceListener.kt
@@ -1,5 +1,7 @@
 package org.rust.cargo.project.workspace
 
+import com.intellij.execution.ExecutionException
+import com.intellij.util.messages.Topic
 import org.rust.cargo.project.CargoProjectDescription
 
 /**
@@ -11,6 +13,14 @@ interface CargoProjectWorkspaceListener {
      * Called every time Cargo's project gets description updated, no
      * matter whether did it actually changed from the previous update or not
      */
-    fun onProjectUpdated(projectDescription: CargoProjectDescription)
+    fun onProjectUpdated(r: UpdateResult)
 
+    sealed class UpdateResult {
+        class Ok(val projectDescription: CargoProjectDescription) : UpdateResult()
+        class Err(val error: ExecutionException) : UpdateResult()
+    }
+
+    object Topics {
+        val UPDATES = Topic("org.rust.CargoProjectUpdatesTopic", CargoProjectWorkspaceListener::class.java)
+    }
 }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
@@ -101,9 +101,6 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
      */
     override fun requestUpdateUsing(toolchain: RustToolchain, immediately: Boolean) {
         val contentRoot = module.cargoProjectRoot ?: return
-
-        val delay = if (ApplicationManager.getApplication().isUnitTestMode) 0 else DELAY
-
         val task = UpdateTask(toolchain, contentRoot.path)
 
         alarm.cancelAllRequests()
@@ -111,7 +108,7 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
         if (immediately)
             task.queue()
         else
-            alarm.addRequest({ task.queue() }, delay, ModalityState.any())
+            alarm.addRequest({ task.queue() }, DELAY, ModalityState.any())
     }
 
     /**

--- a/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
@@ -139,12 +139,12 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
      * Subscribes given listener to the supplied topic on the [CargoProjectWorkspace]'s private
      * message-bus
      */
-    override fun <L> subscribeTo(t: Topic<L>, listener: L, disposer: Disposable?) {
+    override fun <L: Any> subscribeTo(t: Topic<L>, listener: L, disposer: Disposable?) {
         val conn =
             messageBus
                 .connect()
                 .apply {
-                    this.subscribe(t, listener!!)
+                    this.subscribe(t, listener)
                 }
 
         disposer?.let { Disposer.register(disposer, conn) }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
@@ -70,7 +70,7 @@ class CargoProjectWorkspaceImpl(private val module: Module)
      * Works in two phases. First `cargo metadata` is executed on the background thread. Then,
      * the actual Library update happens on the event dispatch thread.
      */
-    override fun requestUpdate(toolchain: RustToolchain, immediately: Boolean) {
+    override fun requestUpdateUsing(toolchain: RustToolchain, immediately: Boolean) {
         val contentRoot = module.cargoProjectRoot ?: return
 
         val delay = if (ApplicationManager.getApplication().isUnitTestMode) 0 else DELAY
@@ -97,7 +97,7 @@ class CargoProjectWorkspaceImpl(private val module: Module)
                                 c -> c.subscribe(
                                         CargoProjectWorkspaceListener.Topics.UPDATES,
                                         object: CargoProjectWorkspaceListener {
-                                            override fun onProjectUpdated(r: UpdateResult) {
+                                            override fun onWorkspaceUpdateCompleted(r: UpdateResult) {
                                                 val d = when (r) {
                                                     is UpdateResult.Ok  -> r.projectDescription
                                                     is UpdateResult.Err -> null
@@ -108,7 +108,7 @@ class CargoProjectWorkspaceImpl(private val module: Module)
                                         })
                             }
 
-                            module.toolchain?.let { requestUpdate(it); f.get() }
+                            module.toolchain?.let { requestUpdateUsing(it); f.get() }
                         }
                 }
             }
@@ -125,7 +125,7 @@ class CargoProjectWorkspaceImpl(private val module: Module)
         }
 
         if (needsUpdate) {
-            requestUpdate(toolchain)
+            requestUpdateUsing(toolchain)
         }
     }
 
@@ -134,7 +134,7 @@ class CargoProjectWorkspaceImpl(private val module: Module)
             if (!module.isDisposed)
                 module.messageBus
                     .syncPublisher(CargoProjectWorkspaceListener.Topics.UPDATES)
-                    .onProjectUpdated(r)
+                    .onWorkspaceUpdateCompleted(r)
         }
     }
 

--- a/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
@@ -48,7 +48,7 @@ class CargoProjectWorkspaceImpl(private val module: Module)
      * Alarm used to coalesce consecutive update requests.
      * It uses pooled thread.
      */
-    private val alarm = Alarm(Alarm.ThreadToUse.POOLED_THREAD, null)
+    private val alarm = Alarm()
 
     /**
      * Lock to guard reads/updates to [cached]

--- a/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
@@ -55,7 +55,7 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
     /**
      * Lock to guard reads/updates to [cached]
      */
-    private var lock: Lock = ReentrantLock()
+    private val lock: Lock = ReentrantLock()
 
     /**
      * Cached instance of the latest [CargoProjectDescription] instance synced with `Cargo.toml`
@@ -66,7 +66,7 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
      * Isolated message-bus to insulate cargo-project-workspace related messaging
      * infra from general-purpose listeners, and properly manage listeners' lifetimes
      */
-    private var messageBus: MessageBus? = null
+    private lateinit var messageBus: MessageBus
 
     /** Component hooks */
 
@@ -81,8 +81,8 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
     }
 
     override fun disposeComponent() {
-        alarm       .dispose()
-        messageBus!!.dispose()
+        alarm.dispose()
+        messageBus.dispose()
     }
 
     override fun projectClosed() { /* NOP */ }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
@@ -5,6 +5,7 @@ import com.intellij.execution.ExecutionException
 import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleUtilCore
@@ -82,7 +83,7 @@ class CargoProjectWorkspaceImpl(private val module: Module)
         if (immediately) {
             task.enqueue()
         } else {
-            alarm.addRequest({ task.enqueue() }, delay)
+            alarm.addRequest({ task.enqueue() }, delay, ModalityState.any())
         }
     }
 

--- a/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
@@ -48,7 +48,7 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
 
     /**
      * Alarm used to coalesce consecutive update requests.
-     * It uses pooled thread.
+     * It uses dispatch-thread.
      */
     private val alarm = Alarm()
 
@@ -140,11 +140,12 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
      * message-bus
      */
     override fun <L> subscribeTo(t: Topic<L>, listener: L, disposer: Disposable?) {
-        val conn = messageBus!!
-            .connect().let {
-                it.subscribe(t, listener!!)
-                it
-            }
+        val conn =
+            messageBus
+                .connect()
+                .apply {
+                    this.subscribe(t, listener!!)
+                }
 
         disposer?.let { Disposer.register(disposer, conn) }
     }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
@@ -130,7 +130,7 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
         ApplicationManager.getApplication().assertIsDispatchThread()
 
         if (!module.isDisposed)
-            module.messageBus
+            messageBus
                 .syncPublisher(CargoProjectWorkspaceListener.Topics.UPDATES)
                 .onWorkspaceUpdateCompleted(r)
     }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
@@ -100,10 +100,9 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
         alarm.cancelAllRequests()
 
         if (immediately)
-            ApplicationManager.getApplication()
-                .invokeLater({ task.enqueue() })
+            task.queue()
         else
-            alarm.addRequest({ task.enqueue() }, delay, ModalityState.any())
+            alarm.addRequest({ task.queue() }, delay, ModalityState.any())
     }
 
     /**

--- a/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
@@ -1,13 +1,10 @@
 package org.rust.cargo.project.workspace.impl
 
+import com.google.common.util.concurrent.SettableFuture
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.components.PersistentStateComponent
-import com.intellij.openapi.components.State
-import com.intellij.openapi.components.Storage
-import com.intellij.openapi.components.StoragePathMacros
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleUtilCore
@@ -26,78 +23,93 @@ import org.rust.cargo.project.CargoProjectDescriptionData
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.CargoProjectWorkspace
+import org.rust.cargo.project.workspace.CargoProjectWorkspaceListener
 import org.rust.cargo.toolchain.RustToolchain
 import org.rust.cargo.util.cargoLibraryName
 import org.rust.cargo.util.cargoProjectRoot
+import org.rust.cargo.util.enqueue
 import org.rust.cargo.util.updateLibrary
-import kotlin.properties.Delegates
+import org.rust.lang.utils.lock
+import org.rust.lang.utils.release
+import org.rust.lang.utils.usingWith
+import java.util.concurrent.locks.Lock
+import java.util.concurrent.locks.ReentrantLock
 
-private val LOG = Logger.getInstance(CargoProjectWorkspaceImpl::class.java);
 
-@State(
-    name = "CargoMetadata",
-    storages = arrayOf(Storage(file = StoragePathMacros.MODULE_FILE))
-)
-class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorkspace, PersistentStateComponent<CargoProjectState>, BulkFileListener {
+class CargoProjectWorkspaceImpl(private val module: Module)
+    : CargoProjectWorkspace
+    , BulkFileListener {
 
-    private val DELAY_MILLIS = 1000
+    private val DELAY = 1000 /* milliseconds */
+
+    private val LOG = Logger.getInstance(CargoProjectWorkspaceImpl::class.java)
 
     /**
      * Alarm used to coalesce consecutive update requests.
-     * It uses EDT thread, but the tasks are really tiny and
-     * only spawn background update.
+     * It uses pooled thread.
      */
-    private val alarm = Alarm()
+    private val alarm = Alarm(Alarm.ThreadToUse.POOLED_THREAD, null)
 
-    private var cargoProjectState: CargoProjectState by Delegates.observable(CargoProjectState()) {
-        prop, old, new ->
-            projectDescription = new.projectData?.let { CargoProjectDescription.deserialize(it) }
-    }
+    /**
+     * Lock to guard reads/updates to [cached]
+     */
+    private var lock: Lock = ReentrantLock()
 
-    override var projectDescription: CargoProjectDescription? = null
+    /**
+     * Cached instance of the latest [CargoProjectDescription] instance synced with `Cargo.toml`
+     */
+    private var cached: CargoProjectDescription? = null
 
     init {
-        module.messageBus.connect().subscribe(VirtualFileManager.VFS_CHANGES, this)
-    }
-
-    @TestOnly
-    fun setState(cargoProject: CargoProjectDescriptionData) {
-        cargoProjectState = CargoProjectState(cargoProject)
+        usingWith (module.messageBus.connect()) {
+            c -> c.subscribe(VirtualFileManager.VFS_CHANGES, this)
+        }
     }
 
     /**
      * Works in two phases. First `cargo metadata` is executed on the background thread. Then,
      * the actual Library update happens on the event dispatch thread.
      */
-    override fun scheduleUpdate(toolchain: RustToolchain) {
+    override fun requestUpdate(toolchain: RustToolchain, immediately: Boolean) {
         val contentRoot = module.cargoProjectRoot ?: return
+
+        val delay = if (ApplicationManager.getApplication().isUnitTestMode) 0 else DELAY
 
         val task = UpdateTask(toolchain, contentRoot.path, showFeedback = false)
+
         alarm.cancelAllRequests()
-        alarm.addRequest({ task.queue() }, DELAY_MILLIS)
+
+        if (immediately) {
+            task.enqueue()
+        } else {
+            alarm.addRequest({ task.enqueue() }, delay)
+        }
     }
 
-    override fun updateNow(toolchain: RustToolchain) {
-        val contentRoot = module.cargoProjectRoot ?: return
+    override val projectDescription: CargoProjectDescription
+        get() =
+            lock (lock) {
+                cached ?: release (lock) {
+                    SettableFuture
+                        .create<CargoProjectDescription>()
+                        .let { f ->
+                            usingWith (module.messageBus.connect()) {
+                                c -> c.subscribe(
+                                        CargoProjectWorkspace.UPDATES,
+                                        object : CargoProjectWorkspaceListener {
+                                            override fun onProjectUpdated(projectDescription: CargoProjectDescription) {
+                                                f.set(projectDescription)
+                                            }
+                                        })
+                            }
 
-        val task = UpdateTask(toolchain, contentRoot.path, showFeedback = true)
-        alarm.cancelAllRequests()
-        task.queue()
-    }
+                            requestUpdate(module.toolchain!!)
+                            f.get()
+                        }
+                }
+            }
 
-    @TestOnly
-    fun flushUpdates() {
-        alarm.flush()
-    }
-
-    override fun loadState(state: CargoProjectState?) {
-        cargoProjectState = state ?: CargoProjectState()
-    }
-
-    override fun getState(): CargoProjectState = cargoProjectState
-
-    override fun before(events: MutableList<out VFileEvent>) {
-    }
+    override fun before(events: MutableList<out VFileEvent>) {}
 
     override fun after(events: MutableList<out VFileEvent>) {
         if (!module.project.rustSettings.autoUpdateEnabled) return
@@ -107,9 +119,24 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
             val file = it.file ?: return@any false
             file.name == RustToolchain.CARGO_TOML && ModuleUtilCore.findModuleForFile(file, module.project) == module
         }
+
         if (needsUpdate) {
-            scheduleUpdate(toolchain)
+            requestUpdate(toolchain)
         }
+    }
+
+    private fun updateCargoProjectState(state: CargoProjectState) {
+        val projectData = state.projectData
+        if (projectData != null)
+            lock (lock) {
+                CargoProjectDescription.deserialize(projectData)?.let {
+                    module.messageBus
+                        .syncPublisher(CargoProjectWorkspace.UPDATES)
+                        .onProjectUpdated(it)
+
+                    cached = it
+                }
+            }
     }
 
     private inner class UpdateTask(
@@ -152,6 +179,7 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
                     showBalloon("Project '${module.project.name}' update failed: ${result.error.message}", MessageType.ERROR)
                     LOG.info("Project '${module.project.name}' update failed", result.error)
                 }
+
                 is Result.Ok  ->
                     ApplicationManager.getApplication().runWriteAction {
                         if (!module.isDisposed) {
@@ -161,7 +189,8 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
                                     .mapNotNull { it.virtualFile }
 
                             module.updateLibrary(module.cargoLibraryName, libraryRoots)
-                            cargoProjectState = CargoProjectState(result.cargoProject.serialize())
+
+                            updateCargoProjectState(CargoProjectState(result.cargoProject.serialize()))
 
                             showBalloon("Project '${module.project.name}' successfully updated!", MessageType.INFO)
 
@@ -181,6 +210,11 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
     private sealed class Result {
         class Ok(val cargoProject: CargoProjectDescription) : Result()
         class Err(val error: ExecutionException) : Result()
+    }
+
+    @TestOnly
+    fun setState(cargoProject: CargoProjectDescriptionData) {
+        updateCargoProjectState(CargoProjectState(cargoProject))
     }
 }
 

--- a/src/main/kotlin/org/rust/cargo/util/ModuleUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/ModuleUtil.kt
@@ -36,6 +36,16 @@ inline fun<reified T: Any> Module.getService(): T? =
 inline fun<reified T: Any> Module.getServiceOrThrow(): T =
     getService()!!
 
+/**
+ * Helper extracting generic component for the particular module
+ */
+inline fun<reified T: Any> Module.getComponent(): T? =
+    this.getComponent(T::class.java)
+
+inline fun<reified T: Any> Module.getComponentOrThrow(): T =
+    getComponent()!!
+
+
 
 /**
  * Extracts content- and library-(ordered)-entries for the given module
@@ -43,7 +53,7 @@ inline fun<reified T: Any> Module.getServiceOrThrow(): T =
 fun Module.getSourceAndLibraryRoots(): Collection<VirtualFile> =
     ModuleRootManager.getInstance(this).orderEntries.flatMap {
         it.getFiles(OrderRootType.CLASSES).toList() +
-            it.getFiles(OrderRootType.SOURCES).toList()
+        it.getFiles(OrderRootType.SOURCES).toList()
     }
 
 /**

--- a/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
@@ -72,5 +72,5 @@ val Module.cargoProjectRoot: VirtualFile?
  * Extracts Cargo project description out of `Cargo.toml`
  */
 val Module.cargoProject: CargoProjectDescription?
-    get() = getServiceOrThrow<CargoProjectWorkspace>().projectDescription
+    get() = getComponentOrThrow<CargoProjectWorkspace>().projectDescription
 

--- a/src/main/kotlin/org/rust/cargo/util/TasksUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/TasksUtil.kt
@@ -1,0 +1,59 @@
+package org.rust.cargo.util
+
+import com.google.common.util.concurrent.*
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.progress.impl.CoreProgressManager
+import com.intellij.util.concurrency.AppExecutorUtil
+
+object TasksUtil
+
+/**
+ * Schedules task to run asynchronously (on the application thread-pool)
+ *
+ * NOTA BENE: This would occupy 2 (sic!) threads: one carrying payload, and the second one to piggyback results of the
+ *            former right into `ListenableFuture`. We need to address that
+ */
+fun Task.Backgroundable.enqueue(): ListenableFuture<*> =
+    JdkFutureAdapters.listenInPoolThread(
+        (ProgressManager.getInstance() as CoreProgressManager).runProcessWithProgressAsynchronously(this),
+        AppExecutorUtil.getAppExecutorService()
+        )
+
+
+/**
+ * Allows to bind one future to the other one, 'piggybacking' results
+ * of the former into the latter one
+ */
+inline fun <reified T> ListenableFuture<T>.flowInto(f: SettableFuture<T>) {
+    check(!f.isDone && !f.isCancelled, { "Target future should not be done or cancelled at that point!" })
+
+    Futures.addCallback(this, object: FutureCallback<T> {
+        override fun onSuccess(result: T?) {
+            f.set(result)
+        }
+        override fun onFailure(t: Throwable?) {
+            f.setException(t)
+        }
+    })
+}
+
+/**
+ * Same as [flowInto], except that it neatly handles the cases of the 'erased' interfaces,
+ * ignoring the result of the source future, and effectively just binding those two
+ */
+fun <T> ListenableFuture<*>.flowIntoDiscardingResult(f: SettableFuture<T>, value: () -> T): ListenableFuture<T> {
+    check(!f.isDone && !f.isCancelled, { "Target future should not be done or cancelled at that point!" })
+
+    Futures.addCallback(this, object: FutureCallback<Any> {
+        override fun onSuccess(result: Any?) {
+            f.set(value())
+        }
+        override fun onFailure(t: Throwable?) {
+            f.setException(t)
+        }
+    })
+
+    return f
+}
+

--- a/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectAction.kt
@@ -9,6 +9,7 @@ import com.intellij.util.containers.isNullOrEmpty
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.CargoProjectWorkspace
 import org.rust.cargo.toolchain.RustToolchain
+import org.rust.cargo.util.getComponentOrThrow
 import org.rust.cargo.util.getModules
 import org.rust.cargo.util.getServiceOrThrow
 
@@ -34,7 +35,7 @@ class RefreshCargoProjectAction : AnAction() {
         if (modules.isNullOrEmpty()) return
         ApplicationManager.getApplication().saveAll()
         for ((module, toolchain) in modules.orEmpty()) {
-            val service = module.getServiceOrThrow<CargoProjectWorkspace>()
+            val service = module.getComponentOrThrow<CargoProjectWorkspace>()
             service.requestUpdateUsing(toolchain, immediately = true)
         }
     }

--- a/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectAction.kt
@@ -41,7 +41,10 @@ class RefreshCargoProjectAction : AnAction() {
             val workspace = module.getComponentOrThrow<CargoProjectWorkspace>()
 
             Notifier(module).let {
-                workspace.subscribeTo(CargoProjectWorkspaceListener.Topics.UPDATES, it, it.connectionDisposer)
+                module.messageBus
+                    .connect(it.connectionDisposer)
+                    .subscribe(CargoProjectWorkspaceListener.Topics.UPDATES, it)
+
                 workspace.requestUpdateUsing(toolchain, immediately = true)
             }
         }

--- a/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectAction.kt
@@ -35,7 +35,7 @@ class RefreshCargoProjectAction : AnAction() {
         ApplicationManager.getApplication().saveAll()
         for ((module, toolchain) in modules.orEmpty()) {
             val service = module.getServiceOrThrow<CargoProjectWorkspace>()
-            service.updateNow(toolchain)
+            service.requestUpdate(toolchain, immediately = true)
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectAction.kt
@@ -35,7 +35,7 @@ class RefreshCargoProjectAction : AnAction() {
         ApplicationManager.getApplication().saveAll()
         for ((module, toolchain) in modules.orEmpty()) {
             val service = module.getServiceOrThrow<CargoProjectWorkspace>()
-            service.requestUpdate(toolchain, immediately = true)
+            service.requestUpdateUsing(toolchain, immediately = true)
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectAction.kt
@@ -50,7 +50,7 @@ class RefreshCargoProjectAction : AnAction() {
     /**
      * Project-update task's notifier
      */
-    inner class Notifier(val module: Module) : CargoProjectWorkspaceListener {
+    private class Notifier(val module: Module) : CargoProjectWorkspaceListener {
 
         val connectionDisposer = Disposer.newDisposable()
 

--- a/src/main/kotlin/org/rust/lang/utils/Utils.kt
+++ b/src/main/kotlin/org/rust/lang/utils/Utils.kt
@@ -1,6 +1,7 @@
 package org.rust.lang.utils
 
 import com.intellij.openapi.Disposable
+import java.util.concurrent.locks.Lock
 
 /**
  * Cookie-helper allowing to mutate the state of the supplied object (exception-safe).
@@ -19,7 +20,7 @@ internal class Cookie<T, V>(val t: T, val set: T.(V) -> V, new: V) : Disposable 
 
 
 /**
- * Helper disposing `d` upon completing the execution of the `block`
+ * Helper disposing [d] upon completing the execution of the [block]
  *
  * @d       Target `Disposable` to be disposed upon completion of the @block
  * @block   Target block to be run prior to disposal of @d
@@ -31,3 +32,43 @@ fun <T> using(d: Disposable, block: () -> T): T {
         d.dispose()
     }
 }
+
+/**
+ * Helper disposing [d] upon completing the execution of the [block] (under the [d])
+ *
+ * @d       Target `Disposable` to be disposed upon completion of the @block
+ * @block   Target block to be run prior to disposal of @d
+ */
+fun <D: Disposable, T> usingWith(d: D, block: (D) -> T): T {
+    try {
+        return block(d)
+    } finally {
+        d.dispose()
+    }
+}
+
+/**
+ * Helper executing the block supplied under the lock being ACQUIRED,
+ * and RELEASED upon completion (successful or not)
+ *
+ * @l       Lock to be acquired
+ * @block   Target block to be run 'under' the lock being acquired
+ */
+fun <T> lock(l: Lock, block: () -> T): T =
+    l.lock().let {
+        using(Disposable { l.unlock() }, block)
+    }
+
+
+/**
+ * Helper executing the block supplied under the lock being RELEASED,
+ * and ACQUIRED upon completion (successful or not), i.e. it performs in the
+ * way exactly opposite to [lock]
+ *
+ * @l       Lock to be release
+ * @block   Target block to be run 'under' the lock being released
+ */
+fun <T> release(l: Lock, block: () -> T): T =
+    l.unlock().let {
+        using(Disposable { l.lock() }, block)
+    }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -151,8 +151,6 @@
                              dynamic="true"/>
         <projectService serviceInterface="org.rust.cargo.project.settings.RustProjectSettingsService"
                         serviceImplementation="org.rust.cargo.project.settings.impl.RustProjectSettingsServiceImpl"/>
-        <moduleService serviceInterface="org.rust.cargo.project.workspace.CargoProjectWorkspace"
-                       serviceImplementation="org.rust.cargo.project.workspace.impl.CargoProjectWorkspaceImpl"/>
 
 
         <!-- Icon Provider -->
@@ -180,7 +178,10 @@
     </project-components>
 
     <module-components>
-        <!-- Add your modules components here -->
+        <component>
+            <interface-class>org.rust.cargo.project.workspace.CargoProjectWorkspace</interface-class>
+            <implementation-class>org.rust.cargo.project.workspace.impl.CargoProjectWorkspaceImpl</implementation-class>
+        </component>
     </module-components>
 
     <actions>

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectResolveTestCase.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectResolveTestCase.kt
@@ -7,10 +7,10 @@ import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiReference
 import org.assertj.core.api.Assertions.assertThat
 import org.rust.cargo.RustWithToolchainTestCaseBase
-import org.rust.cargo.project.CargoProjectDescription
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.CargoProjectWorkspace
 import org.rust.cargo.project.workspace.CargoProjectWorkspaceListener
+import org.rust.cargo.project.workspace.CargoProjectWorkspaceListener.UpdateResult
 import org.rust.cargo.util.getServiceOrThrow
 
 class CargoProjectResolveTestCase : RustWithToolchainTestCaseBase() {
@@ -20,9 +20,11 @@ class CargoProjectResolveTestCase : RustWithToolchainTestCaseBase() {
         module.messageBus
             .connect()
             .subscribe(
-                CargoProjectWorkspace.UPDATES,
+                CargoProjectWorkspaceListener.Topics.UPDATES,
                 object: CargoProjectWorkspaceListener {
-                    override fun onProjectUpdated(projectDescription: CargoProjectDescription) {
+                    override fun onProjectUpdated(r: UpdateResult) {
+                        assertThat(r is UpdateResult.Ok)
+
                         val reference = extractReference("src/main.rs")
                         assertThat(reference.resolve()).isNotNull()
                     }
@@ -35,9 +37,11 @@ class CargoProjectResolveTestCase : RustWithToolchainTestCaseBase() {
         module.messageBus
             .connect()
             .subscribe(
-                CargoProjectWorkspace.UPDATES,
+                CargoProjectWorkspaceListener.Topics.UPDATES,
                 object: CargoProjectWorkspaceListener {
-                    override fun onProjectUpdated(projectDescription: CargoProjectDescription) {
+                    override fun onProjectUpdated(r: UpdateResult) {
+                        assertThat(r is UpdateResult.Ok)
+
                         val reference = extractReference("src/main.rs")
                         assertThat(reference.resolve()).isNotNull()
                     }

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectResolveTestCase.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectResolveTestCase.kt
@@ -25,9 +25,9 @@ class CargoProjectResolveTestCase : RustWithToolchainTestCaseBase() {
     private fun <T> bindToProjectUpdateEvent(callback: (UpdateResult) -> T): Future<T> {
         val f = SettableFuture.create<T>()
 
-        module.messageBus
-            .connect()
-            .subscribe(
+        module
+            .getComponentOrThrow<CargoProjectWorkspace>()
+            .subscribeTo(
                 CargoProjectWorkspaceListener.Topics.UPDATES,
                 object: CargoProjectWorkspaceListener {
                     override fun onWorkspaceUpdateCompleted(r: UpdateResult) {

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectResolveTestCase.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectResolveTestCase.kt
@@ -25,9 +25,9 @@ class CargoProjectResolveTestCase : RustWithToolchainTestCaseBase() {
     private fun <T> bindToProjectUpdateEvent(callback: (UpdateResult) -> T): Future<T> {
         val f = SettableFuture.create<T>()
 
-        module
-            .getComponentOrThrow<CargoProjectWorkspace>()
-            .subscribeTo(
+        module.messageBus
+            .connect()
+            .subscribe(
                 CargoProjectWorkspaceListener.Topics.UPDATES,
                 object: CargoProjectWorkspaceListener {
                     override fun onWorkspaceUpdateCompleted(r: UpdateResult) {

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectResolveTestCase.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectResolveTestCase.kt
@@ -7,33 +7,47 @@ import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiReference
 import org.assertj.core.api.Assertions.assertThat
 import org.rust.cargo.RustWithToolchainTestCaseBase
+import org.rust.cargo.project.CargoProjectDescription
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.CargoProjectWorkspace
-import org.rust.cargo.project.workspace.impl.CargoProjectWorkspaceImpl
-import org.rust.cargo.util.cargoProject
+import org.rust.cargo.project.workspace.CargoProjectWorkspaceListener
 import org.rust.cargo.util.getServiceOrThrow
 
 class CargoProjectResolveTestCase : RustWithToolchainTestCaseBase() {
     override val dataPath: String = "src/test/resources/org/rust/cargo/toolchain/fixtures"
 
     fun testResolveExternalLibrary() = withProject("external_library") {
-        updateCargoMetadata()
-        val reference = extractReference("src/main.rs")
-        assertThat(reference.resolve()).isNotNull()
+        module.messageBus
+            .connect()
+            .subscribe(
+                CargoProjectWorkspace.UPDATES,
+                object: CargoProjectWorkspaceListener {
+                    override fun onProjectUpdated(projectDescription: CargoProjectDescription) {
+                        val reference = extractReference("src/main.rs")
+                        assertThat(reference.resolve()).isNotNull()
+                    }
+                })
+
+        updateCargoProject()
     }
 
     fun testResolveLocalPackage() = withProject("local_package") {
-        updateCargoMetadata()
-        val reference = extractReference("src/main.rs")
-        assertThat(reference.resolve()).isNotNull()
+        module.messageBus
+            .connect()
+            .subscribe(
+                CargoProjectWorkspace.UPDATES,
+                object: CargoProjectWorkspaceListener {
+                    override fun onProjectUpdated(projectDescription: CargoProjectDescription) {
+                        val reference = extractReference("src/main.rs")
+                        assertThat(reference.resolve()).isNotNull()
+                    }
+                })
+
+        updateCargoProject()
     }
 
-    private fun updateCargoMetadata() {
-        check(module.cargoProject == null)
-        val service = module.getServiceOrThrow<CargoProjectWorkspace>()
-        service.scheduleUpdate(module.toolchain!!)
-        (service as CargoProjectWorkspaceImpl).flushUpdates()
-        check(module.cargoProject != null)
+    private fun updateCargoProject() {
+        module.getServiceOrThrow<CargoProjectWorkspace>().requestUpdate(module.toolchain!!)
     }
 
     private fun extractReference(path: String): PsiReference {

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectResolveTestCase.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectResolveTestCase.kt
@@ -11,6 +11,7 @@ import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.CargoProjectWorkspace
 import org.rust.cargo.project.workspace.CargoProjectWorkspaceListener
 import org.rust.cargo.project.workspace.CargoProjectWorkspaceListener.UpdateResult
+import org.rust.cargo.util.getComponentOrThrow
 import org.rust.cargo.util.getServiceOrThrow
 
 class CargoProjectResolveTestCase : RustWithToolchainTestCaseBase() {
@@ -51,7 +52,7 @@ class CargoProjectResolveTestCase : RustWithToolchainTestCaseBase() {
     }
 
     private fun updateCargoProject() {
-        module.getServiceOrThrow<CargoProjectWorkspace>().requestUpdateUsing(module.toolchain!!)
+        module.getComponentOrThrow<CargoProjectWorkspace>().requestUpdateUsing(module.toolchain!!)
     }
 
     private fun extractReference(path: String): PsiReference {

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectResolveTestCase.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectResolveTestCase.kt
@@ -22,7 +22,7 @@ class CargoProjectResolveTestCase : RustWithToolchainTestCaseBase() {
             .subscribe(
                 CargoProjectWorkspaceListener.Topics.UPDATES,
                 object: CargoProjectWorkspaceListener {
-                    override fun onProjectUpdated(r: UpdateResult) {
+                    override fun onWorkspaceUpdateCompleted(r: UpdateResult) {
                         assertThat(r is UpdateResult.Ok)
 
                         val reference = extractReference("src/main.rs")
@@ -39,7 +39,7 @@ class CargoProjectResolveTestCase : RustWithToolchainTestCaseBase() {
             .subscribe(
                 CargoProjectWorkspaceListener.Topics.UPDATES,
                 object: CargoProjectWorkspaceListener {
-                    override fun onProjectUpdated(r: UpdateResult) {
+                    override fun onWorkspaceUpdateCompleted(r: UpdateResult) {
                         assertThat(r is UpdateResult.Ok)
 
                         val reference = extractReference("src/main.rs")
@@ -51,7 +51,7 @@ class CargoProjectResolveTestCase : RustWithToolchainTestCaseBase() {
     }
 
     private fun updateCargoProject() {
-        module.getServiceOrThrow<CargoProjectWorkspace>().requestUpdate(module.toolchain!!)
+        module.getServiceOrThrow<CargoProjectWorkspace>().requestUpdateUsing(module.toolchain!!)
     }
 
     private fun extractReference(path: String): PsiReference {

--- a/src/test/kotlin/org/rust/lang/RustTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/lang/RustTestCaseBase.kt
@@ -77,6 +77,7 @@ abstract class RustTestCaseBase : LightPlatformCodeInsightFixtureTestCase(), Rus
 
             val moduleBaseDir = contentEntry.file!!.url
             val metadataService = module.getServiceOrThrow<CargoProjectWorkspace>() as CargoProjectWorkspaceImpl
+
             metadataService.setState(testCargoProject(module, moduleBaseDir))
 
             // XXX: for whatever reason libraries created by `updateLibrary` are not indexed in tests.
@@ -87,9 +88,9 @@ abstract class RustTestCaseBase : LightPlatformCodeInsightFixtureTestCase(), Rus
             }
         }
 
-        open protected fun testCargoProject(module: Module, contentRoot: String): CargoProjectDescriptionData {
+        open protected fun testCargoProject(module: Module, contentRoot: String): CargoProjectDescription {
             val packages = mutableListOf(testCargoPackage(contentRoot))
-            return CargoProjectDescriptionData(0, packages, ArrayList())
+            return CargoProjectDescription.deserialize(CargoProjectDescriptionData(0, packages, ArrayList()))!!
         }
 
         protected fun testCargoPackage(contentRoot: String, name: String = "test-package") = CargoProjectDescriptionData.Package(
@@ -105,7 +106,7 @@ abstract class RustTestCaseBase : LightPlatformCodeInsightFixtureTestCase(), Rus
     }
 
     class WithStdlibRustProjectDescriptor : RustProjectDescriptor() {
-        override fun testCargoProject(module: Module, contentRoot: String): CargoProjectDescriptionData {
+        override fun testCargoProject(module: Module, contentRoot: String): CargoProjectDescription {
             val sourcesArchive = LocalFileSystem.getInstance()
                 .findFileByPath("${RustTestCase.testResourcesPath}/rustc-src.zip")
 
@@ -115,7 +116,10 @@ abstract class RustTestCaseBase : LightPlatformCodeInsightFixtureTestCase(), Rus
 
             val stdlibPackages = module.attachStandardLibrary(sourceRoot)
             val allPackages = stdlibPackages + testCargoPackage(contentRoot)
-            return CargoProjectDescriptionData(0, allPackages.toMutableList(), ArrayList())
+
+            return CargoProjectDescriptionData(0, allPackages.toMutableList(), ArrayList()).let {
+                CargoProjectDescription.deserialize(it)!!
+            }
         }
     }
 }

--- a/src/test/kotlin/org/rust/lang/RustTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/lang/RustTestCaseBase.kt
@@ -15,7 +15,7 @@ import org.rust.cargo.project.CargoProjectDescriptionData
 import org.rust.cargo.project.workspace.CargoProjectWorkspace
 import org.rust.cargo.project.workspace.impl.CargoProjectWorkspaceImpl
 import org.rust.cargo.util.attachStandardLibrary
-import org.rust.cargo.util.getServiceOrThrow
+import org.rust.cargo.util.getComponentOrThrow
 import java.util.*
 
 abstract class RustTestCaseBase : LightPlatformCodeInsightFixtureTestCase(), RustTestCase {
@@ -76,7 +76,7 @@ abstract class RustTestCaseBase : LightPlatformCodeInsightFixtureTestCase(), Rus
             super.configureModule(module, model, contentEntry)
 
             val moduleBaseDir = contentEntry.file!!.url
-            val metadataService = module.getServiceOrThrow<CargoProjectWorkspace>() as CargoProjectWorkspaceImpl
+            val metadataService = module.getComponentOrThrow<CargoProjectWorkspace>() as CargoProjectWorkspaceImpl
 
             metadataService.setState(testCargoProject(module, moduleBaseDir))
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RustPackageLibraryResolveTestCase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RustPackageLibraryResolveTestCase.kt
@@ -2,18 +2,17 @@ package org.rust.lang.core.resolve
 
 import com.intellij.openapi.module.Module
 import com.intellij.testFramework.LightProjectDescriptor
+import org.rust.cargo.project.CargoProjectDescription
 import org.rust.cargo.project.CargoProjectDescriptionData
 import java.util.*
 
 class RustPackageLibraryResolveTestCase : RustMultiFileResolveTestCaseBase() {
     override fun getProjectDescriptor(): LightProjectDescriptor = object : RustProjectDescriptor() {
 
-        override fun testCargoProject(module: Module, contentRoot: String): CargoProjectDescriptionData =
-            CargoProjectDescriptionData(
-                0,
-                mutableListOf(testCargoPackage(contentRoot, name = "my_lib")),
-                ArrayList()
-            )
+        override fun testCargoProject(module: Module, contentRoot: String): CargoProjectDescription =
+            CargoProjectDescriptionData(0, mutableListOf(testCargoPackage(contentRoot, name = "my_lib")), ArrayList()).let {
+                CargoProjectDescription.deserialize(it)!!
+            }
     }
 
     fun testLibraryAsCrate() = doTestResolved("library_as_crate/main.rs", "library_as_crate/lib.rs")


### PR DESCRIPTION
1. Made module-component instead of a service (as soon as it gets a state, it should not be service anymore).
2. Killed persistence and made it transparent one-directional proxy of the `Cargo.toml` project-workspace.
3. Refactored some concurrency issues (and hopefully didn't introduced new ones).