### PR TITLE
(INSP): Fix self convention inspection for `into_`

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsSelfConventionInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSelfConventionInspection.kt
@@ -54,7 +54,7 @@ private val RsFunction.selfType: SelfType get() {
     val self = selfParameter
     return when {
         self == null -> SelfType.NO_SELF
-        self.isMut -> SelfType.REF_MUT_SELF
+        self.isRef && self.isMut -> SelfType.REF_MUT_SELF
         self.isRef -> SelfType.REF_SELF
         else -> SelfType.SELF
     }

--- a/src/test/kotlin/org/rust/ide/inspections/RsSelfConventionInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSelfConventionInspectionTest.kt
@@ -17,6 +17,7 @@ class RsSelfConventionInspectionTest : RsInspectionsTestBase() {
         struct Foo;
         impl Foo {
             fn into_u32(self) -> u32 { 0 }
+            fn into_u32_mut(mut self) -> u32 { 0 }
             fn into_u16(<warning descr="methods called `into_*` usually take self by value; consider choosing a less ambiguous name">&self</warning>) -> u16 { 0 }
             fn <warning descr="methods called `into_*` usually take self by value; consider choosing a less ambiguous name">into_without_self</warning>() -> u16 { 0 }
         }


### PR DESCRIPTION
Makes the Self Convention Inspection handle `mut self` correctly for the `into_*` case, the same way as Clippy works.
Fixes #950.