### PR TITLE
TY: basic infer non-suffixed numeric types

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/RustTypificationEngine.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RustTypificationEngine.kt
@@ -301,7 +301,7 @@ private fun addTypeMapping(
 ) {
     if (fieldType is RustTypeParameterType) {
         val old = argsMapping[fieldType]
-        if (old == null || old == RustUnknownType)
+        if (old == null || old == RustUnknownType || old is RustNumericType && old.isKindWeak)
             argsMapping[fieldType] = RustTypificationEngine.typifyExpr(expr)
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustFloatType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustFloatType.kt
@@ -2,17 +2,16 @@ package org.rust.lang.core.types.types
 
 import com.intellij.psi.PsiElement
 
-data class RustFloatType(val kind: Kind) : RustPrimitiveType {
+data class RustFloatType(val kind: Kind, override val isKindWeak: Boolean = false) : RustNumericType {
 
     companion object {
         fun fromLiteral(literal: PsiElement): RustFloatType {
             val kind = Kind.values().find { literal.text.endsWith(it.name) }
-                //FIXME: If an floating point type can be uniquely determined from the surrounding program context,
-                // the unsuffixed floating point literal has that type. We use f64 for now.
-                ?: Kind.f64
 
-            return RustFloatType(kind)
+            return RustFloatType(kind ?: DEFAULT_KIND, kind == null)
         }
+
+        val DEFAULT_KIND = Kind.f64
     }
 
     enum class Kind { f32, f64 }

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustIntegerType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustIntegerType.kt
@@ -6,26 +6,26 @@ import org.rust.lang.core.psi.RsLitExpr
 import org.rust.lang.core.psi.RsVariantDiscriminant
 import org.rust.lang.core.psi.ext.sizeExpr
 
-data class RustIntegerType(val kind: Kind) : RustPrimitiveType {
+data class RustIntegerType(val kind: Kind, override val isKindWeak: Boolean = false) : RustNumericType {
 
     companion object {
         fun fromLiteral(literal: PsiElement): RustIntegerType {
             val kind = Kind.values().find { literal.text.endsWith(it.name) }
                 ?: inferKind(literal)
 
-            return RustIntegerType(kind)
+            return RustIntegerType(kind ?: DEFAULT_KIND, kind == null)
         }
 
         /**
          * Tries to infer the kind of an unsuffixed integer literal by its context.
          * Fall back to the default kind if can't infer.
          */
-        private fun inferKind(literal: PsiElement): Kind {
-            val expr = literal.parent as? RsLitExpr ?: return DEFAULT_KIND
+        private fun inferKind(literal: PsiElement): Kind? {
+            val expr = literal.parent as? RsLitExpr ?: return null
             return when {
                 expr.isArraySize -> Kind.usize
                 expr.isEnumVariantDiscriminant -> Kind.isize
-                else -> DEFAULT_KIND
+                else -> null
             }
         }
 

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustNumericType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustNumericType.kt
@@ -1,0 +1,5 @@
+package org.rust.lang.core.types.types
+
+interface RustNumericType : RustPrimitiveType{
+    val isKindWeak: Boolean
+}

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -180,7 +180,7 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    fun `test struct expr with 2 fields of same type`() = testExpr("""
+    fun `test struct expr with 2 fields of same type integer 1`() = testExpr("""
         struct SomeStruct<T> { a: T, b: T }
         fn main() {
             let x = SomeStruct { a: 5u16, b: 0 };
@@ -189,15 +189,23 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    // currently the first wins - a and b resolved as i32
-//    fun `test struct expr with 2 fields of same type 2`() = testExpr("""
-//        struct SomeStruct<T> { a: T, b: T }
-//        fn main() {
-//            let x = SomeStruct { a: 0, b: 5u16 };
-//            x.a
-//            //^ u16
-//        }
-//    """)
+    fun `test struct expr with 2 fields of same type integer 2`() = testExpr("""
+        struct SomeStruct<T> { a: T, b: T }
+        fn main() {
+            let x = SomeStruct { a: 0, b: 5u16 };
+            x.a
+            //^ u16
+        }
+    """)
+
+    fun `test struct expr with 2 fields of same type float 2`() = testExpr("""
+        struct SomeStruct<T> { a: T, b: T }
+        fn main() {
+            let x = SomeStruct { a: 0.0, b: 5f32 };
+            x.a
+            //^ f32
+        }
+    """)
 
     fun `test struct expr with 2 fields of different types`() = testExpr("""
         struct SomeStruct<T1, T2> { a: T1, b: T2 }


### PR DESCRIPTION
Now correctly infer types in cases like this
```rust
struct SomeStruct<T> { a: T, b: T }
fn main() {
    let x = SomeStruct { a: 0, b: 5u16 };
    x.a
    //^ u16
}
```