### PR TITLE
(ANNOT): Allow foreign mutable static consts

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -89,7 +89,6 @@ class RsErrorAnnotator : Annotator, HighlightRangeExtension {
             RsConstantRole.FOREIGN -> {
                 deny(const.default, holder, "$title cannot have the `default` qualifier")
                 require(const.static, holder, "Only static constants are allowed in extern blocks", const.const)
-                    ?: require(const.mut, holder, "Non mutable static constants are not allowed in extern blocks", const.static, const.identifier)
                 deny(const.expr, holder, "Static constants in extern blocks cannot have values", const.eq, const.expr)
             }
         }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -68,10 +68,10 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
         extern "C" {
             static mut FOO: u32;
             pub static mut PUB_FOO: u8;
+            static NON_MUT_FOO: u32;
 
             <error descr="Static constant `DEF_FOO` cannot have the `default` qualifier">default</error> static mut DEF_FOO: bool;
             <error descr="Only static constants are allowed in extern blocks">const</error> CONST_FOO: u32;
-            <error descr="Non mutable static constants are not allowed in extern blocks">static NON_MUT_FOO</error>: u32;
             static mut VAL_FOO: u32 <error descr="Static constants in extern blocks cannot have values">= 10</error>;
         }
     """)


### PR DESCRIPTION
Removes the annotation on mutable static constants in `extern` blocks as they are allowed by Rust (discussed [here](https://github.com/intellij-rust/intellij-rust/pull/967#pullrequestreview-18971241)).