### PR TITLE
MACRO: Surround expressions with parenthesis during macro expansion

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -239,7 +239,13 @@ private class MacroPattern private constructor(
                         MacroExpansionMarks.failMatchPatternByBindingType.hit()
                         return null
                     }
-                    map[name] = macroCallBody.originalText.substring(lastOffset, macroCallBody.currentOffset)
+                    val text = macroCallBody.originalText.substring(lastOffset, macroCallBody.currentOffset)
+
+                    // Wrap expressions in () to avoid problems related to operator precedence during expansion
+                    if (type == "expr")
+                        map[name] = "($text)"
+                    else
+                        map[name] = text
                 }
                 is RsMacroBindingGroup -> {
                     groups += matchGroup(psi, macroCallBody) ?: return null

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -43,7 +43,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         }
         foo! { 2 + 2 * baz(3).quux() }
     """, """
-         fn bar() { 2 + 2 * baz(3).quux(); }
+         fn bar() { (2 + 2 * baz(3).quux()); }
     """)
 
     fun `test ty`() = doTest("""
@@ -353,7 +353,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         }
         foo! { 1, 2, 3, 4 }
     """, """
-        fn foo() { 1; 2; 3; 4; }
+        fn foo() { (1); (2); (3); (4); }
     """)
 
     fun `test match non-group pattern with asterisk`() = doTest("""
@@ -385,7 +385,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         }
         foo! { mod a {}, mod b {}; 1, 2 }
     """, """
-        fn foo() { 1; 2; }
+        fn foo() { (1); (2); }
         mod a {}
         mod b {}
     """)
@@ -398,8 +398,8 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         }
         foo! { foo 1,2,3; bar 4,5,6 }
     """, """
-        fn foo() { 1; 2; 3; }
-        fn bar() { 4; 5; 6; }
+        fn foo() { (1); (2); (3); }
+        fn bar() { (4); (5); (6); }
     """)
 
     fun `test nested groups that uses vars from outer group`() = doTest("""
@@ -410,11 +410,11 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         }
         foo! { 1, foo, bar, baz; 2, quux, eggs }
     """, """
-        fn foo() { 1; }
-        fn bar() { 1; }
-        fn baz() { 1; }
-        fn quux() { 2; }
-        fn eggs() { 2; }
+        fn foo() { (1); }
+        fn bar() { (1); }
+        fn baz() { (1); }
+        fn quux() { (2); }
+        fn eggs() { (2); }
     """)
 
     fun `test group in braces`() = doTest("""
@@ -431,7 +431,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
     """, """
          mod a {}
          mod b {}
-         fn foo() { 2; }
+         fn foo() { (2); }
     """)
 
     fun `test group with the separator the same as the next token 1`() = doTest(MacroExpansionMarks.groupInputEnd1, """

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -481,4 +481,15 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
           //^ Result<(), Error>
         }
     """)
+
+    fun `test write macro &mut`() = stubOnlyTypeInfer("""
+    //- main.rs
+        use std::fmt::Write;
+        fn main() {
+            let mut s = String::new();
+            let a = write!(&mut s, "text");
+            a;
+          //^ Result<(), Error>
+        }
+    """)
 }


### PR DESCRIPTION
We currently expand macros textually instead of based on AST nodes
as rustc does.
This can cause problems where the macro expansion interacts badly
with operator precedence rules and produces wrong results.

For example this code (from the documentation of write!())
```rust
let mut s = String::new();
let a = write!(&mut s, "text");
```

would be wrongly expanded to
```rust
let a = &mut (s.write_fmt(...))
```
and typified as `&mut Result<(), Error>`

instead of
```rust
let a = (&mut s).write_fmt(...)
```
and being typified as `Result<(), Error>`.

Work around this problem by surrounding all expressions with parenthesis
during expansion.
CC #2229
