### PR TITLE
CARGO: RUN: added 'Cargo' submenu to project view context menu

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/RsCargoAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsCargoAction.kt
@@ -1,0 +1,67 @@
+package org.rust.ide.actions
+
+import com.intellij.execution.ExecutorRegistry
+import com.intellij.execution.ProgramRunnerUtil
+import com.intellij.execution.RunManagerEx
+import com.intellij.execution.RunnerAndConfigurationSettings
+import com.intellij.execution.executors.DefaultRunExecutor
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.LangDataKeys
+import com.intellij.openapi.module.Module
+import com.intellij.project.isEqualToProjectFileStorePath
+import org.rust.cargo.icons.CargoIcons
+import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.runconfig.createCargoCommandRunConfiguration
+import org.rust.cargo.toolchain.CargoCommandLine
+import org.rust.cargo.util.modulesWithCargoProject
+import org.rust.ide.icons.RsIcons
+import org.rust.ide.notifications.showBalloon
+import org.rust.ide.utils.isNullOrEmpty
+
+class RsCargoAction(command: String) : AnAction() {
+    val command: String
+
+    init {
+        templatePresentation.text = "Run 'cargo $command'"
+        this.command = command
+    }
+
+    override fun update(e: AnActionEvent) {
+        if (e.project?.toolchain == null || e.project?.modulesWithCargoProject.isNullOrEmpty()) {
+            e.presentation.isEnabled = false
+        }
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val module = getModule(e) ?: return
+        val commandLine = CargoCommandLine(command)
+
+        runCommand(module, commandLine)
+    }
+
+    private fun getModule(e: AnActionEvent): Module? {
+        val cargoModules = e.project?.modulesWithCargoProject.orEmpty()
+        val current = e.getData(LangDataKeys.MODULE)
+
+        return if (current in cargoModules)
+            current
+        else
+            cargoModules.firstOrNull()
+    }
+
+    private fun runCommand(module: Module, cargoCommandLine: CargoCommandLine) {
+        val runConfiguration = createRunConfiguration(module, cargoCommandLine)
+        val executor = ExecutorRegistry.getInstance().getExecutorById(DefaultRunExecutor.EXECUTOR_ID)
+        ProgramRunnerUtil.executeConfiguration(module.project, runConfiguration, executor)
+    }
+
+    private fun createRunConfiguration(module: Module, cargoCommandLine: CargoCommandLine): RunnerAndConfigurationSettings {
+        val runManager = RunManagerEx.getInstanceEx(module.project)
+
+        val configuration = runManager.createCargoCommandRunConfiguration(cargoCommandLine)
+        configuration.isTemporary = true
+        return configuration
+    }
+}

--- a/src/main/kotlin/org/rust/ide/actions/RsCargoActionGroup.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsCargoActionGroup.kt
@@ -1,0 +1,32 @@
+package org.rust.ide.actions
+
+import com.intellij.openapi.actionSystem.ActionGroup
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import org.rust.cargo.icons.CargoIcons
+import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.util.modulesWithCargoProject
+import org.rust.ide.utils.isNullOrEmpty
+
+class RsCargoActionGroup : ActionGroup() {
+    val actions : Array<AnAction>
+
+    init {
+        templatePresentation.text = "_Cargo"
+        templatePresentation.description = "Run cargo command"
+        templatePresentation.icon = CargoIcons.ICON
+        templatePresentation.isEnabledAndVisible = true
+        isPopup = true
+        actions = arrayOf(RsCargoAction("clean"), RsCargoAction("check"), RsCargoAction("update"))
+    }
+
+    override fun update(e: AnActionEvent) {
+        if (e.project?.toolchain == null || e.project?.modulesWithCargoProject.isNullOrEmpty()) {
+            e.presentation.isEnabled = false
+        }
+    }
+
+    override fun getChildren(e: AnActionEvent?): Array<AnAction> {
+        return actions
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,6 +29,11 @@
                 text="_Function..." use-shortcut-of="ExtractMethod">
             <add-to-group group-id="IntroduceActionsGroup" anchor="after" relative-to-action="ExtractMethod"/>
         </action>
+        <group id="Rust.CargoActionGroup.Main">
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="last" />
+            <separator />
+            <group id="Rust.CargoActionGroup" class="org.rust.ide.actions.RsCargoActionGroup" />
+        </group>
     </actions>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
Hi, I often find myself wanting to execute some auxiliary cargo command and I find it slightly inconvenient to be mixed with my regular run/test configurations.

My proposition is to add a sub menu to project context menu to execute certain cargo commands (namely `cargo check | update | clean` and possibly others, which are not strictly related to run/test/bench the code.

Perhaps it would be better to even let user add his/her own commands into the menu as well.

Regards,
Jakub 