### PR TITLE
Type information on var binding #1696

### DIFF
--- a/src/main/kotlin/org/rust/ide/hints/RsExpressionTypeProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/RsExpressionTypeProvider.kt
@@ -8,23 +8,30 @@ package org.rust.ide.hints
 import com.intellij.lang.ExpressionTypeProvider
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiElement
-import com.intellij.psi.SyntaxTraverser
 import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsPatBinding
 import org.rust.lang.core.psi.ext.RsItemElement
+import org.rust.lang.core.psi.ext.ancestors
 import org.rust.lang.core.types.type
 
 
-class RsExpressionTypeProvider : ExpressionTypeProvider<RsExpr>() {
+class RsExpressionTypeProvider : ExpressionTypeProvider<PsiElement>() {
 
     override fun getErrorHint(): String = "Select an expression!"
 
-    override fun getExpressionsAt(pivot: PsiElement): MutableList<RsExpr> =
-        SyntaxTraverser.psiApi().parents(pivot)
+    override fun getExpressionsAt(pivot: PsiElement): List<PsiElement> =
+        pivot.ancestors
             .takeWhile { it !is RsItemElement }
-            .filter(RsExpr::class.java)
+            .filter { it is RsExpr || it is RsPatBinding }
             .toList()
 
-    override fun getInformationHint(element: RsExpr): String =
-        StringUtil.escapeXml(element.type.toString())
+    override fun getInformationHint(element: PsiElement): String {
+        val type = when (element) {
+            is RsExpr -> element.type
+            is RsPatBinding -> element.type
+            else -> error("Unexpected element type: $element")
+        }
+        return StringUtil.escapeXml(type.toString())
+    }
 
 }


### PR DESCRIPTION
Is it legal if method named `getExpressionsAt` now return not only expressions?)