### PR TITLE
 Added the ability to set a fake item path in tests via lang attribute

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -357,20 +357,8 @@ class ImplLookup(
     }
 
     fun findIteratorItemType(ty: Ty): TyWithObligations<Ty>? {
-        return selectProjection(iteratorTraitAndOutput ?: return legacyFindIteratorItemType(ty), ty).ok()
+        return selectProjection(iteratorTraitAndOutput ?: return null, ty).ok()
             ?: selectProjection(intoIteratorTraitAndOutput ?: return null, ty).ok()
-    }
-
-    // TODO legacy; used in tests only; should be removed
-    private fun legacyFindIteratorItemType(ty: Ty): TyWithObligations<Ty>? {
-        val impl = findImplsAndTraits(ty)
-            .find { impl ->
-                val traitName = impl.implementedTrait?.element?.name
-                traitName == "Iterator" || traitName == "IntoIterator"
-            } ?: return null
-
-        val rawType = lookupAssociatedType(impl, "Item")
-        return TyWithObligations(rawType, emptyList())
     }
 
     fun findIndexOutputType(containerType: Ty, indexType: Ty): TyWithObligations<Ty>? {

--- a/src/test/kotlin/org/rust/ide/hints/RsInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RsInlayParameterHintsProviderTest.kt
@@ -240,6 +240,7 @@ class RsInlayParameterHintsProviderTest : RsTestBase() {
     """, ": S<fn(i32) -> i32, S<fn(i32) -> i32, S<_, _>>>", 0)
 
     fun `test inlay hint for loops`() = checkByText<RsForExpr>("""
+        #[lang = "std::iter::Iterator"]
         trait Iterator { type Item; fn next(&mut self) -> Option<Self::Item>; }
         struct S;
         struct I;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -215,6 +215,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
     """)
 
     fun `test iterator for loop resolve`() = checkByCode("""
+        #[lang = "std::iter::Iterator"]
         trait Iterator { type Item; fn next(&mut self) -> Option<Self::Item>; }
 
         struct S;
@@ -234,7 +235,9 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
     """)
 
     fun `test into iterator for loop resolve`() = checkByCode("""
+        #[lang = "std::iter::Iterator"]
         trait Iterator { type Item; fn next(&mut self) -> Option<Self::Item>; }
+        #[lang = "std::iter::IntoIterator"]
         trait IntoIterator {
             type Item;
             type IntoIter: Iterator<Item=Self::Item>;


### PR DESCRIPTION
Example:
```
#[lang = "std::iter::Iterator"]
trait Iterator {}
```

... and thanks to this, removed some legacy code that was used in tests only
