### PR TITLE
ANN: More lifetime error annotations

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -124,7 +124,7 @@ class RsErrorAnnotator : Annotator, HighlightRangeExtension {
         if (expectedLifetimes == actualLifetimes) return
         if (actualLifetimes == 0 && !type.lifetimeElidable) {
             holder.createErrorAnnotation(type, "Missing lifetime specifier [E0106]")
-        } else if (actualLifetimes > 0 && actualLifetimes != expectedLifetimes) {
+        } else if (actualLifetimes > 0) {
             holder.createErrorAnnotation(type, "Wrong number of lifetime parameters: expected $expectedLifetimes, found $actualLifetimes [E0107]")
         }
     }


### PR DESCRIPTION
E0107 (wrong number of lifetime parameters) and more cases of E0106 (missing lifetime) annotations. From #886 
