### PR TITLE
INSP: Make the "Convert to assert_(eq|ne)!" fixes not kick in for non-Debug types

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -155,6 +155,9 @@ class ImplLookup(
     private val sizedTrait: RsTraitItem? by lazy(NONE) {
         RsLangItemIndex.findLangItem(project, "sized")
     }
+    private val debugTrait: RsTraitItem? by lazy(NONE) {
+        RsLangItemIndex.findLangItem(project, "debug_trait")
+    }
     private val derefTraitAndTarget: Pair<RsTraitItem, RsTypeAlias>? = run {
         val trait = RsLangItemIndex.findLangItem(project, "deref") ?: return@run null
         trait.findAssociatedType("Target")?.let { trait to it }
@@ -236,6 +239,9 @@ class ImplLookup(
 
     private fun getHardcodedImplsForPrimitives(ty: Ty): Collection<BoundElement<RsTraitItem>> {
         val impls = mutableListOf<BoundElement<RsTraitItem>>()
+        debugTrait?.let {
+            impls.add(BoundElement(it))
+        }
         if (ty is TyNumeric || ty is TyInfer.IntVar || ty is TyInfer.FloatVar) {
             // libcore/ops/arith.rs libcore/ops/bit.rs
             impls += arithOps.map { it.withSubst(ty).substAssocType("Output", ty) }
@@ -618,6 +624,7 @@ class ImplLookup(
 
     fun isCopy(ty: Ty): Boolean = ty.isTraitImplemented(copyTrait)
     fun isSized(ty: Ty): Boolean = ty.isTraitImplemented(sizedTrait)
+    fun isDebug(ty: Ty): Boolean = ty.isTraitImplemented(debugTrait)
 
     private fun Ty.isTraitImplemented(trait: RsTraitItem?): Boolean {
         if (trait == null) return false

--- a/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt
@@ -18,7 +18,7 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
             let y = 10;
             assert_eq!(x, y);
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test expr assert_eq fix`() = checkFixByText("Convert to assert_eq!", """
         fn answer() -> i32 {
@@ -36,7 +36,7 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         fn main() {
             assert_eq!(answer(), 42);
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test simple assert_eq fix with format_args`() = checkFixByText("Convert to assert_eq!", """
         fn main() {
@@ -50,7 +50,7 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
             let y = 10;
             assert_eq!(x, y, "format {}", 0);
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test simple assert_ne fix`() = checkFixByText("Convert to assert_ne!", """
         fn main() {
@@ -64,7 +64,7 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
             let y = 42;
             assert_ne!(x, y);
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test expr assert_ne fix`() = checkFixByText("Convert to assert_ne!", """
         fn answer() -> i32 {
@@ -82,13 +82,13 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         fn main() {
             assert_ne!(answer(), 50);
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test simple assert_ne fix with format_args`() = checkFixByText("Convert to assert_ne!", """
         fn main() {
             let x = 10;
             let y = 10;
-            <weak_warning descr="assert!(a == b) can be assert_eq!(a, b)">assert!(x != y, "format {}", 0<caret>)</weak_warning>;
+            <weak_warning descr="assert!(a != b) can be assert_ne!(a, b)">assert!(x != y, "format {}", 0<caret>)</weak_warning>;
         }
     """, """
         fn main() {
@@ -96,5 +96,5 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
             let y = 10;
             assert_ne!(x, y, "format {}", 0);
         }
-    """)
+    """, checkWeakWarn = true)
 }


### PR DESCRIPTION
Fixes #2539.