### PR TITLE
(MISC): Go to trait impl gutter icon

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RustTraitLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RustTraitLineMarkerProvider.kt
@@ -1,0 +1,34 @@
+package org.rust.ide.annotator
+
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
+import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.searches.ReferencesSearch
+import org.rust.ide.icons.RustIcons
+import org.rust.lang.core.psi.RustImplItemElement
+import org.rust.lang.core.psi.RustTraitItemElement
+
+/**
+ * Annotates trait declaration with an icon on the gutter that allows to jump to
+ * its implementations.
+ */
+class RustTraitLineMarkerProvider : RelatedItemLineMarkerProvider() {
+
+    override fun collectNavigationMarkers(el: PsiElement, result: MutableCollection<in RelatedItemLineMarkerInfo<PsiElement>>?) {
+        if (result == null || el !is RustTraitItemElement) return
+        val targets = ReferencesSearch.search(el, el.useScope)
+            .map { it.element.parent?.parent }
+            .filter { it is RustImplItemElement && it.type != null }
+            .toList()
+
+        if (!targets.isEmpty()) {
+            val builder = NavigationGutterIconBuilder
+                .create(RustIcons.IMPLEMENTED)
+                .setTargets(targets)
+                .setPopupTitle("Go to implementation")
+                .setTooltipText("Has implementations")
+            result.add(builder.createLineMarkerInfo(el))
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/annotator/RustTraitLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RustTraitLineMarkerProvider.kt
@@ -1,7 +1,7 @@
 package org.rust.ide.annotator
 
-import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
-import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.search.searches.ReferencesSearch
@@ -13,22 +13,26 @@ import org.rust.lang.core.psi.RustTraitItemElement
  * Annotates trait declaration with an icon on the gutter that allows to jump to
  * its implementations.
  */
-class RustTraitLineMarkerProvider : RelatedItemLineMarkerProvider() {
+class RustTraitLineMarkerProvider : LineMarkerProvider {
 
-    override fun collectNavigationMarkers(el: PsiElement, result: MutableCollection<in RelatedItemLineMarkerInfo<PsiElement>>?) {
-        if (result == null || el !is RustTraitItemElement) return
-        val targets = ReferencesSearch.search(el, el.useScope)
-            .map { it.element.parent?.parent }
-            .filter { it is RustImplItemElement && it.type != null }
-            .toList()
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<PsiElement>? = null
 
-        if (!targets.isEmpty()) {
-            val builder = NavigationGutterIconBuilder
-                .create(RustIcons.IMPLEMENTED)
-                .setTargets(targets)
-                .setPopupTitle("Go to implementation")
-                .setTooltipText("Has implementations")
-            result.add(builder.createLineMarkerInfo(el))
+    override fun collectSlowLineMarkers(elements: MutableList<PsiElement>, result: MutableCollection<LineMarkerInfo<PsiElement>>) {
+        for (el in elements) {
+            if (el !is RustTraitItemElement) continue
+            val targets = ReferencesSearch.search(el, el.useScope)
+                .map { it.element.parent?.parent }
+                .filter { it is RustImplItemElement && it.type != null }
+                .toList()
+
+            if (!targets.isEmpty()) {
+                val builder = NavigationGutterIconBuilder
+                    .create(RustIcons.IMPLEMENTED)
+                    .setTargets(targets)
+                    .setPopupTitle("Go to implementation")
+                    .setTooltipText("Has implementations")
+                result.add(builder.createLineMarkerInfo(el.trait))
+            }
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/icons/RustIcons.kt
+++ b/src/main/kotlin/org/rust/ide/icons/RustIcons.kt
@@ -60,6 +60,7 @@ object RustIcons {
 
     // Gutter
 
+    val IMPLEMENTED         = AllIcons.Gutter.ImplementedMethod!!
     val IMPLEMENTING_METHOD = AllIcons.Gutter.ImplementingMethod!!
     val OVERRIDING_METHOD   = AllIcons.Gutter.OverridingMethod!!
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustImplItemImplMixin.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustImplItemImplMixin.kt
@@ -27,6 +27,6 @@ abstract class RustImplItemImplMixin : RustStubbedElementImpl<RustImplItemElemen
                 return PresentationData(pres.presentableText, pres.locationString, RustIcons.IMPL, null)
             }
         }
-        return PresentationData(type?.text ?: "Impl", null, RustIcons.STRUCT, null)
+        return PresentationData(type?.text ?: "Impl", null, RustIcons.IMPL, null)
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustImplItemImplMixin.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RustImplItemImplMixin.kt
@@ -1,19 +1,32 @@
 package org.rust.lang.core.psi.impl.mixin
 
+import com.intellij.ide.projectView.PresentationData
 import com.intellij.lang.ASTNode
+import com.intellij.navigation.ItemPresentation
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RustIcons
 import org.rust.lang.core.psi.RustImplItemElement
+import org.rust.lang.core.psi.RustPathTypeElement
 import org.rust.lang.core.psi.impl.RustStubbedElementImpl
 import org.rust.lang.core.stubs.elements.RustImplItemElementStub
-import javax.swing.Icon
 
 abstract class RustImplItemImplMixin : RustStubbedElementImpl<RustImplItemElementStub>, RustImplItemElement {
 
     constructor(node: ASTNode) : super(node)
     constructor(stub: RustImplItemElementStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
-    override fun getIcon(flags: Int): Icon = RustIcons.IMPL
+    override fun getIcon(flags: Int) = RustIcons.IMPL
 
     override val isPublic: Boolean get() = false // pub does not affect imls at all
+
+    override fun getPresentation(): ItemPresentation {
+        val t = type
+        if (t is RustPathTypeElement) {
+            val pres = t.path?.reference?.resolve()?.presentation
+            if (pres != null) {
+                return PresentationData(pres.presentableText, pres.locationString, RustIcons.IMPL, null)
+            }
+        }
+        return PresentationData(type?.text ?: "Impl", null, RustIcons.STRUCT, null)
+    }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -91,6 +91,7 @@
 
         <!-- Line Marker Providers -->
 
+        <codeInsight.lineMarkerProvider language="Rust" implementationClass="org.rust.ide.annotator.RustTraitLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="Rust" implementationClass="org.rust.ide.annotator.RustTraitMethodImplLineMarkerProvider"/>
 
         <!-- Completion -->

--- a/src/test/kotlin/org/rust/ide/annotator/RustTraitLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RustTraitLineMarkerProviderTest.kt
@@ -34,4 +34,14 @@ class RustTraitLineMarkerProviderTest : RustLineMarkerProviderTestBase() {
         fn bar<T: Foo>(x: T) {}     // Doesn't count
         fn baz(x: &Foo) {}          // Doesn't count
     """)
+
+    fun testIconPosition() = doTestByText("""
+        ///
+        /// Documentation
+        ///
+        #[warn(non_camel_case_types)]
+        trait Foo {}                // - Has implementations
+        struct Bar {}
+        impl Foo for Bar {}
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RustTraitLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RustTraitLineMarkerProviderTest.kt
@@ -29,4 +29,9 @@ class RustTraitLineMarkerProviderTest : RustLineMarkerProviderTestBase() {
         }
     """)
 
+    fun testTraitBoundsAndObjects() = doTestByText("""
+        trait Foo {}
+        fn bar<T: Foo>(x: T) {}     // Doesn't count
+        fn baz(x: &Foo) {}          // Doesn't count
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RustTraitLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RustTraitLineMarkerProviderTest.kt
@@ -1,0 +1,32 @@
+package org.rust.ide.annotator
+
+/**
+ * Tests for Rust Trait Line Marker Provider
+ */
+class RustTraitLineMarkerProviderTest : RustLineMarkerProviderTestBase() {
+
+    fun testNoMarker() = doTestByText("""
+        trait Foo {}
+    """)
+
+    fun testOneImpl() = doTestByText("""
+        trait Foo {}  // - Has implementations
+        struct Bar {}
+        impl Foo for Bar {}
+    """)
+
+    fun testMultipleImpl() = doTestByText("""
+        trait Foo {}  // - Has implementations
+        mod bar {
+            use super::Foo;
+            struct Bar {}
+            impl Foo for Bar {}
+        }
+        mod baz {
+            use super::Foo;
+            struct Baz {}
+            impl Foo for Baz {}
+        }
+    """)
+
+}

--- a/src/test/kotlin/org/rust/ide/annotator/RustTraitMethodImplLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RustTraitMethodImplLineMarkerProviderTest.kt
@@ -6,7 +6,7 @@ package org.rust.ide.annotator
 class RustTraitMethodImplLineMarkerProviderTest : RustLineMarkerProviderTestBase() {
 
     fun testImpl() = doTestByText("""
-        trait Foo {
+        trait Foo {         // - Has implementations
             fn foo(&self);
             fn bar(&self) {
                 self.foo();


### PR DESCRIPTION
A `LineMarkerProvider` that adds an icon to a trait declaration that allows to jump to the trait implementations.

<img width="543" alt="screen shot 2016-10-20 at 22 31 35" src="https://cloud.githubusercontent.com/assets/2101250/19574934/04bc6e1e-9715-11e6-912d-0d1847a2ab77.png">

There's a problem that if a trait has a rustdoc comment and/or attributes, the icon is placed at the beginning of the comment/attribute, not at the trait declaration line. I can try to find a workaround in this marker provider, but I think it would be better (and maybe even easier) to solve the problem in the parser, though I don't know how to do that.