### PR TITLE
(GRAM): Unify functions grammar

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -77,7 +77,7 @@
     ]
 
     elementType("(Fn|Anon|Lambda|Path)Parameter") = ValueParameter
-    elementType("(Fn|Lambda|Path|FnType|ForeignFn|Method|MethodDecl)Parameters") = ValueParameterList
+    elementType("(Fn|Lambda|Path|FnType|ForeignFn)Parameters") = ValueParameterList
 
     extends(".+Expr") = Expr
     elementType(".+BinExpr") = BinaryExpr
@@ -238,7 +238,7 @@ fake ValueParameter ::= Pat? Type? {
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
-FnParameter ::= Pat TypeAscription
+FnParameter ::= [ Pat ':' ] Type
 LambdaParameter ::= Pat TypeAscription?
 AnonParameter ::= [ RestrictedPat ':' ] Type
 PathParameter ::= Type !'='
@@ -256,19 +256,14 @@ fake ValueParameterList ::= SelfParameter? ValueParameter* '...'? {
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
-FnParameters          ::= '(' !',' [ <<comma_separated_list FnParameter>> ] ')' { pin = 1 }
+FnParameters          ::= '(' !',' [ SelfParameter (',' | &')') ] [ <<comma_separated_list FnParameter>> ] ')' { pin = 1 }
 LambdaParameters      ::= '|' !',' [ <<comma_separated_list LambdaParameter>> ] '|'
-
-MethodParameters      ::= <<method_params_impl FnParameter>>
-MethodDeclParameters  ::= <<method_params_impl AnonParameter>>
 
 ForeignFnParameters   ::= <<variadic_params_impl FnParameter>>
 FnTypeParameters      ::= <<variadic_params_impl AnonParameter>>
 PathParameters        ::= '(' [ <<comma_separated_list PathParameter>> ] ')' { pin = 1 }
 
 private meta variadic_params_impl ::= '(' [ <<param>> (',' <<param>>)*  [ ',' '...'? ] ] ')' { pin = 1 }
-private meta method_params_impl ::= '(' ( SelfParameter [ ',' [ <<comma_separated_list <<param>>>> ] ]
-                                        | [ <<comma_separated_list <<param>>>> ] ) ')' { pin = 1 }
 
 private RestrictedPat ::= &( [ mut | '&' '&'? ] ( identifier | '_' ) ) Pat
 
@@ -336,23 +331,7 @@ ForeignFnDecl ::=
 }
 
 FnItem ::=
-  OuterAttr*           Vis? FnAttrs FnHeader FnParameters FnTail InnerAttrsAndBlock
-{
-  pin = FnHeader
-  hooks = [ leftBinder = "DOC_COMMENT_BINDER" ]
-  elementType = Function
-}
-
-TraitMethodMember ::=
-  OuterAttr*                FnAttrs FnHeader MethodDeclParameters FnTail (';' | InnerAttrsAndBlock)
-{
-  pin = FnHeader
-  hooks = [ leftBinder = "DOC_COMMENT_BINDER" ]
-  elementType = Function
-}
-
-ImplMethodMember ::=
-  OuterAttr* default_? Vis? FnAttrs FnHeader MethodParameters FnTail InnerAttrsAndBlock
+  OuterAttr* default_? Vis? FnAttrs FnHeader FnParameters FnTail (';' | InnerAttrsAndBlock)
 {
   pin = FnHeader
   hooks = [ leftBinder = "DOC_COMMENT_BINDER" ]
@@ -624,7 +603,7 @@ TraitItem ::= AttrsAndVis unsafe? trait identifier TypeParameterList? TypeParamB
 
 private TraitBody ::= '{' TraitMember* '}' { pin = 1 }
 
-private TraitMember ::= !'}' ( Constant | TypeAlias | TraitMethodMember ) {
+private TraitMember ::= !'}' ( Constant | TypeAlias | FnItem ) {
   pin = 1
   recoverWhile = TraitMember_recover
 }
@@ -653,7 +632,7 @@ private TypeTraitImpl ::= Type WhereClause? ImplBody { pin = 1 }
 
 private ImplBody ::= '{' InnerAttr* ImplMember* '}' { pin = 1 }
 
-private ImplMember ::= !'}' ( ImplMethodMember | Constant | ImplMacroMember | TypeAlias ) {
+private ImplMember ::= !'}' ( FnItem | Constant | ImplMacroMember | TypeAlias ) {
   pin = 1
   recoverWhile = ImplMember_recover
 }

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -24,7 +24,7 @@ class RsErrorAnnotator : Annotator {
             override fun visitStructItem(o: RsStructItem) = checkStructItem(holder, o)
             override fun visitEnumBody(o: RsEnumBody) = checkEnumBody(holder, o)
             override fun visitForeignModItem(o: RsForeignModItem) = checkForeignModItem(holder, o)
-            override fun visitTypeParameterList(o: RsTypeParameterList) = checkTypeParameterList(holder, o)
+            override fun visitFunction(o: RsFunction) = checkFunction(holder, o)
             override fun visitImplItem(o: RsImplItem) = checkImpl(holder, o)
             override fun visitModDeclItem(o: RsModDeclItem) = checkModDecl(holder, o)
             override fun visitModItem(o: RsModItem) = checkModItem(holder, o)
@@ -32,6 +32,9 @@ class RsErrorAnnotator : Annotator {
             override fun visitBlockFields(o: RsBlockFields) = checkBlockFields(holder, o)
             override fun visitTraitItem(o: RsTraitItem) = checkTraitItem(holder, o)
             override fun visitTypeAlias(o: RsTypeAlias) = checkTypeAlias(holder, o)
+            override fun visitTypeParameterList(o: RsTypeParameterList) = checkTypeParameterList(holder, o)
+            override fun visitValueParameterList(o: RsValueParameterList) = checkValueParameterList(holder, o)
+            override fun visitValueParameter(o: RsValueParameter) = checkValueParameter(holder, o)
             override fun visitVis(o: RsVis) = checkVis(holder, o)
         }
 
@@ -87,6 +90,46 @@ class RsErrorAnnotator : Annotator {
                     ?: require(const.mut, holder, "Non mutable static constants are not allowed in extern blocks", const.static, const.identifier)
                 deny(const.expr, holder, "Static constants in extern blocks cannot have values", const.eq, const.expr)
             }
+        }
+    }
+
+    private fun checkValueParameter(holder: AnnotationHolder, param: RsValueParameter) {
+        val fn = param.parent.parent as? RsFunction ?: return
+        when (fn.role) {
+            RsFunctionRole.FREE, RsFunctionRole.IMPL_METHOD -> {
+                require(param.pat, holder, "${fn.title} cannot have anonymous parameters", param)
+            }
+            RsFunctionRole.TRAIT_METHOD -> {
+                denyType<RsPatTup>(param.pat, holder, "${fn.title} cannot have tuple parameters", param)
+            }
+            RsFunctionRole.FOREIGN -> {}
+        }
+    }
+
+    private fun checkValueParameterList(holder: AnnotationHolder, params: RsValueParameterList) {
+        val fn = params.parent as? RsFunction ?: return
+        if (fn.role == RsFunctionRole.FREE) {
+            deny(params.selfParameter, holder, "${fn.title} cannot have `self` parameter")
+        }
+    }
+
+    private fun checkFunction(holder: AnnotationHolder, fn: RsFunction) {
+        when (fn.role) {
+            RsFunctionRole.FREE -> {
+                require(fn.block, holder, "${fn.title} must have a body", fn.lastChild)
+                deny(fn.default, holder, "${fn.title} cannot have the `default` qualifier")
+            }
+            RsFunctionRole.TRAIT_METHOD -> {
+                deny(fn.default, holder, "${fn.title} cannot have the `default` qualifier")
+                deny(fn.vis, holder, "${fn.title} cannot have the `pub` qualifier")
+            }
+            RsFunctionRole.IMPL_METHOD -> {
+                require(fn.block, holder, "${fn.title} must have a body", fn.lastChild)
+                if (fn.default != null) {
+                    deny(fn.vis, holder, "Default ${fn.title.firstLower} cannot have the `pub` qualifier")
+                }
+            }
+            RsFunctionRole.FOREIGN -> {}
         }
     }
 
@@ -238,6 +281,9 @@ class RsErrorAnnotator : Annotator {
     private fun deny(el: PsiElement?, holder: AnnotationHolder, message: String, vararg highlightElements: PsiElement?): Annotation? =
         if (el == null) null else holder.createErrorAnnotation(highlightElements.combinedRange ?: el.textRange, message)
 
+    private inline fun <reified T: RsCompositeElement>denyType(el: PsiElement?, holder: AnnotationHolder, message: String, vararg highlightElements: PsiElement?): Annotation? =
+        if (el !is T) null else holder.createErrorAnnotation(highlightElements.combinedRange ?: el.textRange, message)
+
     private fun isInTraitImpl(o: RsVis): Boolean {
         val impl = o.parent?.parent
         return impl is RsImplItem && impl.traitRef != null
@@ -267,6 +313,9 @@ class RsErrorAnnotator : Annotator {
             }
     }
 
+    private fun pluralise(count: Int, singular: String, plural: String): String =
+        if (count == 1) singular else plural
+
     private val Array<out PsiElement?>.combinedRange: TextRange?
         get() = if (isEmpty())
             null
@@ -290,6 +339,6 @@ class RsErrorAnnotator : Annotator {
     private val RsNamedElement.namespaced: Sequence<Pair<Namespace, RsNamedElement>>
         get() = namespaces.asSequence().map { Pair(it, this) }
 
-    private fun pluralise(count: Int, singular: String, plural: String): String =
-        if (count == 1) singular else plural
+    private val String.firstLower: String
+        get() = if (isEmpty()) this else this[0].toLowerCase() + substring(1)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RsFunctionImplMixin.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RsFunctionImplMixin.kt
@@ -1,12 +1,13 @@
 package org.rust.lang.core.psi.impl.mixin
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
 import org.rust.ide.icons.addTestMark
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.impl.RustPsiImplUtil
 import org.rust.lang.core.psi.impl.RsStubbedNamedElementImpl
+import org.rust.lang.core.psi.impl.RustPsiImplUtil
 import org.rust.lang.core.psi.util.parentOfType
 import org.rust.lang.core.psi.util.trait
 import org.rust.lang.core.stubs.RsFunctionStub
@@ -76,3 +77,15 @@ val RsFunction.valueParameters: List<RsValueParameter>
 
 val RsFunction.selfParameter: RsSelfParameter?
     get() = valueParameterList?.selfParameter
+
+val RsFunction.default: PsiElement?
+    get() = node.findChildByType(RsElementTypes.DEFAULT)?.psi
+
+val RsFunction.title: String
+    get() = when (role) {
+        RsFunctionRole.TRAIT_METHOD ->
+            if (selfParameter == null) "Trait function `$name`" else "Trait method `$name`"
+        RsFunctionRole.IMPL_METHOD ->
+            if (selfParameter == null) "Associated function `$name`" else "Method `$name`"
+        else -> "Function `$name`"
+    }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -76,6 +76,83 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
         }
     """)
 
+    fun testFunction() = checkErrors("""
+        #[inline]
+        pub fn full<'a, T>(id: u32, name: &'a str, data: &T, _: &mut FnMut(Display)) -> Option<u32> where T: Sized {
+            #![cold]
+            None
+        }
+
+        <error descr="Function `foo_default` cannot have the `default` qualifier">default</error> fn foo_default(f: u32) {}
+        fn ref_self(<error descr="Function `ref_self` cannot have `self` parameter">&mut self</error>, f: u32) {}
+        fn no_body()<error descr="Function `no_body` must have a body">;</error>
+        fn anon_param(<error descr="Function `anon_param` cannot have anonymous parameters">u8</error>, a: i16) {}
+    """)
+
+    fun testImplAssocFunction() = checkErrors("""
+        struct Person<D> { data: D }
+
+        impl<D> Person<D> {
+            #[inline]
+            pub fn new<'a>(id: u32, name: &'a str, data: D, _: bool) -> Person<D> where D: Sized {
+                #![cold]
+                Person { data: data }
+            }
+            default fn def() {}
+
+            default <error descr="Default associated function `def_pub` cannot have the `pub` qualifier">pub</error> fn def_pub() {}
+            fn no_body()<error descr="Associated function `no_body` must have a body">;</error>
+            fn anon_param(<error descr="Associated function `anon_param` cannot have anonymous parameters">u8</error>, a: i16) {}
+        }
+    """)
+
+    fun testImplMethod() = checkErrors("""
+        struct Person<D> { data: D }
+
+        impl<D> Person<D> {
+            #[inline]
+            pub fn check<'a>(&self, s: &'a str) -> bool where D: Sized {
+                #![cold]
+                false
+            }
+            default fn def(&self) {}
+
+            default <error descr="Default method `def_pub` cannot have the `pub` qualifier">pub</error> fn def_pub(&self) {}
+            fn no_body(&self)<error descr="Method `no_body` must have a body">;</error>
+            fn anon_param(&self, <error descr="Method `anon_param` cannot have anonymous parameters">u8</error>, a: i16) {}
+        }
+    """)
+
+    fun testTraitAssocFunction() = checkErrors("""
+        trait Animal<T> {
+            #[inline]
+            fn feed<'a>(food: T, d: &'a str, _: bool, f32) -> Option<f64> where T: Sized {
+                #![cold]
+                None
+            }
+            fn no_body();
+
+            <error descr="Trait function `default_foo` cannot have the `default` qualifier">default</error> fn default_foo();
+            <error descr="Trait function `pub_foo` cannot have the `pub` qualifier">pub</error> fn pub_foo();
+            fn tup_param(<error descr="Trait function `tup_param` cannot have tuple parameters">(x, y): (u8, u8)</error>, a: bool);
+        }
+    """)
+
+    fun testTraitMethod() = checkErrors("""
+        trait Animal<T> {
+            #[inline]
+            fn feed<'a>(&mut self, food: T, d: &'a str, _: bool, f32) -> Option<f64> where T: Sized {
+                #![cold]
+                None
+            }
+            fn no_body(self);
+
+            <error descr="Trait method `default_foo` cannot have the `default` qualifier">default</error> fn default_foo(&self);
+            <error descr="Trait method `pub_foo` cannot have the `pub` qualifier">pub</error> fn pub_foo(&mut self);
+            fn tup_param(&self, <error descr="Trait method `tup_param` cannot have tuple parameters">(x, y): (u8, u8)</error>, a: bool);
+        }
+    """)
+
     fun testUnionTuple() = checkErrors("""
         union U<error descr="Union cannot be tuple-like">(i32, f32)</error>;
     """)

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/partial/fn.txt
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/partial/fn.txt
@@ -35,7 +35,7 @@ FILE
           RsPathImpl(PATH)
             PsiElement(identifier)('i32')
       PsiElement(,)(',')
-      PsiErrorElement:')' or <pat> expected, got ','
+      PsiErrorElement:')' or <fn parameter> expected, got ','
         <empty list>
   PsiElement(,)(',')
   PsiElement(DUMMY_BLOCK)


### PR DESCRIPTION
I'd like to commit this part of the functions grammar unification (#864) to make it survive the next wave of the renaming armageddon :)

Free functions, impl and trait functions/methods are unified along with their parameters.

Foreign functions will be the next step.