### PR TITLE
INSP Apply assert arg on refactor of AssertEqualInspection

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -18,6 +18,7 @@ contradictioned
 d9n
 daschl
 Falkenfighter
+FatalCatharsis
 farodin91
 framlog
 greg-kargin

--- a/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
@@ -75,19 +75,17 @@ class RsAssertEqualInspection : RsLocalInspectionTool() {
             val factory = RsPsiFactory(project)
             val newAssert = factory.createExpression("$assertName!()") as RsCallExpr
 
-            val argPair = comparedAssertArgs(assertArgument) ?: return null
+            val (first, second) = comparedAssertArgs(assertArgument) ?: return null
 
             val args: MutableList<PsiElement> = mutableListOf(
-                argPair.first,
+                first,
                 factory.createComma(),
-                argPair.second
+                second
             )
 
-            if (assertArgument.formatMacroArgList.isNotEmpty()) {
-                for (arg: PsiElement in assertArgument.formatMacroArgList) {
-                    args.add(factory.createComma())
-                    args.add(arg)
-                }
+            for (arg: PsiElement in assertArgument.formatMacroArgList) {
+                args.add(factory.createComma())
+                args.add(arg)
             }
 
             addArguments(args, newAssert.valueArgumentList.lparen, newAssert.valueArgumentList)

--- a/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
@@ -53,9 +53,9 @@ class RsAssertEqualInspection : RsLocalInspectionTool() {
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
             val macro = descriptor.psiElement as RsMacroCall
             val assertArg = macro.assertMacroArgument!!
-            val argPair = comparedAssertArgs(assertArg) ?: return
 
-            macro.replace(buildAssert(project, "$assertName!()", argPair))
+            val newAssert = buildAssert(project, assertArg) ?: return
+            macro.replace(newAssert)
         }
 
         private fun comparedAssertArgs(arg: RsAssertMacroArgument): Pair<RsExpr, RsExpr>? {
@@ -71,12 +71,25 @@ class RsAssertEqualInspection : RsLocalInspectionTool() {
             }
         }
 
-        private fun buildAssert(project: Project, str: String, argPair: Pair<PsiElement, PsiElement>): PsiElement {
+        private fun buildAssert(project: Project, assertArgument: RsAssertMacroArgument): PsiElement? {
             val factory = RsPsiFactory(project)
-            val newAssert = factory.createExpression(str) as RsCallExpr
-            val args: MutableList<PsiElement> = mutableListOf(argPair.first)
-            args.add(factory.createComma())
-            args.add(argPair.second)
+            val newAssert = factory.createExpression("$assertName!()") as RsCallExpr
+
+            val argPair = comparedAssertArgs(assertArgument) ?: return null
+
+            val args: MutableList<PsiElement> = mutableListOf(
+                argPair.first,
+                factory.createComma(),
+                argPair.second
+            )
+
+            if (assertArgument.formatMacroArgList.isNotEmpty()) {
+                for (arg: PsiElement in assertArgument.formatMacroArgList) {
+                    args.add(factory.createComma())
+                    args.add(arg)
+                }
+            }
+
             addArguments(args, newAssert.valueArgumentList.lparen, newAssert.valueArgumentList)
             return newAssert
         }

--- a/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt
@@ -38,6 +38,20 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         }
     """)
 
+    fun `test simple assert_eq fix with format_args`() = checkFixByText("Convert to assert_eq!", """
+        fn main() {
+            let x = 10;
+            let y = 10;
+            <weak_warning descr="assert!(a == b) can be assert_eq!(a, b)">assert!(x == y, "format {}", 0<caret>)</weak_warning>;
+        }
+    """, """
+        fn main() {
+            let x = 10;
+            let y = 10;
+            assert_eq!(x, y, "format {}", 0);
+        }
+    """)
+
     fun `test simple assert_ne fix`() = checkFixByText("Convert to assert_ne!", """
         fn main() {
             let x = 10;
@@ -67,6 +81,20 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
 
         fn main() {
             assert_ne!(answer(), 50);
+        }
+    """)
+
+    fun `test simple assert_ne fix with format_args`() = checkFixByText("Convert to assert_ne!", """
+        fn main() {
+            let x = 10;
+            let y = 10;
+            <weak_warning descr="assert!(a == b) can be assert_eq!(a, b)">assert!(x != y, "format {}", 0<caret>)</weak_warning>;
+        }
+    """, """
+        fn main() {
+            let x = 10;
+            let y = 10;
+            assert_ne!(x, y, "format {}", 0);
         }
     """)
 }


### PR DESCRIPTION
Addresses issue #2042

Changes the AssertEqualInspection refactor suggestion to append the rest of the argument list.

Originally, applying the refactor would pull apart the binary expression and replace it with two args, but any subsequent args on the assert were deleted.

(this is my first PR to this project so I wanted to start small)