### PR TITLE
Support explicit self type in method parameter 

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsSelfParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsSelfParameter.kt
@@ -17,6 +17,7 @@ import org.rust.lang.core.types.ty.Mutability
 
 val RsSelfParameter.mutability: Mutability get() = Mutability.valueOf(stub?.isMut ?: (mut != null))
 val RsSelfParameter.isRef: Boolean get() = stub?.isRef ?: (and != null)
+val RsSelfParameter.isExplicitType get() = stub?.isExplicitType ?: (colon != null)
 
 abstract class RsSelfParameterImplMixin : RsStubbedElementImpl<RsSelfParameterStub>,
                                           PsiNameIdentifierOwner,

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -31,7 +31,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 103
+        override fun getStubVersion(): Int = 104
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)
@@ -760,12 +760,14 @@ class RsValueParameterStub(
 class RsSelfParameterStub(
     parent: StubElement<*>?, elementType: IStubElementType<*, *>,
     val isMut: Boolean,
-    val isRef: Boolean
+    val isRef: Boolean,
+    val isExplicitType: Boolean
 ) : StubBase<RsSelfParameter>(parent, elementType) {
 
     object Type : RsStubElementType<RsSelfParameterStub, RsSelfParameter>("SELF_PARAMETER") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
             RsSelfParameterStub(parentStub, this,
+                dataStream.readBoolean(),
                 dataStream.readBoolean(),
                 dataStream.readBoolean()
             )
@@ -774,13 +776,14 @@ class RsSelfParameterStub(
             with(dataStream) {
                 dataStream.writeBoolean(stub.isMut)
                 dataStream.writeBoolean(stub.isRef)
+                dataStream.writeBoolean(stub.isExplicitType)
             }
 
         override fun createPsi(stub: RsSelfParameterStub): RsSelfParameter =
             RsSelfParameterImpl(stub, this)
 
         override fun createStub(psi: RsSelfParameter, parentStub: StubElement<*>?) =
-            RsSelfParameterStub(parentStub, this, psi.mutability.isMut, psi.isRef)
+            RsSelfParameterStub(parentStub, this, psi.mutability.isMut, psi.isRef, psi.isExplicitType)
 
         override fun indexStub(stub: RsSelfParameterStub, sink: IndexSink) {
             // NOP

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -949,6 +949,13 @@ private val RsSelfParameter.typeOfValue: Ty
             TyTypeParameter.self(trait)
         }
 
+        if (isExplicitType) {
+            // self: Self, self: &Self, self: &mut Self, self: Box<Self>
+            val ty = this.typeReference?.type ?: TyUnknown
+            return ty.substitute(mapOf(TyTypeParameter.self() to Self))
+        }
+
+        // self, &self, &mut self
         if (isRef) {
             Self = TyReference(Self, mutability)
         }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -241,6 +241,96 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test self 1`() = testExpr("""
+        struct Foo;
+        impl Foo {
+            fn foo(self) {
+                self;
+              //^ Foo
+            }
+        }
+    """)
+
+    fun `test self 2`() = testExpr("""
+        struct Foo;
+        impl Foo {
+            fn foo(self: Self) {
+                self;
+              //^ Foo
+            }
+        }
+    """)
+
+    fun `test self 3`() = testExpr("""
+        struct Foo;
+        impl Foo {
+            fn foo(self: Foo) {
+                self;
+              //^ Foo
+            }
+        }
+    """)
+
+    fun `test &mut self 1`() = testExpr("""
+        struct Foo;
+        impl Foo {
+            fn foo(&mut self) {
+                self;
+              //^ &mut Foo
+            }
+        }
+    """)
+
+    fun `test &mut self 2`() = expect<IllegalStateException> {
+        testExpr("""
+        struct Foo;
+        impl Foo {
+            fn foo(self: &mut Self) {
+                self;
+              //^ &mut Foo
+            }
+        }
+    """)
+    }
+
+    fun `test &mut self 3`() = expect<IllegalStateException> {
+        testExpr("""
+        struct Foo;
+        impl Foo {
+            fn foo(self: &mut Foo) {
+                self;
+              //^ &mut Foo
+            }
+        }
+    """)
+    }
+
+    fun `test box self 1`() = expect<IllegalStateException> {
+        testExpr("""
+        struct Box<T>(T);
+        struct Foo;
+        impl Foo {
+            fn foo(self: Box<Self>) {
+                self;
+              //^ Box<Foo>
+            }
+        }
+    """)
+    }
+
+    fun `test box self 2`() = expect<IllegalStateException> {
+        testExpr("""
+        struct Box<T>(T);
+        struct Foo;
+        impl Foo {
+            fn foo(self: Box<Foo>) {
+                self;
+              //^ Box<Foo>
+            }
+        }
+    """)
+    }
+
     fun `test struct expr`() = testExpr("""
         struct S<T> { a: T }
         fn main() {

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -281,8 +281,7 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    fun `test &mut self 2`() = expect<IllegalStateException> {
-        testExpr("""
+    fun `test &mut self 2`() = testExpr("""
         struct Foo;
         impl Foo {
             fn foo(self: &mut Self) {
@@ -291,10 +290,8 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             }
         }
     """)
-    }
 
-    fun `test &mut self 3`() = expect<IllegalStateException> {
-        testExpr("""
+    fun `test &mut self 3`() = testExpr("""
         struct Foo;
         impl Foo {
             fn foo(self: &mut Foo) {
@@ -303,10 +300,8 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             }
         }
     """)
-    }
 
-    fun `test box self 1`() = expect<IllegalStateException> {
-        testExpr("""
+    fun `test box self 1`() = testExpr("""
         struct Box<T>(T);
         struct Foo;
         impl Foo {
@@ -316,10 +311,8 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             }
         }
     """)
-    }
 
-    fun `test box self 2`() = expect<IllegalStateException> {
-        testExpr("""
+    fun `test box self 2`() = testExpr("""
         struct Box<T>(T);
         struct Foo;
         impl Foo {
@@ -329,7 +322,6 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             }
         }
     """)
-    }
 
     fun `test struct expr`() = testExpr("""
         struct S<T> { a: T }


### PR DESCRIPTION
The self parameter of a method can be written in a short hand and in an explicit variant.
The explicit variant also supports a special case for Box<Self>.

```
self      -> self: Self
&self     -> self: &Self
&mut self -> self: &mut Self
-         -> self: Box<Self>
```

Fix type the inference for this explicit type syntax on the self parameter.