### PR TITLE
INSP: Fix false warning of reassignment to immutable type for referen…

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -61,6 +61,7 @@ pcholakov
 pocket7878
 rrevenantt
 sanmai-NL
+sgift
 Shiroy
 shssoichiro
 sirgl

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -71,12 +71,13 @@ val RsExpr.isMutable: Boolean get() {
             if (declaration is RsPatBinding && declaration.mutability.isMut) return true
             if (declaration is RsConstant) return declaration.mutability.isMut
 
-            val type = this.type
-            if (type is TyReference) return type.mutability.isMut
-
             val letExpr = declaration.ancestorStrict<RsLetDecl>()
             if (letExpr != null && letExpr.eq == null) return true
+
+            val type = this.type
+            if (type is TyReference) return type.mutability.isMut
             if (type is TyUnknown) return DEFAULT_MUTABILITY
+
             if (declaration is RsEnumVariant) return true
             if (declaration is RsStructItem) return true
             if (declaration is RsFunction) return true

--- a/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt
@@ -35,10 +35,17 @@ class RsReassignImmutableInspectionTest : RsInspectionsTestBase(RsReassignImmuta
         }
     """)
 
-    fun `test E0384 assign immutbable binding later`() = checkByText("""
+    fun `test E0384 assign immutable binding later`() = checkByText("""
         fn main() {
             let x;
             x = 3;
+        }
+    """)
+
+    fun `test E0384 assign immutable binding later for reference type`() = checkByText("""
+        fn main() {
+            let x;
+            x = &42;
         }
     """)
 


### PR DESCRIPTION
First check if there was already an assignment and then check for reference types.

Fix for #2393 
