### PR TITLE
(EDT): check offset validity

### DIFF
--- a/src/main/kotlin/org/rust/ide/typing/RustEnterInStringLiteralHandler.kt
+++ b/src/main/kotlin/org/rust/ide/typing/RustEnterInStringLiteralHandler.kt
@@ -27,6 +27,7 @@ class RustEnterInStringLiteralHandler : EnterHandlerDelegateAdapter() {
         }
 
         val caretOffset = caretOffsetRef.get()
+        if (!isValidOffset(caretOffset, editor.document.charsSequence)) return Result.Continue
 
         val highlighter = (editor as EditorEx).highlighter
         val iterator = highlighter.createIterator(caretOffset)
@@ -58,5 +59,9 @@ class RustEnterInStringLiteralHandler : EnterHandlerDelegateAdapter() {
 
             else -> Result.Continue
         }
+    }
+
+    private fun isValidOffset(offset: Int, text: CharSequence): Boolean {
+        return offset >= 0 && offset < text.length
     }
 }

--- a/src/test/kotlin/org/rust/ide/typing/RustTypingMiscTests.kt
+++ b/src/test/kotlin/org/rust/ide/typing/RustTypingMiscTests.kt
@@ -1,0 +1,7 @@
+package org.rust.ide.typing
+
+class RustTypingMiscTests : RustTypingTestCaseBase() {
+    override val dataPath: String = ""
+
+    fun testIssue680() = doTestByText("foo.rs", "<caret>", "\n<caret>") // https://github.com/intellij-rust/intellij-rust/issues/680
+}

--- a/src/test/kotlin/org/rust/ide/typing/RustTypingTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/ide/typing/RustTypingTestCaseBase.kt
@@ -6,4 +6,9 @@ abstract class RustTypingTestCaseBase : RustTestCaseBase() {
     protected fun doTest(c: Char = '\n') = checkByFile {
         myFixture.type(c)
     }
+
+    protected fun doTestByText(fileName: String, before: String, after: String, c: Char = '\n') =
+        checkByText(fileName, before, after) {
+            myFixture.type(c)
+        }
 }

--- a/src/test/kotlin/org/rust/lang/RustTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/lang/RustTestCaseBase.kt
@@ -59,6 +59,12 @@ abstract class RustTestCaseBase : LightPlatformCodeInsightFixtureTestCase(), Rus
         PlatformTestUtil.assertDirectoriesEqual(afterDir, beforeDir)
     }
 
+    protected fun checkByText(fileName: String, before: String, after: String, action: () -> Unit) {
+        myFixture.configureByText(fileName, before)
+        action()
+        myFixture.checkResult(after)
+    }
+
     protected fun openFileInEditor(path: String) {
         myFixture.configureFromExistingVirtualFile(myFixture.findFileInTempDir(path))
     }


### PR DESCRIPTION
It's important to remember that `HighlighterIterator#getTokenType()` for empty document throws IndexOutOfBounds exception.

fix #680 