### PR TITLE
ANN: add type mismatch quick fix using derefs and refs

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFix.kt
@@ -1,0 +1,38 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.types.ty.Mutability
+import org.rust.lang.core.types.ty.Ty
+
+/**
+ * The data class represents a sequence of dereferences and references. The dereferences are defined by number of
+ * dereferences and references are defied by the sequence of mutabilities.
+ */
+data class DerefRefPath(val derefs: Int, val refs: List<Mutability>)
+
+/**
+ * The fix applies `path.derefs` dereferences to the expression and then references of the mutability given by
+ * `path.refs`.  Note that correctness of the generated code is not verified.
+ */
+class ConvertToTyWithDerefsRefsFix(expr: PsiElement, val ty: Ty, val path: DerefRefPath) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
+    override fun getFamilyName(): String = "Convert to type"
+
+    override fun getText(): String = "Convert to $ty using dereferences and/or references"
+
+    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
+        if (startElement !is RsExpr) return
+        val psiFactory = RsPsiFactory(project)
+        startElement.replace(psiFactory.createRefExpr(psiFactory.createDerefExpr(startElement, path.derefs), path.refs))
+    }
+}

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFixTest.kt
@@ -1,0 +1,163 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.RsTypeCheckInspection
+
+class ConvertToTyWithDerefsRefsFixTest : RsInspectionsTestBase(RsTypeCheckInspection()) {
+
+    fun `test &T to T `() = checkFixByText("Convert to i32 using dereferences and/or references", """
+        fn main () {
+            let a: &i32 = &42;
+            let b: i32 = <error>a<caret></error>;
+        }
+    """, """
+        fn main () {
+            let a: &i32 = &42;
+            let b: i32 = *a;
+        }
+    """)
+
+    fun `test &mut T to T `() = checkFixByText("Convert to i32 using dereferences and/or references", """
+        fn main () {
+            let a: &mut i32 = &mut 42;
+            let b: i32 = <error>a<caret></error>;
+        }
+    """, """
+        fn main () {
+            let a: &mut i32 = &mut 42;
+            let b: i32 = *a;
+        }
+    """)
+
+    fun `test &&mut T to T`() = checkFixByText("Convert to i32 using dereferences and/or references", """
+        fn main () {
+            let a: &&mut i32 = &&mut 42;
+            let b: i32 = <error>a<caret></error>;
+        }
+    """, """
+        fn main () {
+            let a: &&mut i32 = &&mut 42;
+            let b: i32 = **a;
+        }
+    """)
+
+    fun `test T to &T `() = checkFixByText("Convert to &i32 using dereferences and/or references", """
+        fn main () {
+            let a: i32 = 42;
+            let b: &i32 = <error>a<caret></error>;
+        }
+    """, """
+        fn main () {
+            let a: i32 = 42;
+            let b: &i32 = &a;
+        }
+    """)
+
+    fun `test mut T to &mut T `() = checkFixByText("Convert to &mut i32 using dereferences and/or references", """
+        fn main () {
+            let mut a: i32 = 42;
+            let b: &mut i32 = <error>a<caret></error>;
+        }
+    """, """
+        fn main () {
+            let mut a: i32 = 42;
+            let b: &mut i32 = &mut a;
+        }
+    """)
+
+    fun `test T to &mut T `() = checkFixIsUnavailable("Convert to &mut i32 using dereferences and/or references", """
+        fn main () {
+            let a: i32 = 42;
+            let b: &mut i32 = <error>a<caret></error>;
+        }
+    """)
+
+    fun `test T to &mut &T `() = checkFixByText("Convert to &mut &i32 using dereferences and/or references", """
+        fn main () {
+            let a: i32 = 42;
+            let b: &mut &i32 = <error>a<caret></error>;
+        }
+    """, """
+        fn main () {
+            let a: i32 = 42;
+            let b: &mut &i32 = &mut &a;
+        }
+    """)
+
+    fun `test &T to &mut T`() = checkFixIsUnavailable("Convert to &mut i32 using dereferences and/or references", """
+        fn main () {
+            let a: &i32 = &42;
+            let b: &mut i32 = <error>a<caret></error>;
+        }
+    """)
+
+    fun `test mut &T to &mut T`() = checkFixIsUnavailable("Convert to &mut i32 using dereferences and/or references", """
+        fn main () {
+            let mut a: &i32 = &42;
+            let b: &mut i32 = <error>a<caret></error>;
+        }
+    """)
+
+    fun `test &mut&&mut T to &mut T`() = checkFixIsUnavailable("Convert to &mut i32 using dereferences and/or references", """
+        fn main () {
+            let a: &i32 = &42;
+            let b: &mut i32 = <error>a<caret></error>;
+        }
+    """)
+
+    fun `test &mut&&mut T to &mut& T `() = checkFixByText("Convert to &mut &i32 using dereferences and/or references", """
+        fn main () {
+            let a: &mut &&mut i32 = &mut &&mut 42;
+            let b: &mut &i32 = <error>a<caret></error>;
+        }
+    ""","""
+        fn main () {
+            let a: &mut &&mut i32 = &mut &&mut 42;
+            let b: &mut &i32 = &mut &***a;
+        }
+    """)
+
+    fun `test B to &mut A when Deref for A with target B exists`() = checkFixIsUnavailable("Convert to &mut B using dereferences and/or references", """
+        #[lang = "deref"]
+        trait Deref { type Target; }
+        struct A;
+        struct B;
+        impl Deref for A { type Target = B; }
+
+        fn main () {
+            let a: A = A;
+            let b: &mut B = <error>a<caret></error>;
+        }
+    """)
+
+    fun `test mut B to &mut A when Deref for A with target B exists`() = checkFixByText("Convert to &mut B using dereferences and/or references", """
+        #[lang = "deref"]
+        trait Deref { type Target; }
+        struct A;
+        struct B;
+        impl Deref for A { type Target = B; }
+
+        fn main () {
+            let mut a: A = A;
+            let b: &mut B = <error>a<caret></error>;
+        }
+    """, """
+        #[lang = "deref"]
+        trait Deref { type Target; }
+        struct A;
+        struct B;
+        impl Deref for A { type Target = B; }
+
+        fn main () {
+            let mut a: A = A;
+            let b: &mut B = &mut *a;
+        }
+    """)
+
+}
+


### PR DESCRIPTION
This commit adds quick-fix for the types mismatch when getting from
an actual type to an expected type is possible through a seuence of
dereferences and references, which fulfills the fifth and sixth
bullet-points of the issue:
https://github.com/intellij-rust/intellij-rust/issues/1730.

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
