### PR TITLE
Allow ambiguity in trait bounds checking

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -210,7 +210,7 @@ class ImplLookup(
                         val obligation = confirmCandidate(ref, it, recursionDepth).nestedObligations
                         val ff = FulfillmentContext(ctx, this)
                         obligation.forEach(ff::registerPredicateObligation)
-                        ff.selectAllOrError()
+                        ff.selectUntilError()
                     }
                 }
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt
@@ -158,13 +158,13 @@ class FulfillmentContext(val ctx: RsInferenceContext, val lookup: ImplLookup) {
         while (!obligations.processObligations(this::processPredicate).stalled) {}
     }
 
-    fun selectAllOrError(): Boolean {
+    fun selectUntilError(): Boolean {
         do {
             val res = obligations.processObligations(this::processPredicate, breakOnFirstError = true)
             if (res.hasErrors) return false
         } while (!res.stalled)
 
-        return pendingObligations.count() == 0
+        return true
     }
 
     private fun processPredicate(pendingObligation: PendingPredicateObligation): ProcessPredicateResult {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -857,7 +857,7 @@ private class RsFnInferenceContext(
             ctx.instantiateBounds(impl.bounds, typeParameters)
                 .forEach(ff::registerPredicateObligation)
             impl.typeReference?.type?.substitute(typeParameters)?.let { ctx.combineTypes(callee.selfTy, it) }
-            ctx.probe { ff.selectAllOrError() }
+            ctx.probe { ff.selectUntilError() }
         }.singleOrLet { list ->
             // 3. Pick results on the first deref level
             // TODO this is not how compiler actually work, see `test non inherent impl 2`

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -168,6 +168,25 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
         }
     """, TypeInferenceMarks.methodPickCheckBounds)
 
+    fun `test allow ambiguous trait bounds for postponed selection`() = checkByCode("""
+        trait Into<A> { fn into(&self) -> A; }
+        trait From<B> { fn from(_: B) -> Self; }
+        impl<T, U> Into<U> for T where U: From<T>
+        {
+            fn into(self) -> U { U::from(self) }
+        }    //X
+
+        struct S1;
+        struct S2;
+        impl From<S1> for S2 { fn from(_: B) -> Self { unimplemented!() }
+}
+        fn main() {
+            let a = (&S1).into();
+                        //^
+            let _: S2 = a;
+        }
+    """)
+
     fun `test method defined in out of scope trait 1`() = checkByCode("""
         struct S;
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -495,4 +495,11 @@ class RsStdlibResolveTest : RsResolveTestBase() {
             S.into();
         }   //^ a.rs
     """, TypeInferenceMarks.methodPickTraitScope)
+
+    fun `test &str into String`() = stubOnlyResolve("""
+    //- main.rs
+        fn main() {
+            let _: String = "".into();
+        }                    //^ ...convert.rs
+    """)
 }


### PR DESCRIPTION
Fixes `into()` resolve