### PR TITLE
TY: Supported overloaded deref

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -66,7 +66,7 @@ fun processFieldExprResolveVariants(
     isCompletion: Boolean,
     processor: RsResolveProcessor
 ): Boolean {
-    for (ty in lookup.derefTransitively(receiverType)) {
+    for (ty in lookup.derefSequence(receiverType)) {
         if (ty !is TyStruct) continue
         if (processFieldDeclarations(ty.item, ty.typeParameterValues, processor)) return true
     }
@@ -407,7 +407,7 @@ private fun processMethodDeclarationsWithDeref(lookup: ImplLookup, receiver: Ty,
         val element = entry.element
         element is RsFunction && !element.isAssocFn && processor(entry)
     }
-    return lookup.derefTransitively(receiver).any { processAssociatedItems(lookup, it, VALUES, methodProcessor) }
+    return lookup.derefSequence(receiver).any { processAssociatedItems(lookup, it, VALUES, methodProcessor) }
 }
 
 private fun processAssociatedItems(lookup: ImplLookup, type: Ty, ns: Set<Namespace>, processor: RsResolveProcessor): Boolean {

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -450,6 +450,19 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test overloaded deref`() = testExpr("""
+        #[lang = "deref"]
+        trait Deref { type Target; }
+        struct A;
+        struct B;
+        impl Deref for A { type Target = B; }
+
+        fn foo(a: A) {
+            let b = *a;
+            b
+        } //^ B
+    """)
+
     fun `test slice type`() = testExpr("""
         fn main() {
             let x : [i32];


### PR DESCRIPTION
e.g.
```rust
let a = Box::new(0);
let b = *a;
```