### PR TITLE
(ANNOT): Detect E0061 for tuple-like structs

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -445,6 +445,7 @@ private fun RsCallExpr.expectedParamsCount(): Int? {
     if (el is RsDocAndAttributeOwner && el.queryAttributes.hasCfgAttr()) return null
     return when (el) {
         is RsStructItem -> el.tupleFields?.tupleFieldDeclList?.size
+        is RsEnumVariant -> el.tupleFields?.tupleFieldDeclList?.size
         is RsFunction -> {
             if (el.role == RsFunctionRole.IMPL_METHOD && !el.isInherentImpl) return null
             val count = el.valueParameterList?.valueParameterList?.size ?: return null

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -338,6 +338,18 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
         }
     """)
 
+    fun testE0061_InvalidParametersNumberInTupleStructs() = checkErrors("""
+        struct Foo0();
+        struct Foo1(u8);
+        fn main() {
+            let _ = Foo0();
+            let _ = Foo1(1);
+
+            let _ = Foo0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(4)</error>;
+            let _ = Foo1<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(10, false)</error>;
+        }
+    """)
+
     fun testE0061_RespectsCfgAttribute() = checkErrors("""
         struct Foo;
         impl Foo {

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -350,6 +350,20 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
         }
     """)
 
+    fun testE0061_InvalidParametersNumberInTupleEnumVariants() = checkErrors("""
+        enum Foo {
+            VAR0(),
+            VAR1(u8)
+        }
+        fn main() {
+            let _ = Foo::VAR0();
+            let _ = Foo::VAR1(1);
+
+            let _ = Foo::VAR0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(4)</error>;
+            let _ = Foo::VAR1<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(10, false)</error>;
+        }
+    """)
+
     fun testE0061_RespectsCfgAttribute() = checkErrors("""
         struct Foo;
         impl Foo {


### PR DESCRIPTION
Extends E0061 detection (from #886) to tuple-like structs and enum variants.