### PR TITLE
CARGO: Colorize `rustc` command output

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -164,6 +164,6 @@ class Cargo(
     }
 
     private companion object {
-        val COLOR_ACCEPTING_COMMANDS = listOf("bench", "build", "check", "clean", "clippy", "doc", "install", "publish", "run", "test", "update")
+        val COLOR_ACCEPTING_COMMANDS = listOf("bench", "build", "check", "clean", "clippy", "doc", "install", "publish", "run", "rustc", "test", "update")
     }
 }


### PR DESCRIPTION
Cargo's `rustc` subcommand is color-friendly.