### PR TITLE
TY: catch NumberFormatException if tuple field name isn't number

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt
@@ -9,6 +9,7 @@ import org.rust.lang.core.psi.RsArrayType
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsLitExpr
 import org.rust.lang.core.types.ty.TyInteger
+import org.rust.utils.toIntOrNull
 
 val RsArrayType.arraySize: Int? get() {
     val stub = stub
@@ -19,15 +20,8 @@ val RsArrayType.arraySize: Int? get() {
 }
 
 // TODO: support constants and compile time expressions
-fun calculateArraySize(expr: RsExpr?): Int? {
-    val sizeLiteral = (expr as? RsLitExpr)
-        ?.integerLiteral
-        ?.text
-        ?.removeSuffix(TyInteger.Kind.usize.name)
-    // BACKCOMPAT: Kotlin API 1.0
-    return try {
-        sizeLiteral?.toInt()
-    } catch (e: NumberFormatException) {
-        null
-    }
-}
+fun calculateArraySize(expr: RsExpr?): Int? = (expr as? RsLitExpr)
+    ?.integerLiteral
+    ?.text
+    ?.removeSuffix(TyInteger.Kind.usize.name)
+    ?.toIntOrNull()

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Expressions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Expressions.kt
@@ -11,6 +11,7 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.*
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
+import org.rust.utils.toIntOrNull
 
 fun inferExpressionType(expr: RsExpr) = when (expr) {
     is RsPathExpr -> inferPathExprType(expr)
@@ -88,7 +89,7 @@ private fun inferFieldExprType(expr: RsFieldExpr): Ty {
     val boundField = expr.reference.advancedResolve()
     if (boundField == null) {
         val type = expr.expr.type as? TyTuple ?: return TyUnknown
-        val fieldIndex = expr.fieldId.integerLiteral?.text?.toInt() ?: return TyUnknown
+        val fieldIndex = expr.fieldId.integerLiteral?.text?.toIntOrNull() ?: return TyUnknown
         return type.types.getOrElse(fieldIndex) { TyUnknown }
     }
     val field = boundField.element

--- a/src/main/kotlin/org/rust/utils/Extensions.kt
+++ b/src/main/kotlin/org/rust/utils/Extensions.kt
@@ -17,6 +17,12 @@ import java.nio.file.Paths
 val Int.seconds: Int
     get() = this * 1000
 
+// BACKCOMPAT: Kotlin API 1.0
+fun String.toIntOrNull(): Int? = try {
+   toInt()
+} catch (e: NumberFormatException) {
+    null
+}
 
 fun GeneralCommandLine(path: Path, vararg args: String) = GeneralCommandLine(path.systemIndependentPath, *args)
 fun GeneralCommandLine.withWorkDirectory(path: Path?) = withWorkDirectory(path?.systemIndependentPath)

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -486,13 +486,23 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
     """)
 
     // https://github.com/intellij-rust/intellij-rust/issues/1269
-    fun `test tuple incorrect field`() = testExpr("""
+    fun `test tuple out of bound field`() = testExpr("""
         fn main() {
             let x = (1, "foo").2;
             x
           //^ <unknown>
         }
     """)
+
+    // https://github.com/intellij-rust/intellij-rust/issues/1423
+    fun `test tuple incorrect field`() = testExpr("""
+        fn main() {
+            let x = (1, "foo").1departure_code;
+            x
+          //^ <unknown>
+        }
+    """)
+
 
     fun `test associated types for impl`() = testExpr("""
         trait A {


### PR DESCRIPTION
Fixes #1423 