### PR TITLE
(MISC) Double Negation inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RustDoubleNegInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RustDoubleNegInspection.kt
@@ -1,0 +1,30 @@
+package org.rust.ide.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import org.rust.lang.core.psi.RustElementVisitor
+import org.rust.lang.core.psi.RustExprElement
+import org.rust.lang.core.psi.RustUnaryExprElement
+
+/**
+ * Checks for usage of double negation, which is a no-op in Rust but might be misleading for
+ * programmers with background in languages that have prefix operators.
+ *
+ * Analogue of Clippy's double_neg.
+ */
+class RustDoubleNegInspection : RustLocalInspectionTool() {
+    override fun getDisplayName(): String = "Double negation"
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : RustElementVisitor() {
+            override fun visitUnaryExpr(expr: RustUnaryExprElement) {
+                if (isNegation(expr) && isNegation(expr.expr)) {
+                    holder.registerProblem(expr, "--x could be misinterpreted as a pre-decrement, but effectively is a no-op")
+                }
+            }
+        }
+    }
+
+    private fun isNegation(el: RustExprElement?) =
+        el != null && el is RustUnaryExprElement && el.minus != null
+}

--- a/src/main/kotlin/org/rust/ide/inspections/RustDoubleNegInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RustDoubleNegInspection.kt
@@ -18,13 +18,13 @@ class RustDoubleNegInspection : RustLocalInspectionTool() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
         return object : RustElementVisitor() {
             override fun visitUnaryExpr(expr: RustUnaryExprElement) {
-                if (isNegation(expr) && isNegation(expr.expr)) {
+                if (expr.isNegation && expr.expr.isNegation) {
                     holder.registerProblem(expr, "--x could be misinterpreted as a pre-decrement, but effectively is a no-op")
                 }
             }
         }
     }
 
-    private fun isNegation(el: RustExprElement?) =
-        el != null && el is RustUnaryExprElement && el.minus != null
+    private val RustExprElement?.isNegation: Boolean
+        get() = this is RustUnaryExprElement && minus != null
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -144,6 +144,11 @@
                          enabledByDefault="false" level="ERROR"
                          implementationClass="org.rust.ide.inspections.RustUnresolvedReferenceInspection"/>
 
+        <localInspection language="Rust" groupName="Rust"
+                         displayName="Double negation"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustDoubleNegInspection"/>
+
         <localInspection language="Rust" groupName="Redeclared symbols"
                          displayName="Duplicate field"
                          enabledByDefault="true" level="ERROR"

--- a/src/main/resources/inspectionDescriptions/RustDoubleNeg.html
+++ b/src/main/resources/inspectionDescriptions/RustDoubleNeg.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+Detects expressions of the form --x which might be mistook for pre-decrements.<br>
+Corresponds to <a href="https://github.com/Manishearth/rust-clippy/wiki#double_neg">double_neg</a> lint from Rust Clippy.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/RustDoubleNegInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RustDoubleNegInspectionTest.kt
@@ -1,0 +1,30 @@
+package org.rust.ide.inspections
+
+/**
+ * Tests for Double Negation inspection.
+ */
+class RustDoubleNegInspectionTest : RustInspectionsTestBase() {
+
+    override val dataPath = ""
+
+    fun testSimple() = checkByText<RustDoubleNegInspection>("""
+        fn main() {
+            let a = 12;
+            let b = <warning descr="--x could be misinterpreted as a pre-decrement, but effectively is a no-op">--a</warning>;
+        }
+    """)
+
+    fun testWithSpaces() = checkByText<RustDoubleNegInspection>("""
+        fn main() {
+            let i = 10;
+            while <warning descr="--x could be misinterpreted as a pre-decrement, but effectively is a no-op">- - i</warning> > 0 {}
+        }
+    """)
+
+    fun testExpression() = checkByText<RustDoubleNegInspection>("""
+        fn main() {
+            let a = 7;
+            println!("{}",  <warning descr="--x could be misinterpreted as a pre-decrement, but effectively is a no-op">--(2*a + 1)</warning>);
+        }
+    """)
+}


### PR DESCRIPTION
Inspection that is an analogue of Clippy's [double_neg](https://github.com/Manishearth/rust-clippy/wiki#double_neg) lint. Catches expressions of the form `--x` which are no-op in Rust.