### PR TITLE
TYPE: Join on trailing commas

### DIFF
--- a/src/test/kotlin/org/rust/ide/actions/RsJoinRawLinesHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/RsJoinRawLinesHandlerTest.kt
@@ -109,4 +109,43 @@ class RsJoinRawLinesHandlerTest : RsJoinLinesHandlerTestBase() {
             if true { 92 } else /*caret*/{ 62 }
         }
     """)
+
+    fun `test join struct on last field with trailing comma removes comma`() = doTest("""
+        struct s {
+            pub val1: i32,
+            val2: i32,
+            /*caret*/pub val3: String,
+        }
+    """, """
+        struct s {
+            pub val1: i32,
+            val2: i32,
+            pub val3: String/*caret*/ }
+    """)
+
+    fun `test join struct on intermediate field`() = doTest("""
+        struct s {
+            pub val1: i32,
+            /*caret*/val2: i32,
+            pub val3: String,
+        }
+    """, """
+        struct s {
+            pub val1: i32,
+            val2: i32,/*caret*/ pub val3: String,
+        }
+    """)
+
+    fun `test join struct leaves trailing comma if followed by comment`() = doTest("""
+        struct s {
+            pub val1: i32,
+            val2: i32,
+            /*caret*/pub val3: String, // Dummy comment
+        }
+    """, """
+        struct s {
+            pub val1: i32,
+            val2: i32,
+            pub val3: String, // Dummy comment/*caret*/ }
+    """)
 }


### PR DESCRIPTION
Any join on a line that ends in a comma where the next line begins in an
rbrace will result in the comma being removed, e.g.

```rust
...
    val: i32,
}
```

joins into

```rust
    val: i32 }
```

This allows the user to easily compress a multi-line struct into a
single-line one, e.g.

```rust
struct s {
    val1: i32,
    val2: i32,
    val3: i32,
}
```

into

```rust
struct s { val1: i32, val2: i32, val3: i32 }
```

Fixes #1091