### PR TITLE
FOLD: Fully fold one-liners that exceed line margin

### DIFF
--- a/src/test/resources/org/rust/ide/folding/fixtures/one_liner_function.rs
+++ b/src/test/resources/org/rust/ide/folding/fixtures/one_liner_function.rs
@@ -8,3 +8,7 @@ fn bar()
     println!("Hello World");
 
 }</fold>
+
+fn long() <fold text='{...}'>{
+    println!("This line is too long to fit into the line margin after collapsing, so it will fully collapse as a large block");
+}</fold>


### PR DESCRIPTION
Prevents one-line functions from showing their contents when collapsed if the resulting line is longer than the right margin setting allows. Such functions also don't autofold.

Fixes #1162 