### PR TITLE
Stub and PSI improvements related to inner and outer attributes

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -527,7 +527,8 @@ ModDeclItem ::= AttrsAndVis mod identifier ';' {
 
 ForeignModItem ::= AttrsAndVis ExternAbi '{' InnerAttr* ForeignDecl* '}' {
   hooks = [ leftBinder = "ADJACENT_LINE_COMMENTS" ]
-  implements = [ "org.rust.lang.core.psi.ext.RsItemElement" ]
+  implements = [ "org.rust.lang.core.psi.ext.RsItemElement"
+                 "org.rust.lang.core.psi.ext.RsInnerAttributeOwner" ]
   mixin = "org.rust.lang.core.psi.ext.RsForeignModItemImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsPlaceholderStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"

--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -649,6 +649,7 @@ ImplItem ::= AttrsAndVis default_? unsafe? impl TypeParameterList? ( TraitImpl |
   hooks = [ leftBinder = "ADJACENT_LINE_COMMENTS" ]
   implements = [ "org.rust.lang.core.psi.ext.RsTraitOrImpl"
                  "org.rust.lang.core.psi.ext.RsUnsafetyOwner"
+                 "org.rust.lang.core.psi.ext.RsInnerAttributeOwner"
                  "org.rust.lang.core.psi.ext.RsTypeDeclarationElement" ]
   mixin = "org.rust.lang.core.psi.ext.RsImplItemImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsImplItemStub"

--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1114,6 +1114,9 @@ PatMacro ::= MacroCallNoSemicolons
 fake Block ::= '{' InnerAttr* (Item | Stmt)* Expr? '}' {
   pin = 1
   implements = "org.rust.lang.core.psi.ext.RsItemsOwner"
+  extends = "org.rust.lang.core.psi.ext.RsStubbedElementImpl<?>"
+  stubClass = "org.rust.lang.core.stubs.RsPlaceholderStub"
+  elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
 SimpleBlock ::= '{' BlockElement* '}' {

--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -370,7 +370,6 @@ Function ::= OuterAttr*
   pin = 'identifier'
   implements = [ "org.rust.lang.core.psi.ext.RsQualifiedNamedElement"
                  "org.rust.lang.core.psi.ext.RsGenericDeclaration"
-                 "org.rust.lang.core.psi.ext.RsOuterAttributeOwner"
                  "org.rust.lang.core.psi.ext.RsInnerAttributeOwner"
                  "org.rust.lang.core.psi.ext.RsItemElement"
                  "org.rust.lang.core.psi.ext.RsNameIdentifierOwner"

--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1044,7 +1044,8 @@ MacroExpansionReferenceGroup ::= '$' '(' MacroExpansionContents ')'
 
 
 MacroCall ::= MacroHead <<macroSemicolon>> {
-  implements = [ "org.rust.lang.core.psi.ext.RsReferenceElement" ]
+  implements = [ "org.rust.lang.core.psi.ext.RsReferenceElement"
+                 "org.rust.lang.core.psi.ext.RsOuterAttributeOwner"]
   pin = 2
   hooks = [ leftBinder = "ADJACENT_LINE_COMMENTS" ]
   mixin = "org.rust.lang.core.psi.ext.RsMacroCallImplMixin"

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -62,6 +62,8 @@ inline fun <reified T : PsiElement> PsiElement.contextOrSelf(): T? =
 inline fun <reified T : PsiElement> PsiElement.childrenOfType(): List<T> =
     PsiTreeUtil.getChildrenOfTypeAsList(this, T::class.java)
 
+inline fun <reified T : PsiElement> PsiElement.stubChildrenOfType(): List<T> =
+    PsiTreeUtil.getStubChildrenOfTypeAsList(this, T::class.java)
 
 inline fun <reified T : PsiElement> PsiElement.descendantOfTypeStrict(): T? =
     PsiTreeUtil.findChildOfType(this, T::class.java, /* strict */ true)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
@@ -21,9 +21,13 @@ enum class RsConstantKind {
     CONST
 }
 
+val RsConstant.isMut: Boolean get() = stub?.isMut ?: (mut != null)
+
+val RsConstant.isConst: Boolean get() = stub?.isConst ?: (const != null)
+
 val RsConstant.kind: RsConstantKind get() = when {
-    mut != null -> RsConstantKind.MUT_STATIC
-    const != null -> RsConstantKind.CONST
+    isMut -> RsConstantKind.MUT_STATIC
+    isConst -> RsConstantKind.CONST
     else -> RsConstantKind.STATIC
 }
 
@@ -53,7 +57,7 @@ val RsConstant.owner: RsConstantOwner get() {
 val RsConstant.default: PsiElement?
     get() = node.findChildByType(DEFAULT)?.psi
 
-val RsConstant.mutability: Mutability get() = Mutability.valueOf(mut != null)
+val RsConstant.mutability: Mutability get() = Mutability.valueOf(isMut)
 
 abstract class RsConstantImplMixin : RsStubbedNamedElementImpl<RsConstantStub>, RsConstant {
     constructor(node: ASTNode) : super(node)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt
@@ -21,7 +21,7 @@ abstract class RsForeignModItemImplMixin : RsStubbedElementImpl<RsPlaceholderStu
     constructor(stub: RsPlaceholderStub, elementType: IStubElementType<*, *>) : super(stub, elementType)
 
     override val outerAttrList: List<RsOuterAttr>
-        get() = childrenOfType()
+        get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, RsOuterAttr::class.java)
 
     override val isPublic: Boolean get() = false // visibility does not affect foreign mods
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt
@@ -22,10 +22,10 @@ abstract class RsForeignModItemImplMixin : RsStubbedElementImpl<RsPlaceholderStu
     constructor(stub: RsPlaceholderStub, elementType: IStubElementType<*, *>) : super(stub, elementType)
 
     override val innerAttrList: List<RsInnerAttr>
-        get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, RsInnerAttr::class.java)
+        get() = stubChildrenOfType()
 
     override val outerAttrList: List<RsOuterAttr>
-        get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, RsOuterAttr::class.java)
+        get() = stubChildrenOfType()
 
     override val isPublic: Boolean get() = false // visibility does not affect foreign mods
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.lang.core.macros.ExpansionResult
 import org.rust.lang.core.psi.RsForeignModItem
+import org.rust.lang.core.psi.RsInnerAttr
 import org.rust.lang.core.psi.RsOuterAttr
 import org.rust.lang.core.stubs.RsPlaceholderStub
 
@@ -19,6 +20,9 @@ abstract class RsForeignModItemImplMixin : RsStubbedElementImpl<RsPlaceholderStu
     constructor(node: ASTNode) : super(node)
 
     constructor(stub: RsPlaceholderStub, elementType: IStubElementType<*, *>) : super(stub, elementType)
+
+    override val innerAttrList: List<RsInnerAttr>
+        get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, RsInnerAttr::class.java)
 
     override val outerAttrList: List<RsOuterAttr>
         get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, RsOuterAttr::class.java)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -46,9 +46,6 @@ abstract class RsImplItemImplMixin : RsStubbedElementImpl<RsImplItemStub>, RsImp
     override val innerAttrList: List<RsInnerAttr>
         get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, RsInnerAttr::class.java)
 
-    override val outerAttrList: List<RsOuterAttr>
-        get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, RsOuterAttr::class.java)
-
     override val associatedTypesTransitively: Collection<RsTypeAlias>
         get() = CachedValuesManager.getCachedValue(this, {
             CachedValueProvider.Result.create(

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -44,7 +44,7 @@ abstract class RsImplItemImplMixin : RsStubbedElementImpl<RsImplItemStub>, RsImp
     }
 
     override val innerAttrList: List<RsInnerAttr>
-        get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, RsInnerAttr::class.java)
+        get() = members?.innerAttrList ?: emptyList()
 
     override val associatedTypesTransitively: Collection<RsTypeAlias>
         get() = CachedValuesManager.getCachedValue(this, {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.psi.stubs.StubElement
+import org.rust.lang.core.psi.RsBlock
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.RsModItem
@@ -23,6 +24,10 @@ val RsItemsOwner.itemsAndMacros: Sequence<RsElement>
                 is RsModItem -> {
                     val stub = stub
                     if (stub != null) return@run stub.childrenStubs
+                }
+                is RsBlock -> {
+                    val stub = stub
+                    if(stub != null) return@run stub.childrenStubs
                 }
             }
             null

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsModItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsModItem.kt
@@ -43,10 +43,10 @@ abstract class RsModItemImplMixin : RsStubbedNamedElementImpl<RsModItemStub>,
     override val isCrateRoot: Boolean = false
 
     override val innerAttrList: List<RsInnerAttr>
-        get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, RsInnerAttr::class.java)
+        get() = stubChildrenOfType()
 
     override val outerAttrList: List<RsOuterAttr>
-        get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, RsOuterAttr::class.java)
+        get() = stubChildrenOfType()
 
     override fun getContext() = ExpansionResult.getContextImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -72,9 +72,6 @@ abstract class RsTraitItemImplMixin : RsStubbedNamedElementImpl<RsTraitItemStub>
     override val innerAttrList: List<RsInnerAttr>
         get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, RsInnerAttr::class.java)
 
-    override val outerAttrList: List<RsOuterAttr>
-        get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, RsOuterAttr::class.java)
-
     override fun getIcon(flags: Int): Icon =
         iconWithVisibility(flags, RsIcons.TRAIT)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -124,8 +124,7 @@ class TraitImplementationInfo private constructor(
 
 
     private fun RsMembers.abstractable(): List<RsAbstractable> =
-        PsiTreeUtil.getStubChildrenOfTypeAsList(this, RsAbstractable::class.java)
-            .filter { it.name != null }
+        stubChildrenOfType<RsAbstractable>().filter { it.name != null }
 
     companion object {
         fun create(trait: RsTraitItem, impl: RsImplItem): TraitImplementationInfo? {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -69,9 +69,6 @@ abstract class RsTraitItemImplMixin : RsStubbedNamedElementImpl<RsTraitItemStub>
 
     constructor(stub: RsTraitItemStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
-    override val innerAttrList: List<RsInnerAttr>
-        get() = PsiTreeUtil.getStubChildrenOfTypeAsList(this, RsInnerAttr::class.java)
-
     override fun getIcon(flags: Int): Icon =
         iconWithVisibility(flags, RsIcons.TRAIT)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitOrImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitOrImpl.kt
@@ -8,7 +8,7 @@ package org.rust.lang.core.psi.ext
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.types.BoundElement
 
-interface RsTraitOrImpl : RsItemElement, RsInnerAttributeOwner, RsGenericDeclaration {
+interface RsTraitOrImpl : RsItemElement, RsGenericDeclaration {
     val members: RsMembers?
 
     val implementedTrait: BoundElement<RsTraitItem>?

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -31,7 +31,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 111
+        override fun getStubVersion(): Int = 112
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)
@@ -135,6 +135,8 @@ fun factory(name: String): RsStubElementType<*, *> = when (name) {
 
     "META_ITEM" -> RsMetaItemStub.Type
     "META_ITEM_ARGS" -> RsPlaceholderStub.Type("META_ITEM_ARGS", ::RsMetaItemArgsImpl)
+
+    "BLOCK" -> RsPlaceholderStub.Type("BLOCK", ::RsBlockImpl)
 
     else -> error("Unknown element $name")
 }

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -31,7 +31,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 112
+        override fun getStubVersion(): Int = 113
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)
@@ -533,7 +533,9 @@ class RsFunctionStub(
 class RsConstantStub(
     parent: StubElement<*>?, elementType: IStubElementType<*, *>,
     override val name: String?,
-    override val isPublic: Boolean
+    override val isPublic: Boolean,
+    val isMut: Boolean,
+    val isConst: Boolean
 ) : StubBase<RsConstant>(parent, elementType),
     RsNamedStub,
     RsVisibilityStub {
@@ -542,6 +544,8 @@ class RsConstantStub(
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
             RsConstantStub(parentStub, this,
                 dataStream.readNameAsString(),
+                dataStream.readBoolean(),
+                dataStream.readBoolean(),
                 dataStream.readBoolean()
             )
 
@@ -549,13 +553,15 @@ class RsConstantStub(
             with(dataStream) {
                 writeName(stub.name)
                 writeBoolean(stub.isPublic)
+                writeBoolean(stub.isMut)
+                writeBoolean(stub.isConst)
             }
 
         override fun createPsi(stub: RsConstantStub) =
             RsConstantImpl(stub, this)
 
         override fun createStub(psi: RsConstant, parentStub: StubElement<*>?) =
-            RsConstantStub(parentStub, this, psi.name, psi.isPublic)
+            RsConstantStub(parentStub, this, psi.name, psi.isPublic, psi.isMut, psi.isConst)
 
         override fun indexStub(stub: RsConstantStub, sink: IndexSink) = sink.indexConstant(stub)
     }

--- a/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
@@ -1,0 +1,258 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+import org.intellij.lang.annotations.Language
+import org.rust.lang.RsTestBase
+import org.rust.lang.core.psi.AttributeType.Inner
+import org.rust.lang.core.psi.AttributeType.Outer
+import org.rust.lang.core.psi.AttributeType.Both
+import org.rust.lang.core.psi.AttributeType.None
+import org.rust.lang.core.psi.ext.*
+
+enum class AttributeType { Outer, Inner, Both, None }
+
+class RsAttributeTest : RsTestBase() {
+
+    private fun doTest(element: RsElement, type: AttributeType) {
+        val isInner = element is RsInnerAttributeOwner
+        val hasInner = element is RsDocAndAttributeOwner && element.queryAttributes.hasAttribute("inner")
+        val isOuter = element is RsOuterAttributeOwner
+        val hasOuter = element is RsDocAndAttributeOwner && element.queryAttributes.hasAttribute("outer")
+        check(isInner == hasInner)
+        check(isOuter == hasOuter)
+
+        when (type) {
+            None -> check(!isInner && !isOuter)
+            Both -> check(isInner && isOuter)
+            Inner -> check(isInner && !isOuter)
+            Outer -> check(!isInner && isOuter)
+        }
+    }
+
+    private fun doTest(@Language("Rust") code: String, type: AttributeType) {
+        InlineFile(code)
+        val element = findElementInEditor<RsElement>()
+
+        doTest(element, type)
+    }
+
+    private inline fun <reified T : RsElement> doTest2(@Language("Rust") code: String, type: AttributeType) {
+        InlineFile(code)
+        val element = findElementInEditor<T>()
+
+        doTest(element, type)
+    }
+
+    fun `test file`() = doTest("""
+        //^
+        #![inner]
+        """, Inner)
+
+    fun `test extern crate`() = doTest("""
+        #[outer]
+        extern crate foo;
+        //^
+        """, Outer)
+
+    fun `test use`() = doTest("""
+        #[outer]
+        use foo;
+        //^
+        """, Outer)
+
+    fun `test mod`() = doTest("""
+        #[outer]
+        mod m {
+        //^
+            #![inner]
+        }
+        """, Both)
+
+    fun `test mod separate file`() = doTest("""
+        #[outer]
+        mod m;
+        //^
+        """, Outer)
+
+    fun `test extern`() = expect<IllegalStateException> {
+        doTest2<RsForeignModItem>("""
+        #[outer]
+        extern {
+        //^
+            #![inner]
+        }
+        """, Both)
+    }
+
+    fun `test trait`() = expect<IllegalStateException> {
+        doTest("""
+        #[outer]
+        trait T {
+        //^
+            #![inner]
+        }
+        """, Outer)
+    }
+
+    fun `test struct`() = doTest("""
+        #[outer]
+        struct S { }
+        //^
+        """, Outer)
+
+    fun `test struct item`() = doTest("""
+        struct S {
+            #[outer]
+            s: u16,
+          //^
+        }
+        """, Outer)
+
+    fun `test union`() = doTest("""
+        #[outer]
+        union U {
+        //^
+            u1: u16,
+        }
+        """, Outer)
+
+    fun `test union field`() = doTest("""
+        union U {
+            #[outer]
+            u1: u16,
+          //^
+            u2: i16,
+        }
+        """, Outer)
+
+    fun `test enum`() = doTest("""
+        #[outer]
+        enum E { }
+        //^
+        """, Outer)
+
+    fun `test enum variant`() = doTest("""
+        enum E {
+            #[outer]
+            EV,
+          //^
+        }
+        """, Outer)
+
+    fun `test impl`() = expect<IllegalStateException> {
+        doTest("""
+        struct S { }
+        #[outer]
+        impl S {
+        //^
+            #![inner]
+        }
+        """, Both)
+    }
+
+    fun `test impl trait`() = expect<IllegalStateException> {
+        doTest("""
+        struct S { }
+        trait T { }
+        #[outer]
+        impl T for S {
+        //^
+            #![inner]
+        }
+        """, Both)
+    }
+
+    fun `test fn`() = doTest("""
+        #[outer]
+        fn foo() {
+         //^
+            #![inner]
+        }
+        """, Both)
+
+    fun `test fn type parameter`() = doTest("""
+        fn foo<#[outer] T>( a: u16) {
+                      //^
+        }
+        """, Outer)
+
+    fun `test fn lifetime parameter`() = doTest("""
+        fn foo<#[outer] 'a>( a: u16) {
+                      //^
+        }
+        """, Outer)
+
+    fun `test type alias`() = doTest("""
+        #[outer]
+        type T = u16;
+        //^
+        """, Outer)
+
+    fun `test const`() = doTest("""
+        #[outer]
+        const C: u16 = 1;
+        //^
+        """, Outer)
+
+    fun `test static`() = doTest("""
+        #[outer]
+        static S: u16 = 1;
+        //^
+        """, Outer)
+
+    fun `test macro`() = doTest("""
+        #[outer]
+        macro_rules! makro {
+        //^
+            () => { };
+        }
+        """, Outer)
+
+    fun `test macro call`() = expect<IllegalStateException> {
+        doTest("""
+        macro_rules! makro {
+            () => { };
+        }
+
+        #[outer]
+        makro!();
+        //^
+        """, Outer)
+    }
+
+    fun `test let statement`() = expect<IllegalStateException> {
+        doTest2<RsStmt>("""
+        fn main() {
+            #[outer]
+            let a = 1u16;
+            //^
+        }
+        """, Outer)
+    }
+
+    fun `test fn call expr as statement`() = expect<IllegalStateException> {
+        doTest2<RsStmt>("""
+        fn a() {
+        }
+        fn main() {
+            #[outer]
+            a();
+          //^
+        }
+        """, Outer)
+    }
+
+    fun `test literal expr as statement`() = expect<IllegalStateException> {
+        doTest("""
+        fn main() {
+            #[outer]
+            "Hello Rust!";
+            //^
+        }
+        """, Outer)
+    }
+}

--- a/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
@@ -212,8 +212,7 @@ class RsAttributeTest : RsTestBase() {
         }
         """, Outer)
 
-    fun `test macro call`() = expect<IllegalStateException> {
-        doTest("""
+    fun `test macro call`() = doTest("""
         macro_rules! makro {
             () => { };
         }
@@ -222,7 +221,6 @@ class RsAttributeTest : RsTestBase() {
         makro!();
         //^
         """, Outer)
-    }
 
     fun `test let statement`() = expect<IllegalStateException> {
         doTest2<RsStmt>("""

--- a/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
@@ -143,8 +143,7 @@ class RsAttributeTest : RsTestBase() {
         }
         """, Outer)
 
-    fun `test impl`() = expect<IllegalStateException> {
-        doTest("""
+    fun `test impl`() = doTest("""
         struct S { }
         #[outer]
         impl S {
@@ -152,10 +151,8 @@ class RsAttributeTest : RsTestBase() {
             #![inner]
         }
         """, Both)
-    }
 
-    fun `test impl trait`() = expect<IllegalStateException> {
-        doTest("""
+    fun `test impl trait`() = doTest("""
         struct S { }
         trait T { }
         #[outer]
@@ -164,7 +161,6 @@ class RsAttributeTest : RsTestBase() {
             #![inner]
         }
         """, Both)
-    }
 
     fun `test fn`() = doTest("""
         #[outer]

--- a/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
@@ -78,15 +78,13 @@ class RsAttributeTest : RsTestBase() {
         //^
         """, Outer)
 
-    fun `test extern`() = expect<IllegalStateException> {
-        doTest2<RsForeignModItem>("""
+    fun `test extern`() = doTest2<RsForeignModItem>("""
         #[outer]
         extern {
         //^
             #![inner]
         }
         """, Both)
-    }
 
     fun `test trait`() = doTest("""
         #[outer]

--- a/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
@@ -88,15 +88,13 @@ class RsAttributeTest : RsTestBase() {
         """, Both)
     }
 
-    fun `test trait`() = expect<IllegalStateException> {
-        doTest("""
+    fun `test trait`() = doTest("""
         #[outer]
         trait T {
         //^
             #![inner]
         }
         """, Outer)
-    }
 
     fun `test struct`() = doTest("""
         #[outer]

--- a/src/test/kotlin/org/rust/lang/core/stubs/RsStubAccessTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/stubs/RsStubAccessTest.kt
@@ -16,8 +16,11 @@ import com.intellij.psi.stubs.StubElement
 import com.intellij.testFramework.LoggedErrorProcessor
 import org.apache.log4j.Logger
 import org.rust.lang.RsTestBase
+import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsInnerAttributeOwner
 import org.rust.lang.core.psi.ext.RsNamedElement
+import org.rust.lang.core.psi.ext.RsOuterAttributeOwner
 import java.util.*
 
 class RsStubAccessTest : RsTestBase() {
@@ -43,6 +46,17 @@ class RsStubAccessTest : RsTestBase() {
 
     fun `test getting reference does not need ast`() {
         processStubsWithoutAstAccess<RsElement> { it.reference }
+    }
+
+    fun `test inner outer attributes does not need ast`() {
+        processStubsWithoutAstAccess<RsElement> { element ->
+            if (element is RsInnerAttributeOwner && element !is RsFile) {
+                element.innerAttrList
+            }
+            if (element is RsOuterAttributeOwner) {
+                element.outerAttrList
+            }
+        }
     }
 
     fun `test parent works correctly for stubbed elements`() {

--- a/src/test/kotlin/org/rust/lang/core/type/RsCoercionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsCoercionTest.kt
@@ -1,5 +1,0 @@
-/*
- * Use of this source code is governed by the MIT license that can be
- * found in the LICENSE file.
- */
-

--- a/src/test/resources/org/rust/lang/core/stubs/fixtures/main.rs
+++ b/src/test/resources/org/rust/lang/core/stubs/fixtures/main.rs
@@ -2,25 +2,63 @@ fn main(param: i32) {}
 
 pub use bar::nested::hello;
 
+extern {
+    #[cfg(any(a, all(not(b), c)))]
+    fn ext1(val: u32) -> u64;
+    static ext2: u8;
+}
+
 #[test]
 fn bar() {}
 
+/// Doc
+/// comment
 pub struct S {
     pub f: f32,
     g: u32
+}
+
+enum E {
+    Ok,
+    Error((u32, u8))
+}
+
+#[repr(C)]
+union U {
+    f1: u32,
+    f2: f32,
 }
 
 trait T {
     fn foo(self);
     fn bar(self) {}
     fn new() -> Self;
+    const C1: u32;
+    const C2: u32 = 1;
+    type T1;
+    type T2 = (u8, i8);
 }
 
 impl T for S {
     fn foo(self) {}
+    const C1: u32 = 2;
+    const C2: u32 = 3;
+    type T1 = u8;
+    type T2 = u16;
 }
 
 pub mod bar;
+
+macro_rules! if_std {
+    ($($i:item)*) => ($(
+        #[cfg(feature = "use_std")]
+        $i
+    )*)
+}
+
+if_std! {
+    use bar::foo as f;
+}
 
 #[path="quux.rs"]
 pub mod baz;


### PR DESCRIPTION
Avoid loading the PSI when reading inner/outer attributes.
Correctly allow and attach comments and inner/outer attributes on various items.

This is in preparation for #2166