### PR TITLE
Iterate over psi children effectively

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -16,6 +16,7 @@ import org.rust.lang.core.resolve.ref.resolveFieldExprReferenceWithReceiverType
 import org.rust.lang.core.resolve.ref.resolveMethodCallReferenceWithReceiverType
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
+import org.rust.utils.forEachChild
 
 fun inferTypesIn(fn: RsFunction): RsInferenceContext =
     RsInferenceContext().apply { recursionGuard { infer(fn) } }
@@ -80,7 +81,7 @@ private class RsFnInferenceContext(
     }
 
     private fun walkChildren(psi: PsiElement) {
-        psi.children.forEach { walk(it) }
+        psi.forEachChild(this::walk)
     }
 
     private fun walk(psi: PsiElement) {
@@ -220,7 +221,7 @@ private class RsFnInferenceContext(
         val label = expr.labelDecl?.name
 
         fun collectReturningTypes(element: PsiElement, matchOnlyByLabel: Boolean) {
-            for (child in element.children) {
+            element.forEachChild { child ->
                 when (child) {
                     is RsBreakExpr -> {
                         collectReturningTypes(child, matchOnlyByLabel)

--- a/src/main/kotlin/org/rust/utils/Extensions.kt
+++ b/src/main/kotlin/org/rust/utils/Extensions.kt
@@ -7,6 +7,8 @@ package org.rust.utils
 
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.tree.CompositeElement
 import com.intellij.util.io.systemIndependentPath
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -20,3 +22,17 @@ val Int.seconds: Int
 fun GeneralCommandLine(path: Path, vararg args: String) = GeneralCommandLine(path.systemIndependentPath, *args)
 fun GeneralCommandLine.withWorkDirectory(path: Path?) = withWorkDirectory(path?.systemIndependentPath)
 val VirtualFile.pathAsPath: Path get() = Paths.get(path)
+
+/**
+ * Iterates all children of the `PsiElement` and invokes `action` for each one.
+ */
+inline fun PsiElement.forEachChild(action: (PsiElement) -> Unit) {
+    var psiChild: PsiElement? = firstChild
+
+    while (psiChild != null) {
+        if (psiChild.node is CompositeElement) {
+            action(psiChild)
+        }
+        psiChild = psiChild.nextSibling
+    }
+}


### PR DESCRIPTION
PsiElement.children allocates an ArrayList and an array, so we should iterate over children manually.

In Java I would write an iterator, but in Kotlin we have inline functions, so why do we need an iterator?) Kotlin ruled