### PR TITLE
(INSP): Automatic inspections suppression

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RustLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RustLint.kt
@@ -1,5 +1,12 @@
 package org.rust.ide.inspections
 
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RustDocAndAttributeOwner
+import org.rust.lang.core.psi.RustMod
+import org.rust.lang.core.psi.queryAttributes
+import org.rust.lang.core.psi.superMods
+import org.rust.lang.core.psi.util.ancestors
+
 /**
  * Rust lints.
  */
@@ -9,5 +16,26 @@ enum class RustLint(
 ) {
     NonSnakeCase("non_snake_case"),
     NonCamelCaseTypes("non_camel_case_types"),
-    NonUpperCaseGlobals("non_upper_case_globals")
+    NonUpperCaseGlobals("non_upper_case_globals");
+
+    /**
+     * Returns the level of the lint for the given PSI element.
+     */
+    fun levelFor(el: PsiElement)
+        = explicitLevel(el) ?: superModsLevel(el) ?: defaultLevel
+
+    private fun explicitLevel(el: PsiElement)
+        = el.ancestors
+            .filterIsInstance<RustDocAndAttributeOwner>()
+            .flatMap { it.queryAttributes.metaItems }
+            .filter { it.metaItemList.any { it.text == id } }
+            .mapNotNull { RustLintLevel.valueForId(it.identifier.text) }
+            .firstOrNull()
+
+    private fun superModsLevel(el: PsiElement)
+        = el.ancestors
+            .filterIsInstance<RustMod>()
+            .lastOrNull()
+            ?.superMods
+            ?.mapNotNull { explicitLevel(it) }?.firstOrNull()
 }

--- a/src/main/kotlin/org/rust/ide/inspections/RustLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RustLint.kt
@@ -1,0 +1,13 @@
+package org.rust.ide.inspections
+
+/**
+ * Rust lints.
+ */
+enum class RustLint(
+    val id: String,
+    val defaultLevel: RustLintLevel = RustLintLevel.WARN
+) {
+    NonSnakeCase("non_snake_case"),
+    NonCamelCaseTypes("non_camel_case_types"),
+    NonUpperCaseGlobals("non_upper_case_globals")
+}

--- a/src/main/kotlin/org/rust/ide/inspections/RustLintLevel.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RustLintLevel.kt
@@ -1,0 +1,27 @@
+package org.rust.ide.inspections
+
+/**
+ * Rust lint warning levels.
+ */
+enum class RustLintLevel(
+    val id: String
+) {
+    /**
+     * Warnings are suppressed.
+     */
+    ALLOW("allow"),
+
+    /**
+     * Warnings.
+     */
+    WARN("warn"),
+
+    /**
+     * Compliler errors.
+     */
+    DENY("deny");
+
+    companion object {
+        fun valueForId(id: String) = RustLintLevel.values().filter { it.id == id }.firstOrNull()
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/completion/AttributeCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/AttributeCompletionProvider.kt
@@ -97,13 +97,7 @@ object AttributeCompletionProvider : CompletionProvider<CompletionParameters>() 
 
         val elem = parameters.position.parent?.parent?.parent
 
-        val existing = if (elem is RustDocAndAttributeOwner) {
-            elem.queryAttributes.metaItems.map { it.identifier.text }
-        } else {
-            emptyList<String>()
-        }
-
-        val suggestions = attributes.filter { it.appliesTo.accepts(parameters.position) && it.name !in existing }
+        val suggestions = attributes.filter { it.appliesTo.accepts(parameters.position) && elem.attrMetaItems.none { item -> item == it.name }}
             .map { LookupElementBuilder.create(it.name) }
         result.addAllElements(suggestions)
     }
@@ -123,4 +117,11 @@ object AttributeCompletionProvider : CompletionProvider<CompletionParameters>() 
     private fun onItem(pattern: ElementPattern<out RustDocAndAttributeOwner>): PsiElementPattern.Capture<PsiElement> {
         return psiElement().withSuperParent(3, pattern)
     }
+
+    val PsiElement?.attrMetaItems: Sequence<String>
+        get() = if (this is RustDocAndAttributeOwner) {
+                    queryAttributes.metaItems.map { it.identifier.text }
+                } else {
+                    emptySequence()
+                }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/RustCompositeElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RustCompositeElement.kt
@@ -2,6 +2,9 @@ package org.rust.lang.core.psi
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
+import org.rust.ide.inspections.RustLint
+import org.rust.ide.inspections.RustLintLevel
+import org.rust.lang.core.psi.util.parentOfType
 import org.rust.lang.core.resolve.ref.RustReference
 
 interface RustCompositeElement : PsiElement {
@@ -10,3 +13,21 @@ interface RustCompositeElement : PsiElement {
 
 val RustCompositeElement.containingMod: RustMod?
     get() = PsiTreeUtil.getStubOrPsiParentOfType(this, RustMod::class.java)
+
+/**
+ * Returns the level of the given lint for this element.
+ */
+fun PsiElement.lintLevel(lint: RustLint): RustLintLevel {
+    var level: RustLintLevel? = null
+    if (this is RustDocAndAttributeOwner) {
+        level = queryAttributes.metaItems
+            .filter { it.metaItemList.any { it.text == lint.id } }
+            .map { RustLintLevel.valueForId(it.identifier.text) }
+            .filterNotNull()
+            .firstOrNull()
+    }
+    if (level == null) {
+        level = parentOfType<RustDocAndAttributeOwner>()?.lintLevel(lint)
+    }
+    return level ?: lint.defaultLevel
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RustCompositeElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RustCompositeElement.kt
@@ -2,9 +2,6 @@ package org.rust.lang.core.psi
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
-import org.rust.ide.inspections.RustLint
-import org.rust.ide.inspections.RustLintLevel
-import org.rust.lang.core.psi.util.parentOfType
 import org.rust.lang.core.resolve.ref.RustReference
 
 interface RustCompositeElement : PsiElement {
@@ -13,21 +10,3 @@ interface RustCompositeElement : PsiElement {
 
 val RustCompositeElement.containingMod: RustMod?
     get() = PsiTreeUtil.getStubOrPsiParentOfType(this, RustMod::class.java)
-
-/**
- * Returns the level of the given lint for this element.
- */
-fun PsiElement.lintLevel(lint: RustLint): RustLintLevel {
-    var level: RustLintLevel? = null
-    if (this is RustDocAndAttributeOwner) {
-        level = queryAttributes.metaItems
-            .filter { it.metaItemList.any { it.text == lint.id } }
-            .map { RustLintLevel.valueForId(it.identifier.text) }
-            .filterNotNull()
-            .firstOrNull()
-    }
-    if (level == null) {
-        level = parentOfType<RustDocAndAttributeOwner>()?.lintLevel(lint)
-    }
-    return level ?: lint.defaultLevel
-}

--- a/src/test/kotlin/org/rust/ide/inspections/RustLintLevelTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RustLintLevelTest.kt
@@ -1,0 +1,110 @@
+package org.rust.ide.inspections
+
+import com.intellij.testFramework.LightProjectDescriptor
+
+/**
+ * Tests for lint level detection.
+ */
+class RustLintLevelTest : RustInspectionsTestBase() {
+
+    override val dataPath = ""
+
+    override fun getProjectDescriptor(): LightProjectDescriptor = WithStdlibRustProjectDescriptor
+
+    fun testDirrectAllow() = checkByText<RustStructNamingInspection>("""
+        #[allow(non_camel_case_types)]
+        struct foo;
+    """)
+
+    fun testDirrectWarn() = checkByText<RustStructNamingInspection>("""
+        #[warn(non_camel_case_types)]
+        struct <warning>foo</warning>;
+    """)
+
+    fun testDirrectDeny() = checkByText<RustStructNamingInspection>("""
+        #[deny(non_camel_case_types)]
+        struct <warning>foo</warning>;
+    """)
+
+    fun testParentAllow() = checkByText<RustFieldNamingInspection>("""
+        #[allow(non_snake_case)]
+        struct Foo {
+            Bar: u32
+        }
+    """)
+
+    fun testParentWarn() = checkByText<RustFieldNamingInspection>("""
+        #[warn(non_snake_case)]
+        struct Foo {
+            <warning>Bar</warning>: u32
+        }
+    """)
+
+    fun testParentDeny() = checkByText<RustFieldNamingInspection>("""
+        #[deny(non_snake_case)]
+        struct Foo {
+            <warning>Bar</warning>: u32
+        }
+    """)
+
+    fun testModuleOuterAllow() = checkByText<RustStructNamingInspection>("""
+        #[allow(non_camel_case_types)]
+        mod space {
+            struct planet;
+        }
+    """)
+
+    fun testModuleInnerAllow() = checkByText<RustStructNamingInspection>("""
+        #![allow(non_camel_case_types)]
+        struct planet;
+    """)
+
+    fun testGrandParentAllow() = checkByText<RustStructNamingInspection>("""
+        #[allow(non_camel_case_types)]
+        mod space {
+            mod planet {
+                struct inhabitant;
+            }
+        }
+    """)
+
+    fun testInnerTakesPrecedence() = checkByText<RustStructNamingInspection>("""
+        #[warn(non_camel_case_types)]
+        mod space {
+            #![allow(non_camel_case_types)]
+            struct planet;
+        }
+        #[allow(non_camel_case_types)]
+        mod science {
+            #![warn(non_camel_case_types)]
+            struct <warning>section</warning>;
+        }
+    """)
+
+    fun testIgnoresOtherItems() = checkByText<RustStructNamingInspection>("""
+        #[allow(non_snake_case)]
+        struct <warning>foo</warning>;
+    """)
+
+    fun testMultipleMetaItems() = checkByText<RustStructNamingInspection>("""
+        #[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
+        struct foo;
+    """)
+
+    fun testMixedAttributes() = checkByText<RustStructNamingInspection>("""
+        #[allow(non_camel_case_types, non_upper_case_globals)]
+        mod space {
+            #[allow(non_snake_case)]
+            mod planet {
+                #![warn(non_snake_case, non_upper_case_globals)]
+                struct inhabitant;
+            }
+        }
+    """)
+
+    fun testWorksWithNonLevelAttributes() = checkByText<RustStructNamingInspection>("""
+        #[allow(non_camel_case_types)]
+        #[derive(Debug)]
+        struct inhabitant;
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/inspections/RustNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RustNamingInspectionTest.kt
@@ -18,6 +18,13 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
         }
     """)
 
+    fun testAssociatedTypesSuppression() = checkByText<RustAssocTypeNamingInspection>("""
+        #[allow(non_camel_case_types)]
+        trait Foo {
+            type assoc_foo;
+        }
+    """)
+
     // TODO: Uncomment when associated types support renaming
     //
     // fun testAssociatedTypesFix() = checkFixByText<RustAssocTypeNamingInspection>("Rename to `assocType`", """
@@ -32,10 +39,14 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
     //     }
     // """)
 
-
     fun testConstants() = checkByText<RustConstNamingInspection>("""
         const CONST_OK: u32 = 12;
         const <warning descr="Constant `const_foo` should have an upper case name such as `CONST_FOO`">const_foo</warning>: u32 = 12;
+    """)
+
+    fun testConstantsSuppression() = checkByText<RustConstNamingInspection>("""
+        #[allow(non_upper_case_globals)]
+        const const_foo: u32 = 12;
     """)
 
     fun testConstantsFix() = checkFixByText<RustConstNamingInspection>("Rename to `CONST_FOO`", """
@@ -55,6 +66,11 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
         enum <warning descr="Type `enum_foo` should have a camel case name such as `EnumFoo`">enum_foo</warning> {}
     """)
 
+    fun testEnumsSuppression() = checkByText<RustEnumNamingInspection>("""
+        #[allow(non_camel_case_types)]
+        enum enum_foo {}
+    """)
+
     fun testEnumsFix() = checkFixByText<RustEnumNamingInspection>("Rename to `EnumFoo`", """
         enum <warning descr="Type `enum_foo` should have a camel case name such as `EnumFoo`">enum_f<caret>oo</warning> { Var }
         fn enum_use() {
@@ -70,7 +86,14 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
     fun testEnumVariants() = checkByText<RustEnumVariantNamingInspection>("""
         enum EnumVars {
             VariantOk,
-            <warning descr="Enum variant `variant_foo` should have a camel case name such as `VariantFoo`">variant_foo</warning>,
+            <warning descr="Enum variant `variant_foo` should have a camel case name such as `VariantFoo`">variant_foo</warning>
+        }
+    """)
+
+    fun testEnumVariantsSuppression() = checkByText<RustEnumVariantNamingInspection>("""
+        #[allow(non_camel_case_types)]
+        enum EnumVars {
+            variant_foo
         }
     """)
 
@@ -95,6 +118,15 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
             Variant {
                 field_ok: u32,
                 <warning descr="Field `FieldFoo` should have a snake case name such as `field_foo`">FieldFoo</warning>: u32
+            }
+        }
+    """)
+
+    fun testEnumVariantFieldsSuppression() = checkByText<RustFieldNamingInspection>("""
+        #[allow(non_snake_case)]
+        enum EnumVarFields {
+            Variant {
+                FieldFoo: u32
             }
         }
     """)
@@ -124,6 +156,11 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
         fn <warning descr="Function `FN_BAR` should have a snake case name such as `fn_bar`">FN_BAR</warning>() {}
     """)
 
+    fun testFunctionsSuppression() = checkByText<RustFunctionNamingInspection>("""
+        #[allow(non_snake_case)]
+        fn FN_BAR() {}
+    """)
+
     fun testFunctionsFix() = checkFixByText<RustFunctionNamingInspection>("Rename to `fun_foo`", """
         fn <warning descr="Function `FUN_FOO` should have a snake case name such as `fun_foo`">F<caret>UN_FOO</warning>() {}
         fn fun_use() {
@@ -141,6 +178,11 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
             par_ok: u32,
             <warning descr="Argument `ParFoo` should have a snake case name such as `par_foo`">ParFoo</warning>: u32) {
         }
+    """)
+
+    fun testFunctionArgumentsSuppression() = checkByText<RustArgumentNamingInspection>("""
+        #[allow(non_snake_case)]
+        fn fn_par(ParFoo: u32) {}
     """)
 
     fun testFunctionArgumentsFix() = checkFixByText<RustArgumentNamingInspection>("Rename to `arg_baz`", """
@@ -161,9 +203,19 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
         }
     """)
 
+    fun testLifetimesSuppression() = checkByText<RustLifetimeNamingInspection>("""
+        #[allow(non_snake_case)]
+        fn lifetimes<'LifetimeFoo>() {}
+    """)
+
     fun testMacros() = checkByText<RustMacroNamingInspection>("""
         macro_rules! macro_ok { ( $( ${'$'}x:expr ),* ) => {}; }
         macro_rules! <warning descr="Macro `MacroFoo` should have a snake case name such as `macro_foo`">MacroFoo</warning> { ( $( ${'$'}x:expr ),* ) => {}; }
+    """)
+
+    fun testMacrosSuppression() = checkByText<RustMacroNamingInspection>("""
+        #[allow(non_snake_case)]
+        macro_rules! MacroFoo { ( $( ${'$'}x:expr ),* ) => {}; }
     """)
 
     fun testMethods() = checkByText<RustMethodNamingInspection>("""
@@ -171,6 +223,14 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
         impl Foo {
             fn met_ok(&self) {}
             fn <warning descr="Method `MET_BAR` should have a snake case name such as `met_bar`">MET_BAR</warning>(&self) {}
+        }
+    """)
+
+    fun testMethodsSuppression() = checkByText<RustMethodNamingInspection>("""
+        #![allow(non_snake_case)]
+        struct Foo {}
+        impl Foo {
+            fn MET_BAR(&self) {}
         }
     """)
 
@@ -204,6 +264,14 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
         }
     """)
 
+    fun testMethodArgumentsSuppression() = checkByText<RustArgumentNamingInspection>("""
+        #![allow(non_snake_case)]
+        struct Foo {}
+        impl Foo {
+            fn fn_par(ParFoo: u32,) {}
+        }
+    """)
+
     fun testMethodArgumentsFix() = checkFixByText<RustArgumentNamingInspection>("Rename to `m_arg`", """
         struct Foo;
         impl Foo {
@@ -224,6 +292,13 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
         trait Foo {
             fn met_ok() {}
             fn <warning descr="Method `MET_BAR` should have a snake case name such as `met_bar`">MET_BAR</warning>() {}
+        }
+    """)
+
+    fun testTraitlMethodsSuppression() = checkByText<RustMethodNamingInspection>("""
+        trait Foo {
+            #[allow(non_snake_case)]
+            fn MET_BAR() {}
         }
     """)
 
@@ -252,6 +327,11 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
         mod <warning descr="Module `moduleA` should have a snake case name such as `module_a`">moduleA</warning> {}
     """)
 
+    fun testModulesSuppression() = checkByText<RustModuleNamingInspection>("""
+        #[allow(non_snake_case)]
+        mod moduleA {}
+    """)
+
     fun testModulesFix() = checkFixByText<RustModuleNamingInspection>("Rename to `mod_foo`", """
         mod <warning descr="Module `modFoo` should have a snake case name such as `mod_foo`">modF<caret>oo</warning> {
             pub const ONE: u32 = 1;
@@ -273,6 +353,11 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
         static <warning descr="Static constant `static_foo` should have an upper case name such as `STATIC_FOO`">static_foo</warning>: u32 = 12;
     """)
 
+    fun testStaticsSuppression() = checkByText<RustStaticConstNamingInspection>("""
+        #[allow(non_upper_case_globals)]
+        static static_foo: u32 = 12;
+    """)
+
     fun testStaticsFix() = checkFixByText<RustStaticConstNamingInspection>("Rename to `STATIC_FOO`", """
         static <warning descr="Static constant `staticFoo` should have an upper case name such as `STATIC_FOO`">sta<caret>ticFoo</warning>: u32 = 43;
         fn static_use() {
@@ -288,6 +373,11 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
     fun testStructs() = checkByText<RustStructNamingInspection>("""
         struct StructOk {}
         struct <warning descr="Type `struct_foo` should have a camel case name such as `StructFoo`">struct_foo</warning> {}
+    """)
+
+    fun testStructsSuppression() = checkByText<RustStructNamingInspection>("""
+        #[allow(non_camel_case_types)]
+        struct struct_foo {}
     """)
 
     fun testStructsFix() = checkFixByText<RustStructNamingInspection>("Rename to `StructFoo`", """
@@ -311,7 +401,6 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
 
     fun testStructFieldsSuppression() = checkByText<RustFieldNamingInspection>("""
         #[allow(non_snake_case)]
-        #[derive(Debug, Deserialize)]
         pub struct HoverParams {
             pub textDocument: Document,
             pub position: Position
@@ -339,6 +428,11 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
         trait <warning descr="Trait `trait_foo` should have a camel case name such as `TraitFoo`">trait_foo</warning> {}
     """)
 
+    fun testTraitsSuppression() = checkByText<RustTraitNamingInspection>("""
+        #[allow(non_camel_case_types)]
+        trait trait_foo {}
+    """)
+
      fun testTraitsFix() = checkFixByText<RustTraitNamingInspection>("Rename to `HotFix`", """
          trait <warning descr="Trait `hot_fix` should have a camel case name such as `HotFix`">ho<caret>t_fix</warning> {}
          struct Patch {}
@@ -354,6 +448,11 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
         type <warning descr="Type `type_foo` should have a camel case name such as `TypeFoo`">type_foo</warning> = u32;
     """)
 
+    fun testTypeAliasesSuppression() = checkByText<RustTypeAliasNamingInspection>("""
+        #[allow(non_camel_case_types)]
+        type type_foo = u32;
+    """)
+
     fun testTypeAliasesFix() = checkFixByText<RustTypeAliasNamingInspection>("Rename to `ULong`", """
          type <warning descr="Type `u_long` should have a camel case name such as `ULong`">u_<caret>long</warning> = u64;
          const ZERO: u_long = 0;
@@ -367,6 +466,11 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
             SomeType: Clone,
             <warning descr="Type parameter `some_Type` should have a camel case name such as `SomeType`">some_Type</warning>: Clone> () {
         }
+    """)
+
+    fun testTypeParametersSuppression() = checkByText<RustTypeParameterNamingInspection>("""
+        #[allow(non_camel_case_types)]
+        fn type_params<some_Type: Clone> () {}
     """)
 
     fun testTypeParametersFix() = checkFixByText<RustTypeParameterNamingInspection>("Rename to `To`", """
@@ -392,6 +496,13 @@ class RustNamingInspectionTest : RustInspectionsTestBase() {
         fn loc_var() {
             let var_ok = 12;
             let <warning descr="Variable `VarFoo` should have a snake case name such as `var_foo`">VarFoo</warning> = 12;
+        }
+    """)
+
+    fun testVariablesSuppression() = checkByText<RustVariableNamingInspection>("""
+        #![allow(non_snake_case)]
+        fn loc_var() {
+            let VarFoo = 12;
         }
     """)
 


### PR DESCRIPTION
I've implemented a function that detects the level of the given lint for the given PSI element (`PsiElement.lintLevel(RustLint): RustLintLevel`). 

The function analyses `allow`, `warn` and `deny` attributes and follows the same rules as `rustc` does. As the result, it allows to automatically suppress inspections based on the attributes in the source code. Potentially, it can also be used to automatically change the inspections warning levels. It's now used in the naming inspections and so fixes #775.

The scope of analysis is now limited by a file. This is the only known deviation from how `rustc` works. What would be the better way [than I use](https://github.com/alygin/intellij-rust/blob/f32d0628f96bd4448afdfe1ae26ba23943f504ba/src/main/kotlin/org/rust/lang/core/psi/RustCompositeElement.kt#L30) to iterate through the element parents without being limited by the current file?

I'm also not sure what's the best place for such a function. Would it be better to move it somewhere else from `RustCompositeElement`?
