### PR TITLE
ANN: add type mismatch quick fix using TryFrom

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFix.kt
@@ -1,0 +1,103 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.ide.presentation.tyToStringWithoutTypeArgs
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.resolve.StdKnownItems
+import org.rust.lang.core.resolve.withSubst
+import org.rust.lang.core.types.TraitRef
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyAdt
+import org.rust.lang.core.types.type
+
+/**
+ * Base class for converting the given `expr` to the type [ty] using trait [traitName] and its conversion method
+ * [methodName]. Note the fix neither try to verify that the [traitName] and [methodName] actually exist, nor check
+ * that the [traitName] is actually implemented for [ty].
+ */
+abstract class ConvertToTyUsingTryTraitFix(
+    expr: PsiElement,
+    private val ty: Ty,
+    private val traitName: String,
+    private val methodName: String) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
+
+    override fun getFamilyName(): String = "Convert to type"
+
+    override fun getText(): String = "Convert to $ty using `$traitName` trait"
+
+    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
+        if (startElement !is RsExpr) return
+        val rsPsiFactory = RsPsiFactory(project)
+        val fromCall = rsPsiFactory.createAssocFunctionCall(tyToStringWithoutTypeArgs(ty), methodName, listOf(startElement))
+        addFromCall(rsPsiFactory, startElement, fromCall)
+    }
+
+    open fun addFromCall(rsPsiFactory: RsPsiFactory, startElement: RsExpr, fromCall: RsCallExpr) {
+        startElement.replace(fromCall)
+    }
+}
+
+/**
+ * Similar to [ConvertToTyUsingTryTraitFix], but also "unwraps" the result with `unwrap()` or `?`.
+ */
+abstract class ConvertToTyUsingTryTraitAndUnpackFix(
+    expr: PsiElement,
+    ty: Ty,
+    private val errTy: Ty,
+    traitName: String,
+    methodName: String) : ConvertToTyUsingTryTraitFix(expr, ty, traitName, methodName) {
+
+    override fun addFromCall(rsPsiFactory: RsPsiFactory, startElement: RsExpr, fromCall: RsCallExpr) {
+        val parentFnRetTy = findParentFnOrCLambdaRetTy(startElement)
+        when {
+            parentFnRetTy != null && isFnRetTyResultAndMatchErrTy(startElement, parentFnRetTy) ->
+                startElement.replace(rsPsiFactory.createTryExpression(fromCall))
+            else -> startElement.replace(rsPsiFactory.createNoArgsMethodCall(fromCall, "unwrap"))
+        }
+    }
+
+    private fun findParentFnOrCLambdaRetTy(element: RsExpr): Ty? = findParentFunctionOrLambdaRsRetType(element)?.typeReference?.type
+
+    private fun findParentFunctionOrLambdaRsRetType(element: RsExpr): RsRetType? {
+        var parent = element.parent
+        while (parent != null) {
+            when (parent) {
+                is RsFunction -> return parent.retType
+                is RsLambdaExpr -> return parent.retType
+                else -> parent = parent.parent
+            }
+        }
+        return null
+    }
+
+    private fun isFnRetTyResultAndMatchErrTy(element: RsExpr, fnRetTy: Ty): Boolean {
+        val items = StdKnownItems.relativeTo(element)
+        val lookup = ImplLookup(element.project, items)
+        return fnRetTy is TyAdt && fnRetTy.item == items.findResultItem()
+            && lookup.select(TraitRef(fnRetTy.typeArguments.get(1), (items.findFromTrait()
+            ?: return false).withSubst(errTy))).ok() != null
+    }
+}
+
+/**
+ * For the given `expr` converts it to the type `Result<ty, _>` with `ty::try_from(expr)`.
+ */
+class ConvertToTyUsingTryFromTraitFix(expr: PsiElement, ty: Ty) :
+    ConvertToTyUsingTryTraitFix(expr, ty, "TryFrom", "try_from")
+
+/**
+ * For the given `expr` converts it to the type [ty] with `ty::try_from(expr).unwrap()` or `ty::try_from(expr)?` if
+ * possible.
+ */
+class ConvertToTyUsingTryFromTraitAndUnpackFix(expr: PsiElement, ty: Ty, errTy: Ty) :
+    ConvertToTyUsingTryTraitAndUnpackFix(expr, ty, errTy, "TryFrom", "try_from")

--- a/src/main/kotlin/org/rust/lang/core/resolve/StdKnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/StdKnownItems.kt
@@ -65,6 +65,9 @@ class StdKnownItems private constructor(private val absolutePathResolver: (Strin
     fun findArgumentsTy(): Ty =
         findCoreTy("fmt::Arguments")
 
+    fun findInfallibleTy(): Ty =
+        findCoreTy("convert::Infallible")
+
     fun findOptionItem(): RsNamedElement? =
         findCoreItem("option::Option")
 
@@ -88,6 +91,9 @@ class StdKnownItems private constructor(private val absolutePathResolver: (Strin
 
     fun findFromTrait(): RsTraitItem? =
         findCoreItem("convert::From") as? RsTraitItem
+
+    fun findTryFromTrait(): RsTraitItem? =
+        findCoreItem("convert::TryFrom") as? RsTraitItem
 
     fun findBorrowTrait(): RsTraitItem? =
         findCoreItem("borrow::Borrow") as? RsTraitItem

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFixTest.kt
@@ -1,0 +1,226 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.rust.ide.inspections.RsExperimentalChecksInspection
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class ConvertToTyUsingTryFromTraitFixTest : RsInspectionsTestBase(RsExperimentalChecksInspection()) {
+    override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
+
+    fun `test B from A when impl TryFrom A for B is available`() = checkFixByText("Convert to Bb using `TryFrom` trait", """
+        #![feature(try_from)]
+        use std::convert::TryFrom;
+
+        struct Aa;
+        struct Bb;
+        #[derive(Debug)] struct Ee;
+
+        impl TryFrom<Aa> for Bb { type Error = Ee; fn try_from(a: Aa) -> Result<Self, Self::Error> {Ok(Bb)} }
+
+        fn main () {
+            let b: Bb = <error>Aa<caret></error>;
+        }
+    """, """
+        #![feature(try_from)]
+        use std::convert::TryFrom;
+
+        struct Aa;
+        struct Bb;
+        #[derive(Debug)] struct Ee;
+
+        impl TryFrom<Aa> for Bb { type Error = Ee; fn try_from(a: Aa) -> Result<Self, Self::Error> {Ok(Bb)} }
+
+        fn main () {
+            let b: Bb = Bb::try_from(Aa).unwrap();
+        }
+    """)
+
+    fun `test B from A when impl TryFrom A for B is available and fn ret Result with Err match`() = checkFixByText("Convert to Bb using `TryFrom` trait", """
+        #![feature(try_from)]
+        use std::convert::TryFrom;
+
+        struct Aa;
+        struct Bb;
+        #[derive(Debug)] struct Ee;
+
+        impl TryFrom<Aa> for Bb { type Error = Ee; fn try_from(a: Aa) -> Result<Self, Self::Error> {Ok(Bb)} }
+
+        fn foo() -> Result<B, Ee> {
+            let b: Bb = <error>Aa<caret></error>;
+            return Ok(b);
+        }
+    """, """
+        #![feature(try_from)]
+        use std::convert::TryFrom;
+
+        struct Aa;
+        struct Bb;
+        #[derive(Debug)] struct Ee;
+
+        impl TryFrom<Aa> for Bb { type Error = Ee; fn try_from(a: Aa) -> Result<Self, Self::Error> {Ok(Bb)} }
+
+        fn foo() -> Result<B, Ee> {
+            let b: Bb = Bb::try_from(Aa)?;
+            return Ok(b);
+        }
+    """)
+
+    fun `test B from A when impl TryFrom A for B is available and fn ret Result with Err mismatch`() = checkFixByText("Convert to Bb using `TryFrom` trait", """
+        #![feature(try_from)]
+        use std::convert::TryFrom;
+
+        struct Aa;
+        struct Bb;
+        #[derive(Debug)] struct Ee;
+        #[derive(Debug)] struct Ee2;
+
+        impl TryFrom<Aa> for Bb { type Error = Ee; fn try_from(a: Aa) -> Result<Self, Self::Error> {Ok(Bb)} }
+
+        fn foo() -> Result<B, Ee2> {
+            let b: Bb = <error>Aa<caret></error>;
+            return Ok(b);
+        }
+    """, """
+        #![feature(try_from)]
+        use std::convert::TryFrom;
+
+        struct Aa;
+        struct Bb;
+        #[derive(Debug)] struct Ee;
+        #[derive(Debug)] struct Ee2;
+
+        impl TryFrom<Aa> for Bb { type Error = Ee; fn try_from(a: Aa) -> Result<Self, Self::Error> {Ok(Bb)} }
+
+        fn foo() -> Result<B, Ee2> {
+            let b: Bb = Bb::try_from(Aa).unwrap();
+            return Ok(b);
+        }
+    """)
+
+    fun `test B from A when impl TryFrom A for B is available and fn ret Result with Err match through From trait`() = checkFixByText("Convert to Bb using `TryFrom` trait", """
+        #![feature(try_from)]
+        use std::convert::TryFrom;
+
+        struct Aa;
+        struct Bb;
+        #[derive(Debug)] struct Ee;
+        #[derive(Debug)] struct Ee2;
+
+        impl TryFrom<Aa> for Bb { type Error = Ee; fn try_from(a: Aa) -> Result<Self, Self::Error> {Ok(Bb)} }
+        impl From<Ee> for Ee2 { fn from(e: Ee) -> Self {Ee2} }
+
+        fn foo() -> Result<B, Ee2> {
+            let b: Bb = <error>Aa<caret></error>;
+            return Ok(b);
+        }
+    """, """
+        #![feature(try_from)]
+        use std::convert::TryFrom;
+
+        struct Aa;
+        struct Bb;
+        #[derive(Debug)] struct Ee;
+        #[derive(Debug)] struct Ee2;
+
+        impl TryFrom<Aa> for Bb { type Error = Ee; fn try_from(a: Aa) -> Result<Self, Self::Error> {Ok(Bb)} }
+        impl From<Ee> for Ee2 { fn from(e: Ee) -> Self {Ee2} }
+
+        fn foo() -> Result<B, Ee2> {
+            let b: Bb = Bb::try_from(Aa)?;
+            return Ok(b);
+        }
+    """)
+
+    fun `test B from A when impl TryFrom A for B is available and lambda ret Result with Err match`() = checkFixByText("Convert to Bb using `TryFrom` trait", """
+        #![feature(try_from)]
+        use std::convert::TryFrom;
+
+        struct Aa;
+        struct Bb;
+        #[derive(Debug)] struct Ee;
+
+        impl TryFrom<Aa> for Bb { type Error = Ee; fn try_from(a: Aa) -> Result<Self, Self::Error> {Ok(Bb)} }
+
+        fn main() {
+            let f = || -> Result<B, Ee> { let b: Bb = <error>Aa<caret></error>; return Ok(b);};
+        }
+    """, """
+        #![feature(try_from)]
+        use std::convert::TryFrom;
+
+        struct Aa;
+        struct Bb;
+        #[derive(Debug)] struct Ee;
+
+        impl TryFrom<Aa> for Bb { type Error = Ee; fn try_from(a: Aa) -> Result<Self, Self::Error> {Ok(Bb)} }
+
+        fn main() {
+            let f = || -> Result<B, Ee> { let b: Bb = Bb::try_from(Aa)?; return Ok(b);};
+        }
+    """)
+
+    fun `test Result of B from A when impl TryFrom A for B is available`() = checkFixByText("Convert to Bb using `TryFrom` trait", """
+        #![feature(try_from)]
+        use std::convert::TryFrom;
+
+        struct Aa;
+        struct Bb;
+        #[derive(Debug)] struct Ee;
+
+        impl TryFrom<Aa> for Bb { type Error = Ee; fn try_from(a: Aa) -> Result<Self, Self::Error> {Ok(Bb)} }
+
+        fn main () {
+            let b: Result<Bb, Ee> = <error>Aa<caret></error>;
+        }
+    """, """
+        #![feature(try_from)]
+        use std::convert::TryFrom;
+
+        struct Aa;
+        struct Bb;
+        #[derive(Debug)] struct Ee;
+
+        impl TryFrom<Aa> for Bb { type Error = Ee; fn try_from(a: Aa) -> Result<Self, Self::Error> {Ok(Bb)} }
+
+        fn main () {
+            let b: Result<Bb, Ee> = Bb::try_from(Aa);
+        }
+    """)
+
+    fun `test no fix when impl TryFrom A for B has wrong Err type`() = checkFixIsUnavailable("Convert to Bb using `TryFrom` trait", """
+        #![feature(try_from)]
+        use std::convert::TryFrom;
+
+        struct Aa;
+        struct Bb;
+        #[derive(Debug)] struct Ee;
+        #[derive(Debug)] struct Ee2;
+
+        impl TryFrom<Aa> for Bb { type Error = Ee; fn try_from(a: Aa) -> Result<Self, Self::Error> {Ok(Bb)} }
+
+        fn main () {
+            let b: Result<Bb, Ee2> = <error>Aa<caret></error>;
+        }
+    """)
+
+    fun `test no fix when impl TryFrom A for B is not available`() = checkFixIsUnavailable("Convert to Bb using `TryFrom` trait", """
+        #![feature(try_from)]
+        use std::convert::TryFrom;
+        struct Aa;
+        struct Bb;
+        struct Cc;
+        struct Dd;
+        #[derive(Debug)] struct Ee;
+
+        impl TryFrom<Cc> for Bb { type Error = Ee; fn try_from(c: Cc) -> Result<Self, Self::Error> {Ok(Bb)} }
+        impl TryFrom<Aa> for Dd { type Error = Ee; fn try_from(a: Aa) -> Result<Self, Self::Error> {Ok(Dd)} }
+
+        fn main () {
+            let b: Bb = <error>Aa<caret></error>;
+        }
+    """)
+}


### PR DESCRIPTION
This commit adds quick-fix for the types mismatch when
`impl TryFrom<A> for B` exists where A is actual type and B is expected
type, which fulfills part of the forth bullet-point of the issue:
https://github.com/intellij-rust/intellij-rust/issues/1730.

The Fix skips suggesting the "TryFrom" when it's implemented through
`impl<T, U> TryFrom<U> for T where T: From<U> { type Error = Infallible; ...}`, 
since the regular "From" should is already suggested in those cases.

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->