### PR TITLE
PSI: error_chain macro expansion (WIP)

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -961,7 +961,9 @@ LitExpr ::= STRING_LITERAL | BYTE_STRING_LITERAL
 // Macros
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-fake Macro ::= MacroInvocation MacroArg?
+fake Macro ::= MacroInvocation MacroArg? {
+  mixin = "org.rust.lang.core.psi.ext.RsMacroImplMixin"
+}
 
 // Various kinds of macros
 ExprLikeMacro ::= MacroInvocation MacroArg

--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -95,6 +95,7 @@ class RsFile(
     override val modDeclItemList: List<RsModDeclItem> get() = findItems(MOD_DECL_ITEM)
     override val externCrateItemList: List<RsExternCrateItem> get() = findItems(EXTERN_CRATE_ITEM)
     override val foreignModItemList: List<RsForeignModItem> get() = findItems(FOREIGN_MOD_ITEM)
+    override val macroItemList: List<RsMacroItem> get() = findItems(MACRO_ITEM)
 
     private inline fun <reified T : RsCompositeElement> findItems(elementType: IElementType): List<T> {
         val stub = stub

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsCompositeElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsCompositeElement.kt
@@ -3,6 +3,7 @@ package org.rust.lang.core.psi.ext
 import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.extapi.psi.StubBasedPsiElementBase
 import com.intellij.lang.ASTNode
+import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.stubs.StubElement
@@ -12,6 +13,8 @@ import org.rust.cargo.project.workspace.cargoWorkspace
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.resolve.ref.RsReference
+
+private val RS_ELEMENT_CONTEXT = Key.create<PsiElement>("org.rust.lang.core.psi.ELEMENT_CONTEXT")
 
 interface RsCompositeElement : PsiElement {
     override fun getReference(): RsReference?
@@ -45,8 +48,11 @@ val RsCompositeElement.containingCargoTarget: CargoWorkspace.Target? get() {
 
 val RsCompositeElement.containingCargoPackage: CargoWorkspace.Package? get() = containingCargoTarget?.pkg
 
+fun RsCompositeElement.setContext(ctx: PsiElement) = putUserData(RS_ELEMENT_CONTEXT, ctx)
+
 abstract class RsCompositeElementImpl(node: ASTNode) : ASTWrapperPsiElement(node), RsCompositeElement {
     override fun getReference(): RsReference? = null
+    override fun getContext(): PsiElement? = getUserData(RS_ELEMENT_CONTEXT) ?: parent
 }
 
 abstract class RsStubbedElementImpl<StubT : StubElement<*>> : StubBasedPsiElementBase<StubT>, RsCompositeElement {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
@@ -15,5 +15,6 @@ interface RsItemsOwner : RsCompositeElement {
     val modDeclItemList: List<RsModDeclItem>
     val externCrateItemList: List<RsExternCrateItem>
     val foreignModItemList: List<RsForeignModItem>
+    val macroItemList: List<RsMacroItem>
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
@@ -1,0 +1,34 @@
+package org.rust.lang.core.psi.ext
+
+import com.intellij.lang.ASTNode
+import com.intellij.psi.util.PsiTreeUtil
+import org.rust.lang.core.psi.RsElementTypes
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.RsMacro
+import org.rust.lang.core.psi.RsPsiFactory
+
+abstract class RsMacroImplMixin(node: ASTNode): RsCompositeElementImpl(node), RsMacro {
+    val expansion: RsFile?
+
+    init {
+        expansion = if (isErrorChainInvocation) {
+            val expansionFile = RsPsiFactory(project).createErrorChainExpansion()
+            expansionFile.children
+                .filterIsInstance<RsCompositeElement>()
+                .forEach { it.setContext(parent.parent) }
+            expansionFile
+        } else {
+            null
+        }
+    }
+}
+
+val RsMacro.expansion: RsFile? get() = (this as? RsMacroImplMixin)?.expansion
+
+private val RsMacro.isErrorChainInvocation: Boolean get() {
+    if (macroInvocation.referenceName != "error_chain") return false
+    val lbrace = macroArg?.firstChild ?: return false
+    if (lbrace.node.elementType != RsElementTypes.LBRACE) return false
+    val rbrace = PsiTreeUtil.nextVisibleLeaf(lbrace) ?: return false
+    return rbrace.node.elementType == RsElementTypes.RBRACE
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -356,6 +356,13 @@ private fun processItemDeclarations(scope: RsItemsOwner, ns: Set<Namespace>, ori
         }
     }
 
+    for (macro in scope.macroItemList) {
+        macro.macro.expansion?.let {
+            if (processItemDeclarations(it, ns, originalProcessor, withPrivateImports)) {
+                return true
+            }
+        }
+    }
 
     // Unit like structs are both types and values
     for (struct in scope.structItemList) {


### PR DESCRIPTION
I've drafted an implementation of the `error_chain` macro expansion, but need a review before moving further.

The simple case of the expansion (with predefined names) works fine, but needs several tweaks. The main problems I see now are:
- The expansion is not stubbed, so resolving is not as fast as it could be. It also breaks unit tests because of the fallbacks to the PSI tree. I don't know what would be the right approach to stubbing these implied items. Should the macro invocation be stubbed with it's `expansion` property?
- When I change something inside the `error_chain` macro invocation, it doesn't affect resolving immediately. For instance, if I have an `error_chain! {}` invocation and then use `Result<T>`, this `Result<T>` resolves correctly. Then, if I make some changes: `error_chain! { types {...} }`, the `Result<T>` is still resolved, though the macro is not expanded anymore. Reopening the file solves the problem. Maybe it relates to the previous problem with stubs. Any ideas on that?
