### PR TITLE
Method ambiguity resolution

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -6,12 +6,15 @@
 package org.rust.lang.core.resolve
 
 import com.intellij.openapi.project.Project
+import org.rust.lang.core.macros.setContext
 import org.rust.lang.core.psi.RsImplItem
+import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.indexes.RsImplIndex
 import org.rust.lang.core.resolve.indexes.RsLangItemIndex
+import org.rust.lang.core.resolve.ref.resolvePath
 import org.rust.lang.core.stubs.index.RsNamedElementIndex
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.TraitRef
@@ -471,6 +474,12 @@ class ImplLookup(
             val outputType = (subst[outputParam] ?: TyUnit)
             return TyFunction(argumentTypes, outputType)
         }
+
+    fun isTraitVisibleFrom(trait: RsTraitItem, scope: RsElement): Boolean {
+        val name = trait.name ?: return true
+        val path = RsPsiFactory(project).tryCreatePath(name)?.apply { setContext(scope) } ?: return true
+        return resolvePath(path, this).any { it.element == trait }
+    }
 
     companion object {
         fun relativeTo(psi: RsElement): ImplLookup =

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -242,6 +242,10 @@ class ImplLookup(
                 val bound = ref.selfTy.getTraitBoundsTransitively().find { it.element == element }
                 if (bound != null) add(SelectionCandidate.TypeParameter(bound))
             }
+            if (ref.selfTy is TyTraitObject) {
+                BoundElement(ref.selfTy.trait).flattenHierarchy.find { it.element == ref.trait.element }
+                    ?.let { add(SelectionCandidate.TypeParameter(it)) }
+            }
             getHardcodedImpls(ref.selfTy).find { it.element == element }
                 ?.let { add(SelectionCandidate.TypeParameter(it)) }
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -300,11 +300,8 @@ class ImplLookup(
             is SelectionCandidate.Impl -> {
                 ctx.combineTraitRefs(ref, candidate.ref)
                 val candidateSubst = candidate.subst + mapOf(TyTypeParameter.self() to ref.selfTy)
-                val obligations = candidate.item.bounds.asSequence()
-                    .map { it.substitute(candidateSubst) }
-                    .map { ctx.normalizeAssociatedTypesIn(it, recursionDepth) }
-                    .flatMap { it.obligations.asSequence() + Obligation(newRecDepth, Predicate.Trait(it.value)) }
-                    .toList()
+                ctx.instantiateBounds(candidate.item.bounds, candidateSubst)
+                val obligations = ctx.instantiateBounds(candidate.item.bounds, candidateSubst).toList()
                 Selection(candidate.item, obligations, candidateSubst)
             }
             is SelectionCandidate.DerivedTrait -> Selection(candidate.item, emptyList())

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -668,15 +668,8 @@ private class RsFnInferenceContext(
                 map
             }
         }
-        instantiateBounds(element.bounds, map)
+        ctx.instantiateBounds(element.bounds, map).forEach(fulfill::registerPredicateObligation)
         return map
-    }
-
-    private fun instantiateBounds(bounds: List<TraitRef>, subst: Map<TyTypeParameter, Ty>) {
-        bounds.asSequence()
-                .map { it.substitute(subst) }
-                .map(this::normalizeAssociatedTypesIn)
-                .forEach { fulfill.registerPredicateObligation(Obligation(Predicate.Trait(it))) }
     }
 
     private fun <T : TypeFoldable<T>> normalizeAssociatedTypesIn(ty: T): T {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -146,15 +146,15 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
     """)
 
     fun `test trait bound satisfied for trait`() = checkByCode("""
-        // #[lang = "sized"]
-        // trait Sized {}
+        #[lang = "sized"]
+        trait Sized {}
         trait Tr1 { fn some_fn(&self) {} }
         trait Tr2 { fn some_fn(&self) {} }
                      //X
         trait Bound1 {}
         trait Bound2 {}
         trait ChildOfBound2 : Bound2 {}
-        struct S<T : ?Sized> { value: T }
+        struct S<T: ?Sized> { value: T }
         impl<T: Bound1 + ?Sized> Tr1 for S<T> { }
         impl<T: Bound2 + ?Sized> Tr2 for S<T> { }
         fn f(v: &S<ChildOfBound2>) {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -200,4 +200,48 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
             //^
         }
     """)
+
+    fun `test method defined in out of scope trait 1`() = checkByCode("""
+        struct S;
+
+        mod a {
+            use super::S;
+            pub trait A { fn foo(&self){} }
+                           //X
+            impl A for S {}
+        }
+
+        mod b {
+            use super::S;
+            pub trait B { fn foo(&self){} }
+            impl B for S {}
+        }
+
+        fn main() {
+            use a::A;
+            S.foo();
+        }   //^
+    """)
+
+    fun `test method defined in out of scope trait 2`() = checkByCode("""
+        struct S;
+
+        mod a {
+            use super::S;
+            pub trait A { fn foo(&self){} }
+            impl A for S {}
+        }
+
+        mod b {
+            use super::S;
+            pub trait B { fn foo(&self){} }
+                           //X
+            impl B for S {}
+        }
+
+        fn main() {
+            use b::B;
+            S.foo();
+        }   //^
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -129,9 +129,9 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
     """)
 
     fun `test trait bound satisfied for struct`() = checkByCode("""
-        // TODO: should resolve to Tr2
         trait Tr1 { fn some_fn(&self) {} }
         trait Tr2 { fn some_fn(&self) {} }
+                     //X
         trait Bound1 {}
         trait Bound2 {}
         struct S<T> { value: T }
@@ -141,7 +141,7 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
         impl Bound2 for S0 {}
         fn main(v: S<S0>) {
             v.some_fn();
-            //^ unresolved
+            //^
         }
     """)
 
@@ -164,9 +164,9 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
     """)
 
     fun `test trait bound satisfied for other bound`() = checkByCode("""
-        //TODO: should resolve to Tr2
         trait Tr1 { fn some_fn(&self) {} }
         trait Tr2 { fn some_fn(&self) {} }
+                     //X
         trait Bound1 {}
         trait Bound2 {}
         struct S<T> { value: T }
@@ -177,7 +177,7 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
         impl<T: Bound2> S1<T> {
             fn f(&self, t: S<T>) {
                 t.some_fn();
-                //^ unresolved
+                //^
             }
         }
     """)

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -146,11 +146,11 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
     """)
 
     fun `test trait bound satisfied for trait`() = checkByCode("""
-        // TODO: should resolve to Tr2
         // #[lang = "sized"]
         // trait Sized {}
         trait Tr1 { fn some_fn(&self) {} }
         trait Tr2 { fn some_fn(&self) {} }
+                     //X
         trait Bound1 {}
         trait Bound2 {}
         trait ChildOfBound2 : Bound2 {}
@@ -159,7 +159,7 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
         impl<T: Bound2 + ?Sized> Tr2 for S<T> { }
         fn f(v: &S<ChildOfBound2>) {
             v.some_fn();
-            //^ unresolved
+            //^
         }
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -112,22 +112,6 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
         }
     """)
 
-    fun `test trait bound not satisfied`() = checkByCode("""
-        //TODO: this should be unresolved
-        trait Tr1 { fn some_fn(&self) {} }
-                        //X
-        trait Bound1 {}
-        trait Bound2 {}
-        struct S<T> { value: T }
-        impl<T: Bound1> Tr1 for S<T> {}
-        struct S0;
-        impl Bound2 for S0 {}
-        fn main(v: S<S0>) {
-            v.some_fn();
-            //^
-        }
-    """)
-
     fun `test trait bound satisfied for struct`() = checkByCode("""
         trait Tr1 { fn some_fn(&self) {} }
         trait Tr2 { fn some_fn(&self) {} }
@@ -179,25 +163,6 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
                 t.some_fn();
                 //^
             }
-        }
-    """)
-
-    fun `test auto deref only for impls`() = checkByCode("""
-        //TODO: should be unresolved
-        struct A;
-        struct B;
-        #[lang = "deref"]
-        trait Deref { type Target; }
-        impl Deref for A { type Target = B; }
-
-        trait Tr {}
-        impl Tr for B {}
-        struct S<T>(T);
-        impl<T: Tr> S<T> { fn bar(&self) {} }
-                            //X
-        fn foo(a: S<A>) {
-            a.bar();
-            //^
         }
     """)
 


### PR DESCRIPTION
All `RsPreciseTraitMatchingTest` tests now passes
1. We now filter methods of traits that are not imported
2. We now check trait bounds of impls

We do not do anything above if we don't have method name ambiguity, i.e. name resolution succeeded with exactly single entity