### PR TITLE
(EDT): fix quote completion in raw literals

### DIFF
--- a/src/main/kotlin/org/rust/ide/typing/RustQuoteHandler.kt
+++ b/src/main/kotlin/org/rust/ide/typing/RustQuoteHandler.kt
@@ -80,9 +80,13 @@ class RustQuoteHandler : SimpleTokenSetQuoteHandler(
 
     override fun getClosingQuote(iterator: HighlighterIterator, offset: Int): CharSequence? {
         val literal = getLiteralDumb(iterator) ?: return null
-
         if (literal is RustRawStringLiteralImpl) {
-            return '"' + "#".repeat(literal.hashes)
+            val valueOffsets = literal.offsets.value?.shiftRight(iterator.start) ?: return null
+            if (offset !in valueOffsets || offset == valueOffsets.startOffset || offset == valueOffsets.endOffset) {
+                return '"' + "#".repeat(literal.hashes)
+            } else {
+                return null
+            }
         }
 
         return null

--- a/src/test/kotlin/org/rust/ide/typing/RustQuoteHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/RustQuoteHandlerTest.kt
@@ -13,4 +13,8 @@ class RustQuoteHandlerTest : RustTypingTestCaseBase() {
     fun testCompleteRawStringQuotes2() = doTest('"')
     fun testCompleteByteRawStringQuotes() = doTest('"')
     fun testCompleteByteRawStringQuotes2() = doTest('"')
+
+    // https://github.com/intellij-rust/intellij-rust/issues/687
+    fun testDoubleQuoteInRawLiteral() = doTest('"')
+    fun testSingleQuoteInRawLiteral() = doTest('\'')
 }

--- a/src/test/resources/org/rust/ide/typing/quoteHandler/fixtures/double_quote_in_raw_literal.rs
+++ b/src/test/resources/org/rust/ide/typing/quoteHandler/fixtures/double_quote_in_raw_literal.rs
@@ -1,0 +1,3 @@
+fn main() {
+    r###"Hello, <caret> World!"###
+}

--- a/src/test/resources/org/rust/ide/typing/quoteHandler/fixtures/double_quote_in_raw_literal_after.rs
+++ b/src/test/resources/org/rust/ide/typing/quoteHandler/fixtures/double_quote_in_raw_literal_after.rs
@@ -1,0 +1,3 @@
+fn main() {
+    r###"Hello, "<caret> World!"###
+}

--- a/src/test/resources/org/rust/ide/typing/quoteHandler/fixtures/single_quote_in_raw_literal.rs
+++ b/src/test/resources/org/rust/ide/typing/quoteHandler/fixtures/single_quote_in_raw_literal.rs
@@ -1,0 +1,3 @@
+fn main() {
+    r###"Hello, <caret> World!"###
+}

--- a/src/test/resources/org/rust/ide/typing/quoteHandler/fixtures/single_quote_in_raw_literal_after.rs
+++ b/src/test/resources/org/rust/ide/typing/quoteHandler/fixtures/single_quote_in_raw_literal_after.rs
@@ -1,0 +1,3 @@
+fn main() {
+    r###"Hello, '<caret> World!"###
+}


### PR DESCRIPTION
I decided not to complete quotes inside, as it might be cumbersome sometimes, also checked out what does PyCharm do in `"""..."""` literals and it's also not completing quotes inside.
fix #687 