### PR TITLE
CARGO: Favor selected project when running cargo command

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/CargoToolWindow.kt
+++ b/src/main/kotlin/org/rust/cargo/project/CargoToolWindow.kt
@@ -35,7 +35,7 @@ class CargoToolWindowFactory : ToolWindowFactory {
     }
 }
 
-private class CargoToolWindowPanel(project: Project) : SimpleToolWindowPanel(true, false) {
+class CargoToolWindowPanel(project: Project) : SimpleToolWindowPanel(true, false) {
     private val cargoTab = CargoToolWindow(project)
 
     init {
@@ -43,6 +43,8 @@ private class CargoToolWindowPanel(project: Project) : SimpleToolWindowPanel(tru
         cargoTab.toolbar.setTargetComponent(this)
         setContent(cargoTab.content)
     }
+
+    val selectedProject: CargoProject? get() = cargoTab.selectedProject
 
     override fun getData(dataId: String): Any? {
         if (DetachCargoProjectAction.CARGO_PROJECT_TO_DETACH.`is`(dataId)) {

--- a/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
@@ -24,7 +24,7 @@ fun CargoCommandLine.mergeWithDefault(default: CargoCommandConfiguration): Cargo
         this
 
 fun RunManager.createCargoCommandRunConfiguration(cargoCommandLine: CargoCommandLine): RunnerAndConfigurationSettings {
-    val runnerAndConfigurationSettings = createRunConfiguration(cargoCommandLine.command, CargoCommandConfigurationType().factory)
+    val runnerAndConfigurationSettings = createRunConfiguration(cargoCommandLine.name, CargoCommandConfigurationType().factory)
     val configuration = runnerAndConfigurationSettings.configuration as CargoCommandConfiguration
     configuration.setFromCmd(cargoCommandLine)
     return runnerAndConfigurationSettings

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandAction.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandAction.kt
@@ -17,7 +17,7 @@ class RunCargoCommandAction : RunCargoCommandActionBase(CargoIcons.ICON) {
         val dialog = RunCargoCommandDialog(project, cargoProject)
         if (!dialog.showAndGet()) return
 
-        runCommand(project, dialog.getCargoCommandLine())
+        runCommand(project, dialog.getCargoCommandLine(), cargoProject)
     }
 
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/RunClippyAction.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/RunClippyAction.kt
@@ -18,6 +18,6 @@ class RunClippyAction : RunCargoCommandActionBase(CargoIcons.CLIPPY) {
         val toolchain = project.toolchain ?: return
         val cargoProject = getAppropriateCargoProject(e) ?: return
         val channel = if (toolchain.isRustupAvailable) RustChannel.NIGHTLY else RustChannel.DEFAULT
-        runCommand(project, CargoCommandLine.forProject(cargoProject, "clippy", channel = channel))
+        runCommand(project, CargoCommandLine.forProject(cargoProject, "clippy", channel = channel), cargoProject)
     }
 }

--- a/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
@@ -21,6 +21,8 @@ data class CargoCommandLine(
     val nocapture: Boolean = true
 ) {
 
+    // to pass different name to RunConfiguration if necessary
+    var name = command
 
     fun withDoubleDashFlag(arg: String): CargoCommandLine {
         val (pre, post) = splitOnDoubleDash()


### PR DESCRIPTION
When there are multiple cargo projects, use project that was selected in tool window to run cargo command. Currently first project is always used.

Also I've added project name to generated run configuration to have separate run configurations for each project, otherwise it would be hard to keep in mind what project was run last time.