### PR TITLE
(MISC): Impl blocks without traits are inherent, not inherited

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/RustStructType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RustStructType.kt
@@ -18,7 +18,7 @@ class RustStructType(val struct: RustStructItemElement) : RustType {
      * There may be several `impl` blocks for the same type and they may
      * be spread across different files and modules (we don't handle this yet)
      */
-    val inheritedImpls: Collection<RustImplItemElement> by lazy {
+    val inherentImpls: Collection<RustImplItemElement> by lazy {
         struct.parentOfType<RustMod>()
             ?.itemList.orEmpty()
                 .filterIsInstance<RustImplItemElement>()
@@ -26,7 +26,7 @@ class RustStructType(val struct: RustStructItemElement) : RustType {
     }
 
     val allMethods: Collection<RustImplMethodMemberElement>
-        get() = inheritedImpls.flatMap { it.implBody?.implMethodMemberList.orEmpty() }
+        get() = inherentImpls.flatMap { it.implBody?.implMethodMemberList.orEmpty() }
 
     val nonStaticMethods: Collection<RustImplMethodMemberElement>
         get() = allMethods.filter { !it.isStatic }


### PR DESCRIPTION
For example, see [syntax index](https://doc.rust-lang.org/book/syntax-index.html) for `impl` keyword.