### PR TITLE
RES: Handle pat binding names overlapping with module names

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -582,14 +582,22 @@ private fun processLexicalDeclarations(scope: RsCompositeElement, cameFrom: RsCo
 
         is RsForExpr -> {
             if (scope.expr == cameFrom) return false
+            if (Namespace.Values !in ns) return false
             val pat = scope.pat
             if (pat != null && processPattern(pat, processor)) return true
         }
 
-        is RsIfExpr -> return processCondition(scope.condition, processor)
-        is RsWhileExpr -> return processCondition(scope.condition, processor)
+        is RsIfExpr -> {
+            if (Namespace.Values !in ns) return false
+            return processCondition(scope.condition, processor)
+        }
+        is RsWhileExpr -> {
+            if (Namespace.Values !in ns) return false
+            return processCondition(scope.condition, processor)
+        }
 
         is RsLambdaExpr -> {
+            if (Namespace.Values !in ns) return false
             for (parameter in scope.valueParameterList.valueParameterList) {
                 val pat = parameter.pat
                 if (pat != null && processPattern(pat, processor)) return true
@@ -601,6 +609,7 @@ private fun processLexicalDeclarations(scope: RsCompositeElement, cameFrom: RsCo
             // but they all must bind the same variables, hence we can inspect
             // only the first one.
             if (cameFrom in scope.patList) return false
+            if (Namespace.Values !in ns) return false
             val pat = scope.patList.firstOrNull()
             if (pat != null && processPattern(pat, processor)) return true
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -164,6 +164,86 @@ class RsResolveTest : RsResolveTestBase() {
         }
     """)
 
+    fun `test let overlapping with mod`() = checkByCode("""
+        mod abc {
+            pub fn foo() {}
+                  //X
+        }
+        fn main() {
+            let abc = 1u32;
+            abc::foo();
+               //^
+        }
+    """)
+
+    fun `test if let overlapping with mod`() = checkByCode("""
+        mod abc {
+            pub fn foo() {}
+                  //X
+        }
+        fn main() {
+            if let Some(abc) = Some(1u32) {
+                abc::foo();
+                   //^
+            }
+        }
+    """)
+
+    fun `test while let overlapping with mod`() = checkByCode("""
+        mod abc {
+            pub fn foo() {}
+                  //X
+        }
+        fn main() {
+            while let Some(abc) = Some(1u32) {
+                abc::foo();
+                   //^
+            }
+        }
+    """)
+
+    fun `test for overlapping with mod`() = checkByCode("""
+        mod abc {
+            pub fn foo() {}
+                  //X
+        }
+        fn main() {
+            for abc in Some(1u32).iter() {
+                abc::foo();
+                   //^
+            }
+        }
+    """)
+
+    fun `test match overlapping with mod`() = checkByCode("""
+        mod abc {
+            pub fn foo() {}
+                  //X
+        }
+        fn main() {
+            match Some(1u32) {
+                Some(abc) => {
+                    abc::foo();
+                       //^
+                }
+                None => {}
+            }
+        }
+    """)
+
+    fun `test lambda overlapping with mod`() = checkByCode("""
+        mod abc {
+            pub fn foo() {}
+                  //X
+        }
+        fn main() {
+            let zz = |abc: u32| {
+                abc::foo();
+                   //^
+            };
+        }
+    """)
+
     fun testTraitMethodArgument() = checkByCode("""
         trait T {
             fn foo(x: i32) {


### PR DESCRIPTION
This allows to properly resolve modules when a pat binding with the same name exists.
It covers the following situations creating pat bindings:
- if let
- while let
- for
- match arms
- lambdas