### PR TITLE
TY: improve type inference of function call expr

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/Expressions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Expressions.kt
@@ -215,17 +215,8 @@ private fun mapTypeParameters(
     return argsMapping
 }
 
-private fun addTypeMapping(
-    argsMapping: MutableMap<TyTypeParameter, Ty>,
-    fieldType: Ty?,
-    expr: RsExpr
-) {
-    if (fieldType is TyTypeParameter) {
-        val old = argsMapping[fieldType]
-        if (old == null || old == TyUnknown || old is TyNumeric && old.isKindWeak)
-            argsMapping[fieldType] = expr.type
-    }
-}
+private fun addTypeMapping(argsMapping: TypeMapping, fieldType: Ty?, expr: RsExpr) =
+    fieldType?.canUnifyWith(expr.type, expr.project, argsMapping)
 
 /**
  * Remap type parameters between type declaration and an impl block.

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt
@@ -2,10 +2,10 @@ package org.rust.lang.core.types.ty
 
 import com.intellij.openapi.project.Project
 
-
 class TyArray(val base: Ty, val size: Int) : Ty {
-    override fun canUnifyWith(other: Ty, project: Project): Boolean =
-        other is TyArray && size == other.size && base.canUnifyWith(other.base, project)
+    override fun canUnifyWith(other: Ty, project: Project, mapping: TypeMapping?): Boolean = merge(mapping) {
+        other is TyArray && size == other.size && base.canUnifyWith(other.base, project, it)
+    }
 
     override fun substitute(map: TypeArguments): Ty =
         TyArray(base.substitute(map), size)

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyFunction.kt
@@ -4,10 +4,11 @@ import com.intellij.openapi.project.Project
 
 data class TyFunction(val paramTypes: List<Ty>, val retType: Ty) : Ty {
 
-    override fun canUnifyWith(other: Ty, project: Project): Boolean =
+    override fun canUnifyWith(other: Ty, project: Project, mapping: TypeMapping?): Boolean = merge(mapping) {
         other is TyFunction && paramTypes.size == other.paramTypes.size &&
-            paramTypes.zip(other.paramTypes).all { (type1, type2) -> type1.canUnifyWith(type2, project) } &&
-            retType.canUnifyWith(other.retType, project)
+            paramTypes.zip(other.paramTypes).all { (type1, type2) -> type1.canUnifyWith(type2, project, it) } &&
+            retType.canUnifyWith(other.retType, project, it)
+    }
 
     override fun toString(): String {
         val params = paramTypes.joinToString(", ", "fn(", ")")

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt
@@ -4,8 +4,9 @@ import com.intellij.openapi.project.Project
 
 data class TyPointer(val referenced: Ty, val mutable: Boolean = false) : Ty {
 
-    override fun canUnifyWith(other: Ty, project: Project): Boolean =
-        other is TyPointer && referenced.canUnifyWith(other.referenced, project)
+    override fun canUnifyWith(other: Ty, project: Project, mapping: TypeMapping?): Boolean = merge(mapping) {
+        other is TyPointer && referenced.canUnifyWith(other.referenced, project, it)
+    }
 
     override fun toString() = "*${if (mutable) "mut" else "const"} $referenced"
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
@@ -13,7 +13,7 @@ import org.rust.lang.core.psi.ext.sizeExpr
  * tuples or arrays as primitive.
  */
 interface TyPrimitive : Ty {
-    override fun canUnifyWith(other: Ty, project: Project): Boolean =
+    override fun canUnifyWith(other: Ty, project: Project, mapping: TypeMapping?): Boolean =
         this == other
 
     companion object {
@@ -57,7 +57,7 @@ object TyStr : TyPrimitive {
 interface TyNumeric : TyPrimitive {
     val isKindWeak: Boolean
 
-    override fun canUnifyWith(other: Ty, project: Project): Boolean
+    override fun canUnifyWith(other: Ty, project: Project, mapping: MutableMap<TyTypeParameter, Ty>?): Boolean
         = this == other || javaClass == other.javaClass && (other as TyNumeric).isKindWeak
 }
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
@@ -4,8 +4,9 @@ import com.intellij.openapi.project.Project
 
 data class TyReference(val referenced: Ty, val mutable: Boolean = false) : Ty {
 
-    override fun canUnifyWith(other: Ty, project: Project): Boolean =
-        other is TyReference && referenced.canUnifyWith(other.referenced, project)
+    override fun canUnifyWith(other: Ty, project: Project, mapping: TypeMapping?): Boolean = merge(mapping) {
+        other is TyReference && referenced.canUnifyWith(other.referenced, project, it)
+    }
 
     override fun toString(): String = "${if (mutable) "&mut " else "&"}$referenced"
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TySlice.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TySlice.kt
@@ -3,8 +3,9 @@ package org.rust.lang.core.types.ty
 import com.intellij.openapi.project.Project
 
 data class TySlice(val elementType: Ty) : Ty {
-    override fun canUnifyWith(other: Ty, project: Project): Boolean =
-        other is TySlice && elementType.canUnifyWith(other.elementType, project)
+    override fun canUnifyWith(other: Ty, project: Project, mapping: TypeMapping?): Boolean = merge(mapping) {
+        other is TySlice && elementType.canUnifyWith(other.elementType, project, it)
+    }
 
     override fun substitute(map: TypeArguments): Ty {
         return TySlice(elementType.substitute(map))

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyStructOrEnum.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyStructOrEnum.kt
@@ -28,9 +28,10 @@ interface TyStructOrEnumBase : Ty {
             } else "<anonymous>"
         }
 
-    override fun canUnifyWith(other: Ty, project: Project): Boolean =
+    override fun canUnifyWith(other: Ty, project: Project, mapping: TypeMapping?): Boolean = merge(mapping) {
         other is TyStructOrEnumBase && item == other.item &&
-            typeArguments.zip(other.typeArguments).all { (type1, type2) -> type1.canUnifyWith(type2, project) }
+            typeArguments.zip(other.typeArguments).all { (type1, type2) -> type1.canUnifyWith(type2, project, it) }
+    }
 
     fun aliasTypeArguments(typeArguments: List<TyTypeParameter>): Ty
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
@@ -11,7 +11,7 @@ import org.rust.lang.core.psi.RsTraitItem
  */
 data class TyTraitObject(val trait: RsTraitItem) : Ty {
 
-    override fun canUnifyWith(other: Ty, project: Project): Boolean =
+    override fun canUnifyWith(other: Ty, project: Project, mapping: TypeMapping?): Boolean =
         other is RsTraitItem && trait == other.trait
 
     override fun toString(): String = trait.name ?: "<anonymous>"

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt
@@ -4,9 +4,10 @@ import com.intellij.openapi.project.Project
 
 data class TyTuple(val types: List<Ty>) : Ty {
 
-    override fun canUnifyWith(other: Ty, project: Project): Boolean =
+    override fun canUnifyWith(other: Ty, project: Project, mapping: TypeMapping?): Boolean = merge(mapping) {
         other is TyTuple && types.size == other.types.size &&
-            types.zip(other.types).all { (type1, type2) -> type1.canUnifyWith(type2, project) }
+            types.zip(other.types).all { (type1, type2) -> type1.canUnifyWith(type2, project, it) }
+    }
 
     override fun substitute(map: TypeArguments): TyTuple =
         TyTuple(types.map { it.substitute(map) })

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
@@ -20,7 +20,10 @@ data class TyTypeParameter private constructor(
     fun getTraitBoundsTransitively(): Collection<BoundElement<RsTraitItem>> =
         parameter.bounds.flatMapTo(mutableSetOf()) { it.flattenHierarchy.asSequence() }
 
-    override fun canUnifyWith(other: Ty, project: Project): Boolean = true
+    override fun canUnifyWith(other: Ty, project: Project, mapping: TypeMapping?): Boolean {
+        mapping?.merge(mutableMapOf(this to other))
+        return true
+    }
 
     override fun substitute(map: TypeArguments): Ty = map[this] ?: this
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyUnknown.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyUnknown.kt
@@ -3,7 +3,7 @@ package org.rust.lang.core.types.ty
 import com.intellij.openapi.project.Project
 
 object TyUnknown : Ty {
-    override fun canUnifyWith(other: Ty, project: Project): Boolean = false
+    override fun canUnifyWith(other: Ty, project: Project, mapping: TypeMapping?): Boolean = false
 
     override fun toString(): String = "<unknown>"
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -846,4 +846,38 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
                //^
         }
     """)
+
+    fun `test simple generic function argument`() = checkByCode("""
+        struct Foo<F>(F);
+        struct Bar;
+        impl Bar {
+            fn bar(&self) { unimplemented!() }
+              //X
+        }
+        fn foo<T>(xs: Foo<T>) -> T { unimplemented!() }
+        fn main() {
+            let x = foo(Foo(Bar()));
+            x.bar();
+             //^
+        }
+    """)
+
+    fun `test complex generic function argument`() = checkByCode("""
+        struct Foo<T1, T2>(T1, T2);
+        enum Bar<T3> { V(T3) }
+        struct FooBar<T4, T5>(T4, T5);
+        struct S;
+
+        impl S {
+            fn bar(&self) { unimplemented!() }
+              //X
+        }
+
+        fn foo<F1, F2, F3>(x: FooBar<Foo<F1, F2>, Bar<F3>>) -> Foo<F2, F3> { unimplemented!() }
+        fn main() {
+            let x = foo(FooBar(Foo(123, "foo"), Bar::V(S())));
+            x.1.bar();
+              //^
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -270,5 +270,84 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
           //^ (u8, u16, u8)
         }
     """)
+
+    fun testGenericStructArg() = testExpr("""
+        struct Foo<F>(F);
+        fn foo<T>(xs: Foo<T>) -> T { unimplemented!() }
+        fn main() {
+            let x = foo(Foo(123));
+            x
+          //^ i32
+        }
+    """)
+
+    fun testGenericEnumArg() = testExpr("""
+        enum Foo<F> { V(F) }
+        fn foo<T>(xs: Foo<T>) -> T { unimplemented!() }
+        fn main() {
+            let x = foo(Foo::V(123));
+            x
+          //^ i32
+        }
+    """)
+
+    fun testGenericTupleArg() = testExpr("""
+        fn foo<T, F>(xs: (T, F)) -> F { unimplemented!() }
+        fn main() {
+            let x = foo((123, "str"));
+            x
+          //^ &str
+        }
+    """)
+
+    fun testGenericReferenceArg() = testExpr("""
+        fn foo<T>(xs: &T) -> T { unimplemented!() }
+        fn main() {
+            let x = foo(&8u64);
+            x
+          //^ u64
+        }
+    """)
+
+    fun testGenericPointerArg() = testExpr("""
+        fn foo<T>(xs: *const T) -> T { unimplemented!() }
+        fn main() {
+            let x = foo(&8u16 as *const u16);
+            x
+          //^ u16
+        }
+    """)
+
+    fun testGenericArrayArg() = testExpr("""
+        fn foo<T>(xs: [T; 4]) -> T { unimplemented!() }
+        fn main() {
+            let x = foo([1, 2, 3, 4]);
+            x
+          //^ i32
+        }
+    """)
+
+    fun testGenericSliceArg() = testExpr("""
+        fn foo<T>(xs: &[T]) -> T { unimplemented!() }
+        fn main() {
+            let slice: &[&str] = &["foo", "bar"];
+            let x = foo(slice);
+            x
+          //^ &str
+        }
+    """)
+
+    fun testComplexGenericArg() = testExpr("""
+        struct Foo<T1, T2>(T1, T2);
+        enum Bar<T3, T4> { V(T3, T4) }
+        struct FooBar<T5, T6>(T5, T6);
+
+        fn foo<F1, F2, F3, F4>(x: FooBar<Foo<F1, F2>, Bar<F3, F4>>) -> (Bar<F4, F1>, Foo<F3, F2>) { unimplemented!() }
+        fn main() {
+            let x = foo(FooBar(Foo(123, "foo"), Bar::V([0.0; 3], (0, false))));
+            x
+          //^ (Bar<(i32, bool), i32>, Foo<[f64; 3], &str>)
+        }
+    """)
 }
 


### PR DESCRIPTION
Improve type inference of function call expressions. Now we can infer type parameter not only directly:
```rust
fn foo<T>(arg: T) -> T { ... }

let x = foo(123) // x: i32
```
but also from more complex generic arguments:
```rust
fn foo<T>(arg: (T, T)) -> [T; 2] { ... }

let x = foo((1, 2)); // x: [i32; 2]
``` 
Slightly modified `canUnifyWith` methods are used to achieve it.