### PR TITLE
(COMPL): Fix keywords completion

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/RustPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RustPsiPattern.kt
@@ -100,10 +100,11 @@ object RustPsiPattern {
     private class OnStatementBeginning(vararg startWords: String) : PatternCondition<PsiElement>("on statement beginning") {
         val myStartWords = startWords
         override fun accepts(t: PsiElement, context: ProcessingContext?): Boolean {
-            val prev = t.prevVisibleOrNewLine ?: return true
-            if (prev is PsiWhiteSpace) return true
-            return myStartWords.isEmpty() && prev.node.elementType in STATEMENT_BOUNDARIES
-                || myStartWords.isNotEmpty() && prev.node.text in myStartWords
+            val prev = t.prevVisibleOrNewLine
+            return if (myStartWords.isEmpty())
+                prev == null || prev is PsiWhiteSpace || prev.node.elementType in STATEMENT_BOUNDARIES
+            else
+                prev != null && prev.node.text in myStartWords
         }
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RustKeywordCompletionContributorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RustKeywordCompletionContributorTest.kt
@@ -144,6 +144,12 @@ class RustKeywordCompletionContributorTest : RustCompletionTestBase() {
         extern cr/*caret*/
     """)
 
+    fun testCrateNotAppliedAtFileBeginning() = checkNoCompletion("crat/*caret*/")
+
+    fun testCrateNotAppliedWithoutPrefix() = checkNoCompletion("""
+        crat/*caret*/
+    """)
+
     fun testFn() = checkContainsCompletion("fn", """
         f/*caret*/
     """)

--- a/src/test/kotlin/org/rust/lang/core/completion/RustPsiPatternTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RustPsiPatternTest.kt
@@ -201,6 +201,18 @@ class RustPsiPatternTest : RustTestCaseBase() {
              //^
     """, RustPsiPattern.onStatementBeginning)
 
+    fun testOnStmtBeginningWithWords() = testPattern("""
+        word2
+            //^
+    """, RustPsiPattern.onStatementBeginning("word1", "word2"))
+
+    fun testOnStmtBeginningWithWordsNegativeWhenWordDoesntFit() = testPatternNegative("""
+        word3
+            //^
+    """, RustPsiPattern.onStatementBeginning("word1", "word2"))
+
+    fun testOnStmtBeginningWithWordsNegativeAtVeryBeginning() = testPatternNegative("   \n//^", RustPsiPattern.onStatementBeginning("word1"))
+
     fun testInAnyLoopWithinFor() = testPattern("""
         fn foo() {
             for _ in 1..5 { }


### PR DESCRIPTION
I've fixed a couple of corner cases in keywords completion when they depend on other preceding keywords.