### PR TITLE
(TYPE): Resolve ==,!=,<=,>=,<,>,||,&& to bool

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/visitors/impl/RustTypificationEngine.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/visitors/impl/RustTypificationEngine.kt
@@ -140,7 +140,28 @@ private class RustExprTypificationVisitor : RustComputingVisitor<RustType>() {
     override fun visitParenExpr(o: RustParenExprElement) = set { o.expr.resolvedType }
 
     override fun visitBinaryExpr(o: RustBinaryExprElement) {
-        super.visitBinaryExpr(o)
+        when (o.operatorType) {
+            RustTokenElementTypes.ANDAND,
+            RustTokenElementTypes.OROR -> {
+                if (o.left.resolvedType == RustBooleanType &&
+                    o.right?.resolvedType == RustBooleanType) {
+                    set { RustBooleanType }
+                } else {
+                    super.visitBinaryExpr(o)
+                }
+            }
+
+            RustTokenElementTypes.EQEQ,
+            RustTokenElementTypes.EXCLEQ,
+            RustTokenElementTypes.LT,
+            RustTokenElementTypes.GT,
+            RustTokenElementTypes.GTEQ,
+            RustTokenElementTypes.LTEQ -> {
+                set { RustBooleanType }
+            }
+
+            else -> super.visitBinaryExpr(o)
+        }
     }
 
     private val RustBlockElement.resolvedType: RustType get() = expr?.resolvedType ?: RustUnitType
@@ -150,7 +171,7 @@ private class RustItemTypificationVisitor : RustComputingVisitor<RustType>() {
 
     override fun visitElement(element: PsiElement) = set {
         check(element is RustItemElement) {
-           "Panic! Should not be used with anything except the inheritors of `RustItemElement` hierarchy!"
+            "Panic! Should not be used with anything except the inheritors of `RustItemElement` hierarchy!"
         }
 
         RustUnknownType
@@ -192,7 +213,7 @@ private class RustTypeTypificationVisitor : RustComputingVisitor<RustUnresolvedT
     }
 
     override fun visitPathType(o: RustPathTypeElement) = set {
-         o.path?.let {
+        o.path?.let {
             (   RustIntegerType.deduce(it.text)     ?:
                 RustFloatType.deduce(it.text)       ?:
                 RustBooleanType.deduce(it.text)     ?:

--- a/src/test/kotlin/org/rust/lang/core/type/RustExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RustExpressionTypeInferenceTest.kt
@@ -302,5 +302,32 @@ class RustExpressionTypeInferenceTest : RustTypificationTestBase() {
         }
     """)
 
+    fun testBinOperatorsBool() {
+        val cases = listOf(
+            Pair("1 == 2",          "bool"),
+            Pair("1 != 2",          "bool"),
+            Pair("1 <= 2",          "bool"),
+            Pair("1 >= 2",          "bool"),
+            Pair("1 < 2",           "bool"),
+            Pair("1 > 2",           "bool"),
+            Pair("true && false",   "bool"),
+            Pair("true || false",   "bool"),
+            Pair("1 && 2",          "<unknown>"),
+            Pair("1 || 2",          "<unknown>"),
+            Pair("1 || true",       "<unknown>")
+        )
+
+        for ((i, case) in cases.withIndex()) {
+            testExpr("""
+                fn main() {
+                    let x = ${case.first};
+                    x
+                  //^ ${case.second}
+                }
+                """
+            ,
+                "Case number: $i")
+        }
+    }
 }
 

--- a/src/test/kotlin/org/rust/lang/core/type/RustTypificationTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RustTypificationTestBase.kt
@@ -9,10 +9,11 @@ import org.rust.lang.core.types.util.resolvedType
 abstract class RustTypificationTestBase : RustTestCaseBase() {
     override val dataPath: String get() = ""
 
-    protected fun testExpr(@Language("Rust") code: String) {
+    protected fun testExpr(@Language("Rust") code: String, description: String = "") {
         val (expr, expectedType) = InlineFile(code).elementAndData<RustExprElement>()
 
         assertThat(expr.resolvedType.toString())
+            .`as`(description)
             .isEqualTo(expectedType)
     }
 }


### PR DESCRIPTION
Now expressions with these operators are resolving in undefined type.

I suggest to resolve it in bool.
If it's not too ugly :), it can greatly extend the scope for application surrounders (if exp, for example) and other plugin features.