### PR TITLE
T: add Testcrumbs to make testsuite more resilient to refactorings

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -25,6 +25,7 @@ import org.rust.lang.core.types.ty.Mutability.IMMUTABLE
 import org.rust.lang.core.types.ty.Mutability.MUTABLE
 import org.rust.lang.core.types.type
 import org.rust.lang.utils.RsDiagnostic
+import org.rust.openapiext.Testmark
 import org.rust.openapiext.forEachChild
 import org.rust.stdext.zipValues
 
@@ -240,6 +241,7 @@ class RsInferenceContext {
                 })
                 if (isTy2ContainsTy1) {
                     // "E0308 cyclic type of infinite size"
+                    TypeInferenceMarks.cyclicType.hit()
                     varUnificationTable.unifyVarValue(ty1r, TyUnknown)
                 } else {
                     varUnificationTable.unifyVarValue(ty1r, ty2)
@@ -1266,3 +1268,7 @@ data class TyWithObligations<out T>(
 
 fun <T> TyWithObligations<T>.withObligations(addObligations: List<Obligation>) =
     TyWithObligations(value, obligations + addObligations)
+
+object TypeInferenceMarks {
+    val cyclicType = Testmark("cyclicType")
+}

--- a/src/main/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandler.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandler.kt
@@ -12,14 +12,20 @@ import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.ext.parentOfType
+import org.rust.openapiext.Testmark
 
-class ImplementMembersHandler: LanguageCodeInsightActionHandler {
+class ImplementMembersHandler : LanguageCodeInsightActionHandler {
     override fun isValidFor(editor: Editor, file: PsiFile): Boolean {
         if (file !is RsFile) return false
 
         val elementAtCaret = file.findElementAt(editor.caretModel.offset)
         val classOrObject = elementAtCaret?.parentOfType<RsImplItem>(strict = false)
-        return classOrObject != null
+        return if (classOrObject == null) {
+            ImplementMembersMarks.noImplInHandler.hit()
+            false
+        } else {
+            true
+        }
     }
 
     override fun startInWriteAction() = false
@@ -30,4 +36,10 @@ class ImplementMembersHandler: LanguageCodeInsightActionHandler {
             ?: error("No impl trait item")
         generateTraitMembers(implItem, editor)
     }
+
 }
+
+object ImplementMembersMarks {
+    val noImplInHandler = Testmark("noImplInHandler")
+}
+

--- a/src/main/kotlin/org/rust/openapiext/Testmark.kt
+++ b/src/main/kotlin/org/rust/openapiext/Testmark.kt
@@ -1,0 +1,74 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.openapiext
+
+import junit.framework.TestCase.fail
+import org.jetbrains.annotations.TestOnly
+
+
+/**
+ * Testmarks allow easy navigation between code and tests.
+ * That is, to find a relevant test for some piece of logic,
+ * and to find the precise condition which is supposed to be
+ * tested by a particular test. In a sense, testmarks are
+ * a hand-made artisanal code-coverage tool.
+ *
+ * To use a testmark, first define a static [Testmark] value
+ *
+ * ```
+ * val emptyFrobnicator = Testmark("emptyFrobnicator")
+ * ```
+ *
+ * Then, use [hit] function in the "production" code
+ *
+ * ```
+ * if (myFrobnicator.isEmpty()) {
+ *     emptyFrobnicator.hit()
+ *     handleEmptyFrobnicator()
+ * }
+ * ```
+ *
+ * Finally, in the test case use [checkHit] function:
+ *
+ * ```
+ * fun `test don't blow up on empty frobnicator`() = emptyFrobnicator.checkHit {
+ *    arrange()
+ *    act()
+ *    assert()
+ * }
+ * ```
+ *
+ * You can `Cltr+B` on `emptyFrobnicator` to navigate
+ * between code and tests. If after refactoring the
+ * test fails to hit the testmark, you'll be notified
+ * that the test might not work as it used to.
+ *
+ * Note that if testmark is used in "production", but
+ * not in "test" code, it's useless, but we can't
+ * provide a runtime assertion for this case.
+ */
+class Testmark(val name: String) {
+    @Volatile
+    private var state = 0
+
+    fun hit() {
+        if (state == 1) state = 2
+    }
+
+    @TestOnly
+    fun checkHit(f: () -> Unit) {
+        check(state == 0)
+        try {
+            state = 1
+            f()
+            if (state != 2) {
+                fail("Testmark `$name` not hit")
+            }
+        } finally {
+            state = 0
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -48,8 +48,10 @@ class ImplementMembersHandlerTest : RsTestBase() {
             struct /*caret*/S;
             impl T for S {}
         """)
-        val presentation = myFixture.testAction(ActionManagerEx.getInstanceEx().getAction("ImplementMethods"))
-        check(!presentation.isEnabled)
+        ImplementMembersMarks.noImplInHandler.checkHit {
+            val presentation = myFixture.testAction(ActionManagerEx.getInstanceEx().getAction("ImplementMethods"))
+            check(!presentation.isEnabled)
+        }
         check(myFixture.filterAvailableIntentions("Implement members").isEmpty())
     }
 


### PR DESCRIPTION
Sooo, I've got this idea a while ago (actually, I've stolen it from Dart), that it would be cool to connect certain tests and `if`s in code, to get precise coverage information. Today I've figured out that it can be 90% done without some custom code-generation tricks. 

What do you think?

cc @vlad20012 @Undin @mkaput 