### PR TITLE
ModName should take into account #[path] attribute of mod declaration

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/filters/RsExplainFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/filters/RsExplainFilter.kt
@@ -8,7 +8,7 @@ package org.rust.cargo.runconfig.filters
 import com.intellij.execution.filters.BrowserHyperlinkInfo
 import com.intellij.execution.filters.Filter
 import com.intellij.openapi.project.DumbAware
-import org.rust.ide.RsConstants
+import org.rust.lang.RsConstants
 import java.util.regex.Pattern
 
 

--- a/src/main/kotlin/org/rust/ide/annotator/RsCargoCheckAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsCargoCheckAnnotator.kt
@@ -30,7 +30,7 @@ import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.toolchain.*
-import org.rust.ide.RsConstants
+import org.rust.lang.RsConstants
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.cargoWorkspace

--- a/src/main/kotlin/org/rust/ide/icons/RsIconProvider.kt
+++ b/src/main/kotlin/org/rust/ide/icons/RsIconProvider.kt
@@ -9,7 +9,7 @@ import com.intellij.ide.IconProvider
 import com.intellij.psi.PsiElement
 import org.rust.cargo.CargoConstants
 import org.rust.cargo.icons.CargoIcons
-import org.rust.ide.RsConstants
+import org.rust.lang.RsConstants
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.ext.containingCargoPackage
 import javax.swing.Icon

--- a/src/main/kotlin/org/rust/ide/projectView/RsTreeStructureProvider.kt
+++ b/src/main/kotlin/org/rust/ide/projectView/RsTreeStructureProvider.kt
@@ -10,15 +10,15 @@ import com.intellij.ide.projectView.ViewSettings
 import com.intellij.ide.projectView.impl.nodes.PsiFileNode
 import com.intellij.ide.util.treeView.AbstractTreeNode
 import com.intellij.openapi.project.DumbAware
+import org.rust.lang.RsConstants
 import org.rust.lang.core.psi.RsFile
-import org.rust.lang.core.psi.ext.RsMod.Companion.MOD_RS
 
 /**
  * Moves `mod.rs` files on top
  */
 class RsTreeStructureProvider : TreeStructureProvider, DumbAware {
     override fun modify(parent: AbstractTreeNode<*>, children: Collection<AbstractTreeNode<*>>, settings: ViewSettings?): Collection<AbstractTreeNode<*>> {
-        if (children.none { it is PsiFileNode && it.value?.name == MOD_RS }) {
+        if (children.none { it is PsiFileNode && it.value?.name == RsConstants.MOD_RS_FILE }) {
             return children
         }
 
@@ -36,5 +36,5 @@ class RsTreeStructureProvider : TreeStructureProvider, DumbAware {
 
 private class RsPsiFileNode(original: PsiFileNode, viewSettings: ViewSettings?)
     : PsiFileNode(original.project, original.value, viewSettings) {
-    override fun getSortKey(): Int = if (value.name == MOD_RS) -1 else 0
+    override fun getSortKey(): Int = if (value.name == RsConstants.MOD_RS_FILE) -1 else 0
 }

--- a/src/main/kotlin/org/rust/lang/RsConstants.kt
+++ b/src/main/kotlin/org/rust/lang/RsConstants.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide
+package org.rust.lang
 
 object RsConstants {
     const val MOD_RS_FILE = "mod.rs"

--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -16,6 +16,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiModificationTracker
+import org.rust.lang.RsConstants
 import org.rust.lang.RsFileType
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.ext.*
@@ -49,12 +50,16 @@ class RsFile(
 
     override val `super`: RsMod? get() = declaration?.containingMod
 
-    override val modName: String? = if (name != RsMod.MOD_RS) FileUtil.getNameWithoutExtension(name) else parent?.name
+    // We can't just return file name here because
+    // if mod declaration has `path` attribute file name differs from mod name
+    override val modName: String? get() {
+        return declaration?.name ?: if (name != RsConstants.MOD_RS_FILE) FileUtil.getNameWithoutExtension(name) else parent?.name
+    }
 
     override val crateRelativePath: String? get() = RsPsiImplUtil.modCrateRelativePath(this)
 
     override val ownsDirectory: Boolean
-        get() = name == RsMod.MOD_RS || isCrateRoot
+        get() = name == RsConstants.MOD_RS_FILE || isCrateRoot
 
     override val ownedDirectory: PsiDirectory?
         get() = originalFile.parent
@@ -104,5 +109,3 @@ val PsiFile.rustMod: RsMod? get() = this as? RsFile
 
 val VirtualFile.isNotRustFile: Boolean get() = !isRustFile
 val VirtualFile.isRustFile: Boolean get() = fileType == RsFileType
-
-

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
@@ -32,10 +32,6 @@ interface RsMod : RsQualifiedNamedElement, RsItemsOwner, RsVisible {
     val ownedDirectory: PsiDirectory?
 
     val isCrateRoot: Boolean
-
-    companion object {
-        val MOD_RS = "mod.rs"
-    }
 }
 
 val RsMod.superMods: List<RsMod> get() {

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.util.*
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.lang.RsConstants
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.NameResolutionTestmarks.missingMacroExport
@@ -127,7 +128,7 @@ fun processModDeclResolveVariants(modDecl: RsModDeclItem, processor: RsResolvePr
     if (modDecl.isLocal) return false
 
     for (file in dir.files) {
-        if (file == modDecl.contextualFile.originalFile || file.name == RsMod.MOD_RS) continue
+        if (file == modDecl.contextualFile.originalFile || file.name == RsConstants.MOD_RS_FILE) continue
         val mod = file.rustMod ?: continue
         val fileName = FileUtil.getNameWithoutExtension(file.name)
         val modDeclName = modDecl.referenceName
@@ -141,7 +142,7 @@ fun processModDeclResolveVariants(modDecl: RsModDeclItem, processor: RsResolvePr
     }
 
     for (d in dir.subdirectories) {
-        val mod = d.findFile(RsMod.MOD_RS)?.rustMod ?: continue
+        val mod = d.findFile(RsConstants.MOD_RS_FILE)?.rustMod ?: continue
         if (processor(d.name, mod)) return true
     }
 

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsModulesIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsModulesIndex.kt
@@ -12,7 +12,7 @@ import com.intellij.psi.stubs.StringStubIndexExtension
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
 import com.intellij.util.PathUtil
-import org.rust.ide.RsConstants
+import org.rust.lang.RsConstants
 import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.ext.pathAttribute
@@ -58,7 +58,10 @@ class RsModulesIndex : StringStubIndexExtension<RsModDeclItem>() {
         // We use case-insensitive name as a key, because certain file systems
         // are case-insensitive. It will work correctly with case-sensitive fs
         // because we of the resolve check we do in [getDeclarationFor]
-        private fun key(mod: RsFile): String? = mod.modName?.toLowerCase()
+        private fun key(mod: RsFile): String? {
+            val name = if (mod.name != RsConstants.MOD_RS_FILE) FileUtil.getNameWithoutExtension(mod.name) else mod.parent?.name
+            return name?.toLowerCase()
+        }
 
         private fun key(mod: RsModDeclItem): String? {
             val pathAttribute = mod.pathAttribute

--- a/src/main/kotlin/org/rust/lang/refactoring/RsPromoteModuleToDirectoryAction.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RsPromoteModuleToDirectoryAction.kt
@@ -17,14 +17,14 @@ import com.intellij.psi.impl.file.PsiFileImplUtil
 import com.intellij.refactoring.RefactoringActionHandler
 import com.intellij.refactoring.actions.BaseRefactoringAction
 import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesUtil
+import org.rust.lang.RsConstants
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.RsFile
-import org.rust.lang.core.psi.ext.RsMod
 import org.rust.openapiext.checkWriteAccessAllowed
 
 class RsPromoteModuleToDirectoryAction : BaseRefactoringAction() {
     override fun isEnabledOnElements(elements: Array<out PsiElement>): Boolean =
-        elements.all { it is RsFile && it.name != RsMod.MOD_RS }
+        elements.all { it is RsFile && it.name != RsConstants.MOD_RS_FILE }
 
     override fun getHandler(dataContext: DataContext): RefactoringActionHandler = Handler
 
@@ -55,7 +55,7 @@ class RsPromoteModuleToDirectoryAction : BaseRefactoringAction() {
             val directory = file.containingDirectory?.createSubdirectory(dirName)
                 ?: error("Can't expand file: no parent directory for $file at ${file.virtualFile.path}")
             MoveFilesOrDirectoriesUtil.doMoveFile(file, directory)
-            PsiFileImplUtil.setName(file, RsMod.MOD_RS)
+            PsiFileImplUtil.setName(file, RsConstants.MOD_RS_FILE)
         }
     }
 }

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ take into account path attribute.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ take into account path attribute.xml
@@ -1,0 +1,10 @@
+<configurations>
+  <configuration name="Test test::foo" class="CargoCommandConfiguration">
+    <option name="channel" value="DEFAULT" />
+    <option name="command" value="test --package test-package --lib test::foo -- --exact" />
+    <option name="nocapture" value="true" />
+    <option name="backtrace" value="SHORT" />
+    <option name="workingDirectory" value="file:///my-crate" />
+    <envs />
+  </configuration>
+</configurations>


### PR DESCRIPTION
In the following case
```rust
//- main.rs
#[path="bar.rs"]
mod foo;

//- bar.rs
fn foo() {}
```
fully qualified name of `foo` function is `foo::foo`.
But currently, we don't take into account module declaration and its attributes and return file system name as mod name for file. Because of it we return incorrect `bar::foo` in case above.

This change fixes it.

Fixes #2584
