### PR TITLE
GRAM: better parser recovery for struct fields

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -849,14 +849,19 @@ LambdaExpr ::= move? LambdaParameters RetType? AnyExpr
 
 StructLiteral ::= <<checkStructAllowed>> PathGenericArgsWithColons StructLiteralBody
 
-StructLiteralBody ::= '{' [ <<comma_separated_list StructLiteralField>> ] ('..'  AnyExpr)? '}' { pin = 1 }
+StructLiteralBody ::= '{' StructLiteralField_with_recover* ('..'  AnyExpr)? '}' { pin = 1 }
 
 StructLiteralField ::= OuterAttr* identifier [ ':' AnyExpr ] {
   pin = 2
-  recoverWhile = StructLiteralField_recover
   implements = [ "org.rust.lang.core.psi.ext.RsReferenceElement" ]
   mixin = "org.rust.lang.core.psi.ext.RsStructLiteralFieldImplMixin"
 }
+
+private StructLiteralField_with_recover ::= StructLiteralField (',' | &'}') {
+  pin = 1
+  recoverWhile = StructLiteralField_recover
+}
+
 private StructLiteralField_recover ::= !(identifier | ',' | '}' | '..' | '#')
 
 PathExpr ::= PathGenericArgsWithColons

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPartialParseCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPartialParseCompletionTest.kt
@@ -145,5 +145,10 @@ class RsPartialParseCompletionTest : RsCompletionTestBase() {
     """) {
         executeSoloCompletion()
     }
+
+    fun `test struct field`() = checkSingleCompletion("bar", """
+        struct S { foo: i32, bar: i32}
+        fn main() { let _ = S { foo: 2, .ba/*caret*/ } }
+    """)
 }
 

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/partial/struct_expr_fields.txt
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/partial/struct_expr_fields.txt
@@ -90,29 +90,24 @@ FILE
             PsiWhiteSpace('\n        ')
             RsStructLiteralFieldImpl(STRUCT_LITERAL_FIELD)
               PsiElement(identifier)('bar')
-            PsiErrorElement:',', '..' or '}' expected, got 'baz'
+            PsiErrorElement:':' expected, got 'baz'
               <empty list>
-      PsiWhiteSpace('\n        ')
-      RsPathExprImpl(PATH_EXPR)
-        RsPathImpl(PATH)
-          PsiElement(identifier)('baz')
-      PsiElement(:)(':')
-      PsiErrorElement:<fn pointer type> or <path start> expected, got '62'
-        <empty list>
+            PsiWhiteSpace('\n        ')
+            RsStructLiteralFieldImpl(STRUCT_LITERAL_FIELD)
+              PsiElement(identifier)('baz')
+              PsiElement(:)(':')
+              PsiWhiteSpace(' ')
+              RsLitExprImpl(LIT_EXPR)
+                PsiElement(INTEGER_LITERAL)('62')
+            PsiElement(,)(',')
+            PsiWhiteSpace('\n        ')
+            RsStructLiteralFieldImpl(STRUCT_LITERAL_FIELD)
+              PsiElement(identifier)('quux')
+            PsiElement(:)(':')
+            PsiErrorElement:<any expr> expected, got ','
+              <empty list>
       PsiWhiteSpace(' ')
-      RsLitExprImpl(LIT_EXPR)
-        PsiElement(INTEGER_LITERAL)('62')
-        PsiErrorElement:'&', '(', ';', '[', '^', '|' or '}' expected, got ','
-          <empty list>
       PsiElement(,)(',')
-      PsiWhiteSpace('\n        ')
-      RsPathExprImpl(PATH_EXPR)
-        RsPathImpl(PATH)
-          PsiElement(identifier)('quux')
-      PsiElement(:)(':')
-      PsiWhiteSpace(' ')
-      PsiErrorElement:<fn pointer type> or <path start> expected, got ','
-        PsiElement(,)(',')
       PsiWhiteSpace('\n        ')
       RsPathExprImpl(PATH_EXPR)
         RsPathImpl(PATH)


### PR DESCRIPTION
closes #1284