### PR TITLE
CARGO: Support feature gated stdlib dependencies

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/LIbraryUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/LIbraryUtil.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.util.AutoInjectedCrates
+import org.rust.cargo.util.StdLibType
 import org.rust.ide.utils.checkWriteAccessAllowed
 
 /**
@@ -31,7 +32,7 @@ class StandardLibrary private constructor(
 
     data class StdCrate(
         val name: String,
-        val isRoot: Boolean,
+        val type: StdLibType,
         val crateRootUrl: String,
         val packageRootUrl: String,
         val dependencies: Collection<String>
@@ -50,7 +51,7 @@ class StandardLibrary private constructor(
         return myUrls == libraryUrls
     }
 
-    private val rootCrates: List<StdCrate> = crates.filter { it.isRoot }
+    private val rootCrates: List<StdCrate> = crates.filter { it.type == StdLibType.ROOT }
 
     companion object {
         fun fromPath(path: String): StandardLibrary? =
@@ -65,7 +66,7 @@ class StandardLibrary private constructor(
                 val packageSrcDir = srcDir.findFileByRelativePath(libInfo.srcDir)
                 val libFile = packageSrcDir?.findChild("lib.rs")
                 if (packageSrcDir != null && libFile != null)
-                    StdCrate(libInfo.name, libInfo.isRoot, libFile.url, packageSrcDir.url, libInfo.dependencies)
+                    StdCrate(libInfo.name, libInfo.type, libFile.url, packageSrcDir.url, libInfo.dependencies)
                 else
                     null
             }

--- a/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
@@ -5,9 +5,26 @@ import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.toolchain.RustToolchain
 
+enum class StdLibType {
+    /**
+     * An indispensable part of the stdlib
+     */
+    ROOT,
+
+    /**
+     * A crate that can be used as a dependency if a corresponding feature is turned on
+     */
+    FEATURE_GATED,
+
+    /**
+     * A dependency that is not visible outside of the stdlib
+     */
+    DEPENDENCY
+}
+
 data class StdLibInfo (
     val name: String,
-    val isRoot: Boolean = false,
+    val type: StdLibType,
     val srcDir: String = "lib" + name,
     val dependencies: List<String> = emptyList()
 )
@@ -17,32 +34,33 @@ object AutoInjectedCrates {
     const val core: String = "core"
     val stdlibCrates = listOf(
         // Roots
-        StdLibInfo(std, dependencies = listOf("alloc_jemalloc", "alloc_system", "panic_abort", "rand",
+        StdLibInfo(std, StdLibType.ROOT, dependencies = listOf("alloc_jemalloc", "alloc_system", "panic_abort", "rand",
             "compiler_builtins", "unwind", "rustc_asan", "rustc_lsan", "rustc_msan", "rustc_tsan",
-            "build_helper"), isRoot = true),
-        StdLibInfo(core, isRoot = true),
-        StdLibInfo("alloc", isRoot = true),
-        StdLibInfo("collections", isRoot = true),
-        StdLibInfo("libc", srcDir = "liblibc/src", isRoot = true),
-        StdLibInfo("panic_unwind", isRoot = true),
-        StdLibInfo("rustc_unicode", isRoot = true),
-        StdLibInfo("std_unicode", isRoot = true),
-        StdLibInfo("test", dependencies = listOf("getopts", "term"), isRoot = true),
+            "build_helper")),
+        StdLibInfo(core, StdLibType.ROOT),
+        StdLibInfo("alloc", StdLibType.ROOT),
+        StdLibInfo("collections", StdLibType.ROOT),
+        StdLibInfo("libc", StdLibType.ROOT, srcDir = "liblibc/src"),
+        StdLibInfo("panic_unwind", type = StdLibType.ROOT),
+        StdLibInfo("rustc_unicode", type = StdLibType.ROOT),
+        StdLibInfo("std_unicode", type = StdLibType.ROOT),
+        StdLibInfo("test", dependencies = listOf("getopts", "term"), type = StdLibType.ROOT),
+        // Feature gated
+        StdLibInfo("alloc_jemalloc", StdLibType.FEATURE_GATED),
+        StdLibInfo("alloc_system", StdLibType.FEATURE_GATED),
+        StdLibInfo("compiler_builtins", StdLibType.FEATURE_GATED),
+        StdLibInfo("getopts", StdLibType.FEATURE_GATED),
+        StdLibInfo("panic_unwind", StdLibType.FEATURE_GATED),
+        StdLibInfo("panic_abort", StdLibType.FEATURE_GATED),
+        StdLibInfo("rand", StdLibType.FEATURE_GATED),
+        StdLibInfo("term", StdLibType.FEATURE_GATED),
+        StdLibInfo("unwind", StdLibType.FEATURE_GATED),
         // Dependencies
-        StdLibInfo("alloc_jemalloc"),
-        StdLibInfo("alloc_system"),
-        StdLibInfo("build_helper", srcDir = "build_helper"),
-        StdLibInfo("compiler_builtins"),
-        StdLibInfo("getopts"),
-        StdLibInfo("panic_unwind"),
-        StdLibInfo("panic_abort"),
-        StdLibInfo("rand"),
-        StdLibInfo("rustc_asan"),
-        StdLibInfo("rustc_lsan"),
-        StdLibInfo("rustc_msan"),
-        StdLibInfo("rustc_tsan"),
-        StdLibInfo("term"),
-        StdLibInfo("unwind")
+        StdLibInfo("build_helper", StdLibType.DEPENDENCY, srcDir = "build_helper"),
+        StdLibInfo("rustc_asan", StdLibType.DEPENDENCY),
+        StdLibInfo("rustc_lsan", StdLibType.DEPENDENCY),
+        StdLibInfo("rustc_msan", StdLibType.DEPENDENCY),
+        StdLibInfo("rustc_tsan", StdLibType.DEPENDENCY)
     )
 }
 

--- a/src/test/kotlin/org/rustSlowTests/CargoProjectResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/CargoProjectResolveTest.kt
@@ -9,6 +9,25 @@ import org.rust.lang.core.psi.RsPath
 
 class CargoProjectResolveTest : RustWithToolchainTestBase() {
 
+    fun `test resolve feature gated crate`() = buildProject {
+        toml("Cargo.toml", """
+            [package]
+            name = "intellij-rust-test"
+            version = "0.1.0"
+            authors = []
+    """)
+
+        dir("src") {
+            rust("main.rs", """
+                extern crate rand;
+
+                fn main() {
+                    let _ = rand::XorShiftRng { x: 0, y: 0, z: 0, w: 0 };
+                }                     //^
+            """)
+        }
+    }.checkReferenceIsResolved<RsPath>("src/main.rs")
+
     fun `test resolve external library`() = buildProject {
         toml("Cargo.toml", """
             [package]
@@ -25,8 +44,6 @@ class CargoProjectResolveTest : RustWithToolchainTestBase() {
                 extern crate rand;
 
                 use rand::distributions;
-
-                mod foo;
 
                 fn main() {
                     let _ = distributions::normal::Normal::new(0.0, 1.0);


### PR DESCRIPTION
Rust stdlib includes several crates that can be used as dependencies without mentioning in Cargo.toml yet are not a part of the prelude. For instance, we can use `extern crate rand;` in nightly when `#![feature(rand)]` is provided. So, such crates should be added as stdlib roots to be resolved (they now have `isRoot = false`).

The problem is that there are external crates with the same names (`rand` and `term` are main troublemakers). Adding such crates as dependencies to Cargo.toml brings name conflicts and breaks resolving when [we use the mentioned approach](https://github.com/intellij-rust/intellij-rust/pull/1145#issuecomment-299711548).

This fix introduces stdlib crate types: root, featured, dependency. Unlike roots, featured crates are only added to packages as a part of stdlib when there're no explicit dependencies with the same names.