### PR TITLE
TY: initial support of index expression type inference

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsIndexExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsIndexExpr.kt
@@ -1,0 +1,10 @@
+package org.rust.lang.core.psi.ext
+
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsIndexExpr
+
+val RsIndexExpr.containerExpr: RsExpr?
+    get() = exprList.getOrNull(0)
+
+val RsIndexExpr.indexExpr: RsExpr?
+    get() = exprList.getOrNull(1)

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Expressions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Expressions.kt
@@ -3,6 +3,7 @@ package org.rust.lang.core.types.infer
 import org.rust.ide.utils.isNullOrEmpty
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve.findIndexOutputType
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
 
@@ -124,6 +125,12 @@ fun inferExpressionType(expr: RsExpr): Ty {
         }
 
         is RsArrayExpr -> inferArrayType(expr)
+
+        is RsIndexExpr -> {
+            val containerType = expr.containerExpr?.type ?: return TyUnknown
+            val indexType = expr.indexExpr?.type ?: return TyUnknown
+            findIndexOutputType(expr.project, containerType, indexType)
+        }
 
         else -> TyUnknown
     }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
@@ -56,6 +56,9 @@ object TyStr : TyPrimitive {
 
 interface TyNumeric : TyPrimitive {
     val isKindWeak: Boolean
+
+    override fun canUnifyWith(other: Ty, project: Project): Boolean
+        = this == other || javaClass == other.javaClass && (other as TyNumeric).isKindWeak
 }
 
 class TyInteger(val kind: Kind, override val isKindWeak: Boolean = false) : TyNumeric {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -158,4 +158,12 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }
     """)
 
+    fun `test vec indexing`() = stubOnlyResolve("""
+    //- main.rs
+        fn foo(xs: Vec<String>) {
+            xs[0].capacity();
+                 //^ ...libcollections/string.rs
+        }
+    """)
+
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsIndexTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsIndexTypeInferenceTest.kt
@@ -1,0 +1,127 @@
+package org.rust.lang.core.type
+
+class RsIndexTypeInferenceTest : RsTypificationTestBase() {
+
+    fun testIndex() = testExpr("""
+        #[lang = "index"]
+        pub trait Index<Idx: ?Sized> {
+            type Output: ?Sized;
+            fn index(&self, index: Idx) -> &Self::Output;
+        }
+
+        struct S;
+
+        impl Index<i32> for S {
+            type Output = i32;
+            fn index(&self, index: i32) -> &i32 {
+                unimplemented!()
+            }
+        }
+
+        fn foo(s: S) {
+            let x = s[0];
+            x
+          //^ &i32
+        }
+    """)
+
+    fun testGenericOutput() = testExpr("""
+        #[lang = "index"]
+        pub trait Index<Idx: ?Sized> {
+            type Output: ?Sized;
+            fn index(&self, index: Idx) -> &Self::Output;
+        }
+
+        struct S<T>(T);
+
+        impl<T> Index<i32> for S<T> {
+            type Output = T;
+            fn index(&self, index: i32) -> &T {
+                unimplemented!()
+            }
+        }
+
+        fn foo(s: S<i64>) {
+            let x = s[0];
+            x
+          //^ &i64
+        }
+    """)
+
+    fun testGenericIndexAndOutput() = testExpr("""
+        #[lang = "index"]
+        pub trait Index<Idx: ?Sized> {
+            type Output: ?Sized;
+            fn index(&self, index: Idx) -> &Self::Output;
+        }
+
+        struct Key<K>(K);
+        struct S<K, V>(Key<K>, V);
+
+        impl<K, V> Index<Key<K>> for S<K, V> {
+            type Output = V;
+            fn index(&self, index: Key<K>) -> &V {
+                unimplemented!()
+            }
+        }
+
+        fn foo(s: S<Key<i32>, f64>) {
+            let x = s[Key(10)];
+            x
+          //^ &f64
+        }
+    """)
+
+    fun testMultipleImplementation() = testExpr("""
+        #[lang = "index"]
+        pub trait Index<Idx: ?Sized> {
+            type Output: ?Sized;
+            fn index(&self, index: Idx) -> &Self::Output;
+        }
+
+        struct S;
+
+        impl Index<f64> for S {
+            type Output = f32;
+            fn index(&self, index: f64) -> &f32 {
+                unimplemented!()
+            }
+        }
+
+        impl Index<i64> for S {
+            type Output = i32;
+            fn index(&self, index: i64) -> &i32 {
+                unimplemented!()
+            }
+        }
+
+        fn foo(s: S) {
+            let x = s[0i64];
+            x
+          //^ &i32
+        }
+    """)
+
+    fun testImplicitUsize() = testExpr("""
+        #[lang = "index"]
+        pub trait Index<Idx: ?Sized> {
+            type Output: ?Sized;
+            fn index(&self, index: Idx) -> &Self::Output;
+        }
+
+        struct Vec<T>;
+
+        impl<T> Index<usize> for Vec<T> {
+            type Output = T;
+            fn index(&self, index: usize) -> &T {
+                unimplemented!()
+            }
+        }
+
+        fn foo(s: Vec<i32>) {
+            let x = s[0];
+            x
+          //^ &i32
+        }
+    """)
+}


### PR DESCRIPTION
* more flexible `canUnifyWith` for RustNumericType: numeric type can be unified with type with different kind if it's weak
* initial support for index expression type inference using `Index` trait