### PR TITLE
FMT: redundant semicolon in match expression

### DIFF
--- a/src/main/kotlin/org/rust/ide/formatter/processors/RsStatementSemicolonFormatProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/processors/RsStatementSemicolonFormatProcessor.kt
@@ -26,8 +26,12 @@ class RsStatementSemicolonFormatProcessor : PreFormatProcessor {
                 if (element.textRange in range) {
                     super.visitElement(element)
                 }
-                if ((element is RsRetExpr && element.parent !is RsMatchArm) || element is RsBreakExpr || element is RsContExpr) {
-                    elements.add(element)
+
+                // no semicolons inside "match"
+                if (element.parent !is RsMatchArm) {
+                    if (element is RsRetExpr || element is RsBreakExpr || element is RsContExpr) {
+                        elements.add(element)
+                    }
                 }
             }
         })

--- a/src/test/kotlin/org/rust/ide/formatter/RsStatementSemicolonFormatProcessorTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsStatementSemicolonFormatProcessorTest.kt
@@ -139,4 +139,18 @@ class RsStatementSemicolonFormatProcessorTest : RsFormatterTestBase() {
         """)
     }
 
+    fun `test does not add redundant semicolon`() {
+        val code = """
+        fn main() {
+            loop {
+                match Some(0) {
+                    Some(v) => break Some(v),
+                    None => break Some(0)
+                }
+            }
+        }
+    """;
+        checkNotChanged(code)
+
+    }
 }


### PR DESCRIPTION
fixes: #2339 