### PR TITLE
(HIGHLIGHTER): re-highlight literals in attributes

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RustHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RustHighlightingAnnotator.kt
@@ -2,16 +2,27 @@ package org.rust.ide.annotator
 
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
+import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.psi.PsiElement
 import org.rust.ide.colors.RustColor
+import org.rust.ide.highlight.syntax.RustHighlighter
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.impl.mixin.isMut
+import org.rust.lang.core.psi.util.elementType
 
 // Highlighting logic here should be kept in sync with tags in RustColorSettingsPage
 class RustHighlightingAnnotator : Annotator {
     override fun annotate(element: PsiElement, holder: AnnotationHolder) = element.accept(object : RustElementVisitor() {
         override fun visitAttr(o: RustAttrElement) {
             holder.highlight(o, RustColor.ATTRIBUTE)
+        }
+
+        override fun visitLitExpr(o: RustLitExprElement) {
+            // Re-highlight literals in attributes
+            if (o.parent is RustMetaItemElement) {
+                val literal = o.firstChild
+                holder.highlight(literal, RustHighlighter.map(literal.elementType))
+            }
         }
 
         override fun visitMacroInvocation(m: RustMacroInvocationElement) {
@@ -50,10 +61,14 @@ class RustHighlightingAnnotator : Annotator {
             holder.highlight(o.identifier, color)
         }
     })
-}
 
-private fun AnnotationHolder.highlight(element: PsiElement?, color: RustColor) {
-    if (element != null) {
-        createInfoAnnotation(element, null).textAttributes = color.textAttributesKey
+    private fun AnnotationHolder.highlight(element: PsiElement?, color: RustColor?) {
+        highlight(element, color?.textAttributesKey)
+    }
+
+    private fun AnnotationHolder.highlight(element: PsiElement?, textAttributesKey: TextAttributesKey?) {
+        if (element != null && textAttributesKey != null) {
+            createInfoAnnotation(element, null).textAttributes = textAttributesKey
+        }
     }
 }

--- a/src/main/kotlin/org/rust/ide/highlight/syntax/RustHighlighter.kt
+++ b/src/main/kotlin/org/rust/ide/highlight/syntax/RustHighlighter.kt
@@ -15,40 +15,42 @@ class RustHighlighter : SyntaxHighlighterBase() {
 
     override fun getTokenHighlights(tokenType: IElementType?) = pack(map(tokenType))
 
-    private fun map(tokenType: IElementType?): TextAttributesKey? = when (tokenType) {
-        is RustKeywordTokenType        -> RustColor.KEYWORD
+    companion object {
+        fun map(tokenType: IElementType?): TextAttributesKey? = when (tokenType) {
+            is RustKeywordTokenType        -> RustColor.KEYWORD
 
-        IDENTIFIER                     -> RustColor.IDENTIFIER
+            IDENTIFIER                     -> RustColor.IDENTIFIER
 
-        LIFETIME                       -> RustColor.LIFETIME
+            LIFETIME                       -> RustColor.LIFETIME
 
-        CHAR_LITERAL                   -> RustColor.CHAR
-        BYTE_LITERAL                   -> RustColor.CHAR
-        STRING_LITERAL                 -> RustColor.STRING
-        BYTE_STRING_LITERAL            -> RustColor.STRING
-        RAW_STRING_LITERAL             -> RustColor.STRING
-        RAW_BYTE_STRING_LITERAL        -> RustColor.STRING
-        INTEGER_LITERAL                -> RustColor.NUMBER
-        FLOAT_LITERAL                  -> RustColor.NUMBER
+            CHAR_LITERAL                   -> RustColor.CHAR
+            BYTE_LITERAL                   -> RustColor.CHAR
+            STRING_LITERAL                 -> RustColor.STRING
+            BYTE_STRING_LITERAL            -> RustColor.STRING
+            RAW_STRING_LITERAL             -> RustColor.STRING
+            RAW_BYTE_STRING_LITERAL        -> RustColor.STRING
+            INTEGER_LITERAL                -> RustColor.NUMBER
+            FLOAT_LITERAL                  -> RustColor.NUMBER
 
-        BLOCK_COMMENT                  -> RustColor.BLOCK_COMMENT
-        EOL_COMMENT                    -> RustColor.EOL_COMMENT
+            BLOCK_COMMENT                  -> RustColor.BLOCK_COMMENT
+            EOL_COMMENT                    -> RustColor.EOL_COMMENT
 
-        INNER_DOC_COMMENT              -> RustColor.DOC_COMMENT
-        OUTER_DOC_COMMENT              -> RustColor.DOC_COMMENT
+            INNER_DOC_COMMENT              -> RustColor.DOC_COMMENT
+            OUTER_DOC_COMMENT              -> RustColor.DOC_COMMENT
 
-        LPAREN, RPAREN                 -> RustColor.PARENTHESIS
-        LBRACE, RBRACE                 -> RustColor.BRACES
-        LBRACK, RBRACK                 -> RustColor.BRACKETS
+            LPAREN, RPAREN                 -> RustColor.PARENTHESIS
+            LBRACE, RBRACE                 -> RustColor.BRACES
+            LBRACK, RBRACK                 -> RustColor.BRACKETS
 
-        SEMICOLON                      -> RustColor.SEMICOLON
-        DOT                            -> RustColor.DOT
-        COMMA                          -> RustColor.COMMA
+            SEMICOLON                      -> RustColor.SEMICOLON
+            DOT                            -> RustColor.DOT
+            COMMA                          -> RustColor.COMMA
 
-        VALID_STRING_ESCAPE_TOKEN      -> RustColor.VALID_STRING_ESCAPE
-        INVALID_CHARACTER_ESCAPE_TOKEN -> RustColor.INVALID_STRING_ESCAPE
-        INVALID_UNICODE_ESCAPE_TOKEN   -> RustColor.INVALID_STRING_ESCAPE
+            VALID_STRING_ESCAPE_TOKEN      -> RustColor.VALID_STRING_ESCAPE
+            INVALID_CHARACTER_ESCAPE_TOKEN -> RustColor.INVALID_STRING_ESCAPE
+            INVALID_UNICODE_ESCAPE_TOKEN   -> RustColor.INVALID_STRING_ESCAPE
 
-        else                           -> null
-    }?.textAttributesKey
+            else                           -> null
+        }?.textAttributesKey
+    }
 }

--- a/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
+++ b/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
@@ -22,7 +22,7 @@ fn <function-decl>main</function-decl>() {
 }
 
 /// Some documentation
-<attribute>#[cfg(target_os="linux")]</attribute>
+<attribute>#[cfg(target_os=</attribute>"linux"<attribute>)]</attribute>
 unsafe fn <function-decl>a_function</function-decl><<type-parameter>T</type-parameter>: 'lifetime>() {
     'label: loop {
         println!("Hello\x20W\u{f3}rld!\u{abcdef}");

--- a/src/test/resources/org/rust/ide/annotator/fixtures/attributes.rs
+++ b/src/test/resources/org/rust/ide/annotator/fixtures/attributes.rs
@@ -1,4 +1,4 @@
 <info>#[cfg_attr(foo)]</info>
 fn <info>main</info>() {
-    <info>#![crate_type = "lib"]</info>
+    <info>#![crate_type = <info>"lib"</info>]</info>
 }


### PR DESCRIPTION
Before:
![idea_2016-06-18_21-59-07](https://cloud.githubusercontent.com/assets/3450050/16198210/68f80dae-3705-11e6-8054-65a80cab6edd.png)

After:
![java_2016-06-20_16-10-15](https://cloud.githubusercontent.com/assets/3450050/16198211/690f8934-3705-11e6-99f4-cbb601f8dfe7.png)

Small tweak but makes attributes more appealing to me :smile: 