### PR TITLE
TY: Do not cause IllegalStateException when typifying vec![0; 1]

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -1323,8 +1323,10 @@ private class RsFnInferenceContext(
         val vecArg = expr.macroCall.vecMacroArgument
         if (vecArg != null) {
             val elementType = if (vecArg.semicolon != null) {
-                vecArg.exprList.firstOrNull()?.inferType() ?: TyUnknown
+                // vec![value; repeat]
+                vecArg.exprList.firstOrNull()?.let { ctx.getExprType(it) } ?: TyUnknown
             } else {
+                // vec![value1, value2, value3]
                 val elementTypes = vecArg.exprList.map { ctx.getExprType(it) }
                 getMoreCompleteType(elementTypes)
             }

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -137,7 +137,7 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
     fun `test repeat vec!`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {
-            let x = vec!(1u8, 2usize);
+            let x = vec!(1u8; 2usize);
             x;
           //^ Vec<u8>
         }


### PR DESCRIPTION
When typifying `vec![0; 1]` we would trigger `error("Trying to infer expression type twice")`
in `RsExpr.inferType(expected: Ty?)`

This is because `inferChildExprsRecursively(expr.macroCall)`
already typified all children inside the vec[] and
`vecArg.exprList.firstOrNull()?.inferType()`
would typify the first child a second time.

Adapt a test from #2469 that was not actually testing vec![] repeat mode.
Fixes #2500