### PR TITLE
(HINT): Functions/methods arguments hint

### DIFF
--- a/src/main/kotlin/org/rust/ide/hints/RustParameterInfoHandler.kt
+++ b/src/main/kotlin/org/rust/ide/hints/RustParameterInfoHandler.kt
@@ -27,21 +27,19 @@ class RustParameterInfoHandler : ParameterInfoHandler<PsiElement, RustArgumentsD
         return if (p is RustCallExprElement && p.declaration != null || p is RustMethodCallExprElement && p.declaration != null) arrayOf(p) else emptyArray()
     }
 
-    override fun getParametersForDocumentation(p: RustArgumentsDescription, context: ParameterInfoContext?): Array<out Any> {
-        return p.arguments
-    }
+    override fun getParametersForDocumentation(p: RustArgumentsDescription, context: ParameterInfoContext?) =
+        p.arguments
 
     override fun findElementForParameterInfo(context: CreateParameterInfoContext): PsiElement? {
         val contextElement = context.file.findElementAt(context.editor.caretModel.offset) ?: return null
         return findElementForParameterInfo(contextElement)
     }
 
-    fun findElementForParameterInfo(contextElement: PsiElement)
-        = PsiTreeUtil.getParentOfType(contextElement, RustArgListElement::class.java)
+    fun findElementForParameterInfo(contextElement: PsiElement) =
+        PsiTreeUtil.getParentOfType(contextElement, RustArgListElement::class.java)
 
-    override fun findElementForUpdatingParameterInfo(context: UpdateParameterInfoContext): PsiElement? {
-        return context.file.findElementAt(context.editor.caretModel.offset)
-    }
+    override fun findElementForUpdatingParameterInfo(context: UpdateParameterInfoContext) =
+        context.file.findElementAt(context.editor.caretModel.offset)
 
     override fun showParameterInfo(element: PsiElement, context: CreateParameterInfoContext) {
         if (element !is RustArgListElement) return

--- a/src/main/kotlin/org/rust/ide/info/RustParameterInfoHandler.kt
+++ b/src/main/kotlin/org/rust/ide/info/RustParameterInfoHandler.kt
@@ -1,0 +1,152 @@
+package org.rust.ide.info
+
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.lang.parameterInfo.*
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.util.parentOfType
+
+/**
+ * Provides funcions/methods afruments hint.
+ */
+class RustParameterInfoHandler : ParameterInfoHandler<PsiElement, RustArgumentsDescription> {
+
+    override fun couldShowInLookup() = true
+
+    override fun tracksParameterIndex() = true
+
+    override fun getParameterCloseChars() = ",)"
+
+    override fun getParametersForLookup(item: LookupElement, context: ParameterInfoContext?): Array<out Any> {
+        val el = item.`object` as PsiElement
+        val p = el.parent?.parent
+        return if (p is RustCallExprElement && p.declaration != null || p is RustMethodCallExprElement && p.declaration != null) arrayOf(p) else emptyArray()
+    }
+
+    override fun getParametersForDocumentation(p: RustArgumentsDescription, context: ParameterInfoContext?): Array<out Any> {
+        return p.arguments
+    }
+
+    override fun findElementForParameterInfo(context: CreateParameterInfoContext): PsiElement? {
+        val contextElement = context.file.findElementAt(context.editor.caretModel.offset) ?: return null
+        return findElementForParameterInfo(contextElement)
+    }
+
+    fun findElementForParameterInfo(contextElement: PsiElement)
+        = PsiTreeUtil.getParentOfType(contextElement, RustArgListElement::class.java)
+
+    override fun findElementForUpdatingParameterInfo(context: UpdateParameterInfoContext): PsiElement? {
+        return context.file.findElementAt(context.editor.caretModel.offset)
+    }
+
+    override fun showParameterInfo(element: PsiElement, context: CreateParameterInfoContext) {
+        if (element !is RustArgListElement) return
+        val argsDescr = RustArgumentsDescription.tryGetDescription(element) ?: return
+        context.itemsToShow = arrayOf(argsDescr)
+        context.showHint(element, element.textRange.startOffset, this)
+    }
+
+    override fun updateParameterInfo(place: PsiElement, context: UpdateParameterInfoContext) {
+        val argIndex = findArgumentIndex(place)
+        if (argIndex == INVALID_INDEX) {
+            context.removeHint()
+            return
+        }
+        context.setCurrentParameter(argIndex)
+        if (context.parameterOwner == null) {
+            context.parameterOwner = place
+        } else if (context.parameterOwner != findElementForParameterInfo(place)) {
+            context.removeHint()
+            return
+        }
+        context.objectsToView.mapIndexed { i, o -> context.setUIComponentEnabled(i, true) }
+    }
+
+    override fun updateUI(p: RustArgumentsDescription?, context: ParameterInfoUIContext) {
+        if (p == null) {
+            context.isUIComponentEnabled = false
+            return
+        }
+        val range = p.getArgumentRange(context.currentParameterIndex)
+        context.setupUIComponentPresentation(
+            p.parametersPresentText,
+            range.startOffset,
+            range.endOffset,
+            !context.isUIComponentEnabled,
+            false,
+            false,
+            context.defaultParameterColor)
+    }
+
+    /**
+     * Finds index of the argument in the given place
+     */
+    private fun findArgumentIndex(place: PsiElement): Int {
+        val callArgs = place.parentOfType<RustArgListElement>() ?: return INVALID_INDEX
+        val descr = RustArgumentsDescription.tryGetDescription(callArgs) ?: return INVALID_INDEX
+        var index = -1
+        if (descr.arguments.isNotEmpty()) {
+            index += generateSequence(callArgs.firstChild, { c -> c.nextSibling})
+                .filter { it.text == "," }
+                .takeWhile { it.textRange.startOffset < place.textRange.startOffset }
+                .count() + 1
+            if (index >= descr.arguments.size) {
+                index = -1
+            }
+        }
+        return index
+    }
+
+    private companion object {
+        val INVALID_INDEX: Int = -2
+    }
+}
+
+class RustArgumentsDescription(
+    val arguments: Array<RustArgumentDescription>
+) {
+    fun getArgumentRange(index: Int): TextRange {
+        if (index < 0) return TextRange.EMPTY_RANGE
+        val start = (0..index - 1).sumBy { arguments[it].textLen + 2 }
+        val range = TextRange(start, start + arguments[index].textLen)
+        return range
+    }
+
+    val parametersPresentText = if (arguments.isEmpty()) "<no arguments>" else arguments.joinToString(", ")
+
+    companion object {
+        fun tryGetDescription(args: RustArgListElement): RustArgumentsDescription? {
+            val call = args.parent
+            val decl = when (call) {
+                is RustCallExprElement -> call.declaration
+                is RustMethodCallExprElement -> call.declaration
+                else -> null
+            } ?: return null
+            val paramsList = when (decl) {
+                is RustFnItemElement -> decl.parameters
+                is RustImplMethodMemberElement -> decl.parameters
+                else -> null
+            }?.parameterList
+            val params = paramsList
+                ?.map { RustArgumentDescription(it.pat?.text, it.type?.text) }
+                ?.toTypedArray()
+            return RustArgumentsDescription(params ?: emptyArray())
+        }
+    }
+}
+
+class RustArgumentDescription(
+    val name: String?,
+    val type: String?
+) {
+    val textLen = (name?.length ?: 1) + 2 + (type?.length ?: 1)
+    override fun toString() = (name ?: "?") + ": " + (type ?: "?")
+}
+
+private val RustCallExprElement.declaration: RustFnElement?
+    get() = (expr as? RustPathExprElement)?.path?.reference?.resolve() as? RustFnElement
+
+private val RustMethodCallExprElement.declaration: RustImplMethodMemberElement?
+    get() = reference.resolve() as? RustImplMethodMemberElement

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -86,6 +86,7 @@
         <!-- Hints -->
 
         <codeInsight.typeInfo language="Rust" implementationClass="org.rust.ide.hints.RustExpressionTypeProvider"/>
+        <codeInsight.parameterInfo language="Rust" implementationClass="org.rust.ide.info.RustParameterInfoHandler"/>
 
         <!-- Annotator -->
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -86,7 +86,7 @@
         <!-- Hints -->
 
         <codeInsight.typeInfo language="Rust" implementationClass="org.rust.ide.hints.RustExpressionTypeProvider"/>
-        <codeInsight.parameterInfo language="Rust" implementationClass="org.rust.ide.info.RustParameterInfoHandler"/>
+        <codeInsight.parameterInfo language="Rust" implementationClass="org.rust.ide.hints.RustParameterInfoHandler"/>
 
         <!-- Annotator -->
 

--- a/src/test/kotlin/org/rust/ide/hints/RustParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RustParameterInfoHandlerTest.kt
@@ -157,7 +157,7 @@ class RustParameterInfoHandlerTest : RustTestCaseBase() {
         if (hint.isNotEmpty()) {
             elt ?: throw AssertionFailedError("Element not found")
             handler.showParameterInfo(elt, createContext)
-            val items = createContext.itemsToShow ?: throw AssertionFailedError("Paremeters are not shown")
+            val items = createContext.itemsToShow ?: throw AssertionFailedError("Parameters are not shown")
             if (items.isEmpty()) throw AssertionFailedError("Paremeters are empty")
             val context = MockParameterInfoUIContext(elt)
             handler.updateUI(items[0] as RustArgumentsDescription, context)

--- a/src/test/kotlin/org/rust/ide/hints/RustParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RustParameterInfoHandlerTest.kt
@@ -83,6 +83,28 @@ class RustParameterInfoHandlerTest : RustTestCaseBase() {
         fn main() { foo(|x| x + <caret>); }
     """, "fun: Fn(u32) -> u32", 0)
 
+    fun testFnNestedInner() = checkByText("""
+        fn add(v1: u32, v2: u32) -> u32 { v1 + v2 }
+        fn display(v: u32, format: &'static str) {}
+        fn main() { display(add(4, <caret>), "0.00"); }
+    """, "v1: u32, v2: u32", 1)
+
+    fun testFnNestedOuter() = checkByText("""
+        fn add(v1: u32, v2: u32) -> u32 { v1 + v2 }
+        fn display(v: u32, indent: bool, format: &'static str) {}
+        fn main() { display(add(4, 7), false, <caret>"); }
+    """, "v: u32, indent: bool, format: &'static str", 2)
+
+    fun testMultiline() = checkByText("""
+        fn sum(v1: u32, v2: u32, v3: u32) -> u32 { v1 + v2 + v3 }
+        fn main() {
+            sum(
+                10,
+                <caret>
+            );
+        }
+    """, "v1: u32, v2: u32, v3: u32", 1)
+
     fun testAssocFn() = checkByText("""
         struct Foo;
         impl Foo { fn new(id: u32, val: f64) {} }

--- a/src/test/kotlin/org/rust/ide/hints/RustParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RustParameterInfoHandlerTest.kt
@@ -15,8 +15,6 @@ class RustParameterInfoHandlerTest : RustTestCaseBase() {
 
     override val dataPath = ""
 
-    override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
-
     fun testFnNoArgs() = checkByText("""
         fn foo() {}
         fn main() { foo(<caret>); }

--- a/src/test/kotlin/org/rust/ide/hints/RustParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RustParameterInfoHandlerTest.kt
@@ -1,0 +1,156 @@
+package org.rust.ide.hints
+
+import com.intellij.testFramework.LightProjectDescriptor
+import com.intellij.testFramework.utils.parameterInfo.MockCreateParameterInfoContext
+import com.intellij.testFramework.utils.parameterInfo.MockParameterInfoUIContext
+import com.intellij.testFramework.utils.parameterInfo.MockUpdateParameterInfoContext
+import junit.framework.AssertionFailedError
+import junit.framework.TestCase
+import org.rust.lang.RustTestCaseBase
+
+
+/**
+ * Tests for RustParameterInfoHandler
+ */
+class RustParameterInfoHandlerTest : RustTestCaseBase() {
+
+    override val dataPath = ""
+
+    override fun getProjectDescriptor(): LightProjectDescriptor = WithStdlibRustProjectDescriptor
+
+    fun testFnNoArgs() = checkByText("""
+        fn foo() {}
+        fn main() { foo(<caret>); }
+    """, "<no arguments>", -1)
+
+    fun testFnNoArgsBeforeArgs() = checkByText("""
+        fn foo() {}
+        fn main() { foo<caret>(); }
+    """, "<no arguments>", -1)
+
+    fun testFnOneArg() = checkByText("""
+        fn foo(arg: u32) {}
+        fn main() { foo(<caret>); }
+    """, "arg: u32", 0)
+
+    fun testFnOneArgEnd() = checkByText("""
+        fn foo(arg: u32) {}
+        fn main() { foo(42<caret>); }
+    """, "arg: u32", 0)
+
+    fun testFnManyArgs() = checkByText("""
+        fn foo(id: u32, name: &'static str, mut year: &u16) {}
+        fn main() { foo(<caret>); }
+    """, "id: u32, name: &'static str, mut year: &u16", 0)
+
+    fun testFnPoorlyFormattedArgs() = checkByText("""
+        fn foo(  id   :   u32   , name: &'static str   , mut year   : &u16   ) {}
+        fn main() { foo(<caret>); }
+    """, "id: u32, name: &'static str, mut year: &u16", 0)
+
+    fun testFnArgIndex0() = checkByText("""
+        fn foo(a1: u32, a2: u32) {}
+        fn main() { foo(a1<caret>); }
+    """, "a1: u32, a2: u32", 0)
+
+    fun testFnArgIndex0WithComma() = checkByText("""
+        fn foo(a1: u32, a2: u32) {}
+        fn main() { foo(a1<caret>,); }
+    """, "a1: u32, a2: u32", 0)
+
+    fun testFnArgIndex1() = checkByText("""
+        fn foo(a1: u32, a2: u32) {}
+        fn main() { foo(16,<caret>); }
+    """, "a1: u32, a2: u32", 1)
+
+    fun testFnArgIndex1ValueStart() = checkByText("""
+        fn foo(a1: u32, a2: u32) {}
+        fn main() { foo(12, <caret>32); }
+    """, "a1: u32, a2: u32", 1)
+
+    fun testFnArgIndex1ValueEnd() = checkByText("""
+        fn foo(a1: u32, a2: u32) {}
+        fn main() { foo(5, 32<caret>); }
+    """, "a1: u32, a2: u32", 1)
+
+    fun testFnArgTooManyArgs() = checkByText("""
+        fn foo(a1: u32, a2: u32) {}
+        fn main() { foo(0, 32,<caret>); }
+    """, "a1: u32, a2: u32", -1)
+
+    fun testFnClosure() = checkByText("""
+        fn foo(fun: Fn(u32) -> u32) {}
+        fn main() { foo(|x| x + <caret>); }
+    """, "fun: Fn(u32) -> u32", 0)
+
+    fun testAssocFn() = checkByText("""
+        struct Foo;
+        impl Foo { fn new(id: u32, val: f64) {} }
+        fn main() {
+            Foo::new(10, <caret>);
+        }
+    """, "id: u32, val: f64", 1)
+
+    fun testMethod() = checkByText("""
+        struct Foo;
+        impl Foo { fn bar(&self, id: u32, name: &'static name, year: u16) {} }
+        fn main() {
+            let foo = Foo{};
+            foo.bar(10, "Bo<caret>b", 1987);
+        }
+    """, "id: u32, name: &'static name, year: u16", 1)
+
+    fun testTraitMethod() = checkByText("""
+        trait Named {
+            fn greet(&self, text: &'static str, count: u16, l: f64);
+        }
+        struct Person;
+        impl Named for Person {
+            fn greet(&self, text: &'static str, count: u16, l: f64) {}
+        }
+        fn main() {
+            let p = Person {};
+            p.greet("Hello", 19, 10.21<caret>);
+        }
+    """, "text: &'static str, count: u16, l: f64", 2)
+
+    fun testNotArgs1() = checkByText("""
+        fn foo() {}
+        fn main() { fo<caret>o(); }
+    """, "", -1)
+
+    fun testNotArgs2() = checkByText("""
+        fn foo() {}
+        fn main() { foo()<caret>; }
+    """, "", -1)
+
+    fun testNotArgs3() = checkByText("""
+        fn foo(v<caret>: u32) {}
+    """, "", -1)
+
+    private fun checkByText(code: String, hint: String, index: Int) {
+        myFixture.configureByText("main.rs", code)
+        val handler = RustParameterInfoHandler()
+        val createContext = MockCreateParameterInfoContext(myFixture.editor, myFixture.file)
+
+        // Check hint
+        val elt = handler.findElementForParameterInfo(createContext)
+        if (hint.isNotEmpty()) {
+            elt ?: throw AssertionFailedError("Element not found")
+            handler.showParameterInfo(elt, createContext)
+            val items = createContext.itemsToShow ?: throw AssertionFailedError("Paremeters are not shown")
+            if (items.isEmpty()) throw AssertionFailedError("Paremeters are empty")
+            val context = MockParameterInfoUIContext(elt)
+            handler.updateUI(items[0] as RustArgumentsDescription, context)
+            TestCase.assertEquals(hint, handler.hintText)
+
+            // Check parameter index
+            val updateContext = MockUpdateParameterInfoContext(myFixture.editor, myFixture.file)
+            val element = handler.findElementForUpdatingParameterInfo(updateContext) ?: throw AssertionFailedError("Parameter not found")
+            handler.updateParameterInfo(element, updateContext)
+            TestCase.assertEquals(index, updateContext.currentParameter)
+        } else if (elt != null) {
+            throw AssertionFailedError("Unexpected element found")
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/ide/hints/RustParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RustParameterInfoHandlerTest.kt
@@ -1,6 +1,5 @@
 package org.rust.ide.hints
 
-import com.intellij.testFramework.LightProjectDescriptor
 import com.intellij.testFramework.utils.parameterInfo.MockCreateParameterInfoContext
 import com.intellij.testFramework.utils.parameterInfo.MockParameterInfoUIContext
 import com.intellij.testFramework.utils.parameterInfo.MockUpdateParameterInfoContext
@@ -16,7 +15,7 @@ class RustParameterInfoHandlerTest : RustTestCaseBase() {
 
     override val dataPath = ""
 
-    override fun getProjectDescriptor(): LightProjectDescriptor = WithStdlibRustProjectDescriptor
+    override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
 
     fun testFnNoArgs() = checkByText("""
         fn foo() {}


### PR DESCRIPTION
This one adds arguments info hints to function and method calls (Cmd+P). It works where the current resolvers work:

<img width="274" alt="screen shot 2016-12-02 at 08 25 39" src="https://cloud.githubusercontent.com/assets/2101250/20823860/f862316a-b868-11e6-901d-fa1a2ce6062c.png">

A possible further improvement would be to extract descriptions of the aliased types in generic functions and show them instead of aliases. It might be the common mechanism for both these hints and the completion engine (and something else?).

Fixes #437