### PR TITLE
RES: Enable `impl<T: Bound> for T`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -315,8 +315,7 @@ class ImplLookup(
             is SelectionCandidate.Impl -> {
                 ctx.combineTraitRefs(ref, candidate.ref)
                 val candidateSubst = candidate.subst + mapOf(TyTypeParameter.self() to ref.selfTy)
-                ctx.instantiateBounds(candidate.item.bounds, candidateSubst)
-                val obligations = ctx.instantiateBounds(candidate.item.bounds, candidateSubst).toList()
+                val obligations = ctx.instantiateBounds(candidate.item.bounds, candidateSubst, newRecDepth).toList()
                 Selection(candidate.item, obligations, candidateSubst)
             }
             is SelectionCandidate.DerivedTrait -> Selection(candidate.item, emptyList())

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -194,17 +194,32 @@ class ImplLookup(
      */
     fun select(ref: TraitRef, recursionDepth: Int = 0): SelectionResult<Selection> {
         if (recursionDepth > DEFAULT_RECURSION_LIMIT) return SelectionResult.Err()
-        return traitSelectionCache.getOrPut(project, freshen(ref)) { selectCandidate(ref) }
-            .map { confirmCandidate(ref, recursionDepth, it) }
+        return traitSelectionCache.getOrPut(project, freshen(ref)) { selectCandidate(ref, recursionDepth) }
+            .map { confirmCandidate(ref, it, recursionDepth) }
     }
 
-    private fun selectCandidate(ref: TraitRef): SelectionResult<SelectionCandidate> {
+    private fun selectCandidate(ref: TraitRef, recursionDepth: Int): SelectionResult<SelectionCandidate> {
         val candidates = assembleCandidates(ref)
 
         return when (candidates.size) {
             0 -> SelectionResult.Err()
             1 -> SelectionResult.Ok(candidates.single())
-            else -> SelectionResult.Ambiguous()
+            else -> {
+                val filtered = candidates.filter {
+                    ctx.probe {
+                        val obligation = confirmCandidate(ref, it, recursionDepth).nestedObligations
+                        val ff = FulfillmentContext(ctx, this)
+                        obligation.forEach(ff::registerPredicateObligation)
+                        ff.selectAllOrError()
+                    }
+                }
+
+                when (filtered.size) {
+                    0 -> SelectionResult.Err()
+                    1 -> SelectionResult.Ok(filtered.single())
+                    else -> SelectionResult.Ambiguous()
+                }
+            }
         }
     }
 
@@ -292,8 +307,8 @@ class ImplLookup(
 
     private fun confirmCandidate(
         ref: TraitRef,
-        recursionDepth: Int = 0,
-        candidate: SelectionCandidate
+        candidate: SelectionCandidate,
+        recursionDepth: Int
     ): Selection {
         val newRecDepth = recursionDepth + 1
         return when (candidate) {

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
@@ -20,7 +20,6 @@ import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsImplItemStub
 import org.rust.lang.core.types.TyFingerprint
 import org.rust.lang.core.types.ty.Ty
-import org.rust.lang.core.types.type
 import org.rust.openapiext.getElements
 
 class RsImplIndex : AbstractStubIndex<TyFingerprint, RsImplItem>() {
@@ -38,13 +37,6 @@ class RsImplIndex : AbstractStubIndex<TyFingerprint, RsImplItem>() {
                 ?: return emptyList()
 
             val impls = getElements(KEY, fingerprint, project, GlobalSearchScope.allScope(project))
-                .filter { impl ->
-                    val ty = impl.typeReference?.type
-                    // Addition class check is a temporal solution to filter impls for type parameter
-                    // with the same name
-                    // struct S; impl<S: Tr1> Tr2 for S {}
-                    ty != null && ty.javaClass == target.javaClass
-                }
             val freeImpls = getElements(KEY, TyFingerprint.TYPE_PARAMETER_FINGERPRINT, project, GlobalSearchScope.allScope(project))
             return impls + freeImpls
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
@@ -10,11 +10,9 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.AbstractStubIndex
 import com.intellij.psi.stubs.IndexSink
 import com.intellij.psi.stubs.StubIndexKey
-import com.intellij.util.containers.isNullOrEmpty
 import com.intellij.util.io.KeyDescriptor
 import org.rust.lang.core.psi.RsBaseType
 import org.rust.lang.core.psi.RsImplItem
-import org.rust.lang.core.psi.RsTypeParameter
 import org.rust.lang.core.psi.ext.name
 import org.rust.lang.core.psi.ext.typeElement
 import org.rust.lang.core.psi.ext.typeParameters
@@ -59,9 +57,6 @@ class RsImplIndex : AbstractStubIndex<TyFingerprint, RsImplItem>() {
             val key = if (type is RsBaseType) {
                 val typeParam = impl.typeParameters.find { it.name == type.name }
                 if (typeParam != null) {
-                    // At this moment we support only free trait impls without bounds
-                    // to avoid stack overflow while resolving
-                    if (hasBounds(typeParam, impl)) return
                     TyFingerprint.TYPE_PARAMETER_FINGERPRINT
                 } else {
                     TyFingerprint.create(typeRef)
@@ -73,14 +68,6 @@ class RsImplIndex : AbstractStubIndex<TyFingerprint, RsImplItem>() {
             if (key != null) {
                 sink.occurrence(KEY, key)
             }
-        }
-
-        // We can't use `RsTypeParameter.bounds` because it uses `resolve`
-        // and it can lead to `IndexNotReadyException` while indexing
-        private fun hasBounds(typeParam: RsTypeParameter, impl: RsImplItem): Boolean {
-            if (!typeParam.typeParamBounds?.polyboundList.isNullOrEmpty()) return true
-            return impl.whereClause?.wherePredList.orEmpty()
-                .any { (it.typeReference?.typeElement as? RsBaseType)?.name == typeParam.name }
         }
 
         private val KEY: StubIndexKey<TyFingerprint, RsImplItem> =

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -31,7 +31,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 108
+        override fun getStubVersion(): Int = 109
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -264,14 +264,16 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }
     """)
 
-    fun `test impl not resolved by accident if struct name is the same as generic type`() = checkByCode("""
+    // really unresolved in rustc, but IDE will resolve it anyway
+    fun `test no stack overflow if struct name is the same as generic type`() = checkByCode("""
         struct S;
-        trait Tr1{}
-        trait Tr2{ fn some_fn(&self) {} }
+        trait Tr1 {}
+        trait Tr2 { fn some_fn(&self) {} }
+                     //X
         impl<S: Tr1> Tr2 for S {}
         fn main(v: S) {
             v.some_fn();
-            //^ unresolved
+            //^
         }
     """)
 
@@ -661,11 +663,10 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
     """)
 
     fun `test impl for type parameter with bound`() = checkByCode("""
-        // TODO: Should be resolved to Foo
         trait Bar {}
         trait Foo {
             fn foo(&self) {}
-        }
+        }    //X
 
         impl<T: Bar> Foo for T {}
 
@@ -674,12 +675,14 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
 
         fn main() {
             S.foo();
-             //^ unresolved
+             //^
         }
     """)
 
+    // really unresolved in rustc, but IDE will resolve it anyway
     fun `test impl for type parameter with recursive bounds`() = checkByCode("""
         trait Foo { fn foo(&self) {} }
+                     //X
         trait Bar { fn bar(&self) {} }
 
         impl<T: Bar> Foo for T {}
@@ -689,7 +692,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
 
         fn main() {
             S.foo();
-             //^ unresolved
+             //^
         }
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -662,6 +662,25 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ (u8, u16)
     """)
 
+    fun `test infer generic argument from trait bound with multiple impls`() = testExpr("""
+        struct S<A>(A);
+        trait Tr<B> {}
+        trait Bound1 {}
+        trait Bound2 {}
+
+        impl<C: Bound1> Tr<u8> for S<C> {}
+        impl<D: Bound2> Tr<u16> for S<D> {}
+
+        struct X;
+        impl Bound2 for X {}
+
+        fn foo<T1, T2>(_: T1) -> T2 where T1: Tr<T2> { unimplemented!() }
+        fn main() {
+            let a = foo(S(X));
+            a;
+        } //^ u16
+    """)
+
     fun `test Self substitution to trait method`() = testExpr("""
         trait Tr<A> { fn wrap(self) -> S<Self> where Self: Sized { unimplemented!() } }
         struct X;


### PR DESCRIPTION
Some infrastructure for this was prepared in #1997 and #2058. Additionally now we resolve ambiguous trait impls during trait selection

@Undin, it's done =)