### PR TITLE
(COMPL): Extern crates completion fix

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/CargoProjectDescription.kt
+++ b/src/main/kotlin/org/rust/cargo/project/CargoProjectDescription.kt
@@ -27,9 +27,6 @@ class CargoProjectDescription private constructor(
         val source: String?,
         val origin: PackageOrigin
     ) {
-        // crate name must be a valid Rust identifier, so normalize it by mapping `-` to `_`
-        // https://github.com/rust-lang/cargo/blob/ece4e963a3054cdd078a46449ef0270b88f74d45/src/cargo/core/manifest.rs#L299
-        val normName = name.replace('-', '_')
         val libTarget: Target? get() = targets.find { it.isLib }
         val contentRoot: VirtualFile? get() = VirtualFileManager.getInstance().findFileByUrl(contentRootUrl)
 
@@ -44,6 +41,8 @@ class CargoProjectDescription private constructor(
         val name: String,
         val kind: TargetKind
     ) {
+        // target name must be a valid Rust identifier, so normalize it by mapping `-` to `_`
+        // https://github.com/rust-lang/cargo/blob/ece4e963a3054cdd078a46449ef0270b88f74d45/src/cargo/core/manifest.rs#L299
         val normName = name.replace('-', '_')
         val isLib: Boolean get() = kind == TargetKind.LIB
         val isBin: Boolean get() = kind == TargetKind.BIN

--- a/src/main/kotlin/org/rust/lang/core/completion/RustCompletionEngine.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RustCompletionEngine.kt
@@ -65,6 +65,7 @@ object RustCompletionEngine {
     fun completeExternCrate(extCrate: RustExternCrateItemElement): Array<out LookupElement> =
         extCrate.module?.cargoProject?.packages
             ?.filter { it.origin == PackageOrigin.DEPENDENCY }
+            ?.mapNotNull { it.libTarget }
             ?.map { LookupElementBuilder.create(extCrate, it.normName).withIcon(extCrate.getIcon(0)) }
             ?.toTypedArray() ?: emptyArray()
 }

--- a/src/test/kotlin/org/rust/lang/RustTestCaseBase.kt
+++ b/src/test/kotlin/org/rust/lang/RustTestCaseBase.kt
@@ -220,12 +220,12 @@ abstract class RustTestCaseBase : LightPlatformCodeInsightFixtureTestCase(), Rus
             isWorkspaceMember = true
         )
 
-        protected fun externalPackage(name: String) = CleanCargoMetadata.Package(
+        protected fun externalPackage(name: String, targetName: String = name) = CleanCargoMetadata.Package(
             "",
             name = name,
             version = "0.0.1",
             targets = listOf(
-                CleanCargoMetadata.Target("", name, CargoProjectDescription.TargetKind.LIB)
+                CleanCargoMetadata.Target("", targetName, CargoProjectDescription.TargetKind.LIB)
             ),
             source = null,
             isWorkspaceMember = false
@@ -254,7 +254,7 @@ abstract class RustTestCaseBase : LightPlatformCodeInsightFixtureTestCase(), Rus
 
             val packages = listOf(
                 testCargoPackage(contentRoot),
-                externalPackage("dep-lib"),
+                externalPackage("dep-lib", "dep-lib-target"),
                 externalPackage("trans-lib"))
 
             val depNodes = ArrayList<CleanCargoMetadata.DependencyNode>()

--- a/src/test/kotlin/org/rust/lang/core/completion/RustExternCrateCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RustExternCrateCompletionTest.kt
@@ -7,7 +7,7 @@ class RustExternCrateCompletionTest : RustCompletionTestBase() {
     override val dataPath = ""
     override fun getProjectDescriptor(): LightProjectDescriptor = WithStdlibAndDependencyRustProjectDescriptor
 
-    fun testExternCrate() = checkSingleCompletion("dep_lib", """
+    fun testExternCrate() = checkSingleCompletion("dep_lib_target", """
         extern crate dep_l/*caret*/
     """)
 


### PR DESCRIPTION
Use target with `kind = LIB` in autocompletion instead of the package name.
Fixes #903