### PR TITLE
Initial reexports support for auto import

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/import/ImportNameIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/import/ImportNameIntention.kt
@@ -48,7 +48,7 @@ class ImportNameIntention : RsElementBaseIntentionAction<ImportNameIntention.Con
 
         val candidates = (explicitItems + reexportedItems)
             .filter { basePath != path || !(it.item is RsMod || it.item is RsModDeclItem || it.item.parent is RsMembers) }
-            .mapNotNull { importItem -> importItem.canBeImported(pathSuperMods)?.let { ImportCandidate(importItem.item, it) } }
+            .mapNotNull { importItem -> importItem.canBeImported(pathSuperMods)?.let { ImportCandidate(importItem, it) } }
             // check that result after import can be resolved and resolved element is suitable
             // if no, don't add it in candidate list
             .filter { path.canBeResolvedToSuitableItem(project, pathMod, it.info) }
@@ -178,7 +178,7 @@ sealed class ImportItem(val item: RsQualifiedNamedElement) {
     abstract val containingCargoTarget: CargoWorkspace.Target?
 
     class ReexportedItem(
-        private val useSpeck: RsUseSpeck,
+        val useSpeck: RsUseSpeck,
         item: RsQualifiedNamedElement
     ) : ImportItem(item) {
         override val parentMod: RsMod? get() = useSpeck.containingMod
@@ -211,7 +211,7 @@ sealed class ImportInfo {
     }
 }
 
-data class ImportCandidate(val item: RsQualifiedNamedElement, val info: ImportInfo)
+data class ImportCandidate(val importItem: ImportItem, val info: ImportInfo)
 
 private fun RsItemsOwner.firstItem(): RsElement = itemsAndMacros.first()
 

--- a/src/main/kotlin/org/rust/ide/intentions/import/ImportNameIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/import/ImportNameIntention.kt
@@ -16,6 +16,7 @@ import org.rust.ide.intentions.RsElementBaseIntentionAction
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.stubs.index.RsNamedElementIndex
+import org.rust.lang.core.stubs.index.RsReexportIndex
 import org.rust.lang.core.types.ty.TyPrimitive
 import org.rust.openapiext.Testmark
 import org.rust.openapiext.runWriteCommandAction
@@ -32,31 +33,48 @@ class ImportNameIntention : RsElementBaseIntentionAction<ImportNameIntention.Con
         if (basePath.reference.resolve() != null) return null
         val pathMod = path.containingMod
         val pathSuperMods = HashSet(pathMod.superMods)
-        // TODO: support reexports
-        val candidates = RsNamedElementIndex.findElementsByName(project, basePath.referenceName)
+
+        val explicitItems = RsNamedElementIndex.findElementsByName(project, basePath.referenceName)
             .asSequence()
             .filterIsInstance<RsQualifiedNamedElement>()
-            .filter { basePath != path || !(it is RsMod || it is RsModDeclItem || it.parent is RsMembers) }
-            .mapNotNull { item -> (item as? RsVisible)?.canBeImported(pathSuperMods)?.let { ImportCandidate(item, it) } }
+            .map { ImportItem.ExplicitItem(it) }
+
+        val reexportedItems = RsReexportIndex.findReexportsByName(project, basePath.referenceName)
+            .asSequence()
+            .mapNotNull {
+                val item = it.path?.reference?.resolve() as? RsQualifiedNamedElement ?: return@mapNotNull null
+                ImportItem.ReexportedItem(it, item)
+            }
+
+        val candidates = (explicitItems + reexportedItems)
+            .filter { basePath != path || !(it.item is RsMod || it.item is RsModDeclItem || it.item.parent is RsMembers) }
+            .mapNotNull { importItem -> importItem.canBeImported(pathSuperMods)?.let { ImportCandidate(importItem.item, it) } }
             // check that result after import can be resolved and resolved element is suitable
             // if no, don't add it in candidate list
             .filter { path.canBeResolvedToSuitableItem(project, pathMod, it.info) }
             .toList()
+
         if (candidates.isEmpty()) return null
         return Context(path, candidates)
     }
 
-    // Semantic signature of method is `RsVisible.canBeImported(mod: RsMod)`
+    // Semantic signature of method is `ImportItem.canBeImported(mod: RsMod)`
     // but in our case `mod` is always same and `mod` needs only to get set of its super mods
     // so we pass `superMods` instead of `mod` for optimization
-    private fun RsVisible.canBeImported(superMods: Set<RsMod>): ImportInfo? {
-        val parentMod = (if (this is RsMod) `super` else containingMod) ?: return null
+    private fun ImportItem.canBeImported(superMods: Set<RsMod>): ImportInfo? {
+        if (item !is RsVisible) return null
+
+        val parentMod = parentMod ?: return null
         val ourSuperMods = parentMod.superMods
 
         // try to find latest common ancestor module of `parentMod` and `mod` in module tree
         // we need to do it because we can use direct child items of any super mod with any visibility
         val lca = ourSuperMods.find { it in superMods }
-        val crateRelativePath = (this as? RsQualifiedNamedElement)?.crateRelativePath?.removePrefix("::") ?: return null
+        val crateRelativePath = crateRelativePath ?: return null
+        val isPublic = when (this) {
+            is ImportItem.ExplicitItem -> item.isPublic
+            is ImportItem.ReexportedItem -> true
+        }
 
         val (shouldBePublicMods, importInfo) = if (lca == null) {
             if (!isPublic) return null
@@ -150,6 +168,31 @@ class ImportNameIntention : RsElementBaseIntentionAction<ImportNameIntention.Con
 
     object Testmarks {
         val autoInjectedCrate = Testmark("autoInjectedCrate")
+    }
+}
+
+sealed class ImportItem(val item: RsQualifiedNamedElement) {
+
+    abstract val parentMod: RsMod?
+    abstract val crateRelativePath: String?
+    abstract val containingCargoTarget: CargoWorkspace.Target?
+
+    class ReexportedItem(
+        private val useSpeck: RsUseSpeck,
+        item: RsQualifiedNamedElement
+    ) : ImportItem(item) {
+        override val parentMod: RsMod? get() = useSpeck.containingMod
+        override val containingCargoTarget: CargoWorkspace.Target? get() = useSpeck.containingCargoTarget
+        override val crateRelativePath: String? get() {
+            val modulePath = parentMod?.crateRelativePath?.removePrefix("::") ?: return null
+            val name = useSpeck.nameInScope ?: return null
+            return "$modulePath::$name"
+        }
+    }
+    class ExplicitItem(item: RsQualifiedNamedElement) : ImportItem(item) {
+        override val parentMod: RsMod? get() = if (item is RsMod) item.`super` else item.containingMod
+        override val containingCargoTarget: CargoWorkspace.Target? get() = item.containingCargoTarget
+        override val crateRelativePath: String? get() = item.crateRelativePath?.removePrefix("::")
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseSpeck.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseSpeck.kt
@@ -16,6 +16,16 @@ val RsUseSpeck.isStarImport: Boolean get() = stub?.isStarImport ?: (mul != null)
 val RsUseSpeck.qualifier: RsPath? get() =
     (context as? RsUseGroup)?.parentUseSpeck?.path
 
+val RsUseSpeck.nameInScope: String? get() {
+    if (useGroup != null) return null
+    alias?.name?.let { return it }
+    val baseName = path?.referenceName ?: return null
+    if (baseName == "self") {
+        return qualifier?.referenceName
+    }
+    return baseName
+}
+
 abstract class RsUseSpeckImplMixin : RsStubbedElementImpl<RsUseSpeckStub>, RsUseSpeck {
     constructor (node: ASTNode) : super(node)
     constructor (stub: RsUseSpeckStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)

--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -140,16 +140,6 @@ fun processItemDeclarations(
     return false
 }
 
-private val RsUseSpeck.nameInScope: String? get() {
-    alias?.name?.let { return it }
-    val baseName = path?.referenceName ?: return null
-    if (baseName == "self") {
-        NameResolutionTestmarks.selfInGroupName.hit()
-        return qualifier?.referenceName
-    }
-    return baseName
-}
-
 private fun processMultiResolveWithNs(name: String, ns: Set<Namespace>, ref: RsReference, processor: RsResolveProcessor): Boolean {
     // XXX: use items can legitimately resolve in both namespaces.
     // Because we must be lazy, we don't know up front how many times we

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -688,5 +688,4 @@ object NameResolutionTestmarks {
     val missingMacroExport = Testmark("missingMacroExport")
     val missingMacroUse = Testmark("missingMacroUse")
     val selfInGroup = Testmark("selfInGroup")
-    val selfInGroupName = Testmark("selfInGroupName")
 }

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -31,7 +31,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 113
+        override fun getStubVersion(): Int = 114
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)
@@ -228,9 +228,7 @@ class RsUseSpeckStub(
         override fun createStub(psi: RsUseSpeck, parentStub: StubElement<*>?) =
             RsUseSpeckStub(parentStub, this, psi.isStarImport)
 
-        override fun indexStub(stub: RsUseSpeckStub, sink: IndexSink) {
-            //NOP
-        }
+        override fun indexStub(stub: RsUseSpeckStub, sink: IndexSink) = sink.indexUseSpeck(stub)
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
@@ -13,6 +13,7 @@ import org.rust.lang.core.resolve.indexes.RsLangItemIndex
 import org.rust.lang.core.stubs.index.RsGotoClassIndex
 import org.rust.lang.core.stubs.index.RsModulesIndex
 import org.rust.lang.core.stubs.index.RsNamedElementIndex
+import org.rust.lang.core.stubs.index.RsReexportIndex
 
 fun IndexSink.indexExternCrate(stub: RsExternCrateItemStub) {
     indexNamedStub(stub)
@@ -68,6 +69,10 @@ fun IndexSink.indexFieldDecl(stub: RsFieldDeclStub) {
 
 fun IndexSink.indexMacroDefinition(stub: RsMacroDefinitionStub) {
     indexNamedStub(stub)
+}
+
+fun IndexSink.indexUseSpeck(stub: RsUseSpeckStub) {
+    RsReexportIndex.index(stub, this)
 }
 
 private fun IndexSink.indexNamedStub(stub: RsNamedStub) {

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsReexportIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsReexportIndex.kt
@@ -5,6 +5,8 @@
 
 package org.rust.lang.core.stubs.index
 
+import com.intellij.openapi.project.Project
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.IndexSink
 import com.intellij.psi.stubs.StringStubIndexExtension
 import com.intellij.psi.stubs.StubIndexKey
@@ -14,6 +16,7 @@ import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psi.ext.nameInScope
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsUseSpeckStub
+import org.rust.openapiext.getElements
 
 class RsReexportIndex : StringStubIndexExtension<RsUseSpeck>() {
     override fun getVersion(): Int = RsFileStub.Type.stubVersion
@@ -30,5 +33,8 @@ class RsReexportIndex : StringStubIndexExtension<RsUseSpeck>() {
             val name = useSpeck.nameInScope ?: return
             sink.occurrence(KEY, name)
         }
+
+        fun findReexportsByName(project: Project, target: String): Collection<RsUseSpeck> =
+            getElements(KEY, target, project, GlobalSearchScope.allScope(project))
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsReexportIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsReexportIndex.kt
@@ -1,0 +1,34 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.stubs.index
+
+import com.intellij.psi.stubs.IndexSink
+import com.intellij.psi.stubs.StringStubIndexExtension
+import com.intellij.psi.stubs.StubIndexKey
+import org.rust.lang.core.psi.RsUseItem
+import org.rust.lang.core.psi.RsUseSpeck
+import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psi.ext.nameInScope
+import org.rust.lang.core.stubs.RsFileStub
+import org.rust.lang.core.stubs.RsUseSpeckStub
+
+class RsReexportIndex : StringStubIndexExtension<RsUseSpeck>() {
+    override fun getVersion(): Int = RsFileStub.Type.stubVersion
+    override fun getKey(): StubIndexKey<String, RsUseSpeck> = KEY
+
+    companion object {
+        val KEY: StubIndexKey<String, RsUseSpeck> =
+            StubIndexKey.createIndexKey("org.rust.lang.core.stubs.index.RsReexportIndex")
+
+        fun index(stub: RsUseSpeckStub, sink: IndexSink) {
+            val useSpeck = stub.psi
+            val isPublic = useSpeck.ancestorStrict<RsUseItem>()?.isPublic == true
+            if (!isPublic) return
+            val name = useSpeck.nameInScope ?: return
+            sink.occurrence(KEY, name)
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -565,6 +565,7 @@
         <stubIndex implementation="org.rust.lang.core.stubs.index.RsModulesIndex"/>
         <stubIndex implementation="org.rust.lang.core.stubs.index.RsNamedElementIndex"/>
         <stubIndex implementation="org.rust.lang.core.stubs.index.RsGotoClassIndex"/>
+        <stubIndex implementation="org.rust.lang.core.stubs.index.RsReexportIndex"/>
 
         <stubIndex implementation="org.rust.lang.core.resolve.indexes.RsImplIndex"/>
         <stubIndex implementation="org.rust.lang.core.resolve.indexes.RsLangItemIndex"/>

--- a/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionStdTest.kt
@@ -69,4 +69,16 @@ class ImportNameIntentionStdTest : RsIntentionTestBase(ImportNameIntention()) {
 
         fn foo(t: Bar/*caret*/) {}
     """)
+
+    fun `test import reexported item from stdlib`() = doAvailableTest("""
+        fn main() {
+            let duration = Duration/*caret*/::from_secs(2);
+        }
+    """, """
+        use std::time::Duration;
+
+        fn main() {
+            let duration = Duration/*caret*/::from_secs(2);
+        }
+    """, ImportNameIntention.Testmarks.autoInjectedCrate)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionStdTest.kt
@@ -12,15 +12,15 @@ class ImportNameIntentionStdTest : RsIntentionTestBase(ImportNameIntention()) {
 
     override fun getProjectDescriptor(): LightProjectDescriptor = WithStdlibAndDependencyRustProjectDescriptor
 
-    fun `test import struct from std crate`() = doAvailableTest("""
-        fn foo<T: Read/*caret*/>(t: T) {}
+    fun `test import item from std crate`() = doAvailableTest("""
+        fn foo<T: io::Read/*caret*/>(t: T) {}
     """, """
-        use std::io::Read;
+        use std::io;
 
-        fn foo<T: Read/*caret*/>(t: T) {}
+        fn foo<T: io::Read/*caret*/>(t: T) {}
     """, ImportNameIntention.Testmarks.autoInjectedCrate)
 
-    fun `test import struct from not std crate`() = doAvailableTestWithFileTree("""
+    fun `test import item from not std crate`() = doAvailableTestWithFileTree("""
         //- dep-lib/lib.rs
         pub mod foo {
             pub struct Bar;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
@@ -158,7 +158,7 @@ class RsUseResolveTest : RsResolveTestBase() {
                     //^
             }
         }
-    """, NameResolutionTestmarks.selfInGroupName)
+    """)
 
     fun `test use glob alias`() = checkByCode("""
         mod foo {


### PR DESCRIPTION
Part of #1737 and #2174
Fixes #2157

TODO:
* support `pub use` with wildcards
* filter import candidates for the same item (for example, `std::sync::Arc` and `alloc::arc::Arc`)