### PR TITLE
(MISC): Recursive calls gutter marker

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RustRecursiveCallLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RustRecursiveCallLineMarkerProvider.kt
@@ -39,7 +39,7 @@ class RustRecursiveCallLineMarkerProvider : LineMarkerProvider {
                         el,
                         el.textRange,
                         RustIcons.RECURSIVE_CALL,
-                        Pass.UPDATE_OVERRIDEN_MARKERS,
+                        Pass.LINE_MARKERS,
                         FunctionUtil.constant("Recursive call"),
                         null,
                         GutterIconRenderer.Alignment.RIGHT))

--- a/src/main/kotlin/org/rust/ide/annotator/RustRecursiveCallLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RustRecursiveCallLineMarkerProvider.kt
@@ -39,7 +39,7 @@ class RustRecursiveCallLineMarkerProvider : LineMarkerProvider {
                         el,
                         el.textRange,
                         RustIcons.RECURSIVE_CALL,
-                        Pass.UPDATE_OVERRIDDEN_MARKERS,
+                        Pass.UPDATE_OVERRIDEN_MARKERS,
                         FunctionUtil.constant("Recursive call"),
                         null,
                         GutterIconRenderer.Alignment.RIGHT))

--- a/src/main/kotlin/org/rust/ide/annotator/RustRecursiveCallLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RustRecursiveCallLineMarkerProvider.kt
@@ -4,7 +4,6 @@ import com.intellij.codeHighlighting.Pass
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.openapi.editor.markup.GutterIconRenderer
-import com.intellij.openapi.util.Comparing
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.util.FunctionUtil
@@ -27,7 +26,7 @@ class RustRecursiveCallLineMarkerProvider : LineMarkerProvider {
         val lines = HashSet<Int>()  // To prevent several markers on one line
         for (el in elements) {
             val isRecursive = when (el) {
-                is RustCallExprElement       -> el.isRecursive(el.pathExpr()?.path?.reference)
+                is RustCallExprElement       -> el.isRecursive(el.pathExpr?.path?.reference)
                 is RustMethodCallExprElement -> el.isRecursive(el.reference)
                 else                         -> false
             }
@@ -50,15 +49,12 @@ class RustRecursiveCallLineMarkerProvider : LineMarkerProvider {
         }
     }
 
-    private fun RustCallExprElement.pathExpr() : RustPathExprElement? {
-        val e = expr
-        return if (e is RustPathExprElement) e else null
-    }
+    private val RustCallExprElement.pathExpr: RustPathExprElement?
+        get() = expr as? RustPathExprElement
 
     private fun RustExprElement.isRecursive(ref: RustReference?): Boolean {
-        if (ref == null) return false
-        val def = ref.resolve() ?: return false
-        return (Comparing.equal(parentOfType<RustImplMethodMemberElement>(), def))  // Methods and associative functions
-                || Comparing.equal(parentOfType<RustFnItemElement>(), def)          // Pure functions
+        val def = ref?.resolve() ?: return false
+        return parentOfType<RustImplMethodMemberElement>() == def  // Methods and associated functions
+                || parentOfType<RustFnItemElement>() == def        // Pure functions
     }
 }

--- a/src/main/kotlin/org/rust/ide/annotator/RustRecursiveCallLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RustRecursiveCallLineMarkerProvider.kt
@@ -1,0 +1,64 @@
+package org.rust.ide.annotator
+
+import com.intellij.codeHighlighting.Pass
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProvider
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.openapi.util.Comparing
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.util.FunctionUtil
+import org.rust.ide.icons.RustIcons
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.util.parentOfType
+import org.rust.lang.core.resolve.ref.RustReference
+import java.util.*
+
+/**
+ * Line marker provider that annotates recursive funciton and method calls with
+ * an icon on the gutter.
+ */
+class RustRecursiveCallLineMarkerProvider : LineMarkerProvider {
+
+    override fun getLineMarkerInfo(element: PsiElement) = null
+
+    override fun collectSlowLineMarkers(elements: MutableList<PsiElement>,
+                                        result: MutableCollection<LineMarkerInfo<PsiElement>>) {
+        val lines = HashSet<Int>()  // To prevent several markers on one line
+        for (el in elements) {
+            val isRecursive = when (el) {
+                is RustCallExprElement       -> el.isRecursive(el.pathExpr()?.path?.reference)
+                is RustMethodCallExprElement -> el.isRecursive(el.reference)
+                else                         -> false
+            }
+            if (isRecursive) {
+                val instance = PsiDocumentManager.getInstance(el.project)
+                val doc = instance.getDocument(el.containingFile) ?: continue
+                val lineNumber = doc.getLineNumber(el.textOffset)
+                if (!lines.contains(lineNumber)) {
+                    result.add(LineMarkerInfo(
+                        el,
+                        el.textRange,
+                        RustIcons.RECURSIVE_CALL,
+                        Pass.UPDATE_OVERRIDDEN_MARKERS,
+                        FunctionUtil.constant("Recursive call"),
+                        null,
+                        GutterIconRenderer.Alignment.RIGHT))
+                    lines.add(lineNumber)
+                }
+            }
+        }
+    }
+
+    private fun RustCallExprElement.pathExpr() : RustPathExprElement? {
+        val e = expr
+        return if (e is RustPathExprElement) e else null
+    }
+
+    private fun RustExprElement.isRecursive(ref: RustReference?): Boolean {
+        if (ref == null) return false
+        val def = ref.resolve() ?: return false
+        return (Comparing.equal(parentOfType<RustImplMethodMemberElement>(), def))  // Methods and associative functions
+                || Comparing.equal(parentOfType<RustFnItemElement>(), def)          // Pure functions
+    }
+}

--- a/src/main/kotlin/org/rust/ide/icons/RustIcons.kt
+++ b/src/main/kotlin/org/rust/ide/icons/RustIcons.kt
@@ -63,6 +63,7 @@ object RustIcons {
     val IMPLEMENTED         = AllIcons.Gutter.ImplementedMethod!!
     val IMPLEMENTING_METHOD = AllIcons.Gutter.ImplementingMethod!!
     val OVERRIDING_METHOD   = AllIcons.Gutter.OverridingMethod!!
+    val RECURSIVE_CALL      = AllIcons.Gutter.RecursiveMethod!!
 }
 
 fun Icon.addFinalMark(): Icon = LayeredIcon(this, RustIcons.FINAL_MARK)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -92,6 +92,7 @@
         <!-- Line Marker Providers -->
 
         <codeInsight.lineMarkerProvider language="Rust" implementationClass="org.rust.ide.annotator.RustTraitLineMarkerProvider"/>
+        <codeInsight.lineMarkerProvider language="Rust" implementationClass="org.rust.ide.annotator.RustRecursiveCallLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="Rust" implementationClass="org.rust.ide.annotator.RustTraitMethodImplLineMarkerProvider"/>
 
         <!-- Completion -->

--- a/src/test/kotlin/org/rust/ide/annotator/RustRecursiveCallLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RustRecursiveCallLineMarkerProviderTest.kt
@@ -1,0 +1,56 @@
+package org.rust.ide.annotator
+
+/**
+ * Tests for Rust Recursvice Call Line Marker Provider
+ */
+class RustRecursiveCallLineMarkerProviderTest : RustLineMarkerProviderTestBase() {
+
+    fun testFunction() = doTestByText("""
+        fn foo() {
+            foo();      // - Recursive call
+        }
+    """)
+
+    fun testAssocFunction() = doTestByText("""
+        struct Foo {}
+        impl Foo {
+            fn foo() {
+                Foo::foo();      // - Recursive call
+            }
+        }
+    """)
+
+    fun testMethod() = doTestByText("""
+        struct Foo {}
+        impl Foo {
+            fn foo(&self) {
+                self.foo();      // - Recursive call
+            }
+        }
+    """)
+
+    fun testNamesCollision() = doTestByText("""
+        fn foo() {}
+        struct Foo {}
+        impl Foo {
+            fn foo() {
+                foo();  // It's the high-level function, no marker
+            }
+        }
+    """)
+
+    fun testIgnoreTransitive() = doTestByText("""
+        fn foo() {
+            bar();      // Doesn't count
+        }
+        fn bar() {
+            foo();      // Doesn't count
+        }
+    """)
+
+    fun testMultiple() = doTestByText("""
+        fn increment(v: u32) -> u32 {
+            increment(increment(1))     // - Recursive call
+        }
+    """)
+}


### PR DESCRIPTION
This is #756. Just reopened because of failed checks due to github temporary inaccessibility.

An annotator that detects and marks recursive calls:

<img width="310" alt="screen shot 2016-10-22 at 08 25 03" src="https://cloud.githubusercontent.com/assets/2101250/19617153/c6d53572-9831-11e6-9679-a2e2377c6005.png">

Works for pure functions, associated functions and methods.