### PR TITLE
(GRAM): struct / enum variant fields decl grammar unification

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -525,13 +525,14 @@ EnumVariant ::= OuterAttr* identifier VariantArgs? {
 
 private VariantArgs ::= BlockFields | TupleFields | VariantDiscriminant
 
-BlockFields ::= '{' <<field_with_recover FieldDecl>>* '}' {
+BlockFields ::= '{' FieldDecl_with_recover* '}' {
   pin = 1
   extends = "org.rust.lang.core.psi.impl.RsStubbedElementImpl.WithParent<?>"
   stubClass = "org.rust.lang.core.stubs.RsPlaceholderStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
-TupleFields ::= '(' <<comma_separated_list TupleFieldDecl >> ')' { pin = 1 }
+
+TupleFields ::= '(' <<comma_separated_list TupleFieldDecl>> ')' { pin = 1 }
 
 VariantDiscriminant ::= '=' AnyExpr { pin = 1 }
 
@@ -555,12 +556,11 @@ TupleFieldDecl ::= AttrsAndVis Type {
   hooks = [ leftBinder = "DOC_COMMENT_BINDER" ]
 }
 
-private meta field_with_recover ::= !'}' <<param>> (',' | &'}') {
+private FieldDecl_with_recover ::= !'}' FieldDecl (',' | &'}') {
   pin = 1
   recoverWhile = Field_recover
 }
 private Field_recover ::= !('}' | '#' | pub | identifier)
-
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Trait

--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -525,12 +525,13 @@ EnumVariant ::= OuterAttr* identifier VariantArgs? {
 
 private VariantArgs ::= BlockFields | TupleFields | VariantDiscriminant
 
-BlockFields ::= <<mk_block_fileds FieldDecl>> {
+BlockFields ::= '{' <<field_with_recover FieldDecl>>* '}' {
+  pin = 1
   extends = "org.rust.lang.core.psi.impl.RsStubbedElementImpl.WithParent<?>"
   stubClass = "org.rust.lang.core.stubs.RsPlaceholderStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
-TupleFields ::= <<mk_tuple_fields TupleFieldDecl>>
+TupleFields ::= '(' <<comma_separated_list TupleFieldDecl >> ')' { pin = 1 }
 
 VariantDiscriminant ::= '=' AnyExpr { pin = 1 }
 
@@ -554,14 +555,11 @@ TupleFieldDecl ::= AttrsAndVis Type {
   hooks = [ leftBinder = "DOC_COMMENT_BINDER" ]
 }
 
-private meta mk_block_fileds ::= '{' <<field_with_recover <<param>> >>* '}' { pin = 1}
 private meta field_with_recover ::= !'}' <<param>> (',' | &'}') {
   pin = 1
   recoverWhile = Field_recover
 }
 private Field_recover ::= !('}' | '#' | pub | identifier)
-
-private meta mk_tuple_fields ::= '(' <<comma_separated_list <<param>> >> ')' { pin = 1}
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -523,7 +523,7 @@ EnumVariant ::= OuterAttr* identifier VariantArgs? {
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
-private VariantArgs ::= VariantBlockFields | VariantTupleFields | VariantDiscriminant
+private VariantArgs ::= BlockFields | TupleFields | VariantDiscriminant
 
 BlockFields ::= <<mk_block_fileds FieldDecl>> {
   extends = "org.rust.lang.core.psi.impl.RsStubbedElementImpl.WithParent<?>"
@@ -531,9 +531,6 @@ BlockFields ::= <<mk_block_fileds FieldDecl>> {
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 TupleFields ::= <<mk_tuple_fields TupleFieldDecl>>
-
-VariantBlockFields ::= <<mk_block_fileds VariantFieldDecl>> { elementType = BlockFields }
-VariantTupleFields ::= <<mk_tuple_fields VariantTupleFieldDecl>> { elementType = TupleFields }
 
 VariantDiscriminant ::= '=' AnyExpr { pin = 1 }
 
@@ -548,12 +545,6 @@ FieldDecl ::= AttrsAndVis identifier TypeAscription {
   stubClass = "org.rust.lang.core.stubs.RsFieldDeclStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
-// unlike structs, enum variants can't have `pub` visibility applied to fields
-VariantFieldDecl ::= OuterAttr* identifier TypeAscription {
-  pin = 2
-  hooks = [ leftBinder = "DOC_COMMENT_BINDER" ]
-  elementType = FieldDecl
-}
 
 TupleFieldDecl ::= AttrsAndVis Type {
   implements = [ "org.rust.lang.core.psi.RsOuterAttributeOwner"
@@ -561,10 +552,6 @@ TupleFieldDecl ::= AttrsAndVis Type {
                  "org.rust.lang.core.psi.RsTupleOrStructFieldDeclElement" ]
   mixin = "org.rust.lang.core.psi.impl.mixin.RsTupleFieldDeclImplMixin"
   hooks = [ leftBinder = "DOC_COMMENT_BINDER" ]
-}
-VariantTupleFieldDecl ::= OuterAttr* Type {
-  hooks = [ leftBinder = "DOC_COMMENT_BINDER" ]
-  elementType = TupleFieldDecl
 }
 
 private meta mk_block_fileds ::= '{' <<field_with_recover <<param>> >>* '}' { pin = 1}

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -65,7 +65,7 @@ class RsErrorAnnotator : Annotator, HighlightRangeExtension {
     }
 
     private fun checkVis(holder: AnnotationHolder, vis: RsVis) {
-        if (vis.parent is RsImplItem || vis.parent is RsForeignModItem || isInTraitImpl(vis)) {
+        if (vis.parent is RsImplItem || vis.parent is RsForeignModItem || isInTraitImpl(vis) || isInEnumVariantField(vis) ) {
             holder.createErrorAnnotation(vis, "Unnecessary visibility qualifier [E0449]")
         }
     }
@@ -324,6 +324,13 @@ class RsErrorAnnotator : Annotator, HighlightRangeExtension {
     private fun isInTraitImpl(o: RsVis): Boolean {
         val impl = o.parent?.parent
         return impl is RsImplItem && impl.traitRef != null
+    }
+
+    private fun isInEnumVariantField(o: RsVis): Boolean {
+        val field = o.parent as? RsFieldDecl
+                    ?: o.parent as? RsTupleFieldDecl
+                    ?: return false
+        return field.parent.parent is RsEnumVariant
     }
 
     private fun findDuplicates(holder: AnnotationHolder, owner: RsCompositeElement, messageGenerator: (ns: Namespace, name: String) -> String) {

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -534,8 +534,22 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
     fun testE0449_UnnecessaryPub() = checkErrors("""
         <error descr="Unnecessary visibility qualifier [E0449]">pub</error> extern "C" { }
 
-        pub struct S;
-        <error descr="Unnecessary visibility qualifier [E0449]">pub</error> impl S {}
+        pub struct S {
+            foo: bool,
+            pub bar: u8,
+            pub baz: (u32, f64)
+        }
+        <error>pub</error> impl S {}
+
+        struct STuple (pub u32, f64);
+
+        pub enum E {
+            FOO {
+                bar: u32,
+                <error>pub</error> baz: u32
+            },
+            BAR(<error>pub</error> u32, f64)
+        }
 
         pub trait Foo {
             type A;
@@ -543,10 +557,10 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
             const C: u32;
         }
         struct Bar;
-        <error descr="Unnecessary visibility qualifier [E0449]">pub</error> impl Foo for Bar {
-            <error descr="Unnecessary visibility qualifier [E0449]">pub</error> type A = u32;
-            <error descr="Unnecessary visibility qualifier [E0449]">pub</error> fn b() {}
-            <error descr="Unnecessary visibility qualifier [E0449]">pub</error> const C: u32 = 10;
+        <error>pub</error> impl Foo for Bar {
+            <error>pub</error> type A = u32;
+            <error>pub</error> fn b() {}
+            <error>pub</error> const C: u32 = 10;
         }
     """)
 


### PR DESCRIPTION
One more grammar rules unification from #864: this one is for struct / enum variant field declarations, including tuple-like.