### PR TITLE
(FMT): improve spacing for extern crate items

### DIFF
--- a/src/main/kotlin/org/rust/ide/formatter/RustSpacing.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/RustSpacing.kt
@@ -65,6 +65,8 @@ object RustSpacing {
             .afterInside(LBRACE, BLOCK_LIKE).spacing(1, 1, 0, true, 0)
             .beforeInside(RBRACE, BLOCK_LIKE).spacing(1, 1, 0, true, 0)
 
+            .betweenInside(IDENTIFIER, ALIAS, EXTERN_CRATE_ITEM).spaces(1)
+
             //== types
             .afterInside(LIFETIME, REF_TYPE).spaceIf(true)
             .betweenInside(ts(MUL), ts(CONST, MUT), PTR_TYPE).spaces(0)

--- a/src/test/resources/org/rust/ide/formatter/fixtures/spacing.rs
+++ b/src/test/resources/org/rust/ide/formatter/fixtures/spacing.rs
@@ -1,5 +1,7 @@
 #![   stable   (   feature   =   "rust1"  ,   since   =   "1.0.0"  )  ]
 
+extern    crate    std    as    ruststd   ;
+
 use   core    ::    hash  ::   {    self    ,    Hash    }    ;
 use core ::intrinsics:: {arith_offset ,assume}  ;
 use core::iter::FromIterator;

--- a/src/test/resources/org/rust/ide/formatter/fixtures/spacing_after.rs
+++ b/src/test/resources/org/rust/ide/formatter/fixtures/spacing_after.rs
@@ -1,5 +1,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
+extern crate std as ruststd;
+
 use core::hash::{self, Hash};
 use core::intrinsics::{arith_offset, assume};
 use core::iter::FromIterator;


### PR DESCRIPTION
```rust
extern crate std     as ruststd;
```
was't fixed