### PR TITLE
DBG: load default pretty printers for rust

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -45,7 +45,7 @@ because major platform updates can bring a lot of changes.
 * Rust preferences (in *Languages & Frameworks*)
 * Cargo toolbar
 * Run configuration
-
+* Debugger settings (in *Build, Execution, Deployment > Debugger > Data Views > Rust*, CLion only)
 
 #### Specific places
 * Notifications (see `MissingToolchainNotificationProvider`)

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
@@ -26,7 +26,6 @@ import com.intellij.xdebugger.XDebugSession
 import com.intellij.xdebugger.XDebuggerManager
 import com.intellij.xdebugger.impl.XDebugProcessConfiguratorStarter
 import com.intellij.xdebugger.impl.ui.XDebugSessionData
-import com.jetbrains.cidr.execution.debugger.CidrLocalDebugProcess
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
 import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
@@ -82,12 +81,16 @@ class RsDebugRunner : AsyncProgramRunner<RunnerSettings>() {
                 check(commandLine.workDirectory != null) {
                     "LLDB requires working directory"
                 }
+                val sysroot = state.computeSysroot()
                 val runParameters = RsDebugRunParameters(environment.project, commandLine)
                 XDebuggerManager.getInstance(environment.project)
                     .startSession(environment, object : XDebugProcessConfiguratorStarter() {
                         override fun start(session: XDebugSession): XDebugProcess =
-                            CidrLocalDebugProcess(runParameters, session, state.consoleBuilder).apply {
+                            RsLocalDebugProcess(runParameters, session, state.consoleBuilder).apply {
                                 ProcessTerminatedListener.attach(processHandler, environment.project)
+                                if (sysroot != null) {
+                                    loadPrettyPrinters(sysroot)
+                                }
                                 start()
                             }
 

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
@@ -35,6 +35,7 @@ import org.rust.cargo.toolchain.Cargo
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.toolchain.impl.CargoMetadata
 import org.rust.cargo.toolchain.impl.CargoMetadata.CrateType
+import org.rust.debugger.settings.RsDebuggerSettings
 import org.rust.openapiext.GeneralCommandLine
 import org.rust.openapiext.withWorkDirectory
 import java.nio.file.Path
@@ -88,7 +89,7 @@ class RsDebugRunner : AsyncProgramRunner<RunnerSettings>() {
                         override fun start(session: XDebugSession): XDebugProcess =
                             RsLocalDebugProcess(runParameters, session, state.consoleBuilder).apply {
                                 ProcessTerminatedListener.attach(processHandler, environment.project)
-                                if (sysroot != null) {
+                                if (sysroot != null && RsDebuggerSettings.getInstance().isRendersEnabled) {
                                     loadPrettyPrinters(sysroot)
                                 }
                                 start()

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsLocalDebugProcess.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsLocalDebugProcess.kt
@@ -1,0 +1,69 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger.runconfig
+
+import com.intellij.execution.filters.TextConsoleBuilder
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.xdebugger.XDebugSession
+import com.jetbrains.cidr.execution.RunParameters
+import com.jetbrains.cidr.execution.debugger.CidrLocalDebugProcess
+import com.jetbrains.cidr.execution.debugger.backend.DebuggerCommandException
+import com.jetbrains.cidr.execution.debugger.backend.gdb.GDBDriver
+import com.jetbrains.cidr.execution.debugger.backend.lldb.LLDBDriver
+
+class RsLocalDebugProcess(
+    parameters: RunParameters,
+    debugSession: XDebugSession,
+    consoleBuilder: TextConsoleBuilder
+) : CidrLocalDebugProcess(parameters, debugSession, consoleBuilder) {
+
+    fun loadPrettyPrinters(sysroot: String) {
+        val threadId = currentThreadId
+        val frameIndex = currentFrameIndex
+        postCommand { driver ->
+            when (driver) {
+                is LLDBDriver -> driver.loadPrettyPrinters(threadId, frameIndex, sysroot)
+                is GDBDriver -> driver.loadPrettyPrinters(threadId, frameIndex, sysroot)
+            }
+        }
+    }
+
+    private fun LLDBDriver.loadPrettyPrinters(threadId: Long, frameIndex: Int, sysroot: String) {
+        val path = "$sysroot/lib/rustlib/etc/lldb_rust_formatters.py".systemDependentAndEscaped()
+        try {
+            executeConsoleCommand(threadId, frameIndex, """command script import "$path"""")
+            executeConsoleCommand(threadId, frameIndex, """type summary add --no-value --python-function lldb_rust_formatters.print_val -x ".*" --category Rust""")
+            executeConsoleCommand(threadId, frameIndex, """type category enable Rust""")
+        } catch (e: DebuggerCommandException) {
+            printlnToConsole(e.message)
+            LOG.warn(e)
+        }
+    }
+
+    private fun GDBDriver.loadPrettyPrinters(threadId: Long, frameIndex: Int, sysroot: String) {
+        val path = "$sysroot/lib/rustlib/etc".systemDependentAndEscaped()
+        // Avoid multiline Python scripts due to https://youtrack.jetbrains.com/issue/CPP-9090
+        val command = """python """ +
+            """sys.path.insert(0, "$path"); """ +
+            """import gdb_rust_pretty_printing; """ +
+            """gdb_rust_pretty_printing.register_printers(gdb); """
+        try {
+            executeConsoleCommand(threadId, frameIndex, command)
+        } catch (e: DebuggerCommandException) {
+            printlnToConsole(e.message)
+            LOG.warn(e)
+        }
+    }
+
+    private fun String.systemDependentAndEscaped(): String =
+        StringUtil.escapeStringCharacters(FileUtil.toSystemDependentName(this))
+
+    companion object {
+        private val LOG: Logger = Logger.getInstance(RsLocalDebugProcess::class.java)
+    }
+}

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettings.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettings.kt
@@ -1,0 +1,39 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger.settings
+
+import com.intellij.openapi.options.Configurable
+import com.intellij.util.PlatformUtils
+import com.intellij.util.xmlb.XmlSerializerUtil
+import com.intellij.xdebugger.settings.DebuggerSettingsCategory
+import com.intellij.xdebugger.settings.XDebuggerSettings
+
+class RsDebuggerSettings : XDebuggerSettings<RsDebuggerSettings>("Rust") {
+
+    var isRendersEnabled: Boolean = true
+
+    override fun getState(): RsDebuggerSettings = this
+
+    override fun loadState(state: RsDebuggerSettings) {
+        XmlSerializerUtil.copyBean(state, this)
+    }
+
+    override fun createConfigurables(category: DebuggerSettingsCategory): Collection<Configurable> {
+        return if (category == DebuggerSettingsCategory.DATA_VIEWS) {
+            listOf(RsDebuggerSettingsConfigurable(this))
+        } else {
+            listOf()
+        }
+    }
+
+    override fun isTargetedToProduct(configurable: Configurable): Boolean =
+        PlatformUtils.isCLion() && configurable.displayName == RsDebuggerSettingsConfigurable.DISPLAY_NAME
+
+    companion object {
+        @JvmStatic
+        fun getInstance(): RsDebuggerSettings = getInstance(RsDebuggerSettings::class.java)
+    }
+}

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettingsConfigurable.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettingsConfigurable.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger.settings
+
+import com.intellij.openapi.options.SearchableConfigurable
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.layout.panel
+import org.rust.openapiext.CheckboxDelegate
+import javax.swing.JComponent
+
+class RsDebuggerSettingsConfigurable(
+    private val settings: RsDebuggerSettings
+) : SearchableConfigurable {
+
+    private val isRendersEnabledCheckbox: JBCheckBox = JBCheckBox("Enable Rust library renders")
+    private var isRendersEnabled: Boolean by CheckboxDelegate(isRendersEnabledCheckbox)
+
+    override fun getId(): String = "Debugger.Rust"
+    override fun getDisplayName(): String = DISPLAY_NAME
+
+    override fun createComponent(): JComponent = panel {
+        row { isRendersEnabledCheckbox() }
+    }
+
+    override fun isModified(): Boolean = isRendersEnabled != settings.isRendersEnabled
+
+    override fun apply() {
+        settings.isRendersEnabled = isRendersEnabled
+    }
+
+    override fun reset() {
+        isRendersEnabled = settings.isRendersEnabled
+    }
+
+    companion object {
+        const val DISPLAY_NAME: String = "Rust"
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
@@ -34,8 +34,6 @@ class CargoRunState(
         commandLine.workingDirectory
     )
 
-    fun cargo(): Cargo = toolchain.cargoOrWrapper(cargoProject?.manifest?.parent)
-
     init {
         val scope = SearchScopeProvider.createSearchScope(environment.project, environment.runProfile)
         consoleBuilder = CargoConsoleBuilder(environment.project, scope)
@@ -47,6 +45,13 @@ class CargoRunState(
             consoleBuilder.addFilter(RsPanicFilter(environment.project, dir))
             consoleBuilder.addFilter(RsBacktraceFilter(environment.project, dir, cargoProject?.workspace))
         }
+    }
+
+    fun cargo(): Cargo = toolchain.cargoOrWrapper(cargoProject?.manifest?.parent)
+
+    fun computeSysroot(): String? {
+        val projectDirectory = cargoProject?.manifest?.parent ?: return null
+        return toolchain.rustup(projectDirectory)?.getSysroot()
     }
 
     override fun startProcess(): ProcessHandler {

--- a/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
@@ -45,17 +45,19 @@ class Rustup(
     }
 
     fun getStdlibFromSysroot(): VirtualFile? {
+        val sysroot = getSysroot()
+        val fs = LocalFileSystem.getInstance()
+        return fs.refreshAndFindFileByPath(FileUtil.join(sysroot, "lib/rustlib/src/rust/src"))
+    }
+
+    fun getSysroot(): String {
         val timeoutMs = 10000
-        val sysroot = GeneralCommandLine(rustc)
+        return GeneralCommandLine(rustc)
             .withCharset(Charsets.UTF_8)
             .withWorkDirectory(projectDirectory)
             .withParameters("--print", "sysroot")
             .exec(timeoutMs)
             .stdout.trim()
-
-
-        val fs = LocalFileSystem.getInstance()
-        return fs.refreshAndFindFileByPath(FileUtil.join(sysroot, "lib/rustlib/src/rust/src"))
     }
 
     private fun GeneralCommandLine.exec(timeoutInMilliseconds: Int? = null): ProcessOutput {

--- a/src/main/resources/META-INF/clion-only.xml
+++ b/src/main/resources/META-INF/clion-only.xml
@@ -7,6 +7,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <programRunner implementation="org.rust.debugger.runconfig.RsDebugRunner"/>
+        <xdebugger.settings implementation="org.rust.debugger.settings.RsDebuggerSettings"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
Loads pretty printers into IDE debugger to show values of rust variables in more convenient for user way. `rust-gdb` and `rust-lldb` use the same pretty-printers.

Some samples:
**lldb (without pretty-printers)**
<img width="432" alt="screen shot 2018-04-25 at 13 48 06" src="https://user-images.githubusercontent.com/2539310/39241369-545dbcca-488f-11e8-9c12-6f85a7973abf.png">

**gdb (with rust pretty-printers)**
![deepinscreenshot_select-area_20180425181712](https://user-images.githubusercontent.com/2539310/39240905-e10cd252-488d-11e8-8b1f-55d22a5ca5a8.png)
**lldb (with rust pretty-printers)**
<img width="463" alt="screen shot 2018-04-25 at 13 45 34" src="https://user-images.githubusercontent.com/2539310/39241270-f99c751a-488e-11e8-9363-86245117b414.png">

It's still far from perfect when lldb is used because doesn't allow to see separate elements of `Vec` but it's better than now

Fixes #2140