### PR TITLE
Update Debugger plugin to work with intellij-rust plugin 0.1.0.1698

### DIFF
--- a/debugger/build.gradle
+++ b/debugger/build.gradle
@@ -28,12 +28,12 @@ idea {
 apply plugin: 'org.jetbrains.intellij'
 intellij {
     pluginName 'intellij-rust-debugger'
-    plugins = ['org.rust.lang:0.1.0.1611']
+    plugins = ['org.rust.lang:0.1.0.1698']
     downloadSources false
     updateSinceUntilBuild false
     instrumentCode false
 
-    localPath 'lib/clion-2016.3.2'
+    localPath 'lib/clion-2016.3.3'
 }
 
 apply plugin: 'java'

--- a/debugger/download_deps.sh
+++ b/debugger/download_deps.sh
@@ -4,5 +4,5 @@ set -e
 
 mkdir -p lib
 cd lib
-wget --no-clobber https://download.jetbrains.com/cpp/CLion-2016.3.2.tar.gz
-tar -xzvf CLion-2016.3.2.tar.gz
+wget --no-clobber https://download.jetbrains.com/cpp/CLion-2016.3.3.tar.gz
+tar -xzvf CLion-2016.3.3.tar.gz

--- a/debugger/src/main/kotlin/org/rust/debugger/lang/RsDebuggerTypesHelper.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/lang/RsDebuggerTypesHelper.kt
@@ -6,9 +6,9 @@ import com.jetbrains.cidr.execution.debugger.CidrDebugProcess
 import com.jetbrains.cidr.execution.debugger.backend.LLValue
 import com.jetbrains.cidr.execution.debugger.evaluation.CidrDebuggerTypesHelper
 import com.jetbrains.cidr.execution.debugger.evaluation.CidrMemberValue
-import org.rust.lang.core.psi.RsCompositeElement
-import org.rust.lang.core.psi.impl.RsFile
-import org.rust.lang.core.psi.util.parentOfType
+import org.rust.lang.core.psi.ext.RsCompositeElement
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.ext.parentOfType
 import org.rust.lang.core.resolve.Namespace
 import org.rust.lang.core.resolve.ResolveEngine
 import org.rust.lang.core.symbols.RustPath

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/CargoDebugConfiguration.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/CargoDebugConfiguration.kt
@@ -15,7 +15,7 @@ import com.intellij.ui.layout.Row
 import com.intellij.ui.layout.panel
 import com.intellij.util.xmlb.XmlSerializer
 import org.jdom.Element
-import org.rust.cargo.runconfig.RustRunConfigurationModule
+import org.rust.cargo.runconfig.RsRunConfigurationModule
 import org.rust.cargo.util.cargoProjectRoot
 import org.rust.cargo.util.modulesWithCargoProject
 import org.rust.ide.icons.RsIcons
@@ -37,7 +37,7 @@ class CargoDebugConfigurationType : ConfigurationTypeBase("CargoDebugConfigurati
 
 class CargoDebugConfiguration(
     project: Project, factory: ConfigurationFactory, name: String?
-) : ModuleBasedConfiguration<RustRunConfigurationModule>(name, RustRunConfigurationModule(project), factory),
+) : ModuleBasedConfiguration<RsRunConfigurationModule>(name, RsRunConfigurationModule(project), factory),
     RunConfigurationWithSuppressedDefaultRunAction {
 
     init {


### PR DESCRIPTION
Update Debugger plugin to work with intellij-rust plugin 0.1.0.1698
Also updated CLion dependency from 16.3.2 to 16.3.3.
Tested and now works fine on CLion 16.3.3 with intellij-rust-plugin 0.1.0.1698

Fixes https://github.com/intellij-rust/intellij-rust/issues/1059