### PR TITLE
TY: Correct infer types of byte literals `b'a'` and `b"abc"`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsLiteralKind.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsLiteralKind.kt
@@ -57,7 +57,7 @@ sealed class RsLiteralKind(val node: ASTNode) {
         override val offsets: LiteralOffsets by lazy { offsetsForNumber(node) }
     }
 
-    class String(node: ASTNode) : RsLiteralKind(node), RsLiteralWithSuffix, RsTextLiteral {
+    class String(node: ASTNode, val isByte: kotlin.Boolean) : RsLiteralKind(node), RsLiteralWithSuffix, RsTextLiteral {
         override val offsets: LiteralOffsets by lazy { offsetsForText(node) }
 
         override val validSuffixes: List<kotlin.String> get() = emptyList()
@@ -75,7 +75,7 @@ sealed class RsLiteralKind(val node: ASTNode) {
         }
     }
 
-    class Char(node: ASTNode) : RsLiteralKind(node), RsLiteralWithSuffix, RsTextLiteral {
+    class Char(node: ASTNode, val isByte: kotlin.Boolean) : RsLiteralKind(node), RsLiteralWithSuffix, RsTextLiteral {
         override val offsets: LiteralOffsets by lazy { offsetsForText(node) }
 
         override val validSuffixes: List<kotlin.String> get() = emptyList()
@@ -94,10 +94,11 @@ sealed class RsLiteralKind(val node: ASTNode) {
             INTEGER_LITERAL -> Integer(node)
             FLOAT_LITERAL -> Float(node)
 
-            STRING_LITERAL, RAW_STRING_LITERAL,
-            BYTE_STRING_LITERAL, RAW_BYTE_STRING_LITERAL -> String(node)
+            STRING_LITERAL, RAW_STRING_LITERAL -> String(node, isByte = false)
+            BYTE_STRING_LITERAL, RAW_BYTE_STRING_LITERAL -> String(node, isByte = true)
 
-            CHAR_LITERAL, BYTE_LITERAL -> Char(node)
+            CHAR_LITERAL -> Char(node, isByte = false)
+            BYTE_LITERAL -> Char(node, isByte = true)
             else -> null
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Expressions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Expressions.kt
@@ -10,17 +10,27 @@ import org.rust.lang.core.psi.RsLitExpr
 import org.rust.lang.core.psi.RsLiteralKind
 import org.rust.lang.core.psi.kind
 import org.rust.lang.core.types.ty.*
+import org.rust.lang.core.types.ty.Mutability.IMMUTABLE
 
 fun inferOutOfFnExpressionType(expr: RsExpr) = when (expr) {
     is RsLitExpr -> inferLiteralExprType(expr)
     else -> TyUnknown
 }
 
-private fun inferLiteralExprType(expr: RsLitExpr): Ty = when (expr.kind) {
-    is RsLiteralKind.Boolean -> TyBool
-    is RsLiteralKind.Integer -> TyInteger.fromLiteral(expr.integerLiteral!!)
-    is RsLiteralKind.Float -> TyFloat.fromLiteral(expr.floatLiteral!!)
-    is RsLiteralKind.String -> TyReference(TyStr, Mutability.IMMUTABLE)
-    is RsLiteralKind.Char -> TyChar
-    null -> TyUnknown
+private fun inferLiteralExprType(expr: RsLitExpr): Ty {
+    val kind = expr.kind
+    return when (kind) {
+        is RsLiteralKind.Boolean -> TyBool
+        is RsLiteralKind.Integer -> TyInteger.fromLiteral(expr.integerLiteral!!)
+        is RsLiteralKind.Float -> TyFloat.fromLiteral(expr.floatLiteral!!)
+        is RsLiteralKind.Char -> if (kind.isByte) TyInteger(TyInteger.Kind.u8) else TyChar
+        is RsLiteralKind.String -> {
+            if (kind.isByte) {
+                TyReference(TyArray(TyInteger(TyInteger.Kind.u8), kind.offsets.value?.length ?: 0), IMMUTABLE)
+            } else {
+                TyReference(TyStr, IMMUTABLE)
+            }
+        }
+        null -> TyUnknown
+    }
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -253,6 +253,20 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun testByteChar() = testExpr("""
+        fn main() {
+            let a = b'A';
+                    //^ u8
+        }
+    """)
+
+    fun testByteStr() = testExpr("""
+        fn main() {
+            let a = b"ABC";
+                    //^ &[u8; 3]
+        }
+    """)
+
     fun testStrRef() = testExpr("""
         fn main() {
             let a = "Hello";


### PR DESCRIPTION
Fixes #1739