### PR TITLE
Delegate method/field resolution to type inference engine

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -143,7 +143,7 @@ MetaItemArgs ::= '(' [ <<comma_separated_list (MetaItem | LitExpr)>> ] ')' {
 private PathIdent ::= !("union" identifier) identifier | self | super | 'Self'
 
 fake Path ::= (Path '::' | '::' | TypeQual)? PathIdent PathTypeArguments? {
-  implements = [ "org.rust.lang.core.psi.ext.RsReferenceElement"
+  implements = [ "org.rust.lang.core.psi.ext.RsPathReferenceElement"
                  "org.rust.lang.core.macros.ExpansionResult" ]
   mixin = "org.rust.lang.core.psi.ext.RsPathImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsPathStub"

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
@@ -10,8 +10,8 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.lang.core.macros.ExpansionResult
 import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.resolve.ref.RsPathReference
 import org.rust.lang.core.resolve.ref.RsPathReferenceImpl
-import org.rust.lang.core.resolve.ref.RsReference
 import org.rust.lang.core.stubs.RsPathStub
 
 val RsPath.hasColonColon: Boolean get() = stub?.hasColonColon ?: (coloncolon != null)
@@ -24,7 +24,7 @@ abstract class RsPathImplMixin : RsStubbedElementImpl<RsPathStub>,
 
     constructor(stub: RsPathStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
-    override fun getReference(): RsReference = RsPathReferenceImpl(this)
+    override fun getReference(): RsPathReference = RsPathReferenceImpl(this)
 
     override val referenceNameElement: PsiElement
         get() = checkNotNull(identifier ?: self ?: `super` ?: cself) {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPathReferenceElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPathReferenceElement.kt
@@ -1,0 +1,12 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi.ext
+
+import org.rust.lang.core.resolve.ref.RsPathReference
+
+interface RsPathReferenceElement : RsReferenceElement{
+    override fun getReference(): RsPathReference
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -69,7 +69,7 @@ fun processFieldExprResolveVariants(
 ): Boolean {
     for (ty in lookup.coercionSequence(receiverType)) {
         if (ty !is TyStruct) continue
-        if (processFieldDeclarations(ty.item, ty.typeParameterValues, processor)) return true
+        if (processFieldDeclarations(ty.item, processor)) return true
     }
     if (isCompletion && processMethodDeclarationsWithDeref(lookup, receiverType, processor)) {
         return true
@@ -79,7 +79,7 @@ fun processFieldExprResolveVariants(
 
 fun processStructLiteralFieldResolveVariants(field: RsStructLiteralField, processor: RsResolveProcessor): Boolean {
     val structOrEnumVariant = field.parentStructLiteral.path.reference.resolve() as? RsFieldsOwner ?: return false
-    return processFieldDeclarations(structOrEnumVariant, emptySubstitution, processor)
+    return processFieldDeclarations(structOrEnumVariant, processor)
 }
 
 fun processMethodCallExprResolveVariants(lookup: ImplLookup, receiverType: Ty, processor: RsMethodResolveProcessor): Boolean {
@@ -423,11 +423,11 @@ private fun processItemMacroDeclarations(
     return false
 }
 
-private fun processFieldDeclarations(struct: RsFieldsOwner, subst: Substitution, processor: RsResolveProcessor): Boolean {
-    if (processAllBound(struct.namedFields, subst, processor)) return true
+private fun processFieldDeclarations(struct: RsFieldsOwner, processor: RsResolveProcessor): Boolean {
+    if (processAll(struct.namedFields, processor)) return true
 
     for ((idx, field) in struct.positionalFields.withIndex()) {
-        if (processor(idx.toString(), field, subst)) return true
+        if (processor(idx.toString(), field)) return true
     }
     return false
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -50,9 +50,9 @@ import java.util.*
 // Technicalities:
 //
 //   * We can get into infinite loop during name resolution. This is handled by
-//     `RsReferenceBase`.
+//     `RsReferenceCached`.
 //   * The results of name resolution are cached and invalidated on every code change.
-//     Caching also is handled by `RsReferenceBase`.
+//     Caching also is handled by `RsReferenceCached`.
 //   * Ideally, all of the methods except for `processLexicalDeclarations` should operate on stubs only.
 //   * Rust uses two namespaces for declarations ("types" and "values"). The necessary namespace is
 //     determined by the syntactic position of the reference in `processResolveVariants` function and

--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -48,7 +48,10 @@ enum class ScopeEvent : ScopeEntry {
 typealias RsResolveProcessor = (ScopeEntry) -> Boolean
 typealias RsMethodResolveProcessor = (MethodCallee) -> Boolean
 
-fun collectResolveVariants(referenceName: String, f: (RsResolveProcessor) -> Unit): List<BoundElement<RsCompositeElement>> {
+fun collectPathResolveVariants(
+    referenceName: String,
+    f: (RsResolveProcessor) -> Unit
+): List<BoundElement<RsCompositeElement>> {
     val result = mutableListOf<BoundElement<RsCompositeElement>>()
     f { e ->
         if (e == ScopeEvent.STAR_IMPORTS && result.isNotEmpty()) return@f true
@@ -56,6 +59,19 @@ fun collectResolveVariants(referenceName: String, f: (RsResolveProcessor) -> Uni
         if (e.name == referenceName) {
             val element = e.element ?: return@f false
             result += BoundElement(element, e.subst)
+        }
+        false
+    }
+    return result
+}
+
+fun collectResolveVariants(referenceName: String, f: (RsResolveProcessor) -> Unit): List<RsCompositeElement> {
+    val result = mutableListOf<RsCompositeElement>()
+    f { e ->
+        if (e == ScopeEvent.STAR_IMPORTS && result.isNotEmpty()) return@f true
+
+        if (e.name == referenceName) {
+            result += e.element ?: return@f false
         }
         false
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsBinaryOpReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsBinaryOpReferenceImpl.kt
@@ -12,16 +12,15 @@ import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.psi.ext.operatorType
 import org.rust.lang.core.resolve.collectResolveVariants
 import org.rust.lang.core.resolve.processBinaryOpVariants
-import org.rust.lang.core.types.BoundElement
 
 class RsBinaryOpReferenceImpl(
     element: RsBinaryOp
-) : RsReferenceBase<RsBinaryOp>(element),
+) : RsReferenceCached<RsBinaryOp>(element),
     RsReference {
 
     override val RsBinaryOp.referenceAnchor: PsiElement get() = referenceNameElement
 
-    override fun resolveInner(): List<BoundElement<RsCompositeElement>> {
+    override fun resolveInner(): List<RsCompositeElement> {
         val operator = element.operatorType as? OverloadableBinaryOperator ?: return emptyList()
         return collectResolveVariants(operator.fnName) { processBinaryOpVariants(element, operator, it) }
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsExternCrateReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsExternCrateReferenceImpl.kt
@@ -8,12 +8,13 @@ package org.rust.lang.core.resolve.ref
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsExternCrateItem
 import org.rust.lang.core.psi.ext.RsCompositeElement
-import org.rust.lang.core.resolve.*
-import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.resolve.collectCompletionVariants
+import org.rust.lang.core.resolve.collectResolveVariants
+import org.rust.lang.core.resolve.processExternCrateResolveVariants
 
 class RsExternCrateReferenceImpl(
     externCrate: RsExternCrateItem
-) : RsReferenceBase<RsExternCrateItem>(externCrate),
+) : RsReferenceCached<RsExternCrateItem>(externCrate),
     RsReference {
 
     override val RsExternCrateItem.referenceAnchor: PsiElement get() = referenceNameElement
@@ -21,6 +22,6 @@ class RsExternCrateReferenceImpl(
     override fun getVariants(): Array<out Any> =
         collectCompletionVariants { processExternCrateResolveVariants(element, true, it) }
 
-    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
+    override fun resolveInner(): List<RsCompositeElement> =
         collectResolveVariants(element.name!!) { processExternCrateResolveVariants(element, false, it) }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLabelReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLabelReferenceImpl.kt
@@ -11,16 +11,15 @@ import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.resolve.collectCompletionVariants
 import org.rust.lang.core.resolve.collectResolveVariants
 import org.rust.lang.core.resolve.processLabelResolveVariants
-import org.rust.lang.core.types.BoundElement
 
 class RsLabelReferenceImpl(
     element: RsLabel
-) : RsReferenceBase<RsLabel>(element),
+) : RsReferenceCached<RsLabel>(element),
     RsReference {
 
     override val RsLabel.referenceAnchor: PsiElement get() = quoteIdentifier
 
-    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
+    override fun resolveInner(): List<RsCompositeElement> =
         collectResolveVariants(element.referenceName) { processLabelResolveVariants(element, it) }
 
     override fun getVariants(): Array<out Any> =

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLifetimeReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLifetimeReferenceImpl.kt
@@ -11,16 +11,15 @@ import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.resolve.collectCompletionVariants
 import org.rust.lang.core.resolve.collectResolveVariants
 import org.rust.lang.core.resolve.processLifetimeResolveVariants
-import org.rust.lang.core.types.BoundElement
 
 class RsLifetimeReferenceImpl(
     element: RsLifetime
-) : RsReferenceBase<RsLifetime>(element),
+) : RsReferenceCached<RsLifetime>(element),
     RsReference {
 
     override val RsLifetime.referenceAnchor: PsiElement get() = quoteIdentifier
 
-    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
+    override fun resolveInner(): List<RsCompositeElement> =
         collectResolveVariants(element.referenceName) { processLifetimeResolveVariants(element, it) }
 
     override fun getVariants(): Array<out Any> =

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroCallReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroCallReferenceImpl.kt
@@ -10,14 +10,13 @@ import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.resolve.collectResolveVariants
 import org.rust.lang.core.resolve.processMacroCallVariants
-import org.rust.lang.core.types.BoundElement
 
-class RsMacroCallReferenceImpl(macroInvocation: RsMacroCall) : RsReferenceBase<RsMacroCall>(macroInvocation) {
+class RsMacroCallReferenceImpl(macroInvocation: RsMacroCall) : RsReferenceCached<RsMacroCall>(macroInvocation) {
 
     override val RsMacroCall.referenceAnchor: PsiElement
         get() = referenceNameElement
 
-    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
+    override fun resolveInner(): List<RsCompositeElement> =
         collectResolveVariants(element.referenceName) { processMacroCallVariants(element, it) }
 
     override fun getVariants(): Array<out Any> = emptyArray() // handled by completion contributor

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroReferenceImpl.kt
@@ -11,16 +11,15 @@ import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.resolve.collectCompletionVariants
 import org.rust.lang.core.resolve.collectResolveVariants
 import org.rust.lang.core.resolve.processMacroReferenceVariants
-import org.rust.lang.core.types.BoundElement
 
 
-class RsMacroReferenceImpl(pattern: RsMacroReference) : RsReferenceBase<RsMacroReference>(pattern) {
+class RsMacroReferenceImpl(pattern: RsMacroReference) : RsReferenceCached<RsMacroReference>(pattern) {
     override val RsMacroReference.referenceAnchor: PsiElement
         get() = referenceNameElement
 
     override fun getVariants(): Array<out Any> =
         collectCompletionVariants { processMacroReferenceVariants(element, it) }
 
-    override fun resolveInner(): List<BoundElement<RsCompositeElement>>
+    override fun resolveInner(): List<RsCompositeElement>
         =  collectResolveVariants(element.referenceName) { processMacroReferenceVariants(element, it) }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMetaItemReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMetaItemReferenceImpl.kt
@@ -11,15 +11,14 @@ import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.resolve.collectCompletionVariants
 import org.rust.lang.core.resolve.collectResolveVariants
 import org.rust.lang.core.resolve.processMetaItemResolveVariants
-import org.rust.lang.core.types.BoundElement
 
 class RsMetaItemReferenceImpl(
     element: RsMetaItem
-) : RsReferenceBase<RsMetaItem>(element) {
+) : RsReferenceCached<RsMetaItem>(element) {
 
     override val RsMetaItem.referenceAnchor: PsiElement get() = referenceNameElement
 
-    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
+    override fun resolveInner(): List<RsCompositeElement> =
         collectResolveVariants(element.referenceName) { processMetaItemResolveVariants(element, it) }
 
     override fun getVariants(): Array<out Any> =

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
@@ -58,6 +58,7 @@ class RsFieldLookupReferenceImpl(
         val receiverType = element.parentDotExpr.expr.type
         val lookup = ImplLookup.relativeTo(element)
         return resolveFieldLookupReferenceWithReceiverType(lookup, receiverType, element)
+            .map { BoundElement(it) }
     }
 
     override fun handleElementRename(newName: String): PsiElement {
@@ -81,10 +82,10 @@ fun resolveFieldLookupReferenceWithReceiverType(
     lookup: ImplLookup,
     receiverType: Ty,
     expr: RsFieldLookup
-): List<BoundElement<RsCompositeElement>> {
+): List<RsCompositeElement> {
     return collectResolveVariants(expr.referenceName) {
         processFieldExprResolveVariants(lookup, receiverType, false, it)
-    }
+    }.map { it.element }
 }
 
 data class MethodCallee(

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
@@ -14,7 +14,6 @@ import org.rust.lang.core.psi.ext.RsCompositeElement
 import org.rust.lang.core.psi.ext.parentDotExpr
 import org.rust.lang.core.psi.ext.receiver
 import org.rust.lang.core.resolve.*
-import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.ty.Substitution
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.emptySubstitution
@@ -23,7 +22,7 @@ import org.rust.lang.core.types.type
 
 class RsMethodCallReferenceImpl(
     element: RsMethodCall
-) : RsReferenceBase<RsMethodCall>(element),
+) : RsReferenceCached<RsMethodCall>(element),
     RsReference {
 
     override val RsMethodCall.referenceAnchor: PsiElement get() = referenceNameElement
@@ -33,7 +32,7 @@ class RsMethodCallReferenceImpl(
         return collectCompletionVariants { processMethodCallExprResolveVariants(lookup, element.receiver.type, it) }
     }
 
-    override fun resolveInner(): List<BoundElement<RsCompositeElement>> {
+    override fun resolveInner(): List<RsCompositeElement> {
         val receiverType = element.parentDotExpr.expr.type
         val lookup = ImplLookup.relativeTo(element)
         return collectResolveVariants(element.referenceName) {
@@ -44,7 +43,7 @@ class RsMethodCallReferenceImpl(
 
 class RsFieldLookupReferenceImpl(
     element: RsFieldLookup
-) : RsReferenceBase<RsFieldLookup>(element),
+) : RsReferenceCached<RsFieldLookup>(element),
     RsReference {
 
     override val RsFieldLookup.referenceAnchor: PsiElement get() = referenceNameElement
@@ -54,11 +53,10 @@ class RsFieldLookupReferenceImpl(
         return collectCompletionVariants { processFieldExprResolveVariants(lookup, element.receiver.type, true, it) }
     }
 
-    override fun resolveInner(): List<BoundElement<RsCompositeElement>> {
+    override fun resolveInner(): List<RsCompositeElement> {
         val receiverType = element.parentDotExpr.expr.type
         val lookup = ImplLookup.relativeTo(element)
         return resolveFieldLookupReferenceWithReceiverType(lookup, receiverType, element)
-            .map { BoundElement(it) }
     }
 
     override fun handleElementRename(newName: String): PsiElement {
@@ -85,7 +83,7 @@ fun resolveFieldLookupReferenceWithReceiverType(
 ): List<RsCompositeElement> {
     return collectResolveVariants(expr.referenceName) {
         processFieldExprResolveVariants(lookup, receiverType, false, it)
-    }.map { it.element }
+    }
 }
 
 data class MethodCallee(

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsModReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsModReferenceImpl.kt
@@ -8,12 +8,13 @@ package org.rust.lang.core.resolve.ref
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.ext.RsCompositeElement
-import org.rust.lang.core.resolve.*
-import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.resolve.collectCompletionVariants
+import org.rust.lang.core.resolve.collectResolveVariants
+import org.rust.lang.core.resolve.processModDeclResolveVariants
 
 class RsModReferenceImpl(
     modDecl: RsModDeclItem
-) : RsReferenceBase<RsModDeclItem>(modDecl),
+) : RsReferenceCached<RsModDeclItem>(modDecl),
     RsReference {
 
     override val RsModDeclItem.referenceAnchor: PsiElement get() = identifier
@@ -21,6 +22,6 @@ class RsModReferenceImpl(
     override fun getVariants(): Array<out Any> =
         collectCompletionVariants { processModDeclResolveVariants(element, it) }
 
-    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
+    override fun resolveInner(): List<RsCompositeElement> =
         collectResolveVariants(element.referenceName) { processModDeclResolveVariants(element, it) }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPatBindingReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPatBindingReferenceImpl.kt
@@ -6,20 +6,21 @@
 package org.rust.lang.core.resolve.ref
 
 import com.intellij.psi.PsiElement
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsPatBinding
 import org.rust.lang.core.psi.ext.RsCompositeElement
-import org.rust.lang.core.resolve.*
-import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.resolve.collectCompletionVariants
+import org.rust.lang.core.resolve.collectResolveVariants
+import org.rust.lang.core.resolve.processPatBindingResolveVariants
 
 
 class RsPatBindingReferenceImpl(
     element: RsPatBinding
-) : RsReferenceBase<RsPatBinding>(element),
+) : RsReferenceCached<RsPatBinding>(element),
     RsReference {
 
     override val RsPatBinding.referenceAnchor: PsiElement get() = referenceNameElement
 
-    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
+    override fun resolveInner(): List<RsCompositeElement> =
         collectResolveVariants(element.referenceName) { processPatBindingResolveVariants(element, false, it) }
 
     override fun getVariants(): Array<out Any> =

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReference.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReference.kt
@@ -1,0 +1,15 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve.ref
+
+import org.rust.lang.core.psi.ext.RsCompositeElement
+import org.rust.lang.core.types.BoundElement
+
+interface RsPathReference : RsReference {
+    fun advancedResolve(): BoundElement<RsCompositeElement>?
+
+    fun advancedMultiResolve(): List<BoundElement<RsCompositeElement>>
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReference.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReference.kt
@@ -7,17 +7,12 @@ package org.rust.lang.core.resolve.ref
 
 import com.intellij.psi.PsiPolyVariantReference
 import org.rust.lang.core.psi.ext.RsCompositeElement
-import org.rust.lang.core.types.BoundElement
 
 interface RsReference : PsiPolyVariantReference {
 
     override fun getElement(): RsCompositeElement
 
     override fun resolve(): RsCompositeElement?
-
-    fun advancedResolve(): BoundElement<RsCompositeElement>? = resolve()?.let { BoundElement(it) }
-
-    fun advancedCachedMultiResolve(): List<BoundElement<RsCompositeElement>> = multiResolve().map { BoundElement(it) }
 
     fun multiResolve(): List<RsCompositeElement>
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceBase.kt
@@ -7,7 +7,9 @@ package org.rust.lang.core.resolve.ref
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.PsiPolyVariantReferenceBase
+import com.intellij.psi.ResolveResult
 import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 import org.rust.lang.core.psi.RsElementTypes.QUOTE_IDENTIFIER
 import org.rust.lang.core.psi.RsPsiFactory
@@ -22,6 +24,9 @@ abstract class RsReferenceBase<T : RsReferenceElement>(
     RsReference {
 
     override fun resolve(): RsCompositeElement? = super.resolve() as? RsCompositeElement
+
+    override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> =
+        multiResolve().map { PsiElementResolveResult(it) }.toTypedArray()
 
     abstract val T.referenceAnchor: PsiElement
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceCached.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceCached.kt
@@ -1,0 +1,40 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve.ref
+
+import com.intellij.psi.PsiElementResolveResult
+import com.intellij.psi.ResolveResult
+import com.intellij.psi.impl.source.resolve.ResolveCache
+import org.rust.lang.core.psi.ext.RsCompositeElement
+import org.rust.lang.core.psi.ext.RsNamedElement
+import org.rust.lang.core.psi.ext.RsReferenceElement
+
+abstract class RsReferenceCached<T : RsReferenceElement>(
+    element: T
+) : RsReferenceBase<T>(element),
+    RsReference {
+
+    abstract protected fun resolveInner(): List<RsCompositeElement>
+
+    final override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> =
+        cachedMultiResolve().toTypedArray()
+
+    final override fun multiResolve(): List<RsNamedElement> =
+        cachedMultiResolve().mapNotNull { it.element as? RsNamedElement }
+
+    private fun cachedMultiResolve(): List<PsiElementResolveResult> {
+        return ResolveCache.getInstance(element.project)
+            .resolveWithCaching(this, Resolver,
+                /* needToPreventRecursion = */ true,
+                /* incompleteCode = */ false).orEmpty()
+    }
+
+    private object Resolver : ResolveCache.AbstractResolver<RsReferenceCached<*>, List<PsiElementResolveResult>> {
+        override fun resolve(ref: RsReferenceCached<*>, incompleteCode: Boolean): List<PsiElementResolveResult> {
+            return ref.resolveInner().map { PsiElementResolveResult(it) }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsStructExprFieldReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsStructExprFieldReferenceImpl.kt
@@ -10,12 +10,13 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsStructLiteralField
 import org.rust.lang.core.psi.ext.RsCompositeElement
-import org.rust.lang.core.resolve.*
-import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.resolve.collectCompletionVariants
+import org.rust.lang.core.resolve.collectResolveVariants
+import org.rust.lang.core.resolve.processStructLiteralFieldResolveVariants
 
 class RsStructLiteralFieldReferenceImpl(
     field: RsStructLiteralField
-) : RsReferenceBase<RsStructLiteralField>(field),
+) : RsReferenceCached<RsStructLiteralField>(field),
     RsReference {
 
     override val RsStructLiteralField.referenceAnchor: PsiElement get() = referenceNameElement
@@ -23,7 +24,7 @@ class RsStructLiteralFieldReferenceImpl(
     override fun getVariants(): Array<out LookupElement> =
         collectCompletionVariants { processStructLiteralFieldResolveVariants(element, it) }
 
-    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
+    override fun resolveInner(): List<RsCompositeElement> =
         collectResolveVariants(element.referenceName) {
             processStructLiteralFieldResolveVariants(element, it)
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsUseGlobReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsUseGlobReferenceImpl.kt
@@ -8,12 +8,13 @@ package org.rust.lang.core.resolve.ref
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsUseGlob
 import org.rust.lang.core.psi.ext.RsCompositeElement
-import org.rust.lang.core.resolve.*
-import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.resolve.collectCompletionVariants
+import org.rust.lang.core.resolve.collectResolveVariants
+import org.rust.lang.core.resolve.processUseGlobResolveVariants
 
 class RsUseGlobReferenceImpl(
     useGlob: RsUseGlob
-) : RsReferenceBase<RsUseGlob>(useGlob),
+) : RsReferenceCached<RsUseGlob>(useGlob),
     RsReference {
 
     override val RsUseGlob.referenceAnchor: PsiElement get() = referenceNameElement
@@ -21,7 +22,7 @@ class RsUseGlobReferenceImpl(
     override fun getVariants(): Array<out Any> =
         collectCompletionVariants { processUseGlobResolveVariants(element, it) }
 
-    override fun resolveInner(): List<BoundElement<RsCompositeElement>> =
+    override fun resolveInner(): List<RsCompositeElement> =
         collectResolveVariants(element.referenceName) { processUseGlobResolveVariants(element, it) }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -37,6 +37,9 @@ val RsFunction.inference: RsInferenceResult
         CachedValueProvider.Result.create(inferTypesIn(this), PsiModificationTracker.MODIFICATION_COUNT)
     })
 
+val PsiElement.inference: RsInferenceResult?
+    get() = (parentOfType<RsItemElement>() as? RsFunction)?.inference
+
 val RsPatBinding.type: Ty
     get() = inference?.getBindingType(this) ?: TyUnknown
 
@@ -85,6 +88,3 @@ val RsExpr.isMutable: Boolean get() {
         else -> DEFAULT_MUTABILITY
     }
 }
-
-private val PsiElement.inference: RsInferenceResult?
-    get() = (parentOfType<RsItemElement>() as? RsFunction)?.inference

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -487,7 +487,7 @@ private class RsFnInferenceContext(
     }
 
     private fun inferPathExprType(expr: RsPathExpr): Ty {
-        val variants = expr.path.reference.advancedCachedMultiResolve().mapNotNull { it.downcast<RsNamedElement>() }
+        val variants = expr.path.reference.advancedMultiResolve().mapNotNull { it.downcast<RsNamedElement>() }
         val qualifier = expr.path.path
         if (variants.size > 1 && qualifier != null) {
             val resolved = resolveAmbiguity(variants.map { it.element })


### PR DESCRIPTION
And some references refactoring. Now the one reference that can `advancedResolve` is path reference