### PR TITLE
TY: unify `expected` type with fn/method return type & struct fields

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -60,7 +60,7 @@ fun inferTypeReferenceType(ref: RsTypeReference): Ty {
         }
 
         is RsImplTraitType -> {
-            TyAnon(type.polyboundList.mapNotNull { it.bound.traitRef?.resolveToBoundTrait })
+            TyAnon(type, type.polyboundList.mapNotNull { it.bound.traitRef?.resolveToBoundTrait })
         }
         else -> TyUnknown
     }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -281,7 +281,7 @@ class RsInferenceContext {
     }
 
     private fun combineTypesNoVars(ty1: Ty, ty2: Ty): Boolean {
-        return when {
+        return ty1 === ty2 || when {
             ty1 is TyPrimitive && ty2 is TyPrimitive && ty1 == ty2 -> true
             ty1 is TyTypeParameter && ty2 is TyTypeParameter && ty1 == ty2 -> true
             ty1 is TyReference && ty2 is TyReference && ty1.mutability == ty2.mutability -> {
@@ -301,6 +301,7 @@ class RsInferenceContext {
                 combinePairs(zipValues(ty1.typeParameterValues, ty2.typeParameterValues))
             }
             ty1 is TyTraitObject && ty2 is TyTraitObject && ty1.trait == ty2.trait -> true
+            ty1 is TyAnon && ty2 is TyAnon && ty1.definition == ty2.definition -> true
             ty1 is TyNever || ty2 is TyNever -> true
             else -> false
         }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyAnon.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyAnon.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.types.ty
 
 import org.rust.ide.presentation.tyToString
+import org.rust.lang.core.psi.RsImplTraitType
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.ext.flattenHierarchy
 import org.rust.lang.core.types.BoundElement
@@ -13,7 +14,7 @@ import org.rust.lang.core.types.BoundElement
 /**
  * Represents "impl Trait".
  */
-data class TyAnon(val traits: List<BoundElement<RsTraitItem>>) : Ty() {
+data class TyAnon(val definition: RsImplTraitType, val traits: List<BoundElement<RsTraitItem>>) : Ty() {
 
     fun getTraitBoundsTransitively(): Collection<BoundElement<RsTraitItem>> =
         traits.flatMap { it.flattenHierarchy }

--- a/src/test/kotlin/org/rust/ide/annotator/RsTypeCheckTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsTypeCheckTest.kt
@@ -122,4 +122,19 @@ class RsTypeCheckTest : RsInspectionsTestBase(RsExperimentalChecksInspection()) 
             let x = Foo { v: [10, 20] };
         }
     """)
+
+    // issue 1753
+    fun `test no type mismatch E0308 on struct argument reference coercion`() = checkByText("""
+        #[lang = "deref"]
+        trait Deref { type Target; }
+
+        struct Wrapper<T>(T);
+        struct RefWrapper<'a, T : 'a>(&'a T);
+
+        impl<T> Deref for Wrapper<T> { type Target = T; }
+
+        fn foo(w: &Wrapper<u32>) {
+            let _: RefWrapper<u32> = RefWrapper(w);
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1257,4 +1257,50 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ u8
     """)
+
+    fun `test reference coercion inside tuple struct init (or fn call)`() = testExpr("""
+        #[lang = "deref"]
+        trait Deref { type Target; }
+
+        struct Wrapper<T>(T);
+        struct RefWrapper<'a, T : 'a>(&'a T);
+        impl<T> Deref for Wrapper<T> { type Target = T; }
+
+        fn main() {
+            let _: RefWrapper<u8> = RefWrapper(&Wrapper(0));
+        }                                             //^ u8
+    """)
+
+    fun `test reference coercion inside struct init`() = testExpr("""
+        #[lang = "deref"]
+        trait Deref { type Target; }
+
+        struct Wrapper<T> { f: T }
+        struct RefWrapper<'a, T : 'a> { f: &'a T };
+        impl<T> Deref for Wrapper<T> { type Target = T; }
+
+        fn main() {
+            let _: RefWrapper<u8> = RefWrapper { f: &Wrapper { f: 0 } };
+        }                                                       //^ u8
+    """)
+
+    fun `test reference coercion inside method call`() = testExpr("""
+        #[lang = "deref"]
+        trait Deref { type Target; }
+
+        struct Wrapper<T>(T);
+        struct RefWrapper<'a, T : 'a>(&'a T);
+        impl<T> Deref for Wrapper<T> { type Target = T; }
+
+        struct A;
+        impl A {
+            fn ref_wrapper<'a, T : 'a>(&self, t: &'a T) -> RefWrapper<'a, T> {
+                RefWrapper(t)
+            }
+        }
+
+        fn main() {
+            let _: RefWrapper<u8> = A.ref_wrapper(&Wrapper(0));
+        }                                                //^ u8
+    """)
 }


### PR DESCRIPTION
Finally fixes #1753 ([andy-hanson's case](https://github.com/intellij-rust/intellij-rust/issues/1753#issuecomment-331313940))