### PR TITLE
TY: advanced type inference & unification

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/Ty.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/Ty.kt
@@ -51,6 +51,11 @@ private fun render(ty: Ty, level: Int): String {
             val name = ty.item.name ?: return anonymous
             name + if (ty.typeArguments.isEmpty()) "" else ty.typeArguments.map(r).joinToString(", ", "<", ">")
         }
+        is TyInfer -> when (ty) {
+            is TyInfer.TyVar -> "_"
+            is TyInfer.IntVar -> "{integer}"
+            is TyInfer.FloatVar -> "{float}"
+        }
         else -> error("unreachable")
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -6,13 +6,13 @@
 package org.rust.lang.core.resolve
 
 import com.intellij.openapi.project.Project
-import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.indexes.RsImplIndex
 import org.rust.lang.core.resolve.indexes.RsLangItemIndex
 import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.types.infer.substitute
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.ty.Mutability.IMMUTABLE
 import org.rust.lang.core.types.ty.Mutability.MUTABLE
@@ -181,7 +181,7 @@ class ImplLookup(private val project: Project, private val items: StdKnownItems)
         return result
     }
 
-    private fun findImplOfTrait(ty: Ty, trait: RsTraitItem): BoundElement<RsTraitOrImpl>? =
+    fun findImplOfTrait(ty: Ty, trait: RsTraitItem): BoundElement<RsTraitOrImpl>? =
         findImplsAndTraits(ty).find { it.element.implementedTrait?.element == trait }
 
     private fun findDerefTarget(ty: Ty): Ty? {
@@ -246,6 +246,10 @@ class ImplLookup(private val project: Project, private val items: StdKnownItems)
     fun asTyFunction(ty: Ty): TyFunction? {
         return ty as? TyFunction ?:
             (findImplsAndTraits(ty).mapNotNull { it.downcast<RsTraitItem>()?.asFunctionType }.firstOrNull())
+    }
+
+    fun asTyFunction(ref: BoundElement<RsTraitItem>): TyFunction? {
+        return ref.asFunctionType
     }
 
     private val BoundElement<RsTraitItem>.asFunctionType: TyFunction? get() {

--- a/src/main/kotlin/org/rust/lang/core/resolve/StdKnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/StdKnownItems.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.resolve
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.infer.substitute
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.ty.getTypeParameter

--- a/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
@@ -8,8 +8,10 @@ package org.rust.lang.core.types
 import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveResult
 import org.rust.lang.core.psi.ext.RsCompositeElement
+import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.ty.Substitution
 import org.rust.lang.core.types.ty.emptySubstitution
+import org.rust.lang.core.types.ty.foldValues
 import org.rust.lang.core.types.ty.substituteInValues
 
 /* Represents a potentially generic Psi Element, like
@@ -28,5 +30,8 @@ data class BoundElement<out E : RsCompositeElement>(
 
     fun substitute(subst: Substitution) =
         BoundElement(element, this.subst.substituteInValues(subst))
+
+    fun foldWith(folder: TypeFolder) =
+        BoundElement(element, this.subst.foldValues(folder))
 }
 

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -13,7 +13,10 @@ import com.intellij.psi.util.PsiModificationTracker
 import org.rust.ide.utils.recursionGuard
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
-import org.rust.lang.core.types.infer.*
+import org.rust.lang.core.types.infer.RsInferenceResult
+import org.rust.lang.core.types.infer.inferOutOfFnExpressionType
+import org.rust.lang.core.types.infer.inferTypeReferenceType
+import org.rust.lang.core.types.infer.inferTypesIn
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyReference
 import org.rust.lang.core.types.ty.TyUnknown
@@ -28,16 +31,16 @@ val RsTypeElement.lifetimeElidable: Boolean get() {
     return typeOwner !is RsFieldDecl && typeOwner !is RsTupleFieldDecl && typeOwner !is RsTypeAlias
 }
 
-val RsFunction.inferenceContext: RsInferenceContext
-    get() = CachedValuesManager.getCachedValue(this, CachedValueProvider {
+val RsFunction.inference: RsInferenceResult
+    get() = CachedValuesManager.getCachedValue(this, {
         CachedValueProvider.Result.create(inferTypesIn(this), PsiModificationTracker.MODIFICATION_COUNT)
     })
 
 val RsPatBinding.type: Ty
-    get() = inferenceContext?.getBindingType(this) ?: TyUnknown
+    get() = inference?.getBindingType(this) ?: TyUnknown
 
 val RsExpr.type: Ty
-    get() = inferenceContext?.getExprType(this) ?: inferOutOfFnExpressionType(this)
+    get() = inference?.getExprType(this) ?: inferOutOfFnExpressionType(this)
 
 val RsExpr.declaration: RsCompositeElement?
     get() = when (this) {
@@ -71,5 +74,5 @@ val RsExpr.isMutable: Boolean get() {
     }
 }
 
-private val PsiElement.inferenceContext: RsInferenceContext?
-    get() = (parentOfType<RsItemElement>() as? RsFunction)?.inferenceContext
+private val PsiElement.inference: RsInferenceResult?
+    get() = (parentOfType<RsItemElement>() as? RsFunction)?.inference

--- a/src/main/kotlin/org/rust/lang/core/types/TraitRef.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/TraitRef.kt
@@ -1,0 +1,30 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.types
+
+import org.rust.lang.core.psi.RsTraitItem
+import org.rust.lang.core.psi.ext.typeParameters
+import org.rust.lang.core.types.infer.TypeFoldable
+import org.rust.lang.core.types.infer.TypeFolder
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyUnknown
+import org.rust.lang.core.types.ty.get
+
+/**
+ * A complete reference to a trait. These take numerous guises in syntax,
+ * but perhaps the most recognizable form is in a where clause:
+ *     `T : Foo<U>`
+ */
+data class TraitRef(val selfTy: Ty, val trait: BoundElement<RsTraitItem>): TypeFoldable<TraitRef> {
+    override fun superFoldWith(folder: TypeFolder): TraitRef =
+        TraitRef(selfTy.foldWith(folder), trait.foldWith(folder))
+
+    override fun toString(): String {
+        val (item, subst) = trait
+        val tyArgs = item.typeParameters.map { subst.get(it) ?: TyUnknown }
+        return "$selfTy: ${trait.element.name}" + (if (tyArgs.isEmpty()) "" else tyArgs.joinToString(", ", "<", ">"))
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Fold.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Fold.kt
@@ -1,0 +1,83 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.types.infer
+
+import org.rust.lang.core.types.ty.Substitution
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyInfer
+import org.rust.lang.core.types.ty.TyTypeParameter
+
+typealias TypeFolder = (Ty) -> Ty
+
+interface TypeFoldable<out Self> {
+    /**
+     * Fold `this` type with the folder.
+     *
+     * This works for:
+     * ```
+     *     A.foldWith { C } == C
+     *     A<B>.foldWith { C } == C
+     * ```
+     *
+     * `a.foldWith(folder)` is equivalent to `folder(a)` in cases where `a` is `Ty`.
+     * In other cases the call delegates to [superFoldWith]
+     *
+     * The folding basically is not deep. If you want to fold type deeply, you should write a folder
+     * somehow like this:
+     * ```kotlin
+     * // We initially have `ty = A<B<C>, B<C>>` and want replace C to D to get `A<B<D>, B<D>>`
+     * ty.foldWith(object : TypeFolder {
+     *     override fun invoke(ty: Ty): Ty =
+     *         if (it == C) D else it.superFoldWith(this)
+     * })
+     * ```
+     */
+    fun foldWith(folder: TypeFolder): Self = superFoldWith(folder)
+
+    /**
+     * Fold inner types (not this type) with the folder.
+     * `A<A<B>>.foldWith { C } == A<C>`
+     * This method should be used only by a folder implementations internally
+     */
+    fun superFoldWith(folder: TypeFolder): Self
+}
+
+/** Deeply replace any [TyInfer] with the function [folder] */
+fun <T> TypeFoldable<T>.foldTyInferWith(folder: (TyInfer) -> Ty): T =
+    foldWith(object : TypeFolder {
+        override fun invoke(ty: Ty): Ty =
+            (if (ty is TyInfer) folder(ty) else ty).superFoldWith(this)
+    })
+
+/** Deeply replace any [TyTypeParameter] with the function [folder] */
+fun <T> TypeFoldable<T>.foldTyTypeParameterWith(folder: (TyTypeParameter) -> Ty): T =
+    foldWith(object : TypeFolder {
+        override fun invoke(ty: Ty): Ty =
+            if (ty is TyTypeParameter) folder(ty) else ty.superFoldWith(this)
+    })
+
+/**
+ * Deeply replace any [TyTypeParameter] by [subst] mapping.
+ * It differs from [substitute] in handling of TyTypeParameter where it can't be substituted
+ * TODO remove it
+ */
+fun <T> TypeFoldable<T>.foldWithSubst(subst: Substitution): T =
+    foldWith(object : TypeFolder {
+        override fun invoke(ty: Ty): Ty =
+            subst[ty] ?: ty.superFoldWith(this)
+    })
+
+/**
+ * Deeply replace any [TyTypeParameter] by [subst] mapping.
+ * This is a plain old `Ty.substitute()`. It will be completely replaced with folding alternatives soon
+ * It differs from [foldWithSubst] in handling of TyTypeParameter where it can't be substituted
+ * TODO remove it
+ */
+fun <T> TypeFoldable<T>.substitute(subst: Substitution): T =
+    foldWith(object : TypeFolder {
+        override fun invoke(ty: Ty): Ty =
+            if (ty is TyTypeParameter) ty.substituteOld(subst) else ty.superFoldWith(this)
+    })

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt
@@ -1,0 +1,184 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.types.infer
+
+import org.rust.lang.core.psi.RsTraitItem
+import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.types.TraitRef
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyInfer
+import org.rust.lang.core.types.ty.TyTypeParameter
+
+sealed class Predicate: TypeFoldable<Predicate> {
+    /** where T : Bar<A,B,C> */
+    data class Trait(val trait: TraitRef) : Predicate() {
+        override fun superFoldWith(folder: TypeFolder): Trait =
+            Trait(trait.foldWith(folder))
+    }
+
+    /** where <T as TraitRef>::Name == X */
+    data class Projection(
+        val selfTy: Ty,
+        val trait: RsTraitItem,
+        val target: RsTypeAlias,
+        val ty: Ty
+    ): Predicate() {
+        override fun superFoldWith(folder: TypeFolder): Projection =
+            Projection(selfTy.foldWith(folder), trait, target, ty.foldWith(folder))
+
+        override fun toString(): String =
+            "<$selfTy as ${trait.name}>::${target.name} == $ty"
+    }
+
+    /** where `T1 == T2` */
+    data class Equate(val ty1: Ty, val ty2: Ty) : Predicate() {
+        override fun superFoldWith(folder: TypeFolder): Predicate =
+            Equate(ty1.foldWith(folder), ty2.foldWith(folder))
+
+        override fun toString(): String =
+            "$ty1 == $ty2"
+    }
+}
+
+data class Obligation(val recursionDepth: Int, var predicate: Predicate): TypeFoldable<Obligation> {
+    constructor(predicate: Predicate) : this(0, predicate)
+
+    override fun superFoldWith(folder: TypeFolder): Obligation =
+        copy(predicate = predicate.foldWith(folder))
+}
+
+data class PendingPredicateObligation(val obligation: Obligation, val stalledOn: MutableList<Ty>)
+
+class ObligationForest {
+    enum class NodeState {
+        /** Obligations for which selection had not yet returned a non-ambiguous result */
+        Pending,
+
+        /** This obligation was selected successfully, but may or may not have subobligations */
+        Success,
+
+        /** This obligation was resolved to an error. Error nodes are removed from the vector by the compression step */
+        Error,
+    }
+
+    class Node(val obligation: PendingPredicateObligation) {
+        var state: NodeState = NodeState.Pending
+    }
+
+    private val nodes: MutableList<Node> = mutableListOf()
+
+    val pendingObligations: Sequence<PendingPredicateObligation> =
+        nodes.asSequence().filter { it.state == NodeState.Pending }.map { it.obligation }
+
+    @Suppress("UNUSED_PARAMETER") // TODO use `parent`
+    fun registerObligationAt(obligation: PendingPredicateObligation, parent: Node?) {
+        nodes.add(Node(obligation))
+    }
+
+    fun processObligations(processor: (PendingPredicateObligation) -> ProcessPredicateResult): Boolean {
+        var stalled = true
+        for (index in 0 until nodes.size) {
+            val node = nodes[index]
+            if (node.state != NodeState.Pending) continue
+
+            val result = processor(node.obligation)
+            when (result) {
+                is ProcessPredicateResult.NoChanges -> {}
+                is ProcessPredicateResult.Ok -> {
+                    stalled = false
+                    node.state = NodeState.Success
+                    for (child in result.children) {
+                        registerObligationAt(child, node)
+                    }
+                }
+                is ProcessPredicateResult.Err -> {
+                    stalled = false
+                    node.state = NodeState.Error
+                }
+            }
+        }
+
+        if (!stalled) {
+            nodes.removeIf { it.state != NodeState.Pending }
+        }
+
+        return stalled
+    }
+}
+
+class FulfillmentContext(val ctx: RsInferenceContext, val lookup: ImplLookup) {
+
+    private val obligations: ObligationForest = ObligationForest()
+
+    val pendingObligations: Sequence<PendingPredicateObligation> =
+        obligations.pendingObligations
+
+    fun registerPredicateObligation(obligation: Obligation) {
+        obligations.registerObligationAt(
+            PendingPredicateObligation(ctx.resolveTypeVarsIfPossible(obligation), mutableListOf()),
+            null
+        )
+    }
+
+    fun selectWherePossible() {
+        while (!obligations.processObligations(this::processPredicate)) {}
+    }
+
+    private fun processPredicate(pendingObligation: PendingPredicateObligation): ProcessPredicateResult {
+        val (obligation, stalledOn) = pendingObligation
+        if (!stalledOn.isEmpty()) {
+            val nothingChanged = stalledOn.all {
+                val resolvedTy = ctx.shallowResolve(it)
+                resolvedTy == it
+            }
+            if (nothingChanged) return ProcessPredicateResult.NoChanges
+            stalledOn.clear()
+        }
+
+        obligation.predicate = ctx.resolveTypeVarsIfPossible(obligation.predicate)
+        val predicate = obligation.predicate
+
+        when (predicate) {
+            is Predicate.Trait -> {
+                val selfTy = predicate.trait.selfTy
+                if (selfTy is TyInfer) return ProcessPredicateResult.NoChanges
+                val (trait, subst) = predicate.trait.trait
+                val impl = lookup.findImplOfTrait(selfTy, trait) ?: return ProcessPredicateResult.Err
+                return ProcessPredicateResult.Ok(subst.mapNotNull { (k, ty1) ->
+                    impl.subst[k]?.let { ty2 ->
+                        PendingPredicateObligation(Obligation(
+                            obligation.recursionDepth + 1,
+                            Predicate.Equate(ty1, ty2)
+                        ), mutableListOf())
+                    }
+                })
+            }
+            is Predicate.Equate -> {
+                ctx.combineTypes(predicate.ty1, predicate.ty2)
+                return ProcessPredicateResult.Ok()
+            }
+            is Predicate.Projection -> {
+                val selfTy = predicate.selfTy
+                if (selfTy is TyInfer) return ProcessPredicateResult.NoChanges
+                val impl = lookup.findImplOfTrait(selfTy, predicate.trait) ?: return ProcessPredicateResult.Err
+                val theTy = impl.subst[TyTypeParameter.associated(predicate.target)] ?: return ProcessPredicateResult.Err
+                return ProcessPredicateResult.Ok(PendingPredicateObligation(Obligation(
+                    obligation.recursionDepth + 1,
+                    Predicate.Equate(theTy, predicate.ty)
+                ), mutableListOf()))
+            }
+        }
+    }
+}
+
+sealed class ProcessPredicateResult {
+    object NoChanges: ProcessPredicateResult()
+    data class Ok(val children: List<PendingPredicateObligation>): ProcessPredicateResult() {
+        constructor(vararg children: PendingPredicateObligation): this(listOf(*children))
+    }
+    object Err: ProcessPredicateResult()
+}

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -13,27 +13,57 @@ import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.StdKnownItems
 import org.rust.lang.core.resolve.ref.resolveFieldLookupReferenceWithReceiverType
 import org.rust.lang.core.resolve.ref.resolveMethodCallReferenceWithReceiverType
+import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.types.TraitRef
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.ty.Mutability.IMMUTABLE
 import org.rust.lang.core.types.ty.Mutability.MUTABLE
 import org.rust.lang.core.types.type
 import org.rust.utils.forEachChild
 
-fun inferTypesIn(fn: RsFunction): RsInferenceContext =
-    RsInferenceContext().apply { preventRecursion { infer(fn) } }
+fun inferTypesIn(fn: RsFunction): RsInferenceResult =
+    RsInferenceContext().run { preventRecursion { infer(fn) } }
+
+class RsInferenceResult(
+    private val bindings: MutableMap<RsPatBinding, Ty>,
+    private val exprTypes: MutableMap<RsExpr, Ty>
+) {
+    fun getExprType(expr: RsExpr): Ty =
+        exprTypes[expr] ?: TyUnknown
+
+    fun getBindingType(binding: RsPatBinding): Ty =
+        bindings[binding] ?: TyUnknown
+
+    override fun toString(): String =
+        "RsInferenceResult(bindings=$bindings, exprTypes=$exprTypes)"
+}
 
 class RsInferenceContext {
     private val bindings: MutableMap<RsPatBinding, Ty> = HashMap()
     private val exprTypes: MutableMap<RsExpr, Ty> = HashMap()
 
-    fun infer(fn: RsFunction) {
+    private val intUnificationTable: UnificationTable<TyInfer.IntVar, TyInteger.Kind> =
+        UnificationTable()
+    private val floatUnificationTable: UnificationTable<TyInfer.FloatVar, TyFloat.Kind> =
+        UnificationTable()
+    private val varUnificationTable: UnificationTable<TyInfer.TyVar, Ty> =
+        UnificationTable()
+
+    fun infer(fn: RsFunction): RsInferenceResult {
         extractParameterBindings(fn)
 
         val block = fn.block
         if (block != null) {
             val items = StdKnownItems.relativeTo(fn)
-            RsFnInferenceContext(this, ImplLookup(fn.project, items), items).inferBlockType(block)
+            val fctx = RsFnInferenceContext(this, ImplLookup(fn.project, items), items)
+            fctx.inferBlockType(block)
+
+            fctx.selectObligationsWherePossible()
+            exprTypes.replaceAll { _, ty -> fullyResolve(ty) }
+            bindings.replaceAll { _, ty -> fullyResolve(ty) }
         }
+
+        return RsInferenceResult(bindings, exprTypes)
     }
 
     private fun extractParameterBindings(fn: RsFunction) {
@@ -62,6 +92,103 @@ class RsInferenceContext {
         if (pattern != null) bindings += collectBindings(pattern, baseType)
     }
 
+    fun combineTypes(ty1: Ty, ty2: Ty) {
+        val ty1 = shallowResolve(ty1)
+        val ty2 = shallowResolve(ty2)
+        when {
+            ty1 is TyInfer.TyVar -> combineTyVar(ty1, ty2)
+            ty2 is TyInfer.TyVar -> combineTyVar(ty2, ty1)
+            else -> when {
+                ty1 is TyInfer -> combineIntOrFloatVar(ty1, ty2)
+                ty2 is TyInfer -> combineIntOrFloatVar(ty2, ty1)
+                else -> combineTypesNoVars(ty1, ty2)
+            }
+        }
+    }
+
+    private fun combineTyVar(inner1: TyInfer.TyVar, ty2: Ty) {
+        when (ty2) {
+            is TyInfer.TyVar -> varUnificationTable.unifyVarVar(inner1, ty2)
+            else -> varUnificationTable.unifyVarValue(inner1, ty2)
+        }
+    }
+
+    private fun combineIntOrFloatVar(ty1: TyInfer, ty2: Ty) {
+        when (ty1) {
+            is TyInfer.IntVar -> when (ty2) {
+                is TyInfer.IntVar -> intUnificationTable.unifyVarVar(ty1, ty2)
+                is TyInteger -> intUnificationTable.unifyVarValue(ty1, ty2.kind)
+            }
+            is TyInfer.FloatVar -> when (ty2) {
+                is TyInfer.FloatVar -> floatUnificationTable.unifyVarVar(ty1, ty2)
+                is TyFloat -> floatUnificationTable.unifyVarValue(ty1, ty2.kind)
+            }
+            is TyInfer.TyVar -> error("unreachable")
+        }
+    }
+
+    private fun combineTypesNoVars(ty1: Ty, ty2: Ty) {
+        when {
+            ty1 is TyPrimitive && ty2 is TyPrimitive && ty1 == ty2 -> {}
+            ty1 is TyTypeParameter && ty2 is TyTypeParameter && ty1 == ty2 -> {}
+            ty1 is TyReference && ty2 is TyReference && ty1.mutability == ty2.mutability -> {
+                combineTypes(ty1.referenced, ty2.referenced)
+            }
+            ty1 is TyPointer && ty2 is TyPointer && ty1.mutability == ty2.mutability -> {
+                combineTypes(ty1.referenced, ty2.referenced)
+            }
+            ty1 is TyArray && ty2 is TyArray && ty1.size == ty2.size -> combineTypes(ty1.base, ty2.base)
+            ty1 is TySlice && ty2 is TySlice -> combineTypes(ty1.elementType, ty2.elementType)
+            ty1 is TyTuple && ty2 is TyTuple -> ty1.types.zip(ty2.types).forEach { (t1, t2) -> combineTypes(t1, t2) }
+            ty1 is TyFunction && ty2 is TyFunction -> {
+                ty1.paramTypes.zip(ty2.paramTypes).forEach { (t1, t2) -> combineTypes(t1, t2) }
+                combineTypes(ty1.retType, ty2.retType)
+            }
+            ty1 is TyStructOrEnumBase && ty2 is TyStructOrEnumBase && ty1.item == ty2.item -> {
+                zipValuesForEach(ty1.typeParameterValues, ty2.typeParameterValues) { v1, v2 ->
+                    combineTypes(v1, v2)
+                }
+            }
+            ty1 is TyTraitObject && ty2 is TyTraitObject && ty1.trait == ty2.trait -> {}
+            else -> {} // TODO report type mismatch
+        }
+    }
+
+    fun shallowResolve(ty: Ty): Ty {
+        if (ty !is TyInfer) {
+            return ty
+        }
+
+        return when (ty) {
+            is TyInfer.IntVar -> intUnificationTable.findValue(ty)?.let(::TyInteger) ?: ty
+            is TyInfer.FloatVar -> floatUnificationTable.findValue(ty)?.let(::TyFloat) ?: ty
+            is TyInfer.TyVar -> varUnificationTable.findValue(ty)?.let(this::shallowResolve) ?: ty
+        }
+    }
+
+    fun <T: TypeFoldable<T>> resolveTypeVarsIfPossible(ty: T): T {
+        return ty.foldTyInferWith(this::shallowResolve)
+    }
+
+    private fun fullyResolve(ty: Ty): Ty {
+        return ty.foldTyInferWith(this::fullyResolve0)
+    }
+
+    private fun fullyResolve0(ty: Ty): Ty {
+        if (ty !is TyInfer) {
+            return ty
+        }
+        return when (ty) {
+            is TyInfer.IntVar -> TyInteger(intUnificationTable.findValue(ty) ?: TyInteger.DEFAULT_KIND)
+            is TyInfer.FloatVar -> TyFloat(floatUnificationTable.findValue(ty) ?: TyFloat.DEFAULT_KIND)
+            is TyInfer.TyVar -> varUnificationTable.findValue(ty)?.let(this::fullyResolve0) ?: ty.origin
+        }
+    }
+
+    fun typeVarForParam(ty: TyTypeParameter): Ty {
+        return TyInfer.TyVar(ty)
+    }
+
     override fun toString(): String {
         return "RsInferenceContext(bindings=$bindings, exprTypes=$exprTypes)"
     }
@@ -72,7 +199,18 @@ private class RsFnInferenceContext(
     private val lookup: ImplLookup,
     private val items: StdKnownItems
 ) {
+    private val fulfill: FulfillmentContext = FulfillmentContext(ctx, lookup)
     private val RsStructLiteralField.type: Ty get() = resolveToDeclaration?.typeReference?.type ?: TyUnknown
+
+    private fun resolveTypeVarsWithObligations(ty: Ty): Ty {
+        val ty = ctx.resolveTypeVarsIfPossible(ty)
+        selectObligationsWherePossible()
+        return ctx.resolveTypeVarsIfPossible(ty)
+    }
+
+    fun selectObligationsWherePossible() {
+        fulfill.selectWherePossible()
+    }
 
     fun inferBlockType(block: RsBlock): Ty =
         block.inferType()
@@ -88,8 +226,11 @@ private class RsFnInferenceContext(
     private fun processStatement(psi: RsStmt) {
         when (psi) {
             is RsLetDecl -> {
-                val explicitTy = psi.typeReference?.type
-                val inferredTy = psi.expr?.inferType(explicitTy) ?: TyUnknown
+                val explicitTy = psi.typeReference?.type?.foldTyTypeParameterWith(ctx::typeVarForParam)
+                val inferredTy = explicitTy
+                    ?.let { psi.expr?.inferTypeCoercableTo(it) }
+                    ?: psi.expr?.inferType()
+                    ?: TyUnknown
                 ctx.extractBindings(psi.pat, explicitTy ?: inferredTy)
             }
             is RsExprStmt -> psi.expr.inferType()
@@ -133,36 +274,42 @@ private class RsFnInferenceContext(
         return ty
     }
 
+    private fun RsExpr.inferTypeCoercableTo(expected: Ty): Ty {
+        val inferred = inferType(expected)
+        coerce(inferred, expected)
+        return inferred
+    }
+
+    private fun coerce(inferred: Ty, expected: Ty) {
+        val inferred = resolveTypeVarsWithObligations(inferred)
+        val expected = resolveTypeVarsWithObligations(expected)
+        when {
+            inferred is TyReference && inferred.referenced is TyArray &&
+                expected is TyReference && expected.referenced is TySlice -> {
+                ctx.combineTypes(inferred.referenced.base, expected.referenced.elementType)
+            }
+            // TODO trait object unsizing
+            else -> ctx.combineTypes(inferred, expected)
+        }
+    }
+
     fun inferLitExprType(expr: RsLitExpr, expected: Ty?): Ty {
         return when (expr.kind) {
             is RsLiteralKind.Boolean -> TyBool
             is RsLiteralKind.Char -> TyChar
             is RsLiteralKind.String -> TyReference(TyStr, IMMUTABLE)
             is RsLiteralKind.Integer -> {
-                val ty = TyInteger.fromLiteral(expr.integerLiteral!!)
-                if (ty.isKindWeak) {
-                    // rustc treat unsuffixed integer as `u8` if it should be coerced to `char`,
-                    // e.g. for code `let a: char = 5;` the error will be shown: 'expected char, found u8'
-                    //
-                    // rustc treat unsuffixed integer as `usize` if it should be coerced to `*T` or fn(),
-                    // e.g. for code `let a: *mut u8 = 5;` the error will be shown: 'expected *-ptr, found usize'
-                    when (expected) {
-                        is TyInteger -> expected
-                        is TyChar -> TyInteger(TyInteger.Kind.u8)
-                        is TyPointer, is TyFunction -> TyInteger(TyInteger.Kind.usize)
-                        else -> ty
-                    }
-                } else {
-                    ty
+                val ty = TyInteger.fromSuffixedLiteral(expr.integerLiteral!!)
+                ty ?: when (expected) {
+                    is TyInteger -> expected
+                    is TyChar -> TyInteger(TyInteger.Kind.u8)
+                    is TyPointer, is TyFunction -> TyInteger(TyInteger.Kind.usize)
+                    else -> TyInfer.IntVar()
                 }
             }
             is RsLiteralKind.Float -> {
-                val ty = TyFloat.fromLiteral(expr.floatLiteral!!)
-                if (ty.isKindWeak) {
-                    expected?.takeIf { it is TyFloat } ?: ty
-                } else {
-                    ty
-                }
+                val ty = TyFloat.fromSuffixedLiteral(expr.floatLiteral!!)
+                ty ?: (expected?.takeIf { it is TyFloat } ?: TyInfer.FloatVar())
             }
             null -> TyUnknown
         }
@@ -180,12 +327,64 @@ private class RsFnInferenceContext(
             else -> return TyUnknown
         }
         val tupleFields = (element as? RsFieldsOwner)?.tupleFields
+
+        // This BS is a very temporary (I hope)
+        val typeParameters = ((element as? RsGenericDeclaration)?.let(this::instantiateBounds) ?: emptyMap()) +
+            (element.takeIf { it is RsFunction || it is RsEnumVariant}
+                ?.parentOfType<RsGenericDeclaration>()
+                ?.let(this::instantiateBounds)
+                ?: emptyMap())
+
+        subst.forEach { (k, v1) ->
+            typeParameters[k]?.let { v2 ->
+                if (k != v1 && v1 !is TyTypeParameter && v1 !is TyUnknown) {
+                    ctx.combineTypes(v2, v1)
+                }
+            }
+        }
+
         return if (tupleFields != null) {
             // Treat tuple constructor as a function
             TyFunction(tupleFields.tupleFieldDeclList.map { it.typeReference.type }, type)
         } else {
             type
-        }.substitute(subst)
+        }.foldWithSubst(typeParameters).foldWith(this::normalizeAssociatedTypesIn)
+    }
+
+    private fun instantiateBounds(element: RsGenericDeclaration): Map<TyTypeParameter, Ty> =
+        instantiateBounds(element, emptySubstitution, null)
+
+    private fun instantiateBounds(element: RsGenericDeclaration, subst: Substitution, receiver: Ty?): Map<TyTypeParameter, Ty> {
+        val elementBounds = element.bounds
+        var map = subst + elementBounds.keys.associate { it to ctx.typeVarForParam(it) }
+        if (receiver != null) {
+            map = map.substituteInValues(mapOf(TyTypeParameter.self() to receiver)) +
+                mapOf(TyTypeParameter.self() to receiver)
+        }
+        for ((ty, bounds) in elementBounds) {
+            bounds.asSequence()
+                .map { TraitRef(ty, it) }
+                .map { it.foldTyTypeParameterWith { map[it] ?: it } }
+                .map(this::normalizeAssociatedTypesIn)
+                .forEach { fulfill.registerPredicateObligation(Obligation(Predicate.Trait(it))) }
+        }
+        return map
+    }
+
+    private fun <T: TypeFoldable<T>> normalizeAssociatedTypesIn(ty: T): T {
+        return ty.foldTyTypeParameterWith {
+            val p = it.parameter
+            if (p is TyTypeParameter.AssociatedType) {
+                val selfTy = p.type
+                val tyVar = ctx.typeVarForParam(it)
+                fulfill.registerPredicateObligation(
+                    Obligation(0, Predicate.Projection(selfTy, p.trait, p.target, tyVar))
+                )
+                tyVar
+            } else {
+                it
+            }
+        }
     }
 
     private fun inferStructLiteralType(expr: RsStructLiteral, expected: Ty?): Ty {
@@ -205,7 +404,7 @@ private class RsFnInferenceContext(
 
     private fun inferExprList(exprs: List<RsExpr>, expected: List<Ty>?): List<Ty> {
         val extended = expected.orEmpty().asSequence().infiniteWithTyUnknown()
-        return exprs.asSequence().zip(extended).map { (expr, ty) -> expr.inferType(ty) }.toList()
+        return exprs.asSequence().zip(extended).map { (expr, ty) -> expr.inferTypeCoercableTo(ty) }.toList()
     }
 
     private fun inferCastExprType(expr: RsCastExpr): Ty {
@@ -214,31 +413,71 @@ private class RsFnInferenceContext(
     }
 
     private fun inferCallExprType(expr: RsCallExpr): Ty {
-        val ty = expr.expr.inferType()
+        val ty = resolveTypeVarsWithObligations(expr.expr.inferType()) // or error
         val argExprs = expr.valueArgumentList.exprList
         // `struct S; S();`
         if (ty is TyStructOrEnumBase && argExprs.isEmpty()) return ty
 
         val calleeType = lookup.asTyFunction(ty) ?: unknownTyFunction(argExprs.size)
-        return calleeType.retType.substitute(mapTypeParameters(calleeType.paramTypes, argExprs))
+        inferArgumentTypes(calleeType.paramTypes, argExprs)
+        return calleeType.retType
     }
 
     private fun inferMethodCallExprType(receiver: Ty, methodCall: RsMethodCall): Ty {
+        val receiver = resolveTypeVarsWithObligations(receiver)
         val argExprs = methodCall.valueArgumentList.exprList
         val boundElement = resolveMethodCallReferenceWithReceiverType(lookup, receiver, methodCall)
             .firstOrNull()?.downcast<RsFunction>()
+        val typeParameters = ((boundElement?.element as? RsGenericDeclaration)
+            ?.let { instantiateBounds(it, boundElement?.subst ?: emptyMap(), receiver) }
+            ?: emptyMap())
+
+        boundElement?.subst?.forEach { (k, v1) ->
+            typeParameters[k]?.let { v2 ->
+                if (k != v1 && v1 !is TyTypeParameter && v1 !is TyUnknown) {
+                    ctx.combineTypes(v2, v1)
+                }
+            }
+        }
+
         val methodType = (boundElement?.element?.typeOfValue ?: unknownTyFunction(argExprs.size + 1))
-            .substitute(boundElement?.subst ?: emptySubstitution)
-            .substitute(mapOf(TyTypeParameter.self() to receiver))
+            .foldWithSubst(typeParameters)
+            .foldWith(this::normalizeAssociatedTypesIn) as TyFunction
         // drop first element of paramTypes because it's `self` param
         // and it doesn't have value in `methodCall.valueArgumentList.exprList`
-        val inferredSubst = mapTypeParameters(methodType.paramTypes.drop(1), argExprs)
+        inferArgumentTypes(methodType.paramTypes.drop(1), argExprs)
 
-        return methodType.retType.substitute(inferredSubst)
+        return methodType.retType
     }
 
     private fun unknownTyFunction(arity: Int): TyFunction =
         TyFunction(generateSequence { TyUnknown }.take(arity).toList(), TyUnknown)
+
+    private fun inferArgumentTypes(argDefs: List<Ty>, argExprs: List<RsExpr>) {
+        // We do this just like rustc, and comments copied from rustc too
+
+        // We do this in a pretty awful way: first we typecheck any arguments
+        // that are not closures, then we typecheck the closures. This is so
+        // that we have more information about the types of arguments when we
+        // typecheck the functions.
+        for (checkLambdas in booleanArrayOf(false, true)) {
+            // More awful hacks: before we check argument types, try to do
+            // an "opportunistic" vtable resolution of any trait bounds on
+            // the call. This helps coercions.
+            if (checkLambdas) {
+                selectObligationsWherePossible()
+            }
+
+            // extending argument definitions to be sure that type inference launched for each arg expr
+            val argDefsExt = argDefs.asSequence().infiniteWithTyUnknown()
+            for ((type, expr) in argDefsExt.zip(argExprs.asSequence().map(::unwrapParenExprs))) {
+                val isLambda = expr is RsLambdaExpr
+                if (isLambda != checkLambdas) continue
+
+                expr.inferTypeCoercableTo(type)
+            }
+        }
+    }
 
     private fun inferFieldExprType(receiver: Ty, fieldLookup: RsFieldLookup): Ty {
         val boundField = resolveFieldLookupReferenceWithReceiverType(lookup, receiver, fieldLookup).firstOrNull()
@@ -378,7 +617,7 @@ private class RsFnInferenceContext(
             }
             is AssignmentOp -> {
                 val lhsType = expr.left.inferType()
-                expr.right?.inferType(lhsType)
+                expr.right?.inferTypeCoercableTo(lhsType)
                 TyUnit
             }
         }
@@ -476,7 +715,9 @@ private class RsFnInferenceContext(
 
     private fun inferLambdaExprType(expr: RsLambdaExpr, expected: Ty?): Ty {
         val params = expr.valueParameterList.valueParameterList
-        val expectedFnTy = expected?.let(lookup::asTyFunction) ?: unknownTyFunction(params.size)
+        val expectedFnTy = expected
+            ?.let(this::deduceLambdaType)
+            ?: unknownTyFunction(params.size)
         val extendedArgs = expectedFnTy.paramTypes.asSequence().infiniteWithTyUnknown()
         val paramTypes = extendedArgs.zip(params.asSequence()).map { (expectedArg, actualArg) ->
             val paramTy = actualArg.typeReference?.type ?: expectedArg
@@ -488,6 +729,26 @@ private class RsFnInferenceContext(
         return TyFunction(paramTypes, inferredRetTy ?: expectedFnTy.retType)
     }
 
+    private fun deduceLambdaType(expected: Ty): TyFunction? {
+        return when (expected) {
+            is TyInfer.TyVar -> {
+                fulfill.pendingObligations
+                    .mapNotNull { it.obligation.predicate as? Predicate.Trait }
+                    .find { it.trait.selfTy == expected }
+                    ?.let { lookup.asTyFunction(it.trait.trait) }
+            }
+            is TyReference -> {
+                if (expected.referenced is TyTraitObject) {
+                    null // TODO
+                } else {
+                    null
+                }
+            }
+            is TyFunction -> expected
+            else -> null
+        }
+    }
+
     private fun inferArrayType(expr: RsArrayExpr, expected: Ty?): Ty {
         val expectedElemTy = when (expected) {
             is TyArray -> expected.base
@@ -496,8 +757,11 @@ private class RsFnInferenceContext(
         }
         val (elementType, size) = if (expr.semicolon != null) {
             // It is "repeat expr", e.g. `[1; 5]`
-            val elementType = expr.initializer?.inferType(expectedElemTy) ?: return TySlice(TyUnknown)
-            expr.sizeExpr?.inferType()
+            val elementType = expectedElemTy
+                ?.let { expr.initializer?.inferTypeCoercableTo(expectedElemTy) }
+                ?: expr.initializer?.inferType()
+                ?: return TySlice(TyUnknown)
+            expr.sizeExpr?.inferType(TyInteger(TyInteger.Kind.usize))
             val size = calculateArraySize(expr.sizeExpr) ?: return TySlice(elementType)
             elementType to size
         } else {
@@ -506,6 +770,7 @@ private class RsFnInferenceContext(
 
             // '!!' is safe here because we've just checked that elementTypes isn't null
             val elementType = getMoreCompleteType(elementTypes!!)
+            if (expectedElemTy != null) coerce(elementType, expectedElemTy)
             elementType to elementTypes.size
         }
 
@@ -522,9 +787,20 @@ private class RsFnInferenceContext(
         return TyNever
     }
 
+    // TODO should be replaced with coerceMany
     private fun getMoreCompleteType(types: List<Ty>): Ty {
         if (types.isEmpty()) return TyUnknown
         return types.reduce { acc, ty -> getMoreCompleteType(acc, ty) }
+    }
+
+    // TODO should be replaced with coerceMany
+    fun getMoreCompleteType(ty1: Ty, ty2: Ty): Ty = when (ty1) {
+        is TyUnknown -> ty2
+        is TyNever -> ty2
+        else -> {
+            ctx.combineTypes(ty1, ty2)
+            ty1
+        }
     }
 
     private fun inferStructTypeArguments(literal: RsStructLiteral, expected: TyStructOrEnumBase?): Substitution {
@@ -532,20 +808,10 @@ private class RsFnInferenceContext(
         val results = literal.structLiteralBody.structLiteralFieldList.mapNotNull { field ->
             field.expr?.let { expr ->
                 val fieldType = field.type
-                fieldType.unifyWith(expr.inferType(fieldType.substitute(expectedSubst)), lookup)
+                fieldType.unifyWith(expr.inferTypeCoercableTo(fieldType.substitute(expectedSubst)), lookup)
             }
         }
         return UnifyResult.mergeAll(results).substitution().orEmpty()
-    }
-
-    private fun mapTypeParameters(argDefs: List<Ty>, argExprs: List<RsExpr>): Substitution {
-        // extending argument definitions to be sure that type inference launched for each arg expr
-        val argDefsExt = argDefs.asSequence().infiniteWithTyUnknown()
-        val results = argDefsExt.zip(argExprs.asSequence()).map { (type, expr) ->
-            type.unifyWith(expr.inferType(type), lookup)
-        }
-        val subst = UnifyResult.mergeAll(results.asIterable()).substitution().orEmpty()
-        return subst.substituteInValues(subst) // TODO multiple times?
     }
 }
 
@@ -581,20 +847,36 @@ private val RsFunction.typeOfValue: TyFunction
         val ownerType = (owner as? RsFunctionOwner.Impl)?.impl?.typeReference?.type
         val subst = if (ownerType != null) mapOf(TyTypeParameter.self() to ownerType) else emptyMap()
 
-        return TyFunction(paramTypes, returnType).substitute(subst)
+        return TyFunction(paramTypes, returnType).substitute(subst) as TyFunction
     }
 
+private val RsGenericDeclaration.bounds: Map<TyTypeParameter, List<BoundElement<RsTraitItem>>> get() {
+    val whereBounds = this.whereClause?.wherePredList.orEmpty()
+        .mapNotNull {
+            val key = (it.typeReference?.typeElement as? RsBaseType)?.path?.reference?.resolve()
+                ?.let { it as? RsTypeDeclarationElement }
+                ?.let { it.declaredType as? TyTypeParameter }
+            val value = it.typeParamBounds?.polyboundList.orEmpty()
+                .mapNotNull { it.bound.traitRef?.resolveToBoundTrait }
+            if (key == null) null else key to value
+        }.toMap()
+
+    return typeParameters.associate {
+        TyTypeParameter.named(it) to it.typeParamBounds?.polyboundList.orEmpty()
+            .mapNotNull { it.bound.traitRef?.resolveToBoundTrait }
+    }.mergeReduce(whereBounds) { v1, v2 -> v1 + v2}
+}
 
 private val threadLocalGuard: ThreadLocal<Boolean> = ThreadLocal.withInitial { false }
 
 /**
  * This function asserts that code inside a lambda don't call itself recursively.
  */
-private inline fun preventRecursion(action: () -> Unit) {
+private inline fun <T> preventRecursion(action: () -> T): T {
     if (threadLocalGuard.get()) error("Can not run nested type inference")
     threadLocalGuard.set(true)
     try {
-        action()
+        return action()
     } finally {
         threadLocalGuard.set(false)
     }
@@ -602,3 +884,22 @@ private inline fun preventRecursion(action: () -> Unit) {
 
 private fun Sequence<Ty>.infiniteWithTyUnknown(): Sequence<Ty> =
     this + generateSequence { TyUnknown }
+
+private fun unwrapParenExprs(expr: RsExpr): RsExpr {
+    var expr = expr
+    while (expr is RsParenExpr) {
+        expr = expr.expr
+    }
+    return expr
+}
+
+private inline fun <K, V1, V2> zipValuesForEach(map1: Map<K, V1>, map2: Map<K, V2>, action: (V1, V2) -> Unit) {
+    map1.forEach { (k, v) -> map2[k]?.let { action(v, it) } }
+}
+
+private fun <K, V> Map<K, V>.mergeReduce(other: Map<K, V>, reduce: (V, V) -> V): Map<K, V> {
+    val result = LinkedHashMap<K, V>(this.size + other.size)
+    result.putAll(this)
+    other.forEach { e -> result[e.key] = result[e.key]?.let { reduce(e.value, it) } ?: e.value }
+    return result
+}

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt
@@ -7,13 +7,14 @@ package org.rust.lang.core.types.ty
 
 import org.rust.ide.presentation.tyToString
 import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.types.infer.TypeFolder
 
 class TyArray(val base: Ty, val size: Int) : Ty {
     override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult =
         if (other is TyArray && size == other.size) base.unifyWith(other.base, lookup) else UnifyResult.fail
 
-    override fun substitute(subst: Substitution): Ty =
-        TyArray(base.substitute(subst), size)
+    override fun superFoldWith(folder: TypeFolder): Ty =
+        TyArray(base.foldWith(folder), size)
 
     override fun toString(): String = tyToString(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyFunction.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.types.ty
 
 import org.rust.ide.presentation.tyToString
 import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.types.infer.TypeFolder
 
 data class TyFunction(val paramTypes: List<Ty>, val retType: Ty) : Ty {
 
@@ -20,8 +21,8 @@ data class TyFunction(val paramTypes: List<Ty>, val retType: Ty) : Ty {
         }
     }
 
-    override fun substitute(subst: Substitution): TyFunction =
-        TyFunction(paramTypes.map { it.substitute(subst) }, retType.substitute(subst))
+    override fun superFoldWith(folder: TypeFolder): Ty =
+        TyFunction(paramTypes.map { it.foldWith(folder) }, retType.foldWith(folder))
 
     override fun toString(): String = tyToString(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyInfer.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyInfer.kt
@@ -1,0 +1,23 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.types.ty
+
+import org.rust.ide.presentation.tyToString
+import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.types.infer.Node
+import org.rust.lang.core.types.infer.NodeOrValue
+import org.rust.lang.core.types.infer.VarValue
+
+sealed class TyInfer : Ty {
+    class TyVar(val origin: TyTypeParameter, override var parent: NodeOrValue = VarValue(null, 0)) : TyInfer(), Node
+    class IntVar(override var parent: NodeOrValue = VarValue(null, 0)) : TyInfer(), Node
+    class FloatVar(override var parent: NodeOrValue = VarValue(null, 0)) : TyInfer(), Node
+
+    override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult =
+        UnifyResult.fail
+
+    override fun toString(): String = tyToString(this)
+}

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPointer.kt
@@ -6,14 +6,15 @@
 package org.rust.lang.core.types.ty
 
 import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.types.infer.TypeFolder
 
 data class TyPointer(val referenced: Ty, val mutability: Mutability) : Ty {
 
     override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult =
         if (other is TyPointer) referenced.unifyWith(other.referenced, lookup) else UnifyResult.fail
 
-    override fun substitute(subst: Substitution): Ty =
-        TyPointer(referenced.substitute(subst), mutability)
+    override fun superFoldWith(folder: TypeFolder): Ty =
+        TyPointer(referenced.foldWith(folder), mutability)
 
     override fun toString() = "*${if (mutability.isMut) "mut" else "const"} $referenced"
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyReference.kt
@@ -7,14 +7,15 @@ package org.rust.lang.core.types.ty
 
 import org.rust.ide.presentation.tyToString
 import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.types.infer.TypeFolder
 
 data class TyReference(val referenced: Ty, val mutability: Mutability) : Ty {
 
     override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult =
         if (other is TyReference) referenced.unifyWith(other.referenced, lookup) else UnifyResult.fail
 
-    override fun substitute(subst: Substitution): Ty =
-        TyReference(referenced.substitute(subst), mutability)
+    override fun superFoldWith(folder: TypeFolder): Ty =
+        TyReference(referenced.foldWith(folder), mutability)
 
     override fun toString(): String = tyToString(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TySlice.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TySlice.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.types.ty
 
 import org.rust.ide.presentation.tyToString
 import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.types.infer.TypeFolder
 
 data class TySlice(val elementType: Ty) : Ty {
     override fun unifyWith(other: Ty, lookup: ImplLookup): UnifyResult {
@@ -17,9 +18,8 @@ data class TySlice(val elementType: Ty) : Ty {
         }
     }
 
-    override fun substitute(subst: Substitution): Ty {
-        return TySlice(elementType.substitute(subst))
-    }
+    override fun superFoldWith(folder: TypeFolder): Ty =
+        TySlice(elementType.foldWith(folder))
 
     override fun toString(): String = tyToString(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyStructOrEnum.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyStructOrEnum.kt
@@ -13,6 +13,7 @@ import org.rust.lang.core.psi.ext.RsStructOrEnumItemElement
 import org.rust.lang.core.psi.ext.typeParameters
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.type
 
 interface TyStructOrEnumBase : Ty {
@@ -42,8 +43,8 @@ class TyStruct private constructor(
     override val typeArguments: List<Ty>
         get() = item.typeParameters.map { typeParameterValues.get(it) ?: TyUnknown }
 
-    override fun substitute(subst: Substitution): TyStruct =
-        TyStruct(boundElement.substitute(subst))
+    override fun superFoldWith(folder: TypeFolder): TyStruct =
+        TyStruct(boundElement.foldWith(folder))
 
     override fun equals(other: Any?): Boolean =
         other is TyStruct && boundElement == other.boundElement
@@ -74,8 +75,8 @@ class TyEnum private constructor(
     override val typeArguments: List<Ty>
         get() = item.typeParameters.map { typeParameterValues.get(it) ?: TyUnknown }
 
-    override fun substitute(subst: Substitution): TyEnum =
-        TyEnum(boundElement.substitute(subst))
+    override fun superFoldWith(folder: TypeFolder): TyEnum =
+        TyEnum(boundElement.foldWith(folder))
 
     override fun equals(other: Any?): Boolean =
         other is TyEnum && boundElement == other.boundElement

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTuple.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.types.ty
 
 import org.rust.ide.presentation.tyToString
 import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.types.infer.TypeFolder
 
 data class TyTuple(val types: List<Ty>) : Ty {
 
@@ -18,8 +19,8 @@ data class TyTuple(val types: List<Ty>) : Ty {
         }
     }
 
-    override fun substitute(subst: Substitution): TyTuple =
-        TyTuple(types.map { it.substitute(subst) })
+    override fun superFoldWith(folder: TypeFolder): Ty =
+        TyTuple(types.map { it.foldWith(folder) })
 
     override fun toString(): String = tyToString(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/UnifyResult.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/UnifyResult.kt
@@ -81,7 +81,14 @@ private fun Substitution.merge(other: Substitution): Substitution {
     val newSubst = toMutableMap()
     for ((param, value) in other) {
         val old = get(param)
-        newSubst.put(param, if (old == null) value else getMoreCompleteType(old, value))
+        newSubst.put(param, if (old == null) value else getMoreCompleteTypeOld(old, value))
     }
     return newSubst
+}
+
+private fun getMoreCompleteTypeOld(ty1: Ty, ty2: Ty): Ty {
+    return when (ty1) {
+        is TyUnknown, is TyNever, is TyInfer -> ty2
+        else -> ty1
+    }
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsNumericLiteralTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsNumericLiteralTypeInferenceTest.kt
@@ -262,4 +262,123 @@ class RsNumericLiteralTypeInferenceTest : RsTypificationTestBase() {
             S(1u8).foo(1);
         }            //^ u8
     """)
+
+    fun `test integer unification`() = testExpr("""
+        fn main() {
+            let a = 0;
+                  //^ u8
+            let b: u8 = a;
+        }
+    """)
+
+    fun `test float unification`() = testExpr("""
+        fn main() {
+            let mut a = 0.0;
+                      //^ f32
+            let b: f32 = a;
+        }
+    """)
+
+    fun `test integer unification assign`() = testExpr("""
+        fn main() {
+            let mut a = 0;
+                      //^ u8
+            a = 1u8;
+        }
+    """)
+
+    fun `test integer unification struct field`() = testExpr("""
+        struct S { f: u8 }
+        fn main() {
+            let a = 0;
+                  //^ u8
+            S { f: a };
+        }
+    """)
+
+    fun `test integer unification method param`() = testExpr("""
+        fn foo(a: u8) {}
+        fn main() {
+            let a = 0;
+                  //^ u8
+            foo(a);
+        }
+    """)
+
+    fun `test integer unification generic method param`() = testExpr("""
+        fn foo<T>(a: T, b: T) {}
+        fn main() {
+            let a = 0;
+                  //^ u8
+            let b = 0u8;
+            foo(a, b);
+        }
+    """)
+
+    fun `test integer unification repeat expr`() = testExpr("""
+        fn main() {
+            let a = 0;
+                  //^ u8
+            let b: [u8; 1] = [a; 1];
+        }
+    """)
+
+    fun `test integer unification array expr`() = testExpr("""
+        fn main() {
+            let a = 0;
+                  //^ u8
+            let b: [u8; 3] = [1, a, 3];
+        }
+    """)
+
+    fun `test integer unification tuple expr`() = testExpr("""
+        fn main() {
+            let a = 0;
+                  //^ u8
+            let b: (u8, u8) = (a, 1);
+        }
+    """)
+
+    fun `test integer unification block`() = testExpr("""
+        fn main() {
+        let a = 0;
+              //^ u8
+        let b: u8 = { a };
+        }
+    """)
+
+    fun `test integer unification if else`() = testExpr("""
+        fn main() {
+        let a = 0;
+              //^ u8
+            let b: u8 = if true { a } else { 1 };
+        }
+    """)
+
+    fun `test integer unification if else 2`() = testExpr("""
+        fn main() {
+        let a = 0;
+              //^ u8
+            let b: u8 = if true { 1 } else { a };
+        }
+    """)
+
+    fun `test integer unification if else 3`() = testExpr("""
+        fn main() {
+        let a = 0;
+              //^ u8
+            let b: u8 = if true { 1 } else if true { a } else { 1 };
+        }
+    """)
+
+    fun `test integer unification match`() = testExpr("""
+        fn main() {
+        let a = 0;
+              //^ u8
+            let b: u8 = match true {
+                true => a,
+                false => 1,
+            };
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -292,6 +292,40 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test iterator collect`() = testExpr("""
+        use std::vec::Vec;
+
+        fn main() {
+            let vec = vec![1, 2, 3];
+            let b: Vec<_> = vec.into_iter().collect();
+            b
+          //^ Vec<i32>
+        }
+    """)
+
+    fun `test vec push`() = testExpr("""
+        use std::vec::Vec;
+
+        fn main() {
+            let mut vec = Vec::new();
+            vec.push(1);
+            vec
+          //^ Vec<i32>
+        }
+    """)
+
+    fun `test vec push 2`() = testExpr("""
+        use std::vec::Vec;
+
+        fn main() {
+            let a = 0;
+                  //^ u8
+            let mut vec = Vec::new();
+            vec.push(a);
+            vec.push(1u8);
+        }
+    """)
+
     fun `test all binary ops with all numeric types`() {
         val numericTypes = listOf(
             "usize", "u8", "u16", "u32", "u64", "u128",


### PR DESCRIPTION
Really it's just a part of The Ultimate Type Inference™. I just found something like an "incremental point", so await a new PRs soon.
Good news is that a lot of really advanced type inference are working now:

```rust
fn main() {
    let a = 0;
          //^ u8
    let mut vec = Vec::new();
    vec.push(a);
    vec.push(1u8);
}
```
```rust
fn main() {
    let vec = vec![1, 2, 3];
    let b: Vec<_> = vec.into_iter().collect();
    b
  //^ Vec<i32>
}
```

Bad news is that the code is now like an awful Frankenstein molded out of our old type inference (with substitutions, Ty.unifyWith and so on) and the new one. I think we can live with it for a bit :)