### PR TITLE
TY: infer struct or enum expr type parameters

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -753,4 +753,95 @@ class RsResolveTest : RsResolveTestBase() {
             }
         }
     """)
+
+    fun `test method in specialized trait impl for struct`() = checkByCode("""
+        trait SomeTrait { fn some_fn(&self); }
+        struct SomeStruct<T> { value: T }
+        impl SomeTrait for SomeStruct<u8> {
+            fn some_fn(&self) { }
+        }
+        impl SomeTrait for SomeStruct<u16> {
+            fn some_fn(&self) { }
+             //X
+        }
+        fn main() {
+            let v = SomeStruct {value: 5u16};
+            v.some_fn();
+            //^
+        }
+    """)
+
+    fun `test method in specialized trait impl for struct 2`() = checkByCode("""
+        trait SomeTrait { fn some_fn(&self); }
+        struct SomeStruct<T1, T2> { value1: T1, value2: T2 }
+        impl SomeTrait for SomeStruct<u8, u8> {
+            fn some_fn(&self) { }
+        }
+        impl SomeTrait for SomeStruct<u16, u8> {
+            fn some_fn(&self) { }
+             //X
+        }
+        impl SomeTrait for SomeStruct<u8, u16> {
+            fn some_fn(&self) { }
+        }
+        impl SomeTrait for SomeStruct<u16, u16> {
+            fn some_fn(&self) { }
+        }
+        fn main() {
+            let v = SomeStruct {value1: 5u16, value2: 5u8};
+            v.some_fn();
+            //^
+        }
+    """)
+
+    fun `test method in specialized trait impl for tuple struct`() = checkByCode("""
+        trait SomeTrait { fn some_fn(&self); }
+        struct SomeStruct<T> (T);
+        impl SomeTrait for SomeStruct<u8> {
+            fn some_fn(&self) { }
+        }
+        impl SomeTrait for SomeStruct<u16> {
+            fn some_fn(&self) { }
+             //X
+        }
+        fn main() {
+            let v = SomeStruct (5u16);
+            v.some_fn();
+            //^
+        }
+    """)
+
+    fun `test method in specialized trait impl for enum`() = checkByCode("""
+        trait SomeTrait { fn some_fn(&self); }
+        enum SomeStruct<T> { Var1{value: T}, Var2 }
+        impl SomeTrait for SomeStruct<u8> {
+            fn some_fn(&self) { }
+        }
+        impl SomeTrait for SomeStruct<u16> {
+            fn some_fn(&self) { }
+             //X
+        }
+        fn main() {
+            let v = SomeStruct::Var1 {value: 5u16};
+            v.some_fn();
+            //^
+        }
+    """)
+
+    fun `test method in specialized trait impl for tuple enum`() = checkByCode("""
+        trait SomeTrait { fn some_fn(&self); }
+        enum SomeStruct<T> { Var1(T), Var2  }
+        impl SomeTrait for SomeStruct<u8> {
+            fn some_fn(&self) { }
+        }
+        impl SomeTrait for SomeStruct<u16> {
+            fn some_fn(&self) { }
+             //X
+        }
+        fn main() {
+            let v = SomeStruct::Var1 (5u16);
+            v.some_fn();
+            //^
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -170,5 +170,51 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
                             //^ & Self
         }
     """)
+
+    fun `test struct expr`() = testExpr("""
+        struct SomeStruct<T> { a: T }
+        fn main() {
+            let x = SomeStruct { a: 5u16 };
+            x.a
+            //^ u16
+        }
+    """)
+
+    fun `test struct expr with 2 fields of same type`() = testExpr("""
+        struct SomeStruct<T> { a: T, b: T }
+        fn main() {
+            let x = SomeStruct { a: 5u16, b: 0 };
+            x.b
+            //^ u16
+        }
+    """)
+
+    // currently the first wins - a and b resolved as i32
+//    fun `test struct expr with 2 fields of same type 2`() = testExpr("""
+//        struct SomeStruct<T> { a: T, b: T }
+//        fn main() {
+//            let x = SomeStruct { a: 0, b: 5u16 };
+//            x.a
+//            //^ u16
+//        }
+//    """)
+
+    fun `test struct expr with 2 fields of different types`() = testExpr("""
+        struct SomeStruct<T1, T2> { a: T1, b: T2 }
+        fn main() {
+            let x = SomeStruct { a: 5u16, b: 5u8 };
+            (x.a, x.b)
+          //^ (u16, u8)
+        }
+    """)
+
+    fun testTupleStructExpression() = testExpr("""
+        struct SomeStruct<T> (T);
+        fn main() {
+            let x = SomeStruct(5u16);
+            x.0
+            //^ u16
+        }
+    """)
 }
 


### PR DESCRIPTION
provides generic types inference for struct/enum expressions
```rust
struct SomeStruct<T1, T2> { a: T1, b: T2 }
fn main() {
    let x = SomeStruct { a: 5u16, b: 5u8 };
    (x.a, x.b)
  //^ (u16, u8)
}
```