### PR TITLE
Do not show errors on &mut ref to a function/method

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -80,6 +80,7 @@ val RsExpr.isMutable: Boolean get() {
             if (type is TyUnknown) return DEFAULT_MUTABILITY
             if (declaration is RsEnumVariant) return true
             if (declaration is RsStructItem) return true
+            if (declaration is RsFunction) return true
 
             false
         }

--- a/src/test/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspectionTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.ide.inspections
 
+import org.junit.ComparisonFailure
+
 class RsBorrowCheckerInspectionTest : RsInspectionsTestBase(RsBorrowCheckerInspection(), useStdLib = true) {
 
     fun `test mutable used at ref mutable method call (self)`() = checkByText("""
@@ -304,4 +306,27 @@ class RsBorrowCheckerInspectionTest : RsInspectionsTestBase(RsBorrowCheckerInspe
             test(&mut s);
         }
     """)
+
+    fun `test &mut on function`() = expect<ComparisonFailure> {
+        checkByText("""
+        fn foo() {}
+
+        fn main() {
+            let local = &mut foo;
+        }
+    """)
+    }
+
+    fun `test &mut on method`() = expect<ComparisonFailure> {
+        checkByText("""
+        struct A {}
+        impl A {
+            fn foo(&mut self) {}
+        }
+
+        fn main() {
+            let local = &mut A::foo;
+        }
+    """)
+    }
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspectionTest.kt
@@ -5,8 +5,6 @@
 
 package org.rust.ide.inspections
 
-import org.junit.ComparisonFailure
-
 class RsBorrowCheckerInspectionTest : RsInspectionsTestBase(RsBorrowCheckerInspection(), useStdLib = true) {
 
     fun `test mutable used at ref mutable method call (self)`() = checkByText("""
@@ -307,18 +305,15 @@ class RsBorrowCheckerInspectionTest : RsInspectionsTestBase(RsBorrowCheckerInspe
         }
     """)
 
-    fun `test &mut on function`() = expect<ComparisonFailure> {
-        checkByText("""
+    fun `test &mut on function`() = checkByText("""
         fn foo() {}
 
         fn main() {
             let local = &mut foo;
         }
     """)
-    }
 
-    fun `test &mut on method`() = expect<ComparisonFailure> {
-        checkByText("""
+    fun `test &mut on method`() = checkByText("""
         struct A {}
         impl A {
             fn foo(&mut self) {}
@@ -328,5 +323,4 @@ class RsBorrowCheckerInspectionTest : RsInspectionsTestBase(RsBorrowCheckerInspe
             let local = &mut A::foo;
         }
     """)
-    }
 }


### PR DESCRIPTION
Getting a &mut reference to a function/method works in rustc so we must show an error for it.

Fixes #1858