### PR TITLE
ANN: improved Quick fixes on type mismatch

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFix.kt
@@ -12,9 +12,9 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.rust.ide.presentation.tyToStringWithoutTypeArgs
 import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.withSubst
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.StdKnownItems
-import org.rust.lang.core.resolve.withSubst
 import org.rust.lang.core.types.TraitRef
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyAdt
@@ -58,7 +58,7 @@ abstract class ConvertToTyUsingTryTraitAndUnpackFix(
     methodName: String) : ConvertToTyUsingTryTraitFix(expr, ty, traitName, methodName) {
 
     override fun addFromCall(rsPsiFactory: RsPsiFactory, startElement: RsExpr, fromCall: RsCallExpr) {
-        val parentFnRetTy = findParentFnOrCLambdaRetTy(startElement)
+        val parentFnRetTy = findParentFnOrLambdaRetTy(startElement)
         when {
             parentFnRetTy != null && isFnRetTyResultAndMatchErrTy(startElement, parentFnRetTy) ->
                 startElement.replace(rsPsiFactory.createTryExpression(fromCall))
@@ -66,7 +66,8 @@ abstract class ConvertToTyUsingTryTraitAndUnpackFix(
         }
     }
 
-    private fun findParentFnOrCLambdaRetTy(element: RsExpr): Ty? = findParentFunctionOrLambdaRsRetType(element)?.typeReference?.type
+    private fun findParentFnOrLambdaRetTy(element: RsExpr): Ty? =
+        findParentFunctionOrLambdaRsRetType(element)?.typeReference?.type
 
     private fun findParentFunctionOrLambdaRsRetType(element: RsExpr): RsRetType? {
         var parent = element.parent

--- a/src/main/kotlin/org/rust/lang/core/resolve/StdKnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/StdKnownItems.kt
@@ -65,9 +65,6 @@ class StdKnownItems private constructor(private val absolutePathResolver: (Strin
     fun findArgumentsTy(): Ty =
         findCoreTy("fmt::Arguments")
 
-    fun findInfallibleTy(): Ty =
-        findCoreTy("convert::Infallible")
-
     fun findOptionItem(): RsNamedElement? =
         findCoreItem("option::Option")
 

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -20,7 +20,6 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.StdKnownItems
-import org.rust.lang.core.resolve.withSubst
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.TraitRef
 import org.rust.lang.core.types.ty.*
@@ -56,29 +55,23 @@ sealed class RsDiagnostic(
                     } else  if (element is RsElement) {
                         val items = StdKnownItems.relativeTo(element)
                         val lookup = ImplLookup(element.project, items)
-                        if (isFromActualImplForExpected(items, lookup)) {
+                        val canAddFromFix = isFromActualImplForExpected(items, lookup)
+                        if (canAddFromFix) {
                             add(ConvertToTyUsingFromTraitFix(element, expectedTy))
                         }
                         if (expectedTy is TyAdt && expectedTy.item == items.findResultItem()) {
-                            val expOkTy = expectedTy.typeArguments.get(0)
-                            val expErrTy = expectedTy.typeArguments.get(1)
+                            val (expOkTy, expErrTy) = expectedTy.typeArguments
                             val resultErrTy = errTyOfTryFromActualImplForTy(expOkTy, items, lookup)
                             if (resultErrTy != null && resultErrTy == expErrTy) {
                                 add(ConvertToTyUsingTryFromTraitFix(element, expOkTy))
                             }
-                        } else {
+                        } else if (!canAddFromFix) {
                             val resultErrTy = errTyOfTryFromActualImplForTy(expectedTy, items, lookup)
-                            // this currently won't suggest "TryFrom fix" when `convert::Infallible` is an `Error` type;
-                            // this is partially because ImplLookup.select seem to always find:
-                            // `impl<T, U> TryFrom<U> for T where T: From<U>` even when the corresponding impl From
-                            // doesn't exist;
-                            // but also for the actual cases when the `impl From` exists we will just suggest regular
-                            // "From fix"
-                            if (resultErrTy != null && resultErrTy != items.findInfallibleTy()) {
+                            if (resultErrTy != null) {
                                 add(ConvertToTyUsingTryFromTraitAndUnpackFix(element, expectedTy, resultErrTy))
                             }
                         }
-                        if (isToOwnedImplWithExcpectedForActual(items, lookup)) {
+                        if (isToOwnedImplWithExpectedForActual(items, lookup)) {
                             add(ConvertToOwnedTyFix(element, expectedTy))
                         }
                         val stringTy = items.findStringTy()
@@ -118,30 +111,30 @@ sealed class RsDiagnostic(
 
         private fun isFromActualImplForExpected(items: StdKnownItems, lookup: ImplLookup): Boolean {
             val fromTrait = items.findFromTrait() ?: return false
-            return lookup.select(TraitRef(expectedTy, fromTrait.withSubst(actualTy))).ok() != null
+            return lookup.canSelect(TraitRef(expectedTy, fromTrait.withSubst(actualTy)))
         }
 
         private fun errTyOfTryFromActualImplForTy(ty: Ty, items: StdKnownItems, lookup: ImplLookup): Ty? {
             val fromTrait = items.findTryFromTrait() ?: return null
-            val result = lookup.selectProjection(TraitRef(ty, fromTrait.withSubst(actualTy)),
+            val result = lookup.selectProjectionStrict(TraitRef(ty, fromTrait.withSubst(actualTy)),
                 fromTrait.associatedTypesTransitively.find { it.name == "Error"} ?: return null)
             return result.ok()?.value
         }
 
-        private fun isToOwnedImplWithExcpectedForActual(items: StdKnownItems, lookup: ImplLookup): Boolean {
+        private fun isToOwnedImplWithExpectedForActual(items: StdKnownItems, lookup: ImplLookup): Boolean {
             val toOwnedTrait = items.findToOwnedTrait() ?: return false
-            val result = lookup.selectProjection(TraitRef(actualTy, BoundElement(toOwnedTrait)),
-                toOwnedTrait.associatedTypesTransitively.find { it.name == "Owned" } ?: return false)
+            val result = lookup.selectProjectionStrictWithDeref(TraitRef(actualTy, BoundElement(toOwnedTrait)),
+                toOwnedTrait.findAssociatedType("Owned") ?: return false)
             return expectedTy == result.ok()?.value
         }
 
         private fun isToStringImplForActual(items: StdKnownItems, lookup: ImplLookup): Boolean {
             val toStringTrait = items.findToStringTrait() ?: return false
-            return lookup.select(TraitRef(actualTy, BoundElement(toStringTrait))).ok() != null
+            return lookup.canSelectWithDeref(TraitRef(actualTy, BoundElement(toStringTrait)))
         }
 
         private fun isTraitWithTySubstImplForActual(lookup: ImplLookup, trait: RsTraitItem?, ty: TyReference): Boolean =
-            trait != null && lookup.select(TraitRef(actualTy, trait.withSubst(ty.referenced))).ok() != null
+            trait != null && lookup.canSelectWithDeref(TraitRef(actualTy, trait.withSubst(ty.referenced)))
 
         private fun expectedFound(expectedTy: Ty, actualTy: Ty): String {
             val expectedTyS = escapeTy(expectedTy.toString())

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFixTest.kt
@@ -207,6 +207,19 @@ class ConvertToTyUsingTryFromTraitFixTest : RsInspectionsTestBase(RsExperimental
         }
     """)
 
+    fun `test no fix when impl TryFrom A for B is not available with simple From impl`() = checkFixIsUnavailable("Convert to Bb using `TryFrom` trait", """
+        struct Aa;
+        struct Bb;
+
+        impl From<Aa> for Bb {
+            fn from(a: Aa) -> Self { Bb }
+        }
+
+        fn main () {
+            let b: Bb = <error>Aa<caret></error>;
+        }
+    """)
+
     fun `test no fix when impl TryFrom A for B is not available`() = checkFixIsUnavailable("Convert to Bb using `TryFrom` trait", """
         #![feature(try_from)]
         use std::convert::TryFrom;


### PR DESCRIPTION
Related to #1730. 
 - better (strict) API for trait selection
  - use autoderef to select traits, e.g.
    ```rust
      fn main() {
          let a: Box<Cow<str>> = ...;
          let b: &str = a; // suggest to insert `.borrow()`
      }
    ```
  - TryFrom fix implemented without `convert::Infallible`, that was recently removed from stdlib