### PR TITLE
TY: Fixes #2144 var with later initialization

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -455,7 +455,7 @@ private class RsFnInferenceContext(
             val inferredTy = explicitTy
                 ?.let { psi.expr?.inferTypeCoercableTo(it) }
                 ?: psi.expr?.inferType()
-                ?: TyUnknown
+                ?: TyInfer.TyVar()
             psi.pat?.extractBindings(explicitTy ?: resolveTypeVarsWithObligations(inferredTy))
             inferredTy == TyNever
         }

--- a/src/test/kotlin/org/rust/ide/hints/RsInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RsInlayParameterHintsProviderTest.kt
@@ -61,6 +61,14 @@ class RsInlayParameterHintsProviderTest : RsTestBase() {
         }
     """, ": S", 0, smart = false)
 
+    fun `test let stmt without expression`() = checkByText<RsLetDecl>("""
+        struct S;
+        fn main() {
+            let s/*caret*/;
+            s = S;
+        }
+    """, ": S", 0, smart = false)
+
     fun `test smart hint don't show redundant hints`() = checkNoHint<RsLetDecl>("""
         struct S;
         struct TupleStruct(f32);

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -961,4 +961,12 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
             let b: u8 = a();
         }
     """)
+
+    fun `test var lateinit`() = testExpr("""
+        fn main() {
+            let a;
+            a = 0;
+            a;
+        } //^ i32
+    """)
 }


### PR DESCRIPTION
Fixes #2144

```rust
fn main() {
    let a;
    a = 0;
    a;
} //^ i32
```