### PR TITLE
RUN: Select channel in run configuration

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -19,6 +19,7 @@ import org.rust.cargo.runconfig.RsRunConfigurationModule
 import org.rust.cargo.runconfig.ui.CargoRunConfigurationEditorForm
 import org.rust.cargo.toolchain.BacktraceMode
 import org.rust.cargo.toolchain.CargoCommandLine
+import org.rust.cargo.toolchain.RustChannel
 import org.rust.cargo.toolchain.RustToolchain
 import org.rust.cargo.util.cargoProjectRoot
 import org.rust.cargo.util.modulesWithCargoProject
@@ -33,11 +34,12 @@ class CargoCommandConfiguration(
     @get: com.intellij.util.xmlb.annotations.Transient
     @set: com.intellij.util.xmlb.annotations.Transient
     var cargoCommandLine: CargoCommandLine
-        get() = CargoCommandLine(_cargoArgs.command, _cargoArgs.additionalArguments, BacktraceMode.fromIndex(_cargoArgs.backtraceMode), _cargoArgs.environmentVariables, _cargoArgs.nocapture)
+        get() = CargoCommandLine(_cargoArgs.command, _cargoArgs.additionalArguments, BacktraceMode.fromIndex(_cargoArgs.backtraceMode), RustChannel.fromIndex(_cargoArgs.channel), _cargoArgs.environmentVariables, _cargoArgs.nocapture)
         set(value) = with(value) {
             _cargoArgs.command = command
             _cargoArgs.additionalArguments = additionalArguments
             _cargoArgs.backtraceMode = backtraceMode.index
+            _cargoArgs.channel = channel.index
             _cargoArgs.environmentVariables = environmentVariables
             _cargoArgs.nocapture = nocapture
         }
@@ -101,6 +103,10 @@ class CargoCommandConfiguration(
             return ConfigurationResult.error("Invalid toolchain: ${toolchain.presentableLocation}")
         }
 
+        if (!toolchain.isRustupAvailable && cargoCommandLine.channel != RustChannel.DEFAULT) {
+            return ConfigurationResult.error("Channel '${cargoCommandLine.channel}' is set explicitly with no rustup avaliable")
+        }
+
         return ConfigurationResult.Ok(
             toolchain,
             module,
@@ -115,6 +121,7 @@ data class SerializableCargoCommandLine(
     var command: String = "",
     var additionalArguments: List<String> = mutableListOf(),
     var backtraceMode: Int = BacktraceMode.DEFAULT.index,
+    var channel: Int = RustChannel.DEFAULT.index,
     var environmentVariables: Map<String, String> = mutableMapOf(),
     var nocapture: Boolean = true
 )

--- a/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoRunConfigurationEditorForm.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoRunConfigurationEditorForm.kt
@@ -1,18 +1,20 @@
 package org.rust.cargo.runconfig.ui
 
-import com.intellij.ui.components.CheckBox
-import com.intellij.ui.components.Label
-import com.intellij.ui.layout.*
 import com.intellij.application.options.ModulesComboBox
 import com.intellij.execution.configuration.EnvironmentVariablesComponent
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.RawCommandLineEditor
+import com.intellij.ui.components.CheckBox
+import com.intellij.ui.components.Label
+import com.intellij.ui.layout.*
 import com.intellij.util.execution.ParametersListUtil
+import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.toolchain.BacktraceMode
 import org.rust.cargo.toolchain.CargoCommandLine
+import org.rust.cargo.toolchain.RustChannel
 import java.awt.Dimension
 import javax.swing.JComponent
 import javax.swing.JPanel
@@ -25,9 +27,15 @@ class CargoRunConfigurationEditorForm : SettingsEditor<CargoCommandConfiguration
     private val command = JTextField()
     private val additionalArguments = RawCommandLineEditor()
     private val backtraceMode = ComboBox<BacktraceMode>().apply {
-        addItem(BacktraceMode.NO)
-        addItem(BacktraceMode.SHORT)
-        addItem(BacktraceMode.FULL)
+        BacktraceMode.values()
+            .sortedBy { it.index }
+            .forEach { addItem(it) }
+    }
+    private val channelLabel = Label("C&hannel:")
+    private val channel = ComboBox<RustChannel>().apply {
+        RustChannel.values()
+            .sortedBy { it.index }
+            .forEach { addItem(it) }
     }
     private val environmentVariables = EnvironmentVariablesComponent()
     private val nocapture = CheckBox("Show stdout/stderr in tests", true)
@@ -41,6 +49,7 @@ class CargoRunConfigurationEditorForm : SettingsEditor<CargoCommandConfiguration
             command.text = args.command
             additionalArguments.text = ParametersListUtil.join(args.additionalArguments)
             backtraceMode.selectedIndex = args.backtraceMode.index
+            channel.selectedIndex = args.channel.index
             environmentVariables.envs = args.environmentVariables
             nocapture.isSelected = args.nocapture
         }
@@ -48,19 +57,31 @@ class CargoRunConfigurationEditorForm : SettingsEditor<CargoCommandConfiguration
 
     @Throws(ConfigurationException::class)
     override fun applyEditorTo(configuration: CargoCommandConfiguration) {
+        val rustupAvailable = comboModules.selectedModule?.project?.toolchain?.isRustupAvailable ?: false
+        val configChannel = RustChannel.fromIndex(channel.selectedIndex)
         configuration.setModule(comboModules.selectedModule)
         configuration.cargoCommandLine = CargoCommandLine(
             command.text,
             ParametersListUtil.parse(additionalArguments.text),
             BacktraceMode.fromIndex(backtraceMode.selectedIndex),
+            configChannel,
             environmentVariables.envs,
             nocapture.isSelected
         )
+        channel.isEnabled = rustupAvailable || configChannel != RustChannel.DEFAULT
+        if (!rustupAvailable && configChannel != RustChannel.DEFAULT) {
+            throw ConfigurationException("Channel cannot be set explicitly because rustup is not avaliable")
+        }
     }
 
     override fun createEditor(): JComponent = panel {
         labeledRow("Rust &project:", comboModules) { comboModules(CCFlags.push) }
-        labeledRow("&Command:", command) { command(growPolicy = GrowPolicy.SHORT_TEXT) }
+        labeledRow("&Command:", command) {
+            command(growPolicy = GrowPolicy.SHORT_TEXT)
+            channelLabel.labelFor = channel
+            channelLabel()
+            channel()
+        }
 
         labeledRow("&Additional arguments:", additionalArguments) {
             additionalArguments.apply {

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -33,7 +33,8 @@ class Cargo(
     private val pathToRustExecutable: String,
     // It's more convenient to use project directory rather then path to `Cargo.toml`
     // because some commands don't accept `--manifest-path` argument
-    private val projectDirectory: String?
+    private val projectDirectory: String?,
+    private val rustup: Rustup?
 ) {
     /**
      * Fetch all dependencies and calculate project information.
@@ -84,16 +85,23 @@ class Cargo(
             args += "--nocapture"
         }
 
-        return generalCommand(commandLine.command, args, env)
+        return generalCommand(commandLine.command, args, env, commandLine.channel)
     }
 
     fun generalCommand(
         command: String,
         additionalArguments: List<String> = emptyList(),
-        environmentVariables: Map<String, String> = emptyMap()
+        environmentVariables: Map<String, String> = emptyMap(),
+        channel: RustChannel = RustChannel.DEFAULT
     ): GeneralCommandLine {
-        val cmdLine = GeneralCommandLine(pathToCargoExecutable)
-            .withCharset(Charsets.UTF_8)
+        val cmdLine = if (channel == RustChannel.DEFAULT) {
+            GeneralCommandLine(pathToCargoExecutable)
+        } else {
+            if (rustup == null) error("Channel '$channel' cannot be set explicitly because rustup is not avaliable")
+            rustup.createRunCommandLine(channel, pathToCargoExecutable)
+        }
+
+        cmdLine.withCharset(Charsets.UTF_8)
             .withWorkDirectory(projectDirectory)
             .withParameters(command)
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
@@ -4,6 +4,7 @@ data class CargoCommandLine(
     val command: String, // Can't be `enum` because of custom subcommands
     val additionalArguments: List<String> = emptyList(),
     val backtraceMode: BacktraceMode = BacktraceMode.DEFAULT,
+    val channel: RustChannel = RustChannel.DEFAULT,
     val environmentVariables: Map<String, String> = emptyMap(),
     val nocapture: Boolean = true
 )

--- a/src/main/kotlin/org/rust/cargo/toolchain/RustChannel.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustChannel.kt
@@ -1,0 +1,14 @@
+package org.rust.cargo.toolchain
+
+enum class RustChannel(val index: Int, val title: String, val rustupArgument: String?) {
+    DEFAULT(0, "[Default]", null),
+    STABLE(1, "Stable", "stable"),
+    BETA(2, "Beta", "beta"),
+    NIGHTLY(3, "Nightly", "nightly");
+
+    override fun toString(): String = title
+
+    companion object {
+        fun fromIndex(index: Int) = RustChannel.values().find { it.index == index } ?: RustChannel.DEFAULT
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
@@ -36,16 +36,18 @@ data class RustToolchain(val location: String) {
     }
 
     fun cargo(cargoProjectDirectory: String): Cargo =
-        Cargo(pathToExecutable(CARGO), pathToExecutable(RUSTC), cargoProjectDirectory)
+        Cargo(pathToExecutable(CARGO), pathToExecutable(RUSTC), cargoProjectDirectory, rustup(cargoProjectDirectory))
 
-    fun rustup(cargoProjectDirectory: String): Rustup? {
-        if (!hasExecutable(RUSTUP)) return null
+    fun rustup(cargoProjectDirectory: String): Rustup? =
+        if (isRustupAvailable)
+            Rustup(pathToExecutable(RUSTUP), pathToExecutable(RUSTC), cargoProjectDirectory)
+        else
+            null
 
-        return Rustup(pathToExecutable(RUSTUP), pathToExecutable(RUSTC), cargoProjectDirectory)
-    }
+    val isRustupAvailable: Boolean get() = hasExecutable(RUSTUP)
 
     fun nonProjectCargo(): Cargo =
-        Cargo(pathToExecutable(CARGO), pathToExecutable(RUSTC), null)
+        Cargo(pathToExecutable(CARGO), pathToExecutable(RUSTC), null, null)
 
     val presentableLocation: String = PathUtil.toPresentableUrl(pathToExecutable(CARGO))
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
-import org.jetbrains.annotations.TestOnly
 import org.rust.utils.fullyRefreshDirectory
 import org.rust.utils.seconds
 
@@ -50,6 +49,9 @@ class Rustup(
         val fs = LocalFileSystem.getInstance()
         return fs.refreshAndFindFileByPath(FileUtil.join(sysroot, "lib/rustlib/src/rust/src"))
     }
+
+    fun createRunCommandLine(channel: RustChannel, varargs: String): GeneralCommandLine =
+        GeneralCommandLine(pathToRustupExecutable, "run", channel.rustupArgument, varargs)
 
     private fun GeneralCommandLine.exec(timeoutInMilliseconds: Int? = null): ProcessOutput {
         val handler = CapturingProcessHandler(this)

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable configuration uses default environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable configuration uses default environment.xml
@@ -8,6 +8,7 @@
         </list>
       </option>
       <option name="backtraceMode" value="2" />
+      <option name="channel" value="0" />
       <option name="command" value="run" />
       <option name="environmentVariables">
         <map>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test configuration uses default environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test configuration uses default environment.xml
@@ -10,6 +10,7 @@
         </list>
       </option>
       <option name="backtraceMode" value="2" />
+      <option name="channel" value="0" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executableProducerWorksForBin.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executableProducerWorksForBin.xml
@@ -8,6 +8,7 @@
         </list>
       </option>
       <option name="backtraceMode" value="2" />
+      <option name="channel" value="0" />
       <option name="command" value="run" />
       <option name="environmentVariables">
         <map />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executableProducerWorksForExample.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executableProducerWorksForExample.xml
@@ -8,6 +8,7 @@
         </list>
       </option>
       <option name="backtraceMode" value="2" />
+      <option name="channel" value="0" />
       <option name="command" value="run" />
       <option name="environmentVariables">
         <map />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executableProducerWorksForExamples.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executableProducerWorksForExamples.xml
@@ -2,6 +2,7 @@
   <configuration name="Run hello" class="CargoCommandConfiguration" show_console_on_std_err="false" show_console_on_std_out="false">
     <option name="additionalArguments" value="--package test-package --example hello" />
     <option name="backtraceMode" value="2" />
+    <option name="channel" value="0" />
     <option name="command" value="run" />
     <option name="environmentVariables">
       <map />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/hyphenInNameWorks.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/hyphenInNameWorks.xml
@@ -8,6 +8,7 @@
         </list>
       </option>
       <option name="backtraceMode" value="2" />
+      <option name="channel" value="0" />
       <option name="command" value="run" />
       <option name="environmentVariables">
         <map />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/mainFnIsMoreSpecificThanTestMod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/mainFnIsMoreSpecificThanTestMod.xml
@@ -8,6 +8,7 @@
         </list>
       </option>
       <option name="backtraceMode" value="2" />
+      <option name="channel" value="0" />
       <option name="command" value="run" />
       <option name="environmentVariables">
         <map />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/mainModAndTestModHaveSameSpecificity.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/mainModAndTestModHaveSameSpecificity.xml
@@ -8,6 +8,7 @@
         </list>
       </option>
       <option name="backtraceMode" value="2" />
+      <option name="channel" value="0" />
       <option name="command" value="run" />
       <option name="environmentVariables">
         <map />
@@ -28,6 +29,7 @@
         </list>
       </option>
       <option name="backtraceMode" value="2" />
+      <option name="channel" value="0" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/meaningfulConfigurationName.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/meaningfulConfigurationName.xml
@@ -10,6 +10,7 @@
         </list>
       </option>
       <option name="backtraceMode" value="2" />
+      <option name="channel" value="0" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testFnIsMoreSpecificThanMainMod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testFnIsMoreSpecificThanMainMod.xml
@@ -2,6 +2,7 @@
   <configuration name="Test test_foo" class="CargoCommandConfiguration" show_console_on_std_err="false" show_console_on_std_out="false">
     <option name="additionalArguments" value="--package test-package --bin foo test_foo" />
     <option name="backtraceMode" value="2" />
+    <option name="channel" value="0" />
     <option name="command" value="test" />
     <option name="environmentVariables">
       <map />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerAddsBinName.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerAddsBinName.xml
@@ -11,6 +11,7 @@
         </list>
       </option>
       <option name="backtraceMode" value="2" />
+      <option name="channel" value="0" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForAnnotatedFunctions.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForAnnotatedFunctions.xml
@@ -10,6 +10,7 @@
         </list>
       </option>
       <option name="backtraceMode" value="2" />
+      <option name="channel" value="0" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForFiles.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForFiles.xml
@@ -11,6 +11,7 @@
         </list>
       </option>
       <option name="backtraceMode" value="2" />
+      <option name="channel" value="0" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForModules.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForModules.xml
@@ -10,6 +10,7 @@
         </list>
       </option>
       <option name="backtraceMode" value="2" />
+      <option name="channel" value="0" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForRootModule.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/testProducerWorksForRootModule.xml
@@ -10,6 +10,7 @@
         </list>
       </option>
       <option name="backtraceMode" value="2" />
+      <option name="channel" value="0" />
       <option name="command" value="test" />
       <option name="environmentVariables">
         <map />


### PR DESCRIPTION
If rustup is available, allows to select a channel in run configuration:

<img width="628" alt="screen shot 2017-05-06 at 14 38 26" src="https://cloud.githubusercontent.com/assets/2101250/25772056/1de7b8c2-3273-11e7-90bc-416087c50cf2.png">

If the channel is not `[Default]`, `rustup run {channel}` is used to execute cargo.

At the moment, the set of channels is predefined and their presence is not checked. In the future, the setting can be changed to "Toolchain" and use `rustup show` to fill the list automatically. But I guess such improvement should somehow merge into the current `RustToolchain` infrastructure, and thus be carefully thought over beforehand.

What do you think? Is it ok to have the feature with this caveat?