### PR TITLE
Use relative offsets in `SubstituteText` fix.

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
@@ -159,7 +159,12 @@ private fun checkValueParameter(holder: AnnotationHolder, param: RsValueParamete
                 val annotation = holder
                     .createWarningAnnotation(param, "Anonymous functions parameters are deprecated (RFC 1685)")
 
-                val fix = SubstituteTextFix(param.textRange, "_: ${param.text}", "Add dummy parameter name")
+                val fix = SubstituteTextFix.replace(
+                    "Add dummy parameter name",
+                    param.containingFile,
+                    param.textRange,
+                    "_: ${param.text}"
+                )
                 val descriptor = InspectionManager.getInstance(param.project)
                     .createProblemDescriptor(param, annotation.message, fix, ProblemHighlightType.GENERIC_ERROR_OR_WARNING, true)
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsDanglingElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDanglingElseInspection.kt
@@ -34,14 +34,21 @@ class RsDanglingElseInspection : RsLocalInspectionTool() {
                 val ifEl = breakEl.rightSiblings
                     .dropWhile { it !is RsIfExpr }
                     .firstOrNull() ?: return
-                val range = TextRange(0, ifEl.startOffsetInParent + 2)
-                val fix2Range = TextRange(elseEl.textRange.endOffset, ifEl.textRange.startOffset)
                 holder.registerProblem(
                     expr,
-                    range,
+                    TextRange(0, ifEl.startOffsetInParent + 2),
                     "Suspicious `else if` formatting",
-                    SubstituteTextFix(elseEl.rangeWithPrevSpace(expr.prevSibling), null, "Remove `else`"),
-                    SubstituteTextFix(fix2Range, " ", "Join `else if`"))
+                    SubstituteTextFix.delete(
+                        "Remove `else`",
+                        expr.containingFile,
+                        elseEl.rangeWithPrevSpace(expr.prevSibling)
+                    ),
+                    SubstituteTextFix.replace(
+                        "Join `else if`",
+                        expr.containingFile,
+                        TextRange(elseEl.textRange.endOffset, ifEl.textRange.startOffset),
+                        " "
+                    ))
             }
         }
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsMissingElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsMissingElseInspection.kt
@@ -35,12 +35,11 @@ class RsMissingElseInspection : RsLocalInspectionTool() {
                 val condition = nextIf.condition ?: return
                 val rangeStart = expr.startOffsetInParent + firstIf.textLength
                 val rangeLen = condition.expr.textRange.startOffset - firstIf.textRange.startOffset - firstIf.textLength
-                val fixRange = TextRange(nextIf.textRange.startOffset, nextIf.textRange.startOffset)
                 holder.registerProblem(
                     expr.parent,
                     TextRange(rangeStart, rangeStart + rangeLen),
                     "Suspicious if. Did you mean `else if`?",
-                    SubstituteTextFix(fixRange, "else ", "Change to `else if`"))
+                    SubstituteTextFix.insert("Change to `else if`", nextIf.containingFile, nextIf.textRange.startOffset, "else "))
             }
         }
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspection.kt
@@ -10,7 +10,10 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import org.rust.ide.inspections.fixes.SubstituteTextFix
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsBinaryExpr
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsUnaryExpr
+import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.operator
 
 /**
@@ -49,12 +52,13 @@ class RsSuspiciousAssignmentInspection : RsLocalInspectionTool() {
                     val subst1 = "$left $op= $right"
                     val subst2 = "$left = $right2"
                     val substRange = TextRange(expr.left.textRange.endOffset, unaryBody.textRange.startOffset)
+                    val file = expr.containingFile
                     holder.registerProblem(
                         expr,
                         TextRange(expr.left.text.length, uExprOffset),
                         "Suspicious assignment. Did you mean `$subst1` or `$subst2`?",
-                        SubstituteTextFix(substRange, " $op= ", "Change to `$subst1`"),
-                        SubstituteTextFix(substRange, " = $op", "Change to `$subst2`"))
+                        SubstituteTextFix.replace("Change to `$subst1`", file, substRange, " $op= "),
+                        SubstituteTextFix.replace("Change to `$subst2`", file, substRange, " = $op"))
                 }
             }
         }

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/SubstituteTextFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/SubstituteTextFix.kt
@@ -11,27 +11,46 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
+import com.intellij.psi.SmartPointerManager
 
 /**
  * Fix that removes the given range from the document and places a text onto its place.
- * @param range The range that will be removed from the document.
- * @param text The text that will be placed starting from `range.startOffset`. If `null`, no text will be inserted.
  * @param fixName The name to use for the fix instead of the default one to better fit the inspection.
+ * @param file
+ * @param range The range *inside element* that will be removed from the document.
+ * @param substitution The text that will be placed starting from `range.startOffset`. If `null`, no text will be inserted.
  */
-class SubstituteTextFix(
-    val range: TextRange,
-    val text: String?,
-    val fixName: String = "Substitute"
+class SubstituteTextFix private constructor(
+    private val fixName: String = "Substitute",
+    file: PsiFile,
+    range: TextRange,
+    private val substitution: String?
 ) : LocalQuickFix {
-    override fun getName() = fixName
+
+    private val fileWithRange = SmartPointerManager.getInstance(file.project)
+        .createSmartPsiFileRangePointer(file, range)
+
+    override fun getName(): String = fixName
     override fun getFamilyName() = "Substitute one text to another"
 
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        val file = descriptor.psiElement.containingFile
+        val file = fileWithRange.containingFile ?: return
+        val range = fileWithRange.range ?: return
         val document = PsiDocumentManager.getInstance(project).getDocument(file)
         document?.deleteString(range.startOffset, range.endOffset)
-        if (text != null) {
-            document?.insertString(range.startOffset, text)
+        if (substitution != null) {
+            document?.insertString(range.startOffset, substitution)
         }
+    }
+
+    companion object {
+        fun delete(fixName: String, file: PsiFile, range: TextRange) =
+            SubstituteTextFix(fixName, file, range, null)
+
+        fun insert(fixName: String, file: PsiFile, offsetInElement: Int, text: String) =
+            SubstituteTextFix(fixName, file, TextRange(offsetInElement, offsetInElement), text)
+
+        fun replace(fixName: String, file: PsiFile, range: TextRange, text: String) =
+            SubstituteTextFix(fixName, file, range, text)
     }
 }


### PR DESCRIPTION
This is important because a fix might be not recalculated after whitespace-only changes.