### PR TITLE
(COMPL): Derive completion improvement

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/AttributeCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/AttributeCompletionProvider.kt
@@ -43,7 +43,7 @@ object AttributeCompletionProvider : CompletionProvider<CompletionParameters>() 
         onStaticMut to "thread_local",
         onExternBlock to "link_args link() linked_from",
         onExternBlockDecl to "link_name linkage",
-        onStruct to "repr unsafe_no_drop_flags derive",
+        onStruct to "repr unsafe_no_drop_flags derive()",
         onEnum to "repr derive()",
         onTrait to "rustc_on_unimplemented",
         onMacro to "macro_export",

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
@@ -9,7 +9,7 @@ import org.rust.lang.core.psi.util.elementType
 class RsCompletionContributor : CompletionContributor() {
 
     init {
-        extend(CompletionType.BASIC, DeriveCompletionProvider.elementPattern, DeriveCompletionProvider)
+        extend(CompletionType.BASIC, RsDeriveCompletionProvider.elementPattern, RsDeriveCompletionProvider)
         extend(CompletionType.BASIC, AttributeCompletionProvider.elementPattern, AttributeCompletionProvider)
     }
 

--- a/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt
@@ -5,17 +5,16 @@ import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.patterns.ElementPattern
-import com.intellij.patterns.ElementPatternCondition
 import com.intellij.patterns.PatternCondition
 import com.intellij.patterns.PlatformPatterns.psiElement
 import com.intellij.psi.PsiElement
 import com.intellij.util.ProcessingContext
 import org.rust.lang.RsLanguage
-import org.rust.lang.core.psi.RsOuterAttr
 import org.rust.lang.core.psi.RsElementTypes.*
+import org.rust.lang.core.psi.RsOuterAttr
 import org.rust.lang.core.psi.util.parentOfType
 
-object DeriveCompletionProvider : CompletionProvider<CompletionParameters>() {
+object RsDeriveCompletionProvider : CompletionProvider<CompletionParameters>() {
 
     private val DERIVABLE_TRAITS = listOf(
         "Eq", "PartialEq",
@@ -23,7 +22,8 @@ object DeriveCompletionProvider : CompletionProvider<CompletionParameters>() {
         "Copy", "Clone",
         "Hash",
         "Default",
-        "Debug"
+        "Debug",
+        "RustcEncodable", "RustcDecodable"
     )
 
     override fun addCompletions(parameters: CompletionParameters,
@@ -60,25 +60,4 @@ object DeriveCompletionProvider : CompletionProvider<CompletionParameters>() {
             .inside(traitMetaItem)
             .withLanguage(RsLanguage)
     }
-}
-
-fun ElementPattern<PsiElement>.trace(id: String): ElementPattern<PsiElement> {
-    return Pat(this, id)
-}
-
-class Pat(val p: ElementPattern<PsiElement>, val id: String) : ElementPattern<PsiElement> {
-    override fun accepts(o: Any?, context: ProcessingContext?): Boolean {
-        val result = p.accepts(o, context)
-        println("$id for ${(o as PsiElement).text} = $result")
-        return result
-    }
-
-    override fun getCondition(): ElementPatternCondition<PsiElement> {
-        return p.condition
-    }
-
-    override fun accepts(o: Any?): Boolean {
-        return p.accepts(o)
-    }
-
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProviderTest.kt
@@ -1,6 +1,6 @@
 package org.rust.lang.core.completion
 
-class RsDeriveCompletionTest : RsCompletionTestBase() {
+class RsDeriveCompletionProviderTest : RsCompletionTestBase() {
     override val dataPath = ""
 
     fun testCompleteOnStruct() = checkSingleCompletion("PartialEq", """


### PR DESCRIPTION
Minor `derive` attribute completion improvements:

- Complete `derive` with parentheses on `struct`s
- Complete [RustcEncodable](https://doc.rust-lang.org/rustc-serialize/rustc_serialize/trait.Encodable.html) and [RustcDecodable](https://doc.rust-lang.org/rustc-serialize/rustc_serialize/trait.Decodable.html) derivables
- Debug code removed
- `DeriveCompletionProvider` and its test class renamed to get in line with other classes and to make navigation easier