### PR TITLE
Handle type aliases used in struct literals

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -80,7 +80,13 @@ fun processFieldExprResolveVariants(
 }
 
 fun processStructLiteralFieldResolveVariants(field: RsStructLiteralField, processor: RsResolveProcessor): Boolean {
-    val structOrEnumVariant = field.parentStructLiteral.path.reference.resolve() as? RsFieldsOwner ?: return false
+    var resolved = field.parentStructLiteral.path.reference.resolve()
+
+    // Resolve potential type aliases
+    while (resolved is RsTypeAlias) {
+        resolved = (resolved.typeReference?.typeElement as? RsBaseType)?.path?.reference?.resolve()
+    }
+    val structOrEnumVariant = resolved as? RsFieldsOwner ?: return false
     return processFieldDeclarations(structOrEnumVariant, processor)
 }
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -714,7 +714,15 @@ private class RsFnInferenceContext(
             return TyUnknown
         }
 
-        val (element, subst) = boundElement
+        var (element, subst) = boundElement
+
+        // Resolve potential type aliases
+        while (element is RsTypeAlias) {
+            val resolved = (element.typeReference?.typeElement as? RsBaseType)?.path?.reference?.advancedResolve()
+            element = resolved?.element ?: return TyUnknown
+            subst = resolved.subst.substituteInValues(subst)
+        }
+
         val genericDecl: RsGenericDeclaration = when (element) {
             is RsStructItem -> element
             is RsEnumVariant -> element.parentEnum

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -535,8 +535,7 @@ class RsResolveTest : RsResolveTestBase() {
         }              //^
     """)
 
-    fun `test struct field with alias`() = expect<IllegalStateException> {
-        checkByCode("""
+    fun `test struct field with alias`() = checkByCode("""
         struct S { foo: i32 }
                   //X
         type T1 = S;
@@ -545,7 +544,6 @@ class RsResolveTest : RsResolveTestBase() {
             let _ = T2 { foo: 92 };
         }              //^
     """)
-    }
 
     fun `test enum field`() = checkByCode("""
         enum E { X { foo: i32 } }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -495,6 +495,17 @@ class RsResolveTest : RsResolveTestBase() {
                     //^ unresolved
     """)
 
+    // Enum variants behind an alias are not resolved
+    // https://github.com/rust-lang/rust/issues/26264
+    // https://github.com/rust-lang/rfcs/issues/2218
+    fun `test enum variant with alias`() = checkByCode("""
+        enum E { A }
+        type T1 = E;
+        fn main() {
+            let _ = T1::A;
+        }             //^ unresolved
+    """)
+
     fun `test local fn`() = checkByCode("""
         fn main() {
             foo();
@@ -524,6 +535,17 @@ class RsResolveTest : RsResolveTestBase() {
         }              //^
     """)
 
+    fun `test struct field with alias`() = expect<IllegalStateException> {
+        checkByCode("""
+        struct S { foo: i32 }
+                  //X
+        type T1 = S;
+        type T2 = T1;
+        fn main() {
+            let _ = T2 { foo: 92 };
+        }              //^
+    """)
+    }
 
     fun `test enum field`() = checkByCode("""
         enum E { X { foo: i32 } }

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -725,6 +725,18 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }        //^ i32
     """)
 
+    fun `test struct with alias`() = expect<IllegalStateException> {
+        testExpr("""
+        struct S;
+        type T1 = S;
+        type T2 = T1;
+        fn main() {
+            T2 { }
+        } //^ S
+    """)
+    }
+    // More struct alias tests in [RsGenericExpressionTypeInferenceTest]
+
     fun `test index expr of unresolved path`() = testExpr("""
         fn main() {
             a[1]

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -725,8 +725,7 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }        //^ i32
     """)
 
-    fun `test struct with alias`() = expect<IllegalStateException> {
-        testExpr("""
+    fun `test struct with alias`() = testExpr("""
         struct S;
         type T1 = S;
         type T2 = T1;
@@ -734,7 +733,6 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
             T2 { }
         } //^ S
     """)
-    }
     // More struct alias tests in [RsGenericExpressionTypeInferenceTest]
 
     fun `test index expr of unresolved path`() = testExpr("""

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -442,6 +442,39 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test struct with alias 1`() = expect<IllegalStateException> {
+        testExpr("""
+        struct S<T> { a: T }
+        type T1 = S<u8>;
+        type T2 = T1;
+        fn main() {
+            T2 { a: 1 }
+        } //^ S<u8>
+    """)
+    }
+
+    fun `test struct with alias 2`() = expect<IllegalStateException> {
+        testExpr("""
+        struct S<T> { a: T }
+        type T1<U> = S<U>;
+        type T2 = T1<u8>;
+        fn main() {
+            T2 { a: 1 }
+        } //^ S<u8>
+    """)
+    }
+
+    fun `test struct with alias 3`() = expect<IllegalStateException> {
+        testExpr("""
+        struct S<T> { a: T }
+        type T1<U> = S<U>;
+        type T2<V> = T1<V>;
+        fn main() {
+            T2 { a: 1u8 }
+        } //^ S<u8>
+    """)
+    }
+
     fun `test generic struct arg`() = testExpr("""
         struct Foo<F>(F);
         fn foo<T>(xs: Foo<T>) -> T { unimplemented!() }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -442,8 +442,7 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
-    fun `test struct with alias 1`() = expect<IllegalStateException> {
-        testExpr("""
+    fun `test struct with alias 1`() = testExpr("""
         struct S<T> { a: T }
         type T1 = S<u8>;
         type T2 = T1;
@@ -451,10 +450,8 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             T2 { a: 1 }
         } //^ S<u8>
     """)
-    }
 
-    fun `test struct with alias 2`() = expect<IllegalStateException> {
-        testExpr("""
+    fun `test struct with alias 2`() = testExpr("""
         struct S<T> { a: T }
         type T1<U> = S<U>;
         type T2 = T1<u8>;
@@ -462,10 +459,8 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             T2 { a: 1 }
         } //^ S<u8>
     """)
-    }
 
-    fun `test struct with alias 3`() = expect<IllegalStateException> {
-        testExpr("""
+    fun `test struct with alias 3`() = testExpr("""
         struct S<T> { a: T }
         type T1<U> = S<U>;
         type T2<V> = T1<V>;
@@ -473,7 +468,6 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             T2 { a: 1u8 }
         } //^ S<u8>
     """)
-    }
 
     fun `test generic struct arg`() = testExpr("""
         struct Foo<F>(F);


### PR DESCRIPTION
We resolve all type aliases in the struct literal and use the actual struct type as result.