### PR TITLE
Fixed "unresolved reference" inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
@@ -20,9 +20,9 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
             override fun visitPath(o: RsPath) {
                 if (TyPrimitive.fromPath(o) != null || o.reference.resolve() != null) return
 
-                val parent = o.path ?: return
-                val parentRes = parent.reference.resolve()
-                if (parentRes is RsMod || parentRes is RsEnumItem) {
+                val parent = o.path
+                val parentRes = parent?.reference?.resolve()
+                if (parent == null || parentRes is RsMod || parentRes is RsEnumItem) {
                     holder.registerProblem(o.navigationElement, "Unresolved reference")
                 }
             }


### PR DESCRIPTION
Was broken with bf9dad5300081f4d3b979cb2570594ef87b4e41b