### PR TITLE
(T, MISC): fix bad eol handling

### DIFF
--- a/src/test/kotlin/org/rust/ide/documentation/RustDocumentationProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/documentation/RustDocumentationProviderTest.kt
@@ -3,7 +3,6 @@ package org.rust.ide.documentation
 import com.intellij.codeInsight.documentation.DocumentationManager
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.psi.PsiElement
-import org.assertj.core.api.Assertions.assertThat
 import org.rust.lang.RustTestCaseBase
 import java.io.File
 
@@ -17,6 +16,6 @@ abstract class RustDocumentationProviderTest : RustTestCaseBase() {
         val originalElement = myFixture.elementAtCaret
         val element = DocumentationManager.getInstance(project).findTargetElement(myFixture.editor, myFixture.file)
         val actual = block(element, originalElement)?.trim()
-        assertThat(actual).isEqualTo(expected)
+        assertSameLines(expected, actual)
     }
 }

--- a/src/test/kotlin/org/rust/ide/documentation/RustQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/documentation/RustQuickDocumentationTest.kt
@@ -11,4 +11,3 @@ class RustQuickDocumentationTest : RustDocumentationProviderTest() {
         RustDocumentationProvider().generateDoc(element, originalElement)
     }
 }
-


### PR DESCRIPTION
These tests failed on Windows because `assertThat(actual).isEqualTo(expected)` doesn't differentiate between `\n` and `\r\n`