### PR TITLE
ANNOT: Do not require/allow unsafe on negative impls of traits [E0198]

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -312,9 +312,11 @@ class RsErrorAnnotator : Annotator, HighlightRangeExtension {
         val traitRef = impl.traitRef ?: return
         val trait = traitRef.resolveToTrait ?: return
         val traitName = trait.name ?: return
-        if (impl.unsafe != null && trait.unsafe == null) {
+        if (impl.unsafe != null && impl.excl != null) {
+            holder.createErrorAnnotation(traitRef, "Negative implementations are not unsafe [E0198]")
+        } else if (impl.unsafe != null && trait.unsafe == null) {
             holder.createErrorAnnotation(traitRef, "Implementing the trait `$traitName` is not unsafe [E0199]")
-        } else if (impl.unsafe == null && trait.unsafe != null) {
+        } else if (impl.unsafe == null && trait.unsafe != null && impl.excl == null) {
             holder.createErrorAnnotation(traitRef, "The trait `$traitName` requires an `unsafe impl` declaration [E0200]")
         }
         // Macros can add methods

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -499,6 +499,19 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
         }
     """)
 
+    fun `testE0198 Negative impls for traits`() = checkErrors("""
+        struct Foo;
+        struct Foo2;
+
+        trait Bar1 { }
+        unsafe trait Bar2 { }
+
+        impl !Bar1 for Foo { }
+        impl !Bar2 for Foo { }
+        unsafe impl !<error descr="Negative implementations are not unsafe [E0198]">Bar1</error> for Foo2 { }
+        unsafe impl !<error descr="Negative implementations are not unsafe [E0198]">Bar2</error> for Foo2 { }
+    """)
+
     fun `testE0199 Only safe impls for safe traits`() = checkErrors("""
         struct Foo;
         struct Foo2;


### PR DESCRIPTION
Negative impls can sometimes be necessary when you want to remove certain
automatically derived marker traits like Send and Sync.

This negative impls does not require (or allow) the unsafe keyword even
when the trait itself is marked as unsafe.

This fixes a wrong error being displayed in libcore/marker.rs for
impl<T: ?Sized> !Send for *const T { }

CC #886