### PR TITLE
CARGO: Colored output for clippy

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -161,6 +161,6 @@ class Cargo(
     }
 
     private companion object {
-        val COLOR_ACCEPTING_COMMANDS = listOf("bench", "build", "check", "clean", "doc", "install", "publish", "run", "test", "update")
+        val COLOR_ACCEPTING_COMMANDS = listOf("bench", "build", "check", "clean", "clippy", "doc", "install", "publish", "run", "test", "update")
     }
 }


### PR DESCRIPTION
Colored output works correctly for clippy now, so it's whitelisted.