### PR TITLE
ANN: add quick fix on str/String type mismatch

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToStrFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToStrFix.kt
@@ -1,0 +1,45 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsPsiFactory
+
+/**
+ * For the given `expr` adds `as_str()`/`as_mut_str()` method call. Note the fix doesn't attempt to verify that the type
+ * of `expr` is `String` and so doesn't check if adding the function call will produce a valid expression.
+ */
+abstract class ConvertToStrFix(expr: PsiElement) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
+
+    override fun getFamilyName(): String = "Convert to type"
+
+    override fun getText(): String = "Convert to ${getStrTypeName()} using `${getStrMethodName()}` method"
+
+    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
+        if (startElement !is RsExpr) return
+        startElement.replace(RsPsiFactory(project).createNoArgsMethodCall(startElement, getStrMethodName()))
+    }
+
+    protected abstract fun getStrMethodName(): String
+    protected abstract fun getStrTypeName(): String
+}
+
+class ConvertToImmutableStrFix(expr: PsiElement) : ConvertToStrFix(expr) {
+    override fun getStrMethodName(): String = "as_str"
+
+    override fun getStrTypeName(): String = "&str"
+}
+
+class ConvertToMutStrFix(expr: PsiElement) : ConvertToStrFix(expr) {
+    override fun getStrMethodName(): String = "as_mut_str"
+
+    override fun getStrTypeName(): String = "&mut str"
+}

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToStringFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToStringFix.kt
@@ -17,7 +17,7 @@ import org.rust.lang.core.psi.RsPsiFactory
  * For the given `expr` adds `to_string()` call. Note the fix doesn't attempt to check if adding the function call
  * will produce a valid expression.
  */
-class ConverToStringFix(expr: PsiElement) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
+class ConvertToStringFix(expr: PsiElement) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
 
     override fun getFamilyName(): String = "Convert to type"
 

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToStrFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToStrFixTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.rust.ide.inspections.RsExperimentalChecksInspection
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class ConvertToStrFixTest : RsInspectionsTestBase(RsExperimentalChecksInspection()) {
+    override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
+
+    fun `test String to &str`() = checkFixByText("Convert to &str using `as_str` method", """
+            fn main () {
+                let _: &str = <error>String::from("Hello World!")<caret></error>;
+            }
+            """, """
+            fn main () {
+                let _: &str = String::from("Hello World!").as_str();
+            }
+            """)
+
+    fun `test String to &mut str`() = checkFixByText("Convert to &mut str using `as_mut_str` method", """
+            fn main () {
+                let _: &mut str = <error>String::from("Hello World!")<caret></error>;
+            }
+            """, """
+            fn main () {
+                let _: &mut str = String::from("Hello World!").as_mut_str();
+            }
+            """)
+}

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToStringFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToStringFixTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.annotator.fixes
 import org.rust.ide.inspections.RsExperimentalChecksInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 
-class ConverToStringFixTest : RsInspectionsTestBase(RsExperimentalChecksInspection()) {
+class ConvertToStringFixTest : RsInspectionsTestBase(RsExperimentalChecksInspection()) {
     override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
 
     fun `test str to_string`() = checkFixByText("Convert to String using `ToString` trait", """


### PR DESCRIPTION
This commit adds quick-fix for the types mismatch when `&str`
or `&mut str` is expected type and `String` is actual type.
This fulfills part of the 2nd bullet-point of the issue:
https://github.com/intellij-rust/intellij-rust/issues/1730

Also fixing the name of ConvertToStringFix class.

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
