### PR TITLE
INT: Fix make mutable intention

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -59,6 +59,7 @@ pasa
 pavel-v-chernykh
 pcholakov
 pocket7878
+rrevenantt
 sanmai-NL
 Shiroy
 shssoichiro

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt
@@ -43,6 +43,7 @@ fun updateMutable(project: Project, binding: RsNamedElement, mutable: Boolean = 
         is RsPatBinding -> {
             val tuple = binding.ancestorStrict<RsPatTup>()
             val parameter = binding.ancestorStrict<RsValueParameter>()
+
             if (tuple != null && parameter != null) {
                 return
             }
@@ -54,7 +55,8 @@ fun updateMutable(project: Project, binding: RsNamedElement, mutable: Boolean = 
                 parameter.replace(newParameterExpr)
                 return
             }
-            val newPatBinding = RsPsiFactory(project).createPatBinding(binding.identifier.text, mutable)
+            val isRefBinding = (binding.bindingMode?.ref) != null
+            val newPatBinding = RsPsiFactory(project).createPatBinding(binding.identifier.text, mutable,isRefBinding)
             binding.replace(newPatBinding)
         }
         is RsSelfParameter -> {

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt
@@ -13,6 +13,7 @@ import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psi.ext.isRef
 import org.rust.lang.core.psi.ext.typeElement
 import org.rust.lang.core.types.declaration
 
@@ -55,8 +56,7 @@ fun updateMutable(project: Project, binding: RsNamedElement, mutable: Boolean = 
                 parameter.replace(newParameterExpr)
                 return
             }
-            val isRefBinding = (binding.bindingMode?.ref) != null
-            val newPatBinding = RsPsiFactory(project).createPatBinding(binding.identifier.text, mutable, isRefBinding)
+            val newPatBinding = RsPsiFactory(project).createPatBinding(binding.identifier.text, mutable = mutable, ref = binding.isRef)
             binding.replace(newPatBinding)
         }
         is RsSelfParameter -> {

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt
@@ -56,7 +56,7 @@ fun updateMutable(project: Project, binding: RsNamedElement, mutable: Boolean = 
                 return
             }
             val isRefBinding = (binding.bindingMode?.ref) != null
-            val newPatBinding = RsPsiFactory(project).createPatBinding(binding.identifier.text, mutable,isRefBinding)
+            val newPatBinding = RsPsiFactory(project).createPatBinding(binding.identifier.text, mutable, isRefBinding)
             binding.replace(newPatBinding)
         }
         is RsSelfParameter -> {

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -272,7 +272,7 @@ class RsPsiFactory(private val project: Project) {
     }
 
     fun createPatBinding(name: String, mutable: Boolean = false, ref: Boolean = false): RsPatBinding =
-        (createStatement("let ${if (ref) "ref " else ""}${if (mutable) "mut " else ""}$name = 10;") as RsLetDecl).pat
+        (createStatement("let ${"ref ".iff(ref)}${"mut ".iff(mutable)}$name = 10;") as RsLetDecl).pat
             ?.firstChild as RsPatBinding?
             ?: error("Failed to create pat element")
 

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -271,8 +271,8 @@ class RsPsiFactory(private val project: Project) {
             ?: error("Failed to create parameter element")
     }
 
-    fun createPatBinding(name: String, mutable: Boolean = false): RsPatBinding =
-        (createStatement("let ${if (mutable) "mut " else ""}$name = 10;") as RsLetDecl).pat
+    fun createPatBinding(name: String, mutable: Boolean = false, ref: Boolean = false): RsPatBinding =
+        (createStatement("let ${if (ref) "ref " else ""}${if (mutable) "mut " else ""}$name = 10;") as RsLetDecl).pat
             ?.firstChild as RsPatBinding?
             ?: error("Failed to create pat element")
 

--- a/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt
@@ -162,4 +162,19 @@ class RsReassignImmutableInspectionTest : RsInspectionsTestBase(RsReassignImmuta
         }
     """)
 
+    fun `test E0384 fix let ref at reassign `() = checkFixByText("Make `test` mutable", """
+        fn main() {
+            let mut a = 5;
+            let mut b = 6;
+            let ref test = a;
+            <error>test<caret> = &b</error>;
+        }
+            """, """
+        fn main() {
+            let mut a = 5;
+            let mut b = 6;
+            let ref mut test = a;
+            test = &b;
+        }
+            """)
 }


### PR DESCRIPTION
When variable is assigned with "ref" modifier like `let ref a = ... `, and you apply make mutable quick fix, it will result in wrong `let mut a = ... ` instead of `let ref mut a = ... `.

This PR fixes this issue.