### PR TITLE
(MISC): Add source code links to stack backtraces

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/CargoProjectDescription.kt
+++ b/src/main/kotlin/org/rust/cargo/project/CargoProjectDescription.kt
@@ -26,7 +26,6 @@ class CargoProjectDescription private constructor(
         val dependencies: List<Package>,
         val isWorkspaceMember: Boolean
     ) {
-        val isModule: Boolean get() = source == null
         val libTarget: Target? get() = targets.find { it.isLib }
         val contentRoot: VirtualFile? get() = VirtualFileManager.getInstance().findFileByUrl(contentRootUrl)
 
@@ -120,6 +119,8 @@ class CargoProjectDescription private constructor(
     }
 
     val hasStandardLibrary: Boolean get() = findExternCrateRootByName(AutoInjectedCrates.std) != null
+
+    fun findPackage(name: String): Package? = packages.find { it.name == name }
 
     companion object {
         fun deserialize(data: CleanCargoMetadata): CargoProjectDescription? {

--- a/src/main/kotlin/org/rust/cargo/project/CargoProjectDescription.kt
+++ b/src/main/kotlin/org/rust/cargo/project/CargoProjectDescription.kt
@@ -27,8 +27,8 @@ class CargoProjectDescription private constructor(
     ) {
         val isModule: Boolean get() = source == null
         val libTarget: Target? get() = targets.find { it.isLib }
-
         val contentRoot: VirtualFile? get() = VirtualFileManager.getInstance().findFileByUrl(contentRootUrl)
+        val isExternal: Boolean get() = targets.asSequence().filter { it.crateRoot != null }.any { it.isLib }
 
         override fun toString(): String = "Package(contentRootUrl='$contentRootUrl', name='$name')"
     }

--- a/src/main/kotlin/org/rust/cargo/project/CargoProjectDescription.kt
+++ b/src/main/kotlin/org/rust/cargo/project/CargoProjectDescription.kt
@@ -23,12 +23,12 @@ class CargoProjectDescription private constructor(
         val version: String,
         val targets: Collection<Target>,
         val source: String?,
-        val dependencies: List<Package>
+        val dependencies: List<Package>,
+        val isExternal: Boolean
     ) {
         val isModule: Boolean get() = source == null
         val libTarget: Target? get() = targets.find { it.isLib }
         val contentRoot: VirtualFile? get() = VirtualFileManager.getInstance().findFileByUrl(contentRootUrl)
-        val isExternal: Boolean get() = targets.asSequence().filter { it.crateRoot != null }.any { it.isLib }
 
         override fun toString(): String = "Package(contentRootUrl='$contentRootUrl', name='$name')"
     }
@@ -112,7 +112,8 @@ class CargoProjectDescription private constructor(
                 version = "",
                 targets = listOf(Target(crateRoot.url, name = crateName, kind = TargetKind.LIB)),
                 source = null,
-                dependencies = emptyList()
+                dependencies = emptyList(),
+                isExternal = true
             )
         }
         return CargoProjectDescription(packages + stdlibPackages)
@@ -136,7 +137,8 @@ class CargoProjectDescription private constructor(
                     pkg.version,
                     pkg.targets.map { Target(it.url, it.name, it.kind) },
                     pkg.source,
-                    deps
+                    deps,
+                    pkg.isExternal
                 ) to deps
             }.unzip()
 

--- a/src/main/kotlin/org/rust/cargo/project/CargoProjectDescription.kt
+++ b/src/main/kotlin/org/rust/cargo/project/CargoProjectDescription.kt
@@ -24,7 +24,7 @@ class CargoProjectDescription private constructor(
         val targets: Collection<Target>,
         val source: String?,
         val dependencies: List<Package>,
-        val isExternal: Boolean
+        val isWorkspaceMember: Boolean
     ) {
         val isModule: Boolean get() = source == null
         val libTarget: Target? get() = targets.find { it.isLib }
@@ -113,7 +113,7 @@ class CargoProjectDescription private constructor(
                 targets = listOf(Target(crateRoot.url, name = crateName, kind = TargetKind.LIB)),
                 source = null,
                 dependencies = emptyList(),
-                isExternal = true
+                isWorkspaceMember = false
             )
         }
         return CargoProjectDescription(packages + stdlibPackages)
@@ -138,7 +138,7 @@ class CargoProjectDescription private constructor(
                     pkg.targets.map { Target(it.url, it.name, it.kind) },
                     pkg.source,
                     deps,
-                    pkg.isExternal
+                    pkg.isWorkspaceMember
                 ) to deps
             }.unzip()
 

--- a/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
@@ -137,7 +137,7 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
 
     private fun updateModuleDependencies(projectDescription: CargoProjectDescription) {
         val libraryRoots = projectDescription.packages
-            .filter { !it.isModule }
+            .filter { !it.isWorkspaceMember }
             .mapNotNull { it.contentRoot }
 
         module.updateLibrary(module.cargoLibraryName, libraryRoots)

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandConfiguration.kt
@@ -45,9 +45,7 @@ class CargoCommandConfiguration(
         CargoRunConfigurationEditorForm()
 
     override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState? {
-        val config = getConfiguration()
-        if (config !is ConfigurationResult.Ok) return null
-
+        val config = getConfiguration() as? ConfigurationResult.Ok ?: return null
         val args = ParametersListUtil.parse(additionalArguments)
 
         val environmentVariables = if (printBacktrace)
@@ -55,7 +53,7 @@ class CargoCommandConfiguration(
         else
             environmentVariables
 
-        return CargoRunState(environment, config.toolchain, config.moduleDirectory, command, args, environmentVariables)
+        return CargoRunState(environment, config.toolchain, configurationModule.module, config.moduleDirectory, command, args, environmentVariables)
     }
 
     override fun writeExternal(element: Element) {

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
@@ -5,12 +5,14 @@ import com.intellij.execution.process.KillableColoredProcessHandler
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.module.Module
 import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.toolchain.RustToolchain
 
 class CargoRunState(
     environment: ExecutionEnvironment,
     private val toolchain: RustToolchain,
+    module: Module?,
     private val cargoProjectDirectory: VirtualFile,
     private val command: String,
     private val additionalArguments: List<String>,
@@ -21,7 +23,9 @@ class CargoRunState(
         consoleBuilder.addFilter(RustConsoleFilter(environment.project, cargoProjectDirectory))
         consoleBuilder.addFilter(RustExplainFilter())
         consoleBuilder.addFilter(RustPanicFilter(environment.project, cargoProjectDirectory))
-        consoleBuilder.addFilter(RustBacktraceFilter(environment.project, cargoProjectDirectory))
+        if (module != null) {
+            consoleBuilder.addFilter(RustBacktraceFilter(environment.project, cargoProjectDirectory, module))
+        }
     }
 
     override fun startProcess(): ProcessHandler {

--- a/src/main/kotlin/org/rust/cargo/runconfig/RustBacktraceFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RustBacktraceFilter.kt
@@ -132,6 +132,10 @@ private class RustBacktraceItemFilter(
             .getAttributes(TextAttributesKey.createTextAttributesKey("org.rust.DIMMED_TEXT"))!!
         val GRAYED_LINK_COLOR = Color(135, 135, 135)
         val GRAYED_LINK = TextAttributes(GRAYED_LINK_COLOR, null, GRAYED_LINK_COLOR, EffectType.LINE_UNDERSCORE, Font.PLAIN)
-        val SKIP_PREFIXES = arrayOf("std::", "core::")
+        val SKIP_PREFIXES = arrayOf(
+            "std::rt::lang_start",
+            "std::panicking",
+            "std::sys::backtrace",
+            "core::panicking")
     }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/RustBacktraceFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RustBacktraceFilter.kt
@@ -1,17 +1,137 @@
 package org.rust.cargo.runconfig
 
+import com.intellij.execution.filters.Filter
+import com.intellij.execution.filters.OpenFileHyperlinkInfo
 import com.intellij.execution.filters.RegexpFilter
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.psi.PsiDocumentManager
+import org.rust.cargo.project.CargoProjectDescription
+import org.rust.cargo.util.cargoProject
+import org.rust.cargo.util.getPsiFor
+import org.rust.cargo.util.modulesWithCargoProject
+import org.rust.lang.core.psi.RustCompositeElement
+import org.rust.lang.core.psi.RustNamedElement
+import org.rust.lang.core.resolve.RustResolveEngine
+import org.rust.lang.core.symbols.RustPath
+import org.rust.lang.core.symbols.RustPathHead
+import org.rust.lang.core.symbols.RustPathSegment
+import java.util.*
+import java.util.regex.Pattern
 
 /**
- * Detects messages about panics and adds source code links to them.
+ * Adds features to stack backtraces:
+ * - Wrap function calls into hyperlinks to source code.
+ * - Turn source code links into hyperlinks.
+ * - Dims funcion hashcodes to remove noise.
  */
 class RustBacktraceFilter(
     project: Project,
     cargoProjectDir: VirtualFile
-) : RegexpFileLinkFilter(
-    project,
-    cargoProjectDir,
-    "^\\s+at ${RegexpFilter.FILE_PATH_MACROS}:${RegexpFilter.LINE_MACROS}$") {
+) : Filter {
+    private val sourceLinkFilter = RegexpFileLinkFilter(project, cargoProjectDir, "^\\s+at ${RegexpFilter.FILE_PATH_MACROS}:${RegexpFilter.LINE_MACROS}$")
+    private val backtraceItemFilter = RustBacktraceItemFilter(project)
+
+    override fun applyFilter(line: String, entireLength: Int): Filter.Result? {
+        backtraceItemFilter.applyFilter(line, entireLength)?.let { return it }
+        sourceLinkFilter.applyFilter(line, entireLength)?.let { return it }
+        return null
+    }
+}
+
+/**
+ * Adds hyperlinks to function names in backtraces
+ */
+private class RustBacktraceItemFilter(
+    val project: Project
+) : Filter {
+    private val pattern = Pattern.compile("^(\\s*\\d+:\\s+0x[a-f0-9]+ - )(.+)(::h[0-9a-f]+)$")!!
+    private val docManager = PsiDocumentManager.getInstance(project)
+
+    override fun applyFilter(line: String, entireLength: Int): Filter.Result? {
+        val matcher = pattern.matcher(line)
+        if (!matcher.find()) return null
+        val funcName = matcher.group(2)
+        val resultItems = ArrayList<Filter.ResultItem>(2)
+
+        // Add hyperlink to the function name
+        val funcStart = entireLength - line.length + matcher.group(1).length
+        if (SKIP_PREFIXES.none { funcName.startsWith(it) }) {
+            extractFnHyperlink(funcName, funcStart)?.let { resultItems.add(it) }
+        }
+
+        // Dim the hashcode
+        val funcEnd = funcStart + funcName.length
+        resultItems.add(Filter.ResultItem(funcEnd, funcEnd + matcher.group(3).length, null, DIMMED_TEXT))
+
+        return Filter.Result(resultItems)
+    }
+
+    private fun extractFnHyperlink(funcName: String, start: Int): Filter.ResultItem? {
+        val func = ElementResolver.resolve(funcName, project) ?: return null
+        val funcFile = func.element.containingFile
+        val doc = docManager.getDocument(funcFile) ?: return null
+        val link = OpenFileHyperlinkInfo(project, funcFile.virtualFile, doc.getLineNumber(func.element.textOffset))
+        return Filter.ResultItem(start, start + funcName.length, link, func.pkg.isExternal)
+    }
+
+    private companion object {
+        val DIMMED_TEXT = EditorColorsManager.getInstance().globalScheme
+            .getAttributes(TextAttributesKey.createTextAttributesKey("org.rust.DIMMED_TEXT"))!!
+        val SKIP_PREFIXES = arrayOf(
+            // TODO: Put the whole std:: and core:: here?
+//            "std::sys::backtrace::",
+//            "std::panicking::",
+            "std::rt::lang_start"
+        )
+    }
+}
+
+
+private object ElementResolver {
+    private val vfm = VirtualFileManager.getInstance()
+
+    data class Result (
+        val element: RustNamedElement,
+        val pkg: CargoProjectDescription.Package
+    )
+
+    // TODO: Move to RustResolveEngine
+    fun resolve(pathStr: String, project: Project) : Result? {
+        val segments = pathStr.segments
+        if (segments.isEmpty()) return null
+        val pkg = project.getPackage(segments[0].name) ?: return null
+        val path = RustPath(RustPathHead.Absolute, segments.drop(1))
+        val el = pkg.targets
+            .mapNotNull { vfm.findFileByUrl(it.crateRootUrl) }
+            .mapNotNull { project.getPsiFor(it) as? RustCompositeElement }
+            .flatMap { RustResolveEngine.resolve(path, it) }
+            .mapNotNull { it as? RustNamedElement }
+            .firstOrNull() ?: return null
+
+        return Result(el, pkg)
+    }
+
+    private fun Project.getPackage(name: String): CargoProjectDescription.Package? =
+        modulesWithCargoProject
+            .mapNotNull { it.cargoProject }
+            .flatMap { it.packages }
+            .filter { it.isModule && it.name == name }
+            .firstOrNull()
+
+    private val String.segments: List<RustPathSegment>
+        get() = normalize()
+            .splitToSequence("::")
+            .filter { it != "{{closure}}" }
+            .map { RustPathSegment(it, emptyList()) }
+            .toList()
+
+    private fun String.normalize(): String = when (this) {        // TODO: Implement conversion. And move to RustPath?
+        "<core::option::Option<T>>::unwrap" -> "core::option::Option::unwrap"
+        "<core::result::Result<T, E>>::unwrap" -> "core::result::Result::unwrap"
+        else -> this
+    }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/RustBacktraceFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RustBacktraceFilter.kt
@@ -71,7 +71,7 @@ private class RustBacktraceItemFilter(
         val funcFile = func.element.containingFile
         val doc = docManager.getDocument(funcFile) ?: return null
         val link = OpenFileHyperlinkInfo(project, funcFile.virtualFile, doc.getLineNumber(func.element.textOffset))
-        val linkAttr = if (func.pkg.isExternal) GRAYED_LINK else null
+        val linkAttr = if (!func.pkg.isWorkspaceMember) GRAYED_LINK else null
         return Filter.ResultItem(start, end, link, linkAttr)
     }
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -113,7 +113,7 @@ object CargoMetadata {
         val packageIdToIndex = project.packages.mapIndexed { i, p -> p.id to i }.toMap()
         val fs = LocalFileSystem.getInstance()
         return CleanCargoMetadata(
-            project.packages.mapNotNull { it.clean(fs, it.id !in project.workspace_members) },
+            project.packages.mapNotNull { it.clean(fs, it.id in project.workspace_members) },
             project.resolve.nodes.map { node ->
                 CleanCargoMetadata.DependencyNode(
                     packageIdToIndex[node.id]!!,
@@ -123,7 +123,7 @@ object CargoMetadata {
         )
     }
 
-    private fun Package.clean(fs: LocalFileSystem, isExternal: Boolean): CleanCargoMetadata.Package? {
+    private fun Package.clean(fs: LocalFileSystem, isWorkspaceMember: Boolean): CleanCargoMetadata.Package? {
         val root = checkNotNull(fs.refreshAndFindFileByPath(PathUtil.getParentPath(manifest_path))) {
             "`cargo metadata` reported a package which does not exist at `$manifest_path`"
         }
@@ -133,7 +133,7 @@ object CargoMetadata {
             version,
             targets.mapNotNull { it.clean(root) },
             source,
-            isExternal
+            isWorkspaceMember
         )
     }
 
@@ -178,7 +178,7 @@ data class CleanCargoMetadata(
         val version: String,
         val targets: Collection<Target>,
         val source: String?,
-        val isExternal: Boolean
+        val isWorkspaceMember: Boolean
     )
 
     data class Target(

--- a/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
@@ -1,13 +1,10 @@
 package org.rust.ide.template.postfix
 
+import com.intellij.codeInsight.template.Template
+import com.intellij.codeInsight.template.impl.TextExpression
 import com.intellij.codeInsight.template.postfix.templates.StringBasedPostfixTemplate
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.*
-import com.intellij.codeInsight.template.Template
-import com.intellij.codeInsight.template.impl.TextExpression
-import org.rust.lang.core.psi.RustExprElement
-import org.rust.lang.core.psi.RustQualifiedNameOwner
-import org.rust.lang.core.psi.RustTupleFieldDeclElement
 import org.rust.lang.core.psi.util.descendentsOfType
 import org.rust.lang.core.psi.util.parentOfType
 import org.rust.lang.core.resolve.RustResolveEngine

--- a/src/main/kotlin/org/rust/lang/core/resolve/RustResolveEngine.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RustResolveEngine.kt
@@ -59,14 +59,13 @@ object RustResolveEngine {
         if (segments.isEmpty()) return null
         val pkg = project.getPackage(segments[0].name) ?: return null
         val vfm = VirtualFileManager.getInstance()
-        val rustPath = RustPath(RustPathHead.Absolute, segments.drop(1))
+        val rustPath = RustPath.CrateRelative(segments.drop(1))
         val el = pkg.targets.asSequence()
             .mapNotNull { vfm.findFileByUrl(it.crateRootUrl) }
             .mapNotNull { project.getPsiFor(it) as? RustCompositeElement }
             .flatMap { RustResolveEngine.resolve(rustPath, it).asSequence() }
             .filterIsInstance(RustNamedElement::class.java)
             .firstOrNull() ?: return null
-
         return Result(el, pkg)
     }
 
@@ -190,7 +189,7 @@ object RustResolveEngine {
         }
 
     private fun Project.getPackage(name: String): CargoProjectDescription.Package? =
-        modulesWithCargoProject
+        modules
             .mapNotNull { it.cargoProject }
             .flatMap { it.packages }
             .find { it.isModule && it.name == name }

--- a/src/main/kotlin/org/rust/lang/core/resolve/RustResolveEngine.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RustResolveEngine.kt
@@ -273,7 +273,7 @@ private class RustScopeVisitor(
 
     override fun visitStructItem(o: RustStructItemElement) = set {
         sequenceOf(
-            staticMethods(o),
+            methods(o),
 
             if (isContextLocalTo(o))
                 o.typeParams.scopeEntries
@@ -284,7 +284,7 @@ private class RustScopeVisitor(
 
     override fun visitEnumItem(o: RustEnumItemElement) = set {
         sequenceOf(
-            staticMethods(o),
+            methods(o),
 
             if (isContextLocalTo(o))
                 o.typeParams.scopeEntries
@@ -383,9 +383,9 @@ private class RustScopeVisitor(
 
     private fun isContextLocalTo(o: RustCompositeElement) = o.contains(context.pivot)
 
-    private fun staticMethods(o: RustTypeBearingItemElement): Sequence<ScopeEntry> =
+    private fun methods(o: RustTypeBearingItemElement): Sequence<ScopeEntry> =
         RustImplIndex
-            .findStaticMethodsFor(o.resolvedType, o.project)
+            .findMethodsFor(o.resolvedType, o.project)
             .scopeEntries
 
 }

--- a/src/main/resources/org/rust/ide/colors/RustDarcula.xml
+++ b/src/main/resources/org/rust/ide/colors/RustDarcula.xml
@@ -22,4 +22,9 @@
             <option name="EFFECT_TYPE" value="1" />
         </value>
     </option>
+    <option name="org.rust.DIMMED_TEXT">
+        <value>
+            <option name="FOREGROUND" value="606060" />
+        </value>
+    </option>
 </list>

--- a/src/main/resources/org/rust/ide/colors/RustDefault.xml
+++ b/src/main/resources/org/rust/ide/colors/RustDefault.xml
@@ -27,4 +27,9 @@
             <option name="FOREGROUND" value="404040"/>
         </value>
     </option>
+    <option name="org.rust.DIMMED_TEXT">
+        <value>
+            <option name="FOREGROUND" value="CBCBCB" />
+        </value>
+    </option>
 </list>

--- a/src/test/kotlin/org/rust/cargo/runconfig/HighlightFilterTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/HighlightFilterTestBase.kt
@@ -1,5 +1,6 @@
 package org.rust.cargo.runconfig
 
+import com.intellij.execution.filters.Filter
 import com.intellij.execution.filters.OpenFileHyperlinkInfo
 import com.intellij.openapi.vfs.VirtualFile
 import org.assertj.core.api.Assertions
@@ -18,7 +19,7 @@ abstract class HighlightFilterTestBase : RustTestCaseBase() {
         projectDir = createTestDirectoryAndFile()
     }
 
-    protected fun doTest(filter: RegexpFileLinkFilter, line: String, entireLength: Int, hStart: Int, hEnd: Int) {
+    protected fun doTest(filter: Filter, line: String, entireLength: Int, hStart: Int, hEnd: Int) {
         val result = checkNotNull(filter.applyFilter(line, entireLength)) {
             "No match in $line"
         }

--- a/src/test/kotlin/org/rust/cargo/runconfig/RustBacktraceFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/RustBacktraceFilterTest.kt
@@ -1,6 +1,7 @@
 package org.rust.cargo.runconfig
 
 import com.intellij.openapi.util.SystemInfo
+import org.rust.cargo.util.modules
 
 /**
  * Tests for RustBacktraceFilter
@@ -13,7 +14,8 @@ class RustBacktraceFilterTest : HighlightFilterTestBase() {
 
     override fun setUp() {
         super.setUp()
-        filter = RustBacktraceFilter(project, projectDir)
+        val module = checkNotNull(project.modules.firstOrNull())
+        filter = RustBacktraceFilter(project, projectDir, module)
     }
 
     fun testRustcSourceCodeLink() =

--- a/src/test/kotlin/org/rust/cargo/runconfig/RustBacktraceFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/RustBacktraceFilterTest.kt
@@ -7,6 +7,8 @@ import com.intellij.openapi.util.SystemInfo
  */
 class RustBacktraceFilterTest : HighlightFilterTestBase() {
 
+    override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
+
     private lateinit var filter: RustBacktraceFilter
 
     override fun setUp() {
@@ -27,6 +29,11 @@ class RustBacktraceFilterTest : HighlightFilterTestBase() {
         doTest(filter, text, text.length, 13, 47)
     }
 
+    fun testBacktraceLine() {
+        val line = "   7:     0x7feeefb7d11f - std::mem::drop::h93df64e7370b5253"
+        doTest(filter, line, line.length, 27, 41)
+    }
+
     fun testFullOutput() {
         val output = """    Running `target/debug/test`
 thread '<main>' panicked at 'called `Option::unwrap()` on a `None` value', ../src/libcore/option.rs:325
@@ -39,12 +46,14 @@ stack backtrace:
    6:     0x7feeefb480ee - rust_begin_unwind
    7:     0x7feeefb7d11f - core::panicking::panic_fmt::h93df64e7370b5253
    8:     0x7feeefb7d3f8 - core::panicking::panic::h9d5bd65bbb401959
-   9:     0x7feeefb3f765 - _<std..option..Option<T>>::unwrap::hbe9ea065746f6376
+   9:     0x7feeefb3f765 - <core::option::Option<T>>::unwrap::hbe9ea065746f6376
                         at ../src/libcore/macros.rs:21
   10:     0x7feeefb3f538 - btest::main::h888e623968051ab6
                         at src/main.rs:22"""
-        val line = output.split('\n')[14]
-        doTest(filter, line, output.length, 957, 968)
+
+        val items = output.split('\n')
+        //doTest(filter, items[13], output.length, 910, 939)
+        doTest(filter, items[14], output.length, 957, 968)
     }
 
 }

--- a/src/test/kotlin/org/rust/cargo/runconfig/RustBacktraceFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/RustBacktraceFilterTest.kt
@@ -16,26 +16,49 @@ class RustBacktraceFilterTest : HighlightFilterTestBase() {
         filter = RustBacktraceFilter(project, projectDir)
     }
 
-    fun testOneLine() {
-        val text = "          at src/main.rs:24"
-        doTest(filter, text, text.length, 13, 24)
-    }
+    fun testRustcSourceCodeLink() =
+        checkHighlights(filter,
+            "          at src/main.rs:24",
+            "          at [src/main.rs -> main.rs]:24")
 
-    fun testAbsolutePath() {
+    fun testRustcSourceCodeLinkWIthAbsolutePath() {
         // Windows does not handle abs paths on the tmpfs
         if (SystemInfo.isWindows) return
         val absPath = "${projectDir.canonicalPath}/src/main.rs"
-        val text = "          at $absPath:24"
-        doTest(filter, text, text.length, 13, 47)
+        checkHighlights(filter,
+            "          at $absPath:24",
+            "          at [$absPath -> main.rs]:24")
     }
 
-    fun testBacktraceLine() {
-        val line = "   7:     0x7feeefb7d11f - std::mem::drop::h93df64e7370b5253"
-        doTest(filter, line, line.length, 27, 41)
-    }
+    fun testBacktraceLine() =
+        checkHighlights(filter,
+            "   7:     0x7feeefb7d11f - std::io::Stdin::read_line::h93df64e7370b5253",
+            "   7:     0x7feeefb7d11f - [std::io::Stdin::read_line -> stdio.rs][::h93df64e7370b5253]")
 
-    fun testFullOutput() {
-        val output = """    Running `target/debug/test`
+    fun testBacktraceNoLinksToInternalCalls() =
+        checkHighlights(filter,
+            "  16:        0x106bfe616 - std::rt::lang_start::h538f8960e7644c80",
+            "  16:        0x106bfe616 - std::rt::lang_start[::h538f8960e7644c80]")
+
+    fun testBacktraceLineWithClosure() =
+        checkHighlights(filter,
+            " 103:     0x7feeefb480ee - std::io::Stdin::lock::{{closure}}::hbe9ea065746f6376",
+            " 103:     0x7feeefb480ee - [std::io::Stdin::lock::{{closure}} -> stdio.rs][::hbe9ea065746f6376]")
+
+    fun testBacktraceLineWithGenerics() =
+        checkHighlights(filter,
+            "  10:     0x70ae3fe9d6a3 - <core::option::Option<T>>::unwrap::h5dd7da6bb3d06020",
+            "  10:     0x70ae3fe9d6a3 - [<core::option::Option<T>>::unwrap -> option.rs][::h5dd7da6bb3d06020]")
+
+    fun testBacktraceNoLinksToUnknownFunctions() =
+        checkNoHighlights(filter, "  17:        0x106c24240 - foo::bar::unknown[::h5dd7da6bb3d06020]")
+
+    fun testBacktraceNotAppliedToInternalFunctions() =
+        checkNoHighlights(filter, "  19:        0x106bf9a49 - main")
+
+    fun testFullOutput() =
+        checkHighlights(filter,
+            """    Running `target/debug/test`
 thread '<main>' panicked at 'called `Option::unwrap()` on a `None` value', ../src/libcore/option.rs:325
 stack backtrace:
    1:     0x7feeefb45b1f - std::sys::backtrace::tracing::imp::write::h3800f45f421043b8
@@ -49,11 +72,7 @@ stack backtrace:
    9:     0x7feeefb3f765 - <core::option::Option<T>>::unwrap::hbe9ea065746f6376
                         at ../src/libcore/macros.rs:21
   10:     0x7feeefb3f538 - btest::main::h888e623968051ab6
-                        at src/main.rs:22"""
-
-        val items = output.split('\n')
-        //doTest(filter, items[13], output.length, 910, 939)
-        doTest(filter, items[14], output.length, 957, 968)
-    }
+                        at src/main.rs:22""",
+            "                        at [src/main.rs -> main.rs]:22", 14)
 
 }

--- a/src/test/kotlin/org/rust/cargo/runconfig/RustConsoleFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/RustConsoleFilterTest.kt
@@ -9,24 +9,21 @@ class RustConsoleFilterTest : HighlightFilterTestBase() {
         filter = RustConsoleFilter(project, projectDir)
     }
 
-    fun testTypeError() {
-        val error = "src/main.rs:4:5: 4:12 error: this function takes 0 parameters but 1 parameter was supplied [E0061]\n"
-        doTest(filter, error, error.length, 0, 11)
-    }
+    fun testTypeError() =
+        checkHighlights(filter,
+            "src/main.rs:4:5: 4:12 error: this function takes 0 parameters but 1 parameter was supplied [E0061]",
+            "[src/main.rs -> main.rs]:4:5: 4:12 error: this function takes 0 parameters but 1 parameter was supplied [E0061]")
 
-    fun testOffsetsForSeveralLines() {
-        val text = """/home/user/.multirust/toolchains/beta/bin/cargo run
+    fun testOffsetsForSeveralLines() =
+        checkHighlights(filter,
+            """/home/user/.multirust/toolchains/beta/bin/cargo run
    Compiling rustraytracer v0.1.0 (file:///home/user/projects/rustraytracer)
-src/main.rs:25:26: 25:40 error: no method named `read_to_string` found for type `core::result::Result<std::fs::File, std::io::error::Error>` in the current scope"""
-        val line = text.split('\n')[2]
-        doTest(filter, line, text.length, 129, 140)
-    }
+src/main.rs:25:26: 25:40 error: no method named `read_to_string` found for type `core::result::Result<std::fs::File, std::io::error::Error>` in the current scope""",
+            "[src/main.rs -> main.rs]:25:26: 25:40 error: no method named `read_to_string` found for type `core::result::Result<std::fs::File, std::io::error::Error>` in the current scope", 2)
 
-    fun testNewErrorFormat() {
-        val text = """error: the trait bound `std::string::String: std::ops::Index<_>` is not satisfied [--explain E0277]
- --> src/main.rs:4:5
- """
-        val line = text.split('\n')[1]
-        doTest(filter, line, text.length, 107, 118)
-    }
+    fun testNewErrorFormat() =
+        checkHighlights(filter,
+            """error: the trait bound `std::string::String: std::ops::Index<_>` is not satisfied [--explain E0277]
+ --> src/main.rs:4:5""",
+            " --> [src/main.rs -> main.rs]:4:5", 1)
 }

--- a/src/test/kotlin/org/rust/cargo/runconfig/RustPanicFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/RustPanicFilterTest.kt
@@ -12,19 +12,18 @@ class RustPanicFilterTest : HighlightFilterTestBase() {
         filter = RustPanicFilter(project, projectDir)
     }
 
-    fun testOneLine() {
-        val text = "thread 'main' panicked at 'something went wrong', src/main.rs:24"
-        doTest(filter, text, text.length, 50, 61)
-    }
+    fun testOneLine() =
+        checkHighlights(filter,
+            "thread 'main' panicked at 'something went wrong', src/main.rs:24",
+            "thread 'main' panicked at 'something went wrong', [src/main.rs -> main.rs]:24")
 
-    fun testFullOuput() {
-        val output = """/Users/user/.cargo/bin/cargo run
+    fun testFullOuput() =
+        checkHighlights(filter,
+            """/Users/user/.cargo/bin/cargo run
    Compiling first_rust v0.1.0 (file:///home/user/projects/panics)
     Finished debug [unoptimized + debuginfo] target(s) in 1.20 secs
      Running `target/debug/panics`
-thread 'main' panicked at 'something went wrong', src/main.rs:24"""
-        val line = output.split('\n')[4]
-        doTest(filter, line, output.length, 253, 264)
-    }
+thread 'main' panicked at 'something went wrong', src/main.rs:24""",
+            "thread 'main' panicked at 'something went wrong', [src/main.rs -> main.rs]:24", 4)
 
 }

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestCase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestCase.kt
@@ -305,7 +305,8 @@ class RunConfigurationProducerTestCase : RustTestCaseBase() {
                                     it.kind
                                 )
                             },
-                            source = null
+                            source = null,
+                            isExternal = false
                         )
                     ),
                     dependencies = emptyList()

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestCase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestCase.kt
@@ -306,7 +306,7 @@ class RunConfigurationProducerTestCase : RustTestCaseBase() {
                                 )
                             },
                             source = null,
-                            isExternal = false
+                            isWorkspaceMember = true
                         )
                     ),
                     dependencies = emptyList()

--- a/src/test/kotlin/org/rust/lang/RustTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/lang/RustTestCaseBase.kt
@@ -199,7 +199,8 @@ abstract class RustTestCaseBase : LightPlatformCodeInsightFixtureTestCase(), Rus
                 CleanCargoMetadata.Target("$contentRoot/main.rs", name, CargoProjectDescription.TargetKind.BIN),
                 CleanCargoMetadata.Target("$contentRoot/lib.rs", name, CargoProjectDescription.TargetKind.LIB)
             ),
-            source = null
+            source = null,
+            isExternal = false
         )
 
     }

--- a/src/test/kotlin/org/rust/lang/RustTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/lang/RustTestCaseBase.kt
@@ -200,7 +200,7 @@ abstract class RustTestCaseBase : LightPlatformCodeInsightFixtureTestCase(), Rus
                 CleanCargoMetadata.Target("$contentRoot/lib.rs", name, CargoProjectDescription.TargetKind.LIB)
             ),
             source = null,
-            isExternal = false
+            isWorkspaceMember = true
         )
 
     }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RustTypeAwareResolveTestCase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RustTypeAwareResolveTestCase.kt
@@ -221,9 +221,13 @@ class RustTypeAwareResolveTestCase : RustResolveTestCaseBase() {
         struct S;
 
         impl S { fn test(&self) { } }
+                    //X
 
-        fn main() { S::test(); }
-                      //^ unresolved
+        fn main() {
+            let s = S;
+            S::test(&s);
+               //^
+        }
     """)
 
     fun testHiddenInherentImpl() = checkByCode("""


### PR DESCRIPTION
Work is still in progress on this feature (#821), but it's already pretty functional.

I'm creating the PR to have an early feedback on the general approach and on some parts of the code related to elements resolving and working with cargo project metadata. Those of particular interest are marked with TODO's.

@matklad, could you, please, have a look at it?
