### PR TITLE
RUN: Fix console links

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -67,6 +67,7 @@ val Project.cargoProjects get() = service<CargoProjectsService>()
 interface CargoProject {
     val manifest: Path
     val rootDir: VirtualFile?
+    val workspaceRootDir: VirtualFile?
 
     val presentableName: String
     val workspace: CargoWorkspace?

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -40,10 +40,7 @@ import org.rust.cargo.project.workspace.StandardLibrary
 import org.rust.cargo.toolchain.RustToolchain
 import org.rust.cargo.toolchain.Rustup
 import org.rust.ide.notifications.showBalloon
-import org.rust.openapiext.TaskResult
-import org.rust.openapiext.modules
-import org.rust.openapiext.pathAsPath
-import org.rust.openapiext.runAsyncTask
+import org.rust.openapiext.*
 import org.rust.stdext.AsyncValue
 import org.rust.stdext.joinAll
 import java.nio.file.Path
@@ -262,6 +259,8 @@ data class CargoProjectImpl(
             rootDirCache.set(file)
             return file
         }
+
+    override val workspaceRootDir: VirtualFile? by CachedVirtualFile(workspace?.workspaceRootPath?.toUri()?.toString())
 
     @TestOnly
     fun setRootDir(dir: VirtualFile) = rootDirCache.set(dir)

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
@@ -16,7 +16,8 @@ typealias PackageId = String
  */
 data class CargoWorkspaceData(
     val packages: List<Package>,
-    val dependencies: Map<PackageId, Set<PackageId>>
+    val dependencies: Map<PackageId, Set<PackageId>>,
+    val workspaceRoot: String? = null
 ) {
     data class DependencyNode(
         val packageIndex: Int,

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
@@ -41,7 +41,7 @@ class CargoRunState(
         consoleBuilder = CargoConsoleBuilder(environment.project, scope)
 
         consoleBuilder.addFilter(RsExplainFilter())
-        val dir = cargoProject?.rootDir
+        val dir = cargoProject?.workspaceRootDir ?: cargoProject?.rootDir
         if (dir != null) {
             consoleBuilder.addFilter(RsConsoleFilter(environment.project, dir))
             consoleBuilder.addFilter(RsPanicFilter(environment.project, dir))

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -42,7 +42,13 @@ object CargoMetadata {
         /**
          * Ids of packages that are members of the cargo workspace
          */
-        val workspace_members: List<String>?
+        val workspace_members: List<String>?,
+
+        /**
+         * Path to workspace root folder. Can be null for old cargo version
+         */
+        // BACKCOMPAT: Rust 1.23: use not nullable type here
+        val workspace_root: String?
     )
 
 
@@ -193,7 +199,8 @@ object CargoMetadata {
             project.packages.mapNotNull { it.clean(fs, it.id in members) },
             project.resolve.nodes.associate { (id, dependencies) ->
                 id to dependencies.toSet()
-            }
+            },
+            project.workspace_root
         )
     }
 

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -96,10 +96,11 @@ fun Element.toXmlString() = JDOMUtil.writeElement(this)
 fun elementFromXmlString(xml: String): org.jdom.Element =
     SAXBuilder().build(xml.byteInputStream()).rootElement
 
-class CachedVirtualFile(private val url: String) {
+class CachedVirtualFile(private val url: String?) {
     private val cache = AtomicReference<VirtualFile>()
 
     operator fun getValue(thisRef: Any?, property: KProperty<*>): VirtualFile? {
+        if (url == null) return null
         val cached = cache.get()
         if (cached != null && cached.isValid) return cached
         val file = VirtualFileManager.getInstance().findFileByUrl(url)


### PR DESCRIPTION
Current beta/nightly cargo returns paths relative to workspace directory but stable returns paths relative to project dir.
This fix takes into account these changes to add links in console properly