### PR TITLE
Additional Syntax Highlighting 

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RustHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RustHighlightingAnnotator.kt
@@ -2,73 +2,89 @@ package org.rust.ide.annotator
 
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
-import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.psi.PsiElement
 import org.rust.ide.colors.RustColor
 import org.rust.ide.highlight.syntax.RustHighlighter
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.impl.mixin.isMut
 import org.rust.lang.core.psi.util.elementType
+import org.rust.lang.core.psi.visitors.RustComputingVisitor
 
 // Highlighting logic here should be kept in sync with tags in RustColorSettingsPage
 class RustHighlightingAnnotator : Annotator {
-    override fun annotate(element: PsiElement, holder: AnnotationHolder) = element.accept(object : RustElementVisitor() {
-        override fun visitAttr(o: RustAttrElement) {
-            holder.highlight(o, RustColor.ATTRIBUTE)
+
+    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        if (element is RustReferenceElement) {
+            if (element is RustPathElement && element.isPrimitive) {
+                holder.highlight(element, RustColor.PRIMITIVE_TYPE)
+                return
+            }
+            val text = when (element) {
+                is RustPathElement -> element.identifier
+                else -> element
+            }
+            val ref = element.reference.resolve() ?: return
+            // Highlight the element dependent on what it's referencing.
+            val color = highlightingVisitor().computeNullable(ref)?.second
+            holder.highlight(text, color)
+        } else {
+            val (text, color) = highlightingVisitor().computeNullable(element) ?: return
+            holder.highlight(text, color)
         }
+    }
+
+    fun AnnotationHolder.highlight(element: PsiElement?, color: RustColor?) {
+        val textAttributesKey = color?.textAttributesKey
+        if (element != null && textAttributesKey != null) {
+            createInfoAnnotation(element, null).textAttributes = textAttributesKey
+        }
+    }
+
+    fun highlightingVisitor() = object : RustComputingVisitor<Pair<PsiElement?, RustColor?>>() {
+
+        fun highlight(element: PsiElement?, color: RustColor?) = set { Pair(element, color) }
 
         override fun visitLitExpr(o: RustLitExprElement) {
             // Re-highlight literals in attributes
             if (o.parent is RustMetaItemElement) {
                 val literal = o.firstChild
-                holder.highlight(literal, RustHighlighter.map(literal.elementType))
+                highlight(literal, RustHighlighter.map(literal.elementType))
             }
         }
 
-        override fun visitMacroInvocation(m: RustMacroInvocationElement) {
-            holder.highlight(m, RustColor.MACRO)
-        }
+        override fun visitTypeParam(o: RustTypeParamElement) = highlight(o.identifier, RustColor.TYPE_PARAMETER)
 
-        override fun visitTypeParam(o: RustTypeParamElement) {
-            holder.highlight(o, RustColor.TYPE_PARAMETER)
-        }
+        override fun visitAttr(o: RustAttrElement) = highlight(o, RustColor.ATTRIBUTE)
+
+        override fun visitTraitRef(o: RustTraitRefElement) = highlight(o.path.identifier, RustColor.TRAIT)
 
         override fun visitPatBinding(o: RustPatBindingElement) {
             if (o.isMut) {
-                holder.highlight(o.identifier, RustColor.MUT_BINDING)
+                highlight(o.identifier, RustColor.MUT_BINDING)
             }
         }
 
-        override fun visitPath(o: RustPathElement) {
-            o.reference.resolve().let {
-                if (it is RustPatBindingElement && it.isMut) {
-                    holder.highlight(o.identifier, RustColor.MUT_BINDING)
-                }
-            }
-        }
+        override fun visitEnumItem(o: RustEnumItemElement)       = highlight(o.identifier, RustColor.ENUM)
+        override fun visitEnumVariant(o: RustEnumVariantElement) = highlight(o.identifier, RustColor.ENUM_VARIANT)
 
-        override fun visitFnItem(o: RustFnItemElement) {
-            holder.highlight(o.identifier, RustColor.FUNCTION_DECLARATION)
-        }
+        override fun visitStructItem(o: RustStructItemElement)   = highlight(o.identifier, RustColor.STRUCT)
+        override fun visitTraitItem(o: RustTraitItemElement)     = highlight(o.identifier, RustColor.TRAIT)
+        override fun visitModDeclItem(o: RustModDeclItemElement) = highlight(o.identifier, RustColor.MODULE)
+        override fun visitModItem(o: RustModItemElement)         = highlight(o.identifier, RustColor.MODULE)
 
-        override fun visitImplMethodMember(o: RustImplMethodMemberElement) {
-            val color = if (o.isStatic) RustColor.STATIC_METHOD else RustColor.INSTANCE_METHOD
-            holder.highlight(o.identifier, color)
-        }
+        override fun visitFieldDecl(o: RustFieldDeclElement)     = highlight(o.identifier, RustColor.FIELD)
 
-        override fun visitTraitMethodMember(o: RustTraitMethodMemberElement) {
-            val color = if (o.isStatic) RustColor.STATIC_METHOD else RustColor.INSTANCE_METHOD
-            holder.highlight(o.identifier, color)
-        }
-    })
+        override fun visitExternCrateItem(o: RustExternCrateItemElement) = highlight(o.identifier, RustColor.CRATE)
 
-    private fun AnnotationHolder.highlight(element: PsiElement?, color: RustColor?) {
-        highlight(element, color?.textAttributesKey)
-    }
+        //TODO: When are element and element.identifier different?
+        override fun visitMacroInvocation(m: RustMacroInvocationElement) = highlight(m, RustColor.MACRO)
+        override fun visitMethodCallExpr(o: RustMethodCallExprElement)   = highlight(o.identifier, RustColor.INSTANCE_METHOD)
+        override fun visitFnItem(o: RustFnItemElement)                   = highlight(o.identifier, RustColor.FUNCTION_DECLARATION)
 
-    private fun AnnotationHolder.highlight(element: PsiElement?, textAttributesKey: TextAttributesKey?) {
-        if (element != null && textAttributesKey != null) {
-            createInfoAnnotation(element, null).textAttributes = textAttributesKey
-        }
+        override fun visitImplMethodMember(o: RustImplMethodMemberElement) =
+            highlight(o.identifier, if (o.isStatic) RustColor.STATIC_METHOD else RustColor.INSTANCE_METHOD)
+        override fun visitTraitMethodMember(o: RustTraitMethodMemberElement) =
+            highlight(o.identifier, if (o.isStatic) RustColor.STATIC_METHOD else RustColor.INSTANCE_METHOD)
+
     }
 }

--- a/src/main/kotlin/org/rust/ide/colors/RustColorSettingsPage.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RustColorSettingsPage.kt
@@ -10,17 +10,13 @@ class RustColorSettingsPage : ColorSettingsPage {
     private val ATTRS = RustColor.values().map { it.attributesDescriptor }.toTypedArray()
 
     // This tags should be kept in sync with RustHighlightingAnnotator highlighting logic
-    private val ANNOTATOR_TAGS = mapOf(
-        "attribute" to RustColor.ATTRIBUTE,
-        "macro" to RustColor.MACRO,
-        "type-parameter" to RustColor.TYPE_PARAMETER,
-        "mut-binding" to RustColor.MUT_BINDING,
-        "function-decl" to RustColor.FUNCTION_DECLARATION,
-        "instance-method-decl" to RustColor.INSTANCE_METHOD,
-        "static-method-decl" to RustColor.STATIC_METHOD
-    ).mapValues { it.value.textAttributesKey }
+    // @TODO Figure out how to namespace menu elements a la
+    //       https://github.com/JetBrains/kotlin/blob/8b30e7ef4e48494ba245b441a5b23142f1d6ae33/idea/idea-analysis/src/org/jetbrains/kotlin/idea/KotlinBundle.properties
+    private val ANNOTATOR_TAGS = RustColor.values().associateBy({ it.name }, {it.textAttributesKey })
+
 
     private val DEMO_TEXT by lazy {
+        // @TODO The annotations in this file should be generable, and would be more accurate for it.
         loadCodeSampleResource("org/rust/ide/colors/highlighterDemoText.rs")
     }
 

--- a/src/main/kotlin/org/rust/ide/colors/RustColors.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RustColors.kt
@@ -7,46 +7,58 @@ import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Default
 /**
  * See [RustColorSettingsPage] and [org.rust.ide.highlight.syntax.RustHighlighter]
  */
-enum class RustColor(val humanName: String, externalName: String, fallback: TextAttributesKey) {
-    IDENTIFIER            ("Identifier", "org.rust.IDENTIFIER", Default.IDENTIFIER),
-    FUNCTION_DECLARATION  ("Function declaration", "org.rust.FUNCTION_DECLARATION", Default.FUNCTION_DECLARATION),
-    INSTANCE_METHOD       ("Instance method declaration", "org.rust.INSTANCE_METHOD", Default.INSTANCE_METHOD),
-    STATIC_METHOD         ("Static method declaration", "org.rust.STATIC_METHOD", Default.STATIC_METHOD),
+enum class RustColor(val humanName: String, val default: TextAttributesKey) {
+    IDENTIFIER            ("Identifier",                  Default.IDENTIFIER),
+    FUNCTION_DECLARATION  ("Function declaration",        Default.FUNCTION_DECLARATION),
+    INSTANCE_METHOD       ("Instance method declaration", Default.INSTANCE_METHOD),
+    STATIC_METHOD         ("Static method declaration",   Default.STATIC_METHOD),
 
-    LIFETIME              ("Lifetime", "org.rust.LIFETIME", Default.IDENTIFIER),
+    LIFETIME              ("Lifetime",                    Default.IDENTIFIER),
 
-    CHAR                  ("Char", "org.rust.CHAR", Default.STRING),
-    STRING                ("String", "org.rust.STRING", Default.STRING),
-    NUMBER                ("Number", "org.rust.NUMBER", Default.NUMBER),
+    CHAR                  ("Char",                        Default.STRING),
+    STRING                ("String",                      Default.STRING),
+    NUMBER                ("Number",                      Default.NUMBER),
 
-    KEYWORD               ("Keyword", "org.rust.KEYWORD", Default.KEYWORD),
+    PRIMITIVE_TYPE        ("Primitive Type",              Default.KEYWORD),
 
-    BLOCK_COMMENT         ("Block comment", "org.rust.BLOCK_COMMENT", Default.BLOCK_COMMENT),
-    EOL_COMMENT           ("Line comment", "org.rust.EOL_COMMENT", Default.LINE_COMMENT),
-    DOC_COMMENT           ("Documentation comment", "org.rust.DOC_COMMENT", Default.DOC_COMMENT),
+    CRATE                 ("Crate",                       Default.IDENTIFIER),
+    STRUCT                ("Struct",                      Default.CLASS_NAME),
+    TRAIT                 ("Trait",                       Default.INTERFACE_NAME),
+    MODULE                ("Module",                      Default.IDENTIFIER),
+    ENUM                  ("Enum",                        Default.CLASS_NAME),
+    ENUM_VARIANT          ("Enum Variant",                Default.STATIC_FIELD),
 
-    PARENTHESIS           ("Parenthesis", "org.rust.PARENTHESIS", Default.PARENTHESES),
-    BRACKETS              ("Brackets", "org.rust.BRACKETS", Default.BRACKETS),
-    BRACES                ("Braces", "org.rust.BRACES", Default.BRACES),
+    FIELD                 ("Field",                       Default.INSTANCE_FIELD),
 
-    OPERATORS             ("Operator sign", "org.rust.OPERATORS", Default.OPERATION_SIGN),
+    KEYWORD               ("Keyword",                     Default.KEYWORD),
 
-    SEMICOLON             ("Semicolon", "org.rust.SEMICOLON", Default.SEMICOLON),
-    DOT                   ("Dot", "org.rust.DOT", Default.DOT),
-    COMMA                 ("Comma", "org.rust.COMMA", Default.COMMA),
+    BLOCK_COMMENT         ("Block comment",               Default.BLOCK_COMMENT),
+    EOL_COMMENT           ("Line comment",                Default.LINE_COMMENT),
+    DOC_COMMENT           ("Documentation comment",       Default.DOC_COMMENT),
 
-    ATTRIBUTE             ("Attribute", "org.rust.ATTRIBUTE", Default.METADATA),
+    PARENTHESIS           ("Parenthesis",                 Default.PARENTHESES),
+    BRACKETS              ("Brackets",                    Default.BRACKETS),
+    BRACES                ("Braces",                      Default.BRACES),
 
-    MACRO                 ("Macro", "org.rust.MACRO", Default.IDENTIFIER),
+    OPERATORS             ("Operator sign",               Default.OPERATION_SIGN),
 
-    TYPE_PARAMETER        ("Type parameter", "org.rust.TYPE_PARAMETER", Default.IDENTIFIER),
+    SEMICOLON             ("Semicolon",                   Default.SEMICOLON),
+    DOT                   ("Dot",                         Default.DOT),
+    COMMA                 ("Comma",                       Default.COMMA),
 
-    MUT_BINDING           ("Mutable binding", "org.rust.MUT_BINDING", Default.IDENTIFIER),
+    ATTRIBUTE             ("Attribute",                   Default.METADATA),
 
-    VALID_STRING_ESCAPE   ("Valid escape sequence", "org.rust.VALID_STRING_ESCAPE", Default.VALID_STRING_ESCAPE),
-    INVALID_STRING_ESCAPE ("Invalid excape sequence", "org.rust.INVALID_STRING_ESCAPE", Default.INVALID_STRING_ESCAPE);
+    MACRO                 ("Macro",                       Default.IDENTIFIER),
 
-    val textAttributesKey = TextAttributesKey.createTextAttributesKey(externalName, fallback)
+    TYPE_PARAMETER        ("Type parameter",              Default.IDENTIFIER),
+
+    MUT_BINDING           ("Mutable binding",             Default.IDENTIFIER),
+
+    VALID_STRING_ESCAPE   ("Valid escape sequence",       Default.VALID_STRING_ESCAPE),
+    INVALID_STRING_ESCAPE ("Invalid escape sequence",     Default.INVALID_STRING_ESCAPE),
+    ;
+
+    val textAttributesKey = TextAttributesKey.createTextAttributesKey("org.rust.${this.name}", default)
     val attributesDescriptor = AttributesDescriptor(humanName, textAttributesKey)
 }
 

--- a/src/main/kotlin/org/rust/ide/highlight/syntax/RustHighlighter.kt
+++ b/src/main/kotlin/org/rust/ide/highlight/syntax/RustHighlighter.kt
@@ -1,6 +1,5 @@
 package org.rust.ide.highlight.syntax
 
-import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.fileTypes.SyntaxHighlighterBase
 import com.intellij.psi.StringEscapesTokenTypes.*
 import com.intellij.psi.tree.IElementType
@@ -13,10 +12,10 @@ class RustHighlighter : SyntaxHighlighterBase() {
 
     override fun getHighlightingLexer() = RustHighlightingLexer()
 
-    override fun getTokenHighlights(tokenType: IElementType?) = pack(map(tokenType))
+    override fun getTokenHighlights(tokenType: IElementType?) = pack(map(tokenType)?.textAttributesKey)
 
     companion object {
-        fun map(tokenType: IElementType?): TextAttributesKey? = when (tokenType) {
+        fun map(tokenType: IElementType?): RustColor? = when (tokenType) {
             is RustKeywordTokenType        -> RustColor.KEYWORD
 
             IDENTIFIER                     -> RustColor.IDENTIFIER
@@ -51,6 +50,6 @@ class RustHighlighter : SyntaxHighlighterBase() {
             INVALID_UNICODE_ESCAPE_TOKEN   -> RustColor.INVALID_STRING_ESCAPE
 
             else                           -> null
-        }?.textAttributesKey
+        }
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/RustUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RustUnresolvedReferenceInspection.kt
@@ -2,6 +2,7 @@ package org.rust.ide.inspections
 
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElementVisitor
+import org.rust.lang.core.psi.isPrimitive
 import org.rust.lang.core.psi.*
 
 class RustUnresolvedReferenceInspection : RustLocalInspectionTool() {
@@ -23,12 +24,3 @@ class RustUnresolvedReferenceInspection : RustLocalInspectionTool() {
     }
 }
 
-private val RustPathElement.isPrimitive: Boolean get() = path == null && referenceName in primitives
-
-private val primitives = setOf(
-    "i8", "i16", "i32", "i64", "isize",
-    "u8", "u16", "u32", "u64", "usize",
-    "char", "str",
-    "f32", "f64",
-    "bool"
-)

--- a/src/main/kotlin/org/rust/lang/core/psi/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/Extensions.kt
@@ -1,0 +1,11 @@
+package org.rust.lang.core.psi
+
+val RustPathElement.isPrimitive: Boolean get() = path == null && referenceName in primitives
+
+private val primitives = setOf(
+    "i8", "i16", "i32", "i64", "isize",
+    "u8", "u16", "u32", "u64", "usize",
+    "char", "str",
+    "f32", "f64",
+    "bool"
+)

--- a/src/main/kotlin/org/rust/lang/core/psi/visitors/RustComputingVisitor.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/visitors/RustComputingVisitor.kt
@@ -32,6 +32,11 @@ abstract class RustComputingVisitor<R: Any>: RustElementVisitor() {
         }
     }
 
+    fun computeNullable(element: PsiElement): R? {
+        element.accept(this)
+        return result;
+    }
+
     protected fun set(block: () -> R) {
         result = block()
     }

--- a/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
+++ b/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
@@ -1,30 +1,53 @@
+<ATTRIBUTE>#[macro_use]</ATTRIBUTE>
+extern crate <CRATE>log</CRATE>;
+
+use std::collections::<STRUCT>HashMap</STRUCT>;
+
+mod <MODULE>Stuff</MODULE>;
+
+pub enum <ENUM>Flag</ENUM> {
+    <ENUM_VARIANT>Good</ENUM_VARIANT>,
+    <ENUM_VARIANT>Bad</ENUM_VARIANT>,
+    <ENUM_VARIANT>Ugly</ENUM_VARIANT>
+}
+
+pub trait <TRAIT>Write</TRAIT> {
+    fn <INSTANCE_METHOD>write</INSTANCE_METHOD>(&mut self, buf: &[<PRIMITIVE_TYPE>u8</PRIMITIVE_TYPE>]) -> <ENUM>Result</ENUM><usize>;
+}
+
+struct <STRUCT>Object</STRUCT><<TYPE_PARAMETER>T</TYPE_PARAMETER>> {
+    <FIELD>flag</FIELD>: <ENUM>Flag</ENUM>,
+    <FIELD>fields</FIELD>: <STRUCT>HashMap</STRUCT><<TYPE_PARAMETER>T</TYPE_PARAMETER>, <PRIMITIVE_TYPE>u64</PRIMITIVE_TYPE>>
+}
+
 /* Block comment */
-fn <function-decl>main</function-decl>() {
+fn <FUNCTION_DECLARATION>main</FUNCTION_DECLARATION>() {
     // A simple integer calculator:
     // `+` or `-` means add or subtract by 1
     // `*` or `/` means multiply or divide by 2
 
-    let program = "+ + * - /";
-    let mut <mut-binding>accumulator</mut-binding> = 0;
+    let input = <ENUM>Option</ENUM>::None;
+    let program = input.<INSTANCE_METHOD>unwrap_or_else</INSTANCE_METHOD>(|| "+ + * - /");
+    let mut <MUT_BINDING>accumulator</MUT_BINDING> = 0;
 
-    for token in program.chars() {
+    for token in program.<INSTANCE_METHOD>chars</INSTANCE_METHOD>() {
         match token {
-            '+' => <mut-binding>accumulator</mut-binding> += 1,
-            '-' => <mut-binding>accumulator</mut-binding> -= 1,
-            '*' => <mut-binding>accumulator</mut-binding> *= 2,
-            '/' => <mut-binding>accumulator</mut-binding> /= 2,
+            '+' => <MUT_BINDING>accumulator</MUT_BINDING> += 1,
+            '-' => <MUT_BINDING>accumulator</MUT_BINDING> -= 1,
+            '*' => <MUT_BINDING>accumulator</MUT_BINDING> *= 2,
+            '/' => <MUT_BINDING>accumulator</MUT_BINDING> /= 2,
             _ => { /* ignore everything else */ }
         }
     }
 
-    <macro>println!</macro>("The program \"{}\" calculates the value {}",
-             program, <mut-binding>accumulator</mut-binding>);
+    <MACRO>info!</MACRO>("The program \"{}\" calculates the value {}",
+             program, <MUT_BINDING>accumulator</MUT_BINDING>);
 }
 
 /// Some documentation
-<attribute>#[cfg(target_os=</attribute>"linux"<attribute>)]</attribute>
-unsafe fn <function-decl>a_function</function-decl><<type-parameter>T</type-parameter>: 'lifetime>() {
+<ATTRIBUTE>#[cfg(target_os=</ATTRIBUTE>"linux"<ATTRIBUTE>)]</ATTRIBUTE>
+unsafe fn <FUNCTION_DECLARATION>a_function</FUNCTION_DECLARATION><<TYPE_PARAMETER>T</TYPE_PARAMETER>: <LIFETIME>'lifetime</LIFETIME>>() {
     'label: loop {
-        println!("Hello\x20W\u{f3}rld!\u{abcdef}");
+        <MACRO>println!</MACRO>("Hello\x20W\u{f3}rld!\u{abcdef}");
     }
 }

--- a/src/test/resources/org/rust/ide/annotator/fixtures/functions.rs
+++ b/src/test/resources/org/rust/ide/annotator/fixtures/functions.rs
@@ -1,16 +1,16 @@
 fn <info>main</info>() {}
 
-struct S;
+struct <info>S</info>;
 
-impl S {
+impl <info>S</info> {
     fn <info>foo</info>() {}
 }
 
-trait T {
+trait <info>T</info> {
     fn <info>foo</info>();
     fn <info>bar</info>() {}
 }
 
-impl T for S {
+impl <info>T</info> for <info>S</info> {
     fn <info>foo</info>() {}
 }

--- a/src/test/resources/org/rust/ide/annotator/fixtures/type_parameters.rs
+++ b/src/test/resources/org/rust/ide/annotator/fixtures/type_parameters.rs
@@ -1,8 +1,8 @@
-trait MyTrait {
+trait <info>MyTrait</info> {
     type AssocType;
     fn <info>some_fn</info>(&self);
 }
 
-struct MyStruct<<info>N: ?Sized+Debug+MyTrait</info>> {
-    N: my_field
+struct <info>MyStruct</info><<info>N</info>: ?<info>Sized</info>+<info>Debug</info>+<info><info>MyTrait</info></info>> {
+    <info>N</info>: my_field
 }


### PR DESCRIPTION
Added implementations for some of the simpler syntax highlighting, tests pass and it anecdotally works. 

As I started pulling out elements of expressions it started feeling wrong to do more. Is it possible that this sort of thing could be generated, perhaps by identifying leaf elements and coloring those a particular way? 

I'm aware the resolveColor code is unsightly (and I didn't _really_ add appropriate tests), but I figured I would throw this into a pull request before I had to do more merges and refactoring. Future work would involve moving closer to providing the same the elaborate syntax highlighting available for kotlin or java.

Screenshots http://imgur.com/a/VoAd4 with some placeholder colors :)