### PR TITLE
ANN: add quick fix for type mismatch when impl From<A> for B exists

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFix.kt
@@ -1,0 +1,30 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.ide.presentation.tyToStringWithoutTypeArgs
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.types.ty.Ty
+
+/**
+ * For the given `expr` converts it to the type `ty` with `ty::from(expr)`
+ */
+class ConvertToTyUsingFromTraitFix(expr: PsiElement, val ty: Ty) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
+    override fun getFamilyName(): String = "Convert to type"
+
+    override fun getText(): String = "Convert to type $ty using `From` trait"
+
+    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
+        if (startElement !is RsExpr) return
+        startElement.replace(RsPsiFactory(project).createAssocFunctionCall(tyToStringWithoutTypeArgs(ty), "from", listOf(startElement)))
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -271,6 +271,9 @@ class RsPsiFactory(private val project: Project) {
         else -> createExpressionOfType("${expr.text} as $typeText")
     }
 
+    fun createAssocFunctionCall(typeText: String, methodNameText: String, arguments: Iterable<RsExpr>): RsCallExpr =
+        createExpressionOfType("$typeText::$methodNameText(${arguments.joinToString { it.text }})")
+
     private inline fun <reified E : RsExpr> createExpressionOfType(text: String): E =
         createExpression(text) as? E
             ?: error("Failed to create ${E::class.simpleName} from `$text`")

--- a/src/main/kotlin/org/rust/lang/core/resolve/StdKnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/StdKnownItems.kt
@@ -80,6 +80,9 @@ class StdKnownItems private constructor(private val absolutePathResolver: (Strin
     fun findOrdTrait(): RsTraitItem? =
         findCoreItem("cmp::Ord") as? RsTraitItem
 
+    fun findFromTrait(): RsTraitItem? =
+        findCoreItem("convert::From") as? RsTraitItem
+
     companion object {
         private val stdKnownItemsCache =
             ProjectCache<Pair<CargoWorkspace, String>, Optional<RsNamedElement>>("stdKnownItemsCache")

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFixTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.rust.ide.inspections.RsExperimentalChecksInspection
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class ConvertToTyUsingFromTraitFixTest : RsInspectionsTestBase(RsExperimentalChecksInspection()) {
+    override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
+
+    fun `test B from A when impl From A for B is available`() = checkFixByText("Convert to type B using `From` trait", """
+        struct A{}
+        struct B{}
+
+        impl From<A> for B { fn from(item: A) -> Self {B{}} }
+
+        fn main () {
+            let b: B = <error>A {}<caret></error>;
+        }
+    """, """
+        struct A{}
+        struct B{}
+
+        impl From<A> for B { fn from(item: A) -> Self {B{}} }
+
+        fn main () {
+            let b: B = B::from(A {});
+        }
+    """)
+
+    fun `test no fix when impl From A for B is not available`() = checkFixIsUnavailable("Convert to type B using `From` trait", """
+        struct A{}
+        struct B{}
+        struct C{}
+
+        impl From<A> for C { fn from(item: A) -> Self {C{}} }
+
+        fn main () {
+            let b: B = <error>A {}<caret></error>;
+        }
+    """)
+
+
+    fun `test From impl provided by std lib`() = checkFixByText("Convert to type u32 using `From` trait", """
+        fn main () {
+            let x: u32 = <error>'X'<caret></error>;
+        }
+    """, """
+        fn main () {
+            let x: u32 = u32::from('X');
+        }
+    """)
+
+    fun `test From impl for generic type`() = checkFixByText ("Convert to type Vec<u8> using `From` trait", """
+        fn main () {
+            let v: Vec<u8> = <error>String::new()<caret></error>;
+        }
+    """, """
+        fn main () {
+            let v: Vec<u8> = Vec::from(String::new());
+        }
+    """)
+
+}

--- a/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections
 
+import junit.framework.TestCase
 import org.intellij.lang.annotations.Language
 import org.rust.lang.RsTestBase
 
@@ -50,6 +51,16 @@ abstract class RsInspectionsTestBase(
         myFixture.checkHighlighting(checkWarn, checkInfo, checkWeakWarn)
         applyQuickFix(fixName)
         myFixture.checkResult(after)
+    }
+
+    protected fun checkFixIsUnavailable(
+        fixName: String,
+        @Language("Rust") text: String,
+        checkWarn: Boolean = true, checkInfo: Boolean = false, checkWeakWarn: Boolean = false
+    ) {
+        checkByText(text, checkWarn, checkInfo, checkWeakWarn)
+        TestCase.assertTrue("Fix $fixName should not be possible to apply.",
+            myFixture.filterAvailableIntentions(fixName).isEmpty())
     }
 
 }


### PR DESCRIPTION
This commit adds quick-fix for the types mismatch when
impl From<A> for B exists for actual type A and expected type B,
which fulfills the third bullet-point of the issue:
https://github.com/intellij-rust/intellij-rust/issues/1730

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
