### PR TITLE
INT: Auto import improvements

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -585,7 +585,8 @@ EnumVariant ::= OuterAttr* identifier VariantArgs? {
   implements = [ "org.rust.lang.core.psi.ext.RsQualifiedNamedElement"
                  "org.rust.lang.core.psi.ext.RsNameIdentifierOwner"
                  "org.rust.lang.core.psi.ext.RsOuterAttributeOwner"
-                 "org.rust.lang.core.psi.ext.RsFieldsOwner" ]
+                 "org.rust.lang.core.psi.ext.RsFieldsOwner"
+                 "org.rust.lang.core.psi.ext.RsVisible" ]
   mixin = "org.rust.lang.core.psi.ext.RsEnumVariantImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsEnumVariantStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"

--- a/src/main/kotlin/org/rust/ide/intentions/import/ImportNameIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/import/ImportNameIntention.kt
@@ -219,19 +219,20 @@ sealed class ImportItem(val item: RsQualifiedNamedElement) {
     abstract val superMods: List<RsMod>?
     abstract val containingCargoTarget: CargoWorkspace.Target?
 
-    val superModsCrateRelativePath: String? get() {
-        return superMods
+    val parentCrateRelativePath: String? get() {
+        val path = superMods
             ?.map { it.modName ?: return null }
             ?.asReversed()
             ?.drop(1)
             ?.joinToString("::") ?: return null
+        return if (item is RsEnumVariant) item.parentEnum.name?.let { "$path::$it" } else path
     }
 
     val crateRelativePath: String? get() {
         val name = itemName ?: return null
-        val modsRelativePath = superModsCrateRelativePath ?: return null
-        if (modsRelativePath.isEmpty()) return name
-        return "$modsRelativePath::$name"
+        val parentPath = parentCrateRelativePath ?: return null
+        if (parentPath.isEmpty()) return name
+        return "$parentPath::$name"
     }
 
     class ExplicitItem(item: RsQualifiedNamedElement) : ImportItem(item) {

--- a/src/main/kotlin/org/rust/ide/intentions/import/ImportNameIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/import/ImportNameIntention.kt
@@ -286,7 +286,7 @@ sealed class ImportInfo {
 
 data class ImportCandidate(val importItem: ImportItem, val info: ImportInfo)
 
-private fun RsItemsOwner.firstItem(): RsElement = itemsAndMacros.first()
+private fun RsItemsOwner.firstItem(): RsElement = itemsAndMacros.first { it !is RsInnerAttr }
 
 private val CargoWorkspace.Target.isStd: Boolean
     get() = pkg.origin == PackageOrigin.STDLIB && normName == AutoInjectedCrates.std

--- a/src/main/kotlin/org/rust/ide/intentions/import/ui.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/import/ui.kt
@@ -117,8 +117,8 @@ private class RsElementCellRenderer : DefaultPsiElementCellRenderer() {
         val importItem = importItem
         return if (importItem != null) {
             val crateName = importItem.containingCargoTarget?.normName ?: return null
-            val modulePath = importItem.superModsCrateRelativePath ?: return null
-            "($crateName::$modulePath)"
+            val parentPath = importItem.parentCrateRelativePath ?: return null
+            "($crateName::$parentPath)"
         } else {
             super.getContainerText(element, name)
         }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -63,7 +63,7 @@ class RsPsiFactory(private val project: Project) {
         createExpressionOfType("unsafe { $body }")
 
     fun tryCreatePath(text: String): RsPath? {
-        val path = createFromText<RsPathExpr>("const a = $text;")?.path ?: return null
+        val path = createFromText<RsPath>("fn foo(t: $text) {}") ?: return null
         if (path.text != text) return null
         return path
     }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumVariant.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumVariant.kt
@@ -13,13 +13,16 @@ import org.rust.lang.core.psi.RsEnumVariant
 import org.rust.lang.core.stubs.RsEnumVariantStub
 import javax.swing.Icon
 
-val RsEnumVariant.parentEnum: RsEnumItem get() = parent?.parent as RsEnumItem
+val RsEnumVariant.parentEnum: RsEnumItem
+    get() = stub?.getParentStubOfType(RsEnumItem::class.java) ?: parent?.parent as RsEnumItem
 
 abstract class RsEnumVariantImplMixin : RsStubbedNamedElementImpl<RsEnumVariantStub>, RsEnumVariant {
     constructor(node: ASTNode) : super(node)
     constructor(stub: RsEnumVariantStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
     override fun getIcon(flags: Int): Icon = RsIcons.ENUM_VARIANT
+
+    override val isPublic: Boolean get() = parentEnum.isPublic
 
     override val crateRelativePath: String? get() {
         val variantName = name ?: return null

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -33,7 +33,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 123
+        override fun getStubVersion(): Int = 124
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)
@@ -353,6 +353,10 @@ class RsEnumVariantStub(
 
         override fun createStub(psi: RsEnumVariant, parentStub: StubElement<*>?) =
             RsEnumVariantStub(parentStub, this, psi.name)
+
+        override fun indexStub(stub: RsEnumVariantStub, sink: IndexSink) {
+            sink.indexEnumVariant(stub)
+        }
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
@@ -29,6 +29,10 @@ fun IndexSink.indexEnumItem(stub: RsEnumItemStub) {
     indexGotoClass(stub)
 }
 
+fun IndexSink.indexEnumVariant(stub: RsEnumVariantStub) {
+    indexNamedStub(stub)
+}
+
 fun IndexSink.indexModDeclItem(stub: RsModDeclItemStub) {
     indexNamedStub(stub)
     RsModulesIndex.index(stub, this)

--- a/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionStdTest.kt
@@ -101,6 +101,32 @@ class ImportNameIntentionStdTest : ImportNameIntentionTestBase() {
         }
     """, ImportNameIntention.Testmarks.autoInjectedCrate)
 
+    fun `test module reexport`() = doAvailableTestWithFileTree("""
+        //- dep-lib/lib.rs
+        pub mod foo {
+            mod bar {
+                pub mod baz {
+                    pub struct FooBar;
+                }
+            }
+
+            pub use self::bar::baz;
+        }
+
+        //- main.rs
+        fn main() {
+            let x = FooBar/*caret*/;
+        }
+    """, """
+        extern crate dep_lib_target;
+
+        use dep_lib_target::foo::baz::FooBar;
+
+        fn main() {
+            let x = FooBar/*caret*/;
+        }
+    """)
+
     fun `test module reexport in stdlib`() = doAvailableTestWithMultipleChoice("""
         fn foo<T: Hash/*caret*/>(t: T) {}
     """, setOf("core::hash::Hash", "std::hash::Hash"), "std::hash::Hash", """

--- a/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionStdTest.kt
@@ -69,6 +69,26 @@ class ImportNameIntentionStdTest : ImportNameIntentionTestBase() {
         fn foo(t: Bar/*caret*/) {}
     """)
 
+    fun `test insert extern crate item after inner attributes`() = doAvailableTestWithFileTree("""
+        //- main.rs
+        #![allow(non_snake_case)]
+
+        fn foo(t: Bar/*caret*/) {}
+
+        //- dep-lib/lib.rs
+        pub mod foo {
+            pub struct Bar;
+        }
+    """, """
+        #![allow(non_snake_case)]
+
+        extern crate dep_lib_target;
+
+        use dep_lib_target::foo::Bar;
+
+        fn foo(t: Bar/*caret*/) {}
+    """)
+
     fun `test import reexported item from stdlib`() = doAvailableTest("""
         fn main() {
             let mutex = Mutex/*caret*/::new(Vec::new());

--- a/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionTest.kt
@@ -93,6 +93,22 @@ class ImportNameIntentionTest : ImportNameIntentionTestBase() {
         }
     """)
 
+    fun `test import generic item`() = doAvailableTest("""
+        mod foo {
+            pub struct Foo<T>(T);
+        }
+
+        fn f<T>(foo: Foo/*caret*/<T>) {}
+    """, """
+        use foo::Foo;
+
+        mod foo {
+            pub struct Foo<T>(T);
+        }
+
+        fn f<T>(foo: Foo/*caret*/<T>) {}
+    """)
+
     fun `test import module`() = doAvailableTest("""
         mod foo {
             pub mod bar {

--- a/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionTest.kt
@@ -142,6 +142,30 @@ class ImportNameIntentionTest : ImportNameIntentionTestBase() {
         }
     """)
 
+    fun `test insert use item after inner attributes`() = doAvailableTest("""
+        #![allow(non_snake_case)]
+
+        mod foo {
+            pub struct Foo;
+        }
+
+        fn main() {
+            let f = Foo/*caret*/;
+        }
+    """, """
+        #![allow(non_snake_case)]
+
+        use foo::Foo;
+
+        mod foo {
+            pub struct Foo;
+        }
+
+        fn main() {
+            let f = Foo/*caret*/;
+        }
+    """)
+
     fun `test import item from nested module`() = doAvailableTest("""
         mod foo {
             pub mod bar {

--- a/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionTest.kt
@@ -27,7 +27,7 @@ class ImportNameIntentionTest : ImportNameIntentionTestBase() {
         }
     """)
 
-    fun `test import enum variant`() = doAvailableTest("""
+    fun `test import enum variant 1`() = doAvailableTest("""
         mod foo {
             pub enum Foo { A }
         }
@@ -44,6 +44,26 @@ class ImportNameIntentionTest : ImportNameIntentionTestBase() {
 
         fn main() {
             Foo::A/*caret*/;
+        }
+    """)
+
+    fun `test import enum variant 2`() = doAvailableTest("""
+        mod foo {
+            pub enum Foo { A }
+        }
+
+        fn main() {
+            let a = A/*caret*/;
+        }
+    """, """
+        use foo::Foo::A;
+
+        mod foo {
+            pub enum Foo { A }
+        }
+
+        fn main() {
+            let a = A/*caret*/;
         }
     """)
 


### PR DESCRIPTION
* Take into account inner attributes of module (fixes #2299)
* Fix import of generic items
* Allow importing enum variants
