### PR TITLE
Move autoderef logic to one place

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -142,7 +142,6 @@ private fun deviseFunctionType(fn: RsFunction): RustFunctionType {
 }
 
 private fun getIteratorItemType(iteratorType: RustType, project: Project): RustType {
-
     val impl = findImplsAndTraits(project, iteratorType).first
         .find {
             val traitName = it.traitRef?.resolveToTrait?.name

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -3,8 +3,8 @@ package org.rust.lang.core.types.infer
 import com.intellij.openapi.project.Project
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
-import org.rust.lang.core.resolve.indexes.RsImplIndex
 import org.rust.lang.core.types.RustType
+import org.rust.lang.core.types.findImplsAndTraits
 import org.rust.lang.core.types.type
 import org.rust.lang.core.types.types.*
 
@@ -142,7 +142,8 @@ private fun deviseFunctionType(fn: RsFunction): RustFunctionType {
 }
 
 private fun getIteratorItemType(iteratorType: RustType, project: Project): RustType {
-    val impl = RsImplIndex.findImplsFor(iteratorType, project)
+
+    val impl = findImplsAndTraits(project, iteratorType).first
         .find {
             val traitName = it.traitRef?.resolveToTrait?.name
             traitName == "Iterator" || traitName == "IntoIterator"

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustPrimitiveType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustPrimitiveType.kt
@@ -1,14 +1,9 @@
 package org.rust.lang.core.types.types
 
 import com.intellij.openapi.project.Project
-import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.types.RustType
 
 interface RustPrimitiveType : RustType {
-
-    override fun getTraitsImplementedIn(project: Project): Collection<RsTraitItem> =
-        emptyList()
-
     override fun canUnifyWith(other: RustType, project: Project): Boolean =
         this == other
 

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustReferenceType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustReferenceType.kt
@@ -1,14 +1,9 @@
 package org.rust.lang.core.types.types
 
 import com.intellij.openapi.project.Project
-import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.types.RustType
-import org.rust.lang.core.types.stripAllRefsIfAny
 
 data class RustReferenceType(val referenced: RustType, val mutable: Boolean = false) : RustType {
-
-    override fun getMethodsIn(project: Project): Collection<RsFunction> =
-        super.getMethodsIn(project) + stripAllRefsIfAny().getMethodsIn(project)
 
     override fun canUnifyWith(other: RustType, project: Project): Boolean =
         other is RustReferenceType && referenced.canUnifyWith(other.referenced, project)

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustSliceType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustSliceType.kt
@@ -14,10 +14,6 @@ data class RustSliceType(val elementType: RustType) : RustPrimitiveType {
         return RsImplIndex.findImplsFor(this, project).mapNotNull { it.traitRef?.resolveToTrait }
     }
 
-    override fun getMethodsIn(project: Project): Collection<RsFunction> {
-        return RsImplIndex.findMethodsFor(this, project)
-    }
-
     override fun canUnifyWith(other: RustType, project: Project): Boolean {
         return other is RustSliceType && elementType.canUnifyWith(other.elementType, project)
     }

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustSliceType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustSliceType.kt
@@ -1,18 +1,10 @@
 package org.rust.lang.core.types.types
 
 import com.intellij.openapi.project.Project
-import org.rust.lang.core.psi.RsFunction
-import org.rust.lang.core.psi.RsTraitItem
-import org.rust.lang.core.psi.ext.resolveToTrait
-import org.rust.lang.core.resolve.indexes.RsImplIndex
 import org.rust.lang.core.types.RustType
 
-data class RustSliceType(val elementType: RustType) : RustPrimitiveType {
+data class RustSliceType(val elementType: RustType) : RustPrimitiveType { // TODO: is it really primitive?
     override fun toString() = "[$elementType]"
-
-    override fun getTraitsImplementedIn(project: Project): Collection<RsTraitItem> {
-        return RsImplIndex.findImplsFor(this, project).mapNotNull { it.traitRef?.resolveToTrait }
-    }
 
     override fun canUnifyWith(other: RustType, project: Project): Boolean {
         return other is RustSliceType && elementType.canUnifyWith(other.elementType, project)

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustSliceType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustSliceType.kt
@@ -3,7 +3,7 @@ package org.rust.lang.core.types.types
 import com.intellij.openapi.project.Project
 import org.rust.lang.core.types.RustType
 
-data class RustSliceType(val elementType: RustType) : RustPrimitiveType { // TODO: is it really primitive?
+data class RustSliceType(val elementType: RustType) : RustPrimitiveType {
     override fun toString() = "[$elementType]"
 
     override fun canUnifyWith(other: RustType, project: Project): Boolean {

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustStringSliceType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustStringSliceType.kt
@@ -1,5 +1,5 @@
 package org.rust.lang.core.types.types
 
-object RustStringSliceType : RustPrimitiveType { // TODO: should not be primitive perhaps
+object RustStringSliceType : RustPrimitiveType {
     override fun toString(): String = "str"
 }

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustStringSliceType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustStringSliceType.kt
@@ -1,16 +1,5 @@
 package org.rust.lang.core.types.types
 
-import com.intellij.openapi.project.Project
-import org.rust.lang.core.psi.RsFunction
-import org.rust.lang.core.psi.RsTraitItem
-import org.rust.lang.core.psi.ext.resolveToTrait
-import org.rust.lang.core.resolve.indexes.RsImplIndex
-
-object RustStringSliceType : RustPrimitiveType {
-
+object RustStringSliceType : RustPrimitiveType { // TODO: should not be primitive perhaps
     override fun toString(): String = "str"
-
-    override fun getTraitsImplementedIn(project: Project): Collection<RsTraitItem> {
-        return RsImplIndex.findImplsFor(this, project).mapNotNull { it.traitRef?.resolveToTrait }
-    }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustStringSliceType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustStringSliceType.kt
@@ -13,8 +13,4 @@ object RustStringSliceType : RustPrimitiveType {
     override fun getTraitsImplementedIn(project: Project): Collection<RsTraitItem> {
         return RsImplIndex.findImplsFor(this, project).mapNotNull { it.traitRef?.resolveToTrait }
     }
-
-    override fun getMethodsIn(project: Project): Collection<RsFunction> {
-        return RsImplIndex.findMethodsFor(this, project)
-    }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustTraitType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustTraitType.kt
@@ -17,7 +17,7 @@ data class RustTraitType(val trait: RsTraitItem) : RustType {
         listOf(trait)
 
     override fun getMethodsIn(project: Project): Collection<RsFunction> =
-        getTraitsImplementedIn(project).flatMap { it.functionList}
+        getTraitsImplementedIn(project).flatMap { it.functionList }
 
     override fun canUnifyWith(other: RustType, project: Project): Boolean =
         other is RsTraitItem && trait == other.trait

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustTraitType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustTraitType.kt
@@ -1,7 +1,6 @@
 package org.rust.lang.core.types.types
 
 import com.intellij.openapi.project.Project
-import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.types.RustType
 
@@ -12,12 +11,6 @@ import org.rust.lang.core.types.RustType
  * only the latter are types.
  */
 data class RustTraitType(val trait: RsTraitItem) : RustType {
-
-    override fun getTraitsImplementedIn(project: Project): Collection<RsTraitItem> =
-        listOf(trait)
-
-    override fun getMethodsIn(project: Project): Collection<RsFunction> =
-        getTraitsImplementedIn(project).flatMap { it.functionList }
 
     override fun canUnifyWith(other: RustType, project: Project): Boolean =
         other is RsTraitItem && trait == other.trait

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustUnitType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustUnitType.kt
@@ -1,20 +1,12 @@
 package org.rust.lang.core.types.types
 
 import com.intellij.openapi.project.Project
-import org.rust.lang.core.psi.RsFunction
-import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.types.RustType
 
 object RustUnitType : RustType {
 
     override fun canUnifyWith(other: RustType, project: Project): Boolean =
         other is RustUnitType
-
-    override fun getTraitsImplementedIn(project: Project): Collection<RsTraitItem> =
-        emptyList()
-
-    override fun getMethodsIn(project: Project): Collection<RsFunction> =
-        emptyList()
 
     override fun toString(): String = "()"
 }

--- a/src/main/kotlin/org/rust/lang/core/types/types/RustUnknownType.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/types/RustUnknownType.kt
@@ -1,20 +1,10 @@
 package org.rust.lang.core.types.types
 
 import com.intellij.openapi.project.Project
-import org.rust.lang.core.psi.RsFunction
-import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.types.RustType
 
 object RustUnknownType : RustType {
-
-    override fun getTraitsImplementedIn(project: Project): Collection<RsTraitItem> =
-        emptyList()
-
-    override fun getMethodsIn(project: Project): Collection<RsFunction> =
-        emptyList()
-
     override fun canUnifyWith(other: RustType, project: Project): Boolean = false
 
     override fun toString(): String = "<unknown>"
-
 }


### PR DESCRIPTION
RsImplIndex now just looks for impls and that's it. 

Actual method and trait extraction happens in `RustType.kt`

cc @farodin91 @vlad20012 

This is not ready to merge yet as is (I want to do some cleanups tomorrow), but it's otherwise ready for a review. 