### PR TITLE
FMT: Do not put a space between '?' and 'Sized'

### DIFF
--- a/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt
@@ -125,6 +125,9 @@ fun createSpacingBuilder(commonSettings: CommonCodeStyleSettings, rustSettings: 
         .around(FOR_LIFETIMES).spacing(1, 1, 0, true, 0)
         .aroundInside(EQ, ASSOC_TYPE_BINDING).spaces(0)
 
+        //?Sized
+        .betweenInside(ts(Q), ts(BOUND), POLYBOUND).spaces(0)
+
         //== expressions
         .beforeInside(LPAREN, PAT_ENUM).spaces(0)
         .beforeInside(LBRACK, INDEX_EXPR).spaces(0)

--- a/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt
@@ -295,6 +295,32 @@ class RsFormatterTest : RsFormatterTestBase() {
         }
     """)
 
+    fun `test negative trait bound`() = doTextTest("""
+        struct Foo<T:  ?  Sized> {
+            a: T,
+        }
+
+        impl<T> Foo<T>
+            where T: Bar +  ?  Sized {
+            fn foo<U: Bar +  ?  Sized>(a: &U) {}
+        }
+
+        impl<T:  ?  Sized > Foo<T>
+        {}
+    """, """
+        struct Foo<T: ?Sized> {
+            a: T,
+        }
+
+        impl<T> Foo<T>
+            where T: Bar + ?Sized {
+            fn foo<U: Bar + ?Sized>(a: &U) {}
+        }
+
+        impl<T: ?Sized> Foo<T>
+        {}
+    """)
+
     fun `test spaces in reverse turbofish paths`() = doTextTest("""
         enum E<T> {
             X(< T :: BindTransport  as  IntoFuture > :: Future),


### PR DESCRIPTION
We currently put a space between the '?' and 'Sized' so it looks like "T: ? Sized".

rustfmt does not add a space, so lets match its behavior.

Fixes #2377