### PR TITLE
Add support for offline checking/building on Ctrl+f9

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -15,6 +15,7 @@ AtomicInteger
 bgourlie
 bmusin
 CGavrila
+chabapok
 chriskrycho
 contradictioned
 d9n

--- a/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt
@@ -42,6 +42,9 @@ class RustProjectConfigurable(
     private val useCargoCheckAnnotatorCheckbox = JBCheckBox()
     private var useCargoCheckAnnotator: Boolean by CheckboxDelegate(useCargoCheckAnnotatorCheckbox)
 
+    private val useOfflineForCargoCheckCheckbox = JBCheckBox()
+    private var useOfflineForCargoCheck: Boolean by CheckboxDelegate(useOfflineForCargoCheckCheckbox)
+
     private val hintProvider = InlayParameterHintsExtension.forLanguage(RsLanguage)
     private val hintCheckboxes: Map<String, JBCheckBox> =
         hintProvider.supportedOptions.associate { it.id to JBCheckBox() }
@@ -53,6 +56,7 @@ class RustProjectConfigurable(
         row(label = "Watch Cargo.toml:") { autoUpdateEnabledCheckbox() }
         row(label = "Use cargo check when build project:") { useCargoCheckForBuildCheckbox() }
         row(label = "Use cargo check to analyze code:") { useCargoCheckAnnotatorCheckbox() }
+        row(label = "Use '-Zoffline' for cargo check (nightly only):") { useOfflineForCargoCheckCheckbox() }
 
         var first = true
         for (option in hintProvider.supportedOptions) {
@@ -74,6 +78,7 @@ class RustProjectConfigurable(
         autoUpdateEnabled = settings.autoUpdateEnabled
         useCargoCheckForBuild = settings.useCargoCheckForBuild
         useCargoCheckAnnotator = settings.useCargoCheckAnnotator
+        useOfflineForCargoCheck = settings.useOfflineForCargoCheck
 
         for (option in hintProvider.supportedOptions) {
             checkboxForOption(option).isSelected = option.get()
@@ -94,7 +99,8 @@ class RustProjectConfigurable(
             explicitPathToStdlib = rustProjectSettings.data.explicitPathToStdlib,
             autoUpdateEnabled = autoUpdateEnabled,
             useCargoCheckForBuild = useCargoCheckForBuild,
-            useCargoCheckAnnotator = useCargoCheckAnnotator
+            useCargoCheckAnnotator = useCargoCheckAnnotator,
+            useOfflineForCargoCheck = useOfflineForCargoCheck
         )
     }
 
@@ -107,6 +113,7 @@ class RustProjectConfigurable(
             || autoUpdateEnabled != settings.autoUpdateEnabled
             || useCargoCheckForBuild != settings.useCargoCheckForBuild
             || useCargoCheckAnnotator != settings.useCargoCheckAnnotator
+            || useOfflineForCargoCheck != settings.useOfflineForCargoCheck
     }
 
     override fun getDisplayName(): String = "Rust" // sync me with plugin.xml

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -19,7 +19,8 @@ interface RustProjectSettingsService {
         // provide path to stdlib explicitly.
         val explicitPathToStdlib: String?,
         val useCargoCheckForBuild: Boolean,
-        val useCargoCheckAnnotator: Boolean
+        val useCargoCheckAnnotator: Boolean,
+        val useOfflineForCargoCheck: Boolean
     )
 
     var data: Data
@@ -33,7 +34,7 @@ interface RustProjectSettingsService {
     val autoUpdateEnabled: Boolean get() = data.autoUpdateEnabled
     val useCargoCheckForBuild: Boolean get() = data.useCargoCheckForBuild
     val useCargoCheckAnnotator: Boolean get() = data.useCargoCheckAnnotator
-
+    val useOfflineForCargoCheck: Boolean get() = data.useOfflineForCargoCheck
     /*
      * Show a dialog for toolchain configuration
      */

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -27,7 +27,8 @@ class RustProjectSettingsServiceImpl(
         var autoUpdateEnabled: Boolean = true,
         var explicitPathToStdlib: String? = null,
         var useCargoCheckForBuild: Boolean = true,
-        var useCargoCheckAnnotator: Boolean = false
+        var useCargoCheckAnnotator: Boolean = false,
+        var useOfflineForCargoCheck: Boolean = false
     )
 
     override fun getState(): State = state
@@ -48,7 +49,8 @@ class RustProjectSettingsServiceImpl(
                 autoUpdateEnabled = state.autoUpdateEnabled,
                 explicitPathToStdlib = state.explicitPathToStdlib,
                 useCargoCheckForBuild = state.useCargoCheckForBuild,
-                useCargoCheckAnnotator = state.useCargoCheckAnnotator
+                useCargoCheckAnnotator = state.useCargoCheckAnnotator,
+                useOfflineForCargoCheck = state.useOfflineForCargoCheck
             )
         }
         set(value) {
@@ -57,7 +59,8 @@ class RustProjectSettingsServiceImpl(
                 autoUpdateEnabled = value.autoUpdateEnabled,
                 explicitPathToStdlib = value.explicitPathToStdlib,
                 useCargoCheckForBuild = value.useCargoCheckForBuild,
-                useCargoCheckAnnotator = value.useCargoCheckAnnotator
+                useCargoCheckAnnotator = value.useCargoCheckAnnotator,
+                useOfflineForCargoCheck = value.useOfflineForCargoCheck
             )
             if (state != newState) {
                 state = newState

--- a/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
@@ -63,6 +63,9 @@ fun Project.buildProject() {
     if (allTargets) {
         arguments += "--all-targets"
     }
+    if (rustSettings.useOfflineForCargoCheck) {
+        arguments += "-Zoffline"
+    }
 
     for (cargoProject in cargoProjects.allProjects) {
         val cmd = CargoCommandLine.forProject(cargoProject, command, arguments)

--- a/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
@@ -38,7 +38,8 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
             autoUpdateEnabled = true,
             explicitPathToStdlib = "/stdlib",
             useCargoCheckForBuild = false,
-            useCargoCheckAnnotator = true
+            useCargoCheckAnnotator = true,
+            useOfflineForCargoCheck = false
         ))
     }
 }


### PR DESCRIPTION
This commit add CheckBox for controlling `-Zoffline` flag passed to `cargo check` and `cargo build` commands (usually invoked by Ctrl+F9). It may be useful in some situations.
