### PR TITLE
(MISC): Console now recognizes new error message format

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/RustExplainFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RustExplainFilter.kt
@@ -1,5 +1,6 @@
 package org.rust.cargo.runconfig
 
+import com.intellij.execution.filters.BrowserHyperlinkInfo
 import com.intellij.execution.filters.Filter
 import com.intellij.execution.filters.Filter.Result
 import com.intellij.ide.browsers.OpenUrlHyperlinkInfo
@@ -23,7 +24,7 @@ class RustExplainFilter : Filter, DumbAware {
 
         val eNumber = matcher.group(1)
         val url = "https://doc.rust-lang.org/error-index.html#E$eNumber"
-        val info = OpenUrlHyperlinkInfo(url)
+        val info = BrowserHyperlinkInfo(url)
 
         val highlightStartOffset = entireLength - line.length + matcher.start()
         val highlightEndOffset = highlightStartOffset + link_length

--- a/src/test/kotlin/org/rust/cargo/runconfig/RustExplainFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/RustExplainFilterTest.kt
@@ -8,14 +8,19 @@ class RustExplainFilterTest : RustTestCaseBase() {
     override val dataPath = ""
     private var filter: Filter = RustExplainFilter()
 
-    fun testOldErrorFormat() {
+    fun testOldExplainFormat() {
         val text = "src/lib.rs:57:17: 57:25 help: run `rustc --explain E0282` to see a detailed explanation"
         doTest(text, text.length, 41, 56)
     }
 
-    fun testNewErrorFormat() {
+    fun testNewExplainFormat() {
         val text = "error: the trait bound `std::string::String: std::ops::Index<_>` is not satisfied [--explain E0277]"
         doTest(text, text.length, 83, 98)
+    }
+
+    fun testErrorFormat() {
+        val text = "error[E0382]: use of moved value: `v`"
+        doTest(text, text.length, 0, 12)
     }
 
     fun testNothingToSee() {


### PR DESCRIPTION
The compiler used to output errors with an [--explain E####] message,
but recent changes now use a new error[E####] format instead.

This CL updates the relevant console filter to recongize both
formats. If it comes across either pattern, it will turn them into
links to the appropriate Rust Compiler Error Index entry.