### PR TITLE
(MISC): Add function parameter color control

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RustHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RustHighlightingAnnotator.kt
@@ -96,5 +96,8 @@ class RustHighlightingAnnotator : Annotator {
         override fun visitTraitMethodMember(o: RustTraitMethodMemberElement) =
             highlight(o.identifier, if (o.isStatic) RustColor.STATIC_METHOD else RustColor.INSTANCE_METHOD)
 
+        override fun visitParameters(o: RustParametersElement) = o.parameterList.forEach { highlight(it.pat, RustColor.PARAMETER) }
+
+        override fun visitSelfArgument(o: RustSelfArgumentElement) = highlight(o.self, RustColor.SELF_PARAMETER)
     }
 }

--- a/src/main/kotlin/org/rust/ide/colors/RustColors.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RustColors.kt
@@ -12,6 +12,8 @@ enum class RustColor(humanName: String, val default: TextAttributesKey) {
     FUNCTION_DECLARATION  ("Function declaration",        Default.FUNCTION_DECLARATION),
     INSTANCE_METHOD       ("Instance method declaration", Default.INSTANCE_METHOD),
     STATIC_METHOD         ("Static method declaration",   Default.STATIC_METHOD),
+    PARAMETER             ("Function parameter",          Default.IDENTIFIER),
+    SELF_PARAMETER        ("Self parameter",              Default.IDENTIFIER),
 
     LIFETIME              ("Lifetime",                    Default.IDENTIFIER),
 

--- a/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
+++ b/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
@@ -12,7 +12,7 @@ pub enum <ENUM>Flag</ENUM> {
 }
 
 pub trait <TRAIT>Write</TRAIT> {
-    fn <INSTANCE_METHOD>write</INSTANCE_METHOD>(&mut self, buf: &[<PRIMITIVE_TYPE>u8</PRIMITIVE_TYPE>]) -> <ENUM>Result</ENUM><usize>;
+    fn <INSTANCE_METHOD>write</INSTANCE_METHOD>(&mut <SELF_PARAMETER>self</SELF_PARAMETER>, <PARAMETER>buf</PARAMETER>: &[<PRIMITIVE_TYPE>u8</PRIMITIVE_TYPE>]) -> <ENUM>Result</ENUM><usize>;
 }
 
 struct <STRUCT>Object</STRUCT><<TYPE_PARAMETER>T</TYPE_PARAMETER>> {

--- a/src/test/kotlin/org/rust/ide/annotator/RustHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RustHighlightingAnnotatorTest.kt
@@ -9,5 +9,6 @@ class RustHighlightingAnnotatorTest : RustAnnotatorTestBase() {
     fun testMacro() = doTestInfo()
     fun testMutBinding() = doTestInfo()
     fun testTypeParameters() = doTestInfo()
+    fun testFunctionArguments() = doTestInfo()
 
 }

--- a/src/test/resources/org/rust/ide/annotator/fixtures/highlighting/function_arguments.rs
+++ b/src/test/resources/org/rust/ide/annotator/fixtures/highlighting/function_arguments.rs
@@ -1,0 +1,7 @@
+struct <info>Foo</info> {}
+
+impl <info>Foo</info> {
+    fn <info>bar</info>(&<info>self</info>, <info>i</info>: <info>i32</info>) {}
+}
+
+fn <info>baz</info>(<info>u</info>: <info>u32</info>) {}

--- a/src/test/resources/org/rust/ide/annotator/fixtures/highlighting/type_parameters.rs
+++ b/src/test/resources/org/rust/ide/annotator/fixtures/highlighting/type_parameters.rs
@@ -1,6 +1,6 @@
 trait <info>MyTrait</info> {
     type AssocType;
-    fn <info>some_fn</info>(&self);
+    fn <info>some_fn</info>(&<info>self</info>);
 }
 
 struct <info>MyStruct</info><<info>N</info>: ?<info>Sized</info>+<info>Debug</info>+<info><info>MyTrait</info></info>> {


### PR DESCRIPTION
This adds parameters to the color settings as requested in #734. I split `self` params from the rest (similar to the screenshot in #734), but I'm not sure if that is what the project wants, so please give input if this PR seems misguided.
