### PR TITLE
RES: Resolve to correct crate version

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt
@@ -15,7 +15,7 @@ import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.ui.RustProjectSettingsPanel
 import org.rust.cargo.project.workspace.cargoWorkspace
 import org.rust.cargo.toolchain.RustToolchain
-import org.rust.cargo.project.workspace.StandardLibraryRoots
+import org.rust.cargo.project.workspace.StandardLibrary
 import org.rust.cargo.util.cargoProjectRoot
 import org.rust.cargo.util.modulesWithCargoProject
 import javax.swing.JComponent
@@ -81,7 +81,7 @@ class RustProjectConfigurable(
         val module = rustModule
         val newStdlibLocation = stdlibLocation.text
         if (module != null && newStdlibLocation != getCurrentStdlibLocation(module) && !newStdlibLocation.isNullOrBlank()) {
-            val stdlib = StandardLibraryRoots.fromPath(newStdlibLocation)
+            val stdlib = StandardLibrary.fromPath(newStdlibLocation)
                 ?: throw ConfigurationException("Invalid standard library location: `$newStdlibLocation`")
 
             runWriteAction { stdlib.attachTo(module) }

--- a/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt
@@ -81,10 +81,10 @@ class RustProjectConfigurable(
         val module = rustModule
         val newStdlibLocation = stdlibLocation.text
         if (module != null && newStdlibLocation != getCurrentStdlibLocation(module) && !newStdlibLocation.isNullOrBlank()) {
-            val roots = StandardLibraryRoots.fromPath(newStdlibLocation)
+            val stdlib = StandardLibraryRoots.fromPath(newStdlibLocation)
                 ?: throw ConfigurationException("Invalid standard library location: `$newStdlibLocation`")
 
-            runWriteAction { roots.attachTo(module) }
+            runWriteAction { stdlib.attachTo(module) }
         }
 
     }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -95,7 +95,7 @@ class CargoWorkspace private constructor(
 
     fun isCrateRoot(file: VirtualFile): Boolean = findTargetForCrateRootFile(file) != null
 
-    fun withStdlib(libs: List<StandardLibraryRoots.StdCrate>): CargoWorkspace {
+    fun withStdlib(libs: List<StandardLibrary.StdCrate>): CargoWorkspace {
         val stdlib = libs.map { crate ->
             val pkg = Package(
                 contentRootUrl = crate.packageRootUrl,

--- a/src/main/kotlin/org/rust/cargo/project/workspace/LIbraryUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/LIbraryUtil.kt
@@ -22,10 +22,10 @@ val Module.cargoLibraryName: String get() = "Cargo <$name>"
 val Module.rustLibraryName: String get() = "Rust <$name>"
 
 /**
- * Rust standard library crates source roots extracted from a zip archive or a folder with rust.
+ * Rust standard library crates sources extracted from a zip archive or a folder with rust.
  * Hopefully this class will go away when a standard way to get rust sources appears.
  */
-class StandardLibraryRoots private constructor(
+class StandardLibrary private constructor(
     val crates: List<StdCrate>
 ) {
 
@@ -50,13 +50,13 @@ class StandardLibraryRoots private constructor(
         return myUrls == libraryUrls
     }
 
-    val rootCrates: List<StdCrate> = crates.filter { it.isRoot }
+    private val rootCrates: List<StdCrate> = crates.filter { it.isRoot }
 
     companion object {
-        fun fromPath(path: String): StandardLibraryRoots? =
+        fun fromPath(path: String): StandardLibrary? =
             LocalFileSystem.getInstance().findFileByPath(path)?.let { fromFile(it) }
 
-        fun fromFile(sources: VirtualFile): StandardLibraryRoots? {
+        fun fromFile(sources: VirtualFile): StandardLibrary? {
             if (!sources.isDirectory) return null
             val srcDir = if (sources.name == "src") sources else sources.findChild("src")
                 ?: return null
@@ -70,7 +70,7 @@ class StandardLibraryRoots private constructor(
                     null
             }
             if (stdlib.isEmpty()) return null
-            return StandardLibraryRoots(stdlib)
+            return StandardLibrary(stdlib)
         }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/Stdlib.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/Stdlib.kt
@@ -13,7 +13,7 @@ import org.rust.ide.notifications.showBalloon
 class SetupRustStdlibTask(
     private val module: Module,
     private val rustup: Rustup,
-    private val withCurrentStdlib: (List<StandardLibraryRoots.StdCrate>) -> Unit
+    private val withCurrentStdlib: (List<StandardLibrary.StdCrate>) -> Unit
 ) : Task.Backgroundable(module.project, "Setup Rust stdlib") {
     private lateinit var result: Rustup.DownloadResult
     private val oldLibrary = rustStandardLibrary(module)
@@ -32,16 +32,16 @@ class SetupRustStdlibTask(
         val result = result
         when (result) {
             is Rustup.DownloadResult.Ok -> {
-                val roots = StandardLibraryRoots.fromFile(result.library)
+                val stdlib = StandardLibrary.fromFile(result.library)
                     ?: return failWithMessage("${result.library.presentableUrl} is not a valid Rust standard library")
 
-                if (oldLibrary != null && roots.sameAsLibrary(oldLibrary)) {
-                    withCurrentStdlib(roots.rootCrates)
+                if (oldLibrary != null && stdlib.sameAsLibrary(oldLibrary)) {
+                    withCurrentStdlib(stdlib.crates)
                     return
                 }
 
-                runWriteAction { roots.attachTo(module) }
-                withCurrentStdlib(roots.rootCrates)
+                runWriteAction { stdlib.attachTo(module) }
+                withCurrentStdlib(stdlib.crates)
                 project.showBalloon(
                     "Using Rust standard library at ${result.library.presentableUrl}",
                     NotificationType.INFORMATION

--- a/src/main/kotlin/org/rust/cargo/project/workspace/Stdlib.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/Stdlib.kt
@@ -36,12 +36,12 @@ class SetupRustStdlibTask(
                     ?: return failWithMessage("${result.library.presentableUrl} is not a valid Rust standard library")
 
                 if (oldLibrary != null && roots.sameAsLibrary(oldLibrary)) {
-                    withCurrentStdlib(roots.crates)
+                    withCurrentStdlib(roots.rootCrates)
                     return
                 }
 
                 runWriteAction { roots.attachTo(module) }
-                withCurrentStdlib(roots.crates)
+                withCurrentStdlib(roots.rootCrates)
                 project.showBalloon(
                     "Using Rust standard library at ${result.library.presentableUrl}",
                     NotificationType.INFORMATION

--- a/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/impl/CargoProjectWorkspaceServiceImpl.kt
@@ -44,9 +44,9 @@ private val LOG = Logger.getInstance(CargoProjectWorkspaceServiceImpl::class.jav
  */
 private class WorkspaceMerger {
     private var rawWorkspace: CargoWorkspace? = null
-    private var stdlib: List<StandardLibraryRoots.StdCrate> = emptyList()
+    private var stdlib: List<StandardLibrary.StdCrate> = emptyList()
 
-    fun setStdlib(libs: List<StandardLibraryRoots.StdCrate>) {
+    fun setStdlib(libs: List<StandardLibrary.StdCrate>) {
         checkWriteAccessAllowed()
         stdlib = libs
         update()
@@ -231,7 +231,7 @@ class CargoProjectWorkspaceServiceImpl(private val module: Module) : CargoProjec
     }
 
     @TestOnly
-    fun setStdlib(libs: List<StandardLibraryRoots.StdCrate>) {
+    fun setStdlib(libs: List<StandardLibrary.StdCrate>) {
         workspaceMerger.setStdlib(libs)
     }
 }

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -134,6 +134,7 @@ object CargoMetadata {
             "`cargo metadata` reported a package which does not exist at `$manifest_path`"
         }
         return CleanCargoMetadata.Package(
+            id,
             root.url,
             name,
             version,
@@ -179,6 +180,7 @@ data class CleanCargoMetadata(
     )
 
     data class Package(
+        val id: String,
         val url: String,
         val name: String,
         val version: String,

--- a/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
@@ -5,11 +5,45 @@ import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.toolchain.RustToolchain
 
+data class StdLibInfo (
+    val name: String,
+    val isRoot: Boolean = false,
+    val srcDir: String = "lib" + name,
+    val dependencies: List<String> = emptyList()
+)
 
 object AutoInjectedCrates {
     const val std: String = "std"
     const val core: String = "core"
-    val stdlibCrateNames = listOf(std, core, "collections", "alloc", "rustc_unicode", "std_unicode")
+    val stdlibCrates = listOf(
+        // Roots
+        StdLibInfo(std, dependencies = listOf("alloc_jemalloc", "alloc_system", "panic_abort", "rand",
+            "compiler_builtins", "unwind", "rustc_asan", "rustc_lsan", "rustc_msan", "rustc_tsan",
+            "build_helper"), isRoot = true),
+        StdLibInfo(core, isRoot = true),
+        StdLibInfo("alloc", isRoot = true),
+        StdLibInfo("collections", isRoot = true),
+        StdLibInfo("libc", srcDir = "liblibc/src", isRoot = true),
+        StdLibInfo("panic_unwind", isRoot = true),
+        StdLibInfo("rustc_unicode", isRoot = true),
+        StdLibInfo("std_unicode", isRoot = true),
+        StdLibInfo("test", dependencies = listOf("getopts", "term"), isRoot = true),
+        // Dependencies
+        StdLibInfo("alloc_jemalloc"),
+        StdLibInfo("alloc_system"),
+        StdLibInfo("build_helper", srcDir = "build_helper"),
+        StdLibInfo("compiler_builtins"),
+        StdLibInfo("getopts"),
+        StdLibInfo("panic_unwind"),
+        StdLibInfo("panic_abort"),
+        StdLibInfo("rand"),
+        StdLibInfo("rustc_asan"),
+        StdLibInfo("rustc_lsan"),
+        StdLibInfo("rustc_msan"),
+        StdLibInfo("rustc_tsan"),
+        StdLibInfo("term"),
+        StdLibInfo("unwind")
+    )
 }
 
 /**
@@ -19,4 +53,3 @@ val Module.cargoProjectRoot: VirtualFile?
     get() = ModuleRootManager.getInstance(this).contentRoots.firstOrNull {
         it.findChild(RustToolchain.CARGO_TOML) != null
     }
-

--- a/src/main/kotlin/org/rust/ide/annotator/RsCrateDocLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsCrateDocLineMarkerProvider.kt
@@ -6,11 +6,9 @@ import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.execution.filters.BrowserHyperlinkInfo
 import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.psi.PsiElement
-import org.rust.cargo.project.workspace.cargoWorkspace
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.psi.RsExternCrateItem
 import org.rust.lang.core.psi.ext.containingCargoPackage
-import org.rust.lang.core.psi.ext.module
 
 /**
  * Provides an external crate imports with gutter icons that open documentation on docs.rs.
@@ -22,8 +20,8 @@ class RsCrateDocLineMarkerProvider : LineMarkerProvider {
     override fun collectSlowLineMarkers(elements: List<PsiElement>, result: MutableCollection<LineMarkerInfo<PsiElement>>) {
         for (el in elements) {
             val crateItem = el as? RsExternCrateItem ?: continue
-            val cargoProject = crateItem.module?.cargoWorkspace ?: continue
-            val crate = cargoProject.findCrateByName(crateItem.identifier.text, crateItem.containingCargoPackage) ?: continue
+            val crateName = crateItem.identifier.text
+            val crate = crateItem.containingCargoPackage?.findCrateByName(crateName) ?: continue
             if (crate.pkg.source == null) continue
             result.add(LineMarkerInfo(
                 crateItem.crate,
@@ -31,7 +29,7 @@ class RsCrateDocLineMarkerProvider : LineMarkerProvider {
                 RsIcons.DOCS_MARK,
                 // BACKCOMPAT: 2016.2
                 Pass.UPDATE_OVERRIDDEN_MARKERS,
-                { "Open documentation for `${crate.normName}`" },
+                { "Open documentation for `${crate.pkg.normName}`" },
                 { _, _ -> BrowserHyperlinkInfo.openUrl("https://docs.rs/${crate.pkg.name}/${crate.pkg.version}/${crate.normName}") },
                 GutterIconRenderer.Alignment.LEFT))
         }

--- a/src/main/kotlin/org/rust/ide/annotator/RsCrateDocLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsCrateDocLineMarkerProvider.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiElement
 import org.rust.cargo.project.workspace.cargoWorkspace
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.psi.RsExternCrateItem
+import org.rust.lang.core.psi.ext.containingCargoPackage
 import org.rust.lang.core.psi.ext.module
 
 /**
@@ -22,7 +23,7 @@ class RsCrateDocLineMarkerProvider : LineMarkerProvider {
         for (el in elements) {
             val crateItem = el as? RsExternCrateItem ?: continue
             val cargoProject = crateItem.module?.cargoWorkspace ?: continue
-            val crate = cargoProject.findCrateByName(crateItem.identifier.text) ?: continue
+            val crate = cargoProject.findCrateByName(crateItem.identifier.text, crateItem.containingCargoPackage) ?: continue
             if (crate.pkg.source == null) continue
             result.add(LineMarkerInfo(
                 crateItem.crate,

--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -22,7 +22,7 @@ import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.cargoWorkspace
 import org.rust.cargo.toolchain.RustToolchain
-import org.rust.cargo.project.workspace.StandardLibraryRoots
+import org.rust.cargo.project.workspace.StandardLibrary
 import org.rust.cargo.util.cargoProjectRoot
 import org.rust.lang.core.psi.isNotRustFile
 import java.awt.Component
@@ -150,7 +150,7 @@ class MissingToolchainNotificationProvider(
     }
 
     private fun tryAttachStdlibToModule(module: Module, stdlib: VirtualFile): Boolean {
-        val roots = StandardLibraryRoots.fromFile(stdlib)
+        val roots = StandardLibrary.fromFile(stdlib)
             ?: return false
 
         runWriteAction { roots.attachTo(module) }

--- a/src/main/kotlin/org/rust/lang/core/completion/CompletionEngine.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/CompletionEngine.kt
@@ -7,21 +7,14 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.openapi.editor.EditorModificationUtil
 import com.intellij.psi.PsiFile
 import org.rust.cargo.project.workspace.PackageOrigin
-import org.rust.cargo.project.workspace.cargoWorkspace
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
-import org.rust.lang.core.psi.RsFile
-import org.rust.lang.core.psi.ext.asRustPath
-import org.rust.lang.core.psi.ext.basePath
-import org.rust.lang.core.psi.ext.valueParameters
-import org.rust.lang.core.psi.ext.module
-import org.rust.lang.core.psi.ext.parentOfType
 import org.rust.lang.core.resolve.*
 import org.rust.lang.core.symbols.RustPath
 import org.rust.lang.core.types.RustTypificationEngine
-import org.rust.lang.core.types.type
 import org.rust.lang.core.types.stripAllRefsIfAny
+import org.rust.lang.core.types.type
 import org.rust.lang.core.types.types.RustStructType
 import org.rust.lang.core.types.types.RustUnknownType
 import org.rust.utils.sequenceOfNotNull
@@ -78,7 +71,7 @@ object CompletionEngine {
     }
 
     fun completeExternCrate(extCrate: RsExternCrateItem): Array<out LookupElement> =
-        extCrate.module?.cargoWorkspace?.packages
+        extCrate.containingCargoPackage?.dependencies
             ?.filter { it.origin == PackageOrigin.DEPENDENCY }
             ?.mapNotNull { it.libTarget }
             ?.map { LookupElementBuilder.create(extCrate, it.normName).withIcon(extCrate.getIcon(0)) }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsCompositeElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsCompositeElement.kt
@@ -37,7 +37,7 @@ val RsCompositeElement.crateRoot: RsMod? get() {
 val RsCompositeElement.containingCargoTarget: CargoWorkspace.Target? get() {
     val cargoProject = module?.cargoWorkspace ?: return null
     val root = crateRoot ?: return null
-    val file = root.containingFile.virtualFile ?: return null
+    val file = root.containingFile.originalFile.virtualFile ?: return null
     return cargoProject.findTargetForCrateRootFile(file)
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsCompositeElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsCompositeElement.kt
@@ -36,8 +36,8 @@ val RsCompositeElement.crateRoot: RsMod? get() {
 
 val RsCompositeElement.containingCargoTarget: CargoWorkspace.Target? get() {
     val cargoProject = module?.cargoWorkspace ?: return null
-    val crateRoot = crateRoot ?: return null
-    val file = crateRoot.containingFile.virtualFile ?: return null
+    val root = crateRoot ?: return null
+    val file = root.containingFile.virtualFile ?: return null
     return cargoProject.findTargetForCrateRootFile(file)
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsCompositeElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsCompositeElement.kt
@@ -37,8 +37,11 @@ val RsCompositeElement.crateRoot: RsMod? get() {
 val RsCompositeElement.containingCargoTarget: CargoWorkspace.Target? get() {
     val cargoProject = module?.cargoWorkspace ?: return null
     val crateRoot = crateRoot ?: return null
-    return cargoProject.findTargetForCrateRootFile(crateRoot.containingFile.virtualFile)
+    val file = crateRoot.containingFile.virtualFile ?: return null
+    return cargoProject.findTargetForCrateRootFile(file)
 }
+
+val RsCompositeElement.containingCargoPackage: CargoWorkspace.Package? get() = containingCargoTarget?.pkg
 
 abstract class RsCompositeElementImpl(node: ASTNode) : ASTWrapperPsiElement(node), RsCompositeElement {
     override fun getReference(): RsReference? = null

--- a/src/test/kotlin/org/rust/FileTree.kt
+++ b/src/test/kotlin/org/rust/FileTree.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.*
 import org.intellij.lang.annotations.Language
 import org.rust.lang.core.psi.ext.RsReferenceElement
+import org.rust.lang.core.psi.ext.containingCargoPackage
 import org.rust.lang.core.psi.ext.parentOfType
 import org.rust.utils.fullyRefreshDirectory
 import kotlin.text.Charsets.UTF_8
@@ -86,7 +87,8 @@ class TestProject(
 
     inline fun <reified T : RsReferenceElement> checkReferenceIsResolved(
         path: String,
-        shouldNotResolve: Boolean = false
+        shouldNotResolve: Boolean = false,
+        toCrate: String? = null
     ) {
         val ref = findElementInFile<T>(path)
         val res = ref.reference.resolve()
@@ -97,6 +99,12 @@ class TestProject(
         } else {
             check(res != null) {
                 "Failed to resolve the reference `${ref.text}` in `$path`."
+            }
+            if (toCrate != null && res != null) {
+                val pkg = res.containingCargoPackage?.let { "${it.name} ${it.version}" } ?: "[nowhere]"
+                check(pkg == toCrate) {
+                    "Expected to be resolved to $toCrate but actually resolved to $pkg"
+                }
             }
         }
     }

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt
@@ -334,7 +334,8 @@ class RunConfigurationProducerTest : RsTestBase() {
                 CleanCargoMetadata(
                     packages = listOf(
                         CleanCargoMetadata.Package(
-                            myFixture.tempDirFixture.getFile(".")!!.url,
+                            id = "test-package 0.0.1",
+                            url = myFixture.tempDirFixture.getFile(".")!!.url,
                             name = "test-package",
                             version = "0.0.1",
                             targets = targets.map {

--- a/src/test/kotlin/org/rust/ide/annotator/RsCrateDocLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsCrateDocLineMarkerProviderTest.kt
@@ -16,6 +16,6 @@ class RsCrateDocLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
     """)
 
     fun testNoDocumentationLink() = doTestByText("""
-        extern crate dep_nosrc_lib;       // It's a package name, no documentation
+        extern crate nosrc_lib;           // It's a package name, no documentation
     """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsCrateDocLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsCrateDocLineMarkerProviderTest.kt
@@ -8,14 +8,14 @@ class RsCrateDocLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
 
     fun testDocumentationLink() = doTestByText("""
         #[cfg(not(windows))]
-        extern crate trans_lib;             // - Open documentation for `trans_lib`
+        extern crate dep_lib;             // - Open documentation for `dep_lib`
     """)
 
     fun testDocumentationLinkWithAlias() = doTestByText("""
-        extern crate trans_lib as tlib;     // - Open documentation for `trans_lib`
+        extern crate dep_lib as dlib;     // - Open documentation for `dep_lib`
     """)
 
     fun testNoDocumentationLink() = doTestByText("""
-        extern crate dep_lib;               // It's a package name, no documentation
+        extern crate dep_nosrc_lib;       // It's a package name, no documentation
     """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsLineMarkerProviderTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsLineMarkerProviderTestBase.kt
@@ -3,14 +3,13 @@ package org.rust.ide.annotator
 import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import org.rust.lang.RsFileType
 import org.rust.lang.RsTestBase
 
 abstract class RsLineMarkerProviderTestBase : RsTestBase() {
     override val dataPath = ""
 
     protected fun doTestByText(source: String) {
-        myFixture.configureByText(RsFileType, source)
+        myFixture.configureByText("lib.rs", source)
         myFixture.doHighlighting()
         val expected = markersFrom(source)
         val actual = markersFrom(myFixture.editor, myFixture.project)

--- a/src/test/kotlin/org/rust/lang/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/RsTestBase.kt
@@ -213,7 +213,8 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
         }
 
         protected fun testCargoPackage(contentRoot: String, name: String = "test-package") = CleanCargoMetadata.Package(
-            contentRoot,
+            id = name + " 0.0.1",
+            url = contentRoot,
             name = name,
             version = "0.0.1",
             targets = listOf(
@@ -225,7 +226,8 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
         )
 
         protected fun externalPackage(source: String?, name: String, targetName: String = name) = CleanCargoMetadata.Package(
-            "",
+            id = name + " 0.0.1",
+            url = "",
             name = name,
             version = "0.0.1",
             targets = listOf(

--- a/src/test/kotlin/org/rust/lang/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/RsTestBase.kt
@@ -21,7 +21,7 @@ import org.rust.cargo.project.workspace.impl.CargoProjectWorkspaceServiceImpl
 import org.rust.cargo.toolchain.RustToolchain
 import org.rust.cargo.toolchain.Rustup
 import org.rust.cargo.toolchain.impl.CleanCargoMetadata
-import org.rust.cargo.project.workspace.StandardLibraryRoots
+import org.rust.cargo.project.workspace.StandardLibrary
 import org.rust.lang.core.psi.ext.parentOfType
 import java.util.*
 
@@ -243,10 +243,10 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
     protected object WithStdlibRustProjectDescriptor : RustProjectDescriptorBase.WithRustup() {
         override fun testCargoProject(module: Module, contentRoot: String): CargoWorkspace {
 
-            val stdlib = StandardLibraryRoots.fromFile(stdlib!!)!!
+            val stdlib = StandardLibrary.fromFile(stdlib!!)!!
             stdlib.attachTo(module)
             (CargoProjectWorkspaceService.getInstance(module) as CargoProjectWorkspaceServiceImpl)
-                .setStdlib(stdlib.rootCrates)
+                .setStdlib(stdlib.crates)
 
             val packages = listOf(testCargoPackage(contentRoot))
 
@@ -259,13 +259,13 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
     protected object WithStdlibAndDependencyRustProjectDescriptor : RustProjectDescriptorBase.WithRustup() {
         override fun testCargoProject(module: Module, contentRoot: String): CargoWorkspace {
 
-            val stdlib = StandardLibraryRoots.fromFile(stdlib!!)!!
+            val stdlib = StandardLibrary.fromFile(stdlib!!)!!
             stdlib.attachTo(module)
 
             val packages = listOf(
                 testCargoPackage(contentRoot),
                 externalPackage("dep-lib/lib.rs", "dep-lib", "dep-lib-target"),
-                externalPackage(null, "dep-nosrc-lib", "dep-nosrc-lib-target"),
+                externalPackage(null, "nosrc-lib", "nosrc-lib-target"),
                 externalPackage("trans-lib/lib.rs", "trans-lib"))
 
             val depNodes = ArrayList<CleanCargoMetadata.DependencyNode>()

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -8,7 +8,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
 
     fun testHasStdlibSources() {
         val cargoProject = myModule.cargoWorkspace
-        cargoProject?.findCrateByName("std")?.crateRoot
+        cargoProject?.findCrateByNameApproximately("std")?.crateRoot
             ?: error("No Rust sources found during test.\nTry running `rustup component add rust-src`")
     }
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -461,7 +461,7 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
 
         fn bar<T: D>(x: T) { x.foo() }
                               //^
-""")
+    """)
 
     fun testChainedBoundsCycle() = checkByCode("""
         trait A: B {}

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeParametersResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeParametersResolveTest.kt
@@ -84,5 +84,5 @@ class RsTypeParametersResolveTest : RsResolveTestBase() {
 
         fn main() { let _: S::T = unreachable!(); }
                             //^ unresolved
-        """)
+    """)
 }


### PR DESCRIPTION
When multiple versions of a particular crate are used in the same project (transitively, through dependencies), resolve references to the correct version of the crate depending on what package the reference belongs to.

Fixes #1015 