### PR TITLE
Fix self-assignment of state in RustProjectSettingsServiceImpl

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -42,7 +42,7 @@ class RustProjectSettingsServiceImpl(
 
     override var data: RustProjectSettingsService.Data
         get() {
-            state = state
+            val state = state
             return RustProjectSettingsService.Data(
                 toolchain = state.toolchainHomeDirectory?.let { RustToolchain(Paths.get(it)) },
                 autoUpdateEnabled = state.autoUpdateEnabled,


### PR DESCRIPTION
IntelliJ IDEA complains about this, so I removed it.

CLA will come later, since the sign-up form is currently broken.

Since the fix is so small and should not actually change anything, I am unsure which prefix to pick from https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#commit-messages