### PR TITLE
TY: autoderef does not erase type parameter info

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/LangItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/LangItems.kt
@@ -12,11 +12,12 @@ import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
 
 fun findDerefTarget(project: Project, ty: Ty): Ty? {
-    val impls = RsImplIndex.findImpls(project, ty)
-    for (impl in impls) {
+    val impls = findImplsAndTraits(project, ty).first
+    for ((impl, subst) in impls) {
         val trait = impl.traitRef?.resolveToTrait ?: continue
         if (!trait.isDeref) continue
         return lookupAssociatedType(impl, "Target")
+            .substitute(subst)
     }
     return null
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -318,4 +318,17 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                                                       //^ ...time/mod.rs
         }
     """)
+
+    fun `test autoderef Rc`() = stubOnlyResolve("""
+    //- main.rs
+        use std::rc::Rc;
+        struct Foo;
+        impl Foo { fn foo(&self) {} }
+
+        fn main() {
+            let x = Rc::new(Foo);
+            x.foo()
+        }    //^ ...main.rs
+    """)
+
 }


### PR DESCRIPTION
closes https://github.com/intellij-rust/intellij-rust/issues/865