### PR TITLE
(MISC): Coloring ? operator

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RustHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RustHighlightingAnnotator.kt
@@ -98,6 +98,7 @@ class RustHighlightingAnnotator : Annotator {
         override fun visitMacroInvocation(m: RustMacroInvocationElement) = highlight(m, RustColor.MACRO)
         override fun visitMethodCallExpr(o: RustMethodCallExprElement)   = highlight(o.identifier, RustColor.INSTANCE_METHOD)
         override fun visitFnItem(o: RustFnItemElement)                   = highlight(o.identifier, RustColor.FUNCTION_DECLARATION)
+        override fun visitTryExpr(o: RustTryExprElement)                 = highlight(o.q, RustColor.Q_OPERATOR)
 
         override fun visitImplMethodMember(o: RustImplMethodMemberElement) =
             highlight(o.identifier, if (o.isStatic) RustColor.STATIC_METHOD else RustColor.INSTANCE_METHOD)

--- a/src/main/kotlin/org/rust/ide/colors/RustColors.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RustColors.kt
@@ -13,7 +13,8 @@ enum class RustColor(humanName: String, val default: TextAttributesKey) {
     INSTANCE_METHOD       ("Instance method declaration", Default.INSTANCE_METHOD),
     STATIC_METHOD         ("Static method declaration",   Default.STATIC_METHOD),
     PARAMETER             ("Function parameter",          Default.PARAMETER),
-    SELF_PARAMETER        ("Self parameter",              Default.PARAMETER),
+    SELF_PARAMETER        ("Self parameter",              Default.KEYWORD),
+    Q_OPERATOR            ("? operator",                  Default.KEYWORD),
 
     LIFETIME              ("Lifetime",                    Default.IDENTIFIER),
 

--- a/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
+++ b/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
@@ -3,7 +3,7 @@ extern crate <CRATE>log</CRATE>;
 
 use std::collections::<STRUCT>HashMap</STRUCT>;
 
-mod <MODULE>Stuff</MODULE>;
+mod <MODULE>stuff</MODULE>;
 
 pub enum <ENUM>Flag</ENUM> {
     <ENUM_VARIANT>Good</ENUM_VARIANT>,
@@ -20,13 +20,21 @@ struct <STRUCT>Object</STRUCT><<TYPE_PARAMETER>T</TYPE_PARAMETER>> {
     <FIELD>fields</FIELD>: <STRUCT>HashMap</STRUCT><<TYPE_PARAMETER>T</TYPE_PARAMETER>, <PRIMITIVE_TYPE>u64</PRIMITIVE_TYPE>>
 }
 
+impl<<TYPE_PARAMETER>T</TYPE_PARAMETER>> Write for <STRUCT>Object</STRUCT><<TYPE_PARAMETER>T</TYPE_PARAMETER>> {
+    fn <INSTANCE_METHOD>write</INSTANCE_METHOD>(&mut <SELF_PARAMETER>self</SELF_PARAMETER>, <PARAMETER>buf</PARAMETER>: &[<PRIMITIVE_TYPE>u8</PRIMITIVE_TYPE>]) -> <ENUM>Result</ENUM><usize> {
+        let s = stuff::<FUNCTION_DECLARATION>write_map</FUNCTION_DECLARATION>(&self.<FIELD>fields</FIELD>, <PARAMETER>buf</PARAMETER>)<Q_OPERATOR>?</Q_OPERATOR>;
+        <MACRO>info!</MACRO>("{} byte(s) written", s);
+        <ENUM_VARIANT>Ok</ENUM_VARIANT>(s)
+    }
+}
+
 /* Block comment */
 fn <FUNCTION_DECLARATION>main</FUNCTION_DECLARATION>() {
     // A simple integer calculator:
     // `+` or `-` means add or subtract by 1
     // `*` or `/` means multiply or divide by 2
 
-    let input = <ENUM>Option</ENUM>::None;
+    let input = <ENUM>Option</ENUM>::<ENUM_VARIANT>None</ENUM_VARIANT>;
     let program = input.<INSTANCE_METHOD>unwrap_or_else</INSTANCE_METHOD>(|| "+ + * - /");
     let mut <MUT_BINDING>accumulator</MUT_BINDING> = 0;
 


### PR DESCRIPTION
Makes the `?` operator colored as a keyword ([screenshots](https://github.com/intellij-rust/intellij-rust/issues/785#issuecomment-264547200)). A setting to customise the color is also provided.

We can decide what color to use before merging the PR.

Fixes #785. Also fixes the `self` parameter display in the color settings window (it's displayed as a simple parameter now).
