### PR TITLE
(COMPL): Add parentheses when autocomplete functions/methods

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RustCompletionEngine.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RustCompletionEngine.kt
@@ -85,6 +85,7 @@ fun RustCompositeElement.createLookupElement(scopeName: String): LookupElement {
             .withInsertHandler handler@ { context: InsertionContext, lookupElement: LookupElement ->
                 val element = context.file.findElementAt(context.startOffset - 1)!!
                 if (element.parentOfType<RustUseGlobListElement>() != null) return@handler
+                if (element.parentOfType<RustUseItemElement>() != null) return@handler
                 val argsCount = parameters?.parameterList?.size ?: 0
                 context.document.insertString(context.selectionEndOffset, "()")
                 EditorModificationUtil.moveCaretRelatively(context.editor, if (argsCount > 0) 1 else 2)

--- a/src/test/kotlin/org/rust/lang/core/completion/RustCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RustCompletionTest.kt
@@ -8,13 +8,13 @@ class RustCompletionTest : RustCompletionTestBase() {
         fn foo(quux: i32) { qu/*caret*/ }
     """)
 
-    fun testFunctionName() = checkSingleCompletion("frobnicate", """
+    fun testFunctionName() = checkSingleCompletion("frobnicate()", """
         fn frobnicate() {}
 
         fn main() { frob/*caret*/ }
     """)
 
-    fun testPath() = checkSingleCompletion("frobnicate", """
+    fun testPath() = checkSingleCompletion("foo::bar::frobnicate()", """
         mod foo {
             mod bar {
                 fn frobnicate() {}
@@ -28,7 +28,7 @@ class RustCompletionTest : RustCompletionTestBase() {
         }
     """)
 
-    fun testAnonymousItemDoesNotBreakCompletion() = checkSingleCompletion("frobnicate", """
+    fun testAnonymousItemDoesNotBreakCompletion() = checkSingleCompletion("frobnicate()", """
         extern "C" { }
 
         fn frobnicate() {}
@@ -48,7 +48,7 @@ class RustCompletionTest : RustCompletionTestBase() {
         fn main() {}
     """)
 
-    fun testWildcardImports() = checkSingleCompletion("transmogrify", """
+    fun testWildcardImports() = checkSingleCompletion("transmogrify()", """
         mod foo {
             fn transmogrify() {}
         }
@@ -68,7 +68,7 @@ class RustCompletionTest : RustCompletionTestBase() {
         }
     """)
 
-    fun testCompleteAlias() = checkSingleCompletion("frobnicate", """
+    fun testCompleteAlias() = checkSingleCompletion("frobnicate()", """
         mod m {
             pub fn transmogrify() {}
         }

--- a/src/test/kotlin/org/rust/lang/core/completion/RustCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RustCompletionTest.kt
@@ -48,6 +48,16 @@ class RustCompletionTest : RustCompletionTestBase() {
         fn main() {}
     """)
 
+    fun testUseItem() = checkSingleCompletion("quux", """
+        mod foo {
+            pub fn quux() {}
+        }
+
+        use self::foo::q/*caret*/;
+
+        fn main() {}
+    """)
+
     fun testWildcardImports() = checkSingleCompletion("transmogrify()", """
         mod foo {
             fn transmogrify() {}

--- a/src/test/kotlin/org/rust/lang/core/completion/RustCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RustCompletionTestBase.kt
@@ -16,9 +16,10 @@ abstract class RustCompletionTestBase : RustTestCaseBase() {
         check(variants == null) {
             "Expected a single completion, but got ${variants.size}\n" + "${variants.toList()}"
         }
+        val fnName = target.substringBeforeLast("()").substringAfterLast("::").substringAfterLast(".")
         val shift = if (target.endsWith("()")) 3 else 1
         val element = myFixture.file.findElementAt(myFixture.caretOffset - shift)!!
-        check(element.correspondsToText(target)) {
+        check(element.text == fnName && element.correspondsToText(target)) {
             "Wrong completion, expected `$target`, but got `${element.text}`"
         }
     }
@@ -43,12 +44,10 @@ abstract class RustCompletionTestBase : RustTestCaseBase() {
         }
     }
 
-    private fun PsiElement.correspondsToText(target: String): Boolean {
-        return when {
+    private fun PsiElement.correspondsToText(target: String): Boolean = when {
             text == target -> true
             text.length > target.length -> false
             parent != null -> parent.correspondsToText(target)
             else -> false
         }
-    }
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RustCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RustCompletionTestBase.kt
@@ -16,8 +16,7 @@ abstract class RustCompletionTestBase : RustTestCaseBase() {
         check(variants == null) {
             "Expected a single completion, but got ${variants.size}\n" + "${variants.toList()}"
         }
-        val parentheses = target.endsWith("()")
-        val shift = if (parentheses) 3 else 1
+        val shift = if (target.endsWith("()")) 3 else 1
         val element = myFixture.file.findElementAt(myFixture.caretOffset - shift)!!
         check(element.correspondsToText(target)) {
             "Wrong completion, expected `$target`, but got `${element.text}`"

--- a/src/test/kotlin/org/rust/lang/core/completion/RustStdlibCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RustStdlibCompletionTest.kt
@@ -7,7 +7,7 @@ class RustStdlibCompletionTest: RustCompletionTestBase() {
 
     override fun getProjectDescriptor(): LightProjectDescriptor = WithStdlibRustProjectDescriptor
 
-    fun testPrelude() = checkSingleCompletion("drop", """
+    fun testPrelude() = checkSingleCompletion("drop()", """
         fn main() {
             dr/*caret*/
         }

--- a/src/test/kotlin/org/rust/lang/core/completion/RustTypeAwareCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RustTypeAwareCompletionTest.kt
@@ -3,7 +3,7 @@ package org.rust.lang.core.completion
 class RustTypeAwareCompletionTest : RustCompletionTestBase() {
     override val dataPath = ""
 
-    fun testMethodCallExpr() = checkSingleCompletion("transmogrify", """
+    fun testMethodCallExpr() = checkSingleCompletion("S.transmogrify()", """
         struct S;
 
         impl S { fn transmogrify(&self) {} }
@@ -13,7 +13,7 @@ class RustTypeAwareCompletionTest : RustCompletionTestBase() {
         }
     """)
 
-    fun testMethodCallExprRef() = checkSingleCompletion("transmogrify", """
+    fun testMethodCallExprRef() = checkSingleCompletion("self.transmogrify()", """
         struct S;
 
         impl S {
@@ -25,7 +25,7 @@ class RustTypeAwareCompletionTest : RustCompletionTestBase() {
         }
     """)
 
-    fun testMethodCallExprEnum() = checkSingleCompletion("quux", """
+    fun testMethodCallExprEnum() = checkSingleCompletion("self.quux()", """
         enum E { X }
 
         impl E {
@@ -46,7 +46,7 @@ class RustTypeAwareCompletionTest : RustCompletionTestBase() {
         }
     """)
 
-    fun testStaticMethod() = checkSingleCompletion("create", """
+    fun testStaticMethod() = checkSingleCompletion("S::create()", """
         struct S;
 
         impl S {


### PR DESCRIPTION
Adds parentheses to functions/methods on autocompletion.

If the function has arguments, the cursor is positioned between parentheses, otherwise it moves after the closing parenthesis.

Parentheses are not added when the completion is performed within a `use` block.
