### PR TITLE
TYPE: Initial import optimizer

### DIFF
--- a/src/main/kotlin/org/rust/lang/refactoring/RsImportOptimizer.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RsImportOptimizer.kt
@@ -1,0 +1,77 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.refactoring
+
+import com.intellij.lang.ImportOptimizer
+import com.intellij.psi.PsiFile
+import org.rust.ide.formatter.processors.asTrivial
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.childrenOfType
+import org.rust.lang.core.psi.ext.descendantsOfType
+import org.rust.openapiext.runWriteCommandAction
+
+class RsImportOptimizer : ImportOptimizer {
+    override fun supports(file: PsiFile?): Boolean = file is RsFile
+
+    override fun processFile(file: PsiFile?) = Runnable {
+        execute(file as RsFile)
+    }
+
+    fun execute(mod: RsMod) {
+        val uses = mod.childrenOfType<RsUseItem>()
+        if (uses.isEmpty()) {
+            return
+        }
+        replaceOrder(mod, uses)
+        val mods = mod.childrenOfType<RsMod>()
+        mods.forEach { execute(it) }
+    }
+
+    companion object {
+
+        private fun optimizeUseSpeck(psiFactory: RsPsiFactory, useSpeck: RsUseSpeck) {
+            if (removeCurlyBraces(psiFactory, useSpeck)) return
+            val useSpeckList = useSpeck.useGroup?.useSpeckList ?: return
+            if (useSpeckList.size < 2) return
+            useSpeckList.forEach { optimizeUseSpeck(psiFactory, it) }
+            val sortedList = useSpeckList
+                .sortedWith(compareByDescending<RsUseSpeck>{ it.path?.self?.text }.thenBy { it.pathText })
+                .map { it.copy() }
+            useSpeckList.zip(sortedList).forEach { it.first.replace(it.second) }
+        }
+
+        private fun removeCurlyBraces(psiFactory: RsPsiFactory, useSpeck: RsUseSpeck): Boolean {
+            val (_, _, name) = useSpeck.useGroup?.asTrivial ?: return false
+            val path = useSpeck.path?.text
+            val tempPath = "${if (path != null) "$path::" else ""}$name"
+            val newUseSpeck = psiFactory.createUseSpeck(tempPath)
+            useSpeck.replace(newUseSpeck)
+            return true
+        }
+
+        private fun replaceOrder(file: RsMod, uses: Collection<RsUseItem>) {
+            val first = file.childrenOfType<RsElement>()
+                .filter { it !is RsExternCrateItem }
+                .firstOrNull() ?: return
+            val psiFactory = RsPsiFactory(file.project)
+            val sortedUses = uses
+                .sortedBy { it.useSpeck?.pathText }
+                .mapNotNull { it.copy() as? RsUseItem }
+            sortedUses
+                .mapNotNull { it.useSpeck }
+                .forEach { optimizeUseSpeck(psiFactory, it) }
+            for (importPath in sortedUses) {
+                file.addBefore(importPath, first)
+            }
+            uses.lastOrNull()?.nextSibling?.delete()
+            uses.forEach { it.delete() }
+        }
+    }
+}
+
+private val RsUseSpeck.pathText get() = path?.text?.toLowerCase()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -108,6 +108,9 @@
         <lang.smartEnterProcessor language="Rust"
                                   implementationClass="org.rust.ide.typing.assist.RsSmartEnterProcessor"/>
 
+        <!--Imports-->
+        <lang.importOptimizer language="Rust" implementationClass="org.rust.lang.refactoring.RsImportOptimizer" />
+
         <!-- Navigation -->
 
         <gotoClassContributor implementation="org.rust.ide.navigation.goto.RsClassNavigationContributor"/>

--- a/src/test/kotlin/org/rust/lang/refactoring/RsImportOptimizerTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/RsImportOptimizerTest.kt
@@ -5,7 +5,6 @@
 
 package org.rust.lang.refactoring
 
-import com.intellij.openapi.actionSystem.IdeActions
 import org.intellij.lang.annotations.Language
 import org.rust.lang.RsTestBase
 
@@ -75,7 +74,7 @@ class RsImportOptimizerTest: RsTestBase() {
     """, """
         use bar::bar;
         use foo::bar;
-        
+
     """)
 
     fun `test sort alphabetical with multiple layer of groups`() = doTest("""

--- a/src/test/kotlin/org/rust/lang/refactoring/RsImportOptimizerTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/RsImportOptimizerTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.refactoring
+
+import com.intellij.openapi.actionSystem.IdeActions
+import org.intellij.lang.annotations.Language
+import org.rust.lang.RsTestBase
+
+class RsImportOptimizerTest: RsTestBase() {
+
+    fun `test should do nothing`() = doTest("""
+        use foo;
+    """, """
+        use foo;
+    """)
+
+    fun `test should be at the beginnging`() = doTest("""
+        //! test
+        extern crate log;
+
+        fn test() {}
+        use foo;
+    """, """
+        //! test
+        extern crate log;
+
+        use foo;
+
+        fn test() {}
+
+    """)
+
+    fun `test sort alphabetical of useItem`() = doTest("""
+        use foo;
+        use bar;
+    """, """
+        use bar;
+        use foo;
+
+    """)
+
+    fun `test sort alphabetical of multi layer paths`() = doTest("""
+        use test::foo;
+        use test::bar;
+    """, """
+        use test::bar;
+        use test::foo;
+
+    """)
+
+    fun `test sort alphabetical of useSpeck`() = doTest("""
+        use foo::{test, foo, bar};
+    """, """
+        use foo::{bar, foo, test};
+    """)
+
+    fun `test sort alphabetical with self at start`() = doTest("""
+        use foo::{test, foo, bar, self};
+    """, """
+        use foo::{self, bar, foo, test};
+    """)
+
+    fun `test sort alphabetical with self at star`() = doTest("""
+        use foo::{test, foo, bar, *};
+    """, """
+        use foo::{*, bar, foo, test};
+    """)
+
+    fun `test sort alphabetical with multiple layer`() = doTest("""
+        use foo::bar;
+        use bar::bar;
+    """, """
+        use bar::bar;
+        use foo::bar;
+        
+    """)
+
+    fun `test sort alphabetical with multiple layer of groups`() = doTest("""
+        use foo::{
+            baz::{Test, quux::Bar},
+            bar::{Foo, Bar},
+        };
+    """, """
+        use foo::{
+            bar::{Bar, Foo},
+            baz::{quux::Bar, Test},
+        };
+    """)
+
+    fun `test should sort mod areas by its own`() = doTest("""
+        use foo;
+        use bar;
+
+        mod test {
+            use test2;
+            use deep;
+
+            mod level2 {
+                use foo;
+                use bar;
+            }
+        }
+    """, """
+        use bar;
+        use foo;
+
+        mod test {
+            use deep;
+            use test2;
+
+            mod level2 {
+                use bar;
+                use foo;
+            }
+        }
+    """)
+
+    fun `test remove curly braces simple`() = doTest(
+        "use std::{mem};",
+        "use std::mem;"
+    )
+
+    fun `test remove curly braces with no path`() = doTest(
+        "use {std};",
+        "use std;"
+    )
+
+    fun `test remove curly braces longer`() = doTest(
+        "use foo::bar::baz::{qux};",
+        "use foo::bar::baz::qux;"
+    )
+
+    fun `test remove curly braces extra`() = doTest("""
+        #[macro_use]
+        pub use /*comment*/ std::{mem};
+    """, """
+        #[macro_use]
+        pub use /*comment*/ std::mem;
+    """
+    )
+
+    private fun doTest(@Language("Rust") code: String, @Language("Rust") excepted: String){
+        checkByText(code.trimIndent(), excepted.trimIndent()) {
+            myFixture.performEditorAction("OptimizeImports")
+        }
+    }
+}


### PR DESCRIPTION
@Undin r?
I start working on it. 
# DONE
- Remove curly braces
- Order using the only path of a UseSpeck
- support optimize of all mod in a file
- sort inner usegroup (first level)
- move use to the top level of a mod

# Next PR?
- support merging of imports (no trivial)
- grouping into semantic imports (std, crates, inner mods) (no trivial)
- remove unused imports (possible use anntoation by cargo check) (no trivial)
- next sort mod extern crates
  
  