### PR TITLE
T: drop assertj dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,7 +106,6 @@ project(":") {
             exclude(module = "kotlin-runtime")
             exclude(module = "kotlin-stdlib")
         }
-        testCompile("org.assertj:assertj-core:3.2.0")
     }
 
     java.sourceSets {

--- a/src/test/kotlin/org/rust/cargo/runconfig/RunConfigurationTestCase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/RunConfigurationTestCase.kt
@@ -12,7 +12,6 @@ import com.intellij.execution.process.*
 import com.intellij.execution.runners.ExecutionEnvironmentBuilder
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.Key
-import org.assertj.core.api.Assertions.assertThat
 import org.rust.cargo.RustWithToolchainTestBase
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.runconfig.command.CargoCommandConfigurationType
@@ -41,7 +40,7 @@ class RunConfigurationTestCase : RustWithToolchainTestBase() {
         val configuration = createConfiguration()
         val result = execute(configuration)
 
-        assertThat(result.stdout).contains("Hello, world!")
+        check("Hello, world!" in result.stdout)
     }
 
     private fun createConfiguration(): CargoCommandConfiguration {

--- a/src/test/kotlin/org/rust/cargo/runconfig/filters/HighlightFilterTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/filters/HighlightFilterTestBase.kt
@@ -10,7 +10,6 @@ import com.intellij.execution.filters.OpenFileHyperlinkInfo
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VirtualFile
-import org.assertj.core.api.Assertions
 import org.rust.lang.RsTestBase
 import java.util.*
 
@@ -32,7 +31,9 @@ abstract class HighlightFilterTestBase : RsTestBase() {
 
     protected fun checkNoHighlights(filter: Filter, text: String) {
         val items = filter.applyFilter(text, text.length)?.resultItems ?: return
-        Assertions.assertThat(items.size).isEqualTo(0)
+        check(items.size == 0) {
+            "Expected zero highlights, got $items"
+        }
     }
 
     protected fun checkHighlights(filter: Filter, before: String, after: String, lineIndex: Int = 0) {
@@ -52,7 +53,7 @@ abstract class HighlightFilterTestBase : RsTestBase() {
             checkText = checkText.replaceRange(range, "[$itemText]")
         }
         checkText = checkText.splitLinesKeepSeparators()[lineIndex]
-        Assertions.assertThat(checkText).isEqualTo(after)
+        check(checkText == after)
     }
 
     private fun String.splitLinesKeepSeparators() = split("(?<=\n)".toRegex())

--- a/src/test/kotlin/org/rust/cargo/runconfig/filters/RsExplainFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/filters/RsExplainFilterTest.kt
@@ -6,7 +6,6 @@
 package org.rust.cargo.runconfig.filters
 
 import com.intellij.execution.filters.Filter
-import org.assertj.core.api.Assertions.assertThat
 import org.rust.lang.RsTestBase
 
 class RsExplainFilterTest : RsTestBase() {
@@ -34,7 +33,7 @@ class RsExplainFilterTest : RsTestBase() {
 
     fun testNothingToSee() {
         val text = "src/lib.rs:57:17: 57:25 error: unable to infer enough type information about `_`; type annotations or generic parameter binding required [E0282]"
-        assertThat(filter.applyFilter(text, text.length)).isNull()
+        check(filter.applyFilter(text, text.length) == null)
     }
 
     private fun doTest(line: String, entireLength: Int, highlightingStartOffset: Int, highlightingEndOffset: Int) {
@@ -43,8 +42,8 @@ class RsExplainFilterTest : RsTestBase() {
         }
 
         val item = result.resultItems.single()
-        assertThat(item.getHighlightStartOffset()).isEqualTo(highlightingStartOffset)
-        assertThat(item.getHighlightEndOffset()).isEqualTo(highlightingEndOffset)
-        assertThat(item.getHyperlinkInfo()).isNotNull()
+        check(item.getHighlightStartOffset() == highlightingStartOffset)
+        check(item.getHighlightEndOffset() == highlightingEndOffset)
+        check(item.getHyperlinkInfo() != null)
     }
 }

--- a/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.docs
 
 import com.intellij.psi.PsiManager
-import org.assertj.core.api.Assertions
 import org.intellij.lang.annotations.Language
 import org.rust.lang.RsTestBase
 import org.rust.lang.core.psi.ext.RsNamedElement
@@ -84,6 +83,6 @@ class RsResolveLinkTest : RsTestBase() {
         val expectedElement = findElementInEditor<RsNamedElement>("X")
         val actualElement = RsDocumentationProvider()
             .getDocumentationElementForLink(PsiManager.getInstance(project), link, context)
-        Assertions.assertThat(actualElement).isEqualTo(expectedElement)
+        check(actualElement == expectedElement)
     }
 }

--- a/src/test/kotlin/org/rust/ide/hints/RsInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RsInlayParameterHintsProviderTest.kt
@@ -7,7 +7,6 @@ package org.rust.ide.hints
 
 import com.intellij.openapi.vfs.VirtualFileFilter
 import com.intellij.psi.PsiElement
-import org.assertj.core.api.Assertions
 import org.intellij.lang.annotations.Language
 import org.rust.fileTreeFromText
 import org.rust.lang.RsTestBase
@@ -184,7 +183,7 @@ class RsInlayParameterHintsProviderTest : RsTestBase() {
         }
     """, ": S<fn(i32) -> i32, S<fn(i32) -> i32, S<_, _>>>", 0)
 
-    fun `test inlay hint for loops`() =checkByText<RsForExpr>("""
+    fun `test inlay hint for loops`() = checkByText<RsForExpr>("""
         trait Iterator { type Item; fn next(&mut self) -> Option<Self::Item>; }
         struct S;
         struct I;
@@ -224,7 +223,7 @@ class RsInlayParameterHintsProviderTest : RsTestBase() {
         val handler = RsInlayParameterHintsProvider()
         val target = findElementInEditor<T>("^")
         val inlays = handler.getParameterHints(target)
-        Assertions.assertThat(inlays.size).isEqualTo(0)
+        check(inlays.isEmpty())
     }
 
     inline private fun <reified T : PsiElement> checkByText(@Language("Rust") code: String, hint: String, pos: Int) {
@@ -235,8 +234,8 @@ class RsInlayParameterHintsProviderTest : RsTestBase() {
             check(pos < inlays.size) {
                 "Expected at least ${pos + 1} hints, got ${inlays.map { it.text }}"
             }
-            Assertions.assertThat(inlays[pos].text).isEqualTo(hint)
-            Assertions.assertThat(inlays[pos].offset).isEqualTo(myFixture.editor.caretModel.offset)
+            check(inlays[pos].text == hint)
+            check(inlays[pos].offset == myFixture.editor.caretModel.offset)
         }
     }
 }

--- a/src/test/kotlin/org/rust/ide/hints/RsQuickDefinitionTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RsQuickDefinitionTest.kt
@@ -12,7 +12,6 @@ import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import org.assertj.core.api.Assertions
 import org.intellij.lang.annotations.Language
 import org.rust.lang.RsTestBase
 
@@ -185,6 +184,6 @@ class RsQuickDefinitionTest : RsTestBase() {
             .dropWhile { it.isBlank() }
             .dropLastWhile { it.isBlank() }
             .joinToString("\n")
-        Assertions.assertThat(actualText).isEqualTo(expected)
+        check(actualText == expected)
     }
 }

--- a/src/test/kotlin/org/rust/ide/surroundWith/RsSurrounderTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/surroundWith/RsSurrounderTestBase.kt
@@ -9,14 +9,12 @@ import com.intellij.codeInsight.generation.surroundWith.SurroundWithHandler
 import com.intellij.lang.LanguageSurrounders
 import com.intellij.lang.surroundWith.Surrounder
 import com.intellij.openapi.command.WriteCommandAction
-import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.rust.lang.RsFileType
 import org.rust.lang.RsLanguage
 import org.rust.lang.RsTestBase
-import java.util.*
 
-abstract class RsSurrounderTestBase(val surrounder: Surrounder) : RsTestBase() {
+abstract class RsSurrounderTestBase(private val surrounder: Surrounder) : RsTestBase() {
     protected fun doTest(@Language("Rust") before: String,
                          @Language("Rust") after: String,
                          checkSyntaxErrors: Boolean = true) {
@@ -51,13 +49,10 @@ abstract class RsSurrounderTestBase(val surrounder: Surrounder) : RsTestBase() {
         val elements = descriptor.getElementsToSurround(
             myFixture.file, selectionModer.selectionStart, selectionModer.selectionEnd)
 
-        assertThat(surrounder.isApplicable(elements))
-            .withFailMessage(
-                "surrounder %s be applicable to given selection:\n\n%s\nElements: %s",
-                if (isApplicable) "should" else "shouldn't",
-                testCase,
-                Arrays.toString(elements)
-            )
-            .isEqualTo(isApplicable)
+        check(surrounder.isApplicable(elements) == isApplicable) {
+            "surrounder ${if (isApplicable) "should" else "shouldn't"} be applicable to given selection:\n\n" +
+                "$testCase\n" +
+                "Elements: ${elements.toList()}"
+        }
     }
 }

--- a/src/test/kotlin/org/rust/ide/template/postfix/PostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/PostfixTemplateTest.kt
@@ -8,7 +8,6 @@ package org.rust.ide.template.postfix
 import com.intellij.codeInsight.template.postfix.templates.LanguagePostfixTemplate
 import com.intellij.codeInsight.template.postfix.templates.PostfixLiveTemplate
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplate
-import org.assertj.core.api.Assertions
 import org.intellij.lang.annotations.Language
 import org.rust.lang.RsLanguage
 import org.rust.lang.RsTestBase
@@ -40,19 +39,15 @@ abstract class PostfixTemplateTest(val postfixTemplate: PostfixTemplate) : RsTes
                 }
             }
 
-        Assertions.assertThat(
+        check(
             PostfixLiveTemplate.isApplicableTemplate(
                 provider,
                 postfixTemplate.key,
                 myFixture.file,
                 myFixture.editor
-            )
-        )
-            .withFailMessage(
-                "postfixTemplate %s be applicable to given case:\n\n%s",
-                if (isApplicable) "should" else "shouldn't",
-                testCase
-            )
-            .isEqualTo(isApplicable)
+            ) == isApplicable
+        ) {
+            "postfixTemplate ${if (isApplicable) "should" else "shouldn't"} be applicable to given case:\n\n$testCase"
+        }
     }
 }

--- a/src/test/kotlin/org/rust/ide/typing/RsBraceMatcherTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/RsBraceMatcherTest.kt
@@ -8,7 +8,6 @@ package org.rust.ide.typing
 import com.intellij.codeInsight.highlighting.BraceMatchingUtil
 import com.intellij.codeInsight.highlighting.BraceMatchingUtil.getMatchedBraceOffset
 import com.intellij.openapi.editor.ex.EditorEx
-import org.assertj.core.api.Assertions.assertThat
 import org.rust.lang.RsFileType
 import org.rust.lang.RsTestBase
 
@@ -57,7 +56,7 @@ class RsBraceMatcherTest : RsTestBase() {
 
             val pairOffset = try {
                 BraceMatchingUtil.getMatchedBraceOffset(myFixture.editor, forward, myFixture.file)
-            } catch(e: AssertionError) {
+            } catch (e: AssertionError) {
                 error("Failed to find a pair for `$brace` in `${parent.text}`")
             }
             check(text[pairOffset] == coBrace)
@@ -80,13 +79,13 @@ class RsBraceMatcherTest : RsTestBase() {
         val editorHighlighter = (myFixture.editor as EditorEx).highlighter
         val iterator = editorHighlighter.createIterator(myFixture.editor.caretModel.offset)
         val matched = BraceMatchingUtil.matchBrace(myFixture.editor.document.charsSequence, myFixture.file.fileType, iterator, true)
-        assertThat(matched).`as`(source).isFalse()
+        check(!matched)
     }
 
     private fun doMatch(source: String, coBrace: String) {
         myFixture.configureByText(RsFileType, source)
-        assertThat(getMatchedBraceOffset(myFixture.editor, true, myFixture.file))
-            .isEqualTo(source.replace("<caret>", "").lastIndexOf(coBrace))
+        val expected = source.replace("<caret>", "").lastIndexOf(coBrace)
+        check(getMatchedBraceOffset(myFixture.editor, true, myFixture.file) == expected)
     }
 
     private fun doTest(before: String, type: Char, after: String) {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionAutoPopupTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.completion
 
 import com.intellij.testFramework.fixtures.CompletionAutoPopupTester
-import org.assertj.core.api.Assertions.assertThat
 
 class RsCompletionAutoPopupTest : RsCompletionTestBase() {
     private lateinit var tester: CompletionAutoPopupTester
@@ -32,7 +31,7 @@ class RsCompletionAutoPopupTest : RsCompletionTestBase() {
             }
         """)
         tester.typeWithPauses("::")
-        assertThat(tester.lookup).isNotNull()
+        check(tester.lookup != null)
     }
 
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsLookupElementTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsLookupElementTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.completion
 
 import com.intellij.codeInsight.lookup.LookupElementPresentation
-import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.rust.lang.RsTestBase
 import org.rust.lang.core.psi.ext.RsNamedElement
@@ -97,8 +96,8 @@ class RsLookupElementTest : RsTestBase() {
         val presentation = LookupElementPresentation()
 
         lookup.renderElement(presentation)
-        assertThat(presentation.icon).isNotNull()
-        assertThat(presentation.itemText).isEqualTo("foo")
+        check(presentation.icon != null)
+        check(presentation.itemText == "foo")
     }
 
     private fun check(@Language("Rust") code: String, tailText: String? = null, typeText: String? = null) {
@@ -108,9 +107,8 @@ class RsLookupElementTest : RsTestBase() {
         val presentation = LookupElementPresentation()
 
         lookup.renderElement(presentation)
-        assertThat(presentation.icon).isNotNull()
-        assertThat(presentation.tailText).isEqualTo(tailText)
-        assertThat(presentation.typeText).isEqualTo(typeText)
+        check(presentation.icon != null)
+        check(presentation.tailText == tailText)
+        check(presentation.typeText == typeText)
     }
-
 }

--- a/src/test/kotlin/org/rust/lang/core/ext/RsPsiStructureTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/ext/RsPsiStructureTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.ext
 
 import com.intellij.psi.PsiFileFactory
-import org.assertj.core.api.Assertions
 import org.intellij.lang.annotations.Language
 import org.rust.ide.presentation.presentationInfo
 import org.rust.ide.presentation.shortPresentableText
@@ -26,7 +25,7 @@ class RsPsiStructureTest : RsTestBase() {
 
     fun `test function role free`() = checkFunctionOwner({ it is RsFunctionOwner.Free }, "fn main() {}")
     fun `test function role foreign`() = checkFunctionOwner({ it is RsFunctionOwner.Foreign }, "extern { fn foo(); }")
-    fun `test function role trait method`() = checkFunctionOwner({ it is RsFunctionOwner.Trait}, "trait S { fn foo() {} }")
+    fun `test function role trait method`() = checkFunctionOwner({ it is RsFunctionOwner.Trait }, "trait S { fn foo() {} }")
     fun `test function role inherent impl method`() =
         checkFunctionOwner({ it is RsFunctionOwner.Impl && it.isInherentImpl }, "impl S { fn foo() {} }")
 
@@ -117,8 +116,7 @@ class RsPsiStructureTest : RsTestBase() {
     fun testShortTypeExpr(@Language("Rust") code: String) {
         InlineFile(code)
         val (expr, expectedType) = findElementAndDataInEditor<RsExpr>()
-            Assertions.assertThat(expr.type.shortPresentableText)
-                .isEqualTo(expectedType)
+        check(expr.type.shortPresentableText == expectedType)
     }
 
     fun `test extern crate presentation info`() = checkElement<RsExternCrateItem>("""

--- a/src/test/kotlin/org/rust/lang/core/parser/RsCompleteParsingTestCase.kt
+++ b/src/test/kotlin/org/rust/lang/core/parser/RsCompleteParsingTestCase.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.parser
 
 import com.intellij.psi.PsiFile
-import org.assertj.core.api.Assertions.assertThat
 
 class RsCompleteParsingTestCase : RsParsingTestCaseBase("complete") {
 
@@ -49,9 +48,9 @@ class RsCompleteParsingTestCase : RsParsingTestCaseBase("complete") {
 
     override fun checkResult(targetDataName: String?, file: PsiFile?) {
         super.checkResult(targetDataName, file)
-        assertThat(hasError(file!!))
-            .withFailMessage("Error in well formed file ${file.name}")
-            .isFalse()
+        check(!hasError(file!!)){
+            "Error in well formed file ${file.name}"
+        }
     }
 
 }

--- a/src/test/kotlin/org/rust/lang/core/parser/RsPartialParsingTestCase.kt
+++ b/src/test/kotlin/org/rust/lang/core/parser/RsPartialParsingTestCase.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.parser
 
 import com.intellij.psi.PsiFile
-import org.assertj.core.api.Assertions.assertThat
 
 /**
  * Tests parser recovery (`pin` and `recoverWhile` attributes from `rust.bnf`)
@@ -29,13 +28,10 @@ class RsPartialParsingTestCase : RsParsingTestCaseBase("partial") {
     fun testRequireCommas() = doTest(true)
 
     override fun checkResult(targetDataName: String?, file: PsiFile) {
-        checkHasError(file)
+        check(hasError(file)) {
+            "Invalid file was parsed successfully: ${file.name}"
+        }
         super.checkResult(targetDataName, file)
     }
 
-    private fun checkHasError(file: PsiFile) {
-        assertThat(hasError(file))
-            .withFailMessage("Invalid file was parsed successfully: ${file.name}")
-            .isTrue()
-    }
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsNonPhysicalFileResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsNonPhysicalFileResolveTest.kt
@@ -9,7 +9,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
-import org.assertj.core.api.Assertions.assertThat
 import org.rust.lang.RsLanguage
 
 class RsNonPhysicalFileResolveTest : RsResolveTestBase() {
@@ -55,6 +54,6 @@ class RsNonPhysicalFileResolveTest : RsResolveTestBase() {
 
     private fun memoryOnlyFile(code: String): PsiFile =
         PsiFileFactory.getInstance(project).createFileFromText("foo.rs", RsLanguage, code, false, false).apply {
-            assertThat(this.containingFile.virtualFile).isNull()
+            check(this.containingFile.virtualFile == null)
         }
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
@@ -6,8 +6,6 @@
 package org.rust.lang.core.resolve
 
 import com.intellij.openapi.vfs.VirtualFileFilter
-import com.intellij.psi.impl.PsiManagerEx
-import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.rust.fileTreeFromText
 import org.rust.lang.RsTestBase
@@ -41,7 +39,7 @@ abstract class RsResolveTestBase : RsTestBase() {
 
         val target = findElementInEditor<RsNamedElement>("X")
 
-        assertThat(resolved).isEqualTo(target)
+        check(resolved == target)
     }
 
     protected fun stubOnlyResolve(@Language("Rust") code: String) {

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -5,7 +5,6 @@
 
 package org.rust.lang.core.type
 
-import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.rust.lang.core.psi.RsTypeReference
 import org.rust.lang.core.types.type
@@ -198,8 +197,7 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
         InlineFile(code)
         val (typeAtCaret, expectedType) = findElementAndDataInEditor<RsTypeReference>()
 
-        assertThat(typeAtCaret.type.toString())
-            .isEqualTo(expectedType)
+        check(typeAtCaret.type.toString() == expectedType)
     }
 }
 

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypificationTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypificationTestBase.kt
@@ -5,7 +5,6 @@
 
 package org.rust.lang.core.type
 
-import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.rust.lang.RsTestBase
 import org.rust.lang.core.psi.RsExpr
@@ -16,8 +15,8 @@ abstract class RsTypificationTestBase : RsTestBase() {
         InlineFile(code)
         val (expr, expectedType) = findElementAndDataInEditor<RsExpr>()
 
-        assertThat(expr.type.toString())
-            .`as`(description)
-            .isEqualTo(expectedType)
+        check(expr.type.toString() == expectedType) {
+            description
+        }
     }
 }

--- a/src/test/kotlin/org/rust/lang/refactoring/RsNameSuggestionsKtTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/RsNameSuggestionsKtTest.kt
@@ -5,7 +5,6 @@
 
 package org.rust.lang.refactoring
 
-import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.rust.lang.RsTestBase
 import org.rust.lang.core.psi.RsFile
@@ -22,7 +21,7 @@ class RsNameSuggestionsKtTest : RsTestBase() {
             foo(4, 10/*caret*/)
         }
     """) {
-        assertThat(it).containsExactly("i", "name", "variable_name", "cool_variable_name", "very_cool_variable_name")
+        checkSuggestions(it, "i", "name", "variable_name", "cool_variable_name", "very_cool_variable_name")
     }
 
     fun testNonDirectArgumentNames() = doTest("""
@@ -34,7 +33,7 @@ class RsNameSuggestionsKtTest : RsTestBase() {
             foo(4, 1/*caret*/0 + 2)
         }
     """) {
-        assertThat(it).containsExactly("i")
+        checkSuggestions(it, "i")
     }
 
 
@@ -47,7 +46,7 @@ class RsNameSuggestionsKtTest : RsTestBase() {
             f/*caret*/oo(4, 10 + 2)
         }
     """) {
-        assertThat(it).containsExactly("i", "foo")
+        checkSuggestions(it, "i", "foo")
     }
 
     fun testStringNew() = doTest("""
@@ -56,7 +55,7 @@ class RsNameSuggestionsKtTest : RsTestBase() {
 
             file.read_to_string(&mut String:/*caret*/:new())?;
     }""") {
-        assertThat(it).containsExactly("string", "new")
+        checkSuggestions(it, "string", "new")
     }
 
     fun testLocalNames() = doTest("""
@@ -65,7 +64,7 @@ class RsNameSuggestionsKtTest : RsTestBase() {
             let b = String:/*caret*/:new();
         }
     """) {
-        assertThat(it).containsExactly("new")
+        checkSuggestions(it, "new")
     }
 
     fun testFunctionCallAsArgument() = doTest("""
@@ -75,7 +74,7 @@ class RsNameSuggestionsKtTest : RsTestBase() {
             foo(Default::de/*caret*/fault());
         }
     """) {
-        assertThat(it).containsExactly("size", "board_size")
+        checkSuggestions(it, "size", "board_size")
     }
 
     fun testStructLiteral() = doTest("""
@@ -90,7 +89,7 @@ class RsNameSuggestionsKtTest : RsTestBase() {
             }
         }
         """) {
-        assertThat(it).containsExactly("i", "baz")
+        checkSuggestions(it, "i", "baz")
     }
 
     fun testGenericPath() = doTest("""
@@ -108,7 +107,7 @@ class RsNameSuggestionsKtTest : RsTestBase() {
             Foo:/*caret*/:<i32>::new(10)
         }
         """) {
-        assertThat(it).containsExactly("f", "foo", "new")
+        checkSuggestions(it, "f", "foo", "new")
     }
 
     private fun doTest(@Language("Rust") before: String, action: (Set<String>) -> Unit) {
@@ -117,5 +116,9 @@ class RsNameSuggestionsKtTest : RsTestBase() {
         val refactoring = RsIntroduceVariableRefactoring(myFixture.project, myFixture.editor, myFixture.file as RsFile)
         val expr = refactoring.possibleTargets().first()
         action(expr.suggestNames())
+    }
+
+    private fun checkSuggestions(actual: Set<String>, vararg expected: String) {
+        check(actual == expected.toSet())
     }
 }


### PR DESCRIPTION
Instead of using fluent assertions, write a plain `check` and, once a
test fails, add an artisanal hand-crafted error message with the help of
awesome "Kotlin $string literals".

r? @vlad20012 