### PR TITLE
PSI: 'Not all trait items implemented' checks items only by their names

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -9,7 +9,6 @@ import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.Condition
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.stubs.IStubElementType
-import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.Query
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.icons.RsIcons
@@ -103,15 +102,15 @@ class TraitImplementationInfo private constructor(
     val declared = traitMembers.abstractable()
     private val implemented = implMembers.abstractable()
     private val declaredByName = declared.associateBy { it.name!! }
-    private val implementedByName = implemented.associateBy { it.name!! }
+    private val implementedByNameAndType = implemented.associateBy { it.name!! to it.elementType }
 
 
     val missingImplementations: List<RsAbstractable> = if (!hasMacros)
-        declared.filter { it.isAbstract }.filter { it.name !in implementedByName }
+        declared.filter { it.isAbstract }.filter { it.name to it.elementType !in implementedByNameAndType }
     else emptyList()
 
     val alreadyImplemented: List<RsAbstractable> =  if (!hasMacros)
-        declared.filter { it.isAbstract }.filter { it.name in implementedByName }
+        declared.filter { it.isAbstract }.filter { it.name to it.elementType in implementedByNameAndType }
     else emptyList()
 
     val nonExistentInTrait: List<RsAbstractable> = implemented.filter { it.name !in declaredByName }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -67,6 +67,16 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
         }
     """)
 
+    fun `test different type items have same name E0046`() = checkErrors("""
+        trait A {
+            type C;
+            const C: i32;
+        }
+        <error descr="Not all trait items implemented, missing: `C` [E0046]">impl A for ()</error> {
+            type C = ();
+        }
+    """)
+
     fun `test not applied E0046`() = checkErrors("""
         trait T {
             fn foo() {}

--- a/src/test/kotlin/org/rust/lang/core/ext/RsPsiStructureTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/ext/RsPsiStructureTest.kt
@@ -55,23 +55,26 @@ class RsPsiStructureTest : RsTestBase() {
             fn required_fn();
             fn another_required_fn();
             type RequiredType;
+            type same_name;
+            const same_name: i32;
         }
 
         struct S;
 
         impl T for S {
             fn another_required_fn() { }
+            type same_name = ();
             fn spam() {}
         }
     """) { impl ->
         val trait = impl.traitRef!!.resolveToTrait!!
         val implInfo = TraitImplementationInfo.create(trait, impl)!!
         check(implInfo.declared.map { it.name } == listOf(
-            "optional_fn", "required_fn", "another_required_fn", "RequiredType"
+            "optional_fn", "required_fn", "another_required_fn", "RequiredType", "same_name", "same_name"
         ))
 
         check(implInfo.missingImplementations.map { it.name } == listOf(
-            "required_fn", "RequiredType"
+            "required_fn", "RequiredType", "same_name"
         ))
 
         check(implInfo.nonExistentInTrait.map { it.name } == listOf(
@@ -79,7 +82,8 @@ class RsPsiStructureTest : RsTestBase() {
         ))
 
         check(implInfo.implementationToDeclaration.map { (it.first.name to it.second.name) } == listOf(
-            "another_required_fn" to "another_required_fn"
+            "another_required_fn" to "another_required_fn",
+            "same_name" to "same_name"
         ))
     }
 


### PR DESCRIPTION
Fix for #2258