### PR TITLE
Coerce references to pointers

### DIFF
--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator
 
+import org.junit.ComparisonFailure
 import org.rust.fileTreeFromText
 
 class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
@@ -948,7 +949,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
         }
     """)
 
-    fun `test type mismatch E0308 ptr mutability`() = checkErrors("""
+    fun `test type mismatch E0308 coerce ptr mutability`() = checkErrors("""
         fn fn_const(p: *const u8) { }
         fn fn_mut(p: *mut u8) { }
 
@@ -965,6 +966,23 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
             ptr_mut = <error>ptr_const</error>;
         }
     """)
+
+    // TODO In TypeInference.coerceResolved() we currently ignore type errors when references are involved
+    fun `test type mismatch E0308 coerce reference to ptr`() = expect<ComparisonFailure> {
+        checkErrors("""
+        fn fn_const(p: *const u8) { }
+        fn fn_mut(p: *mut u8) { }
+
+        fn main () {
+            let const_u8 = &1u8;
+            let mut_u8 = &mut 1u8;
+            fn_const(const_u8);
+            fn_const(mut_u8);
+            fn_mut(<error>const_u8</error>);
+            fn_mut(mut_u8);
+        }
+    """)
+    }
 
     fun `test type mismatch E0308 struct`() = checkErrors("""
         struct X; struct Y;

--- a/src/test/kotlin/org/rust/ide/inspections/RsVariableMutableInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsVariableMutableInspectionTest.kt
@@ -53,8 +53,8 @@ class RsVariableMutableInspectionTest : RsInspectionsTestBase(RsVariableMutableI
     """)
 
     fun `test should not annotate mutated parameter`() = checkByText("""
-        fn foo(&mut i: i32) {
-            i = 20;
+        fn foo(i: &mut i32) {
+            *i = 20;
         }
 
         fn main() {

--- a/src/test/kotlin/org/rust/lang/core/type/RsNumericLiteralTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsNumericLiteralTypeInferenceTest.kt
@@ -174,6 +174,14 @@ class RsNumericLiteralTypeInferenceTest : RsTypificationTestBase() {
         }                   //^ u8
     """)
 
+    fun `test infer coerce reference to ptr`() = expect<IllegalStateException> {
+        testExpr("""
+        fn main() {
+            let a: *const u8 = &0;
+        }                     //^ u8
+    """)
+    }
+
     fun `test infer unary minus rvalue from lvalue`() = testExpr("""
         fn main() {
             let a: i8 = -1;

--- a/src/test/kotlin/org/rust/lang/core/type/RsNumericLiteralTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsNumericLiteralTypeInferenceTest.kt
@@ -174,13 +174,11 @@ class RsNumericLiteralTypeInferenceTest : RsTypificationTestBase() {
         }                   //^ u8
     """)
 
-    fun `test infer coerce reference to ptr`() = expect<IllegalStateException> {
-        testExpr("""
+    fun `test infer coerce reference to ptr`() = testExpr("""
         fn main() {
             let a: *const u8 = &0;
         }                     //^ u8
     """)
-    }
 
     fun `test infer unary minus rvalue from lvalue`() = testExpr("""
         fn main() {


### PR DESCRIPTION
In places that expect a pointer it is possible to pass a reference due to coercion.
Coercion can also remove mutability.
See https://doc.rust-lang.org/nomicon/coercions.html

&T     -> *const T
&mut T -> *mut T
&mut T -> *const T