### PR TITLE
Intentions to add/remove curly braces on singleton imports

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/AddCurlyBracesIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddCurlyBracesIntention.kt
@@ -1,0 +1,76 @@
+package org.rust.ide.intentions;
+
+import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RustElementFactory
+import org.rust.lang.core.psi.RustUseItemElement
+import org.rust.lang.core.psi.util.parentOfType
+
+/**
+ * Adds curly braces to singleton imports, changing from this
+ *
+ * ```
+ * import std::mem;
+ * ```
+ *
+ * to this:
+ *
+ * ```
+ * import std::{mem};
+ * ```
+ */
+class AddCurlyBracesIntention : PsiElementBaseIntentionAction() {
+    override fun getText() = "Add curly braces"
+    override fun getFamilyName() = getText()
+    override fun startInWriteAction() = true
+
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        // Get our hands on the pieces:
+        val useItem = element.parentOfType<RustUseItemElement>() ?: return
+        val path = useItem.path ?: return
+        val identifier = path.identifier ?: return;
+        val alias = useItem.alias;
+
+        // Remember the caret position, adjusting by the new curly braces
+        val caret = editor?.caretModel?.offset ?: 0
+        val newOffset =
+            if (caret < identifier.textOffset)
+                caret
+            else if (caret < identifier.textOffset + identifier.textLength)
+                caret + 1
+            else
+                caret + 2
+
+        // Create a new use item that contains a glob list that we can use.
+        // Then extract from it the glob list and the double colon.
+        val newUseItem = RustElementFactory.createFileFromText(project,
+            "use foo::{" + identifier.text + "};")?.children?.get(0) as RustUseItemElement
+        val newGlobList = newUseItem.useGlobList ?: return
+        val newColonColon = newUseItem.coloncolon ?: return
+
+        // If there was an alias before, insert it into the new glob item
+        alias?.let { it ->
+            val newGlobItem = newGlobList.children[0]
+            newGlobItem.addAfter(it, newGlobItem.lastChild)
+        }
+
+        // Remove the identifier from the path by replacing it with its subpath
+        path.replace(path.path ?: return)
+        // Delete the alias of the identifier, if any
+        useItem.alias?.delete()
+        // Insert the double colon and glob list into the use item
+        useItem.addBefore(newColonColon, useItem.semicolon)
+        useItem.addBefore(newGlobList, useItem.semicolon)
+
+        editor?.caretModel?.moveToOffset(newOffset)
+    }
+
+    override fun isAvailable(project: Project, editor: Editor?, element: PsiElement): Boolean {
+        if (!element.isWritable) return false
+
+        val useItem = element.parentOfType<RustUseItemElement>() ?: return false
+        return useItem.useGlobList == null && useItem.path != null
+    }
+}

--- a/src/main/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntention.kt
@@ -1,0 +1,72 @@
+package org.rust.ide.intentions;
+
+import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RustElementFactory
+import org.rust.lang.core.psi.RustUseItemElement
+import org.rust.lang.core.psi.util.parentOfType
+
+/**
+ * Removes the curly braces on singleton imports, changing from this
+ *
+ * ```
+ * import std::{mem};
+ * ```
+ *
+ * to this:
+ *
+ * ```
+ * import std::mem;
+ * ```
+ */
+class RemoveCurlyBracesIntention : PsiElementBaseIntentionAction() {
+    override fun getText() = "Remove curly braces"
+    override fun getFamilyName() = getText()
+    override fun startInWriteAction() = true
+
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        // Get our hands on the various parts of the use item:
+        val useItem = element.parentOfType<RustUseItemElement>() ?: return
+        val path = useItem.path ?: return
+        val globList = useItem.useGlobList ?: return
+        val identifier = globList.children[0]
+
+        // Save the cursor position, adjusting for curly brace removal
+        val caret = editor?.caretModel?.offset ?: 0
+        val newOffset =
+            if (caret < identifier.textOffset)
+                caret
+            else if (caret < identifier.textOffset + identifier.textLength)
+                caret - 1
+            else
+                caret - 2
+
+        // Conjure up a new use item to make a new path containing the
+        // identifier we want; then grab the relevant parts
+        val newUseItem = RustElementFactory.createFileFromText(project,
+            "use foo::" + identifier.text)?.children?.get(0) as RustUseItemElement
+        val newPath = newUseItem.path ?: return
+        val newSubPath = newPath.path ?: return
+        val newAlias = newUseItem.alias
+
+        // Attach the identifier to the old path, then splice that path into
+        // the use item. Delete the old glob list and attach the alias, if any.
+        newSubPath.replace(path.copy())
+        path.replace(newPath)
+        useItem.coloncolon?.delete()
+        globList.delete()
+        newAlias?.let { it -> useItem.addBefore(it, useItem.semicolon) }
+
+        editor?.caretModel?.moveToOffset(newOffset)
+    }
+
+    override fun isAvailable(project: Project, editor: Editor?, element: PsiElement): Boolean {
+        if (!element.isWritable) return false
+
+        val useItem = element.parentOfType<RustUseItemElement>() ?: return false
+        val list = useItem.useGlobList ?: return false
+        return list.children.size == 1
+    }
+}

--- a/src/main/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntention.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RustElementFactory
+import org.rust.lang.core.psi.RustUseGlobElement
 import org.rust.lang.core.psi.RustUseItemElement
 import org.rust.lang.core.psi.util.parentOfType
 
@@ -67,6 +68,13 @@ class RemoveCurlyBracesIntention : PsiElementBaseIntentionAction() {
 
         val useItem = element.parentOfType<RustUseItemElement>() ?: return false
         val list = useItem.useGlobList ?: return false
-        return list.children.size == 1
+        if (list.children.size != 1) return false
+
+        val listItem = list.children[0]
+        if (listItem is RustUseGlobElement) {
+            return listItem.self == null
+        } else {
+            return false
+        }
     }
 }

--- a/src/main/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntention.kt
@@ -1,4 +1,4 @@
-package org.rust.ide.intentions;
+package org.rust.ide.intentions
 
 import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction
 import com.intellij.openapi.editor.Editor
@@ -27,7 +27,7 @@ class RemoveCurlyBracesIntention : PsiElementBaseIntentionAction() {
     override fun getFamilyName() = getText()
     override fun startInWriteAction() = true
 
-    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+    override fun invoke(project: Project, editor: Editor, element: PsiElement) {
         // Get our hands on the various parts of the use item:
         val useItem = element.parentOfType<RustUseItemElement>() ?: return
         val path = useItem.path ?: return
@@ -35,19 +35,16 @@ class RemoveCurlyBracesIntention : PsiElementBaseIntentionAction() {
         val identifier = globList.children[0]
 
         // Save the cursor position, adjusting for curly brace removal
-        val caret = editor?.caretModel?.offset ?: 0
-        val newOffset =
-            if (caret < identifier.textOffset)
-                caret
-            else if (caret < identifier.textOffset + identifier.textLength)
-                caret - 1
-            else
-                caret - 2
+        val caret = editor.caretModel.offset
+        val newOffset = when {
+            caret < identifier.textOffset -> caret
+            caret < identifier.textOffset + identifier.textLength -> caret - 1
+            else -> caret - 2
+        }
 
         // Conjure up a new use item to make a new path containing the
         // identifier we want; then grab the relevant parts
-        val newUseItem = RustElementFactory.createFileFromText(project,
-            "use foo::" + identifier.text)?.children?.get(0) as RustUseItemElement
+        val newUseItem = RustElementFactory.createUseItem(project, "dummy::${identifier.text}") ?: return
         val newPath = newUseItem.path ?: return
         val newSubPath = newPath.path ?: return
         val newAlias = newUseItem.alias
@@ -60,7 +57,7 @@ class RemoveCurlyBracesIntention : PsiElementBaseIntentionAction() {
         globList.delete()
         newAlias?.let { it -> useItem.addBefore(it, useItem.semicolon) }
 
-        editor?.caretModel?.moveToOffset(newOffset)
+        editor.caretModel.moveToOffset(newOffset)
     }
 
     override fun isAvailable(project: Project, editor: Editor?, element: PsiElement): Boolean {

--- a/src/main/kotlin/org/rust/lang/core/psi/RustElementFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RustElementFactory.kt
@@ -24,4 +24,9 @@ object RustElementFactory {
         val file = createFileFromText(project, "#[$attrContents] struct Dummy;")
         return file?.childOfType<RustOuterAttrElement>()
     }
+
+    fun createUseItem(project: Project, path: String): RustUseItemElement? {
+        val file = createFileFromText(project, "use $path;")
+        return file?.childOfType<RustUseItemElement>()
+    }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -162,6 +162,14 @@
             <category>Rust</category>
         </intentionAction>
         <intentionAction>
+            <className>org.rust.ide.intentions.RemoveCurlyBracesIntention</className>
+            <category>Rust</category>
+        </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.AddCurlyBracesIntention</className>
+            <category>Rust</category>
+        </intentionAction>
+        <intentionAction>
             <className>org.rust.ide.intentions.RemoveParenthesesFromExprIntention</className>
             <category>Rust</category>
         </intentionAction>

--- a/src/main/resources/intentionDescriptions/AddCurlyBracesIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/AddCurlyBracesIntention/after.rs.template
@@ -1,0 +1,1 @@
+use std::{mem};

--- a/src/main/resources/intentionDescriptions/AddCurlyBracesIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/AddCurlyBracesIntention/before.rs.template
@@ -1,0 +1,1 @@
+use std::mem;

--- a/src/main/resources/intentionDescriptions/AddCurlyBracesIntention/description.html
+++ b/src/main/resources/intentionDescriptions/AddCurlyBracesIntention/description.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+This intention adds curly braces to a use statement that imports only
+one item.
+</body>
+</html>

--- a/src/main/resources/intentionDescriptions/RemoveCurlyBracesIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/RemoveCurlyBracesIntention/after.rs.template
@@ -1,0 +1,1 @@
+use std::mem;

--- a/src/main/resources/intentionDescriptions/RemoveCurlyBracesIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/RemoveCurlyBracesIntention/before.rs.template
@@ -1,0 +1,1 @@
+use std::{mem};

--- a/src/main/resources/intentionDescriptions/RemoveCurlyBracesIntention/description.html
+++ b/src/main/resources/intentionDescriptions/RemoveCurlyBracesIntention/description.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+This intention removes unnecessary curly braces from a use statement that
+imports only one item.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/AddCurlyBracesIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddCurlyBracesIntentionTest.kt
@@ -1,0 +1,27 @@
+package org.rust.ide.intentions
+
+import org.rust.lang.RustTestCaseBase
+
+class AddCurlyBracesIntentionTest : RustTestCaseBase() {
+    override val dataPath = "org/rust/ide/intentions/fixtures/add_curly_braces/"
+
+    fun testAddCurlyBracesSimple() = checkByFile {
+        openFileInEditor("add_curly_braces_simple.rs")
+        myFixture.launchAction(AddCurlyBracesIntention())
+    }
+
+    fun testAddCurlyBracesLonger() = checkByFile {
+        openFileInEditor("add_curly_braces_longer.rs")
+        myFixture.launchAction(AddCurlyBracesIntention())
+    }
+
+    fun testAddCurlyBracesAlias() = checkByFile {
+        openFileInEditor("add_curly_braces_alias.rs")
+        myFixture.launchAction(AddCurlyBracesIntention())
+    }
+
+    fun testAddCurlyBracesExtra() = checkByFile {
+        openFileInEditor("add_curly_braces_extra.rs")
+        myFixture.launchAction(AddCurlyBracesIntention())
+    }
+}

--- a/src/test/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntentionTest.kt
@@ -1,0 +1,27 @@
+package org.rust.ide.intentions
+
+import org.rust.lang.RustTestCaseBase
+
+class RemoveCurlyBracesIntentionTest : RustTestCaseBase() {
+    override val dataPath = "org/rust/ide/intentions/fixtures/remove_curly_braces/"
+
+    fun testRemoveCurlyBracesSimple() = checkByFile {
+        openFileInEditor("remove_curly_braces_simple.rs")
+        myFixture.launchAction(RemoveCurlyBracesIntention())
+    }
+
+    fun testRemoveCurlyBracesLonger() = checkByFile {
+        openFileInEditor("remove_curly_braces_longer.rs")
+        myFixture.launchAction(RemoveCurlyBracesIntention())
+    }
+
+    fun testRemoveCurlyBracesAlias() = checkByFile {
+        openFileInEditor("remove_curly_braces_alias.rs")
+        myFixture.launchAction(RemoveCurlyBracesIntention())
+    }
+
+    fun testRemoveCurlyBracesExtra() = checkByFile {
+        openFileInEditor("remove_curly_braces_extra.rs")
+        myFixture.launchAction(RemoveCurlyBracesIntention())
+    }
+}

--- a/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_alias.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_alias.rs
@@ -1,0 +1,1 @@
+use std::mem as mem<caret>ory;

--- a/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_alias_after.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_alias_after.rs
@@ -1,0 +1,1 @@
+use std::{mem as mem<caret>ory};

--- a/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_extra.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_extra.rs
@@ -1,0 +1,1 @@
+#[macro_use] pub use /*comment*/ std::me<caret>m;

--- a/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_extra_after.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_extra_after.rs
@@ -1,0 +1,1 @@
+#[macro_use] pub use /*comment*/ std::{me<caret>m};

--- a/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_longer.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_longer.rs
@@ -1,0 +1,1 @@
+use foo::bar::<caret>baz::qux;

--- a/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_longer_after.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_longer_after.rs
@@ -1,0 +1,1 @@
+use foo::bar::<caret>baz::{qux};

--- a/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_simple.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_simple.rs
@@ -1,0 +1,1 @@
+use std::m<caret>em;

--- a/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_simple_after.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/add_curly_braces/add_curly_braces_simple_after.rs
@@ -1,0 +1,1 @@
+use std::{m<caret>em};

--- a/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_alias.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_alias.rs
@@ -1,0 +1,1 @@
+use std::{mem as mem<caret>ory};

--- a/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_alias_after.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_alias_after.rs
@@ -1,0 +1,1 @@
+use std::mem as mem<caret>ory;

--- a/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_extra.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_extra.rs
@@ -1,0 +1,1 @@
+#[macro_use] pub use /*comment*/ std::{me<caret>m};

--- a/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_extra_after.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_extra_after.rs
@@ -1,0 +1,1 @@
+#[macro_use] pub use /*comment*/ std::me<caret>m;

--- a/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_longer.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_longer.rs
@@ -1,0 +1,1 @@
+use foo::bar::<caret>baz::{qux};

--- a/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_longer_after.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_longer_after.rs
@@ -1,0 +1,1 @@
+use foo::bar::<caret>baz::qux;

--- a/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_simple.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_simple.rs
@@ -1,0 +1,1 @@
+use std::{m<caret>em};

--- a/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_simple_after.rs
+++ b/src/test/resources/org/rust/ide/intentions/fixtures/remove_curly_braces/remove_curly_braces_simple_after.rs
@@ -1,0 +1,1 @@
+use std::m<caret>em;


### PR DESCRIPTION
Changes `use std::ptr;` to `use std::{ptr};` and back.