### PR TITLE
(MISC): Line markers for trait method implementations

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RustTraitMethodImplLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RustTraitMethodImplLineMarkerProvider.kt
@@ -1,0 +1,43 @@
+package org.rust.ide.annotator
+
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
+import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.rust.ide.icons.RustIcons
+import org.rust.lang.core.psi.RustImplItemElement
+import org.rust.lang.core.psi.RustImplMethodMemberElement
+import org.rust.lang.core.psi.RustTraitItemElement
+import javax.swing.Icon
+
+/**
+ * Annotates the implementation of a trait method with an icon on the gutter.
+ */
+class RustTraitMethodImplLineMarkerProvider : RelatedItemLineMarkerProvider() {
+    override fun collectNavigationMarkers(el: PsiElement, result: MutableCollection<in RelatedItemLineMarkerInfo<PsiElement>>?) {
+        if (result == null || el !is RustImplMethodMemberElement) return
+        val implBlock = PsiTreeUtil.getParentOfType(el, RustImplItemElement::class.java) ?: return
+        val trait = implBlock.traitRef?.path?.reference?.resolve() ?: return
+        if (trait !is RustTraitItemElement) return
+        for (traitMethod in trait.traitMethodMemberList) {
+            if (traitMethod.name == el.name) {
+                val action: String
+                val icon: Icon
+                if (traitMethod.block == null) {
+                    action = "Implements"
+                    icon = RustIcons.IMPLEMENTING_METHOD
+                } else {
+                    action = "Overrides"
+                    icon = RustIcons.OVERRIDING_METHOD
+                }
+                val builder = NavigationGutterIconBuilder
+                    .create(icon)
+                    .setTargets(listOf(traitMethod))
+                    .setTooltipText("$action method in `${trait.name}`")
+                result.add(builder.createLineMarkerInfo(el))
+                break
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/icons/RustIcons.kt
+++ b/src/main/kotlin/org/rust/ide/icons/RustIcons.kt
@@ -57,6 +57,11 @@ object RustIcons {
     val MUT_STATIC      = GLOBAL_BINDING.addStaticMark()
     val STATIC          = MUT_STATIC.addFinalMark()
     val ENUM_VARIANT    = FIELD.addFinalMark().addStaticMark()
+
+    // Gutter
+
+    val IMPLEMENTING_METHOD = AllIcons.Gutter.ImplementingMethod!!
+    val OVERRIDING_METHOD   = AllIcons.Gutter.OverridingMethod!!
 }
 
 fun Icon.addFinalMark(): Icon = LayeredIcon(this, RustIcons.FINAL_MARK)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -89,7 +89,12 @@
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RustItemsAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RustInvalidSyntaxAnnotator"/>
 
+        <!-- Line Marker Providers -->
+
+        <codeInsight.lineMarkerProvider language="Rust" implementationClass="org.rust.ide.annotator.RustTraitMethodImplLineMarkerProvider"/>
+
         <!-- Completion -->
+
         <completion.contributor language="Rust" implementationClass="org.rust.lang.core.completion.RustCompletionContributor"/>
 
         <!-- Description Provider -->

--- a/src/test/kotlin/org/rust/ide/annotator/RustLineMarkerProviderTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RustLineMarkerProviderTestBase.kt
@@ -1,0 +1,38 @@
+package org.rust.ide.annotator
+
+import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import org.rust.lang.RustFileType
+import org.rust.lang.RustTestCaseBase
+
+abstract class RustLineMarkerProviderTestBase : RustTestCaseBase() {
+    override val dataPath = ""
+
+    protected fun doTestByText(source: String) {
+        myFixture.configureByText(RustFileType, source)
+        myFixture.doHighlighting()
+        val expected = markersFrom(source)
+        val actual = markersFrom(myFixture.editor, myFixture.project)
+        assertEquals(expected.joinToString(COMPARE_SEPARATOR), actual.joinToString(COMPARE_SEPARATOR))
+    }
+
+    private fun markersFrom(text: String) =
+        text.split('\n')
+            .withIndex()
+            .filter { it.value.contains(MARKER) }
+            .map { Pair(it.index, it.value.substring(it.value.indexOf(MARKER) + MARKER.length).trim()) }
+            .toList()
+
+    private fun markersFrom(editor: Editor, project: Project) =
+        DaemonCodeAnalyzerImpl.getLineMarkers(editor.document, project)
+        .map { Pair(editor.document.getLineNumber(it.element?.textRange?.startOffset as Int),
+                    it.lineMarkerTooltip) }
+        .sortedBy { it.first }
+        .toList()
+
+    private companion object {
+        val MARKER = "// - "
+        val COMPARE_SEPARATOR = " | "
+    }
+}

--- a/src/test/kotlin/org/rust/ide/annotator/RustTraitMethodImplLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RustTraitMethodImplLineMarkerProviderTest.kt
@@ -1,0 +1,23 @@
+package org.rust.ide.annotator
+
+/**
+ * Tests for Trait Method Implementation Line Marker
+ */
+class RustTraitMethodImplLineMarkerProviderTest : RustLineMarkerProviderTestBase() {
+
+    fun testImpl() = doTestByText("""
+        trait Foo {
+            fn foo(&self);
+            fn bar(&self) {
+                self.foo();
+            }
+        }
+        struct Bar {}
+        impl Foo for Bar {
+            fn foo(&self) { // - Implements method in `Foo`
+            }
+            fn bar(&self) { // - Overrides method in `Foo`
+            }
+        }
+    """)
+}


### PR DESCRIPTION
Trait methods implementations are annotated with icons on the gutter. Icons are linked to the trait method declarations. Pure implementations and overridings feature different icons:

<img width="336" alt="screen shot 2016-10-16 at 22 35 43" src="https://cloud.githubusercontent.com/assets/2101250/19420289/f03e6964-93f0-11e6-9060-037402d2c2fa.png">

