### PR TITLE
TY: Improve primitive types impls

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
@@ -16,45 +16,51 @@ import org.rust.lang.core.psi.ext.macroName
 import org.rust.lang.core.psi.ext.operatorType
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.types.type
+import org.rust.openapiext.Testmark
 
 class RsAssertEqualInspection : RsLocalInspectionTool() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
 
         override fun visitMacroCall(o: RsMacroCall) {
-            val macroName = o.macroName
+            if (o.macroName != "assert") return
             val assertMacroArg = o.assertMacroArgument ?: return
-            if (macroName != "assert") return
 
             val expr = assertMacroArg.expr as? RsBinaryExpr ?: return
+
+            val (macroName, operator) = when (expr.operatorType) {
+                EqualityOp.EQ -> "assert_eq" to "=="
+                EqualityOp.EXCLEQ -> "assert_ne" to "!="
+                else -> return
+            }
+
+            if (!isExprSuitable(expr)) return
+
+            holder.registerProblem(
+                o,
+                "assert!(a $operator b) can be $macroName!(a, b)",
+                SpecializedAssertQuickFix(macroName)
+            )
+        }
+
+        private fun isExprSuitable(expr: RsBinaryExpr): Boolean {
             val leftType = expr.left.type
-            val rightType = (expr.right ?: return).type
+            val rightType = expr.right?.type ?: return false
 
             val lookup = ImplLookup.relativeTo(expr)
             // The `assert_eq!` macro, as opposed to `assert!`, requires both arguments to implement `core::fmt::Debug`.
             if (!lookup.isDebug(leftType) || !lookup.isDebug(rightType)) {
-                return
+                Testmarks.debugTraitIsNotImplemented.hit()
+                return false
             }
-
-            when (expr.operatorType) {
-                EqualityOp.EQ -> {
-                    holder.registerProblem(
-                        o,
-                        "assert!(a == b) can be assert_eq!(a, b)",
-                        SpecializedAssertQuickFix("assert_eq")
-                    )
-                }
-                EqualityOp.EXCLEQ -> {
-                    holder.registerProblem(
-                        o,
-                        "assert!(a != b) can be assert_ne!(a, b)",
-                        SpecializedAssertQuickFix("assert_ne")
-                    )
-                }
-                else -> return
+            // Don't try to convert `assert!` macro into `assert_eq!/assert_ne!`
+            // if expressions can't be compared at all
+            if (!lookup.isPartialEq(leftType, rightType)) {
+                Testmarks.partialEqTraitIsNotImplemented.hit()
+                return false
             }
+            return true
         }
     }
-
 
     private class SpecializedAssertQuickFix(private val assertName: String) : LocalQuickFix {
         override fun getName() = "Convert to $assertName!"
@@ -105,4 +111,8 @@ class RsAssertEqualInspection : RsLocalInspectionTool() {
 
     }
 
+    object Testmarks {
+        val partialEqTraitIsNotImplemented = Testmark("partialEqTraitIsNotImplemented")
+        val debugTraitIsNotImplemented = Testmark("debugTraitIsNotImplemented")
+    }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -15,7 +15,6 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.indexes.RsImplIndex
 import org.rust.lang.core.resolve.indexes.RsLangItemIndex
 import org.rust.lang.core.resolve.ref.resolvePath
-import org.rust.lang.core.stubs.index.RsNamedElementIndex
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.TraitRef
 import org.rust.lang.core.types.infer.*
@@ -138,8 +137,8 @@ class ImplLookup(
     }
     private val comparisionOps by lazy(NONE) {
         listOfNotNull (
-            items.findCoreItem("cmp::PartialOrd") as? RsTraitItem,
-            items.findCoreItem("cmp::PartialEq") as? RsTraitItem
+            items.findPartialOrdTrait(),
+            items.findPartialEqTrait()
         )
     }
     private val fnTraits by lazy(NONE) {
@@ -149,15 +148,7 @@ class ImplLookup(
         val trait = RsLangItemIndex.findLangItem(project, "fn_once") ?: return@lazy null
         trait.findAssociatedType("Output")
     }
-    private val copyTrait: RsTraitItem? by lazy(NONE) {
-        RsNamedElementIndex.findDerivableTraits(project, "Copy").firstOrNull()
-    }
-    private val sizedTrait: RsTraitItem? by lazy(NONE) {
-        RsLangItemIndex.findLangItem(project, "sized")
-    }
-    private val debugTrait: RsTraitItem? by lazy(NONE) {
-        RsLangItemIndex.findLangItem(project, "debug_trait")
-    }
+
     private val derefTraitAndTarget: Pair<RsTraitItem, RsTypeAlias>? = run {
         val trait = RsLangItemIndex.findLangItem(project, "deref") ?: return@run null
         trait.findAssociatedType("Target")?.let { trait to it }
@@ -239,48 +230,60 @@ class ImplLookup(
 
     private fun getHardcodedImplsForPrimitives(ty: Ty): Collection<BoundElement<RsTraitItem>> {
         val impls = mutableListOf<BoundElement<RsTraitItem>>()
-        debugTrait?.let {
-            impls.add(BoundElement(it))
+
+        fun addImpl(trait: RsTraitItem?, vararg subst: Ty) {
+            trait?.let { impls += it.withSubst(*subst) }
         }
+
         if (ty is TyNumeric || ty is TyInfer.IntVar || ty is TyInfer.FloatVar) {
             // libcore/ops/arith.rs libcore/ops/bit.rs
             impls += arithOps.map { it.withSubst(ty).substAssocType("Output", ty) }
             impls += assignArithOps.map { it.withSubst(ty) }
             impls += comparisionOps.map { it.withSubst(ty) }
+            // Debug (libcore/fmt/num.rs libcore/fmt/float.rs)
+            addImpl(items.findDebugTrait())
         }
         if (ty is TyInteger || ty is TyInfer.IntVar) {
             // libcore/num/mod.rs
             items.findFromStrTrait()?.let {
                 impls += it.substAssocType("Err", items.findCoreTy("num::ParseIntError"))
             }
+
+            // libcore/hash/mod.rs
+            addImpl(items.findHashTrait())
         }
         HARDCODED_FROM_IMPLS_MAP[ty]?.forEach { from ->
-            items.findFromTrait()?.let { trait ->
-                impls += trait.withSubst(from)
-            }
+            addImpl(items.findFromTrait(), from)
         }
         if (ty != TyStr) {
-            // libcore/cmp.rs
-            if (ty != TyUnit) {
-                RsLangItemIndex.findLangItem(project, "eq")?.let {
-                    impls.add(BoundElement(it, it.typeParamSingle?.let { mapOf(it to ty) } ?: emptySubstitution))
-                }
+            // Default (libcore/default.rs)
+            addImpl(items.findDefaultTrait())
+
+            // PatrialEq (libcore/cmp.rs)
+            if (ty != TyNever && ty != TyUnit) {
+                addImpl(items.findPartialEqTrait(), ty)
             }
-            if (ty != TyUnit && ty != TyBool) {
-                RsLangItemIndex.findLangItem(project, "ord")?.let {
-                    impls.add(BoundElement(it, it.typeParamSingle?.let { mapOf(it to ty) } ?: emptySubstitution))
-                }
+
+            // Eq (libcore/cmp.rs)
+            if (ty !is TyFloat && ty !is TyInfer.FloatVar && ty != TyNever) {
+                addImpl(items.findEqTrait())
             }
-            if (ty !is TyFloat && ty !is TyInfer.FloatVar) {
-                items.findEqTrait()?.let { impls.add(BoundElement(it)) }
-                if (ty != TyUnit && ty != TyBool) {
-                    items.findOrdTrait()?.let { impls.add(BoundElement(it)) }
+
+            // PartialOrd (libcore/cmp.rs)
+            if (ty != TyUnit && ty != TyBool && ty != TyNever) {
+                addImpl(items.findPartialOrdTrait(), ty)
+                // Ord (libcore/cmp.rs)
+                if (ty !is TyFloat && ty !is TyInfer.FloatVar) {
+                    addImpl(items.findOrdTrait())
                 }
             }
 
+            // Clone (libcore/clone.rs)
+            addImpl(items.findCloneTrait())
+            // Copy (libcore/markers.rs)
+            addImpl(items.findCopyTrait())
         }
-        // libcore/clone.rs
-        items.findCloneTrait()?.let { impls.add(BoundElement(it)) }
+
         return impls
     }
 
@@ -391,7 +394,7 @@ class ImplLookup(
     private fun assembleCandidates(ref: TraitRef): Set<SelectionCandidate> {
         val element = ref.trait.element
         return when {
-            element == sizedTrait -> sizedTraitCandidates(ref.selfTy, element)
+            element == items.findSizedTrait() -> sizedTraitCandidates(ref.selfTy, element)
             ref.selfTy is TyTypeParameter -> {
                 ref.selfTy.getTraitBoundsTransitively().find { it.element == element }
                     ?.let { setOf(SelectionCandidate.TypeParameter(it)) } ?: emptySet()
@@ -622,13 +625,13 @@ class ImplLookup(
         return ref.asFunctionType
     }
 
-    fun isCopy(ty: Ty): Boolean = ty.isTraitImplemented(copyTrait)
-    fun isSized(ty: Ty): Boolean = ty.isTraitImplemented(sizedTrait)
-    fun isDebug(ty: Ty): Boolean = ty.isTraitImplemented(debugTrait)
+    fun isCopy(ty: Ty): Boolean = ty.isTraitImplemented(items.findCopyTrait())
+    fun isSized(ty: Ty): Boolean = ty.isTraitImplemented(items.findSizedTrait())
+    fun isDebug(ty: Ty): Boolean = ty.isTraitImplemented(items.findDebugTrait())
 
     private fun Ty.isTraitImplemented(trait: RsTraitItem?): Boolean {
         if (trait == null) return false
-        return select(TraitRef(this, trait.withSubst())).ok() != null
+        return canSelect(TraitRef(this, trait.withSubst()))
     }
 
     private val BoundElement<RsTraitItem>.asFunctionType: TyFunction?

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -628,10 +628,11 @@ class ImplLookup(
     fun isCopy(ty: Ty): Boolean = ty.isTraitImplemented(items.findCopyTrait())
     fun isSized(ty: Ty): Boolean = ty.isTraitImplemented(items.findSizedTrait())
     fun isDebug(ty: Ty): Boolean = ty.isTraitImplemented(items.findDebugTrait())
+    fun isPartialEq(ty: Ty, rhsType: Ty = ty): Boolean = ty.isTraitImplemented(items.findPartialEqTrait(), rhsType)
 
-    private fun Ty.isTraitImplemented(trait: RsTraitItem?): Boolean {
+    private fun Ty.isTraitImplemented(trait: RsTraitItem?, vararg subst: Ty): Boolean {
         if (trait == null) return false
-        return canSelect(TraitRef(this, trait.withSubst()))
+        return canSelect(TraitRef(this, trait.withSubst(*subst)))
     }
 
     private val BoundElement<RsTraitItem>.asFunctionType: TyFunction?

--- a/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionConfig.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/extractFunction/RsExtractFunctionConfig.kt
@@ -171,10 +171,7 @@ class RsExtractFunctionConfig private constructor(
                         operatorType == UnaryOperator.REF || operatorType == UnaryOperator.REF_MUT
                     }
                     val requiredBorrowing = hasRefOperator || result.any { it.element.textOffset > end }
-                        // We manually check primitive types because of ImplLookup.isCopy does not support them
-                        && it.type != TyBool && it.type != TyChar && it.type !is TyInteger && it.type !is TyFloat
-                        && it.type !is TyReference
-                        && !implLookup.isCopy(it.type)
+                        && it.type !is TyReference && !implLookup.isCopy(it.type)
 
                     val requiredMutableValue = it.mutability.isMut && targets.any {
                         if (it.element.ancestorStrict<RsValueArgumentList>() == null) return@any false

--- a/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt
@@ -5,12 +5,12 @@
 
 package org.rust.ide.inspections
 
-class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspection(), useStdLib = true) {
+class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspection(), true) {
     fun `test simple assert_eq fix`() = checkFixByText("Convert to assert_eq!", """
         fn main() {
             let x = 10;
             let y = 10;
-            <weak_warning descr="assert!(a == b) can be assert_eq!(a, b)">assert!(x == y<caret>)</weak_warning>;
+            <weak_warning descr="assert!(a == b) can be assert_eq!(a, b)">assert!(x == y/*caret*/)</weak_warning>;
         }
     """, """
         fn main() {
@@ -26,7 +26,7 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         }
 
         fn main() {
-            <weak_warning descr="assert!(a == b) can be assert_eq!(a, b)">assert!(answer() == 42<caret>)</weak_warning>;
+            <weak_warning descr="assert!(a == b) can be assert_eq!(a, b)">assert!(answer() == 42/*caret*/)</weak_warning>;
         }
     """, """
         fn answer() -> i32 {
@@ -42,7 +42,7 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         fn main() {
             let x = 10;
             let y = 10;
-            <weak_warning descr="assert!(a == b) can be assert_eq!(a, b)">assert!(x == y, "format {}", 0<caret>)</weak_warning>;
+            <weak_warning descr="assert!(a == b) can be assert_eq!(a, b)">assert!(x == y, "format {}", 0/*caret*/)</weak_warning>;
         }
     """, """
         fn main() {
@@ -56,7 +56,7 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         fn main() {
             let x = 10;
             let y = 42;
-            <weak_warning descr="assert!(a != b) can be assert_ne!(a, b)">assert!(x != y<caret>)</weak_warning>;
+            <weak_warning descr="assert!(a != b) can be assert_ne!(a, b)">assert!(x != y/*caret*/)</weak_warning>;
         }
     """, """
         fn main() {
@@ -68,15 +68,15 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
 
     fun `test expr assert_ne fix`() = checkFixByText("Convert to assert_ne!", """
         fn answer() -> i32 {
-            return 42
+            return 42;
         }
 
         fn main() {
-            <weak_warning descr="assert!(a != b) can be assert_ne!(a, b)">assert!(answer() != 50<caret>)</weak_warning>;
+            <weak_warning descr="assert!(a != b) can be assert_ne!(a, b)">assert!(answer() != 50/*caret*/)</weak_warning>;
         }
     """, """
         fn answer() -> i32 {
-            return 42
+            return 42;
         }
 
         fn main() {
@@ -88,7 +88,7 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
         fn main() {
             let x = 10;
             let y = 10;
-            <weak_warning descr="assert!(a != b) can be assert_ne!(a, b)">assert!(x != y, "format {}", 0<caret>)</weak_warning>;
+            <weak_warning descr="assert!(a != b) can be assert_ne!(a, b)">assert!(x != y, "format {}", 0/*caret*/)</weak_warning>;
         }
     """, """
         fn main() {
@@ -107,16 +107,27 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
             let y = Number(10);
             assert!(x == y/*caret*/);
         }
-    """)
+    """, checkWeakWarn = true, testmark = RsAssertEqualInspection.Testmarks.debugTraitIsNotImplemented)
 
-    fun `test fix available when arguments derive Debug`() = checkFixByText("Convert to assert_ne!", """
+    fun `test fix unavailable when arguments do not implement PartialEq`() = checkFixIsUnavailable("Convert to assert_eq!", """
+        #[derive(Debug)]
+        struct Number(u32);
+
+        fn main() {
+            let x = Number(10);
+            let y = Number(10);
+            assert!(x == y/*caret*/);
+        }
+    """, checkWeakWarn = true, testmark = RsAssertEqualInspection.Testmarks.partialEqTraitIsNotImplemented)
+
+    fun `test fix available when arguments derive PartialEq & Debug`() = checkFixByText("Convert to assert_ne!", """
         #[derive(Debug, PartialEq)]
         struct Number(u32);
 
         fn main() {
             let x = Number(10);
             let y = Number(10);
-            assert!(x != y/*caret*/);
+            <weak_warning descr="assert!(a != b) can be assert_ne!(a, b)">assert!(x != y/*caret*/)</weak_warning>;
         }
     """, """
         #[derive(Debug, PartialEq)]
@@ -127,5 +138,5 @@ class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspectio
             let y = Number(10);
             assert_ne!(x, y);
         }
-    """)
+    """, checkWeakWarn = true)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspectionTest.kt
@@ -7,19 +7,19 @@ package org.rust.ide.inspections
 
 class RsFieldInitShorthandInspectionTest : RsInspectionsTestBase(RsFieldInitShorthandInspection()) {
 
-    fun `test not applicable`() = checkByText("""
+    fun `test not applicable`() = checkFixIsUnavailable("Use initialization shorthand", """
         fn main() {
-            let _ = S { foo: bar, baz: &baz };
+            let _ = S { foo: bar/*caret*/, baz: &baz };
         }
-    """)
+    """, checkWeakWarn = true)
 
     fun `test fix`() = checkFixByText("Use initialization shorthand", """
         fn main() {
-            let _ = S { <weak_warning descr="Expression can be simplified">foo: foo<caret></weak_warning>, baz: quux };
+            let _ = S { <weak_warning descr="Expression can be simplified">foo: foo/*caret*/</weak_warning>, baz: quux };
         }
     """, """
         fn main() {
-            let _ = S { foo<caret>, baz: quux };
+            let _ = S { foo/*caret*/, baz: quux };
         }
-    """)
+    """, checkWeakWarn = true)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspectionTest.kt
@@ -9,11 +9,11 @@ class RsSimplifyPrintInspectionTest : RsInspectionsTestBase(RsSimplifyPrintInspe
 
     fun testFix() = checkFixByText("Remove unnecessary argument", """
         fn main() {
-            <weak_warning descr="println! macro invocation can be simplified">println!(""<caret>)</weak_warning>;
+            <weak_warning descr="println! macro invocation can be simplified">println!(""/*caret*/)</weak_warning>;
         }
     """, """
         fn main() {
             println!();
         }
-    """)
+    """, checkWeakWarn = true)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsTryMacroInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsTryMacroInspectionTest.kt
@@ -9,7 +9,7 @@ class RsTryMacroInspectionTest : RsInspectionsTestBase(RsTryMacroInspection()) {
 
     fun testFix() = checkFixByText("Change try! to ?", """
         fn foo() -> Result<(), ()> {
-            <weak_warning descr="try! macro can be replaced with ? operator">try<caret>!</weak_warning>(Err(()));
+            <weak_warning descr="try! macro can be replaced with ? operator">try/*caret*/!(Err(()))</weak_warning>;
             Ok(())
         }
     """, """
@@ -17,5 +17,5 @@ class RsTryMacroInspectionTest : RsInspectionsTestBase(RsTryMacroInspection()) {
             Err(())?;
             Ok(())
         }
-    """)
+    """, checkWeakWarn = true)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsPrimitiveTypeImplsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsPrimitiveTypeImplsTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.type
+
+import com.intellij.testFramework.LightProjectDescriptor
+import org.rust.lang.RsTestBase
+import org.rust.lang.core.psi.RsTraitItem
+import org.rust.lang.core.psi.RsTypeParamBounds
+import org.rust.lang.core.psi.ext.withSubst
+import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.types.TraitRef
+import org.rust.lang.core.types.ty.*
+
+class RsPrimitiveTypeImplsTest : RsTestBase() {
+
+    override fun getProjectDescriptor(): LightProjectDescriptor = WithStdlibRustProjectDescriptor
+
+    fun `test Sized types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool + TyChar + TyUnit, "Sized")
+    fun `test Clone types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool + TyChar + TyUnit, "Clone")
+    fun `test Copy types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool + TyChar + TyUnit, "Copy")
+    fun `test Default types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool + TyChar + TyUnit, "Default")
+    fun `test Debug types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool + TyChar + TyUnit + TyStr, "std::fmt::Debug")
+    fun `test PartialEq types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool + TyChar + TyUnit + TyStr, "PartialEq")
+    fun `test Eq types`() = doTest(TyInteger.VALUES + TyBool + TyChar + TyUnit + TyStr, "Eq")
+    fun `test PartialOrd types`() = doTest(TyInteger.VALUES + TyFloat.VALUES + TyBool + TyChar + TyUnit + TyStr, "PartialOrd")
+    fun `test Ord types`() = doTest(TyInteger.VALUES + TyBool + TyChar + TyUnit + TyStr, "Ord")
+    fun `test Hash types`() = doTest(TyInteger.VALUES + TyBool + TyChar + TyStr, "std::hash::Hash")
+
+    private fun doTest(primitiveTypes: List<TyPrimitive>, trait: String) {
+        InlineFile("""
+            fn foo<T: $trait>(x: T) {}
+                    //^
+        """)
+        val typeBounds = findElementInEditor<RsTypeParamBounds>()
+        val traitItems = typeBounds.polyboundList.map {
+            it.bound.traitRef?.path?.reference?.resolve() as? RsTraitItem ?: error("Can't find type bounds")
+        }
+
+        val lookup = ImplLookup.relativeTo(typeBounds)
+        for (type in primitiveTypes) {
+            for (traitItem in traitItems) {
+                check(lookup.canSelect(TraitRef(type, traitItem.withSubst(type)))) {
+                    "`$type` should implement `${traitItem.name}` trait"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Move some code related to core traits from `ImplLookup` into `StdKnownItems`
* Hardcode impls of some core traits:`Copy`, `Clone`, `Default`, `Hash`, `PartialEq`, `Eq`, `PartialOrd` and `Ord` for primitive types
* Add tests to check impls of core traits for primitive types
* Check types implement `PartialEq` trait in `RsAssertEqualInspection` 