### PR TITLE
(PSI): Fix assertion related to Self type in impls

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustPathImplMixin.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustPathImplMixin.kt
@@ -14,7 +14,7 @@ abstract class RustPathImplMixin(node: ASTNode) : RustNamedElementImpl(node)
     override fun getReference(): RustReference = RustQualifiedReferenceImpl(this)
 
     override val nameElement: PsiElement?
-        get() = identifier ?: self ?: `super`
+        get() = identifier ?: self ?: `super` ?: cself
 
     override val qualifier: RustQualifiedReferenceElement? get() = path
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RustResolveTestCase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RustResolveTestCase.kt
@@ -35,6 +35,8 @@ class RustResolveTestCase : RustResolveTestCaseBase() {
     fun testEnumField()           = checkIsBound()
     fun testNonGlobalPathWithColons() = checkIsBound()
 
+    fun testSelfType()            = checkIsUnbound() // TODO: some form of resolve for Self should be implemented
+
     fun testLetCycle1()           = checkIsUnbound()
     fun testLetCycle3()           = checkIsUnbound()
     fun testUnbound()             = checkIsUnbound()

--- a/src/test/resources/org/rust/lang/core/resolve/fixtures/self_type.rs
+++ b/src/test/resources/org/rust/lang/core/resolve/fixtures/self_type.rs
@@ -1,0 +1,11 @@
+struct DumbIterator<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> Iterator for DumbIterator<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<S<caret>elf::Item> {
+        None
+    }
+}


### PR DESCRIPTION
This adds a resolve test a a way to trigger the assertion, but it seems that actually implementing resolve for Self right now is hard, so the test just checks for Self not resolving. If this is not desirable, I can drop the test altogether.