### PR TITLE
(PSI): refactor RustNamedElement

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RustNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RustNamedElement.kt
@@ -8,7 +8,5 @@ interface RustNamedElement   : RustCompositeElement
                              , PsiNamedElement
                              , NavigatablePsiElement {
 
-    val nameElement: PsiElement?
-
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/RustQualifiedReferenceElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RustQualifiedReferenceElement.kt
@@ -52,7 +52,5 @@ interface RustQualifiedReferenceElement : RustNamedElement {
 
     val qualifier: RustQualifiedReferenceElement?
 
-    override val nameElement: PsiElement?
-
     override fun getReference(): RustReference
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/RustFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/RustFile.kt
@@ -26,8 +26,6 @@ import org.rust.lang.core.resolve.ref.RustReference
 class RustFile(fileViewProvider: FileViewProvider) : PsiFileBase(fileViewProvider, RustLanguage), RustMod {
     override fun getReference(): RustReference? = null
 
-    override val nameElement: PsiElement? = null
-
     override fun getFileType(): FileType = RustFileType
 
     override val items: List<RustItem>

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/RustNamedElementImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/RustNamedElementImpl.kt
@@ -8,7 +8,7 @@ import org.rust.lang.core.psi.RustNamedElement
 abstract class RustNamedElementImpl(node: ASTNode)   : RustCompositeElementImpl(node)
                                                      , RustNamedElement {
 
-    override val nameElement: PsiElement?
+    protected open val nameElement: PsiElement?
         get() = findChildByType(RustTokenElementTypes.IDENTIFIER)
 
     override fun getName(): String? = nameElement?.text

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/RustStubbedNamedElementImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/RustStubbedNamedElementImpl.kt
@@ -15,7 +15,7 @@ abstract class RustStubbedNamedElementImpl<StubT> : RustStubbedElementImpl<StubT
 
     constructor(stub: StubT, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
-    override val nameElement: PsiElement?
+    protected open val nameElement: PsiElement?
         get() = findChildByType(RustTokenElementTypes.IDENTIFIER)
 
     override fun getName(): String? = stub?.let { stub ->


### PR DESCRIPTION
Make `nameElement` an implementation detail, because it is one.

https://github.com/intellij-rust/intellij-rust/issues/360#issuecomment-215733855