### PR TITLE
CARGO: Don't explicitely set RUSTC env var

### DIFF
--- a/src/main/kotlin/org/rust/cargo/CargoConstants.kt
+++ b/src/main/kotlin/org/rust/cargo/CargoConstants.kt
@@ -12,7 +12,6 @@ object CargoConstants {
     const val LOCK_FILE = "Cargo.lock"
     const val BUILD_RS_FILE = "build.rs"
 
-    const val RUSTC_ENV_VAR = "RUSTC"
     const val RUST_BACTRACE_ENV_VAR = "RUST_BACKTRACE"
 
     object ProjectLayout {

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -118,7 +118,6 @@ class Cargo(
         val cmdLine = GeneralCommandLine(cargoExecutable)
             .withCharset(Charsets.UTF_8)
             .withWorkDirectory(commandLine.workingDirectory)
-            .withEnvironment(CargoConstants.RUSTC_ENV_VAR, rustExecutable.toString())
             .withEnvironment("TERM", "ansi")
             .withRedirectErrorStream(true)
 

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt
@@ -16,19 +16,19 @@ class CargoTest : RsTestBase() {
     fun `test run arguments preserved`() = checkCommandLine(
         cargo.toColoredCommandLine(CargoCommandLine("run", wd, listOf("--bin", "parity", "--", "--prune", "archive"))), """
         cmd: /usr/bin/cargo run --color=always --bin parity -- --prune archive
-        env: RUSTC=/usr/bin/rustc, RUST_BACKTRACE=full, TERM=ansi
+        env: RUST_BACKTRACE=full, TERM=ansi
         """, """
         cmd: C:/usr/bin/cargo.exe run --bin parity -- --prune archive
-        env: RUSTC=C:/usr/bin/rustc.exe, RUST_BACKTRACE=full, TERM=ansi
+        env: RUST_BACKTRACE=full, TERM=ansi
     """)
 
     fun `test basic command`() = checkCommandLine(
         cargo.toGeneralCommandLine(CargoCommandLine("test", wd, listOf("--all"))), """
         cmd: /usr/bin/cargo test --all -- --nocapture
-        env: RUSTC=/usr/bin/rustc, RUST_BACKTRACE=full, TERM=ansi
+        env: RUST_BACKTRACE=full, TERM=ansi
         """, """
         cmd: C:/usr/bin/cargo.exe test --all -- --nocapture
-        env: RUSTC=C:/usr/bin/rustc.exe, RUST_BACKTRACE=full, TERM=ansi
+        env: RUST_BACKTRACE=full, TERM=ansi
     """)
 
     fun `test propagates proxy settings`() {
@@ -44,38 +44,38 @@ class CargoTest : RsTestBase() {
         checkCommandLine(
             cargo.toGeneralCommandLine(CargoCommandLine("check", wd)), """
             cmd: /usr/bin/cargo check
-            env: RUSTC=/usr/bin/rustc, RUST_BACKTRACE=full, TERM=ansi, http_proxy=http://user:pwd@host:3268/
+            env: RUST_BACKTRACE=full, TERM=ansi, http_proxy=http://user:pwd@host:3268/
             """, """
             cmd: C:/usr/bin/cargo.exe check
-            env: RUSTC=C:/usr/bin/rustc.exe, RUST_BACKTRACE=full, TERM=ansi, http_proxy=http://user:pwd@host:3268/
+            env: RUST_BACKTRACE=full, TERM=ansi, http_proxy=http://user:pwd@host:3268/
         """)
     }
 
     fun `test adds colors for common commands`() = checkCommandLine(
         cargo.toColoredCommandLine(CargoCommandLine("run", wd, listOf("--release", "--", "foo"))), """
         cmd: /usr/bin/cargo run --color=always --release -- foo
-        env: RUSTC=/usr/bin/rustc, RUST_BACKTRACE=full, TERM=ansi
+        env: RUST_BACKTRACE=full, TERM=ansi
         """, """
         cmd: C:/usr/bin/cargo.exe run --release -- foo
-        env: RUSTC=C:/usr/bin/rustc.exe, RUST_BACKTRACE=full, TERM=ansi
+        env: RUST_BACKTRACE=full, TERM=ansi
     """)
 
     fun `test don't add color for unknown command`() = checkCommandLine(
         cargo.toColoredCommandLine(CargoCommandLine("tree", wd)), """
         cmd: /usr/bin/cargo tree
-        env: RUSTC=/usr/bin/rustc, RUST_BACKTRACE=full, TERM=ansi
+        env: RUST_BACKTRACE=full, TERM=ansi
         """, """
         cmd: C:/usr/bin/cargo.exe tree
-        env: RUSTC=C:/usr/bin/rustc.exe, RUST_BACKTRACE=full, TERM=ansi
+        env: RUST_BACKTRACE=full, TERM=ansi
     """)
 
     fun `test adds nightly channel`() = checkCommandLine(
         cargo.toColoredCommandLine(CargoCommandLine("run", wd, listOf("--release", "--", "foo"), channel = RustChannel.NIGHTLY)), """
         cmd: /usr/bin/cargo +nightly run --color=always --release -- foo
-        env: RUSTC=/usr/bin/rustc, RUST_BACKTRACE=full, TERM=ansi
+        env: RUST_BACKTRACE=full, TERM=ansi
         """, """
         cmd: C:/usr/bin/cargo.exe +nightly run --release -- foo
-        env: RUSTC=C:/usr/bin/rustc.exe, RUST_BACKTRACE=full, TERM=ansi
+        env: RUST_BACKTRACE=full, TERM=ansi
     """)
 
     private fun checkCommandLine(cmd: GeneralCommandLine, expected: String, expectedWin: String) {


### PR DESCRIPTION
It helps tools like clippy, which use their own RUSTC. Historically,
this was implemented because not everyone was using rustup, and, thus,
not everybody had `rustc` in PATH, but hopefully this is not a problem
anymore.

closes https://github.com/intellij-rust/intellij-rust/issues/1941