### PR TITLE
COMP: Implement unsafe methods.

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -249,6 +249,7 @@ class RsPsiFactory(private val project: Project) {
 
 private val RsFunction.signatureText: String?
     get() {
+        val unsafe = if (isUnsafe) "unsafe " else ""
         // We can't simply take a substring of original method declaration
         // because of anonymous parameters.
         val name = name ?: return null
@@ -261,7 +262,7 @@ private val RsFunction.signatureText: String?
 
         val ret = retType?.text?.let { it + " " } ?: ""
         val where = whereClause?.text ?: ""
-        return "fn $name$generics(${allArguments.joinToString(",")}) $ret$where"
+        return "${unsafe}fn $name$generics(${allArguments.joinToString(",")}) $ret$where"
     }
 
 private fun String.iff(cond: Boolean) = if (cond) this + " " else " "

--- a/src/test/kotlin/org/rust/ide/core/overrideImplement/ImplementMembersFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/core/overrideImplement/ImplementMembersFixTest.kt
@@ -174,6 +174,56 @@ class ImplementMembersFixTest : RsTestBase() {
         }
     """)
 
+    fun test6() = doTest("""
+        trait T {
+            unsafe fn foo();
+            unsafe fn bar() {}
+        }
+        struct S;
+        impl T for S {}
+    """, """
+        |*s foo()
+        |   bar()
+    """, """
+        trait T {
+            unsafe fn foo();
+            unsafe fn bar() {}
+        }
+        struct S;
+        impl T for S {
+            unsafe fn foo() {
+                unimplemented!()
+            }
+        }
+    """)
+
+    fun test7() = doTest("""
+        trait T {
+            unsafe fn foo();
+            unsafe fn bar() {}
+        }
+        struct S;
+        impl T for S {}
+    """, """
+        |*s foo()
+        | s bar()
+    """, """
+        trait T {
+            unsafe fn foo();
+            unsafe fn bar() {}
+        }
+        struct S;
+        impl T for S {
+            unsafe fn foo() {
+                unimplemented!()
+            }
+
+            unsafe fn bar() {
+                unimplemented!()
+            }
+        }
+    """)
+
     private fun doTest(@Language("Rust") code: String,
                        chooser: String,
                        @Language("Rust") expected: String) {


### PR DESCRIPTION
Fixes #1895.

Properly include `unsafe` keyword when implementing trait methods.