### PR TITLE
TY: implemented `!` type

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/Ty.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/Ty.kt
@@ -20,6 +20,7 @@ private fun render(ty: Ty, level: Int): String {
             is TyBool -> "bool"
             is TyChar -> "char"
             is TyUnit -> "()"
+            is TyNever -> "!"
             is TyStr -> "str"
             is TyInteger -> ty.kind.toString()
             is TyFloat -> ty.kind.toString()

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsBaseType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsBaseType.kt
@@ -12,7 +12,5 @@ val RsBaseType.isCself: Boolean get() {
     return path != null && !path.hasColonColon && path.hasCself
 }
 
-val RsBaseType.isUnit: Boolean get() {
-    val stub = stub
-    return (stub?.isUnit) ?: (lparen != null && rparen != null)
-}
+val RsBaseType.isUnit: Boolean get() = (stub?.isUnit) ?: (lparen != null && rparen != null)
+val RsBaseType.isNever: Boolean get() = (stub?.isNever) ?: (excl != null)

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -30,7 +30,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 93
+        override fun getStubVersion(): Int = 94
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)
@@ -783,7 +783,8 @@ class RsRefLikeTypeStub(
 
 class RsBaseTypeStub(
     parent: StubElement<*>?, elementType: IStubElementType<*, *>,
-    val isUnit: Boolean
+    val isUnit: Boolean,
+    val isNever: Boolean
 ) : StubBase<RsBaseType>(parent, elementType) {
 
     object Type : RsStubElementType<RsBaseTypeStub, RsBaseType>("BASE_TYPE") {
@@ -791,17 +792,18 @@ class RsBaseTypeStub(
         override fun shouldCreateStub(node: ASTNode): Boolean = createStubIfParentIsStub(node)
 
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
-            RsBaseTypeStub(parentStub, this, dataStream.readBoolean())
+            RsBaseTypeStub(parentStub, this, dataStream.readBoolean(), dataStream.readBoolean())
 
         override fun serialize(stub: RsBaseTypeStub, dataStream: StubOutputStream) = with(dataStream) {
             dataStream.writeBoolean(stub.isUnit)
+            dataStream.writeBoolean(stub.isNever)
         }
 
         override fun createPsi(stub: RsBaseTypeStub) =
             RsBaseTypeImpl(stub, this)
 
         override fun createStub(psi: RsBaseType, parentStub: StubElement<*>?) =
-            RsBaseTypeStub(parentStub, this, psi.isUnit)
+            RsBaseTypeStub(parentStub, this, psi.isUnit, psi.isNever)
 
         override fun indexStub(stub: RsBaseTypeStub, sink: IndexSink) {
         }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -33,6 +33,7 @@ fun inferTypeReferenceType(ref: RsTypeReference): Ty {
 
         is RsBaseType -> {
             if (type.isUnit) return TyUnit
+            if (type.isNever) return TyNever
 
             val path = type.path ?: return TyUnknown
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -123,6 +123,7 @@ private class RsFnInferenceContext(
             is RsLambdaExpr -> inferLambdaExprType(this, expected)
             is RsRetExpr -> inferRetExprType(this)
             is RsBreakExpr -> inferBreakExprType(this)
+            is RsContExpr -> TyNever
             else -> TyUnknown
         }
 
@@ -311,10 +312,7 @@ private class RsFnInferenceContext(
             arm.expr?.inferType(expected)
         }
 
-        return arms.asSequence()
-            .mapNotNull { it.expr?.let(ctx::getExprType) }
-            .firstOrNull { it !is TyUnknown }
-            ?: TyUnknown
+        return getMoreCompleteType(arms.mapNotNull { it.expr?.let(ctx::getExprType) })
     }
 
     private fun inferUnaryExprType(expr: RsUnaryExpr, expected: Ty?): Ty {
@@ -345,13 +343,14 @@ private class RsFnInferenceContext(
 
     private fun inferIfExprType(expr: RsIfExpr, expected: Ty?): Ty {
         expr.condition?.let { ctx.extractBindings(it.pat, it.expr.inferType(TyBool)) }
-        val blockTy = expr.block?.inferType(expected)
+        val blockTys = mutableListOf<Ty?>()
+        blockTys.add(expr.block?.inferType(expected))
         val elseBranch = expr.elseBranch
         if (elseBranch != null) {
-            elseBranch.ifExpr?.inferType(expected)
-            elseBranch.block?.inferType(expected)
+            blockTys.add(elseBranch.ifExpr?.inferType(expected))
+            blockTys.add(elseBranch.block?.inferType(expected))
         }
-        return if (expr.elseBranch == null) TyUnit else (blockTy ?: TyUnknown)
+        return if (expr.elseBranch == null) TyUnit else getMoreCompleteType(blockTys.filterNotNull())
     }
 
     private fun inferBinaryExprType(expr: RsBinaryExpr): Ty {
@@ -452,6 +451,7 @@ private class RsFnInferenceContext(
             name == "format" -> items.findStringTy()
             name == "format_args" -> items.findArgumentsTy()
             expr.macroCall.formatMacroArgument != null || expr.macroCall.logMacroArgument != null -> TyUnit
+            name == "unimplemented" || name == "panic" -> TyNever
             else -> TyUnknown
         }
     }
@@ -503,12 +503,12 @@ private class RsFnInferenceContext(
 
     private fun inferRetExprType(expr: RsRetExpr): Ty {
         expr.expr?.inferType()
-        return TyUnit // TODO TyNever `!`
+        return TyNever
     }
 
     private fun inferBreakExprType(expr: RsBreakExpr): Ty {
         expr.expr?.inferType()
-        return TyUnit // TODO TyNever `!`
+        return TyNever
     }
 
     private fun getMoreCompleteType(types: List<Ty>): Ty {

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -53,6 +53,7 @@ fun Ty.getTypeParameter(name: String): TyTypeParameter? {
 fun getMoreCompleteType(ty1: Ty, ty2: Ty): Ty {
     return when {
         ty1 is TyUnknown -> ty2
+        ty1 is TyNever -> ty2
         ty1 is TyInteger && ty2 is TyInteger && ty1.isKindWeak -> ty2
         ty1 is TyFloat && ty2 is TyFloat && ty1.isKindWeak -> ty2
         else -> ty1

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
@@ -56,6 +56,11 @@ object TyUnit : TyPrimitive {
     override fun toString(): String = tyToString(this)
 }
 
+/** The `!` type. E.g. `unimplemented!()` */
+object TyNever : TyPrimitive {
+    override fun toString(): String = tyToString(this)
+}
+
 object TyStr : TyPrimitive {
     override fun toString(): String = tyToString(this)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -93,6 +93,30 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test if else with return 1`() = testExpr("""
+        fn main() {
+            let a = if true { return } else { 1 };
+            a
+        } //^ i32
+    """)
+
+    fun `test if else with return 2`() = testExpr("""
+        fn main() {
+            let a = if true { return } else if true { return } else { 1 };
+            a
+        } //^ i32
+    """)
+
+    fun `test match with return`() = testExpr("""
+        fn main() {
+            let a = match true {
+                true => return,
+                false => 1,
+            };
+            a
+        } //^ i32
+    """)
+
     fun `test loop`() = testExpr("""
         fn main() {
             let x = loop { break; };
@@ -234,6 +258,28 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
             let a = "Hello";
                        //^ &str
         }
+    """)
+
+    fun testNever() = testExpr("""
+        fn never() -> ! { unimplemented!() }
+        fn main() {
+            let a = never();
+            a
+        } //^ !
+    """)
+
+    fun `test unimplemented macro`() = testExpr("""
+        fn main() {
+            let a = unimplemented!();
+            a
+        } //^ !
+    """)
+
+    fun `test panic macro`() = testExpr("""
+        fn main() {
+            let a = unimplemented!();
+            a
+        } //^ !
     """)
 
     fun testEnumVariantA() = testExpr("""
@@ -608,6 +654,28 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
             loop {
                 break 1;
             }       //^ i32
+        }
+    """)
+
+    fun `test return expr`() = testExpr("""
+        fn main() {
+            return;
+        } //^ !
+    """)
+
+    fun `test loop break expr`() = testExpr("""
+        fn main() {
+            loop {
+                break 1;
+            } //^ !
+        }
+    """)
+
+    fun `test loop continue expr`() = testExpr("""
+        fn main() {
+            loop {
+                continue;
+            } //^ !
         }
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -250,39 +250,33 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    fun `test struct expr with 2 fields of same type integer 1`() = testExpr("""
+    fun `test struct expr with 2 fields of same type 1`() = testExpr("""
+        struct X;
         struct S<T> { a: T, b: T }
         fn main() {
-            let x = S { a: 5u16, b: 0 };
+            let x = S { a: X, b: unimplemented!() };
             x.b
-            //^ u16
+            //^ X
         }
     """)
 
-    fun `test struct expr with 2 fields of same type integer 2`() = testExpr("""
+    fun `test struct expr with 2 fields of same type 2`() = testExpr("""
+        struct X;
         struct S<T> { a: T, b: T }
         fn main() {
-            let x = S { a: 0, b: 5u16 };
+            let x = S { a: unimplemented!(), b: X };
             x.a
-            //^ u16
-        }
-    """)
-
-    fun `test struct expr with 2 fields of same type float 2`() = testExpr("""
-        struct S<T> { a: T, b: T }
-        fn main() {
-            let x = S { a: 0.0, b: 5f32 };
-            x.a
-            //^ f32
+            //^ X
         }
     """)
 
     fun `test struct expr with 2 fields of different types`() = testExpr("""
+        struct X; struct Y;
         struct S<T1, T2> { a: T1, b: T2 }
         fn main() {
-            let x = S { a: 5u16, b: 5u8 };
+            let x = S { a: X, b: Y };
             (x.a, x.b)
-          //^ (u16, u8)
+          //^ (X, Y)
         }
     """)
 


### PR DESCRIPTION
`!` type (TyNever) is result of `return`, `break` & `continue` exprs, and also `panic!()`, `unimplemented!()` and so on. Rust handles `!` in a special way, e.g. allow it to become any type, or ignore match arm that return it.

It isn't fixing #1599 completely, but if remove semicolon after `return 0` in that example,  it will work. 