### PR TITLE
(INSP) Dangling Else inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RustDanglingElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RustDanglingElseInspection.kt
@@ -1,0 +1,50 @@
+package org.rust.ide.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
+import org.rust.ide.inspections.fixes.SubstituteTextFix
+import org.rust.lang.core.psi.RustElementVisitor
+import org.rust.lang.core.psi.RustElseBranchElement
+import org.rust.lang.core.psi.RustIfExprElement
+
+/**
+ * Detects `else if` statements broken by new lines. A partial analogue
+ * of the Clippy's suspicious_else_formatting lint.
+ * Quick fix 1: Remove `else`
+ * Quick fix 2: Join `else if`
+ */
+class RustDanglingElseInspection : RustLocalInspectionTool() {
+    override fun getDisplayName(): String = "Dangling else"
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitElseBranch(expr: RustElseBranchElement) {
+                val elseEl = expr.`else`
+                val breakEl = elseEl.rightSiblings
+                    .dropWhile { (it is PsiWhiteSpace || it is PsiComment) && '\n' !in it.text }
+                    .firstOrNull() ?: return
+                val ifEl = breakEl.rightSiblings
+                    .dropWhile { it !is RustIfExprElement }
+                    .firstOrNull() ?: return
+                val range = TextRange(0, ifEl.startOffsetInParent + 2)
+                val fix2Range = TextRange(elseEl.textRange.endOffset, ifEl.textRange.startOffset)
+                holder.registerProblem(
+                    expr,
+                    range,
+                    "Suspicious `else if` formatting",
+                    SubstituteTextFix(expr.containingFile, elseEl.rangeWithPrevSpace(expr.prevSibling), null, "Remove `else`"),
+                    SubstituteTextFix(expr.containingFile, fix2Range, " ", "Join `else if`"))
+            }
+        }
+
+    private fun PsiElement.rangeWithPrevSpace(prev: PsiElement?) = when(prev) {
+        is PsiWhiteSpace -> textRange.union(prev.textRange)
+        else -> textRange
+    }
+
+    private val PsiElement.rightSiblings: Sequence<PsiElement>
+        get() = generateSequence(this.nextSibling) { it.nextSibling }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -155,6 +155,11 @@
                          implementationClass="org.rust.ide.inspections.RustSuspiciousAssignmentInspection"/>
 
         <localInspection language="Rust" groupName="Rust"
+                         displayName="Dangling else"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustDanglingElseInspection"/>
+
+        <localInspection language="Rust" groupName="Rust"
                          displayName="Missing else"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RustMissingElseInspection"/>

--- a/src/main/resources/inspectionDescriptions/RustDanglingElse.html
+++ b/src/main/resources/inspectionDescriptions/RustDanglingElse.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+Detects suspiciously looking <code>`else if`</code>-statements devided by new lines.<br>
+Partially corresponds to <a href="https://github.com/Manishearth/rust-clippy/wiki#suspicious_else_formatting">suspicious_else_formatting</a> lint from Rust Clippy.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/RustDanglingElseInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RustDanglingElseInspectionTest.kt
@@ -1,0 +1,101 @@
+package org.rust.ide.inspections
+
+/**
+ * Tests for Dangling Else inspection.
+ */
+class RustDanglingElseInspectionTest : RustInspectionsTestBase() {
+
+    override val dataPath = ""
+
+    fun testSimple() = checkByText<RustDanglingElseInspection>("""
+        fn main() {
+            if true {
+            } <warning descr="Suspicious `else if` formatting">else
+            if</warning> true {
+            }
+        }
+    """)
+
+    fun testElseOnSeparateLine() = checkByText<RustDanglingElseInspection>("""
+        fn main() {
+            if true {
+            }
+            <warning descr="Suspicious `else if` formatting">else
+            if</warning> true {
+            }
+        }
+    """)
+
+    fun testMultipleNewLines() = checkByText<RustDanglingElseInspection>("""
+        fn main() {
+            if true {
+            } <warning descr="Suspicious `else if` formatting">else
+
+
+            if</warning> true {
+            }
+        }
+    """)
+
+    fun testComments() = checkByText<RustDanglingElseInspection>("""
+        fn main() {
+            if true {
+            } <warning descr="Suspicious `else if` formatting">else
+
+            // comments
+            /* inside */
+
+            if</warning> true {
+            }
+        }
+    """)
+
+    fun testNotAppliedWhenNoIf() = checkByText<RustDanglingElseInspection>("""
+        fn main() {
+            if true {
+            } else {
+            }
+        }
+    """)
+
+    fun testNotAppliedWhenNotDangling() = checkByText<RustDanglingElseInspection>("""
+        fn main() {
+            if true {
+            } else if false {
+            }
+        }
+    """)
+
+    fun testFixRemoveElse() = checkFixByText<RustDanglingElseInspection>("Remove `else`", """
+        fn main() {
+            if true {
+            }    <warning descr="Suspicious `else if` formatting">els<caret>e
+            if</warning> false {
+            }
+        }
+    """, """
+        fn main() {
+            if true {
+            }
+            if false {
+            }
+        }
+    """)
+
+    fun testFixJoin() = checkFixByText<RustDanglingElseInspection>("Join `else if`", """
+        fn main() {
+            if true {
+            } <warning descr="Suspicious `else if` formatting">else
+
+            <caret>if</warning> false {
+            }
+        }
+    """, """
+        fn main() {
+            if true {
+            } else if false {
+            }
+        }
+    """)
+
+}


### PR DESCRIPTION
A partial analogue of the Clippy's [suspicious_else_formatting](https://github.com/Manishearth/rust-clippy/wiki#suspicious_else_formatting) inspection. Detects `else if`s that are separated by new lines:

    if (cond) {
    } else

    if (another_cond) {
    }

The inspection provides quick fixes for removing `else` and for joining `else if`.