### PR TITLE
Display consts and statics in the Project Structure window

### DIFF
--- a/src/main/kotlin/org/rust/ide/icons/RustIcons.kt
+++ b/src/main/kotlin/org/rust/ide/icons/RustIcons.kt
@@ -25,6 +25,7 @@ object RustIcons {
 
     // Marks
 
+    val FINAL_MARK = AllIcons.Nodes.FinalMark!!
     val STATIC_MARK  = AllIcons.Nodes.StaticMark!!
     val TEST_MARK    = AllIcons.Nodes.JunitTestMark!!
 
@@ -48,7 +49,12 @@ object RustIcons {
 
     val FIELD    = AllIcons.Nodes.Field!!
     val BINDING  = AllIcons.Nodes.Variable!!
+    val CONSTANT = BINDING.addFinalMark()
+    val STATIC   = BINDING.addStaticMark()
+
 }
+
+fun Icon.addFinalMark(): Icon = LayeredIcon(this, RustIcons.FINAL_MARK)
 
 fun Icon.addStaticMark(): Icon = LayeredIcon(this, RustIcons.STATIC_MARK)
 

--- a/src/main/kotlin/org/rust/ide/structure/RustConstTreeElement.kt
+++ b/src/main/kotlin/org/rust/ide/structure/RustConstTreeElement.kt
@@ -1,0 +1,12 @@
+package org.rust.ide.structure
+
+import com.intellij.ide.structureView.StructureViewTreeElement
+import com.intellij.ide.structureView.impl.common.PsiTreeElementBase
+import org.rust.lang.core.psi.RustConstItemElement
+
+class RustConstTreeElement(element: RustConstItemElement) : PsiTreeElementBase<RustConstItemElement>(element) {
+
+    override fun getPresentableText(): String? = element?.name
+
+    override fun getChildrenBase(): Collection<StructureViewTreeElement> = emptyList()
+}

--- a/src/main/kotlin/org/rust/ide/structure/RustModTreeElement.kt
+++ b/src/main/kotlin/org/rust/ide/structure/RustModTreeElement.kt
@@ -12,11 +12,13 @@ open class RustModTreeElement(item: RustMod) : PsiTreeElementBase<RustMod>(item)
 
     private fun toTreeElement(it: RustItemElement): StructureViewTreeElement? =
         when (it) {
+            is RustConstItemElement     -> RustConstTreeElement(it)
             is RustEnumItemElement      -> RustEnumTreeElement(it)
             is RustFnItemElement        -> RustFnTreeElement(it)
             is RustImplItemElement      -> RustImplTreeElement(it)
             is RustModDeclItemElement   -> RustModDeclTreeElement(it)
             is RustModItemElement       -> RustModTreeElement(it)
+            is RustStaticItemElement    -> RustStaticTreeElement(it)
             is RustStructItemElement    -> RustStructTreeElement(it)
             is RustTraitItemElement     -> RustTraitTreeElement(it)
             is RustTypeItemElement      -> RustTypeTreeElement(it)

--- a/src/main/kotlin/org/rust/ide/structure/RustStaticTreeElement.kt
+++ b/src/main/kotlin/org/rust/ide/structure/RustStaticTreeElement.kt
@@ -1,0 +1,12 @@
+package org.rust.ide.structure
+
+import com.intellij.ide.structureView.StructureViewTreeElement
+import com.intellij.ide.structureView.impl.common.PsiTreeElementBase
+import org.rust.lang.core.psi.RustStaticItemElement
+
+class RustStaticTreeElement(element: RustStaticItemElement) : PsiTreeElementBase<RustStaticItemElement>(element) {
+
+    override fun getPresentableText(): String? = element?.name
+
+    override fun getChildrenBase(): Collection<StructureViewTreeElement> = emptyList()
+}

--- a/src/main/kotlin/org/rust/ide/structure/RustStructureViewModel.kt
+++ b/src/main/kotlin/org/rust/ide/structure/RustStructureViewModel.kt
@@ -18,10 +18,12 @@ class RustStructureViewModel(editor: Editor?, file: RustFile) : TextEditorBasedS
 
     override fun isAlwaysLeaf(element: StructureViewTreeElement) =
         when (element.value) {
+            is RustConstItemElement,
             is RustFieldDeclElement,
             is RustFnItemElement,
             is RustImplMethodMemberElement,
             is RustModDeclItemElement,
+            is RustStaticItemElement,
             is RustTypeItemElement -> true
             else -> false
         }

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustConstItemImplMixin.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustConstItemImplMixin.kt
@@ -2,7 +2,9 @@ package org.rust.lang.core.psi.impl.mixin
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.stubs.IStubElementType
+import org.rust.ide.icons.RustIcons
 import org.rust.lang.core.psi.RustConstItemElement
+import org.rust.lang.core.psi.iconWithVisibility
 import org.rust.lang.core.psi.impl.RustPsiImplUtil
 import org.rust.lang.core.psi.impl.RustStubbedNamedElementImpl
 import org.rust.lang.core.stubs.elements.RustConstItemElementStub
@@ -11,6 +13,8 @@ abstract class RustConstItemImplMixin : RustStubbedNamedElementImpl<RustConstIte
     constructor(node: ASTNode) : super(node)
 
     constructor(stub: RustConstItemElementStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
+
+    override fun getIcon(flags: Int) = iconWithVisibility(flags, RustIcons.CONSTANT)
 
     override val isPublic: Boolean get() = RustPsiImplUtil.isPublic(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustStaticItemImplMixin.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustStaticItemImplMixin.kt
@@ -2,7 +2,9 @@ package org.rust.lang.core.psi.impl.mixin
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.stubs.IStubElementType
+import org.rust.ide.icons.RustIcons
 import org.rust.lang.core.psi.RustStaticItemElement
+import org.rust.lang.core.psi.iconWithVisibility
 import org.rust.lang.core.psi.impl.RustPsiImplUtil
 import org.rust.lang.core.psi.impl.RustStubbedNamedElementImpl
 import org.rust.lang.core.stubs.elements.RustStaticItemElementStub
@@ -11,6 +13,8 @@ abstract class RustStaticItemImplMixin : RustStubbedNamedElementImpl<RustStaticI
     constructor(node: ASTNode) : super(node)
 
     constructor(stub: RustStaticItemElementStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
+
+    override fun getIcon(flags: Int) = iconWithVisibility(flags, RustIcons.STATIC)
 
     override val isPublic: Boolean get() = RustPsiImplUtil.isPublic(this)
 }

--- a/src/test/kotlin/org/rust/ide/structure/RustStructureViewTest.kt
+++ b/src/test/kotlin/org/rust/ide/structure/RustStructureViewTest.kt
@@ -12,10 +12,12 @@ class RustStructureViewTest : RustTestCaseBase() {
 
     fun testFunctions() = doFileTest()
 
+    fun testConsts() = doFileTest()
     fun testEnums() = doFileTest()
     fun testImpls() = doFileTest()
     fun testMods() = doFileTest()
     fun testStructs() = doFileTest()
+    fun testStatics() = doFileTest()
     fun testTraits() = doFileTest()
     fun testTypeAliases() = doFileTest()
 

--- a/src/test/resources/org/rust/ide/structure/fixtures/consts.rs
+++ b/src/test/resources/org/rust/ide/structure/fixtures/consts.rs
@@ -1,0 +1,5 @@
+const SEVEN: f64 = 7.0;
+
+const BOOK_TITLE: &'static str = "Alice in Wonderland";
+
+pub const PUB_CONSTANT: i32 = 42;

--- a/src/test/resources/org/rust/ide/structure/fixtures/consts.txt
+++ b/src/test/resources/org/rust/ide/structure/fixtures/consts.txt
@@ -1,0 +1,4 @@
+-consts.rs
+ SEVEN
+ BOOK_TITLE
+ PUB_CONSTANT

--- a/src/test/resources/org/rust/ide/structure/fixtures/statics.rs
+++ b/src/test/resources/org/rust/ide/structure/fixtures/statics.rs
@@ -1,0 +1,5 @@
+static N: i32 = 5;
+
+static NAME: &'static str = "John Doe";
+
+static mut MUT_N: i64 = 5;

--- a/src/test/resources/org/rust/ide/structure/fixtures/statics.txt
+++ b/src/test/resources/org/rust/ide/structure/fixtures/statics.txt
@@ -1,0 +1,4 @@
+-statics.rs
+ N
+ NAME
+ MUT_N


### PR DESCRIPTION
This fix adds information about constants and static values to the Project Structure window. They are displayed as bindings with the final and static markers respectively:

<img width="183" alt="const-static" src="https://cloud.githubusercontent.com/assets/2101250/19014450/9982e71e-87f5-11e6-958f-eac2c7a7cf9a.png">
