### PR TITLE
INT: Support module reexports

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/import/ImportNameIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/import/ImportNameIntention.kt
@@ -48,6 +48,7 @@ class ImportNameIntention : RsElementBaseIntentionAction<ImportNameIntention.Con
 
         val candidates = (explicitItems + reexportedItems)
             .filter { basePath != path || !(it.item is RsMod || it.item is RsModDeclItem || it.item.parent is RsMembers) }
+            .flatMap { it.withModuleReexports(project) }
             .mapNotNull { importItem -> importItem.canBeImported(pathSuperMods)?.let { ImportCandidate(importItem, it) } }
             // check that result after import can be resolved and resolved element is suitable
             // if no, don't add it in candidate list
@@ -58,23 +59,48 @@ class ImportNameIntention : RsElementBaseIntentionAction<ImportNameIntention.Con
         return Context(path, candidates)
     }
 
+
+    private fun ImportItem.withModuleReexports(
+        project: Project
+    ): Sequence<ImportItem> {
+        check(this !is ImportItem.CompositeImportItem) {
+            "`ImportItem.withModuleReexports` should be called only for `ImportItem.ExplicitItem` and `ImportItem.ReexportedItem`"
+        }
+
+        val superMods = superMods ?: return sequenceOf(this)
+        val reexportedItems = superMods
+            .asSequence()
+            // only public items can be reexported
+            .filter { it.isPublic }
+            .withIndex()
+            .flatMap { (index, ancestorMod) ->
+                val modName = ancestorMod.modName ?: return@flatMap sequenceOf<ImportItem>()
+                RsReexportIndex.findReexportsByName(project, modName)
+                    .asSequence()
+                    .mapNotNull {
+                        val item = it.path?.reference?.resolve() as? RsMod
+                        if (item != ancestorMod) return@mapNotNull null
+                        ImportItem.ReexportedItem(it, item)
+                    }
+                    .flatMap { it.withModuleReexports(project) }
+                    .map { ImportItem.CompositeImportItem(itemName, isPublic, it, superMods.subList(0, index + 1), item) }
+            }
+        return sequenceOf(this) + reexportedItems
+    }
+
     // Semantic signature of method is `ImportItem.canBeImported(mod: RsMod)`
     // but in our case `mod` is always same and `mod` needs only to get set of its super mods
     // so we pass `superMods` instead of `mod` for optimization
     private fun ImportItem.canBeImported(superMods: Set<RsMod>): ImportInfo? {
         if (item !is RsVisible) return null
 
-        val parentMod = parentMod ?: return null
-        val ourSuperMods = parentMod.superMods
+        val ourSuperMods = this.superMods ?: return null
+        val parentMod = ourSuperMods.getOrNull(0) ?: return null
 
         // try to find latest common ancestor module of `parentMod` and `mod` in module tree
         // we need to do it because we can use direct child items of any super mod with any visibility
         val lca = ourSuperMods.find { it in superMods }
         val crateRelativePath = crateRelativePath ?: return null
-        val isPublic = when (this) {
-            is ImportItem.ExplicitItem -> item.isPublic
-            is ImportItem.ReexportedItem -> true
-        }
 
         val (shouldBePublicMods, importInfo) = if (lca == null) {
             if (!isPublic) return null
@@ -173,26 +199,58 @@ class ImportNameIntention : RsElementBaseIntentionAction<ImportNameIntention.Con
 
 sealed class ImportItem(val item: RsQualifiedNamedElement) {
 
-    abstract val parentMod: RsMod?
-    abstract val crateRelativePath: String?
+    abstract val itemName: String?
+    abstract val isPublic: Boolean
+    abstract val superMods: List<RsMod>?
     abstract val containingCargoTarget: CargoWorkspace.Target?
 
+    val superModsCrateRelativePath: String? get() {
+        return superMods
+            ?.map { it.modName ?: return null }
+            ?.asReversed()
+            ?.drop(1)
+            ?.joinToString("::") ?: return null
+    }
+
+    val crateRelativePath: String? get() {
+        val name = itemName ?: return null
+        val modsRelativePath = superModsCrateRelativePath ?: return null
+        if (modsRelativePath.isEmpty()) return name
+        return "$modsRelativePath::$name"
+    }
+
+    class ExplicitItem(item: RsQualifiedNamedElement) : ImportItem(item) {
+        override val itemName: String? get() = item.name
+        override val isPublic: Boolean get() = (item as? RsVisible)?.isPublic == true
+        override val superMods: List<RsMod>? get() = (if (item is RsMod) item.`super` else item.containingMod)?.superMods
+        override val containingCargoTarget: CargoWorkspace.Target? get() = item.containingCargoTarget
+    }
+
     class ReexportedItem(
-        val useSpeck: RsUseSpeck,
+        private val useSpeck: RsUseSpeck,
         item: RsQualifiedNamedElement
     ) : ImportItem(item) {
-        override val parentMod: RsMod? get() = useSpeck.containingMod
+
+        override val itemName: String? get() = useSpeck.nameInScope
+        override val isPublic: Boolean get() = true
+        override val superMods: List<RsMod>? get() = useSpeck.containingMod.superMods
         override val containingCargoTarget: CargoWorkspace.Target? get() = useSpeck.containingCargoTarget
-        override val crateRelativePath: String? get() {
-            val modulePath = parentMod?.crateRelativePath?.removePrefix("::") ?: return null
-            val name = useSpeck.nameInScope ?: return null
-            return "$modulePath::$name"
-        }
     }
-    class ExplicitItem(item: RsQualifiedNamedElement) : ImportItem(item) {
-        override val parentMod: RsMod? get() = if (item is RsMod) item.`super` else item.containingMod
-        override val containingCargoTarget: CargoWorkspace.Target? get() = item.containingCargoTarget
-        override val crateRelativePath: String? get() = item.crateRelativePath?.removePrefix("::")
+
+    class CompositeImportItem(
+        override val itemName: String?,
+        override val isPublic: Boolean,
+        private val reexportedModItem: ImportItem,
+        private val explicitSuperMods: List<RsMod>,
+        item: RsQualifiedNamedElement
+    ) : ImportItem(item) {
+
+        override val superMods: List<RsMod>? get() {
+            val mods = ArrayList(explicitSuperMods)
+            mods += reexportedModItem.superMods.orEmpty()
+            return mods
+        }
+        override val containingCargoTarget: CargoWorkspace.Target? get() = reexportedModItem.containingCargoTarget
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/intentions/import/ui.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/import/ui.kt
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.TestOnly
 import org.rust.cargo.icons.CargoIcons
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.icons.RsIcons
-import org.rust.lang.core.psi.ext.nameInScope
 import org.rust.openapiext.isUnitTestMode
 import java.awt.BorderLayout
 import java.awt.Component
@@ -112,15 +111,13 @@ private class RsElementCellRenderer : DefaultPsiElementCellRenderer() {
         return super.getListCellRendererComponent(list, realValue, index, isSelected, cellHasFocus)
     }
 
-    override fun getElementText(element: PsiElement): String {
-        return (importItem as? ImportItem.ReexportedItem)?.useSpeck?.nameInScope ?: super.getElementText(element)
-    }
+    override fun getElementText(element: PsiElement): String = importItem?.itemName ?: super.getElementText(element)
 
     override fun getContainerText(element: PsiElement, name: String): String? {
         val importItem = importItem
         return if (importItem != null) {
             val crateName = importItem.containingCargoTarget?.normName ?: return null
-            val modulePath = importItem.parentMod?.crateRelativePath?.removePrefix("::") ?: return null
+            val modulePath = importItem.superModsCrateRelativePath ?: return null
             "($crateName::$modulePath)"
         } else {
             super.getContainerText(element, name)

--- a/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionStdTest.kt
@@ -6,9 +6,8 @@
 package org.rust.ide.intentions.import
 
 import com.intellij.testFramework.LightProjectDescriptor
-import org.rust.ide.intentions.RsIntentionTestBase
 
-class ImportNameIntentionStdTest : RsIntentionTestBase(ImportNameIntention()) {
+class ImportNameIntentionStdTest : ImportNameIntentionTestBase() {
 
     override fun getProjectDescriptor(): LightProjectDescriptor = WithStdlibAndDependencyRustProjectDescriptor
 
@@ -81,4 +80,12 @@ class ImportNameIntentionStdTest : RsIntentionTestBase(ImportNameIntention()) {
             let mutex = Mutex/*caret*/::new(Vec::new());
         }
     """, ImportNameIntention.Testmarks.autoInjectedCrate)
+
+    fun `test module reexport in stdlib`() = doAvailableTestWithMultipleChoice("""
+        fn foo<T: Hash/*caret*/>(t: T) {}
+    """, setOf("core::hash::Hash", "std::hash::Hash"), "std::hash::Hash", """
+        use std::hash::Hash;
+
+        fn foo<T: Hash/*caret*/>(t: T) {}
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionTestBase.kt
@@ -1,0 +1,27 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions.import
+
+import org.intellij.lang.annotations.Language
+import org.rust.ide.intentions.RsIntentionTestBase
+
+abstract class ImportNameIntentionTestBase : RsIntentionTestBase(ImportNameIntention()) {
+
+    protected fun doAvailableTestWithMultipleChoice(@Language("Rust") before: String,
+                                                    expectedElements: Set<String>,
+                                                    choice: String,
+                                                    @Language("Rust") after: String) {
+        withMockImportItemUi(object : ImportItemUi {
+            override fun chooseItem(items: List<ImportCandidate>, callback: (ImportCandidate) -> Unit) {
+                val actualItems = items.mapTo(HashSet()) { it.info.usePath }
+                assertEquals(expectedElements, actualItems)
+                val selectedValue = items.find { it.info.usePath == choice }
+                    ?: error("Can't find `$choice` in `$actualItems`")
+                callback(selectedValue)
+            }
+        }) { doAvailableTest(before, after) }
+    }
+}


### PR DESCRIPTION
These changes allow collecting items which are reachable via module reexports
```rust
mod foo {
    mod bar {
        pub mod baz {
            pub struct FooBar;
        }
    }

    pub use self::bar::baz; // <- reexported module
}

fn main() {
    let x = FooBar;  // <- now auto import can find correct import path `foo::baz::FooBar`
}
```

Note: these changes don't intent to support module reexports with alias and reexports with wildcard