### PR TITLE
(ACTION) add rustfmt reformat file action

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_script:
   - rust-nightly-x86_64-unknown-linux-gnu/install.sh --prefix=$HOME/rust
   # because of this export, we can't put this into separate `install-rust.sh` script
   - export PATH=$PATH:$HOME/rust/bin
+  - cargo install rustfmt
+  - export PATH=$PATH:$HOME/.cargo/bin
 
 # https://docs.travis-ci.com/user/languages/java/#Caching
 before_cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,9 @@ environment:
 install:
   - curl -sSf -o rustup-init.exe https://dev-static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe
   - rustup-init.exe -y
-  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin 
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - rustup default stable-x86_64-pc-windows-msvc
+  - cargo install rustfmt
 
 build_script:
   - gradlew.bat assemble testClasses --no-daemon

--- a/src/main/kotlin/org/rust/ide/actions/RustFmtFileAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RustFmtFileAction.kt
@@ -1,0 +1,50 @@
+package org.rust.ide.actions
+
+import com.intellij.execution.ExecutionException
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.util.PathUtil
+import org.rust.cargo.project.settings.toolchain
+import org.rust.ide.notifications.showBalloon
+import org.rust.lang.core.psi.impl.isRustFile
+
+class RustFmtFileAction : DumbAwareAction() {
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        val project = e.project
+        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
+        val editor = e.getData(CommonDataKeys.EDITOR)
+
+        e.presentation.isEnabled = project != null && file != null && file.isInLocalFileSystem && file.isRustFile && editor != null
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val file = e.getRequiredData(CommonDataKeys.VIRTUAL_FILE)
+
+        file.canonicalPath ?: return
+
+        val document = FileDocumentManager.getInstance().getDocument(file)
+        if (document != null) {
+            FileDocumentManager.getInstance().saveDocument(document)
+        } else {
+            FileDocumentManager.getInstance().saveAllDocuments()
+        }
+
+        val module = ModuleUtilCore.findModuleForFile(file, project) ?: return
+        val moduleDirectory = PathUtil.getParentPath(module.moduleFilePath)
+
+        try {
+            module.project.toolchain?.cargo(moduleDirectory)?.reformatFile(file.path) ?: return
+        } catch (e: ExecutionException) {
+            project.showBalloon(e.message ?: "", NotificationType.ERROR)
+        }
+
+        VfsUtil.markDirtyAndRefresh(true, true, true, file)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -277,6 +277,11 @@
                 description="Move this module to a dedicated directory">
             <add-to-group group-id="RefactoringMenu"/>
         </action>
+
+        <action class="org.rust.ide.actions.RustFmtFileAction" id="Rust.CargoFmtFile"  text="Reformat file with rustfmt"
+                description="Reformat current file with rustfmt">
+            <add-to-group group-id="CodeMenu" anchor="last"/>
+        </action>
     </actions>
 
 </idea-plugin>

--- a/src/test/kotlin/org/rust/cargo/commands/CargoFmtTest.kt
+++ b/src/test/kotlin/org/rust/cargo/commands/CargoFmtTest.kt
@@ -1,0 +1,19 @@
+package org.rust.cargo.commands
+
+import com.intellij.util.PathUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.rust.cargo.RustWithToolchainTestCaseBase
+import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.toolchain.RustToolchain
+
+class CargoFmtTest : RustWithToolchainTestCaseBase() {
+    override val dataPath = "src/test/resources/org/rust/cargo/commands/fixtures/fmt"
+
+    fun testCargoFmt() = withProject("hello")  {
+        val filePath = "src/main.rs"
+        val moduleDirectory = PathUtil.getParentPath(module.moduleFilePath)
+
+        val result = module.project.toolchain!!.cargo(moduleDirectory).reformatFile("./$filePath")
+        assertThat(result.exitCode).isEqualTo(0)
+    }
+}

--- a/src/test/resources/org/rust/cargo/commands/fixtures/fmt/hello/Cargo.toml
+++ b/src/test/resources/org/rust/cargo/commands/fixtures/fmt/hello/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "hello"
+version = "0.1.0"
+authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
+
+[dependencies]

--- a/src/test/resources/org/rust/cargo/commands/fixtures/fmt/hello/src/main.rs
+++ b/src/test/resources/org/rust/cargo/commands/fixtures/fmt/hello/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
Fixes #256 

@matklad hey,  it's been a while since our last discussion about this issue, i think i may pick it up and fix it again. i update the code use `RustToolchain` and the reformat action behaviors alright. so there still emerge the question that should i call `rustfmt` command directly just as your last comment in the deprecated PR or `cargo fmt` is just fine now, cause the version of `rustfmt` is bumped up from `0.3.0` to `0.5.0`.

and `multirust` has been placed with `rustup`, so maybe the exit code problem may not bother us any longer right?

btw, `RustToolchain` abstraction layer is such a excellent idea 😄 