### PR TITLE
RES: resolve UFCS & assoc fn calls to a particular impls

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -55,7 +55,7 @@ class RsPsiFactory(private val project: Project) {
         createExpressionOfType("unsafe { $body }")
 
     fun tryCreatePath(text: String): RsPath? {
-        val path = createFromText<RsPathExpr>("fn main() { $text;}")?.path ?: return null
+        val path = createFromText<RsPathExpr>("const a = $text;")?.path ?: return null
         if (path.text != text) return null
         return path
     }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -691,4 +691,48 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
              //^ unresolved
         }
     """)
+
+    // TODO should resolves to T<S2>
+    fun `test resolve method call with multiple impls of the same trait`() = checkByCode("""
+        struct S; struct S1; struct S2;
+        trait T<A> { fn foo(&self, _: A); }
+        impl T<S1> for S { fn foo(&self, _: S1) {} }
+        impl T<S2> for S { fn foo(&self, _: S2) {} }
+        fn main() {
+            S.foo(S2)
+        }    //^ unresolved
+    """)
+
+    fun `test resolve UFCS method call with multiple impls of the same trait`() = checkByCode("""
+        struct S; struct S1; struct S2;
+        trait T<A> { fn foo(&self, _: A); }
+        impl T<S1> for S { fn foo(&self, _: S1) {} }
+        impl T<S2> for S { fn foo(&self, _: S2) {} }
+                            //X
+        fn main() {
+            T::foo(&S, S2);
+        }    //^
+    """)
+
+    fun `test resolve trait associated function with multiple impls of the same trait`() = checkByCode("""
+        struct S; struct S1; struct S2;
+        trait T<A> { fn foo(_: A) -> Self; }
+        impl T<S1> for S { fn foo(_: S1) -> Self { unimplemented!() } }
+        impl T<S2> for S { fn foo(_: S2) -> Self { unimplemented!() } }
+                            //X
+        fn main() {
+            let a: S = T::foo(S2);
+        }               //^
+    """)
+
+    fun `test resolve trait associated function with multiple impls of the same trait 2`() = checkByCode("""
+        struct S; struct S1; struct S2;
+        trait T<A> { fn foo(_: A) -> Self; }
+        impl T<S1> for S { fn foo(_: S1) -> Self { unimplemented!() } }
+        impl T<S2> for S { fn foo(_: S2) -> Self { unimplemented!() } }
+                            //X
+        fn main() {
+            S::foo(S2);
+        }    //^
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -584,4 +584,24 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
             foo.foo();
         }      //^
     """)
+
+    fun `test resolve UFCS method call`() = checkByCode("""
+        struct S;
+        trait T { fn foo(&self); }
+        impl T for S { fn foo(&self) {} }
+                        //X
+        fn main() {
+            T::foo(&S);
+        }    //^
+    """)
+
+    fun `test resolve trait associated function`() = checkByCode("""
+        struct S;
+        trait T { fn foo() -> Self; }
+        impl T for S { fn foo() -> Self { unimplemented!() } }
+                        //X
+        fn main() {
+            let a: S = T::foo();
+        }               //^
+    """)
 }


### PR DESCRIPTION
The PR make this `default` call to be resolved to the particular impl of the `Default` trait for `String`.
```rust
let a: String = Default::default();
```
And even more complicated stuff:
```rust
let a = From::from;
let b = a("");
let c: String = b;
```
Yes, this compiles by rustc and `from` now resolved to the particular impl `From` for `String` =)
Same with UFCS.

And the same approach should also be applied for regular method calls.

Really the current implementation does not suit me very much. It looks a bit ugly. Discussion is required =D