### PR TITLE
Intelligently complete return with `;` or ` `

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionProvider.kt
@@ -8,6 +8,8 @@ import com.intellij.util.ProcessingContext
 import org.rust.lang.core.completion.CompletionEngine.KEYWORD_PRIORITY
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.parentOfType
+import org.rust.lang.core.psi.ext.returnType
+import org.rust.lang.core.types.ty.TyUnit
 
 class RsKeywordCompletionProvider(
     private vararg val keywords: String
@@ -37,7 +39,7 @@ private fun addInsertionHandler(keyword: String, builder: LookupElementBuilder, 
         in ALWAYS_NEEDS_SPACE -> " "
         "return" -> {
             val fn = parameters.position.parentOfType<RsFunction>() ?: return builder
-            if (fn.retType != null) " " else ";"
+            if (fn.returnType !is TyUnit) " " else ";"
         }
         else -> return builder
     }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionProvider.kt
@@ -6,6 +6,8 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.openapi.editor.EditorModificationUtil
 import com.intellij.util.ProcessingContext
 import org.rust.lang.core.completion.CompletionEngine.KEYWORD_PRIORITY
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.ext.parentOfType
 
 class RsKeywordCompletionProvider(
     private vararg val keywords: String
@@ -13,21 +15,10 @@ class RsKeywordCompletionProvider(
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext?, result: CompletionResultSet) {
         for (keyword in keywords) {
             var builder = LookupElementBuilder.create(keyword)
-            SUFFIXES
-                .filter { keyword in it.second }
-                .firstOrNull()
-                ?.let { builder = builder.withInsertHandler(it.first) }
+            builder = addInsertionHandler(keyword, builder, parameters)
             result.addElement(PrioritizedLookupElement.withPriority(builder, KEYWORD_PRIORITY))
         }
     }
-
-    private companion object {
-        val SUFFIXES = listOf(
-            AddSuffixInsertionHandler(" ") to listOf("crate", "const", "enum", "extern", "fn", "impl", "let", "mod", "mut", "pub",
-                "static", "struct", "trait", "type", "unsafe", "use")
-        )
-    }
-
 }
 
 class AddSuffixInsertionHandler(val suffix: String) : InsertHandler<LookupElement> {
@@ -35,4 +26,21 @@ class AddSuffixInsertionHandler(val suffix: String) : InsertHandler<LookupElemen
         context.document.insertString(context.selectionEndOffset, suffix)
         EditorModificationUtil.moveCaretRelatively(context.editor, suffix.length)
     }
+}
+
+private val ALWAYS_NEEDS_SPACE = setOf("crate", "const", "enum", "extern", "fn", "impl", "let", "mod", "mut", "pub",
+    "static", "struct", "trait", "type", "unsafe", "use")
+
+
+private fun addInsertionHandler(keyword: String, builder: LookupElementBuilder, parameters: CompletionParameters): LookupElementBuilder {
+    val suffix = when (keyword) {
+        in ALWAYS_NEEDS_SPACE -> " "
+        "return" -> {
+            val fn = parameters.position.parentOfType<RsFunction>() ?: return builder
+            if (fn.retType != null) " " else ";"
+        }
+        else -> return builder
+    }
+
+    return builder.withInsertHandler(AddSuffixInsertionHandler(suffix))
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -7,6 +7,10 @@ import org.rust.ide.icons.RsIcons
 import org.rust.ide.icons.addTestMark
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.stubs.RsFunctionStub
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyUnit
+import org.rust.lang.core.types.ty.TyUnknown
+import org.rust.lang.core.types.type
 import javax.swing.Icon
 
 val RsFunction.isAssocFn: Boolean get() = selfParameter == null
@@ -60,6 +64,11 @@ val RsFunction.title: String
         RsFunctionRole.FOREIGN -> "Foreign function `$name`"
         else -> "Function `$name`"
     }
+
+val RsFunction.returnType: Ty get() {
+    val retType = retType ?: return TyUnit
+    return retType.typeReference?.type ?: TyUnknown
+}
 
 abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, RsFunction {
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -184,6 +184,6 @@ private fun deviseFunctionType(fn: RsFunction): TyFunction {
 
     paramTypes += fn.valueParameters.map { it.typeReference?.type ?: TyUnknown }
 
-    return TyFunction(paramTypes, fn.retType?.typeReference?.type ?: TyUnit)
+    return TyFunction(paramTypes, fn.returnType)
 }
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
@@ -341,13 +341,25 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         }
     """)
 
+    fun `test return from unit function`() = checkCompletion("return",
+        "fn foo() { ret/*caret*/}",
+        "fn foo() { return;/*caret*/}"
+    )
+
+    fun `test return from non-unit function`() = checkCompletion("return",
+        "fn foo() -> i32 { ret/*caret*/}",
+        "fn foo() -> i32 { return /*caret*/}"
+    )
+
     private fun checkCompletion(
         lookupString: String,
         @Language("Rust") before: String,
         @Language("Rust") after: String
     ) = checkByText(before, after) {
         val items = myFixture.completeBasic()
-        myFixture.lookup.currentItem = items.find { it.lookupString == lookupString }
+            ?: return@checkByText // single completion was inserted
+        val lookupItem = items.find { it.lookupString == lookupString }
+        myFixture.lookup.currentItem = lookupItem
         myFixture.type('\n')
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
@@ -346,6 +346,11 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         "fn foo() { return;/*caret*/}"
     )
 
+    fun `test return from explicit unit function`() = checkCompletion("return",
+        "fn foo() -> () { ret/*caret*/}",
+        "fn foo() -> () { return;/*caret*/}"
+    )
+
     fun `test return from non-unit function`() = checkCompletion("return",
         "fn foo() -> i32 { ret/*caret*/}",
         "fn foo() -> i32 { return /*caret*/}"


### PR DESCRIPTION
r? @alygin 