### PR TITLE
CARGO: Support proc-macro crate kind

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -151,6 +151,7 @@ object CargoMetadata {
             "example" -> CargoWorkspace.TargetKind.EXAMPLE
             "test" -> CargoWorkspace.TargetKind.TEST
             "bench" -> CargoWorkspace.TargetKind.BENCH
+            "proc-macro" -> CargoWorkspace.TargetKind.LIB
             else ->
                 if (kind.any { it.endsWith("lib") })
                     CargoWorkspace.TargetKind.LIB


### PR DESCRIPTION
Cargo reports library crates with `proc-macro = true` as `kind = proc-macro`, not `kind = lib` (for example, `serde_derive`). As a result, such crates are not resolved in `extern crate` clauses. This fix makes proc-macro crates treated as lib crates and correctly resolved.