### PR TITLE
(INSP): Add duplicate trait item inspections

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/duplicates/RustDuplicateInspectionTool.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/duplicates/RustDuplicateInspectionTool.kt
@@ -1,0 +1,19 @@
+package org.rust.ide.inspections.duplicates
+
+import com.intellij.psi.PsiElement
+import org.rust.ide.inspections.RustLocalInspectionTool
+import org.rust.lang.core.psi.RustElementVisitor
+import org.rust.lang.core.psi.RustNamedElement
+
+abstract class RustDuplicateInspectionTool : RustLocalInspectionTool() {
+    protected inline fun <reified T : Any, E: RustNamedElement> createInspection(
+        crossinline memberList: T.() -> List<E>,
+        crossinline holderFunc: (E) -> Unit
+    ) = object : RustElementVisitor() {
+        override fun visitElement(element: PsiElement) {
+            (element as? T)?.memberList()?.findDuplicates()?.forEach {
+                holderFunc(it)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/duplicates/RustDuplicateStructFieldInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/duplicates/RustDuplicateStructFieldInspection.kt
@@ -2,21 +2,16 @@ package org.rust.ide.inspections.duplicates
 
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
-import com.intellij.psi.PsiElement
-import org.rust.ide.inspections.RustLocalInspectionTool
-import org.rust.lang.core.psi.RustElementVisitor
+import org.rust.lang.core.psi.RustFieldDeclElement
 import org.rust.lang.core.psi.RustFieldsOwner
 import org.rust.lang.core.psi.fields
 
-class RustDuplicateStructFieldInspection : RustLocalInspectionTool() {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : RustElementVisitor() {
-        override fun visitElement(element: PsiElement) {
-            if (element is RustFieldsOwner) {
-                for (dupe in element.fields.findDuplicates()) {
-                    holder.registerProblem(dupe, "Duplicate field <code>#ref</code>", ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
-                }
-            }
+class RustDuplicateStructFieldInspection : RustDuplicateInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        createInspection(RustFieldsOwner::getFields) {
+            holder.registerProblem(it, "Duplicate field <code>#ref</code>", ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
         }
-    }
 }
 
+//TODO: Why do we need this extra layer of indirection? Why can't we rely on the property's getter via reference?
+private fun RustFieldsOwner.getFields(): List<RustFieldDeclElement> = fields

--- a/src/main/kotlin/org/rust/ide/inspections/duplicates/RustDuplicateTraitConstantInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/duplicates/RustDuplicateTraitConstantInspection.kt
@@ -1,0 +1,12 @@
+package org.rust.ide.inspections.duplicates
+
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import org.rust.lang.core.psi.RustTraitBodyElement
+
+class RustDuplicateTraitConstantInspection : RustDuplicateInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        createInspection(RustTraitBodyElement::getTraitConstMemberList) {
+            holder.registerProblem(it.identifier, "Duplicate trait constant <code>#ref</code>", ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
+        }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/duplicates/RustDuplicateTraitMethodInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/duplicates/RustDuplicateTraitMethodInspection.kt
@@ -1,0 +1,12 @@
+package org.rust.ide.inspections.duplicates
+
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import org.rust.lang.core.psi.RustTraitBodyElement
+
+class RustDuplicateTraitMethodInspection : RustDuplicateInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        createInspection(RustTraitBodyElement::getTraitMethodMemberList) {
+            holder.registerProblem(it.identifier, "Duplicate trait method <code>#ref</code>", ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
+        }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/duplicates/RustDuplicateTraitTypeInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/duplicates/RustDuplicateTraitTypeInspection.kt
@@ -1,0 +1,12 @@
+package org.rust.ide.inspections.duplicates
+
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import org.rust.lang.core.psi.RustTraitBodyElement
+
+class RustDuplicateTraitTypeInspection : RustDuplicateInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        createInspection(RustTraitBodyElement::getTraitTypeMemberList) {
+            holder.registerProblem(it.identifier, "Duplicate associated type <code>#ref</code>", ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
+        }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -140,6 +140,21 @@
                          enabledByDefault="true" level="ERROR"
                          implementationClass="org.rust.ide.inspections.duplicates.RustDuplicateStructFieldInspection"/>
 
+        <localInspection language="Rust" groupName="Redeclared symbols"
+                         displayName="Duplicate trait constant"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.rust.ide.inspections.duplicates.RustDuplicateTraitConstantInspection"/>
+
+        <localInspection language="Rust" groupName="Redeclared symbols"
+                         displayName="Duplicate trait method"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.rust.ide.inspections.duplicates.RustDuplicateTraitMethodInspection"/>
+
+        <localInspection language="Rust" groupName="Redeclared symbols"
+                         displayName="Duplicate trait associated type"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.rust.ide.inspections.duplicates.RustDuplicateTraitTypeInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RustDuplicateTraitConstant.html
+++ b/src/main/resources/inspectionDescriptions/RustDuplicateTraitConstant.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Inspects trait declaration for duplicate constants.
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/RustDuplicateTraitMethod.html
+++ b/src/main/resources/inspectionDescriptions/RustDuplicateTraitMethod.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Inspects trait declaration for duplicate methods.
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/RustDuplicateTraitType.html
+++ b/src/main/resources/inspectionDescriptions/RustDuplicateTraitType.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Inspects trait declaration for duplicate associated types.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/RustInspectionsTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RustInspectionsTest.kt
@@ -1,6 +1,9 @@
 package org.rust.ide.inspections
 
 import org.rust.ide.inspections.duplicates.RustDuplicateStructFieldInspection
+import org.rust.ide.inspections.duplicates.RustDuplicateTraitConstantInspection
+import org.rust.ide.inspections.duplicates.RustDuplicateTraitMethodInspection
+import org.rust.ide.inspections.duplicates.RustDuplicateTraitTypeInspection
 
 class RustInspectionsTest : RustInspectionsTestBase() {
 
@@ -10,6 +13,10 @@ class RustInspectionsTest : RustInspectionsTestBase() {
     fun testSelfConvention() = doTest<RustSelfConventionInspection>()
 
     fun testDuplicateField() = doTest<RustDuplicateStructFieldInspection>()
+
+    fun testDuplicateTraitConstant() = doTest<RustDuplicateTraitConstantInspection>()
+    fun testDuplicateTraitMethod() = doTest<RustDuplicateTraitMethodInspection>()
+    fun testDuplicateTraitType() = doTest<RustDuplicateTraitTypeInspection>()
 
     fun testSuppression() = checkByFile {
         enableInspection<RustSelfConventionInspection>()

--- a/src/test/resources/org/rust/ide/inspections/fixtures/duplicate_trait_constant.rs
+++ b/src/test/resources/org/rust/ide/inspections/fixtures/duplicate_trait_constant.rs
@@ -1,0 +1,5 @@
+trait T {
+     const B: i32;
+     const <error descr="Duplicate trait constant 'B'">B</error>: i32;
+     const <error descr="Duplicate trait constant 'B'">B</error>: i32 = 1;
+ }

--- a/src/test/resources/org/rust/ide/inspections/fixtures/duplicate_trait_method.rs
+++ b/src/test/resources/org/rust/ide/inspections/fixtures/duplicate_trait_method.rs
@@ -1,0 +1,4 @@
+trait T {
+    fn foo(&self) -> f64;
+    fn <error descr="Duplicate trait method 'foo'">foo</error>(&self) -> f64;
+}

--- a/src/test/resources/org/rust/ide/inspections/fixtures/duplicate_trait_type.rs
+++ b/src/test/resources/org/rust/ide/inspections/fixtures/duplicate_trait_type.rs
@@ -1,0 +1,5 @@
+trait T {
+    type A;
+    type <error descr="Duplicate associated type 'A'">A</error>;
+    type <error descr="Duplicate associated type 'A'">A</error>: bool;
+}


### PR DESCRIPTION
Addresses #542 

Added `RustDuplicateInspectionTool` to facilitate the creation of inspections to find duplicate occurrences. 

Rewrote`RustDuplicateStructFieldInspection` to extend `RustDuplicateInspectionTool`.

Added inspections for duplicate trait methods, constants, and associated types (respectively `RustDuplicateTraitMethodInspection`, `RustDuplicateTraitConstantInspection`, and `RustDuplicateTraitConstantInspection`).

Feedback is very much appreciated.