### PR TITLE
Improve folding

### DIFF
--- a/src/main/kotlin/org/rust/ide/folding/RustFoldingBuilder.kt
+++ b/src/main/kotlin/org/rust/ide/folding/RustFoldingBuilder.kt
@@ -94,6 +94,32 @@ class RustFoldingBuilder() : FoldingBuilderEx(), DumbAware {
                     descriptors += FoldingDescriptor(o.node, TextRange(o.lbrace.textOffset, rbrace.textOffset + 1))
                 }
             }
+
+            override fun visitMatchExpr(o: RustMatchExprElement) {
+                super.visitMatchExpr(o)
+
+                val body = o.matchBody
+                if (body != null) {
+                    descriptors += FoldingDescriptor(o.node, body.textRange)
+                }
+            }
+
+            override fun visitMacroArg(o: RustMacroArgElement) {
+                super.visitMacroArg(o)
+
+                val lbrace = o.lbrace
+                val rbrace = o.rbrace
+
+                if (lbrace != null && rbrace != null) {
+                    descriptors += FoldingDescriptor(o.node, TextRange(lbrace.textOffset, rbrace.textOffset + 1))
+                }
+            }
+
+            override fun visitUseGlobList(o: RustUseGlobListElement) {
+                super.visitUseGlobList(o)
+
+                descriptors += FoldingDescriptor(o.node, o.textRange)
+            }
         })
 
         return descriptors.toTypedArray()

--- a/src/main/kotlin/org/rust/ide/folding/RustFoldingBuilder.kt
+++ b/src/main/kotlin/org/rust/ide/folding/RustFoldingBuilder.kt
@@ -14,12 +14,7 @@ import org.rust.lang.core.psi.visitors.RustRecursiveElementVisitor
 import java.util.*
 
 class RustFoldingBuilder() : FoldingBuilderEx(), DumbAware {
-    override fun getPlaceholderText(node: ASTNode): String {
-        when {
-            node.psi is PsiComment -> return "/* ... */"
-            else -> return "{...}"
-        }
-    }
+    override fun getPlaceholderText(node: ASTNode): String = if (node.psi is PsiComment) "/* ... */" else "{...}"
 
     override fun buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array<out FoldingDescriptor> {
         if (root !is RustFile) return emptyArray()
@@ -127,14 +122,11 @@ class RustFoldingBuilder() : FoldingBuilderEx(), DumbAware {
                 descriptors += FoldingDescriptor(o.node, o.textRange)
             }
 
-            override fun visitComment(comment: PsiComment?) {
+            override fun visitComment(comment: PsiComment) {
                 super.visitComment(comment)
 
-                if (comment != null) {
-                    when (comment.tokenType) {
-                        RustTokenElementTypes.BLOCK_COMMENT ->
-                            descriptors += FoldingDescriptor(comment.node, comment.textRange)
-                    }
+                if (comment.tokenType == RustTokenElementTypes.BLOCK_COMMENT) {
+                    descriptors += FoldingDescriptor(comment.node, comment.textRange)
                 }
             }
         })

--- a/src/test/kotlin/org/rust/ide/folding/RustFoldingTestCase.kt
+++ b/src/test/kotlin/org/rust/ide/folding/RustFoldingTestCase.kt
@@ -19,6 +19,7 @@ class RustFoldingTestCase : RustTestCaseBase() {
     fun testMatchExpr() = doTest()
     fun testMacroBraceArg() = doTest()
     fun testUseGlobList() = doTest()
+    fun testBlockComment() = doTest()
 
     private fun doTest() {
         myFixture.testFolding("$testDataPath/$fileName")

--- a/src/test/kotlin/org/rust/ide/folding/RustFoldingTestCase.kt
+++ b/src/test/kotlin/org/rust/ide/folding/RustFoldingTestCase.kt
@@ -16,6 +16,9 @@ class RustFoldingTestCase : RustTestCaseBase() {
     fun testEnum() = doTest()
     fun testEnumVariant() = doTest()
     fun testMod() = doTest()
+    fun testMatchExpr() = doTest()
+    fun testMacroBraceArg() = doTest()
+    fun testUseGlobList() = doTest()
 
     private fun doTest() {
         myFixture.testFolding("$testDataPath/$fileName")

--- a/src/test/resources/org/rust/ide/folding/fixtures/block_comment.rs
+++ b/src/test/resources/org/rust/ide/folding/fixtures/block_comment.rs
@@ -1,0 +1,3 @@
+<fold text='/* ... */'>/*
+hello
+*/</fold>

--- a/src/test/resources/org/rust/ide/folding/fixtures/macro_brace_arg.rs
+++ b/src/test/resources/org/rust/ide/folding/fixtures/macro_brace_arg.rs
@@ -1,0 +1,5 @@
+fn test() <fold text='{...}'>{
+    awesome! <fold text='{...}'>{ }</fold>
+}</fold>
+
+awesome_invoke! <fold text='{...}'>{ }</fold>

--- a/src/test/resources/org/rust/ide/folding/fixtures/match_expr.rs
+++ b/src/test/resources/org/rust/ide/folding/fixtures/match_expr.rs
@@ -1,0 +1,5 @@
+fn test() <fold text='{...}'>{
+    match 1 <fold text='{...}'>{
+        _ => println!("Hello!")
+    }</fold>;
+}</fold>

--- a/src/test/resources/org/rust/ide/folding/fixtures/use_glob_list.rs
+++ b/src/test/resources/org/rust/ide/folding/fixtures/use_glob_list.rs
@@ -1,0 +1,4 @@
+use test::<fold text='{...}'>{
+    one,
+    two
+}</fold>;


### PR DESCRIPTION
Couple of improvements to folding.

* Now using a recursive visitor. This should have much higher performance than using a find-all operation for every kind of fold possible on every edit.
* A few more foldables.
* Block comments fold with appropriate fold indicator.

Future improvements could include folding up all attributes in a block (doc comments included), various argument-like elements, use blocks.