### PR TITLE
(Misc) Local variable names suggestions

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RustNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RustNamingInspection.kt
@@ -103,7 +103,7 @@ open class RustUpperCaseNamingInspection(elementType: String) : RustNamingInspec
     }
 }
 
-private fun String.toSnakeCase(upper: Boolean): String {
+fun String.toSnakeCase(upper: Boolean): String {
     val result = StringBuilder(length + 3)     // 3 is a reasonable margin for growth when `_`s are added
     result.append(takeWhile { it == '_' || it == '\'' })    // Preserve prefix
     var firstPart = true

--- a/src/main/kotlin/org/rust/lang/refactoring/NameSuggestions.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/NameSuggestions.kt
@@ -8,37 +8,49 @@ import org.rust.lang.core.psi.RustCallExprElement
 import org.rust.lang.core.psi.RustExprElement
 import org.rust.lang.core.psi.RustFnItemElement
 import org.rust.lang.core.psi.util.parentOfType
+import org.rust.lang.core.types.util.resolvedType
 import java.util.*
 
 fun suggestedNames(project: Project, expr: RustExprElement): LinkedHashSet<String> {
     val names = LinkedHashSet<String>()
 
+    val typeString = expr.resolvedType.toString()
+    //doesn't really seem to do that much.
+    if (typeString != "unkown") {
+        names.addAll(RustNameUtil(typeString.take(1)))
+    }
+
     if (expr.isArgument()) {
         val name = nameForArgument(project, expr)
-        val suggestionsByName = NameUtil.getSuggestionsByName(name, "", "", false, false, false).map(String::toSnakeCase)
+        val suggestionsByName = RustNameUtil(name)
         names.addAll(suggestionsByName)
+    } else if (expr is RustCallExprElement) {
+        names.addAll(RustNameUtil(expr.expr.text))
     }
 
     return names
 }
 
-
 fun nameForArgument(project: Project, expr: RustExprElement): String {
     val call = expr.parentOfType<RustCallExprElement>(strict = false) ?: return ""
 
     val parameterIndex = call.argList.children.indexOf(expr)
+    val fn = findFnImpl(project, call)
 
+    return fn?.parameters?.parameterList?.get(parameterIndex)?.pat?.text ?: ""
+}
+
+fun findFnImpl(project: Project, callExpr: RustCallExprElement): RustFnItemElement? {
     val navigator = RustSymbolNavigationContributor()
-    val items = navigator.getItemsByName(call.firstChild.text, null, project, false)
-    val fn = items[0] as RustFnItemElement
+    val items = navigator.getItemsByName(callExpr.firstChild.text, null, project, false)
 
-    return fn.parameters?.parameterList?.get(parameterIndex)?.pat?.text ?: ""
+    return items.firstOrNull() as? RustFnItemElement
 }
 
 fun String.toSnakeCase(): String {
     val builder = StringBuilder()
     for (char in this.toCharArray()) {
-        if(char.isUpperCase()) {
+        if (char.isUpperCase()) {
             builder
                 .append('_')
                 .append(char.toLowerCase())
@@ -50,4 +62,6 @@ fun String.toSnakeCase(): String {
     return builder.toString()
 }
 
-fun RustExprElement.isArgument() = this.parentOfType<RustArgListElement>(strict = false) != null
+fun RustExprElement.isArgument() = this.parent is RustArgListElement
+
+fun RustNameUtil(name: String) = NameUtil.getSuggestionsByName(name, "", "", false, false, false).map(String::toSnakeCase)

--- a/src/main/kotlin/org/rust/lang/refactoring/NameSuggestions.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/NameSuggestions.kt
@@ -1,0 +1,53 @@
+package org.rust.lang.refactoring
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.codeStyle.NameUtil
+import org.rust.ide.navigation.goto.RustSymbolNavigationContributor
+import org.rust.lang.core.psi.RustArgListElement
+import org.rust.lang.core.psi.RustCallExprElement
+import org.rust.lang.core.psi.RustExprElement
+import org.rust.lang.core.psi.RustFnItemElement
+import org.rust.lang.core.psi.util.parentOfType
+import java.util.*
+
+fun suggestedNames(project: Project, expr: RustExprElement): LinkedHashSet<String> {
+    val names = LinkedHashSet<String>()
+
+    if (expr.isArgument()) {
+        val name = nameForArgument(project, expr)
+        val suggestionsByName = NameUtil.getSuggestionsByName(name, "", "", false, false, false).map(String::toSnakeCase)
+        names.addAll(suggestionsByName)
+    }
+
+    return names
+}
+
+
+fun nameForArgument(project: Project, expr: RustExprElement): String {
+    val call = expr.parentOfType<RustCallExprElement>(strict = false) ?: return ""
+
+    val parameterIndex = call.argList.children.indexOf(expr)
+
+    val navigator = RustSymbolNavigationContributor()
+    val items = navigator.getItemsByName(call.firstChild.text, null, project, false)
+    val fn = items[0] as RustFnItemElement
+
+    return fn.parameters?.parameterList?.get(parameterIndex)?.pat?.text ?: ""
+}
+
+fun String.toSnakeCase(): String {
+    val builder = StringBuilder()
+    for (char in this.toCharArray()) {
+        if(char.isUpperCase()) {
+            builder
+                .append('_')
+                .append(char.toLowerCase())
+        } else {
+            builder.append(char)
+        }
+    }
+
+    return builder.toString()
+}
+
+fun RustExprElement.isArgument() = this.parentOfType<RustArgListElement>(strict = false) != null

--- a/src/main/kotlin/org/rust/lang/refactoring/RustLocalVariableHandler.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RustLocalVariableHandler.kt
@@ -133,7 +133,7 @@ class RustIntroduceVariableRefactoring(
         }
 
         PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
-        nameElem?.let { RustInPlaceVariableIntroducer(it, editor, project, "choose a variable", emptyArray()).performInplaceRefactoring(suggestedNames(project, expr)) }
+        nameElem?.let { RustInPlaceVariableIntroducer(it, editor, project, "choose a variable", emptyArray()).performInplaceRefactoring(expr.suggestNames()) }
     }
 
     /**
@@ -170,7 +170,7 @@ class RustIntroduceVariableRefactoring(
         }
 
         PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
-        newNameElem?.let { RustInPlaceVariableIntroducer(it, editor, project, "choose a variable", emptyArray()).performInplaceRefactoring(suggestedNames(project, stmt)) }
+        newNameElem?.let { RustInPlaceVariableIntroducer(it, editor, project, "choose a variable", emptyArray()).performInplaceRefactoring(stmt.suggestNames()) }
     }
 
     private fun moveEditorToNameElement(editor: Editor, element: PsiElement?): RustPatBindingElement? {

--- a/src/main/kotlin/org/rust/lang/refactoring/RustLocalVariableHandler.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RustLocalVariableHandler.kt
@@ -133,7 +133,7 @@ class RustIntroduceVariableRefactoring(
         }
 
         PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
-        nameElem?.let { RustInPlaceVariableIntroducer(it, editor, project, "choose a variable", emptyArray()).performInplaceRefactoring(LinkedHashSet()) }
+        nameElem?.let { RustInPlaceVariableIntroducer(it, editor, project, "choose a variable", emptyArray()).performInplaceRefactoring(suggestedNames(project, expr)) }
     }
 
     /**
@@ -170,7 +170,7 @@ class RustIntroduceVariableRefactoring(
         }
 
         PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
-        newNameElem?.let { RustInPlaceVariableIntroducer(it, editor, project, "choose a variable", emptyArray()).performInplaceRefactoring(LinkedHashSet()) }
+        newNameElem?.let { RustInPlaceVariableIntroducer(it, editor, project, "choose a variable", emptyArray()).performInplaceRefactoring(suggestedNames(project, stmt)) }
     }
 
     private fun moveEditorToNameElement(editor: Editor, element: PsiElement?): RustPatBindingElement? {

--- a/src/main/kotlin/org/rust/lang/refactoring/RustLocalVariableHandler.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RustLocalVariableHandler.kt
@@ -120,6 +120,7 @@ class RustIntroduceVariableRefactoring(
 
     fun replaceElementForAllExpr(exprs: List<PsiElement>) {
         val expr = exprs.first()
+        val suggestNames = expr.suggestNames()
 
         val (let, name) = createLet(expr)
             ?: return
@@ -133,7 +134,7 @@ class RustIntroduceVariableRefactoring(
         }
 
         PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
-        nameElem?.let { RustInPlaceVariableIntroducer(it, editor, project, "choose a variable", emptyArray()).performInplaceRefactoring(expr.suggestNames()) }
+        nameElem?.let { RustInPlaceVariableIntroducer(it, editor, project, "choose a variable", emptyArray()).performInplaceRefactoring(suggestNames) }
     }
 
     /**
@@ -162,6 +163,7 @@ class RustIntroduceVariableRefactoring(
 
     private fun <T : PsiElement> inlineLet(project: Project, editor: Editor, stmt: T, statementFactory: (T) -> RustStmtElement) {
         var newNameElem: RustPatBindingElement? = null
+        val suggestNames = stmt.suggestNames()
         WriteCommandAction.runWriteCommandAction(project) {
             val statement = statementFactory.invoke(stmt)
             val newStatement = stmt.replace(statement)
@@ -170,7 +172,7 @@ class RustIntroduceVariableRefactoring(
         }
 
         PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
-        newNameElem?.let { RustInPlaceVariableIntroducer(it, editor, project, "choose a variable", emptyArray()).performInplaceRefactoring(stmt.suggestNames()) }
+        newNameElem?.let { RustInPlaceVariableIntroducer(it, editor, project, "choose a variable", emptyArray()).performInplaceRefactoring(suggestNames) }
     }
 
     private fun moveEditorToNameElement(editor: Editor, element: PsiElement?): RustPatBindingElement? {

--- a/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
@@ -1,13 +1,10 @@
 package org.rust.lang.refactoring
 
-import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.codeStyle.NameUtil
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.inspections.toSnakeCase
-import org.rust.ide.navigation.goto.RustSymbolNavigationContributor
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.util.childOfType
 import org.rust.lang.core.psi.util.parentOfType
 import org.rust.lang.core.types.RustUnknownType
 import org.rust.lang.core.types.util.resolvedType
@@ -19,6 +16,7 @@ import java.util.*
  * If the type is resolved suggest the first letter of the type name.
  * If its an argument to a function call, suggest the name of the argument in the function definition.
  * If its a function call suggest the name of the function and the enclosing name space (if any).
+ * If the expression is in a struct literal (Foo {x: 5, y: 6}) suggest the tag for the expression as a name
  * If a name is already bound in the local scope do not suggest it.
  */
 fun PsiElement.suggestNames(): LinkedHashSet<String> {
@@ -28,6 +26,7 @@ fun PsiElement.suggestNames(): LinkedHashSet<String> {
     val foundNames = when {
         this.isArgument() -> rustNameUtil(nameForArgument())
         this is RustCallExprElement -> nameForCall(this).flatMap(::rustNameUtil)
+        isStructField() -> rustNameUtil((this.parent as? RustStructExprFieldElement)?.identifier?.text ?: "")
         else -> emptyList()
     }
 
@@ -38,6 +37,7 @@ fun PsiElement.suggestNames(): LinkedHashSet<String> {
 
     return names
 }
+
 
 private fun nameForType(expr: PsiElement): String? {
     val type = (expr as? RustExprElement)?.resolvedType
@@ -83,5 +83,6 @@ fun findNamesInLocalScope(expr: PsiElement): List<String> {
 }
 
 private fun PsiElement.isArgument() = this.parent is RustArgListElement
+private fun PsiElement.isStructField() = this.parent is RustStructExprFieldElement
 
 private fun rustNameUtil(name: String) = NameUtil.getSuggestionsByName(name, "", "", false, false, false).map { it.toSnakeCase(false) }

--- a/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
@@ -1,42 +1,53 @@
-    package org.rust.lang.refactoring
+package org.rust.lang.refactoring
 
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.codeStyle.NameUtil
+import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.navigation.goto.RustSymbolNavigationContributor
 import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.util.childOfType
 import org.rust.lang.core.psi.util.parentOfType
 import org.rust.lang.core.types.util.resolvedType
 import java.util.*
 
+/**
+ * This suggests names for an expression about to be bound to a local variable
+ *
+ * If the type is resolved suggest the first letter of the type name.
+ * If its an argument to a function call, suggest the name of the argument in the function definition.
+ * If its a function call suggest the name of the function and the enclosing name space (if any).
+ * If a name is already bound in the local scope do not suggest it.
+ */
 fun suggestedNames(project: Project, expr: PsiElement): LinkedHashSet<String> {
     val names = LinkedHashSet<String>()
-
-
     nameForType(expr)?.let { names.addAll(RustNameUtil(it)) }
 
-    if (expr.isArgument()) {
-        val name = nameForArgument(project, expr)
-        val suggestionsByName = RustNameUtil(name)
-        names.addAll(suggestionsByName)
-    } else if (expr is RustCallExprElement) {
-        names.addAll(nameForCall(expr).flatMap(::RustNameUtil))
+    val foundNames = when {
+        expr.isArgument() -> RustNameUtil(nameForArgument(project, expr))
+        expr is RustCallExprElement -> nameForCall(expr).flatMap(::RustNameUtil)
+        else -> emptyList()
     }
+
+    names.addAll(foundNames)
+
+    val usedNames = findNamesInLocalScope(expr)
+    names.removeAll(usedNames)
 
     return names
 }
 
-fun nameForType(expr: PsiElement): String? {
+private fun nameForType(expr: PsiElement): String? {
     val typeString = (expr as? RustExprElement)?.resolvedType.toString()
     //doesn't really seem to do that much.
-    if (typeString != "unkown" && typeString != "null") {
+    if (typeString != "unknown" && typeString != "null") {
         return typeString.take(1)
     }
 
     return null
 }
 
-fun nameForCall(expr: RustCallExprElement): List<String> {
+private fun nameForCall(expr: RustCallExprElement): List<String> {
     val pathElement = expr.expr
     if (pathElement is RustPathExprElement) {
         val path = pathElement.path
@@ -56,7 +67,7 @@ fun nameForArgument(project: Project, expr: PsiElement): String {
     return fn?.parameters?.parameterList?.get(parameterIndex)?.pat?.text ?: ""
 }
 
-fun findFnImpl(project: Project, callExpr: RustCallExprElement): RustFnItemElement? {
+private fun findFnImpl(project: Project, callExpr: RustCallExprElement): RustFnItemElement? {
     val navigator = RustSymbolNavigationContributor()
     val items = navigator.getItemsByName(callExpr.firstChild.text, null, project, false)
 
@@ -78,6 +89,13 @@ fun String.toSnakeCase(): String {
     return builder.toString()
 }
 
-fun PsiElement.isArgument() = this.parent is RustArgListElement
+fun findNamesInLocalScope(expr: PsiElement): List<String> {
+    val blockScope = expr.parentOfType<RustBlockElement>(strict = false)
+    val letDecls = PsiTreeUtil.findChildrenOfType(blockScope, RustLetDeclElement::class.java)
 
-fun RustNameUtil(name: String) = NameUtil.getSuggestionsByName(name, "", "", false, false, false).map(String::toSnakeCase)
+    return letDecls.map { it.pat?.text }.filterNotNull()
+}
+
+private fun PsiElement.isArgument() = this.parent is RustArgListElement
+
+private fun RustNameUtil(name: String) = NameUtil.getSuggestionsByName(name, "", "", false, false, false).map(String::toSnakeCase)

--- a/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
@@ -54,8 +54,8 @@ private fun nameForCall(expr: RustCallExprElement): List<String> {
     if (pathElement is RustPathExprElement) {
         val path = pathElement.path
 
-        //path.path gives us the x's out of: Xxx::yyy
-        return listOf(path.identifier, path.path).filterNotNull().map(PsiElement::getText).reverseNew()
+        //path.path.identifier gives us the x's out of: Xxx::<T>::yyy
+        return listOf(path.identifier, path.path?.identifier).filterNotNull().map(PsiElement::getText).reverseNew()
     }
     return listOf(pathElement.text)
 }

--- a/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
@@ -64,17 +64,14 @@ fun PsiElement.nameForArgument(): String {
     val call = this.parentOfType<RustCallExprElement>(strict = false) ?: return ""
 
     val parameterIndex = call.argList.children.indexOf(this)
-    val fn = findFnImpl(project, call)
+    val fn = call.findFnImpl()
 
     return fn?.parameters?.parameterList?.get(parameterIndex)?.pat?.text ?: ""
 }
 
-private fun findFnImpl(project: Project, callExpr: RustCallExprElement): RustFnItemElement? {
-//    return  callExpr.reference?.resolve() as? RustFnItemElement
-    val navigator = RustSymbolNavigationContributor()
-    val items = navigator.getItemsByName(callExpr.firstChild.text, null, project, false)
-
-    return items.firstOrNull() as? RustFnItemElement
+private fun RustCallExprElement.findFnImpl(): RustFnItemElement? {
+    val path = expr as? RustPathExprElement
+    return path?.path?.reference?.resolve() as? RustFnItemElement
 }
 
 

--- a/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
@@ -61,7 +61,7 @@ private fun nameForCall(expr: RustCallExprElement): List<String> {
 }
 
 fun PsiElement.nameForArgument(): String {
-    val call = this.parentOfType<RustCallExprElement>(strict = false) ?: return ""
+    val call = this.parentOfType<RustCallExprElement>(strict = true) ?: return ""
 
     val parameterIndex = call.argList.children.indexOf(this)
     val fn = call.findFnImpl()

--- a/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
@@ -55,9 +55,15 @@ private fun nameForCall(expr: RustCallExprElement): List<String> {
         val path = pathElement.path
 
         //path.path gives us the x's out of: Xxx::yyy
-        return listOf(path.identifier, path.path).filterNotNull().map(PsiElement::getText)
+        return listOf(path.identifier, path.path).filterNotNull().map(PsiElement::getText).reverseNew()
     }
     return listOf(pathElement.text)
+}
+
+private fun List<String>.reverseNew() = if (this.firstOrNull() == "new") {
+    this.reversed()
+} else {
+    this
 }
 
 fun PsiElement.nameForArgument(): String {

--- a/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
@@ -19,7 +19,7 @@ import java.util.*
  * If the expression is in a struct literal (Foo {x: 5, y: 6}) suggest the tag for the expression as a name
  * If a name is already bound in the local scope do not suggest it.
  */
-fun PsiElement.suggestNames(): LinkedHashSet<String> {
+fun RustExprElement.suggestNames(): LinkedHashSet<String> {
     val names = LinkedHashSet<String>()
     nameForType(this)?.let { names.addAll(rustNameUtil(it)) }
 
@@ -39,10 +39,10 @@ fun PsiElement.suggestNames(): LinkedHashSet<String> {
 }
 
 
-private fun nameForType(expr: PsiElement): String? {
-    val type = (expr as? RustExprElement)?.resolvedType
+private fun nameForType(expr: RustExprElement): String? {
+    val type = expr.resolvedType
 
-    if (type is RustUnknownType || type == null) {
+    if (type is RustUnknownType) {
         return null
     }
 

--- a/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RustNameSuggestions.kt
@@ -22,11 +22,12 @@ import java.util.*
 fun RustExprElement.suggestNames(): LinkedHashSet<String> {
     val names = LinkedHashSet<String>()
     nameForType(this)?.let { names.addAll(rustNameUtil(it)) }
+    val parent = this.parent
 
     val foundNames = when {
         this.isArgument() -> rustNameUtil(nameForArgument())
         this is RustCallExprElement -> nameForCall(this).flatMap(::rustNameUtil)
-        isStructField() -> rustNameUtil((this.parent as? RustStructExprFieldElement)?.identifier?.text ?: "")
+        parent is RustStructExprFieldElement -> rustNameUtil(parent.identifier.text)
         else -> emptyList()
     }
 

--- a/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
@@ -10,14 +10,14 @@ class RustNameSuggestionsKtTest : RustTestCaseBase() {
     override val dataPath = "org/rust/lang/refactoring/fixtures/introduce_variable/"
 
     fun testArgumentNames() = doTest("""
-fn foo(a: i32, veryCoolVariableName: i32) {
-    a + b
-}
+        fn foo(a: i32, veryCoolVariableName: i32) {
+            a + b
+        }
 
-fn bar() {
-    foo(4, 10/*caret*/ + 2)
-}
-""") {
+        fn bar() {
+            foo(4, 10/*caret*/ + 2)
+        }
+    """) {
         val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
         val expr = refactoring.possibleTargets().first()
 
@@ -26,14 +26,14 @@ fn bar() {
     }
 
     fun testNonDirectArgumentNames() = doTest("""
-fn foo(a: i32, veryCoolVariableName: i32) {
-    a + b
-}
+        fn foo(a: i32, veryCoolVariableName: i32) {
+            a + b
+        }
 
-fn bar() {
-    foo(4, 1/*caret*/0 + 2)
-}
-""") {
+        fn bar() {
+            foo(4, 1/*caret*/0 + 2)
+        }
+    """) {
         val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
         val expr = refactoring.possibleTargets().first()
 
@@ -42,15 +42,14 @@ fn bar() {
 
 
     fun testFunctionNames() = doTest("""
-fn foo(a: i32, veryCoolVariableName: i32) -> i32 {
-    a + b
-}
+        fn foo(a: i32, veryCoolVariableName: i32) -> i32 {
+            a + b
+        }
 
-fn bar() {
-    f/*caret*/oo(4, 10 + 2)
-}
-"""
-    ) {
+        fn bar() {
+            f/*caret*/oo(4, 10 + 2)
+        }
+    """) {
         val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
         val expr = refactoring.possibleTargets().first()
 
@@ -58,14 +57,13 @@ fn bar() {
         assertThat(names).containsExactly("i", "foo")
     }
 
-    fun testStringNew() = doTest(
-        """
+    fun testStringNew() = doTest("""
         fn read_file() -> Result<String, Error> {
-        let file = File::open("res/input.txt")?;
+            let file = File::open("res/input.txt")?;
 
-        file.read_to_string(&mut String:/*caret*/:new())?;
+            file.read_to_string(&mut String:/*caret*/:new())?;
 
-        Ok(x)
+            Ok(x)
     }""") {
         val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
         val expr = refactoring.possibleTargets().first()
@@ -74,12 +72,12 @@ fn bar() {
     }
 
     fun testLocalNames() = doTest("""
-fn foo() {
-    let a = 5;
-    let b = String::new();
-    5/*caret*/+ 10;
-}
-""") {
+        fn foo() {
+            let a = 5;
+            let b = String::new();
+            5/*caret*/+ 10;
+        }
+    """) {
         val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
         val expr = refactoring.possibleTargets().first()
 
@@ -87,11 +85,11 @@ fn foo() {
     }
 
     fun testFunctionCallAsArgument() = doTest("""
-fn foo(board_size: i32) {}
+        fn foo(board_size: i32) {}
 
-fn bar() {
-    foo(Default::de/*caret*/fault());
-}
+        fn bar() {
+            foo(Default::de/*caret*/fault());
+        }
     """) {
         val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
         val expr = refactoring.possibleTargets().first()

--- a/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
@@ -92,11 +92,4 @@ fn foo() {
         openFileInEditor("main.rs")
         action()
     }
-
-
-    @Test
-    fun testToSnakeCase() {
-        assertThat("variableName".toSnakeCase()).isEqualTo("variable_name")
-    }
-
 }

--- a/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
@@ -9,7 +9,7 @@ import org.rust.lang.core.psi.impl.RustFile
 class NameSuggestionsKtTest : RustTestCaseBase() {
     override val dataPath = "org/rust/lang/refactoring/fixtures/introduce_variable/"
 
-    fun testSuggestedNames() = doTest("""
+    fun testArgumentNames() = doTest("""
 fn foo(a: i32, veryCoolVariableName: i32) {
     a + b
 }
@@ -17,13 +17,46 @@ fn foo(a: i32, veryCoolVariableName: i32) {
 fn bar() {
     foo(4, 10/*caret*/ + 2)
 }
-
 """) {
         val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
         val expr = refactoring.possibleTargets().first()
 
         assertThat(nameForArgument(project, expr)).isEqualTo("veryCoolVariableName")
-        assertThat(suggestedNames(project, expr)).contains("name", "variable_name", "cool_variable_name" ,"very_cool_variable_name")
+        assertThat(suggestedNames(project, expr)).containsExactly("name", "variable_name", "cool_variable_name" ,"very_cool_variable_name")
+    }
+
+    fun testNonDirectArgumentNames() = doTest("""
+fn foo(a: i32, veryCoolVariableName: i32) {
+    a + b
+}
+
+fn bar() {
+    foo(4, 1/*caret*/0 + 2)
+}
+""") {
+        val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
+        val expr = refactoring.possibleTargets().first()
+
+        assertThat(suggestedNames(project, expr)).containsExactly("i")
+    }
+
+
+
+    fun testFunctionNames() = doTest("""
+fn foo(a: i32, veryCoolVariableName: i32) -> i32 {
+    a + b
+}
+
+fn bar() {
+    f/*caret*/oo(4, 10 + 2)
+}
+"""
+    ) {
+        val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
+        val expr = refactoring.possibleTargets().first()
+
+        val names = suggestedNames(project, expr)
+        assertThat(names).containsExactly("i", "foo")
     }
 
     private fun doTest(@Language("Rust") before: String, action: () -> Unit) {

--- a/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
@@ -66,7 +66,7 @@ class RustNameSuggestionsKtTest : RustTestCaseBase() {
         val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
         val expr = refactoring.possibleTargets().first()
 
-        assertThat(expr.suggestNames()).containsExactly("new", "string")
+        assertThat(expr.suggestNames()).containsExactly("string", "new")
     }
 
     fun testLocalNames() = doTest("""

--- a/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
@@ -113,6 +113,27 @@ class RustNameSuggestionsKtTest : RustTestCaseBase() {
         assertThat(expr.suggestNames()).containsExactly("i", "baz")
     }
 
+    fun testGenericPath() = doTest("""
+        struct Foo<T> {
+            t: T,
+        }
+
+        impl <T> Foo<T> {
+            fn new(t: T) -> Foo<T> {
+                Foo {t: t}
+            }
+        }
+
+        fn bar() {
+            Foo:/*caret*/:<i32>::new(10)
+        }
+        """) {
+        val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
+        val expr = refactoring.possibleTargets().first()
+
+        assertThat(expr.suggestNames()).containsExactly("f", "foo", "new")
+    }
+
 
     private fun doTest(@Language("Rust") before: String, action: () -> Unit) {
         InlineFile(before).withCaret()

--- a/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
@@ -21,8 +21,8 @@ fn bar() {
         val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
         val expr = refactoring.possibleTargets().first()
 
-        assertThat(nameForArgument(project, expr)).isEqualTo("veryCoolVariableName")
-        assertThat(suggestedNames(project, expr)).containsExactly("name", "variable_name", "cool_variable_name", "very_cool_variable_name")
+        assertThat(expr.nameForArgument()).isEqualTo("veryCoolVariableName")
+        assertThat(expr.suggestNames()).containsExactly("name", "variable_name", "cool_variable_name", "very_cool_variable_name")
     }
 
     fun testNonDirectArgumentNames() = doTest("""
@@ -37,7 +37,7 @@ fn bar() {
         val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
         val expr = refactoring.possibleTargets().first()
 
-        assertThat(suggestedNames(project, expr)).containsExactly("i")
+        assertThat(expr.suggestNames()).containsExactly("i")
     }
 
 
@@ -54,7 +54,7 @@ fn bar() {
         val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
         val expr = refactoring.possibleTargets().first()
 
-        val names = suggestedNames(project, expr)
+        val names = expr.suggestNames()
         assertThat(names).containsExactly("i", "foo")
     }
 
@@ -70,7 +70,7 @@ fn bar() {
         val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
         val expr = refactoring.possibleTargets().first()
 
-        assertThat(suggestedNames(project, expr)).containsExactly("new", "string")
+        assertThat(expr.suggestNames()).containsExactly("new", "string")
     }
 
     fun testLocalNames() = doTest("""

--- a/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
@@ -86,6 +86,19 @@ fn foo() {
         assertThat(findNamesInLocalScope(expr)).containsExactly("a", "b")
     }
 
+    fun testFunctionCallAsArgument() = doTest("""
+fn foo(board_size: i32) {}
+
+fn bar() {
+    foo(Default::de/*caret*/fault());
+}
+    """) {
+        val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
+        val expr = refactoring.possibleTargets().first()
+
+        assertThat(expr.suggestNames()).contains("board_size")
+    }
+
 
     private fun doTest(@Language("Rust") before: String, action: () -> Unit) {
         InlineFile(before).withCaret()

--- a/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
@@ -1,0 +1,41 @@
+package org.rust.lang.refactoring
+
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+import org.rust.lang.RustTestCaseBase
+import org.rust.lang.core.psi.impl.RustFile
+
+class NameSuggestionsKtTest : RustTestCaseBase() {
+    override val dataPath = "org/rust/lang/refactoring/fixtures/introduce_variable/"
+
+    fun testSuggestedNames() = doTest("""
+fn foo(a: i32, veryCoolVariableName: i32) {
+    a + b
+}
+
+fn bar() {
+    foo(4, 10/*caret*/ + 2)
+}
+
+""") {
+        val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
+        val expr = refactoring.possibleTargets().first()
+
+        assertThat(nameForArgument(project, expr)).isEqualTo("veryCoolVariableName")
+        assertThat(suggestedNames(project, expr)).contains("name", "variable_name", "cool_variable_name" ,"very_cool_variable_name")
+    }
+
+    private fun doTest(@Language("Rust") before: String, action: () -> Unit) {
+        InlineFile(before).withCaret()
+        openFileInEditor("main.rs")
+        action()
+    }
+
+
+    @Test
+    fun testToSnakeCase() {
+        assertThat("variableName".toSnakeCase()).isEqualTo("variable_name")
+    }
+
+}

--- a/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
@@ -62,8 +62,6 @@ class RustNameSuggestionsKtTest : RustTestCaseBase() {
             let file = File::open("res/input.txt")?;
 
             file.read_to_string(&mut String:/*caret*/:new())?;
-
-            Ok(x)
     }""") {
         val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
         val expr = refactoring.possibleTargets().first()

--- a/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
@@ -92,7 +92,25 @@ class RustNameSuggestionsKtTest : RustTestCaseBase() {
         val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
         val expr = refactoring.possibleTargets().first()
 
-        assertThat(expr.suggestNames()).contains("board_size")
+        assertThat(expr.suggestNames()).containsExactly("size", "board_size")
+    }
+
+    fun testStructLiteral() = doTest("""
+        struct Foo {
+            bar: i32,
+            baz: i32,
+        }
+
+        impl Foo {
+            fn new() -> Foo {
+                Foo{bar: 5, baz: 1/*caret*/0}
+            }
+        }
+        """) {
+        val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
+        val expr = refactoring.possibleTargets().first()
+
+        assertThat(expr.suggestNames()).containsExactly("i", "baz")
     }
 
 

--- a/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.rust.lang.RustTestCaseBase
 import org.rust.lang.core.psi.impl.RustFile
 
-class NameSuggestionsKtTest : RustTestCaseBase() {
+class RustNameSuggestionsKtTest : RustTestCaseBase() {
     override val dataPath = "org/rust/lang/refactoring/fixtures/introduce_variable/"
 
     fun testArgumentNames() = doTest("""
@@ -22,7 +22,7 @@ fn bar() {
         val expr = refactoring.possibleTargets().first()
 
         assertThat(nameForArgument(project, expr)).isEqualTo("veryCoolVariableName")
-        assertThat(suggestedNames(project, expr)).containsExactly("name", "variable_name", "cool_variable_name" ,"very_cool_variable_name")
+        assertThat(suggestedNames(project, expr)).containsExactly("name", "variable_name", "cool_variable_name", "very_cool_variable_name")
     }
 
     fun testNonDirectArgumentNames() = doTest("""
@@ -39,7 +39,6 @@ fn bar() {
 
         assertThat(suggestedNames(project, expr)).containsExactly("i")
     }
-
 
 
     fun testFunctionNames() = doTest("""
@@ -60,7 +59,7 @@ fn bar() {
     }
 
     fun testStringNew() = doTest(
-    """
+        """
         fn read_file() -> Result<String, Error> {
         let file = File::open("res/input.txt")?;
 
@@ -72,6 +71,19 @@ fn bar() {
         val expr = refactoring.possibleTargets().first()
 
         assertThat(suggestedNames(project, expr)).containsExactly("new", "string")
+    }
+
+    fun testLocalNames() = doTest("""
+fn foo() {
+    let a = 5;
+    let b = String::new();
+    5/*caret*/+ 10;
+}
+""") {
+        val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
+        val expr = refactoring.possibleTargets().first()
+
+        assertThat(findNamesInLocalScope(expr)).containsExactly("a", "b")
     }
 
 

--- a/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/NameSuggestionsKtTest.kt
@@ -59,6 +59,22 @@ fn bar() {
         assertThat(names).containsExactly("i", "foo")
     }
 
+    fun testStringNew() = doTest(
+    """
+        fn read_file() -> Result<String, Error> {
+        let file = File::open("res/input.txt")?;
+
+        file.read_to_string(&mut String:/*caret*/:new())?;
+
+        Ok(x)
+    }""") {
+        val refactoring = RustIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RustFile)
+        val expr = refactoring.possibleTargets().first()
+
+        assertThat(suggestedNames(project, expr)).containsExactly("new", "string")
+    }
+
+
     private fun doTest(@Language("Rust") before: String, action: () -> Unit) {
         InlineFile(before).withCaret()
         openFileInEditor("main.rs")

--- a/src/test/kotlin/org/rust/lang/refactoring/RustLocalVariableHandlerTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/RustLocalVariableHandlerTest.kt
@@ -19,7 +19,8 @@ class RustLocalVariableHandlerTest : RustTestCaseBase() {
         val ref = refactoring()
         val targets = ref.possibleTargets()
         check(targets.size == 3)
-        ref.replaceElementForAllExpr(listOf(targets[0]))
+        val expr = targets[0]
+        ref.replaceElementForAllExpr(expr, listOf(expr))
     }
 
     fun testExplicitSelectionWorks() {
@@ -54,7 +55,7 @@ class RustLocalVariableHandlerTest : RustTestCaseBase() {
         check(targets.size == 3)
         val expr = targets[1]
         val occurrences = findOccurrences(expr)
-        ref.replaceElementForAllExpr(occurrences)
+        ref.replaceElementForAllExpr(expr, occurrences)
     }
 
     fun testCaretAfterElement() = doTest("""
@@ -62,13 +63,13 @@ class RustLocalVariableHandlerTest : RustTestCaseBase() {
             1/*caret*/;
         }""", """
         fn main() {
-            let x = 1;
+            let i = 1;
         }""")
     {
         val ref = refactoring()
         val targets = ref.possibleTargets()
         check(targets.size == 1)
-        ref.replaceElement(targets)
+        ref.replaceElement(targets[0], targets)
     }
 
     fun testStatement() = doTest("""
@@ -76,13 +77,13 @@ class RustLocalVariableHandlerTest : RustTestCaseBase() {
             foo(5 + /*caret*/10);
         }""", """
         fn hello() {
-            let x = foo(5 + 10);
+            let foo = foo(5 + 10);
         }""")
     {
         val ref = refactoring()
         val targets = ref.possibleTargets()
         check(targets.size == 3)
-        ref.replaceElement(listOf(targets[2]))
+        ref.replaceElement(targets[2], listOf(targets[2]))
     }
 
     fun testMatch() = doTest("""
@@ -101,7 +102,7 @@ class RustLocalVariableHandlerTest : RustTestCaseBase() {
     {
         val ref = refactoring()
         val targets = ref.possibleTargets()
-        ref.replaceElement(listOf(targets.single()))
+        ref.replaceElement(targets.single(), listOf(targets.single()))
     }
 
     fun testFile() = doTest("""
@@ -115,7 +116,7 @@ class RustLocalVariableHandlerTest : RustTestCaseBase() {
         val ref = refactoring()
         val targets = ref.possibleTargets()
         check(targets.size == 2)
-        ref.replaceElement(listOf(targets[1]))
+        ref.replaceElement(targets[1], listOf(targets[1]))
     }
 
     fun testRefMut() = doTest("""
@@ -133,7 +134,7 @@ class RustLocalVariableHandlerTest : RustTestCaseBase() {
     {
         val ref = refactoring()
         val targets = ref.possibleTargets()
-        ref.replaceElement(listOf(targets[0]))
+        ref.replaceElement(targets[0], listOf(targets[0]))
     }
 
     private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String, action: () -> Unit) {

--- a/src/test/kotlin/org/rust/lang/refactoring/RustLocalVariableHandlerTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/RustLocalVariableHandlerTest.kt
@@ -123,16 +123,12 @@ class RustLocalVariableHandlerTest : RustTestCaseBase() {
             let file = File::open("res/input.txt")?;
 
             file.read_to_string(&mut String:/*caret*/:new())?;
-
-            Ok(x)
         }""", """
         fn read_file() -> Result<String, Error> {
             let file = File::open("res/input.txt")?;
             let mut new = String::new();
 
             file.read_to_string(&mut new)?;
-
-            Ok(new)
         }""")
     {
         val ref = refactoring()

--- a/src/test/kotlin/org/rust/lang/refactoring/RustLocalVariableHandlerTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/RustLocalVariableHandlerTest.kt
@@ -12,8 +12,8 @@ class RustLocalVariableHandlerTest : RustTestCaseBase() {
             foo(5 + /*caret*/10);
         }""", """
         fn hello() {
-            let x = 10;
-            foo(5 + x);
+            let i = 10;
+            foo(5 + i);
         }""")
     {
         val ref = refactoring()
@@ -128,11 +128,11 @@ class RustLocalVariableHandlerTest : RustTestCaseBase() {
         }""", """
         fn read_file() -> Result<String, Error> {
             let file = File::open("res/input.txt")?;
-            let mut x = String::new();
+            let mut new = String::new();
 
-            file.read_to_string(&mut x)?;
+            file.read_to_string(&mut new)?;
 
-            Ok(x)
+            Ok(new)
         }""")
     {
         val ref = refactoring()

--- a/src/test/kotlin/org/rust/lang/refactoring/RustLocalVariableHandlerTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/RustLocalVariableHandlerTest.kt
@@ -126,9 +126,9 @@ class RustLocalVariableHandlerTest : RustTestCaseBase() {
         }""", """
         fn read_file() -> Result<String, Error> {
             let file = File::open("res/input.txt")?;
-            let mut new = String::new();
+            let mut string = String::new();
 
-            file.read_to_string(&mut new)?;
+            file.read_to_string(&mut string)?;
         }""")
     {
         val ref = refactoring()


### PR DESCRIPTION
This pr expands the functionality introduced in #796

So far it follows these rules:

If the type is resolved suggest the first letter of the type name.
If its an argument to a function call, suggest the name of the argument in the function definition.
If its a function call suggest the name of the function and the enclosing namespace (if any).
If a name is already bound in the local scope do not suggest it.

This is mainly based on what the go plugin does.

Intellij in java also does the following if you are introducing a variable for a string literal, it uses the contents of the literal for the name, would this special case also make sense for rust?

We might want to use the is array setting on the Intellij NameUtil, however i'm not completely certain what it does and how much value it might add, any thoughts on this?