### PR TITLE
(TYPE): support for type parameters substitutions

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/RustEnumType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RustEnumType.kt
@@ -4,12 +4,21 @@ import com.intellij.codeInsight.completion.CompletionUtil
 import org.rust.lang.core.psi.RustEnumItemElement
 import org.rust.lang.core.types.visitors.RustTypeVisitor
 
-class RustEnumType(enum: RustEnumItemElement) : RustStructOrEnumTypeBase() {
+class RustEnumType(
+    enum: RustEnumItemElement,
+    typeArguments: List<RustType> = emptyList()
+) : RustStructOrEnumTypeBase(typeArguments) {
 
     override val item = CompletionUtil.getOriginalOrSelf(enum)
 
     override fun <T> accept(visitor: RustTypeVisitor<T>): T = visitor.visitEnum(this)
 
     override fun toString(): String = item.name ?: "<anonymous>"
+
+    override fun withTypeArguments(typeArguments: List<RustType>): RustEnumType =
+        RustEnumType(item, typeArguments)
+
+    override fun substitute(map: Map<RustTypeParameterType, RustType>): RustEnumType =
+        RustEnumType(item, typeArguments.map { it.substitute(map) })
 
 }

--- a/src/main/kotlin/org/rust/lang/core/types/RustFunctionType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RustFunctionType.kt
@@ -10,4 +10,7 @@ class RustFunctionType(val paramTypes: List<RustType>, val retType: RustType) : 
         val params = paramTypes.joinToString(", ", "fn(", ")")
         return if (retType === RustUnitType) params else "$params -> $retType"
     }
+
+    override fun substitute(map: Map<RustTypeParameterType, RustType>): RustFunctionType =
+        RustFunctionType(paramTypes.map { it.substitute(map) }, retType.substitute(map))
 }

--- a/src/main/kotlin/org/rust/lang/core/types/RustStructOrEnumTypeBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RustStructOrEnumTypeBase.kt
@@ -1,9 +1,17 @@
 package org.rust.lang.core.types
 
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RustStructOrEnumItemElement
 
-abstract class RustStructOrEnumTypeBase : RustTypeBase() {
+abstract class RustStructOrEnumTypeBase(val typeArguments: List<RustType>) : RustTypeBase() {
 
     abstract val item: RustStructOrEnumItemElement
+
+    override val typeParameterValues: Map<RustTypeParameterType, RustType>
+        get() = item.genericParams?.typeParamList.orEmpty()
+            .zip(typeArguments)
+            .mapNotNull {
+                val (param, arg) = it
+                RustTypeParameterType(param) to arg
+            }.toMap()
 
 }

--- a/src/main/kotlin/org/rust/lang/core/types/RustStructType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RustStructType.kt
@@ -4,11 +4,20 @@ import com.intellij.codeInsight.completion.CompletionUtil
 import org.rust.lang.core.psi.RustStructItemElement
 import org.rust.lang.core.types.visitors.RustTypeVisitor
 
-class RustStructType(struct: RustStructItemElement) : RustStructOrEnumTypeBase() {
+class RustStructType(
+    struct: RustStructItemElement,
+    typeArguments: List<RustType> = emptyList()
+) : RustStructOrEnumTypeBase(typeArguments) {
 
     override val item = CompletionUtil.getOriginalOrSelf(struct)
 
     override fun <T> accept(visitor: RustTypeVisitor<T>): T = visitor.visitStruct(this)
 
     override fun toString(): String = item.name ?: "<anonymous>"
+
+    override fun withTypeArguments(typeArguments: List<RustType>): RustStructType =
+        RustStructType(item, typeArguments)
+
+    override fun substitute(map: Map<RustTypeParameterType, RustType>): RustStructType =
+        RustStructType(item, typeArguments.map { it.substitute(map) })
 }

--- a/src/main/kotlin/org/rust/lang/core/types/RustTupleType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RustTupleType.kt
@@ -14,6 +14,9 @@ class RustTupleType(private val elements: List<RustType>) : RustTypeBase() {
 
     val size: Int = elements.size
 
+    override fun substitute(map: Map<RustTypeParameterType, RustType>): RustTupleType =
+        RustTupleType(elements.map { it.substitute(map) })
+
     override fun <T> accept(visitor: RustTypeVisitor<T>): T = visitor.visitTupleType(this)
 
     override fun toString(): String = elements.joinToString(", ", "(", ")")

--- a/src/main/kotlin/org/rust/lang/core/types/RustType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RustType.kt
@@ -17,6 +17,26 @@ interface RustType {
      */
     fun getNonStaticMethodsIn(project: Project): Sequence<RustFnElement>
 
+    /**
+     * Apply positional type arguments to a generic type.
+     *
+     * This works for `some::path::<Type1, Type2>` case.
+     */
+    fun withTypeArguments(typeArguments: List<RustType>): RustType = this
+
+    /**
+     * Apply named type arguments to a generic type.
+     *
+     * This works for `struct S<T> { field: T }`, when we
+     * know the type of `T` and want to find the type of `field`.
+     */
+    fun substitute(map: Map<RustTypeParameterType, RustType>): RustType = this
+
+    /**
+     * Bindings between formal type parameters and actual type arguments.
+     */
+    val typeParameterValues: Map<RustTypeParameterType, RustType> get() = emptyMap()
+
     fun <T> accept(visitor: RustTypeVisitor<T>): T
 
     override fun equals(other: Any?): Boolean

--- a/src/main/kotlin/org/rust/lang/core/types/RustTypeParameterType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RustTypeParameterType.kt
@@ -16,6 +16,8 @@ class RustTypeParameterType(val parameter: RustTypeParamElement) : RustTypeBase(
     override fun getNonStaticMethodsIn(project: Project): Sequence<RustFnElement> =
         getTraitsImplementedIn(project).flatMap { it.traitMethodMemberList.asSequence() }
 
+    override fun substitute(map: Map<RustTypeParameterType, RustType>): RustType = map[this] ?: this
+
     override fun <T> accept(visitor: RustTypeVisitor<T>): T = visitor.visitTypeParameter(this)
 
     override fun toString(): String = parameter.name ?: "<unknown>"

--- a/src/main/kotlin/org/rust/lang/core/types/visitors/impl/RustTypeResolvingVisitor.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/visitors/impl/RustTypeResolvingVisitor.kt
@@ -3,6 +3,7 @@ package org.rust.lang.core.types.visitors.impl
 import org.rust.lang.core.psi.RustCompositeElement
 import org.rust.lang.core.resolve.Namespace
 import org.rust.lang.core.resolve.RustResolveEngine
+import org.rust.lang.core.symbols.RustPathHead
 import org.rust.lang.core.types.*
 import org.rust.lang.core.types.unresolved.*
 import org.rust.lang.core.types.visitors.RustUnresolvedTypeVisitor
@@ -18,10 +19,12 @@ open class RustTypeResolvingVisitor(private val pivot: RustCompositeElement) : R
     override fun visitTupleType(type: RustUnresolvedTupleType): RustType =
         RustTupleType(type.elements.map { visit(it) })
 
-    override fun visitPathType(type: RustUnresolvedPathType): RustType =
-        RustResolveEngine.resolve(type.path, pivot, namespace = Namespace.Types).firstOrNull()?.let {
-            RustTypificationEngine.typify(it)
-        } ?: RustUnknownType
+    override fun visitPathType(type: RustUnresolvedPathType): RustType {
+        val target = RustResolveEngine.resolve(type.path, pivot, Namespace.Types).firstOrNull() ?: return RustUnknownType
+        val typeArguments = (type.path.head as? RustPathHead.Named)?.segment?.typeArguments.orEmpty()
+        return RustTypificationEngine.typify(target)
+            .withTypeArguments(typeArguments.map { it.accept(RustTypeResolvingVisitor(pivot))  })
+    }
 
     override fun visitFunctionType(type: RustUnresolvedFunctionType): RustType =
         RustFunctionType(type.paramTypes.map { visit(it) }, visit(type.retType))

--- a/src/test/kotlin/org/rust/lang/core/type/RustGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RustGenericExpressionTypeInferenceTest.kt
@@ -1,0 +1,117 @@
+package org.rust.lang.core.type
+
+class RustGenericExpressionTypeInferenceTest : RustTypificationTestBase() {
+    fun testGenericField() = testExpr("""
+        struct S<T> { field: T }
+
+        fn foo(s: S<f64>) {
+            let x = s.field;
+            x
+          //^ f64
+        }
+    """)
+
+    fun testNestedGenericField() = testExpr("""
+        struct A<T> { field: T }
+        struct B<S> { field: S }
+
+        fn foo(s: A<B<f64>>) {
+            let x = s.field.field;
+            x
+          //^ f64
+        }
+    """)
+
+    fun testNestedGenericField2() = testExpr("""
+        struct S<T> { field: T }
+
+        fn foo(s: S<S<u64>>) {
+            let x = s.field.field;
+            x
+          //^ u64
+        }
+    """)
+
+    fun testGenericMethod() = testExpr("""
+        struct B<T> { field: T }
+
+        impl<T> B<T> {
+            fn unwrap(self) -> T { self.field }
+        }
+
+        fn foo(s: B<i32>) {
+            let x = s.unwrap();
+            x
+          //^ i32
+        }
+    """)
+
+    fun testTwoParameters() = testExpr("""
+         enum Result<T, E> { Ok(T), Err(E)}
+         impl<T, E> Result<T, E> {
+             fn unwrap(self) -> T { unimplemented!() }
+         }
+
+         fn foo(r: Result<(u32, u32), ()>) {
+             let x = r.unwrap();
+             x
+           //^ (u32, u32)
+         }
+    """)
+
+    fun testParamSwap() = testExpr("""
+        struct S<A, B> { a: A, b: B}
+
+        impl<X, Y> S<Y, X> {
+            fn swap(self) -> (X, Y) { (self.b, self.a) }
+        }
+
+        fn f(s: S<i32, ()>) {
+            let x = s.swap();
+            x
+          //^ ((), i32)
+        }
+    """)
+
+    fun testParamRepeat() = testExpr("""
+        struct S<A, B> { a: A, b: B}
+
+        impl <T> S<T, T> {
+            fn foo(self) -> (T, T) { (self.a, self.b) }
+        }
+
+        fn f(s: S<i32, i32>) {
+            let x = s.foo();
+            x
+          //^ (i32, i32)
+        }
+    """)
+
+    fun testPartialSpec() = testExpr("""
+        struct S<A, B> { a: A, b: B}
+
+        impl <T> S<i32, T> {
+            fn foo(self) -> T { self.b }
+        }
+
+        fn f(s: S<i32, ()>) {
+            let x = s.foo();
+            x
+          //^ ()
+        }
+    """)
+
+    fun testRecursiveType() = testExpr("""
+        struct S<T> {
+            rec: S<T>,
+            field: T
+        }
+
+        fn foo(s: S<char>) {
+            let x = s.rec.field;
+            x
+          //^ char
+        }
+    """)
+}
+


### PR DESCRIPTION
@alexeykudinkin @mkaput please review. The main interface changes are here: https://github.com/intellij-rust/intellij-rust/compare/type-params?expand=1#diff-231e8a807fef2b7083c5227a54b3aed0R23