### PR TITLE
FOLD: Fold one liner functions

### DIFF
--- a/src/main/kotlin/org/rust/ide/folding/RsCodeFoldingOptionsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/folding/RsCodeFoldingOptionsProvider.kt
@@ -1,0 +1,17 @@
+package org.rust.ide.folding
+
+import com.intellij.application.options.editor.CodeFoldingOptionsProvider
+import com.intellij.openapi.options.BeanConfigurable
+
+class RsCodeFoldingOptionsProvider :
+    BeanConfigurable<RsCodeFoldingSettings>(RsCodeFoldingSettings.instance),
+    CodeFoldingOptionsProvider {
+
+    init {
+        val settings = instance
+        val getter: () -> Boolean = { settings.collapsibleOneLineMethods }
+        val setter: (Boolean) -> Unit = { v -> settings.collapsibleOneLineMethods = v }
+
+        checkBox("Rust one-line methods", getter, setter)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/folding/RsCodeFoldingSettings.kt
+++ b/src/main/kotlin/org/rust/ide/folding/RsCodeFoldingSettings.kt
@@ -1,0 +1,14 @@
+package org.rust.ide.folding
+
+import com.intellij.openapi.components.ServiceManager
+
+
+abstract class RsCodeFoldingSettings {
+
+    abstract var collapsibleOneLineMethods: Boolean
+
+    companion object {
+        val instance: RsCodeFoldingSettings get() = ServiceManager.getService(RsCodeFoldingSettings::class.java)
+    }
+}
+

--- a/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt
+++ b/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt
@@ -108,7 +108,8 @@ class RsFoldingBuilder : FoldingBuilderEx(), DumbAware {
         }
     }
 
-    override fun isCollapsedByDefault(node: ASTNode): Boolean = node.elementType in COLLAPSED_BY_DEFAULT
+    override fun isCollapsedByDefault(node: ASTNode): Boolean =
+        RsCodeFoldingSettings.instance.collapsibleOneLineMethods && node.elementType in COLLAPSED_BY_DEFAULT
 
     private companion object {
         val COLLAPSED_BY_DEFAULT = TokenSet.create(LBRACE, RBRACE)

--- a/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt
+++ b/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt
@@ -4,18 +4,31 @@ import com.intellij.lang.ASTNode
 import com.intellij.lang.folding.FoldingBuilderEx
 import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.FoldingGroup
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.util.PsiTreeUtil
+import org.rust.lang.core.leftSiblings
 import org.rust.lang.core.parser.RustParserDefinition.Companion.BLOCK_COMMENT
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.RsElementTypes.LBRACE
+import org.rust.lang.core.psi.RsElementTypes.RBRACE
+import org.rust.lang.core.rightSiblings
 import java.util.*
 
-class RsFoldingBuilder() : FoldingBuilderEx(), DumbAware {
-    override fun getPlaceholderText(node: ASTNode): String = if (node.psi is PsiComment) "/* ... */" else "{...}"
+class RsFoldingBuilder : FoldingBuilderEx(), DumbAware {
+    override fun getPlaceholderText(node: ASTNode): String =
+        when {
+            node.elementType == LBRACE -> " { "
+            node.elementType == RBRACE -> " }"
+            node.psi is PsiComment -> "/* ... */"
+            else -> "{...}"
+        }
 
     override fun buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array<out FoldingDescriptor> {
         if (root !is RsFile) return emptyArray()
@@ -35,7 +48,12 @@ class RsFoldingBuilder() : FoldingBuilderEx(), DumbAware {
 
         override fun visitBlockFields(o: RsBlockFields) = fold(o)
 
-        override fun visitBlock(o: RsBlock) = fold(o)
+        override fun visitBlock(o: RsBlock) {
+            if (o.parent is RsFunction && o.isSingleLine) {
+                if (tryFoldBlockWhitespaces(o)) return
+            }
+            fold(o)
+        }
 
         override fun visitMatchBody(o: RsMatchBody) = fold(o)
 
@@ -72,7 +90,39 @@ class RsFoldingBuilder() : FoldingBuilderEx(), DumbAware {
                 descriptors += FoldingDescriptor(element.node, range)
             }
         }
+
+        private fun tryFoldBlockWhitespaces(block: RsBlock): Boolean {
+            val leftEl = block.prevSibling as? PsiWhiteSpace ?: block.lbrace
+            val rightEl = block.rbrace ?: return false
+            val leadingSpace = block.lbrace.nextSibling as? PsiWhiteSpace ?: return false
+            val trailingSpace = rightEl.prevSibling as? PsiWhiteSpace ?: return false
+            if (leadingSpace == trailingSpace || !leadingSpace.worthFolding && !trailingSpace.worthFolding) return false
+
+            val range1 = TextRange(leftEl.textOffset, leadingSpace.textRange.endOffset)
+            val range2 = TextRange(trailingSpace.textOffset, rightEl.textRange.endOffset)
+            val group = FoldingGroup.newGroup("OneLiner")
+            descriptors += FoldingDescriptor(block.lbrace.node, range1, group)
+            descriptors += FoldingDescriptor(rightEl.node, range2, group)
+
+            return true
+        }
     }
 
-    override fun isCollapsedByDefault(node: ASTNode): Boolean = false
+    override fun isCollapsedByDefault(node: ASTNode): Boolean = node.elementType in COLLAPSED_BY_DEFAULT
+
+    private companion object {
+        val COLLAPSED_BY_DEFAULT = TokenSet.create(LBRACE, RBRACE)
+    }
 }
+
+private val RsBlock.isSingleLine: Boolean get() {
+    // remove all leading and trailing spaces before counting lines
+    val startContents = lbrace.rightSiblings.dropWhile { it is PsiWhiteSpace }.firstOrNull() ?: return false
+    if (startContents.node.elementType == RBRACE) return false
+    val endContents = rbrace?.leftSiblings?.dropWhile { it is PsiWhiteSpace }?.firstOrNull() ?: return false
+
+    val doc = PsiDocumentManager.getInstance(project).getDocument(containingFile) ?: return false
+    return doc.getLineNumber(startContents.textOffset) == doc.getLineNumber(endContents.textRange.endOffset)
+}
+
+private val PsiWhiteSpace?.worthFolding: Boolean get() = this != null && text.length > 1

--- a/src/main/kotlin/org/rust/ide/folding/impl/RsCodeFoldingSettingsImpl.kt
+++ b/src/main/kotlin/org/rust/ide/folding/impl/RsCodeFoldingSettingsImpl.kt
@@ -1,0 +1,18 @@
+package org.rust.ide.folding.impl
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.XmlSerializerUtil
+import org.rust.ide.folding.RsCodeFoldingSettings
+
+@State(name = "RsCodeFoldingSettings", storages = arrayOf(Storage("editor.codeinsight.xml")))
+class RsCodeFoldingSettingsImpl : RsCodeFoldingSettings(), PersistentStateComponent<RsCodeFoldingSettingsImpl> {
+
+    override var collapsibleOneLineMethods: Boolean = true
+
+    override fun getState(): RsCodeFoldingSettingsImpl = this
+
+    override fun loadState(state: RsCodeFoldingSettingsImpl) = XmlSerializerUtil.copyBean(state, this)
+
+}

--- a/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
@@ -120,6 +120,8 @@ val PsiElement.leftLeaves: Sequence<PsiElement> get() = generateSequence(this, P
 
 val PsiElement.rightSiblings: Sequence<PsiElement> get() = generateSequence(this.nextSibling) { it.nextSibling }
 
+val PsiElement.leftSiblings: Sequence<PsiElement> get() = generateSequence(this.prevSibling) { it.prevSibling }
+
 private fun <T, Self : ObjectPattern<T, Self>> ObjectPattern<T, Self>.with(name: String, cond: (T) -> Boolean): Self =
     with(object : PatternCondition<T>(name) {
         override fun accepts(t: T, context: ProcessingContext?): Boolean = cond(t)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -339,6 +339,9 @@
         <!-- Folding -->
 
         <lang.foldingBuilder language="Rust" implementationClass="org.rust.ide.folding.RsFoldingBuilder"/>
+        <codeFoldingOptionsProvider instance="org.rust.ide.folding.RsCodeFoldingOptionsProvider"/>
+        <applicationService serviceInterface="org.rust.ide.folding.RsCodeFoldingSettings"
+                            serviceImplementation="org.rust.ide.folding.impl.RsCodeFoldingSettingsImpl" />
 
         <!-- Live Templates -->
 

--- a/src/test/kotlin/org/rust/ide/folding/RsFoldingTest.kt
+++ b/src/test/kotlin/org/rust/ide/folding/RsFoldingTest.kt
@@ -21,6 +21,7 @@ class RsFoldingTest : RsTestBase() {
     fun testMacroBraceArg() = doTest()
     fun testUseGlobList() = doTest()
     fun testBlockComment() = doTest()
+    fun testOneLinerFunction() = doTest()
 
     private fun doTest() {
         myFixture.testFolding("$testDataPath/$fileName")

--- a/src/test/resources/org/rust/ide/folding/fixtures/macro_brace_arg.rs
+++ b/src/test/resources/org/rust/ide/folding/fixtures/macro_brace_arg.rs
@@ -1,4 +1,5 @@
 fn test() <fold text='{...}'>{
+    // comment to prevent one-liner folding
     awesome! <fold text='{...}'>{ }</fold>
 }</fold>
 

--- a/src/test/resources/org/rust/ide/folding/fixtures/one_liner_function.rs
+++ b/src/test/resources/org/rust/ide/folding/fixtures/one_liner_function.rs
@@ -1,0 +1,10 @@
+fn foo()<fold text=' { '> {
+    </fold>println!("Hello World");<fold text=' }'>
+}</fold>
+
+fn bar()<fold text=' { '>
+{
+
+    </fold>println!("Hello World");<fold text=' }'>
+
+}</fold>


### PR DESCRIPTION
Implements #1097 

I'd like to only fold one-liners by default when the flag Preferences -> Editor -> General -> Code Folding -> One-line methods is on, but don't know how to get its value. There's the `CodeFoldingSettings` class, but it doesn't provide access to the "Collapse by default" preferences block. Any hints on how that could be achieved?
