### PR TITLE
Correct since build value

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,7 +15,7 @@
     </change-notes>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="171" until-build="173.*"/>
+    <idea-version since-build="172" until-build="173.*"/>
 
     <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
          on how to target different products -->


### PR DESCRIPTION
The latest plugin versions support only 2017.2 and 2017.3 builds but plugin.xml says that plugin supports 2017.1 as well.
This change fixes it.

Fixes #2031 (I know that it is already closed:) )