### PR TITLE
Executable and library rust project types

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt
@@ -43,11 +43,11 @@ class RustProjectConfigurable(
         val toolchain = settings.toolchain ?: RustToolchain.suggest()
 
         rustProjectSettings.data = RustProjectSettingsPanel.Data(
-            toolchain,
-            settings.autoUpdateEnabled,
-            settings.data.explicitPathToStdlib,
-            settings.data.useCargoCheckForBuild,
-            settings.data.useCargoCheckAnnotator
+            toolchain = toolchain,
+            autoUpdateEnabled = settings.autoUpdateEnabled,
+            explicitPathToStdlib = settings.data.explicitPathToStdlib,
+            useCargoCheckForBuild = settings.data.useCargoCheckForBuild,
+            useCargoCheckAnnotator = settings.data.useCargoCheckAnnotator
         )
         val module = rustModule
 

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -39,15 +39,20 @@ class RustProjectSettingsServiceImpl(
 
     override var data: RustProjectSettingsService.Data
         get() = RustProjectSettingsService.Data(
-            state.toolchainHomeDirectory?.let(::RustToolchain),
-            state.autoUpdateEnabled,
-            state.explicitPathToStdlib,
-            state.useCargoCheckForBuild,
-            state.useCargoCheckAnnotator
+            toolchain = state.toolchainHomeDirectory?.let(::RustToolchain),
+            autoUpdateEnabled = state.autoUpdateEnabled,
+            explicitPathToStdlib = state.explicitPathToStdlib,
+            useCargoCheckForBuild = state.useCargoCheckForBuild,
+            useCargoCheckAnnotator = state.useCargoCheckAnnotator
         )
         set(value) {
-            val newState = State(value.toolchain?.location, value.autoUpdateEnabled, value.explicitPathToStdlib,
-                value.useCargoCheckForBuild, value.useCargoCheckAnnotator)
+            val newState = State(
+                toolchainHomeDirectory = value.toolchain?.location,
+                autoUpdateEnabled = value.autoUpdateEnabled,
+                explicitPathToStdlib = value.explicitPathToStdlib,
+                useCargoCheckForBuild = value.useCargoCheckForBuild,
+                useCargoCheckAnnotator = value.useCargoCheckAnnotator
+            )
             if (state != newState) {
                 state = newState
                 notifyToolchainChanged()

--- a/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
@@ -36,11 +36,11 @@ class RustProjectSettingsPanel(private val cargoProjectDir: Path = Paths.get("."
     ) {
         fun applyTo(settings: RustProjectSettingsService) {
             settings.data = RustProjectSettingsService.Data(
-                toolchain,
-                autoUpdateEnabled,
-                explicitPathToStdlib,
-                useCargoCheckForBuild,
-                useCargoCheckAnnotator
+                toolchain = toolchain,
+                autoUpdateEnabled = autoUpdateEnabled,
+                explicitPathToStdlib = explicitPathToStdlib,
+                useCargoCheckForBuild = useCargoCheckForBuild,
+                useCargoCheckAnnotator = useCargoCheckAnnotator
             )
         }
     }
@@ -78,11 +78,11 @@ class RustProjectSettingsPanel(private val cargoProjectDir: Path = Paths.get("."
 
     var data: Data
         get() = Data(
-            RustToolchain(pathToToolchainField.text),
-            autoUpdateEnabled.isSelected,
-            (if (downloadStdlibLink.isVisible) null else pathToStdlibField.text.blankToNull()),
-            useCargoCheckForBuildCheckbox.isSelected,
-            useCargoCheckAnnotatorCheckbox.isSelected
+            toolchain = RustToolchain(pathToToolchainField.text),
+            autoUpdateEnabled = autoUpdateEnabled.isSelected,
+            explicitPathToStdlib = (if (downloadStdlibLink.isVisible) null else pathToStdlibField.text.blankToNull()),
+            useCargoCheckForBuild = useCargoCheckForBuildCheckbox.isSelected,
+            useCargoCheckAnnotator = useCargoCheckAnnotatorCheckbox.isSelected
         )
         set(value) {
             // https://youtrack.jetbrains.com/issue/KT-16367
@@ -96,11 +96,11 @@ class RustProjectSettingsPanel(private val cargoProjectDir: Path = Paths.get("."
 
     fun attachTo(layout: LayoutBuilder) = with(layout) {
         data = Data(
-            RustToolchain.suggest(),
-            true,
-            null,
-            false,
-            true
+            toolchain = RustToolchain.suggest(),
+            autoUpdateEnabled = true,
+            explicitPathToStdlib = null,
+            useCargoCheckForBuild = false,
+            useCargoCheckAnnotator = true
         )
 
         row("Toolchain location:") { pathToToolchainField(CCFlags.pushX) }

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -65,9 +65,10 @@ class Cargo(
     }
 
     @Throws(ExecutionException::class)
-    fun init(owner: Disposable, directory: VirtualFile) {
+    fun init(owner: Disposable, directory: VirtualFile, createExecutableModule: Boolean) {
         val path = PathUtil.toSystemDependentName(directory.path)
-        CargoCommandLine("init", listOf("--bin", path))
+        val moduleTypeOption = if (createExecutableModule) "--bin" else "--lib"
+        CargoCommandLine("init", listOf(moduleTypeOption, path))
             .execute(owner)
         check(File(directory.path, RustToolchain.Companion.CARGO_TOML).exists())
         fullyRefreshDirectory(directory)

--- a/src/main/kotlin/org/rust/ide/idea/CargoConfigurationWizardStep.kt
+++ b/src/main/kotlin/org/rust/ide/idea/CargoConfigurationWizardStep.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.io.FileUtil
+import com.intellij.ui.components.JBCheckBox
 import org.rust.cargo.CargoConstants
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.ui.RustProjectSettingsPanel
@@ -26,9 +27,11 @@ class CargoConfigurationWizardStep(
 ) : ModuleWizardStep() {
 
     private val rustProjectSettings = RustProjectSettingsPanel()
+    private val createExecutableModuleCheckbox = JBCheckBox(null, true)
 
     override fun getComponent(): JComponent = panel {
         rustProjectSettings.attachTo(this)
+        row("Create executable project: ") { createExecutableModuleCheckbox() }
     }
 
     override fun disposeUIResources() = Disposer.dispose(rustProjectSettings)
@@ -38,7 +41,10 @@ class CargoConfigurationWizardStep(
 
         val projectBuilder = context.projectBuilder
         if (projectBuilder is RsModuleBuilder) {
-            projectBuilder.rustProjectData = rustProjectSettings.data
+            projectBuilder.configurationData = RsModuleBuilder.ConfigurationData(
+                rustProjectSettings.data,
+                createExecutableModuleCheckbox.isSelected
+            )
             projectBuilder.addModuleConfigurationUpdater(ConfigurationUpdater)
         } else {
             projectDescriptor?.modules?.firstOrNull()?.addConfigurationUpdater(ConfigurationUpdater)


### PR DESCRIPTION
Closes #1277 

Add checkbox into new project wizard to choose project/module type: executable or library.