### PR TITLE
CARGO: Refresh the cargo project when src/lib.rs is created or deleted

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcher.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcher.kt
@@ -30,6 +30,8 @@ class CargoTomlWatcher(
         "/src/bin", "/examples", "/tests", "/benches"
     )
 
+    private val MAIN = "main.rs"
+
     override fun before(events: List<VFileEvent>) {
     }
 
@@ -38,9 +40,12 @@ class CargoTomlWatcher(
             if (isCargoTomlChange(event)) return true
             if (event.path.endsWith(RustToolchain.CARGO_LOCK)) return true
             if (event is VFileContentChangeEvent || PathUtil.getFileExtension(event.path) != "rs") return false
+            val parent = PathUtil.getParentPath(event.path)
+            val grandParent = PathUtil.getParentPath(parent)
+            val name = PathUtil.getFileName(event.path)
 
             if (IMPLICIT_TARGET_FILES.any { event.path.endsWith(it) }) return true
-            return IMPLICIT_TARGET_DIRS.any { PathUtil.getParentPath(event.path).endsWith(it) }
+            return IMPLICIT_TARGET_DIRS.any { parent.endsWith(it) || (name == MAIN && grandParent.endsWith(it)) }
         }
 
         if (events.any(::isInterestingEvent)) {

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcher.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcher.kt
@@ -23,11 +23,11 @@ class CargoTomlWatcher(
     // These are paths and files names used by Cargo to infer targets without Cargo.toml
     // https://github.com/rust-lang/cargo/blob/2c2e07f5cfc9a5de10854654bc1e8abd02ae7b4f/src/cargo/util/toml.rs#L50-L56
     private val IMPLICIT_TARGET_FILES = listOf(
-        "build.rs", "src/main.rs", "src/lib.rs"
+        "/build.rs", "/src/main.rs", "/src/lib.rs"
     )
 
     private val IMPLICIT_TARGET_DIRS = listOf(
-        "src/bin", "examples", "tests", "benches"
+        "/src/bin", "/examples", "/tests", "/benches"
     )
 
     override fun before(events: List<VFileEvent>) {

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcher.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcher.kt
@@ -14,6 +14,7 @@ import org.rust.cargo.toolchain.RustToolchain
 
 /**
  * File changes listener, detecting changes inside the `Cargo.toml` files
+ * and creation of `*.rs` files acting as automatic crate root.
  */
 class CargoTomlWatcher(
     private val onCargoTomlChange: () -> Unit
@@ -22,7 +23,7 @@ class CargoTomlWatcher(
     // These are paths and files names used by Cargo to infer targets without Cargo.toml
     // https://github.com/rust-lang/cargo/blob/2c2e07f5cfc9a5de10854654bc1e8abd02ae7b4f/src/cargo/util/toml.rs#L50-L56
     private val IMPLICIT_TARGET_FILES = listOf(
-        "build.rs", "src/main.rs", "src/bin.rs"
+        "build.rs", "src/main.rs", "src/lib.rs"
     )
 
     private val IMPLICIT_TARGET_DIRS = listOf(

--- a/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherTest.kt
@@ -39,14 +39,24 @@ class CargoTomlWatcherTest : RsTestBase() {
     fun `test implicit targets`() {
         val watcher = CargoTomlWatcher { counter += 1 }
 
+        // src/bin/*.rs
         val (binFile, createEvent) = newCreateEvent("src/bin/foo.rs")
         watcher.checkTriggered(createEvent)
         watcher.checkNotTriggered(newChangeEvent(binFile))
 
+        // src/main.rs
+        watcher.checkTriggered(newCreateEvent("src/main.rs").second)
+
+        // src/lib.rs
+        watcher.checkTriggered(newCreateEvent("src/lib.rs").second)
         watcher.checkNotTriggered(newCreateEvent("src/bar.rs").second)
 
+        // benches/*.rs, examples/*.rs, tests/*.rs
+        watcher.checkTriggered(newCreateEvent("benches/foo.rs").second)
+        watcher.checkTriggered(newCreateEvent("examples/foo.rs").second)
         watcher.checkTriggered(newCreateEvent("tests/foo.rs").second)
 
+        // build.rs
         watcher.checkTriggered(newCreateEvent("build.rs").second)
     }
 

--- a/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherTest.kt
@@ -46,18 +46,22 @@ class CargoTomlWatcherTest : RsTestBase() {
 
         // src/main.rs
         watcher.checkTriggered(newCreateEvent("src/main.rs").second)
+        watcher.checkNotTriggered(newCreateEvent("prefix_src/main.rs").second)
 
         // src/lib.rs
         watcher.checkTriggered(newCreateEvent("src/lib.rs").second)
+        watcher.checkNotTriggered(newCreateEvent("prefix_src/lib.rs").second)
         watcher.checkNotTriggered(newCreateEvent("src/bar.rs").second)
 
         // benches/*.rs, examples/*.rs, tests/*.rs
         watcher.checkTriggered(newCreateEvent("benches/foo.rs").second)
         watcher.checkTriggered(newCreateEvent("examples/foo.rs").second)
         watcher.checkTriggered(newCreateEvent("tests/foo.rs").second)
+        watcher.checkNotTriggered(newCreateEvent("prefix_tests/foo.rs").second)
 
         // build.rs
         watcher.checkTriggered(newCreateEvent("build.rs").second)
+        watcher.checkNotTriggered(newCreateEvent("prefix_build.rs").second)
     }
 
     private fun CargoTomlWatcher.checkTriggered(event: VFileEvent) {

--- a/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherTest.kt
@@ -44,6 +44,9 @@ class CargoTomlWatcherTest : RsTestBase() {
         watcher.checkTriggered(createEvent)
         watcher.checkNotTriggered(newChangeEvent(binFile))
 
+        // src/bin/*/main.rs
+        watcher.checkTriggered(newCreateEvent("src/bin/foo/main.rs").second)
+
         // src/main.rs
         watcher.checkTriggered(newCreateEvent("src/main.rs").second)
         watcher.checkNotTriggered(newCreateEvent("prefix_src/main.rs").second)
@@ -58,6 +61,11 @@ class CargoTomlWatcherTest : RsTestBase() {
         watcher.checkTriggered(newCreateEvent("examples/foo.rs").second)
         watcher.checkTriggered(newCreateEvent("tests/foo.rs").second)
         watcher.checkNotTriggered(newCreateEvent("prefix_tests/foo.rs").second)
+
+        // benches/*/main.rs, examples/*/main.rs, tests/*/main.rs
+        watcher.checkTriggered(newCreateEvent("benches/foo/main.rs").second)
+        watcher.checkTriggered(newCreateEvent("examples/foo/main.rs").second)
+        watcher.checkTriggered(newCreateEvent("tests/foo/main.rs").second)
 
         // build.rs
         watcher.checkTriggered(newCreateEvent("build.rs").second)


### PR DESCRIPTION
Due to a typo we would not react to src/lib.rs being created.
This would cause us to not refresh our cargo workspace / crate roots.
(WorkspaceImpl.targetByCrateRootUrl)

This in turn could cause a wrong error
"Cannot declare a new module at this location"
because src/lib.rs would not be recognized as crate root.

Fixes #1638