### PR TITLE
CARGO: Add proc_macro to stdlib roots

### DIFF
--- a/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
@@ -42,6 +42,7 @@ object AutoInjectedCrates {
         StdLibInfo("collections", StdLibType.ROOT),
         StdLibInfo("libc", StdLibType.ROOT, srcDir = "liblibc/src"),
         StdLibInfo("panic_unwind", type = StdLibType.ROOT),
+        StdLibInfo("proc_macro", type = StdLibType.ROOT),
         StdLibInfo("rustc_unicode", type = StdLibType.ROOT),
         StdLibInfo("std_unicode", type = StdLibType.ROOT),
         StdLibInfo("test", dependencies = listOf("getopts", "term"), type = StdLibType.ROOT),
@@ -60,7 +61,8 @@ object AutoInjectedCrates {
         StdLibInfo("rustc_asan", StdLibType.DEPENDENCY),
         StdLibInfo("rustc_lsan", StdLibType.DEPENDENCY),
         StdLibInfo("rustc_msan", StdLibType.DEPENDENCY),
-        StdLibInfo("rustc_tsan", StdLibType.DEPENDENCY)
+        StdLibInfo("rustc_tsan", StdLibType.DEPENDENCY),
+        StdLibInfo("syntax", StdLibType.DEPENDENCY)
     )
 }
 


### PR DESCRIPTION
Add `proc_macro` to stdlib roots.

For some unknown to me reasons, rustup doesn't install `libproc_macro` sources for nightly toolchain, so the resolving of `extern crate proc_macro` won't work with nightly at the moment. I'll try to find out more about it, but there's nothing more to do on the plugin side, so it closes #1311.