### PR TITLE
GRAM: optimize macro parsing

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1030,7 +1030,7 @@ MacroCallNoSemicolons ::= MacroHead {
   hooks = [ leftBinder = "DOC_COMMENT_BINDER" ]
 }
 
-private MacroHead ::= AttrsAndVis (SpecialMacro | identifier '!' identifier? MacroArgument)
+private MacroHead ::= AttrsAndVis &(identifier '!') (SpecialMacro | identifier '!' identifier? MacroArgument)
 
 MacroArgument ::= <<any_braces TT>>
 TT ::= (<<any_braces TT>> | <<unpairedToken>>)*


### PR DESCRIPTION
A tiny parser optimization: special macros do a ton of matching by text, but we can try to match on tokens first.