### PR TITLE
ANN: Fix wrong mutability annotation on empty structs without braces

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -62,6 +62,7 @@ val RsExpr.isMutable: Boolean get() {
             if (letExpr != null && letExpr.eq == null) return true
             if (type is TyUnknown) return DEFAULT_MUTABILITY
             if (declaration is RsEnumVariant) return true
+            if (declaration is RsStructItem) return true
 
             false
         }

--- a/src/test/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspectionTest.kt
@@ -171,6 +171,15 @@ class RsBorrowCheckerInspectionTest : RsInspectionsTestBase(RsBorrowCheckerInspe
         }
     """)
 
+    fun `test mutable reference to empty struct with and without braces`() = checkByText("""
+        struct S;
+
+        fn main() {
+            let test1 = &mut S; // Must not be highlighted
+            let test2 = &mut S {}; // Must not be highlighted
+        }
+    """)
+
     fun `test fix method at method call (self)`() = checkFixByText("Make `self` mutable", """
         struct S;
         impl S {


### PR DESCRIPTION
A mutable reference to a empty struct without braces would produce an error
"Cannot borrow immutable local variable `EmptyStruct` as mutable"

struct EmptyStruct;
let error = &mut EmptyStruct;
let ok = &mut EmptyStruct { };

The solution for this is very similar to 6842c263b91feeb99c78fb7319d8757203d47ebf for #1114

An empty struct expression with and without braces have a different
PSI representation.
EmptyStruct is a RsPathExpr which resolves to a RsStructItem
EmptyStruct {} is a RsStructLiteral which is handled by the else in RsExpr.isMutable