### PR TITLE
(RES): relax type bounds in resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RustCompletionEngine.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RustCompletionEngine.kt
@@ -64,7 +64,7 @@ private class CompletionScopeVisitor(private val context: RustQualifiedReference
     }
 }
 
-private fun RustNamedElement?.completionsFromResolveScope(): Collection<RustNamedElement> =
+private fun RustCompositeElement?.completionsFromResolveScope(): Collection<RustNamedElement> =
     when (this) {
         is RustResolveScope -> boundElements
         else                -> emptyList()

--- a/src/main/kotlin/org/rust/lang/core/resolve/RustResolveEngine.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RustResolveEngine.kt
@@ -22,9 +22,9 @@ import org.rust.lang.core.resolve.util.RustResolveUtil
 import java.util.*
 
 object RustResolveEngine {
-    open class ResolveResult private constructor(val resolved: RustNamedElement?) : com.intellij.psi.ResolveResult {
-        override fun getElement():      RustNamedElement? = resolved
-        override fun isValidResult():   Boolean           = resolved != null
+    open class ResolveResult private constructor(val resolved: RustCompositeElement?) : com.intellij.psi.ResolveResult {
+        override fun getElement():      RustCompositeElement? = resolved
+        override fun isValidResult():   Boolean               = resolved != null
 
         /**
          * Designates resolve-engine failure to properly resolve item
@@ -35,12 +35,12 @@ object RustResolveEngine {
          * Designates resolve-engine failure to properly recognise target item
          * among the possible candidates
          */
-        class Ambiguous(val candidates: Collection<RustNamedElement>) : ResolveResult(null)
+        class Ambiguous(val candidates: Collection<RustCompositeElement>) : ResolveResult(null)
 
         /**
          * Designates resolve-engine successfully resolved given target
          */
-        class Resolved(resolved: RustNamedElement) : ResolveResult(resolved)
+        class Resolved(resolved: RustCompositeElement) : ResolveResult(resolved)
     }
 
     /**
@@ -240,19 +240,19 @@ private class Resolver {
      * Resolve-context wrapper
      */
     interface ResolveContext {
-        fun accept(scope: RustResolveScope): RustNamedElement?
+        fun accept(scope: RustResolveScope): RustCompositeElement?
 
         companion object {
 
             class Trivial(val v: ResolveScopeVisitor) : ResolveContext {
-                override fun accept(scope: RustResolveScope): RustNamedElement? {
+                override fun accept(scope: RustResolveScope): RustCompositeElement? {
                     scope.accept(v)
                     return v.matched
                 }
             }
 
             object Empty : ResolveContext {
-                override fun accept(scope: RustResolveScope): RustNamedElement? = null
+                override fun accept(scope: RustResolveScope): RustCompositeElement? = null
             }
         }
     }
@@ -277,7 +277,7 @@ private class Resolver {
         /**
          * Matched resolve-target
          */
-        abstract var matched: RustNamedElement?
+        abstract var matched: RustCompositeElement?
     }
 
     /**
@@ -285,7 +285,7 @@ private class Resolver {
      */
     open inner class ResolveNonLocalScopesVisitor(protected val name: String) : ResolveScopeVisitor() {
 
-        override var matched: RustNamedElement? = null
+        override var matched: RustCompositeElement? = null
 
         override fun visitFile(file: PsiFile) {
             file.rustMod?.let { visitMod(it) }
@@ -439,7 +439,7 @@ fun enumerateScopesFor(ref: RustQualifiedReferenceElement): Sequence<RustResolve
 }
 
 
-private fun RustResolveScope.resolveUsing(c: Resolver.ResolveContext): RustNamedElement? = c.accept(this)
+private fun RustResolveScope.resolveUsing(c: Resolver.ResolveContext): RustCompositeElement? = c.accept(this)
 
 
 private fun RustNamedElement?.asResolveResult(): RustResolveEngine.ResolveResult =

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RustExternCrateReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RustExternCrateReferenceImpl.kt
@@ -1,8 +1,8 @@
 package org.rust.lang.core.resolve.ref
 
 import com.intellij.psi.PsiReferenceBase
+import org.rust.lang.core.psi.RustCompositeElement
 import org.rust.lang.core.psi.RustExternCrateItem
-import org.rust.lang.core.psi.RustNamedElement
 import org.rust.lang.core.psi.util.parentRelativeRange
 import org.rust.lang.core.resolve.RustResolveEngine
 
@@ -12,5 +12,5 @@ class RustExternCrateReferenceImpl(externCrate: RustExternCrateItem)
 
     override fun getVariants(): Array<out Any> = emptyArray()
 
-    override fun resolve(): RustNamedElement? = RustResolveEngine.resolveExternCrate(element).element
+    override fun resolve(): RustCompositeElement? = RustResolveEngine.resolveExternCrate(element).element
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RustQualifiedReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RustQualifiedReferenceImpl.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReferenceBase
 import org.rust.lang.core.completion.RustCompletionEngine
-import org.rust.lang.core.psi.RustNamedElement
+import org.rust.lang.core.psi.RustCompositeElement
 import org.rust.lang.core.psi.RustQualifiedReferenceElement
 import org.rust.lang.core.psi.RustTokenElementTypes
 import org.rust.lang.core.resolve.RustResolveEngine
@@ -15,7 +15,7 @@ internal class RustQualifiedReferenceImpl<T : RustQualifiedReferenceElement>(ele
     : PsiReferenceBase<T>(element, null, soft)
     , RustReference {
 
-    override fun resolve(): RustNamedElement? =
+    override fun resolve(): RustCompositeElement? =
         RustResolveEngine.resolve(element).element
 
     override fun getVariants(): Array<out Any> =

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RustReference.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RustReference.kt
@@ -2,13 +2,12 @@ package org.rust.lang.core.resolve.ref
 
 import com.intellij.psi.PsiReference
 import org.rust.lang.core.psi.RustCompositeElement
-import org.rust.lang.core.psi.RustNamedElement
 
 interface RustReference : PsiReference {
 
     override fun getElement(): RustCompositeElement
 
-    override fun resolve(): RustNamedElement?
+    override fun resolve(): RustCompositeElement?
 }
 
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RustUseGlobReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RustUseGlobReferenceImpl.kt
@@ -3,7 +3,7 @@ package org.rust.lang.core.resolve.ref
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiReferenceBase
 import org.rust.lang.core.completion.RustCompletionEngine
-import org.rust.lang.core.psi.RustNamedElement
+import org.rust.lang.core.psi.RustCompositeElement
 import org.rust.lang.core.psi.RustUseGlob
 import org.rust.lang.core.resolve.RustResolveEngine
 
@@ -14,7 +14,7 @@ class RustUseGlobReferenceImpl(useGlob: RustUseGlob)
     override fun getVariants(): Array<out Any> =
         RustCompletionEngine.complete(element)
 
-    override fun resolve(): RustNamedElement? {
+    override fun resolve(): RustCompositeElement? {
         return RustResolveEngine.resolveUseGlob(element).element
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RustMultifileResolveTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RustMultifileResolveTestCaseBase.kt
@@ -1,7 +1,7 @@
 package org.rust.lang.core.resolve
 
 import org.assertj.core.api.Assertions.assertThat
-import org.rust.lang.core.psi.RustNamedElement
+import org.rust.lang.core.psi.RustCompositeElement
 import org.rust.lang.core.resolve.ref.RustReference
 
 
@@ -28,7 +28,7 @@ abstract class RustMultiFileResolveTestCaseBase : RustResolveTestCaseBase() {
         assertThat(configureAndResolve(*files)).isNull()
     }
 
-    protected fun configureAndResolve(vararg files: String): RustNamedElement? {
+    protected fun configureAndResolve(vararg files: String): RustCompositeElement? {
         files.reversed().forEach {
             configureByFile(it)
         }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RustResolveTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RustResolveTestCaseBase.kt
@@ -4,7 +4,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.util.indexing.FileBasedIndex
 import org.assertj.core.api.Assertions.assertThat
 import org.rust.lang.RustTestCaseBase
-import org.rust.lang.core.psi.RustNamedElement
+import org.rust.lang.core.psi.RustCompositeElement
 import org.rust.lang.core.resolve.indexes.RustModulesIndex
 import org.rust.lang.core.resolve.ref.RustReference
 
@@ -15,8 +15,8 @@ abstract class RustResolveTestCaseBase : RustTestCaseBase() {
     private fun assertIsValidDeclaration(declaration: PsiElement, usage: RustReference,
                                          expectedOffset: Int?) {
 
-        assertThat(declaration).isInstanceOf(RustNamedElement::class.java)
-        declaration as RustNamedElement
+        assertThat(declaration).isInstanceOf(RustCompositeElement::class.java)
+        declaration as RustCompositeElement
 
 
         if (expectedOffset != null) {


### PR DESCRIPTION
Resolve to `RustCompositeElement` instead of `RustNamedElement`.

Resolving to `NamedElement` is both useless and wrong.

It is useless because an element can be renamed several times via `as` alias, so the name of the resolved element has no connection with the name of the referring element.

It is wrong because in fact it is possible to resolve to an anonymous element!

Example 1, tuple struct fields:

```Rust
#[derive(Default)]
struct Pair(String, i32);

fn main() {
    let p: Pair = Default::default();
    p.<caret>1; // this should resolve to the anonymous field of the Pair.
}
```

Example 2, the root module is always anonymous so `::` resolves to a nameless item. 

@alexeykudinkin what do you think about this? I think this is the right step in the direction of fixing #360.