### PR TITLE
Quick documentation support for resolved items.

### DIFF
--- a/src/main/kotlin/org/rust/ide/documentation/RustDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/documentation/RustDocumentationProvider.kt
@@ -1,12 +1,16 @@
 package org.rust.ide.documentation
 
 import com.intellij.lang.documentation.AbstractDocumentationProvider
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.text.MarkdownUtil
 import com.petebevin.markdown.MarkdownProcessor
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.impl.RustImplMethodMemberImpl
 import org.rust.lang.core.psi.impl.mixin.isMut
+import java.util.*
 
 class RustDocumentationProvider : AbstractDocumentationProvider() {
 
@@ -17,12 +21,10 @@ class RustDocumentationProvider : AbstractDocumentationProvider() {
                 return if (doc != null) formatDoc(element.name!!, doc)
                 else null
             }
-            // THIS IS A HACK UNTIL RustImplMethodMember IS A RustItem
-            // I have a hunch fixing that will also fix struct member resolution...
+            // Hack until there is a trait interface for "documentable" elements.
             is RustImplMethodMemberImpl -> {
-                val doc = element.documentation
-                return if (doc != null) formatDoc(element.name!!, doc)
-                else null
+                val doc = (element.outerDocumentationLinesForElement + element.innerDocumentationLinesForElement).joinToString("\n")
+                return formatDoc(element.name.orEmpty(), doc)
             }
             else -> {
                 return null
@@ -73,3 +75,66 @@ class RustDocumentationProvider : AbstractDocumentationProvider() {
     private val PsiElement.locationString: String
         get() = containingFile?.let { " [${it.name}]" }.orEmpty()
 }
+
+val RustItem.documentation: String?
+    get() {
+        return (outerDocumentationLinesForElement +
+            innerDocumentationLinesForElement).joinToString("\n")
+    }
+
+
+private val PsiElement.outerDocumentationLinesForElement: List<String>
+    get() {
+        // rustdoc appends the contents of each doc comment and doc attribute in order
+        // so we have to resolve these attributes that are edge-bound at the top of the
+        // children list.
+        val childOuterIterator = PsiTreeUtil.childIterator(this, PsiElement::class.java)
+        val lines: List<String> = ArrayList<String>().apply {
+            for (c in childOuterIterator) {
+                if (c !is RustOuterAttr && c !is PsiComment && c !is PsiWhiteSpace) {
+                    // All these outer elements have been edge bound; if we reach something that isn't one
+                    // of these, we have reached the actual parse children of this item.
+                    break
+                } else if (c is RustOuterAttr && c.metaItem.identifier.textMatches("doc")) {
+                    val s = (c.metaItem.litExpr)?.stringLiteral?.text?.removeSurrounding("\"")?.trim()
+                    if (s != null) add(s)
+                } else if (c is PsiComment && c.tokenType == RustTokenElementTypes.OUTER_DOC_COMMENT) {
+                    val s = c.text.substringAfter("///").trim()
+                    add(s)
+                }
+            }
+        }
+
+        return lines
+    }
+
+private val PsiElement.innerDocumentationLinesForElement: List<String>
+    get() {
+        // Next, we have to consider inner comments and meta. These, like the outer case, are appended in
+        // lexical order, after the outer elements. This only applies to functions and modules.
+        val lines: MutableList<String> = ArrayList()
+
+        val childBlock = PsiTreeUtil.findChildOfType(this, RustBlock::class.java)
+
+        if (childBlock != null) {
+            val childInnerIterator = PsiTreeUtil.childIterator(childBlock, PsiElement::class.java)
+            childInnerIterator.next() // skip the first open bracket ...
+            lines.apply {
+                for (c in childInnerIterator) {
+                    // We only consider comments and attributes at the beginning.
+                    // Technically, anything else is a syntax error.
+                    if (c !is RustInnerAttr && c !is PsiComment && c !is PsiWhiteSpace) {
+                        break
+                    } else if (c is RustInnerAttr && c.metaItem.identifier.textMatches("doc")) {
+                        val s = (c.metaItem.litExpr)?.stringLiteral?.text?.removeSurrounding("\"")?.trim()
+                        if (s != null) add(s)
+                    } else if (c is PsiComment && c.tokenType == RustTokenElementTypes.INNER_DOC_COMMENT) {
+                        val s = c.text.substringAfter("//!").trim()
+                        add(s)
+                    }
+                }
+            }
+        }
+
+        return lines
+    }

--- a/src/main/kotlin/org/rust/lang/core/grammar/rust.bnf
+++ b/src/main/kotlin/org/rust/lang/core/grammar/rust.bnf
@@ -610,10 +610,10 @@ impl_item ::= UNSAFE? IMPL generic_params type where_clause? impl_body
 impl_body ::= '{' inner_attr* impl_member* '}' { pin = 1 }
 
 // TODO: unify with trait_member?
-private impl_member ::= impl_method_member
-                      | impl_const_member
-                      | impl_macro_member
-                      | impl_type_member
+private impl_member ::= impl_method_member <<bindDocComments>>
+                      | impl_const_member <<bindDocComments>>
+                      | impl_macro_member <<bindDocComments>>
+                      | impl_type_member <<bindDocComments>>
 
 impl_method_member ::= attrs_and_vis fn_header method_parameters ret_type? where_clause? inner_attrs_and_block {
   pin = fn_header

--- a/src/main/kotlin/org/rust/lang/core/psi/RustNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RustNamedElement.kt
@@ -6,6 +6,5 @@ import com.intellij.psi.PsiNamedElement
 interface RustNamedElement   : RustCompositeElement
                              , PsiNamedElement
                              , NavigatablePsiElement {
-    val documentation: String?
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/RustNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RustNamedElement.kt
@@ -1,12 +1,11 @@
 package org.rust.lang.core.psi
 
 import com.intellij.psi.NavigatablePsiElement
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
 
 interface RustNamedElement   : RustCompositeElement
                              , PsiNamedElement
                              , NavigatablePsiElement {
-
+    val documentation: String?
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/RustFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/RustFile.kt
@@ -54,9 +54,6 @@ class RustFile(fileViewProvider: FileViewProvider) : PsiFileBase(fileViewProvide
 
     override val declarations: Collection<RustDeclaringElement>
         get() = items
-
-    override val documentation: String?
-        get() = RustNamedElementImpl.innerDocumentationLinesForElement(this).joinToString("\n")
 }
 
 

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/RustFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/RustFile.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.FileViewProvider
 import com.intellij.psi.PsiDirectory
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.cargo.util.crateRoots
@@ -55,6 +54,9 @@ class RustFile(fileViewProvider: FileViewProvider) : PsiFileBase(fileViewProvide
 
     override val declarations: Collection<RustDeclaringElement>
         get() = items
+
+    override val documentation: String?
+        get() = RustNamedElementImpl.innerDocumentationLinesForElement(this).joinToString("\n")
 }
 
 

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/RustNamedElementImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/RustNamedElementImpl.kt
@@ -1,12 +1,9 @@
 package org.rust.lang.core.psi.impl
 
 import com.intellij.lang.ASTNode
-import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiWhiteSpace
-import com.intellij.psi.util.PsiTreeUtil
-import org.rust.lang.core.psi.*
-import java.util.*
+import org.rust.lang.core.psi.RustNamedElement
+import org.rust.lang.core.psi.RustTokenElementTypes
 
 abstract class RustNamedElementImpl(node: ASTNode)   : RustCompositeElementImpl(node)
                                                      , RustNamedElement {
@@ -26,64 +23,4 @@ abstract class RustNamedElementImpl(node: ASTNode)   : RustCompositeElementImpl(
     override fun getNavigationElement(): PsiElement = nameElement ?: this
 
     override fun getTextOffset(): Int = nameElement?.textOffset ?: super.getTextOffset()
-
-    companion object {
-        fun outerDocumentationLinesForElement(psi: RustNamedElement): List<String> {
-            // rustdoc appends the contents of each doc comment and doc attribute in order
-            // so we have to resolve these attributes that are edge-bound at the top of the
-            // children list.
-            val childOuterIterator = PsiTreeUtil.childIterator(psi, PsiElement::class.java)
-            val lines: List<String> = ArrayList<String>().apply {
-                for (c in childOuterIterator) {
-                    if (c !is RustOuterAttr && c !is PsiComment && c !is PsiWhiteSpace) {
-                        // All these outer elements have been edge bound; if we reach something that isn't one
-                        // of these, we have reached the actual parse children of this item.
-                        break
-                    } else if (c is RustOuterAttr && c.metaItem?.identifier?.textMatches("doc") ?: false) {
-                        val s = (c.metaItem?.litExpr)?.stringLiteral?.text?.removeSurrounding("\"")?.trim()
-                        if (s != null) add(s)
-                    } else if (c is PsiComment && c.tokenType == RustTokenElementTypes.OUTER_DOC_COMMENT) {
-                        val s = c.text.substringAfter("///").trim()
-                        add(s)
-                    }
-                }
-            }
-
-            return lines
-        }
-
-        fun innerDocumentationLinesForElement(psi: RustNamedElement): List<String> {
-            // Next, we have to consider inner comments and meta. These, like the outer case, are appended in
-            // lexical order, after the outer elements. This only applies to functions and modules.
-            val lines: MutableList<String> = ArrayList()
-
-            val childBlock = PsiTreeUtil.findChildOfType(psi, RustBlock::class.java)
-
-            if (childBlock != null) {
-                val childInnerIterator = PsiTreeUtil.childIterator(childBlock, PsiElement::class.java)
-                childInnerIterator.next() // skip the first open bracket ...
-                lines.apply {
-                    for (c in childInnerIterator) {
-                        // We only consider comments and attributes at the beginning.
-                        // Technically, anything else is a syntax error.
-                        if (c !is RustInnerAttr && c !is PsiComment && c !is PsiWhiteSpace) {
-                            break
-                        } else if (c is RustInnerAttr && c.metaItem?.identifier?.textMatches("doc") ?: false) {
-                            val s = (c.metaItem?.litExpr)?.stringLiteral?.text?.removeSurrounding("\"")?.trim()
-                            if (s != null) add(s)
-                        } else if (c is PsiComment && c.tokenType == RustTokenElementTypes.INNER_DOC_COMMENT) {
-                            val s = c.text.substringAfter("//!").trim()
-                            add(s)
-                        }
-                    }
-                }
-            }
-
-            return lines
-        }
-    }
-
-    override val documentation: String?
-        get() = (outerDocumentationLinesForElement(this) +
-            innerDocumentationLinesForElement(this)).joinToString("\n")
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/RustNamedElementImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/RustNamedElementImpl.kt
@@ -1,9 +1,12 @@
 package org.rust.lang.core.psi.impl
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
-import org.rust.lang.core.psi.RustTokenElementTypes
-import org.rust.lang.core.psi.RustNamedElement
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.util.PsiTreeUtil
+import org.rust.lang.core.psi.*
+import java.util.*
 
 abstract class RustNamedElementImpl(node: ASTNode)   : RustCompositeElementImpl(node)
                                                      , RustNamedElement {
@@ -23,4 +26,64 @@ abstract class RustNamedElementImpl(node: ASTNode)   : RustCompositeElementImpl(
     override fun getNavigationElement(): PsiElement = nameElement ?: this
 
     override fun getTextOffset(): Int = nameElement?.textOffset ?: super.getTextOffset()
+
+    companion object {
+        fun outerDocumentationLinesForElement(psi: RustNamedElement): List<String> {
+            // rustdoc appends the contents of each doc comment and doc attribute in order
+            // so we have to resolve these attributes that are edge-bound at the top of the
+            // children list.
+            val childOuterIterator = PsiTreeUtil.childIterator(psi, PsiElement::class.java)
+            val lines: List<String> = ArrayList<String>().apply {
+                for (c in childOuterIterator) {
+                    if (c !is RustOuterAttr && c !is PsiComment && c !is PsiWhiteSpace) {
+                        // All these outer elements have been edge bound; if we reach something that isn't one
+                        // of these, we have reached the actual parse children of this item.
+                        break
+                    } else if (c is RustOuterAttr && c.metaItem?.identifier?.textMatches("doc") ?: false) {
+                        val s = (c.metaItem?.litExpr)?.stringLiteral?.text?.removeSurrounding("\"")?.trim()
+                        if (s != null) add(s)
+                    } else if (c is PsiComment && c.tokenType == RustTokenElementTypes.OUTER_DOC_COMMENT) {
+                        val s = c.text.substringAfter("///").trim()
+                        add(s)
+                    }
+                }
+            }
+
+            return lines
+        }
+
+        fun innerDocumentationLinesForElement(psi: RustNamedElement): List<String> {
+            // Next, we have to consider inner comments and meta. These, like the outer case, are appended in
+            // lexical order, after the outer elements. This only applies to functions and modules.
+            val lines: MutableList<String> = ArrayList()
+
+            val childBlock = PsiTreeUtil.findChildOfType(psi, RustBlock::class.java)
+
+            if (childBlock != null) {
+                val childInnerIterator = PsiTreeUtil.childIterator(childBlock, PsiElement::class.java)
+                childInnerIterator.next() // skip the first open bracket ...
+                lines.apply {
+                    for (c in childInnerIterator) {
+                        // We only consider comments and attributes at the beginning.
+                        // Technically, anything else is a syntax error.
+                        if (c !is RustInnerAttr && c !is PsiComment && c !is PsiWhiteSpace) {
+                            break
+                        } else if (c is RustInnerAttr && c.metaItem?.identifier?.textMatches("doc") ?: false) {
+                            val s = (c.metaItem?.litExpr)?.stringLiteral?.text?.removeSurrounding("\"")?.trim()
+                            if (s != null) add(s)
+                        } else if (c is PsiComment && c.tokenType == RustTokenElementTypes.INNER_DOC_COMMENT) {
+                            val s = c.text.substringAfter("//!").trim()
+                            add(s)
+                        }
+                    }
+                }
+            }
+
+            return lines
+        }
+    }
+
+    override val documentation: String?
+        get() = (outerDocumentationLinesForElement(this) +
+            innerDocumentationLinesForElement(this)).joinToString("\n")
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustImplMethodImplMixinMember.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustImplMethodImplMixinMember.kt
@@ -24,12 +24,6 @@ abstract class RustImplMethodImplMixinMember(node: ASTNode) : RustNamedElementIm
         }
         return iconWithVisibility(flags, icon)
     }
-
-    override val documentation: String?
-        get() {
-            return (RustNamedElementImpl.outerDocumentationLinesForElement(this) +
-                RustNamedElementImpl.innerDocumentationLinesForElement(this)).joinToString("\n")
-        }
 }
 
 val RustImplMethodMember.isStatic: Boolean get() = parameters?.selfArgument == null

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustImplMethodImplMixinMember.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustImplMethodImplMixinMember.kt
@@ -25,6 +25,11 @@ abstract class RustImplMethodImplMixinMember(node: ASTNode) : RustNamedElementIm
         return iconWithVisibility(flags, icon)
     }
 
+    override val documentation: String?
+        get() {
+            return (RustNamedElementImpl.outerDocumentationLinesForElement(this) +
+                RustNamedElementImpl.innerDocumentationLinesForElement(this)).joinToString("\n")
+        }
 }
 
 val RustImplMethodMember.isStatic: Boolean get() = parameters?.selfArgument == null

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustItemImplMixin.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustItemImplMixin.kt
@@ -4,7 +4,6 @@ import com.intellij.lang.ASTNode
 import com.intellij.navigation.ItemPresentation
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.impl.RustNamedElementImpl
 import org.rust.lang.core.psi.impl.RustStubbedNamedElementImpl
 import org.rust.lang.core.psi.impl.usefulName
 import org.rust.lang.core.stubs.RustItemStub
@@ -27,10 +26,6 @@ abstract class RustItemImplMixin : RustStubbedNamedElementImpl<RustItemStub>
 
         override fun getPresentableText(): String? = name
     }
-
-    override val documentation: String?
-        get() = (RustNamedElementImpl.outerDocumentationLinesForElement(this) +
-            RustNamedElementImpl.innerDocumentationLinesForElement(this)).joinToString("\n")
 }
 
 
@@ -42,12 +37,6 @@ class QueryAttributes(private val outerAttributes: List<RustOuterAttr>) {
      */
     fun findOuterAttr(name: String): RustOuterAttr? =
         outerAttributes.find { it.metaItem.identifier.textMatches(name) }
-
-    /**
-     * Find all the outer attributes with the given identifier.
-     */
-    fun filterOuterAttributes(name: String): List<RustOuterAttr> =
-        outerAttributes.filter { it.metaItem?.identifier?.textMatches(name) ?: false }
 
     fun hasAtomAttribute(name: String): Boolean =
         metaItems

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustItemImplMixin.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustItemImplMixin.kt
@@ -4,6 +4,7 @@ import com.intellij.lang.ASTNode
 import com.intellij.navigation.ItemPresentation
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.impl.RustNamedElementImpl
 import org.rust.lang.core.psi.impl.RustStubbedNamedElementImpl
 import org.rust.lang.core.psi.impl.usefulName
 import org.rust.lang.core.stubs.RustItemStub
@@ -26,14 +27,27 @@ abstract class RustItemImplMixin : RustStubbedNamedElementImpl<RustItemStub>
 
         override fun getPresentableText(): String? = name
     }
+
+    override val documentation: String?
+        get() = (RustNamedElementImpl.outerDocumentationLinesForElement(this) +
+            RustNamedElementImpl.innerDocumentationLinesForElement(this)).joinToString("\n")
 }
 
 
 val RustItem.queryAttributes: QueryAttributes get() = QueryAttributes(outerAttrList)
 
 class QueryAttributes(private val outerAttributes: List<RustOuterAttr>) {
+    /**
+     * Find the first outer attribute with the given identifier.
+     */
     fun findOuterAttr(name: String): RustOuterAttr? =
         outerAttributes.find { it.metaItem.identifier.textMatches(name) }
+
+    /**
+     * Find all the outer attributes with the given identifier.
+     */
+    fun filterOuterAttributes(name: String): List<RustOuterAttr> =
+        outerAttributes.filter { it.metaItem?.identifier?.textMatches(name) ?: false }
 
     fun hasAtomAttribute(name: String): Boolean =
         metaItems


### PR DESCRIPTION
Implements quick documentation in the Documentation Provider by adding a read-only property `documentation: String?` on `RustNamedItem`. This is not _quite_ the right way to go about implementing this, but it is robust enough that it works over all resolved items.

The Markdown parser available in the IntelliJ API is not quite suitable for formatting the documentation string. It does not properly handle the HTML entity codes necessary to provide space indentation in code blocks, nor does it handle things like strikethrough.

A continued improvement would be to provide the full declaration at the top of the documentation text (i.e. instead of just the name, show `pub fn the_function(t: isize) -> isize`) for functions, and visibility for traits structs and enums.

Fixes #370 