### PR TITLE
Add a workaround for loading of the intellij-toml plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,7 +104,7 @@ project(":") {
     intellij {
         pluginName = "intellij-rust"
 //        alternativeIdePath = "deps/clion-$clionVersion"
-        setPlugins(project(":intellij-toml"))
+        setPlugins("org.toml.lang:0.2.0.12")
     }
 
     repositories {


### PR DESCRIPTION
The current way (since #2213) of loading the intellij-toml plugin
from build.gradle.kts requires a fix for
JetBrains/gradle-intellij-plugin#238.
But the current latest stable version 0.2.18 of gradle-intellij-plugin
does not yet contain this fix.
This causes toml support to not work during development.

Go back to the old way of loading the intellij-toml plugin
until a bugfix version of intellij-toml containing the fix is released.

See JetBrains/gradle-intellij-plugin#258 for more details.