### PR TITLE
ANN: add quick fix on String type mismatch

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConverToStringFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConverToStringFix.kt
@@ -10,21 +10,21 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import org.rust.ide.presentation.tyToStringWithoutTypeArgs
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsPsiFactory
-import org.rust.lang.core.types.ty.Ty
 
 /**
- * For the given `expr` converts it to the type `ty` with `ty::from(expr)`
+ * For the given `expr` adds `to_string()` call. Note the fix doesn't attempt to check if adding the function call
+ * will produce a valid expression.
  */
-class ConvertToTyUsingFromTraitFix(expr: PsiElement, val ty: Ty) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
+class ConverToStringFix(expr: PsiElement) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
+
     override fun getFamilyName(): String = "Convert to type"
 
-    override fun getText(): String = "Convert to $ty using `From` trait"
+    override fun getText(): String = "Convert to String using `ToString` trait"
 
     override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
         if (startElement !is RsExpr) return
-        startElement.replace(RsPsiFactory(project).createAssocFunctionCall(tyToStringWithoutTypeArgs(ty), "from", listOf(startElement)))
+        startElement.replace(RsPsiFactory(project).createNoArgsMethodCall(startElement, "to_string"))
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/StdKnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/StdKnownItems.kt
@@ -86,6 +86,9 @@ class StdKnownItems private constructor(private val absolutePathResolver: (Strin
     fun findToOwnedTrait(): RsTraitItem? =
         findCoreItem("borrow::ToOwned") as? RsTraitItem
 
+    fun findToStringTrait(): RsTraitItem? =
+        findCoreItem("string::ToString") as? RsTraitItem
+
     companion object {
         private val stdKnownItemsCache =
             ProjectCache<Pair<CargoWorkspace, String>, Optional<RsNamedElement>>("stdKnownItemsCache")

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ConverToStringFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ConverToStringFixTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.rust.ide.inspections.RsExperimentalChecksInspection
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class ConverToStringFixTest : RsInspectionsTestBase(RsExperimentalChecksInspection()) {
+    override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
+
+    fun `test str to_string`() = checkFixByText("Convert to String using `ToString` trait", """
+            fn main () {
+                let _: String = <error>"Hello World!"<caret></error>;
+            }
+            """, """
+            fn main () {
+                let _: String = "Hello World!".to_string();
+            }
+            """)
+
+    fun `test {integer} to_string`() = checkFixByText("Convert to String using `ToString` trait", """
+            fn main () {
+                let _: String = <error>42<caret></error>;
+            }
+            """, """
+            fn main () {
+                let _: String = 42.to_string();
+            }
+            """)
+
+    fun `test f32 to_string`() = checkFixByText("Convert to String using `ToString` trait", """
+            fn main () {
+                let _: String = <error>42f32<caret></error>;
+            }
+            """, """
+            fn main () {
+                let _: String = 42f32.to_string();
+            }
+            """)
+
+    fun `test struct to_string`() = checkFixByText ("Convert to String using `ToString` trait", """
+        use std::fmt;
+
+        struct A;
+
+        impl fmt::Display for A {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { Ok(()) }
+        }
+
+        fn main () {
+            let s: String = <error>A<caret></error>;
+        }
+    """, """
+        use std::fmt;
+
+        struct A;
+
+        impl fmt::Display for A {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { Ok(()) }
+        }
+
+        fn main () {
+            let s: String = A.to_string();
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFixTest.kt
@@ -11,7 +11,7 @@ import org.rust.ide.inspections.RsInspectionsTestBase
 class ConvertToTyUsingFromTraitFixTest : RsInspectionsTestBase(RsExperimentalChecksInspection()) {
     override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
 
-    fun `test B from A when impl From A for B is available`() = checkFixByText("Convert to type B using `From` trait", """
+    fun `test B from A when impl From A for B is available`() = checkFixByText("Convert to B using `From` trait", """
         struct A{}
         struct B{}
 
@@ -31,7 +31,7 @@ class ConvertToTyUsingFromTraitFixTest : RsInspectionsTestBase(RsExperimentalChe
         }
     """)
 
-    fun `test no fix when impl From A for B is not available`() = checkFixIsUnavailable("Convert to type B using `From` trait", """
+    fun `test no fix when impl From A for B is not available`() = checkFixIsUnavailable("Convert to B using `From` trait", """
         struct A{}
         struct B{}
         struct C{}
@@ -44,7 +44,7 @@ class ConvertToTyUsingFromTraitFixTest : RsInspectionsTestBase(RsExperimentalChe
     """)
 
 
-    fun `test From impl provided by std lib`() = checkFixByText("Convert to type u32 using `From` trait", """
+    fun `test From impl provided by std lib`() = checkFixByText("Convert to u32 using `From` trait", """
         fn main () {
             let x: u32 = <error>'X'<caret></error>;
         }
@@ -54,7 +54,7 @@ class ConvertToTyUsingFromTraitFixTest : RsInspectionsTestBase(RsExperimentalChe
         }
     """)
 
-    fun `test From impl for generic type`() = checkFixByText ("Convert to type Vec<u8> using `From` trait", """
+    fun `test From impl for generic type`() = checkFixByText ("Convert to Vec<u8> using `From` trait", """
         fn main () {
             let v: Vec<u8> = <error>String::new()<caret></error>;
         }


### PR DESCRIPTION
This commit adds quick-fix for the types mismatch when String is
expected type and impl `ToString` for actual type exists.
This fulfills part of the 2nd bullet-point of the issue:
https://github.com/intellij-rust/intellij-rust/issues/1730

Also unifying naming of couple of Fixes.
<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
