### PR TITLE
FMT: Should not break the code by leave `use some::self`

### DIFF
--- a/src/main/kotlin/org/rust/ide/formatter/RsSingleImportRemoveBracesFormatProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/RsSingleImportRemoveBracesFormatProcessor.kt
@@ -15,6 +15,7 @@ import org.rust.lang.core.psi.RsUseGlob
 import org.rust.lang.core.psi.ext.elementType
 import org.rust.lang.core.psi.ext.getNextNonCommentSibling
 import org.rust.lang.core.psi.ext.getPrevNonCommentSibling
+import org.rust.lang.core.psi.ext.isSelf
 
 /**
  * Pre format processor ensuring that if an import statement only contains a single import from a crate that
@@ -54,7 +55,8 @@ class RsSingleImportRemoveBracesFormatProcessor : PreFormatProcessor {
         val leftBrace = element.getPrevNonCommentSibling() ?: return false
         val rightBrace = element.getNextNonCommentSibling() ?: return false
         if (leftBrace.elementType == RsElementTypes.LBRACE &&
-            rightBrace.elementType == RsElementTypes.RBRACE) {
+            rightBrace.elementType == RsElementTypes.RBRACE &&
+            !element.isSelf) {
             leftBrace.delete()
             rightBrace.delete()
             return true

--- a/src/test/kotlin/org/rust/ide/formatter/RsFormatterImportBracesTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsFormatterImportBracesTest.kt
@@ -12,7 +12,7 @@ class RsFormatterImportBracesTest : RsFormatterTestBase() {
     fun testWontRemoveBracesIfMultiImport() = doTextTest("use getopts::{optopt, optarg};",
         "use getopts::{optopt, optarg};")
 
-    fun `test wan't remove braces for single self`() = doTextTest("use getopts::{self};",
+    fun `test won't remove braces for single self`() = doTextTest("use getopts::{self};",
         "use getopts::{self};")
 
     fun testRemoveBracesWithMultipleImports() = doTextTest(

--- a/src/test/kotlin/org/rust/ide/formatter/RsFormatterImportBracesTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsFormatterImportBracesTest.kt
@@ -12,6 +12,9 @@ class RsFormatterImportBracesTest : RsFormatterTestBase() {
     fun testWontRemoveBracesIfMultiImport() = doTextTest("use getopts::{optopt, optarg};",
         "use getopts::{optopt, optarg};")
 
+    fun `test wan't remove braces for single self`() = doTextTest("use getopts::{self};",
+        "use getopts::{self};")
+
     fun testRemoveBracesWithMultipleImports() = doTextTest(
         """
         use getopts::{optopt};


### PR DESCRIPTION
Fix #1512 and don't leave broken code.