### PR TITLE
(RES): change ModuleIndex algorithm

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RustModulesIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RustModulesIndex.kt
@@ -1,40 +1,46 @@
 package org.rust.lang.core.resolve.indexes
 
-import com.intellij.openapi.module.Module
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.indexing.FileBasedIndex
 import com.intellij.util.indexing.ID
-import org.rust.lang.core.names.RustQualifiedName
+import org.rust.cargo.util.getPsiFor
 import org.rust.lang.core.psi.RustMod
 import org.rust.lang.core.psi.impl.RustFile
-import org.rust.lang.core.psi.impl.cratePath
-import org.rust.lang.core.psi.util.module
-import org.rust.lang.core.resolve.RustResolveEngine
+import org.rust.lang.core.psi.util.parentOfType
 
-interface RustModulesIndex {
+object RustModulesIndex {
+    val ID: ID<RustModulesIndexExtension.Key, RustModulesIndexExtension.Value> =
+        com.intellij.util.indexing.ID.create("org.rust.lang.indexes.RustModulesIndex")
 
-    companion object {
+    fun getSuperFor(mod: RustFile): RustMod? {
+        val project = mod.project
+        val key = getKey(mod) ?: return null
 
-        val ID: ID<RustCratePath, RustQualifiedName> =
-            com.intellij.util.indexing.ID.create("org.rust.lang.indexes.RustModulesIndex")
+        var result: RustMod? = null
+        FileBasedIndex.getInstance().processValues(ID, key, null, { file, value ->
+            val reference = project.getPsiFor(file)?.findReferenceAt(value.referenceOffset)
+                ?: return@processValues true
 
-        fun getSuperFor(mod: RustFile): RustMod? =
-            mod.containingFile.originalFile.let { file ->
-                mod.module?.let { module ->
-                    file.cratePath?.let { path ->
-                        findByHeterogeneous(
-                            FileBasedIndex.getInstance()
-                                .getValues(ID, path, GlobalSearchScope.allScope(module.project))
-                                .firstOrNull(),
-                            module
-                        )
-                    }
-                }
+            if (reference.resolve() == mod.originalFile) {
+                result = reference.element.parentOfType<RustMod>()
+                false
+            } else {
+                true
             }
+        }, GlobalSearchScope.allScope(project) )
 
-        private fun findByHeterogeneous(path: RustQualifiedName?, module: Module): RustMod? =
-            path?.let {
-                RustResolveEngine.resolve(path, module).resolved as RustMod?
-            }
+        return result
+    }
+
+    private fun getKey(file: RustFile): RustModulesIndexExtension.Key? {
+        val name = if (file.name != RustMod.MOD_RS)
+            FileUtil.getNameWithoutExtension(file.name)
+        else
+            file.parent?.name
+
+        return name?.let {
+            RustModulesIndexExtension.Key(it)
+        }
     }
 }

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectResolveTestCase.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoProjectResolveTestCase.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiReference
+import com.intellij.util.indexing.FileBasedIndex
 import org.assertj.core.api.Assertions.assertThat
 import org.rust.cargo.RustWithToolchainTestCaseBase
 import org.rust.cargo.project.settings.toolchain
@@ -13,6 +14,7 @@ import org.rust.cargo.project.workspace.CargoProjectWorkspace
 import org.rust.cargo.project.workspace.CargoProjectWorkspaceListener
 import org.rust.cargo.project.workspace.CargoProjectWorkspaceListener.UpdateResult
 import org.rust.cargo.util.getComponentOrThrow
+import org.rust.lang.core.resolve.indexes.RustModulesIndex
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 
@@ -33,9 +35,16 @@ class CargoProjectResolveTestCase : RustWithToolchainTestCaseBase() {
             reference.resolve()
         }
 
+        // make sure that indexes do not depend on cargo project
+        populateIndexes()
+
         updateCargoProject()
 
         assertThat(f.get(TIMEOUT, TimeUnit.MILLISECONDS)).isNotNull()
+    }
+
+    private fun populateIndexes() {
+        FileBasedIndex.getInstance().getAllKeys(RustModulesIndex.ID, myProject)
     }
 
     private fun <T> bindToProjectUpdateEvent(callback: (UpdateResult) -> T): Future<T> {


### PR DESCRIPTION
Module index stores a mapping from names to mod_decls. Each mod decl is
represented as an offset in the file.

Finding a super module for a given file is a two step process.

First, mod_decl candidates are found in the index based on their
names (this may give false positives).

Then, each candidate is resovled and if it resolves to the target
file (modulo usual complication with the `origianlFile` for completion),
then it is the answer.

closes #421 

Looks like I have not hit a roadblock. Tests pass and looks like it actually works :) 
@alexeykudinkin please review