### PR TITLE
Consider type parameters in paths when resolving associated items

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -20,6 +20,7 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ref.RsReference
 import org.rust.lang.core.stubs.index.RsNamedElementIndex
 import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.types.infer.substitute
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
 import java.util.*
@@ -203,14 +204,14 @@ fun processPathResolveVariants(lookup: ImplLookup, path: RsPath, isCompletion: B
             if (processAssociatedItems(lookup, primitiveType, ns, processor)) return true
         }
 
-        val base = qualifier.reference.resolve() ?: return false
-        if (base is RsMod) {
-            val s = base.`super`
+        val base = qualifier.reference.advancedResolve() ?: return false
+        if (base.element is RsMod) {
+            val s = base.element.`super`
             if (s != null && processor("super", s)) return true
         }
-        if (processItemOrEnumVariantDeclarations(base, ns, processor, isSuperChain(qualifier))) return true
-        if (base is RsTypeDeclarationElement && parent !is RsUseItem) {
-            if (processAssociatedItems(lookup, base.declaredType, ns, processor)) return true
+        if (processItemOrEnumVariantDeclarations(base.element, ns, processor, isSuperChain(qualifier))) return true
+        if (base.element is RsTypeDeclarationElement && parent !is RsUseItem) {
+            if (processAssociatedItems(lookup, base.element.declaredType.substitute(base.subst), ns, processor)) return true
         }
         return false
     }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -333,6 +333,18 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         }      //^ u8
     """)
 
+    fun `test struct new with type parameters`() = testExpr("""
+        struct Foo<F>(F);
+        impl<T> Foo<T> {
+            fn new() -> Self { loop {} }
+        }
+        fn main() {
+            let x = Foo::<u16>::new();
+            x
+          //^ Foo<u16>
+        }
+    """)
+
     fun testGenericAlias() = testExpr("""
         struct S1<T>(T);
         struct S3<T1, T2, T3>(T1, T2, T3);


### PR DESCRIPTION
This helps in the case of
```
let v = Vec::<u16>::new();
```
which is now correctly typified as Vec<u16>