### PR TITLE
TY: Fixed `write!` & `writeln!` macro return type

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -856,7 +856,8 @@ Expr ::= RetExpr
        | UnaryExpr
        | TryExpr
        | AtomExpr {
-  extends = "org.rust.lang.core.psi.ext.RsStubbedElementImpl<?>"
+  implements = "org.rust.lang.core.macros.ExpansionResult"
+  mixin = "org.rust.lang.core.psi.ext.RsExprMixin"
   stubClass = "org.rust.lang.core.stubs.RsPlaceholderStub"
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -42,8 +42,11 @@ class RsPsiFactory(private val project: Project) {
             ?: error("Failed to create quote identifier: `$text`")
 
     fun createExpression(text: String): RsExpr =
-        createFromText("fn main() { $text; }")
+        tryCreateExpression(text)
             ?: error("Failed to create expression from text: `$text`")
+
+    fun tryCreateExpression(text: CharSequence): RsExpr? =
+        createFromText("fn main() { $text; }")
 
     fun createTryExpression(expr: RsExpr): RsTryExpr {
         val newElement = createExpressionOfType<RsTryExpr>("a?")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
@@ -5,8 +5,12 @@
 
 package org.rust.lang.core.psi.ext
 
+import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.IStubElementType
+import org.rust.lang.core.macros.ExpansionResult
 import org.rust.lang.core.psi.*
+import org.rust.lang.core.stubs.RsPlaceholderStub
 
 /**
  * Extracts [RsLitExpr] raw value
@@ -180,3 +184,10 @@ val RsBinaryOp.operatorType: BinaryOperator get() = when (op) {
 
 val RsBinaryExpr.operator: PsiElement get() = binaryOp.operator
 val RsBinaryExpr.operatorType: BinaryOperator get() = binaryOp.operatorType
+
+abstract class RsExprMixin : RsStubbedElementImpl<RsPlaceholderStub>, RsExpr {
+    constructor(node: ASTNode) : super(node)
+    constructor(stub: RsPlaceholderStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
+
+    override fun getContext() = ExpansionResult.getContextImpl(this)
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -45,7 +45,7 @@ val RsMacroCall.macroBody: String?
     get() {
         val stub = stub
         if (stub != null) return stub.macroBody
-        return macroArgument?.compactTT?.text
+        return macroArgument?.compactTT?.text ?: formatMacroArgument?.braceListBodyText()?.toString()
     }
 
 val RsMacroCall.expansion: List<ExpansionResult>?

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -37,7 +37,7 @@ val RsInferenceContextOwner.inference: RsInferenceResult
     })
 
 val PsiElement.inference: RsInferenceResult?
-    get() = ancestorOrSelf<RsInferenceContextOwner>()?.inference
+    get() = contextOrSelf<RsInferenceContextOwner>()?.inference
 
 val RsPatBinding.type: Ty
     get() = inference?.getBindingType(this) ?: TyUnknown

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -1321,6 +1321,9 @@ private class RsFnInferenceContext(
             name == "format" -> items.findStringTy()
             name == "format_args" -> items.findArgumentsTy()
             name == "unimplemented" || name == "unreachable" || name == "panic" -> TyNever
+            name == "write" || name == "writeln" -> {
+                (expr.macroCall.expansion?.singleOrNull() as? RsExpr)?.inferType() ?: TyUnknown
+            }
             expr.macroCall.formatMacroArgument != null || expr.macroCall.logMacroArgument != null -> TyUnit
 
             else -> TyUnknown

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -460,4 +460,15 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
           //^ ($expectedOutputType, $lhsType)
         }
     """)
+
+    fun `test write macro`() = stubOnlyTypeInfer("""
+    //- main.rs
+        use std::fmt::Write;
+        fn main() {
+            let mut s = String::new();
+            let a = write!(s, "text");
+            a;
+          //^ Result<(), Error>
+        }
+    """)
 }


### PR DESCRIPTION
Really this commit as a first experiment with
expression-context macro expansion and type inference inside macros

Fixes #2229
Fixes #2452 
Fixes #2461