### PR TITLE
DOC: Fix names of recommended plugins in contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,8 @@ during import IDEA may delete `.idea/runConfigurations`, just revert changes in
 the directory if this happens.
 
 You might want to install the following plugins:
-  - Grammar Kit to get highlighting for the files with BNFish grammar.
-  - PSI viewer to view the AST of Rust files right in the IDE.
+  - Grammar-Kit to get highlighting for the files with BNFish grammar.
+  - PsiViewer to view the AST of Rust files right in the IDE.
 
 
 # Contributing


### PR DESCRIPTION
Change the names to reflect what the actual plugins are called, to simplify search for future contributors.

CLA will come later, since the sign-up form is currently broken.