### PR TITLE
(ANNOT): Wrong arguments number annotation

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RsFunctionImplMixin.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/impl/mixin/RsFunctionImplMixin.kt
@@ -43,7 +43,8 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
 val RsFunction.isAbstract: Boolean get() = stub?.isAbstract ?: (block == null)
 val RsFunction.isAssocFn: Boolean get() = stub?.isStatic ?: (selfParameter == null)
 val RsFunction.isTest: Boolean get() = stub?.isTest ?: queryAttributes.hasAtomAttribute("test")
-
+val RsFunction.isInherentImpl: Boolean
+    get() = (parent as? RsImplItem)?.let { return@let if (it.traitRef == null) it else null } != null
 
 enum class RsFunctionRole {
     // Bump stub version if reorder fields

--- a/src/main/kotlin/org/rust/lang/core/resolve/ResolveEngine.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ResolveEngine.kt
@@ -222,7 +222,7 @@ object ResolveEngine {
      * a function/method from inherent implementation takes precedence over trait implementations.
      */
     private fun Sequence<RsNamedElement>.chooseMajor(): RsNamedElement? =
-        partition { it.isInherent }.let {
+        partition { it is RsFunction && it.isInherentImpl }.let {
             when {
                 it.first.isNotEmpty() -> it.first[0]
                 it.second.isNotEmpty() -> it.second[0]
@@ -531,9 +531,6 @@ private fun <T> Sequence<T>.takeWhileInclusive(pred: (T) -> Boolean): Sequence<T
 
 private fun PsiElement.isStrictAncestorOf(child: PsiElement) =
     PsiTreeUtil.isAncestor(this, child, true)
-
-private val RsCompositeElement.isInherent: Boolean
-    get() = (parent as? RsImplItem)?.let { return@let if (it.traitRef == null) it else null } != null
 
 /**
  * Helper to debug complex iterator pipelines

--- a/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt
@@ -81,7 +81,7 @@ class RsExpressionAnnotatorTest : RsAnnotatorTestBase() {
 
         struct Win {
             foo: i32,
-            #[cfg(widows)] bar: i32,
+            #[cfg(windows)] bar: i32,
         }
 
         #[cfg(unix)]


### PR DESCRIPTION
Wrong arguments number detection ([E0061](https://doc.rust-lang.org/error-index.html#E0061) from #886).

I had to skip cases when a function call resolves to a trait implementation to eliminate some tricky false positives (see tests).