### PR TITLE
INSP: enable typecheck for reference types

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -498,9 +498,6 @@ private class RsFnInferenceContext(
                 TyUnknown::class.java,
                 TyInfer.TyVar::class.java,
                 TyTypeParameter::class.java,
-                // TODO TyReference ignored because we actually ignore deref level on method call and so
-                // TODO sometimes substitute a wrong receiver. This should be fixed as soon as possible
-                TyReference::class.java,
                 TyTraitObject::class.java
             )
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsTypeCheckTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsTypeCheckTest.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.annotator
 
-import org.junit.ComparisonFailure
 import org.rust.ide.inspections.RsExperimentalChecksInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 
@@ -36,9 +35,7 @@ class RsTypeCheckTest : RsInspectionsTestBase(RsExperimentalChecksInspection()) 
         }
     """)
 
-    // TODO In TypeInference.coerceResolved() we currently ignore type errors when references are involved
-    fun `test type mismatch E0308 coerce reference to ptr`() = expect<ComparisonFailure> {
-        checkByText("""
+    fun `test type mismatch E0308 coerce reference to ptr`() = checkByText("""
         fn fn_const(p: *const u8) { }
         fn fn_mut(p: *mut u8) { }
 
@@ -51,7 +48,6 @@ class RsTypeCheckTest : RsInspectionsTestBase(RsExperimentalChecksInspection()) 
             fn_mut(mut_u8);
         }
     """)
-    }
 
     fun `test type mismatch E0308 struct`() = checkByText("""
         struct X; struct Y;

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -592,7 +592,7 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
     fun `test tuple field`() = testExpr("""
         fn main() {
             let x = (1, "foo").1;
-            x
+            x;
           //^ &str
         }
     """)
@@ -601,7 +601,7 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
     fun `test tuple out of bound field`() = testExpr("""
         fn main() {
             let x = (1, "foo").2;
-            x
+            x;
           //^ <unknown>
         }
     """)
@@ -610,7 +610,7 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
     fun `test tuple incorrect field`() = testExpr("""
         fn main() {
             let x = (1, "foo").1departure_code;
-            x
+            x;
           //^ <unknown>
         }
     """)

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -561,7 +561,7 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         fn main() {
             let slice: &[&str] = &["foo", "bar"];
             let x = foo(slice);
-            x
+            x;
           //^ &str
         }
     """)
@@ -574,7 +574,7 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         fn foo<F1, F2, F3, F4>(x: FooBar<Foo<F1, F2>, Bar<F3, F4>>) -> (Bar<F4, F1>, Foo<F3, F2>) { unimplemented!() }
         fn main() {
             let x = foo(FooBar(Foo(123, "foo"), Bar::V([0.0; 3], (0, false))));
-            x
+            x;
           //^ (Bar<(i32, bool), i32>, Foo<[f64; 3], &str>)
         }
     """)


### PR DESCRIPTION
Note: typecheck is a disabled by default inspection, and this PR **do not** enables it by default =)

Most of bugs with references has been already fixed, so now we can safely enable typecheck for it. 
Also it allows to implement more items from #1730 (c.c @oleg-semenov)

Can be merged after #2209