### PR TITLE
(SURR): Refactor statements surrounders

### DIFF
--- a/src/main/kotlin/org/rust/ide/surroundWith/statement/RustStatementsSurrounderBase.kt
+++ b/src/main/kotlin/org/rust/ide/surroundWith/statement/RustStatementsSurrounderBase.kt
@@ -1,24 +1,44 @@
 package org.rust.ide.surroundWith.statement
 
+import com.intellij.codeInsight.CodeInsightUtilBase
 import com.intellij.lang.surroundWith.Surrounder
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
+import org.rust.ide.surroundWith.addStatements
+import org.rust.lang.core.psi.RustBlockElement
 
 abstract class RustStatementsSurrounderBase : Surrounder {
-    abstract fun surroundStatements(
-        project: Project,
-        editor: Editor,
-        container: PsiElement,
-        statements: Array<out PsiElement>
-    ): TextRange?
+    protected abstract fun createTemplate(project: Project): PsiElement
+    protected abstract fun getCodeBlock(expression: PsiElement): RustBlockElement
 
-    final override fun isApplicable(elements: Array<out PsiElement>): Boolean = elements.isNotEmpty()
+    protected open fun getExprForRemove(expression: PsiElement): PsiElement? = null
+    protected open val shouldRemoveExpr = false
+
+    final override fun isApplicable(elements: Array<out PsiElement>): Boolean =
+        elements.isNotEmpty()
 
     final override fun surroundElements(project: Project, editor: Editor, elements: Array<out PsiElement>): TextRange? {
         require(elements.isNotEmpty())
         val container = requireNotNull(elements[0].parent)
-        return surroundStatements(project, editor, container, elements)
+
+        var template = createTemplate(project)
+        template = container.addBefore(template, elements[0])
+
+        getCodeBlock(template).addStatements(elements)
+
+        container.deleteChildRange(elements.first(), elements.last())
+
+        return if (shouldRemoveExpr) {
+            template = CodeInsightUtilBase.forcePsiPostprocessAndRestoreElement(template)
+            val removeIt = getExprForRemove(template)
+            val conditionTextRange = checkNotNull(removeIt).textRange
+            editor.document.deleteString(conditionTextRange.startOffset, conditionTextRange.endOffset)
+            val range = TextRange.from(conditionTextRange.startOffset, 0)
+            range
+        } else {
+            TextRange.from(template.firstChild.textRange.endOffset, 0)
+        }
     }
 }

--- a/src/main/kotlin/org/rust/ide/surroundWith/statement/RustWithBlockSurrounder.kt
+++ b/src/main/kotlin/org/rust/ide/surroundWith/statement/RustWithBlockSurrounder.kt
@@ -1,34 +1,18 @@
 package org.rust.ide.surroundWith.statement
 
-import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-import org.rust.ide.surroundWith.statement.RustStatementsSurrounderBase
-import org.rust.ide.surroundWith.addStatements
+import org.rust.lang.core.psi.RustBlockElement
 import org.rust.lang.core.psi.RustBlockExprElement
 import org.rust.lang.core.psi.RustElementFactory
 import org.rust.lang.core.psi.RustExprStmtElement
 
 class RustWithBlockSurrounder : RustStatementsSurrounderBase() {
-    override fun getTemplateDescription(): String = "{ }"
+    override fun getTemplateDescription(): String = "{}"
 
-    override fun surroundStatements(
-        project: Project,
-        editor: Editor,
-        container: PsiElement,
-        statements: Array<out PsiElement>
-    ): TextRange? {
-        // TODO: Move declarations out (tricky part: borrowing)
+    override fun createTemplate(project: Project): PsiElement =
+        checkNotNull(RustElementFactory.createStatement(project, "{\n}"))
 
-        var blockStmt = RustElementFactory.createStatement(project, "{\n}") as RustExprStmtElement
-        blockStmt = container.addBefore(blockStmt, statements[0]) as RustExprStmtElement
-
-        val block = (blockStmt.expr as RustBlockExprElement).block!!
-        block.addStatements(statements)
-        container.deleteChildRange(statements.first(), statements.last())
-
-        val range = blockStmt.firstChild?.textRange ?: return null
-        return TextRange.from(range.endOffset, 0)
-    }
+    override fun getCodeBlock(expression: PsiElement): RustBlockElement =
+        checkNotNull(((expression as RustExprStmtElement).expr as RustBlockExprElement).block)
 }

--- a/src/main/kotlin/org/rust/ide/surroundWith/statement/RustWithIfSurrounder.kt
+++ b/src/main/kotlin/org/rust/ide/surroundWith/statement/RustWithIfSurrounder.kt
@@ -1,36 +1,22 @@
 package org.rust.ide.surroundWith.statement
 
-import com.intellij.codeInsight.CodeInsightUtilBase
-import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-import org.rust.ide.surroundWith.statement.RustStatementsSurrounderBase
-import org.rust.ide.surroundWith.addStatements
+import org.rust.lang.core.psi.RustBlockElement
 import org.rust.lang.core.psi.RustElementFactory
 import org.rust.lang.core.psi.RustIfExprElement
 
 class RustWithIfSurrounder : RustStatementsSurrounderBase() {
     override fun getTemplateDescription(): String = "if { }"
 
-    override fun surroundStatements(
-        project: Project,
-        editor: Editor,
-        container: PsiElement,
-        statements: Array<out PsiElement>
-    ): TextRange? {
-        var ifExpr = RustElementFactory.createExpression(project, "if true {\n}") as RustIfExprElement
+    override fun createTemplate(project: Project): PsiElement =
+        checkNotNull(RustElementFactory.createExpression(project, "if a {\n}"))
 
-        ifExpr = container.addBefore(ifExpr, statements[0]) as RustIfExprElement
-        checkNotNull(ifExpr.block).addStatements(statements)
-        container.deleteChildRange(statements.first(), statements.last())
+    override fun getCodeBlock(expression: PsiElement): RustBlockElement =
+        checkNotNull((expression as RustIfExprElement).block)
 
-        ifExpr = CodeInsightUtilBase.forcePsiPostprocessAndRestoreElement(ifExpr)
+    override val shouldRemoveExpr = true
 
-        val conditionTextRange = ifExpr.expr.textRange
-        val range = TextRange.from(conditionTextRange.startOffset, 0)
-        editor.document.deleteString(conditionTextRange.startOffset, conditionTextRange.endOffset)
-
-        return range
-    }
+    override fun getExprForRemove(expression: PsiElement): PsiElement =
+        (expression as RustIfExprElement).expr
 }

--- a/src/main/kotlin/org/rust/ide/surroundWith/statement/RustWithLoopSurrounder.kt
+++ b/src/main/kotlin/org/rust/ide/surroundWith/statement/RustWithLoopSurrounder.kt
@@ -1,30 +1,17 @@
 package org.rust.ide.surroundWith.statement
 
-import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-import org.rust.ide.surroundWith.statement.RustStatementsSurrounderBase
-import org.rust.ide.surroundWith.addStatements
+import org.rust.lang.core.psi.RustBlockElement
 import org.rust.lang.core.psi.RustElementFactory
 import org.rust.lang.core.psi.RustLoopExprElement
 
 class RustWithLoopSurrounder : RustStatementsSurrounderBase() {
     override fun getTemplateDescription(): String = "loop { }"
 
-    override fun surroundStatements(
-        project: Project,
-        editor: Editor,
-        container: PsiElement,
-        statements: Array<out PsiElement>
-    ): TextRange? {
-        var loopExpr = RustElementFactory.createExpression(project, "loop {\n}") as RustLoopExprElement
-        loopExpr = container.addBefore(loopExpr, statements[0]) as RustLoopExprElement
+    override fun createTemplate(project: Project): PsiElement =
+        checkNotNull(RustElementFactory.createExpression(project, "loop {\n}"))
 
-        loopExpr.block.addStatements(statements)
-        container.deleteChildRange(statements.first(), statements.last())
-
-        val range = loopExpr.firstChild?.textRange ?: return null
-        return TextRange.from(range.endOffset, 0)
-    }
+    override fun getCodeBlock(expression: PsiElement): RustBlockElement =
+        (expression as RustLoopExprElement).block
 }

--- a/src/main/kotlin/org/rust/ide/surroundWith/statement/RustWithWhileSurrounder.kt
+++ b/src/main/kotlin/org/rust/ide/surroundWith/statement/RustWithWhileSurrounder.kt
@@ -1,36 +1,22 @@
 package org.rust.ide.surroundWith.statement
 
-import com.intellij.codeInsight.CodeInsightUtilBase
-import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-import org.rust.ide.surroundWith.statement.RustStatementsSurrounderBase
-import org.rust.ide.surroundWith.addStatements
+import org.rust.lang.core.psi.RustBlockElement
 import org.rust.lang.core.psi.RustElementFactory
 import org.rust.lang.core.psi.RustWhileExprElement
 
 class RustWithWhileSurrounder : RustStatementsSurrounderBase() {
     override fun getTemplateDescription(): String = "while { }"
 
-    override fun surroundStatements(
-        project: Project,
-        editor: Editor,
-        container: PsiElement,
-        statements: Array<out PsiElement>
-    ): TextRange? {
-        var whileExpr = RustElementFactory.createExpression(project, "while true {\n}") as RustWhileExprElement
+    override fun createTemplate(project: Project): PsiElement =
+        checkNotNull(RustElementFactory.createExpression(project, "while a {\n}"))
 
-        whileExpr = container.addBefore(whileExpr, statements[0]) as RustWhileExprElement
-        checkNotNull(whileExpr.block).addStatements(statements)
-        container.deleteChildRange(statements.first(), statements.last())
+    override fun getCodeBlock(expression: PsiElement): RustBlockElement =
+        checkNotNull((expression as RustWhileExprElement).block)
 
-        whileExpr = CodeInsightUtilBase.forcePsiPostprocessAndRestoreElement(whileExpr)
+    override val shouldRemoveExpr = true
 
-        val conditionTextRange = whileExpr.expr.textRange
-        val range = TextRange.from(conditionTextRange.startOffset, 0)
-        editor.document.deleteString(conditionTextRange.startOffset, conditionTextRange.endOffset)
-
-        return range
-    }
+    override fun getExprForRemove(expression: PsiElement): PsiElement =
+        (expression as RustWhileExprElement).expr
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/util/RustPsiNavigationExtensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/util/RustPsiNavigationExtensions.kt
@@ -145,13 +145,14 @@ private fun PsiElement.getTopmostParentInside(parent: PsiElement): PsiElement {
 }
 
 private fun collectElements(start: PsiElement, stop: PsiElement?, pred: (PsiElement) -> Boolean): Array<out PsiElement> {
-    val list = mutableListOf<PsiElement>()
-    var current = start
-    while (current != stop) {
-        if (pred(current)) {
-            list.add(current)
-        }
-        current = current.nextSibling
+    check(stop == null || start.parent == stop.parent)
+
+    val psiSeq = generateSequence(start) {
+        if (it.nextSibling == stop)
+            null
+        else
+            it.nextSibling
     }
-    return PsiUtilCore.toPsiElementArray(list)
+
+    return PsiUtilCore.toPsiElementArray(psiSeq.filter(pred).toList())
 }

--- a/src/test/kotlin/org/rust/ide/surroundWith/RustSurrounderTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/ide/surroundWith/RustSurrounderTestCaseBase.kt
@@ -13,7 +13,7 @@ import java.util.*
 abstract class RustSurrounderTestCaseBase(val surrounder: Surrounder) : RustTestCaseBase() {
     override val dataPath: String  = ""
 
-    public fun doTest(before: String, after: String) {
+    protected fun doTest(before: String, after: String) {
         myFixture.configureByText(RustFileType, before)
 
         checkApplicability(fileName, true)
@@ -24,7 +24,7 @@ abstract class RustSurrounderTestCaseBase(val surrounder: Surrounder) : RustTest
         myFixture.checkResult(after)
     }
 
-    public fun doTestNotApplicable(before: String) {
+    protected fun doTestNotApplicable(before: String) {
         myFixture.configureByText(RustFileType, before)
         checkApplicability(before, false)
     }

--- a/src/test/kotlin/org/rust/ide/surroundWith/statement/RustWithBlockSurrounderTest.kt
+++ b/src/test/kotlin/org/rust/ide/surroundWith/statement/RustWithBlockSurrounderTest.kt
@@ -29,6 +29,20 @@ class RustWithBlockSurrounderTest : RustSurrounderTestCaseBase(RustWithBlockSurr
         )
     }
 
+    fun testNotApplicable3() {
+        doTestNotApplicable(
+            """
+            fn main() {
+                loop<selection> {
+                    for 1 in 1..10 {
+                        println!("Hello, world!");
+                    }
+                }</selection>
+            }
+            """
+        )
+    }
+
     fun testApplicableComment() {
         doTest(
             """
@@ -136,6 +150,38 @@ class RustWithBlockSurrounderTest : RustSurrounderTestCaseBase(RustWithBlockSurr
                     server.get("**", hello_world);
                 }
                 server.listen("127.0.0.1:6767").unwrap();
+            }
+            """
+        )
+    }
+
+    // FIXME Indents after apply Surround With...
+    // Should be:
+//            fn main() {
+//                {
+//                    loop {
+//                        println!("Hello");
+//                    }
+//                }
+//            }
+
+    fun testNested() {
+        doTest(
+            """
+            fn main() {
+                <selection>loop {
+                    println!("Hello");
+                }</selection>
+            }
+            """
+            ,
+            """
+            fn main() {
+                {
+                    loop {
+                                        println!("Hello");
+                                    }
+                }
             }
             """
         )

--- a/src/test/kotlin/org/rust/ide/surroundWith/statement/RustWithForSurrounderTest.kt
+++ b/src/test/kotlin/org/rust/ide/surroundWith/statement/RustWithForSurrounderTest.kt
@@ -29,6 +29,20 @@ class RustWithForSurrounderTest : RustSurrounderTestCaseBase(RustWithForSurround
         )
     }
 
+    fun testNotApplicable3() {
+        doTestNotApplicable(
+            """
+            fn main() {
+                loop<selection> {
+                    for 1 in 1..10 {
+                        println!("Hello, world!");
+                    }
+                }</selection>
+            }
+            """
+        )
+    }
+
     fun testApplicableComment() {
         doTest(
             """
@@ -136,6 +150,38 @@ class RustWithForSurrounderTest : RustSurrounderTestCaseBase(RustWithForSurround
                     server.get("**", hello_world);
                 }
                 server.listen("127.0.0.1:6767").unwrap();
+            }
+            """
+        )
+    }
+
+    // FIXME Indents after apply Surround With...
+    // Should be:
+//            fn main() {
+//                for <caret> {
+//                    loop {
+//                        println!("Hello");
+//                    }
+//                }
+//            }
+
+    fun testNested() {
+        doTest(
+            """
+            fn main() {
+                <selection>loop {
+                    println!("Hello");
+                }</selection>
+            }
+            """
+            ,
+            """
+            fn main() {
+                for <caret> {
+                    loop {
+                                        println!("Hello");
+                                    }
+                }
             }
             """
         )

--- a/src/test/kotlin/org/rust/ide/surroundWith/statement/RustWithIfSurrounderTest.kt
+++ b/src/test/kotlin/org/rust/ide/surroundWith/statement/RustWithIfSurrounderTest.kt
@@ -53,6 +53,20 @@ class RustWithIfSurrounderTest : RustSurrounderTestCaseBase(RustWithIfSurrounder
         )
     }
 
+    fun testNotApplicable3() {
+        doTestNotApplicable(
+            """
+            fn main() {
+                loop<selection> {
+                    for 1 in 1..10 {
+                        println!("Hello, world!");
+                    }
+                }</selection>
+            }
+            """
+        )
+    }
+
     fun testSimple1() {
         doTest(
             """
@@ -136,6 +150,37 @@ class RustWithIfSurrounderTest : RustSurrounderTestCaseBase(RustWithIfSurrounder
                     server.get("**", hello_world);
                 }
                 server.listen("127.0.0.1:6767").unwrap();
+            }
+            """
+        )
+    }
+
+    // FIXME Indents after apply Surround With...
+    // Should be:
+//            fn main() {
+//                if <caret> {
+//                    loop {
+//                        println!("Hello");
+//                    }
+//                }
+//            }
+    fun testNested() {
+        doTest(
+            """
+            fn main() {
+                <selection>loop {
+                    println!("Hello");
+                }</selection>
+            }
+            """
+            ,
+            """
+            fn main() {
+                if <caret> {
+                    loop {
+                                        println!("Hello");
+                                    }
+                }
             }
             """
         )

--- a/src/test/kotlin/org/rust/ide/surroundWith/statement/RustWithLoopSurrounderTest.kt
+++ b/src/test/kotlin/org/rust/ide/surroundWith/statement/RustWithLoopSurrounderTest.kt
@@ -29,6 +29,20 @@ class RustWithLoopSurrounderTest : RustSurrounderTestCaseBase(RustWithLoopSurrou
         )
     }
 
+    fun testNotApplicable3() {
+        doTestNotApplicable(
+            """
+            fn main() {
+                loop<selection> {
+                    for 1 in 1..10 {
+                        println!("Hello, world!");
+                    }
+                }</selection>
+            }
+            """
+        )
+    }
+
     fun testApplicableComment() {
         doTest(
             """
@@ -136,6 +150,37 @@ class RustWithLoopSurrounderTest : RustSurrounderTestCaseBase(RustWithLoopSurrou
                     server.get("**", hello_world);
                 }
                 server.listen("127.0.0.1:6767").unwrap();
+            }
+            """
+        )
+    }
+
+    // FIXME Indents after apply Surround With...
+    // Should be:
+//            fn main() {
+//                loop {
+//                    loop {
+//                        println!("Hello");
+//                    }
+//                }
+//            }
+    fun testNested() {
+        doTest(
+            """
+            fn main() {
+                <selection>loop {
+                    println!("Hello");
+                }</selection>
+            }
+            """
+            ,
+            """
+            fn main() {
+                loop {
+                    loop {
+                                        println!("Hello");
+                                    }
+                }
             }
             """
         )

--- a/src/test/kotlin/org/rust/ide/surroundWith/statement/RustWithWhileSurrounderTest.kt
+++ b/src/test/kotlin/org/rust/ide/surroundWith/statement/RustWithWhileSurrounderTest.kt
@@ -1,7 +1,6 @@
 package org.rust.ide.surroundWith.statement
 
 import org.rust.ide.surroundWith.RustSurrounderTestCaseBase
-import org.rust.ide.surroundWith.statement.RustWithWhileSurrounder
 
 class RustWithWhileSurrounderTest : RustSurrounderTestCaseBase(RustWithWhileSurrounder()) {
     fun testNotApplicable1() {
@@ -24,6 +23,20 @@ class RustWithWhileSurrounderTest : RustSurrounderTestCaseBase(RustWithWhileSurr
                 let mut server = Nickel::new();
                 server.get("**", hello_world);
                 server.listen("127.0.0.1:6767").unwrap();</selection>
+            }
+            """
+        )
+    }
+
+    fun testNotApplicable3() {
+        doTestNotApplicable(
+            """
+            fn main() {
+                loop<selection> {
+                    for 1 in 1..10 {
+                        println!("Hello, world!");
+                    }
+                }</selection>
             }
             """
         )
@@ -136,6 +149,38 @@ class RustWithWhileSurrounderTest : RustSurrounderTestCaseBase(RustWithWhileSurr
                     server.get("**", hello_world);
                 }
                 server.listen("127.0.0.1:6767").unwrap();
+            }
+            """
+        )
+    }
+
+    // FIXME Indents after apply Surround With...
+    // Should be:
+//            fn main() {
+//                while <caret> {
+//                    loop {
+//                        println!("Hello");
+//                    }
+//                }
+//            }
+
+    fun testNested() {
+        doTest(
+            """
+            fn main() {
+                <selection>loop {
+                    println!("Hello");
+                }</selection>
+            }
+            """
+            ,
+            """
+            fn main() {
+                while <caret> {
+                    loop {
+                                        println!("Hello");
+                                    }
+                }
             }
             """
         )


### PR DESCRIPTION
The major part of code moved to `RustStatementsSurrounderBase`.

In src/main/kotlin/org/rust/lang/core/psi/util/RustPsiNavigationExtensions.kt 
Тype of `var current` is `PsiElement`. But current.nextSibling is Nullable.
For this reason, exceptions periodically appear.