### PR TITLE
RES & TY: Prevent infinite loops with cyclic type aliases

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
@@ -20,6 +20,16 @@ import javax.swing.Icon
 val RsTypeAlias.default: PsiElement?
     get() = node.findChildByType(DEFAULT)?.psi
 
+fun RsTypeAlias.baseType(): RsElement? {
+    var base: RsElement? = this
+    val visited = mutableSetOf<RsElement>(this)
+    while (base is RsTypeAlias) {
+        base = (base.typeReference?.typeElement as? RsBaseType)?.path?.reference?.resolve() ?: return null
+        if (base in visited) return null
+        visited += base
+    }
+    return base
+}
 
 abstract class RsTypeAliasImplMixin : RsStubbedNamedElementImpl<RsTypeAliasStub>, RsTypeAlias {
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -94,8 +94,8 @@ fun processStructLiteralFieldResolveVariants(field: RsStructLiteralField, proces
     }
 
     // Resolve potential type aliases
-    while (resolved is RsTypeAlias) {
-        resolved = (resolved.typeReference?.typeElement as? RsBaseType)?.path?.reference?.resolve()
+    if (resolved is RsTypeAlias) {
+        resolved = resolved.baseType()
     }
     val structOrEnumVariant = resolved as? RsFieldsOwner ?: return false
     return processFieldDeclarations(structOrEnumVariant, processor)

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -573,6 +573,16 @@ class RsResolveTest : RsResolveTestBase() {
         }              //^
     """)
 
+    fun `test cyclic type aliases`() = checkByCode("""
+        type Foo = Bar;
+        type Bar = Foo;
+
+        fn main() {
+            let x = Foo { foo: 123 };
+                        //^ unresolved
+        }
+    """)
+
     fun `test struct field Self`() = checkByCode("""
         struct S { foo: i32 }
                   //X

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -779,6 +779,16 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
             T2 { };
         } //^ S
     """)
+
+    fun `test cyclic type aliases`() = testExpr("""
+        type Foo = Bar;
+        type Bar = Foo;
+        fn main() {
+            let x = Foo { x: 123 };
+            x;
+          //^ <unknown>
+        }
+    """)
     // More struct alias tests in [RsGenericExpressionTypeInferenceTest]
 
     fun `test struct update syntax`() = testExpr("""


### PR DESCRIPTION
Collects already visited type alias elements to prevent infinite loops while resolving fields in struct literals and struct literal type inference