### PR TITLE
(MISC): Error links improvements

### DIFF
--- a/src/test/kotlin/org/rust/cargo/runconfig/RustExplainFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/RustExplainFilterTest.kt
@@ -20,7 +20,12 @@ class RustExplainFilterTest : RustTestCaseBase() {
 
     fun testErrorFormat() {
         val text = "error[E0382]: use of moved value: `v`"
-        doTest(text, text.length, 0, 12)
+        doTest(text, text.length, 5, 12)
+    }
+
+    fun testWarningFormat() {
+        val text = "warning[E0122]: trait bounds are not (yet) enforced in type definitions"
+        doTest(text, text.length, 7, 14)
     }
 
     fun testNothingToSee() {


### PR DESCRIPTION
Fixes #804

Those messages now look like this:

<img width="293" alt="screen shot 2016-12-02 at 19 00 03" src="https://cloud.githubusercontent.com/assets/2101250/20840904/e600f7fe-b8c2-11e6-9421-e68f2bd65817.png">
