### PR TITLE
REN: Don’t fail on wrong id type while renaming

### DIFF
--- a/src/main/kotlin/org/rust/lang/refactoring/RsNamesValidator.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RsNamesValidator.kt
@@ -9,51 +9,22 @@ import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 import org.rust.lang.core.psi.RsElementTypes.QUOTE_IDENTIFIER
 
 class RsNamesValidator : NamesValidator {
-    override fun isKeyword(name: String, project: Project?): Boolean =
-        isKeyword(name, project, true)
 
-    fun isKeyword(name: String, @Suppress("UNUSED_PARAMETER") project: Project?, withPrimitives: Boolean): Boolean =
-        getLexerType(name) in RS_KEYWORDS || (withPrimitives && name in PrimitiveTypes)
+    override fun isKeyword(name: String, project: Project?): Boolean = getLexerType(name) in RS_KEYWORDS
 
     override fun isIdentifier(name: String, project: Project?): Boolean =
-        isIdentifier(name, project, true)
-
-    fun isIdentifier(name: String, @Suppress("UNUSED_PARAMETER") project: Project?, withPrimitives: Boolean): Boolean =
         when (getLexerType(name)) {
-            IDENTIFIER -> !withPrimitives || name !in PrimitiveTypes
-            QUOTE_IDENTIFIER -> true
+            IDENTIFIER, QUOTE_IDENTIFIER -> true
             else -> false
         }
 
     private fun getLexerType(text: String): IElementType? {
         val lexer = RsLexer()
         lexer.start(text)
-        if (lexer.tokenEnd == text.length) {
-            return lexer.tokenType
-        } else {
-            return null
-        }
+        return if (lexer.tokenEnd == text.length) lexer.tokenType else null
     }
 
     companion object {
-        val PrimitiveTypes = arrayOf(
-            "bool",
-            "char",
-            "i8",
-            "i16",
-            "i32",
-            "i64",
-            "u8",
-            "u16",
-            "u32",
-            "u64",
-            "isize",
-            "usize",
-            "f32",
-            "f64",
-            "str"
-        )
-
         val PredefinedLifetimes = arrayOf("'static")
     }
 }

--- a/src/main/kotlin/org/rust/lang/refactoring/RsRenameProcessor.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RsRenameProcessor.kt
@@ -1,0 +1,26 @@
+package org.rust.lang.refactoring
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.SearchScope
+import com.intellij.refactoring.rename.RenamePsiElementProcessor
+import org.rust.lang.core.psi.RsLabel
+import org.rust.lang.core.psi.RsLabelDecl
+import org.rust.lang.core.psi.RsLifetime
+import org.rust.lang.core.psi.RsLifetimeDecl
+
+class RsRenameProcessor : RenamePsiElementProcessor() {
+
+    override fun canProcessElement(element: PsiElement): Boolean = true
+
+    override fun prepareRenaming(element: PsiElement, newName: String?, allRenames: MutableMap<PsiElement, String>, scope: SearchScope) {
+        if (newName == null) return
+        if (element is RsLifetime || element is RsLifetimeDecl || element is RsLabel || element is RsLabelDecl) {
+            allRenames.put(element, newName.ensureQuote())
+        } else {
+            allRenames.put(element, newName.trimStart('\''))
+        }
+    }
+
+    private fun String.ensureQuote(): String = if (startsWith('\'')) { this } else { "'$this" }
+
+}

--- a/src/main/kotlin/org/rust/lang/refactoring/RsRenameProcessor.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RsRenameProcessor.kt
@@ -12,8 +12,7 @@ class RsRenameProcessor : RenamePsiElementProcessor() {
 
     override fun canProcessElement(element: PsiElement): Boolean = true
 
-    override fun prepareRenaming(element: PsiElement, newName: String?, allRenames: MutableMap<PsiElement, String>, scope: SearchScope) {
-        if (newName == null) return
+    override fun prepareRenaming(element: PsiElement, newName: String, allRenames: MutableMap<PsiElement, String>, scope: SearchScope) {
         if (element is RsLifetime || element is RsLifetimeDecl || element is RsLabel || element is RsLabelDecl) {
             allRenames.put(element, newName.ensureQuote())
         } else {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -111,6 +111,10 @@
         <codeInsight.lineMarkerProvider language="Rust"
                                         implementationClass="org.rust.ide.annotator.RsCrateDocLineMarkerProvider"/>
 
+        <!-- Rename Processor -->
+
+        <renamePsiElementProcessor implementation="org.rust.lang.refactoring.RsRenameProcessor" />
+
         <!-- Completion -->
 
         <completion.contributor language="Rust"

--- a/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
@@ -6,7 +6,7 @@ import org.rust.lang.RsTestBase
 class RenameTest : RsTestBase() {
     override val dataPath = "org/rust/ide/refactoring/fixtures/rename"
 
-    fun testFunction() = doTest("spam", """
+    fun `test function`() = doTest("spam", """
         mod a {
             mod b {
                 fn /*caret*/foo() {}
@@ -52,7 +52,13 @@ class RenameTest : RsTestBase() {
         }
     """)
 
-    fun testField() = doTest("spam", """
+    fun `test function with quote`() = doTest("'bar", """
+        fn fo/*caret*/o() { foo(); }
+    """, """
+        fn bar() { bar(); }
+    """)
+
+    fun `test field`() = doTest("spam", """
         struct S { /*caret*/foo: i32 }
 
         fn main() {
@@ -76,6 +82,12 @@ class RenameTest : RsTestBase() {
         fn foo<'foo>(a: &/*caret*/'foo u32) {}
     """, """
         fn foo<'bar>(a: &'bar u32) {}
+    """)
+
+    fun `test rename lifetime without quote`() = doTest("baz", """
+        fn foo<'foo>(a: &/*caret*/'foo u32) {}
+    """, """
+        fn foo<'baz>(a: &'baz u32) {}
     """)
 
     fun `test rename loop label`() = doTest("'bar", """


### PR DESCRIPTION
There's a problem with renaming now: `RsNameValidator` hasn't a clue about the type of the element being renamed. So, it has to always allow both regular `identifier`s and `quote_identifier`s because we want to be able to rename everything. This leads to throwing an error when you provide a name of a wrong type (for instance, `foo` for a lifetime, or `'foo` for a function).

This change introduces an implementation of `RenamePsiElementProcessor` that substitutes wrong names to valid ones (by adding or removing a quote sign when needed) thus preventing mentioned errors.

The problem could have been solved in the `RsReferenceBase.doRename()`, but `RenamePsiElementProcessor` provides additional functionality that will allow us to do other refactoring improvements (like handling name conflicts), so I think it's good to have one.