### PR TITLE
(FMT): add spacing rules for lifetime lists in polybounds

### DIFF
--- a/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt
@@ -110,6 +110,8 @@ fun createSpacingBuilder(commonSettings: CommonCodeStyleSettings, rustSettings: 
         .betweenInside(ts(MUL), ts(CONST, MUT), PTR_TYPE).spaces(0)
         .before(TYPE_PARAM_BOUNDS).spaces(0)
         .beforeInside(LPAREN, PATH).spaces(0)
+        .aroundInside(LT, POLYBOUND).spacing(0, 0, 0, true, 0)
+        .beforeInside(GT, POLYBOUND).spacing(0, 0, 0, true, 0)
 
         //== expressions
         .beforeInside(LPAREN, PAT_ENUM).spaces(0)

--- a/src/test/kotlin/org/rust/ide/formatter/RustFormatterTestCase.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RustFormatterTestCase.kt
@@ -82,6 +82,7 @@ class RustFormatterTestCase : FormatterTestCase() {
 
     fun testIssue451() = doTest()   // https://github.com/intellij-rust/intellij-rust/issues/451
     fun testIssue526() = doTest()   // https://github.com/intellij-rust/intellij-rust/issues/526
+    fun testIssue569() = doTest()   // https://github.com/intellij-rust/intellij-rust/issues/569
 
     // https://github.com/intellij-rust/intellij-rust/issues/543
     fun testIssue543a() = doTest()

--- a/src/test/resources/org/rust/ide/formatter/fixtures/issue569.rs
+++ b/src/test/resources/org/rust/ide/formatter/fixtures/issue569.rs
@@ -1,0 +1,3 @@
+struct Foo<T> where T: for   <'a,'b>Fn(i32) -> () {
+    a: T
+}

--- a/src/test/resources/org/rust/ide/formatter/fixtures/issue569_after.rs
+++ b/src/test/resources/org/rust/ide/formatter/fixtures/issue569_after.rs
@@ -1,0 +1,3 @@
+struct Foo<T> where T: for<'a, 'b> Fn(i32) -> () {
+    a: T
+}


### PR DESCRIPTION
fixes #569 