### PR TITLE
TY: initial support of arithmetic binary expression type inference

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -502,12 +502,12 @@ class RsErrorAnnotator : Annotator, HighlightRangeExtension {
 
 private fun RsExpr?.isComparisonBinaryExpr(): Boolean {
     val op = this as? RsBinaryExpr ?: return false
-    return op.operatorType in RS_COMPARISON_OPERATOR
+    return op.operatorType is ComparisonOp
 }
 
 private fun RsExpr?.isAssignBinaryExpr(): Boolean {
     val op = this as? RsBinaryExpr ?: return false
-    return op.operatorType in RS_ASSIGN_OPERATOR
+    return op.operatorType is AssignmentOp
 }
 
 private fun checkDuplicates(holder: AnnotationHolder, element: RsNamedElement, scope: PsiElement = element.parent, recursively: Boolean = false) {

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFix.kt
@@ -6,13 +6,8 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
 import org.rust.ide.intentions.RsElementBaseIntentionAction
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.operatorType
-import org.rust.lang.core.psi.ext.parentOfType
-import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.RsFileType
-import org.rust.lang.core.psi.ext.RsCompositeElement
-import org.rust.lang.core.psi.ext.childOfType
-
+import org.rust.lang.core.psi.ext.*
 
 class AddTurbofishFix : RsElementBaseIntentionAction<AddTurbofishFix.Context>() {
     private val TURBOFISH = "::"
@@ -40,7 +35,7 @@ class AddTurbofishFix : RsElementBaseIntentionAction<AddTurbofishFix.Context>() 
             return resolveMatchExpression(base) ?: base
         }
         val left = base.left as RsBinaryExpr
-        if (left.operatorType == GTGT) {
+        if (left.operatorType == ArithmeticOp.SHR) {
             return resolveMatchExpression(base) ?: base
         }
         return base

--- a/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
@@ -5,8 +5,8 @@ import com.intellij.codeInsight.template.impl.TextExpression
 import com.intellij.codeInsight.template.postfix.templates.StringBasedPostfixTemplate
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsBinaryExpr
-import org.rust.lang.core.psi.RsElementTypes.EQEQ
 import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.ext.ComparisonOp
 import org.rust.lang.core.psi.ext.operatorType
 
 abstract class AssertPostfixTemplateBase(name: String) : StringBasedPostfixTemplate(
@@ -15,7 +15,7 @@ abstract class AssertPostfixTemplateBase(name: String) : StringBasedPostfixTempl
     RsTopMostInScopeSelector(RsExpr::isBool)) {
 
     override fun getTemplateString(element: PsiElement): String =
-        if (element is RsBinaryExpr && element.operatorType == EQEQ) {
+        if (element is RsBinaryExpr && element.operatorType == ComparisonOp.EQ) {
             "${this.presentableName}_eq!(${element.left.text}, ${element.right?.text});\$END$"
         } else {
             "$presentableName!(${element.text});\$END$"

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
@@ -1,7 +1,6 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.psi.PsiElement
-import com.intellij.psi.tree.IElementType
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.*
 
@@ -29,31 +28,63 @@ val RsUnaryExpr.operatorType: UnaryOperator get() = when {
     else -> error("Unknown unary operator type: `$text`")
 }
 
-enum class ArithmeticOp(val traitName: String, val itemName: String, val sign: String) {
-    ADD("Add", "add", "+"), // `a + b`
-    SUB("Sub", "sub", "-"), // `a - b`
-    MUL("Mul", "mul", "*"), // `a * b`
-    DIV("Div", "div", "/"), // `a / b`
-    REM("Rem", "rem", "%"), // `a % b`
-    BIT_AND("BitAnd", "bitand", "&"), // `a & b`
-    BIT_OR("BitOr", "bitor", "|"), // `a | b`
-    BIT_XOR("BitXor", "bitxor", "^"), // `a ^ b`
-    SHL("Shl", "shl", "<<"), // `a << b`
-    SHR("Shr", "shr", ">>"); // `a >> b`
+sealed class BinaryOperator
+
+sealed class ArithmeticOp(val traitName: String, val itemName: String, val sign: String) : BinaryOperator() {
+    object ADD : ArithmeticOp("Add", "add", "+") // `a + b`
+    object SUB : ArithmeticOp("Sub", "sub", "-") // `a - b`
+    object MUL : ArithmeticOp("Mul", "mul", "*") // `a * b`
+    object DIV : ArithmeticOp("Div", "div", "/") // `a / b`
+    object REM : ArithmeticOp("Rem", "rem", "%") // `a % b`
+    object BIT_AND : ArithmeticOp("BitAnd", "bitand", "&") // `a & b`
+    object BIT_OR : ArithmeticOp("BitOr", "bitor", "|") // `a | b`
+    object BIT_XOR : ArithmeticOp("BitXor", "bitxor", "^") // `a ^ b`
+    object SHL : ArithmeticOp("Shl", "shl", "<<") // `a << b`
+    object SHR : ArithmeticOp("Shr", "shr", ">>") // `a >> b
 
     operator fun component1(): String = traitName
     operator fun component2(): String = itemName
     operator fun component3(): String = sign
+
+    companion object {
+        fun values(): List<ArithmeticOp> = listOf(ADD, SUB, MUL, DIV, REM, BIT_AND, BIT_OR, BIT_XOR, SHL, SHR)
+    }
+}
+
+sealed class BoolOp : BinaryOperator()
+
+sealed class LogicOp : BoolOp() {
+    object AND : LogicOp() // `a && b`
+    object OR : LogicOp() // `a || b`
+}
+
+sealed class ComparisonOp : BoolOp() {
+    object EQ : ComparisonOp() // `a == b`
+    object EXCLEQ : ComparisonOp() // `a != b`
+    object LT : ComparisonOp() // `a < b`
+    object LTEQ : ComparisonOp() // `a <= b`
+    object GT : ComparisonOp() // `a > b`
+    object GTEQ : ComparisonOp() // `a >= b`
+}
+
+sealed class AssignmentOp : BinaryOperator() {
+    object EQ : AssignmentOp() // `a = b`
+    object ANDEQ : AssignmentOp() // `a &= b`
+    object OREQ : AssignmentOp() // `a |= b`
+    object PLUSEQ : AssignmentOp() // `a += b`
+    object MINUSEQ : AssignmentOp() // `a -= b`
+    object MULEQ : AssignmentOp() // `a *= b`
+    object DIVEQ : AssignmentOp() // `a /= b`
+    object REMEQ : AssignmentOp() // `a %= b`
+    object XOREQ : AssignmentOp() // `a ^= b`
+    object GTGTEQ : AssignmentOp() // `a >>= b`
+    object LTLTEQ : AssignmentOp() // `a <<= b`
 }
 
 val RsBinaryExpr.operator: PsiElement
     get() = requireNotNull(node.findChildByType(BINARY_OPS)) { "guaranteed to be not-null by parser" }.psi
 
-// TODO: probably want to use a special `enum` here instead of `IElementType`.
-val RsBinaryExpr.operatorType: IElementType
-    get() = operator.elementType
-
-val RsBinaryExpr.arithmeticOp: ArithmeticOp? get() = when (operatorType) {
+val RsBinaryExpr.operatorType: BinaryOperator get() = when (operator.elementType) {
     PLUS -> ArithmeticOp.ADD
     MINUS -> ArithmeticOp.SUB
     MUL -> ArithmeticOp.MUL
@@ -64,32 +95,31 @@ val RsBinaryExpr.arithmeticOp: ArithmeticOp? get() = when (operatorType) {
     XOR -> ArithmeticOp.BIT_XOR
     LTLT -> ArithmeticOp.SHL
     GTGT -> ArithmeticOp.SHR
-    else -> null
+
+    ANDAND -> LogicOp.AND
+    OROR -> LogicOp.OR
+
+    EQEQ -> ComparisonOp.EQ
+    EXCLEQ -> ComparisonOp.EXCLEQ
+    GT -> ComparisonOp.GT
+    LT -> ComparisonOp.LT
+    LTEQ -> ComparisonOp.LTEQ
+    GTEQ -> ComparisonOp.GTEQ
+
+    EQ -> AssignmentOp.EQ
+    ANDEQ -> AssignmentOp.ANDEQ
+    OREQ -> AssignmentOp.OREQ
+    PLUSEQ -> AssignmentOp.PLUSEQ
+    MINUSEQ -> AssignmentOp.MINUSEQ
+    MULEQ -> AssignmentOp.MULEQ
+    DIVEQ -> AssignmentOp.DIVEQ
+    REMEQ -> AssignmentOp.REMEQ
+    XOREQ -> AssignmentOp.XOREQ
+    GTGTEQ -> AssignmentOp.GTGTEQ
+    LTLTEQ -> AssignmentOp.LTLTEQ
+
+    else -> error("Unknown binary operator type: `$text`")
 }
-
-val BOOL_BINARY_OPS = tokenSetOf(
-    ANDAND,
-    OROR,
-    EQEQ,
-    EXCLEQ,
-    LT,
-    GT,
-    GTEQ,
-    LTEQ
-)
-
-val ARITHMETIC_BINARY_OPS = tokenSetOf(
-    PLUS,
-    MINUS,
-    MUL,
-    DIV,
-    REM,
-    AND,
-    OR,
-    XOR,
-    LTLT,
-    GTGT
-)
 
 private val BINARY_OPS = tokenSetOf(
     AND,

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
@@ -29,6 +29,23 @@ val RsUnaryExpr.operatorType: UnaryOperator get() = when {
     else -> error("Unknown unary operator type: `$text`")
 }
 
+enum class ArithmeticOp(val traitName: String, val itemName: String, val sign: String) {
+    ADD("Add", "add", "+"), // `a + b`
+    SUB("Sub", "sub", "-"), // `a - b`
+    MUL("Mul", "mul", "*"), // `a * b`
+    DIV("Div", "div", "/"), // `a / b`
+    REM("Rem", "rem", "%"), // `a % b`
+    BIT_AND("BitAnd", "bitand", "&"), // `a & b`
+    BIT_OR("BitOr", "bitor", "|"), // `a | b`
+    BIT_XOR("BitXor", "bitxor", "^"), // `a ^ b`
+    SHL("Shl", "shl", "<<"), // `a << b`
+    SHR("Shr", "shr", ">>"); // `a >> b`
+
+    operator fun component1(): String = traitName
+    operator fun component2(): String = itemName
+    operator fun component3(): String = sign
+}
+
 val RsBinaryExpr.operator: PsiElement
     get() = requireNotNull(node.findChildByType(BINARY_OPS)) { "guaranteed to be not-null by parser" }.psi
 
@@ -36,6 +53,43 @@ val RsBinaryExpr.operator: PsiElement
 val RsBinaryExpr.operatorType: IElementType
     get() = operator.elementType
 
+val RsBinaryExpr.arithmeticOp: ArithmeticOp? get() = when (operatorType) {
+    PLUS -> ArithmeticOp.ADD
+    MINUS -> ArithmeticOp.SUB
+    MUL -> ArithmeticOp.MUL
+    DIV -> ArithmeticOp.DIV
+    REM -> ArithmeticOp.REM
+    AND -> ArithmeticOp.BIT_AND
+    OR -> ArithmeticOp.BIT_OR
+    XOR -> ArithmeticOp.BIT_XOR
+    LTLT -> ArithmeticOp.SHL
+    GTGT -> ArithmeticOp.SHR
+    else -> null
+}
+
+val BOOL_BINARY_OPS = tokenSetOf(
+    ANDAND,
+    OROR,
+    EQEQ,
+    EXCLEQ,
+    LT,
+    GT,
+    GTEQ,
+    LTEQ
+)
+
+val ARITHMETIC_BINARY_OPS = tokenSetOf(
+    PLUS,
+    MINUS,
+    MUL,
+    DIV,
+    REM,
+    AND,
+    OR,
+    XOR,
+    LTLT,
+    GTGT
+)
 
 private val BINARY_OPS = tokenSetOf(
     AND,

--- a/src/main/kotlin/org/rust/lang/core/resolve/LangItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/LangItems.kt
@@ -3,15 +3,13 @@ package org.rust.lang.core.resolve
 import com.intellij.openapi.project.Project
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsTraitItem
+import org.rust.lang.core.psi.ext.ArithmeticOp
 import org.rust.lang.core.psi.ext.queryAttributes
 import org.rust.lang.core.psi.ext.resolveToTrait
 import org.rust.lang.core.resolve.indexes.RsImplIndex
-import org.rust.lang.core.types.ty.Ty
-import org.rust.lang.core.types.ty.findImplsAndTraits
 import org.rust.lang.core.types.infer.remapTypeParameters
-import org.rust.lang.core.types.ty.TyReference
+import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
-import org.rust.lang.core.types.ty.TyUnknown
 
 fun findDerefTarget(project: Project, ty: Ty): Ty? {
     val impls = RsImplIndex.findImpls(project, ty)
@@ -41,24 +39,39 @@ fun findIndexOutputType(project: Project, containerType: Ty, indexType: Ty): Ty 
     val suitableImpl = if (impls.size < 2) {
         impls.firstOrNull()
     } else {
-        impls.find { impl ->
-            // TODO: get index type from impl declaration
-            impl.functionList
-                .find { it.name == "index" }
-                ?.valueParameterList
-                ?.valueParameterList
-                // 'index' function have only one value parameter
-                // fn index(&self, index: Idx) -> &Self::Output;
-                ?.getOrNull(0)
-                ?.typeReference
-                ?.type
-                ?.canUnifyWith(indexType, project) ?: false
-        }
+        impls.find { isImplSuitable(project, it, "index", 0, indexType) }
     } ?: return TyUnknown
 
     val rawOutputType = lookupAssociatedType(suitableImpl, "Output")
     val typeParameterMap = suitableImpl.remapTypeParameters(containerType.typeParameterValues)
     return TyReference(rawOutputType.substitute(typeParameterMap))
+}
+
+fun findArithmeticBinaryExprOutputType(project: Project, lhsType: Ty, rhsType: Ty, op: ArithmeticOp): Ty {
+    val impls = RsImplIndex.findImpls(project, lhsType)
+        .filter { op.itemName == it.traitRef?.resolveToTrait?.langAttribute }
+
+    val suitableImpl = if (impls.size < 2) {
+        impls.firstOrNull()
+    } else {
+        impls.find { isImplSuitable(project, it, op.itemName, 0, rhsType) }
+    } ?: return TyUnknown
+
+    val rawOutputType = lookupAssociatedType(suitableImpl, "Output")
+    val typeParameterMap = suitableImpl.remapTypeParameters(lhsType.typeParameterValues)
+    return rawOutputType.substitute(typeParameterMap)
+}
+
+private fun isImplSuitable(project: Project, impl: RsImplItem,
+                           fnName: String, paramIndex: Int, paramType: Ty): Boolean {
+    return impl.functionList
+        .find { it.name == fnName }
+        ?.valueParameterList
+        ?.valueParameterList
+        ?.getOrNull(paramIndex)
+        ?.typeReference
+        ?.type
+        ?.canUnifyWith(paramType, project) ?: false
 }
 
 private val RsTraitItem.langAttribute: String? get() {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Expressions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Expressions.kt
@@ -106,11 +106,14 @@ fun inferExpressionType(expr: RsExpr): Ty {
             }
         }
 
-        is RsBinaryExpr -> when (expr.operatorType) {
-            in BOOL_BINARY_OPS -> TyBool
-            in ARITHMETIC_BINARY_OPS -> inferArithmeticBinaryExprType(expr)
+        is RsBinaryExpr -> {
+            val op = expr.operatorType
+            when (op) {
+                is BoolOp -> TyBool
+                is ArithmeticOp -> inferArithmeticBinaryExprType(expr, op)
 
-            else -> TyUnknown
+                else -> TyUnknown
+            }
         }
 
         is RsTryExpr -> {
@@ -201,10 +204,9 @@ private fun inferTypeParametersForTuple(
     return mapTypeParameters(tupleFields.tupleFieldDeclList.map { it.typeReference.type }, tupleExprs)
 }
 
-private fun inferArithmeticBinaryExprType(expr: RsBinaryExpr): Ty {
+private fun inferArithmeticBinaryExprType(expr: RsBinaryExpr, op: ArithmeticOp): Ty {
     val lhsType = expr.left.type
     val rhsType = expr.right?.type ?: TyUnknown
-    val op = requireNotNull(expr.arithmeticOp)
     return findArithmeticBinaryExprOutputType(expr.project, lhsType, rhsType, op)
 }
 

--- a/src/main/kotlin/org/rust/lang/utils/RsBooleanExpUtils.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsBooleanExpUtils.kt
@@ -2,14 +2,14 @@ package org.rust.lang.utils
 
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.RsElementTypes.*
+import org.rust.lang.core.psi.ext.ComparisonOp.*
 import org.rust.lang.core.psi.ext.operatorType
 
 fun RsBinaryExpr.negateToString(): String {
     val lhs = left.text
     val rhs = right?.text ?: ""
     val op = when (operatorType) {
-        EQEQ -> "!="
+        EQ -> "!="
         EXCLEQ -> "=="
         GT -> "<="
         LT -> ">="

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -301,4 +301,21 @@ class RsStdlibResolveTest : RsResolveTestBase() {
 
         fn foo() -> Result<i32, i32> { Ok(42) }
     """)
+
+    fun `test String plus &str`() = stubOnlyResolve("""
+    //- main.rs
+        fn main() {
+            (String::new() + "foo").capacity();
+                                     //^ ...libcollections/string.rs
+        }
+    """)
+
+    fun `test Instant minus Duration`() = stubOnlyResolve("""
+    //- main.rs
+        use std::time::{Duration, Instant};
+        fn main() {
+            (Instant::now() - Duration::from_secs(3)).elapsed();
+                                                      //^ ...time/mod.rs
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsArithmeticOpsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsArithmeticOpsTest.kt
@@ -1,0 +1,137 @@
+package org.rust.lang.core.type
+
+import org.rust.lang.core.psi.ext.ArithmeticOp
+
+class RsArithmeticOpsTest : RsTypificationTestBase() {
+
+    fun `test same type of lhs and rhs`() = testExprWithAllOps { traitName, itemName, sign ->
+        """
+        #[lang = "$itemName"]
+        pub trait $traitName<RHS=Self> {
+            type Output;
+            fn $itemName(self, rhs: RHS) -> Self::Output;
+        }
+
+        struct Foo;
+
+        impl $traitName for Foo {
+            type Output = Foo;
+            fn $itemName(self, rhs: Foo) -> Foo { unimplemented!() }
+        }
+
+        fn foo(lhs: Foo, rhs: Foo) {
+            let x = lhs $sign rhs;
+            x
+          //^ Foo
+        }
+        """
+    }
+
+    fun `test same type of lhs and rhs with 'Self' output`() = testExprWithAllOps { traitName, itemName, sign ->
+        """
+        #[lang = "$itemName"]
+        pub trait $traitName<RHS=Self> {
+            type Output;
+            fn $itemName(self, rhs: RHS) -> Self::Output;
+        }
+
+        struct Foo;
+
+        impl $traitName for Foo {
+            type Output = Self;
+            fn $itemName(self, rhs: Self) -> Self { unimplemented!() }
+        }
+
+        fn foo(lhs: Foo, rhs: Foo) {
+            let x = lhs $sign rhs;
+            x
+          //^ Foo
+        }
+        """
+    }
+
+    fun `test different types of lhs, rhs and output`() = testExprWithAllOps { traitName, itemName, sign ->
+        """
+        #[lang = "$itemName"]
+        pub trait $traitName<RHS=Self> {
+            type Output;
+            fn $itemName(self, rhs: RHS) -> Self::Output;
+        }
+
+        struct Foo;
+        struct Bar;
+
+        impl $traitName<i32> for Foo {
+            type Output = Bar;
+            fn $itemName(self, rhs: i32) -> Bar { unimplemented!() }
+        }
+
+        fn foo(lhs: Foo, rhs: i32) {
+            let x = lhs $sign rhs;
+            x
+          //^ Bar
+        }
+        """
+    }
+
+    fun `test multiple impls`() = testExprWithAllOps { traitName, itemName, sign ->
+        """
+        #[lang = "$itemName"]
+        pub trait $traitName<RHS=Self> {
+            type Output;
+            fn $itemName(self, rhs: RHS) -> Self::Output;
+        }
+
+        struct Foo;
+        struct Bar;
+        struct FooBar;
+
+        impl $traitName<f64> for Foo {
+            type Output = Bar;
+            fn $itemName(self, rhs: f64) -> Bar { unimplemented!() }
+        }
+
+        impl $traitName<i32> for Foo {
+            type Output = FooBar;
+            fn $itemName(self, rhs: i32) -> FooBar { unimplemented!() }
+        }
+
+        fn foo(lhs: Foo, rhs: i32) {
+            let x = lhs $sign rhs;
+            x
+          //^ FooBar
+        }
+        """
+    }
+
+    fun `test generic lhs and output`() = testExprWithAllOps { traitName, itemName, sign ->
+        """
+        #[lang = "$itemName"]
+        pub trait $traitName<RHS=Self> {
+            type Output;
+            fn $itemName(self, rhs: RHS) -> Self::Output;
+        }
+
+        struct Foo<T1>(T1);
+        struct Bar;
+        struct FooBar<T2>(T2);
+
+        impl<T> $traitName<Bar> for Foo<T> {
+            type Output = FooBar<T>;
+            fn $itemName(self, rhs: Bar) -> FooBar<T> { unimplemented!() }
+        }
+
+        fn foo(lhs: Foo<i32>, rhs: Bar) {
+            let x = lhs $sign rhs;
+            x
+          //^ FooBar<i32>
+        }
+        """
+    }
+
+    private inline fun testExprWithAllOps(codeGenerator: (String, String, String) -> String) {
+        for ((traitName, itemName, sign) in ArithmeticOp.values()) {
+            testExpr(codeGenerator(traitName, itemName, sign))
+        }
+    }
+}


### PR DESCRIPTION
Infer type of arithmetic binary expression.

Now inference doesn't work in following cases:
* for primitive types because their implementations are created with macros
* for generic types when `Output = Self`:
```rust
impl<T> Add for Foo<T> {
    type Output = Self;
    fn add(self, rhs: Self) -> Self { ... }
}
```
* if `Output` is generic and its type parameters should be inferred from `RHS` type:
```rust
impl<T1, T2> Add<Bar<T2>> for Foo<T1> {
    type Output = FooBar<T1, T2>;
    fn add(self, rhs: Bar<T2>) -> FooBar<T1, T2> { ... }
}
```