### PR TITLE
Fix unsound `findWithCache`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsNamedElementIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsNamedElementIndex.kt
@@ -15,7 +15,7 @@ import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.containingCargoPackage
 import org.rust.lang.core.resolve.STD_DERIVABLE_TRAITS
 import org.rust.lang.core.stubs.RsFileStub
-import org.rust.lang.utils.findWithCache
+import org.rust.lang.utils.ProjectCache
 import org.rust.lang.utils.getElements
 
 class RsNamedElementIndex : StringStubIndexExtension<RsNamedElement>() {
@@ -26,8 +26,9 @@ class RsNamedElementIndex : StringStubIndexExtension<RsNamedElement>() {
         val KEY: StubIndexKey<String, RsNamedElement> =
             StubIndexKey.createIndexKey("org.rust.lang.core.stubs.index.RustNamedElementIndex")
 
+        private val derivableTraitsCache = ProjectCache<String, Collection<RsTraitItem>>("derivableTraitsCache")
         fun findDerivableTraits(project: Project, target: String): Collection<RsTraitItem> =
-            findWithCache(project, target) {
+            derivableTraitsCache.getOrPut(project, target) {
                 val stdTrait = STD_DERIVABLE_TRAITS[target]
                 getElements(KEY, target, project, GlobalSearchScope.allScope(project))
                     .mapNotNull { it as? RsTraitItem }

--- a/src/main/kotlin/org/rust/lang/utils/IndexUtils.kt
+++ b/src/main/kotlin/org/rust/lang/utils/IndexUtils.kt
@@ -10,24 +10,9 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
-import com.intellij.psi.util.CachedValueProvider
-import com.intellij.psi.util.CachedValuesManager
-import com.intellij.psi.util.PsiModificationTracker
-import com.intellij.util.containers.ContainerUtil
 
 inline fun <Key, reified Psi : PsiElement> getElements(indexKey: StubIndexKey<Key, Psi>,
                                                        key: Key, project: Project,
                                                        scope: GlobalSearchScope?): Collection<Psi> =
     StubIndex.getElements(indexKey, key, project, scope, Psi::class.java)
 
-inline fun <T, R> findWithCache(project: Project, key: T, find: () -> R): R {
-    val cache = CachedValuesManager.getManager(project)
-        .getCachedValue(project, {
-            CachedValueProvider.Result.create(
-                ContainerUtil.newConcurrentMap<T, R>(),
-                PsiModificationTracker.MODIFICATION_COUNT
-            )
-        })
-
-    return cache.getOrPut(key) { find() }
-}

--- a/src/main/kotlin/org/rust/lang/utils/ProjectCache.kt
+++ b/src/main/kotlin/org/rust/lang/utils/ProjectCache.kt
@@ -1,0 +1,45 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.utils
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.PsiModificationTracker
+import com.intellij.util.containers.ContainerUtil
+import java.util.concurrent.ConcurrentMap
+
+class ProjectCache<in T, R>(cacheName: String) {
+    init {
+        if (!registered.add(cacheName)) {
+            error("""
+                ProjectCache `$cacheName` is already registered.
+                Make sure ProjectCache is static, that is, put it inside companion object.
+            """.trimIndent())
+        }
+    }
+
+    private val cacheKey: Key<CachedValue<ConcurrentMap<T, R>>> = Key.create(cacheName)
+
+    private val provider = CachedValueProvider {
+        CachedValueProvider.Result.create(
+            ContainerUtil.newConcurrentMap<T, R>(),
+            PsiModificationTracker.MODIFICATION_COUNT
+        )
+    }
+
+    fun getOrPut(project: Project, key: T, defaultValue: () -> R): R {
+        val cache = CachedValuesManager.getManager(project)
+            .getCachedValue(project, cacheKey, provider, false)
+        return cache.getOrPut(key) { defaultValue() }
+    }
+
+    companion object {
+        private val registered = ContainerUtil.newConcurrentSet<String>()
+    }
+}


### PR DESCRIPTION
`getCachedValue` relies on identity of passed-in lambdas, and Kotlin's
inline does not help us to maintain these identities. So let's create
keys ourselves instead.

r? @vlad20012