### PR TITLE
RUN: Support short backtraces

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -17,6 +17,7 @@ import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.runconfig.CargoRunState
 import org.rust.cargo.runconfig.RsRunConfigurationModule
 import org.rust.cargo.runconfig.ui.CargoRunConfigurationEditorForm
+import org.rust.cargo.toolchain.BacktraceMode
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.toolchain.RustToolchain
 import org.rust.cargo.util.cargoProjectRoot
@@ -32,11 +33,11 @@ class CargoCommandConfiguration(
     @get: com.intellij.util.xmlb.annotations.Transient
     @set: com.intellij.util.xmlb.annotations.Transient
     var cargoCommandLine: CargoCommandLine
-        get() = CargoCommandLine(_cargoArgs.command, _cargoArgs.additionalArguments, _cargoArgs.printBacktrace, _cargoArgs.environmentVariables)
+        get() = CargoCommandLine(_cargoArgs.command, _cargoArgs.additionalArguments, BacktraceMode.fromIndex(_cargoArgs.backtraceMode), _cargoArgs.environmentVariables)
         set(value) = with(value) {
             _cargoArgs.command = command
             _cargoArgs.additionalArguments = additionalArguments
-            _cargoArgs.printBacktrace = printBacktrace
+            _cargoArgs.backtraceMode = backtraceMode.index
             _cargoArgs.environmentVariables = environmentVariables
         }
 
@@ -112,6 +113,6 @@ class CargoCommandConfiguration(
 data class SerializableCargoCommandLine(
     var command: String = "",
     var additionalArguments: List<String> = mutableListOf(),
-    var printBacktrace: Boolean = true,
+    var backtraceMode: Int = BacktraceMode.DEFAULT.index,
     var environmentVariables: Map<String, String> = mutableMapOf()
 )

--- a/src/main/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilter.kt
@@ -46,7 +46,7 @@ private class RsBacktraceItemFilter(
     val project: Project,
     val module: Module
 ) : Filter {
-    private val pattern = Pattern.compile("^(\\s*\\d+:\\s+0x[a-f0-9]+ - )(.+)(::h[0-9a-f]+)$")!!
+    private val pattern = Pattern.compile("^(\\s*\\d+:\\s+(?:0x[a-f0-9]+ - )?)(.+?)(::h[0-9a-f]+)?$")!!
     private val docManager = PsiDocumentManager.getInstance(project)
 
     override fun applyFilter(line: String, entireLength: Int): Filter.Result? {
@@ -66,7 +66,9 @@ private class RsBacktraceItemFilter(
         }
 
         // Dim the hashcode
-        resultItems.add(Filter.ResultItem(funcEnd, funcEnd + funcHash.length, null, DIMMED_TEXT))
+        if (funcHash != null) {
+            resultItems.add(Filter.ResultItem(funcEnd, funcEnd + funcHash.length, null, DIMMED_TEXT))
+        }
 
         return Filter.Result(resultItems)
     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoRunConfigurationEditorForm.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoRunConfigurationEditorForm.kt
@@ -1,15 +1,16 @@
 package org.rust.cargo.runconfig.ui
 
-import backcompat.ui.components.CheckBox
 import backcompat.ui.components.Label
 import backcompat.ui.layout.*
 import com.intellij.application.options.ModulesComboBox
 import com.intellij.execution.configuration.EnvironmentVariablesComponent
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.options.SettingsEditor
+import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.RawCommandLineEditor
 import com.intellij.util.execution.ParametersListUtil
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.toolchain.BacktraceMode
 import org.rust.cargo.toolchain.CargoCommandLine
 import java.awt.Dimension
 import javax.swing.JComponent
@@ -23,7 +24,7 @@ class CargoRunConfigurationEditorForm : SettingsEditor<CargoCommandConfiguration
     private val command = JTextField()
     private val additionalArguments = RawCommandLineEditor()
     private val environmentVariables = EnvironmentVariablesComponent()
-    private val printBacktrace = CheckBox("Print back&trace")
+    private val backtraceMode = ComboBox<BacktraceMode>()
 
     override fun resetEditorFrom(configuration: CargoCommandConfiguration) {
         comboModules.setModules(configuration.validModules)
@@ -32,7 +33,7 @@ class CargoRunConfigurationEditorForm : SettingsEditor<CargoCommandConfiguration
         configuration.cargoCommandLine.let { args ->
             command.text = args.command
             additionalArguments.text = ParametersListUtil.join(args.additionalArguments)
-            printBacktrace.isSelected = args.printBacktrace
+            backtraceMode.selectedIndex = args.backtraceMode.index
             environmentVariables.envs = args.environmentVariables
         }
     }
@@ -43,7 +44,7 @@ class CargoRunConfigurationEditorForm : SettingsEditor<CargoCommandConfiguration
         configuration.cargoCommandLine = CargoCommandLine(
             command.text,
             ParametersListUtil.parse(additionalArguments.text),
-            printBacktrace.isSelected,
+            BacktraceMode.fromIndex(backtraceMode.selectedIndex),
             environmentVariables.envs
         )
     }
@@ -56,7 +57,11 @@ class CargoRunConfigurationEditorForm : SettingsEditor<CargoCommandConfiguration
             makeWide()
         }() }
         row(environmentVariables.label) { environmentVariables.apply { makeWide() }() }
-        row { printBacktrace() }
+        labeledRow("Back&trace:", backtraceMode) { backtraceMode.apply{
+            addItem(BacktraceMode.NO)
+            addItem(BacktraceMode.SHORT)
+            addItem(BacktraceMode.FULL)
+        }() }
     }
 
     private fun LayoutBuilder.labeledRow(labelText: String, component: JComponent, init: Row.() -> Unit) {

--- a/src/main/kotlin/org/rust/cargo/toolchain/BacktraceMode.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/BacktraceMode.kt
@@ -1,0 +1,14 @@
+package org.rust.cargo.toolchain
+
+enum class BacktraceMode(val index: Int, val title: String) {
+    NO(0, "No"),
+    SHORT(1, "Short"),
+    FULL(2, "Full");
+
+    override fun toString(): String = title
+
+    companion object {
+        val DEFAULT = FULL
+        fun fromIndex(index: Int) = BacktraceMode.values().find { it.index == index } ?: DEFAULT
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -69,7 +69,11 @@ class Cargo(
         rustfmtCommandline(filePath).execute(owner, listener)
 
     fun generalCommand(commandLine: CargoCommandLine): GeneralCommandLine {
-        val env = (if (commandLine.printBacktrace) mapOf(RUST_BACTRACE_ENV_VAR to "1") else emptyMap()) + commandLine.environmentVariables
+        val env = when (commandLine.backtraceMode) {
+            BacktraceMode.SHORT -> mapOf(RUST_BACTRACE_ENV_VAR to "short")
+            BacktraceMode.FULL -> mapOf(RUST_BACTRACE_ENV_VAR to "full")
+            else -> emptyMap()
+        } + commandLine.environmentVariables
         return generalCommand(commandLine.command, commandLine.additionalArguments, env)
     }
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
@@ -3,6 +3,6 @@ package org.rust.cargo.toolchain
 data class CargoCommandLine(
     val command: String, // Can't be `enum` because of custom subcommands
     val additionalArguments: List<String> = emptyList(),
-    val printBacktrace: Boolean = true,
+    val backtraceMode: BacktraceMode = BacktraceMode.DEFAULT,
     val environmentVariables: Map<String, String> = emptyMap()
 )

--- a/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterTest.kt
@@ -11,12 +11,12 @@ class RsBacktraceFilterTest : HighlightFilterTestBase() {
 
     override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
 
-    fun testRustcSourceCodeLink() =
+    fun `test rustc source code link`() =
         checkHighlights(filter,
             "          at src/main.rs:24",
             "          at [src/main.rs -> main.rs]:24")
 
-    fun testRustcSourceCodeLinkWIthAbsolutePath() {
+    fun `test rustc source code link wIth absolute path`() {
         // Windows does not handle abs paths on the tmpfs
         if (SystemInfo.isWindows) return
         val absPath = "${projectDir.canonicalPath}/src/main.rs"
@@ -25,33 +25,38 @@ class RsBacktraceFilterTest : HighlightFilterTestBase() {
             "          at [$absPath -> main.rs]:24")
     }
 
-    fun testBacktraceLine() =
+    fun `test full backtrace line`() =
         checkHighlights(filter,
             "   7:     0x7feeefb7d11f - std::io::Stdin::read_line::h93df64e7370b5253",
             "   7:     0x7feeefb7d11f - [std::io::Stdin::read_line -> stdio.rs][::h93df64e7370b5253]")
 
-    fun testBacktraceNoLinksToInternalCalls() =
+    fun `test short backtrace line`() =
+        checkHighlights(filter,
+            "   7: std::io::Stdin::read_line",
+            "   7: [std::io::Stdin::read_line -> stdio.rs]")
+
+    fun `test backtrace no links to internal calls`() =
         checkHighlights(filter,
             "  16:        0x106bfe616 - std::rt::lang_start::h538f8960e7644c80",
             "  16:        0x106bfe616 - std::rt::lang_start[::h538f8960e7644c80]")
 
-    fun testBacktraceLineWithClosure() =
+    fun `test backtrace line with closure`() =
         checkHighlights(filter,
             " 103:     0x7feeefb480ee - std::io::Stdin::lock::{{closure}}::hbe9ea065746f6376",
             " 103:     0x7feeefb480ee - [std::io::Stdin::lock::{{closure}} -> stdio.rs][::hbe9ea065746f6376]")
 
-    fun testBacktraceLineWithGenerics() =
+    fun `test backtrace line with generics`() =
         checkHighlights(filter,
             "  10:     0x70ae3fe9d6a3 - <core::option::Option<T>>::unwrap::h5dd7da6bb3d06020",
             "  10:     0x70ae3fe9d6a3 - [<core::option::Option<T>>::unwrap -> option.rs][::h5dd7da6bb3d06020]")
 
-    fun testBacktraceNoLinksToUnknownFunctions() =
+    fun `test backtrace no links to unknown functions`() =
         checkNoHighlights(filter, "  17:        0x106c24240 - foo::bar::unknown[::h5dd7da6bb3d06020]")
 
-    fun testBacktraceNotAppliedToInternalFunctions() =
+    fun `test backtrace not applied to internal functions`() =
         checkNoHighlights(filter, "  19:        0x106bf9a49 - main")
 
-    fun testFullOutput() =
+    fun `test full output`() =
         checkHighlights(filter,
             """    Running `target/debug/test`
 thread '<main>' panicked at 'called `Option::unwrap()` on a `None` value', ../src/libcore/option.rs:325

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable configuration uses default environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable configuration uses default environment.xml
@@ -7,13 +7,13 @@
           <option value="hello" />
         </list>
       </option>
+      <option name="backtraceMode" value="2" />
       <option name="command" value="run" />
       <option name="environmentVariables">
         <map>
           <entry key="FOO" value="BAR" />
         </map>
       </option>
-      <option name="printBacktrace" value="true" />
     </parameters>
     <module name="light_idea_test_case" />
   </configuration>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test configuration uses default environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test configuration uses default environment.xml
@@ -9,13 +9,13 @@
           <option value="test_foo" />
         </list>
       </option>
+      <option name="backtraceMode" value="2" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map>
           <entry key="FOO" value="BAR" />
         </map>
       </option>
-      <option name="printBacktrace" value="true" />
     </parameters>
     <module name="light_idea_test_case" />
   </configuration>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executableProducerWorksForBin.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executableProducerWorksForBin.xml
@@ -7,11 +7,11 @@
           <option value="hello" />
         </list>
       </option>
+      <option name="backtraceMode" value="2" />
       <option name="command" value="run" />
       <option name="environmentVariables">
         <map />
       </option>
-      <option name="printBacktrace" value="true" />
     </parameters>
     <module name="light_idea_test_case" />
   </configuration>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executableProducerWorksForExample.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executableProducerWorksForExample.xml
@@ -7,11 +7,11 @@
           <option value="hello" />
         </list>
       </option>
+      <option name="backtraceMode" value="2" />
       <option name="command" value="run" />
       <option name="environmentVariables">
         <map />
       </option>
-      <option name="printBacktrace" value="true" />
     </parameters>
     <module name="light_idea_test_case" />
   </configuration>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executableProducerWorksForExamples.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executableProducerWorksForExamples.xml
@@ -1,11 +1,11 @@
 <configurations>
   <configuration name="Run hello" class="CargoCommandConfiguration" show_console_on_std_err="false" show_console_on_std_out="false">
     <option name="additionalArguments" value="--package test-package --example hello" />
+    <option name="backtraceMode" value="2" />
     <option name="command" value="run" />
     <option name="environmentVariables">
       <map />
     </option>
-    <option name="printBacktrace" value="true" />
     <module name="light_idea_test_case" />
   </configuration>
 </configurations>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/hyphenInNameWorks.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/hyphenInNameWorks.xml
@@ -7,11 +7,11 @@
           <option value="hello-world" />
         </list>
       </option>
+      <option name="backtraceMode" value="2" />
       <option name="command" value="run" />
       <option name="environmentVariables">
         <map />
       </option>
-      <option name="printBacktrace" value="true" />
     </parameters>
     <module name="light_idea_test_case" />
   </configuration>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/mainFnIsMoreSpecificThanTestMod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/mainFnIsMoreSpecificThanTestMod.xml
@@ -7,11 +7,11 @@
           <option value="foo" />
         </list>
       </option>
+      <option name="backtraceMode" value="2" />
       <option name="command" value="run" />
       <option name="environmentVariables">
         <map />
       </option>
-      <option name="printBacktrace" value="true" />
     </parameters>
     <module name="light_idea_test_case" />
   </configuration>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/mainModAndTestModHaveSameSpecificity.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/mainModAndTestModHaveSameSpecificity.xml
@@ -7,11 +7,11 @@
           <option value="foo" />
         </list>
       </option>
+      <option name="backtraceMode" value="2" />
       <option name="command" value="run" />
       <option name="environmentVariables">
         <map />
       </option>
-      <option name="printBacktrace" value="true" />
     </parameters>
     <module name="light_idea_test_case" />
   </configuration>
@@ -26,11 +26,11 @@
           <option value="" />
         </list>
       </option>
+      <option name="backtraceMode" value="2" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map />
       </option>
-      <option name="printBacktrace" value="true" />
     </parameters>
     <module name="light_idea_test_case" />
   </configuration>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/meaningfulConfigurationName.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/meaningfulConfigurationName.xml
@@ -9,11 +9,11 @@
           <option value="bar::tests" />
         </list>
       </option>
+      <option name="backtraceMode" value="2" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map />
       </option>
-      <option name="printBacktrace" value="true" />
     </parameters>
     <module name="light_idea_test_case" />
   </configuration>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testFnIsMoreSpecificThanMainMod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testFnIsMoreSpecificThanMainMod.xml
@@ -1,11 +1,11 @@
 <configurations>
   <configuration name="Test test_foo" class="CargoCommandConfiguration" show_console_on_std_err="false" show_console_on_std_out="false">
     <option name="additionalArguments" value="--package test-package --bin foo test_foo" />
+    <option name="backtraceMode" value="2" />
     <option name="command" value="test" />
     <option name="environmentVariables">
       <map />
     </option>
-    <option name="printBacktrace" value="true" />
     <module name="light_idea_test_case" />
   </configuration>
 </configurations>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerAddsBinName.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerAddsBinName.xml
@@ -10,11 +10,11 @@
           <option value="test_foo" />
         </list>
       </option>
+      <option name="backtraceMode" value="2" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map />
       </option>
-      <option name="printBacktrace" value="true" />
     </parameters>
     <module name="light_idea_test_case" />
   </configuration>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForAnnotatedFunctions.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForAnnotatedFunctions.xml
@@ -9,11 +9,11 @@
           <option value="test_foo" />
         </list>
       </option>
+      <option name="backtraceMode" value="2" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map />
       </option>
-      <option name="printBacktrace" value="true" />
     </parameters>
     <module name="light_idea_test_case" />
   </configuration>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForFiles.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForFiles.xml
@@ -10,11 +10,11 @@
           <option value="" />
         </list>
       </option>
+      <option name="backtraceMode" value="2" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map />
       </option>
-      <option name="printBacktrace" value="true" />
     </parameters>
     <module name="light_idea_test_case" />
   </configuration>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForModules.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForModules.xml
@@ -9,11 +9,11 @@
           <option value="foo" />
         </list>
       </option>
+      <option name="backtraceMode" value="2" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map />
       </option>
-      <option name="printBacktrace" value="true" />
     </parameters>
     <module name="light_idea_test_case" />
   </configuration>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForRootModule.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForRootModule.xml
@@ -9,11 +9,11 @@
           <option value="" />
         </list>
       </option>
+      <option name="backtraceMode" value="2" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map />
       </option>
-      <option name="printBacktrace" value="true" />
     </parameters>
     <module name="light_idea_test_case" />
   </configuration>


### PR DESCRIPTION
Rust now supports [short backtraces](https://github.com/rust-lang/rust/pull/38165) in nightly.

This PR:
1. Changes the "Print backtrace" flag to backtrace mode combo box (No, Short, Full). "Short" will work the same way as "Full" in beta and stable until the feature is promoted. Full is default.
2. Adds support of short backtraces to the filter that "linkifies" function names.
