### PR TITLE
(MISC): Colored output

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -76,8 +76,10 @@ class Cargo(
             .withEnvironment(CargoConstants.RUSTC_ENV_VAR, pathToRustExecutable)
             .withEnvironment(environmentVariables)
 
-        // Make output colorful
-        if ((SystemInfo.isLinux || SystemInfo.isMac) && additionalArguments.none { it.startsWith("--color") }) {
+        // Make output colored
+        if ((SystemInfo.isLinux || SystemInfo.isMac)
+            && command != "fmt"
+            && additionalArguments.none { it.startsWith("--color") }) {
             cmdLine
                 .withEnvironment("TERM", "linux")
                 .withRedirectErrorStream(true)

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -7,6 +7,7 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
 import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.process.ProcessOutput
+import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.PathUtil
 import org.rust.cargo.CargoConstants
@@ -67,13 +68,23 @@ class Cargo(
         command: String,
         additionalArguments: List<String> = emptyList(),
         environmentVariables: Map<String, String> = emptyMap()
-    ): GeneralCommandLine =
-        GeneralCommandLine(pathToCargoExecutable)
+    ): GeneralCommandLine {
+        var args = additionalArguments
+        val cmdLine = GeneralCommandLine(pathToCargoExecutable)
             .withWorkDirectory(projectDirectory)
             .withParameters(command)
-            .withParameters(additionalArguments)
             .withEnvironment(CargoConstants.RUSTC_ENV_VAR, pathToRustExecutable)
             .withEnvironment(environmentVariables)
+
+        // Make output colorful
+        if ((SystemInfo.isLinux || SystemInfo.isMac) && additionalArguments.none { it.startsWith("--color") }) {
+            cmdLine
+                .withEnvironment("TERM", "linux")
+                .withRedirectErrorStream(true)
+            args = additionalArguments + "--color=always"
+        }
+        return cmdLine.withParameters(args)
+    }
 
     private fun rustfmtCommandline(filePath: String) =
         generalCommand("fmt").withParameters("--", "--write-mode=overwrite", "--skip-children", filePath)

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -78,7 +78,7 @@ class Cargo(
 
         // Make output colored
         if ((SystemInfo.isLinux || SystemInfo.isMac)
-            && command != "fmt"
+            && command in COLOR_ACCEPTING_COMMANDS
             && additionalArguments.none { it.startsWith("--color") }) {
             cmdLine
                 .withEnvironment("TERM", "linux")
@@ -116,5 +116,9 @@ class Cargo(
         } catch(e: JsonSyntaxException) {
             throw ExecutionException(e)
         }
+    }
+
+    private companion object {
+        val COLOR_ACCEPTING_COMMANDS = listOf("bench", "build", "clean", "doc", "install", "publish", "run", "test", "update")
     }
 }

--- a/src/test/kotlin/org/rust/cargo/runconfig/RunConfigurationTestCase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/RunConfigurationTestCase.kt
@@ -3,10 +3,10 @@ package org.rust.cargo.runconfig
 import com.intellij.execution.configurations.ConfigurationTypeUtil
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.execution.executors.DefaultRunExecutor
-import com.intellij.execution.process.CapturingProcessAdapter
-import com.intellij.execution.process.ProcessOutput
+import com.intellij.execution.process.*
 import com.intellij.execution.runners.ExecutionEnvironmentBuilder
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.Key
 import org.assertj.core.api.Assertions.assertThat
 import org.rust.cargo.RustWithToolchainTestBase
 
@@ -37,7 +37,7 @@ class RunConfigurationTestCase : RustWithToolchainTestBase() {
 
         val result = state.execute(executor, RustRunner())!!
 
-        val listener = CapturingProcessAdapter()
+        val listener = AnsiAwareCapturingProcessAdapter()
         with(result.processHandler) {
             addProcessListener(listener)
             startNotify()
@@ -46,4 +46,33 @@ class RunConfigurationTestCase : RustWithToolchainTestBase() {
         Disposer.dispose(result.executionConsole)
         return listener.output
     }
+}
+
+/**
+ * Capturing adapter that removes ANSI escape codes from the output
+ */
+class AnsiAwareCapturingProcessAdapter : ProcessAdapter(), AnsiEscapeDecoder.ColoredTextAcceptor {
+    val output = ProcessOutput()
+
+    private val decoder = object : AnsiEscapeDecoder() {
+        override fun getCurrentOutputAttributes(outputType: Key<*>) = outputType
+    }
+
+    override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>)
+        = decoder.escapeText(event.text, outputType, this)
+
+    private fun addToOutput(text: String, outputType: Key<*>) {
+        if (outputType === ProcessOutputTypes.STDERR) {
+            output.appendStderr(text)
+        } else {
+            output.appendStdout(text)
+        }
+    }
+
+    override fun processTerminated(event: ProcessEvent) {
+        output.exitCode = event.exitCode
+    }
+
+    override fun coloredTextAvailable(text: String, attributes: Key<*>)
+        = addToOutput(text, attributes)
 }

--- a/src/test/kotlin/org/rust/cargo/runconfig/RunConfigurationTestCase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/RunConfigurationTestCase.kt
@@ -58,8 +58,8 @@ class AnsiAwareCapturingProcessAdapter : ProcessAdapter(), AnsiEscapeDecoder.Col
         override fun getCurrentOutputAttributes(outputType: Key<*>) = outputType
     }
 
-    override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>)
-        = decoder.escapeText(event.text, outputType, this)
+    override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) =
+        decoder.escapeText(event.text, outputType, this)
 
     private fun addToOutput(text: String, outputType: Key<*>) {
         if (outputType === ProcessOutputTypes.STDERR) {
@@ -73,6 +73,6 @@ class AnsiAwareCapturingProcessAdapter : ProcessAdapter(), AnsiEscapeDecoder.Col
         output.exitCode = event.exitCode
     }
 
-    override fun coloredTextAvailable(text: String, attributes: Key<*>)
-        = addToOutput(text, attributes)
+    override fun coloredTextAvailable(text: String, attributes: Key<*>) =
+        addToOutput(text, attributes)
 }


### PR DESCRIPTION
Makes the `cargo` and `rustc` output colored on Linux and Mac.
Unfortunately, I don't know how to make it work on Windows and have no Windows machine for experiments. It uses Win API by default and can switch to `msys` under certain circumstances, but I think neither of these will work in IDEA. Though, I might be wrong about it.

Fixes #646 for Linux and Mac