### PR TITLE
PRJ: support rust project creation in small IDEs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,7 @@ change. Common tags are:
   * RUN for run configurations
   * QDOC for quick documentation
   * PERF for performance optimizations
+  * PRJ for project creation changes 
 
 
   * CARGO for cargo-related changes

--- a/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
@@ -21,7 +21,10 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import javax.swing.JLabel
 
-class RustProjectSettingsPanel(private val cargoProjectDir: Path = Paths.get(".")) : Disposable {
+class RustProjectSettingsPanel(
+    private val cargoProjectDir: Path = Paths.get("."),
+    private val updateListener: (() -> Unit)? = null
+) : Disposable {
     data class Data(
         val toolchain: RustToolchain?,
         val explicitPathToStdlib: String?
@@ -114,6 +117,7 @@ class RustProjectSettingsPanel(private val cargoProjectDir: Path = Paths.get("."
                     toolchainVersion.text = rustcVersion.parsedVersion
                     toolchainVersion.foreground = JBColor.foreground()
                 }
+                updateListener?.invoke()
             }
         )
     }

--- a/src/main/kotlin/org/rust/ide/idea/RsModuleBuilder.kt
+++ b/src/main/kotlin/org/rust/ide/idea/RsModuleBuilder.kt
@@ -16,18 +16,13 @@ import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.projectRoots.SdkTypeId
 import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.util.Disposer
-import org.rust.cargo.project.settings.ui.RustProjectSettingsPanel
 import org.rust.cargo.toolchain.RustToolchain
+import org.rust.ide.newProject.ConfigurationData
 
 /**
  * Builder which is used when a new project or module is created and not imported from source.
  */
 class RsModuleBuilder : ModuleBuilder() {
-
-    data class ConfigurationData(
-        val settings: RustProjectSettingsPanel.Data,
-        val createBinary: Boolean
-    )
 
     override fun getModuleType(): ModuleType<*>? = RsModuleType.INSTANCE
 

--- a/src/main/kotlin/org/rust/ide/newProject/ConfigurationData.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/ConfigurationData.kt
@@ -1,0 +1,13 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.newProject
+
+import org.rust.cargo.project.settings.ui.RustProjectSettingsPanel
+
+data class ConfigurationData(
+    val settings: RustProjectSettingsPanel.Data,
+    val createBinary: Boolean
+)

--- a/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
@@ -5,15 +5,23 @@
 
 package org.rust.ide.newProject
 
+import com.intellij.ide.util.projectWizard.AbstractNewProjectStep
+import com.intellij.ide.util.projectWizard.CustomStepProjectGenerator
+import com.intellij.ide.util.projectWizard.ProjectSettingsStepBase
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.wm.impl.welcomeScreen.AbstractActionWithPanel
+import com.intellij.platform.DirectoryProjectGenerator
 import com.intellij.platform.DirectoryProjectGeneratorBase
 import com.intellij.platform.ProjectGeneratorPeer
 import org.rust.ide.icons.RsIcons
 import javax.swing.Icon
 
-class RsDirectoryProjectGenerator : DirectoryProjectGeneratorBase<ConfigurationData>() {
+// We implement `CustomStepProjectGenerator` as well to correctly show settings UI
+// because otherwise PyCharm doesn't add peer's component into project settings panel
+class RsDirectoryProjectGenerator : DirectoryProjectGeneratorBase<ConfigurationData>(),
+                                    CustomStepProjectGenerator<ConfigurationData> {
 
     override fun getName(): String = "Rust"
     override fun getLogo(): Icon? = RsIcons.RUST
@@ -23,4 +31,11 @@ class RsDirectoryProjectGenerator : DirectoryProjectGeneratorBase<ConfigurationD
         val (settings, createBinary) = data
         settings.toolchain?.rawCargo()?.init(module, baseDir, createBinary)
     }
+
+    override fun createStep(projectGenerator: DirectoryProjectGenerator<ConfigurationData>,
+                            callback: AbstractNewProjectStep.AbstractCallback<ConfigurationData>): AbstractActionWithPanel =
+        RsProjectSettingsStep(projectGenerator)
 }
+
+private class RsProjectSettingsStep(generator: DirectoryProjectGenerator<ConfigurationData>)
+    : ProjectSettingsStepBase<ConfigurationData>(generator, AbstractNewProjectStep.AbstractCallback<ConfigurationData>())

--- a/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.newProject
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.platform.DirectoryProjectGeneratorBase
+import com.intellij.platform.ProjectGeneratorPeer
+import org.rust.ide.icons.RsIcons
+import javax.swing.Icon
+
+class RsDirectoryProjectGenerator : DirectoryProjectGeneratorBase<ConfigurationData>() {
+
+    override fun getName(): String = "Rust"
+    override fun getLogo(): Icon? = RsIcons.RUST
+    override fun createPeer(): ProjectGeneratorPeer<ConfigurationData> = RsProjectGeneratorPeer()
+
+    override fun generateProject(project: Project, baseDir: VirtualFile, data: ConfigurationData, module: Module) {
+        val (settings, createBinary) = data
+        settings.toolchain?.rawCargo()?.init(module, baseDir, createBinary)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/newProject/RsProjectGeneratorPeer.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsProjectGeneratorPeer.kt
@@ -1,0 +1,38 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.newProject
+
+import com.intellij.openapi.options.ConfigurationException
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.platform.GeneratorPeerImpl
+import com.intellij.ui.layout.panel
+import org.rust.ide.newProject.ui.RsNewProjectPanel
+import javax.swing.JComponent
+
+class RsProjectGeneratorPeer : GeneratorPeerImpl<ConfigurationData>() {
+
+    private val newProjectPanel = RsNewProjectPanel(showProjectTypeCheckbox = true) { checkValid?.run() }
+    private var checkValid: Runnable? = null
+
+    override fun getSettings(): ConfigurationData = newProjectPanel.data
+
+    override fun getComponent(myLocationField: TextFieldWithBrowseButton, checkValid: Runnable): JComponent {
+        this.checkValid = checkValid
+        return super.getComponent(myLocationField, checkValid)
+    }
+
+    override fun getComponent(): JComponent = panel {
+        newProjectPanel.attachTo(this)
+    }
+
+    override fun validate(): ValidationInfo? = try {
+        newProjectPanel.validateSettings()
+        null
+    } catch (e: ConfigurationException) {
+        ValidationInfo(e.message ?: "")
+    }
+}

--- a/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt
@@ -1,0 +1,40 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.newProject.ui
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.options.ConfigurationException
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.layout.LayoutBuilder
+import org.rust.cargo.project.settings.ui.RustProjectSettingsPanel
+import org.rust.ide.newProject.ConfigurationData
+
+class RsNewProjectPanel(
+    private val showProjectTypeCheckbox: Boolean,
+    updateListener: (() -> Unit)? = null
+) : Disposable {
+
+    private val rustProjectSettings = RustProjectSettingsPanel(updateListener = updateListener)
+    private val createBinaryCheckbox = JBCheckBox(null, true)
+
+    val data: ConfigurationData get() = ConfigurationData(rustProjectSettings.data, createBinaryCheckbox.isSelected)
+
+    fun attachTo(layout: LayoutBuilder) = with(layout) {
+        rustProjectSettings.attachTo(this)
+        if (showProjectTypeCheckbox) {
+            row("Use a binary (application) template:") { createBinaryCheckbox() }
+        }
+    }
+
+    @Throws(ConfigurationException::class)
+    fun validateSettings() {
+        rustProjectSettings.validateSettings()
+    }
+
+    override fun dispose() {
+        rustProjectSettings.dispose()
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -39,6 +39,10 @@
 
         <!-- Rust -->
 
+        <!-- Project Creation -->
+
+        <directoryProjectGenerator implementation="org.rust.ide.newProject.RsDirectoryProjectGenerator"/>
+
         <!-- File-type Factory -->
 
         <fileTypeFactory implementation="org.rust.lang.RsFileTypeFactory"/>


### PR DESCRIPTION
Partially closes #557 

This implementation should work with:
* **PyCharm Community** (checked with 172.4343.24 and 173.3727.88)
* **PyCharm Professional** (checked with 172.4343.24 and 173.3727.88)
* **PyCharm Edu** (checked with 172.4539)
* **WebStorm** (checked with 172.4343.25 and 173.3727.69)
* **RubyMine** (checked with 172.4155.44 and 173.3727.77)
* **PhpStorm** (checked with 172.4155.41 and 173.3727.84)

Unfortunately, project creation in **CLion** still **doesn't work**