### PR TITLE
QDOC: quick doc improvements 2

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -20,6 +20,11 @@ import org.rust.lang.utils.filterQuery
 import org.rust.lang.utils.mapQuery
 import javax.swing.Icon
 
+val RsTraitItem.isUnsafe: Boolean get() {
+    val stub = stub
+    return stub?.isUnsafe ?: (unsafe != null)
+}
+
 val BoundElement<RsTraitItem>.flattenHierarchy: Collection<BoundElement<RsTraitItem>> get() {
     val result = mutableSetOf<BoundElement<RsTraitItem>>()
     val visited = mutableSetOf<RsTraitItem>()

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -30,7 +30,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 85
+        override fun getStubVersion(): Int = 86
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)
@@ -368,7 +368,8 @@ class RsModItemStub(
 class RsTraitItemStub(
     parent: StubElement<*>?, elementType: IStubElementType<*, *>,
     override val name: String?,
-    override val isPublic: Boolean
+    override val isPublic: Boolean,
+    val isUnsafe: Boolean
 ) : StubBase<RsTraitItem>(parent, elementType),
     RsNamedStub,
     RsVisibilityStub {
@@ -377,6 +378,7 @@ class RsTraitItemStub(
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
             RsTraitItemStub(parentStub, this,
                 dataStream.readNameAsString(),
+                dataStream.readBoolean(),
                 dataStream.readBoolean()
             )
 
@@ -384,13 +386,14 @@ class RsTraitItemStub(
             with(dataStream) {
                 writeName(stub.name)
                 writeBoolean(stub.isPublic)
+                writeBoolean(stub.isUnsafe)
             }
 
         override fun createPsi(stub: RsTraitItemStub): RsTraitItem =
             RsTraitItemImpl(stub, this)
 
         override fun createStub(psi: RsTraitItem, parentStub: StubElement<*>?) =
-            RsTraitItemStub(parentStub, this, psi.name, psi.isPublic)
+            RsTraitItemStub(parentStub, this, psi.name, psi.isPublic, psi.isUnsafe)
 
         override fun indexStub(stub: RsTraitItemStub, sink: IndexSink) = sink.indexTraitItem(stub)
     }

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -189,6 +189,78 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         Inner comment</p>
     """)
 
+    fun `test struct`() = doTest("""
+        struct Foo(i32);
+              //^
+    """, """
+        <pre>test_package</pre>
+        <pre>struct <b>Foo</b></pre>
+    """)
+
+    fun `test pub struct`() = doTest("""
+        pub struct Foo(i32);
+                  //^
+    """, """
+        <pre>test_package</pre>
+        <pre>pub struct <b>Foo</b></pre>
+    """)
+
+    fun `test generic struct`() = doTest("""
+        struct Foo<T>(T);
+              //^
+    """, """
+        <pre>test_package</pre>
+        <pre>struct <b>Foo</b>&lt;T&gt;</pre>
+    """)
+
+    fun `test generic struct with where clause`() = doTest("""
+        struct Foo<T>(T) where T: Into<String>;
+              //^
+    """, """
+        <pre>test_package</pre>
+        <pre>struct <b>Foo</b>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Into&lt;String&gt;,</pre>
+    """)
+
+    fun `test enum`() = doTest("""
+        enum Foo {
+            //^
+            Bar
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>enum <b>Foo</b></pre>
+    """)
+
+    fun `test pub enum`() = doTest("""
+        pub enum Foo {
+               //^
+            Bar
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>pub enum <b>Foo</b></pre>
+    """)
+
+    fun `test generic enum`() = doTest("""
+        enum Foo<T> {
+            //^
+            Bar(T)
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>enum <b>Foo</b>&lt;T&gt;</pre>
+    """)
+
+    fun `test generic enum with where clause`() = doTest("""
+        enum Foo<T> where T: Into<String> {
+             //^
+            Bar(T)
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>enum <b>Foo</b>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Into&lt;String&gt;,</pre>
+    """)
+
     fun testEnumVariant() = doTest("""
         enum Foo {
             /// I am a well documented enum variant
@@ -205,14 +277,162 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <p>I am a well documented enum variant</p>
     """)
 
-    fun testTraitAssocType() = doTest("""
+    fun `test trait`() = doTest("""
+        trait Foo {
+            //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>trait <b>Foo</b></pre>
+    """)
+
+    fun `test pub trait`() = doTest("""
+        pub trait Foo {
+                 //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>pub trait <b>Foo</b></pre>
+    """)
+
+    fun `test unsafe trait`() = doTest("""
+        unsafe trait Foo {
+                    //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>unsafe trait <b>Foo</b></pre>
+    """)
+
+    fun `test generic trait`() = doTest("""
+        trait Foo<T> {
+             //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>trait <b>Foo</b>&lt;T&gt;</pre>
+    """)
+
+    fun `test generic trait with where clause`() = doTest("""
+        trait Foo<T> where T: Into<String> {
+             //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>trait <b>Foo</b>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Into&lt;String&gt;,</pre>
+    """)
+
+    fun `test type alias`() = doTest("""
+        type Foo = Result<(), i32>;
+            //^
+    """, """
+        <pre>test_package</pre>
+        <pre>type <b>Foo</b> = Result&lt;(), i32&gt;</pre>
+    """)
+
+    fun `test pub type alias`() = doTest("""
+        pub type Foo = Result<(), i32>;
+                //^
+    """, """
+        <pre>test_package</pre>
+        <pre>pub type <b>Foo</b> = Result&lt;(), i32&gt;</pre>
+    """)
+
+    fun `test generic type alias`() = doTest("""
+        type Foo<T> = Result<T, i32>;
+            //^
+    """, """
+        <pre>test_package</pre>
+        <pre>type <b>Foo</b>&lt;T&gt; = Result&lt;T, i32&gt;</pre>
+    """)
+
+    fun `test generic type alias with where clause`() = doTest("""
+        type Foo<T> where T: Into<String> = Result<T, i32>;
+             //^
+    """, """
+        <pre>test_package</pre>
+        <pre>type <b>Foo</b>&lt;T&gt; = Result&lt;T, i32&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Into&lt;String&gt;,</pre>
+    """)
+
+    fun `test impl assoc type`() = doTest("""
+        trait Trait {
+            type AssocType;
+        }
+        struct Foo(i32);
+        impl Trait for Foo {
+            type AssocType = Option<i32>;
+                //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>impl Trait for Foo</pre>
+        <pre>type <b>AssocType</b> = Option&lt;i32&gt;</pre>
+    """)
+
+    fun `test generic impl assoc type`() = doTest("""
+        trait Trait {
+            type AssocType;
+        }
+        struct Foo<T>(T);
+        impl<T> Trait for Foo<T> {
+            type AssocType = Option<T>;
+                //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>impl&lt;T&gt; Trait for Foo&lt;T&gt;</pre>
+        <pre>type <b>AssocType</b> = Option&lt;T&gt;</pre>
+    """)
+
+    fun `test generic impl assoc type with where clause`() = doTest("""
+        trait Trait {
+            type AssocType;
+        }
+        struct Foo<T>(T);
+        impl<T> Trait for Foo<T> where T: Into<String> {
+            type AssocType = Option<T>;
+                //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>impl&lt;T&gt; Trait for Foo&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Into&lt;String&gt;,</pre>
+        <pre>type <b>AssocType</b> = Option&lt;T&gt;</pre>
+    """)
+
+    fun `test trait assoc type`() = doTest("""
         trait MyTrait {
             /// Documented
             type Awesome;
                //^
         }
     """, """
-        <pre>test_package::Awesome</pre>
+        <pre>test_package::MyTrait</pre>
+        <pre>type <b>Awesome</b></pre>
+        <p>Documented</p>
+    """)
+
+    fun `test generic trait assoc type`() = doTest("""
+        trait MyTrait<T> {
+            /// Documented
+            type Awesome;
+               //^
+        }
+    """, """
+        <pre>test_package::MyTrait&lt;T&gt;</pre>
+        <pre>type <b>Awesome</b></pre>
+        <p>Documented</p>
+    """)
+
+    fun `test generic trait assoc type with where clause`() = doTest("""
+        trait MyTrait<T> where T: Into<String> {
+            /// Documented
+            type Awesome;
+               //^
+        }
+    """, """
+        <pre>test_package::MyTrait&lt;T&gt;</pre>
+        <pre>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Into&lt;String&gt;,</pre>
+        <pre>type <b>Awesome</b></pre>
         <p>Documented</p>
     """)
 
@@ -429,7 +649,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         impl <T> AsRef<T> {}
                   //^
     """, """
-        <pre>test_package::AsRef</pre>
+        <pre>test_package</pre>
+        <pre>pub trait <b>AsRef</b>&lt;T: ?Sized&gt;</pre>
         <p>A cheap, reference-to-reference conversion.</p><p><code>AsRef</code> is very similar to, but different than, <code>Borrow</code>. See
         <a href="../../book/borrow-and-asref.html">the book</a> for more.</p><p><strong>Note: this trait must not fail</strong>. If the conversion can fail, use a dedicated method which
         returns an <code>Option&lt;T&gt;</code> or a <code>Result&lt;T, E&gt;</code>.</p><h1>Examples</h1><p>Both <code>String</code> and <code>&amp;str</code> implement <code>AsRef&lt;str&gt;</code>:</p><pre><code>fn is_hello&lt;T: AsRef&lt;str&gt;&gt;(s: T) {

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
@@ -265,15 +265,32 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
         use self::Foo;
                   //^
     """, """
-        pub struct <b>Foo</b> [main.rs]
+        test_package
+        pub struct <b>Foo</b>
     """)
 
-    fun `test struct with tuple fields`() = doTest("""
-        pub struct Foo(a: bool);
-        use self::Foo;
+    fun `test pub struct`() = doTest("""
+        pub struct Foo(i32);
                   //^
     """, """
-        pub struct <b>Foo</b>(a: bool) [main.rs]
+        test_package
+        pub struct <b>Foo</b>
+    """)
+
+    fun `test generic struct`() = doTest("""
+        struct Foo<T>(T);
+              //^
+    """, """
+        test_package
+        struct <b>Foo</b>&lt;T&gt;
+    """)
+
+    fun `test generic struct with where clause`() = doTest("""
+        struct Foo<T>(T) where T: Into<String>;
+              //^
+    """, """
+        test_package
+        struct <b>Foo</b>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Into&lt;String&gt;,
     """)
 
     fun `test struct field`() = doTest("""
@@ -291,7 +308,38 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
         use self::Foo;
                   //^
     """, """
-        enum <b>Foo</b> [main.rs]
+        test_package
+        enum <b>Foo</b>
+    """)
+
+    fun `test pub enum`() = doTest("""
+        pub enum Foo {
+               //^
+            Bar
+        }
+    """, """
+        test_package
+        pub enum <b>Foo</b>
+    """)
+
+    fun `test generic enum`() = doTest("""
+        enum Foo<T> {
+            //^
+            Bar(T)
+        }
+    """, """
+        test_package
+        enum <b>Foo</b>&lt;T&gt;
+    """)
+
+    fun `test generic enum with where clause`() = doTest("""
+        enum Foo<T> where T: Into<String> {
+             //^
+            Bar(T)
+        }
+    """, """
+        test_package
+        enum <b>Foo</b>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Into&lt;String&gt;,
     """)
 
     fun `test enum variant`() = doTest("""
@@ -303,11 +351,48 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
     """)
 
     fun `test trait`() = doTest("""
-        pub trait Foo { /* no methods */ }
+        trait Foo { /* no methods */ }
         impl Foo for u32 {}
              //^
     """, """
-        pub trait <b>Foo</b> [main.rs]
+        test_package
+        trait <b>Foo</b>
+    """)
+
+    fun `test pub trait`() = doTest("""
+        pub trait Foo {
+                 //^
+        }
+    """, """
+        test_package
+        pub trait <b>Foo</b>
+    """)
+
+    fun `test unsafe trait`() = doTest("""
+        unsafe trait Foo {
+                    //^
+        }
+    """, """
+        test_package
+        unsafe trait <b>Foo</b>
+    """)
+
+    fun `test generic trait`() = doTest("""
+        trait Foo<T> {
+             //^
+        }
+    """, """
+        test_package
+        trait <b>Foo</b>&lt;T&gt;
+    """)
+
+    fun `test generic trait with where clause`() = doTest("""
+        trait Foo<T> where T: Into<String> {
+             //^
+        }
+    """, """
+        test_package
+        trait <b>Foo</b>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Into&lt;String&gt;,
     """)
 
     fun `test type alias`() = doTest("""
@@ -315,7 +400,111 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
         fn foo(s: Str) {}
                   //^
     """, """
-        type <b>Str</b> = &amp;&#39;static str [main.rs]
+        test_package
+        type <b>Str</b> = &amp;&#39;static str
+    """)
+
+    fun `test pub type alias`() = doTest("""
+        pub type Foo = Result<(), i32>;
+                //^
+    """, """
+        test_package
+        pub type <b>Foo</b> = Result&lt;(), i32&gt;
+    """)
+
+    fun `test generic type alias`() = doTest("""
+        type Foo<T> = Result<T, i32>;
+            //^
+    """, """
+        test_package
+        type <b>Foo</b>&lt;T&gt; = Result&lt;T, i32&gt;
+    """)
+
+    fun `test generic type alias with where clause`() = doTest("""
+        type Foo<T> where T: Into<String> = Result<T, i32>;
+             //^
+    """, """
+        test_package
+        type <b>Foo</b>&lt;T&gt; = Result&lt;T, i32&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Into&lt;String&gt;,
+    """)
+
+    fun `test impl assoc type`() = doTest("""
+        trait Trait {
+            type AssocType;
+        }
+        struct Foo(i32);
+        impl Trait for Foo {
+            type AssocType = Option<i32>;
+                //^
+        }
+    """, """
+        test_package
+        impl Trait for Foo
+        type <b>AssocType</b> = Option&lt;i32&gt;
+    """)
+
+    fun `test generic impl assoc type`() = doTest("""
+        trait Trait {
+            type AssocType;
+        }
+        struct Foo<T>(T);
+        impl<T> Trait for Foo<T> {
+            type AssocType = Option<T>;
+                //^
+        }
+    """, """
+        test_package
+        impl&lt;T&gt; Trait for Foo&lt;T&gt;
+        type <b>AssocType</b> = Option&lt;T&gt;
+    """)
+
+    fun `test generic impl assoc type with where clause`() = doTest("""
+        trait Trait {
+            type AssocType;
+        }
+        struct Foo<T>(T);
+        impl<T> Trait for Foo<T> where T: Into<String> {
+            type AssocType = Option<T>;
+                //^
+        }
+    """, """
+        test_package
+        impl&lt;T&gt; Trait for Foo&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Into&lt;String&gt;,
+        type <b>AssocType</b> = Option&lt;T&gt;
+    """)
+
+    fun `test trait assoc type`() = doTest("""
+        trait MyTrait {
+            /// Documented
+            type Awesome;
+               //^
+        }
+    """, """
+        test_package::MyTrait
+        type <b>Awesome</b>
+    """)
+
+    fun `test generic trait assoc type`() = doTest("""
+        trait MyTrait<T> {
+            /// Documented
+            type Awesome;
+               //^
+        }
+    """, """
+        test_package::MyTrait&lt;T&gt;
+        type <b>Awesome</b>
+    """)
+
+    fun `test generic trait assoc type with where clause`() = doTest("""
+        trait MyTrait<T> where T: Into<String> {
+            /// Documented
+            type Awesome;
+               //^
+        }
+    """, """
+        test_package::MyTrait&lt;T&gt;
+        where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: Into&lt;String&gt;,
+        type <b>Awesome</b>
     """)
 
     fun `test const`() = doTest("""


### PR DESCRIPTION
Improve quick doc and navigation info for structs, enums, traits, type aliases and associated types