### PR TITLE
Add reference to TOML plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ install Rust plugin, and use **project from existing sources** action to import 
 
 Unstable master branch builds can be downloaded from [TeamCity].
 
+If you are looking for a TOML plugin for `Cargo.toml` and `Cargo.lock` files, see [intellij-toml].
+
 ## Compatible IDEs
 
 The plugin should be compatible with any Intellij based IDE starting from build
@@ -43,6 +45,7 @@ first bugs are tagged with [up-for-grab].
 [up-for-grab]: https://github.com/intellij-rust/intellij-rust/labels/up%20for%20grab
 [CONTRIBUTING.md]: CONTRIBUTING.md
 [TeamCity]: https://teamcity.jetbrains.com/repository/download/IntellijIdeaPlugins_Rust_CurrentIdea_TestsRust/.lastSuccessful/intellij-rust-0.1.0.%7Bbuild.number%7D.zip
+[intellij-toml]: https://github.com/intellij-rust/intellij-toml
 
 <!-- Badges -->
 [gitter-chat]: https://gitter.im/intellij-rust/intellij-rust


### PR DESCRIPTION
Help new users find the related TOML plugin for `Cargo.toml` and `Cargo.lock` files.