### PR TITLE
INT: Purity check of expressions, improved simplification of boolean expressions

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspection.kt
@@ -1,0 +1,47 @@
+package org.rust.ide.inspections
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import org.rust.ide.utils.isPure
+import org.rust.ide.utils.simplifyBooleanExpression
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsVisitor
+
+/**
+ * Simplify pure boolean expressions
+ */
+class RsSimplifyBooleanExpressionInspection : RsLocalInspectionTool() {
+    override fun getDisplayName() = "Simplify boolean expression"
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+
+        override fun visitExpr(o: RsExpr) {
+            if (o.isPure() != true)
+                return
+            val (expr, result) = o.simplifyBooleanExpression()
+            if (!result)
+                return
+            holder.registerProblem(
+                o,
+                "Boolean expression can be simplified",
+                object : LocalQuickFix {
+                    override fun getName() = "Simplify boolean expression"
+
+                    override fun getFamilyName() = name
+
+                    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+                        val expression = descriptor.psiElement as RsExpr
+                        if (expression.isPure() != true)
+                            return
+                        val (simplifiedExpr, simplificationResult) = expression.simplifyBooleanExpression()
+                        if (!simplificationResult)
+                            return
+                        expression.replace(simplifiedExpr)
+                    }
+                }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntention.kt
@@ -3,14 +3,10 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import org.rust.ide.template.postfix.isBool
-import org.rust.ide.utils.UnaryOperator
-import org.rust.ide.utils.operatorType
-import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.RsElementTypes.*
+import org.rust.ide.utils.simplifyBooleanExpression
+import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.util.ancestors
 import org.rust.lang.core.psi.util.parentOfType
-import org.rust.lang.core.types.type
 
 class SimplifyBooleanExpressionIntention : RsElementBaseIntentionAction<RsExpr>() {
     override fun getText() = "Simplify boolean expression"
@@ -24,105 +20,12 @@ class SimplifyBooleanExpressionIntention : RsElementBaseIntentionAction<RsExpr>(
             ?.findLast { isSimplifiableExpression(it) }
 
     private fun isSimplifiableExpression(psi: RsExpr): Boolean {
-        return (psi.copy() as RsExpr).simplify().second
+        return (psi.copy() as RsExpr).simplifyBooleanExpression().second
     }
 
     override fun invoke(project: Project, editor: Editor, ctx: RsExpr) {
-        val (expr, isSimplified) = ctx.simplify()
+        val (expr, isSimplified) = ctx.simplifyBooleanExpression()
         if (isSimplified)
             ctx.replace(expr)
-    }
-
-    private fun createPsiElement(project: Project, value: Any) = RsPsiFactory(project).createExpression(value.toString())
-
-    private fun RsExpr.simplify(): Pair<RsExpr, Boolean> {
-        if (this is RsLitExpr)
-            return this to false
-        return this.eval()?.let {
-            createPsiElement(project, it) to true
-        } ?: when (this) {
-            is RsBinaryExpr -> {
-                val (leftExpr, leftSimplified) = left.simplify()
-                val (rightExpr, rightSimplified) = right!!.simplify()
-                if (leftExpr is RsLitExpr) {
-                    leftExpr.boolLiteral?.let {
-                        when (this.operatorType) {
-                            ANDAND ->
-                                when (it.text) {
-                                    "true" -> return rightExpr to true
-                                    "false" -> return createPsiElement(project, "false") to true
-                                }
-                            OROR ->
-                                when (it.text) {
-                                    "true" -> return createPsiElement(project, "true") to true
-                                    "false" -> return rightExpr to true
-                                }
-                        }
-                        {}
-                    }
-                }
-                if (rightExpr is RsLitExpr) {
-                    rightExpr.boolLiteral?.let {
-                        when (this.operatorType) {
-                            ANDAND ->
-                                when (it.text) {
-                                    "true" -> return leftExpr to true
-                                    "false" -> return createPsiElement(project, "false") to true
-                                }
-                            OROR ->
-                                when (it.text) {
-                                    "true" -> return createPsiElement(project, "true") to true
-                                    "false" -> return leftExpr to true
-                                }
-                        }
-                        {}
-                    }
-                }
-                if (leftSimplified)
-                    this.left.replace(leftExpr)
-                if (rightSimplified)
-                    this.right!!.replace(rightExpr)
-                this to (leftSimplified || rightSimplified)
-            }
-            else ->
-                this to false
-        }
-    }
-
-    private fun RsExpr.eval(): Boolean? {
-        return when (this) {
-            is RsLitExpr ->
-                (kind as? RsLiteralKind.Boolean)?.value
-
-            is RsBinaryExpr -> when (operatorType) {
-                ANDAND -> {
-                    val lhs = left.eval() ?: return null
-                    if (!lhs) return false
-                    val rhs = right?.eval() ?: return null
-                    lhs && rhs
-                }
-                OROR -> {
-                    val lhs = left.eval() ?: return null
-                    if (lhs) return true
-                    val rhs = right?.eval() ?: return null
-                    lhs || rhs
-                }
-                XOR -> {
-                    val lhs = left.eval() ?: return null
-                    val rhs = right?.eval() ?: return null
-                    lhs xor rhs
-                }
-                else -> null
-            }
-
-            is RsUnaryExpr -> when (operatorType) {
-                UnaryOperator.NOT -> expr?.eval()?.let { !it }
-                else -> null
-            }
-
-            is RsParenExpr -> expr.eval()
-
-            else -> null
-        }
     }
 }

--- a/src/main/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntention.kt
@@ -3,7 +3,8 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import org.rust.ide.intentions.SimplifyBooleanExpressionIntention.UnaryOperator.*
+import org.rust.ide.utils.UnaryOperator
+import org.rust.ide.utils.operatorType
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.psi.util.ancestors
@@ -14,11 +15,11 @@ class SimplifyBooleanExpressionIntention : RsElementBaseIntentionAction<RsExpr>(
     override fun getFamilyName() = "Simplify boolean expression"
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsExpr? =
-        element.parentOfType<RsExpr>()
-            ?.ancestors
-            ?.takeWhile { it is RsExpr }
-            ?.map { it as RsExpr }
-            ?.findLast { isSimplifiableExpression(it) }
+            element.parentOfType<RsExpr>()
+                    ?.ancestors
+                    ?.takeWhile { it is RsExpr }
+                    ?.map { it as RsExpr }
+                    ?.findLast { isSimplifiableExpression(it) }
 
     private fun isSimplifiableExpression(psi: RsExpr): Boolean {
         if (psi !is RsLitExpr && psi.eval() != null) return true
@@ -90,35 +91,4 @@ class SimplifyBooleanExpressionIntention : RsElementBaseIntentionAction<RsExpr>(
             else -> null
         }
     }
-
-    /**
-     * Enum class representing unary operator in rust.
-     */
-    enum class UnaryOperator {
-        REF, // `&a`
-        REF_MUT, // `&mut a`
-        DEREF, // `*a`
-        MINUS, // `-a`
-        NOT, // `!a`
-        BOX, // `box a`
-    }
-
-    /**
-     * Operator of current psi node with unary operation.
-     *
-     * The result can be [REF] (`&`), [REF_MUT] (`&mut`),
-     * [DEREF] (`*`), [MINUS] (`-`), [NOT] (`!`),
-     * [BOX] (`box`) or `null` if none of these.
-     */
-    val RsUnaryExpr.operatorType: UnaryOperator?
-        get() = when {
-            this.and != null -> UnaryOperator.REF
-            this.mut != null -> UnaryOperator.REF_MUT
-            this.mul != null -> UnaryOperator.DEREF
-            this.minus != null -> UnaryOperator.MINUS
-            this.excl != null -> UnaryOperator.NOT
-            this.box != null -> UnaryOperator.BOX
-            else -> null
-        }
-
 }

--- a/src/main/kotlin/org/rust/ide/utils/ExprUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/ExprUtils.kt
@@ -1,0 +1,102 @@
+package org.rust.ide.utils
+
+import org.rust.lang.core.psi.*
+
+/**
+ * Returns `true` if all elements are `true`, `false` if there exists
+ * `false` element and `null` otherwise.
+ */
+private fun <T> List<T>.allMaybe(predicate: (T) -> Boolean?): Boolean? {
+    val values = map(predicate)
+    val nullsTrue = values.all {
+        it ?: true
+    }
+    val nullsFalse = values.all {
+        it ?: false
+    }
+    return if (nullsTrue == nullsFalse) nullsTrue else null
+}
+
+/**
+ * Check if an expression is functionally pure
+ * (has no side-effects and throws no errors).
+ *
+ * @return `true` if the expression is pure, `false` if
+ *        > it is not pure (has side-effects / throws errors)
+ *        > or `null` if it is unknown.
+ */
+fun RsExpr.isPure(): Boolean? {
+    return when (this) {
+        is RsArrayExpr -> when (semicolon) {
+            null -> exprList.allMaybe { it.isPure() }
+            else -> exprList[0].isPure() // Array literal of form [expr; size],
+        // size is a compile-time constant, so it is always pure
+        }
+        is RsStructExpr -> when (structExprBody.dotdot) {
+            null -> structExprBody.structExprFieldList
+                .map { it.expr }
+                .allMaybe { it?.isPure() } // TODO: Why `it` can be null?
+            else -> null // TODO: handle update case (`Point{ y: 0, z: 10, .. base}`)
+        }
+        is RsTupleExpr -> exprList.allMaybe { it.isPure() }
+        is RsFieldExpr -> expr.isPure()
+        is RsParenExpr -> expr.isPure()
+        is RsBreakExpr -> false // Changes execution flow
+        is RsContExpr -> false  // -//-
+        is RsRetExpr -> false   // -//-
+        is RsTryExpr -> false   // -//-
+        is RsPathExpr -> true   // Paths are always pure
+        is RsQualPathExpr -> true
+        is RsLitExpr -> true
+        is RsUnitExpr -> true
+
+        // TODO: more complex analysis of blocks of code and search of implemented traits
+        is RsBinaryExpr -> null // Have to search if operation is overloaded
+        is RsBlockExpr -> null  // Have to analyze lines, very hard case
+        is RsCastExpr -> null;  // `expr.isPure()` maybe not true, think about side-effects, may panic while cast
+        is RsCallExpr -> null   // All arguments and function itself must be pure, very hard case
+        is RsForExpr -> null    // Always return (), if pure then can be replaced with it
+        is RsIfExpr -> null
+        is RsIndexExpr -> null  // Index trait can be overloaded, can panic if out of bounds
+        is RsLambdaExpr -> null
+        is RsLoopExpr -> null
+        is RsMacroExpr -> null
+        is RsMatchExpr -> null
+        is RsMethodCallExpr -> null
+        is RsRangeExpr -> null
+        is RsUnaryExpr -> null  // May be overloaded
+        is RsWhileExpr -> null
+        else -> null
+    }
+}
+
+/**
+ * Enum class representing unary operator in rust.
+ */
+enum class UnaryOperator {
+    REF, // `&a`
+    REF_MUT, // `&mut a`
+    DEREF, // `*a`
+    MINUS, // `-a`
+    NOT, // `!a`
+    BOX, // `box a`
+}
+
+/**
+ * Operator of current psi node with unary operation.
+ *
+ * The result can be [REF] (`&`), [REF_MUT] (`&mut`),
+ * [DEREF] (`*`), [MINUS] (`-`), [NOT] (`!`),
+ * [BOX] (`box`) or `null` if none of these.
+ */
+val RsUnaryExpr.operatorType: UnaryOperator?
+    get() = when {
+        this.and != null -> UnaryOperator.REF
+        this.mut != null -> UnaryOperator.REF_MUT
+        this.mul != null -> UnaryOperator.DEREF
+        this.minus != null -> UnaryOperator.MINUS
+        this.excl != null -> UnaryOperator.NOT
+        this.box != null -> UnaryOperator.BOX
+        else -> null
+    }
+

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -306,6 +306,11 @@
                          enabledByDefault="true" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.RsSimplifyPrintInspection"/>
 
+        <localInspection language="Rust" groupName="Rust"
+                         displayName="Simplify boolean expression"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RsSimplifyBooleanExpressionInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsSimplifyBooleanExpression.html
+++ b/src/main/resources/inspectionDescriptions/RsSimplifyBooleanExpression.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+Detects boolean expressions that can be safely simplified like <code>a || true</code>.<br>
+Does not simplify expressions if some side effects can be eliminated, such as <code>return || true</code> for example.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntentionTest.kt
@@ -94,6 +94,76 @@ class SimplifyBooleanExpressionIntentionTest : RsIntentionTestBase(SimplifyBoole
         }
     """)
 
+    fun testNonEquivalent1() = doAvailableTest("""
+        fn main() {
+            let a = a ||/*caret*/ true || true;
+        }
+    """, """
+        fn main() {
+            let a = true;
+        }
+    """)
+
+    fun testNonEquivalent2() = doAvailableTest("""
+        fn main() {
+            let a = a ||/*caret*/ false;
+        }
+    """, """
+        fn main() {
+            let a = a;
+        }
+    """)
+
+    fun testNonEquivalent3() = doAvailableTest("""
+        fn main() {
+            let a = a &&/*caret*/ false;
+        }
+    """, """
+        fn main() {
+            let a = false;
+        }
+    """)
+
+    fun testNonEquivalent4() = doAvailableTest("""
+        fn main() {
+            let a = a &&/*caret*/ true;
+        }
+    """, """
+        fn main() {
+            let a = a;
+        }
+    """)
+
+    fun testComplexNonEquivalent1() = doAvailableTest("""
+        fn main() {
+            let a = f() && (g() &&/*caret*/ false);
+        }
+    """, """
+        fn main() {
+            let a = f() && (false);
+        }
+    """)
+
+    fun testComplexNonEquivalent2() = doAvailableTest("""
+        fn main() {
+            let a = 1 > 2 &&/*caret*/ 2 > 3 && 3 > 4 || true;
+        }
+    """, """
+        fn main() {
+            let a = true;
+        }
+    """)
+
+    fun testComplexNonEquivalent3() = doAvailableTest("""
+        fn main() {
+            let a = 1 > 2 &&/*caret*/ 2 > 3 && 3 > 4 || false;
+        }
+    """, """
+        fn main() {
+            let a = 1 > 2 && 2 > 3 && 3 > 4;
+        }
+    """)
+
     fun testNotAvailable3() = doUnavailableTest("""
         fn main() {
             let a = a /*caret*/&& b;
@@ -102,23 +172,17 @@ class SimplifyBooleanExpressionIntentionTest : RsIntentionTestBase(SimplifyBoole
 
     fun testNotAvailable4() = doUnavailableTest("""
         fn main() {
-            let a = a ||/*caret*/ true || true;
+            let a = true /*caret*/^ a;
         }
     """)
 
     fun testNotAvailable5() = doUnavailableTest("""
         fn main() {
-            let a = true /*caret*/^ a;
-        }
-    """)
-
-    fun testNotAvailable6() = doUnavailableTest("""
-        fn main() {
             let a =  !/*caret*/a;
         }
     """)
 
-    fun testNotAvailable7() = doUnavailableTest("""
+    fun testNotAvailable6() = doUnavailableTest("""
         fn main() {
             let a = /*caret*/true;
         }


### PR DESCRIPTION
First sketch of advanced analisys of expressions and its usage in simplifications.
`expr.isPure()` tries to infer if an expression is functionally pure and throws no errors.
Now expressions like `a || true` are simplified to `true` (since paths like `a` are always pure, so expression `a || true` has no side effects, no panics and `||` is not overloadable).
Expressions like `f() || true` are not simplified because function call can have side effects.
There is a lot of work to do, but I want to know, is a design like this ok or it should be done in the completely another way.