### PR TITLE
(MISC) DeMorgan intention title fix

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/DemorgansLawIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/DemorgansLawIntention.kt
@@ -10,7 +10,7 @@ import org.rust.lang.core.psi.util.descendentsOfType
 import org.rust.lang.core.psi.util.parentOfType
 
 class DemorgansLawIntention : PsiElementBaseIntentionAction() {
-    override fun getFamilyName() = text
+    override fun getFamilyName() = "DeMorgan's Law"
     override fun startInWriteAction() = true
 
     private fun setTextForElement(element: PsiElement) {


### PR DESCRIPTION
IDEA uses `familyName` as the title of an intention in the Preferences window. `DemorgansLawIntention` returns the `text` field as its family name. The problem is that the value of the `text` property is dynamic. It depends on the last performed code analysis and can even be empty when no suitable piece of code is found for the intention. Thus, the intention is displayed under different titles and sometimes even with no title at all.

The PR fixes the problem by providing the DeMorgan's Law intention with a constant family name.