### PR TITLE
TYPE: Narrow the search scope of lambda expression parameter bindings

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatBinding.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatBinding.kt
@@ -55,7 +55,8 @@ abstract class RsPatBindingImplMixin(node: ASTNode) : RsNamedElementImpl(node),
     override fun getUseScope(): SearchScope {
         val owner = PsiTreeUtil.getParentOfType(this,
             RsBlock::class.java,
-            RsFunction::class.java
+            RsFunction::class.java,
+            RsLambdaExpr::class.java
         )
 
         if (owner != null) return LocalSearchScope(owner)

--- a/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
@@ -170,13 +170,34 @@ class RenameTest : RsTestBase() {
         myFixture.renameElement(file, "mod.rs")
     }
 
+    fun `test does not rename lambda parameter shadowed in an outer comment`() = doTest("new_name", """
+        fn test() {
+            let param = 123;
+            vec!["abc"].iter().inspect(|param/*caret*/| {
+                println!("{}", param);
+                // Prints out `param`.
+            });
+            // `param` printed out.
+        }
+    """, """
+        fn test() {
+            let param = 123;
+            vec!["abc"].iter().inspect(|new_name| {
+                println!("{}", new_name);
+                // Prints out `new_name`.
+            });
+            // `param` printed out.
+        }
+    """)
+
     private fun doTest(
         newName: String,
         @Language("Rust") before: String,
         @Language("Rust") after: String
     ) {
         InlineFile(before).withCaret()
-        myFixture.renameElementAtCaret(newName)
+        val element = myFixture.elementAtCaret
+        myFixture.renameElement(element, newName, true, true)
         myFixture.checkResult(after)
     }
 }


### PR DESCRIPTION
This makes sure that renaming a lambda parameter, with text occurrences,
does not touch comments outside the lambda expression.

Fixes #2557.