### PR TITLE
DBG: improve error messages for debugger

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
@@ -17,6 +17,7 @@ import com.intellij.execution.runners.AsyncProgramRunner
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
@@ -26,13 +27,15 @@ import com.intellij.xdebugger.XDebugSession
 import com.intellij.xdebugger.XDebuggerManager
 import com.intellij.xdebugger.impl.XDebugProcessConfiguratorStarter
 import com.intellij.xdebugger.impl.ui.XDebugSessionData
+import com.jetbrains.cidr.cpp.toolchains.CPPToolchains
+import com.jetbrains.cidr.cpp.toolchains.CPPToolchainsConfigurable
+import com.jetbrains.cidr.toolchains.OSType
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
 import org.rust.cargo.project.workspace.CargoWorkspace.CrateType
 import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
 import org.rust.cargo.runconfig.CargoRunState
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
-import org.rust.cargo.toolchain.Cargo
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.toolchain.impl.CargoMetadata
 import org.rust.debugger.settings.RsDebuggerSettings
@@ -40,6 +43,8 @@ import org.rust.openapiext.GeneralCommandLine
 import org.rust.openapiext.withWorkDirectory
 import java.nio.file.Path
 import java.nio.file.Paths
+
+private const val ERROR_MESSAGE_TITLE: String = "Debugging is not possible"
 
 class RsDebugRunner : AsyncProgramRunner<RunnerSettings>() {
     override fun getRunnerId(): String = "RsDebugRunner"
@@ -76,7 +81,7 @@ class RsDebugRunner : AsyncProgramRunner<RunnerSettings>() {
                 .withEnvironment(cmd.environmentVariables.envs)
         }
 
-        return buildProjectAndGetBinaryArtifactPath(environment.project, buildCommand, state.cargo())
+        return buildProjectAndGetBinaryArtifactPath(environment.project, buildCommand, state)
             .then { binary ->
                 val path = binary?.path ?: return@then null
                 val commandLine = runCommand(path)
@@ -106,14 +111,20 @@ class RsDebugRunner : AsyncProgramRunner<RunnerSettings>() {
 
 private class Binary(val path: Path)
 
+private sealed class DebugBuildResult {
+    data class Binaries(val paths: List<String>) : DebugBuildResult()
+    object MSVCToolchain : DebugBuildResult()
+}
+
 /**
  * Runs `command` twice:
  *   * once to show console with errors
  *   * the second time to get json output
  * See https://github.com/rust-lang/cargo/issues/3855
  */
-private fun buildProjectAndGetBinaryArtifactPath(project: Project, command: CargoCommandLine, cargo: Cargo): Promise<Binary?> {
+private fun buildProjectAndGetBinaryArtifactPath(project: Project, command: CargoCommandLine, state: CargoRunState): Promise<Binary?> {
     val promise = AsyncPromise<Binary?>()
+    val cargo = state.cargo()
 
     val processForUserOutput = ProcessOutput()
     val processForUser = KillableColoredProcessHandler(cargo.toColoredCommandLine(command))
@@ -121,6 +132,18 @@ private fun buildProjectAndGetBinaryArtifactPath(project: Project, command: Carg
     processForUser.addProcessListener(CapturingProcessAdapter(processForUserOutput))
 
     ApplicationManager.getApplication().invokeLater {
+        val toolchains = CPPToolchains.getInstance()
+        val toolchain = toolchains.defaultToolchain
+        if (toolchain == null) {
+            val option = Messages.showDialog(project, "Debug toolchain is not configured.", ERROR_MESSAGE_TITLE,
+                arrayOf("Configure"), 0, Messages.getErrorIcon())
+            if (option == 0) {
+                ShowSettingsUtil.getInstance().showSettingsDialog(project, CPPToolchainsConfigurable::class.java, null)
+            }
+            promise.setResult(null)
+            return@invokeLater
+        }
+
         RunContentExecutor(project, processForUser)
             .withAfterCompletion {
                 if (processForUserOutput.exitCode != 0) {
@@ -129,10 +152,15 @@ private fun buildProjectAndGetBinaryArtifactPath(project: Project, command: Carg
                 }
 
                 object : Task.Backgroundable(project, "Building Cargo project") {
-                    var result: List<String>? = null
+                    var result: DebugBuildResult? = null
 
                     override fun run(indicator: ProgressIndicator) {
                         indicator.isIndeterminate = true
+                        if (toolchains.osType == OSType.WIN && "msvc" in state.rustVersion().rustc.host.orEmpty()) {
+                            result = DebugBuildResult.MSVCToolchain
+                            return
+                        }
+
                         val processForJson = CapturingProcessHandler(cargo.toGeneralCommandLine(command.prependArgument("--message-format=json")))
                         val output = processForJson.runProcessWithProgressIndicator(indicator)
                         if (output.isCancelled || output.exitCode != 0) {
@@ -160,21 +188,31 @@ private fun buildProjectAndGetBinaryArtifactPath(project: Project, command: Carg
                                     || (kind == TargetKind.LIB && profile.test)
                             }
                             .flatMap { it.filenames.filter { !it.endsWith(".dSYM") } } // FIXME: correctly launch debug binaries for macos
+                            .let(DebugBuildResult::Binaries)
                     }
 
                     override fun onSuccess() {
-                        val binaries = result!!
-                        when {
-                            binaries.isEmpty() -> {
-                                project.showErrorDialog("Can't find a binary to debug")
+                        val result = result!!
+                        when (result) {
+                            DebugBuildResult.MSVCToolchain -> {
+                                project.showErrorDialog("MSVC toolchain is not supported for debugging. Please use GNU toolchain.")
                                 promise.setResult(null)
                             }
-                            binaries.size > 1 -> {
-                                project.showErrorDialog("More than one binary produced. " +
-                                    "Please specify `--bin`, `--lib`, `--test` or `--example` flag explicitly.")
-                                promise.setResult(null)
+                            is DebugBuildResult.Binaries -> {
+                                val binaries = result.paths
+                                when {
+                                    binaries.isEmpty() -> {
+                                        project.showErrorDialog("Can't find a binary to debug")
+                                        promise.setResult(null)
+                                    }
+                                    binaries.size > 1 -> {
+                                        project.showErrorDialog("More than one binary produced. " +
+                                            "Please specify `--bin`, `--lib`, `--test` or `--example` flag explicitly.")
+                                        promise.setResult(null)
+                                    }
+                                    else -> promise.setResult(Binary(Paths.get(binaries.single())))
+                                }
                             }
-                            else -> promise.setResult(Binary(Paths.get(binaries.single())))
                         }
                     }
 
@@ -190,9 +228,8 @@ private fun buildProjectAndGetBinaryArtifactPath(project: Project, command: Carg
 }
 
 private fun Project.showErrorDialog(message: String) {
-    Messages.showErrorDialog(this, message, "Debugging is not possible")
+    Messages.showErrorDialog(this, message, ERROR_MESSAGE_TITLE)
 }
-
 
 private fun CargoCommandLine.prependArgument(arg: String): CargoCommandLine =
     copy(additionalArguments = listOf(arg) + additionalArguments)

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
@@ -54,6 +54,8 @@ class CargoRunState(
         return toolchain.rustup(projectDirectory)?.getSysroot()
     }
 
+    fun rustVersion(): RustToolchain.VersionInfo = toolchain.queryVersions()
+
     override fun startProcess(): ProcessHandler {
         val cmd = toolchain.cargoOrWrapper(cargoProject?.manifest?.parent)
             .toColoredCommandLine(commandLine)


### PR DESCRIPTION
Shows error messages in the following cases:
* Debug toolchain is not configured. It prevents the following error
![clion-error](https://user-images.githubusercontent.com/2539310/39967601-3fe4e91c-56c7-11e8-8593-f73b44785303.jpg)
* Rust toolchain is `msvc`

Currently, CLion doesn't support debugging with `msvc` toolchain. Also in this case `rustc` generates `.pdb` file and adds it in artefact list (now it's reason why we show weird error message about multiple binary files). I do nothing with such files intentionally to support them properly when `msvc` toolchain will be supported by CLion

Fixes #2462 