### PR TITLE
TY: initial support of array expression type inference

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayExpr.kt
@@ -1,0 +1,22 @@
+package org.rust.lang.core.psi.ext
+
+import org.rust.lang.core.psi.RsArrayExpr
+import org.rust.lang.core.psi.RsExpr
+
+/**
+ * Extracts the expression that defines the array initializer.
+ */
+val RsArrayExpr.initializer: RsExpr?
+    get() = if (semicolon != null && exprList.size == 2) exprList[0] else null
+
+/**
+ * Extracts the expression that defines the size of an array.
+ */
+val RsArrayExpr.sizeExpr: RsExpr?
+    get() = if (semicolon != null && exprList.size == 2) exprList[1] else null
+
+/**
+ * Extracts the expression list that defines the elements of an array.
+ */
+val RsArrayExpr.arrayElements: List<RsExpr>?
+    get() = if (semicolon == null) exprList else null

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt
@@ -1,16 +1,28 @@
 package org.rust.lang.core.psi.ext
 
 import org.rust.lang.core.psi.RsArrayType
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsLitExpr
+import org.rust.lang.core.types.types.RustIntegerType
 
 val RsArrayType.arraySize: Int? get() {
     val stub = stub
     if (stub != null) {
         return if (stub.arraySize == -1) null else stub.arraySize
     }
+    return calculateArraySize(expr)
+}
 
+// TODO: support constants and compile time expressions
+fun calculateArraySize(expr: RsExpr?): Int? {
+    val sizeLiteral = (expr as? RsLitExpr)
+        ?.integerLiteral
+        ?.text
+        ?.removeSuffix(RustIntegerType.Kind.usize.name)
+    // BACKCOMPAT: Kotlin API 1.0
     return try {
-        expr?.text?.toInt() // TODO need more precise handling
+        sizeLiteral?.toInt()
     } catch (e: NumberFormatException) {
-        return null
+        null
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
@@ -10,12 +10,6 @@ import org.rust.lang.core.psi.RsElementTypes.*
  */
 val RsLitExpr.stringLiteralValue: String? get() = (kind as? RsTextLiteral)?.value
 
-/**
- * Extracts the expression that defines the size of an array.
- */
-val RsArrayExpr.sizeExpr: RsExpr?
-    get() = if (semicolon != null && exprList.size == 2) exprList[1] else null
-
 enum class UnaryOperator {
     REF, // `&a`
     REF_MUT, // `&mut a`

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -412,11 +412,42 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    fun `test slice`() = testExpr("""
+    fun `test array type3`() = testExpr("""
+        fn main() {
+            let x : [bool; 8usize];
+            x
+          //^ [bool; 8]
+        }
+    """)
+
+    fun `test array expression type1`() = testExpr("""
         fn main() {
             let x = [""];
             x
-        } //^ <unknown>
+        } //^ [& str; 1]
+    """)
+
+    fun `test array expression type2`() = testExpr("""
+        fn main() {
+            let x = [1, 2, 3];
+            x
+          //^ [i32; 3]
+        }
+    """)
+
+    fun `test array expression type3`() = testExpr("""
+        fn main() {
+            let x = [0; 8];
+            x
+          //^ [i32; 8]
+        }
+    """)
+
+    fun `test array expression type4`() = testExpr("""
+        fn main() {
+            let x = [0; 8usize];
+            x
+          //^ [i32; 8]
+        }
     """)
 }
-


### PR DESCRIPTION
Support inference of:
* sequence expressions like `[1, 2, 3]`. Array element type is the same with type of first element of the sequence. Should we infer type of all elements?
* expressions with initialization value like `[0; 8]`. Size can be extracted only from integer literal.

TODO:
* support compile time expressions as array size