### PR TITLE
Improve error messages, distinguish "standard library" and "Rust source"

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
@@ -62,7 +62,7 @@ class RsProjectConfigurable(
 
         rustProjectSettings.data = RustProjectSettingsPanel.Data(
             toolchain = toolchain,
-            explicitPathToStdlib = settings.explicitPathToStdlib
+            explicitPathToRustSource = settings.explicitPathToRustSource
         )
         expandMacros = settings.expandMacros
 
@@ -82,7 +82,7 @@ class RsProjectConfigurable(
         val currentData = settings.data
         settings.data = currentData.copy(
             toolchain = rustProjectSettings.data.toolchain,
-            explicitPathToStdlib = rustProjectSettings.data.explicitPathToStdlib,
+            explicitPathToRustSource = rustProjectSettings.data.explicitPathToRustSource,
             expandMacros = expandMacros
         )
     }
@@ -91,7 +91,7 @@ class RsProjectConfigurable(
         val data = rustProjectSettings.data
         if (hintProvider.supportedOptions.any { checkboxForOption(it).isSelected != it.get() }) return true
         return data.toolchain?.location != settings.toolchain?.location
-            || data.explicitPathToStdlib != settings.explicitPathToStdlib
+            || data.explicitPathToRustSource != settings.explicitPathToRustSource
             || expandMacros != settings.expandMacros
     }
 

--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -85,11 +85,11 @@ interface CargoProject {
     val rustcInfo: RustcInfo?
 
     val workspaceStatus: UpdateStatus
-    val stdlibStatus: UpdateStatus
+    val rustSourceStatus: UpdateStatus
     val rustcInfoStatus: UpdateStatus
 
     val mergedStatus: UpdateStatus get() = workspaceStatus
-        .merge(stdlibStatus)
+        .merge(rustSourceStatus)
         .merge(rustcInfoStatus)
 
     sealed class UpdateStatus(private val priority: Int) {

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -17,7 +17,7 @@ interface RustProjectSettingsService {
         // Usually, we use `rustup` to find stdlib automatically,
         // but if one does not use rustup, it's possible to
         // provide path to stdlib explicitly.
-        val explicitPathToStdlib: String?,
+        val explicitPathToRustSource: String?,
         val useCargoCheckForBuild: Boolean,
         val useCargoCheckAnnotator: Boolean,
         val compileAllTargets: Boolean,
@@ -29,10 +29,10 @@ interface RustProjectSettingsService {
     var data: Data
 
     val toolchain: RustToolchain? get() = data.toolchain
-    var explicitPathToStdlib: String?
-        get() = data.explicitPathToStdlib
+    var explicitPathToRustSource: String?
+        get() = data.explicitPathToRustSource
         set(value) {
-            data = data.copy(explicitPathToStdlib = value)
+            data = data.copy(explicitPathToRustSource = value)
         }
     val autoUpdateEnabled: Boolean get() = data.autoUpdateEnabled
     val useCargoCheckForBuild: Boolean get() = data.useCargoCheckForBuild

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -25,7 +25,7 @@ class RustProjectSettingsServiceImpl(
     data class State(
         var toolchainHomeDirectory: String? = null,
         var autoUpdateEnabled: Boolean = true,
-        var explicitPathToStdlib: String? = null,
+        var explicitPathToRustSource: String? = null,
         var useCargoCheckForBuild: Boolean = true,
         var useCargoCheckAnnotator: Boolean = false,
         var compileAllTargets: Boolean = true,
@@ -50,7 +50,7 @@ class RustProjectSettingsServiceImpl(
             return RustProjectSettingsService.Data(
                 toolchain = state.toolchainHomeDirectory?.let { RustToolchain(Paths.get(it)) },
                 autoUpdateEnabled = state.autoUpdateEnabled,
-                explicitPathToStdlib = state.explicitPathToStdlib,
+                explicitPathToRustSource = state.explicitPathToRustSource,
                 useCargoCheckForBuild = state.useCargoCheckForBuild,
                 useCargoCheckAnnotator = state.useCargoCheckAnnotator,
                 compileAllTargets = state.compileAllTargets,
@@ -63,7 +63,7 @@ class RustProjectSettingsServiceImpl(
             val newState = State(
                 toolchainHomeDirectory = value.toolchain?.location?.systemIndependentPath,
                 autoUpdateEnabled = value.autoUpdateEnabled,
-                explicitPathToStdlib = value.explicitPathToStdlib,
+                explicitPathToRustSource = value.explicitPathToRustSource,
                 useCargoCheckForBuild = value.useCargoCheckForBuild,
                 useCargoCheckAnnotator = value.useCargoCheckAnnotator,
                 compileAllTargets = value.compileAllTargets,

--- a/src/main/kotlin/org/rust/cargo/project/workspace/RustSource.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/RustSource.kt
@@ -16,7 +16,7 @@ import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.cargo.util.StdLibType
 import org.rust.ide.notifications.showBalloon
 
-class StandardLibrary private constructor(
+class RustSource private constructor(
     val crates: List<StdCrate>
 ) {
 
@@ -31,15 +31,15 @@ class StandardLibrary private constructor(
     }
 
     companion object {
-        fun fromPath(path: String): StandardLibrary? =
+        fun fromPath(path: String): RustSource? =
             LocalFileSystem.getInstance().findFileByPath(path)?.let { fromFile(it) }
 
-        fun fromFile(sources: VirtualFile): StandardLibrary? {
+        fun fromFile(sources: VirtualFile): RustSource? {
             if (!sources.isDirectory) return null
             val srcDir = if (sources.name == "src") sources else sources.findChild("src")
                 ?: return null
 
-            val stdlib = AutoInjectedCrates.stdlibCrates.mapNotNull { libInfo ->
+            val rustSource = AutoInjectedCrates.stdlibCrates.mapNotNull { libInfo ->
                 val packageSrcDir = srcDir.findFileByRelativePath(libInfo.srcDir)
                 val libFile = packageSrcDir?.findChild("lib.rs")
                 if (packageSrcDir != null && libFile != null)
@@ -47,8 +47,8 @@ class StandardLibrary private constructor(
                 else
                     null
             }
-            if (stdlib.isEmpty()) return null
-            return StandardLibrary(stdlib)
+            if (rustSource.isEmpty()) return null
+            return RustSource(rustSource)
         }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
@@ -27,14 +27,14 @@ class Rustup(
         class Err(val error: String) : DownloadResult<Nothing>()
     }
 
-    fun downloadStdlib(): DownloadResult<VirtualFile> {
+    fun downloadRustSource(): DownloadResult<VirtualFile> {
         val downloadProcessOutput = GeneralCommandLine(rustup)
             .withWorkDirectory(projectDirectory)
             .withParameters("component", "add", "rust-src")
             .execute(null)
 
         return if (downloadProcessOutput?.isSuccess == true) {
-            val sources = getStdlibFromSysroot() ?: return DownloadResult.Err("Failed to find stdlib in sysroot")
+            val sources = getRustSourceFromSysroot() ?: return DownloadResult.Err("Failed to find Rust source in sysroot")
             fullyRefreshDirectory(sources)
             DownloadResult.Ok(sources)
         } else {
@@ -58,7 +58,7 @@ class Rustup(
         }
     }
 
-    fun getStdlibFromSysroot(): VirtualFile? {
+    fun getRustSourceFromSysroot(): VirtualFile? {
         val sysroot = toolchain.getSysroot(projectDirectory) ?: return null
         val fs = LocalFileSystem.getInstance()
         return fs.refreshAndFindFileByPath(FileUtil.join(sysroot, "lib/rustlib/src/rust/src"))

--- a/src/main/kotlin/org/rust/ide/idea/CargoConfigurationWizardStep.kt
+++ b/src/main/kotlin/org/rust/ide/idea/CargoConfigurationWizardStep.kt
@@ -63,7 +63,7 @@ class CargoConfigurationWizardStep private constructor(
             if (data != null) {
                 module.project.rustSettings.data = module.project.rustSettings.data.copy(
                     toolchain = data.toolchain,
-                    explicitPathToStdlib = data.explicitPathToStdlib
+                    explicitPathToRustSource = data.explicitPathToRustSource
                 )
             }
             // We don't use SDK, but let's inherit one to reduce the amount of

--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -22,13 +22,13 @@ import org.rust.cargo.project.model.guessAndSetupRustProject
 import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.toolchain
-import org.rust.cargo.project.workspace.StandardLibrary
+import org.rust.cargo.project.workspace.RustSource
 import org.rust.lang.core.psi.isNotRustFile
 
 /**
- * Warn user if rust toolchain or standard library is not properly configured.
+ * Warn user if Rust toolchain or Rust source is not properly configured.
  *
- * Try to fix this automatically (toolchain from PATH, standard library from the last project)
+ * Try to fix this automatically (toolchain from PATH, Rust source from the last project)
  * and if not successful show the actual notification to the user.
  */
 class MissingToolchainNotificationProvider(
@@ -74,11 +74,11 @@ class MissingToolchainNotificationProvider(
             return createNoCargoProjectForFilePanel()
 
         val workspace = cargoProject.workspace ?: return null
-        if (!workspace.hasStandardLibrary) {
+        if (!workspace.hasRustSource) {
             // If rustup is not null, the WorkspaceService will use it
-            // to add stdlib automatically. This happens asynchronously,
+            // to add Rust source automatically. This happens asynchronously,
             // so we can't reliably say here if that succeeded or not.
-            if (!toolchain.isRustupAvailable) return createLibraryAttachingPanel()
+            if (!toolchain.isRustupAvailable) return createAttachRustSourcePanel()
         }
 
         return null
@@ -112,17 +112,17 @@ class MissingToolchainNotificationProvider(
             }
         }
 
-    private fun createLibraryAttachingPanel(): EditorNotificationPanel =
+    private fun createAttachRustSourcePanel(): EditorNotificationPanel =
         EditorNotificationPanel().apply {
-            setText("Can not attach stdlib sources automatically without rustup.")
+            setText("Can not attach Rust sources automatically without rustup.")
             createActionLabel("Attach manually") {
                 val descriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
-                val stdlib = FileChooser.chooseFile(descriptor, this, project, null) ?: return@createActionLabel
-                if (StandardLibrary.fromFile(stdlib) != null) {
-                    project.rustSettings.explicitPathToStdlib = stdlib.path
+                val rustSource = FileChooser.chooseFile(descriptor, this, project, null) ?: return@createActionLabel
+                if (RustSource.fromFile(rustSource) != null) {
+                    project.rustSettings.explicitPathToRustSource = rustSource.path
                 } else {
                     project.showBalloon(
-                        "Invalid Rust standard library source path: `${stdlib.presentableUrl}`",
+                        "Invalid Rust source path: `${rustSource.presentableUrl}`",
                         NotificationType.ERROR
                     )
                 }

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -19,7 +19,7 @@ import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.cargo.project.workspace.CargoWorkspaceData.Package
 import org.rust.cargo.project.workspace.CargoWorkspaceData.Target
 import org.rust.cargo.project.workspace.PackageOrigin
-import org.rust.cargo.project.workspace.StandardLibrary
+import org.rust.cargo.project.workspace.RustSource
 import org.rust.cargo.toolchain.RustToolchain
 import org.rust.cargo.toolchain.Rustup
 import java.nio.file.Paths
@@ -71,7 +71,7 @@ open class WithRustup(private val delegate: RustProjectDescriptorBase) : RustPro
     private val toolchain: RustToolchain? by lazy { RustToolchain.suggest() }
 
     private val rustup by lazy { toolchain?.rustup(Paths.get(".")) }
-    val stdlib by lazy { (rustup?.downloadStdlib() as? Rustup.DownloadResult.Ok)?.value }
+    val stdlib by lazy { (rustup?.downloadRustSource() as? Rustup.DownloadResult.Ok)?.value }
 
     override val skipTestReason: String?
         get() {
@@ -89,8 +89,8 @@ open class WithRustup(private val delegate: RustProjectDescriptorBase) : RustPro
         }
 
     override fun testCargoProject(module: Module, contentRoot: String): CargoWorkspace {
-        val stdlib = StandardLibrary.fromFile(stdlib!!)!!
-        return delegate.testCargoProject(module, contentRoot).withStdlib(stdlib)
+        val stdlib = RustSource.fromFile(stdlib!!)!!
+        return delegate.testCargoProject(module, contentRoot).withRustSource(stdlib)
     }
 
     override fun setUp(fixture: CodeInsightTestFixture) {

--- a/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
@@ -26,7 +26,7 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
               <option name="autoUpdateEnabled" value="false" />
               <option name="compileAllTargets" value="false" />
               <option name="expandMacros" value="false" />
-              <option name="explicitPathToStdlib" value="/stdlib" />
+              <option name="explicitPathToRustSource" value="/stdlib" />
               <option name="toolchainHomeDirectory" value="/" />
               <option name="useCargoCheckAnnotator" value="true" />
               <option name="useCargoCheckForBuild" value="false" />
@@ -43,7 +43,7 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
         check(service.data == RustProjectSettingsService.Data(
             toolchain = RustToolchain(Paths.get("/")),
             autoUpdateEnabled = false,
-            explicitPathToStdlib = "/stdlib",
+            explicitPathToRustSource = "/stdlib",
             useCargoCheckForBuild = false,
             useCargoCheckAnnotator = true,
             compileAllTargets = false,

--- a/src/test/kotlin/org/rustSlowTests/RsCompilerSourcesPerformance.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsCompilerSourcesPerformance.kt
@@ -31,7 +31,7 @@ class RsCompilerSourcesPerformance : RsTestBase() {
 //        }
 //    }
 
-    fun `test parsing standard library sources`() {
+    fun `test parsing Rust sources`() {
         val sources = rustSrcDir()
         parseRustFiles(
             sources,


### PR DESCRIPTION
The original intention was to improve error message, which was confusing
 some users.  Since the source code itself was also referring to the
 Rust source as "stdlib" or "standard library", I fixed that as well.

Fixes: intellij-rust/intellij-rust#2267

Signed-off-by: Dennis Schridde <devurandom@gmx.net>