### PR TITLE
TYPE: automatically insert '>' after '::<'

### DIFF
--- a/src/main/kotlin/org/rust/ide/typing/RsTypingHandler.kt
+++ b/src/main/kotlin/org/rust/ide/typing/RsTypingHandler.kt
@@ -1,0 +1,53 @@
+package org.rust.ide.typing
+
+import com.intellij.codeInsight.CodeInsightSettings
+import com.intellij.codeInsight.editorActions.TypedHandlerDelegate
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RsElementTypes
+import org.rust.lang.core.psi.RsFile
+
+class RsTypingHandler : TypedHandlerDelegate() {
+
+    private var rsLTTyped = false
+
+    override fun beforeCharTyped(c: Char, project: Project, editor: Editor, file: PsiFile, fileType: FileType): Result {
+        if (file !is RsFile) {
+            return Result.CONTINUE
+        }
+        if (c == '<' && CodeInsightSettings.getInstance().AUTOINSERT_PAIR_BRACKET) {
+            rsLTTyped = isAfterColonColonToken(editor)
+        }
+
+        return Result.CONTINUE
+    }
+
+    override fun charTyped(c: Char, project: Project, editor: Editor, file: PsiFile): Result {
+        if (file !is RsFile) {
+            return Result.CONTINUE
+        }
+        if (rsLTTyped) {
+            rsLTTyped = false
+            val offset = editor.caretModel.offset
+            editor.document.insertString(offset, ">")
+            return Result.STOP
+
+        }
+        return Result.CONTINUE
+    }
+
+    private fun isAfterColonColonToken(editor: Editor): Boolean {
+        val offset = editor.caretModel.offset
+        val iterator = (editor as EditorEx).highlighter.createIterator(offset)
+        if (iterator.atEnd()) {
+            return false
+        }
+        if (iterator.start > 0) {
+            iterator.retreat()
+        }
+        return iterator.tokenType == RsElementTypes.COLONCOLON
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -148,6 +148,8 @@
 
         <typedHandler implementation="org.rust.ide.typing.RsRawLiteralHashesInserter"
                       id="RustRawLiteralHashesInserter"/>
+        <typedHandler implementation="org.rust.ide.typing.RsTypingHandler"
+                      id="RustTypingHandler"/>
 
         <backspaceHandlerDelegate implementation="org.rust.ide.typing.RsRawLiteralHashesDeleter"
                                   id="RustRawLiteralHashesDeleter"/>

--- a/src/test/kotlin/org/rust/ide/typing/RsBraceMatcherTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/RsBraceMatcherTest.kt
@@ -28,6 +28,24 @@ class RsBraceMatcherTest : RsTestBase() {
         "fn foo(<caret>){}"
     )
 
+    fun `test pair angle brace after colon colon token`() = doTest(
+        "fn main() { let _ = foo::<caret> }",
+        '<',
+        "fn main() { let _ = foo::<<caret>> }"
+    )
+
+    fun `test don't pair angle brace after colon colon in string literal`() = doTest(
+        """fn main() { let _ = "foo::<caret>" }""",
+        '<',
+        """fn main() { let _ = "foo::<<caret>" }"""
+    )
+
+    fun `test don't pair angle brace after colon colon in comments`() = doTest(
+        "fn main() { let _ = /* foo::<caret> */ }",
+        '<',
+        "fn main() { let _ = /* foo::<<caret> */ }"
+    )
+
     fun `test match parenthesis`() = doMatch("fn foo<caret>(x: (i32, ()) ) {}", ")")
 
     fun `test match square brackets`() = doMatch("fn foo(x: <caret>[i32; 192]) {}", "]")


### PR DESCRIPTION
https://github.com/intellij-rust/intellij-rust/issues/1022
This case is similar with inserting `>` after `.<` in Java so my implementation is based on
https://github.com/JetBrains/intellij-community/blob/f8093cba578089b13314197faee7b3436ab831f5/java/java-impl/src/com/intellij/codeInsight/editorActions/JavaTypedHandler.java#L290