### PR TITLE
MACRO: fix stub based code path for macro definition

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -19,7 +19,7 @@ class RsPsiFactory(private val project: Project) {
             .createFileFromText("DUMMY.rs", RsFileType, text) as RsFile
 
     fun createMacroDefinitionBody(text: String): RsMacroDefinitionBody? = createFromText(
-        "macro rules m! $text"
+        "macro_rules! m $text"
     )
 
     fun createSelf(mutable: Boolean = false): RsSelfParameter {


### PR DESCRIPTION
This is embarrassing 😓 

@Undin this might fix the problem with futures.