### PR TITLE
INSP: fix warnings

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsVariableMutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsVariableMutableInspection.kt
@@ -30,7 +30,7 @@ class RsVariableMutableInspection : RsLocalInspectionTool() {
                 holder.registerProblem(
                     o,
                     "Variable `${o.identifier.text}` does not need to be mutable",
-                    *arrayOf(RemoveMutableFix(o))
+                    RemoveMutableFix()
                 )
             }
         }

--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongTypeParametersNumberInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongTypeParametersNumberInspection.kt
@@ -57,7 +57,7 @@ class RsWrongTypeParametersNumberInspection : RsLocalInspectionTool() {
 
         val problemText = "Wrong number of type parameters: expected ${data.expectedText}, found $nArguments [${data.code}]"
         if (data.fix) {
-            holder.registerProblem(o, problemText, RemoveTypeParameter(o))
+            holder.registerProblem(o, problemText, RemoveTypeParameter())
         } else {
             holder.registerProblem(o, problemText)
         }

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveMutableFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveMutableFix.kt
@@ -11,8 +11,9 @@ import com.intellij.openapi.project.Project
 import org.rust.ide.annotator.fixes.updateMutable
 import org.rust.lang.core.psi.RsPatBinding
 
-class RemoveMutableFix(val patBinding: RsPatBinding) : LocalQuickFix {
+class RemoveMutableFix : LocalQuickFix {
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val patBinding = descriptor.psiElement as? RsPatBinding ?: return
         updateMutable(project, patBinding, false)
     }
 

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveRefFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveRefFix.kt
@@ -5,10 +5,11 @@
 
 package org.rust.ide.inspections.fixes
 
-import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsExpr
 
 
@@ -19,18 +20,17 @@ import org.rust.lang.core.psi.RsExpr
  * @param fixName A name to use for the fix instead of the default one to better fit the inspection.
  */
 class RemoveRefFix(
-    val argEl: RsExpr,
+    argEl: RsExpr,
     val fixName: String = "Change reference to owned value"
-) : LocalQuickFix {
-    override fun getName() = fixName
+) : LocalQuickFixOnPsiElement(argEl) {
+    override fun getText() = fixName
     override fun getFamilyName() = "Change reference to owned value"
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+    override fun invoke(project: Project, file: PsiFile, argEl: PsiElement, endElement: PsiElement) {
         if (argEl.text != null && argEl.text[0] == '&') {
             val offset = argEl.textRange.startOffset
             val document = PsiDocumentManager.getInstance(project).getDocument(argEl.containingFile)
             document?.deleteString(offset, offset + 1)
         }
     }
-
 }

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveTypeParameter.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveTypeParameter.kt
@@ -11,12 +11,13 @@ import com.intellij.openapi.project.Project
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
 
-class RemoveTypeParameter(val element: RsElement) : LocalQuickFix {
+class RemoveTypeParameter : LocalQuickFix {
 
     override fun getName() = "Remove all type parameters"
     override fun getFamilyName() = name
 
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val element = descriptor.psiElement as? RsElement ?: return
         val typeArgumentList = when (element) {
             is RsMethodCall -> element.typeArgumentList
             is RsCallExpr -> (element.expr as RsPathExpr?)?.path?.typeArgumentList

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RenameFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RenameFix.kt
@@ -5,10 +5,11 @@
 
 package org.rust.ide.inspections.fixes
 
-import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiNamedElement
 import com.intellij.refactoring.RefactoringFactory
 
@@ -19,15 +20,15 @@ import com.intellij.refactoring.RefactoringFactory
  * @param fixName The name to use for the fix instead of the default one to better fit the inspection.
  */
 class RenameFix(
-    val element: PsiNamedElement,
+    element: PsiNamedElement,
     val newName: String,
     val fixName: String = "Rename to `$newName`"
-) : LocalQuickFix {
-    override fun getName() = fixName
+) : LocalQuickFixOnPsiElement(element) {
+    override fun getText() = fixName
     override fun getFamilyName() = "Rename element"
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor) =
+    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) =
         ApplicationManager.getApplication().invokeLater {
-            RefactoringFactory.getInstance(project).createRename(element, newName).run()
+            RefactoringFactory.getInstance(project).createRename(startElement, newName).run()
         }
 }


### PR DESCRIPTION
Don't save psi elements directly in quick fix object to avoid potential memory leak
and recalculate them after typing