### PR TITLE
[WIP] (PSI): Make RustMacroItemElement extend RustOuterAttributeOwner

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/grammar/rust.bnf
+++ b/src/main/kotlin/org/rust/lang/core/grammar/rust.bnf
@@ -222,7 +222,6 @@
     extends     ("pat_(wild|ref|tup|vec|macro|struct|enum|ident|range|uniq|qual_path)")  = pat
     extends     (".*_attr") = attr
 
-    implements  ("macro_item") = [ "org.rust.lang.core.psi.RustOuterAttributeOwner" "org.rust.lang.core.psi.RustCompositeElement" ]
     elementType ("expr_like_macro|item_like_macro") = macro
     extends     ("(try|format_like)_macro") = macro
     elementType (".*_macro_invocation|macro_rules_invocation") = macro_invocation
@@ -1071,7 +1070,9 @@ private meta macro_args_delim ::= '(' <<param>> ')'
 macro_expr ::= zz_macro_call
 pat_macro  ::= zz_macro_call
 // TODO: Maybe implement item-related stuff for this production?
-macro_item ::= attrs_and_vis zz_macro_item
+macro_item ::= attrs_and_vis zz_macro_item {
+    implements = [ "org.rust.lang.core.psi.RustOuterAttributeOwner" ]
+}
 impl_macro_member ::= zz_macro_item
 
 // Utils

--- a/src/main/kotlin/org/rust/lang/core/grammar/rust.bnf
+++ b/src/main/kotlin/org/rust/lang/core/grammar/rust.bnf
@@ -222,6 +222,7 @@
     extends     ("pat_(wild|ref|tup|vec|macro|struct|enum|ident|range|uniq|qual_path)")  = pat
     extends     (".*_attr") = attr
 
+    implements  ("macro_item") = [ "org.rust.lang.core.psi.RustOuterAttributeOwner" "org.rust.lang.core.psi.RustCompositeElement" ]
     elementType ("expr_like_macro|item_like_macro") = macro
     extends     ("(try|format_like)_macro") = macro
     elementType (".*_macro_invocation|macro_rules_invocation") = macro_invocation


### PR DESCRIPTION
`RustMacroItemElement` declares a `getOuterAttrList()`, it should really just extend `RustOuterAttributeOwner`.  This is my naive attempt to do this.  It's a WIP because I still need to figure out how to make `RustMacroItemElement` not declare its own `getOuterAttrList()` method.

This is a generalization I need for [this](https://github.com/intellij-rust/intellij-rust/pull/486) PR.