### PR TITLE
(INSP): Suppress Self Convention Inspection for copyable items

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RustDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RustDocAndAttributeOwner.kt
@@ -30,6 +30,12 @@ class QueryAttributes(private val attributes: Sequence<RustAttrElement>) {
             .filter { it.eq == null && it.lparen == null }
             .any { it.identifier.text == name }
 
+    fun hasMetaItem(attribute: String, item: String): Boolean =
+        metaItems
+            .filter { it.identifier.text == attribute }
+            .flatMap { it.metaItemList.asSequence() }
+            .any { it.text == item }
+
     fun lookupStringValueForKey(key: String): String? =
         metaItems
             .filter { it.identifier.text == key }

--- a/src/test/resources/org/rust/ide/inspections/fixtures/self_convention.rs
+++ b/src/test/resources/org/rust/ide/inspections/fixtures/self_convention.rs
@@ -12,3 +12,9 @@ impl T {
 
     fn is_awesome(<warning descr="methods called `is_*` usually take self by reference or no self; consider choosing a less ambiguous name">self</warning>) {}
 }
+
+#[derive(Copy)]
+struct Copyable;
+impl Copyable {
+    fn is_ok(self) {}
+}


### PR DESCRIPTION
Suppresses Self Convention Inspections for items that derive `Copy`.
It won't work if one uses `impl Copy for T` explicitly, but I think such cases are rare and can be ignored here.

Fixes #515
