### PR TITLE
(MISC) Source code links in panics and stacktraces

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
@@ -20,6 +20,8 @@ class CargoRunState(
     init {
         consoleBuilder.addFilter(RustConsoleFilter(environment.project, cargoProjectDirectory))
         consoleBuilder.addFilter(RustExplainFilter())
+        consoleBuilder.addFilter(RustPanicFilter(environment.project, cargoProjectDirectory))
+        consoleBuilder.addFilter(RustBacktraceFilter(environment.project, cargoProjectDirectory))
     }
 
     override fun startProcess(): ProcessHandler {

--- a/src/main/kotlin/org/rust/cargo/runconfig/RegexpFileLinkFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RegexpFileLinkFilter.kt
@@ -7,11 +7,15 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import java.io.File
 
-
-class RustConsoleFilter(
+/**
+ * Base class for regexp-based output filters that extract
+ * source code location from the output and add corresponding hyperlinks.
+ */
+open class RegexpFileLinkFilter(
     private val project: Project,
-    private val cargoProjectDirectory: VirtualFile
-) : RegexpFilter(project, "(?: --> )?${RegexpFilter.FILE_PATH_MACROS}:${RegexpFilter.LINE_MACROS}:${RegexpFilter.COLUMN_MACROS}") {
+    private val cargoProjectDirectory: VirtualFile,
+    expression: String
+) : RegexpFilter(project, expression) {
 
     override fun createOpenFileHyperlink(fileName: String, line: Int, column: Int): HyperlinkInfo? {
         val platformNeutralName = fileName.replace(File.separatorChar, '/')
@@ -20,4 +24,3 @@ class RustConsoleFilter(
         }
     }
 }
-

--- a/src/main/kotlin/org/rust/cargo/runconfig/RustBacktraceFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RustBacktraceFilter.kt
@@ -1,0 +1,17 @@
+package org.rust.cargo.runconfig
+
+import com.intellij.execution.filters.RegexpFilter
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Detects messages about panics and adds source code links to them.
+ */
+class RustBacktraceFilter(
+    project: Project,
+    cargoProjectDir: VirtualFile
+) : RegexpFileLinkFilter(
+    project,
+    cargoProjectDir,
+    "^\\s+at ${RegexpFilter.FILE_PATH_MACROS}:${RegexpFilter.LINE_MACROS}$") {
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/RustConsoleFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RustConsoleFilter.kt
@@ -1,0 +1,17 @@
+package org.rust.cargo.runconfig
+
+import com.intellij.execution.filters.RegexpFilter
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Detects source code locations in rustc output and adds links to them.
+ */
+class RustConsoleFilter(
+    project: Project,
+    cargoProjectDir: VirtualFile
+) : RegexpFileLinkFilter(
+    project,
+    cargoProjectDir,
+    "(?: --> )?${RegexpFilter.FILE_PATH_MACROS}:${RegexpFilter.LINE_MACROS}:${RegexpFilter.COLUMN_MACROS}") {
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/RustPanicFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RustPanicFilter.kt
@@ -1,0 +1,17 @@
+package org.rust.cargo.runconfig
+
+import com.intellij.execution.filters.RegexpFilter
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Detects messages about panics and adds source code links to them.
+ */
+class RustPanicFilter(
+    project: Project,
+    cargoProjectDir: VirtualFile
+) : RegexpFileLinkFilter(
+    project,
+    cargoProjectDir,
+    "^\\s*thread '.+' panicked at '.+', ${RegexpFilter.FILE_PATH_MACROS}:${RegexpFilter.LINE_MACROS}$") {
+}

--- a/src/test/kotlin/org/rust/cargo/runconfig/HighlightFilterTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/HighlightFilterTestBase.kt
@@ -1,0 +1,40 @@
+package org.rust.cargo.runconfig
+
+import com.intellij.execution.filters.OpenFileHyperlinkInfo
+import com.intellij.openapi.vfs.VirtualFile
+import org.assertj.core.api.Assertions
+import org.rust.ide.utils.runWriteAction
+import org.rust.lang.RustTestCaseBase
+
+/**
+ * Base class for tests of output highlighting filters.
+ */
+abstract class HighlightFilterTestBase : RustTestCaseBase() {
+    override val dataPath = ""
+    lateinit var projectDir: VirtualFile
+
+    override fun setUp() {
+        super.setUp()
+        projectDir = createTestDirectoryAndFile()
+    }
+
+    protected fun doTest(filter: RegexpFileLinkFilter, line: String, entireLength: Int, hStart: Int, hEnd: Int) {
+        val result = checkNotNull(filter.applyFilter(line, entireLength)) {
+            "No match in $line"
+        }
+
+        val item = result.resultItems.single()
+        Assertions.assertThat(item.getHighlightStartOffset()).isEqualTo(hStart)
+        Assertions.assertThat(item.getHighlightEndOffset()).isEqualTo(hEnd)
+        val hyperlink = checkNotNull(item.getHyperlinkInfo())
+        val file = requireNotNull((hyperlink as OpenFileHyperlinkInfo).descriptor?.file)
+        Assertions.assertThat(file.name).isEqualTo("main.rs")
+
+    }
+
+    private fun createTestDirectoryAndFile(): VirtualFile = runWriteAction {
+        val baseDir = myFixture.tempDirFixture.findOrCreateDir("consoleFilterTest")
+        baseDir.createChildDirectory(this, "src").createChildData(this, "main.rs")
+        baseDir
+    }
+}

--- a/src/test/kotlin/org/rust/cargo/runconfig/RustBacktraceFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/RustBacktraceFilterTest.kt
@@ -1,0 +1,40 @@
+package org.rust.cargo.runconfig
+
+/**
+ * Tests for RustBacktraceFilter
+ */
+class RustBacktraceFilterTest : HighlightFilterTestBase() {
+
+    private lateinit var filter: RustBacktraceFilter
+
+    override fun setUp() {
+        super.setUp()
+        filter = RustBacktraceFilter(project, projectDir)
+    }
+
+    fun testOneLine() {
+        val text = "          at src/main.rs:24"
+        doTest(filter, text, text.length, 13, 24)
+    }
+
+    fun testFullOuput() {
+        val output = """    Running `target/debug/test`
+thread '<main>' panicked at 'called `Option::unwrap()` on a `None` value', ../src/libcore/option.rs:325
+stack backtrace:
+   1:     0x7feeefb45b1f - std::sys::backtrace::tracing::imp::write::h3800f45f421043b8
+   2:     0x7feeefb47b93 - std::panicking::default_hook::hf3839060ccbb8764
+   3:     0x7feeefb4095d - std::panicking::rust_panic_with_hook::h5dd7da6bb3d06020
+   4:     0x7feeefb48151 - std::panicking::begin_panic::h9bf160aee246b9f6
+   5:     0x7feeefb411fa - std::panicking::begin_panic_fmt::haf08a9a70a097ee1
+   6:     0x7feeefb480ee - rust_begin_unwind
+   7:     0x7feeefb7d11f - core::panicking::panic_fmt::h93df64e7370b5253
+   8:     0x7feeefb7d3f8 - core::panicking::panic::h9d5bd65bbb401959
+   9:     0x7feeefb3f765 - _<std..option..Option<T>>::unwrap::hbe9ea065746f6376
+                        at ../src/libcore/macros.rs:21
+  10:     0x7feeefb3f538 - btest::main::h888e623968051ab6
+                        at src/main.rs:22"""
+        val line = output.split('\n')[14]
+        doTest(filter, line, output.length, 957, 968)
+    }
+
+}

--- a/src/test/kotlin/org/rust/cargo/runconfig/RustConsoleFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/RustConsoleFilterTest.kt
@@ -1,26 +1,17 @@
 package org.rust.cargo.runconfig
 
-import com.intellij.execution.filters.Filter
-import com.intellij.execution.filters.OpenFileHyperlinkInfo
-import com.intellij.openapi.vfs.VirtualFile
-import org.assertj.core.api.Assertions.assertThat
-import org.rust.ide.utils.runWriteAction
-import org.rust.lang.RustTestCaseBase
+class RustConsoleFilterTest : HighlightFilterTestBase() {
 
-class RustConsoleFilterTest : RustTestCaseBase() {
-    override val dataPath = ""
-
-    private lateinit var filter: Filter
+    private lateinit var filter: RustConsoleFilter
 
     override fun setUp() {
         super.setUp()
-        val dir = createTestDirectoryAndFile()
-        filter = RustConsoleFilter(project, dir)
+        filter = RustConsoleFilter(project, projectDir)
     }
 
     fun testTypeError() {
         val error = "src/main.rs:4:5: 4:12 error: this function takes 0 parameters but 1 parameter was supplied [E0061]\n"
-        doTest(error, error.length, 0, 11)
+        doTest(filter, error, error.length, 0, 11)
     }
 
     fun testOffsetsForSeveralLines() {
@@ -28,7 +19,7 @@ class RustConsoleFilterTest : RustTestCaseBase() {
    Compiling rustraytracer v0.1.0 (file:///home/user/projects/rustraytracer)
 src/main.rs:25:26: 25:40 error: no method named `read_to_string` found for type `core::result::Result<std::fs::File, std::io::error::Error>` in the current scope"""
         val line = text.split('\n')[2]
-        doTest(line, text.length, 129, 140)
+        doTest(filter, line, text.length, 129, 140)
     }
 
     fun testNewErrorFormat() {
@@ -36,25 +27,6 @@ src/main.rs:25:26: 25:40 error: no method named `read_to_string` found for type 
  --> src/main.rs:4:5
  """
         val line = text.split('\n')[1]
-        doTest(line, text.length, 107, 118)
-    }
-
-    private fun doTest(line: String, entireLength: Int, highlightingStartOffset: Int, highlightingEndOffset: Int) {
-        val result = checkNotNull(filter.applyFilter(line, entireLength)) {
-            "No match in $line"
-        }
-
-        val item = result.resultItems.single()
-        assertThat(item.getHighlightStartOffset()).isEqualTo(highlightingStartOffset)
-        assertThat(item.getHighlightEndOffset()).isEqualTo(highlightingEndOffset)
-        val hyperlink = checkNotNull(item.getHyperlinkInfo())
-        val file = requireNotNull((hyperlink as OpenFileHyperlinkInfo).descriptor?.file)
-        assertThat(file.name).isEqualTo("main.rs")
-    }
-
-    private fun createTestDirectoryAndFile(): VirtualFile = runWriteAction {
-        val baseDir = myFixture.tempDirFixture.findOrCreateDir("consoleFilterTest")
-        baseDir.createChildDirectory(this, "src").createChildData(this, "main.rs")
-        baseDir
+        doTest(filter, line, text.length, 107, 118)
     }
 }

--- a/src/test/kotlin/org/rust/cargo/runconfig/RustPanicFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/RustPanicFilterTest.kt
@@ -1,0 +1,30 @@
+package org.rust.cargo.runconfig
+
+/**
+ * Tests for RustPanicFilter
+ */
+class RustPanicFilterTest : HighlightFilterTestBase() {
+
+    private lateinit var filter: RustPanicFilter
+
+    override fun setUp() {
+        super.setUp()
+        filter = RustPanicFilter(project, projectDir)
+    }
+
+    fun testOneLine() {
+        val text = "thread 'main' panicked at 'something went wrong', src/main.rs:24"
+        doTest(filter, text, text.length, 50, 61)
+    }
+
+    fun testFullOuput() {
+        val output = """/Users/user/.cargo/bin/cargo run
+   Compiling first_rust v0.1.0 (file:///home/user/projects/panics)
+    Finished debug [unoptimized + debuginfo] target(s) in 1.20 secs
+     Running `target/debug/panics`
+thread 'main' panicked at 'something went wrong', src/main.rs:24"""
+        val line = output.split('\n')[4]
+        doTest(filter, line, output.length, 253, 264)
+    }
+
+}


### PR DESCRIPTION
I've added source code links for panics and stack backtraces output the same way they are added to the compiler messages now.

In this outuput:

    thread 'main' panicked at 'something went wrong', src/main.rs:24
    stack backtrace:
       1:        0x10df17d88 - std::sys::backtrace::tracing::imp::write::hb03a0f85d9cccd1b
       2:        0x10df1983f - std::panicking::default_hook::{{closure}}::h945d25329ef3fdd6
       3:        0x10df18dd5 - std::panicking::default_hook::hc98de28314f7e4d1
       4:        0x10df19326 - std::panicking::rust_panic_with_hook::hf47d6a84575c96f5
       5:        0x10df11f33 - std::panicking::begin_panic::hc373b7d24bec0770
       6:        0x10df121e9 - ptest::main::h2cd7a4ff8d266cce
                            at src/main.rs:24
       7:        0x10df19dfa - __rust_maybe_catch_panic
       8:        0x10df18916 - std::rt::lang_start::h95854775e4ac8b95
       9:        0x10df12219 - main

two source code locations will be wrapped into hyperlinks: the one in the very first line and another one between stack positions 6 and 7.

Since `rustc` only emits source code locations in the backtraces on Linux, the PR at least partially fixes #720 on this platform.

I've also extracted the common code from `RustConsoleFilter` to `RegexpFileLinkFilter` and from `RustConsoleFilterTest` to `HighlightFilterTestBase`.