### PR TITLE
Correctly rebuild workspace when adding stdlib

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
@@ -30,7 +30,7 @@ data class CargoWorkspaceData(
         val version: String,
         val targets: Collection<Target>,
         val source: String?,
-        val isWorkspaceMember: Boolean
+        val origin: PackageOrigin
     )
 
     data class Target(

--- a/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
@@ -26,7 +26,9 @@ class StandardLibrary private constructor(
         val crateRootUrl: String,
         val packageRootUrl: String,
         val dependencies: Collection<String>
-    )
+    ) {
+        val id: PackageId get() = "(stdlib) $name"
+    }
 
     companion object {
         fun fromPath(path: String): StandardLibrary? =

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -13,6 +13,7 @@ import com.intellij.util.PathUtil
 import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
 import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.cargo.project.workspace.PackageId
+import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.openapiext.findFileByMaybeRelativePath
 
 /**
@@ -177,7 +178,7 @@ object CargoMetadata {
             version,
             targets.mapNotNull { it.clean(root) },
             source,
-            isWorkspaceMember
+            origin = if (isWorkspaceMember) PackageOrigin.WORKSPACE else PackageOrigin.TRANSITIVE_DEPENDENCY
         )
     }
 

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt
@@ -20,6 +20,7 @@ import org.rust.cargo.runconfig.command.CargoCommandConfigurationType
 import org.rust.cargo.runconfig.command.CargoExecutableRunConfigurationProducer
 import org.rust.cargo.runconfig.test.CargoTestRunConfigurationProducer
 import org.rust.cargo.project.workspace.CargoWorkspaceData
+import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.RsTestBase
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsFunction
@@ -368,7 +369,7 @@ class RunConfigurationProducerTest : RsTestBase() {
                                 )
                             },
                             source = null,
-                            isWorkspaceMember = true
+                            origin = PackageOrigin.WORKSPACE
                         )
                     ),
                     dependencies = emptyMap()

--- a/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
@@ -9,6 +9,7 @@ import com.intellij.codeInsight.completion.PlainPrefixMatcher
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspaceData
+import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.RsTestBase
 import java.nio.file.Paths
 
@@ -113,7 +114,7 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
             version = "1.0.0",
             targets = targets,
             source = null,
-            isWorkspaceMember = isWorkspaceMember
+            origin = if (isWorkspaceMember) PackageOrigin.WORKSPACE else PackageOrigin.DEPENDENCY
         )
 
         val pkgs = listOf(

--- a/src/test/kotlin/org/rust/lang/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/RsTestBase.kt
@@ -33,6 +33,7 @@ import org.rust.cargo.project.workspace.StandardLibrary
 import org.rust.cargo.toolchain.RustToolchain
 import org.rust.cargo.toolchain.Rustup
 import org.rust.cargo.project.workspace.CargoWorkspaceData
+import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.fileTreeFromText
 import org.rust.lang.core.psi.ext.parentOfType
 import java.nio.file.Paths
@@ -222,7 +223,7 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
                 CargoWorkspaceData.Target("$contentRoot/lib.rs", name, CargoWorkspace.TargetKind.LIB)
             ),
             source = null,
-            isWorkspaceMember = true
+            origin = PackageOrigin.WORKSPACE
         )
     }
 
@@ -250,10 +251,9 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
                     CargoWorkspaceData.Target(source?.let { FileUtil.join(contentRoot, it) } ?: "", targetName, CargoWorkspace.TargetKind.LIB)
                 ),
                 source = source,
-                isWorkspaceMember = false
+                origin = PackageOrigin.DEPENDENCY
             )
         }
-
 
         fun setUp(fixture: CodeInsightTestFixture) {
             val root = fixture.findFileInTempDir(".")!!


### PR DESCRIPTION
Fixes #1945 

Some preliminary refactoring were done in #1946 and #1947.

So, what the hell is going on here, and why am I so excited about this issue? :) 

We use `CargoWorkspace` as our project model. Workspace is a hierarchical structure `Workspace > Package > Target`. Here are some useful properties about it:

1) It's logically immutable and tread safe (there's some caching of virtual file happening for perfromance).

2) Packages have dependencies on each other, which creates a graph data structure. 

3) Targets and packages have backlinks to containing package and workspace, to make it easy to go not only in Workspace > Package > Target direction, but int the opposite one as well.

Crucially, 2) and 3) imply that the data structure is cyclic. Together with 1), it poses an interesting problem of constructing an immutable object with cycles. We solve this conundrum by splitting the data structure into immutable `CargoWorkspace` inteface, and a mutable `CargoWorksapceImpl` implementaion, which acts as a builder of the workspace.

One more twist is that we construct Workspace from two pieces: standard librariy from rustup, and cargo metadata output from Cargo. It's possible that standard library is not available, so we have a `withStdlib` method on `CargoWorkspace`, which should return a new workspace with standard library.

Previously, this was handled by just adding packages from stdlib to packages from old workspace. However, this is wrong, because backlinks in old packages point to **the wrong workspace**! In this PR we instead completely rebuild the whole data structure. 

Turns out cyclic data structures are hard not only in Rust!

r? @Undin 