### PR TITLE
TY: Type inference for array sizes and enum variant discriminants

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/util/RustExprExtensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/util/RustExprExtensions.kt
@@ -5,7 +5,7 @@ import org.rust.lang.core.psi.*
 /**
  *  `RsExpr` related extensions
  */
-// TODO: rename to make it clear that these are filed of the type and not of the expression.
+// TODO: rename to make it clear that these are fields of the type and not of the expression.
 val RsStructExpr.fields: List<RsNamedElement>
     get() = (path.reference.resolve() as? RsFieldsOwner)?.namedFields.orEmpty()
 
@@ -14,3 +14,9 @@ val RsStructExpr.fields: List<RsNamedElement>
  * Extracts [RsLitExpr] raw value
  */
 val RsLitExpr.stringLiteralValue: String? get() = (kind as? RsTextLiteral)?.value
+
+/**
+ * Extracts the expression that defines the size of an array.
+ */
+val RsArrayExpr.sizeExpr: RsExpr?
+    get() = if (semicolon != null && exprList.size == 2) exprList[1] else null

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustIntegerType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustIntegerType.kt
@@ -1,19 +1,38 @@
 package org.rust.lang.core.types.types
 
 import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RsArrayExpr
+import org.rust.lang.core.psi.RsLitExpr
+import org.rust.lang.core.psi.RsVariantDiscriminant
+import org.rust.lang.core.psi.util.sizeExpr
 
 data class RustIntegerType(val kind: Kind) : RustPrimitiveType {
 
     companion object {
         fun fromLiteral(literal: PsiElement): RustIntegerType {
             val kind = Kind.values().find { literal.text.endsWith(it.name) }
-                //FIXME: If an integer type can be uniquely determined from the surrounding program context,
-                // the unsuffixed integer literal has that type. We use just i32 for now
-                ?: Kind.i32
+                ?: inferKind(literal)
 
             return RustIntegerType(kind)
         }
 
+        /**
+         * Tries to infer the kind of an unsuffixed integer literal by its context.
+         * Fall back to the default kind if can't infer.
+         */
+        private fun inferKind(literal: PsiElement): Kind {
+            val expr = literal.parent as? RsLitExpr ?: return DEFAULT_KIND
+            return when {
+                expr.isArraySize -> Kind.usize
+                expr.isEnumVariantDiscriminant -> Kind.isize
+                else -> DEFAULT_KIND
+            }
+        }
+
+        private val RsLitExpr.isArraySize: Boolean get() = (parent as? RsArrayExpr)?.sizeExpr == this
+        private val RsLitExpr.isEnumVariantDiscriminant: Boolean get() = parent is RsVariantDiscriminant
+
+        val DEFAULT_KIND = Kind.i32
     }
 
     enum class Kind {

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -330,6 +330,16 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test usize in array size`() = testExpr("""
+        fn foo() { let _ = [0u8; 10]; }
+                                //^ usize
+    """)
+
+    fun `test isize in enum variant discriminant`() = testExpr("""
+        enum Foo { BAR = 32 }
+                        //^ isize
+    """)
+
     fun testBinOperatorsBool() {
         val cases = listOf(
             Pair("1 == 2", "bool"),


### PR DESCRIPTION
Infer integer literal kinds for array sizes and enum variant discriminants. It will help with a couple of error annotations.