### PR TITLE
(COMPL): Complete self and super after use

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RustKeywordCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RustKeywordCompletionContributor.kt
@@ -29,6 +29,8 @@ class RustKeywordCompletionContributor : CompletionContributor(), DumbAware {
             RustKeywordCompletionProvider("crate", "fn"))
         extend(CompletionType.BASIC, unsafeDeclarationPattern(),
             RustKeywordCompletionProvider("fn", "impl", "trait", "extern"))
+        extend(CompletionType.BASIC, usePattern(),
+            RustKeywordCompletionProvider("self", "super"))
         extend(CompletionType.BASIC, newCodeStatementPattern(),
             RustKeywordCompletionProvider("return", "let"))
         extend(CompletionType.BASIC, letPattern(),
@@ -45,6 +47,9 @@ class RustKeywordCompletionContributor : CompletionContributor(), DumbAware {
 
     private fun externDeclarationPattern(): PsiElementPattern.Capture<PsiElement> =
         baseDeclarationPattern().and(statementBeginningPattern("extern"))
+
+    private fun usePattern(): PsiElementPattern.Capture<PsiElement> =
+        baseDeclarationPattern().and(statementBeginningPattern("use"))
 
     private fun unsafeDeclarationPattern(): PsiElementPattern.Capture<PsiElement> =
         baseDeclarationPattern().and(statementBeginningPattern("unsafe"))

--- a/src/test/kotlin/org/rust/lang/core/completion/RustKeywordCompletionContributorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RustKeywordCompletionContributorTest.kt
@@ -312,4 +312,12 @@ class RustKeywordCompletionContributorTest : RustCompletionTestBase() {
     fun testPubUse() = checkSingleCompletion("use", """
         pub us/*caret*/
     """)
+
+    fun testUseSelf() = checkSingleCompletion("self::", """
+        use se/*caret*/
+    """)
+
+    fun testUseSuper() = checkSingleCompletion("super::", """
+        use su/*caret*/
+    """)
 }


### PR DESCRIPTION
Autocomplete `self::` and `super::` after `use`.