### PR TITLE
(COMPL): Keywords completion improvement

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RustKeywordCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RustKeywordCompletionProvider.kt
@@ -26,6 +26,6 @@ class RustKeywordCompletionProvider(
     }
 
     private companion object {
-        val ADD_SPACE = listOf("enum", "extern crate", "let", "mod", "struct", "trait", "type", "use")
+        val ADD_SPACE = listOf("crate", "enum", "extern", "fn", "impl", "let", "mod", "mut", "pub", "struct", "trait", "type", "unsafe", "use")
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RustCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RustCompletionTestBase.kt
@@ -1,6 +1,7 @@
 package org.rust.lang.core.completion
 
 import com.intellij.psi.PsiElement
+import junit.framework.TestCase
 import org.intellij.lang.annotations.Language
 import org.rust.lang.RustTestCaseBase
 
@@ -31,6 +32,16 @@ abstract class RustCompletionTestBase : RustTestCaseBase() {
         check((skipTextCheck || element.text == normName) && (element.fitsHierarchically(target) || element.fitsLinearly(target))) {
             "Wrong completion, expected `$target`, but got `${element.text}`"
         }
+    }
+
+    protected fun checkContainsCompletion(text: String, @Language("Rust") code: String) {
+        InlineFile(code).withCaret()
+        val variants = myFixture.completeBasic()
+        checkNotNull(variants) {
+            "Expected completions that contain $text, but no completions found"
+        }
+        variants.filter { it.lookupString == text }.forEach { return }
+        error("Expected completions that contain $text, but got ${variants.toList()}")
     }
 
     protected fun checkNoCompletion(@Language("Rust") code: String) {

--- a/src/test/kotlin/org/rust/lang/core/completion/RustKeywordCompletionContributorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RustKeywordCompletionContributorTest.kt
@@ -9,9 +9,38 @@ class RustKeywordCompletionContributorTest : RustCompletionTestBase() {
 
     fun testEnumAtTheFileVeryBeginning() = checkSingleCompletion("enum", "enu/*caret*/")
 
+    fun testPubEnum() = checkSingleCompletion("enum", """
+        pub enu/*caret*/
+    """)
+
     fun testEnumWithinMod() = checkSingleCompletion("enum", """
         mod foo {
             en/*caret*/
+        }
+    """)
+
+    fun testEnumWithinFn() = checkSingleCompletion("enum", """
+        fn foo() {
+            en/*caret*/
+        }
+    """)
+
+    fun testEnumWithinFnNestedBlock() = checkSingleCompletion("enum", """
+        fn foo() {{
+            en/*caret*/
+        }}
+    """)
+
+    fun testEnumWithinFnAfterOtherStmt() = checkSingleCompletion("enum", """
+        fn foo() {
+            let _ = 10;
+            en/*caret*/
+        }
+    """)
+
+    fun testEnumNotAppliedIfDoesntStartStmtWithinFn() = checkNoCompletion("""
+        fn foo() {
+            let en/*caret*/
         }
     """)
 
@@ -21,12 +50,52 @@ class RustKeywordCompletionContributorTest : RustCompletionTestBase() {
         }
     """)
 
-    fun testEnumNotAppliedIfDoesntStartExpression() = checkNoCompletion("""
+    fun testEnumNotAppliedIfDoesntStartStmt() = checkNoCompletion("""
         mod en/*caret*/
     """)
 
-    fun testExternCrate() = checkSingleCompletion("extern crate", """
-        exte/*caret*/
+    fun testExtern() = checkSingleCompletion("extern", """
+        ext/*caret*/
+    """)
+
+    fun testPubExtern() = checkSingleCompletion("extern", """
+        pub ext/*caret*/
+    """)
+
+    fun testUnsafeExtern() = checkSingleCompletion("extern", """
+        unsafe ext/*caret*/
+    """)
+
+    fun testPubUnsafeExtern() = checkSingleCompletion("extern", """
+        pub unsafe ext/*caret*/
+    """)
+
+    fun testExternCrate() = checkSingleCompletion("crate", """
+        extern cr/*caret*/
+    """)
+
+    fun testFn() = checkContainsCompletion("fn", """
+        f/*caret*/
+    """)
+
+    fun testPubFn() = checkContainsCompletion("fn", """
+        pub f/*caret*/
+    """)
+
+    fun testExternFn() = checkSingleCompletion("fn", """
+        extern f/*caret*/
+    """)
+
+    fun testUnsafeFn() = checkSingleCompletion("fn", """
+        unsafe f/*caret*/
+    """)
+
+    fun testImpl() = checkSingleCompletion("impl", """
+        imp/*caret*/
+    """)
+
+    fun testUnsafeImpl() = checkSingleCompletion("impl", """
+        unsafe im/*caret*/
     """)
 
     fun testLetWithinFn() = checkSingleCompletion("let", """
@@ -39,7 +108,7 @@ class RustKeywordCompletionContributorTest : RustCompletionTestBase() {
     fun testLetWithinAssocFn() = checkSingleCompletion("let", """
         struct Foo;
         impl Foo {
-            fn shutdown() { l/*caret*/ }
+            fn shutdown() { le/*caret*/ }
         }
     """)
 
@@ -47,6 +116,28 @@ class RustKeywordCompletionContributorTest : RustCompletionTestBase() {
         struct Foo;
         impl Foo {
             fn calc(&self) { le/*caret*/ }
+        }
+    """)
+
+    fun testLetNotAppliedWithinNestedMod() = checkNoCompletion("""
+        fn foo() {
+            mod bar {
+                le/*caret*/
+            }
+        }
+    """)
+
+    fun testMod() = checkSingleCompletion("mod", """
+        mo/*caret*/
+    """)
+
+    fun testPubMod() = checkSingleCompletion("mod", """
+        pub mo/*caret*/
+    """)
+
+    fun testMut() = checkSingleCompletion("mut", """
+        fn main() {
+            let m/*caret*/
         }
     """)
 
@@ -90,15 +181,43 @@ class RustKeywordCompletionContributorTest : RustCompletionTestBase() {
         str/*caret*/
     """)
 
+    fun testPubStruct() = checkSingleCompletion("struct", """
+        pub str/*caret*/
+    """)
+
     fun testTrait() = checkSingleCompletion("trait", """
         tra/*caret*/
+    """)
+
+    fun testPubTrait() = checkSingleCompletion("trait", """
+        pub tra/*caret*/
+    """)
+
+    fun testUnsafeTrait() = checkSingleCompletion("trait", """
+        unsafe tra/*caret*/
     """)
 
     fun testType() = checkSingleCompletion("type", """
         typ/*caret*/
     """)
 
+    fun testPubType() = checkSingleCompletion("type", """
+        pub typ/*caret*/
+    """)
+
+    fun testUnsafe() = checkSingleCompletion("unsafe", """
+        uns/*caret*/
+    """)
+
+    fun testPubUnsafe() = checkSingleCompletion("unsafe", """
+        pub unsa/*caret*/
+    """)
+
     fun testUse() = checkSingleCompletion("use", """
         us/*caret*/
+    """)
+
+    fun testPubUse() = checkSingleCompletion("use", """
+        pub us/*caret*/
     """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RustPsiPatternTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RustPsiPatternTest.kt
@@ -1,7 +1,6 @@
 package org.rust.lang.core.completion
 
 import com.intellij.patterns.ElementPattern
-import com.intellij.patterns.PatternCondition
 import com.intellij.psi.PsiElement
 import org.intellij.lang.annotations.Language
 import org.rust.lang.RustTestCaseBase
@@ -170,37 +169,37 @@ class RustPsiPatternTest : RustTestCaseBase() {
 
     fun testOnStmtBeginning() = testPattern("""
         //^
-    """, RustPsiPattern.OnStatementBeginning())
+    """, RustPsiPattern.onStatementBeginning)
 
     fun testOnStmtBeginningWithinMod() = testPattern("""
         mod foo {    }
                 //^
-    """, RustPsiPattern.OnStatementBeginning())
+    """, RustPsiPattern.onStatementBeginning)
 
     fun testOnStmtBeginningAfterOtherStmt() = testPattern("""
         extern crate foo;
                        //^
-    """, RustPsiPattern.OnStatementBeginning())
+    """, RustPsiPattern.onStatementBeginning)
 
     fun testOnStmtBeginningAfterBlock() = testPattern("""
         mod foo {}
                 //^
-    """, RustPsiPattern.OnStatementBeginning())
+    """, RustPsiPattern.onStatementBeginning)
 
     fun testOnStmtBeginningIgnoresComments() = testPattern("""
         const A: u8 = 3; /* three */    /* it's greater than two */
                                     //^
-    """, RustPsiPattern.OnStatementBeginning())
+    """, RustPsiPattern.onStatementBeginning)
 
     fun testOnStmtBeginningNegativeWhenFollowsVisible() = testPatternNegative("""
         abc
           //^
-    """, RustPsiPattern.OnStatementBeginning())
+    """, RustPsiPattern.onStatementBeginning)
 
     fun testOnStmtBeginningNegativeInMiddleOfOtherStmt() = testPatternNegative("""
         mod abc {}
              //^
-    """, RustPsiPattern.OnStatementBeginning())
+    """, RustPsiPattern.onStatementBeginning)
 
     private fun <T> testPattern(@Language("Rust") code: String, pattern: ElementPattern<T>) {
         InlineFile(code)
@@ -208,13 +207,7 @@ class RustPsiPatternTest : RustTestCaseBase() {
         assertTrue(pattern.accepts(element))
     }
 
-    private fun testPattern(@Language("Rust") code: String, pattern: PatternCondition<PsiElement>) {
-        InlineFile(code)
-        val element = findElementInEditor<PsiElement>()
-        assertTrue(pattern.accepts(element, null))
-    }
-
-    private fun testPatternNegative(@Language("Rust") code: String, pattern: PatternCondition<PsiElement>) {
+    private fun <T> testPatternNegative(@Language("Rust") code: String, pattern: ElementPattern<T>) {
         InlineFile(code)
         val element = findElementInEditor<PsiElement>()
         assertFalse(pattern.accepts(element, null))


### PR DESCRIPTION
1. New keywords added: `crate`, `extern`, `fn`, `impl`, `mod`, `mut`, `pub`, `unsafe`, `use`.
2. Each part of a keywords phrase is now completed separately. For instance, the phrase `pub unsafe fn` completes word by word, each completion variant depends on the preceding keyword.
3. Many keywords (`enum`, `struct`, `use` etc) are now also completed within functions/methods.
