### PR TITLE
TY: use common infra for resolving Fn traits

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitRef.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitRef.kt
@@ -7,38 +7,11 @@ package org.rust.lang.core.psi.ext
 
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTraitRef
-import org.rust.lang.core.resolve.fnOutputParam
-import org.rust.lang.core.resolve.fnTypeArgsParam
-import org.rust.lang.core.resolve.isAnyFnTrait
 import org.rust.lang.core.types.BoundElement
-import org.rust.lang.core.types.ty.TyTuple
-import org.rust.lang.core.types.ty.TyTypeParameter
-import org.rust.lang.core.types.ty.TyUnit
-import org.rust.lang.core.types.ty.TyUnknown
-import org.rust.lang.core.types.type
 
 val RsTraitRef.resolveToTrait: RsTraitItem?
     get() = path.reference.resolve() as? RsTraitItem
 
-val RsTraitRef.resolveToBoundTrait: BoundElement<RsTraitItem>? get() {
-    val trait = resolveToTrait ?: return null
-    val typeArguments = if (trait.isAnyFnTrait) {
-        val argsParam = trait.fnTypeArgsParam
-        val outputParam = trait.fnOutputParam
-        val args = path.valueParameterList?.valueParameterList
-            ?.map { it.typeReference?.type ?: TyUnknown }
-        val output = path.retType?.typeReference?.type
-        if (argsParam == null || args == null || outputParam == null) {
-            emptyMap()
-        } else {
-            mapOf(argsParam to TyTuple(args), outputParam to (output ?: TyUnit))
-        }
-    } else {
-        val params = trait.typeParameters.map { TyTypeParameter(it) }
-        val args = path.typeArgumentList?.typeReferenceList.orEmpty().map { it.type }
-        params.zip(args).toMap()
-    }
-
-    return BoundElement(trait, typeArguments)
-}
+val RsTraitRef.resolveToBoundTrait: BoundElement<RsTraitItem>?
+    get() = path.reference.advancedResolve()?.downcast<RsTraitItem>()
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -6,13 +6,17 @@
 package org.rust.lang.core.resolve.ref
 
 import com.intellij.psi.PsiElement
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.psi.ext.RsGenericDeclaration
 import org.rust.lang.core.psi.ext.typeParameters
-import org.rust.lang.core.resolve.*
+import org.rust.lang.core.resolve.collectCompletionVariants
+import org.rust.lang.core.resolve.collectResolveVariants
+import org.rust.lang.core.resolve.fnOutputParam
+import org.rust.lang.core.resolve.processPathResolveVariants
 import org.rust.lang.core.types.BoundElement
-import org.rust.lang.core.types.ty.TyTypeParameter
+import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
 
 
@@ -25,14 +29,42 @@ class RsPathReferenceImpl(
 
     override fun resolveInner(): List<BoundElement<RsCompositeElement>> {
         val result = collectResolveVariants(element.referenceName) { processPathResolveVariants(element, false, it) }
-        val typeArguments = element.typeArgumentList?.typeReferenceList.orEmpty().map { it.type }
-        if (typeArguments.isEmpty()) return result
+
+        val typeArguments: List<Ty> = run {
+            val inAngles = element.typeArgumentList
+            val fnSugar = element.valueParameterList
+            when {
+                inAngles != null -> inAngles.typeReferenceList.map { it.type }
+                fnSugar != null -> listOf(
+                    TyTuple(fnSugar.valueParameterList.map { it.typeReference?.type ?: TyUnknown })
+                )
+                else -> null
+            }
+        } ?: return result
+
+        val outputArg = element.retType?.typeReference?.type
 
         return result.map { boundElement ->
-            val parameters = (boundElement.element as? RsGenericDeclaration)?.typeParameters ?: return@map boundElement
+            val element = boundElement.element as? RsGenericDeclaration
+                ?: return@map boundElement
+
+            val parameters = element.typeParameters
+
+            val assocTypes = run {
+                if (element is RsTraitItem) {
+                    val outputParam = element.fnOutputParam
+                    if (outputArg != null && outputParam != null) {
+                        return@run mapOf(outputParam to outputArg)
+                    }
+                }
+                emptySubstitution
+            }
+
             BoundElement(
-                boundElement.element,
-                boundElement.subst + parameters.map { TyTypeParameter(it) }.zip(typeArguments).toMap()
+                element,
+                boundElement.subst
+                    + parameters.map { TyTypeParameter(it) }.zip(typeArguments).toMap()
+                    + assocTypes
             )
         }
     }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -570,4 +570,18 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
             t.foo();
         }    //^
     """)
+
+    fun `test trait with bounds on itself`() = checkByCode("""
+        trait Foo<T: Foo<T>> {
+            fn foo(&self) { }
+        }     //X
+
+        impl Foo<()> for () { }
+
+        fn bar<T: Foo<T>>(t: T) {
+            t.foo()
+        }    //^
+
+        fn main() { bar(()) }
+    """)
 }


### PR DESCRIPTION
Turns out that to fix that SO, one has to simply remove logic duplication between `resolveToBoundTrait` and `advanceResolve` of paths themselves. 

closes #1455 
