### PR TITLE
QDOC: Provide links to external documentation

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -628,7 +628,8 @@ FieldDecl ::= AttrsAndVis identifier TypeAscription {
   hooks = [ leftBinder = "ADJACENT_LINE_COMMENTS" ]
   implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner"
                  "org.rust.lang.core.psi.ext.RsVisibilityOwner"
-                 "org.rust.lang.core.psi.ext.RsNameIdentifierOwner" ]
+                 "org.rust.lang.core.psi.ext.RsNameIdentifierOwner"
+                 "org.rust.lang.core.psi.ext.RsQualifiedNamedElement" ]
   mixin = "org.rust.lang.core.psi.ext.RsFieldDeclImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsFieldDeclStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
@@ -1110,7 +1111,8 @@ LitExpr ::= OuterAttr*
 
 MacroDefinition ::= AttrsAndVis "macro_rules" '!' identifier MacroDefinitionBody <<macroSemicolon>>{
   implements = [ "org.rust.lang.core.psi.ext.RsNameIdentifierOwner"
-                 "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
+                 "org.rust.lang.core.psi.ext.RsOuterAttributeOwner"
+                 "org.rust.lang.core.psi.ext.RsQualifiedNamedElement" ]
   extends = "org.rust.lang.core.psi.ext.RsMacroDefinitionImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsMacroDefinitionStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"

--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -35,6 +35,7 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
         is RsConstant -> element.presentationInfo?.quickDocumentationText
         is RsMod -> element.presentationInfo?.quickDocumentationText
         is RsItemElement -> element.header(false) + element.signature(false)
+        is RsMacroDefinition -> element.header(false) + element.signature(false)
         is RsNamedElement -> element.presentationInfo?.quickDocumentationText
         else -> null
     }
@@ -128,7 +129,9 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
 private fun RsDocAndAttributeOwner.header(usePreTag: Boolean): String {
     val rawLines = when (this) {
         is RsFieldDecl -> listOfNotNull((parent?.parent as? RsDocAndAttributeOwner)?.presentableQualifiedName)
-        is RsStructOrEnumItemElement, is RsTraitItem -> listOfNotNull(presentableQualifiedModName)
+        is RsStructOrEnumItemElement,
+        is RsTraitItem,
+        is RsMacroDefinition -> listOfNotNull(presentableQualifiedModName)
         is RsAbstractable -> {
             val owner = owner
             when (owner) {
@@ -186,6 +189,7 @@ private fun RsDocAndAttributeOwner.signature(usePreTag: Boolean): String {
                 listOf(buffer.toString()) + whereClause?.documentationText.orEmpty()
             } else emptyList()
         }
+        is RsMacroDefinition -> listOf("macro <b>$name</b>")
         else -> emptyList()
     }
     val startTag = if (usePreTag) "<pre>" else ""

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -45,6 +45,8 @@ inline fun <reified T : PsiElement> PsiElement.ancestorOrSelf(): T? =
 inline fun <reified T : PsiElement> PsiElement.ancestorOrSelf(stopAt: Class<out PsiElement>): T? =
     PsiTreeUtil.getParentOfType(this, T::class.java, /* strict */ false, stopAt)
 
+inline fun <reified T : PsiElement> PsiElement.stubAncestorStrict(): T? =
+    PsiTreeUtil.getStubOrPsiParentOfType(this, T::class.java)
 
 /**
  * Same as [ancestorStrict], but with "fake" parent links. See [org.rust.lang.core.macros.ExpansionResult].

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumVariant.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumVariant.kt
@@ -13,8 +13,7 @@ import org.rust.lang.core.psi.RsEnumVariant
 import org.rust.lang.core.stubs.RsEnumVariantStub
 import javax.swing.Icon
 
-val RsEnumVariant.parentEnum: RsEnumItem
-    get() = stub?.getParentStubOfType(RsEnumItem::class.java) ?: parent?.parent as RsEnumItem
+val RsEnumVariant.parentEnum: RsEnumItem get() = stubAncestorStrict()!!
 
 abstract class RsEnumVariantImplMixin : RsStubbedNamedElementImpl<RsEnumVariantStub>, RsEnumVariant {
     constructor(node: ASTNode) : super(node)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldDecl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldDecl.kt
@@ -10,8 +10,11 @@ import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.psi.RsFieldDecl
 import org.rust.lang.core.psi.RsPsiImplUtil
+import org.rust.lang.core.psi.RsStructItem
 import org.rust.lang.core.stubs.RsFieldDeclStub
 import javax.swing.Icon
+
+val RsFieldDecl.parentStruct: RsStructItem? get() = stubAncestorStrict()
 
 abstract class RsFieldDeclImplMixin : RsStubbedNamedElementImpl<RsFieldDeclStub>, RsFieldDecl {
     constructor(node: ASTNode) : super(node)
@@ -23,4 +26,6 @@ abstract class RsFieldDeclImplMixin : RsStubbedNamedElementImpl<RsFieldDeclStub>
 
     override val isPublic: Boolean get() = RsPsiImplUtil.isPublic(this, stub)
 
+    // temporary solution.
+    override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroDefinition.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroDefinition.kt
@@ -26,6 +26,8 @@ abstract class RsMacroDefinitionImplMixin : RsStubbedNamedElementImpl<RsMacroDef
             .getOrNull(1) // Zeroth is `macro_rules` itself
 
     override fun getIcon(flags: Int): Icon? = RsIcons.MACRO
+
+    override val crateRelativePath: String? get() = name?.let { "::$it" }
 }
 
 val RsMacroDefinition.hasMacroExport: Boolean

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
@@ -5,6 +5,11 @@
 
 package org.rust.lang.core.psi.ext
 
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsQualifiedName.ChildItemType.*
+import org.rust.lang.core.psi.ext.RsQualifiedName.ParentItemType.*
+import org.rust.lang.core.types.ty.TyPrimitive
+
 interface RsQualifiedNamedElement : RsNamedElement {
     val crateRelativePath: String?
 }
@@ -13,4 +18,163 @@ val RsQualifiedNamedElement.qualifiedName: String? get() {
     val inCratePath = crateRelativePath ?: return null
     val cargoTarget = containingCargoTarget?.normName ?: return null
     return "$cargoTarget$inCratePath"
+}
+
+class RsQualifiedName private constructor(
+    private val crateName: String,
+    private val modSegments: List<String>,
+    private val parentItem: Item,
+    private val childItem: Item?
+) {
+
+    fun toUrlPath(): String {
+        val segments = mutableListOf(crateName)
+        segments += modSegments
+        val (pageName, anchor) =
+        if (parentItem.type == MOD) {
+            "index.html" to ""
+        } else {
+            "$parentItem.html" to (if (childItem != null) "#$childItem" else "")
+        }
+        segments += pageName
+        return segments.joinToString(separator = "/", postfix = anchor)
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun from(element: RsQualifiedNamedElement): RsQualifiedName? {
+
+            val parent = parentItem(element)
+
+            val (parentItem, childItem) = if (parent != null) {
+                parent to (element.toChildItem() ?: return null)
+            } else {
+                val parentItem = element.toParentItem() ?: return null
+                parentItem to null
+            }
+
+            val crateName = element.containingCargoTarget?.normName ?: return null
+            val modSegments = if (parentItem.type == ParentItemType.PRIMITIVE) {
+                listOf()
+            } else {
+                element.containingMod.superMods
+                    .asReversed()
+                    .drop(1)
+                    .map { it.modName ?: return null }
+            }
+
+            return RsQualifiedName(crateName, modSegments, parentItem, childItem)
+        }
+
+        private fun parentItem(element: RsQualifiedNamedElement): Item? {
+            val parentItem: RsQualifiedNamedElement? = when (element) {
+                is RsAbstractable -> {
+                    val owner = element.owner
+                    when (owner) {
+                        is RsAbstractableOwner.Trait -> owner.trait
+                        is RsAbstractableOwner.Impl -> {
+                            return owner.impl.typeReference?.toParentItem()
+                        }
+                        else -> return null
+                    }
+                }
+                is RsEnumVariant -> element.parentEnum
+                is RsFieldDecl -> element.parentStruct
+                else -> return null
+            }
+            return parentItem?.toParentItem()
+        }
+
+        private fun RsTypeReference.toParentItem(): Item? {
+            val type = typeElement
+            return when (type) {
+                is RsTupleType -> Item("tuple", PRIMITIVE)
+                is RsFnPointerType -> Item("fn", PRIMITIVE)
+                is RsArrayType -> Item(if (type.isSlice) "slice" else "array", PRIMITIVE)
+                is RsRefLikeType -> {
+                    when {
+                        type.isRef -> Item("reference", PRIMITIVE)
+                        type.isPointer -> Item("pointer", PRIMITIVE)
+                        else -> null
+                    }
+
+                }
+                is RsBaseType -> {
+                    when {
+                        type.isNever -> Item("never", PRIMITIVE)
+                        type.isUnit -> Item("unit", PRIMITIVE)
+                        else -> {
+                            val path = type.path ?: return null
+                            val primitiveType = TyPrimitive.fromPath(path)
+                            if (primitiveType != null) return Item(primitiveType.name, PRIMITIVE)
+                            (path.reference.resolve() as? RsQualifiedNamedElement)?.toParentItem()
+                        }
+                    }
+                }
+                else -> null
+            }
+        }
+
+        private fun RsQualifiedNamedElement.toParentItem(): Item? {
+            val name = name ?: return null
+            val itemType = when (this) {
+                is RsStructItem -> STRUCT
+                is RsEnumItem -> ENUM
+                is RsTraitItem -> TRAIT
+                is RsTypeAlias -> TYPE
+                is RsFunction -> FN
+                is RsConstant -> CONSTANT
+                is RsMacroDefinition -> MACRO
+                is RsMod,
+                is RsModDeclItem -> MOD
+                else -> error("Unexpected type: `$this`")
+            }
+            return Item(name, itemType)
+        }
+
+        private fun RsQualifiedNamedElement.toChildItem(): Item? {
+            val name = name ?: return null
+            val type = when (this) {
+                is RsEnumVariant -> VARIANT
+                is RsFieldDecl -> if (parentStruct != null) STRUCTFIELD else return null
+                is RsTypeAlias -> ASSOCIATEDTYPE
+                is RsConstant -> ASSOCIATEDCONSTANT
+                is RsFunction -> if (isAbstract) TYMETHOD else METHOD
+                else -> return null
+            }
+            return Item(name, type)
+        }
+    }
+
+    private data class Item(val name: String, val type: ItemType) {
+        override fun toString(): String = "$type.$name"
+    }
+
+    private interface ItemType
+
+    private enum class ParentItemType : ItemType {
+        STRUCT,
+        ENUM,
+        TRAIT,
+        TYPE,
+        FN,
+        CONSTANT,
+        MACRO,
+        MOD,
+        PRIMITIVE;
+
+        override fun toString(): String = name.toLowerCase()
+    }
+
+    private enum class ChildItemType : ItemType {
+        VARIANT,
+        STRUCTFIELD,
+        ASSOCIATEDTYPE,
+        ASSOCIATEDCONSTANT,
+        TYMETHOD,
+        METHOD;
+
+        override fun toString(): String = name.toLowerCase()
+    }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
@@ -17,6 +17,8 @@ import org.rust.lang.core.psi.ext.hasColonColon
  */
 abstract class TyPrimitive : Ty() {
 
+    abstract val name: String
+
     companion object {
         fun fromPath(path: RsPath): TyPrimitive? {
             if (path.hasColonColon) return null
@@ -35,20 +37,30 @@ abstract class TyPrimitive : Ty() {
     }
 }
 
-object TyBool : TyPrimitive()
+object TyBool : TyPrimitive() {
+    override val name: String = "bool"
+}
 
-object TyChar : TyPrimitive()
+object TyChar : TyPrimitive() {
+    override val name: String = "char"
+}
 
-object TyUnit : TyPrimitive()
+object TyUnit : TyPrimitive() {
+    override val name: String = "unit"
+}
 
 /** The `!` type. E.g. `unimplemented!()` */
-object TyNever : TyPrimitive()
+object TyNever : TyPrimitive() {
+    override val name: String = "never"
+}
 
-object TyStr : TyPrimitive()
+object TyStr : TyPrimitive() {
+    override val name: String = "str"
+}
 
 abstract class TyNumeric : TyPrimitive()
 
-sealed class TyInteger(val name: String, val ordinal: Int) : TyNumeric() {
+sealed class TyInteger(override val name: String, val ordinal: Int) : TyNumeric() {
 
     // This fixes NPE caused by java classes initialization order. Details:
     // Kotlin `object`s compile into java classes with `INSTANCE` static field
@@ -97,7 +109,7 @@ sealed class TyInteger(val name: String, val ordinal: Int) : TyNumeric() {
     object ISize: TyInteger("isize", 11)
 }
 
-sealed class TyFloat(val name: String, val ordinal: Int) : TyNumeric() {
+sealed class TyFloat(override val name: String, val ordinal: Int) : TyNumeric() {
 
     // See TyIntegerValuesHolder
     private object TyFloatValuesHolder {

--- a/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlStdTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.docs
+
+import junit.framework.AssertionFailedError
+
+class RsExternalDocUrlStdTest : RsDocumentationProviderTest() {
+
+    override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
+
+    fun `test mod`() = doUrlTestByText("""
+        fn foo<T: std::fmt::Debug>(x: T) {}
+                     //^
+    """, "https://doc.rust-lang.org/alloc/fmt/index.html")
+
+    fun `test function`() = doUrlTestByText("""
+        fn main() {
+            let v = std::env::var("HOME");
+                             //^
+        }
+    """, "https://doc.rust-lang.org/std/env/fn.var.html")
+
+    fun `test struct`() = doUrlTestByText("""
+        fn foo(x: String) {}
+                 //^
+    """, "https://doc.rust-lang.org/alloc/string/struct.String.html")
+
+    fun `test enum`() = doUrlTestByText("""
+        fn foo(x: Option<i32>) {}
+                  //^
+    """, "https://doc.rust-lang.org/core/option/enum.Option.html")
+
+    fun `test trait`() = doUrlTestByText("""
+        fn foo<T: Eq>(x: T) {}
+                //^
+    """, "https://doc.rust-lang.org/core/cmp/trait.Eq.html")
+
+    fun `test type`() = doUrlTestByText("""
+        fn foo(x: std::fmt::Result) {}
+                           //^
+    """, "https://doc.rust-lang.org/core/fmt/type.Result.html")
+
+    fun `test const`() = doUrlTestByText("""
+        fn main() {
+            let e = std::f64::consts::E;
+                                    //^
+        }
+    """, "https://doc.rust-lang.org/core/f64/consts/constant.E.html")
+
+    fun `test macro`() = expect<AssertionFailedError> {
+        doUrlTestByText("""
+            fn main() {
+                println!("Hello!");
+                //^
+            }
+        """, "https://doc.rust-lang.org/std/macro.println.html")
+    }
+
+    fun `test method`() = doUrlTestByText("""
+        fn main() {
+            let x = Vec::new();
+                       //^
+        }
+    """, "https://doc.rust-lang.org/alloc/vec/struct.Vec.html#method.new")
+
+    fun `test primitive method`() = doUrlTestByText("""
+        fn main() {
+            let x = 0.0f64.is_nan();
+                          //^
+        }
+    """, "https://doc.rust-lang.org/std/primitive.f64.html#method.is_nan")
+
+    fun `test tymethod`() = doUrlTestByText("""
+        fn foo<T: Default>() -> T {
+            T::default()
+                //^
+        }
+    """, "https://doc.rust-lang.org/core/default/trait.Default.html#tymethod.default")
+
+    fun `test associated type`() = expect<AssertionFailedError> {
+        doUrlTestByText("""
+        fn foo<T: Iterator>(x: T) -> T::Item {
+                                       //^
+            unimplemented!();
+        }
+    """, "https://doc.rust-lang.org/core/iter/trait.Iterator.html#associatedtype.Item")
+    }
+
+    fun `test enum variant`() = doUrlTestByText("""
+        fn main() {
+            let x = Some(123);
+                   //^
+        }
+    """, "https://doc.rust-lang.org/core/option/enum.Option.html#variant.Some")
+
+    fun `test struct field`() = doUrlTestByText("""
+        fn foo(x: std::raw::TraitObject) {
+            let data = x.data;
+                         //^
+        }
+    """, "https://doc.rust-lang.org/core/raw/struct.TraitObject.html#structfield.data")
+}

--- a/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.docs
+
+import com.intellij.testFramework.LightProjectDescriptor
+
+class RsExternalDocUrlTest : RsDocumentationProviderTest() {
+
+    override fun getProjectDescriptor(): LightProjectDescriptor = WithStdlibAndDependencyRustProjectDescriptor
+
+    fun `test not stdlib item`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        pub struct Foo;
+                  //^
+    """, "test://doc-host.org/dep_lib_target/struct.Foo.html")
+
+    fun `test associated const`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        pub struct Foo;
+
+        impl Foo {
+            pub const BAR: i32 = 123;
+                     //^
+        }
+    """, "test://doc-host.org/dep_lib_target/struct.Foo.html#associatedconstant.BAR")
+
+    fun `test private item`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        struct Foo;
+              //^
+    """, null)
+
+    fun `test pub item in private module`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        mod foo {
+            pub struct Foo;
+                       //^
+        }
+    """, null)
+
+    fun `test doc hidden`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        #[doc(hidden)]
+        pub fn foo() {}
+               //^
+    """, null, RsDocumentationProvider.Testmarks.docHidden)
+
+    fun `test macro`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        #[macro_export]
+        macro_rules! foo {
+                    //^
+            () => { unimplemented!() };
+        }
+    """, "test://doc-host.org/dep_lib_target/macro.foo.html")
+
+    fun `test not exported macro`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        macro_rules! foo {
+                    //^
+            () => { unimplemented!() };
+        }
+    """, null, RsDocumentationProvider.Testmarks.notExportedMacro)
+}

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -665,7 +665,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         fn main() {
         }
     """, """
-        <pre>makro</pre>
+        <pre>test_package</pre>
+        <pre>macro <b>makro</b></pre>
         <p>Outer documentation</p>
     """)
 

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
@@ -519,7 +519,8 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
         }
 
     """, """
-        macro_rules! <b>makro</b> [main.rs]
+        test_package
+        macro <b>makro</b>
     """)
 
     fun `test const`() = doTest("""

--- a/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt
@@ -162,14 +162,6 @@ abstract class RsInspectionsTestBase(
             myFixture.filterAvailableIntentions(fixName).isEmpty())
     }
 
-    private fun configureByText(text: String) {
-        InlineFile(text.trimIndent())
-    }
-
-    private fun configureByFileTree(text: String) {
-        fileTreeFromText(text).createAndOpenFileWithCaretMarker()
-    }
-
     private fun checkByText(text: String) {
         myFixture.checkResult(replaceCaretMarker(text.trimIndent()))
     }

--- a/src/test/kotlin/org/rust/lang/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/RsTestBase.kt
@@ -292,6 +292,14 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
         PsiManagerEx.getInstanceEx(project).setAssertOnFileLoadingFilter(fileFilter, testRootDisposable)
     }
 
+    protected fun configureByText(text: String) {
+        InlineFile(text.trimIndent())
+    }
+
+    protected fun configureByFileTree(text: String) {
+        fileTreeFromText(text).createAndOpenFileWithCaretMarker()
+    }
+
     companion object {
         // XXX: hides `Assert.fail`
         fun fail(message: String): Nothing {


### PR DESCRIPTION
It's initial implementation - it provides links only for stdlib items and it doesn't support reexports (as well as all our quick documentation does).
It means:
* we generate link according to a fully qualified name of resolved item and don't take into account its reexport path. For example, we generate https://doc.rust-lang.org/alloc/string/struct.String.html instead of https://doc.rust-lang.org/std/string/struct.String.html. It's not a big problem, because doc.rust-lang.org provides very similar pages for both links.
* we don't provide links to element from private module but available only via reexport. For example, `Iterator` trait.

Also, it's the first part of big plan to generate fully qualified name with similar schema as documentation link.

Part of #1875