### PR TITLE
ANN: Fixed #2082 correctly display generic type in tooltips

### DIFF
--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -99,10 +99,18 @@ sealed class RsDiagnostic(
         }
 
         private fun expectedFound(expectedTy: Ty, actualTy: Ty): String {
-            val expectedTyS = escapeString(expectedTy.toString())
-            val actualTyS = escapeString(actualTy.toString())
+            val expectedTyS = escapeTy(expectedTy.toString())
+            val actualTyS = escapeTy(actualTy.toString())
             return "expected `$expectedTyS`, found `$actualTyS`"
         }
+
+        // BACKCOMPAT: ???
+        // Fix for IntelliJ platform bug: https://youtrack.jetbrains.com/issue/IDEA-186991
+        // replace it with `escapeString()` after the end of support IDEs with the bug
+        private fun escapeTy(str: String): String = str
+            .replace("<", "&#60;")
+            .replace(">", "&#62;")
+            .replace("&", "&amp;")
     }
 
     class AccessError(


### PR DESCRIPTION
Fixes #2082

Temorary replace `<` & `>` with `❮` & `❯`. But I don't sure it's the best possible symbols.

![image](https://user-images.githubusercontent.com/3221931/36623376-373107aa-1915-11e8-8eee-2e8462cc971d.png)
