### PR TITLE
DOC: add 'MACRO' tag in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,7 @@ change. Common tags are:
   * TY for type inference
   * COMP for code completion
   * STUB for PSI stubs
+  * MACRO for macro expansion
   
   
   * FMT for formatter


### PR DESCRIPTION
I like tag concept very much and dislike documentation inconsistency with reality