### PR TITLE
ACT: Implement build action for small IDEs

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt
@@ -14,7 +14,6 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.Label
 import com.intellij.ui.layout.panel
-import com.intellij.util.PlatformUtils
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.settings.rustSettings
@@ -51,11 +50,9 @@ class RustProjectConfigurable(
 
     override fun createComponent(): JComponent = panel {
         rustProjectSettings.attachTo(this)
-        row(label = Label("Watch Cargo.toml:")) { autoUpdateEnabledCheckbox() }
-        if (PlatformUtils.isIntelliJ()) {
-            row("Use cargo check when build project:") { useCargoCheckForBuildCheckbox() }
-        }
-        row(label = Label("Use cargo check to analyze code:")) { useCargoCheckAnnotatorCheckbox() }
+        row(label = "Watch Cargo.toml:") { autoUpdateEnabledCheckbox() }
+        row(label = "Use cargo check when build project:") { useCargoCheckForBuildCheckbox() }
+        row(label = "Use cargo check to analyze code:") { useCargoCheckAnnotatorCheckbox() }
 
         var first = true
         for (option in hintProvider.supportedOptions) {

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsProjectTasksRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsProjectTasksRunner.kt
@@ -6,29 +6,14 @@
 package org.rust.cargo.runconfig
 
 import com.intellij.execution.Executor
-import com.intellij.execution.ExecutorRegistry
-import com.intellij.execution.ProgramRunnerUtil
-import com.intellij.execution.RunManager
-import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.project.Project
 import com.intellij.task.*
-import org.rust.cargo.project.model.cargoProjects
-import org.rust.cargo.project.settings.rustSettings
-import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.util.cargoProjectRoot
 
 class RsProjectTasksRunner : ProjectTaskRunner() {
     override fun run(project: Project, context: ProjectTaskContext, callback: ProjectTaskNotification?, tasks: MutableCollection<out ProjectTask>) {
-        val command = if (project.rustSettings.useCargoCheckForBuild) "check" else "build"
-
-        for (cargoProject in project.cargoProjects.allProjects) {
-            val cmd = CargoCommandLine.forProject(cargoProject, command, listOf("--all"))
-            val runnerAndConfigurationSettings = RunManager.getInstance(project)
-                .createCargoCommandRunConfiguration(cmd)
-            val executor = ExecutorRegistry.getInstance().getExecutorById(DefaultRunExecutor.EXECUTOR_ID)
-            ProgramRunnerUtil.executeConfiguration(runnerAndConfigurationSettings, executor)
-        }
+        project.buildProject()
     }
 
     override fun canRun(projectTask: ProjectTask): Boolean =

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandActionBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandActionBase.kt
@@ -17,12 +17,13 @@ import com.intellij.openapi.project.Project
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.runconfig.createCargoCommandRunConfiguration
+import org.rust.cargo.runconfig.hasCargoProject
 import org.rust.cargo.toolchain.CargoCommandLine
 import javax.swing.Icon
 
 abstract class RunCargoCommandActionBase(icon: Icon) : AnAction(icon) {
     override fun update(e: AnActionEvent) {
-        val hasCargoProject = e.project?.cargoProjects?.allProjects.orEmpty().isNotEmpty()
+        val hasCargoProject = e.project?.hasCargoProject == true
         e.presentation.isEnabledAndVisible = hasCargoProject
     }
 

--- a/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectAction.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.model.guessAndSetupRustProject
 import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.runconfig.hasCargoProject
 
 class RefreshCargoProjectAction : AnAction() {
     init {
@@ -19,14 +20,14 @@ class RefreshCargoProjectAction : AnAction() {
 
     override fun update(e: AnActionEvent) {
         val project = e.project
-        if (project == null || project.toolchain == null || project.cargoProjects.allProjects.isEmpty()) {
+        if (project == null || project.toolchain == null || !project.hasCargoProject) {
             e.presentation.isEnabled = false
         }
     }
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        if (project.toolchain == null || project.cargoProjects.allProjects.isEmpty()) {
+        if (project.toolchain == null || !project.hasCargoProject) {
             guessAndSetupRustProject(project, explicitRequest = true)
         } else {
             project.cargoProjects.refreshAllProjects()

--- a/src/main/kotlin/org/rust/ide/actions/RsBuildAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsBuildAction.kt
@@ -1,0 +1,37 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.actions
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.util.BuildNumber
+import com.intellij.util.PlatformUtils
+import org.rust.cargo.runconfig.buildProject
+import org.rust.cargo.runconfig.hasCargoProject
+
+class RsBuildAction : AnAction() {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        e.project?.buildProject()
+    }
+
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        e.presentation.isEnabledAndVisible = isSuitablePlatform() && e.project?.hasCargoProject == true
+    }
+
+    companion object {
+        private val BUILD_181 = BuildNumber.fromString("181")
+
+        private fun isSuitablePlatform(): Boolean {
+            val buildNumber = ApplicationInfo.getInstance().build
+            // BACKCOMPAT: 2017.3
+            // Drop check for 181 version or above
+            return !(PlatformUtils.isIntelliJ() || PlatformUtils.isCLion() && buildNumber < BUILD_181)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/actions/RsBuildAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsBuildAction.kt
@@ -30,8 +30,8 @@ class RsBuildAction : AnAction() {
         private fun isSuitablePlatform(): Boolean {
             val buildNumber = ApplicationInfo.getInstance().build
             // BACKCOMPAT: 2017.3
-            // Drop check for 181 version or above
-            return !(PlatformUtils.isIntelliJ() || PlatformUtils.isCLion() && buildNumber < BUILD_181)
+            // Drop version condition for CLion
+            return !(PlatformUtils.isIntelliJ() || PlatformUtils.isAppCode() || PlatformUtils.isCLion() && buildNumber < BUILD_181)
         }
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -627,6 +627,14 @@
             <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFile"/>
         </action>
 
+        <action id="Rust.Build"
+                class="org.rust.ide.actions.RsBuildAction"
+                text="Build"
+                description="Build Project"
+                icon="AllIcons.Actions.Compile"
+                use-shortcut-of="CompileDirty">
+            <add-to-group group-id="ToolbarRunGroup" relative-to-action="RunConfiguration" anchor="before"/>
+        </action>
 
         <action id="Rust.RsPromoteModuleToDirectoryAction"
                 class="org.rust.lang.refactoring.RsPromoteModuleToDirectoryAction"
@@ -634,6 +642,7 @@
                 description="Move this module to a dedicated directory">
             <add-to-group group-id="RefactoringMenu"/>
         </action>
+
         <action id="Rust.RsDowngradeModuleToFile"
                 class="org.rust.lang.refactoring.RsDowngradeModuleToFile"
                 text="Downgrade module to file"


### PR DESCRIPTION
* build action for small IDEs (if IDE is CLion then the action is available only for 2018.1 and above)
* show `Use cargo check when build project` checkbox in all IDEs