### PR TITLE
QDOC: quick doc improvements

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -68,7 +68,7 @@ class RsErrorAnnotator : Annotator, HighlightRangeExtension {
 
     private fun checkMethodCallExpr(holder: AnnotationHolder, o: RsMethodCallExpr) {
         val fn = o.reference.resolve() as? RsFunction ?: return
-        if (fn.unsafe != null) {
+        if (fn.isUnsafe) {
             checkUnsafeCall(holder, o)
         }
     }
@@ -76,7 +76,7 @@ class RsErrorAnnotator : Annotator, HighlightRangeExtension {
     private fun checkCallExpr(holder: AnnotationHolder, o: RsCallExpr) {
         val path = (o.expr as? RsPathExpr)?.path ?: return
         val fn = path.reference.resolve() as? RsFunction ?: return
-        if (fn.unsafe != null) {
+        if (fn.isUnsafe) {
             checkUnsafeCall(holder, o)
         }
     }
@@ -92,7 +92,7 @@ class RsErrorAnnotator : Annotator, HighlightRangeExtension {
                 }
             } ?: return false
 
-        return parent is RsBlockExpr || (parent is RsFunction && parent.unsafe != null)
+        return parent is RsBlockExpr || (parent is RsFunction && parent.isUnsafe)
     }
 
     private fun checkUnsafeCall(holder: AnnotationHolder, o: RsExpr) {

--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -24,8 +24,15 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
 
     override fun generateDoc(element: PsiElement, originalElement: PsiElement?): String? = when (element) {
         is RsDocAndAttributeOwner -> generateDoc(element)
-        is RsPatBinding -> generateDoc(element)?.let { "<pre>$it</pre>" }
-        is RsTypeParameter -> generateDoc(element)
+        is RsPatBinding -> pre { generateDoc(element) }
+        is RsTypeParameter -> pre { generateDoc(element) }
+        else -> null
+    }
+
+    override fun getQuickNavigateInfo(e: PsiElement, originalElement: PsiElement?): String? = when (e) {
+        is RsPatBinding -> generateDoc(e)
+        is RsTypeParameter -> generateDoc(e)
+        is RsNamedElement -> e.presentationInfo?.quickDocumentationText
         else -> null
     }
 
@@ -45,13 +52,7 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
         val typeBounds = element.bounds
         val bounds = if (typeBounds.isEmpty()) "" else typeBounds.joinToString(" + ", ": ") { it.text.escaped }
         val defaultValue = element.typeReference?.let { " = ${it.text}" } ?: ""
-        return "<pre>type parameter <b>$name</b>$bounds$defaultValue</pre>"
-    }
-
-    override fun getQuickNavigateInfo(e: PsiElement, originalElement: PsiElement?): String? = when (e) {
-        is RsPatBinding -> generateDoc(e)
-        is RsNamedElement -> e.presentationInfo?.quickDocumentationText
-        else -> null
+        return "type parameter <b>$name</b>$bounds$defaultValue"
     }
 }
 
@@ -77,3 +78,5 @@ private val RsDocAndAttributeOwner.signature: String get() {
     }
     return if (rawSignature != null) "<pre>$rawSignature</pre>\n" else ""
 }
+
+private inline fun pre(block: () -> String?): String? = block()?.let { "<pre>$it</pre>" }

--- a/src/main/kotlin/org/rust/ide/utils/PresentationUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/PresentationUtils.kt
@@ -32,7 +32,8 @@ class PresentationInfo(
 
     val projectStructureItemTextWithValue: String get() = "$projectStructureItemText${declaration.value}"
 
-    val signatureText: String = "${declaration.prefix}<b>$name</b>${declaration.suffix.escaped}"
+    val shortSignatureText = "<b>$name</b>${declaration.suffix.escaped}"
+    val signatureText: String = "${declaration.prefix}$shortSignatureText"
 
     val quickDocumentationText: String
         get() = if (declaration.isAmbiguous && type != null) {
@@ -101,11 +102,11 @@ val RsNamedElement.presentationInfo: PresentationInfo? get() {
     return declInfo.second?.let { PresentationInfo(this, declInfo.first, elementName, it) }
 }
 
-fun presentableQualifiedName(element: RsDocAndAttributeOwner): String? {
-    val qName = (element as? RsQualifiedNamedElement)?.qualifiedName
+val RsDocAndAttributeOwner.presentableQualifiedName: String? get() {
+    val qName = (this as? RsQualifiedNamedElement)?.qualifiedName
     if (qName != null) return qName
-    if (element is RsMod) return element.modName
-    return element.name
+    if (this is RsMod) return modName
+    return name
 }
 
 private fun createDeclarationInfo(decl: RsCompositeElement, name: PsiElement?, isAmbiguous: Boolean, stopAt: List<PsiElement?> = emptyList(), valueSeparator: PsiElement? = null): DeclarationInfo? {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -20,9 +20,34 @@ import javax.swing.Icon
 
 val RsFunction.isAssocFn: Boolean get() = selfParameter == null
     && (role == RsFunctionRole.IMPL_METHOD || role == RsFunctionRole.TRAIT_METHOD)
-val RsFunction.isTest: Boolean get() = stub?.isTest ?: queryAttributes.hasAtomAttribute("test")
+
+val RsFunction.isTest: Boolean get() {
+    val stub = stub
+    return stub?.isTest ?: queryAttributes.hasAtomAttribute("test")
+}
+
 val RsFunction.isInherentImpl: Boolean
     get() = (parent as? RsImplItem)?.let { return@let if (it.traitRef == null) it else null } != null
+
+val RsFunction.isConst: Boolean get() {
+    val stub = stub
+    return stub?.isConst ?: (const != null)
+}
+
+val RsFunction.isUnsafe: Boolean get() {
+    val stub = stub
+    return stub?.isUnsafe ?: (unsafe != null)
+}
+
+val RsFunction.isExtern: Boolean get() {
+    val stub = stub
+    return stub?.isExtern ?: (abi != null)
+}
+
+val RsFunction.abiName: String? get() {
+    val stub = stub
+    return stub?.abiName ?: abi?.stringLiteral?.text
+}
 
 enum class RsFunctionRole {
     // Bump stub version if reorder fields
@@ -74,6 +99,8 @@ val RsFunction.returnType: Ty get() {
     val retType = retType ?: return TyUnit
     return retType.typeReference?.type ?: TyUnknown
 }
+
+val RsFunction.abi: RsExternAbi? get() = externAbi ?: (parent as? RsForeignModItem)?.externAbi
 
 abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, RsFunction {
 

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -9,7 +9,7 @@ import org.intellij.lang.annotations.Language
 
 class RsQuickDocumentationTest : RsDocumentationProviderTest() {
 
-    fun testFn() = doTest("""
+    fun `test fn`() = doTest("""
         /// Adds one to the number given.
         ///
         /// # Examples
@@ -28,12 +28,140 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
              //^
         }
     """, """
-        <pre>test_package::add_one</pre>
+        <pre>test_package</pre>
         <pre>fn <b>add_one</b>(x: i32) -&gt; i32</pre>
         <p>Adds one to the number given.</p><h1>Examples</h1><pre><code>let five = 5;
 
         assert_eq!(6, add_one(5));
         </code></pre>
+    """)
+
+    fun `test pub fn`() = doTest("""
+        pub fn foo() {}
+              //^
+    """, """
+        <pre>test_package</pre>
+        <pre>pub fn <b>foo</b>()</pre>
+    """)
+
+    fun `test const fn`() = doTest("""
+        const fn foo() {}
+                 //^
+    """, """
+        <pre>test_package</pre>
+        <pre>const fn <b>foo</b>()</pre>
+    """)
+
+    fun `test unsafe fn`() = doTest("""
+        unsafe fn foo() {}
+                  //^
+    """, """
+        <pre>test_package</pre>
+        <pre>unsafe fn <b>foo</b>()</pre>
+    """)
+
+    fun `test fn in extern block`() = doTest("""
+        extern {
+            fn foo();
+              //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>extern fn <b>foo</b>()</pre>
+    """)
+
+    fun `test fn in extern block with abi name`() = doTest("""
+        extern "C" {
+            fn foo();
+              //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>extern "C" fn <b>foo</b>()</pre>
+    """)
+
+    fun `test extern fn`() = doTest("""
+        extern fn foo() {}
+                 //^
+    """, """
+        <pre>test_package</pre>
+        <pre>extern fn <b>foo</b>()</pre>
+    """)
+
+    fun `test extern fn with abi name`() = doTest("""
+        extern "C" fn foo() {}
+                      //^
+    """, """
+        <pre>test_package</pre>
+        <pre>extern "C" fn <b>foo</b>()</pre>
+    """)
+
+    fun `test generic fn`() = doTest("""
+        fn foo<T: Into<String>>(t: T) {}
+          //^
+    """, """
+        <pre>test_package</pre>
+        <pre>fn <b>foo</b>&lt;T: Into&lt;String&gt;&gt;(t: T)</pre>
+    """)
+
+    fun `test generic fn with where clause`() = doTest("""
+        fn foo<T>(t: T) where T: Into<String> {}
+          //^
+    """, """
+        <pre>test_package</pre>
+        <pre>fn <b>foo</b>&lt;T&gt;(t: T) where T: Into&lt;String&gt;</pre>
+    """)
+
+    fun `test complex fn`() = doTest("""
+        /// Docs
+        #[cfg(test)]
+        /// More Docs
+        pub const unsafe extern "C" fn foo<T: Into<String>, F>(t: T, f: F) where F: Ord {}
+                                      //^
+    """, """
+        <pre>test_package</pre>
+        <pre>pub const unsafe extern "C" fn <b>foo</b>&lt;T: Into&lt;String&gt;, F&gt;(t: T, f: F) where F: Ord</pre>
+        <p>Docs
+        More Docs</p>
+    """)
+
+    fun `test method`() = doTest("""
+        struct Foo;
+
+        impl Foo {
+            pub fn foo(&self) {}
+                  //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>impl Foo</pre>
+        <pre>pub fn <b>foo</b>(&amp;self)</pre>
+    """)
+
+    fun `test generic struct method`() = doTest("""
+        struct Foo<T>(T);
+
+        impl<T> Foo<T> {
+            pub fn foo(&self) {}
+                  //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>impl&lt;T&gt; Foo&lt;T&gt;</pre>
+        <pre>pub fn <b>foo</b>(&amp;self)</pre>
+    """)
+
+    fun `test generic struct method with where clause`() = doTest("""
+        struct Foo<T, F>(T, F);
+
+        impl<T, F> Foo<T, F> where T: Ord, F: Into<String> {
+            pub fn foo(&self) {}
+                  //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>impl&lt;T, F&gt; Foo&lt;T, F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Ord,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: Into&lt;String&gt;,</pre>
+        <pre>pub fn <b>foo</b>(&amp;self)</pre>
     """)
 
     fun testDifferentComments() = doTest("""
@@ -49,7 +177,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
             //! Inner comment
         }
     """, """
-        <pre>test_package::overly_documented</pre>
+        <pre>test_package</pre>
         <pre>fn <b>overly_documented</b>()</pre>
         <p>Outer comment
         111
@@ -99,16 +227,86 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <p>Documented</p>
     """)
 
-    fun testTraitMethod() = doTest("""
+    fun `test trait method`() = doTest("""
         trait MyTrait {
             /// Documented
             fn my_func();
              //^
         }
     """, """
-        <pre>test_package::my_func</pre>
+        <pre>test_package::MyTrait</pre>
         <pre>fn <b>my_func</b>()</pre>
         <p>Documented</p>
+    """)
+
+    fun `test generic trait method`() = doTest("""
+        trait MyTrait<T> {
+            /// Documented
+            fn my_func();
+             //^
+        }
+    """, """
+        <pre>test_package::MyTrait&lt;T&gt;</pre>
+        <pre>fn <b>my_func</b>()</pre>
+        <p>Documented</p>
+    """)
+
+    fun `test generic trait method with where clause`() = doTest("""
+        trait MyTrait<T> where T: Into<String> {
+            /// Documented
+            fn my_func();
+             //^
+        }
+    """, """
+        <pre>test_package::MyTrait&lt;T&gt;</pre>
+        <pre>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Into&lt;String&gt;,</pre>
+        <pre>fn <b>my_func</b>()</pre>
+        <p>Documented</p>
+    """)
+
+    fun `test trait method impl`() = doTest("""
+        trait Trait {
+            fn foo();
+        }
+        struct Foo;
+        impl Trait for Foo {
+            fn foo() {}
+              //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>impl Trait for Foo</pre>
+        <pre>fn <b>foo</b>()</pre>
+    """)
+
+    fun `test generic trait method impl`() = doTest("""
+        trait Trait<T> {
+            fn foo();
+        }
+        struct Foo<T>(T);
+        impl<T, F> Trait<T> for Foo<F> {
+            fn foo() {}
+              //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>impl&lt;T, F&gt; Trait&lt;T&gt; for Foo&lt;F&gt;</pre>
+        <pre>fn <b>foo</b>()</pre>
+    """)
+
+    fun `test generic trait method impl with where clause`() = doTest("""
+        trait Trait<T> {
+            fn foo();
+        }
+        struct Foo<T>(T);
+        impl<T, F> Trait<T> for Foo<F> where T: Ord, F: Into<String> {
+            fn foo() {}
+              //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>impl&lt;T, F&gt; Trait&lt;T&gt; for Foo&lt;F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Ord,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: Into&lt;String&gt;,</pre>
+        <pre>fn <b>foo</b>()</pre>
     """)
 
     fun testTraitMethodProvided() = doTest("""
@@ -119,7 +317,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
             }
         }
     """, """
-        <pre>test_package::my_func</pre>
+        <pre>test_package::MyTrait</pre>
         <pre>fn <b>my_func</b>()</pre>
         <p>Inner doc</p>
     """)
@@ -151,7 +349,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
           //^
         }
     """, """
-        <pre>test_package::foo</pre>
+        <pre>test_package</pre>
         <pre>fn <b>foo</b>()</pre>
         <p>Inner doc.</p>
     """)
@@ -183,7 +381,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        <pre>test_package::q::foo</pre>
+        <pre>test_package::q</pre>
         <pre>fn <b>foo</b>()</pre>
         <p>Blurb.</p>
     """)

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
@@ -24,7 +24,8 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
             }
         }
     """, """
-        pub fn <b>double</b>(x: i16) -&gt; i32 [main.rs]
+        test_package::a::b::c
+        pub fn <b>double</b>(x: i16) -&gt; i32
     """)
 
     fun `test no comments`() = doTest("""
@@ -37,7 +38,8 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
           //^
         }
     """, """
-        fn <b>foo</b>() [main.rs]
+        test_package
+        fn <b>foo</b>()
     """)
 
     fun `test big signature`() = doTest("""
@@ -51,7 +53,8 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
           //^
         }
     """, """
-        pub const unsafe extern &quot;C&quot; fn <b>foo</b>&lt;T&gt;(x: T) -&gt; u32 where T: Clone [main.rs]
+        test_package
+        pub const unsafe extern "C" fn <b>foo</b>&lt;T&gt;(x: T) -&gt; u32 where T: Clone
     """)
 
     fun `test method`() = doTest("""
@@ -65,7 +68,35 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
             //^
         }
     """, """
-        pub fn <b>consume</b>(self) -&gt; i32 [main.rs]
+        test_package
+        impl S
+        pub fn <b>consume</b>(self) -&gt; i32
+    """)
+
+    fun `test generic struct method`() = doTest("""
+        struct Foo<T>(T);
+
+        impl<T> Foo<T> {
+            pub fn foo(&self) {}
+                  //^
+        }
+    """, """
+        test_package
+        impl&lt;T&gt; Foo&lt;T&gt;
+        pub fn <b>foo</b>(&amp;self)
+    """)
+
+    fun `test generic struct method with where clause`() = doTest("""
+        struct Foo<T, F>(T, F);
+
+        impl<T, F> Foo<T, F> where T: Ord, F: Into<String> {
+            pub fn foo(&self) {}
+                  //^
+        }
+    """, """
+        test_package
+        impl&lt;T, F&gt; Foo&lt;T, F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Ord,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: Into&lt;String&gt;,
+        pub fn <b>foo</b>(&amp;self)
     """)
 
     fun `test trait method`() = doTest("""
@@ -75,7 +106,31 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
              //^
         }
     """, """
-        fn <b>my_func</b>() [main.rs]
+        test_package::MyTrait
+        fn <b>my_func</b>()
+    """)
+
+    fun `test generic trait method`() = doTest("""
+        trait MyTrait<T> {
+            /// Documented
+            fn my_func();
+             //^
+        }
+    """, """
+        test_package::MyTrait&lt;T&gt;
+        fn <b>my_func</b>()
+    """)
+
+    fun `test generic trait method with where clause`() = doTest("""
+        trait MyTrait<T> where T: Into<String> {
+            /// Documented
+            fn my_func();
+             //^
+        }
+    """, """
+        test_package::MyTrait&lt;T&gt;
+        where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Into&lt;String&gt;,
+        fn <b>my_func</b>()
     """)
 
     fun `test multiple where`() = doTest("""
@@ -92,7 +147,8 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
           //^
         }
     """, """
-        pub const unsafe extern &quot;C&quot; fn <b>foo</b>&lt;T, U, V&gt;(x: T) -&gt; u32 where T: Clone, U: Debug, V: Display [main.rs]
+        test_package
+        pub const unsafe extern "C" fn <b>foo</b>&lt;T, U, V&gt;(x: T) -&gt; u32 where T: Clone, U: Debug, V: Display
     """)
 
     fun `test expanded signature`() = doTest("""
@@ -119,7 +175,53 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
           //^
         }
     """, """
-        pub const unsafe extern &quot;C&quot; fn <b>foo</b>&lt;T, U, V&gt;(x: T, y: u32, z: u64) -&gt; (u32, u64, u64) where T: Clone, U: Debug, V: Display [main.rs]
+        test_package
+        pub const unsafe extern "C" fn <b>foo</b>&lt;T, U, V&gt;(x: T, y: u32, z: u64) -&gt; (u32, u64, u64) where T: Clone, U: Debug, V: Display
+    """)
+
+    fun `test trait method impl`() = doTest("""
+        trait Trait {
+            fn foo();
+        }
+        struct Foo;
+        impl Trait for Foo {
+            fn foo() {}
+              //^
+        }
+    """, """
+        test_package
+        impl Trait for Foo
+        fn <b>foo</b>()
+    """)
+
+    fun `test generic trait method impl`() = doTest("""
+        trait Trait<T> {
+            fn foo();
+        }
+        struct Foo<T>(T);
+        impl<T, F> Trait<T> for Foo<F> {
+            fn foo() {}
+              //^
+        }
+    """, """
+        test_package
+        impl&lt;T, F&gt; Trait&lt;T&gt; for Foo&lt;F&gt;
+        fn <b>foo</b>()
+    """)
+
+    fun `test generic trait method impl with where clause`() = doTest("""
+        trait Trait<T> {
+            fn foo();
+        }
+        struct Foo<T>(T);
+        impl<T, F> Trait<T> for Foo<F> where T: Ord, F: Into<String> {
+            fn foo() {}
+              //^
+        }
+    """, """
+        test_package
+        impl&lt;T, F&gt; Trait&lt;T&gt; for Foo&lt;F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Ord,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: Into&lt;String&gt;,
+        fn <b>foo</b>()
     """)
 
     fun `test variable 1`() = doTest("""

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
@@ -239,11 +239,18 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
         <i>lifetime:</i> <b>'foo</b> [main.rs]
     """)
 
-    fun `test type parameter`() = doTest("""
+    fun `test simple type parameter`() = doTest("""
         fn foo<T>(t: T) {}
                    //^
     """, """
-        <i>type parameter:</i> <b>T</b> [main.rs]
+        type parameter <b>T</b>
+    """)
+
+    fun `test complex type parameter`() = doTest("""
+        fn foo<'a, Q, T: 'a + Eq>(t: T) where T: Hash + Borrow<Q> { }
+                                   //^
+    """, """
+        type parameter <b>T</b>: &#39;a + Eq + Hash + Borrow&lt;Q&gt;
     """)
 
     fun `test loop label`() = doTest("""


### PR DESCRIPTION
* use same type parameter representation in navigation info as in quick doc
* add info if function/method in extern block and its abi name
* show parent object: trait or module name for function/method instead of full path of function/method
* show type parameters declared in impl object