### PR TITLE
CARGO: Fix channel selection command lines

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -154,7 +154,6 @@ class CargoCommandConfiguration(
             return CleanConfiguration.error("Invalid toolchain: ${toolchain.presentableLocation}")
         }
 
-
         if (!toolchain.isRustupAvailable && channel != RustChannel.DEFAULT) {
             return CleanConfiguration.error("Channel '$channel' is set explicitly with no rustup available")
         }

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -92,7 +92,6 @@ class Cargo(
     fun clippyCommandLine(channel: RustChannel): CargoCommandLine =
         CargoCommandLine("clippy", channel = channel)
 
-
     fun toColoredCommandLine(commandLine: CargoCommandLine): GeneralCommandLine =
         generalCommandLine(commandLine, true)
 
@@ -102,12 +101,10 @@ class Cargo(
     private fun generalCommandLine(commandLine: CargoCommandLine, colors: Boolean): GeneralCommandLine {
         val cmdLine = if (commandLine.channel == RustChannel.DEFAULT) {
             GeneralCommandLine(cargoExecutable)
+        } else if (rustup == null) {
+            error("Channel cannot be set because rustup is not available")
         } else {
-            if (rustup == null) {
-                error("Channel '${commandLine.channel}' cannot be set explicitly because rustup is not available")
-            } else {
                 GeneralCommandLine(cargoExecutable, "+${commandLine.channel}")
-            }
         }
 
         cmdLine

--- a/src/main/kotlin/org/rust/cargo/toolchain/RustChannel.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustChannel.kt
@@ -5,13 +5,13 @@
 
 package org.rust.cargo.toolchain
 
-enum class RustChannel(val index: Int, val title: String, val rustupArgument: String?) {
-    DEFAULT(0, "[Default]", null),
-    STABLE(1, "Stable", "stable"),
-    BETA(2, "Beta", "beta"),
-    NIGHTLY(3, "Nightly", "nightly");
+enum class RustChannel(val index: Int, val channel: String?) {
+    DEFAULT(0, null),
+    STABLE(1, "stable"),
+    BETA(2, "beta"),
+    NIGHTLY(3, "nightly");
 
-    override fun toString(): String = title
+    override fun toString(): String = if (channel != null) { channel } else { "[default]" }
 
     companion object {
         fun fromIndex(index: Int) = RustChannel.values().find { it.index == index } ?: RustChannel.DEFAULT

--- a/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
@@ -59,8 +59,8 @@ class Rustup(
     }
 
     fun createRunCommandLine(channel: RustChannel, varargs: String): GeneralCommandLine =
-        if (channel.rustupArgument != null) {
-            GeneralCommandLine(rustup, "run", channel.rustupArgument, varargs)
+        if (channel.channel != null) {
+            GeneralCommandLine(rustup, "run", channel.channel, varargs)
         } else {
             GeneralCommandLine(rustup, "run", varargs)
         }


### PR DESCRIPTION
Rustup channel names are case sensitive. Remove distinction between actual
channel names and their UI caption (with initial capitals).

Resolves #1827