### PR TITLE
(ANNOT): Detect type param names duplication

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RustErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RustErrorAnnotator.kt
@@ -23,6 +23,7 @@ class RustErrorAnnotator : Annotator {
             override fun visitConstant(o: RustConstantElement) = checkConstant(holder, o)
             override fun visitEnumBody(o: RustEnumBodyElement) = checkEnumBody(holder, o)
             override fun visitForeignModItem(o: RustForeignModItemElement) = checkForeignModItem(holder, o)
+            override fun visitGenericParams(o: RustGenericParamsElement) = checkGenericParams(holder, o)
             override fun visitImplItem(o: RustImplItemElement) = checkImpl(holder, o)
             override fun visitModDeclItem(o: RustModDeclItemElement) = checkModDecl(holder, o)
             override fun visitModItem(o: RustModItemElement) = checkModItem(holder, o)
@@ -124,6 +125,11 @@ class RustErrorAnnotator : Annotator {
     private fun checkForeignModItem(holder: AnnotationHolder, mod: RustForeignModItemElement) =
         findDuplicates(holder, mod, { ns, name ->
             "A ${ns.itemName} named `$name` has already been defined in this module [E0428]"
+        })
+
+    private fun checkGenericParams(holder: AnnotationHolder, params: RustGenericParamsElement) =
+        findDuplicates(holder, params, { ns, name ->
+            "The name `$name` is already used for a type parameter in this type parameter list [E0403]"
         })
 
     private fun checkImpl(holder: AnnotationHolder, impl: RustImplItemElement) {

--- a/src/test/kotlin/org/rust/ide/annotator/RustErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RustErrorAnnotatorTest.kt
@@ -253,6 +253,20 @@ class RustErrorAnnotatorTest: RustAnnotatorTestBase() {
         }
     """)
 
+    fun testE0403_NameDuplicationInGenericParams() = checkErrors("""
+        fn sub<T, P>() {}
+        struct Str<T, P> { t: T, p: P }
+        impl<T, P> Str<T, P> {}
+        enum Direction<T, P> { LEFT(T), RIGHT(P) }
+        trait Trait<T, P> {}
+
+        fn add<T,   <error descr="The name `T` is already used for a type parameter in this type parameter list [E0403]">T</error>, P>() {}
+        struct S<T, <error descr="The name `T` is already used for a type parameter in this type parameter list [E0403]">T</error>, P> { t: T, p: P }
+        impl<T,     <error descr="The name `T` is already used for a type parameter in this type parameter list [E0403]">T</error>, P> S<T, P> {}
+        enum En<T,  <error descr="The name `T` is already used for a type parameter in this type parameter list [E0403]">T</error>, P> { LEFT(T), RIGHT(P) }
+        trait Tr<T, <error descr="The name `T` is already used for a type parameter in this type parameter list [E0403]">T</error>, P> { fn foo(t: T) -> P; }
+    """)
+
     fun testE0407_UnknownMethodInTraitImpl() = checkErrors("""
         trait T {
             fn foo();


### PR DESCRIPTION
Annotation to highlight the E0403 error &mdash; duplication of type parameter names.
Part of #886 