### PR TITLE
ANN: Fix mutability annotation on enum variants

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -648,6 +648,8 @@ private fun RsExpr.isMutable(): Boolean {
             if (type is RustUnknownType) {
                 return true
             }
+            if (declaration is RsEnumVariant) return true
+
             false
         }
         is RsFieldExpr -> (this.expr.type as? RustReferenceType)?.mutable ?: true

--- a/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt
@@ -468,4 +468,12 @@ class RsExpressionAnnotatorTest : RsAnnotatorTestBase() {
             }
         }
     """)
+
+    fun `test simple enum variant is treated as mutable`() = checkErrors("""
+        enum Foo { FOO }
+        fn foo (f: &mut Foo) {}
+        fn bar () {
+            foo(&mut Foo::FOO);     // Must not be annotated
+        }
+    """)
 }


### PR DESCRIPTION
Fixes the #1114 false positive. I'm not sure this should be the final solution, just want to provide some fix before the alpha release.

cc @farodin91