### PR TITLE
Set TERM to "ansi"

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -82,13 +82,8 @@ class Cargo(
             && command in COLOR_ACCEPTING_COMMANDS
             && additionalArguments.none { it.startsWith("--color") }) {
 
-            if (SystemInfo.isLinux) {
-                cmdLine.withEnvironment("TERM", "xterm+256color")
-            } else if (SystemInfo.isMac) {
-                cmdLine.withEnvironment("TERM", "linux")
-            }
-
             cmdLine
+                .withEnvironment("TERM", "ansi")
                 .withRedirectErrorStream(true)
                 .withParameters("--color=always") // Must come first in order not to corrupt the running program arguments
         }


### PR DESCRIPTION
Should work on Mac (thanks, @alygin!) and Linux

Closes #988 (for real, this time)