### PR TITLE
TY: `Self` & recursive receiver substitution (simple iterator chains works now!)

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/LangItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/LangItems.kt
@@ -62,7 +62,7 @@ fun findIndexOutputType(project: Project, containerType: Ty, indexType: Ty): Ty 
     } ?: return TyUnknown
 
     val rawOutputType = lookupAssociatedType(suitableImpl, "Output")
-    val typeParameterMap = suitableImpl.remapTypeParameters(containerType.typeParameterValues)
+    val typeParameterMap = suitableImpl.remapTypeParameters(containerType)
     return rawOutputType.substitute(typeParameterMap)
 }
 
@@ -77,7 +77,7 @@ fun findArithmeticBinaryExprOutputType(project: Project, lhsType: Ty, rhsType: T
     } ?: return TyUnknown
 
     return lookupAssociatedType(suitableImpl, "Output")
-        .substitute(suitableImpl.remapTypeParameters(lhsType.typeParameterValues))
+        .substitute(suitableImpl.remapTypeParameters(lhsType))
         .substitute(mapOf(TyTypeParameter(suitableImpl) to lhsType))
 }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/LangItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/LangItems.kt
@@ -76,9 +76,9 @@ fun findArithmeticBinaryExprOutputType(project: Project, lhsType: Ty, rhsType: T
         impls.find { isImplSuitable(project, it, op.itemName, 0, rhsType) }
     } ?: return TyUnknown
 
-    val rawOutputType = lookupAssociatedType(suitableImpl, "Output")
-    val typeParameterMap = suitableImpl.remapTypeParameters(lhsType.typeParameterValues)
-    return rawOutputType.substitute(typeParameterMap)
+    return lookupAssociatedType(suitableImpl, "Output")
+        .substitute(suitableImpl.remapTypeParameters(lhsType.typeParameterValues))
+        .substitute(mapOf(TyTypeParameter(suitableImpl) to lhsType))
 }
 
 private fun isImplSuitable(project: Project, impl: RsImplItem,

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -192,12 +192,8 @@ fun processPathResolveVariants(path: RsPath, isCompletion: Boolean, processor: R
             val s = base.`super`
             if (s != null && processor("super", s)) return true
         }
-        if (base is RsTraitItem && qualifier.referenceName == "Self") {
+        if (base is RsTraitOrImpl && qualifier.referenceName == "Self") {
             if (processAll(base.typeAliasList, processor)) return true
-        }
-        if (base is RsStructItem && qualifier.referenceName == "Self") {
-            val traitItem = path.parentOfType<RsImplItem>()
-            if (traitItem != null && processAll(traitItem.typeAliasList, processor)) return true
         }
         if (processItemOrEnumVariantDeclarations(base, ns, processor, isSuperChain(qualifier))) return true
         if (base is RsTypeBearingItemElement && parent !is RsUseItem) {
@@ -638,16 +634,9 @@ private fun processLexicalDeclarations(scope: RsCompositeElement, cameFrom: RsCo
             if (processAll(scope.typeParameters, processor)) return true
         }
 
-        is RsTraitItem -> {
+        is RsTraitOrImpl -> {
             if (processAll(scope.typeParameters, processor)) return true
             if (processor("Self", scope)) return true
-        }
-
-        is RsImplItem -> {
-            if (processAll(scope.typeParameters, processor)) return true
-            //TODO: handle types which are not `NamedElements` (e.g. tuples)
-            val selfType = (scope.typeReference?.typeElement as? RsBaseType)?.path?.reference?.resolve()
-            if (selfType != null && processor("Self", selfType)) return true
         }
 
         is RsFunction -> {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -44,12 +44,12 @@ fun inferTypeReferenceType(ref: RsTypeReference): Ty {
 
             val primitiveType = TyPrimitive.fromPath(path)
             if (primitiveType != null) return primitiveType
-            val (target, subst) = path.reference.advancedResolve()?.downcast<RsNamedElement>() ?: return TyUnknown
+            val (target, subst) = path.reference.advancedResolve() ?: return TyUnknown
 
-            if (target is RsTraitItem && type.isCself) {
+            if (target is RsTraitOrImpl && type.isCself) {
                 TyTypeParameter(target)
             } else {
-                inferDeclarationType(target).substitute(subst)
+                inferDeclarationType(target as? RsNamedElement ?: return TyUnknown).substitute(subst)
             }
         }
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Expressions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Expressions.kt
@@ -32,18 +32,10 @@ fun inferLiteralExprType(expr: RsLitExpr): Ty = when (expr.kind) {
  * impl<X, Y> Flip<Y, X> { ... }
  * ```
  */
-fun RsImplItem.remapTypeParameters(subst: Substitution): Substitution {
-    val positional = typeReference?.type?.typeParameterValues.orEmpty()
-        .mapNotNull { (structParam, structType) ->
-            if (structType is TyTypeParameter) {
-                val implType = subst[structParam] ?: return@mapNotNull null
-                structType to implType
-            } else {
-                null
-            }
-        }.toMap()
-
+fun RsImplItem.remapTypeParameters(receiver: Ty): Substitution {
+    val subst = mutableMapOf<TyTypeParameter, Ty>()
+    typeReference?.type?.canUnifyWith(receiver, project, subst)
     val associated = (implementedTrait?.subst ?: emptyMap())
-        .substituteInValues(positional)
-    return positional + associated
+        .substituteInValues(subst)
+    return subst + associated
 }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -182,11 +182,15 @@ private class RsFnInferenceContext(private val ctx: RsInferenceContext) {
     }
 
     private fun inferMethodCallExprType(expr: RsMethodCallExpr): Ty {
-        val (method, subst) = resolveMethodCallReferenceWithReceiverType(expr.expr.ty, expr)
+        val receiver = expr.expr.ty
+        val (method, subst) = resolveMethodCallReferenceWithReceiverType(receiver, expr)
             .firstOrNull()?.downcast<RsFunction>() ?: return TyUnknown
 
-        val returnType = (method.retType?.typeReference?.type ?: TyUnit)
+        var returnType = (method.retType?.typeReference?.type ?: TyUnit)
             .substitute(subst)
+        method.parentOfType<RsTraitOrImpl>()?.let { trait ->
+            returnType = returnType.substitute(mapOf(TyTypeParameter(trait) to receiver))
+        }
         val methodType = method.type as? TyFunction ?: return returnType
         // drop first element of paramTypes because it's `self` param
         // and it doesn't have value in `expr.valueArgumentList.exprList`

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -14,6 +14,7 @@ import org.rust.lang.core.resolve.findDerefTarget
 import org.rust.lang.core.resolve.indexes.RsImplIndex
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.infer.remapTypeParameters
+import org.rust.lang.utils.findWithCache
 
 typealias Substitution = Map<TyTypeParameter, Ty>
 typealias TypeMapping = MutableMap<TyTypeParameter, Ty>
@@ -75,7 +76,10 @@ fun Ty.getTypeParameter(name: String): TyTypeParameter? {
     return typeParameterValues.keys.find { it.toString() == name }
 }
 
-fun findImplsAndTraits(project: Project, ty: Ty): Collection<BoundElement<RsTraitOrImpl>> {
+fun findImplsAndTraits(project: Project, ty: Ty): Collection<BoundElement<RsTraitOrImpl>> =
+    findWithCache(project, ty) { project, ty -> rawFindImplsAndTraits(project, ty) }
+
+private fun rawFindImplsAndTraits(project: Project, ty: Ty): Collection<BoundElement<RsTraitOrImpl>> {
     return when (ty) {
         is TyTypeParameter -> ty.getTraitBoundsTransitively()
         is TyTraitObject -> BoundElement(ty.trait).flattenHierarchy

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -95,7 +95,7 @@ fun findImplsAndTraits(project: Project, ty: Ty): Collection<BoundElement<RsTrai
                 }.map { BoundElement(it, mapOf(TyTypeParameter(it) to ty)) }
 
             derived + RsImplIndex.findImpls(project, ty).map { impl ->
-                BoundElement(impl, impl.remapTypeParameters(ty.typeParameterValues).orEmpty())
+                BoundElement(impl, impl.remapTypeParameters(ty).orEmpty())
             }
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.types.ty
 import com.intellij.openapi.project.Project
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTypeParameter
+import org.rust.lang.core.psi.ext.RsTraitOrImpl
 import org.rust.lang.core.psi.ext.bounds
 import org.rust.lang.core.psi.ext.flattenHierarchy
 import org.rust.lang.core.psi.ext.resolveToBoundTrait
@@ -22,7 +23,11 @@ class TyTypeParameter private constructor(
 ) : Ty {
 
     constructor(parameter: RsTypeParameter) : this(Named(parameter), parameter.name, bounds(parameter))
-    constructor(trait: RsTraitItem) : this(Self(trait), "Self", listOf(BoundElement(trait)))
+    constructor(trait: RsTraitOrImpl) : this(
+        Self(trait),
+        "Self",
+        trait.implementedTrait?.let { listOf(it) } ?: emptyList()
+    )
     constructor(trait: RsTraitItem, target: String) : this(
         AssociatedType(trait, target),
         "${trait.name}::target",
@@ -70,7 +75,7 @@ class TyTypeParameter private constructor(
 
     private interface TypeParameter
     private data class Named(val parameter: RsTypeParameter) : TypeParameter
-    private data class Self(val trait: RsTraitItem) : TypeParameter
+    private data class Self(val trait: RsTraitOrImpl) : TypeParameter
     private data class AssociatedType(val trait: RsTraitItem, val target: String) : TypeParameter
 }
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsClosuresResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsClosuresResolveTest.kt
@@ -158,8 +158,6 @@ class RsClosuresResolveTest : RsResolveTestBase() {
     """)
 
     fun `test layered visitor example`() = checkByCode("""
-        //TODO: this should resolve once we implement unification...
-
         struct PhantomData;
 
         trait NodeVisitor<'f, C> {
@@ -191,7 +189,7 @@ class RsClosuresResolveTest : RsResolveTestBase() {
             Visitor(&mut ctx)
                 .visit::<(), _>(|ctx, t| ctx.foo())
                 .visit::<(), _>(|ctx, t| ctx.foo())
-            ;                               //^ unresolved
+            ;                               //^
         }
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -589,18 +589,6 @@ class RsResolveTest : RsResolveTestBase() {
         }
     """)
 
-    fun testImplSelfType() = checkByCode("""
-        struct DumbIterator<'a> { data: &'a [u8], }
-                 //X
-
-        impl<'a> Iterator for DumbIterator<'a> {
-            type Item = &'a [u8];
-
-            fn next(&mut self) -> Option<Self::Item> { None }
-                                       //^
-        }
-    """)
-
     fun testTraitSelfType() = checkByCode("""
         trait T {
             //X

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -574,4 +574,23 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             a
         } //^ S<S<S<S<X>>>>
     """)
+
+    fun `test recursive receiver substitution`() = testExpr("""
+        trait Tr<A> {
+            fn wrap(self) -> S<Self> where Self: Sized { unimplemented!() }
+            fn fold(self) -> A where Self: Sized { unimplemented!() }
+        }
+
+        struct X;
+        struct S1<B>(B);
+        struct S<C>(C);
+
+        impl<D> Tr<D> for S1<D> {}
+        impl<Src, Dst> Tr<Dst> for S<Src> where Src: Tr<Dst> {}
+
+        fn main() {
+            let a = S1(X).wrap().wrap().wrap().fold();
+            a
+        } //^ X
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -552,4 +552,26 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             a
         } //^ i32
     """)
+
+    fun `test Self substitution to trait method`() = testExpr("""
+        trait Tr<A> { fn wrap(self) -> S<Self> where Self: Sized { unimplemented!() } }
+        struct X;
+        struct S<C>(C);
+        impl<D> Tr<D> for S<D> {}
+        fn main() {
+            let a = S(X).wrap().wrap().wrap();
+            a
+        } //^ S<S<S<S<X>>>>
+    """)
+
+    fun `test Self substitution to impl method`() = testExpr("""
+        trait Tr<A> { fn wrap(self) -> S<Self> where Self: Sized { unimplemented!() } }
+        struct X;
+        struct S<C>(C);
+        impl<D> Tr<D> for S<D> { fn wrap(self) -> S<Self> where Self: Sized { unimplemented!() } }
+        fn main() {
+            let a = S(X).wrap().wrap().wrap();
+            a
+        } //^ S<S<S<S<X>>>>
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -239,4 +239,18 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
            //^ Foo
         }
     """)
+
+    fun `test infer iterator map chain`() = testExpr("""
+        struct S<T>(T);
+        fn main() {
+            let test: Vec<String> = Vec::new();
+            let a = test.into_iter()
+            .map(|x| x.to_string())
+            .map(|x| S(x))
+            .map(|x| x.0)
+            .next().unwrap();
+            a
+          //^ String
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -78,7 +78,7 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
         trait T { fn new() -> Self; }
 
         impl T for S { fn new() -> Self { S } }
-                                  //^ S
+                                  //^ Self
     """)
 
     fun testPrimitiveBool() = testType("""


### PR DESCRIPTION
1. `Self` type in `impl` block is now resolves to corresponding impl, not to particular type. Then `Self` type substitutes with with the receiver type. It allows to substitute complex types.
```rust
trait Tr<A> { fn wrap(self) -> S<Self> where Self: Sized { unimplemented!() } }
struct X;
struct S<C>(C);
impl<D> Tr<D> for S<D> {}
fn main() {
    let a = S(X).wrap().wrap().wrap();
    a
} //^ S<S<S<S<X>>>>
```
2. Now we substitute `impl` type parameters with receiver recursively (`RsImplItem.remapTypeParameters`). 
```rust
trait Tr<A> {
    fn wrap(self) -> S<Self> where Self: Sized { unimplemented!() }
    fn fold(self) -> A where Self: Sized { unimplemented!() }
}

struct X;
struct S1<B>(B);
struct S<C>(C);

impl<D> Tr<D> for S1<D> {}
impl<Src, Dst> Tr<Dst> for S<Src> where Src: Tr<Dst> {}

fn main() {
    let a = S1(X).wrap().wrap().wrap().fold();
    a
} //^ X
```
The magic is in line
```rust
impl<Src, Dst> Tr<Dst> for S<Src> where Src: Tr<Dst> {}
```
Many traits are implemented in a similar way, e.g. std iterators. And iterator map chains are working now!
```rust
struct S<T>(T);
fn main() {
    let test: Vec<String> = Vec::new();
    let a = test.into_iter()
    .map(|x| x.to_string())
    .map(|x| S(x))
    .map(|x| x.0)
    .next().unwrap();
    a
  //^ String
}
```
Also, the complex @matklad's test now passes (`test layered visitor example`).

3. This improvements resulted in a 40-fold performance regression... But it was enough to cache substituted (remapped) impls instead of raw. I.e. move caching from `RsImplIndex.findImpls` to `findImplsAndTraits`. Now it's even 15% faster than baseline.