### PR TITLE
ANN: Coerce *mut pointers to *const pointers to fix a wrong E0308

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -340,6 +340,10 @@ private class RsFnInferenceContext(
                 expected is TyReference && expected.referenced is TySlice -> {
                 ctx.combineTypes(inferred.referenced.base, expected.referenced.elementType)
             }
+            inferred is TyPointer && inferred.mutability.isMut
+                && expected is TyPointer && !expected.mutability.isMut -> {
+                ctx.combineTypes(inferred.referenced, expected.referenced)
+            }
         // TODO trait object unsizing
             else -> ctx.combineTypes(inferred, expected)
         }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -948,6 +948,24 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
         }
     """)
 
+    fun `test type mismatch E0308 ptr mutability`() = checkErrors("""
+        fn fn_const(p: *const u8) { }
+        fn fn_mut(p: *mut u8) { }
+
+        fn main () {
+            let mut ptr_const: *const u8;
+            let mut ptr_mut: *mut u8;
+
+            fn_const(ptr_const);
+            fn_const(ptr_mut);
+            fn_mut(<error>ptr_const</error>);
+            fn_mut(ptr_mut);
+
+            ptr_const = ptr_mut;
+            ptr_mut = <error>ptr_const</error>;
+        }
+    """)
+
     fun `test type mismatch E0308 struct`() = checkErrors("""
         struct X; struct Y;
         fn main () {


### PR DESCRIPTION
In places that expect a *const T it is possible to pass a *mut T due to coercion.
See https://doc.rust-lang.org/nomicon/coercions.html

This fixes a wrong E0308 error when using a *mut T at a points where a *const T is expected.
(function argument, let statement, ...)

CC: #1753