### PR TITLE
(COM): Add derivable trait completion

### DIFF
--- a/src/main/kotlin/org/rust/ide/completion/DeriveCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/ide/completion/DeriveCompletionProvider.kt
@@ -1,0 +1,63 @@
+package org.rust.ide.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.patterns.ElementPattern
+import com.intellij.patterns.PlatformPatterns.psiElement
+import com.intellij.psi.PsiElement
+import com.intellij.util.ProcessingContext
+import org.rust.lang.RustLanguage
+import org.rust.lang.core.parser.RustPsiTreeUtil
+import org.rust.lang.core.psi.RustCompositeElementTypes
+import org.rust.lang.core.psi.RustMetaItemElement
+import org.rust.lang.core.psi.RustTokenElementTypes
+import org.rust.lang.core.resolve.util.RustResolveUtil
+
+class DeriveCompletionProvider : CompletionProvider<CompletionParameters>() {
+
+    private val DERIVABLE_TRAITS = listOf("Eq", "PartialEq", "Ord", "PartialOrd", "Copy", "Clone", "Hash", "Default",
+        "Debug")
+
+    override fun addCompletions(parameters: CompletionParameters,
+                                context: ProcessingContext?,
+                                result: CompletionResultSet) {
+
+        val outerAttrElem = RustResolveUtil.getResolveScopeFor(parameters.position)?.firstChild
+        val deriveMetaItem = RustPsiTreeUtil.getChildOfType(outerAttrElem, RustMetaItemElement::class.java)
+        val alreadyDerived = RustPsiTreeUtil.getChildrenOfType(deriveMetaItem, RustMetaItemElement::class.java)
+            ?.mapNotNull { it.firstChild.text }.orEmpty()
+        val lookupElements = DERIVABLE_TRAITS.filter { !alreadyDerived.contains(it) }
+            .map { LookupElementBuilder.create(it) }
+        result.addAllElements(lookupElements)
+    }
+
+    companion object ElementPatternFactory {
+        val elementPattern: ElementPattern<PsiElement> get() {
+
+            val deriveIdentifier = psiElement()
+                .withElementType(RustTokenElementTypes.IDENTIFIER)
+                .withText("derive")
+
+            val outerAttr = psiElement()
+                .withElementType(RustCompositeElementTypes.OUTER_ATTR)
+
+            val openParen = psiElement().withElementType(RustTokenElementTypes.LPAREN)
+
+            val traitEntry = psiElement(RustCompositeElementTypes.META_ITEM)
+                .afterLeafSkipping(openParen, deriveIdentifier)
+
+            val deriveMetaItem = psiElement()
+                .withElementType(RustCompositeElementTypes.META_ITEM)
+                .withFirstChild(traitEntry)
+                .withParent(outerAttr)
+
+            val traitMetaItem = psiElement()
+                .withElementType(RustCompositeElementTypes.META_ITEM)
+                .withParent(deriveMetaItem)
+
+            return psiElement().inside(traitMetaItem).withLanguage(RustLanguage);
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/completion/RustCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/ide/completion/RustCompletionContributor.kt
@@ -1,0 +1,11 @@
+package org.rust.ide.completion
+
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionType
+
+class RustCompletionContributor : CompletionContributor() {
+
+    init {
+        extend(CompletionType.BASIC, DeriveCompletionProvider.elementPattern, DeriveCompletionProvider())
+    }
+}

--- a/src/main/kotlin/org/rust/ide/completion/RustCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/ide/completion/RustCompletionContributor.kt
@@ -6,6 +6,6 @@ import com.intellij.codeInsight.completion.CompletionType
 class RustCompletionContributor : CompletionContributor() {
 
     init {
-        extend(CompletionType.BASIC, DeriveCompletionProvider.elementPattern, DeriveCompletionProvider())
+        extend(CompletionType.BASIC, DeriveCompletionProvider.elementPattern, DeriveCompletionProvider)
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -87,6 +87,9 @@
         <annotator language="RUST" implementationClass="org.rust.ide.annotator.RustExpressionAnnotator"/>
         <annotator language="RUST" implementationClass="org.rust.ide.annotator.RustInvalidSyntaxAnnotator"/>
 
+        <!-- Completion -->
+        <completion.contributor language="RUST" implementationClass="org.rust.ide.completion.RustCompletionContributor"/>
+
         <!-- Description Provider -->
 
         <elementDescriptionProvider implementation="org.rust.ide.RustDescriptionProvider"/>

--- a/src/test/kotlin/org/rust/completion/RustDeriveCompletionTest.kt
+++ b/src/test/kotlin/org/rust/completion/RustDeriveCompletionTest.kt
@@ -1,43 +1,21 @@
 package org.rust.completion
 
-import com.intellij.codeInsight.completion.CompletionType
-import org.rust.lang.RustTestCaseBase
+import org.rust.lang.core.completion.RustCompletionTestBase
 
-class RustDeriveCompletionTest : RustTestCaseBase() {
+class RustDeriveCompletionTest : RustCompletionTestBase() {
     override val dataPath = "org/rust/ide/completion/fixtures/derive_traits/"
 
-    fun testCompleteOnStruct() = checkByFile {
-        openFileInEditor("complete_on_struct.rs")
-        myFixture.complete(CompletionType.BASIC)
-    }
+    fun testCompleteOnStruct() = checkSoleCompletion()
 
-    fun testCompleteOnEnum() = checkByFile {
-        openFileInEditor("complete_on_enum.rs")
-        myFixture.complete(CompletionType.BASIC)
-    }
+    fun testCompleteOnEnum() = checkSoleCompletion()
 
-    fun testDoesntCompleteOnFn() = checkByFile {
-        openFileInEditor("doesnt_complete_on_fn.rs")
-        myFixture.complete(CompletionType.BASIC)
-    }
+    fun testDoesntCompleteOnFn() = checkNoCompletion()
 
-    fun testDoesntCompleteOnMod() = checkByFile {
-        openFileInEditor("doesnt_complete_on_mod.rs")
-        myFixture.complete(CompletionType.BASIC)
-    }
+    fun testDoesntCompleteOnMod() = checkNoCompletion()
 
-    fun testDoesntCompleteNonDeriveAttr() = checkByFile {
-        openFileInEditor("doesnt_complete_non_derive_attr.rs")
-        myFixture.complete(CompletionType.BASIC)
-    }
+    fun testDoesntCompleteNonDeriveAttr() = checkNoCompletion()
 
-    fun testDoesntCompleteInnerAttr() = checkByFile {
-        openFileInEditor("doesnt_complete_inner_attr.rs")
-        myFixture.complete(CompletionType.BASIC)
-    }
+    fun testDoesntCompleteInnerAttr() = checkNoCompletion()
 
-    fun testDoesntCompleteAlreadyDerived() = checkByFile {
-        openFileInEditor("doesnt_complete_already_derived.rs")
-        myFixture.complete(CompletionType.BASIC)
-    }
+    fun testDoesntCompleteAlreadyDerived() = checkNoCompletion()
 }

--- a/src/test/kotlin/org/rust/completion/RustDeriveCompletionTest.kt
+++ b/src/test/kotlin/org/rust/completion/RustDeriveCompletionTest.kt
@@ -1,0 +1,43 @@
+package org.rust.completion
+
+import com.intellij.codeInsight.completion.CompletionType
+import org.rust.lang.RustTestCaseBase
+
+class RustDeriveCompletionTest : RustTestCaseBase() {
+    override val dataPath = "org/rust/ide/completion/fixtures/derive_traits/"
+
+    fun testCompleteOnStruct() = checkByFile {
+        openFileInEditor("complete_on_struct.rs")
+        myFixture.complete(CompletionType.BASIC)
+    }
+
+    fun testCompleteOnEnum() = checkByFile {
+        openFileInEditor("complete_on_enum.rs")
+        myFixture.complete(CompletionType.BASIC)
+    }
+
+    fun testDoesntCompleteOnFn() = checkByFile {
+        openFileInEditor("doesnt_complete_on_fn.rs")
+        myFixture.complete(CompletionType.BASIC)
+    }
+
+    fun testDoesntCompleteOnMod() = checkByFile {
+        openFileInEditor("doesnt_complete_on_mod.rs")
+        myFixture.complete(CompletionType.BASIC)
+    }
+
+    fun testDoesntCompleteNonDeriveAttr() = checkByFile {
+        openFileInEditor("doesnt_complete_non_derive_attr.rs")
+        myFixture.complete(CompletionType.BASIC)
+    }
+
+    fun testDoesntCompleteInnerAttr() = checkByFile {
+        openFileInEditor("doesnt_complete_inner_attr.rs")
+        myFixture.complete(CompletionType.BASIC)
+    }
+
+    fun testDoesntCompleteAlreadyDerived() = checkByFile {
+        openFileInEditor("doesnt_complete_already_derived.rs")
+        myFixture.complete(CompletionType.BASIC)
+    }
+}

--- a/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/complete_on_enum.rs
+++ b/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/complete_on_enum.rs
@@ -1,0 +1,4 @@
+#[derive(PartialE<caret>)]
+enum Test {
+    Something
+}

--- a/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/complete_on_enum_after.rs
+++ b/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/complete_on_enum_after.rs
@@ -1,0 +1,4 @@
+#[derive(PartialEq)]
+enum Test {
+    Something
+}

--- a/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/complete_on_struct.rs
+++ b/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/complete_on_struct.rs
@@ -1,0 +1,4 @@
+#[derive(PartialE<caret>)]
+struct Test {
+    foo: u8
+}

--- a/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/complete_on_struct_after.rs
+++ b/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/complete_on_struct_after.rs
@@ -1,0 +1,4 @@
+#[derive(PartialEq)]
+struct Test {
+    foo: u8
+}

--- a/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_already_derived.rs
+++ b/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_already_derived.rs
@@ -1,0 +1,4 @@
+#[derive(PartialEq, PartialE<caret>)]
+enum Test {
+    Something
+}

--- a/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_already_derived_after.rs
+++ b/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_already_derived_after.rs
@@ -1,0 +1,4 @@
+#[derive(PartialEq, PartialE)]
+enum Test {
+    Something
+}

--- a/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_inner_attr.rs
+++ b/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_inner_attr.rs
@@ -1,0 +1,3 @@
+mod bar {
+    #![derive(PartialE<caret>)]
+}

--- a/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_inner_attr_after.rs
+++ b/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_inner_attr_after.rs
@@ -1,0 +1,3 @@
+mod bar {
+    #![derive(PartialE)]
+}

--- a/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_non_derive_attr.rs
+++ b/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_non_derive_attr.rs
@@ -1,0 +1,4 @@
+#[foo(PartialE<caret>)]
+enum Test {
+    Something
+}

--- a/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_non_derive_attr_after.rs
+++ b/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_non_derive_attr_after.rs
@@ -1,0 +1,4 @@
+#[foo(PartialE)]
+enum Test {
+    Something
+}

--- a/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_on_fn.rs
+++ b/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_on_fn.rs
@@ -1,0 +1,3 @@
+#[foo(PartialE<caret>)]
+fn foo() {
+}

--- a/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_on_fn_after.rs
+++ b/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_on_fn_after.rs
@@ -1,0 +1,3 @@
+#[foo(PartialE)]
+fn foo() {
+}

--- a/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_on_mod.rs
+++ b/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_on_mod.rs
@@ -1,0 +1,3 @@
+#[foo(PartialE<caret>)]
+mod foo() {
+}

--- a/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_on_mod_after.rs
+++ b/src/test/resources/org/rust/ide/completion/fixtures/derive_traits/doesnt_complete_on_mod_after.rs
@@ -1,0 +1,3 @@
+#[foo(PartialE)]
+mod foo() {
+}


### PR DESCRIPTION
This PR adds autocompletion for derivable traits.  It's pretty naive right now, only omitting suggestions for traits that have already been specified in the `derive` attribute.  Eventually, I would like it to omit suggestions for traits that can't be derived (not suggesting `Copy` for a struct that has non-Copy fields, for example), and traits that have already been manually implemented.