### PR TITLE
TY: treat path to tuple struct/enum as function type

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -331,6 +331,14 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test reference to generic tuple constructor`() = testExpr("""
+        struct S<T>(T);
+        fn main() {
+            let f = S::<u8>;
+            f(1).0
+        }      //^ u8
+    """)
+
     fun testGenericAlias() = testExpr("""
         struct S1<T>(T);
         struct S3<T1, T2, T3>(T1, T2, T3);


### PR DESCRIPTION
It was done as part of a refactoring, but references to a tuple struct (constructor) are works now.
```rust
struct S<T>(T);
fn main() {
    let f = S::<u8>;
    f(1).0
}      //^ u8
```
There is a special case with unit struct (`struct S;`). It may be initialized in both syntax: as literal `S {}` or as tuple `S()`. So we can't treat it as a function type (or literal syntax will not work) and should handle in a special way