### PR TITLE
TY: index operation must return 'Output' type instead of '&Output'

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/LangItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/LangItems.kt
@@ -63,7 +63,7 @@ fun findIndexOutputType(project: Project, containerType: Ty, indexType: Ty): Ty 
 
     val rawOutputType = lookupAssociatedType(suitableImpl, "Output")
     val typeParameterMap = suitableImpl.remapTypeParameters(containerType.typeParameterValues)
-    return TyReference(rawOutputType.substitute(typeParameterMap))
+    return rawOutputType.substitute(typeParameterMap)
 }
 
 fun findArithmeticBinaryExprOutputType(project: Project, lhsType: Ty, rhsType: Ty, op: ArithmeticOp): Ty {

--- a/src/test/kotlin/org/rust/lang/core/type/RsIndexTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsIndexTypeInferenceTest.kt
@@ -26,7 +26,7 @@ class RsIndexTypeInferenceTest : RsTypificationTestBase() {
         fn foo(s: S) {
             let x = s[0];
             x
-          //^ &i32
+          //^ i32
         }
     """)
 
@@ -49,7 +49,7 @@ class RsIndexTypeInferenceTest : RsTypificationTestBase() {
         fn foo(s: S<i64>) {
             let x = s[0];
             x
-          //^ &i64
+          //^ i64
         }
     """)
 
@@ -73,7 +73,7 @@ class RsIndexTypeInferenceTest : RsTypificationTestBase() {
         fn foo(s: S<Key<i32>, f64>) {
             let x = s[Key(10)];
             x
-          //^ &f64
+          //^ f64
         }
     """)
 
@@ -103,7 +103,7 @@ class RsIndexTypeInferenceTest : RsTypificationTestBase() {
         fn foo(s: S) {
             let x = s[0i64];
             x
-          //^ &i32
+          //^ i32
         }
     """)
 
@@ -126,7 +126,7 @@ class RsIndexTypeInferenceTest : RsTypificationTestBase() {
         fn foo(s: Vec<i32>) {
             let x = s[0];
             x
-          //^ &i32
+          //^ i32
         }
     """)
 }


### PR DESCRIPTION
Closes #1420 

`container[index]` is syntactic sugar for `*container.index(index)` (see [index doc](https://doc.rust-lang.org/std/ops/trait.Index.html)) so type of `container[index]` must be `Output` instead of `&Output`.