### PR TITLE
PRJ: create temporary action for new rust project creation in CLion

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/RsNewProjectAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsNewProjectAction.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.util.ui.JBUI
+import org.rust.ide.newProject.RsDirectoryProjectGenerator
+import org.rust.ide.newProject.RsProjectSettingsStep
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+// Temporary action to create new Rust project in CLion (but works in all IDEs)
+class RsNewProjectAction : RsProjectSettingsStep(RsDirectoryProjectGenerator(true)) {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val panel = createPanel()
+        panel.preferredSize = JBUI.size(600, 300)
+        RsNewProjectDialog(panel).show()
+    }
+}
+
+private class RsNewProjectDialog(private val centerPanel: JPanel) : DialogWrapper(true) {
+
+    init {
+        title = "New Project"
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent? = centerPanel
+    override fun createSouthPanel(): JComponent? = null
+}

--- a/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
@@ -7,21 +7,24 @@ package org.rust.ide.newProject
 
 import com.intellij.ide.util.projectWizard.AbstractNewProjectStep
 import com.intellij.ide.util.projectWizard.CustomStepProjectGenerator
-import com.intellij.ide.util.projectWizard.ProjectSettingsStepBase
+import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.impl.welcomeScreen.AbstractActionWithPanel
 import com.intellij.platform.DirectoryProjectGenerator
 import com.intellij.platform.DirectoryProjectGeneratorBase
 import com.intellij.platform.ProjectGeneratorPeer
+import com.intellij.util.PlatformUtils
 import org.rust.ide.icons.RsIcons
 import javax.swing.Icon
 
 // We implement `CustomStepProjectGenerator` as well to correctly show settings UI
 // because otherwise PyCharm doesn't add peer's component into project settings panel
-class RsDirectoryProjectGenerator : DirectoryProjectGeneratorBase<ConfigurationData>(),
-                                    CustomStepProjectGenerator<ConfigurationData> {
+class RsDirectoryProjectGenerator(private val isNewProjectAction: Boolean = false)
+    : DirectoryProjectGeneratorBase<ConfigurationData>(),
+      CustomStepProjectGenerator<ConfigurationData> {
 
     override fun getName(): String = "Rust"
     override fun getLogo(): Icon? = RsIcons.RUST
@@ -30,12 +33,24 @@ class RsDirectoryProjectGenerator : DirectoryProjectGeneratorBase<ConfigurationD
     override fun generateProject(project: Project, baseDir: VirtualFile, data: ConfigurationData, module: Module) {
         val (settings, createBinary) = data
         settings.toolchain?.rawCargo()?.init(module, baseDir, createBinary)
+        if (isNewProjectAction && PlatformUtils.isCLion()) {
+            // It's temporarily hack to support more or less workable project creation in CLion
+            // because at this moment CLion works only with CMake projects
+            generateCMakeFile(project, baseDir, createBinary)
+        }
+    }
+
+    private fun generateCMakeFile(project: Project, baseDir: VirtualFile, createBinary: Boolean) = runWriteAction {
+        val cmakeList = baseDir.createChildData(this, "CMakeLists.txt")
+        VfsUtil.saveText(cmakeList, """
+                project(${project.name})
+
+                add_executable(${project.name}
+                        src/${if (createBinary) "main.rs" else "lib.rs"}
+                        Cargo.toml)""".trimIndent())
     }
 
     override fun createStep(projectGenerator: DirectoryProjectGenerator<ConfigurationData>,
                             callback: AbstractNewProjectStep.AbstractCallback<ConfigurationData>): AbstractActionWithPanel =
         RsProjectSettingsStep(projectGenerator)
 }
-
-private class RsProjectSettingsStep(generator: DirectoryProjectGenerator<ConfigurationData>)
-    : ProjectSettingsStepBase<ConfigurationData>(generator, AbstractNewProjectStep.AbstractCallback<ConfigurationData>())

--- a/src/main/kotlin/org/rust/ide/newProject/RsProjectSettingsStep.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsProjectSettingsStep.kt
@@ -1,0 +1,13 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.newProject
+
+import com.intellij.ide.util.projectWizard.AbstractNewProjectStep
+import com.intellij.ide.util.projectWizard.ProjectSettingsStepBase
+import com.intellij.platform.DirectoryProjectGenerator
+
+open class RsProjectSettingsStep(generator: DirectoryProjectGenerator<ConfigurationData>)
+    : ProjectSettingsStepBase<ConfigurationData>(generator, AbstractNewProjectStep.AbstractCallback<ConfigurationData>())

--- a/src/main/resources/META-INF/clion-only.xml
+++ b/src/main/resources/META-INF/clion-only.xml
@@ -8,4 +8,11 @@
         <programRunner implementation="org.rust.debugger.runconfig.RsDebugRunner"/>
         <xdebugger.breakpointType implementation="org.rust.debugger.RsLineBreakpointType"/>
     </extensions>
+
+    <actions>
+        <reference id="Rust.NewProject">
+            <add-to-group group-id="WelcomeScreen.QuickStart"/>
+        </reference>
+    </actions>
+
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -606,6 +606,11 @@
     </application-components>
 
     <actions>
+        <action id="Rust.NewProject"
+                class="org.rust.ide.actions.RsNewProjectAction"
+                text="New Rust Project"
+                description="Create new Rust project"/>
+
         <action id="Rust.NewRustFile"
                 class="org.rust.ide.actions.RsCreateFileAction"
                 text="Rust File"


### PR DESCRIPTION
Temporary workaround for new project creation in CLion.
Should be removed when CLion will support not CMake projects.

* Introduce 'New Rust Project' action
* Add this action to welcome screen in CLion because otherwise it can be found only from search