### PR TITLE
ANN: don't try to annotate non project files

### DIFF
--- a/src/test/kotlin/org/rustSlowTests/RsCargoCheckAnnotatorTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsCargoCheckAnnotatorTest.kt
@@ -8,6 +8,7 @@ package org.rustSlowTests
 import com.intellij.lang.annotation.HighlightSeverity
 import org.rust.cargo.RustWithToolchainTestBase
 import org.rust.cargo.project.settings.rustSettings
+import org.rust.cargo.project.workspace.cargoWorkspace
 import org.rust.fileTree
 
 class RsCargoCheckAnnotatorTest : RustWithToolchainTestBase() {
@@ -57,6 +58,44 @@ class RsCargoCheckAnnotatorTest : RustWithToolchainTestBase() {
         }.create()
         myFixture.openFileInEditor(cargoProjectDirectory.findFileByRelativePath("src/main.rs")!!)
         val highlights = myFixture.doHighlighting(HighlightSeverity.WEAK_WARNING)
+        check(highlights.isEmpty(), {
+            "Did not expect any highlights, got:\n$highlights"
+        })
+    }
+
+    // https://github.com/intellij-rust/intellij-rust/issues/1497
+    fun `test don't try to highlight non project files`() {
+        fileTree {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+
+                [dependencies]
+                rand = "0.3.15"
+            """)
+
+            dir("src") {
+                rust("lib.rs", """
+                    extern crate rand;
+
+                    fn foo() {
+                        let a: i32 = "
+                        ";
+                    }
+                """)
+            }
+        }.create()
+
+        val path = myModule.cargoWorkspace
+            ?.findPackage("rand")
+            ?.contentRoot
+            ?.findFileByRelativePath("src/lib.rs")
+            ?: error("Can't find 'src/lib.rs' in 'rand' library")
+        myFixture.openFileInEditor(path)
+
+        val highlights = myFixture.doHighlighting(HighlightSeverity.ERROR)
         check(highlights.isEmpty(), {
             "Did not expect any highlights, got:\n$highlights"
         })


### PR DESCRIPTION
Closes #1497 

In `RsCargoCheckAnnotator` we check that message belongs to file by [equality of path suffix](https://github.com/intellij-rust/intellij-rust/blob/78754355e3cc823d75292f596d5c4ca1c17b26ad/src/main/kotlin/org/rust/ide/annotator/RsCargoCheckAnnotator.kt#L147-L148) with path from the message. But if the current file is not project file (from stdlib or dependency) and it has path with the same suffix, we calculate offsets for incorrect file and sometimes it can lead to invalid range.