### PR TITLE
Improvements of trait types support

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/RsMoveLeftRightHandler.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsMoveLeftRightHandler.kt
@@ -19,6 +19,7 @@ class RsMoveLeftRightHandler : MoveElementLeftRightHandler() {
             is RsLifetimeParamBounds -> element.lifetimeList
             is RsLogMacroArgument -> element.formatMacroArgList
             is RsMetaItemArgs -> element.metaItemList + element.litExprList
+            is RsTraitType -> element.polyboundList
             is RsTupleExpr -> element.exprList
             is RsTupleType -> element.typeReferenceList
             is RsTupleFields -> element.tupleFieldDeclList

--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsTypeDeclarationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsTypeDeclarationProvider.kt
@@ -46,6 +46,7 @@ class RsTypeDeclarationProvider : TypeDeclarationProvider {
             is TyPointer -> referenced.baseTypeDeclaration()
             is TyArray -> base.baseTypeDeclaration()
             is TySlice -> elementType.baseTypeDeclaration()
+            is TyAnon -> traits.firstOrNull()?.element
             else -> null
         }
     }

--- a/src/test/kotlin/org/rust/ide/actions/RsMoveLeftRightHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/RsMoveLeftRightHandlerTest.kt
@@ -175,6 +175,18 @@ class RsMoveLeftRightHandlerTest : RsTestBase() {
         }
     """)
 
+    fun `test trait type 1`() = doRightLeftTest("""
+        fn foo(a: &(Read/*caret*/ + Sync)) {}
+    """, """
+        fn foo(a: &(Sync + Read/*caret*/)) {}
+    """)
+
+    fun `test trait type 2`() = doRightLeftTest("""
+        fn foo() -> impl Read/*caret*/ + Sync {}
+    """, """
+        fn foo() -> impl Sync + Read/*caret*/ {}
+    """)
+
     private fun doRightLeftTest(@Language("Rust") before: String, @Language("Rust") after: String) {
         doMoveRightTest(before, after)
         doMoveLeftTest(after, before)

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoTypeDeclarationTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoTypeDeclarationTest.kt
@@ -229,6 +229,22 @@ class RsGotoTypeDeclarationTest : RsTestBase() {
         }
     """)
 
+    fun `test impl trait`() = doTest("""
+        trait Foo {}
+        fn foo() -> impl Foo { unimplemented!() }
+
+        fn main() {
+            foo/*caret*/();
+        }
+    """, """
+        trait /*caret*/Foo {}
+        fn foo() -> impl Foo { unimplemented!() }
+
+        fn main() {
+            foo();
+        }
+    """)
+
     private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) = checkByText(before, after) {
         myFixture.performEditorAction(ACTION_GOTO_TYPE_DECLARATION)
     }


### PR DESCRIPTION
* implement move left/right action for bounds of trait types (trait objects, `impl`/`dyn Trait`)
* support `goto type declaration` for `impl Trait`