### PR TITLE
GRD: bump rust to 1.19 for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ jdk: oraclejdk8
 
 env:
   - ORG_GRADLE_PROJECT_ideaVersion=LATEST-EAP-SNAPSHOT RUST_VERSION=nightly
-  - ORG_GRADLE_PROJECT_ideaVersion=2017.2              RUST_VERSION=1.18.0
-  - ORG_GRADLE_PROJECT_ideaVersion=2017.1              RUST_VERSION=1.18.0
+  - ORG_GRADLE_PROJECT_ideaVersion=2017.2              RUST_VERSION=1.19.0
+  - ORG_GRADLE_PROJECT_ideaVersion=2017.1              RUST_VERSION=1.19.0
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Part of #1491