### PR TITLE
#1989: Implement trait members - remove already implement members

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -116,6 +116,10 @@ class TraitImplementationInfo private constructor(
         declared.filter { it.isAbstract }.filter { it.name !in implementedByName }
     else emptyList()
 
+    val alreadyImplemented: List<RsAbstractable> =  if (!hasMacros)
+        declared.filter { it.isAbstract }.filter { it.name in implementedByName }
+    else emptyList()
+
     val nonExistentInTrait: List<RsAbstractable> = implemented.filter { it.name !in declaredByName }
 
     val implementationToDeclaration: List<Pair<RsAbstractable, RsAbstractable>> =

--- a/src/main/kotlin/org/rust/lang/refactoring/implementMembers/ui.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/implementMembers/ui.kt
@@ -56,9 +56,10 @@ fun showTraitMemberChooser(
 
     val base = MemberChooserObjectBase(implInfo.traitName, implInfo.trait.getIcon(0))
     val all = implInfo.declared.map { RsTraitMemberChooserMember(base, it) }
-    val selectedByDefault = all.filter { it.member in implInfo.missingImplementations }
+    val nonImplemented = all.filter { it.member !in implInfo.alreadyImplemented }
+    val selectedByDefault = nonImplemented.filter { it.member in implInfo.missingImplementations }
     val chooser = if (ApplicationManager.getApplication().isUnitTestMode) MOCK!! else memberChooserDialog
-    return chooser(project, all, selectedByDefault).map { it.member }
+    return chooser(project, nonImplemented, selectedByDefault).map { it.member }
 }
 
 typealias TraitMemberChooser = (

--- a/src/test/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -264,6 +264,35 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
     """)
 
+    fun `test do not implement methods already present`() = doTest("""
+        trait T {
+            fn f1();
+            fn f2();
+            fn f3() {}
+        }
+        struct S;
+        impl T for S {
+            fn f1() { }
+            /*caret*/
+        }
+    """, listOf(
+        ImplementMemberSelection("f2()", true, true),
+        ImplementMemberSelection("f3()", false, false)
+    ), """
+        trait T {
+            fn f1();
+            fn f2();
+            fn f3() {}
+        }
+        struct S;
+        impl T for S {
+            fn f1() { }
+            fn f2() {
+                unimplemented!()
+            }
+        }
+    """)
+
     private data class ImplementMemberSelection(val member: String, val byDefault: Boolean, val isSelected: Boolean = byDefault)
 
     private fun doTest(@Language("Rust") code: String,


### PR DESCRIPTION
Hello,

I propose a fix for "Implement members fix lists members that are already implemented" #1989

I'm not sure the change I made in TraitImplementationInfo is the best solution. If someone has a better idea, I will be happy to update my fix.

Guillaume