### PR TITLE
PSI: fix NPE when retrieving lang attribute

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -91,9 +91,9 @@ class QueryAttributes(private val attributes: Sequence<RsAttr>) {
 
 
     fun getStringAttribute(attributeName: String): String? {
-        val attr = attrByName(attributeName) ?: return null;
-        if (attr.eq == null) return null;
-        return attr.litExpr?.stringLiteralValue;
+        val attr = attrByName(attributeName) ?: return null
+        if (attr.eq == null) return null
+        return attr.litExpr?.stringLiteralValue
     }
 
     val metaItems: Sequence<RsMetaItem>

--- a/src/main/kotlin/org/rust/lang/core/resolve/LangItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/LangItems.kt
@@ -76,8 +76,9 @@ private fun isImplSuitable(project: Project, impl: RsImplItem,
 }
 
 private val RsTraitItem.langAttribute: String? get() {
-    if (this.stub != null) return this.stub.langAttribute
-    return this.queryAttributes.langAttribute
+    val stub = stub
+    if (stub != null) return stub.langAttribute
+    return queryAttributes.langAttribute
 }
 
 private val RsTraitItem.isDeref: Boolean get() = langAttribute == "deref"


### PR DESCRIPTION
closes #1313

Stub can be updated concurrently, so we need to store it in a local
variable. At least, that is the theory: I don't know any other way we
could get a Java NPE here!