### PR TITLE
INSP: don't highlight paths with primitive type name

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/import/AutoImportFix.kt
@@ -134,8 +134,8 @@ class AutoImportFix(path: RsPath) : LocalQuickFixOnPsiElement(path), HighPriorit
         const val NAME = "Import"
 
         fun findApplicableContext(project: Project, path: RsPath): Context? {
-            if (TyPrimitive.fromPath(path) != null) return null
             val basePath = getBasePath(path)
+            if (TyPrimitive.fromPath(basePath) != null) return null
             if (basePath.reference.multiResolve().isNotEmpty()) return null
 
             // Don't try to import path in use item

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
@@ -296,4 +296,17 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
             let x = Foo/*caret*/;
         }
     """, AutoImportFix.Testmarks.externCrateItemInNotCrateRoot)
+
+    fun `test do not try to highlight primitive types`() = checkAutoImportFixIsUnavailable("""
+        pub trait Zero<N> {
+            fn zero() -> N;
+        }
+        impl Zero<f32> for f32 {
+            fn zero() -> f32 { 0f32 }
+        }
+
+        fn main() {
+            let x = f32/*error*/::zero();
+        }
+    """)
 }


### PR DESCRIPTION
Now we ignore primitive types in a path if all path is a primitive type name.
But when primitive type name is part of path, for example `f64::abs`,
we highlight it as an unresolved reference because our resolve can't resolve primitive types.

This fix checks if base path is a primitive type name instead of full path

Fixes #2367
Fixes #2388
