### PR TITLE
ANN: Improvement on add turbofish quick fix.Support nested generics.

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFix.kt
@@ -94,7 +94,6 @@ class AddTurbofishFix : RsElementBaseIntentionAction<AddTurbofishFix.Context>() 
 
     private fun isCallExpression(expr: RsExpr) = expr is RsParenExpr || expr.firstChild is RsParenExpr
 
-    /* Maybe there' s a better way than cut and paste these methods from RsFactory */
     private inline fun <reified T : RsCompositeElement> create(project: Project, text: String): T? =
         createFromText(project, "fn main() { $text; }")
 

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFix.kt
@@ -3,27 +3,32 @@ package org.rust.ide.annotator.fixes
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFileFactory
 import org.rust.ide.intentions.RsElementBaseIntentionAction
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.psi.ext.operatorType
 import org.rust.lang.core.psi.ext.parentOfType
+import org.rust.lang.core.psi.RsElementTypes.*
+import org.rust.lang.RsFileType
+import org.rust.lang.core.psi.ext.RsCompositeElement
+import org.rust.lang.core.psi.ext.childOfType
+
 
 class AddTurbofishFix : RsElementBaseIntentionAction<AddTurbofishFix.Context>() {
     private val TURBOFISH = "::"
 
     override fun invoke(project: Project, editor: Editor, ctx: Context) {
-        val (matchExpr, caller, gen, more) = ctx
-        val callWithNamespace =
-            RsPsiFactory(project).createExpression("""${caller.text}$TURBOFISH<${gen.text}>${more.text}""")
-        matchExpr.replace(callWithNamespace)
+        val (matchExpr, insertion) = ctx
+        val expression = matchExpr.text
+        val left = expression.substring(0, insertion)
+        val right = expression.substring(insertion)
+        val fixed = create<RsExpr>(project, """$left$TURBOFISH$right""") ?: return
+        matchExpr.replace(fixed)
     }
 
     data class Context(
         val matchExpr: RsBinaryExpr,
-        val caller: RsExpr,
-        val gen: RsPathExpr,
-        val more: RsExpr
+        val offset: Int
     )
 
     override fun getText() = "Add turbofish operator"
@@ -31,27 +36,70 @@ class AddTurbofishFix : RsElementBaseIntentionAction<AddTurbofishFix.Context>() 
 
     private fun resolveMatchExpression(element: PsiElement): RsBinaryExpr? {
         val base = element.parentOfType<RsBinaryExpr>() ?: return null
-        return if (base.left is RsBinaryExpr) {
-            base
-        } else {
-            base.parentOfType<RsBinaryExpr>()
+        if (base.left !is RsBinaryExpr) {
+            return resolveMatchExpression(base) ?: base
         }
+        val left = base.left as RsBinaryExpr
+        if (left.operatorType == GTGT) {
+            return resolveMatchExpression(base) ?: base
+        }
+        return base
     }
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
-        val matchExpr = resolveMatchExpression(element) ?: return null
-        val left = matchExpr.left as? RsBinaryExpr ?: return null
-        if (left.operatorType != LT || matchExpr.operatorType != GT) {
-            return null
+        val m = resolveMatchExpression(element) ?: return null
+        return guessContext(project, m)
+    }
+
+    private fun innerOffset(root: PsiElement, child: PsiElement): Int? {
+        if (child == root) {
+            return 0
         }
-        val caller = left.left
-        val gen = left.right as? RsPathExpr ?: return null
-        val more = matchExpr.right ?: return null
-        if (!isCallExpression(more)) {
-            return null
-        };
-        return Context(matchExpr, caller, gen, more)
+        val parent = child.parent ?: return null
+        val upper = innerOffset(root, parent) ?: return null
+        return upper + child.startOffsetInParent
+    }
+
+    private fun guessContext(project: Project, binary: RsBinaryExpr): Context? {
+        val nodes = bfsLeafs(binary)
+        val called = rightBoundary(nodes) ?: return null
+        val typeListEndIndex = binary.textLength - called.textLength
+
+        val turbofish_offset = nodes.takeWhile { it != called }.map {
+            val offset = innerOffset(binary, it)!! + it.textLength
+            val typeListCandidate = binary.text.substring(offset, typeListEndIndex)
+            if (isTypeArgumentList(project, typeListCandidate)) {
+                offset
+            } else {
+                null
+            }
+        }.filterNotNull().firstOrNull() ?: return null
+        return Context(binary, turbofish_offset)
+    }
+
+    private fun rightBoundary(nodes: List<RsExpr>) = nodes.asReversed().firstOrNull { isCallExpression(it) }
+
+    private fun isTypeArgumentList(project: Project, candidate: String) =
+        create<RsCallExpr>(project, "something$TURBOFISH$candidate()") != null
+
+    private fun bfsLeafs(expr: RsExpr?): List<RsExpr> {
+        return when (expr) {
+            is RsBinaryExpr -> {
+                bfsLeafs(expr.left) + bfsLeafs(expr.right)
+            }
+            null -> listOf<RsExpr>()
+            else -> listOf(expr)
+        }
     }
 
     private fun isCallExpression(expr: RsExpr) = expr is RsParenExpr || expr.firstChild is RsParenExpr
+
+    /* Maybe there' s a better way than cut and paste these methods from RsFactory */
+    private inline fun <reified T : RsCompositeElement> create(project: Project, text: String): T? =
+        createFromText(project, "fn main() { $text; }")
+
+    private inline fun <reified T : RsCompositeElement> createFromText(project: Project, code: String): T? =
+        PsiFileFactory.getInstance(project)
+            .createFileFromText("DUMMY.rs", RsFileType, code)
+            .childOfType<T>()
 }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFixTest.kt
@@ -6,131 +6,90 @@ import org.rust.ide.annotator.RsAnnotatorTestBase
 class AddTurbofishFixTest : RsAnnotatorTestBase() {
     val intention = "Add turbofish operator"
 
-    fun `test trivial happy path`() = checkQuickFix("""
-        fn main() {
-            let _ = std::parse</*caret*/i32>("42");
-        }
-    """, """
-        fn main() {
-            let _ = std::parse::</*caret*/i32>("42");
-        }
-    """)
+    fun `test trivial happy path`() = checkStatement(
+        """std::parse</*caret*/i32>("42")""",
+        """std::parse::</*caret*/i32>("42")"""
+    )
 
-    fun `test should not be applied`() = checkNoIntention(intention,
-        """
-        fn main() {
-            let my_bool = 1 < 5 /*carret*/> 3;
-        }
-        """)
 
-    fun `test should be available also in right side`() = checkQuickFix(
-        """
-        fn foo() {
-            let _ = parse<i32>(/*caret*/"42");
-        }
-        """,
-        """
-        fn foo() {
-            let _ = parse::<i32>(/*caret*/"42");
-        }
-        """)
+    fun `test should not be applied`() = checkNoIntention("""1 < 5 /*carret*/> 3;""")
 
-    fun `test should be available also when call is chained by another function`() = checkQuickFix(
-        """
-        fn foo() {
-            let _ = parse<i32>(/*caret*/"42").unwrap();
-        }
-        """,
-        """
-        fn foo() {
-            let _ = parse::<i32>(/*caret*/"42").unwrap();
-        }
-        """)
+    fun `test should be available also in right side`() = checkStatement(
+            """parse<i32>(/*caret*/"42")""",
+            """parse::<i32>(/*caret*/"42")""")
+
+    fun `test should be available also when call is chained by another function`() =
+        checkStatement(
+            """parse<i32>(/*caret*/"42").unwrap()""",
+            """parse::<i32>(/*caret*/"42").unwrap()""")
 
     fun `test should recognize also generics arguments`() {
-        for (gen in listOf("<Option<String>>",
-            "<Option<Option<String>>>",
-            "<Option<Option<Option<String>>>>",
-            "<Option<Option<Option<Option<String>>>>>")) {
-            checkQuickFix(
-                """
-                    fn foo() {
-                        let _ = something$gen(/*caret*/"42");
-                    }
-                """, """
-                    fn foo() {
-                        let _ = something::$gen(/*caret*/"42");
-                    }
-                """)
-        }
+        checkStatement(
+            """something<Option<String>>(/*caret*/"42")""",
+            """something::<Option<String>>(/*caret*/"42")""")
+        checkStatement(
+            """something<Option<Option<String>>>(/*caret*/"42")""",
+            """something::<Option<Option<String>>>(/*caret*/"42")""")
+        checkStatement(
+            """something<Option<Option<Option<String>>>>(/*caret*/"42")""",
+            """something::<Option<Option<Option<String>>>>(/*caret*/"42")""")
+        checkStatement(
+            """something<Option<Option<Option<Option<String>>>>>(/*caret*/"42")""",
+            """something::<Option<Option<Option<Option<String>>>>>(/*caret*/"42")""")
     }
 
     fun `test should guess the correct boundary`() {
-        val cases = listOf(
-            Pair("", " >> 3"), Pair("", " > 3 > 5"), Pair("", " == call_something()"),
-            Pair("3 < ", ""), Pair("3 == ", ""), Pair("bye() == 3 < ", " > more() >> 2")
-        )
-
-        for ((before, after) in cases) {
-            checkQuickFix(
-                """
-                fn foo() {
-                    let _ = ${before}something<Option<i32>>(/*caret*/"42")$after;
-                }
-                """, """
-                fn foo() {
-                    let _ = ${before}something::<Option<i32>>(/*caret*/"42")$after;
-                }
-                """)
-
-        }
+        checkStatement(
+            """something<Option<i32>>(/*caret*/"42") >> 3""",
+            """something::<Option<i32>>(/*caret*/"42") >> 3""")
+        checkStatement(
+            """something<Option<i32>>(/*caret*/"42") > 3 > 5""",
+            """something::<Option<i32>>(/*caret*/"42") > 3 > 5""")
+        checkStatement(
+            """something<Option<i32>>(/*caret*/"42") == call_something()""",
+            """something::<Option<i32>>(/*caret*/"42") == call_something()""")
+        checkStatement(
+            """3 < something<Option<i32>>(/*caret*/"42")""",
+            """3 < something::<Option<i32>>(/*caret*/"42")""")
+        checkStatement(
+            """3 == something<Option<i32>>(/*caret*/"42")""",
+            """3 == something::<Option<i32>>(/*caret*/"42")""")
+        checkStatement(
+            """bye() == 3 < something<Option<i32>>(/*caret*/"42") > more() >> 2""",
+            """bye() == 3 < something::<Option<i32>>(/*caret*/"42") > more() >> 2""")
     }
 
 
-    fun `test should not be available if the instance is corrected yet`() = checkNoIntention(intention,
-        """
-        fn foo() {
-            let _ = parse::</*caret*/i32>("42");
-        }
-        """)
+    fun `test should not be available if the instance is corrected yet`() =
+        checkNoIntention("""parse::</*caret*/i32>("42")""")
 
     fun `test should not trigger misspelled comparison sentences`() {
-        checkNoIntention(intention,
-            """
-            fn foo(x: i32) {
-                let _ = 1 < /*caret*/x < 5;
-            }
-            """)
-        checkNoIntention(intention,
-            """
-            fn foo(x: i32, y: i32) {
-                let _ = 1 < /*caret*/x > 5;
-            }
-            """)
+        checkNoIntention("""1 < /*caret*/x < 5""")
+        checkNoIntention("""1 < /*caret*/x > 5""")
     }
 
     fun `test should be available just if looks like a generic reference`() {
-        checkNoIntention(intention,
-            """
-            fn foo(x: i32) {
-                let _ = parse>/*caret*/i32>("42");
-            }
-            """)
-        checkNoIntention(intention,
-            """
-            fn foo(x: i32) {
-                let _ = parse</*caret*/i32<("42");
-            }
-            """)
+        checkNoIntention("""parse>/*caret*/i32>("42")""")
+        checkNoIntention("""parse</*caret*/i32<("42")""")
     }
 
-    private fun checkNoIntention(name: String, @Language("Rust") code: String) {
-        InlineFile(code)
+    private fun checkNoIntention(code: String) {
+        InlineFile(wrapStatement(code))
 
-        check(name !in myFixture.availableIntentions.mapNotNull { it.familyName }) {
-            "\"$name\" shouldn't be in intentions list"
+        check(intention !in myFixture.availableIntentions.mapNotNull { it.familyName }) {
+            "\"$intention\" shouldn't be in intentions list"
         }
     }
+
+    private fun checkStatement(before: String, after: String) =
+        checkQuickFix(wrapStatement(before), wrapStatement(after))
+
+    private fun wrapStatement(statement: String) =
+        """
+            fn foo(x: i32) {
+                let _ = $statement;
+            }
+        """
 
     private fun checkQuickFix(@Language("Rust") before: String, @Language("Rust") after: String) =
         checkQuickFix(intention, before, after)


### PR DESCRIPTION
Now addressing:

* nesting `parse<Option<Option<i32>>("41")`
* boundary `3 < parse<i32>("41") > 10`

But not yet:

* `Something<Gen>::func()`
* `func<Some<_>>()`
* `func<A, B>()`

*Note*: `create()` and `createFromText()` come from `RsPsiFactory` because I didn't find any other usable and public implementation. Thoughts are welcome.