### PR TITLE
CARGO: Adding `xargo` support

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -20,6 +20,7 @@ greg-kargin
 HeyLey
 himikof
 HybridEidolon
+idubrov
 johnthagen
 jonas-schievink
 Keats

--- a/src/main/kotlin/org/rust/cargo/CargoConstants.kt
+++ b/src/main/kotlin/org/rust/cargo/CargoConstants.kt
@@ -8,6 +8,7 @@ package org.rust.cargo
 object CargoConstants {
 
     const val MANIFEST_FILE = "Cargo.toml"
+    const val XARGO_MANIFEST_FILE = "Xargo.toml"
     const val LOCK_FILE = "Cargo.lock"
     const val BUILD_RS_FILE = "build.rs"
 

--- a/src/main/kotlin/org/rust/cargo/icons/CargoIconProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/icons/CargoIconProvider.kt
@@ -14,6 +14,7 @@ import javax.swing.Icon
 class CargoIconProvider : FileIconProvider {
     override fun getIcon(file: VirtualFile, flags: Int, project: Project?): Icon? = when (file.name) {
         CargoConstants.MANIFEST_FILE -> CargoIcons.ICON
+        CargoConstants.XARGO_MANIFEST_FILE -> CargoIcons.ICON
         CargoConstants.LOCK_FILE -> CargoIcons.LOCK_ICON
         else -> null
     }

--- a/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
@@ -35,7 +35,16 @@ data class RustToolchain(val location: String) {
     }
 
     fun cargo(cargoProjectDirectory: Path): Cargo =
-        Cargo(pathToExecutable(CARGO), pathToExecutable(RUSTC), cargoProjectDirectory, rustup(cargoProjectDirectory))
+        Cargo(chooseCargoExecutable(cargoProjectDirectory), pathToExecutable(RUSTC), cargoProjectDirectory, rustup(cargoProjectDirectory))
+
+    private fun hasXargoToml(projectDirectory: Path): Boolean =
+        projectDirectory.resolve(XARGO_TOML)?.let { Files.isRegularFile(it) } == true
+
+    private fun chooseCargoExecutable(cargoProjectDirectory: Path): Path =
+        if (hasXargoToml(cargoProjectDirectory) && hasExecutable(XARGO))
+            pathToExecutable(XARGO)
+        else
+            pathToExecutable(CARGO)
 
     fun rustup(cargoProjectDirectory: Path): Rustup? =
         if (isRustupAvailable)
@@ -66,9 +75,11 @@ data class RustToolchain(val location: String) {
         private val RUSTC = "rustc"
         private val CARGO = "cargo"
         private val RUSTUP = "rustup"
+        private val XARGO = "xargo"
 
         val CARGO_TOML = "Cargo.toml"
         val CARGO_LOCK = "Cargo.lock"
+        val XARGO_TOML = "Xargo.toml"
 
         fun suggest(): RustToolchain? = Suggestions.all().mapNotNull {
             val candidate = RustToolchain(it.absolutePath)


### PR DESCRIPTION
Run `xargo` command instead of `cargo` if both `xargo` binary is available and cargo project directory contains `Xargo.toml`.

Closes #1477