### PR TITLE
(INSP): Fix for Naming Convention inspection false positives

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RustNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RustNamingInspection.kt
@@ -254,7 +254,8 @@ class RustVariableNamingInspection : RustSnakeCaseNamingInspection("Variable") {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
         object : RustElementVisitor() {
             override fun visitPatBinding(el: RustPatBindingElement) {
-                if (el.parent?.parent !is RustParameterElementImpl) {
+                val parent = el.parent?.parent
+                if (parent is RustLetDeclElement || parent is RustPatTupElement) {
                     inspect(el.identifier, holder)
                 }
             }

--- a/src/main/kotlin/org/rust/ide/inspections/RustNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RustNamingInspection.kt
@@ -3,6 +3,7 @@ package org.rust.ide.inspections
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.inspections.fixes.RenameFix
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.impl.RustParameterElementImpl
@@ -254,9 +255,9 @@ class RustVariableNamingInspection : RustSnakeCaseNamingInspection("Variable") {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
         object : RustElementVisitor() {
             override fun visitPatBinding(el: RustPatBindingElement) {
-                val parent = el.parent?.parent
-                if (parent is RustLetDeclElement || parent is RustPatTupElement) {
-                    inspect(el.identifier, holder)
+                val pattern = PsiTreeUtil.getTopmostParentOfType(el, RustPatElement::class.java) ?: return
+                when (pattern.parent) {
+                    is RustLetDeclElement -> inspect(el.identifier, holder)
                 }
             }
         }

--- a/src/test/kotlin/org/rust/ide/inspections/RustNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RustNamingInspectionTest.kt
@@ -386,6 +386,13 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
         }
     """)
 
+    fun testVariablesWithinStruct() = checkByText<RustVariableNamingInspection>("""
+        struct Foo { fld: u32 }
+        fn test() {
+            let Foo { fld: <warning descr="Variable `FLD_VAL` should have a snake case name such as `fld_val`">FLD_VAL</warning> } = Foo { fld: 17 };
+        }
+    """)
+
     fun testVariablesFix() = checkFixByText<RustVariableNamingInspection>("Rename to `dwarfs_count`", """
         fn test() {
             let <warning descr="Variable `DWARFS_COUNT` should have a snake case name such as `dwarfs_count`">DWARF<caret>S_COUNT</warning> = 7;
@@ -423,11 +430,19 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
             match Some(()) {
                 None => ()
             }
+
             match 1 {
                 Foo => { }
             }
+
             let seven = Some(7);
             if let Some(Number) = seven {
+            }
+
+            let (a, b) = (Some(10), Some(12));
+            match (a, b) {
+                (None, Some(x)) => {}
+                _ => {}
             }
         }
     """)

--- a/src/test/kotlin/org/rust/ide/inspections/RustNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RustNamingInspectionTest.kt
@@ -397,4 +397,38 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
             let legs_count = dwarfs_count * 2;
         }
      """)
+
+    fun testTupleVariables() = checkByText<RustVariableNamingInspection>("""
+        fn loc_var() {
+            let (var1_ok, var2_ok) = (17, 83);
+            let (<warning descr="Variable `VarFoo` should have a snake case name such as `var_foo`">VarFoo</warning>, var2_ok) = (120, 30);
+        }
+    """)
+
+    fun testTupleVariablesFix() = checkFixByText<RustVariableNamingInspection>("Rename to `real`", """
+        fn test() {
+            let (<warning descr="Variable `Real` should have a snake case name such as `real`">Re<caret>al</warning>, imaginary) = (7.2, 3.5);
+            println!("{} + {}i", Real, imaginary);
+        }
+     """, """
+        fn test() {
+            let (real, imaginary) = (7.2, 3.5);
+            println!("{} + {}i", real, imaginary);
+        }
+     """)
+
+    // Issue #730. The inspection must not be applied in the following cases
+    fun testVariablesNotApplied() = checkByText<RustVariableNamingInspection>("""
+        fn test_not_applied() {
+            match Some(()) {
+                None => ()
+            }
+            match 1 {
+                Foo => { }
+            }
+            let seven = Some(7);
+            if let Some(Number) = seven {
+            }
+        }
+    """)
 }


### PR DESCRIPTION
The scope of Variable Naming inspection is narrowed to local `let ...` statements. Bindings within `match`es and `if let`s  are ignored.

Fixes #730