### PR TITLE
(ANNOT): Detect undeclared lifetimes

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/util/RustPsiNavigationExtensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/util/RustPsiNavigationExtensions.kt
@@ -20,6 +20,8 @@ inline fun <reified T : PsiElement> PsiElement.childOfType(strict: Boolean = tru
 inline fun <reified T : PsiElement> PsiElement.descendantsOfType(): Collection<T> =
     PsiTreeUtil.findChildrenOfType(this, T::class.java)
 
+val PsiElement.branch: Sequence<PsiElement>
+    get() = generateSequence(this) { it.parent }
 
 /**
  * Finds first sibling that is neither comment, nor whitespace before given element.

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -535,6 +535,69 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
         }
     """)
 
+    fun testE0261_UndeclareLifetimeInStruct() = checkErrors("""
+        struct Foo<'a, 'b> {
+            a: &'a u32,
+            b: (bool, &'b str),
+            c: &'static str,
+        }
+        struct Bar<'a> {
+            a: &<error descr="Use of undeclared lifetime name `'c` [E0261]">'c</error> u32,
+            b: (bool, &<error>'d</error> str),
+        }
+    """)
+
+    fun testE0261_UndeclareLifetimeInTupleStruct() = checkErrors("""
+        struct Foo<'a, 'b>(
+            &'a u32,
+            (bool, &'b str),
+            &'static str
+        );
+        struct Bar<'a>(
+            &<error descr="Use of undeclared lifetime name `'c` [E0261]">'c</error> u32,
+            (bool, &<error>'d</error> str)
+        );
+    """)
+
+    fun testE0261_UndeclareLifetimeInEnums() = checkErrors("""
+        enum Foo<'a, 'b> {
+            FOO(&'a u32),
+            BAR(bool, &'b str),
+            BAZ(&'static str),
+        }
+        enum Bar<'a> {
+            FOO(&<error descr="Use of undeclared lifetime name `'c` [E0261]">'c</error> u32),
+            BAR(bool, &<error>'d</error> str)
+        }
+    """)
+
+    fun testE0261_UndeclareLifetimeInTypeAliases() = checkErrors("""
+        type U32<'a> = &'a u32;
+        type Tup<'a> = (bool, &'a str);
+        type Str = &'static str;
+
+        type ErrU32 = &<error descr="Use of undeclared lifetime name `'c` [E0261]">'c</error> u32;
+        type ErrTup<'a> = (bool, &<error>'b</error> str);
+    """)
+
+    fun testE0262_UndeclareLifetimeInTypeParameters() = checkErrors("""
+        trait Foo<'a, 'b> {
+            type U32 = &'a u32;
+            type Tup = (bool, &'b str);
+            type Str = &'static str;
+        }
+        struct Bar;
+        impl<'c, 'd> Foo<'c, 'd> for Bar {
+            type U32 = &'c u32;
+            type Tup = (bool, &'d str);
+        }
+        struct Baz;
+        impl<'a, 'b> Foo<'a, 'b> for Baz {
+            type U32 = &<error descr="Use of undeclared lifetime name `'c` [E0261]">'c</error> u32;
+            type Tup = (bool, &<error>'d</error> str);
+        }
+    """)
+
     fun testE0263_LifetimeNameDuplicationInGenericParams() = checkErrors("""
         fn foo<'a, 'b>(x: &'a str, y: &'b str) { }
         struct Str<'a, 'b> { a: &'a u32, b: &'b f64 }


### PR DESCRIPTION
Detects usage of undefined lifetimes ([E0261](https://doc.rust-lang.org/error-index.html#E0261) from #886). Covers cases for structs / enums / type aliases.

It could be easily extended to type arguments, but I faced a problem I don't know how to solve. In the following code:

```rust
trait Foo<'a> {
    type It = &'a u8;
}
struct Bar;
impl<'a> Foo<'a> for Bar {}
         // ^^^^ the problem is here
```

the marked part (`<'a>`) is represented by a `RsTypeArgumentList`, but in the PSI tree it's just a single leaf node that has no children. Both its `assocTypeBindingList` and `typeReferenceList` properties are empty. The PSI tree viewer shows me three elements under the `TYPE_ARGUMENT_LIST` (`<`, `lifetime`, and `>`), but when I analyse this arguments list in code, it returns no children.

Is there something that should be done in the grammar to make it work? Or am I missing something?