### PR TITLE
Fix the return type of panic!() and unreachable!()

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1042,7 +1042,7 @@ TryMacroArgument ::= <<any_braces AnyExpr>>
 
 // https://doc.rust-lang.org/std/fmt/
 private FormatLikeMacro ::=
-  ("format" | "format_args" | "write" | "writeln" | "print" | "println" | "eprint" | "eprintln" | "panic")
+  ("format" | "format_args" | "write" | "writeln" | "print" | "println" | "eprint" | "eprintln" | "panic" | "unimplemented" | "unreachable")
   '!' FormatMacroArgument { pin = 2 }
 
 FormatMacroArgument ::= <<any_braces [ <<comma_separated_list FormatMacroArg>> ] >>

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -460,8 +460,9 @@ private class RsFnInferenceContext(
             "print" in name || "assert" in name -> TyUnit
             name == "format" -> items.findStringTy()
             name == "format_args" -> items.findArgumentsTy()
+            name == "unimplemented" || name == "unreachable" || name == "panic" -> TyNever
             expr.macroCall.formatMacroArgument != null || expr.macroCall.logMacroArgument != null -> TyUnit
-            name == "unimplemented" || name == "panic" -> TyNever
+
             else -> TyUnknown
         }
     }

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -275,9 +275,16 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ !
     """)
 
+    fun `test unreachable macro`() = testExpr("""
+        fn main() {
+            let a = unreachable!();
+            a
+        } //^ !
+    """)
+
     fun `test panic macro`() = testExpr("""
         fn main() {
-            let a = unimplemented!();
+            let a = panic!();
             a
         } //^ !
     """)

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -182,14 +182,6 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    fun `test panic!`() = testExpr("""
-        fn main() {
-            let x = panic!("Something went wrong");
-            x
-          //^ ()
-        }
-    """)
-
     fun `test print!`() = testExpr("""
         fn main() {
             let x = print!("Something went wrong");

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/partial/enum_vis.txt
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/partial/enum_vis.txt
@@ -10,7 +10,7 @@ FILE
         <empty list>
   PsiWhiteSpace('\n    ')
   PsiElement(pub)('pub')
-  PsiErrorElement:'(', assert, assert_eq, assert_ne, const, debug, debug_assert, debug_assert_eq, debug_assert_ne, enum, eprint, eprintln, error, extern, fn, format, format_args, identifier, impl, info, log, macro_rules, mod, panic, print, println, static, struct, trace, trait, try, type, unsafe, use, vec, warn, write or writeln expected, got 'F'
+  PsiErrorElement:'(', assert, assert_eq, assert_ne, const, debug, debug_assert, debug_assert_eq, debug_assert_ne, enum, eprint, eprintln, error, extern, fn, format, format_args, identifier, impl, info, log, macro_rules, mod, panic, print, println, static, struct, trace, trait, try, type, unimplemented, unreachable, unsafe, use, vec, warn, write or writeln expected, got 'F'
     <empty list>
   PsiWhiteSpace(' ')
   PsiElement(identifier)('F')


### PR DESCRIPTION
panic!(), unimplemented!() and unreachable!() unconditionally panic
and thus have a return type of "!".

All 3 support a format!() syntax so support that as well.