### PR TITLE
TY: Fixed type of `vec![1; 2]` macro

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -1310,8 +1310,12 @@ private class RsFnInferenceContext(
         inferChildExprsRecursively(expr.macroCall)
         val vecArg = expr.macroCall.vecMacroArgument
         if (vecArg != null) {
-            val elementTypes = vecArg.exprList.map { ctx.getExprType(it) }
-            val elementType = getMoreCompleteType(elementTypes)
+            val elementType = if (vecArg.semicolon != null) {
+                vecArg.exprList.firstOrNull()?.inferType() ?: TyUnknown
+            } else {
+                val elementTypes = vecArg.exprList.map { ctx.getExprType(it) }
+                getMoreCompleteType(elementTypes)
+            }
             return items.findVecForElementTy(elementType)
         }
 

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -132,6 +132,15 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test repeat vec!`() = stubOnlyTypeInfer("""
+    //- main.rs
+        fn main() {
+            let x = vec!(1u8, 2usize);
+            x;
+          //^ Vec<u8>
+        }
+    """)
+
     fun `test format!`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {


### PR DESCRIPTION
Fixes #2448