### PR TITLE
Refactored Ty.canUnifyWith

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
@@ -12,7 +12,6 @@ import com.intellij.psi.stubs.IndexSink
 import com.intellij.psi.stubs.StubIndexKey
 import com.intellij.util.io.KeyDescriptor
 import org.rust.lang.core.psi.RsImplItem
-import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsImplItemStub
 import org.rust.lang.core.types.TyFingerprint
@@ -26,7 +25,11 @@ class RsImplIndex : AbstractStubIndex<TyFingerprint, RsImplItem>() {
     override fun getKeyDescriptor(): KeyDescriptor<TyFingerprint> = TyFingerprint.KeyDescriptor
 
     companion object {
-        fun findImpls(project: Project, lookup: ImplLookup, target: Ty): Collection<RsImplItem> {
+        /**
+         * Note this method may return false positives
+         * @see TyFingerprint
+         */
+        fun findPotentialImpls(project: Project, target: Ty): Collection<RsImplItem> {
             val fingerprint = TyFingerprint.create(target)
                 ?: return emptyList()
 
@@ -36,7 +39,7 @@ class RsImplIndex : AbstractStubIndex<TyFingerprint, RsImplItem>() {
                     // Addition class check is a temporal solution to filter impls for type parameter
                     // with the same name
                     // struct S; impl<S: Tr1> Tr2 for S {}
-                    ty != null && ty.javaClass == target.javaClass && ty.canUnifyWith(target, lookup)
+                    ty != null && ty.javaClass == target.javaClass
                 }
             }
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt
@@ -8,9 +8,8 @@ package org.rust.lang.core.types.ty
 import org.rust.lang.core.resolve.ImplLookup
 
 class TyArray(val base: Ty, val size: Int) : Ty {
-    override fun canUnifyWith(other: Ty, lookup: ImplLookup, mapping: TypeMapping?): Boolean = merge(mapping) {
-        other is TyArray && size == other.size && base.canUnifyWith(other.base, lookup, it)
-    }
+    override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult =
+        if (other is TyArray && size == other.size) base.unifyWith(other.base, lookup) else UnifyResult.fail
 
     override fun substitute(subst: Substitution): Ty =
         TyArray(base.substitute(subst), size)

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyFunction.kt
@@ -9,10 +9,14 @@ import org.rust.lang.core.resolve.ImplLookup
 
 data class TyFunction(val paramTypes: List<Ty>, val retType: Ty) : Ty {
 
-    override fun canUnifyWith(other: Ty, lookup: ImplLookup, mapping: TypeMapping?): Boolean = merge(mapping) {
-        other is TyFunction && paramTypes.size == other.paramTypes.size &&
-            paramTypes.zip(other.paramTypes).all { (type1, type2) -> type1.canUnifyWith(type2, lookup, it) } &&
-            retType.canUnifyWith(other.retType, lookup, it)
+    override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult {
+        return if(other is TyFunction && paramTypes.size == other.paramTypes.size) {
+            UnifyResult.mergeAll(
+                paramTypes.zip(other.paramTypes).map { (type1, type2) -> type1.unifyWith(type2, lookup) }
+            ).merge(retType.unifyWith(other.retType, lookup))
+        } else {
+            UnifyResult.fail
+        }
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt
@@ -9,9 +9,8 @@ import org.rust.lang.core.resolve.ImplLookup
 
 data class TyPointer(val referenced: Ty, val mutable: Boolean = false) : Ty {
 
-    override fun canUnifyWith(other: Ty, lookup: ImplLookup, mapping: TypeMapping?): Boolean = merge(mapping) {
-        other is TyPointer && referenced.canUnifyWith(other.referenced, lookup, it)
-    }
+    override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult =
+        if (other is TyPointer) referenced.unifyWith(other.referenced, lookup) else UnifyResult.fail
 
     override fun toString() = "*${if (mutable) "mut" else "const"} $referenced"
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
@@ -18,8 +18,8 @@ import org.rust.lang.core.resolve.ImplLookup
  * tuples or arrays as primitive.
  */
 interface TyPrimitive : Ty {
-    override fun canUnifyWith(other: Ty, lookup: ImplLookup, mapping: TypeMapping?): Boolean =
-        this == other
+    override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult =
+        UnifyResult.exactIf(this == other)
 
     companion object {
         fun fromPath(path: RsPath): TyPrimitive? {
@@ -62,8 +62,8 @@ object TyStr : TyPrimitive {
 interface TyNumeric : TyPrimitive {
     val isKindWeak: Boolean
 
-    override fun canUnifyWith(other: Ty, lookup: ImplLookup, mapping: MutableMap<TyTypeParameter, Ty>?): Boolean
-        = this == other || javaClass == other.javaClass && (other as TyNumeric).isKindWeak
+    override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult =
+        UnifyResult.exactIf(this == other || javaClass == other.javaClass && (other as TyNumeric).isKindWeak)
 }
 
 class TyInteger(val kind: Kind, override val isKindWeak: Boolean = false) : TyNumeric {

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
@@ -9,9 +9,8 @@ import org.rust.lang.core.resolve.ImplLookup
 
 data class TyReference(val referenced: Ty, val mutable: Boolean = false) : Ty {
 
-    override fun canUnifyWith(other: Ty, lookup: ImplLookup, mapping: TypeMapping?): Boolean = merge(mapping) {
-        other is TyReference && referenced.canUnifyWith(other.referenced, lookup, it)
-    }
+    override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult =
+        if (other is TyReference) referenced.unifyWith(other.referenced, lookup) else UnifyResult.fail
 
     override fun toString(): String = "${if (mutable) "&mut " else "&"}$referenced"
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TySlice.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TySlice.kt
@@ -8,9 +8,12 @@ package org.rust.lang.core.types.ty
 import org.rust.lang.core.resolve.ImplLookup
 
 data class TySlice(val elementType: Ty) : Ty {
-    override fun canUnifyWith(other: Ty, lookup: ImplLookup, mapping: TypeMapping?): Boolean = merge(mapping) {
-        other is TySlice && elementType.canUnifyWith(other.elementType, lookup, it) ||
-            other is TyArray && elementType.canUnifyWith(other.base, lookup, it)
+    override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult {
+        return when (other) {
+            is TySlice -> elementType.unifyWith(other.elementType, lookup)
+            is TyArray -> elementType.unifyWith(other.base, lookup)
+            else -> UnifyResult.fail
+        }
     }
 
     override fun substitute(subst: Substitution): Ty {

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyStructOrEnum.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyStructOrEnum.kt
@@ -26,9 +26,12 @@ interface TyStructOrEnumBase : Ty {
             } else "<anonymous>"
         }
 
-    override fun canUnifyWith(other: Ty, lookup: ImplLookup, mapping: TypeMapping?): Boolean = merge(mapping) {
-        other is TyStructOrEnumBase && item == other.item &&
-            typeArguments.zip(other.typeArguments).all { (type1, type2) -> type1.canUnifyWith(type2, lookup, it) }
+    override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult {
+        return if (other is TyStructOrEnumBase && item == other.item) {
+            UnifyResult.mergeAll(typeArguments.zip(other.typeArguments).map { (type1, type2) -> type1.unifyWith(type2, lookup) })
+        } else {
+            UnifyResult.fail
+        }
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
@@ -16,8 +16,8 @@ import org.rust.lang.core.resolve.ImplLookup
  */
 data class TyTraitObject(val trait: RsTraitItem) : Ty {
 
-    override fun canUnifyWith(other: Ty, lookup: ImplLookup, mapping: TypeMapping?): Boolean =
-        other is RsTraitItem && trait == other.trait
+    override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult =
+        UnifyResult.exactIf(other is RsTraitItem && trait == other.trait)
 
     override fun toString(): String = trait.name ?: "<anonymous>"
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt
@@ -9,9 +9,12 @@ import org.rust.lang.core.resolve.ImplLookup
 
 data class TyTuple(val types: List<Ty>) : Ty {
 
-    override fun canUnifyWith(other: Ty, lookup: ImplLookup, mapping: TypeMapping?): Boolean = merge(mapping) {
-        other is TyTuple && types.size == other.types.size &&
-            types.zip(other.types).all { (type1, type2) -> type1.canUnifyWith(type2, lookup, it) }
+    override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult {
+        return if (other is TyTuple && types.size == other.types.size) {
+            UnifyResult.mergeAll(types.zip(other.types).map { (type1, type2) -> type1.unifyWith(type2, lookup) })
+        } else {
+            UnifyResult.fail
+        }
     }
 
     override fun substitute(subst: Substitution): TyTuple =

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyUnknown.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyUnknown.kt
@@ -8,7 +8,7 @@ package org.rust.lang.core.types.ty
 import org.rust.lang.core.resolve.ImplLookup
 
 object TyUnknown : Ty {
-    override fun canUnifyWith(other: Ty, lookup: ImplLookup, mapping: TypeMapping?): Boolean = false
+    override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult = UnifyResult.fail
 
     override fun toString(): String = "<unknown>"
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/UnifyResult.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/UnifyResult.kt
@@ -1,0 +1,87 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.types.ty
+
+/**
+ * ```rust
+ * struct S<T>(T);
+ * #[derive(Eq)]
+ * struct X;
+ * struct Y;
+ *
+ * fn foo<T: Eq>(t: S<T>) {}
+ *
+ * foo(S<X>); // exact
+ * foo(S<Y>); // fuzzy
+ * foo(X);    // fail
+ * ```
+ * @see Ty.unifyWith
+ */
+sealed class UnifyResult {
+    abstract fun merge(other: UnifyResult): UnifyResult
+
+    fun merge(other: Substitution): UnifyResult =
+        merge(Exact(other))
+
+    abstract fun substitution(): Substitution?
+
+    /** All types matches and trait bounds satisfied */
+    data class Exact(val subst: Substitution): UnifyResult() {
+        override fun merge(other: UnifyResult): UnifyResult = when (other) {
+            is Failure -> Failure
+            is Fuzzy -> Fuzzy(subst.merge(other.subst))
+            is Exact -> Exact(subst.merge(other.subst))
+        }
+
+        override fun substitution(): Substitution? = subst
+    }
+
+    /** All types matches, but trait bounds are not satisfied */
+    data class Fuzzy(val subst: Substitution): UnifyResult() {
+        override fun merge(other: UnifyResult): UnifyResult = when (other) {
+            is Failure -> Failure
+            is Fuzzy -> Fuzzy(subst.merge(other.subst))
+            is Exact -> Fuzzy(subst.merge(other.subst))
+        }
+
+        override fun substitution(): Substitution? = subst
+    }
+
+    /** Type mismatch */
+    object Failure : UnifyResult() {
+        override fun substitution(): Substitution? = null
+        override fun merge(other: UnifyResult): UnifyResult = Failure
+    }
+
+    companion object {
+        val exact: UnifyResult = Exact(emptySubstitution)
+        val fuzzy: UnifyResult = Fuzzy(emptySubstitution)
+        val fail: UnifyResult = Failure
+
+        fun exactIf(condition: Boolean): UnifyResult =
+            if (condition) exact else fail
+
+        fun mergeAll(others: Iterable<UnifyResult>): UnifyResult {
+            var result: UnifyResult = exact
+            for (other in others) {
+                result = result.merge(other)
+            }
+            return result
+        }
+    }
+}
+
+private fun Substitution.merge(other: Substitution): Substitution {
+    if (isEmpty()) return other
+    if (other.isEmpty()) return this
+
+    val newSubst = toMutableMap()
+    for ((param, value) in other) {
+        val old = get(param)
+        newSubst.put(param, if (old == null) value else getMoreCompleteType(old, value))
+    }
+    return newSubst
+}


### PR DESCRIPTION
Refactored extremely hacky `Ty.canUnifyWith` method.

Now it's possible to implement precise/fuzzy impl lookup originally discussed at #1245 (also you can look at `RsPreciseTraitMatchingTest` TODO tests).

To do it we should somehow filter fuzzy matched impls after `findImplsAndTraits` call (currently there are no any flags and return type `Collection<BoundElement<RsTraitOrImpl>>` already seems quite complicated)

And I guess after it we'll be able to easily implement `impl<T> for T` resolution.