### PR TITLE
(SNIPPETS): Do not offer live templates in attributes

### DIFF
--- a/src/main/kotlin/org/rust/ide/template/RustContextType.kt
+++ b/src/main/kotlin/org/rust/ide/template/RustContextType.kt
@@ -67,6 +67,12 @@ sealed class RustContextType(
             PsiTreeUtil.findFirstParent(element, blockOrItem) is RustModItemElement
     }
 
+    class Attribute : RustContextType("RUST_ATTRIBUTE", "Attribute", Item::class) {
+        override fun isInContext(element: PsiElement): Boolean =
+
+            element.parentOfType<RustAttrElement>() != null
+    }
+
     companion object {
         private val blockOrItem = Condition<PsiElement> { element ->
             element is RustBlockElement || element is RustItemElement || element is RustAttrElement

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -180,6 +180,7 @@
         <liveTemplateContext implementation="org.rust.ide.template.RustContextType$Item"/>
         <liveTemplateContext implementation="org.rust.ide.template.RustContextType$Struct"/>
         <liveTemplateContext implementation="org.rust.ide.template.RustContextType$Mod"/>
+        <liveTemplateContext implementation="org.rust.ide.template.RustContextType$Attribute"/>
 
         <liveTemplateMacro implementation="org.rust.ide.template.macros.RustSuggestIndexNameMacro"/>
         <liveTemplateMacro implementation="org.rust.ide.template.macros.RustCollectionElementNameMacro"/>

--- a/src/main/resources/org/rust/ide/liveTemplates/other.xml
+++ b/src/main/resources/org/rust/ide/liveTemplates/other.xml
@@ -25,6 +25,7 @@
             <option name="RUST_FILE" value="true"/>
             <option name="RUST_STATEMENT" value="false"/>
             <option name="RUST_ITEM" value="false"/>
+            <option name="RUST_ATTRIBUTE" value="false"/>
         </context>
     </template>
 
@@ -35,6 +36,7 @@
         <variable name="TRANSCRIBER" expression="" defaultValue="" alwaysStopAt="true"/>
         <context>
             <option name="RUST_FILE" value="true"/>
+            <option name="RUST_ATTRIBUTE" value="false"/>
         </context>
     </template>
 

--- a/src/main/resources/org/rust/ide/liveTemplates/test.xml
+++ b/src/main/resources/org/rust/ide/liveTemplates/test.xml
@@ -25,6 +25,7 @@
             <option name="RUST_FILE" value="true"/>
             <option name="RUST_STATEMENT" value="false"/>
             <option name="RUST_ITEM" value="false"/>
+            <option name="RUST_STATEMENT" value="false"/>
             <option name="RUST_MOD" value="true"/>
         </context>
     </template>
@@ -36,6 +37,7 @@
             <option name="RUST_FILE" value="true"/>
             <option name="RUST_STATEMENT" value="false"/>
             <option name="RUST_ITEM" value="false"/>
+            <option name="RUST_STATEMENT" value="false"/>
             <option name="RUST_MOD" value="true"/>
         </context>
     </template>

--- a/src/test/kotlin/org/rust/ide/template/RustLiveTemplatesTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/RustLiveTemplatesTest.kt
@@ -9,6 +9,7 @@ class RustLiveTemplatesTest : RustTestCaseBase() {
     fun testStructField() = expandAndCompare()
     fun testPrint() = expandAndCompare()
 
+    fun testAttribute() = noSnippetApplicable()
     fun testComment() = noSnippetApplicable()
     fun testDocComment() = noSnippetApplicable()
     fun testStringLiteral() = noSnippetApplicable()

--- a/src/test/resources/org/rust/ide/template/fixtures/attribute.rs
+++ b/src/test/resources/org/rust/ide/template/fixtures/attribute.rs
@@ -1,0 +1,5 @@
+#[macro<caret>]
+extern crate std;
+
+fn main() {
+}

--- a/src/test/resources/org/rust/ide/template/fixtures/attribute_after.rs
+++ b/src/test/resources/org/rust/ide/template/fixtures/attribute_after.rs
@@ -1,0 +1,5 @@
+#[macro]
+extern crate std;
+
+fn main() {
+}


### PR DESCRIPTION
The live templates "macro", "main", "tfn" and "tmod" are enabed
in most areas of a rust file.

Disable this live templates inside attributes where they are not useful.

Fixes #634