### PR TITLE
(MISC): Qualify mod.rs files with parent dir name

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/RustModTabTitleProvider.kt
+++ b/src/main/kotlin/org/rust/ide/utils/RustModTabTitleProvider.kt
@@ -1,16 +1,17 @@
 package org.rust.ide.utils
 
-import com.intellij.openapi.fileEditor.impl.EditorTabTitleProvider
+import com.intellij.openapi.fileEditor.impl.UniqueNameEditorTabTitleProvider
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import org.rust.lang.core.psi.impl.isRustFile
 
-class RustModTabTitleProvider : EditorTabTitleProvider {
+class RustModTabTitleProvider : UniqueNameEditorTabTitleProvider() {
     val MOD_FILE_NAME = "mod.rs"
 
     override fun getEditorTabTitle(project: Project, file: VirtualFile): String? {
         if (file.isRustFile && MOD_FILE_NAME == file.name) {
-            return "${file.parent.name}/${file.name}"
+            return  super.getEditorTabTitle(project, file) ?:
+                "${file.parent.name}/${file.name}"
         }
 
         return null

--- a/src/main/kotlin/org/rust/ide/utils/RustModTabTitleProvider.kt
+++ b/src/main/kotlin/org/rust/ide/utils/RustModTabTitleProvider.kt
@@ -1,0 +1,18 @@
+package org.rust.ide.utils
+
+import com.intellij.openapi.fileEditor.impl.EditorTabTitleProvider
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import org.rust.lang.core.psi.impl.isRustFile
+
+class RustModTabTitleProvider : EditorTabTitleProvider {
+    val MOD_FILE_NAME = "mod.rs"
+
+    override fun getEditorTabTitle(project: Project, file: VirtualFile): String? {
+        if (file.isRustFile && MOD_FILE_NAME == file.name) {
+            return "${file.parent.name}/${file.name}"
+        }
+
+        return null
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -266,6 +266,10 @@
 
         <editorNotificationProvider implementation="org.rust.ide.notifications.MissingToolchainNotificationProvider" />
 
+        <!-- Editor Tab Title Providers -->
+
+        <editorTabTitleProvider implementation="org.rust.ide.utils.RustModTabTitleProvider"/>
+
         <!-- Refactoring -->
 
         <lang.namesValidator language="Rust" implementationClass="org.rust.lang.refactoring.RustNamesValidator"/>


### PR DESCRIPTION
Overview
===
In order to help figure users understand what module file they're working in, this PR forces the editor to _qualify_ the tab name.

Previously, a tab for a module file would simply display `mod.rs`. This has been changed to include the parent directory (e.g. `foo/mod.rs`).

Addresses #696 

Technical Details
===
Created an concrete implementation of `EditorTabTitleProvider` for module files and registered it with the plugin.

When providing a tab title, we check to see if we are using a rust file and if that file is a module. If that's the case, we just pull in the parent directory's name and separate them with a forward slash. 
