### PR TITLE
(MISC): Gutter icon position fix

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RustTraitMethodImplLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RustTraitMethodImplLineMarkerProvider.kt
@@ -36,6 +36,6 @@ class RustTraitMethodImplLineMarkerProvider : RelatedItemLineMarkerProvider() {
             .setTargets(listOf(traitMethod))
             .setTooltipText("$action method in `${trait.name}`")
 
-        result.add(builder.createLineMarkerInfo(el))
+        result.add(builder.createLineMarkerInfo(el.fn))
     }
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RustTraitMethodImplLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RustTraitMethodImplLineMarkerProviderTest.kt
@@ -20,4 +20,19 @@ class RustTraitMethodImplLineMarkerProviderTest : RustLineMarkerProviderTestBase
             }
         }
     """)
+
+    fun testIconPosition() = doTestByText("""
+        trait Foo {         // - Has implementations
+            fn foo(&self);
+        }
+        struct Bar {}
+        impl Foo for Bar {
+            ///
+            /// Documentation
+            ///
+            #[warn(non_camel_case_types)]
+            fn foo(&self) { // - Implements method in `Foo`
+            }
+        }
+    """)
 }


### PR DESCRIPTION
Fixes positioning of the "go to declaration" gutter icon when comments or attributes are provided for the function/method.

Before the fix, it was placed at the beginning of the comment/attribute.