### PR TITLE
TY: fixed inference consts and statics inside functions

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.types
 
 import com.intellij.openapi.util.Computable
+import com.intellij.psi.PsiElement
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiModificationTracker
@@ -40,10 +41,10 @@ val RsFunction.inferenceContext: RsInferenceContext
     })
 
 val RsPatBinding.type: Ty
-    get() = parentOfType<RsFunction>()?.inferenceContext?.getBindingType(this) ?: TyUnknown
+    get() = inferenceContext?.getBindingType(this) ?: TyUnknown
 
 val RsExpr.type: Ty
-    get() = parentOfType<RsFunction>()?.inferenceContext?.getExprType(this) ?: inferOutOfFnExpressionType(this)
+    get() = inferenceContext?.getExprType(this) ?: inferOutOfFnExpressionType(this)
 
 val RsExpr.declaration: RsCompositeElement?
     get() = when (this) {
@@ -76,3 +77,6 @@ val RsExpr.isMutable: Boolean get() {
         else -> DEFAULT_MUTABILITY
     }
 }
+
+private val PsiElement.inferenceContext: RsInferenceContext?
+    get() = (parentOfType<RsItemElement>() as? RsFunction)?.inferenceContext

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -635,4 +635,16 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
             let a: fn(u8) = |x, y: u8| y;
         }                            //^ u8
     """)
+
+    fun `test infer const inside a function`() = testExpr("""
+        fn main() {
+            const X: i32 = 1;
+        }                //^ i32
+    """)
+
+    fun `test infer static inside a function`() = testExpr("""
+        fn main() {
+            static X: i32 = 1;
+        }                 //^ i32
+    """)
 }


### PR DESCRIPTION
Fixed:
```rust
fn main() {
    const X: i32 = 1;
}                //^ i32
```