### PR TITLE
TY: fully supported generic type aliasing of struct/enum

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/RustTypificationEngine.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RustTypificationEngine.kt
@@ -17,7 +17,11 @@ object RustTypificationEngine {
             is RsEnumItem -> RustEnumType(named)
             is RsEnumVariant -> RustEnumType((named.parent as RsEnumBody).parent as RsEnumItem)
 
-            is RsTypeAlias -> named.typeReference?.type ?: RustUnknownType
+            is RsTypeAlias -> {
+                val t = named.typeReference?.type ?: RustUnknownType
+                (t as? RustStructOrEnumTypeBase)
+                    ?.aliasTypeArguments(named.typeParameters.map(::RustTypeParameterType)) ?: t
+            }
 
             is RsFunction -> deviseFunctionType(named)
 
@@ -33,7 +37,6 @@ object RustTypificationEngine {
 
             else -> RustUnknownType
         }
-        if (named is RsGenericDeclaration) return type.withTypeArguments(named.typeParameters.map(::RustTypeParameterType))
         return type
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustEnumType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustEnumType.kt
@@ -2,11 +2,13 @@ package org.rust.lang.core.types.types
 
 import com.intellij.codeInsight.completion.CompletionUtil
 import org.rust.lang.core.psi.RsEnumItem
+import org.rust.lang.core.psi.ext.typeParameters
 import org.rust.lang.core.types.RustType
 
 class RustEnumType(
     enum: RsEnumItem,
-    override val typeArguments: List<RustType> = emptyList()
+    override val typeArgumentsMapping: List<RustTypeParameterType> = enum.typeParameters.map(::RustTypeParameterType),
+    override val typeArguments: List<RustType> = typeArgumentsMapping
 ) : RustStructOrEnumTypeBase {
 
     override val item = CompletionUtil.getOriginalOrSelf(enum)
@@ -14,10 +16,13 @@ class RustEnumType(
     override fun toString(): String = item.name ?: "<anonymous>"
 
     override fun withTypeArguments(typeArguments: List<RustType>): RustEnumType =
-        RustEnumType(item, typeArguments)
+        super.withTypeArguments(typeArguments) as RustEnumType
+
+    override fun aliasTypeArguments(typeArguments: List<RustTypeParameterType>): RustEnumType =
+        RustEnumType(item, typeArguments, this.typeArguments)
 
     override fun substitute(map: Map<RustTypeParameterType, RustType>): RustEnumType =
-        RustEnumType(item, typeArguments.map { it.substitute(map) })
+        RustEnumType(item, typeArgumentsMapping, typeArguments.map { it.substitute(map) })
 
     override fun equals(other: Any?): Boolean =
         other is RustEnumType && item == other.item && typeArguments == other.typeArguments

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustStructOrEnumTypeBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustStructOrEnumTypeBase.kt
@@ -7,6 +7,8 @@ import org.rust.lang.core.types.RustType
 interface RustStructOrEnumTypeBase : RustType {
     val typeArguments: List<RustType>
 
+    val typeArgumentsMapping: List<RustTypeParameterType>
+
     val item: RsStructOrEnumItemElement
 
     override val typeParameterValues: Map<RustTypeParameterType, RustType>
@@ -16,4 +18,8 @@ interface RustStructOrEnumTypeBase : RustType {
                 RustTypeParameterType(param) to arg
             }.toMap()
 
+    fun aliasTypeArguments(typeArguments: List<RustTypeParameterType>): RustType
+
+    override fun withTypeArguments(typeArguments: List<RustType>): RustType =
+        substitute(typeArgumentsMapping.withIndex().associate { (i, type) -> type to (typeArguments.getOrNull(i) ?: type) })
 }

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustStructType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustStructType.kt
@@ -2,11 +2,13 @@ package org.rust.lang.core.types.types
 
 import com.intellij.codeInsight.completion.CompletionUtil
 import org.rust.lang.core.psi.RsStructItem
+import org.rust.lang.core.psi.ext.typeParameters
 import org.rust.lang.core.types.RustType
 
 class RustStructType(
     struct: RsStructItem,
-    override val typeArguments: List<RustType> = emptyList()
+    override val typeArgumentsMapping: List<RustTypeParameterType> = struct.typeParameters.map(::RustTypeParameterType),
+    override val typeArguments: List<RustType> = typeArgumentsMapping
 ) : RustStructOrEnumTypeBase {
 
     override val item = CompletionUtil.getOriginalOrSelf(struct)
@@ -14,10 +16,13 @@ class RustStructType(
     override fun toString(): String = item.name ?: "<anonymous>"
 
     override fun withTypeArguments(typeArguments: List<RustType>): RustStructType =
-        RustStructType(item, typeArguments)
+        super.withTypeArguments(typeArguments) as RustStructType
+
+    override fun aliasTypeArguments(typeArguments: List<RustTypeParameterType>): RustStructType =
+        RustStructType(item, typeArguments, this.typeArguments)
 
     override fun substitute(map: Map<RustTypeParameterType, RustType>): RustStructType =
-        RustStructType(item, typeArguments.map { it.substitute(map) })
+        RustStructType(item, typeArgumentsMapping, typeArguments.map { it.substitute(map) })
 
     override fun equals(other: Any?): Boolean =
         other is RustStructType && item == other.item && typeArguments == other.typeArguments

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -224,5 +224,18 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             //^ u16
         }
     """)
+
+    fun testGenericAlias() = testExpr("""
+        struct S1<T>(T);
+        struct S3<T1, T2, T3>(T1, T2, T3);
+
+        type A<T1, T2> = S3<T2, S1<T1>, S3<S1<T2>, T2, T2>>;
+        type B = A<u16, u8>;
+
+        fn f(b: B) {
+            (b.0, (b.1).0, ((b.2).0).0)
+          //^ (u8, u16, u8)
+        }
+    """)
 }
 


### PR DESCRIPTION
It works now!
```rust
struct S1<T>(T);
struct S3<T1, T2, T3>(T1, T2, T3);

type A<T1, T2> = S3<T2, S1<T1>, S3<S1<T2>, T2, T2>>;
type B = A<u16, u8>;

fn f(b: B) {
    (b.0, (b.1).0, ((b.2).0).0)
  //^ (u8, u16, u8)
}
```