### PR TITLE
TY: Improve indexing and type resolving for primitive types

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -68,7 +68,7 @@ class ImplLookup(private val project: Project, private val items: StdKnownItems)
             is TyFunction -> {
                 val params = TyTuple(ty.paramTypes)
                 val fnOutputSubst = fnOutputParam?.let { mapOf(it to ty.retType) } ?: emptySubstitution
-                fnTraits.map {
+                findSimpleImpls(ty) + fnTraits.map {
                     val subst = mutableMapOf<TyTypeParameter, Ty>()
                     subst.putAll(fnOutputSubst)
                     it.typeParamSingle?.let { subst.put(it, params) }

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -31,7 +31,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 100
+        override fun getStubVersion(): Int = 101
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -11,6 +11,7 @@ import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
 
 
+// Keep in sync with TyFingerprint-create
 fun inferTypeReferenceType(ref: RsTypeReference): Ty {
     val type = ref.typeElement
     return when (type) {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -30,16 +30,22 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }    //^
     """)
 
-    fun `test trait impl for ()`() = checkByCode("""
-        trait T { fn foo(&self){} }
-                   //X
-        impl T for () {}
-        fn main() {
-            let a = ();
-            a.foo()
-            //^
+    fun `test trait impl for various types`() {
+        for (type in listOf("bool", "char", "&str", "u32", "f32", "f64", "()", "(i32)", "(i16,)", "(u32, u16)",
+            "[u8; 1]", "&[u16]", "*const u8", "*const i8", "fn(u32) -> u8", "!")) {
+            checkByCode("""
+            trait T { fn foo(&self) {} }
+
+            impl T for $type {
+                fn foo(&self) {}
+            }      //X
+
+            fn test(s: $type) {
+                s.foo()
+            }    //^
+        """)
         }
-    """)
+    }
 
     fun `test trait default method`() = checkByCode("""
         trait T { fn foo(&self) {} }


### PR DESCRIPTION
This improves resolving of trait methods for various primitive types.
In particular tuples, arrays, functions and the never type.

All tuples share the same fingerprint "(tuple)".
All arrays and slices share the same fingerprint "[T]".
All functions share the same fingerprint "fn()".
The never type uses the fingerprint "!".