### PR TITLE
rustfmt: use write-mode and skip-children flags only when supported

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -39,6 +39,7 @@ johnthagen
 jonas-schievink
 Keats
 kumbayo
+king6cong
 la10736
 LiamClark
 Litarvan

--- a/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
@@ -30,12 +30,12 @@ data class RustToolchain(val location: Path) {
     fun queryVersionsSync(): VersionInfo = VersionInfo(scrapeRustcVersion(pathToExecutable(RUSTC)))
 
     fun rawCargo(): Cargo =
-        Cargo(pathToExecutable(CARGO), pathToExecutable(RUSTC))
+        Cargo(pathToExecutable(CARGO), pathToExecutable(RUSTC), pathToExecutable(RUSTFMT))
 
     fun cargoOrWrapper(cargoProjectDirectory: Path?): Cargo {
         val hasXargoToml = cargoProjectDirectory?.resolve(XARGO_TOML)?.let { Files.isRegularFile(it) } == true
         val cargoWrapper = if (hasXargoToml && hasExecutable(XARGO)) XARGO else CARGO
-        return Cargo(pathToExecutable(cargoWrapper), pathToExecutable(RUSTC))
+        return Cargo(pathToExecutable(cargoWrapper), pathToExecutable(RUSTC), pathToExecutable(RUSTFMT))
     }
 
     fun rustup(cargoProjectDirectory: Path): Rustup? =
@@ -62,6 +62,7 @@ data class RustToolchain(val location: Path) {
 
     companion object {
         private val RUSTC = "rustc"
+        private val RUSTFMT = "rustfmt"
         private val CARGO = "cargo"
         private val RUSTUP = "rustup"
         private val XARGO = "xargo"


### PR DESCRIPTION
See also: https://github.com/rust-lang-nursery/rustfmt/commit/5d9f5aa05a668e7dfef87b46d89dad2884df9d41

Fixes #2579