### PR TITLE
Improve navigation around const and type in traits

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -437,7 +437,8 @@ BindingMode ::= ref mut? | mut
 
 Constant ::= OuterAttr* default_? Vis? (static mut? | const) identifier TypeAscription [ '=' AnyExpr ] ';' {
   pin = 'identifier'
-  implements = [ "org.rust.lang.core.psi.ext.RsNameIdentifierOwner"
+  implements = [ "org.rust.lang.core.psi.ext.RsQualifiedNamedElement"
+                 "org.rust.lang.core.psi.ext.RsNameIdentifierOwner"
                  "org.rust.lang.core.psi.ext.RsItemElement"
                  "org.rust.lang.core.psi.ext.RsAbstractable"
                  "org.rust.lang.core.macros.ExpansionResult" ]

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -495,7 +495,7 @@ private fun checkTypesAreSized(holder: AnnotationHolder, fn: RsFunction) {
 
     fun isError(ty: Ty): Boolean = !ty.isSized() &&
         // Self type in trait method is not an error
-        !(owner is RsFunctionOwner.Trait && ty is TyTypeParameter && ty.parameter is TyTypeParameter.Self)
+        !(owner is RsAbstractableOwner.Trait && ty is TyTypeParameter && ty.parameter is TyTypeParameter.Self)
 
     for (arg in arguments) {
         val typeReference = arg.typeReference ?: continue

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -91,8 +91,8 @@ private fun colorFor(element: RsElement): RsColor? = when (element) {
     is RsExternCrateItem -> RsColor.CRATE
     is RsFieldDecl -> RsColor.FIELD
     is RsFunction -> when (element.owner) {
-        is RsFunctionOwner.Foreign, is RsFunctionOwner.Free -> RsColor.FUNCTION
-        is RsFunctionOwner.Trait, is RsFunctionOwner.Impl ->
+        is RsAbstractableOwner.Foreign, is RsAbstractableOwner.Free -> RsColor.FUNCTION
+        is RsAbstractableOwner.Trait, is RsAbstractableOwner.Impl ->
             if (element.isAssocFn) RsColor.ASSOC_FUNCTION else RsColor.METHOD
     }
     is RsMethodCall -> RsColor.METHOD

--- a/src/main/kotlin/org/rust/ide/annotator/RsTraitMethodImplLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsTraitMethodImplLineMarkerProvider.kt
@@ -40,6 +40,6 @@ class RsTraitMethodImplLineMarkerProvider : RelatedItemLineMarkerProvider() {
             .setTargets(listOf(traitMethod))
             .setTooltipText("$action method in `${trait.name}`")
 
-        result.add(builder.createLineMarkerInfo(el.fn))
+        result.add(builder.createLineMarkerInfo(el.identifier))
     }
 }

--- a/src/main/kotlin/org/rust/ide/annotator/RsTraitMethodImplLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsTraitMethodImplLineMarkerProvider.kt
@@ -22,7 +22,7 @@ class RsTraitMethodImplLineMarkerProvider : RelatedItemLineMarkerProvider() {
     override fun collectNavigationMarkers(el: PsiElement, result: MutableCollection<in RelatedItemLineMarkerInfo<PsiElement>>) {
         if (!(el is RsFunction && el.owner.isTraitImpl)) return
 
-        val traitMethod = el.superMethod ?: return
+        val traitMethod = el.superItem ?: return
         val trait = traitMethod.ancestorStrict<RsTraitItem>() ?: return
 
         val action: String

--- a/src/main/kotlin/org/rust/ide/annotator/RsTraitMethodImplLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsTraitMethodImplLineMarkerProvider.kt
@@ -10,24 +10,26 @@ import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
 import com.intellij.psi.PsiElement
 import org.rust.ide.icons.RsIcons
+import org.rust.lang.core.psi.RsConstant
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsTraitItem
+import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.psi.ext.*
 import javax.swing.Icon
 
 /**
- * Annotates the implementation of a trait method with an icon on the gutter.
+ * Annotates the implementation of a trait members (const, fn, type) with an icon on the gutter.
  */
 class RsTraitMethodImplLineMarkerProvider : RelatedItemLineMarkerProvider() {
     override fun collectNavigationMarkers(el: PsiElement, result: MutableCollection<in RelatedItemLineMarkerInfo<PsiElement>>) {
-        if (!(el is RsFunction && el.owner.isTraitImpl)) return
+        if (el !is RsAbstractable) return
 
-        val traitMethod = el.superItem ?: return
-        val trait = traitMethod.ancestorStrict<RsTraitItem>() ?: return
+        val superItem = el.superItem ?: return
+        val trait = superItem.ancestorStrict<RsTraitItem>() ?: return
 
         val action: String
         val icon: Icon
-        if (traitMethod.isAbstract) {
+        if (superItem.isAbstract) {
             action = "Implements"
             icon = RsIcons.IMPLEMENTING_METHOD
         } else {
@@ -35,11 +37,18 @@ class RsTraitMethodImplLineMarkerProvider : RelatedItemLineMarkerProvider() {
             icon = RsIcons.OVERRIDING_METHOD
         }
 
+        val (type, element) = when (el) {
+            is RsConstant -> "constant" to el.identifier
+            is RsFunction -> "method" to el.identifier
+            is RsTypeAlias -> "type" to el.identifier
+            else -> error("unreachable")
+        }
+
         val builder = NavigationGutterIconBuilder
             .create(icon)
-            .setTargets(listOf(traitMethod))
-            .setTooltipText("$action method in `${trait.name}`")
+            .setTargets(listOf(superItem))
+            .setTooltipText("$action $type in `${trait.name}`")
 
-        result.add(builder.createLineMarkerInfo(el.identifier))
+        result.add(builder.createLineMarkerInfo(element))
     }
 }

--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -73,30 +73,13 @@ private fun RsDocAndAttributeOwner.header(usePreTag: Boolean): String {
     val rawLines = when (this) {
         is RsFieldDecl -> listOfNotNull((parent?.parent as? RsDocAndAttributeOwner)?.presentableQualifiedName)
         is RsStructOrEnumItemElement, is RsTraitItem -> listOfNotNull(presentableQualifiedModName)
-        is RsFunction -> {
+        is RsAbstractable -> {
             val owner = owner
             when (owner) {
-                is RsFunctionOwner.Foreign,
-                is RsFunctionOwner.Free -> listOfNotNull(presentableQualifiedModName)
-                is RsFunctionOwner.Impl -> listOfNotNull(presentableQualifiedModName) + owner.impl.declarationText
-                is RsFunctionOwner.Trait -> owner.trait.declarationText
-            }
-        }
-        is RsConstant -> {
-            val owner = owner
-            when (owner) {
-                is RsConstantOwner.Foreign,
-                is RsConstantOwner.Free -> listOfNotNull(presentableQualifiedModName)
-                is RsConstantOwner.Impl -> listOfNotNull(presentableQualifiedModName) + owner.impl.declarationText
-                is RsConstantOwner.Trait -> owner.trait.declarationText
-            }
-        }
-        is RsTypeAlias -> {
-            val owner = owner
-            when (owner) {
-                is RsTypeAliasOwner.Free -> listOfNotNull(presentableQualifiedModName)
-                is RsTypeAliasOwner.Impl -> listOfNotNull(presentableQualifiedModName) + owner.impl.declarationText
-                is RsTypeAliasOwner.Trait -> owner.trait.declarationText
+                is RsAbstractableOwner.Foreign,
+                is RsAbstractableOwner.Free -> listOfNotNull(presentableQualifiedModName)
+                is RsAbstractableOwner.Impl -> listOfNotNull(presentableQualifiedModName) + owner.impl.declarationText
+                is RsAbstractableOwner.Trait -> owner.trait.declarationText
             }
         }
         else -> listOfNotNull(presentableQualifiedName)

--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -72,22 +72,22 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
 private fun RsDocAndAttributeOwner.header(usePreTag: Boolean): String {
     val rawLines = when (this) {
         is RsFieldDecl -> listOfNotNull((parent?.parent as? RsDocAndAttributeOwner)?.presentableQualifiedName)
+        is RsStructOrEnumItemElement, is RsTraitItem -> listOfNotNull(presentableQualifiedModName)
         is RsFunction -> {
             val owner = owner
             when (owner) {
-                is RsFunctionOwner.Foreign, is RsFunctionOwner.Free -> listOfNotNull(presentableQualifiedModName)
-                is RsFunctionOwner.Impl ->
-                    listOfNotNull(presentableQualifiedModName) + owner.impl.declarationText
+                is RsFunctionOwner.Foreign,
+                is RsFunctionOwner.Free -> listOfNotNull(presentableQualifiedModName)
+                is RsFunctionOwner.Impl -> listOfNotNull(presentableQualifiedModName) + owner.impl.declarationText
                 is RsFunctionOwner.Trait -> owner.trait.declarationText
             }
         }
-        is RsStructOrEnumItemElement, is RsTraitItem -> listOfNotNull(presentableQualifiedModName)
         is RsTypeAlias -> {
             val owner = owner
             when (owner) {
+                is RsTypeAliasOwner.Free -> listOfNotNull(presentableQualifiedModName)
                 is RsTypeAliasOwner.Impl -> listOfNotNull(presentableQualifiedModName) + owner.impl.declarationText
                 is RsTypeAliasOwner.Trait -> owner.trait.declarationText
-                is RsTypeAliasOwner.Free -> listOfNotNull(presentableQualifiedModName)
             }
         }
         else -> listOfNotNull(presentableQualifiedName)
@@ -118,8 +118,7 @@ private fun RsDocAndAttributeOwner.signature(usePreTag: Boolean): String {
             retType?.generateDocumentation(buffer)
             listOf(buffer.toString()) + whereClause?.documentationText.orEmpty()
         }
-        // All these types extend RsTypeBearingItemElement and RsGenericDeclaration interfaces
-        // so all casts are safe
+        // All these types extend RsItemElement and RsGenericDeclaration interfaces so all casts are safe
         is RsStructOrEnumItemElement, is RsTraitItem, is RsTypeAlias -> {
             val name = name
             if (name != null) {

--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -82,6 +82,15 @@ private fun RsDocAndAttributeOwner.header(usePreTag: Boolean): String {
                 is RsFunctionOwner.Trait -> owner.trait.declarationText
             }
         }
+        is RsConstant -> {
+            val owner = owner
+            when (owner) {
+                is RsConstantOwner.Foreign,
+                is RsConstantOwner.Free -> listOfNotNull(presentableQualifiedModName)
+                is RsConstantOwner.Impl -> listOfNotNull(presentableQualifiedModName) + owner.impl.declarationText
+                is RsConstantOwner.Trait -> owner.trait.declarationText
+            }
+        }
         is RsTypeAlias -> {
             val owner = owner
             when (owner) {
@@ -117,6 +126,14 @@ private fun RsDocAndAttributeOwner.signature(usePreTag: Boolean): String {
             valueParameterList?.generateDocumentation(buffer)
             retType?.generateDocumentation(buffer)
             listOf(buffer.toString()) + whereClause?.documentationText.orEmpty()
+        }
+        is RsConstant -> {
+            val buffer = StringBuilder()
+            declarationModifiers.joinTo(buffer, " ", "", " ")
+            buffer.b { it += name }
+            typeReference?.generateDocumentation(buffer, ": ")
+            expr?.generateDocumentation(buffer, " = ")
+            listOf(buffer.toString())
         }
         // All these types extend RsItemElement and RsGenericDeclaration interfaces so all casts are safe
         is RsStructOrEnumItemElement, is RsTraitItem, is RsTypeAlias -> {
@@ -180,6 +197,7 @@ private val RsItemElement.declarationModifiers: List<String> get() {
         }
         is RsStructItem -> modifiers += "struct"
         is RsEnumItem -> modifiers += "enum"
+        is RsConstant -> modifiers += "const"
         is RsTypeAlias -> modifiers += "type"
         is RsTraitItem -> {
             if (isUnsafe) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsNamingInspection.kt
@@ -191,7 +191,7 @@ class RsFunctionNamingInspection : RsSnakeCaseNamingInspection("Function") {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitFunction(el: RsFunction) {
-                if (el.owner is RsFunctionOwner.Free) {
+                if (el.owner is RsAbstractableOwner.Free) {
                     inspect(el.identifier, holder)
                 }
             }
@@ -202,7 +202,7 @@ class RsMethodNamingInspection : RsSnakeCaseNamingInspection("Method") {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitFunction(el: RsFunction) = when (el.owner) {
-                is RsFunctionOwner.Trait, is RsFunctionOwner.Impl -> inspect(el.identifier, holder)
+                is RsAbstractableOwner.Trait, is RsAbstractableOwner.Impl -> inspect(el.identifier, holder)
                 else -> Unit
             }
         }
@@ -255,7 +255,7 @@ class RsTypeAliasNamingInspection : RsCamelCaseNamingInspection("Type", "Type al
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitTypeAlias(el: RsTypeAlias) {
-                if (el.owner is RsTypeAliasOwner.Free) {
+                if (el.owner is RsAbstractableOwner.Free) {
                     inspect(el.identifier, holder)
                 }
             }
@@ -266,7 +266,7 @@ class RsAssocTypeNamingInspection : RsCamelCaseNamingInspection("Type", "Associa
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitTypeAlias(el: RsTypeAlias) {
-                if (el.owner is RsTypeAliasOwner.Trait) {
+                if (el.owner is RsAbstractableOwner.Trait) {
                     inspect(el.identifier, holder, false)
                 }
             }

--- a/src/main/kotlin/org/rust/ide/inspections/RsSelfConventionInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSelfConventionInspection.kt
@@ -22,8 +22,8 @@ class RsSelfConventionInspection : RsLocalInspectionTool() {
             override fun visitFunction(m: RsFunction) {
                 val owner = m.owner
                 val traitOrImpl = when (owner) {
-                    is RsFunctionOwner.Trait -> typeAscription<RsTraitOrImpl>(owner.trait)
-                    is RsFunctionOwner.Impl -> owner.impl.takeIf { owner.isInherent }
+                    is RsAbstractableOwner.Trait -> typeAscription<RsTraitOrImpl>(owner.trait)
+                    is RsAbstractableOwner.Impl -> owner.impl.takeIf { owner.isInherent }
                     else -> null
                 } ?: return
 

--- a/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
@@ -52,10 +52,11 @@ class RsImplsLineMarkerProvider : LineMarkerProvider {
         fun implsQuery(psi: PsiElement): Query<RsImplItem>? {
             val parent = psi.parent
             return when  {
-                parent is RsTraitItem && parent.trait == psi -> parent.searchForImplementations()
-                parent is RsStructItem && (parent.struct == psi || parent.union == psi) ->
-                    parent.searchForImplementations()
-                parent is RsEnumItem && parent.enum == psi -> parent.searchForImplementations()
+                // For performance reasons (see LineMarkerProvider.getLineMarkerInfo)
+                // we need to add the line marker only to leaf elements
+                parent is RsTraitItem && parent.identifier == psi -> parent.searchForImplementations()
+                parent is RsStructItem && parent.identifier == psi -> parent.searchForImplementations()
+                parent is RsEnumItem && parent.identifier == psi -> parent.searchForImplementations()
                 else -> return null
             }
         }

--- a/src/main/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProvider.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.annotator
+package org.rust.ide.lineMarkers
 
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
 import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
@@ -20,7 +20,7 @@ import javax.swing.Icon
 /**
  * Annotates the implementation of a trait members (const, fn, type) with an icon on the gutter.
  */
-class RsTraitMethodImplLineMarkerProvider : RelatedItemLineMarkerProvider() {
+class RsTraitItemImplLineMarkerProvider : RelatedItemLineMarkerProvider() {
     override fun collectNavigationMarkers(el: PsiElement, result: MutableCollection<in RelatedItemLineMarkerInfo<PsiElement>>) {
         if (el !is RsAbstractable) return
 

--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandler.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandler.kt
@@ -13,7 +13,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.lang.core.psi.RsFile
-import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.ext.RsAbstractable
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.owner
 import org.rust.lang.core.psi.ext.superItem
@@ -32,21 +32,21 @@ class RsGotoSuperHandler : LanguageCodeInsightActionHandler {
 
 // public for testing
 fun gotoSuperTarget(source: PsiElement): NavigatablePsiElement? {
-    val modOrMethod = PsiTreeUtil.getNonStrictParentOfType(
+    val modOrAbstractable = PsiTreeUtil.getNonStrictParentOfType(
         source,
-        RsFunction::class.java,
+        RsAbstractable::class.java,
         RsMod::class.java
     ) ?: return null
 
-    if (modOrMethod is RsFunction) {
-        return if (modOrMethod.owner.isTraitImpl) {
-            modOrMethod.superItem
+    if (modOrAbstractable is RsAbstractable) {
+        return if (modOrAbstractable.owner.isTraitImpl) {
+            modOrAbstractable.superItem
         } else {
-            gotoSuperTarget(modOrMethod.parent)
+            gotoSuperTarget(modOrAbstractable.parent)
         }
     }
 
-    val mod = modOrMethod as RsMod
+    val mod = modOrAbstractable as RsMod
     return when (mod) {
         is RsFile -> mod.declaration
         else -> mod.`super`

--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandler.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandler.kt
@@ -16,7 +16,7 @@ import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.owner
-import org.rust.lang.core.psi.ext.superMethod
+import org.rust.lang.core.psi.ext.superItem
 
 class RsGotoSuperHandler : LanguageCodeInsightActionHandler {
     override fun startInWriteAction() = false
@@ -40,7 +40,7 @@ fun gotoSuperTarget(source: PsiElement): NavigatablePsiElement? {
 
     if (modOrMethod is RsFunction) {
         return if (modOrMethod.owner.isTraitImpl) {
-            modOrMethod.superMethod
+            modOrMethod.superItem
         } else {
             gotoSuperTarget(modOrMethod.parent)
         }

--- a/src/main/kotlin/org/rust/ide/presentation/Utils.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/Utils.kt
@@ -90,7 +90,7 @@ fun breadcrumbName(e: RsElement): String? {
     return when (e) {
         is RsMacroDefinition -> e.name?.let { "$it!" }
 
-        is RsModItem, is RsStructOrEnumItemElement, is RsTraitItem, is RsConstant ->
+        is RsModItem, is RsStructOrEnumItemElement, is RsTraitItem, is RsConstant, is RsTypeAlias ->
             (e as RsNamedElement).name
 
         is RsImplItem -> {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
@@ -6,14 +6,44 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.psi.PsiNameIdentifierOwner
-import org.rust.lang.core.psi.RsConstant
-import org.rust.lang.core.psi.RsFunction
-import org.rust.lang.core.psi.RsImplItem
-import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.psi.*
 
 interface RsAbstractable : RsNamedElement, PsiNameIdentifierOwner {
     val isAbstract: Boolean
 }
+
+sealed class RsAbstractableOwner {
+    object Free : RsAbstractableOwner()
+    object Foreign : RsAbstractableOwner()
+    class Trait(val trait: RsTraitItem) : RsAbstractableOwner()
+    class Impl(val impl: RsImplItem, val isInherent: Boolean) : RsAbstractableOwner()
+
+    val isInherentImpl: Boolean get() = this is Impl && isInherent
+    val isTraitImpl: Boolean get() = this is Impl && !isInherent
+    val isImplOrTrait: Boolean get() = this is Impl || this is Trait
+}
+
+val RsAbstractable.owner: RsAbstractableOwner
+    get() {
+        val stubOnlyParent = when (this) {
+            is RsConstant -> if (stub != null) stub.parentStub.psi else parent
+            is RsFunction -> if (stub != null) stub.parentStub.psi else parent
+            is RsTypeAlias -> if (stub != null) stub.parentStub.psi else parent
+            else -> error("unreachable")
+        }
+        return when (stubOnlyParent) {
+            is RsForeignModItem -> RsAbstractableOwner.Foreign
+            is RsMembers -> {
+                val traitOrImpl = parent.parent
+                when (traitOrImpl) {
+                    is RsImplItem -> RsAbstractableOwner.Impl(traitOrImpl, isInherent = traitOrImpl.traitRef == null)
+                    is RsTraitItem -> RsAbstractableOwner.Trait(traitOrImpl)
+                    else -> error("unreachable")
+                }
+            }
+            else -> RsAbstractableOwner.Free
+        }
+    }
 
 // Resolve a const, fn or type in a impl block to the corresponding item in the trait block
 val RsAbstractable.superItem: RsAbstractable?

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
@@ -6,7 +6,24 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.psi.PsiNameIdentifierOwner
+import org.rust.lang.core.psi.RsConstant
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsImplItem
+import org.rust.lang.core.psi.RsTypeAlias
 
 interface RsAbstractable : RsNamedElement, PsiNameIdentifierOwner {
     val isAbstract: Boolean
 }
+
+// Resolve a const, fn or type in a impl block to the corresponding item in the trait block
+val RsAbstractable.superItem: RsAbstractable?
+    get() {
+        val rustImplItem = ancestorStrict<RsImplItem>() ?: return null
+        val superTrait = rustImplItem.traitRef?.resolveToTrait ?: return null
+        return when (this) {
+            is RsConstant -> superTrait.members?.constantList?.find { it.name == this.name }
+            is RsFunction -> superTrait.members?.functionList?.find { it.name == this.name }
+            is RsTypeAlias -> superTrait.members?.typeAliasList?.find { it.name == this.name }
+            else -> error("unreachable")
+        }
+    }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
@@ -31,29 +31,6 @@ val RsConstant.kind: RsConstantKind get() = when {
     else -> RsConstantKind.STATIC
 }
 
-sealed class RsConstantOwner {
-    object Free : RsConstantOwner()
-    object Foreign : RsConstantOwner()
-    class Trait(val trait: RsTraitItem) : RsConstantOwner()
-    class Impl(val impl: RsImplItem) : RsConstantOwner()
-}
-
-val RsConstant.owner: RsConstantOwner get() {
-    return when (parent) {
-        is RsItemsOwner -> RsConstantOwner.Free
-        is RsForeignModItem -> RsConstantOwner.Foreign
-        is RsMembers -> {
-            val grandDad = parent.parent
-            when (grandDad) {
-                is RsTraitItem -> RsConstantOwner.Trait(grandDad)
-                is RsImplItem -> RsConstantOwner.Impl(grandDad)
-                else -> error("unreachable")
-            }
-        }
-        else -> error("Unexpected constant parent: $parent")
-    }
-}
-
 val RsConstant.default: PsiElement?
     get() = node.findChildByType(DEFAULT)?.psi
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
@@ -74,5 +74,7 @@ abstract class RsConstantImplMixin : RsStubbedNamedElementImpl<RsConstantStub>, 
 
     override val isAbstract: Boolean get() = expr == null
 
+    override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
+
     override fun getContext(): RsElement = ExpansionResult.getContextImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -74,14 +74,6 @@ val RsFunction.owner: RsFunctionOwner get() {
     }
 }
 
-
-val RsFunction.superMethod: RsFunction? get() {
-    val rustImplItem = ancestorStrict<RsImplItem>() ?: return null
-    val superTrait = rustImplItem.traitRef?.resolveToTrait ?: return null
-
-    return superTrait.members?.functionList.orEmpty().find { it.name == this.name }
-}
-
 val RsFunction.valueParameters: List<RsValueParameter>
     get() = valueParameterList?.valueParameterList.orEmpty()
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -46,34 +46,6 @@ val RsFunction.abiName: String? get() {
     return stub?.abiName ?: abi?.stringLiteral?.text
 }
 
-sealed class RsFunctionOwner {
-    object Free : RsFunctionOwner()
-    object Foreign : RsFunctionOwner()
-    class Trait(val trait: RsTraitItem) : RsFunctionOwner()
-    class Impl(val impl: RsImplItem, val isInherent: Boolean) : RsFunctionOwner()
-
-    val isInherentImpl: Boolean get() = this is Impl && isInherent
-    val isTraitImpl: Boolean get() = this is Impl && !isInherent
-    val isImplOrTrait: Boolean get() = this is Impl || this is Trait
-}
-
-val RsFunction.owner: RsFunctionOwner get() {
-    val stub = stub
-    val stubOnlyParent = if (stub != null) stub.parentStub.psi else parent
-    return when (stubOnlyParent) {
-        is RsForeignModItem -> RsFunctionOwner.Foreign
-        is RsMembers -> {
-            val traitOrImpl = parent.parent
-            when (traitOrImpl) {
-                is RsImplItem -> RsFunctionOwner.Impl(traitOrImpl, isInherent = traitOrImpl.traitRef == null)
-                is RsTraitItem -> RsFunctionOwner.Trait(traitOrImpl)
-                else -> error("unreachable")
-            }
-        }
-        else -> RsFunctionOwner.Free
-    }
-}
-
 val RsFunction.valueParameters: List<RsValueParameter>
     get() = valueParameterList?.valueParameterList.orEmpty()
 
@@ -85,9 +57,9 @@ val RsFunction.default: PsiElement?
 
 val RsFunction.title: String
     get() = when (owner) {
-        is RsFunctionOwner.Free -> "Function `$name`"
-        is RsFunctionOwner.Foreign -> "Foreign function `$name`"
-        is RsFunctionOwner.Trait, is RsFunctionOwner.Impl ->
+        is RsAbstractableOwner.Free -> "Function `$name`"
+        is RsAbstractableOwner.Foreign -> "Foreign function `$name`"
+        is RsAbstractableOwner.Trait, is RsAbstractableOwner.Impl ->
             if (isAssocFn) "Associated function `$name`" else "Method `$name`"
     }
 
@@ -116,10 +88,10 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
         get() = block?.innerAttrList.orEmpty()
 
     override fun getIcon(flags: Int): Icon = when (owner) {
-        is RsFunctionOwner.Free, is RsFunctionOwner.Foreign ->
+        is RsAbstractableOwner.Free, is RsAbstractableOwner.Foreign ->
             if (isTest) RsIcons.FUNCTION.addTestMark() else RsIcons.FUNCTION
 
-        is RsFunctionOwner.Trait, is RsFunctionOwner.Impl -> when {
+        is RsAbstractableOwner.Trait, is RsAbstractableOwner.Impl -> when {
             isAssocFn && isAbstract -> RsIcons.ABSTRACT_ASSOC_FUNCTION
             isAssocFn -> RsIcons.ASSOC_FUNCTION
             isAbstract -> RsIcons.ABSTRACT_METHOD

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
@@ -17,29 +17,6 @@ import org.rust.lang.core.types.RsPsiTypeImplUtil
 import org.rust.lang.core.types.ty.Ty
 import javax.swing.Icon
 
-sealed class RsTypeAliasOwner {
-    object Free: RsTypeAliasOwner()
-    class Trait(val trait: RsTraitItem): RsTypeAliasOwner()
-    class Impl(val impl: RsImplItem): RsTypeAliasOwner()
-}
-
-val RsTypeAlias.owner: RsTypeAliasOwner get() {
-    val stub = stub
-    val stubOnlyParent = if (stub != null) stub.parentStub.psi else parent
-    return when (stubOnlyParent) {
-        is RsMembers -> {
-            val grandDad = parent.parent
-            when (grandDad) {
-                is RsTraitItem -> RsTypeAliasOwner.Trait(grandDad)
-                is RsImplItem -> RsTypeAliasOwner.Impl(grandDad)
-                else -> error("unreachable")
-            }
-        }
-        else -> RsTypeAliasOwner.Free
-    }
-}
-
-
 val RsTypeAlias.default: PsiElement?
     get() = node.findChildByType(DEFAULT)?.psi
 

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
@@ -6,7 +6,7 @@
 package org.rust.lang.core.stubs
 
 import com.intellij.psi.stubs.IndexSink
-import org.rust.lang.core.psi.ext.RsTypeAliasOwner
+import org.rust.lang.core.psi.ext.RsAbstractableOwner
 import org.rust.lang.core.psi.ext.owner
 import org.rust.lang.core.resolve.indexes.RsImplIndex
 import org.rust.lang.core.resolve.indexes.RsLangItemIndex
@@ -58,7 +58,7 @@ fun IndexSink.indexConstant(stub: RsConstantStub) {
 
 fun IndexSink.indexTypeAlias(stub: RsTypeAliasStub) {
     indexNamedStub(stub)
-    if (stub.psi.owner !is RsTypeAliasOwner.Impl) {
+    if (stub.psi.owner !is RsAbstractableOwner.Impl) {
         indexGotoClass(stub)
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/RsPsiTypeImplUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RsPsiTypeImplUtil.kt
@@ -6,7 +6,7 @@
 package org.rust.lang.core.types
 
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.RsTypeAliasOwner
+import org.rust.lang.core.psi.ext.RsAbstractableOwner
 import org.rust.lang.core.psi.ext.owner
 import org.rust.lang.core.types.ty.*
 
@@ -20,9 +20,10 @@ object RsPsiTypeImplUtil {
         val typeReference = psi.typeReference
         if (typeReference != null) return typeReference.type
         return when (psi.owner) {
-            is RsTypeAliasOwner.Free -> TyUnknown
-            is RsTypeAliasOwner.Trait -> TyTypeParameter.associated(psi)
-            is RsTypeAliasOwner.Impl -> TyUnknown
+            is RsAbstractableOwner.Free -> TyUnknown
+            is RsAbstractableOwner.Trait -> TyTypeParameter.associated(psi)
+            is RsAbstractableOwner.Impl -> TyUnknown
+            is RsAbstractableOwner.Foreign -> TyUnknown
         }
     }
     fun declaredType(psi: RsImplItem): Ty = TyTypeParameter.self(psi)

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -610,8 +610,8 @@ private class RsFnInferenceContext(
         val traits = elements.mapNotNull {
             val owner = (it as? RsFunction)?.owner
             when (owner) {
-                is RsFunctionOwner.Impl -> owner.impl.traitRef?.resolveToTrait
-                is RsFunctionOwner.Trait -> owner.trait
+                is RsAbstractableOwner.Impl -> owner.impl.traitRef?.resolveToTrait
+                is RsAbstractableOwner.Trait -> owner.trait
                 else -> null
             }
         }
@@ -645,13 +645,13 @@ private class RsFnInferenceContext(
             is RsFunction -> {
                 val owner = element.owner
                 var (typeParameters, selfTy) = when (owner) {
-                    is RsFunctionOwner.Impl -> {
+                    is RsAbstractableOwner.Impl -> {
                         val typeParameters = instantiateBounds(owner.impl)
                         val selfTy = owner.impl.typeReference?.type?.substitute(typeParameters) ?: TyUnknown
                         subst[TyTypeParameter.self()]?.let { ctx.combineTypes(selfTy, it) }
                         typeParameters to selfTy
                     }
-                    is RsFunctionOwner.Trait -> {
+                    is RsAbstractableOwner.Trait -> {
                         val typeParameters = instantiateBounds(owner.trait)
                         // UFCS - add predicate `Self : Trait<Args>`
                         val selfTy = subst[TyTypeParameter.self()] ?: ctx.typeVarForParam(TyTypeParameter.self())
@@ -816,7 +816,7 @@ private class RsFnInferenceContext(
         var typeParameters = if (impl != null) {
             val typeParameters = instantiateBounds(impl)
             impl.typeReference?.type?.substitute(typeParameters)?.let { ctx.combineTypes(callee.selfTy, it) }
-            if (callee.element.owner is RsFunctionOwner.Trait) {
+            if (callee.element.owner is RsAbstractableOwner.Trait) {
                 impl.traitRef?.resolveToBoundTrait?.substitute(typeParameters)?.subst ?: emptySubstitution
             } else {
                 typeParameters
@@ -825,7 +825,7 @@ private class RsFnInferenceContext(
             // Method has been resolved to a trait, so we should add a predicate
             // `Self : Trait<Args>` to select args and also refine method path if possible.
             // Method path refinement needed if there are multiple impls of the same trait to the same type
-            val trait = (callee.element.owner as RsFunctionOwner.Trait).trait
+            val trait = (callee.element.owner as RsAbstractableOwner.Trait).trait
             when (callee.selfTy) {
             // All these branches except `else` are optimization, they can be removed without loss of functionality
                 is TyTypeParameter -> callee.selfTy.getTraitBoundsTransitively()
@@ -1286,8 +1286,8 @@ private val RsSelfParameter.typeOfValue: Ty
     get() {
         val owner = parentFunction.owner
         var selfType = when (owner) {
-            is RsFunctionOwner.Impl -> owner.impl.selfType
-            is RsFunctionOwner.Trait -> owner.trait.selfType
+            is RsAbstractableOwner.Impl -> owner.impl.selfType
+            is RsAbstractableOwner.Trait -> owner.trait.selfType
             else -> return TyUnknown
         }
 

--- a/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionHandlerAction.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionHandlerAction.kt
@@ -11,7 +11,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiParserFacade
 import org.rust.lang.core.psi.RsPsiFactory
-import org.rust.lang.core.psi.ext.RsFunctionOwner
+import org.rust.lang.core.psi.ext.RsAbstractableOwner
 import org.rust.lang.core.psi.ext.owner
 
 class RsExtractFunctionHandlerAction(
@@ -32,7 +32,7 @@ class RsExtractFunctionHandlerAction(
 
         val function = psiFactory.createFunction(config)
         when {
-            owner is RsFunctionOwner.Impl && !owner.isInherent -> {
+            owner is RsAbstractableOwner.Impl && !owner.isInherent -> {
                 val beforeNewline = PsiParserFacade.SERVICE.getInstance(project).createWhiteSpaceFromText("\n")
                 val afterNewline = PsiParserFacade.SERVICE.getInstance(project).createWhiteSpaceFromText("\n")
                 val type = owner.impl.typeReference!!
@@ -63,8 +63,8 @@ class RsExtractFunctionHandlerAction(
         } else {
             val owner = config.containingFunction.owner
             val type = when (owner) {
-                is RsFunctionOwner.Impl -> owner.impl.typeReference?.text
-                is RsFunctionOwner.Trait -> "Self"
+                is RsAbstractableOwner.Impl -> owner.impl.typeReference?.text
+                is RsAbstractableOwner.Trait -> "Self"
                 else -> null
             }
             "${if (type != null) "$type::" else ""}${config.name}(${config.argumentsText})"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -136,7 +136,7 @@
         <codeInsight.lineMarkerProvider language="Rust"
                                         implementationClass="org.rust.ide.lineMarkers.RsRecursiveCallLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="Rust"
-                                        implementationClass="org.rust.ide.annotator.RsTraitMethodImplLineMarkerProvider"/>
+                                        implementationClass="org.rust.ide.lineMarkers.RsTraitItemImplLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="Rust"
                                         implementationClass="org.rust.ide.lineMarkers.RsCrateDocLineMarkerProvider"/>
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsTraitMethodImplLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsTraitMethodImplLineMarkerProviderTest.kt
@@ -18,6 +18,10 @@ class RsTraitMethodImplLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
             fn bar(&self) {
                 self.foo();
             }
+            type T1;
+            type T2 = ();
+            const C1: u32;
+            const C2: u32 = 1;
         }
         struct Bar {} // - Has implementations
         impl Foo for Bar {
@@ -25,6 +29,10 @@ class RsTraitMethodImplLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
             }
             fn bar(&self) { // - Overrides method in `Foo`
             }
+            type T1 = ();
+            type T2 = ();
+            const C1: u32 = 1;
+            const C2: u32 = 1;
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsTraitMethodImplLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsTraitMethodImplLineMarkerProviderTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.annotator
 import org.rust.ide.lineMarkers.RsLineMarkerProviderTestBase
 
 /**
- * Tests for Trait Method Implementation Line Marker
+ * Tests for Trait member (const, fn, type) Implementation Line Marker
  */
 class RsTraitMethodImplLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
 
@@ -29,10 +29,10 @@ class RsTraitMethodImplLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
             }
             fn bar(&self) { // - Overrides method in `Foo`
             }
-            type T1 = ();
-            type T2 = ();
-            const C1: u32 = 1;
-            const C2: u32 = 1;
+            type T1 = (); // - Implements type in `Foo`
+            type T2 = (); // - Overrides type in `Foo`
+            const C1: u32 = 1; // - Implements constant in `Foo`
+            const C2: u32 = 1; // - Overrides constant in `Foo`
         }
     """)
 
@@ -66,11 +66,11 @@ class RsTraitMethodImplLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
             }
 
             type
-            T1
+            T1 // - Implements type in `Foo`
             = ();
 
             const
-            C1
+            C1 // - Implements constant in `Foo`
             : u32 = 1;
         }
     """)

--- a/src/test/kotlin/org/rust/ide/annotator/RsTraitMethodImplLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsTraitMethodImplLineMarkerProviderTest.kt
@@ -29,17 +29,41 @@ class RsTraitMethodImplLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
     """)
 
     fun `test icon position`() = doTestByText("""
-        trait Foo {         // - Has implementations
-            fn foo(&self);
+        trait
+        Foo // - Has implementations
+        {
+            fn
+            foo
+            (&self);
+
+            type
+            T1
+            ;
+
+            const
+            C1
+            : u32;
         }
-        struct Bar {} // - Has implementations
+        struct
+        Bar // - Has implementations
+        {}
         impl Foo for Bar {
             ///
             /// Documentation
             ///
             #[warn(non_camel_case_types)]
-            fn foo(&self) { // - Implements method in `Foo`
+            fn
+            foo // - Implements method in `Foo`
+            (&self) {
             }
+
+            type
+            T1
+            = ();
+
+            const
+            C1
+            : u32 = 1;
         }
     """)
 }

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -461,15 +461,43 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <p>Documented</p>
     """)
 
-    fun testTraitConst() = doTest("""
+    fun `test const`() = doTest("""
+        fn main() {
+            /// Documented
+            const AWESOME: i32 = 1;
+                //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>const <b>AWESOME</b>: i32 = 1</pre>
+        <p>Documented</p>
+    """)
+
+    fun `test trait const`() = doTest("""
         trait MyTrait {
             /// Documented
             const AWESOME: i32;
                 //^
         }
     """, """
-        <pre>AWESOME</pre>
+        <pre>test_package::MyTrait</pre>
+        <pre>const <b>AWESOME</b>: i32</pre>
         <p>Documented</p>
+    """)
+
+    fun `test impl assoc const`() = doTest("""
+        trait Trait {
+            const AWESOME: u8;
+        }
+        struct Foo(i32);
+        impl Trait for Foo {
+            const AWESOME: u8 = 42;
+                //^
+        }
+    """, """
+        <pre>test_package</pre>
+        <pre>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a></pre>
+        <pre>const <b>AWESOME</b>: u8 = 42</pre>
     """)
 
     fun `test trait method`() = doTest("""

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt
@@ -38,8 +38,12 @@ class RsImplsLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
         /// Documentation
         ///
         #[warn(non_camel_case_types)]
-        trait Foo {}                // - Has implementations
-        struct Bar {}               // - Has implementations
+        trait
+        Foo // - Has implementations
+        {}
+        struct
+        Bar // - Has implementations
+        {}
         impl Foo for Bar {}
     """)
 }

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProviderTest.kt
@@ -3,14 +3,14 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.annotator
+package org.rust.ide.lineMarkers
 
 import org.rust.ide.lineMarkers.RsLineMarkerProviderTestBase
 
 /**
  * Tests for Trait member (const, fn, type) Implementation Line Marker
  */
-class RsTraitMethodImplLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
+class RsTraitItemImplLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
 
     fun `test impl`() = doTestByText("""
         trait Foo {         // - Has implementations

--- a/src/test/kotlin/org/rust/ide/miscExtensions/RsBreadcrumbsInfoProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/miscExtensions/RsBreadcrumbsInfoProviderTest.kt
@@ -24,6 +24,8 @@ class RsBreadcrumbsInfoProviderTest : RsTestBase() {
             impl S<S> for X<T> {}
             impl T for (i32, i32) {}
             macro_rules! foo {}
+            const C: u32 = 1;
+            type TA = u32;
         """)
 
         val actual = myFixture.file.descendantsOfType<RsElement>()
@@ -40,6 +42,8 @@ class RsBreadcrumbsInfoProviderTest : RsTestBase() {
             S for X
             T for (i32, i32)
             foo!
+            C
+            TA
         """.trimIndent()
 
         UsefulTestCase.assertSameLines(expected, actual)

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandlerTest.kt
@@ -26,19 +26,51 @@ class RsGotoSuperHandlerTest : RsTestBase() {
         }
     """)
 
-    fun `test method declataion from impl`() = checkNavigation("""
+    fun `test method declaration from impl`() = checkNavigation("""
         trait T {
-             fn foo(); // <- should go here
+            fn foo(); // <- should go here
         }
         impl T for () {
             fn foo/*caret*/() {}
         }
     """, """
         trait T {
-             fn /*caret*/foo(); // <- should go here
+            fn /*caret*/foo(); // <- should go here
         }
         impl T for () {
             fn foo() {}
+        }
+    """)
+
+    fun `test constant declaration from impl`() = checkNavigation("""
+        trait T {
+            const Z: u32; // <- should go here
+        }
+        impl T for () {
+            const /*caret*/Z: u32 = 1;
+        }
+    """, """
+        trait T {
+            const /*caret*/Z: u32; // <- should go here
+        }
+        impl T for () {
+            const Z: u32 = 1;
+        }
+    """)
+
+    fun `test type alias declaration from impl`() = checkNavigation("""
+        trait T {
+             type Z; // <- should go here
+        }
+        impl T for () {
+            type /*caret*/Z = ();
+        }
+    """, """
+        trait T {
+             type /*caret*/Z; // <- should go here
+        }
+        impl T for () {
+            type Z = ();
         }
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/ext/RsPsiStructureTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/ext/RsPsiStructureTest.kt
@@ -20,34 +20,34 @@ import org.rust.lang.core.types.type
 // which use `instanceof` under the hood and thus sensitive
 // to PSI structure
 class RsPsiStructureTest : RsTestBase() {
-    private fun checkFunctionOwner(cond: (RsFunctionOwner) -> Boolean, @Language("Rust") code: String) =
+    private fun checkFunctionOwner(cond: (RsAbstractableOwner) -> Boolean, @Language("Rust") code: String) =
         checkElement<RsFunction>(code) { check(cond(it.owner)) }
 
-    fun `test function role free`() = checkFunctionOwner({ it is RsFunctionOwner.Free }, "fn main() {}")
-    fun `test function role foreign`() = checkFunctionOwner({ it is RsFunctionOwner.Foreign }, "extern { fn foo(); }")
-    fun `test function role trait method`() = checkFunctionOwner({ it is RsFunctionOwner.Trait }, "trait S { fn foo() {} }")
+    fun `test function role free`() = checkFunctionOwner({ it is RsAbstractableOwner.Free }, "fn main() {}")
+    fun `test function role foreign`() = checkFunctionOwner({ it is RsAbstractableOwner.Foreign }, "extern { fn foo(); }")
+    fun `test function role trait method`() = checkFunctionOwner({ it is RsAbstractableOwner.Trait }, "trait S { fn foo() {} }")
     fun `test function role inherent impl method`() =
-        checkFunctionOwner({ it is RsFunctionOwner.Impl && it.isInherentImpl }, "impl S { fn foo() {} }")
+        checkFunctionOwner({ it is RsAbstractableOwner.Impl && it.isInherentImpl }, "impl S { fn foo() {} }")
 
     fun `test function role trait impl method`() =
-        checkFunctionOwner({ it is RsFunctionOwner.Impl && it.isTraitImpl }, "impl S for T { fn foo() {} }")
+        checkFunctionOwner({ it is RsAbstractableOwner.Impl && it.isTraitImpl }, "impl S for T { fn foo() {} }")
 
-    private fun checkTypeAliasOwner(cond: (RsTypeAliasOwner) -> Boolean, @Language("Rust") code: String) =
+    private fun checkTypeAliasOwner(cond: (RsAbstractableOwner) -> Boolean, @Language("Rust") code: String) =
         checkElement<RsTypeAlias>(code) { check(cond(it.owner)) }
 
-    fun `test type alias role free 1`() = checkTypeAliasOwner({ it is RsTypeAliasOwner.Free }, "type T = ();")
-    fun `test type alias role free 2`() = checkTypeAliasOwner({ it is RsTypeAliasOwner.Free }, "fn main() { type T = (); }")
-    fun `test type alias role impl method`() = checkTypeAliasOwner({ it is RsTypeAliasOwner.Impl }, "impl S for X { type T = (); }")
-    fun `test type alias role trait method`() = checkTypeAliasOwner({ it is RsTypeAliasOwner.Trait }, "trait S { type T; }")
+    fun `test type alias role free 1`() = checkTypeAliasOwner({ it is RsAbstractableOwner.Free }, "type T = ();")
+    fun `test type alias role free 2`() = checkTypeAliasOwner({ it is RsAbstractableOwner.Free }, "fn main() { type T = (); }")
+    fun `test type alias role impl method`() = checkTypeAliasOwner({ it is RsAbstractableOwner.Impl }, "impl S for X { type T = (); }")
+    fun `test type alias role trait method`() = checkTypeAliasOwner({ it is RsAbstractableOwner.Trait }, "trait S { type T; }")
 
-    private fun checkConstantRole(cond: (RsConstantOwner) -> Boolean, @Language("Rust") code: String) =
+    private fun checkConstantRole(cond: (RsAbstractableOwner) -> Boolean, @Language("Rust") code: String) =
         checkElement<RsConstant>(code) { check(cond(it.owner)) }
 
-    fun `test constant role free 1`() = checkConstantRole({ it is RsConstantOwner.Free }, "const C: () = ();")
-    fun `test constant role free 2`() = checkConstantRole({ it is RsConstantOwner.Free }, "fn main() { const C: () = (); }")
-    fun `test constant role foreign`() = checkConstantRole({ it is RsConstantOwner.Foreign }, "extern { static C: (); }")
-    fun `test constant role impl method`() = checkConstantRole({ it is RsConstantOwner.Impl }, "impl S for X { const C: () = (); }")
-    fun `test constant role trait method`() = checkConstantRole({ it is RsConstantOwner.Trait }, "trait S { const C: () = (); }")
+    fun `test constant role free 1`() = checkConstantRole({ it is RsAbstractableOwner.Free }, "const C: () = ();")
+    fun `test constant role free 2`() = checkConstantRole({ it is RsAbstractableOwner.Free }, "fn main() { const C: () = (); }")
+    fun `test constant role foreign`() = checkConstantRole({ it is RsAbstractableOwner.Foreign }, "extern { static C: (); }")
+    fun `test constant role impl method`() = checkConstantRole({ it is RsAbstractableOwner.Impl }, "impl S for X { const C: () = (); }")
+    fun `test constant role trait method`() = checkConstantRole({ it is RsAbstractableOwner.Trait }, "trait S { const C: () = (); }")
 
     fun `test trait implementation info`() = checkElement<RsImplItem>("""
         trait T {


### PR DESCRIPTION
Allow to navigate from "const" and "type" in trait impl blocks to the according place in the trait the same way we already do for "fn".

Also slightly improve documentation and the breadcrumb bar entries related to "const" and "type".

This is a preparation for #2163 