### PR TITLE
TY: Correctly typify length of byte string literals containing escape characters

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsLitExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsLitExpr.kt
@@ -20,7 +20,7 @@ val RsLitExpr.stubType: RsStubLiteralType? get() {
     return when (kind) {
         is RsLiteralKind.Boolean ->  RsStubLiteralType.Boolean
         is RsLiteralKind.Char -> RsStubLiteralType.Char(kind.isByte)
-        is RsLiteralKind.String -> RsStubLiteralType.String(kind.offsets.value?.length?.toLong(), kind.isByte)
+        is RsLiteralKind.String -> RsStubLiteralType.String(kind.value?.length?.toLong(), kind.isByte)
         is RsLiteralKind.Integer -> RsStubLiteralType.Integer(TyInteger.fromSuffixedLiteral(integerLiteral!!))
         is RsLiteralKind.Float -> RsStubLiteralType.Float(TyFloat.fromSuffixedLiteral(floatLiteral!!))
         else -> null

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -33,7 +33,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 125
+        override fun getStubVersion(): Int = 126
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -287,6 +287,34 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test byte str escape 1`() = testExpr("""
+        fn main() {
+            let a = b"\x52"; // R
+                    //^ &[u8; 1]
+        }
+    """)
+
+    fun `test byte str escape 2`() = testExpr("""
+        fn main() {
+            let a = b"\\x52"; // \x52
+                    //^ &[u8; 4]
+        }
+    """)
+
+    fun `test byte str escape 3`() = testExpr("""
+        fn main() {
+            let a = br"\x52"; // \x52
+                    //^ &[u8; 4]
+        }
+    """)
+
+    fun `test byte str escape 4`() = testExpr("""
+        fn main() {
+            let a = br##"\x52"#"##; // \x52"#
+                    //^ &[u8; 6]
+        }
+    """)
+
     fun `test str ref`() = testExpr("""
         fn main() {
             let a = "Hello";


### PR DESCRIPTION
Byte string literals like b"Example" are &[u8; ?] arrays.
Currently we infer the array length from the raw text length.
But if the string contains escape characters this will give us
the wrong array length.

Instead first unescape the string and then check its length.

This also requires bumping he stub version
as the literal length is stored in stubs.
