### PR TITLE
(PROJ): Introduce PackageOrigin

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/PackageOrigin.kt
+++ b/src/main/kotlin/org/rust/cargo/project/PackageOrigin.kt
@@ -1,0 +1,30 @@
+package org.rust.cargo.project
+
+/**
+ * Defines a reason a package is in a project.
+ */
+enum class PackageOrigin(private val level: Int) {
+    /**
+     * The package comes from the standard library.
+     */
+    STDLIB(0),
+
+    /**
+     * The package is a part of our workspace.
+     */
+    WORKSPACE(1),
+
+    /**
+     * The package is a dependency defined in Cargo.toml.
+     */
+    DEPENDENCY(2),
+
+    /**
+     * The package is a dependency of one of our dependencies.
+     */
+    TRANSITIVE_DEPENDENCY(3);
+
+    companion object {
+        fun min(o1: PackageOrigin, o2: PackageOrigin) = if (o1.level < o2.level) o1 else o2
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoProjectWorkspace.kt
@@ -2,10 +2,11 @@ package org.rust.cargo.project.workspace
 
 import com.intellij.execution.ExecutionException
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
 import org.jetbrains.annotations.TestOnly
 import org.rust.cargo.project.CargoProjectDescription
 import org.rust.cargo.toolchain.RustToolchain
-import org.rust.cargo.util.extendProjectDescriptionWithStandardLibraryCrates
+import org.rust.cargo.util.rustLibraryName
 
 /**
  * Cargo based project's workspace abstraction insulating inter-op with the `cargo` & `Cargo.toml`
@@ -54,5 +55,7 @@ interface CargoProjectWorkspace {
  */
 val Module.cargoProject: CargoProjectDescription?
     get() = CargoProjectWorkspace.forModule(this).projectDescription?.let {
-        extendProjectDescriptionWithStandardLibraryCrates(it)
+        val lib = LibraryTablesRegistrar.getInstance().getLibraryTable(project).getLibraryByName(rustLibraryName)
+            ?: return it
+        return it.withStdlib(lib)
     }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceImpl.kt
@@ -24,6 +24,7 @@ import com.intellij.util.PathUtil
 import org.jetbrains.annotations.TestOnly
 import org.rust.cargo.CargoConstants
 import org.rust.cargo.project.CargoProjectDescription
+import org.rust.cargo.project.PackageOrigin
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.CargoProjectWorkspace
@@ -137,7 +138,7 @@ class CargoProjectWorkspaceImpl(private val module: Module) : CargoProjectWorksp
 
     private fun updateModuleDependencies(projectDescription: CargoProjectDescription) {
         val libraryRoots = projectDescription.packages
-            .filter { !it.isWorkspaceMember }
+            .filter { it.origin != PackageOrigin.WORKSPACE }
             .mapNotNull { it.contentRoot }
 
         module.updateLibrary(module.cargoLibraryName, libraryRoots)

--- a/src/main/kotlin/org/rust/cargo/runconfig/RustBacktraceFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RustBacktraceFilter.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiDocumentManager
+import org.rust.cargo.project.PackageOrigin
 import org.rust.lang.core.resolve.RustResolveEngine
 import java.awt.Color
 import java.awt.Font
@@ -74,7 +75,7 @@ private class RustBacktraceItemFilter(
         val funcFile = func.element.containingFile
         val doc = docManager.getDocument(funcFile) ?: return null
         val link = OpenFileHyperlinkInfo(project, funcFile.virtualFile, doc.getLineNumber(func.element.textOffset))
-        val linkAttr = if (!func.pkg.isWorkspaceMember) GRAYED_LINK else null
+        val linkAttr = if (func.pkg.origin != PackageOrigin.WORKSPACE) GRAYED_LINK else null
         return Filter.ResultItem(start, end, link, linkAttr)
     }
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -165,7 +165,7 @@ object CargoMetadata {
  */
 data class CleanCargoMetadata(
     val packages: List<Package>,
-    val dependencies: Collection<DependencyNode>
+    val dependencies: List<DependencyNode>
 ) {
     data class DependencyNode(
         val packageIndex: Int,

--- a/src/main/kotlin/org/rust/cargo/util/ModuleUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/ModuleUtil.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.project.CargoProjectDescription
+import org.rust.cargo.project.PackageOrigin
 import org.rust.ide.utils.checkWriteAccessAllowed
 
 /**
@@ -69,7 +70,7 @@ fun Module.extendProjectDescriptionWithStandardLibraryCrates(projectDescription:
         }
     }
 
-    return projectDescription.withAdditionalPackages(stdlibPackages)
+    return projectDescription.withAdditionalPackages(stdlibPackages, PackageOrigin.STDLIB)
 }
 
 /**

--- a/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
@@ -3,14 +3,13 @@ package org.rust.cargo.util
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.PsiFile
-import org.rust.cargo.project.workspace.cargoProject
 import org.rust.cargo.toolchain.RustToolchain
 
 
 object AutoInjectedCrates {
     const val std: String = "std"
     const val core: String = "core"
+    val stdlibCrateNames = listOf(std, core, "collections", "alloc", "rustc_unicode", "std_unicode")
 }
 
 /**


### PR DESCRIPTION
`Package.isWorkspaceMember` is substituted for `Package.origin`, which allows to make distinction between stdandard libraries, workspace packages, direct dependencies and transitive dependencies.

I've also removed `Package.dependencies` since it has always been empty and none used it.