### PR TITLE
Advanced resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -10,22 +10,25 @@ import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RustPsiImplUtil
 import org.rust.lang.core.stubs.RsTraitItemStub
+import org.rust.lang.core.types.BoundElement
 import org.rust.lang.utils.filterIsInstanceQuery
 import org.rust.lang.utils.filterQuery
 import org.rust.lang.utils.mapQuery
 import javax.swing.Icon
 
-val RsTraitItem.superTraits: Sequence<RsTraitItem> get() {
+val RsTraitItem.superTraits: Sequence<BoundElement<RsTraitItem>> get() {
     val bounds = typeParamBounds?.polyboundList.orEmpty().asSequence()
-    return bounds.mapNotNull { it.bound.traitRef?.resolveToTrait }
+    return bounds.mapNotNull { it.bound.traitRef?.resolveToBoundTrait }
 }
 
-val RsTraitItem.flattenHierarchy: Collection<RsTraitItem> get() {
-    val result = mutableSetOf<RsTraitItem>()
-    fun dfs(trait: RsTraitItem) {
-        if (trait in result) return
-        result += trait
-        trait.superTraits.forEach(::dfs)
+val BoundElement<RsTraitItem>.flattenHierarchy: Collection<BoundElement<RsTraitItem>> get() {
+    val result = mutableSetOf<BoundElement<RsTraitItem>>()
+    val visited = mutableSetOf<RsTraitItem>()
+    fun dfs(boundTrait: BoundElement<RsTraitItem>) {
+        if (boundTrait.element in visited) return
+        visited += boundTrait.element
+        result += boundTrait
+        boundTrait.element.superTraits.forEach(::dfs)
     }
     dfs(this)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -16,11 +16,6 @@ import org.rust.lang.utils.filterQuery
 import org.rust.lang.utils.mapQuery
 import javax.swing.Icon
 
-val RsTraitItem.superTraits: Sequence<BoundElement<RsTraitItem>> get() {
-    val bounds = typeParamBounds?.polyboundList.orEmpty().asSequence()
-    return bounds.mapNotNull { it.bound.traitRef?.resolveToBoundTrait }
-}
-
 val BoundElement<RsTraitItem>.flattenHierarchy: Collection<BoundElement<RsTraitItem>> get() {
     val result = mutableSetOf<BoundElement<RsTraitItem>>()
     val visited = mutableSetOf<RsTraitItem>()
@@ -40,6 +35,11 @@ fun RsTraitItem.searchForImplementations(): Query<RsImplItem> {
         .mapQuery { it.element.parent?.parent }
         .filterIsInstanceQuery<RsImplItem>()
         .filterQuery(Condition { it.typeReference != null })
+}
+
+private val RsTraitItem.superTraits: Sequence<BoundElement<RsTraitItem>> get() {
+    val bounds = typeParamBounds?.polyboundList.orEmpty().asSequence()
+    return bounds.mapNotNull { it.bound.traitRef?.resolveToBoundTrait }
 }
 
 abstract class RsTraitItemImplMixin : RsStubbedNamedElementImpl<RsTraitItemStub>, RsTraitItem {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitRef.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitRef.kt
@@ -2,7 +2,23 @@ package org.rust.lang.core.psi.ext
 
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTraitRef
+import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.types.ty.TyTypeParameter
+import org.rust.lang.core.types.type
 
 val RsTraitRef.resolveToTrait: RsTraitItem?
     get() = path.reference.resolve() as? RsTraitItem
+
+val RsTraitRef.resolveToBoundTrait: BoundElement<RsTraitItem>? get() {
+    val trait = resolveToTrait ?: return null
+    trait.typeParameters.map {it.typeReference}
+    val typeParameters = trait.typeParameters.map { TyTypeParameter(it) }
+    val typeArguments = path.typeArgumentList?.typeReferenceList.orEmpty().map { it.type }
+    val args = typeParameters.zip(typeArguments)
+        .mapNotNull { (param, arg) ->
+            if (param is TyTypeParameter) param to arg else null
+        }
+        .toMap()
+    return BoundElement(trait, args)
+}
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/LangItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/LangItems.kt
@@ -25,14 +25,13 @@ fun findDerefTarget(project: Project, ty: Ty): Ty? {
 
 fun findIteratorItemType(project: Project, ty: Ty): Ty {
     val impl = findImplsAndTraits(project, ty).first
-        .find {
-            val traitName = it.traitRef?.resolveToTrait?.name
+        .find { boundImpl ->
+            val traitName = boundImpl.element.traitRef?.resolveToTrait?.name
             traitName == "Iterator" || traitName == "IntoIterator"
         } ?: return TyUnknown
 
-    val rawType = lookupAssociatedType(impl, "Item")
-    val typeParameterMap = impl.remapTypeParameters(ty.typeParameterValues)
-    return rawType.substitute(typeParameterMap)
+    val rawType = lookupAssociatedType(impl.element, "Item")
+    return rawType.substitute(impl.typeArguments)
 }
 
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -4,8 +4,9 @@ import com.intellij.codeInsight.lookup.LookupElement
 import org.rust.lang.core.completion.createLookupElement
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.RsCompositeElement
-import org.rust.lang.core.psi.ext.allAttributes
 import org.rust.lang.core.psi.ext.isTest
+import org.rust.lang.core.types.ty.TypeArguments
+import org.rust.lang.core.types.ty.emptyTypeArguments
 
 /**
  * ScopeEntry is some PsiElement visible in some code scope.
@@ -17,6 +18,7 @@ import org.rust.lang.core.psi.ext.isTest
 interface ScopeEntry {
     val name: String
     val element: RsCompositeElement?
+    val typeArguments: TypeArguments get() = emptyTypeArguments
 }
 
 /**

--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -5,6 +5,7 @@ import org.rust.lang.core.completion.createLookupElement
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.psi.ext.isTest
+import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.ty.TypeArguments
 import org.rust.lang.core.types.ty.emptyTypeArguments
 
@@ -40,14 +41,14 @@ enum class ScopeEvent : ScopeEntry {
  */
 typealias RsResolveProcessor = (ScopeEntry) -> Boolean
 
-fun collectResolveVariants(referenceName: String, f: (RsResolveProcessor) -> Unit): List<RsCompositeElement> {
-    val result = mutableListOf<RsCompositeElement>()
+fun collectResolveVariants(referenceName: String, f: (RsResolveProcessor) -> Unit): List<BoundElement<RsCompositeElement>> {
+    val result = mutableListOf<BoundElement<RsCompositeElement>>()
     f { e ->
         if (e == ScopeEvent.STAR_IMPORTS && result.isNotEmpty()) return@f true
 
         if (e.name == referenceName) {
             val element = e.element ?: return@f false
-            result += element
+            result += BoundElement(element, e.typeArguments)
         }
         false
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsExternCrateReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsExternCrateReferenceImpl.kt
@@ -4,6 +4,7 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsExternCrateItem
 import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.resolve.*
+import org.rust.lang.core.types.BoundElement
 
 class RsExternCrateReferenceImpl(
     externCrate: RsExternCrateItem
@@ -15,6 +16,6 @@ class RsExternCrateReferenceImpl(
     override fun getVariants(): Array<out Any> =
         collectCompletionVariants { processExternCrateResolveVariants(element, true, it) }
 
-    override fun resolveInner(): List<RsCompositeElement> =
+    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
         collectResolveVariants(element.name!!) { processExternCrateResolveVariants(element, false, it) }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsFieldExprReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsFieldExprReferenceImpl.kt
@@ -4,6 +4,7 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsFieldExpr
 import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.resolve.*
+import org.rust.lang.core.types.BoundElement
 
 class RsFieldExprReferenceImpl(
     fieldExpr: RsFieldExpr
@@ -17,7 +18,7 @@ class RsFieldExprReferenceImpl(
             processFieldExprResolveVariants(element, true, it)
         }
 
-    override fun resolveInner(): List<RsCompositeElement> =
+    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
         collectResolveVariants(element.referenceName) {
             processFieldExprResolveVariants(element, false, it)
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLabelReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLabelReferenceImpl.kt
@@ -5,15 +5,8 @@ import org.rust.lang.core.psi.RsLabel
 import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.resolve.collectCompletionVariants
 import org.rust.lang.core.resolve.collectResolveVariants
-import org.rust.lang.core.resolve.processLifetimeResolveVariants
 import org.rust.lang.core.resolve.processLabelResolveVariants
-import org.rust.lang.core.resolve.processPathResolveVariants
-import org.rust.lang.core.resolve.processExternCrateResolveVariants
-import org.rust.lang.core.resolve.processModDeclResolveVariants
-import org.rust.lang.core.resolve.processUseGlobResolveVariants
-import org.rust.lang.core.resolve.processMethodCallExprResolveVariants
-import org.rust.lang.core.resolve.processStructLiteralFieldResolveVariants
-import org.rust.lang.core.resolve.processFieldExprResolveVariants
+import org.rust.lang.core.types.BoundElement
 
 class RsLabelReferenceImpl(
     element: RsLabel
@@ -22,7 +15,7 @@ class RsLabelReferenceImpl(
 
     override val RsLabel.referenceAnchor: PsiElement get() = quoteIdentifier
 
-    override fun resolveInner(): List<RsCompositeElement> =
+    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
         collectResolveVariants(element.referenceName) { processLabelResolveVariants(element, it) }
 
     override fun getVariants(): Array<out Any> =

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLifetimeReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLifetimeReferenceImpl.kt
@@ -6,14 +6,7 @@ import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.resolve.collectCompletionVariants
 import org.rust.lang.core.resolve.collectResolveVariants
 import org.rust.lang.core.resolve.processLifetimeResolveVariants
-import org.rust.lang.core.resolve.processLabelResolveVariants
-import org.rust.lang.core.resolve.processPathResolveVariants
-import org.rust.lang.core.resolve.processExternCrateResolveVariants
-import org.rust.lang.core.resolve.processModDeclResolveVariants
-import org.rust.lang.core.resolve.processUseGlobResolveVariants
-import org.rust.lang.core.resolve.processMethodCallExprResolveVariants
-import org.rust.lang.core.resolve.processStructLiteralFieldResolveVariants
-import org.rust.lang.core.resolve.processFieldExprResolveVariants
+import org.rust.lang.core.types.BoundElement
 
 class RsLifetimeReferenceImpl(
     element: RsLifetime
@@ -22,7 +15,7 @@ class RsLifetimeReferenceImpl(
 
     override val RsLifetime.referenceAnchor: PsiElement get() = quoteIdentifier
 
-    override fun resolveInner(): List<RsCompositeElement> =
+    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
         collectResolveVariants(element.referenceName) { processLifetimeResolveVariants(element, it) }
 
     override fun getVariants(): Array<out Any> =

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroReferenceImpl.kt
@@ -6,18 +6,22 @@ import com.intellij.psi.stubs.StubIndex
 import org.rust.lang.core.psi.RsMacroDefinition
 import org.rust.lang.core.psi.RsMacroInvocation
 import org.rust.lang.core.psi.RsMacroItem
+import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.psi.ext.parentOfType
 import org.rust.lang.core.stubs.index.RsMacroDefinitionIndex
+import org.rust.lang.core.types.BoundElement
 
 class RsMacroReferenceImpl(macroInvocation: RsMacroInvocation) : RsReferenceBase<RsMacroInvocation>(macroInvocation) {
-    override fun resolveInner(): List<RsMacroItem> =
+    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
         StubIndex.getElements(
             RsMacroDefinitionIndex.KEY,
             element.referenceName,
             element.project,
             GlobalSearchScope.allScope(element.project),
             RsMacroDefinition::class.java
-        ).mapNotNull{ it.parentOfType<RsMacroItem>() }.toList()
+        ).mapNotNull { it.parentOfType<RsMacroItem>() }
+            .map { BoundElement(it) }
+            .toList()
 
     override val RsMacroInvocation.referenceAnchor: PsiElement
         get() = referenceNameElement

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
@@ -4,6 +4,7 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsMethodCallExpr
 import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.resolve.*
+import org.rust.lang.core.types.BoundElement
 
 class RsMethodCallReferenceImpl(
     element: RsMethodCallExpr
@@ -15,6 +16,6 @@ class RsMethodCallReferenceImpl(
     override fun getVariants(): Array<out Any> =
         collectCompletionVariants { processMethodCallExprResolveVariants(element, it) }
 
-    override fun resolveInner(): List<RsCompositeElement> =
+    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
         collectResolveVariants(element.referenceName) { processMethodCallExprResolveVariants(element, it) }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsModReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsModReferenceImpl.kt
@@ -4,6 +4,7 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.resolve.*
+import org.rust.lang.core.types.BoundElement
 
 class RsModReferenceImpl(
     modDecl: RsModDeclItem
@@ -15,6 +16,6 @@ class RsModReferenceImpl(
     override fun getVariants(): Array<out Any> =
         collectCompletionVariants { processModDeclResolveVariants(element, it) }
 
-    override fun resolveInner(): List<RsCompositeElement> =
+    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
         collectResolveVariants(element.referenceName) { processModDeclResolveVariants(element, it) }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPatBindingReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPatBindingReferenceImpl.kt
@@ -4,6 +4,7 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.resolve.*
+import org.rust.lang.core.types.BoundElement
 
 
 class RsPatBindingReferenceImpl(
@@ -13,7 +14,7 @@ class RsPatBindingReferenceImpl(
 
     override val RsPatBinding.referenceAnchor: PsiElement get() = referenceNameElement
 
-    override fun resolveInner(): List<RsCompositeElement> =
+    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
         collectResolveVariants(element.referenceName) { processPatBindingResolveVariants(element, false, it) }
 
     override fun getVariants(): Array<out Any> =

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -4,6 +4,7 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.resolve.*
+import org.rust.lang.core.types.BoundElement
 
 
 class RsPathReferenceImpl(
@@ -13,7 +14,7 @@ class RsPathReferenceImpl(
 
     override val RsPath.referenceAnchor: PsiElement get() = referenceNameElement
 
-    override fun resolveInner(): List<RsCompositeElement> =
+    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
         collectResolveVariants(element.referenceName) { processPathResolveVariants(element, false, it) }
 
     override fun getVariants(): Array<out Any> =

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReference.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReference.kt
@@ -2,12 +2,15 @@ package org.rust.lang.core.resolve.ref
 
 import com.intellij.psi.PsiPolyVariantReference
 import org.rust.lang.core.psi.ext.RsCompositeElement
+import org.rust.lang.core.types.BoundElement
 
 interface RsReference : PsiPolyVariantReference {
 
     override fun getElement(): RsCompositeElement
 
     override fun resolve(): RsCompositeElement?
+
+    fun advancedResolve(): BoundElement<RsCompositeElement>? = resolve()?.let { BoundElement(it) }
 
     fun multiResolve(): List<RsCompositeElement>
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceBase.kt
@@ -13,20 +13,21 @@ import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.RsReferenceElement
 import org.rust.lang.core.psi.ext.elementType
+import org.rust.lang.core.types.BoundElement
 
 abstract class RsReferenceBase<T : RsReferenceElement>(
     element: T
 ) : PsiPolyVariantReferenceBase<T>(element),
     RsReference {
 
-    abstract protected fun resolveInner(): List<RsCompositeElement>
+    abstract protected fun resolveInner(): List<BoundElement<RsCompositeElement>>
 
     override fun resolve(): RsCompositeElement? = super.resolve() as? RsCompositeElement
 
     final override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> =
         ResolveCache.getInstance(element.project)
             .resolveWithCaching(this, { r, _ ->
-                r.resolveInner().map(::PsiElementResolveResult).toTypedArray()
+                r.resolveInner().map { PsiElementResolveResult(it.element) }.toTypedArray()
             },
                 /* needToPreventRecursion = */ true,
                 /* incompleteCode = */ false)

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceBase.kt
@@ -6,11 +6,11 @@ import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.PsiPolyVariantReferenceBase
 import com.intellij.psi.ResolveResult
 import com.intellij.psi.impl.source.resolve.ResolveCache
-import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 import org.rust.lang.core.psi.RsElementTypes.QUOTE_IDENTIFIER
-import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.ext.RsCompositeElement
+import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.RsReferenceElement
 import org.rust.lang.core.psi.ext.elementType
 
@@ -19,11 +19,9 @@ abstract class RsReferenceBase<T : RsReferenceElement>(
 ) : PsiPolyVariantReferenceBase<T>(element),
     RsReference {
 
-    override fun resolve(): RsCompositeElement? {
-        return super.resolve() as? RsCompositeElement
-    }
+    abstract protected fun resolveInner(): List<RsCompositeElement>
 
-    abstract fun resolveInner(): List<RsCompositeElement>
+    override fun resolve(): RsCompositeElement? = super.resolve() as? RsCompositeElement
 
     final override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> =
         ResolveCache.getInstance(element.project)

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsStructExprFieldReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsStructExprFieldReferenceImpl.kt
@@ -6,6 +6,7 @@ import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsStructLiteralField
 import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.resolve.*
+import org.rust.lang.core.types.BoundElement
 
 class RsStructLiteralFieldReferenceImpl(
     field: RsStructLiteralField
@@ -17,7 +18,7 @@ class RsStructLiteralFieldReferenceImpl(
     override fun getVariants(): Array<out LookupElement> =
         collectCompletionVariants { processStructLiteralFieldResolveVariants(element, it) }
 
-    override fun resolveInner(): List<RsCompositeElement> =
+    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
         collectResolveVariants(element.referenceName) {
             processStructLiteralFieldResolveVariants(element, it)
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsUseGlobReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsUseGlobReferenceImpl.kt
@@ -4,6 +4,7 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsUseGlob
 import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.resolve.*
+import org.rust.lang.core.types.BoundElement
 
 class RsUseGlobReferenceImpl(
     useGlob: RsUseGlob
@@ -15,7 +16,7 @@ class RsUseGlobReferenceImpl(
     override fun getVariants(): Array<out Any> =
         collectCompletionVariants { processUseGlobResolveVariants(element, it) }
 
-    override fun resolveInner(): List<RsCompositeElement> =
+    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
         collectResolveVariants(element.referenceName) { processUseGlobResolveVariants(element, it) }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
@@ -1,5 +1,7 @@
 package org.rust.lang.core.types
 
+import com.intellij.psi.PsiElement
+import com.intellij.psi.ResolveResult
 import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.types.ty.TypeArguments
 import org.rust.lang.core.types.ty.emptyTypeArguments
@@ -11,5 +13,8 @@ import org.rust.lang.core.types.ty.emptyTypeArguments
 data class BoundElement<out E : RsCompositeElement>(
     val element: E,
     val typeArguments: TypeArguments = emptyTypeArguments
-)
+) : ResolveResult {
+    override fun getElement(): PsiElement = element
+    override fun isValidResult(): Boolean = true
+}
 

--- a/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
@@ -1,0 +1,15 @@
+package org.rust.lang.core.types
+
+import org.rust.lang.core.psi.ext.RsCompositeElement
+import org.rust.lang.core.types.ty.TypeArguments
+import org.rust.lang.core.types.ty.emptyTypeArguments
+
+/* Represents a potentially generic Psi Element, like
+ * `fn make_t<T>() -> T { ... }`, together with actual
+ * type arguments, like `T := i32`.
+ */
+data class BoundElement<out E : RsCompositeElement>(
+    val element: E,
+    val typeArguments: TypeArguments = emptyTypeArguments
+)
+

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -74,7 +74,7 @@ fun inferTypeReferenceType(ref: RsTypeReference): Ty {
                 ?: return TyUnknown
             val typeArguments = path.typeArgumentList?.typeReferenceList.orEmpty()
             inferDeclarationType(target)
-                .withTypeArguments(typeArguments.map { it.type })
+                .applyTypeArguments(typeArguments.map { it.type })
 
         }
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Expressions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Expressions.kt
@@ -44,12 +44,9 @@ fun inferExpressionType(expr: RsExpr): Ty {
         }
 
         is RsMethodCallExpr -> {
-            val method = expr.reference.resolve() as? RsFunction
-                ?: return TyUnknown
-
-            val impl = method.parentOfType<RsImplItem>()
-            val typeParameterMap = impl?.remapTypeParameters(expr.expr.type.typeParameterValues).orEmpty()
-            return (method.retType?.typeReference?.type ?: TyUnit).substitute(typeParameterMap)
+            val boundMethod = expr.reference.advancedResolve()
+            val method = boundMethod?.element as? RsFunction ?: return TyUnknown
+            return (method.retType?.typeReference?.type ?: TyUnit).substitute(boundMethod.typeArguments)
         }
 
         is RsFieldExpr -> {

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -9,6 +9,9 @@ import org.rust.lang.core.psi.ext.resolveToTrait
 import org.rust.lang.core.resolve.findDerefTarget
 import org.rust.lang.core.resolve.indexes.RsImplIndex
 
+typealias TypeArguments = Map<TyTypeParameter, Ty>
+val emptyTypeArguments: TypeArguments = emptyMap()
+
 /**
  * Represents both a type, like `i32` or `S<Foo, Bar>`, as well
  * as an unbound constructor `S`.
@@ -29,7 +32,7 @@ interface Ty {
      *
      * This works for `some::path::<Type1, Type2>` case.
      */
-    fun withTypeArguments(typeArguments: List<Ty>): Ty = this
+    fun applyTypeArguments(typeArguments: List<Ty>): Ty = this
 
     /**
      * Substitute type parameters for their values
@@ -37,12 +40,12 @@ interface Ty {
      * This works for `struct S<T> { field: T }`, when we
      * know the type of `T` and want to find the type of `field`.
      */
-    fun substitute(map: Map<TyTypeParameter, Ty>): Ty = this
+    fun substitute(map: TypeArguments): Ty = this
 
     /**
      * Bindings between formal type parameters and actual type arguments.
      */
-    val typeParameterValues: Map<TyTypeParameter, Ty> get() = emptyMap()
+    val typeParameterValues: TypeArguments get() = emptyTypeArguments
 
     /**
      * User visible string representation of a type

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt
@@ -7,7 +7,7 @@ class TyArray(val base: Ty, val size: Int) : Ty {
     override fun canUnifyWith(other: Ty, project: Project): Boolean =
         other is TyArray && size == other.size && base.canUnifyWith(other.base, project)
 
-    override fun substitute(map: Map<TyTypeParameter, Ty>): Ty =
+    override fun substitute(map: TypeArguments): Ty =
         TyArray(base.substitute(map), size)
 
     override fun toString() = "[$base; $size]"

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyFunction.kt
@@ -14,6 +14,6 @@ data class TyFunction(val paramTypes: List<Ty>, val retType: Ty) : Ty {
         return if (retType === TyUnit) params else "$params -> $retType"
     }
 
-    override fun substitute(map: Map<TyTypeParameter, Ty>): TyFunction =
+    override fun substitute(map: TypeArguments): TyFunction =
         TyFunction(paramTypes.map { it.substitute(map) }, retType.substitute(map))
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt
@@ -9,6 +9,6 @@ data class TyPointer(val referenced: Ty, val mutable: Boolean = false) : Ty {
 
     override fun toString() = "*${if (mutable) "mut" else "const"} $referenced"
 
-    override fun substitute(map: Map<TyTypeParameter, Ty>): Ty =
+    override fun substitute(map: TypeArguments): Ty =
         TyPointer(referenced.substitute(map), mutable)
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
@@ -9,6 +9,6 @@ data class TyReference(val referenced: Ty, val mutable: Boolean = false) : Ty {
 
     override fun toString(): String = "${if (mutable) "&mut " else "&"}$referenced"
 
-    override fun substitute(map: Map<TyTypeParameter, Ty>): Ty =
+    override fun substitute(map: TypeArguments): Ty =
         TyReference(referenced.substitute(map), mutable)
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TySlice.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TySlice.kt
@@ -6,7 +6,7 @@ data class TySlice(val elementType: Ty) : Ty {
     override fun canUnifyWith(other: Ty, project: Project): Boolean =
         other is TySlice && elementType.canUnifyWith(other.elementType, project)
 
-    override fun substitute(map: Map<TyTypeParameter, Ty>): Ty {
+    override fun substitute(map: TypeArguments): Ty {
         return TySlice(elementType.substitute(map))
     }
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyStructOrEnum.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyStructOrEnum.kt
@@ -14,7 +14,7 @@ interface TyStructOrEnumBase : Ty {
 
     val item: RsStructOrEnumItemElement
 
-    override val typeParameterValues: Map<TyTypeParameter, Ty>
+    override val typeParameterValues: TypeArguments
         get() = item.typeParameters.zip(typeArguments)
             .mapNotNull {
                 val (param, arg) = it
@@ -34,7 +34,7 @@ interface TyStructOrEnumBase : Ty {
 
     fun aliasTypeArguments(typeArguments: List<TyTypeParameter>): Ty
 
-    override fun withTypeArguments(typeArguments: List<Ty>): Ty =
+    override fun applyTypeArguments(typeArguments: List<Ty>): Ty =
         substitute(typeArgumentsMapping.withIndex().associate { (i, type) -> type to (typeArguments.getOrNull(i) ?: type) })
 }
 
@@ -48,13 +48,13 @@ class TyStruct(
 
     override fun toString(): String = fullName
 
-    override fun withTypeArguments(typeArguments: List<Ty>): TyStruct =
-        super.withTypeArguments(typeArguments) as TyStruct
+    override fun applyTypeArguments(typeArguments: List<Ty>): TyStruct =
+        super.applyTypeArguments(typeArguments) as TyStruct
 
     override fun aliasTypeArguments(typeArguments: List<TyTypeParameter>): TyStruct =
         TyStruct(item, typeArguments, this.typeArguments)
 
-    override fun substitute(map: Map<TyTypeParameter, Ty>): TyStruct =
+    override fun substitute(map: TypeArguments): TyStruct =
         TyStruct(item, typeArgumentsMapping, typeArguments.map { it.substitute(map) })
 
     override fun equals(other: Any?): Boolean =
@@ -74,13 +74,13 @@ class TyEnum(
 
     override fun toString(): String = fullName
 
-    override fun withTypeArguments(typeArguments: List<Ty>): TyEnum =
-        super.withTypeArguments(typeArguments) as TyEnum
+    override fun applyTypeArguments(typeArguments: List<Ty>): TyEnum =
+        super.applyTypeArguments(typeArguments) as TyEnum
 
     override fun aliasTypeArguments(typeArguments: List<TyTypeParameter>): TyEnum =
         TyEnum(item, typeArguments, this.typeArguments)
 
-    override fun substitute(map: Map<TyTypeParameter, Ty>): TyEnum =
+    override fun substitute(map: TypeArguments): TyEnum =
         TyEnum(item, typeArgumentsMapping, typeArguments.map { it.substitute(map) })
 
     override fun equals(other: Any?): Boolean =

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt
@@ -8,7 +8,7 @@ data class TyTuple(val types: List<Ty>) : Ty {
         other is TyTuple && types.size == other.types.size &&
             types.zip(other.types).all { (type1, type2) -> type1.canUnifyWith(type2, project) }
 
-    override fun substitute(map: Map<TyTypeParameter, Ty>): TyTuple =
+    override fun substitute(map: TypeArguments): TyTuple =
         TyTuple(types.map { it.substitute(map) })
 
     override fun toString(): String = types.joinToString(", ", "(", ")")

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
@@ -26,7 +26,7 @@ data class TyTypeParameter private constructor(
         return parameter.bounds.all { implTraits.contains(it) }
     }
 
-    override fun substitute(map: Map<TyTypeParameter, Ty>): Ty = map[this] ?: this
+    override fun substitute(map: TypeArguments): Ty = map[this] ?: this
 
     override fun toString(): String = parameter.name ?: "<unknown>"
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
@@ -6,7 +6,8 @@ import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTypeParameter
 import org.rust.lang.core.psi.ext.RsGenericDeclaration
 import org.rust.lang.core.psi.ext.flattenHierarchy
-import org.rust.lang.core.psi.ext.resolveToTrait
+import org.rust.lang.core.psi.ext.resolveToBoundTrait
+import org.rust.lang.core.types.BoundElement
 
 data class TyTypeParameter private constructor(
     private val parameter: TypeParameter
@@ -16,14 +17,14 @@ data class TyTypeParameter private constructor(
 
     constructor(trait: RsTraitItem) : this(Self(trait))
 
-    fun getTraitBoundsTransitively(): Collection<RsTraitItem> =
+    fun getTraitBoundsTransitively(): Collection<BoundElement<RsTraitItem>> =
         parameter.bounds.flatMapTo(mutableSetOf()) { it.flattenHierarchy.asSequence() }
 
     override fun canUnifyWith(other: Ty, project: Project): Boolean {
         if (this == other) return true
 
         val implTraits = findTraits(project, other).toSet()
-        return parameter.bounds.all { implTraits.contains(it) }
+        return parameter.bounds.all { implTraits.contains(it.element) }
     }
 
     override fun substitute(map: TypeArguments): Ty = map[this] ?: this
@@ -32,13 +33,13 @@ data class TyTypeParameter private constructor(
 
     private interface TypeParameter {
         val name: String?
-        val bounds: Sequence<RsTraitItem>
+        val bounds: Sequence<BoundElement<RsTraitItem>>
     }
 
     private data class Named(val parameter: RsTypeParameter) : TypeParameter {
         override val name: String? get() = parameter.name
 
-        override val bounds: Sequence<RsTraitItem> get() {
+        override val bounds: Sequence<BoundElement<RsTraitItem>> get() {
             val owner = parameter.parent?.parent as? RsGenericDeclaration
             val whereBounds =
                 owner?.whereClause?.wherePredList.orEmpty()
@@ -47,13 +48,13 @@ data class TyTypeParameter private constructor(
                     .flatMap { it.typeParamBounds?.polyboundList.orEmpty().asSequence() }
 
             return (parameter.typeParamBounds?.polyboundList.orEmpty().asSequence() + whereBounds)
-                .mapNotNull { it.bound.traitRef?.resolveToTrait }
+                .mapNotNull { it.bound.traitRef?.resolveToBoundTrait }
         }
     }
 
     private data class Self(val trait: RsTraitItem) : TypeParameter {
         override val name: String? get() = "Self"
 
-        override val bounds: Sequence<RsTraitItem> get() = sequenceOf(trait)
+        override val bounds: Sequence<BoundElement<RsTraitItem>> get() = sequenceOf(BoundElement(trait))
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -880,4 +880,18 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }
     """)
 
+    fun `test propagates trait type arguments`() = checkByCode("""
+        trait I<T> {
+            fn foo(&self) -> T;
+        }
+
+        struct S;
+        impl S {
+            fn bar(&self) {}
+        }     //X
+
+        fn baz<T: I<S>>(t: T) {
+            t.foo().bar()
+        }         //^
+    """)
 }


### PR DESCRIPTION
This is a rather major improvement of type inference (at least, ground work for this improvement). 

This allows us to resolve this case:

```Rust
        trait I<T> {
            fn foo(&self) -> T;
        }

        struct S;
        impl S {
            fn bar(&self) {}
        }     //X

        fn baz<T: I<S>>(t: T) {
            t.foo().bar()
        }         //^
```


Previously, we were able to resolve `.foo()`, but not `.bar()`. The problem was that while we know the function `foo`, we lost the knowlage of its type parameter `T`.

The crux of the fix is to extend `ScopeEntry` with `typeArguments` field, so that once we resolve `foo`, we know that `T` is in fact maps to `S` for this particular reference.

This type arguments must be threaded through all of the resolve infrastructure, so `BoundElement` class is introduced to hold a pair of PsiElement and TypeArguments, and `advanceResolve` function is added to `RsReference`, which returns bound PsiElement .

