### PR TITLE
Delete branches after merging them with bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -2,3 +2,4 @@ status = [
   "continuous-integration/travis-ci/push",
   "continuous-integration/appveyor/branch",
 ]
+delete-merged-branches = true


### PR DESCRIPTION
By turning on this switch, bors will delete your branch after it merges it, as long as that branch is opened on the intellij-rust repository (it can't delete branches off of forks).