### PR TITLE
TY: Support associated type bindings

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -179,7 +179,14 @@ ColonTypeArgumentList ::= '::' TypeArgumentListImpl { elementType = TypeArgument
 private TypeArgumentListImpl ::= '<' !'=' ( <<list_element Lifetime>>*
                                             <<list_element (!(identifier '=') TypeReference)>>*
                                             <<list_element AssocTypeBinding>>*) '>' { pin = 2 }
-AssocTypeBinding ::= identifier '=' TypeReference
+AssocTypeBinding ::= identifier '=' TypeReference {
+  pin = 2
+  implements = [ "org.rust.lang.core.psi.ext.RsNameIdentifierOwner"
+                 "org.rust.lang.core.psi.ext.RsReferenceElement" ]
+  mixin = "org.rust.lang.core.psi.ext.RsAssocTypeBindingMixin"
+  stubClass = "org.rust.lang.core.stubs.RsAssocTypeBindingStub"
+  elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
+}
 
 
 // Paths for expressions:

--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -223,7 +223,7 @@ private fun PsiElement.generateDocumentation(buffer: StringBuilder, prefix: Stri
         is RsPath -> generatePathDocumentation(this, buffer)
         is RsAssocTypeBinding -> {
             buffer += identifier.text
-            typeReference.generateDocumentation(buffer, " = ")
+            typeReference?.generateDocumentation(buffer, " = ")
         }
         is RsTraitRef -> path.generateDocumentation(buffer)
         is RsLifetimeParamBounds -> lifetimeList.joinTo(buffer, " + ", ": ") { generateDocumentation(it) }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAssocTypeBinding.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAssocTypeBinding.kt
@@ -1,0 +1,34 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi.ext
+
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.IStubElementType
+import org.rust.lang.core.psi.RsAssocTypeBinding
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.resolve.ref.RsAssocTypeBindingReferenceImpl
+import org.rust.lang.core.resolve.ref.RsReference
+import org.rust.lang.core.stubs.RsAssocTypeBindingStub
+
+// Current grammar allows to write assoc type bindings in method calls, e.g.
+// `a.foo::<Item = i32>()`, so it's nullable
+val RsAssocTypeBinding.parentPath: RsPath?
+    get() = ancestorStrict()
+
+abstract class RsAssocTypeBindingMixin : RsStubbedNamedElementImpl<RsAssocTypeBindingStub>,
+                                         RsAssocTypeBinding {
+
+    constructor(node: ASTNode) : super(node)
+
+    constructor(stub: RsAssocTypeBindingStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
+
+    override fun getReference(): RsReference = RsAssocTypeBindingReferenceImpl(this)
+
+    override val referenceNameElement: PsiElement get() = identifier
+
+    override val referenceName: String get() = stub?.name ?: referenceNameElement.text
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -329,6 +329,7 @@ class ImplLookup(
             }
             is SelectionCandidate.TypeParameter -> {
                 ctx.combinePairs(zipValues(candidate.bound.subst, ref.trait.subst))
+                ctx.combinePairs(zipValues(candidate.bound.assoc, ref.trait.assoc))
                 Selection(candidate.bound.element, emptyList())
             }
         }
@@ -415,12 +416,15 @@ class ImplLookup(
     )
 
     private fun lookupAssociatedType(selfTy: Ty, res: Selection, assocType: RsTypeAlias): Ty? {
-        if (selfTy is TyTypeParameter) {
-            return lookupAssocTypeInBounds(selfTy.getTraitBoundsTransitively(), res.impl, assocType)
+        return when (selfTy) {
+            is TyTypeParameter -> lookupAssocTypeInBounds(selfTy.getTraitBoundsTransitively(), res.impl, assocType)
+            is TyTraitObject -> selfTy.trait.assoc[assocType]
+            else -> {
+                val ty = lookupAssocTypeInSelection(res, assocType)
+                    ?: lookupAssocTypeInBounds(getHardcodedImpls(selfTy), res.impl, assocType)
+                ty?.substitute(mapOf(TyTypeParameter.self() to selfTy))
+            }
         }
-        val ty = lookupAssocTypeInSelection(res, assocType) ?:
-            lookupAssocTypeInBounds(getHardcodedImpls(selfTy), res.impl, assocType)
-        return ty?.substitute(mapOf(TyTypeParameter.self() to selfTy))
     }
 
     private fun lookupAssocTypeInSelection(selection: Selection, assoc: RsTypeAlias): Ty? =

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -419,6 +419,7 @@ class ImplLookup(
         return when (selfTy) {
             is TyTypeParameter -> lookupAssocTypeInBounds(selfTy.getTraitBoundsTransitively(), res.impl, assocType)
             is TyTraitObject -> selfTy.trait.assoc[assocType]
+            is TyAnon -> lookupAssocTypeInBounds(selfTy.getTraitBoundsTransitively(), res.impl, assocType)
             else -> {
                 val ty = lookupAssocTypeInSelection(res, assocType)
                     ?: lookupAssocTypeInBounds(getHardcodedImpls(selfTy), res.impl, assocType)

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsAssocTypeBindingReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsAssocTypeBindingReferenceImpl.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve.ref
+
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RsAssocTypeBinding
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.resolve.collectCompletionVariants
+import org.rust.lang.core.resolve.collectResolveVariants
+import org.rust.lang.core.resolve.processAssocTypeVariants
+
+class RsAssocTypeBindingReferenceImpl(
+    element: RsAssocTypeBinding
+) : RsReferenceCached<RsAssocTypeBinding>(element) {
+    override val RsAssocTypeBinding.referenceAnchor: PsiElement
+        get() = referenceNameElement
+
+    override fun resolveInner(): List<RsElement> =
+        collectResolveVariants(element.referenceName) { processAssocTypeVariants(element, it) }
+
+    override fun getVariants(): Array<out Any> =
+        collectCompletionVariants { processAssocTypeVariants(element, it) }
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsAssocTypeBindingReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsAssocTypeBindingReferenceImpl.kt
@@ -7,6 +7,8 @@ package org.rust.lang.core.resolve.ref
 
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsAssocTypeBinding
+import org.rust.lang.core.psi.RsTraitItem
+import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.resolve.collectCompletionVariants
 import org.rust.lang.core.resolve.collectResolveVariants

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -33,7 +33,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 124
+        override fun getStubVersion(): Int = 125
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)
@@ -120,6 +120,7 @@ fun factory(name: String): RsStubElementType<*, *> = when (name) {
     "TYPE_PARAMETER" -> RsTypeParameterStub.Type
     "LIFETIME_PARAMETER" -> RsLifetimeParameterStub.Type
     "TYPE_ARGUMENT_LIST" -> RsPlaceholderStub.Type("TYPE_ARGUMENT_LIST", ::RsTypeArgumentListImpl)
+    "ASSOC_TYPE_BINDING" -> RsAssocTypeBindingStub.Type
 
     "TYPE_PARAM_BOUNDS" -> RsPlaceholderStub.Type("TYPE_PARAM_BOUNDS", ::RsTypeParamBoundsImpl)
     "POLYBOUND" -> RsPlaceholderStub.Type("POLYBOUND", ::RsPolyboundImpl)
@@ -1168,6 +1169,31 @@ private fun RsStubLiteralType?.serialize(dataStream: StubOutputStream) {
         }
         is RsStubLiteralType.Integer -> dataStream.writeByte(kind?.ordinal ?: -1)
         is RsStubLiteralType.Float -> dataStream.writeByte(kind?.ordinal ?: -1)
+    }
+}
+
+class RsAssocTypeBindingStub(
+    parent: StubElement<*>?, elementType: IStubElementType<*, *>,
+    override val name: String?
+) : StubBase<RsAssocTypeBinding>(parent, elementType),
+    RsNamedStub {
+
+    object Type : RsStubElementType<RsAssocTypeBindingStub, RsAssocTypeBinding>("ASSOC_TYPE_BINDING") {
+        override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
+            RsAssocTypeBindingStub(parentStub, this,
+                dataStream.readNameAsString()
+            )
+
+        override fun serialize(stub: RsAssocTypeBindingStub, dataStream: StubOutputStream) =
+            with(dataStream) {
+                writeName(stub.name)
+            }
+
+        override fun createPsi(stub: RsAssocTypeBindingStub): RsAssocTypeBinding =
+            RsAssocTypeBindingImpl(stub, this)
+
+        override fun createStub(psi: RsAssocTypeBinding, parentStub: StubElement<*>?) =
+            RsAssocTypeBindingStub(parentStub, this, psi.identifier.text)
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -26,12 +26,13 @@ fun inferTypeReferenceType(ref: RsTypeReference): Ty {
 
             val primitiveType = TyPrimitive.fromPath(path)
             if (primitiveType != null) return primitiveType
-            val (target, subst) = path.reference.advancedResolve() ?: return TyUnknown
+            val boundElement = path.reference.advancedResolve() ?: return TyUnknown
+            val (target, subst) = boundElement
 
-            if (target is RsTraitOrImpl && type.isCself) {
-                TyTypeParameter.self(target)
-            } else {
-                (target as? RsTypeDeclarationElement ?: return TyUnknown).declaredType.substitute(subst)
+            when {
+                target is RsTraitOrImpl && type.isCself -> TyTypeParameter.self(target)
+                target is RsTraitItem -> TyTraitObject(boundElement.downcast()!!)
+                else -> (target as? RsTypeDeclarationElement ?: return TyUnknown).declaredType.substitute(subst)
             }
         }
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -569,6 +569,7 @@ private class RsFnInferenceContext(
     private fun processStatement(psi: RsStmt): Boolean = when (psi) {
         is RsLetDecl -> {
             val explicitTy = psi.typeReference?.type
+                ?.let { normalizeAssociatedTypesIn(it) }
             val inferredTy = explicitTy
                 ?.let { psi.expr?.inferTypeCoercableTo(it) }
                 ?: psi.expr?.inferType()

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -557,4 +557,20 @@ class RsCompletionTest : RsCompletionTestBase() {
             fn main() { private_m/*caret*/ }
         }
     """)
+
+    fun `test explicit associated type binding`() = doSingleCompletion("""
+        trait Tr { type Item; }
+        type T = Tr<It/*caret*/=u8>;
+    """, """
+        trait Tr { type Item; }
+        type T = Tr<Item/*caret*/=u8>;
+    """)
+
+    fun `test possible associated type binding`() = doSingleCompletion("""
+        trait Tr { type Item; }
+        type T = Tr<It/*caret*/>;
+    """, """
+        trait Tr { type Item; }
+        type T = Tr<Item/*caret*/>;
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -952,4 +952,36 @@ class RsResolveTest : RsResolveTestBase() {
             }
         }
     """)
+
+    fun `test associated type binding`() = checkByCode("""
+        trait Tr {
+            type Item;
+        }      //X
+        type T = Tr<Item=u8>;
+                  //^
+    """)
+
+    fun `test inherited associated type binding`() = checkByCode("""
+        trait Tr1 {
+            type Item;
+        }      //X
+        trait Tr2: Tr1 {}
+        type T = Tr2<Item=u8>;
+                   //^
+    """)
+
+    fun `test associated type binding in (wrong) non-type context (fn call)`() = checkByCode("""
+        fn foo() {}
+        fn main () {
+            foo::<Item=u8>();
+        }       //^ unresolved
+    """)
+
+    fun `test associated type binding in (wrong) non-type context (method call)`() = checkByCode("""
+        struct S;
+        impl S { fn foo(&self) {} }
+        fn main () {
+            S.foo::<Item=u8>();
+        }         //^ unresolved
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1346,6 +1346,20 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ u8
     """)
 
+    fun `test aliased associated type binding in trait object`() = testExpr("""
+        trait Tr {
+            type Item;
+            fn foo(&self) -> Self::Item;
+        }
+
+        type TrAlias<T> = Tr<Item=T>;
+
+        fn foo(a: &TrAlias<u8>) {
+            let b = a.foo();
+            b;
+        } //^ u8
+    """)
+
     fun `test associated type binding in 'impl Trait'`() = testExpr("""
         trait Tr {
             type Item;

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1333,4 +1333,16 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ u8
     """)
+
+    fun `test associated type binding in trait object`() = testExpr("""
+        trait Tr {
+            type Item;
+            fn foo(&self) -> Self::Item;
+        }
+
+        fn foo(a: &Tr<Item=u8>) {
+            let b = a.foo();
+            b;
+        } //^ u8
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1345,4 +1345,17 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             b;
         } //^ u8
     """)
+
+    fun `test associated type binding in 'impl Trait'`() = testExpr("""
+        trait Tr {
+            type Item;
+            fn foo(&self) -> Self::Item;
+        }
+
+        fn new() -> impl Tr<Item=u8> { unimplemented!() }
+        fn main() {
+            let b = new().foo();
+            b;
+        } //^ u8
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1324,4 +1324,13 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             }
         }
     """)
+
+    fun `test associated type binding in trait bound`() = testExpr("""
+        trait Tr { type Item; }
+
+        fn foo<B: Tr<Item=u8>>(_: B) {
+            let a: B::Item = 0;
+            a;
+        } //^ u8
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -231,28 +231,43 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
 
     fun `test generic trait object`() = testType("""
         trait Trait<A> {}
-
         fn foo(_: &Trait<u8>) { unimplemented!() }
                   //^ Trait<u8>
     """)
 
     fun `test generic 'dyn Trait' trait object`() = testType("""
         trait Trait<A> {}
-
         fn foo(_: &dyn Trait<u8>) { unimplemented!() }
                   //^ Trait<u8>
     """)
 
-    fun `test impl Trait`() = testType("""
-        trait Trait { }
+    fun `test trait object with bound associated type`() = testType("""
+        trait Trait { type Item; }
+        fn foo(_: &Trait<Item=u8>) { unimplemented!() }
+                  //^ Trait<Item=u8>
+    """)
 
+    fun `test impl Trait`() = testType("""
+        trait Trait {}
         fn foo() -> impl Trait { unimplemented!() }
                   //^ impl Trait
     """)
 
+    fun `test generic impl Trait`() = testType("""
+        trait Trait<T> {}
+        fn foo() -> impl Trait<u8> { unimplemented!() }
+                  //^ impl Trait<u8>
+    """)
+
+    fun `test 'impl Trait' with bound associated type`() = testType("""
+        trait Trait { type Item; }
+        fn foo() -> impl Trait<Item=u8> { unimplemented!() }
+                  //^ impl Trait<Item=u8>
+    """)
+
     fun `test impl Trait1+Trait2`() = testType("""
-        trait Trait1 { }
-        trait Trait2 { }
+        trait Trait1 {}
+        trait Trait2 {}
 
         fn foo() -> impl Trait1+Trait2 { unimplemented!() }
                   //^ impl Trait1+Trait2


### PR DESCRIPTION
We now support this stuff:
```rust
        trait Tr { type Item; }

        fn foo<B: Tr<Item=u8>>(_: B) {
            let a: B::Item = 0;
            a;
        } //^ u8
```

And it's even don't affect performance because of #2287 