### PR TITLE
RES: Fix lifetime resolve in where clauses

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/Resolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Resolve.kt
@@ -205,6 +205,7 @@ fun processResolveVariants(lifetime: RsLifetime, processor: RsResolveProcessor):
     loop@ for (scope in lifetime.ancestors) {
         val lifetimeParameters = when (scope) {
             is RsGenericDeclaration -> scope.typeParameterList?.lifetimeParameterList
+            is RsWhereClause -> scope.wherePredList.mapNotNull { it.forLifetimes }.flatMap { it.lifetimeParameterList }
             is RsForInType -> scope.forLifetimes.lifetimeParameterList
             is RsPolybound -> scope.forLifetimes?.lifetimeParameterList
             else -> continue@loop

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -691,6 +691,14 @@ class RsResolveTest : RsResolveTestBase() {
                //^
     """)
 
+    fun `test lifetime in for lifetimes 3`() = checkByCode("""
+        trait Foo<T> {}
+        fn foo<T>(t: T) where for<'a>
+                                 //X
+                              T: Foo<&'a T> {}
+                                     //^
+    """)
+
     fun `test static lifetime unresolved`() = checkByCode("""
         fn foo(name: &'static str) {}
                       //^ unresolved


### PR DESCRIPTION
Fix lifetime resolve when it's declared in a `where for<...>` clause.