### PR TITLE
INSP: don't highlight generic params by unresolved reference inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
@@ -9,6 +9,7 @@ import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.codeInspection.ui.MultipleCheckboxOptionsPanel
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElementVisitor
 import org.rust.ide.inspections.fixes.import.AutoImportFix
 import org.rust.ide.inspections.fixes.import.AutoImportHintFix
@@ -40,8 +41,11 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
                         AutoImportFix(path)
                     }
                 }
+
+                // Don't highlight generic parameters
+                val range = TextRange(0, path.typeArgumentList?.startOffsetInParent ?: path.textLength)
                 holder.registerProblem(path, description,
-                    ProblemHighlightType.LIKE_UNKNOWN_SYMBOL, *listOfNotNull(fix).toTypedArray())
+                    ProblemHighlightType.LIKE_UNKNOWN_SYMBOL, range, *listOfNotNull(fix).toTypedArray())
             }
         }
 

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -42,6 +42,17 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         }
     """, false)
 
+    fun `test do not highlight generic params`() = checkByText("""
+        mod foo_bar {
+            pub struct Foo<T>(T);
+            pub struct Bar<T>(T);
+        }
+
+        fn foo<T>() -> <error descr="Unresolved reference: `Foo`">Foo</error><<error descr="Unresolved reference: `Bar`">Bar</error><T>> {
+            unimplemented!()
+        }
+    """)
+
     private fun checkByText(@Language("Rust") text: String, ignoreWithoutQuickFix: Boolean) {
         val defaultValue = (inspection as RsUnresolvedReferenceInspection).ignoreWithoutQuickFix
         try {

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -120,7 +120,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             pub struct Foo<T>(T);
         }
 
-        fn f<T>(foo: <error descr="Unresolved reference: `Foo`">Foo/*caret*/<T></error>) {}
+        fn f<T>(foo: <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error><T>) {}
     """, """
         use foo::Foo;
 


### PR DESCRIPTION
Closes #2394 