### PR TITLE
ANN: Only allow BororwMut and AsMut quick-fixes on mutable expressions

### DIFF
--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -25,6 +25,7 @@ import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.StdKnownItems
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.TraitRef
+import org.rust.lang.core.types.isMutable
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.refactoring.implementMembers.ImplementMembersFix
 import org.rust.lang.utils.RsErrorCode.*
@@ -87,8 +88,9 @@ sealed class RsDiagnostic(
                                 if (isTraitWithTySubstImplForActual(lookup, items.findAsRefTrait(), expectedTy)) {
                                     add(ConvertToRefTyFix(element, expectedTy))
                                 }
-                            } else if (expectedTy.mutability == Mutability.MUTABLE) {
-                                if (isTraitWithTySubstImplForActual(lookup, items.findBorrowMutTrait(), expectedTy)){
+                            } else if (expectedTy.mutability == Mutability.MUTABLE && element is RsExpr && element.isMutable
+                                && lookup.coercionSequence(actualTy).all { it !is TyReference || it.mutability.isMut }) {
+                                if (isTraitWithTySubstImplForActual(lookup, items.findBorrowMutTrait(), expectedTy)) {
                                     add(ConvertToBorrowedTyWithMutFix(element, expectedTy))
                                 }
                                 if (isTraitWithTySubstImplForActual(lookup, items.findAsMutTrait(), expectedTy)) {

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToBorrowedTyWithMutFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToBorrowedTyWithMutFixTest.kt
@@ -6,5 +6,34 @@
 package org.rust.ide.annotator.fixes
 
 
-internal class ConvertToBorrowedTyWithMutFixTest : ConvertToTyUsingTraitFixTestBase(
-    true, "BorrowMut", "borrow_mut", "use std::borrow::BorrowMut;")
+class ConvertToBorrowedTyWithMutFixTest : ConvertToTyUsingTraitFixTestBase(
+    true, "BorrowMut", "borrow_mut", "use std::borrow::BorrowMut;") {
+
+    fun `test &String to &mut String`() = checkFixIsUnavailable("Convert to &mut String using `BorrowMut` trait", """
+        $imports
+
+        fn main() {
+            let mut s = String::from("hello");
+
+            change(<error>&s<caret></error>);
+        }
+
+        fn change(some_string: &mut String) {
+            some_string.push_str(", world");
+        }
+    """)
+
+    fun `test String to &mut String`() = checkFixIsUnavailable("Convert to &mut String using `BorrowMut` trait", """
+        $imports
+
+        fn main() {
+            let s = String::from("hello");
+
+            change(<error>s<caret></error>);
+        }
+
+        fn change(some_string: &mut String) {
+            some_string.push_str(", world");
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTraitFixTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTraitFixTestBase.kt
@@ -9,7 +9,7 @@ import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsTypeCheckInspection
 
 abstract class ConvertToTyUsingTraitFixTestBase(
-    isExpectedMut: Boolean, private val trait: String, private val method: String, private val imports: String = ""
+    isExpectedMut: Boolean, private val trait: String, private val method: String, protected val imports: String = ""
 ) : RsInspectionsTestBase(RsTypeCheckInspection()) {
     private val ref = if (isExpectedMut) "&mut " else "&"
     private val fixName = "Convert to ${ref}A using `$trait` trait"


### PR DESCRIPTION
This commit makes the quick-fixes that use BororwMut and AsMut traits
to be applicable only for truly mutable expressions. This fixes part of
the: https://github.com/intellij-rust/intellij-rust/issues/2472

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
