### PR TITLE
Fix namespacing of macro definitions

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
@@ -11,12 +11,13 @@ import org.rust.lang.core.psi.ext.RsNamedElement
 import java.util.*
 
 enum class Namespace(val itemName: String) {
-    Values("value"), Types("type"), Lifetimes("lifetime")
+    Values("value"), Types("type"), Lifetimes("lifetime"), Macros("macro")
 }
 
 val TYPES: Set<Namespace> = EnumSet.of(Namespace.Types)
 val VALUES: Set<Namespace> = EnumSet.of(Namespace.Values)
 val LIFETIMES: Set<Namespace> = EnumSet.of(Namespace.Lifetimes)
+val MACROS: Set<Namespace> = EnumSet.of(Namespace.Macros)
 val TYPES_N_VALUES: Set<Namespace> = TYPES + VALUES
 
 val RsNamedElement.namespaces: Set<Namespace> get() = when (this) {
@@ -35,6 +36,8 @@ val RsNamedElement.namespaces: Set<Namespace> get() = when (this) {
     is RsStructItem -> if (blockFields == null) TYPES_N_VALUES else TYPES
 
     is RsLifetimeParameter -> LIFETIMES
+
+    is RsMacroDefinition -> MACROS
 
     else -> TYPES_N_VALUES
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -5,8 +5,6 @@
 
 package org.rust.ide.annotator
 
-import org.junit.ComparisonFailure
-
 class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
     override val dataPath = "org/rust/ide/annotator/fixtures/errors"
 
@@ -631,24 +629,20 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
         }
     """)
 
-    fun `test macro mod fn no E0428`() = expect<ComparisonFailure> {
-        checkErrors("""
+    fun `test macro mod fn no E0428`() = checkErrors("""
         macro_rules! example {
             () => ()
         }
         mod example { }
         fn example() { }
     """)
-    }
 
-    fun `test macro struct no E0428`() = expect<ComparisonFailure> {
-        checkErrors("""
+    fun `test macro struct no E0428`() = checkErrors("""
         macro_rules! example {
             () => ()
         }
         struct example { }
     """)
-    }
 
     fun `test duplicate macro no E0428`() = checkErrors("""
         macro_rules! example {

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.ide.annotator
 
+import org.junit.ComparisonFailure
+
 class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
     override val dataPath = "org/rust/ide/annotator/fixtures/errors"
 
@@ -626,6 +628,34 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
 
             #[cfg(windows)] fn <error descr="A value named `hello_world` has already been defined in this module [E0428]">hello_world</error>() {}
             fn <error descr="A value named `hello_world` has already been defined in this module [E0428]">hello_world</error>() {}
+        }
+    """)
+
+    fun `test macro mod fn no E0428`() = expect<ComparisonFailure> {
+        checkErrors("""
+        macro_rules! example {
+            () => ()
+        }
+        mod example { }
+        fn example() { }
+    """)
+    }
+
+    fun `test macro struct no E0428`() = expect<ComparisonFailure> {
+        checkErrors("""
+        macro_rules! example {
+            () => ()
+        }
+        struct example { }
+    """)
+    }
+
+    fun `test duplicate macro no E0428`() = checkErrors("""
+        macro_rules! example {
+            () => ()
+        }
+        macro_rules! example {
+            () => ()
         }
     """)
 


### PR DESCRIPTION
In Rust macros are in a different namespace than names and types.

This change fixes a wrong E0428 error when a macro has the same name
as a module, struct or function.