### PR TITLE
QDOC: quick documentation for type parameters

### DIFF
--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -13,8 +13,10 @@ import org.rust.ide.utils.presentationInfo
 import org.rust.lang.core.psi.RsFieldDecl
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsPatBinding
+import org.rust.lang.core.psi.RsTypeParameter
 import org.rust.lang.core.psi.ext.RsDocAndAttributeOwner
 import org.rust.lang.core.psi.ext.RsNamedElement
+import org.rust.lang.core.psi.ext.bounds
 import org.rust.lang.core.types.infer.inferDeclarationType
 import org.rust.lang.doc.documentationAsHtml
 
@@ -23,6 +25,7 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
     override fun generateDoc(element: PsiElement, originalElement: PsiElement?): String? = when (element) {
         is RsDocAndAttributeOwner -> generateDoc(element)
         is RsPatBinding -> generateDoc(element)?.let { "<pre>$it</pre>" }
+        is RsTypeParameter -> generateDoc(element)
         else -> null
     }
 
@@ -35,6 +38,14 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
         val presentationInfo = element.presentationInfo ?: return null
         val type = inferDeclarationType(element).toString().escaped
         return "${presentationInfo.type} <b>${presentationInfo.name}</b>: $type"
+    }
+
+    private fun generateDoc(element: RsTypeParameter): String? {
+        val name = element.name ?: return null
+        val typeBounds = element.bounds
+        val bounds = if (typeBounds.isEmpty()) "" else typeBounds.joinToString(" + ", ": ") { it.text.escaped }
+        val defaultValue = element.typeReference?.let { " = ${it.text}" } ?: ""
+        return "<pre>type parameter <b>$name</b>$bounds$defaultValue</pre>"
     }
 
     override fun getQuickNavigateInfo(e: PsiElement, originalElement: PsiElement?): String? = when (e) {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeParameter.kt
@@ -1,0 +1,20 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi.ext
+
+import org.rust.lang.core.psi.RsBaseType
+import org.rust.lang.core.psi.RsPolybound
+import org.rust.lang.core.psi.RsTypeParameter
+
+val RsTypeParameter.bounds: List<RsPolybound> get() {
+    val owner = parent?.parent as? RsGenericDeclaration
+    val whereBounds =
+        owner?.whereClause?.wherePredList.orEmpty()
+            .filter { (it.typeReference?.typeElement as? RsBaseType)?.path?.reference?.resolve() == this }
+            .flatMap { it.typeParamBounds?.polyboundList.orEmpty() }
+
+    return typeParamBounds?.polyboundList.orEmpty() + whereBounds
+}

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
@@ -6,13 +6,11 @@
 package org.rust.lang.core.types.ty
 
 import com.intellij.openapi.project.Project
-import org.rust.lang.core.psi.RsBaseType
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTypeParameter
-import org.rust.lang.core.psi.ext.RsGenericDeclaration
+import org.rust.lang.core.psi.ext.bounds
 import org.rust.lang.core.psi.ext.flattenHierarchy
 import org.rust.lang.core.psi.ext.resolveToBoundTrait
-import org.rust.lang.core.psi.ext.typeElement
 import org.rust.lang.core.types.BoundElement
 
 class TyTypeParameter private constructor(
@@ -53,13 +51,5 @@ class TyTypeParameter private constructor(
     private data class AssociatedType(val trait: RsTraitItem, val target: String) : TypeParameter
 }
 
-private fun bounds(parameter: RsTypeParameter): List<BoundElement<RsTraitItem>> {
-    val owner = parameter.parent?.parent as? RsGenericDeclaration
-    val whereBounds =
-        owner?.whereClause?.wherePredList.orEmpty()
-            .filter { (it.typeReference?.typeElement as? RsBaseType)?.path?.reference?.resolve() == parameter }
-            .flatMap { it.typeParamBounds?.polyboundList.orEmpty() }
-
-    return (parameter.typeParamBounds?.polyboundList.orEmpty() + whereBounds)
-        .mapNotNull { it.bound.traitRef?.resolveToBoundTrait }
-}
+private fun bounds(parameter: RsTypeParameter): List<BoundElement<RsTraitItem>> =
+    parameter.bounds.mapNotNull { it.bound.traitRef?.resolveToBoundTrait }

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -328,6 +328,55 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <p>Documented</p>
     """)
 
+    fun `test type parameter`() = doTest("""
+        fn foo<T>() { unimplemented!() }
+             //^
+    """, """
+        <pre>type parameter <b>T</b></pre>
+    """)
+
+    fun `test type parameter with single bound`() = doTest("""
+        fn foo<T: Borrow<Q>>() { unimplemented!() }
+             //^
+    """, """
+        <pre>type parameter <b>T</b>: Borrow&lt;Q&gt;</pre>
+    """)
+
+    fun `test type parameter with multiple bounds`() = doTest("""
+        fn foo<Q, T: Eq + Hash + Borrow<Q>>() { unimplemented!() }
+                //^
+    """, """
+        <pre>type parameter <b>T</b>: Eq + Hash + Borrow&lt;Q&gt;</pre>
+    """)
+
+    fun `test type parameter with lifetime bound`() = doTest("""
+        fn foo<'a, T: 'a>() { unimplemented!() }
+                 //^
+    """, """
+        <pre>type parameter <b>T</b>: &#39;a</pre>
+    """)
+
+    fun `test type parameter with default value`() = doTest("""
+        fn foo<T = RandomState>() { unimplemented!() }
+             //^
+    """, """
+        <pre>type parameter <b>T</b> = RandomState</pre>
+    """)
+
+    fun `test type parameter with bounds in where clause`() = doTest("""
+        fn foo<Q, T>() where T: Eq + Hash + Borrow<Q> { unimplemented!() }
+                //^
+    """, """
+        <pre>type parameter <b>T</b>: Eq + Hash + Borrow&lt;Q&gt;</pre>
+    """)
+
+    fun `test type parameter with complex bounds`() = doTest("""
+        fn foo<'a, Q, T: 'a + Eq>() where T: Hash + Borrow<Q> { unimplemented!() }
+                    //^
+    """, """
+        <pre>type parameter <b>T</b>: &#39;a + Eq + Hash + Borrow&lt;Q&gt;</pre>
+    """)
+
     private fun doTest(@Language("Rust") code: String, @Language("Html") expected: String)
         = doTest(code, expected, RsDocumentationProvider::generateDoc)
 }


### PR DESCRIPTION
**NOTE**:
This implementation uses original text of type parameter bound to create quick doc. So if type parameter bound contains extra whitespace symbols:
```rust
fn foo<T: Into< String >> { ... }
```
quick doc will contain them too:
```
type parameter T: Into< String >
```
But quick doc for some other language items, for example, struct fields, has the same problem, so I think it should be fixed at the same time in other PR.