### PR TITLE
(RES): Resolve conflicts between inherent / trait functions

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ResolveEngine.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ResolveEngine.kt
@@ -36,7 +36,7 @@ object ResolveEngine {
      * Resolves abstract qualified-path [path] in such a way, like it was a qualified-reference
      * used at [pivot]
      */
-    fun resolve(path: RustPath, pivot: RsCompositeElement, namespace: Namespace? = null): List<RsCompositeElement> {
+    fun resolve(path: RustPath, pivot: RsCompositeElement, namespace: Namespace? = null, single: Boolean = true): List<RsCompositeElement> {
         val start: Sequence<ScopeEntry> = when (path) {
             is RustPath.CrateRelative -> sequenceOfNotNull(
                 pivot.crateRoot?.let { ScopeEntry.of(it) }
@@ -72,7 +72,7 @@ object ResolveEngine {
             current = scope.filter { it.name == name }
         }
 
-        val filteredByNs = if (namespace == null) current else current.filterByNamespace(namespace).take(1)
+        val filteredByNs = if (namespace == null) current else current.filterByNamespace(namespace).take(if (single) 1 else Int.MAX_VALUE)
         return filteredByNs
             .mapNotNull { it.element }
             .toList()
@@ -128,26 +128,22 @@ object ResolveEngine {
         return emptyList()
     }
 
+    fun resolveCallExpr(path: RustPath, element: RsPath, namespace: Namespace?): List<RsCompositeElement> {
+        val fn = resolve(path, element, namespace, false).asSequence()
+            .filterIsInstance<RsNamedElement>()
+            .chooseMajor()
+        return if (fn == null) emptyList() else listOf(fn)
+    }
+
     /**
      * Resolves method-call expressions
      */
     fun resolveMethodCallExpr(call: RsMethodCallExpr): RsNamedElement? {
         val receiverType = call.expr.type
         val name = call.identifier.text
-        var method: RsFunction? = null
-
-        receiverType.getMethodsIn(call.project)
+        return receiverType.getMethodsIn(call.project)
             .filter { it.name == name }
-            .forEach {
-                (it.parent as? RsImplItem)?.let {impl ->
-                    if (impl.traitRef == null) return it
-                }
-                if (method == null) {
-                    method = it
-                }
-            }
-
-        return method
+            .chooseMajor()
     }
 
     fun resolveUseGlob(ref: RsUseGlob): List<RsCompositeElement> = recursionGuard(ref, Computable {
@@ -220,6 +216,19 @@ object ResolveEngine {
         get() = splitToSequence("::")
             .map { RustPathSegment(it, emptyList()) }
             .toList()
+
+    /**
+     * Chooses the major element from the given sequence of candidates. For instance,
+     * a function/method from inherent implementation takes precedence over trait implementations.
+     */
+    private fun Sequence<RsNamedElement>.chooseMajor(): RsNamedElement? =
+        partition { it.isInherent }.let {
+            when {
+                it.first.isNotEmpty() -> it.first[0]
+                it.second.isNotEmpty() -> it.second[0]
+                else -> null
+            }
+        }
 }
 
 /**
@@ -522,6 +531,9 @@ private fun <T> Sequence<T>.takeWhileInclusive(pred: (T) -> Boolean): Sequence<T
 
 private fun PsiElement.isStrictAncestorOf(child: PsiElement) =
     PsiTreeUtil.isAncestor(this, child, true)
+
+private val RsCompositeElement.isInherent: Boolean
+    get() = (parent as? RsImplItem)?.let { return@let if (it.traitRef == null) it else null } != null
 
 /**
  * Helper to debug complex iterator pipelines

--- a/src/main/kotlin/org/rust/lang/core/resolve/ResolveEngine.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ResolveEngine.kt
@@ -134,9 +134,20 @@ object ResolveEngine {
     fun resolveMethodCallExpr(call: RsMethodCallExpr): RsNamedElement? {
         val receiverType = call.expr.type
         val name = call.identifier.text
+        var method: RsFunction? = null
 
-        return receiverType.getMethodsIn(call.project)
-            .find { it.name == name }
+        receiverType.getMethodsIn(call.project)
+            .filter { it.name == name }
+            .forEach {
+                (it.parent as? RsImplItem)?.let {impl ->
+                    if (impl.traitRef == null) return it
+                }
+                if (method == null) {
+                    method = it
+                }
+            }
+
+        return method
     }
 
     fun resolveUseGlob(ref: RsUseGlob): List<RsCompositeElement> = recursionGuard(ref, Computable {

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -18,7 +18,11 @@ class RsPathReferenceImpl(
 
     override fun resolveInner(): List<RsCompositeElement> {
         val path = element.asRustPath ?: return emptyList()
-        return ResolveEngine.resolve(path, element, namespaceForResolve)
+        val parent = element.parent.parent
+        return when (parent) {
+            is RsCallExpr -> ResolveEngine.resolveCallExpr(path, element, namespaceForResolve)
+            else -> ResolveEngine.resolve(path, element, namespaceForResolve)
+        }
     }
 
     override fun getVariants(): Array<out Any> =

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -7,29 +7,37 @@ import org.rust.cargo.toolchain.impl.CleanCargoMetadata
 
 class RsPackageLibraryResolveTest : RsResolveTestBase() {
 
-    fun testLibraryAsCrate() = stubOnlyResolve("""
-    //- main.rs
-        extern crate my_lib;
+    fun testLibraryAsCrate() {
+        if (is2016_1()) return
 
-        fn main() {
-            my_lib::hello();
-        }         //^ lib.rs
+        stubOnlyResolve("""
+        //- main.rs
+            extern crate my_lib;
 
-    //- lib.rs
-        pub fn hello() {}
-    """)
+            fn main() {
+                my_lib::hello();
+            }         //^ lib.rs
 
-    fun testCrateAlias() = stubOnlyResolve("""
-    //- main.rs
-        extern crate my_lib as other_name;
+        //- lib.rs
+            pub fn hello() {}
+        """)
+    }
 
-        fn main() {
-            other_name::hello();
-        }                //^ lib.rs
+    fun testCrateAlias() {
+        if (is2016_1()) return
 
-    //- lib.rs
-        pub fn hello() {}
-    """)
+        stubOnlyResolve("""
+        //- main.rs
+            extern crate my_lib as other_name;
+
+            fn main() {
+                other_name::hello();
+            }                //^ lib.rs
+
+        //- lib.rs
+            pub fn hello() {}
+        """)
+    }
 
     override fun getProjectDescriptor(): LightProjectDescriptor = WithLibraryProjectDescriptor
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -485,8 +485,8 @@ class RsResolveTest : RsResolveTestBase() {
     """)
 
     fun testForeignStatic() = checkByCode("""
-        extern "C" { static mut FOO: i32; }
-                                //X
+        extern "C" { static FOO: i32; }
+                            //X
 
         fn main() {
             let _ = FOO;
@@ -589,75 +589,6 @@ class RsResolveTest : RsResolveTestBase() {
         fn main() {
             foo::bar // Yep, we used to resolve this!
                 //^ unresolved
-        }
-    """)
-
-    fun testMethod() = checkByCode("""
-        struct Foo;
-        impl Foo {
-            fn bar(&self) {}
-               //X
-        }
-
-        fn main() {
-            let foo = Foo;
-            foo.bar();
-               //^
-        }
-    """)
-
-    fun testAssocFunction() = checkByCode("""
-        struct Foo;
-        impl Foo {
-            fn bar() {}
-               //X
-        }
-
-        fn main() {
-            Foo::bar();
-                //^
-        }
-    """)
-
-    fun testMethodVsTraitConflict() = checkByCode("""
-        struct Foo;
-        impl Foo {
-            fn bar(&self) {}
-               //X
-        }
-
-        trait Bar {
-            fn bar(&self);
-        }
-        impl Bar for Foo {
-            fn bar(&self) {}
-        }
-
-        fn main() {
-            let foo = Foo;
-            foo.bar();
-               //^
-        }
-    """)
-
-    // TODO: Associated function conflicts are not resolved correctly yet
-    fun ignoreTestAssocFunctionVsTraitConflict() = checkByCode("""
-        struct Foo;
-        impl Foo {
-            fn bar() {}
-               //X
-        }
-
-        trait Bar {
-            fn bar();
-        }
-        impl Bar for Foo {
-            fn bar() {}
-        }
-
-        fn main() {
-            Foo::bar();
-                //^
         }
     """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
@@ -1,5 +1,6 @@
 package org.rust.lang.core.resolve
 
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.vfs.VirtualFileFilter
 import com.intellij.psi.impl.PsiManagerImpl
 import org.assertj.core.api.Assertions.assertThat
@@ -73,5 +74,12 @@ abstract class RsResolveTestBase : RsTestBase() {
                 "Should resolve to ${expectedResolveFile.path}, was ${actualResolveFile.path} instead"
             }
         }
+    }
+
+    // BACKCOMPAT: 2016.1
+    // See org.rust.lang.core.psi.impl.RsStubbedElementImpl.WithParent
+    protected fun is2016_1(): Boolean {
+        val info = ApplicationInfo.getInstance()
+        return (info.majorVersion == "2016" && info.minorVersion == "1")
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -20,48 +20,68 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         fn main() {}
     """)
 
-    fun testResolveCollections() = stubOnlyResolve("""
-    //- main.rs
-        use std::collections::Bound;
-                             //^ ...libcollections/lib.rs
+    fun testResolveCollections() {
+        if (is2016_1()) return
 
-        fn main() {}
-    """)
+        stubOnlyResolve("""
+        //- main.rs
+            use std::collections::Bound;
+                                 //^ ...libcollections/lib.rs
 
-    fun testResolveCore() = stubOnlyResolve("""
-    //- main.rs
-        // FromStr is defined in `core` and reexported in `std`
-        use std::str::FromStr;
-                        //^ ...libcore/str/mod.rs
+            fn main() {}
+        """)
+    }
 
-        fn main() { }
-    """)
+    fun testResolveCore() {
+        if (is2016_1()) return
 
-    fun testResolvePrelude() = stubOnlyResolve("""
-    //- main.rs
-        fn main() {
-            let _ = String::new();
-                    //^  ...libcollections/string.rs
-        }
-    """)
+        stubOnlyResolve("""
+        //- main.rs
+            // FromStr is defined in `core` and reexported in `std`
+            use std::str::FromStr;
+                            //^ ...libcore/str/mod.rs
 
-    fun testResolvePreludeInModule() = stubOnlyResolve("""
-    //- main.rs
-        mod tests {
-            fn test() {
+            fn main() { }
+        """)
+    }
+
+    fun testResolvePrelude() {
+        if (is2016_1()) return
+
+        stubOnlyResolve("""
+        //- main.rs
+            fn main() {
                 let _ = String::new();
                         //^  ...libcollections/string.rs
             }
-        }
-    """)
+        """)
+    }
 
-    fun testResolveBox() = stubOnlyResolve("""
-    //- main.rs
-        fn main() {
-            let _ = Box::new(92);
-                   //^ ...liballoc/boxed.rs
-        }
-    """)
+    fun testResolvePreludeInModule() {
+        if (is2016_1()) return
+
+        stubOnlyResolve("""
+        //- main.rs
+            mod tests {
+                fn test() {
+                    let _ = String::new();
+                            //^  ...libcollections/string.rs
+                }
+            }
+        """)
+    }
+
+    fun testResolveBox() {
+        if (is2016_1()) return
+
+        stubOnlyResolve("""
+        //- main.rs
+            fn main() {
+                let _ = Box::new(92);
+                       //^ ...liballoc/boxed.rs
+            }
+        """)
+    }
 
     fun testDontPutStdInStd() = stubOnlyResolve("""
     //- main.rs
@@ -83,19 +103,23 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                   //^ unresolved
     """)
 
-    fun testResolveOption() = stubOnlyResolve("""
-    //- main.rs
-        fn f(i: i32) -> Option<i32> {}
+    fun testResolveOption() {
+        if (is2016_1()) return
 
-        fn bar() {
-            if let Some(x) = f() {
-                if let Some(y) = f(x) {
-                      //^ ...libcore/option.rs
-                    if let Some(z) = f(y) {}
+        stubOnlyResolve("""
+        //- main.rs
+            fn f(i: i32) -> Option<i32> {}
+
+            fn bar() {
+                if let Some(x) = f() {
+                    if let Some(y) = f(x) {
+                          //^ ...libcore/option.rs
+                        if let Some(z) = f(y) {}
+                    }
                 }
             }
-        }
-    """)
+        """)
+    }
 
     fun testPreludeVisibility1() = stubOnlyResolve("""
     //- main.rs

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -1,35 +1,41 @@
 package org.rust.lang.core.resolve
 
-import com.intellij.openapi.application.ApplicationInfo
-
 class RsStubOnlyResolveTest : RsResolveTestBase() {
-    fun testChildMod() = stubOnlyResolve("""
-    //- main.rs
-        mod child;
+    fun testChildMod() {
+        if (is2016_1()) return
 
-        fn main() {
-            child::foo();
-                  //^ child.rs
-        }
+        stubOnlyResolve("""
+        //- main.rs
+            mod child;
 
-    //- child.rs
-        pub fn foo() {}
-    """)
+            fn main() {
+                child::foo();
+                      //^ child.rs
+            }
 
-    fun testNestedChildMod() = stubOnlyResolve("""
-    //- main.rs
-        mod inner {
-            pub mod child;
-        }
+        //- child.rs
+            pub fn foo() {}
+        """)
+    }
 
-        fn main() {
-            inner::child::foo();
-                         //^ inner/child.rs
-        }
+    fun testNestedChildMod() {
+        if (is2016_1()) return
 
-    //- inner/child.rs
-        fn foo() {}
-    """)
+        stubOnlyResolve("""
+        //- main.rs
+            mod inner {
+                pub mod child;
+            }
+
+            fn main() {
+                inner::child::foo();
+                             //^ inner/child.rs
+            }
+
+        //- inner/child.rs
+            fn foo() {}
+        """)
+    }
 
     fun testModDecl() = stubOnlyResolve("""
     //- main.rs
@@ -68,77 +74,97 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         fn quux() {}
     """)
 
-    fun testModDeclPathSuper() = stubOnlyResolve("""
-    //- bar/baz/quux.rs
-        fn quux() {
-            super::main();
-        }          //^ main.rs
+    fun testModDeclPathSuper() {
+        if (is2016_1()) return
 
-    //- main.rs
-        #[path = "bar/baz/quux.rs"]
-        mod foo;
+        stubOnlyResolve("""
+        //- bar/baz/quux.rs
+            fn quux() {
+                super::main();
+            }          //^ main.rs
 
-        fn main(){}
-    """)
+        //- main.rs
+            #[path = "bar/baz/quux.rs"]
+            mod foo;
 
-    fun testModRelative() = stubOnlyResolve("""
-    //- main.rs
-        mod sub;
+            fn main(){}
+        """)
+    }
 
-        fn main() {
-            sub::foobar::quux();
-        }               //^ foo.rs
+    fun testModRelative() {
+        if (is2016_1()) return
 
-    //- sub.rs
-        #[path="./foo.rs"]
-        pub mod foobar;
+        stubOnlyResolve("""
+        //- main.rs
+            mod sub;
 
-    //- foo.rs
-        fn quux() {}
-    """)
+            fn main() {
+                sub::foobar::quux();
+            }               //^ foo.rs
 
-    fun testModRelative2() = stubOnlyResolve("""
-    //- main.rs
-        mod sub;
+        //- sub.rs
+            #[path="./foo.rs"]
+            pub mod foobar;
 
-        fn main() {
-            sub::foobar::quux();
-        }               //^ foo.rs
+        //- foo.rs
+            fn quux() {}
+        """)
+    }
 
-    //- sub/mod.rs
-        #[path="../foo.rs"]
-        pub mod foobar;
+    fun testModRelative2() {
+        if (is2016_1()) return
 
-    //- foo.rs
-        pub fn quux() {}
-    """)
+        stubOnlyResolve("""
+        //- main.rs
+            mod sub;
 
-    fun testUseFromChild() = stubOnlyResolve("""
-    //- main.rs
-        use child::{foo};
-        mod child;
+            fn main() {
+                sub::foobar::quux();
+            }               //^ foo.rs
 
-        fn main() {
-            foo();
-        }  //^ child.rs
+        //- sub/mod.rs
+            #[path="../foo.rs"]
+            pub mod foobar;
 
-    //- child.rs
-        pub fn foo() {}
-    """)
+        //- foo.rs
+            pub fn quux() {}
+        """)
+    }
 
-    fun testUseGlobalPath() = stubOnlyResolve("""
-    //- foo.rs
-        fn main() {
-            ::bar::hello();
-        }         //^ bar.rs
+    fun testUseFromChild() {
+        if (is2016_1()) return
 
-    //- lib.rs
-        mod foo;
-        pub mod bar;
+        stubOnlyResolve("""
+        //- main.rs
+            use child::{foo};
+            mod child;
 
-    //- bar.rs
-        pub fn hello() {}
-    """)
+            fn main() {
+                foo();
+            }  //^ child.rs
+
+        //- child.rs
+            pub fn foo() {}
+        """)
+    }
+
+    fun testUseGlobalPath() {
+        if (is2016_1()) return
+
+        stubOnlyResolve("""
+        //- foo.rs
+            fn main() {
+                ::bar::hello();
+            }         //^ bar.rs
+
+        //- lib.rs
+            mod foo;
+            pub mod bar;
+
+        //- bar.rs
+            pub fn hello() {}
+        """)
+    }
 
     // We resolve mod_decls even if the parent module does not own a directory and mod_decl should not be allowed.
     // This way, we don't need to know the set of crate roots for resolve, which helps indexing.

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -202,11 +202,4 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         """)
     }
 
-    // BACKCOMPAT: 2016.1
-    // See org.rust.lang.core.psi.impl.RsStubbedElementImpl.WithParent
-    private fun is2016_1(): Boolean {
-        val info = ApplicationInfo.getInstance()
-        return (info.majorVersion == "2016" && info.minorVersion == "1")
-    }
-
 }


### PR DESCRIPTION
While working on [E0061](https://doc.rust-lang.org/error-index.html#E0061) (wrong arguments number) detection I stumbled upon a problem with methods and associated functions resolve when there's a conflict between the inherent implementation and a trait implementation.

For instance:

```rust
struct Foo;
impl Foo {
    fn bar(&self) {}
}

trait Bar {
    fn bar(&self);
}
impl Bar for Foo {
    fn bar(&self) {}
}

fn main() {
    let foo = Foo;
    foo.bar();  // <-- resolves to Bar::bar() now, but must be resolved to Foo::bar()
}
```

I've fixed the problem for methods, but left associated functions intact so far (though, I've provided an ignored failing test for them).

If this fix looks fine, I'll get back to associated functions. Do I understand correctly that I have to extract something like `RsFnCallReferenceImpl` from `RsPathReferenceImpl` first?