### PR TITLE
Fix file icons

### DIFF
--- a/src/main/kotlin/org/rust/cargo/icons/CargoIconProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/icons/CargoIconProvider.kt
@@ -5,28 +5,16 @@
 
 package org.rust.cargo.icons
 
-import com.intellij.ide.IconProvider
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
+import com.intellij.ide.FileIconProvider
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.CargoConstants
-import org.rust.lang.core.psi.RsFile
-import org.rust.lang.core.psi.ext.cargoWorkspace
 import javax.swing.Icon
 
-class CargoIconProvider : IconProvider() {
-    override fun getIcon(element: PsiElement, flags: Int): Icon? = when (element) {
-        is PsiFile -> getFileIcon(element)
+class CargoIconProvider : FileIconProvider {
+    override fun getIcon(file: VirtualFile, flags: Int, project: Project?): Icon? = when (file.name) {
+        CargoConstants.MANIFEST_FILE -> CargoIcons.ICON
+        CargoConstants.LOCK_FILE -> CargoIcons.LOCK_ICON
         else -> null
     }
-
-    private fun getFileIcon(element: PsiFile): Icon? = when {
-        element.name == CargoConstants.MANIFEST_FILE -> CargoIcons.ICON
-        element.name == CargoConstants.LOCK_FILE -> CargoIcons.LOCK_ICON
-        element is RsFile && isBuildRs(element) -> CargoIcons.BUILD_RS_ICON
-        else -> null
-    }
-
-    private fun isBuildRs(element: RsFile): Boolean =
-        element.name == CargoConstants.BUILD_RS_FILE
-            && element.containingDirectory?.virtualFile == element.cargoWorkspace?.contentRoot
 }

--- a/src/main/kotlin/org/rust/ide/icons/RsIconProvider.kt
+++ b/src/main/kotlin/org/rust/ide/icons/RsIconProvider.kt
@@ -7,24 +7,31 @@ package org.rust.ide.icons
 
 import com.intellij.ide.IconProvider
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
+import org.rust.cargo.CargoConstants
+import org.rust.cargo.icons.CargoIcons
 import org.rust.ide.RsConstants
-import org.rust.lang.core.psi.rustMod
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.ext.containingCargoPackage
 import javax.swing.Icon
 
 class RsIconProvider : IconProvider() {
     override fun getIcon(element: PsiElement, flags: Int): Icon? = when (element) {
-        is PsiFile -> getFileIcon(element)
+        is RsFile -> getFileIcon(element)
         else -> null
     }
 
-    private fun getFileIcon(element: PsiFile): Icon? = when {
-        element.name == RsConstants.MOD_RS_FILE -> RsIcons.MOD_RS
-        isMainFile(element) -> RsIcons.MAIN_RS
+    private fun getFileIcon(file: RsFile): Icon? = when {
+        file.name == RsConstants.MOD_RS_FILE -> RsIcons.MOD_RS
+        isMainFile(file) -> RsIcons.MAIN_RS
+        isBuildRs(file) -> CargoIcons.BUILD_RS_ICON
         else -> null
     }
 
-    private fun isMainFile(element: PsiFile) =
+    private fun isMainFile(element: RsFile) =
         (element.name == RsConstants.MAIN_RS_FILE || element.name == RsConstants.LIB_RS_FILE)
-            && element.rustMod?.isCrateRoot ?: false
+            && element.isCrateRoot
+
+    private fun isBuildRs(element: RsFile): Boolean =
+        element.name == CargoConstants.BUILD_RS_FILE
+            && element.containingCargoPackage?.contentRoot == element.containingDirectory?.virtualFile
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -547,7 +547,7 @@
 
         <!-- Icon Provider -->
 
-        <iconProvider implementation="org.rust.cargo.icons.CargoIconProvider"/>
+        <fileIconProvider implementation="org.rust.cargo.icons.CargoIconProvider"/>
         <iconProvider implementation="org.rust.ide.icons.RsIconProvider"/>
 
         <!-- Indices -->


### PR DESCRIPTION
1) Make sure that Cargo.toml & Cargo.lock icons work in file chooser
2) Move build.rs to other special crate roots and make it work again,
   after yet one another regression due to Java's polymorphic equality