### PR TITLE
TY: Use destructuring declaration to clean up newly introduced code

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -204,14 +204,14 @@ fun processPathResolveVariants(lookup: ImplLookup, path: RsPath, isCompletion: B
             if (processAssociatedItems(lookup, primitiveType, ns, processor)) return true
         }
 
-        val base = qualifier.reference.advancedResolve() ?: return false
-        if (base.element is RsMod) {
-            val s = base.element.`super`
+        val (base, subst) = qualifier.reference.advancedResolve() ?: return false
+        if (base is RsMod) {
+            val s = base.`super`
             if (s != null && processor("super", s)) return true
         }
-        if (processItemOrEnumVariantDeclarations(base.element, ns, processor, isSuperChain(qualifier))) return true
-        if (base.element is RsTypeDeclarationElement && parent !is RsUseItem) {
-            if (processAssociatedItems(lookup, base.element.declaredType.substitute(base.subst), ns, processor)) return true
+        if (processItemOrEnumVariantDeclarations(base, ns, processor, isSuperChain(qualifier))) return true
+        if (base is RsTypeDeclarationElement && parent !is RsUseItem) {
+            if (processAssociatedItems(lookup, base.declaredType.substitute(subst), ns, processor)) return true
         }
         return false
     }


### PR DESCRIPTION
The code added by 2b958e5c090742f (#1747) can be made more clear
by using a destructuring declaration instead of writing
"base.element" in many places.