### PR TITLE
QDOC: update quick doc layout

### DIFF
--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -30,36 +30,36 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
              //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>fn <b>add_one</b>(x: i32) -&gt; i32</pre>
-        <p>Adds one to the number given.</p><h1>Examples</h1><pre><code>let five = 5;
+        <div class='definition'><pre>test_package
+        fn <b>add_one</b>(x: i32) -&gt; i32</pre></div>
+        <div class='content'><p>Adds one to the number given.</p><h2>Examples</h2><pre><code>let five = 5;
 
         assert_eq!(6, add_one(5));
-        </code></pre>
+        </code></pre></div>
     """)
 
     fun `test pub fn`() = doTest("""
         pub fn foo() {}
               //^
     """, """
-        <pre>test_package</pre>
-        <pre>pub fn <b>foo</b>()</pre>
+        <div class='definition'><pre>test_package
+        pub fn <b>foo</b>()</pre></div>
     """)
 
     fun `test const fn`() = doTest("""
         const fn foo() {}
                  //^
     """, """
-        <pre>test_package</pre>
-        <pre>const fn <b>foo</b>()</pre>
+        <div class='definition'><pre>test_package
+        const fn <b>foo</b>()</pre></div>
     """)
 
     fun `test unsafe fn`() = doTest("""
         unsafe fn foo() {}
                   //^
     """, """
-        <pre>test_package</pre>
-        <pre>unsafe fn <b>foo</b>()</pre>
+        <div class='definition'><pre>test_package
+        unsafe fn <b>foo</b>()</pre></div>
     """)
 
     fun `test fn in extern block`() = doTest("""
@@ -68,8 +68,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>extern fn <b>foo</b>()</pre>
+        <div class='definition'><pre>test_package
+        extern fn <b>foo</b>()</pre></div>
     """)
 
     fun `test fn in extern block with abi name`() = doTest("""
@@ -78,40 +78,40 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>extern "C" fn <b>foo</b>()</pre>
+        <div class='definition'><pre>test_package
+        extern "C" fn <b>foo</b>()</pre></div>
     """)
 
     fun `test extern fn`() = doTest("""
         extern fn foo() {}
                  //^
     """, """
-        <pre>test_package</pre>
-        <pre>extern fn <b>foo</b>()</pre>
+        <div class='definition'><pre>test_package
+        extern fn <b>foo</b>()</pre></div>
     """)
 
     fun `test extern fn with abi name`() = doTest("""
         extern "C" fn foo() {}
                       //^
     """, """
-        <pre>test_package</pre>
-        <pre>extern "C" fn <b>foo</b>()</pre>
+        <div class='definition'><pre>test_package
+        extern "C" fn <b>foo</b>()</pre></div>
     """)
 
     fun `test generic fn`() = doTest("""
         fn foo<T: Into<String>>(t: T) {}
           //^
     """, """
-        <pre>test_package</pre>
-        <pre>fn <b>foo</b>&lt;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;&gt;(t: T)</pre>
+        <div class='definition'><pre>test_package
+        fn <b>foo</b>&lt;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;&gt;(t: T)</pre></div>
     """)
 
     fun `test generic fn with where clause`() = doTest("""
         fn foo<T>(t: T) where T: Into<String> {}
           //^
     """, """
-        <pre>test_package</pre>
-        <pre>fn <b>foo</b>&lt;T&gt;(t: T)<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre>
+        <div class='definition'><pre>test_package
+        fn <b>foo</b>&lt;T&gt;(t: T)<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre></div>
     """)
 
     fun `test complex fn`() = doTest("""
@@ -121,10 +121,10 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         pub const unsafe extern "C" fn foo<T: Into<String>, F>(t: T, f: F) where F: Ord {}
                                       //^
     """, """
-        <pre>test_package</pre>
-        <pre>pub const unsafe extern "C" fn <b>foo</b>&lt;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;, F&gt;(t: T, f: F)<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Ord">Ord</a>,</pre>
-        <p>Docs
-        More Docs</p>
+        <div class='definition'><pre>test_package
+        pub const unsafe extern "C" fn <b>foo</b>&lt;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;, F&gt;(t: T, f: F)<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Ord">Ord</a>,</pre></div>
+        <div class='content'><p>Docs
+        More Docs</p></div>
     """)
 
     fun `test fn with complex types`() = doTest("""
@@ -133,8 +133,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
             unimplemented!();
         }
     """, """
-        <pre>test_package</pre>
-        <pre>fn <b>foo</b>&lt;&#39;a&gt;(tuple: (<a href="psi_element://String">String</a>, &amp;&#39;a i32), f: fn(<a href="psi_element://String">String</a>) -&gt; [<a href="psi_element://Vec">Vec</a>&lt;u32&gt;; 3]) -&gt; <a href="psi_element://Option">Option</a>&lt;[<a href="psi_element://Vec">Vec</a>&lt;u32&gt;; 3]&gt;</pre>
+        <div class='definition'><pre>test_package
+        fn <b>foo</b>&lt;&#39;a&gt;(tuple: (<a href="psi_element://String">String</a>, &amp;&#39;a i32), f: fn(<a href="psi_element://String">String</a>) -&gt; [<a href="psi_element://Vec">Vec</a>&lt;u32&gt;; 3]) -&gt; <a href="psi_element://Option">Option</a>&lt;[<a href="psi_element://Vec">Vec</a>&lt;u32&gt;; 3]&gt;</pre></div>
     """)
 
     fun `test method`() = doTest("""
@@ -145,9 +145,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                   //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>impl <a href="psi_element://Foo">Foo</a></pre>
-        <pre>pub fn <b>foo</b>(&amp;self)</pre>
+        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Foo">Foo</a>
+        pub fn <b>foo</b>(&amp;self)</pre></div>
     """)
 
     fun `test method with Self ret type`() = doTest("""
@@ -158,9 +157,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                   //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>impl <a href="psi_element://Foo">Foo</a></pre>
-        <pre>pub fn <b>foo</b>(&amp;self) -&gt; Self</pre>
+        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Foo">Foo</a>
+        pub fn <b>foo</b>(&amp;self) -&gt; Self</pre></div>
     """)
 
     fun `test generic struct method`() = doTest("""
@@ -171,9 +169,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                   //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>impl&lt;T&gt; <a href="psi_element://Foo">Foo</a>&lt;T&gt;</pre>
-        <pre>pub fn <b>foo</b>(&amp;self)</pre>
+        <div class='definition'><pre>test_package<br>impl&lt;T&gt; <a href="psi_element://Foo">Foo</a>&lt;T&gt;
+        pub fn <b>foo</b>(&amp;self)</pre></div>
     """)
 
     fun `test generic struct method with where clause`() = doTest("""
@@ -184,9 +181,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                   //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>impl&lt;T, F&gt; <a href="psi_element://Foo">Foo</a>&lt;T, F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre>
-        <pre>pub fn <b>foo</b>(&amp;self)</pre>
+        <div class='definition'><pre>test_package<br>impl&lt;T, F&gt; <a href="psi_element://Foo">Foo</a>&lt;T, F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        pub fn <b>foo</b>(&amp;self)</pre></div>
     """)
 
     fun `test different comments`() = doTest("""
@@ -202,48 +198,48 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
             //! Inner comment
         }
     """, """
-        <pre>test_package</pre>
-        <pre>fn <b>overly_documented</b>()</pre>
-        <p>Outer comment
+        <div class='definition'><pre>test_package
+        fn <b>overly_documented</b>()</pre></div>
+        <div class='content'><p>Outer comment
         111
         outer attribute
         Second outer comment
         222
         second outer attribute
         inner attribute
-        Inner comment</p>
+        Inner comment</p></div>
     """)
 
     fun `test struct`() = doTest("""
         struct Foo(i32);
               //^
     """, """
-        <pre>test_package</pre>
-        <pre>struct <b>Foo</b></pre>
+        <div class='definition'><pre>test_package
+        struct <b>Foo</b></pre></div>
     """)
 
     fun `test pub struct`() = doTest("""
         pub struct Foo(i32);
                   //^
     """, """
-        <pre>test_package</pre>
-        <pre>pub struct <b>Foo</b></pre>
+        <div class='definition'><pre>test_package
+        pub struct <b>Foo</b></pre></div>
     """)
 
     fun `test generic struct`() = doTest("""
         struct Foo<T>(T);
               //^
     """, """
-        <pre>test_package</pre>
-        <pre>struct <b>Foo</b>&lt;T&gt;</pre>
+        <div class='definition'><pre>test_package
+        struct <b>Foo</b>&lt;T&gt;</pre></div>
     """)
 
     fun `test generic struct with where clause`() = doTest("""
         struct Foo<T>(T) where T: Into<String>;
               //^
     """, """
-        <pre>test_package</pre>
-        <pre>struct <b>Foo</b>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre>
+        <div class='definition'><pre>test_package
+        struct <b>Foo</b>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre></div>
     """)
 
     fun `test enum`() = doTest("""
@@ -252,8 +248,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
             Bar
         }
     """, """
-        <pre>test_package</pre>
-        <pre>enum <b>Foo</b></pre>
+        <div class='definition'><pre>test_package
+        enum <b>Foo</b></pre></div>
     """)
 
     fun `test pub enum`() = doTest("""
@@ -262,8 +258,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
             Bar
         }
     """, """
-        <pre>test_package</pre>
-        <pre>pub enum <b>Foo</b></pre>
+        <div class='definition'><pre>test_package
+        pub enum <b>Foo</b></pre></div>
     """)
 
     fun `test generic enum`() = doTest("""
@@ -272,8 +268,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
             Bar(T)
         }
     """, """
-        <pre>test_package</pre>
-        <pre>enum <b>Foo</b>&lt;T&gt;</pre>
+        <div class='definition'><pre>test_package
+        enum <b>Foo</b>&lt;T&gt;</pre></div>
     """)
 
     fun `test generic enum with where clause`() = doTest("""
@@ -282,8 +278,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
             Bar(T)
         }
     """, """
-        <pre>test_package</pre>
-        <pre>enum <b>Foo</b>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre>
+        <div class='definition'><pre>test_package
+        enum <b>Foo</b>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre></div>
     """)
 
     fun `test enum variant`() = doTest("""
@@ -298,8 +294,9 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                        //^
         }
     """, """
-        <pre>test_package::Foo::Bar</pre>
-        <p>I am a well documented enum variant</p>
+        <div class='definition'><pre>test_package::Foo::Bar
+        </pre></div>
+        <div class='content'><p>I am a well documented enum variant</p></div>
     """)
 
     fun `test trait`() = doTest("""
@@ -307,8 +304,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
             //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>trait <b>Foo</b></pre>
+        <div class='definition'><pre>test_package
+        trait <b>Foo</b></pre></div>
     """)
 
     fun `test pub trait`() = doTest("""
@@ -316,8 +313,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                  //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>pub trait <b>Foo</b></pre>
+        <div class='definition'><pre>test_package
+        pub trait <b>Foo</b></pre></div>
     """)
 
     fun `test unsafe trait`() = doTest("""
@@ -325,8 +322,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                     //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>unsafe trait <b>Foo</b></pre>
+        <div class='definition'><pre>test_package
+        unsafe trait <b>Foo</b></pre></div>
     """)
 
     fun `test generic trait`() = doTest("""
@@ -334,8 +331,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
              //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>trait <b>Foo</b>&lt;T&gt;</pre>
+        <div class='definition'><pre>test_package
+        trait <b>Foo</b>&lt;T&gt;</pre></div>
     """)
 
     fun `test generic trait with where clause`() = doTest("""
@@ -343,40 +340,40 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
              //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>trait <b>Foo</b>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre>
+        <div class='definition'><pre>test_package
+        trait <b>Foo</b>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre></div>
     """)
 
     fun `test type alias`() = doTest("""
         type Foo = Result<(), i32>;
             //^
     """, """
-        <pre>test_package</pre>
-        <pre>type <b>Foo</b> = <a href="psi_element://Result">Result</a>&lt;(), i32&gt;</pre>
+        <div class='definition'><pre>test_package
+        type <b>Foo</b> = <a href="psi_element://Result">Result</a>&lt;(), i32&gt;</pre></div>
     """)
 
     fun `test pub type alias`() = doTest("""
         pub type Foo = Result<(), i32>;
                 //^
     """, """
-        <pre>test_package</pre>
-        <pre>pub type <b>Foo</b> = <a href="psi_element://Result">Result</a>&lt;(), i32&gt;</pre>
+        <div class='definition'><pre>test_package
+        pub type <b>Foo</b> = <a href="psi_element://Result">Result</a>&lt;(), i32&gt;</pre></div>
     """)
 
     fun `test generic type alias`() = doTest("""
         type Foo<T> = Result<T, i32>;
             //^
     """, """
-        <pre>test_package</pre>
-        <pre>type <b>Foo</b>&lt;T&gt; = <a href="psi_element://Result">Result</a>&lt;T, i32&gt;</pre>
+        <div class='definition'><pre>test_package
+        type <b>Foo</b>&lt;T&gt; = <a href="psi_element://Result">Result</a>&lt;T, i32&gt;</pre></div>
     """)
 
     fun `test generic type alias with where clause`() = doTest("""
         type Foo<T> where T: Into<String> = Result<T, i32>;
              //^
     """, """
-        <pre>test_package</pre>
-        <pre>type <b>Foo</b>&lt;T&gt; = <a href="psi_element://Result">Result</a>&lt;T, i32&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre>
+        <div class='definition'><pre>test_package
+        type <b>Foo</b>&lt;T&gt; = <a href="psi_element://Result">Result</a>&lt;T, i32&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre></div>
     """)
 
     fun `test impl assoc type`() = doTest("""
@@ -389,9 +386,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a></pre>
-        <pre>type <b>AssocType</b> = <a href="psi_element://Option">Option</a>&lt;i32&gt;</pre>
+        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
+        type <b>AssocType</b> = <a href="psi_element://Option">Option</a>&lt;i32&gt;</pre></div>
     """)
 
     fun `test generic impl assoc type`() = doTest("""
@@ -404,9 +400,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;</pre>
-        <pre>type <b>AssocType</b> = <a href="psi_element://Option">Option</a>&lt;T&gt;</pre>
+        <div class='definition'><pre>test_package<br>impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;
+        type <b>AssocType</b> = <a href="psi_element://Option">Option</a>&lt;T&gt;</pre></div>
     """)
 
     fun `test generic impl assoc type with where clause`() = doTest("""
@@ -419,9 +414,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre>
-        <pre>type <b>AssocType</b> = <a href="psi_element://Option">Option</a>&lt;T&gt;</pre>
+        <div class='definition'><pre>test_package<br>impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        type <b>AssocType</b> = <a href="psi_element://Option">Option</a>&lt;T&gt;</pre></div>
     """)
 
     fun `test trait assoc type`() = doTest("""
@@ -431,9 +425,9 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                //^
         }
     """, """
-        <pre>test_package::MyTrait</pre>
-        <pre>type <b>Awesome</b></pre>
-        <p>Documented</p>
+        <div class='definition'><pre>test_package::MyTrait
+        type <b>Awesome</b></pre></div>
+        <div class='content'><p>Documented</p></div>
     """)
 
     fun `test generic trait assoc type`() = doTest("""
@@ -443,9 +437,9 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                //^
         }
     """, """
-        <pre>test_package::MyTrait&lt;T&gt;</pre>
-        <pre>type <b>Awesome</b></pre>
-        <p>Documented</p>
+        <div class='definition'><pre>test_package::MyTrait&lt;T&gt;
+        type <b>Awesome</b></pre></div>
+        <div class='content'><p>Documented</p></div>
     """)
 
     fun `test generic trait assoc type with where clause`() = doTest("""
@@ -455,10 +449,9 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                //^
         }
     """, """
-        <pre>test_package::MyTrait&lt;T&gt;</pre>
-        <pre>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre>
-        <pre>type <b>Awesome</b></pre>
-        <p>Documented</p>
+        <div class='definition'><pre>test_package::MyTrait&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        type <b>Awesome</b></pre></div>
+        <div class='content'><p>Documented</p></div>
     """)
 
     fun `test const`() = doTest("""
@@ -468,9 +461,9 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>const <b>AWESOME</b>: i32 = 1</pre>
-        <p>Documented</p>
+        <div class='definition'><pre>test_package
+        const <b>AWESOME</b>: i32 = 1</pre></div>
+        <div class='content'><p>Documented</p></div>
     """)
 
     fun `test static`() = doTest("""
@@ -480,9 +473,9 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                  //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>static <b>AWESOME</b>: i32 = 1</pre>
-        <p>Documented</p>
+        <div class='definition'><pre>test_package
+        static <b>AWESOME</b>: i32 = 1</pre></div>
+        <div class='content'><p>Documented</p></div>
     """)
 
     fun `test trait const`() = doTest("""
@@ -492,9 +485,9 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        <pre>test_package::MyTrait</pre>
-        <pre>const <b>AWESOME</b>: i32</pre>
-        <p>Documented</p>
+        <div class='definition'><pre>test_package::MyTrait
+        const <b>AWESOME</b>: i32</pre></div>
+        <div class='content'><p>Documented</p></div>
     """)
 
     fun `test impl assoc const`() = doTest("""
@@ -507,9 +500,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a></pre>
-        <pre>const <b>AWESOME</b>: u8 = 42</pre>
+        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
+        const <b>AWESOME</b>: u8 = 42</pre></div>
     """)
 
     fun `test trait method`() = doTest("""
@@ -519,9 +511,9 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
              //^
         }
     """, """
-        <pre>test_package::MyTrait</pre>
-        <pre>fn <b>my_func</b>()</pre>
-        <p>Documented</p>
+        <div class='definition'><pre>test_package::MyTrait
+        fn <b>my_func</b>()</pre></div>
+        <div class='content'><p>Documented</p></div>
     """)
 
     fun `test generic trait method`() = doTest("""
@@ -531,9 +523,9 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
              //^
         }
     """, """
-        <pre>test_package::MyTrait&lt;T&gt;</pre>
-        <pre>fn <b>my_func</b>()</pre>
-        <p>Documented</p>
+        <div class='definition'><pre>test_package::MyTrait&lt;T&gt;
+        fn <b>my_func</b>()</pre></div>
+        <div class='content'><p>Documented</p></div>
     """)
 
     fun `test generic trait method with where clause`() = doTest("""
@@ -543,10 +535,9 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
              //^
         }
     """, """
-        <pre>test_package::MyTrait&lt;T&gt;</pre>
-        <pre>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre>
-        <pre>fn <b>my_func</b>()</pre>
-        <p>Documented</p>
+        <div class='definition'><pre>test_package::MyTrait&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        fn <b>my_func</b>()</pre></div>
+        <div class='content'><p>Documented</p></div>
     """)
 
     fun `test trait method impl`() = doTest("""
@@ -559,9 +550,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a></pre>
-        <pre>fn <b>foo</b>()</pre>
+        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
+        fn <b>foo</b>()</pre></div>
     """)
 
     fun `test generic trait method impl`() = doTest("""
@@ -574,9 +564,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;</pre>
-        <pre>fn <b>foo</b>()</pre>
+        <div class='definition'><pre>test_package<br>impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;
+        fn <b>foo</b>()</pre></div>
     """)
 
     fun `test generic trait method impl with where clause`() = doTest("""
@@ -589,9 +578,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre>
-        <pre>fn <b>foo</b>()</pre>
+        <div class='definition'><pre>test_package<br>impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        fn <b>foo</b>()</pre></div>
     """)
 
     fun `test trait method provided`() = doTest("""
@@ -602,9 +590,9 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
             }
         }
     """, """
-        <pre>test_package::MyTrait</pre>
-        <pre>fn <b>my_func</b>()</pre>
-        <p>Inner doc</p>
+        <div class='definition'><pre>test_package::MyTrait
+        fn <b>my_func</b>()</pre></div>
+        <div class='content'><p>Inner doc</p></div>
     """)
 
     fun `test mod inner docstring`() = doTest("""
@@ -619,9 +607,10 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
           //^
         }
     """, """
-        <pre>test_package::foo</pre>
-        <p><em>outer</em>
-        <strong>inner</strong></p>
+        <div class='definition'><pre>test_package::foo
+        </pre></div>
+        <div class='content'><p><em>outer</em>
+        <strong>inner</strong></p></div>
     """)
 
     fun `test fn inner docstring`() = doTest("""
@@ -634,9 +623,9 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
           //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>fn <b>foo</b>()</pre>
-        <p>Inner doc.</p>
+        <div class='definition'><pre>test_package
+        fn <b>foo</b>()</pre></div>
+        <div class='content'><p>Inner doc.</p></div>
     """)
 
     // TODO: fix quick doc for files
@@ -665,9 +654,9 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         fn main() {
         }
     """, """
-        <pre>test_package</pre>
-        <pre>macro <b>makro</b></pre>
-        <p>Outer documentation</p>
+        <div class='definition'><pre>test_package
+        macro <b>makro</b></pre></div>
+        <div class='content'><p>Outer documentation</p></div>
     """)
 
     fun `test qualified name`() = doTest("""
@@ -683,9 +672,9 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        <pre>test_package::q</pre>
-        <pre>fn <b>foo</b>()</pre>
-        <p>Blurb.</p>
+        <div class='definition'><pre>test_package::q
+        fn <b>foo</b>()</pre></div>
+        <div class='content'><p>Blurb.</p></div>
     """)
 
     // https://github.com/intellij-rust/intellij-rust/issues/495
@@ -731,11 +720,11 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         impl <T> AsRef<T> {}
                   //^
     """, """
-        <pre>test_package</pre>
-        <pre>pub trait <b>AsRef</b>&lt;T: ?<a href="psi_element://Sized">Sized</a>&gt;</pre>
-        <p>A cheap, reference-to-reference conversion.</p><p><code>AsRef</code> is very similar to, but different than, <code>Borrow</code>. See
+        <div class='definition'><pre>test_package
+        pub trait <b>AsRef</b>&lt;T: ?<a href="psi_element://Sized">Sized</a>&gt;</pre></div>
+        <div class='content'><p>A cheap, reference-to-reference conversion.</p><p><code>AsRef</code> is very similar to, but different than, <code>Borrow</code>. See
         <a href="../../book/borrow-and-asref.html">the book</a> for more.</p><p><strong>Note: this trait must not fail</strong>. If the conversion can fail, use a dedicated method which
-        returns an <code>Option&lt;T&gt;</code> or a <code>Result&lt;T, E&gt;</code>.</p><h1>Examples</h1><p>Both <code>String</code> and <code>&amp;str</code> implement <code>AsRef&lt;str&gt;</code>:</p><pre><code>fn is_hello&lt;T: AsRef&lt;str&gt;&gt;(s: T) {
+        returns an <code>Option&lt;T&gt;</code> or a <code>Result&lt;T, E&gt;</code>.</p><h2>Examples</h2><p>Both <code>String</code> and <code>&amp;str</code> implement <code>AsRef&lt;str&gt;</code>:</p><pre><code>fn is_hello&lt;T: AsRef&lt;str&gt;&gt;(s: T) {
            assert_eq!(&quot;hello&quot;, s.as_ref());
         }
 
@@ -744,15 +733,15 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
 
         let s = &quot;hello&quot;.to_string();
         is_hello(s);
-        </code></pre><h1>Generic Impls</h1><ul><li><code>AsRef</code> auto-dereference if the inner type is a reference or a mutable
-        reference (eg: <code>foo.as_ref()</code> will work the same if <code>foo</code> has type <code>&amp;mut Foo</code> or <code>&amp;&amp;mut Foo</code>)</li></ul>
+        </code></pre><h2>Generic Impls</h2><ul><li><code>AsRef</code> auto-dereference if the inner type is a reference or a mutable
+        reference (eg: <code>foo.as_ref()</code> will work the same if <code>foo</code> has type <code>&amp;mut Foo</code> or <code>&amp;&amp;mut Foo</code>)</li></ul></div>
     """)
 
     fun `test fn arg`() = doTest("""
         fn foo(x: i32) -> i32 { x }
              //^
     """, """
-        <pre>value parameter <b>x</b>: i32</pre>
+        <div class='definition'><pre>value parameter <b>x</b>: i32</pre></div>
     """)
 
     fun `test variable`() = doTest("""
@@ -762,7 +751,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                    //^
         }
     """, """
-        <pre>variable <b>x</b>: &amp;str</pre>
+        <div class='definition'><pre>variable <b>x</b>: &amp;str</pre></div>
     """)
 
     fun `test generic enum variable`() = doTest("""
@@ -777,7 +766,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
           //^
         }
     """, """
-        <pre>variable <b>x</b>: E&lt;i32&gt;</pre>
+        <div class='definition'><pre>variable <b>x</b>: E&lt;i32&gt;</pre></div>
     """)
 
     fun `test generic struct variable`() = doTest("""
@@ -789,7 +778,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
           //^
         }
     """, """
-        <pre>variable <b>x</b>: S&lt;i32&gt;</pre>
+        <div class='definition'><pre>variable <b>x</b>: S&lt;i32&gt;</pre></div>
     """)
 
     fun `test tuple destructuring`() = doTest("""
@@ -798,7 +787,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                   //^
         }
     """, """
-        <pre>variable <b>b</b>: (&amp;str, i32)</pre>
+        <div class='definition'><pre>variable <b>b</b>: (&amp;str, i32)</pre></div>
     """)
 
     fun `test conditional binding`() = doTest("""
@@ -809,7 +798,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
             }
         }
     """, """
-        <pre>condition binding <b>y</b>: f64</pre>
+        <div class='definition'><pre>condition binding <b>y</b>: f64</pre></div>
     """)
 
     fun `test struct field`() = doTest("""
@@ -824,16 +813,16 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        <pre>test_package::Foo</pre>
-        <pre>pub <b>foo</b>: i32</pre>
-        <p>Documented</p>
+        <div class='definition'><pre>test_package::Foo
+        pub <b>foo</b>: i32</pre></div>
+        <div class='content'><p>Documented</p></div>
     """)
 
     fun `test type parameter`() = doTest("""
         fn foo<T>() { unimplemented!() }
              //^
     """, """
-        <pre>type parameter <b>T</b></pre>
+        <div class='definition'><pre>type parameter <b>T</b></pre></div>
     """)
 
     fun `test type parameter with single bound`() = doTest("""
@@ -842,7 +831,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         fn foo<T: Borrow<Q>>() { unimplemented!() }
              //^
     """, """
-        <pre>type parameter <b>T</b>: <a href="psi_element://Borrow">Borrow</a>&lt;Q&gt;</pre>
+        <div class='definition'><pre>type parameter <b>T</b>: <a href="psi_element://Borrow">Borrow</a>&lt;Q&gt;</pre></div>
     """)
 
     fun `test type parameter with multiple bounds`() = doTest("""
@@ -852,14 +841,14 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         fn foo<Q, T: Eq + Hash + Borrow<Q>>() { unimplemented!() }
                 //^
     """, """
-        <pre>type parameter <b>T</b>: <a href="psi_element://Eq">Eq</a> + <a href="psi_element://Hash">Hash</a> + <a href="psi_element://Borrow">Borrow</a>&lt;Q&gt;</pre>
+        <div class='definition'><pre>type parameter <b>T</b>: <a href="psi_element://Eq">Eq</a> + <a href="psi_element://Hash">Hash</a> + <a href="psi_element://Borrow">Borrow</a>&lt;Q&gt;</pre></div>
     """)
 
     fun `test type parameter with lifetime bound`() = doTest("""
         fn foo<'a, T: 'a>() { unimplemented!() }
                  //^
     """, """
-        <pre>type parameter <b>T</b>: &#39;a</pre>
+        <div class='definition'><pre>type parameter <b>T</b>: &#39;a</pre></div>
     """)
 
     fun `test type parameter with default value`() = doTest("""
@@ -868,7 +857,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         fn foo<T = RandomState>() { unimplemented!() }
              //^
     """, """
-        <pre>type parameter <b>T</b> = <a href="psi_element://RandomState">RandomState</a></pre>
+        <div class='definition'><pre>type parameter <b>T</b> = <a href="psi_element://RandomState">RandomState</a></pre></div>
     """)
 
     fun `test type parameter with bounds in where clause`() = doTest("""
@@ -878,7 +867,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         fn foo<Q, T>() where T: Eq + Hash + Borrow<Q> { unimplemented!() }
                 //^
     """, """
-        <pre>type parameter <b>T</b>: <a href="psi_element://Eq">Eq</a> + <a href="psi_element://Hash">Hash</a> + <a href="psi_element://Borrow">Borrow</a>&lt;Q&gt;</pre>
+        <div class='definition'><pre>type parameter <b>T</b>: <a href="psi_element://Eq">Eq</a> + <a href="psi_element://Hash">Hash</a> + <a href="psi_element://Borrow">Borrow</a>&lt;Q&gt;</pre></div>
     """)
 
     fun `test type parameter with complex bounds`() = doTest("""
@@ -888,15 +877,15 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         fn foo<'a, Q, T: 'a + Eq>() where T: Hash + Borrow<Q> { unimplemented!() }
                     //^
     """, """
-        <pre>type parameter <b>T</b>: &#39;a + <a href="psi_element://Eq">Eq</a> + <a href="psi_element://Hash">Hash</a> + <a href="psi_element://Borrow">Borrow</a>&lt;Q&gt;</pre>
+        <div class='definition'><pre>type parameter <b>T</b>: &#39;a + <a href="psi_element://Eq">Eq</a> + <a href="psi_element://Hash">Hash</a> + <a href="psi_element://Borrow">Borrow</a>&lt;Q&gt;</pre></div>
     """)
 
     fun `test don't create link for unresolved items`() = doTest("""
         fn foo() -> Foo { unimplemented!() }
            //^
     """, """
-        <pre>test_package</pre>
-        <pre>fn <b>foo</b>() -&gt; Foo</pre>
+        <div class='definition'><pre>test_package
+        fn <b>foo</b>() -&gt; Foo</pre></div>
     """)
 
     fun `test assoc type bound`() = doTest("""
@@ -907,8 +896,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         fn foo<T>(t: T) where T: Foo, T::Bar: Into<String> {}
           //^
     """, """
-        <pre>test_package</pre>
-        <pre>fn <b>foo</b>&lt;T&gt;(t: T)<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Foo">Foo</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;T::<a href="psi_element://T::Bar">Bar</a>: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre>
+        <div class='definition'><pre>test_package
+        fn <b>foo</b>&lt;T&gt;(t: T)<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Foo">Foo</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;T::<a href="psi_element://T::Bar">Bar</a>: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,</pre></div>
     """)
 
     fun `test type qual`() = doTest("""
@@ -931,25 +920,24 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        <pre>test_package</pre>
-        <pre>impl <a href="psi_element://Foo2">Foo2</a> for <a href="psi_element://S">S</a></pre>
-        <pre>type <b>Bar</b> = &lt;Self as <a href="psi_element://Foo1">Foo1</a>&gt;::<a href="psi_element://&lt;Self as Foo1&gt;::Bar">Bar</a></pre>
+        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Foo2">Foo2</a> for <a href="psi_element://S">S</a>
+        type <b>Bar</b> = &lt;Self as <a href="psi_element://Foo1">Foo1</a>&gt;::<a href="psi_element://&lt;Self as Foo1&gt;::Bar">Bar</a></pre></div>
     """)
 
     fun `test type value parameters 1`() = doTest("""
         fn run<F, T>(f: F, t: T) where F: FnOnce(T) { f(t); }
           //^
     """, """
-        <pre>test_package</pre>
-        <pre>fn <b>run</b>&lt;F, T&gt;(f: F, t: T)<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://FnOnce">FnOnce</a>(T),</pre>
+        <div class='definition'><pre>test_package
+        fn <b>run</b>&lt;F, T&gt;(f: F, t: T)<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://FnOnce">FnOnce</a>(T),</pre></div>
     """)
 
     fun `test type value parameters 2`() = doTest("""
         fn call<F, T, R>(f: F, t: T) -> R where F: FnOnce(T) -> R { f(t) }
           //^
     """, """
-        <pre>test_package</pre>
-        <pre>fn <b>call</b>&lt;F, T, R&gt;(f: F, t: T) -&gt; R<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://FnOnce">FnOnce</a>(T) -&gt; R,</pre>
+        <div class='definition'><pre>test_package
+        fn <b>call</b>&lt;F, T, R&gt;(f: F, t: T) -&gt; R<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://FnOnce">FnOnce</a>(T) -&gt; R,</pre></div>
     """)
 
     fun `test type value parameters 3`() = doTest("""
@@ -961,8 +949,26 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                 where Self: Sized, F: FnMut(&mut St, Self::Item) -> Option<B> { unimplemented!() }
         }
     """, """
-        <pre>test_package::Iter</pre>
-        <pre>fn <b>scan</b>&lt;St, B, F&gt;(self, initial_state: St, f: F) -&gt; Scan&lt;Self, St, F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;Self: <a href="psi_element://Sized">Sized</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://FnMut">FnMut</a>(&amp;mut St, Self::<a href="psi_element://Self::Item">Item</a>) -&gt; <a href="psi_element://Option">Option</a>&lt;B&gt;,</pre>
+        <div class='definition'><pre>test_package::Iter
+        fn <b>scan</b>&lt;St, B, F&gt;(self, initial_state: St, f: F) -&gt; Scan&lt;Self, St, F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;Self: <a href="psi_element://Sized">Sized</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://FnMut">FnMut</a>(&amp;mut St, Self::<a href="psi_element://Self::Item">Item</a>) -&gt; <a href="psi_element://Option">Option</a>&lt;B&gt;,</pre></div>
+    """)
+
+    fun `test markdown sections`() = doTest("""
+        /// Some text
+        ///
+        /// # Section level 1
+        ///
+        /// Some text
+        ///
+        /// ## Section level 2
+        ///
+        /// Some other text
+        struct Foo;
+              //^
+    """, """
+        <div class='definition'><pre>test_package
+        struct <b>Foo</b></pre></div>
+        <div class='content'><p>Some text</p><h2>Section level 1</h2><p>Some text</p><h3>Section level 2</h3><p>Some other text</p></div>
     """)
 
     private fun doTest(@Language("Rust") code: String, @Language("Html") expected: String)

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
@@ -68,8 +68,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
             //^
         }
     """, """
-        test_package
-        impl <a href="psi_element://S">S</a>
+        test_package<br>impl <a href="psi_element://S">S</a>
         pub fn <b>consume</b>(self) -&gt; i32
     """)
 
@@ -81,8 +80,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
                   //^
         }
     """, """
-        test_package
-        impl&lt;T&gt; <a href="psi_element://Foo">Foo</a>&lt;T&gt;
+        test_package<br>impl&lt;T&gt; <a href="psi_element://Foo">Foo</a>&lt;T&gt;
         pub fn <b>foo</b>(&amp;self)
     """)
 
@@ -94,8 +92,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
                   //^
         }
     """, """
-        test_package
-        impl&lt;T, F&gt; <a href="psi_element://Foo">Foo</a>&lt;T, F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        test_package<br>impl&lt;T, F&gt; <a href="psi_element://Foo">Foo</a>&lt;T, F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
         pub fn <b>foo</b>(&amp;self)
     """)
 
@@ -128,8 +125,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
              //^
         }
     """, """
-        test_package::MyTrait&lt;T&gt;
-        where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        test_package::MyTrait&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
         fn <b>my_func</b>()
     """)
 
@@ -193,8 +189,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        test_package
-        impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
+        test_package<br>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
         fn <b>foo</b>()
     """)
 
@@ -208,8 +203,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        test_package
-        impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;
+        test_package<br>impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;
         fn <b>foo</b>()
     """)
 
@@ -223,8 +217,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        test_package
-        impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        test_package<br>impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
         fn <b>foo</b>()
     """)
 
@@ -442,8 +435,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        test_package
-        impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
+        test_package<br>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
         type <b>AssocType</b> = <a href="psi_element://Option">Option</a>&lt;i32&gt;
     """)
 
@@ -457,8 +449,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        test_package
-        impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;
+        test_package<br>impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;
         type <b>AssocType</b> = <a href="psi_element://Option">Option</a>&lt;T&gt;
     """)
 
@@ -472,8 +463,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        test_package
-        impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        test_package<br>impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
         type <b>AssocType</b> = <a href="psi_element://Option">Option</a>&lt;T&gt;
     """)
 
@@ -506,8 +496,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
                //^
         }
     """, """
-        test_package::MyTrait&lt;T&gt;
-        where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        test_package::MyTrait&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
         type <b>Awesome</b>
     """)
 


### PR DESCRIPTION
* Create quick documentation html using `DocumentationMarkup`
* Use `h2` and `h3` tags for sections instead of `h1` and `h2` respectively

**Before:**
<img width="598" alt="screen shot 2018-06-28 at 15 37 53" src="https://user-images.githubusercontent.com/2539310/42034609-4493b16e-7ae9-11e8-8fcd-0eb50d982eed.png">
**After:**
<img width="596" alt="screen shot 2018-06-28 at 15 37 19" src="https://user-images.githubusercontent.com/2539310/42034630-523156a0-7ae9-11e8-8858-71c3a5291e41.png">
