### PR TITLE
(INSP) Naming Convention inspections

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RustNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RustNamingInspection.kt
@@ -47,16 +47,18 @@ open class RustCamelCaseNamingInspection(
         val result = StringBuilder(name.length)
         var wasUnderscore = true
         var startWord = true
-        name.forEach { char ->
-            if (char == '_') {
-                wasUnderscore = true
-            } else if (wasUnderscore || startWord && char.canStartWord) {
-                result.append(char.toUpperCase())
-                wasUnderscore = false
-                startWord = false
-            } else {
-                startWord = char.isLowerCase()
-                result.append(char.toLowerCase())
+        for (char in name) {
+            when {
+                char == '_' -> wasUnderscore = true
+                wasUnderscore || startWord && char.canStartWord -> {
+                    result.append(char.toUpperCase())
+                    wasUnderscore = false
+                    startWord = false
+                }
+                else -> {
+                    startWord = char.isLowerCase()
+                    result.append(char.toLowerCase())
+                }
             }
         }
         return if (result.isEmpty()) "CamelCase" else result.toString()

--- a/src/main/kotlin/org/rust/ide/inspections/RustNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RustNamingInspection.kt
@@ -1,0 +1,253 @@
+package org.rust.ide.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.impl.RustParameterElementImpl
+
+/**
+ * Base class for naming inspections. Implements the core logic of checking names
+ * and registering problems.
+ */
+abstract class RustNamingInspection(
+    val elementType: String,
+    val styleName: String,
+    elementTitle: String = elementType
+) : RustLocalInspectionTool() {
+    val dispName = elementTitle + " naming convention"
+    override fun getDisplayName(): String = dispName
+
+    fun inspect(id: PsiElement?, holder: ProblemsHolder) {
+        if (id == null) return
+        val (isOk, suggestedName) = checkName(id.text)
+        if (!isOk) {
+            holder.registerProblem(id, "$elementType `${id.text}` should have $styleName case name such as `$suggestedName`")
+        }
+    }
+
+    abstract fun checkName(name: String): Pair<Boolean, String?>
+}
+
+/**
+ * Checks if the name is CamelCase.
+ */
+open class RustCamelCaseNamingInspection(
+    elementType: String,
+    elementTitle: String = elementType
+) : RustNamingInspection(elementType, "a camel", elementTitle) {
+    override fun checkName(name: String): Pair<Boolean, String?> {
+        val str = name.trim('_')
+        if (!str.isEmpty() && str[0].canStartWord && '_' !in str) {
+            return Pair(true, null)
+        }
+        return Pair(false, if (str.isEmpty()) "CamelCase" else suggestName(name))
+    }
+
+    private fun suggestName(name: String): String {
+        val result = StringBuilder(name.length)
+        var wasUnderscore = true
+        var startWord = true
+        name.forEach { char ->
+            if (char == '_') {
+                wasUnderscore = true
+            } else if (wasUnderscore || startWord && char.canStartWord) {
+                result.append(char.toUpperCase())
+                wasUnderscore = false
+                startWord = false
+            } else {
+                startWord = char.isLowerCase()
+                result.append(char.toLowerCase())
+            }
+        }
+        return if (result.isEmpty()) "CamelCase" else result.toString()
+    }
+
+    private val Char.canStartWord: Boolean get() = isUpperCase() || isDigit()
+}
+
+/**
+ * Checks if the name is snake_case.
+ */
+open class RustSnakeCaseNamingInspection(elementType: String) : RustNamingInspection(elementType, "a snake") {
+    override fun checkName(name: String): Pair<Boolean, String?> {
+        val str = name.trim('_')
+        if (!str.isEmpty() && str.all { !it.isLetter() || it.isLowerCase() }) {
+            return Pair(true, null)
+        }
+        return Pair(false, if (str.isEmpty()) "snake_case" else name.toSnakeCase(false))
+    }
+}
+
+/**
+ * Checks if the name is UPPER_CASE.
+ */
+open class RustUpperCaseNamingInspection(elementType: String) : RustNamingInspection(elementType, "an upper") {
+    override fun checkName(name: String): Pair<Boolean, String?> {
+        val str = name.trim('_')
+        if (!str.isEmpty() && str.all { !it.isLetter() || it.isUpperCase() }) {
+            return Pair(true, null)
+        }
+        return Pair(false, if (str.isEmpty()) "UPPER_CASE" else name.toSnakeCase(true))
+    }
+}
+
+private fun String.toSnakeCase(upper: Boolean): String {
+    val result = StringBuilder(length + 3)     // 3 is a reasonable margin for growth when `_`s are added
+    result.append(takeWhile { it == '_' || it == '\'' })    // Preserve prefix
+    var firstPart = true
+    drop(result.length).splitToSequence('_').forEach pit@ { part ->
+        if (part.isEmpty()) return@pit
+        if (!firstPart) {
+            result.append('_')
+        }
+        firstPart = false
+        var newWord = false
+        var firstWord = true
+        part.forEach { char ->
+            if (newWord && char.isUpperCase()) {
+                if (!firstWord) {
+                    result.append('_')
+                }
+                newWord = false
+            } else {
+                newWord = char.isLowerCase()
+            }
+            result.append(if (upper) char.toUpperCase() else char.toLowerCase())
+            firstWord = false
+        }
+    }
+    return result.toString()
+}
+
+//
+// Concrete inspections
+//
+
+class RustArgumentNamingInspection : RustSnakeCaseNamingInspection("Argument") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitPatBinding(el: RustPatBindingElement) {
+                if (el.parent?.parent is RustParameterElementImpl) {
+                    inspect(el.identifier, holder)
+                }
+            }
+        }
+}
+
+class RustAssocTypeNamingInspection : RustCamelCaseNamingInspection("Type", "Associated type") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitTraitTypeMember(el: RustTraitTypeMemberElement) = inspect(el.identifier, holder)
+        }
+}
+
+class RustConstNamingInspection : RustUpperCaseNamingInspection("Constant") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitConstItem(el: RustConstItemElement) = inspect(el.identifier, holder)
+        }
+}
+
+class RustEnumNamingInspection : RustCamelCaseNamingInspection("Type", "Enum") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitEnumItem(el: RustEnumItemElement) = inspect(el.identifier, holder)
+        }
+}
+
+class RustEnumVariantNamingInspection : RustCamelCaseNamingInspection("Enum variant") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitEnumVariant(el: RustEnumVariantElement) = inspect(el.identifier, holder)
+        }
+}
+
+class RustFunctionNamingInspection : RustSnakeCaseNamingInspection("Function") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitFnItem(el: RustFnItemElement) = inspect(el.identifier, holder)
+        }
+}
+
+class RustLifetimeNamingInspection : RustSnakeCaseNamingInspection("Lifetime") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitLifetimeParam(el: RustLifetimeParamElement) = inspect(el, holder)
+        }
+}
+
+class RustMacroNamingInspection : RustSnakeCaseNamingInspection("Macro") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitMacroDefinition(el: RustMacroDefinitionElement) = inspect(el.identifier, holder)
+        }
+}
+
+class RustMethodNamingInspection : RustSnakeCaseNamingInspection("Method") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitTraitMethodMember(el: RustTraitMethodMemberElement) = inspect(el.identifier, holder)
+            override fun visitImplMethodMember(el: RustImplMethodMemberElement) = inspect(el.identifier, holder)
+        }
+}
+
+class RustModuleNamingInspection : RustSnakeCaseNamingInspection("Module") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitModDeclItem(el: RustModDeclItemElement) = inspect(el.identifier, holder)
+            override fun visitModItem(el: RustModItemElement) = inspect(el.identifier, holder)
+        }
+}
+
+class RustStaticConstNamingInspection : RustUpperCaseNamingInspection("Static constant") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitStaticItem(el: RustStaticItemElement) = inspect(el.identifier, holder)
+        }
+}
+
+class RustStructNamingInspection : RustCamelCaseNamingInspection("Type", "Struct") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitStructItem(el: RustStructItemElement) = inspect(el.identifier, holder)
+        }
+}
+
+class RustFieldNamingInspection : RustSnakeCaseNamingInspection("Field") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitFieldDecl(el: RustFieldDeclElement) = inspect(el.identifier, holder)
+        }
+}
+
+class RustTraitNamingInspection : RustCamelCaseNamingInspection("Trait") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitTraitItem(el: RustTraitItemElement) = inspect(el.identifier, holder)
+        }
+}
+
+class RustTypeAliasNamingInspection : RustCamelCaseNamingInspection("Type", "Type alias") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitTypeItem(el: RustTypeItemElement) = inspect(el.identifier, holder)
+        }
+}
+
+class RustTypeParameterNamingInspection : RustCamelCaseNamingInspection("Type parameter") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitTypeParam(el: RustTypeParamElement) = inspect(el.identifier, holder)
+        }
+}
+
+class RustVariableNamingInspection : RustSnakeCaseNamingInspection("Variable") {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RustElementVisitor() {
+            override fun visitPatBinding(el: RustPatBindingElement) {
+                if (el.parent?.parent !is RustParameterElementImpl) {
+                    inspect(el.identifier, holder)
+                }
+            }
+        }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -130,11 +130,6 @@
                          implementationClass="org.rust.ide.inspections.RustApproxConstantInspection"/>
 
         <localInspection language="Rust" groupName="Rust"
-                         displayName="Self Convention"
-                         enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RustSelfConventionInspection"/>
-
-        <localInspection language="Rust" groupName="Rust"
                          displayName="Unsafe CString pointer"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RustCStringPointerInspection"/>
@@ -188,6 +183,96 @@
                          displayName="Dropping reference"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RustDropRefInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Argument naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustArgumentNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Associated type naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustAssocTypeNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Constant naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustConstNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Enum naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustEnumNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Enum variant naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustEnumVariantNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Function naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustFunctionNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Lifetime naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustLifetimeNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Macro naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustMacroNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Method naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustMethodNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Module naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustModuleNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Static constant naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustStaticConstNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Self convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustSelfConventionInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Struct naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustStructNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Field naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustFieldNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Trait naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustTraitNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Type alias naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustTypeAliasNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Type parameter naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustTypeParameterNamingInspection"/>
+
+        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+                         displayName="Variable naming convention"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RustVariableNamingInspection"/>
 
         <!-- Surrounders -->
 

--- a/src/main/resources/inspectionDescriptions/RustArgumentNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustArgumentNaming.html
@@ -1,0 +1,1 @@
+Checks if function and method argument names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustAssocTypeNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustAssocTypeNaming.html
@@ -1,0 +1,1 @@
+Checks if associated type names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustConstNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustConstNaming.html
@@ -1,0 +1,1 @@
+Checks if constant names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustEnumNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustEnumNaming.html
@@ -1,0 +1,1 @@
+Checks if enum names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustEnumVariantNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustEnumVariantNaming.html
@@ -1,0 +1,1 @@
+Checks if enum variant names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustFieldNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustFieldNaming.html
@@ -1,0 +1,1 @@
+Checks if field names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustFunctionNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustFunctionNaming.html
@@ -1,0 +1,1 @@
+Checks if function names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustLifetimeNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustLifetimeNaming.html
@@ -1,0 +1,1 @@
+Checks if lifetime names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustMacroNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustMacroNaming.html
@@ -1,0 +1,1 @@
+Checks if macro names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustMethodNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustMethodNaming.html
@@ -1,0 +1,1 @@
+Checks if method names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustModuleNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustModuleNaming.html
@@ -1,0 +1,1 @@
+Checks if module names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustStaticConstNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustStaticConstNaming.html
@@ -1,0 +1,1 @@
+Checks if static constant names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustStructNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustStructNaming.html
@@ -1,0 +1,1 @@
+Checks if struct names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustTraitNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustTraitNaming.html
@@ -1,0 +1,1 @@
+Checks if trait names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustTypeAliasNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustTypeAliasNaming.html
@@ -1,0 +1,1 @@
+Checks if type alias names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustTypeParameterNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustTypeParameterNaming.html
@@ -1,0 +1,1 @@
+Checks if type parameter names follow the Rust naming convention.

--- a/src/main/resources/inspectionDescriptions/RustVariableNaming.html
+++ b/src/main/resources/inspectionDescriptions/RustVariableNaming.html
@@ -1,0 +1,1 @@
+Checks if variable names follow the Rust naming convention.

--- a/src/test/kotlin/org/rust/ide/inspections/NamingNotationsTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/NamingNotationsTest.kt
@@ -1,0 +1,151 @@
+package org.rust.ide.inspections
+
+import junit.framework.TestCase
+
+/**
+ * Base class for naming notations tests.
+ */
+abstract class NamingNotationTest : TestCase() {
+    protected abstract val inspection: RustNamingInspection
+
+    /**
+     * Checks that the given name is acceptable in the notation.
+     */
+    protected fun testOk(name: String) {
+        testResult(name, true, null)
+    }
+
+    /**
+     * Checks that the given name is not acceptable in the notation and the must be suggested
+     * to be changed to `expSuggestion`.
+     */
+    protected fun testSuggestion(name: String, expSuggestion: String) {
+        testResult(name, false, expSuggestion)
+    }
+
+    private fun testResult(name: String, expOk: Boolean, expSuggestion: String?) {
+        val (isOk, suggestion) = inspection.checkName(name)
+        assertEquals("Name $name acceptance: is expected $expOk, but was $isOk", expOk, isOk)
+        assertEquals("Suggestion for name $name is expected to be $expSuggestion, but was $suggestion", expSuggestion, suggestion)
+    }
+}
+
+/**
+ * CamelCase notation tests.
+ */
+class CamelCaseNotationTest: NamingNotationTest() {
+    override val inspection = RustCamelCaseNamingInspection("Camel")
+
+    fun testAcceptable() {
+        testOk("_0")
+        testOk("_1234")
+        testOk("A")
+        testOk("ABC")
+        testOk("Camel")
+        testOk("Camel2Qamel")
+        testOk("CamelCaseName")
+        testOk("__CamelCaseName")
+        testOk("CamelCaseName__")
+        testOk("__Cam1elCa2seN3ame__")
+    }
+
+    fun testDefaultSuggestion() {
+        testSuggestion("__", "CamelCase")
+        testSuggestion("____", "CamelCase")
+    }
+
+    fun testSuggestions() {
+        testSuggestion("foo", "Foo")
+        testSuggestion("fOO", "Foo")
+        testSuggestion("foo_bar", "FooBar")
+        testSuggestion("FOO_BAR", "FooBar")
+        testSuggestion("fooBar", "FooBar")
+        testSuggestion("FOo_BAr", "FooBar")
+        testSuggestion("FooBar__baz_", "FooBarBaz")
+        testSuggestion("Foo_1", "Foo1")
+        testSuggestion("___FOo___barBaz__", "FooBarBaz")
+        testSuggestion("a1234", "A1234")
+    }
+}
+
+/**
+ * snake_case notation tests.
+ */
+class SnakeCaseNotationTest: NamingNotationTest() {
+    override val inspection = RustSnakeCaseNamingInspection("Snake")
+
+    fun testAcceptable() {
+        testOk("_0")
+        testOk("_1234")
+        testOk("a")
+        testOk("abc")
+        testOk("snake")
+        testOk("snake2cake")
+        testOk("snake_case_name")
+        testOk("__snake_case_name")
+        testOk("snake_case_name__")
+        testOk("___snake___ca3e__2__name__")
+        testOk("'a")
+        testOk("'__")
+        testOk("'lifetime")
+        testOk("'static_lifetime")
+    }
+
+    fun testDefaultSuggestion() {
+        testSuggestion("__", "snake_case")
+        testSuggestion("____", "snake_case")
+    }
+
+    fun testSuggestions() {
+        testSuggestion("Snake", "snake")
+        testSuggestion("FooBar", "foo_bar")
+        testSuggestion("fooBar", "foo_bar")
+        testSuggestion("FOoBAr", "foo_bar")
+        testSuggestion("FOO_BAR", "foo_bar")
+        testSuggestion("___FooBar__", "___foo_bar")
+        testSuggestion("fooBar__Baz__", "foo_bar_baz")
+        testSuggestion("Foo1", "foo1")
+        testSuggestion("Foo_1", "foo_1")
+        testSuggestion("fooA", "foo_a")
+        testSuggestion("'StaticLifetime", "'static_lifetime")
+        testSuggestion("'___StaticLifetime__2", "'___static_lifetime_2")
+    }
+}
+
+/**
+ * UPPER_CASE notation tests.
+ */
+class UpperCaseNotationTest: NamingNotationTest() {
+    override val inspection = RustUpperCaseNamingInspection("Upper")
+
+    fun testAcceptable() {
+        testOk("_0")
+        testOk("_1234")
+        testOk("A")
+        testOk("ABC")
+        testOk("UPPER")
+        testOk("UPPER2SUPPER")
+        testOk("UPPER_CASE_NAME")
+        testOk("__UPPER_CASE_NAME")
+        testOk("UPPER_CASE_NAME__")
+        testOk("___UPPER___CA3E__2__NAME__")
+    }
+
+    fun testDefaultSuggestion() {
+        testSuggestion("__", "UPPER_CASE")
+        testSuggestion("____", "UPPER_CASE")
+    }
+
+    fun testSuggestions() {
+        testSuggestion("Upper", "UPPER")
+        testSuggestion("FooBar", "FOO_BAR")
+        testSuggestion("fooBar", "FOO_BAR")
+        testSuggestion("FOoBAr", "FOO_BAR")
+        testSuggestion("foo_bar", "FOO_BAR")
+        testSuggestion("___FooBar__", "___FOO_BAR")
+        testSuggestion("fooBar__Baz__", "FOO_BAR_BAZ")
+        testSuggestion("Foo1", "FOO1")
+        testSuggestion("Foo_1", "FOO_1")
+        testSuggestion("fooA", "FOO_A")
+    }
+}

--- a/src/test/kotlin/org/rust/ide/inspections/NamingNotationsTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/NamingNotationsTest.kt
@@ -16,7 +16,7 @@ abstract class NamingNotationTest : TestCase() {
     }
 
     /**
-     * Checks that the given name is not acceptable in the notation and the must be suggested
+     * Checks that the given name is not acceptable in the notation and must be suggested
      * to be changed to `expSuggestion`.
      */
     protected fun testSuggestion(name: String, expSuggestion: String) {
@@ -25,8 +25,8 @@ abstract class NamingNotationTest : TestCase() {
 
     private fun testResult(name: String, expOk: Boolean, expSuggestion: String?) {
         val (isOk, suggestion) = inspection.checkName(name)
-        assertEquals("Name $name acceptance: is expected $expOk, but was $isOk", expOk, isOk)
-        assertEquals("Suggestion for name $name is expected to be $expSuggestion, but was $suggestion", expSuggestion, suggestion)
+        assertEquals("Name $name acceptance: expected $expOk, but was $isOk", expOk, isOk)
+        assertEquals("Suggestion for name $name: expected $expSuggestion, but was $suggestion", expSuggestion, suggestion)
     }
 }
 

--- a/src/test/kotlin/org/rust/ide/inspections/RustNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RustNamingInspectionTest.kt
@@ -14,43 +14,24 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
     fun testAssociatedTypes() = checkByText<RustAssocTypeNamingInspection>("""
         trait Foo {
             type AssocTypeOk;
-            type _AssocTypeOd;
-            type <warning descr="Type `__` should have a camel case name such as `CamelCase`">__</warning>;
             type <warning descr="Type `assoc_foo` should have a camel case name such as `AssocFoo`">assoc_foo</warning>;
-            type <warning descr="Type `assocBar` should have a camel case name such as `AssocBar`">assocBar</warning>;
-            type <warning descr="Type `ASSOC_BAZ` should have a camel case name such as `AssocBaz`">ASSOC_BAZ</warning>;
         }
     """)
 
     fun testConstants() = checkByText<RustConstNamingInspection>("""
         const CONST_OK: u32 = 12;
-        const _CONST_OK: u32 = 12;
-        const _0: u32 = 0;
-        const <warning descr="Constant `__` should have an upper case name such as `UPPER_CASE`">__</warning>: u32 = 41;
         const <warning descr="Constant `const_foo` should have an upper case name such as `CONST_FOO`">const_foo</warning>: u32 = 12;
-        const <warning descr="Constant `ConstBar` should have an upper case name such as `CONST_BAR`">ConstBar</warning>: u32 = 34;
-        const <warning descr="Constant `constBaz` should have an upper case name such as `CONST_BAZ`">constBaz</warning>: u32 = 34;
     """)
 
     fun testEnums() = checkByText<RustEnumNamingInspection>("""
         enum EnumOk {}
-        enum _EnumOk {}
-        enum _1 {}
-        enum <warning descr="Type `__` should have a camel case name such as `CamelCase`">__</warning> {}
         enum <warning descr="Type `enum_foo` should have a camel case name such as `EnumFoo`">enum_foo</warning> {}
-        enum <warning descr="Type `enumBar` should have a camel case name such as `EnumBar`">enumBar</warning> {}
-        enum <warning descr="Type `ENUM_BAZ` should have a camel case name such as `EnumBaz`">ENUM_BAZ</warning> {}
     """)
 
     fun testEnumVariants() = checkByText<RustEnumVariantNamingInspection>("""
         enum EnumVars {
             VariantOk,
-            _VariantOk,
-            _1,
-            <warning descr="Enum variant `__` should have a camel case name such as `CamelCase`">__</warning>,
             <warning descr="Enum variant `variant_foo` should have a camel case name such as `VariantFoo`">variant_foo</warning>,
-            <warning descr="Enum variant `variantBar` should have a camel case name such as `VariantBar`">variantBar</warning>,
-            <warning descr="Enum variant `VARIANT_BAZ` should have a camel case name such as `VariantBaz`">VARIANT_BAZ</warning>
         }
     """)
 
@@ -58,70 +39,41 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
         enum EnumVarFields {
             Variant {
                 field_ok: u32,
-                _field_ok: u32,
-                _3: u32,
-                <warning descr="Field `__` should have a snake case name such as `snake_case`">__</warning>: u32,
-                <warning descr="Field `FieldFoo` should have a snake case name such as `field_foo`">FieldFoo</warning>: u32,
-                <warning descr="Field `fieldBar` should have a snake case name such as `field_bar`">fieldBar</warning>: u32,
-                <warning descr="Field `FIELD_BAZ` should have a snake case name such as `field_baz`">FIELD_BAZ</warning>: u32
+                <warning descr="Field `FieldFoo` should have a snake case name such as `field_foo`">FieldFoo</warning>: u32
             }
         }
     """)
 
     fun testFunctions() = checkByText<RustFunctionNamingInspection>("""
         fn fn_ok() {}
-        fn _fn_ok() {}
-        fn _6() {}
-        fn <warning descr="Function `__` should have a snake case name such as `snake_case`">__</warning>() {}
         fn <warning descr="Function `FN_BAR` should have a snake case name such as `fn_bar`">FN_BAR</warning>() {}
-        fn <warning descr="Function `FnFoo` should have a snake case name such as `fn_foo`">FnFoo</warning>() {}
-        fn <warning descr="Function `fnBaz` should have a snake case name such as `fn_baz`">fnBaz</warning>() {}
     """)
 
     fun testFunctionArguments() = checkByText<RustArgumentNamingInspection>("""
         fn fn_par(
             par_ok: u32,
-            _par_ok: u32,
-            _1: u32,
-            <warning descr="Argument `__` should have a snake case name such as `snake_case`">__</warning>: u32,
-            <warning descr="Argument `ParFoo` should have a snake case name such as `par_foo`">ParFoo</warning>: u32,
-            <warning descr="Argument `parBar` should have a snake case name such as `par_bar`">parBar</warning>: u32,
-            <warning descr="Argument `PAR_BAZ` should have a snake case name such as `par_baz`">PAR_BAZ</warning>: u32) {
+            <warning descr="Argument `ParFoo` should have a snake case name such as `par_foo`">ParFoo</warning>: u32) {
         }
     """)
 
     fun testLifetimes() = checkByText<RustLifetimeNamingInspection>("""
         fn lifetimes<
             'lifetime_ok,
-            '_lifetime_ok,
             '__,
-            '_9,
-            <warning descr="Lifetime `'LifetimeFoo` should have a snake case name such as `'lifetime_foo`">'LifetimeFoo</warning>,
-            <warning descr="Lifetime `'lifetimeBar` should have a snake case name such as `'lifetime_bar`">'lifetimeBar</warning>,
-            <warning descr="Lifetime `'LIFETIME_BAZ` should have a snake case name such as `'lifetime_baz`">'LIFETIME_BAZ</warning>>() {
+            <warning descr="Lifetime `'LifetimeFoo` should have a snake case name such as `'lifetime_foo`">'LifetimeFoo</warning>>() {
         }
     """)
 
     fun testMacros() = checkByText<RustMacroNamingInspection>("""
         macro_rules! macro_ok { ( $( ${'$'}x:expr ),* ) => {}; }
-        macro_rules! _macro_ok { ( $( ${'$'}x:expr ),* ) => {}; }
-        macro_rules! _9 { ( $( ${'$'}x:expr ),* ) => {}; }
-        macro_rules! <warning descr="Macro `__` should have a snake case name such as `snake_case`">__</warning> { ( $( ${'$'}x:expr ),* ) => {}; }
         macro_rules! <warning descr="Macro `MacroFoo` should have a snake case name such as `macro_foo`">MacroFoo</warning> { ( $( ${'$'}x:expr ),* ) => {}; }
-        macro_rules! <warning descr="Macro `macroBar` should have a snake case name such as `macro_bar`">macroBar</warning> { ( $( ${'$'}x:expr ),* ) => {}; }
-        macro_rules! <warning descr="Macro `MACRO_BAZ` should have a snake case name such as `macro_baz`">MACRO_BAZ</warning> { ( $( ${'$'}x:expr ),* ) => {}; }
     """)
 
     fun testMethods() = checkByText<RustMethodNamingInspection>("""
         struct Foo {}
         impl Foo {
             fn met_ok(&self) {}
-            fn _met_ok(&self) {}
-            fn _5(&self) {}
-            fn <warning descr="Method `__` should have a snake case name such as `snake_case`">__</warning>(&self) {}
             fn <warning descr="Method `MET_BAR` should have a snake case name such as `met_bar`">MET_BAR</warning>(&self) {}
-            fn <warning descr="Method `MetFoo` should have a snake case name such as `met_foo`">MetFoo</warning>(&self) {}
-            fn <warning descr="Method `metBaz` should have a snake case name such as `met_baz`">metBaz</warning>(&self) {}
         }
     """)
 
@@ -130,12 +82,7 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
         impl Foo {
             fn fn_par(
                 par_ok: u32,
-                _par_ok: u32,
-                _1: u32,
-                <warning descr="Argument `__` should have a snake case name such as `snake_case`">__</warning>: u32,
-                <warning descr="Argument `ParFoo` should have a snake case name such as `par_foo`">ParFoo</warning>: u32,
-                <warning descr="Argument `parBar` should have a snake case name such as `par_bar`">parBar</warning>: u32,
-                <warning descr="Argument `PAR_BAZ` should have a snake case name such as `par_baz`">PAR_BAZ</warning>: u32) {
+                <warning descr="Argument `ParFoo` should have a snake case name such as `par_foo`">ParFoo</warning>: u32,) {
             }
         }
     """)
@@ -143,137 +90,60 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
     fun testTraitlMethods() = checkByText<RustMethodNamingInspection>("""
         trait Foo {
             fn met_ok() {}
-            fn _met_ok() {}
-            fn _5() {}
-            fn <warning descr="Method `__` should have a snake case name such as `snake_case`">__</warning>() {}
             fn <warning descr="Method `MET_BAR` should have a snake case name such as `met_bar`">MET_BAR</warning>() {}
-            fn <warning descr="Method `MetFoo` should have a snake case name such as `met_foo`">MetFoo</warning>() {}
-            fn <warning descr="Method `metBaz` should have a snake case name such as `met_baz`">metBaz</warning>() {}
         }
     """)
 
     fun testModules() = checkByText<RustModuleNamingInspection>("""
         mod module_ok {}
-        mod _module_ok {}
-        mod _7 {}
-        mod <warning descr="Module `__` should have a snake case name such as `snake_case`">__</warning> {}
-        mod <warning descr="Module `Module1` should have a snake case name such as `module1`">Module1</warning> {}
         mod <warning descr="Module `moduleA` should have a snake case name such as `module_a`">moduleA</warning> {}
-        mod <warning descr="Module `MODULE_BAZ` should have a snake case name such as `module_baz`">MODULE_BAZ</warning> {}
     """)
 
     fun testStatics() = checkByText<RustStaticConstNamingInspection>("""
         static STATIC_OK: u32 = 12;
-        static _STATIC_OK: u32 = 12;
-        static _6: u32 = 6;
-        static <warning descr="Static constant `__` should have an upper case name such as `UPPER_CASE`">__</warning>: u32 = 14;
         static <warning descr="Static constant `static_foo` should have an upper case name such as `STATIC_FOO`">static_foo</warning>: u32 = 12;
-        static <warning descr="Static constant `StaticBar` should have an upper case name such as `STATIC_BAR`">StaticBar</warning>: u32 = 34;
-        static <warning descr="Static constant `staticBaz` should have an upper case name such as `STATIC_BAZ`">staticBaz</warning>: u32 = 34;
     """)
 
     fun testStructs() = checkByText<RustStructNamingInspection>("""
         struct StructOk {}
-        struct _StructOk {}
-        struct _8 {}
-        struct <warning descr="Type `__` should have a camel case name such as `CamelCase`">__</warning> {}
         struct <warning descr="Type `struct_foo` should have a camel case name such as `StructFoo`">struct_foo</warning> {}
-        struct <warning descr="Type `structBar` should have a camel case name such as `StructBar`">structBar</warning> {}
-        struct <warning descr="Type `STRUCT_BAZ` should have a camel case name such as `StructBaz`">STRUCT_BAZ</warning> {}
     """)
 
     fun testStructFields() = checkByText<RustFieldNamingInspection>("""
         struct Foo {
             field_ok: u32,
-            _field_ok: u32,
-            _1: u32,
-            <warning descr="Field `__` should have a snake case name such as `snake_case`">__</warning>: u32,
-            <warning descr="Field `FieldFoo` should have a snake case name such as `field_foo`">FieldFoo</warning>: u32,
-            <warning descr="Field `fieldBar` should have a snake case name such as `field_bar`">fieldBar</warning>: u32,
-            <warning descr="Field `FIELD_BAZ` should have a snake case name such as `field_baz`">FIELD_BAZ</warning>: u32
+            <warning descr="Field `FieldFoo` should have a snake case name such as `field_foo`">FieldFoo</warning>: u32
         }
     """)
 
     fun testTraits() = checkByText<RustTraitNamingInspection>("""
         trait TraitOk {}
-        trait _TraitOk {}
-        trait _4 {}
-        trait <warning descr="Trait `__` should have a camel case name such as `CamelCase`">__</warning> {}
         trait <warning descr="Trait `trait_foo` should have a camel case name such as `TraitFoo`">trait_foo</warning> {}
-        trait <warning descr="Trait `traitFoo` should have a camel case name such as `TraitFoo`">traitFoo</warning> {}
-        trait <warning descr="Trait `TRAIT_BAZ` should have a camel case name such as `TraitBaz`">TRAIT_BAZ</warning> {}
     """)
 
     fun testTypeAliases() = checkByText<RustTypeAliasNamingInspection>("""
         type TypeOk = u32;
-        type _TypeOk = u32;
-        type _32 = u32;
-        type <warning descr="Type `__` should have a camel case name such as `CamelCase`">__</warning> = u32;
         type <warning descr="Type `type_foo` should have a camel case name such as `TypeFoo`">type_foo</warning> = u32;
-        type <warning descr="Type `typeBar` should have a camel case name such as `TypeBar`">typeBar</warning> = u32;
-        type <warning descr="Type `TYPE_BAZ` should have a camel case name such as `TypeBaz`">TYPE_BAZ</warning> = u32;
     """)
 
     fun testTypeParameters() = checkByText<RustTypeParameterNamingInspection>("""
         fn type_params<
             SomeType: Clone,
-            _SomeType: Clone,
-            _8: Clone,
-            <warning descr="Type parameter `__` should have a camel case name such as `CamelCase`">__</warning>: Clone,
-            <warning descr="Type parameter `some_Type` should have a camel case name such as `SomeType`">some_Type</warning>: Clone,
-            <warning descr="Type parameter `someType` should have a camel case name such as `SomeType`">someType</warning>: Clone,
-            <warning descr="Type parameter `SOMET_TYPE` should have a camel case name such as `SometType`">SOMET_TYPE</warning>: Clone>() {
+            <warning descr="Type parameter `some_Type` should have a camel case name such as `SomeType`">some_Type</warning>: Clone> () {
         }
     """)
 
     fun testTypeParametersWithWhere() = checkByText<RustTypeParameterNamingInspection>("""
         fn type_params<
             SomeType,
-            _SomeType,
-            _1,
-            <warning descr="Type parameter `__` should have a camel case name such as `CamelCase`">__</warning>,
-            <warning descr="Type parameter `some_Type` should have a camel case name such as `SomeType`">some_Type</warning>,
-            <warning descr="Type parameter `someType` should have a camel case name such as `SomeType`">someType</warning>,
-            <warning descr="Type parameter `SOMET_TYPE` should have a camel case name such as `SometType`">SOMET_TYPE</warning>>() where SomeType: Clone, _SomeType: Clone, some_Type: Clone, someType: Clone, SOMET_TYPE: Clone {
+            <warning descr="Type parameter `some_Type` should have a camel case name such as `SomeType`">some_Type</warning>>() where some_Type: Clone {
         }
     """)
 
     fun testVariables() = checkByText<RustVariableNamingInspection>("""
         fn loc_var() {
             let var_ok = 12;
-            let _var_ok = 12;
-            let _7 = 7;
-            let <warning descr="Variable `__` should have a snake case name such as `snake_case`">__</warning> = 12;
             let <warning descr="Variable `VarFoo` should have a snake case name such as `var_foo`">VarFoo</warning> = 12;
-            let <warning descr="Variable `varBar` should have a snake case name such as `var_bar`">varBar</warning> = 12;
-            let <warning descr="Variable `VAR_BAZ` should have a snake case name such as `var_baz`">VAR_BAZ</warning> = 12;
         }
-    """)
-
-    fun testSnakeCase() = checkByText<RustFunctionNamingInspection>("""
-        fn snake_case() {}
-        fn __snake_case__() {}
-        fn _12345() {}
-        fn <warning descr="Function `___` should have a snake case name such as `snake_case`">___</warning>() {}
-        fn <warning descr="Function `___FOoBarBAZ___boo___` should have a snake case name such as `___foo_bar_baz_boo`">___FOoBarBAZ___boo___</warning>() {}
-        fn <warning descr="Function `___123___45A___` should have a snake case name such as `___123_45a`">___123___45A___</warning>() {}
-    """)
-
-    fun testUpperCase() = checkByText<RustConstNamingInspection>("""
-        const UPPER_CASE: u32 = 1;
-        const __UPPER_CASE__: u32 = 1;
-        const _12345: u32 = 12345;
-        const <warning descr="Constant `___` should have an upper case name such as `UPPER_CASE`">___</warning>: u32 = 10;
-        const <warning descr="Constant `___FOoBarBAZ___boo___` should have an upper case name such as `___FOO_BAR_BAZ_BOO`">___FOoBarBAZ___boo___</warning>: u32 = 10;
-        const <warning descr="Constant `___123___45a___` should have an upper case name such as `___123_45A`">___123___45a___</warning>: u32 = 10;
-    """)
-
-    fun testCamelCase() = checkByText<RustStructNamingInspection>("""
-        struct CamelCase {}
-        struct __CamelCase__ {}
-        struct _12345 {}
-        struct <warning descr="Type `___` should have a camel case name such as `CamelCase`">___</warning> {}
-        struct <warning descr="Type `___FOo___barBaz__` should have a camel case name such as `FooBarBaz`">___FOo___barBaz__</warning> {}
-        struct <warning descr="Type `_a123456` should have a camel case name such as `A123456`">_a123456</warning> {}
     """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RustNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RustNamingInspectionTest.kt
@@ -1,0 +1,279 @@
+package org.rust.ide.inspections
+
+import com.intellij.testFramework.LightProjectDescriptor
+
+/**
+ * Tests for the set of Naming Convention inspections.
+ */
+class RustNamingInspectionTest : RustInspectionsTestBase() {
+
+    override val dataPath = ""
+
+    override fun getProjectDescriptor(): LightProjectDescriptor = WithStdlibRustProjectDescriptor()
+
+    fun testAssociatedTypes() = checkByText<RustAssocTypeNamingInspection>("""
+        trait Foo {
+            type AssocTypeOk;
+            type _AssocTypeOd;
+            type <warning descr="Type `__` should have a camel case name such as `CamelCase`">__</warning>;
+            type <warning descr="Type `assoc_foo` should have a camel case name such as `AssocFoo`">assoc_foo</warning>;
+            type <warning descr="Type `assocBar` should have a camel case name such as `AssocBar`">assocBar</warning>;
+            type <warning descr="Type `ASSOC_BAZ` should have a camel case name such as `AssocBaz`">ASSOC_BAZ</warning>;
+        }
+    """)
+
+    fun testConstants() = checkByText<RustConstNamingInspection>("""
+        const CONST_OK: u32 = 12;
+        const _CONST_OK: u32 = 12;
+        const _0: u32 = 0;
+        const <warning descr="Constant `__` should have an upper case name such as `UPPER_CASE`">__</warning>: u32 = 41;
+        const <warning descr="Constant `const_foo` should have an upper case name such as `CONST_FOO`">const_foo</warning>: u32 = 12;
+        const <warning descr="Constant `ConstBar` should have an upper case name such as `CONST_BAR`">ConstBar</warning>: u32 = 34;
+        const <warning descr="Constant `constBaz` should have an upper case name such as `CONST_BAZ`">constBaz</warning>: u32 = 34;
+    """)
+
+    fun testEnums() = checkByText<RustEnumNamingInspection>("""
+        enum EnumOk {}
+        enum _EnumOk {}
+        enum _1 {}
+        enum <warning descr="Type `__` should have a camel case name such as `CamelCase`">__</warning> {}
+        enum <warning descr="Type `enum_foo` should have a camel case name such as `EnumFoo`">enum_foo</warning> {}
+        enum <warning descr="Type `enumBar` should have a camel case name such as `EnumBar`">enumBar</warning> {}
+        enum <warning descr="Type `ENUM_BAZ` should have a camel case name such as `EnumBaz`">ENUM_BAZ</warning> {}
+    """)
+
+    fun testEnumVariants() = checkByText<RustEnumVariantNamingInspection>("""
+        enum EnumVars {
+            VariantOk,
+            _VariantOk,
+            _1,
+            <warning descr="Enum variant `__` should have a camel case name such as `CamelCase`">__</warning>,
+            <warning descr="Enum variant `variant_foo` should have a camel case name such as `VariantFoo`">variant_foo</warning>,
+            <warning descr="Enum variant `variantBar` should have a camel case name such as `VariantBar`">variantBar</warning>,
+            <warning descr="Enum variant `VARIANT_BAZ` should have a camel case name such as `VariantBaz`">VARIANT_BAZ</warning>
+        }
+    """)
+
+    fun testEnumVariantFields() = checkByText<RustFieldNamingInspection>("""
+        enum EnumVarFields {
+            Variant {
+                field_ok: u32,
+                _field_ok: u32,
+                _3: u32,
+                <warning descr="Field `__` should have a snake case name such as `snake_case`">__</warning>: u32,
+                <warning descr="Field `FieldFoo` should have a snake case name such as `field_foo`">FieldFoo</warning>: u32,
+                <warning descr="Field `fieldBar` should have a snake case name such as `field_bar`">fieldBar</warning>: u32,
+                <warning descr="Field `FIELD_BAZ` should have a snake case name such as `field_baz`">FIELD_BAZ</warning>: u32
+            }
+        }
+    """)
+
+    fun testFunctions() = checkByText<RustFunctionNamingInspection>("""
+        fn fn_ok() {}
+        fn _fn_ok() {}
+        fn _6() {}
+        fn <warning descr="Function `__` should have a snake case name such as `snake_case`">__</warning>() {}
+        fn <warning descr="Function `FN_BAR` should have a snake case name such as `fn_bar`">FN_BAR</warning>() {}
+        fn <warning descr="Function `FnFoo` should have a snake case name such as `fn_foo`">FnFoo</warning>() {}
+        fn <warning descr="Function `fnBaz` should have a snake case name such as `fn_baz`">fnBaz</warning>() {}
+    """)
+
+    fun testFunctionArguments() = checkByText<RustArgumentNamingInspection>("""
+        fn fn_par(
+            par_ok: u32,
+            _par_ok: u32,
+            _1: u32,
+            <warning descr="Argument `__` should have a snake case name such as `snake_case`">__</warning>: u32,
+            <warning descr="Argument `ParFoo` should have a snake case name such as `par_foo`">ParFoo</warning>: u32,
+            <warning descr="Argument `parBar` should have a snake case name such as `par_bar`">parBar</warning>: u32,
+            <warning descr="Argument `PAR_BAZ` should have a snake case name such as `par_baz`">PAR_BAZ</warning>: u32) {
+        }
+    """)
+
+    fun testLifetimes() = checkByText<RustLifetimeNamingInspection>("""
+        fn lifetimes<
+            'lifetime_ok,
+            '_lifetime_ok,
+            '__,
+            '_9,
+            <warning descr="Lifetime `'LifetimeFoo` should have a snake case name such as `'lifetime_foo`">'LifetimeFoo</warning>,
+            <warning descr="Lifetime `'lifetimeBar` should have a snake case name such as `'lifetime_bar`">'lifetimeBar</warning>,
+            <warning descr="Lifetime `'LIFETIME_BAZ` should have a snake case name such as `'lifetime_baz`">'LIFETIME_BAZ</warning>>() {
+        }
+    """)
+
+    fun testMacros() = checkByText<RustMacroNamingInspection>("""
+        macro_rules! macro_ok { ( $( ${'$'}x:expr ),* ) => {}; }
+        macro_rules! _macro_ok { ( $( ${'$'}x:expr ),* ) => {}; }
+        macro_rules! _9 { ( $( ${'$'}x:expr ),* ) => {}; }
+        macro_rules! <warning descr="Macro `__` should have a snake case name such as `snake_case`">__</warning> { ( $( ${'$'}x:expr ),* ) => {}; }
+        macro_rules! <warning descr="Macro `MacroFoo` should have a snake case name such as `macro_foo`">MacroFoo</warning> { ( $( ${'$'}x:expr ),* ) => {}; }
+        macro_rules! <warning descr="Macro `macroBar` should have a snake case name such as `macro_bar`">macroBar</warning> { ( $( ${'$'}x:expr ),* ) => {}; }
+        macro_rules! <warning descr="Macro `MACRO_BAZ` should have a snake case name such as `macro_baz`">MACRO_BAZ</warning> { ( $( ${'$'}x:expr ),* ) => {}; }
+    """)
+
+    fun testMethods() = checkByText<RustMethodNamingInspection>("""
+        struct Foo {}
+        impl Foo {
+            fn met_ok(&self) {}
+            fn _met_ok(&self) {}
+            fn _5(&self) {}
+            fn <warning descr="Method `__` should have a snake case name such as `snake_case`">__</warning>(&self) {}
+            fn <warning descr="Method `MET_BAR` should have a snake case name such as `met_bar`">MET_BAR</warning>(&self) {}
+            fn <warning descr="Method `MetFoo` should have a snake case name such as `met_foo`">MetFoo</warning>(&self) {}
+            fn <warning descr="Method `metBaz` should have a snake case name such as `met_baz`">metBaz</warning>(&self) {}
+        }
+    """)
+
+    fun testMethodArguments() = checkByText<RustArgumentNamingInspection>("""
+        struct Foo {}
+        impl Foo {
+            fn fn_par(
+                par_ok: u32,
+                _par_ok: u32,
+                _1: u32,
+                <warning descr="Argument `__` should have a snake case name such as `snake_case`">__</warning>: u32,
+                <warning descr="Argument `ParFoo` should have a snake case name such as `par_foo`">ParFoo</warning>: u32,
+                <warning descr="Argument `parBar` should have a snake case name such as `par_bar`">parBar</warning>: u32,
+                <warning descr="Argument `PAR_BAZ` should have a snake case name such as `par_baz`">PAR_BAZ</warning>: u32) {
+            }
+        }
+    """)
+
+    fun testTraitlMethods() = checkByText<RustMethodNamingInspection>("""
+        trait Foo {
+            fn met_ok() {}
+            fn _met_ok() {}
+            fn _5() {}
+            fn <warning descr="Method `__` should have a snake case name such as `snake_case`">__</warning>() {}
+            fn <warning descr="Method `MET_BAR` should have a snake case name such as `met_bar`">MET_BAR</warning>() {}
+            fn <warning descr="Method `MetFoo` should have a snake case name such as `met_foo`">MetFoo</warning>() {}
+            fn <warning descr="Method `metBaz` should have a snake case name such as `met_baz`">metBaz</warning>() {}
+        }
+    """)
+
+    fun testModules() = checkByText<RustModuleNamingInspection>("""
+        mod module_ok {}
+        mod _module_ok {}
+        mod _7 {}
+        mod <warning descr="Module `__` should have a snake case name such as `snake_case`">__</warning> {}
+        mod <warning descr="Module `Module1` should have a snake case name such as `module1`">Module1</warning> {}
+        mod <warning descr="Module `moduleA` should have a snake case name such as `module_a`">moduleA</warning> {}
+        mod <warning descr="Module `MODULE_BAZ` should have a snake case name such as `module_baz`">MODULE_BAZ</warning> {}
+    """)
+
+    fun testStatics() = checkByText<RustStaticConstNamingInspection>("""
+        static STATIC_OK: u32 = 12;
+        static _STATIC_OK: u32 = 12;
+        static _6: u32 = 6;
+        static <warning descr="Static constant `__` should have an upper case name such as `UPPER_CASE`">__</warning>: u32 = 14;
+        static <warning descr="Static constant `static_foo` should have an upper case name such as `STATIC_FOO`">static_foo</warning>: u32 = 12;
+        static <warning descr="Static constant `StaticBar` should have an upper case name such as `STATIC_BAR`">StaticBar</warning>: u32 = 34;
+        static <warning descr="Static constant `staticBaz` should have an upper case name such as `STATIC_BAZ`">staticBaz</warning>: u32 = 34;
+    """)
+
+    fun testStructs() = checkByText<RustStructNamingInspection>("""
+        struct StructOk {}
+        struct _StructOk {}
+        struct _8 {}
+        struct <warning descr="Type `__` should have a camel case name such as `CamelCase`">__</warning> {}
+        struct <warning descr="Type `struct_foo` should have a camel case name such as `StructFoo`">struct_foo</warning> {}
+        struct <warning descr="Type `structBar` should have a camel case name such as `StructBar`">structBar</warning> {}
+        struct <warning descr="Type `STRUCT_BAZ` should have a camel case name such as `StructBaz`">STRUCT_BAZ</warning> {}
+    """)
+
+    fun testStructFields() = checkByText<RustFieldNamingInspection>("""
+        struct Foo {
+            field_ok: u32,
+            _field_ok: u32,
+            _1: u32,
+            <warning descr="Field `__` should have a snake case name such as `snake_case`">__</warning>: u32,
+            <warning descr="Field `FieldFoo` should have a snake case name such as `field_foo`">FieldFoo</warning>: u32,
+            <warning descr="Field `fieldBar` should have a snake case name such as `field_bar`">fieldBar</warning>: u32,
+            <warning descr="Field `FIELD_BAZ` should have a snake case name such as `field_baz`">FIELD_BAZ</warning>: u32
+        }
+    """)
+
+    fun testTraits() = checkByText<RustTraitNamingInspection>("""
+        trait TraitOk {}
+        trait _TraitOk {}
+        trait _4 {}
+        trait <warning descr="Trait `__` should have a camel case name such as `CamelCase`">__</warning> {}
+        trait <warning descr="Trait `trait_foo` should have a camel case name such as `TraitFoo`">trait_foo</warning> {}
+        trait <warning descr="Trait `traitFoo` should have a camel case name such as `TraitFoo`">traitFoo</warning> {}
+        trait <warning descr="Trait `TRAIT_BAZ` should have a camel case name such as `TraitBaz`">TRAIT_BAZ</warning> {}
+    """)
+
+    fun testTypeAliases() = checkByText<RustTypeAliasNamingInspection>("""
+        type TypeOk = u32;
+        type _TypeOk = u32;
+        type _32 = u32;
+        type <warning descr="Type `__` should have a camel case name such as `CamelCase`">__</warning> = u32;
+        type <warning descr="Type `type_foo` should have a camel case name such as `TypeFoo`">type_foo</warning> = u32;
+        type <warning descr="Type `typeBar` should have a camel case name such as `TypeBar`">typeBar</warning> = u32;
+        type <warning descr="Type `TYPE_BAZ` should have a camel case name such as `TypeBaz`">TYPE_BAZ</warning> = u32;
+    """)
+
+    fun testTypeParameters() = checkByText<RustTypeParameterNamingInspection>("""
+        fn type_params<
+            SomeType: Clone,
+            _SomeType: Clone,
+            _8: Clone,
+            <warning descr="Type parameter `__` should have a camel case name such as `CamelCase`">__</warning>: Clone,
+            <warning descr="Type parameter `some_Type` should have a camel case name such as `SomeType`">some_Type</warning>: Clone,
+            <warning descr="Type parameter `someType` should have a camel case name such as `SomeType`">someType</warning>: Clone,
+            <warning descr="Type parameter `SOMET_TYPE` should have a camel case name such as `SometType`">SOMET_TYPE</warning>: Clone>() {
+        }
+    """)
+
+    fun testTypeParametersWithWhere() = checkByText<RustTypeParameterNamingInspection>("""
+        fn type_params<
+            SomeType,
+            _SomeType,
+            _1,
+            <warning descr="Type parameter `__` should have a camel case name such as `CamelCase`">__</warning>,
+            <warning descr="Type parameter `some_Type` should have a camel case name such as `SomeType`">some_Type</warning>,
+            <warning descr="Type parameter `someType` should have a camel case name such as `SomeType`">someType</warning>,
+            <warning descr="Type parameter `SOMET_TYPE` should have a camel case name such as `SometType`">SOMET_TYPE</warning>>() where SomeType: Clone, _SomeType: Clone, some_Type: Clone, someType: Clone, SOMET_TYPE: Clone {
+        }
+    """)
+
+    fun testVariables() = checkByText<RustVariableNamingInspection>("""
+        fn loc_var() {
+            let var_ok = 12;
+            let _var_ok = 12;
+            let _7 = 7;
+            let <warning descr="Variable `__` should have a snake case name such as `snake_case`">__</warning> = 12;
+            let <warning descr="Variable `VarFoo` should have a snake case name such as `var_foo`">VarFoo</warning> = 12;
+            let <warning descr="Variable `varBar` should have a snake case name such as `var_bar`">varBar</warning> = 12;
+            let <warning descr="Variable `VAR_BAZ` should have a snake case name such as `var_baz`">VAR_BAZ</warning> = 12;
+        }
+    """)
+
+    fun testSnakeCase() = checkByText<RustFunctionNamingInspection>("""
+        fn snake_case() {}
+        fn __snake_case__() {}
+        fn _12345() {}
+        fn <warning descr="Function `___` should have a snake case name such as `snake_case`">___</warning>() {}
+        fn <warning descr="Function `___FOoBarBAZ___boo___` should have a snake case name such as `___foo_bar_baz_boo`">___FOoBarBAZ___boo___</warning>() {}
+        fn <warning descr="Function `___123___45A___` should have a snake case name such as `___123_45a`">___123___45A___</warning>() {}
+    """)
+
+    fun testUpperCase() = checkByText<RustConstNamingInspection>("""
+        const UPPER_CASE: u32 = 1;
+        const __UPPER_CASE__: u32 = 1;
+        const _12345: u32 = 12345;
+        const <warning descr="Constant `___` should have an upper case name such as `UPPER_CASE`">___</warning>: u32 = 10;
+        const <warning descr="Constant `___FOoBarBAZ___boo___` should have an upper case name such as `___FOO_BAR_BAZ_BOO`">___FOoBarBAZ___boo___</warning>: u32 = 10;
+        const <warning descr="Constant `___123___45a___` should have an upper case name such as `___123_45A`">___123___45a___</warning>: u32 = 10;
+    """)
+
+    fun testCamelCase() = checkByText<RustStructNamingInspection>("""
+        struct CamelCase {}
+        struct __CamelCase__ {}
+        struct _12345 {}
+        struct <warning descr="Type `___` should have a camel case name such as `CamelCase`">___</warning> {}
+        struct <warning descr="Type `___FOo___barBaz__` should have a camel case name such as `FooBarBaz`">___FOo___barBaz__</warning> {}
+        struct <warning descr="Type `_a123456` should have a camel case name such as `A123456`">_a123456</warning> {}
+    """)
+}


### PR DESCRIPTION
A set of inspections that match the `rustc`'s lints `non_snake_case`, `non_camel_case_types` and `non_upper_case_globals` with the following minor differences:
- Associated constants are not inspected (they are experimental in Rust and not supported by the plugin so far, if I understand correctly)
- Associated types are inspected while `rustc` ignores them when checking names
- The inspections sometimes offer better renaming options (`fooBar` &rarr; `FooBar` instead of `fooBar` &rarr; `Foobar` in `rustc`)

I've extracted separate inspections for every element type (the same way it's done in Java) because it will help to adjust inspections with higher level of granularity after improvements (see below).

Further improvements I'm thinking of:
- Analyze `#[allow(...)]` attributes to suppress inspections.
- Add a Rename fix. I have a working implementation that leverages IntelliJ's refactoring facilities, but it throws an exception somewhere in its internals that warns about possible deadlocks. So I'm not confident to include it into the PR so far.
- In the future, inspections may also impose reasonable name length limits (`rustc` doesn't care much about it) and RegEx to match to (as they do in Java).