### PR TITLE
ANN: Show only unique annotations by 'RsCargoCheckAnnotator'

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsCargoCheckAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsCargoCheckAnnotator.kt
@@ -58,6 +58,8 @@ class CargoCheckAnnotationResult(commandOutput: List<String>) {
             .map { parser.parse(it) }
             .filter { it.isJsonObject }
             .mapNotNull { CargoTopMessage.fromJson(it.asJsonObject) }
+            // Cargo can duplicate some error messages when `--all-targets` attribute is used
+            .distinct()
 }
 
 class RsCargoCheckAnnotator : ExternalAnnotator<CargoCheckAnnotationInfo, CargoCheckAnnotationResult>() {

--- a/src/main/kotlin/org/rust/ide/annotator/RsCargoCheckAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsCargoCheckAnnotator.kt
@@ -24,7 +24,6 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiModificationTracker
-import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.PathUtil
 import org.apache.commons.lang.StringEscapeUtils.escapeHtml
 import org.rust.cargo.project.settings.rustSettings
@@ -33,10 +32,10 @@ import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.toolchain.*
 import org.rust.ide.RsConstants
 import org.rust.lang.core.psi.RsFile
-import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.cargoWorkspace
 import org.rust.lang.core.psi.ext.containingCargoPackage
+import org.rust.openapiext.isUnitTestMode
 import java.nio.file.Path
 import java.util.*
 
@@ -91,14 +90,20 @@ class RsCargoCheckAnnotator : ExternalAnnotator<CargoCheckAnnotationInfo, CargoC
 
         for ((topMessage) in annotationResult.messages) {
             val message = filterMessage(file, doc, topMessage) ?: continue
-            holder.createAnnotation(message.severity, message.textRange, message.message, message.htmlTooltip)
+            // We can't control what messages cargo generates, so we can't test them well.
+            // Let's use special message for tests to distinguish annotation from `RsCargoCheckAnnotator`
+            val annotationMessage = if (isUnitTestMode) TEST_MESSAGE else message.message
+            holder.createAnnotation(message.severity, message.textRange, annotationMessage, message.htmlTooltip)
                 .apply {
-                    problemGroup = ProblemGroup { message.message }
+                    problemGroup = ProblemGroup { annotationMessage }
                     setNeedsUpdateOnTyping(true)
                 }
         }
     }
 
+    companion object {
+        const val TEST_MESSAGE = "CargoAnnotation"
+    }
 }
 
 // NB: executed asynchronously off EDT, so care must be taken not to access

--- a/src/test/kotlin/org/rustSlowTests/RsCargoCheckAnnotatorTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsCargoCheckAnnotatorTest.kt
@@ -6,11 +6,12 @@
 package org.rustSlowTests
 
 import com.intellij.lang.annotation.HighlightSeverity
-import com.intellij.openapi.application.ApplicationManager
+import org.intellij.lang.annotations.Language
 import org.rust.cargo.RustWithToolchainTestBase
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.fileTree
+import org.rust.ide.annotator.RsCargoCheckAnnotator
 
 class RsCargoCheckAnnotatorTest : RustWithToolchainTestBase() {
 
@@ -26,7 +27,16 @@ class RsCargoCheckAnnotatorTest : RustWithToolchainTestBase() {
     fun `test highlights type errors`() = doTest("""
         struct X; struct Y;
         fn main() {
-            let _: X = <error>Y</error>;
+            let _: X = <error descr="${RsCargoCheckAnnotator.TEST_MESSAGE}">Y</error>;
+        }
+    """)
+
+    fun `test highlights errors in tests`() = doTest("""
+        fn main() {}
+
+        #[test]
+        fn test() {
+            let x: i32 = <error descr="${RsCargoCheckAnnotator.TEST_MESSAGE}">0.0</error>;
         }
     """)
 
@@ -51,9 +61,9 @@ class RsCargoCheckAnnotatorTest : RustWithToolchainTestBase() {
         }.create()
         myFixture.openFileInEditor(cargoProjectDirectory.findFileByRelativePath("src/main.rs")!!)
         val highlights = myFixture.doHighlighting(HighlightSeverity.WEAK_WARNING)
-        check(highlights.isEmpty(), {
+        check(highlights.isEmpty()) {
             "Did not expect any highlights, got:\n$highlights"
-        })
+        }
     }
 
     // https://github.com/intellij-rust/intellij-rust/issues/1497
@@ -89,12 +99,12 @@ class RsCargoCheckAnnotatorTest : RustWithToolchainTestBase() {
         myFixture.openFileInEditor(path)
 
         val highlights = myFixture.doHighlighting(HighlightSeverity.ERROR)
-        check(highlights.isEmpty(), {
+        check(highlights.isEmpty()) {
             "Did not expect any highlights, got:\n$highlights"
-        })
+        }
     }
 
-    private fun doTest(mainRs: String) {
+    private fun doTest(@Language("Rust") mainRs: String) {
         fileTree {
             toml("Cargo.toml", """
                 [package]


### PR DESCRIPTION
Currently `cargo check` command with `--all-targets` can generate the same messages.
The previous implementation of `RsCargoCheckAnnotator` didn't take into account it and created an annotation for each `cargo check` message.
Now it uses only unique messages

Fixes #2503