### PR TITLE
ANN: Fix E0384 false positive

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -625,27 +625,16 @@ private fun RsExpr.isMutable(): Boolean {
     return when (this) {
         is RsPathExpr -> {
             val declaration = this.path.reference.resolve() ?: return true
-
-            if (declaration is RsSelfParameter) {
-                return declaration.mut != null
-            }
-
-            if (declaration is RsPatBinding && declaration.isMut) {
-                return true
-            }
+            if (declaration is RsSelfParameter) return declaration.isMut
+            if (declaration is RsPatBinding && declaration.isMut) return true
+            if (declaration is RsConstant) return declaration.isMut
 
             val type = this.type
-            if (type is TyReference) {
-                return type.mutable
-            }
+            if (type is TyReference) return type.mutable
 
             val letExpr = declaration.parentOfType<RsLetDecl>()
-            if (letExpr != null && letExpr.eq == null) {
-                return true
-            }
-            if (type is TyUnknown) {
-                return true
-            }
+            if (letExpr != null && letExpr.eq == null) return true
+            if (type is TyUnknown) return true
             if (declaration is RsEnumVariant) return true
 
             false

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
@@ -40,6 +40,8 @@ val RsConstant.role: RsConstantRole get() {
 val RsConstant.default: PsiElement?
     get() = node.findChildByType(DEFAULT)?.psi
 
+val RsConstant.isMut: Boolean
+    get() = mut != null
 
 abstract class RsConstantImplMixin : RsStubbedNamedElementImpl<RsConstantStub>, RsConstant {
     constructor(node: ASTNode) : super(node)

--- a/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt
@@ -113,6 +113,13 @@ class RsExpressionAnnotatorTest : RsAnnotatorTestBase() {
         }
     """)
 
+    fun testE0384_ReassignMutableFromStatic() = checkErrors("""
+        fn main() {
+            static mut X: u32 = 5;
+            X = 3;
+        }
+    """)
+
     fun testE0384_ReassignMutableFromBindingWithoutAssignement() = checkErrors("""
         fn main() {
             let mut x;


### PR DESCRIPTION
Fixes an E0384 false positive when a mutable static constant is reassigned. Also a minor refactoring.

Though technically, it's not a E0384, I think we can still handle it here because Rust has no designated code for this case.

cc @farodin91 