### PR TITLE
DBG: allow to debug example binaries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,9 @@ other files do.
 Consider prefixing commit with a `TAG:` which describes the area of the
 change. Common tags are:
 
+<details>
+<summary>Tags list</summary>
+
   * GRAM for changes to `.bnf` files
   * PSI for other PSI related changes
   * RES for name resolution
@@ -148,12 +151,14 @@ change. Common tags are:
   * PERF for performance optimizations
   * PRJ for project creation changes 
   * ACT for actions
+  * DBG for debugger
 
 
   * CARGO for cargo-related changes
   * GRD for build changes
   * T for tests
   * DOC for documentation
+</details>
 
 Try to keep the summary line of a commit message under 50 characters.
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -98,7 +98,14 @@ object CargoMetadata {
         /**
          * Path to the root module of the crate (aka crate root)
          */
-        val src_path: String
+        val src_path: String,
+
+        /**
+         * List of crate types
+         *
+         * See [linkage](https://doc.rust-lang.org/reference/linkage.html)
+         */
+        val crate_types: List<String>
     ) {
         val cleanKind: TargetKind
             get() = when (kind.singleOrNull()) {
@@ -113,8 +120,31 @@ object CargoMetadata {
                     else
                         TargetKind.UNKNOWN
             }
-    }
 
+        val cleanCrateTypes: List<CrateType>
+            get() = crate_types.map {
+                when (it) {
+                    "bin" -> CrateType.BIN
+                    "lib" -> CrateType.LIB
+                    "dylib" -> CrateType.DYLIB
+                    "staticlib" -> CrateType.STATICLIB
+                    "cdylib" -> CrateType.CDYLIB
+                    "rlib" -> CrateType.RLIB
+                    "proc-macro" -> CrateType.PROC_MACRO
+                    else -> CrateType.UNKNOWN
+                }
+            }
+        }
+
+    /**
+     * Represents possible variants of generated artifact binary
+     * corresponded to `--crate-type` compiler attribute
+     *
+     * See [linkage](https://doc.rust-lang.org/reference/linkage.html)
+     */
+    enum class CrateType {
+        BIN, LIB, DYLIB, STATICLIB, CDYLIB, RLIB, PROC_MACRO, UNKNOWN
+    }
 
     /**
      * A rooted graph of dependencies, represented as adjacency list


### PR DESCRIPTION
Don't filter example targets to allow launching them in debug mode
Fixes #2200 