### PR TITLE
INT: Filter import candidates

### DIFF
--- a/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionStdTest.kt
@@ -17,7 +17,7 @@ class ImportNameIntentionStdTest : ImportNameIntentionTestBase() {
         use std::io;
 
         fn foo<T: io::Read/*caret*/>(t: T) {}
-    """, ImportNameIntention.Testmarks.autoInjectedCrate)
+    """, ImportNameIntention.Testmarks.autoInjectedStdCrate)
 
     fun `test import item from not std crate`() = doAvailableTestWithFileTree("""
         //- dep-lib/lib.rs
@@ -99,7 +99,7 @@ class ImportNameIntentionStdTest : ImportNameIntentionTestBase() {
         fn main() {
             let mutex = Mutex/*caret*/::new(Vec::new());
         }
-    """, ImportNameIntention.Testmarks.autoInjectedCrate)
+    """, ImportNameIntention.Testmarks.autoInjectedStdCrate)
 
     fun `test module reexport`() = doAvailableTestWithFileTree("""
         //- dep-lib/lib.rs
@@ -127,11 +127,41 @@ class ImportNameIntentionStdTest : ImportNameIntentionTestBase() {
         }
     """)
 
-    fun `test module reexport in stdlib`() = doAvailableTestWithMultipleChoice("""
+    fun `test module reexport in stdlib`() = doAvailableTest("""
         fn foo<T: Hash/*caret*/>(t: T) {}
-    """, setOf("core::hash::Hash", "std::hash::Hash"), "std::hash::Hash", """
+    """, """
         use std::hash::Hash;
 
         fn foo<T: Hash/*caret*/>(t: T) {}
+    """, ImportNameIntention.Testmarks.autoInjectedStdCrate)
+
+    fun `test import without std crate 1`() = doAvailableTest("""
+        #![no_std]
+
+        fn foo<T: Hash/*caret*/>(t: T) {}
+    """, """
+        #![no_std]
+
+        use core::hash::Hash;
+
+        fn foo<T: Hash/*caret*/>(t: T) {}
+    """, ImportNameIntention.Testmarks.autoInjectedCoreCrate)
+
+    fun `test import without std crate 2`() = doAvailableTest("""
+        #![no_std]
+
+        fn main() {
+            let x = Arc::new/*caret*/(123);
+        }
+    """, """
+        #![no_std]
+
+        extern crate alloc;
+
+        use alloc::arc::Arc;
+
+        fn main() {
+            let x = Arc::new/*caret*/(123);
+        }
     """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionTest.kt
@@ -833,4 +833,48 @@ class ImportNameIntentionTest : ImportNameIntentionTestBase() {
             let z = Z/*caret*/;
         }
     """)
+
+    fun `test filter imports`() = doAvailableTestWithMultipleChoice("""
+        mod foo {
+            pub mod bar {
+                pub struct FooBar;
+            }
+
+            pub use self::bar::FooBar;
+        }
+
+        mod baz {
+            pub use foo::bar::FooBar;
+        }
+
+        mod quuz {
+            pub use foo::bar;
+        }
+
+        fn main() {
+            let x = FooBar/*caret*/;
+        }
+    """, setOf("foo::FooBar", "baz::FooBar", "quuz::bar::FooBar"), "baz::FooBar", """
+        use baz::FooBar;
+
+        mod foo {
+            pub mod bar {
+                pub struct FooBar;
+            }
+
+            pub use self::bar::FooBar;
+        }
+
+        mod baz {
+            pub use foo::bar::FooBar;
+        }
+
+        mod quuz {
+            pub use foo::bar;
+        }
+
+        fn main() {
+            let x = FooBar/*caret*/;
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/import/ImportNameIntentionTestBase.kt
@@ -14,8 +14,11 @@ abstract class ImportNameIntentionTestBase : RsIntentionTestBase(ImportNameInten
                                                     expectedElements: Set<String>,
                                                     choice: String,
                                                     @Language("Rust") after: String) {
+        var chooseItemWasCalled = false
+
         withMockImportItemUi(object : ImportItemUi {
             override fun chooseItem(items: List<ImportCandidate>, callback: (ImportCandidate) -> Unit) {
+                chooseItemWasCalled = true
                 val actualItems = items.mapTo(HashSet()) { it.info.usePath }
                 assertEquals(expectedElements, actualItems)
                 val selectedValue = items.find { it.info.usePath == choice }
@@ -23,5 +26,7 @@ abstract class ImportNameIntentionTestBase : RsIntentionTestBase(ImportNameInten
                 callback(selectedValue)
             }
         }) { doAvailableTest(before, after) }
+
+        check(chooseItemWasCalled) { "`chooseItem` was not called" }
     }
 }


### PR DESCRIPTION
part of #1737

* drop useless candidates from stdlib
* don't add import candidate if there is import candidate with reexport from ancestor module