### PR TITLE
ANN: add quick fix for type mismatch when impl ToOwned for A exists and B is Owned type of A

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToOwnedTyFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToOwnedTyFix.kt
@@ -1,0 +1,29 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsPsiFactory
+
+/**
+ * For the given `expr` converts it to the owned type with with `(expr).to_owned()`
+ */
+class ConvertToOwnedTyFix(expr: PsiElement): LocalQuickFixAndIntentionActionOnPsiElement(expr) {
+    override fun getFamilyName(): String = "Convert to type"
+
+    override fun getText(): String = "Convert to owned type using `ToOwned` trait"
+
+    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
+        if (startElement !is RsExpr) return
+        startElement.replace(RsPsiFactory(project).createNoArgsMethodCall(startElement, "to_owned"))
+    }
+
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -274,6 +274,11 @@ class RsPsiFactory(private val project: Project) {
     fun createAssocFunctionCall(typeText: String, methodNameText: String, arguments: Iterable<RsExpr>): RsCallExpr =
         createExpressionOfType("$typeText::$methodNameText(${arguments.joinToString { it.text }})")
 
+    fun createNoArgsMethodCall(expr: RsExpr, methodNameText: String): RsDotExpr = when (expr) {
+        is RsBinaryExpr, is RsCastExpr -> createExpressionOfType("(${expr.text}).$methodNameText()")
+        else -> createExpressionOfType("${expr.text}.$methodNameText()")
+    }
+
     private inline fun <reified E : RsExpr> createExpressionOfType(text: String): E =
         createExpression(text) as? E
             ?: error("Failed to create ${E::class.simpleName} from `$text`")

--- a/src/main/kotlin/org/rust/lang/core/resolve/StdKnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/StdKnownItems.kt
@@ -83,6 +83,9 @@ class StdKnownItems private constructor(private val absolutePathResolver: (Strin
     fun findFromTrait(): RsTraitItem? =
         findCoreItem("convert::From") as? RsTraitItem
 
+    fun findToOwnedTrait(): RsTraitItem? =
+        findCoreItem("borrow::ToOwned") as? RsTraitItem
+
     companion object {
         private val stdKnownItemsCache =
             ProjectCache<Pair<CargoWorkspace, String>, Optional<RsNamedElement>>("stdKnownItemsCache")

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToOwnedTyFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToOwnedTyFixTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.rust.ide.inspections.RsExperimentalChecksInspection
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class ConvertToOwnedTyFixTest : RsInspectionsTestBase(RsExperimentalChecksInspection()) {
+    override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
+
+    fun `test B is Owned type of A`() = checkFixByText("Convert to owned type using `ToOwned` trait","""
+        use std::borrow::Borrow;
+
+        struct A;
+        struct B;
+
+        impl Borrow<A> for B { fn borrow(&self) -> &A { &A } }
+
+        impl ToOwned for A {
+            type Owned = B;
+            fn to_owned(&self) -> B { B }
+        }
+
+        fn main () {
+            let b: B = <error>A<caret></error>;
+        }
+    ""","""
+        use std::borrow::Borrow;
+
+        struct A;
+        struct B;
+
+        impl Borrow<A> for B { fn borrow(&self) -> &A { &A } }
+
+        impl ToOwned for A {
+            type Owned = B;
+            fn to_owned(&self) -> B { B }
+        }
+
+        fn main () {
+            let b: B = A.to_owned();
+        }
+    """)
+
+    fun `test B is not Owned type of A`() = checkFixIsUnavailable("Convert to type B using `From` trait", """
+        use std::borrow::Borrow;
+
+        struct A;
+        struct B;
+        struct C;
+
+        impl Borrow<A> for C { fn borrow(&self) -> &A { &A; } }
+
+        impl ToOwned for A {
+            type Owned = C;
+            fn to_owned(&self) -> C { C; }
+        }
+
+        fn main () {
+            let b: B = <error>A<caret></error>;
+        }
+    """)
+
+    fun `test no ToOwned impl for A`() = checkFixIsUnavailable("Convert to type B using `From` trait", """
+        struct A;
+        struct B;
+
+        fn main () {
+            let b: B = <error>A<caret></error>;
+        }
+    """)
+}


### PR DESCRIPTION
This commit adds quick-fix for the types mismatch when
impl `ToOwned` for A exists and B is `Owned` type of A
where A is actual type and B is expected type,
which fulfills part of the forth bullet-point of the issue:
https://github.com/intellij-rust/intellij-rust/issues/1730

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->