### PR TITLE
(MISC): Color customization terms cleanup

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RustHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RustHighlightingAnnotator.kt
@@ -97,14 +97,14 @@ class RustHighlightingAnnotator : Annotator {
         override fun visitExternCrateItem(o: RustExternCrateItemElement) = highlight(o.identifier, RustColor.CRATE)
 
         override fun visitMacroInvocation(m: RustMacroInvocationElement) = highlight(m, RustColor.MACRO)
-        override fun visitMethodCallExpr(o: RustMethodCallExprElement)   = highlight(o.identifier, RustColor.INSTANCE_METHOD)
-        override fun visitFnItem(o: RustFnItemElement)                   = highlight(o.identifier, RustColor.FUNCTION_DECLARATION)
+        override fun visitMethodCallExpr(o: RustMethodCallExprElement)   = highlight(o.identifier, RustColor.METHOD)
+        override fun visitFnItem(o: RustFnItemElement)                   = highlight(o.identifier, RustColor.FUNCTION)
         override fun visitTryExpr(o: RustTryExprElement)                 = highlight(o.q, RustColor.Q_OPERATOR)
 
         override fun visitImplMethodMember(o: RustImplMethodMemberElement) =
-            highlight(o.identifier, if (o.isStatic) RustColor.STATIC_METHOD else RustColor.INSTANCE_METHOD)
+            highlight(o.identifier, if (o.isStatic) RustColor.ASSOC_FUNCTION else RustColor.METHOD)
         override fun visitTraitMethodMember(o: RustTraitMethodMemberElement) =
-            highlight(o.identifier, if (o.isStatic) RustColor.STATIC_METHOD else RustColor.INSTANCE_METHOD)
+            highlight(o.identifier, if (o.isStatic) RustColor.ASSOC_FUNCTION else RustColor.METHOD)
 
         override fun visitSelfArgument(o: RustSelfArgumentElement) = highlight(o.self, RustColor.SELF_PARAMETER)
     }

--- a/src/main/kotlin/org/rust/ide/colors/RustColors.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RustColors.kt
@@ -9,10 +9,10 @@ import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Default
  */
 enum class RustColor(humanName: String, val default: TextAttributesKey) {
     IDENTIFIER            ("Identifier",                  Default.IDENTIFIER),
-    FUNCTION_DECLARATION  ("Function declaration",        Default.FUNCTION_DECLARATION),
-    INSTANCE_METHOD       ("Instance method declaration", Default.INSTANCE_METHOD),
-    STATIC_METHOD         ("Static method declaration",   Default.STATIC_METHOD),
-    PARAMETER             ("Function parameter",          Default.PARAMETER),
+    FUNCTION              ("Function",                    Default.FUNCTION_DECLARATION),
+    METHOD                ("Method",                      Default.INSTANCE_METHOD),
+    ASSOC_FUNCTION        ("Associated function",         Default.STATIC_METHOD),
+    PARAMETER             ("Parameter",                   Default.PARAMETER),
     SELF_PARAMETER        ("Self parameter",              Default.KEYWORD),
     Q_OPERATOR            ("? operator",                  Default.KEYWORD),
 
@@ -22,14 +22,14 @@ enum class RustColor(humanName: String, val default: TextAttributesKey) {
     STRING                ("String",                      Default.STRING),
     NUMBER                ("Number",                      Default.NUMBER),
 
-    PRIMITIVE_TYPE        ("Primitive Type",              Default.KEYWORD),
+    PRIMITIVE_TYPE        ("Primitive type",              Default.KEYWORD),
 
     CRATE                 ("Crate",                       Default.IDENTIFIER),
     STRUCT                ("Struct",                      Default.CLASS_NAME),
     TRAIT                 ("Trait",                       Default.INTERFACE_NAME),
     MODULE                ("Module",                      Default.IDENTIFIER),
     ENUM                  ("Enum",                        Default.CLASS_NAME),
-    ENUM_VARIANT          ("Enum Variant",                Default.STATIC_FIELD),
+    ENUM_VARIANT          ("Enum variant",                Default.STATIC_FIELD),
     TYPE_ALIAS            ("Type alias",                  Default.CLASS_NAME),
 
     FIELD                 ("Field",                       Default.INSTANCE_FIELD),
@@ -66,7 +66,7 @@ enum class RustColor(humanName: String, val default: TextAttributesKey) {
     INVALID_STRING_ESCAPE ("Invalid escape sequence",     Default.INVALID_STRING_ESCAPE),
     ;
 
-    val textAttributesKey = TextAttributesKey.createTextAttributesKey("org.rust.${this.name}", default)
+    val textAttributesKey = TextAttributesKey.createTextAttributesKey("org.rust.$name", default)
     val attributesDescriptor = AttributesDescriptor(humanName, textAttributesKey)
 }
 

--- a/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
+++ b/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
@@ -13,7 +13,7 @@ pub enum <ENUM>Flag</ENUM> {
 }
 
 pub trait <TRAIT>Write</TRAIT> {
-    fn <INSTANCE_METHOD>write</INSTANCE_METHOD>(&mut <SELF_PARAMETER>self</SELF_PARAMETER>, <PARAMETER>buf</PARAMETER>: &[<PRIMITIVE_TYPE>u8</PRIMITIVE_TYPE>]) -> <ENUM>Result</ENUM><usize>;
+    fn <METHOD>write</METHOD>(&mut <SELF_PARAMETER>self</SELF_PARAMETER>, <PARAMETER>buf</PARAMETER>: &[<PRIMITIVE_TYPE>u8</PRIMITIVE_TYPE>]) -> <ENUM>Result</ENUM><usize>;
 }
 
 struct <STRUCT>Object</STRUCT><<TYPE_PARAMETER>T</TYPE_PARAMETER>> {
@@ -24,24 +24,25 @@ struct <STRUCT>Object</STRUCT><<TYPE_PARAMETER>T</TYPE_PARAMETER>> {
 type <TYPE_ALIAS>RcObject</TYPE_ALIAS><<TYPE_PARAMETER>T</TYPE_PARAMETER>> = <STRUCT>Rc</STRUCT><<STRUCT>Object</STRUCT><<TYPE_PARAMETER>T</TYPE_PARAMETER>>>;
 
 impl<<TYPE_PARAMETER>T</TYPE_PARAMETER>> Write for <STRUCT>Object</STRUCT><<TYPE_PARAMETER>T</TYPE_PARAMETER>> {
-    fn <INSTANCE_METHOD>write</INSTANCE_METHOD>(&mut <SELF_PARAMETER>self</SELF_PARAMETER>, <PARAMETER>buf</PARAMETER>: &[<PRIMITIVE_TYPE>u8</PRIMITIVE_TYPE>]) -> <ENUM>Result</ENUM><usize> {
-        let s = stuff::<FUNCTION_DECLARATION>write_map</FUNCTION_DECLARATION>(&self.<FIELD>fields</FIELD>, <PARAMETER>buf</PARAMETER>)<Q_OPERATOR>?</Q_OPERATOR>;
+    fn <METHOD>write</METHOD>(&mut <SELF_PARAMETER>self</SELF_PARAMETER>, <PARAMETER>buf</PARAMETER>: &[<PRIMITIVE_TYPE>u8</PRIMITIVE_TYPE>]) -> <ENUM>Result</ENUM><usize> {
+        let s = stuff::<FUNCTION>write_map</FUNCTION>(&self.<FIELD>fields</FIELD>, <PARAMETER>buf</PARAMETER>)<Q_OPERATOR>?</Q_OPERATOR>;
         <MACRO>info!</MACRO>("{} byte(s) written", s);
         <ENUM_VARIANT>Ok</ENUM_VARIANT>(s)
     }
 }
 
 /* Block comment */
-fn <FUNCTION_DECLARATION>main</FUNCTION_DECLARATION>() {
+fn <FUNCTION>main</FUNCTION>() {
     // A simple integer calculator:
     // `+` or `-` means add or subtract by 1
     // `*` or `/` means multiply or divide by 2
+    <MODULE>stuff</MODULE>::<STRUCT>AppVersion</STRUCT>::<ASSOC_FUNCTION>print</ASSOC_FUNCTION>();
 
     let input = <ENUM>Option</ENUM>::<ENUM_VARIANT>None</ENUM_VARIANT>;
-    let program = input.<INSTANCE_METHOD>unwrap_or_else</INSTANCE_METHOD>(|| "+ + * - /");
+    let program = input.<METHOD>unwrap_or_else</METHOD>(|| "+ + * - /");
     let mut <MUT_BINDING>accumulator</MUT_BINDING> = 0;
 
-    for token in program.<INSTANCE_METHOD>chars</INSTANCE_METHOD>() {
+    for token in program.<METHOD>chars</METHOD>() {
         match token {
             '+' => <MUT_BINDING>accumulator</MUT_BINDING> += 1,
             '-' => <MUT_BINDING>accumulator</MUT_BINDING> -= 1,
@@ -59,7 +60,7 @@ fn <FUNCTION_DECLARATION>main</FUNCTION_DECLARATION>() {
 /// # Heading
 /// [Rust](https://www.rust-lang.org/)
 <ATTRIBUTE>#[cfg(target_os=</ATTRIBUTE>"linux"<ATTRIBUTE>)]</ATTRIBUTE>
-unsafe fn <FUNCTION_DECLARATION>a_function</FUNCTION_DECLARATION><<TYPE_PARAMETER>T</TYPE_PARAMETER>: <LIFETIME>'lifetime</LIFETIME>>() {
+unsafe fn <FUNCTION>a_function</FUNCTION><<TYPE_PARAMETER>T</TYPE_PARAMETER>: <LIFETIME>'lifetime</LIFETIME>>() {
     'label: loop {
         <MACRO>println!</MACRO>("Hello\x20W\u{f3}rld!\u{abcdef}");
     }


### PR DESCRIPTION
Brings element names that are used in the color customization panel into line with the Rust lingo (used in the official documentation). Also provides an example of an associated function call in the demo source code.

I would also rename some of the `RustColor` variant names accordingly, but that will reset colors for those users who have customized them and there're no simple way (at least, I didn't find it) to just copy values from the old settings. So, I'm not sure if it's ok to do so.