### PR TITLE
CARGO: Treat nested packages as workspace members

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -140,6 +140,7 @@ object CargoMetadata {
             version,
             targets.mapNotNull { it.clean(root) },
             source,
+            manifest_path,
             isWorkspaceMember
         )
     }
@@ -186,6 +187,7 @@ data class CleanCargoMetadata(
         val version: String,
         val targets: Collection<Target>,
         val source: String?,
+        val manifestPath: String,
         val isWorkspaceMember: Boolean
     )
 

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt
@@ -346,6 +346,7 @@ class RunConfigurationProducerTest : RsTestBase() {
                                 )
                             },
                             source = null,
+                            manifestPath = "/somewhere/test-package/Cargo.toml",
                             isWorkspaceMember = true
                         )
                     ),

--- a/src/test/kotlin/org/rust/lang/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/RsTestBase.kt
@@ -215,7 +215,7 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
         }
 
         protected fun testCargoPackage(contentRoot: String, name: String = "test-package") = CleanCargoMetadata.Package(
-            id = name + " 0.0.1",
+            id = "$name 0.0.1",
             url = contentRoot,
             name = name,
             version = "0.0.1",
@@ -224,6 +224,7 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
                 CleanCargoMetadata.Target("$contentRoot/lib.rs", name, CargoWorkspace.TargetKind.LIB)
             ),
             source = null,
+            manifestPath = "$contentRoot/../Cargo.toml",
             isWorkspaceMember = true
         )
 
@@ -232,7 +233,7 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
             val vFile = source?.let { VfsTestUtil.createFile(root, it) }
 
             return CleanCargoMetadata.Package(
-                id = name + " 0.0.1",
+                id = "$name 0.0.1",
                 url = "",
                 name = name,
                 version = "0.0.1",
@@ -240,6 +241,7 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
                     CleanCargoMetadata.Target(vFile?.url ?: "", targetName, CargoWorkspace.TargetKind.LIB)
                 ),
                 source = source,
+                manifestPath = "/ext-libs/$name/Cargo.toml",
                 isWorkspaceMember = false
             )
         }


### PR DESCRIPTION
Makes all the packages that reside within our project treated as workspace members even if they're not listed by cargo in the `workspace_members` block.

Since cargo doesn't explicitly provide package paths, I extract them from the package `id`s and check if manifests of other packages sit somewhere within them.

Fixes #1137