### PR TITLE
MACRO: added an option to disable macro expansion

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RustProjectConfigurable.kt
@@ -45,6 +45,9 @@ class RustProjectConfigurable(
     private val useOfflineForCargoCheckCheckbox = JBCheckBox()
     private var useOfflineForCargoCheck: Boolean by CheckboxDelegate(useOfflineForCargoCheckCheckbox)
 
+    private val expandMacrosCheckbox = JBCheckBox()
+    private var expandMacros: Boolean by CheckboxDelegate(expandMacrosCheckbox)
+
     private val hintProvider = InlayParameterHintsExtension.forLanguage(RsLanguage)
     private val hintCheckboxes: Map<String, JBCheckBox> =
         hintProvider.supportedOptions.associate { it.id to JBCheckBox() }
@@ -57,6 +60,7 @@ class RustProjectConfigurable(
         row(label = "Use cargo check when build project:") { useCargoCheckForBuildCheckbox() }
         row(label = "Use cargo check to analyze code:") { useCargoCheckAnnotatorCheckbox() }
         row(label = "Use '-Zoffline' for cargo check (nightly only):") { useOfflineForCargoCheckCheckbox() }
+        row(label = "Expand macros (may be slow):") { expandMacrosCheckbox() }
 
         var first = true
         for (option in hintProvider.supportedOptions) {
@@ -79,6 +83,7 @@ class RustProjectConfigurable(
         useCargoCheckForBuild = settings.useCargoCheckForBuild
         useCargoCheckAnnotator = settings.useCargoCheckAnnotator
         useOfflineForCargoCheck = settings.useOfflineForCargoCheck
+        expandMacros = settings.expandMacros
 
         for (option in hintProvider.supportedOptions) {
             checkboxForOption(option).isSelected = option.get()
@@ -100,7 +105,8 @@ class RustProjectConfigurable(
             autoUpdateEnabled = autoUpdateEnabled,
             useCargoCheckForBuild = useCargoCheckForBuild,
             useCargoCheckAnnotator = useCargoCheckAnnotator,
-            useOfflineForCargoCheck = useOfflineForCargoCheck
+            useOfflineForCargoCheck = useOfflineForCargoCheck,
+            expandMacros = expandMacros
         )
     }
 
@@ -114,6 +120,7 @@ class RustProjectConfigurable(
             || useCargoCheckForBuild != settings.useCargoCheckForBuild
             || useCargoCheckAnnotator != settings.useCargoCheckAnnotator
             || useOfflineForCargoCheck != settings.useOfflineForCargoCheck
+            || expandMacros != settings.expandMacros
     }
 
     override fun getDisplayName(): String = "Rust" // sync me with plugin.xml

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -20,7 +20,8 @@ interface RustProjectSettingsService {
         val explicitPathToStdlib: String?,
         val useCargoCheckForBuild: Boolean,
         val useCargoCheckAnnotator: Boolean,
-        val useOfflineForCargoCheck: Boolean
+        val useOfflineForCargoCheck: Boolean,
+        val expandMacros: Boolean
     )
 
     var data: Data
@@ -35,6 +36,8 @@ interface RustProjectSettingsService {
     val useCargoCheckForBuild: Boolean get() = data.useCargoCheckForBuild
     val useCargoCheckAnnotator: Boolean get() = data.useCargoCheckAnnotator
     val useOfflineForCargoCheck: Boolean get() = data.useOfflineForCargoCheck
+    val expandMacros: Boolean get() = data.expandMacros
+
     /*
      * Show a dialog for toolchain configuration
      */

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -28,7 +28,8 @@ class RustProjectSettingsServiceImpl(
         var explicitPathToStdlib: String? = null,
         var useCargoCheckForBuild: Boolean = true,
         var useCargoCheckAnnotator: Boolean = false,
-        var useOfflineForCargoCheck: Boolean = false
+        var useOfflineForCargoCheck: Boolean = false,
+        var expandMacros: Boolean = true
     )
 
     override fun getState(): State = state
@@ -50,7 +51,8 @@ class RustProjectSettingsServiceImpl(
                 explicitPathToStdlib = state.explicitPathToStdlib,
                 useCargoCheckForBuild = state.useCargoCheckForBuild,
                 useCargoCheckAnnotator = state.useCargoCheckAnnotator,
-                useOfflineForCargoCheck = state.useOfflineForCargoCheck
+                useOfflineForCargoCheck = state.useOfflineForCargoCheck,
+                expandMacros = state.expandMacros
             )
         }
         set(value) {
@@ -60,7 +62,8 @@ class RustProjectSettingsServiceImpl(
                 explicitPathToStdlib = value.explicitPathToStdlib,
                 useCargoCheckForBuild = value.useCargoCheckForBuild,
                 useCargoCheckAnnotator = value.useCargoCheckAnnotator,
-                useOfflineForCargoCheck = value.useOfflineForCargoCheck
+                useOfflineForCargoCheck = value.useOfflineForCargoCheck,
+                expandMacros = value.expandMacros
             )
             if (state != newState) {
                 state = newState

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.macros
 
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.PsiModificationTracker
+import org.rust.cargo.project.settings.rustSettings
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.RsMacroDefinition
 import org.rust.lang.core.psi.ext.RsElement
@@ -24,6 +25,7 @@ fun expandMacro(call: RsMacroCall): CachedValueProvider.Result<List<ExpansionRes
             CachedValueProvider.Result.create(result, call.containingFile)
         }
         else -> {
+            if (!context.project.rustSettings.expandMacros) return NULL_RESULT
             val def = call.reference.resolve() as? RsMacroDefinition ?: return NULL_RESULT
             val project = context.project
             val expander = MacroExpander(project)

--- a/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
@@ -39,7 +39,8 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
             explicitPathToStdlib = "/stdlib",
             useCargoCheckForBuild = false,
             useCargoCheckAnnotator = true,
-            useOfflineForCargoCheck = false
+            useOfflineForCargoCheck = false,
+            expandMacros = true
         ))
     }
 }


### PR DESCRIPTION
Macros now can be disabled in the plugin settings
![image](https://user-images.githubusercontent.com/3221931/38519703-60db5c5c-3c49-11e8-9e9f-a9fe15d7b508.png)
