### PR TITLE
Mod completion

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsModReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsModReferenceImpl.kt
@@ -1,6 +1,7 @@
 package org.rust.lang.core.resolve.ref
 
 import com.intellij.psi.PsiElement
+import org.rust.lang.core.completion.CompletionEngine
 import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.RsNamedElement
 import org.rust.lang.core.resolve.ResolveEngine
@@ -14,5 +15,5 @@ class RsModReferenceImpl(
 
     override fun resolveInner(): List<RsNamedElement> = listOfNotNull(ResolveEngine.resolveModDecl(element))
 
-    override fun getVariants(): Array<out Any> = EMPTY_ARRAY
+    override fun getVariants(): Array<out Any> = CompletionEngine.completeMod(element)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
@@ -11,28 +11,7 @@ abstract class RsCompletionTestBase : RsTestBase() {
 
     protected fun checkSingleCompletion(target: String, @Language("Rust") code: String) {
         InlineFile(code).withCaret()
-        val variants = myFixture.completeBasic()
-
-        fun LookupElement.debug(): String = "$lookupString ($psiElement)"
-        check(variants == null) {
-            "Expected a single completion, but got ${variants.size}:\n" +
-                variants.map { it.debug() }.joinToString("\n")
-        }
-        val normName = target
-            .substringBeforeLast("()")
-            .substringBeforeLast(" {}")
-            .substringAfterLast("::")
-            .substringAfterLast(".")
-        val shift = when {
-            target.endsWith("()") || target.endsWith("::") -> 3
-            target.endsWith(" {}") -> 4
-            else -> 2
-        }
-        val element = myFixture.file.findElementAt(myFixture.caretOffset - shift)!!
-        val skipTextCheck = normName.isEmpty() || normName.contains(' ')
-        check((skipTextCheck || element.text == normName) && (element.fitsHierarchically(target) || element.fitsLinearly(target))) {
-            "Wrong completion, expected `$target`, but got\n${myFixture.file.text}"
-        }
+        singleCompletionCheck(target)
     }
 
     protected fun checkSingleCompletionWithMultipleFiles(target: String, @Language("Rust") code: String) {
@@ -43,6 +22,10 @@ abstract class RsCompletionTestBase : RsTestBase() {
 
         openFileInEditor(files[0].path)
 
+        singleCompletionCheck(target)
+    }
+
+    protected fun singleCompletionCheck(target: String) {
         val variants = myFixture.completeBasic()
 
         fun LookupElement.debug(): String = "$lookupString ($psiElement)"
@@ -79,14 +62,7 @@ abstract class RsCompletionTestBase : RsTestBase() {
 
     protected fun checkNoCompletion(@Language("Rust") code: String) {
         InlineFile(code).withCaret()
-        val variants = myFixture.completeBasic()
-        checkNotNull(variants) {
-            val element = myFixture.file.findElementAt(myFixture.caretOffset - 1)
-            "Expected zero completions, but one completion was auto inserted: `${element?.text}`."
-        }
-        check(variants.isEmpty()) {
-            "Expected zero completions, got ${variants.size}."
-        }
+        noCompletionCheck()
     }
 
     protected fun checkNoCompletionWithMultipleFiles(@Language("Rust") code: String) {
@@ -96,6 +72,10 @@ abstract class RsCompletionTestBase : RsTestBase() {
         }
 
         openFileInEditor(files[0].path)
+        noCompletionCheck()
+    }
+
+    protected fun noCompletionCheck() {
         val variants = myFixture.completeBasic()
         checkNotNull(variants) {
             val element = myFixture.file.findElementAt(myFixture.caretOffset - 1)

--- a/src/test/kotlin/org/rust/lang/core/completion/RsModCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsModCompletionTest.kt
@@ -1,0 +1,40 @@
+package org.rust.lang.core.completion
+
+class RsModCompletionTest : RsCompletionTestBase() {
+    fun testModCompletionSameDirectory() = checkSingleCompletionWithMultipleFiles("my_mod", """
+    //- main.rs
+        mod my_m/*caret*/;
+
+        fn main() {}
+
+    //- my_mod.rs
+        pub fn test() {}
+    """)
+
+    fun testModCompletionSubdirectory() = checkSingleCompletionWithMultipleFiles("my_mod", """
+    //- main.rs
+        mod my_m/*caret*/;
+
+        fn main() {}
+
+    //- my_mod/mod.rs
+        pub fn test() {}
+    """)
+
+    fun testModCompletionSameDirectoryNoModRS() = checkNoCompletionWithMultipleFiles("""
+    //- function.rs
+        mod mo/*caret*/;
+
+        fn main() {}
+
+    //- mod.rs
+        pub fn test() {}
+    """)
+
+    fun testModCompletionSameDirectoryNoMainRS() = checkNoCompletionWithMultipleFiles("""
+    //- main.rs
+        mod m/*caret*/;
+
+        fn main() {}
+    """)
+}


### PR DESCRIPTION
This PR add autocomplete for module declaration statements.

The autocomplete is created by taking all the `.rs` filenames without the extension + all the directory name that contains a `mod.rs` file inside.

Fix #883