### PR TITLE
TY: infer type parameters from trait bounds

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -394,7 +394,7 @@ private class RsFnInferenceContext(private val ctx: RsInferenceContext) {
     private fun mapTypeParameters(argDefs: Iterable<Ty>, argExprs: Iterable<RsExpr>): Substitution {
         val subst = mutableMapOf<TyTypeParameter, Ty>()
         argExprs.zip(argDefs).forEach { (expr, type) -> addTypeMapping(subst, type, expr) }
-        return subst
+        return subst.substituteInValues(subst) // TODO multiple times?
     }
 
     private fun addTypeMapping(argsMapping: TypeMapping, fieldType: Ty?, expr: RsExpr) =

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -118,7 +118,7 @@ internal inline fun merge(mapping: TypeMapping?, canUnify: (TypeMapping?) -> Boo
     }
 }
 
-internal fun TypeMapping.merge(otherMapping: TypeMapping) {
+internal fun TypeMapping.merge(otherMapping: Substitution) {
     for ((param, value) in otherMapping) {
         val old = get(param)
         if (old == null || old == TyUnknown || old is TyNumeric && old.isKindWeak) {
@@ -129,3 +129,7 @@ internal fun TypeMapping.merge(otherMapping: TypeMapping) {
 
 fun Substitution.substituteInValues(map: Substitution): Substitution =
     mapValues { (_, value) -> value.substitute(map) }
+
+fun Substitution.reverse(): Substitution =
+    mapNotNull { if (it.value is TyTypeParameter) it else null }
+        .associate { (k, v) -> Pair(v as TyTypeParameter, k) }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
@@ -34,7 +34,16 @@ class TyTypeParameter private constructor(
         bounds.flatMap { it.flattenHierarchy }
 
     override fun canUnifyWith(other: Ty, project: Project, mapping: TypeMapping?): Boolean {
-        mapping?.merge(mutableMapOf(this to other))
+        if (mapping != null) {
+            val traits = findImplsAndTraits(project, other)
+            for (bound in bounds) {
+                val trait = traits.find { it.element.implementedTrait?.element == bound.element }
+                if (trait != null) {
+                    mapping.merge(bound.subst.reverse().substituteInValues(trait.subst))
+                }
+            }
+            mapping.merge(mapOf(this to other))
+        }
         return true
     }
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsClosuresResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsClosuresResolveTest.kt
@@ -194,4 +194,15 @@ class RsClosuresResolveTest : RsResolveTestBase() {
             ;                               //^ unresolved
         }
     """)
+
+    fun `test infer generic parameter from lambda return type`() = checkByCode("""
+        struct X;
+        impl X { fn foo(&self) {} }
+                   //X
+        fn apply<T1, T2, F: Fn(T1) -> T2>(t: T1, f: F) -> T2 { f(t) }
+        fn main() {
+            let a = apply(X, |x| x);
+            a.foo()
+        }   //^
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -541,4 +541,15 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
           //^ (Bar<(i32, bool), i32>, Foo<[f64; 3], &str>)
         }
     """)
+
+    fun `test infer generic argument from trait bound`() = testExpr("""
+        struct S<X>(X);
+        trait Tr<Y> { fn foo(&self) -> Y; }
+        impl<Z> Tr<Z> for S<Z> { fn foo(&self) -> Z { unimplemented!() } }
+        fn bar<A, B: Tr<A>>(b: B) -> A { b.foo() }
+        fn main() {
+            let a = bar(S(1));
+            a
+        } //^ i32
+    """)
 }


### PR DESCRIPTION
```rust
struct S<X>(X);
trait Tr<Y> { fn foo(&self) -> Y; }
impl<Z> Tr<Z> for S<Z> { fn foo(&self) -> Z { unimplemented!() } }
fn bar<A, B: Tr<A>>(b: B) -> A { b.foo() }
fn main() {
    let a = bar(S(1));
    a
} //^ i32
```