### PR TITLE
COMP: Complete trait methods implemented for struct or enum (Fixes #1120)

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/types/RustEnumType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustEnumType.kt
@@ -4,8 +4,8 @@ import com.intellij.codeInsight.completion.CompletionUtil
 import org.rust.lang.core.psi.RsEnumItem
 import org.rust.lang.core.types.RustType
 
-data class RustEnumType(
-    val enum: RsEnumItem,
+class RustEnumType(
+    enum: RsEnumItem,
     override val typeArguments: List<RustType> = emptyList()
 ) : RustStructOrEnumTypeBase {
 
@@ -18,5 +18,11 @@ data class RustEnumType(
 
     override fun substitute(map: Map<RustTypeParameterType, RustType>): RustEnumType =
         RustEnumType(item, typeArguments.map { it.substitute(map) })
+
+    override fun equals(other: Any?): Boolean =
+        other is RustEnumType && item == other.item && typeArguments == other.typeArguments
+
+    override fun hashCode(): Int =
+        item.hashCode() xor typeArguments.hashCode()
 
 }

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustStructType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustStructType.kt
@@ -4,8 +4,8 @@ import com.intellij.codeInsight.completion.CompletionUtil
 import org.rust.lang.core.psi.RsStructItem
 import org.rust.lang.core.types.RustType
 
-data class RustStructType(
-    val struct: RsStructItem,
+class RustStructType(
+    struct: RsStructItem,
     override val typeArguments: List<RustType> = emptyList()
 ) : RustStructOrEnumTypeBase {
 
@@ -18,4 +18,10 @@ data class RustStructType(
 
     override fun substitute(map: Map<RustTypeParameterType, RustType>): RustStructType =
         RustStructType(item, typeArguments.map { it.substitute(map) })
+
+    override fun equals(other: Any?): Boolean =
+        other is RustStructType && item == other.item && typeArguments == other.typeArguments
+
+    override fun hashCode(): Int =
+        item.hashCode() xor typeArguments.hashCode()
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -203,6 +203,52 @@ class RsCompletionTest : RsCompletionTestBase() {
         }
     """) { executeSoloCompletion() }
 
+    fun testCallStructMethod() = checkContainsCompletion("some_fn", """
+        struct SomeStruct { }
+        impl SomeStruct {
+            fn some_fn(&self) {}
+        }
+        fn main() {
+            let v = SomeStruct { };
+            v./*caret*/
+        }
+    """)
+
+    fun testCallEnumMethod() = checkContainsCompletion("some_fn", """
+        enum SomeEnum { Var1, Var2 }
+        impl SomeEnum {
+            fn some_fn(&self) {}
+        }
+        fn main() {
+            let v = SomeEnum::Var1 ;
+            v./*caret*/
+        }
+    """)
+
+    fun testCallTraitImplForStructMethod() = checkContainsCompletion("some_fn", """
+        trait SomeTrait { fn some_fn(&self); }
+        struct SomeStruct { }
+        impl SomeTrait for SomeStruct {
+            fn some_fn(&self) {}
+        }
+        fn main() {
+            let v = SomeStruct { };
+            v./*caret*/
+        }
+    """)
+
+    fun testCallTraitImplForEnumMethod() = checkContainsCompletion("some_fn", """
+        trait SomeTrait { fn some_fn(&self); }
+        enum SomeEnum { Var1, Var2 }
+        impl SomeTrait for SomeEnum {
+            fn some_fn(&self) {}
+        }
+        fn main() {
+            let v = SomeEnum::Var1 ;
+            v./*caret*/
+        }
+    """)
+
     fun testEnumVariant() = checkSingleCompletion("BAZBAR", """
         enum Foo {
             BARBOO,


### PR DESCRIPTION
See #1120 for more info. I removed `RustStructType.struct` field and made equality by `item` (same with `RustEnumType`). I'm not sure about the implementation, but this PR contains useful tests that demonstrate the problem (and its fix).