### PR TITLE
Support setting the enum discriminant type via #[repr(u*)] attribute 

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -64,8 +64,10 @@ class QueryAttributes(
     private val attributes: Sequence<RsAttr> = Sequence { (psi as? RsInnerAttributeOwner)?.innerAttrList.orEmpty().iterator() } +
         Sequence { (psi as? RsOuterAttributeOwner)?.outerAttrList.orEmpty().iterator() }
 
+    // #[doc(hidden)]
     val isDocHidden: Boolean get() = hasAttributeWithArg("doc", "hidden")
 
+    // #[cfg(test)], #[cfg(target_has_atomic = "ptr")], #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     fun hasCfgAttr(): Boolean {
         if (psi is RsFunction) {
             val stub = psi.stub
@@ -98,9 +100,11 @@ class QueryAttributes(
             .mapNotNull { it.value }
             .singleOrNull()
 
+    // #[lang = "copy"]
     val langAttribute: String?
         get() = getStringAttributes("lang").firstOrNull()
 
+    // #[derive(Clone)], #[derive(Copy, Clone, Debug)]
     val deriveAttributes: Sequence<RsMetaItem>
         get() = attrsByName("derive")
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -108,6 +108,10 @@ class QueryAttributes(
     val deriveAttributes: Sequence<RsMetaItem>
         get() = attrsByName("derive")
 
+    // #[repr(u16)], #[repr(C, packed)], #[repr(simd)], #[repr(align(8))]
+    val reprAttributes: Sequence<RsMetaItem>
+        get() = attrsByName("repr")
+
     // `#[attributeName = "Xxx"]`
     private fun getStringAttributes(attributeName: String): Sequence<String?> = attrsByName(attributeName).map { it.value }
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -129,7 +129,18 @@ class RsInferenceContext(
             val (retTy, expr) = when (element) {
                 is RsConstant -> element.typeReference?.type to element.expr
                 is RsArrayType -> TyInteger.USize to element.expr
-                is RsVariantDiscriminant -> TyInteger.ISize to element.expr
+                is RsVariantDiscriminant -> {
+                    // A repr attribute like #[repr(u16)] changes the discriminant type of an enum
+                    // https://doc.rust-lang.org/nomicon/other-reprs.html#repru-repri
+                    val enum = element.ancestorStrict<RsEnumItem>()
+                    val reprType = enum?.queryAttributes?.reprAttributes
+                        ?.flatMap { it.metaItemArgs?.metaItemList?.asSequence() ?: emptySequence() }
+                        ?.mapNotNull { TyInteger.fromName(it.referenceName) }
+                        ?.lastOrNull()
+                        ?: TyInteger.ISize
+
+                    reprType to element.expr
+                }
                 else -> error("Type inference is not implemented for PSI element of type " +
                         "`${element.javaClass}` that implement `RsInferenceContextOwner`")
             }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
@@ -22,10 +22,8 @@ abstract class TyPrimitive : Ty() {
             if (path.hasColonColon) return null
             val name = path.referenceName
 
-            TyInteger.VALUES.find { it.name == name }
-                ?.let { return it }
-            TyFloat.VALUES.find { it.name == name }
-                ?.let { return it }
+            TyInteger.fromName(name)?.let { return it }
+            TyFloat.fromName(name)?.let { return it }
 
             return when (name) {
                 "bool" -> TyBool
@@ -74,6 +72,10 @@ sealed class TyInteger(val name: String, val ordinal: Int) : TyNumeric() {
         val VALUES: List<TyInteger> get() = TyIntegerValuesHolder.VALUES
         val NAMES: List<String> get() = TyIntegerValuesHolder.NAMES
 
+        fun fromName(name: String): TyInteger? {
+            return VALUES.find { it.name == name }
+        }
+
         fun fromSuffixedLiteral(literal: PsiElement): TyInteger? {
             val text = literal.text
             return VALUES.find { text.endsWith(it.name) }
@@ -108,6 +110,10 @@ sealed class TyFloat(val name: String, val ordinal: Int) : TyNumeric() {
         val DEFAULT: TyFloat get() = TyFloatValuesHolder.DEFAULT
         val VALUES: List<TyFloat> get() = TyFloatValuesHolder.VALUES
         val NAMES: List<String> get() = TyFloatValuesHolder.NAMES
+
+        fun fromName(name: String): TyFloat? {
+            return VALUES.find { it.name == name }
+        }
 
         fun fromSuffixedLiteral(literal: PsiElement): TyFloat? {
             val text = literal.text

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -428,6 +428,29 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
                         //^ isize
     """)
 
+    fun `test u8 in enum variant discriminant repr()`() = testExpr("""
+        #[repr(u8)]
+        enum Foo { BAR = 32 }
+                        //^ u8
+    """)
+
+    fun `test isize in enum variant discriminant unknown repr()`() = testExpr("""
+        #[repr(unrecognized_future_attribute)]
+        enum Foo { BAR = 32 }
+                        //^ isize
+    """)
+
+    // With rustc, duplicate representation hints only produces a "warning[E0566]: conflicting representation hints"
+    // while using the last found explicit representation
+    fun `test u16 in enum variant discriminant duplicate repr()`() = testExpr("""
+        #[repr(u8)]
+        #[repr(i8, u16)]
+        #[repr(C)]
+        #[repr(unrecognized_future_attribute)]
+        enum Foo { BAR = 32 }
+                        //^ u16
+    """)
+
     fun `test bin operators bool`() {
         val cases = listOf(
             Pair("1 == 2", "bool"),


### PR DESCRIPTION
This makes typification of enums honor repr attributes like `#[repr(u16)]`.