### PR TITLE
UI & CARGO: Improve workspace tree

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
@@ -28,13 +28,13 @@ import com.intellij.xdebugger.impl.XDebugProcessConfiguratorStarter
 import com.intellij.xdebugger.impl.ui.XDebugSessionData
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
+import org.rust.cargo.project.workspace.CargoWorkspace.CrateType
 import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
 import org.rust.cargo.runconfig.CargoRunState
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.toolchain.Cargo
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.toolchain.impl.CargoMetadata
-import org.rust.cargo.toolchain.impl.CargoMetadata.CrateType
 import org.rust.debugger.settings.RsDebuggerSettings
 import org.rust.openapiext.GeneralCommandLine
 import org.rust.openapiext.withWorkDirectory

--- a/src/main/kotlin/org/rust/cargo/project/model/DetachCargoProjectAction.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/DetachCargoProjectAction.kt
@@ -7,7 +7,7 @@ package org.rust.cargo.project.model
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import org.rust.cargo.project.toolwindow.CargoToolWindowPanel.Companion.SELECTED_CARGO_PROJECT
+import org.rust.cargo.project.toolwindow.CargoToolWindow
 
 class DetachCargoProjectAction : AnAction() {
     override fun update(e: AnActionEvent) {
@@ -20,6 +20,6 @@ class DetachCargoProjectAction : AnAction() {
         project.cargoProjects.detachCargoProject(cargoProject)
     }
 
-    private val AnActionEvent.cargoProject get() = dataContext.getData(SELECTED_CARGO_PROJECT)
+    private val AnActionEvent.cargoProject get() = getData(CargoToolWindow.SELECTED_CARGO_PROJECT)
 
 }

--- a/src/main/kotlin/org/rust/cargo/project/model/DetachCargoProjectAction.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/DetachCargoProjectAction.kt
@@ -7,7 +7,7 @@ package org.rust.cargo.project.model
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import org.rust.cargo.project.CargoToolWindowPanel.Companion.SELECTED_CARGO_PROJECT
+import org.rust.cargo.project.toolwindow.CargoToolWindowPanel.Companion.SELECTED_CARGO_PROJECT
 
 class DetachCargoProjectAction : AnAction() {
     override fun update(e: AnActionEvent) {

--- a/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructure.kt
+++ b/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructure.kt
@@ -1,0 +1,89 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.toolwindow
+
+import com.intellij.icons.AllIcons
+import com.intellij.ui.tree.BaseTreeModel
+import org.rust.cargo.icons.CargoIcons
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.toolwindow.CargoProjectStructure.Node.*
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.PackageOrigin
+import javax.swing.Icon
+import javax.swing.tree.DefaultMutableTreeNode
+
+class CargoProjectStructure(private var cargoProjects: List<CargoProject> = emptyList()) : BaseTreeModel<DefaultMutableTreeNode>() {
+
+    private val root = DefaultMutableTreeNode(Node.Root)
+
+    fun updateCargoProjects(cargoProjects: List<CargoProject>) {
+        this.cargoProjects = cargoProjects
+        treeStructureChanged(null, null, null)
+    }
+
+    override fun getChildren(parent: Any): List<DefaultMutableTreeNode>? {
+        val userObject = (parent as? DefaultMutableTreeNode)?.userObject
+        val childrenObjects = when (userObject) {
+            is Root -> cargoProjects.map(::Project)
+            is Project -> {
+                val cargoProject = userObject.cargoProject
+                val (ourPackage, workspaceMembers) = cargoProject.workspace
+                    ?.packages
+                    ?.filter { it.origin == PackageOrigin.WORKSPACE }
+                    .orEmpty()
+                    .partition { it.rootDirectory == cargoProject.manifest.parent }
+                val childrenNodes = mutableListOf<Node>()
+                ourPackage.mapTo(childrenNodes) { Targets(it.targets) }
+                workspaceMembers.mapTo(childrenNodes, ::WorkspaceMember)
+                childrenNodes
+            }
+            is WorkspaceMember -> listOf(Targets(userObject.pkg.targets))
+            is Targets -> userObject.targets.map { Node.Target(it) }
+            is Node.Target -> emptyList()
+            else -> null
+        }
+        return childrenObjects?.map(::DefaultMutableTreeNode)
+    }
+
+    override fun getRoot(): Any = root
+
+    override fun toString(): String = "CargoProjectStructure(workspaces = $cargoProjects)"
+
+    sealed class Node {
+        object Root : Node() {
+            override fun toString(): String = "Root"
+        }
+        data class Project(val cargoProject: CargoProject) : Node() {
+            override fun toString(): String = "Project"
+        }
+        data class WorkspaceMember(val pkg: CargoWorkspace.Package) : Node() {
+            override fun toString(): String = "WorkspaceMember($name)"
+        }
+        data class Targets(val targets: Collection<CargoWorkspace.Target>) : Node() {
+            override fun toString(): String = "Targets"
+        }
+        data class Target(val target: CargoWorkspace.Target) : Node() {
+            override fun toString(): String = "Target($name[${target.kind.name.toLowerCase()}])"
+        }
+
+        val name: String get() = when (this) {
+            Root -> ""
+            is Project -> cargoProject.presentableName
+            is WorkspaceMember -> pkg.name
+            is Targets -> "targets"
+            is Target -> target.name
+        }
+
+        // TODO: come up with icons
+        val icon: Icon? get() = when (this) {
+            is Project -> CargoIcons.ICON
+            is WorkspaceMember -> CargoIcons.ICON
+            is Targets -> AllIcons.Nodes.Folder
+            is Target -> CargoIcons.ICON
+            else -> null
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructureTree.kt
+++ b/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructureTree.kt
@@ -1,0 +1,73 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.toolwindow
+
+import com.intellij.ui.ColoredTreeCellRenderer
+import com.intellij.ui.JBColor
+import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.treeStructure.SimpleTree
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.workspace.CargoWorkspace
+import javax.swing.JTree
+import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.TreeSelectionModel
+
+class CargoProjectStructureTree(model: CargoProjectStructure) : SimpleTree(model) {
+
+    val selectedProject: CargoProject? get() {
+        val path = selectionPath ?: return null
+        if (path.pathCount < 2) return null
+        val treeNode = path.getPathComponent(1) as? DefaultMutableTreeNode ?: return null
+        return (treeNode.userObject as? CargoProjectStructure.Node.Project)?.cargoProject
+    }
+
+    init {
+        isRootVisible = false
+        emptyText.text = "There are no Cargo projects to display."
+        selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
+    }
+}
+
+class CargoProjectTreeRenderer : ColoredTreeCellRenderer() {
+
+    override fun customizeCellRenderer(tree: JTree, value: Any?, selected: Boolean, expanded: Boolean, leaf: Boolean, row: Int, hasFocus: Boolean) {
+        val node = (value as? DefaultMutableTreeNode)?.userObject as? CargoProjectStructure.Node ?: return
+        icon = node.icon
+        appendName(node)
+    }
+
+    private fun appendName(node: CargoProjectStructure.Node) {
+        when (node) {
+            is CargoProjectStructure.Node.Project -> {
+                val cargoProject = node.cargoProject
+                var attrs = SimpleTextAttributes.REGULAR_ATTRIBUTES
+                val status = cargoProject.mergedStatus
+                when (status) {
+                    is CargoProject.UpdateStatus.UpdateFailed -> {
+                        attrs = attrs.derive(SimpleTextAttributes.STYLE_WAVED, null, null, JBColor.RED)
+                        toolTipText = status.reason
+                    }
+                    is CargoProject.UpdateStatus.NeedsUpdate -> {
+                        attrs = attrs.derive(SimpleTextAttributes.STYLE_WAVED, null, null, JBColor.GRAY)
+                        toolTipText = "Project needs update"
+                    }
+                    is CargoProject.UpdateStatus.UpToDate -> {
+                        toolTipText = "Project is up-to-date"
+                    }
+                }
+                append(cargoProject.presentableName, attrs)
+            }
+            is CargoProjectStructure.Node.Target -> {
+                append(node.name)
+                val targetKind = node.target.kind
+                if (targetKind != CargoWorkspace.TargetKind.UNKNOWN) {
+                    append(" (${targetKind.name.toLowerCase()})", SimpleTextAttributes.GRAYED_ATTRIBUTES)
+                }
+            }
+            else -> append(node.name)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoToolWindow.kt
+++ b/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoToolWindow.kt
@@ -35,7 +35,7 @@ class CargoToolWindowFactory : ToolWindowFactory {
     }
 }
 
-class CargoToolWindowPanel(project: Project) : SimpleToolWindowPanel(true, false) {
+private class CargoToolWindowPanel(project: Project) : SimpleToolWindowPanel(true, false) {
     private val cargoTab = CargoToolWindow(project)
 
     init {
@@ -45,19 +45,14 @@ class CargoToolWindowPanel(project: Project) : SimpleToolWindowPanel(true, false
     }
 
     override fun getData(dataId: String): Any? {
-        if (SELECTED_CARGO_PROJECT.`is`(dataId)) {
+        if (CargoToolWindow.SELECTED_CARGO_PROJECT.`is`(dataId)) {
             return cargoTab.selectedProject
         }
         return super.getData(dataId)
     }
-
-    companion object {
-        val SELECTED_CARGO_PROJECT: DataKey<CargoProject> =
-            DataKey.create<CargoProject>("SELECTED_CARGO_PROJECT")
-    }
 }
 
-private class CargoToolWindow(
+class CargoToolWindow(
     private val project: Project
 ) {
     val toolbar: ActionToolbar = run {
@@ -104,4 +99,9 @@ private class CargoToolWindow(
         </body>
         </html>
     """
+
+    companion object {
+        @JvmStatic
+        val SELECTED_CARGO_PROJECT: DataKey<CargoProject> = DataKey.create<CargoProject>("SELECTED_CARGO_PROJECT")
+    }
 }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
@@ -37,6 +37,7 @@ data class CargoWorkspaceData(
     data class Target(
         val crateRootUrl: String,
         val name: String,
-        val kind: CargoWorkspace.TargetKind
+        val kind: CargoWorkspace.TargetKind,
+        val crateTypes: List<CargoWorkspace.CrateType>
     )
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandAction.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandAction.kt
@@ -8,6 +8,7 @@ package org.rust.cargo.runconfig.command
 import com.intellij.openapi.actionSystem.AnActionEvent
 import org.rust.cargo.icons.CargoIcons
 import org.rust.cargo.runconfig.ui.RunCargoCommandDialog
+import org.rust.cargo.toolchain.run
 
 class RunCargoCommandAction : RunCargoCommandActionBase(CargoIcons.ICON) {
 
@@ -17,7 +18,7 @@ class RunCargoCommandAction : RunCargoCommandActionBase(CargoIcons.ICON) {
         val dialog = RunCargoCommandDialog(project, cargoProject)
         if (!dialog.showAndGet()) return
 
-        runCommand(project, dialog.getCargoCommandLine(), cargoProject)
+        dialog.getCargoCommandLine().run(project, cargoProject)
     }
 
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandActionBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandActionBase.kt
@@ -14,9 +14,9 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.project.Project
-import org.rust.cargo.project.CargoToolWindowPanel
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.toolwindow.CargoToolWindow
 import org.rust.cargo.runconfig.createCargoCommandRunConfiguration
 import org.rust.cargo.runconfig.hasCargoProject
 import org.rust.cargo.toolchain.CargoCommandLine
@@ -36,7 +36,7 @@ abstract class RunCargoCommandActionBase(icon: Icon) : AnAction(icon) {
             ?.let { cargoProjects.findProjectForFile(it) }
             ?.let { return it }
 
-        return e.dataContext.getData(CargoToolWindowPanel.SELECTED_CARGO_PROJECT)
+        return e.getData(CargoToolWindow.SELECTED_CARGO_PROJECT)
             ?: cargoProjects.allProjects.firstOrNull()
     }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandActionBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandActionBase.kt
@@ -5,21 +5,13 @@
 
 package org.rust.cargo.runconfig.command
 
-import com.intellij.execution.ExecutorRegistry
-import com.intellij.execution.ProgramRunnerUtil
-import com.intellij.execution.RunManagerEx
-import com.intellij.execution.RunnerAndConfigurationSettings
-import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.project.Project
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.toolwindow.CargoToolWindow
-import org.rust.cargo.runconfig.createCargoCommandRunConfiguration
 import org.rust.cargo.runconfig.hasCargoProject
-import org.rust.cargo.toolchain.CargoCommandLine
 import javax.swing.Icon
 
 abstract class RunCargoCommandActionBase(icon: Icon) : AnAction(icon) {
@@ -38,25 +30,5 @@ abstract class RunCargoCommandActionBase(icon: Icon) : AnAction(icon) {
 
         return e.getData(CargoToolWindow.SELECTED_CARGO_PROJECT)
             ?: cargoProjects.allProjects.firstOrNull()
-    }
-
-    protected fun runCommand(project: Project, cargoCommandLine: CargoCommandLine, cargoProject: CargoProject) {
-
-
-        val runConfiguration =
-            if (project.cargoProjects.allProjects.size > 1)
-                createRunConfiguration(project, cargoCommandLine, name = cargoCommandLine.command + " [" + cargoProject.presentableName + "]")
-            else
-                createRunConfiguration(project, cargoCommandLine)
-        val executor = ExecutorRegistry.getInstance().getExecutorById(DefaultRunExecutor.EXECUTOR_ID)
-        ProgramRunnerUtil.executeConfiguration(runConfiguration, executor)
-    }
-
-    private fun createRunConfiguration(project: Project, cargoCommandLine: CargoCommandLine, name: String? = null): RunnerAndConfigurationSettings {
-        val runManager = RunManagerEx.getInstanceEx(project)
-
-        return runManager.createCargoCommandRunConfiguration(cargoCommandLine, name).apply {
-            runManager.setTemporaryConfiguration(this)
-        }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/RunClippyAction.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/RunClippyAction.kt
@@ -10,6 +10,7 @@ import org.rust.cargo.icons.CargoIcons
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.toolchain.RustChannel
+import org.rust.cargo.toolchain.run
 
 class RunClippyAction : RunCargoCommandActionBase(CargoIcons.CLIPPY) {
 
@@ -18,6 +19,6 @@ class RunClippyAction : RunCargoCommandActionBase(CargoIcons.CLIPPY) {
         val toolchain = project.toolchain ?: return
         val cargoProject = getAppropriateCargoProject(e) ?: return
         val channel = if (toolchain.isRustupAvailable) RustChannel.NIGHTLY else RustChannel.DEFAULT
-        runCommand(project, CargoCommandLine.forProject(cargoProject, "clippy", channel = channel), cargoProject)
+        CargoCommandLine.forProject(cargoProject, "clippy", channel = channel).run(project, cargoProject)
     }
 }

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -10,6 +10,7 @@ import com.google.gson.JsonObject
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.PathUtil
+import org.rust.cargo.project.workspace.CargoWorkspace.CrateType
 import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
 import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.cargo.project.workspace.PackageId
@@ -143,16 +144,6 @@ object CargoMetadata {
         }
 
     /**
-     * Represents possible variants of generated artifact binary
-     * corresponded to `--crate-type` compiler attribute
-     *
-     * See [linkage](https://doc.rust-lang.org/reference/linkage.html)
-     */
-    enum class CrateType {
-        BIN, LIB, DYLIB, STATICLIB, CDYLIB, RLIB, PROC_MACRO, UNKNOWN
-    }
-
-    /**
      * A rooted graph of dependencies, represented as adjacency list
      */
     data class Resolve(
@@ -223,7 +214,7 @@ object CargoMetadata {
 
         val mainFile = root.findFileByMaybeRelativePath(src_path)
 
-        return mainFile?.let { CargoWorkspaceData.Target(it.url, name, cleanKind) }
+        return mainFile?.let { CargoWorkspaceData.Target(it.url, name, cleanKind, cleanCrateTypes) }
     }
 }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -572,7 +572,7 @@
 
         <toolWindow id="Cargo"
                     anchor="right"
-                    factoryClass="org.rust.cargo.project.CargoToolWindowFactory"
+                    factoryClass="org.rust.cargo.project.toolwindow.CargoToolWindowFactory"
                     icon="/icons/tool-window.svg"/>
 
         <additionalLibraryRootsProvider

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt
@@ -15,12 +15,14 @@ import com.intellij.testFramework.LightProjectDescriptor
 import org.jdom.Element
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.CrateType
+import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
+import org.rust.cargo.project.workspace.CargoWorkspaceData
+import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.runconfig.command.CargoCommandConfigurationType
 import org.rust.cargo.runconfig.command.CargoExecutableRunConfigurationProducer
 import org.rust.cargo.runconfig.test.CargoTestRunConfigurationProducer
-import org.rust.cargo.project.workspace.CargoWorkspaceData
-import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.RsTestBase
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsFunction
@@ -297,7 +299,8 @@ class RunConfigurationProducerTest : RsTestBase() {
         private inner class Target(
             val name: String,
             val file: File,
-            val kind: CargoWorkspace.TargetKind
+            val kind: CargoWorkspace.TargetKind,
+            val crateTypes: List<CargoWorkspace.CrateType>
         )
 
         private var targets = arrayListOf<Target>()
@@ -308,22 +311,22 @@ class RunConfigurationProducerTest : RsTestBase() {
         private val hello = """pub fn hello() -> String { return "Hello, World!".to_string() }"""
 
         fun bin(name: String, path: String, code: String = helloWorld): TestProjectBuilder {
-            addTarget(name, CargoWorkspace.TargetKind.BIN, path, code)
+            addTarget(name, TargetKind.BIN, CrateType.BIN, path, code)
             return this
         }
 
         fun example(name: String, path: String, code: String = helloWorld): TestProjectBuilder {
-            addTarget(name, CargoWorkspace.TargetKind.EXAMPLE, path, code)
+            addTarget(name, TargetKind.EXAMPLE, CrateType.BIN, path, code)
             return this
         }
 
         fun test(name: String, path: String, code: String = simpleTest): TestProjectBuilder {
-            addTarget(name, CargoWorkspace.TargetKind.TEST, path, code)
+            addTarget(name, TargetKind.TEST, CrateType.BIN, path, code)
             return this
         }
 
         fun lib(name: String, path: String, code: String = hello): TestProjectBuilder {
-            addTarget(name, CargoWorkspace.TargetKind.LIB, path, code)
+            addTarget(name, TargetKind.LIB, CrateType.LIB, path, code)
             return this
         }
 
@@ -365,7 +368,8 @@ class RunConfigurationProducerTest : RsTestBase() {
                                 CargoWorkspaceData.Target(
                                     myFixture.tempDirFixture.getFile(it.file.path)!!.url,
                                     it.name,
-                                    it.kind
+                                    it.kind,
+                                    it.crateTypes
                                 )
                             },
                             source = null,
@@ -379,9 +383,9 @@ class RunConfigurationProducerTest : RsTestBase() {
             project.cargoProjects.createTestProject(myFixture.findFileInTempDir("."), projectDescription)
         }
 
-        private fun addTarget(name: String, kind: CargoWorkspace.TargetKind, path: String, code: String) {
+        private fun addTarget(name: String, kind: CargoWorkspace.TargetKind, crateType: CargoWorkspace.CrateType, path: String, code: String) {
             val file = addFile(path, code)
-            targets.add(Target(name, file, kind))
+            targets.add(Target(name, file, kind, listOf(crateType)))
         }
 
         private fun addFile(path: String, code: String): File {

--- a/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
@@ -8,11 +8,12 @@ package org.rust.cargo.util
 import com.intellij.codeInsight.completion.PlainPrefixMatcher
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.CrateType
+import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
 import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.RsTestBase
 import java.nio.file.Paths
-
 
 class CargoCommandCompletionProviderTest : RsTestBase() {
     fun `test split context prefix`() {
@@ -97,10 +98,11 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
     }
 
     private val TEST_WORKSPACE = run {
-        fun target(name: String, kind: CargoWorkspace.TargetKind): CargoWorkspaceData.Target = CargoWorkspaceData.Target(
+        fun target(name: String, kind: TargetKind, crateType: CrateType): CargoWorkspaceData.Target = CargoWorkspaceData.Target(
             crateRootUrl = "/tmp/lib/rs",
             name = name,
-            kind = kind
+            kind = kind,
+            crateTypes = listOf(crateType)
         )
 
         fun pkg(
@@ -119,11 +121,11 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
 
         val pkgs = listOf(
             pkg("foo", true, listOf(
-                target("foo", CargoWorkspace.TargetKind.LIB),
-                target("bar", CargoWorkspace.TargetKind.BIN),
-                target("baz", CargoWorkspace.TargetKind.BIN)
+                target("foo", TargetKind.LIB, CrateType.LIB),
+                target("bar", TargetKind.BIN, CrateType.BIN),
+                target("baz", TargetKind.BIN, CrateType.BIN)
             )),
-            pkg("quux", false, listOf(target("quux", CargoWorkspace.TargetKind.LIB)))
+            pkg("quux", false, listOf(target("quux", TargetKind.LIB, CrateType.LIB)))
         )
         CargoWorkspace.deserialize(Paths.get("/my-crate/Cargo.toml"), CargoWorkspaceData(pkgs, dependencies = emptyMap()))
     }

--- a/src/test/kotlin/org/rust/lang/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/RsTestBase.kt
@@ -28,6 +28,8 @@ import org.rust.FileTree
 import org.rust.TestProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.CrateType
+import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
 import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.project.workspace.StandardLibrary
@@ -223,8 +225,8 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
             name = name,
             version = "0.0.1",
             targets = listOf(
-                CargoWorkspaceData.Target("$contentRoot/main.rs", name, CargoWorkspace.TargetKind.BIN),
-                CargoWorkspaceData.Target("$contentRoot/lib.rs", name, CargoWorkspace.TargetKind.LIB)
+                CargoWorkspaceData.Target("$contentRoot/main.rs", name, TargetKind.BIN, listOf(CrateType.BIN)),
+                CargoWorkspaceData.Target("$contentRoot/lib.rs", name, TargetKind.LIB, listOf(CrateType.LIB))
             ),
             source = null,
             origin = PackageOrigin.WORKSPACE
@@ -254,7 +256,7 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
                 targets = listOf(
                     // don't use `FileUtil.join` here because it uses `File.separator`
                     // which is system dependent although all other code uses `/` as separator
-                    CargoWorkspaceData.Target(source?.let { "$contentRoot/$it" } ?: "", targetName, CargoWorkspace.TargetKind.LIB)
+                    CargoWorkspaceData.Target(source?.let { "$contentRoot/$it" } ?: "", targetName, TargetKind.LIB, listOf(CrateType.BIN))
                 ),
                 source = source,
                 origin = PackageOrigin.DEPENDENCY

--- a/src/test/kotlin/org/rustSlowTests/CargoProjectStructureTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/CargoProjectStructureTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rustSlowTests
+
+import com.intellij.testFramework.PlatformTestUtil
+import org.rust.FileTreeBuilder
+import org.rust.cargo.RustWithToolchainTestBase
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.toolwindow.CargoProjectStructure
+import org.rust.fileTree
+
+class CargoProjectStructureTest : RustWithToolchainTestBase() {
+
+    fun `test targets`() = doTest("""
+        Root
+         Project
+          Targets
+           Target(foo[lib])
+           Target(foo[bin])
+           Target(example[example])
+           Target(test[test])
+           Target(bench[bench])
+    """) {
+        toml("Cargo.toml", """
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+        """)
+
+        dir("src") {
+            rust("main.rs", "")
+            rust("lib.rs", "")
+        }
+        dir("benches") {
+            rust("bench.rs", "")
+        }
+        dir("examples") {
+            rust("example.rs", "")
+        }
+        dir("tests") {
+            rust("test.rs", "")
+        }
+    }
+
+    fun `test workspace members`() = doTest("""
+        Root
+         Project
+          Targets
+           Target(foo[bin])
+          WorkspaceMember(bar)
+           Targets
+            Target(bar[bin])
+    """) {
+        toml("Cargo.toml", """
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
+
+            [workspace]
+            members = [
+                "inner-project"
+            ]
+        """)
+
+        dir("src") {
+            rust("main.rs", "fn main() {}")
+        }
+        dir("inner-project") {
+            toml("Cargo.toml", """
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+            """)
+            dir("src") {
+                rust("main.rs", "fn main() {}")
+            }
+        }
+    }
+
+    private fun doTest(expectedTreeStructure: String, builder: FileTreeBuilder.() -> Unit) {
+        fileTree(builder).create()
+        val structure = CargoProjectStructure(project.cargoProjects.allProjects.toList())
+        PlatformTestUtil.assertTreeStructureEquals(structure, expectedTreeStructure.trimIndent())
+    }
+}


### PR DESCRIPTION
* Show workspace members and targets in cargo toolwindow
* Allow running targets from cargo toolwindow by double click

TODO:
* Come up with icons for target nodes

Fixes #2151