### PR TITLE
TY&RES: find impls for unconstrained integers/floats

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
@@ -41,10 +41,8 @@ class RsImplIndex : AbstractStubIndex<TyFingerprint, RsImplItem>() {
         fun index(stub: RsImplItemStub, sink: IndexSink) {
             val impl = stub.psi
             val typeRef = impl.typeReference ?: return
-            val key = TyFingerprint.create(typeRef, impl.typeParameters.mapNotNull { it.name })
-            if (key != null) {
-                sink.occurrence(KEY, key)
-            }
+            TyFingerprint.create(typeRef, impl.typeParameters.mapNotNull { it.name })
+                .forEach { sink.occurrence(KEY, it) }
         }
 
         private val KEY: StubIndexKey<TyFingerprint, RsImplItem> =

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -33,7 +33,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 126
+        override fun getStubVersion(): Int = 127
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt
@@ -184,7 +184,7 @@ class FulfillmentContext(val ctx: RsInferenceContext, val lookup: ImplLookup) {
 
         when (predicate) {
             is Predicate.Trait -> {
-                if (predicate.trait.selfTy is TyInfer) return ProcessPredicateResult.NoChanges
+                if (predicate.trait.selfTy is TyInfer.TyVar) return ProcessPredicateResult.NoChanges
                 val impl = lookup.select(predicate.trait, obligation.recursionDepth)
                 return when (impl) {
                     is SelectionResult.Err -> ProcessPredicateResult.Err
@@ -204,7 +204,7 @@ class FulfillmentContext(val ctx: RsInferenceContext, val lookup: ImplLookup) {
                 return ProcessPredicateResult.Ok()
             }
             is Predicate.Projection -> {
-                if (predicate.projectionTy.type is TyInfer) return ProcessPredicateResult.NoChanges
+                if (predicate.projectionTy.type is TyInfer.TyVar) return ProcessPredicateResult.NoChanges
                 val result = ctx.optNormalizeProjectionType(predicate.projectionTy, obligation.recursionDepth)
                 return if (result == null) {
                     pendingObligation.stalledOn = traitRefTypeVars(predicate.projectionTy.traitRef)

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -402,7 +402,7 @@ class RsInferenceContext(
 
     /** See [optNormalizeProjectionType] */
     private fun optNormalizeProjectionTypeResolved(projectionTy: TyProjection, recursionDepth: Int): TyWithObligations<Ty>? {
-        if (projectionTy.type is TyInfer) return null
+        if (projectionTy.type is TyInfer.TyVar) return null
 
         val cacheResult = projectionCache.tryStart(projectionTy)
         return when (cacheResult) {

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
@@ -54,6 +54,7 @@ sealed class TyInteger(val name: String, val ordinal: Int) : TyNumeric() {
     companion object {
         val DEFAULT = TyInteger.I32
         val VALUES = listOf(U8, U16, U32, U64, U128, USize, I8, I16, I32, I64, I128, ISize)
+        val NAMES = VALUES.map { it.name }
 
         fun fromSuffixedLiteral(literal: PsiElement): TyInteger? {
             val text = literal.text
@@ -80,6 +81,7 @@ sealed class TyFloat(val name: String, val ordinal: Int) : TyNumeric() {
     companion object {
         val DEFAULT = TyFloat.F64
         val VALUES = listOf(F32, F64)
+        val NAMES = VALUES.map { it.name }
 
         fun fromSuffixedLiteral(literal: PsiElement): TyFloat? {
             val text = literal.text

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -572,6 +572,44 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }      //^
     """)
 
+    fun `test impl trait for integer`() = checkByCode("""
+        trait T { fn foo(self); }
+        impl T for u8 { fn foo(self) {} }
+                         //X
+        fn main() {
+            0.foo();
+        }   //^
+    """)
+
+    fun `test impl trait for float`() = checkByCode("""
+        trait T { fn foo(self); }
+        impl T for f32 { fn foo(self) {} }
+                          //X
+        fn main() {
+            0.0.foo();
+        }     //^
+    """)
+
+    fun `test impl trait for integer reference`() = checkByCode("""
+        trait T { fn foo(self); }
+        impl T for &u8 { fn foo(self) {} }
+                         //X
+        fn main() {
+            (&0).foo();
+        }      //^
+    """)
+
+    // TODO should be resolved to i32
+    fun `test multiple impl trait for integer`() = checkByCode("""
+        trait T { fn foo(self); }
+                   //X
+        impl T for u8 { fn foo(self) {} }
+        impl T for i32 { fn foo(self) {} }
+        fn main() {
+            0.foo();
+        }   //^
+    """)
+
     fun `test resolve UFCS method call`() = checkByCode("""
         struct S;
         trait T { fn foo(&self); }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1384,4 +1384,26 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             b;
         } //^ u8
     """)
+
+    fun `test select trait from unconstrained integer`() = testExpr("""
+        struct X;
+        trait Tr<A> {}
+        impl Tr<X> for u8 {}
+        fn foo<B: Tr<C>, C>(_: B) -> C { unimplemented!() }
+        fn main() {
+            let a = foo(0);
+            a;
+        } //^ X
+    """)
+
+    fun `test select projection from unconstrained integer`() = testExpr("""
+        struct X;
+        trait Tr { type Item; }
+        impl Tr for u8 { type Item = X; }
+        fn foo<B: Tr>(_: B) -> B::Item { unimplemented!() }
+        fn main() {
+            let a = foo(0);
+            a;
+        } //^ X
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsNumericLiteralTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsNumericLiteralTypeInferenceTest.kt
@@ -499,4 +499,20 @@ class RsNumericLiteralTypeInferenceTest : RsTypificationTestBase() {
             };
         }
     """)
+
+    fun `test unify unconstrained integer receiver with impl type`() = testExpr("""
+        trait T { fn foo(self); }
+        impl T for u8 { fn foo(self) {} }
+        fn main() {
+            0.foo();
+        } //^ u8
+    """)
+
+    fun `test unify unconstrained float receiver with impl type`() = testExpr("""
+        trait T { fn foo(self); }
+        impl T for f32 { fn foo(self) {} }
+        fn main() {
+            0.0.foo();
+        } //^ f32
+    """)
 }


### PR DESCRIPTION
Now we corrrectly resolve method calls on unconstrained integers/floats, e.g. `0.foo()`.

Also a part of #1806