### PR TITLE
Improve handling of explicit #[path = "foo/mod.rs"] attribute

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -277,7 +277,7 @@ edit some files.
 
 The current implementation uses the following trick. When indexing `mod foo;`,
 we associated the declaration with the potential name of the file. In this case,
-it would be `"foo"`, for `#[path=bar/baz.rs]` it would be `baz`. Then, when we
+it would be `"foo"`, for `#[path="bar/baz.rs"]` it would be `baz`. Then, when we
 want to find the parent of the `foo.rs` or `foo/mod.rs` file, we query the index
 for all mod decls with the `foo` key. This may give us some false positives, if
 there are several `foo` modules in the different parts of the project, but it

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -128,7 +128,7 @@ fun processModDeclResolveVariants(modDecl: RsModDeclItem, processor: RsResolvePr
 
     val explicitPath = modDecl.pathAttribute
     if (explicitPath != null) {
-        val vFile = dir.virtualFile.findFileByRelativePath(explicitPath) ?: return false
+        val vFile = dir.virtualFile.findFileByRelativePath(explicitPath.replace('\\', '/')) ?: return false
         val mod = vFile.toPsiFile(modDecl.project)?.rustMod ?: return false
 
         val name = modDecl.name ?: return false

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -31,7 +31,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 106
+        override fun getStubVersion(): Int = 107
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsModulesIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsModulesIndex.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.stubs.StringStubIndexExtension
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
 import com.intellij.util.PathUtil
+import org.rust.ide.RsConstants
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.RsFile
@@ -57,13 +58,18 @@ class RsModulesIndex : StringStubIndexExtension<RsModDeclItem>() {
 
         // We use case-insensitive name as a key, because certain file systems
         // are case-insensitive. It will work correctly with case-sensitive fs
-        // because we of the resolv check we do in [getSuperFor]
+        // because we of the resolve check we do in [getSuperFor]
         private fun key(mod: RsFile): String? = mod.modName?.toLowerCase()
 
         private fun key(mod: RsModDeclItem): String? {
             val pathAttribute = mod.pathAttribute
             return if (pathAttribute != null) {
-                FileUtil.getNameWithoutExtension(PathUtil.getFileName(pathAttribute))
+                val fileName = PathUtil.getFileName(pathAttribute)
+                if (fileName == RsConstants.MOD_RS_FILE)
+                    // Use the name of the parent directory for files named mod.rs
+                    PathUtil.getFileName(PathUtil.getParentPath(pathAttribute))
+                else
+                    FileUtil.getNameWithoutExtension(fileName)
             } else {
                 mod.name
             }?.toLowerCase()

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -152,6 +152,19 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
        }
     """)
 
+    fun `test resolve explicit mod path mod rs windows path separator`() = stubOnlyResolve("""
+    //- main.rs
+        #[path = "sub\\bar\\mod.rs"]
+        mod foo;
+
+        fn quux() {}
+    //- sub/bar/mod.rs
+        fn foo() {
+            ::quux();
+            //^ main.rs
+       }
+    """)
+
     fun testUseFromChild() = stubOnlyResolve("""
     //- main.rs
         use child::{foo};

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -126,8 +126,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         pub fn quux() {}
     """)
 
-    fun `test resolve explicit mod path mod rs`() = expect<IllegalStateException> {
-        stubOnlyResolve("""
+    fun `test resolve explicit mod path mod rs`() = stubOnlyResolve("""
     //- main.rs
         #[path = "sub/mod.rs"]
         mod foo;
@@ -139,10 +138,8 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
             //^ main.rs
        }
     """)
-    }
 
-    fun `test resolve explicit mod path mod rs 2`() = expect<IllegalStateException> {
-        stubOnlyResolve("""
+    fun `test resolve explicit mod path mod rs 2`() = stubOnlyResolve("""
     //- main.rs
         #[path = "sub/bar/mod.rs"]
         mod foo;
@@ -154,7 +151,6 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
             //^ main.rs
        }
     """)
-    }
 
     fun testUseFromChild() = stubOnlyResolve("""
     //- main.rs

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -126,6 +126,36 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         pub fn quux() {}
     """)
 
+    fun `test resolve explicit mod path mod rs`() = expect<IllegalStateException> {
+        stubOnlyResolve("""
+    //- main.rs
+        #[path = "sub/mod.rs"]
+        mod foo;
+
+        fn quux() {}
+    //- sub/mod.rs
+        fn foo() {
+            ::quux();
+            //^ main.rs
+       }
+    """)
+    }
+
+    fun `test resolve explicit mod path mod rs 2`() = expect<IllegalStateException> {
+        stubOnlyResolve("""
+    //- main.rs
+        #[path = "sub/bar/mod.rs"]
+        mod foo;
+
+        fn quux() {}
+    //- sub/bar/mod.rs
+        fn foo() {
+            ::quux();
+            //^ main.rs
+       }
+    """)
+    }
+
     fun testUseFromChild() = stubOnlyResolve("""
     //- main.rs
         use child::{foo};


### PR DESCRIPTION
When the explicit path ends with "/mod.rs" then resolving inside this module would be broken.