### PR TITLE
Resolve #1587: It is not possible to debug applications with command line parameters

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
@@ -63,7 +63,7 @@ class RsDebugRunner : com.intellij.execution.runners.AsyncGenericProgramRunner<R
         val cargo = env.project.toolchain!!.cargo(cargoProjectDirectory)
 
         val buildCommand = if (cleaned.cmd.command == "run") {
-            cleaned.cmd.copy(command = "build")
+            cleaned.cmd.copy(command = "build", additionalArguments = cleaned.cmd.getBuildArguments())
         } else {
             check(cleaned.cmd.command == "test")
             cleaned.cmd.prependArgument("--no-run")
@@ -73,6 +73,7 @@ class RsDebugRunner : com.intellij.execution.runners.AsyncGenericProgramRunner<R
             .then { result ->
                 result?.path?.let {
                     val commandLine = GeneralCommandLine(it).withWorkDirectory(cargoProjectDirectory)
+                    commandLine.withParameters(cleaned.cmd.getRunArguments())
                     RsRunProfileStarter(commandLine)
                 }
             }

--- a/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
@@ -6,6 +6,7 @@
 package org.rust.cargo.toolchain
 
 import com.intellij.execution.configuration.EnvironmentVariablesData
+import com.intellij.util.execution.ParametersListUtil
 import org.rust.cargo.project.model.CargoProject
 import java.nio.file.Path
 
@@ -33,5 +34,23 @@ data class CargoCommandLine(
             listOf("--manifest-path", project.manifest.toString()) + additionalArguments,
             backtraceMode, channel, workingDirectory, environmentVariables, nocapture
         )
+    }
+
+    /**
+     * Returns the list of arguments after the "--". If there is no "--" returns an empty list.
+     */
+    fun getRunArguments() : List<String> {
+        val idx = additionalArguments.indexOf("--")
+        val cnt = if(idx >= 0) idx else additionalArguments.size-1
+        return additionalArguments.takeLast(Math.max(0, additionalArguments.size - cnt - 1))
+    }
+
+    /**
+     * Returns the arguments before any "--" argument, intended for the "cargo build" command.
+     */
+    fun getBuildArguments() : List<String> {
+        val idx = additionalArguments.indexOf("--")
+        val cnt = if(idx >= 0) idx else additionalArguments.size
+        return additionalArguments.take(cnt)
     }
 }

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoCommandLineTest.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoCommandLineTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.toolchain
+
+import com.intellij.testFramework.UsefulTestCase
+import com.intellij.util.containers.EmptyListIterator
+import org.junit.Assert
+import org.junit.Test
+
+class CargoCommandLineTest {
+    @Test
+    public fun `getRunArguments should return an empty array if no arguments`() {
+        val cot = CargoCommandLine("run", listOf("--bin", "someproj"))
+        val actual = cot.getRunArguments()
+        val expected = emptyList<String>()
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    public fun `getRunArguments should return an empty array if no arguments but arg indicator`() {
+        val cot = CargoCommandLine("run", listOf("--bin", "someproj", "--"))
+        val actual = cot.getRunArguments()
+        val expected = emptyList<String>()
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    public fun `getRunArguments should return an array if arguments`() {
+        val cot = CargoCommandLine("run", listOf("--bin", "someproj", "--", "arg1"))
+        val actual = cot.getRunArguments()
+        val expected = listOf("arg1")
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    public fun `getBuildArguments should return build arguments`() {
+        val expected = listOf("--bin", "someproj")
+        val cot = CargoCommandLine("run", expected)
+        val actual = cot.getBuildArguments()
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    public fun `getBuildArguments should return build arguments no arguments but arg indicator`() {
+        val cot = CargoCommandLine("run", listOf("--bin", "someproj", "--"))
+        val actual = cot.getBuildArguments()
+        val expected = listOf("--bin", "someproj")
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    public fun `getBuildArguments should return build arguments only preceeding arguments`() {
+        val cot = CargoCommandLine("run", listOf("--bin", "someproj", "--", "arg1"))
+        val actual = cot.getBuildArguments()
+        val expected = listOf("--bin", "someproj")
+        Assert.assertEquals(expected, actual)
+    }
+}

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt
@@ -8,10 +8,24 @@ package org.rust.cargo.toolchain
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.net.HttpConfigurable
+import org.junit.Test
 import org.rust.lang.RsTestBase
+import org.rust.openapiext.pathAsPath
 import java.nio.file.Paths
 
 class CargoTest : RsTestBase() {
+
+    fun `test run arguments preserved`() = checkCommandLine(
+        cargo
+            .toColoredCommandLine(CargoCommandLine("run", listOf("--bin", "parity", "--", "--prune", "archive")))
+            .withCharset(Charsets.UTF_8),
+        "cmd: /usr/bin/cargo run --color=always --bin parity -- --prune archive\n" +
+            "env: RUSTC=/usr/bin/rustc, RUST_BACKTRACE=full, TERM=ansi"
+        , """
+            cmd: C:/usr/bin/cargo.exe run --bin parity -- --prune archive
+            env: RUSTC=C:/usr/bin/rustc.exe, RUST_BACKTRACE=full, TERM=ansi
+    """)
+
     fun `test basic command`() = checkCommandLine(
         cargo.toGeneralCommandLine(CargoCommandLine("test", listOf("--all"))), """
         cmd: /usr/bin/cargo test --all -- --nocapture


### PR DESCRIPTION
I was unable to debug a program in CLion because it was not possible in the Run Configuration dialog box to set parameters to pass to the application being debugged.

I added a new "Run Arguments" field to the dialog box, plumbed it through to both run and debug mode, and tested as much as I could with IntelliJ (I'm not sure how to debug it in CLion, but it appears to launch with the correct parameters...)

![screenshot at 2017-10-15 17 23 01](https://user-images.githubusercontent.com/3855243/31590727-86f4e45a-b1d2-11e7-9ffd-67a0d6e02f5f.png)