### PR TITLE
QDOC: initial support of documentation links

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.psi.ext
 
+import com.intellij.openapi.diagnostic.Logger
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsQualifiedName.ChildItemType.*
 import org.rust.lang.core.psi.ext.RsQualifiedName.ParentItemType.*
@@ -20,11 +21,12 @@ val RsQualifiedNamedElement.qualifiedName: String? get() {
     return "$cargoTarget$inCratePath"
 }
 
-class RsQualifiedName private constructor(
-    private val crateName: String,
-    private val modSegments: List<String>,
-    private val parentItem: Item,
-    private val childItem: Item?
+@Suppress("DataClassPrivateConstructor")
+data class RsQualifiedName private constructor(
+    val crateName: String,
+    val modSegments: List<String>,
+    val parentItem: Item,
+    val childItem: Item?
 ) {
 
     fun toUrlPath(): String {
@@ -41,10 +43,53 @@ class RsQualifiedName private constructor(
     }
 
     companion object {
+        
+        private val LOG: Logger = Logger.getInstance(RsQualifiedName::class.java)
+
+        @JvmStatic
+        fun from(path: String): RsQualifiedName? {
+            val segments = path.split("/")
+            if (segments.size < 2) return null
+
+            // Last segment contains info about item type and name
+            // and it should have the following structure:
+            // parentItem ( '#' childItem )?
+            val itemParts = segments.last().split("#")
+            val parentRaw = itemParts[0]
+            val childRaw = itemParts.getOrNull(1)
+
+            val parentItem = parentItem(segments[segments.lastIndex - 1], parentRaw) ?: return null
+            val childItem = if (childRaw != null) {
+                childItem(childRaw) ?: return null
+            } else {
+                null
+            }
+
+            val endModSegmentsIndex = if (parentItem.type == ParentItemType.MOD) segments.lastIndex - 1 else segments.lastIndex
+            return RsQualifiedName(segments[0], segments.subList(1, endModSegmentsIndex), parentItem, childItem)
+        }
+
+        private fun parentItem(prevSegment: String, raw: String): Item? {
+            if (raw == "index.html") {
+                return Item(prevSegment, MOD)
+            }
+            val parts = raw.split(".")
+            // We suppose that string representation of parent item has the following structure:
+            // type.Name.html
+            if (parts.size != 3 || parts.last() != "html") return null
+            val type = ParentItemType.fromString(parts[0]) ?: return null
+            return Item(parts[1], type)
+        }
+        
+        private fun childItem(raw: String): Item? {
+            val parts = raw.split(".")
+            if (parts.size != 2) return null
+            val type = ChildItemType.fromString(parts[0]) ?: return null
+            return Item(parts[1], type)
+        } 
 
         @JvmStatic
         fun from(element: RsQualifiedNamedElement): RsQualifiedName? {
-
             val parent = parentItem(element)
 
             val (parentItem, childItem) = if (parent != null) {
@@ -55,7 +100,7 @@ class RsQualifiedName private constructor(
             }
 
             val crateName = element.containingCargoTarget?.normName ?: return null
-            val modSegments = if (parentItem.type == ParentItemType.PRIMITIVE) {
+            val modSegments = if (parentItem.type == PRIMITIVE) {
                 listOf()
             } else {
                 element.containingMod.superMods
@@ -147,13 +192,13 @@ class RsQualifiedName private constructor(
         }
     }
 
-    private data class Item(val name: String, val type: ItemType) {
+    data class Item(val name: String, val type: ItemType) {
         override fun toString(): String = "$type.$name"
     }
 
-    private interface ItemType
+    interface ItemType
 
-    private enum class ParentItemType : ItemType {
+    enum class ParentItemType : ItemType {
         STRUCT,
         ENUM,
         TRAIT,
@@ -165,9 +210,29 @@ class RsQualifiedName private constructor(
         PRIMITIVE;
 
         override fun toString(): String = name.toLowerCase()
+        
+        companion object {
+
+            fun fromString(name: String): ParentItemType? {
+                return when (name) {
+                    "struct" -> STRUCT
+                    "enum" -> ENUM
+                    "trait" -> TRAIT
+                    "type" -> TYPE
+                    "fn" -> FN
+                    "constant" -> CONSTANT
+                    "macro" -> MACRO
+                    "primitive" -> PRIMITIVE
+                    else -> {
+                        LOG.warn("Unexpected parent item type: `$name`")
+                        null
+                    }
+                }
+            }
+        }
     }
 
-    private enum class ChildItemType : ItemType {
+    enum class ChildItemType : ItemType {
         VARIANT,
         STRUCTFIELD,
         ASSOCIATEDTYPE,
@@ -176,5 +241,22 @@ class RsQualifiedName private constructor(
         METHOD;
 
         override fun toString(): String = name.toLowerCase()
+        
+        companion object {
+            fun fromString(name: String): ChildItemType? {
+                return when (name) {
+                    "variant" -> VARIANT
+                    "structfield" -> STRUCTFIELD
+                    "associatedtype" -> ASSOCIATEDTYPE
+                    "associatedconstant" -> ASSOCIATEDCONSTANT
+                    "tymethod" -> TYMETHOD
+                    "method" -> METHOD
+                    else -> {
+                        LOG.warn("Unexpected child item type: `$name`")
+                        null
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/main/kotlin/org/rust/lang/doc/RsDocPipeline.kt
+++ b/src/main/kotlin/org/rust/lang/doc/RsDocPipeline.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.doc
 
+import com.intellij.codeInsight.documentation.DocumentationManagerProtocol
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.SyntaxTraverser
@@ -22,10 +23,11 @@ import org.rust.lang.core.parser.RustParserDefinition.Companion.INNER_BLOCK_DOC_
 import org.rust.lang.core.parser.RustParserDefinition.Companion.INNER_EOL_DOC_COMMENT
 import org.rust.lang.core.parser.RustParserDefinition.Companion.OUTER_BLOCK_DOC_COMMENT
 import org.rust.lang.core.parser.RustParserDefinition.Companion.OUTER_EOL_DOC_COMMENT
-import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.RsDocAndAttributeOwner
-import org.rust.lang.core.psi.ext.name
-import org.rust.lang.core.psi.ext.stringLiteralValue
+import org.rust.lang.core.psi.RsBlock
+import org.rust.lang.core.psi.RsInnerAttr
+import org.rust.lang.core.psi.RsMetaItem
+import org.rust.lang.core.psi.RsOuterAttr
+import org.rust.lang.core.psi.ext.*
 import org.rust.lang.doc.psi.RsDocKind
 import java.net.URI
 
@@ -36,10 +38,29 @@ fun RsDocAndAttributeOwner.documentation(): String? =
         .joinToString("\n")
 
 fun RsDocAndAttributeOwner.documentationAsHtml(): String? {
+    // We need some host with unique scheme to
+    //
+    // 1. make `URI#resolve` work properly somewhere in markdown to html converter implementation
+    // 2. identify relative links to language items from other links
+    //
+    // We can't use `DocumentationManagerProtocol.PSI_ELEMENT_PROTOCOL` scheme here
+    // because it contains `_` and it is invalid symbol for URI scheme
+    val tmpUriPrefix = "psi://element/"
+    val baseURI = if (this is RsQualifiedNamedElement) {
+        val path = RsQualifiedName.from(this)?.toUrlPath()
+        if (path != null) {
+            try {
+                URI.create("$tmpUriPrefix$path")
+            } catch (e: Exception) {
+                null
+            }
+        } else null
+    } else null
     val text = documentation() ?: return null
-    val flavour = RustDocMarkdownFlavourDescriptor()
+    val flavour = RustDocMarkdownFlavourDescriptor(baseURI)
     val root = MarkdownParser(flavour).buildMarkdownTreeFromString(text)
     return HtmlGenerator(text, root, flavour).generateHtml()
+        .replace(tmpUriPrefix, DocumentationManagerProtocol.PSI_ELEMENT_PROTOCOL)
 }
 
 private fun RsDocAndAttributeOwner.outerDocs(): Sequence<Pair<RsDocKind, String>> {
@@ -83,11 +104,12 @@ private val RsMetaItem.docAttr: String?
     get() = if (name == "doc") litExpr?.stringLiteralValue else null
 
 private class RustDocMarkdownFlavourDescriptor(
+    private val uri: URI? = null,
     private val gfm: MarkdownFlavourDescriptor = GFMFlavourDescriptor()
 ) : MarkdownFlavourDescriptor by gfm {
 
     override fun createHtmlGeneratingProviders(linkMap: LinkMap, baseURI: URI?): Map<IElementType, GeneratingProvider> {
-        val generatingProviders = HashMap(gfm.createHtmlGeneratingProviders(linkMap, baseURI))
+        val generatingProviders = HashMap(gfm.createHtmlGeneratingProviders(linkMap, uri ?: baseURI))
         // Filter out MARKDOWN_FILE to avoid producing unnecessary <body> tags
         generatingProviders.remove(MarkdownElementTypes.MARKDOWN_FILE)
         // h1 and h2 are too large

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -723,7 +723,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <div class='definition'><pre>test_package
         pub trait <b>AsRef</b>&lt;T: ?<a href="psi_element://Sized">Sized</a>&gt;</pre></div>
         <div class='content'><p>A cheap, reference-to-reference conversion.</p><p><code>AsRef</code> is very similar to, but different than, <code>Borrow</code>. See
-        <a href="../../book/borrow-and-asref.html">the book</a> for more.</p><p><strong>Note: this trait must not fail</strong>. If the conversion can fail, use a dedicated method which
+        <a href="psi_element://../book/borrow-and-asref.html">the book</a> for more.</p><p><strong>Note: this trait must not fail</strong>. If the conversion can fail, use a dedicated method which
         returns an <code>Option&lt;T&gt;</code> or a <code>Result&lt;T, E&gt;</code>.</p><h2>Examples</h2><p>Both <code>String</code> and <code>&amp;str</code> implement <code>AsRef&lt;str&gt;</code>:</p><pre><code>fn is_hello&lt;T: AsRef&lt;str&gt;&gt;(s: T) {
            assert_eq!(&quot;hello&quot;, s.as_ref());
         }
@@ -969,6 +969,51 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <div class='definition'><pre>test_package
         struct <b>Foo</b></pre></div>
         <div class='content'><p>Some text</p><h2>Section level 1</h2><p>Some text</p><h3>Section level 2</h3><p>Some other text</p></div>
+    """)
+
+    fun `test lang item links in doc comment`() = doTest("""
+        struct Bar;
+        /// [`Bar`]
+        ///
+        /// [`Bar`]: struct.Bar.html
+        struct Foo;
+              //^
+    """, """
+        <div class='definition'><pre>test_package
+        struct <b>Foo</b></pre></div>
+        <div class='content'><p><a href="psi_element://test_package/struct.Bar.html"><code>Bar</code></a></p></div>
+    """)
+
+    fun `test lang item links in doc comment 2`() = doTest("""
+        enum Bar { V }
+        mod foo {
+            /// [`Bar`]
+            ///
+            /// [`Bar`]: ../enum.Bar.html
+            struct Foo;
+                 //^
+        }
+    """, """
+        <div class='definition'><pre>test_package::foo
+        struct <b>Foo</b></pre></div>
+        <div class='content'><p><a href="psi_element://test_package/enum.Bar.html"><code>Bar</code></a></p></div>
+    """)
+
+    fun `test lang item links in doc comment 3`() = doTest("""
+        struct Foo;
+
+        impl Foo {
+            /// [`Foo::bar`]
+            ///
+            /// [`Foo::bar`]: #method.bar
+            fn foo(&self) {}
+              //^
+            fn bar(&self) {}
+        }
+    """, """
+        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Foo">Foo</a>
+        fn <b>foo</b>(&amp;self)</pre></div>
+        <div class='content'><p><a href="psi_element://test_package/struct.Foo.html#method.bar"><code>Foo::bar</code></a></p></div>
     """)
 
     private fun doTest(@Language("Rust") code: String, @Language("Html") expected: String)

--- a/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
@@ -77,6 +77,161 @@ class RsResolveLinkTest : RsTestBase() {
         }
     """, "<Self as Foo1>::Bar")
 
+    fun `test struct fqn link`() = doTest("""
+        struct Foo;
+              //X
+        struct Bar;
+              //^
+    """, "test_package/struct.Foo.html")
+
+    fun `test enum fqn link`() = doTest("""
+        enum Foo { V }
+            //X
+        struct Bar;
+              //^
+    """, "test_package/enum.Foo.html")
+
+    fun `test function fqn link`() = doTest("""
+        fn foo() { }
+          //X
+        struct Bar;
+              //^
+    """, "test_package/fn.foo.html")
+
+    fun `test type alias fqn link`() = doTest("""
+        type Foo = i32;
+            //X
+        struct Bar;
+              //^
+    """, "test_package/type.Foo.html")
+
+    fun `test trait alias fqn link`() = doTest("""
+        trait Foo {}
+             //X
+        struct Bar;
+              //^
+    """, "test_package/trait.Foo.html")
+
+    fun `test mod fqn link`() = doTest("""
+        mod foo {
+            //X
+        }
+
+        struct Bar;
+              //^
+    """, "test_package/foo/index.html")
+
+    fun `test macro fqn link`() = doTest("""
+        macro_rules! foo {
+                    //X
+            () => {};
+        }
+
+        struct Bar;
+              //^
+    """, "test_package/macro.foo.html")
+
+    fun `test method fqn link`() = doTest("""
+        struct Foo;
+        impl Foo {
+            fn foo(&self) {}
+              //X
+        }
+
+        struct Bar;
+              //^
+    """, "test_package/struct.Foo.html#method.foo")
+
+    fun `test tymethod fqn link`() = doTest("""
+        trait Foo {
+            fn foo(&self);
+               //X
+        }
+
+        struct Bar;
+              //^
+    """, "test_package/trait.Foo.html#tymethod.foo")
+
+    fun `test enum variant fqn link`() = doTest("""
+        enum Foo {
+            Var1,
+            //X
+            Var2
+        }
+
+        struct Bar;
+              //^
+    """, "test_package/enum.Foo.html#variant.Var1")
+
+    fun `test struct field fqn link`() = doTest("""
+        struct Foo {
+            foo: i32
+            //X
+        }
+
+        struct Bar;
+              //^
+    """, "test_package/struct.Foo.html#structfield.foo")
+
+    fun `test assoc type fqn link 1`() = doTest("""
+        trait Foo {
+            type Bar;
+                //X
+        }
+
+        struct Bar;
+              //^
+    """, "test_package/trait.Foo.html#associatedtype.Bar")
+
+    fun `test assoc type fqn link 2`() = doTest("""
+        trait Foo {
+            type Bar;
+        }
+
+        struct Bar;
+              //^
+        impl Foo for Bar {
+            type Bar = i32;
+                //X
+        }
+    """, "test_package/struct.Bar.html#associatedtype.Bar")
+
+    fun `test assoc const fqn link 2`() = doTest("""
+        struct Foo;
+        impl Foo {
+            const FOO: i32 = 123;
+                 //X
+        }
+
+        struct Bar;
+              //^
+    """, "test_package/struct.Foo.html#associatedconstant.FOO")
+
+    fun `test complex fqn link`() = doTest("""
+        mod foo {
+            mod baz {
+                trait foo {
+                    type foo;
+                }
+            }
+            mod bar {
+                struct foo;
+                      //X
+                impl foo {
+                    const foo: i32 = 123;
+                }
+            }
+            fn foo() {}
+        }
+
+        enum Baz {
+            foo
+        }
+
+        struct Bar;
+              //^
+    """, "test_package/foo/bar/struct.foo.html")
+
     private fun doTest(@Language("Rust") code: String, link: String) {
         InlineFile(code)
         val context = findElementInEditor<RsNamedElement>("^")

--- a/src/test/kotlin/org/rust/ide/docs/RsStdlibResolveLinkTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsStdlibResolveLinkTest.kt
@@ -26,6 +26,11 @@ class RsStdlibResolveLinkTest : RsTestBase() {
           //^
     """, "String", ".../string.rs")
 
+    fun `test crate fqn link`() = doTest("""
+        fn foo() {}
+          //^
+    """, "std/index.html", ".../libstd/lib.rs")
+
     fun `test mod fqn link`() = doTest("""
         fn foo() {}
           //^

--- a/src/test/kotlin/org/rust/ide/docs/RsStdlibResolveLinkTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsStdlibResolveLinkTest.kt
@@ -26,6 +26,11 @@ class RsStdlibResolveLinkTest : RsTestBase() {
           //^
     """, "String", ".../string.rs")
 
+    fun `test mod fqn link`() = doTest("""
+        fn foo() {}
+          //^
+    """, "std/io/index.html", ".../libstd/io/mod.rs")
+
     private fun doTest(@Language("Rust") code: String, link: String, expectedPath: String) {
         check(expectedPath.startsWith("...")) {
             "Expected path should start with '...', but '$expectedPath' was found"


### PR DESCRIPTION
Rust doc comments may contain relative links like `struct.String.html`, `#method.clear`, `../../std/macro.vec.html`, etc.
Currently, we don't process them and final documentation text in quick doc contains relative links
which can't be opened.
These changes do the following things:
* resolve all relative links with base URI, where base URI is constructed from current item path
* use `psi_element://` scheme to make quick doc processes such links
* try to parse link content in `RsDocumentationProvider#getDocumentationElementForLink` into `RsQualifiedName` and find `RsElement` with the same qualified name object.

Note: a lot of links in stdlib provide paths based on reexports. This implementation does **NOT** support such path, i.e. `RsDocumentationProvider#getDocumentationElementForLink` fails to find element with required qualified name.

Note 2: there are relative links in documentation that refer to not language items, for example, to some documentation page. Now we don't distinguish them and process as language items. For users it doesn't break anything because such links didn't work before.

Initial part of #667 and #2327