### PR TITLE
CARGO: use new channel syntax

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -43,6 +43,7 @@ oistein
 osialr
 pavel-v-chernykh
 pocket7878
+sanmai-NL
 Shiroy
 sirgl
 slavam2605


### PR DESCRIPTION
Also, allow colorized command output without forcing colorization.

Resolves #1824, #1822.