### PR TITLE
RUN: Run config UI fixes

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoRunConfigurationEditorForm.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoRunConfigurationEditorForm.kt
@@ -11,7 +11,9 @@ import com.intellij.ui.RawCommandLineEditor
 import com.intellij.util.execution.ParametersListUtil
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.toolchain.CargoCommandLine
+import java.awt.Dimension
 import javax.swing.JComponent
+import javax.swing.JPanel
 import javax.swing.JTextField
 
 
@@ -47,10 +49,13 @@ class CargoRunConfigurationEditorForm : SettingsEditor<CargoCommandConfiguration
     }
 
     override fun createEditor(): JComponent = panel {
-        labeledRow("Rust project:", comboModules) { comboModules(CCFlags.push) }
+        labeledRow("Rust &project:", comboModules) { comboModules(CCFlags.push) }
         labeledRow("&Command:", command) { command(growPolicy = GrowPolicy.SHORT_TEXT) }
-        labeledRow("Additional arguments:", additionalArguments) { additionalArguments() }
-        row(environmentVariables.label) { environmentVariables() }
+        labeledRow("&Additional arguments:", additionalArguments) { additionalArguments.apply {
+            dialogCaption = "Additional arguments"
+            makeWide()
+        }() }
+        row(environmentVariables.label) { environmentVariables.apply { makeWide() }() }
         row { printBacktrace() }
     }
 
@@ -58,5 +63,9 @@ class CargoRunConfigurationEditorForm : SettingsEditor<CargoCommandConfiguration
         val label = Label(labelText)
         label.labelFor = component
         row(label) { init() }
+    }
+
+    private fun JPanel.makeWide() {
+        preferredSize = Dimension(1000, height)
     }
 }


### PR DESCRIPTION
Various small fixes of the run configuration edit window:

1. Add title to the "Additional arguments" window to fix `Assertion failed: Dialog title shouldn't be empty or null: []` exception that sometimes occurs.
2. Make fields wide again!
3. Add quick focus hotkeys to the fields with no such keys.
