### PR TITLE
INSP: highlight only part of impl 

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
@@ -9,6 +9,7 @@ import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsItemElement
 import org.rust.lang.core.psi.ext.RsTraitOrImpl
@@ -19,9 +20,11 @@ class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
         override fun visitImplItem(impl: RsImplItem) {
             val trait = impl.traitRef?.resolveToTrait ?: return
+            val typeRef = impl.typeReference ?: return
             if (sortedImplItems(impl.items(), trait.items()) == null) return
+            val textRange = TextRange(0, typeRef.startOffsetInParent + typeRef.textLength)
             holder.registerProblem(
-                impl,
+                impl, textRange,
                 "Different impl member order from the trait",
                 SortImplTraitMembersFix()
             )

--- a/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
@@ -94,7 +94,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
             fn test3(&self) -> i32;
         }
 
-        <weak_warning descr="Different impl member order from the trait">/*caret*/impl Trait for Struct {
+        <weak_warning descr="Different impl member order from the trait">/*caret*/impl Trait for Struct</weak_warning> {
             type T2 = T;
             const ID2: i32 = 2;
             fn test3(&self) -> i32 {
@@ -108,7 +108,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
             }
             type T1 = T;
             const ID1: i32 = 1;
-        }</weak_warning>
+        }
     """, """
         struct Struct {
             i: i32
@@ -150,11 +150,11 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
             fn bar();
         }
 
-        <weak_warning descr="Different impl member order from the trait">/*caret*/impl Foo for () {
+        <weak_warning descr="Different impl member order from the trait">/*caret*/impl Foo for ()</weak_warning> {
             fn bar() {
             }
             type bar = ();
-        }</weak_warning>
+        }
     """, """
         trait Foo {
             type bar;
@@ -191,7 +191,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
 
         struct T;
 
-        <weak_warning descr="Different impl member order from the trait">/*caret*/impl Trait for Struct {
+        <weak_warning descr="Different impl member order from the trait">/*caret*/impl Trait for Struct</weak_warning> {
             type T2 = T;
             const ID2: i32 = 2;
             fn test3(&self) -> i32 {
@@ -205,7 +205,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
             }
             type T1 = T;
             const ID1: i32 = 1;
-        }</weak_warning>
+        }
     """, """
         mod foo;
 


### PR DESCRIPTION
Improve `Different impl member order from the trait` inspection highlighting to underline only `impl Trait for Type` part instead of the whole impl element