### PR TITLE
Primitive type resolving improvements

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -198,6 +198,11 @@ fun processPathResolveVariants(lookup: ImplLookup, path: RsPath, isCompletion: B
     }
 
     if (qualifier != null) {
+        val primitiveType = TyPrimitive.fromPath(qualifier);
+        if (primitiveType != null) {
+            if (processAssociatedItems(lookup, primitiveType, ns, processor)) return true
+        }
+
         val base = qualifier.reference.resolve() ?: return false
         if (base is RsMod) {
             val s = base.`super`

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt
@@ -10,7 +10,10 @@ import org.rust.lang.core.resolve.ImplLookup
 data class TyPointer(val referenced: Ty, val mutability: Mutability) : Ty {
 
     override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult =
-        if (other is TyPointer) referenced.unifyWith(other.referenced, lookup) else UnifyResult.fail
+        if (other is TyPointer && mutability == other.mutability)
+            referenced.unifyWith(other.referenced, lookup)
+        else
+            UnifyResult.fail
 
     override fun substitute(subst: Substitution): Ty =
         TyPointer(referenced.substitute(subst), mutability)

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
@@ -25,7 +25,6 @@ interface TyPrimitive : Ty {
     companion object {
         fun fromPath(path: RsPath): TyPrimitive? {
             if (path.hasColonColon) return null
-            if (path.parent !is RsBaseType) return null
             val name = path.referenceName
 
             val integerKind = TyInteger.Kind.values().find { it.name == name }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
@@ -11,7 +11,10 @@ import org.rust.lang.core.resolve.ImplLookup
 data class TyReference(val referenced: Ty, val mutability: Mutability) : Ty {
 
     override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult =
-        if (other is TyReference) referenced.unifyWith(other.referenced, lookup) else UnifyResult.fail
+        if (other is TyReference && mutability == other.mutability)
+            referenced.unifyWith(other.referenced, lookup)
+        else
+            UnifyResult.fail
 
     override fun substitute(subst: Substitution): Ty =
         TyReference(referenced.substitute(subst), mutability)

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -116,6 +116,16 @@ class RsHighlightingAnnotatorTest : RsAnnotatorTestBase() {
         }
     """)
 
+    fun testPrimitive() = checkInfo("""
+        fn <info>main</info>() -> <info>bool</info> {
+            let a: <info>u8</info> = 42;
+            let b: <info>f32</info> = 10.0;
+            let c: &<info>str</info> = "example";
+            <info>char</info>::is_lowercase('a');
+            true
+        }
+    """)
+
     fun testDontTouchAstInOtherFiles() = checkDontTouchAstInOtherFiles(
         fileTreeFromText("""
         //- main.rs

--- a/src/test/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspectionTest.kt
@@ -125,12 +125,11 @@ class RsBorrowCheckerInspectionTest : RsInspectionsTestBase(RsBorrowCheckerInspe
         }
     """)
 
-    //TODO: this should not show error here
     fun `test no highlight for mutable for loops`() = checkByText("""
         fn test() {
             let mut xs: Vec<Vec<usize>> = vec![vec![1, 2], vec![3, 4]];
             for test in &mut xs {
-                <error>test</error>.push(0)
+                test.push(0);
             }
         }
     """)

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -199,8 +199,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
     """)
     }
 
-    fun `test inherent impl const ptr 1`() = expect<IllegalStateException> {
-        stubOnlyResolve("""
+    fun `test inherent impl const ptr 1`() = stubOnlyResolve("""
     //- main.rs
         fn main() {
             let p: *const char;
@@ -208,7 +207,6 @@ class RsStdlibResolveTest : RsResolveTestBase() {
             //^ ...libcore/ptr.rs
         }
     """)
-    }
 
     fun `test inherent impl const ptr 2`() = expect<IllegalStateException> {
         stubOnlyResolve("""
@@ -232,8 +230,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
     """)
     }
 
-    fun `test inherent impl mut ptr 1`() = expect<IllegalStateException> {
-        stubOnlyResolve("""
+    fun `test inherent impl mut ptr 1`() = stubOnlyResolve("""
     //- main.rs
         fn main() {
             let p: *mut char;
@@ -241,7 +238,6 @@ class RsStdlibResolveTest : RsResolveTestBase() {
             //^ ...libcore/ptr.rs
         }
     """)
-    }
 
     fun `test inherent impl mut ptr 2`() = expect<IllegalStateException> {
         stubOnlyResolve("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -141,13 +141,11 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                       //^ .../char.rs
     """)
 
-    fun `test inherent impl char 2`() = expect<IllegalStateException> {
-        stubOnlyResolve("""
+    fun `test inherent impl char 2`() = stubOnlyResolve("""
     //- main.rs
         fn main() { char::is_lowercase('Z'); }
                         //^ .../char.rs
     """)
-    }
 
     fun `test inherent impl str 1`() = stubOnlyResolve("""
     //- main.rs
@@ -155,13 +153,11 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                       //^ ...str.rs
     """)
 
-    fun `test inherent impl str 2`() = expect<IllegalStateException> {
-        stubOnlyResolve("""
+    fun `test inherent impl str 2`() = stubOnlyResolve("""
     //- main.rs
         fn main() { str::to_uppercase("Z"); }
                        //^ ...str.rs
     """)
-    }
 
     fun `test inherent impl f32 1`() = stubOnlyResolve("""
     //- main.rs
@@ -169,13 +165,11 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                          //^ .../f32.rs
     """)
 
-    fun `test inherent impl f32 2`() = expect<IllegalStateException> {
-        stubOnlyResolve("""
+    fun `test inherent impl f32 2`() = stubOnlyResolve("""
     //- main.rs
         fn main() { f32::sqrt(0.0f32); }
                        //^ .../f32.rs
     """)
-    }
 
     fun `test inherent impl f32 3`() = expect<IllegalStateException> {
         stubOnlyResolve("""
@@ -191,13 +185,11 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                          //^ .../f64.rs
     """)
 
-    fun `test inherent impl f64 2`() = expect<IllegalStateException> {
-        stubOnlyResolve("""
+    fun `test inherent impl f64 2`() = stubOnlyResolve("""
     //- main.rs
         fn main() { f64::sqrt(0.0f64); }
                        //^ .../f64.rs
     """)
-    }
 
     fun `test inherent impl const ptr 1`() = stubOnlyResolve("""
     //- main.rs

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -558,4 +558,34 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
                //^
         }
     """)
+
+    fun `test impl trait for mutable reference`() = expect<AssertionFailedError> {
+        checkByCode("""
+        struct Foo;
+        trait T { fn foo(self); }
+        impl<'a> T for &'a Foo { fn foo(self) {} }
+        impl<'a> T for &'a mut Foo { fn foo(self) {} }
+                                       //X
+
+        fn main() {
+            let foo = &mut Foo {};
+            foo.foo();
+        }      //^
+    """)
+    }
+
+    fun `test impl trait for mutable pointer`() = expect<AssertionFailedError> {
+        checkByCode("""
+        struct Foo;
+        trait T { fn foo(self); }
+        impl T for *const Foo { fn foo(self) {} }
+        impl T for *mut Foo { fn foo(self) {} }
+                                //X
+
+        fn main() {
+            let foo = &mut Foo {} as *mut Foo;
+            foo.foo();
+        }      //^
+    """)
+    }
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -559,8 +559,7 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }
     """)
 
-    fun `test impl trait for mutable reference`() = expect<AssertionFailedError> {
-        checkByCode("""
+    fun `test impl trait for mutable reference`() = checkByCode("""
         struct Foo;
         trait T { fn foo(self); }
         impl<'a> T for &'a Foo { fn foo(self) {} }
@@ -572,10 +571,8 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
             foo.foo();
         }      //^
     """)
-    }
 
-    fun `test impl trait for mutable pointer`() = expect<AssertionFailedError> {
-        checkByCode("""
+    fun `test impl trait for mutable pointer`() = checkByCode("""
         struct Foo;
         trait T { fn foo(self); }
         impl T for *const Foo { fn foo(self) {} }
@@ -587,5 +584,4 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
             foo.foo();
         }      //^
     """)
-    }
 }


### PR DESCRIPTION
- Distinguish between *const and *mut pointers to help resolving to only 1 candidate
- Distinguish between & and &mut references to help resolving to only 1 candidate
- Resolve inherent implementations on primitives for "primitive::method()" syntax
CC #371
Fixes #1667