### PR TITLE
Try to fix Cargo deadlock in CLion on windows.

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
@@ -118,7 +118,6 @@ private fun buildProjectAndGetBinaryArtifactPath(module: Module, command: CargoC
 
     val processForUserOutput = ProcessOutput()
     val processForUser = KillableColoredProcessHandler(cargo.toColoredCommandLine(command))
-    val processForJson = CapturingProcessHandler(cargo.toGeneralCommandLine(command.prependArgument("--message-format=json")))
 
     processForUser.addProcessListener(CapturingProcessAdapter(processForUserOutput))
 
@@ -135,6 +134,7 @@ private fun buildProjectAndGetBinaryArtifactPath(module: Module, command: CargoC
 
                     override fun run(indicator: ProgressIndicator) {
                         indicator.isIndeterminate = true
+                        val processForJson = CapturingProcessHandler(cargo.toGeneralCommandLine(command.prependArgument("--message-format=json")))
                         val output = processForJson.runProcessWithProgressIndicator(indicator)
                         if (output.isCancelled || output.exitCode != 0) {
                             promise.setResult(null)


### PR DESCRIPTION
I've failed to pinpoint the actual issue within Cargo: executing a ton
of processes manually works flawlessly. That means that perhaps we do
something different in CLion, but I have no idea what exactly is
different.