### PR TITLE
Improve SemicolonsFixer in smart enter action

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/smartenter/SemicolonFixer.kt
+++ b/src/main/kotlin/org/rust/ide/actions/smartenter/SemicolonFixer.kt
@@ -3,43 +3,27 @@ package org.rust.ide.actions.smartenter
 import com.intellij.lang.SmartEnterProcessorWithFixers
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiWhiteSpace
-import org.rust.lang.core.psi.RustCallExpr
-import org.rust.lang.core.psi.RustLetDecl
-import org.rust.lang.core.psi.util.parentOfType
+import org.rust.lang.core.psi.*
 
 /**
  * Fixer that adds missing semicolons at the end of statements.
  */
 class SemicolonFixer : SmartEnterProcessorWithFixers.Fixer<RustSmartEnterProcessor>() {
     override fun apply(editor: Editor, processor: RustSmartEnterProcessor, element: PsiElement) {
-        fixMethodCall(editor, element)
-        fixDeclaration(editor, element)
+        fixStatement(editor, element)
+        fixLastExprInBlock(editor, element)
     }
 
-    private fun fixMethodCall(editor: Editor, element: PsiElement) {
-        if (isOutermostCallExpr(element) && !endsWithSemicolon(element)) {
+    private fun fixLastExprInBlock(editor: Editor, element: PsiElement) {
+        val parent = element.parent
+        if (parent is RustBlock && element == parent.expr) {
             editor.document.insertString(element.textRange.endOffset, ";")
         }
     }
 
-    private fun fixDeclaration(editor: Editor, element: PsiElement) {
-        if (element is RustLetDecl && element.semicolon == null) {
+    private fun fixStatement(editor: Editor, element: PsiElement) {
+        if (element is RustStmt && element.semicolon == null) {
             editor.document.insertString(element.textRange.endOffset, ";")
         }
-    }
-
-    private fun isOutermostCallExpr(element: PsiElement): Boolean {
-        return element is RustCallExpr && element.parentOfType<RustCallExpr>() == null
-    }
-
-    private fun endsWithSemicolon(element: PsiElement): Boolean {
-        if (element.nextSibling != null) {
-            if (element.nextSibling is PsiWhiteSpace) {
-                return endsWithSemicolon(element.nextSibling)
-            }
-            return element.nextSibling.text == ";"
-        }
-        return false
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/grammar/rust.bnf
+++ b/src/main/kotlin/org/rust/lang/core/grammar/rust.bnf
@@ -1098,7 +1098,7 @@ inner_attrs_and_block ::= '{' inner_attr* block_tail '}' {
 
 private block_tail ::= (stmt | docs_and_item)* any_expr?
 
-stmt ::= expr_stmt | let_decl | empty_stmt
+stmt ::= expr_stmt | let_decl | empty_stmt | never ';'
 
 expr_stmt ::= outer_attr? ( block_expr !('.' | '?') ';'? | any_expr ';' ) {
   extends = stmt

--- a/src/test/kotlin/org/rust/ide/actions/smartenter/RustSmartEnterProcessorTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/smartenter/RustSmartEnterProcessorTest.kt
@@ -40,4 +40,6 @@ class RustSmartEnterProcessorTest : RustTestCaseBase() {
     fun testFixWhitespaceAndSemicolon() = doTest()
     fun testFixSemicolonAfterDeclaration() = doTest()
     fun testFixDeclarationWithCall() = doTest()
+    fun testFixMatchInLet() = doTest()
+    fun testFixCallInStmt() = doTest()
 }

--- a/src/test/resources/org/rust/ide/actions/smartenter/fixtures/fix_call_in_stmt.rs
+++ b/src/test/resources/org/rust/ide/actions/smartenter/fixtures/fix_call_in_stmt.rs
@@ -1,0 +1,4 @@
+fn f(s: String) {
+    <caret>f(
+    let x = 5;
+}

--- a/src/test/resources/org/rust/ide/actions/smartenter/fixtures/fix_call_in_stmt_after.rs
+++ b/src/test/resources/org/rust/ide/actions/smartenter/fixtures/fix_call_in_stmt_after.rs
@@ -1,0 +1,5 @@
+fn f(s: String) {
+    f();
+
+    let x = 5;
+}

--- a/src/test/resources/org/rust/ide/actions/smartenter/fixtures/fix_match_in_let.rs
+++ b/src/test/resources/org/rust/ide/actions/smartenter/fixtures/fix_match_in_let.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let version_req = match version {
+        Some(v) => try!(VersionReq::parse(v)),
+        None => VersionReq::any()
+    }<caret>
+}

--- a/src/test/resources/org/rust/ide/actions/smartenter/fixtures/fix_match_in_let_after.rs
+++ b/src/test/resources/org/rust/ide/actions/smartenter/fixtures/fix_match_in_let_after.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let version_req = match version {
+        Some(v) => try!(VersionReq::parse(v)),
+        None => VersionReq::any()
+    };
+
+}


### PR DESCRIPTION
Smart enter action did bogus things in `fix_match_in_let.rs` test case, so I simplified/fixed the implementation and added some tests.

The new implementation uncovers an interesting question: should a smart enter action in Rust always insert a semicolon when used for the last expression in a block? I think that it should, and the previously existing tests already require this behavior.