### PR TITLE
PERF: introduce fn-local modification trackers

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/ExpansionResult.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpansionResult.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.macros
 
 import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiElement
 import com.intellij.psi.StubBasedPsiElement
 import org.rust.lang.core.psi.ext.RsElement
 
@@ -16,17 +17,16 @@ import org.rust.lang.core.psi.ext.RsElement
  *  the plugin as the children of [getContext] element.
  */
 interface ExpansionResult : RsElement {
-    override fun getContext(): RsElement
+    override fun getContext(): PsiElement?
 
     companion object {
-        fun getContextImpl(psi: ExpansionResult): RsElement {
+        fun getContextImpl(psi: ExpansionResult): PsiElement? {
             psi.getUserData(RS_EXPANSION_CONTEXT)?.let { return it }
             if (psi is StubBasedPsiElement<*>) {
                 val stub = psi.stub
                 if (stub != null) return stub.parentStub.psi as RsElement
             }
-            (psi.parent as? RsElement)?.let { return it }
-            error("Parent for ExpansionResult $psi is not RsElement")
+            return psi.parent
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
@@ -1,0 +1,88 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+import com.intellij.openapi.components.ProjectComponent
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.ModificationTracker
+import com.intellij.openapi.util.SimpleModificationTracker
+import com.intellij.psi.*
+import com.intellij.psi.impl.PsiTreeChangeEventImpl
+import com.intellij.psi.util.PsiTreeUtil.getContextOfType
+import org.rust.lang.RsFileType
+import org.rust.lang.core.psi.ext.RsItemElement
+import org.rust.lang.core.psi.ext.RsModificationTrackerOwner
+
+interface RsPsiManager {
+    /**
+     * A project-global modification tracker that increments on each PSI change that can affect
+     * name resolution or type inference. It will be incremented with a change of most types of
+     * PSI element excluding function bodies (expressions and statements)
+     */
+    val rustStructureModificationTracker: ModificationTracker
+}
+
+class RsPsiManagerImpl(val project: Project) : ProjectComponent, RsPsiManager {
+
+    override val rustStructureModificationTracker = SimpleModificationTracker()
+
+    override fun projectOpened() {
+        PsiManager.getInstance(project).addPsiTreeChangeListener(CacheInvalidator())
+    }
+
+    inner class CacheInvalidator : PsiTreeChangeAdapter() {
+        override fun childRemoved(event: PsiTreeChangeEvent) = onPsiChange(event)
+        override fun childReplaced(event: PsiTreeChangeEvent) = onPsiChange(event)
+        override fun childAdded(event: PsiTreeChangeEvent) = onPsiChange(event)
+        override fun childrenChanged(event: PsiTreeChangeEvent) = onPsiChange(event)
+        override fun childMoved(event: PsiTreeChangeEvent) = onPsiChange(event)
+        override fun propertyChanged(event: PsiTreeChangeEvent) = onPsiChange(event)
+
+        private fun onPsiChange(event: PsiTreeChangeEvent) {
+            // `GenericChange` event means that "something changed in the file" and sends
+            // after all events for concrete PSI changes in a file.
+            // We handle more concrete events and so should ignore generic event
+            if (event is PsiTreeChangeEventImpl && event.isGenericChange) return
+
+            if (event.file?.fileType != RsFileType) return
+
+            val child = event.child
+            if (child is PsiComment || child is PsiWhiteSpace) return
+
+            updateModificationCount(child ?: event.parent)
+        }
+    }
+
+    private fun updateModificationCount(psi: PsiElement) {
+        // We find the nearest parent item or macro call (because macro call can produce items)
+        // If found item implements RsModificationTrackerOwner, we increment its own
+        // modification counter. Otherwise we increment global modification counter.
+        //
+        // So, if something is changed inside a function except an item, we will only
+        // increment the function local modification counter.
+        //
+        // It may not be intuitive that if we change an item inside a function,
+        // like this struct: `fn foo() { struct Bar; }`, we will increment the
+        // global modification counter instead of function-local. We do not care
+        // about it because it is a rare case and implementing it differently
+        // is much more difficult.
+
+        val owner = getContextOfType(psi, true,
+            RsItemElement::class.java, RsMacroCall::class.java, RsMacro::class.java)
+            as? RsModificationTrackerOwner
+
+        if (owner == null || !owner.incModificationCount(psi)) {
+            rustStructureModificationTracker.incModificationCount()
+        }
+    }
+}
+
+private val Project.rustPsiManager: RsPsiManager
+    get() = getComponent(RsPsiManager::class.java)
+
+/** @see RsPsiManager.rustStructureModificationTracker */
+val Project.rustStructureModificationTracker: ModificationTracker
+    get() = rustPsiManager.rustStructureModificationTracker

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -96,3 +96,6 @@ fun PsiElement?.getPrevNonCommentSibling(): PsiElement? =
  */
 fun PsiElement?.getNextNonCommentSibling(): PsiElement? =
     PsiTreeUtil.skipSiblingsForward(this, PsiWhiteSpace::class.java, PsiComment::class.java)
+
+fun RsElement.isParentOf(child: PsiElement): Boolean =
+    child.ancestors.contains(this)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
@@ -10,8 +10,9 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.ExpansionResult
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsConstant
 import org.rust.lang.core.psi.RsElementTypes.DEFAULT
+import org.rust.lang.core.psi.RsPsiImplUtil
 import org.rust.lang.core.stubs.RsConstantStub
 import org.rust.lang.core.types.ty.Mutability
 
@@ -53,5 +54,5 @@ abstract class RsConstantImplMixin : RsStubbedNamedElementImpl<RsConstantStub>, 
 
     override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
 
-    override fun getContext(): RsElement = ExpansionResult.getContextImpl(this)
+    override fun getContext(): PsiElement? = ExpansionResult.getContextImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumItem.kt
@@ -33,5 +33,5 @@ abstract class RsEnumItemImplMixin : RsStubbedNamedElementImpl<RsEnumItemStub>, 
 
     override val declaredType: Ty get() = RsPsiTypeImplUtil.declaredType(this)
 
-    override fun getContext() = ExpansionResult.getContextImpl(this)
+    override fun getContext(): PsiElement? = ExpansionResult.getContextImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
@@ -189,5 +189,5 @@ abstract class RsExprMixin : RsStubbedElementImpl<RsPlaceholderStub>, RsExpr {
     constructor(node: ASTNode) : super(node)
     constructor(stub: RsPlaceholderStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
-    override fun getContext() = ExpansionResult.getContextImpl(this)
+    override fun getContext(): PsiElement? = ExpansionResult.getContextImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt
@@ -38,5 +38,5 @@ abstract class RsExternCrateItemImplMixin : RsStubbedNamedElementImpl<RsExternCr
 
     override fun getIcon(flags: Int) = RsIcons.CRATE
 
-    override fun getContext() = ExpansionResult.getContextImpl(this)
+    override fun getContext(): PsiElement? = ExpansionResult.getContextImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt
@@ -6,8 +6,8 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
-import com.intellij.psi.util.PsiTreeUtil
 import org.rust.lang.core.macros.ExpansionResult
 import org.rust.lang.core.psi.RsForeignModItem
 import org.rust.lang.core.psi.RsInnerAttr
@@ -29,5 +29,5 @@ abstract class RsForeignModItemImplMixin : RsStubbedElementImpl<RsPlaceholderStu
 
     override val isPublic: Boolean get() = false // visibility does not affect foreign mods
 
-    override fun getContext() = ExpansionResult.getContextImpl(this)
+    override fun getContext(): PsiElement? = ExpansionResult.getContextImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -100,7 +100,7 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
         }
     }
 
-    override fun getContext(): RsElement = ExpansionResult.getContextImpl(this)
+    override fun getContext(): PsiElement? = ExpansionResult.getContextImpl(this)
 
     override val modificationTracker: SimpleModificationTracker =
         SimpleModificationTracker()

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
+import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
@@ -70,7 +71,7 @@ val RsFunction.returnType: Ty get() {
 
 val RsFunction.abi: RsExternAbi? get() = externAbi ?: (parent as? RsForeignModItem)?.externAbi
 
-abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, RsFunction {
+abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, RsFunction, RsModificationTrackerOwner {
 
     constructor(node: ASTNode) : super(node)
 
@@ -100,4 +101,13 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
     }
 
     override fun getContext(): RsElement = ExpansionResult.getContextImpl(this)
+
+    override val modificationTracker: SimpleModificationTracker =
+        SimpleModificationTracker()
+
+    override fun incModificationCount(element: PsiElement): Boolean {
+        val shouldInc = element !is RsItemElement && block?.isParentOf(element) == true
+        if (shouldInc) modificationTracker.incModificationCount()
+        return shouldInc
+    }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
 import com.intellij.navigation.ItemPresentation
+import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
@@ -65,5 +66,5 @@ abstract class RsImplItemImplMixin : RsStubbedElementImpl<RsImplItemStub>, RsImp
 
     override val isUnsafe: Boolean get() = unsafe != null
 
-    override fun getContext(): RsElement = ExpansionResult.getContextImpl(this)
+    override fun getContext(): PsiElement? = ExpansionResult.getContextImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -31,7 +31,7 @@ abstract class RsMacroCallImplMixin : RsStubbedElementImpl<RsMacroCallStub>, RsM
     override val referenceNameElement: PsiElement
         get() = findChildByType(IDENTIFIER)!!
 
-    override fun getContext(): RsElement = ExpansionResult.getContextImpl(this)
+    override fun getContext(): PsiElement? = ExpansionResult.getContextImpl(this)
 }
 
 val RsMacroCall.macroName: String

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt
@@ -61,7 +61,7 @@ abstract class RsModDeclItemImplMixin : RsStubbedNamedElementImpl<RsModDeclItemS
 
     override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
 
-    override fun getContext() = ExpansionResult.getContextImpl(this)
+    override fun getContext(): PsiElement? = ExpansionResult.getContextImpl(this)
 }
 
 val RsModDeclItem.hasMacroUse: Boolean get() =

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsModItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsModItem.kt
@@ -8,10 +8,14 @@ package org.rust.lang.core.psi.ext
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.ExpansionResult
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsInnerAttr
+import org.rust.lang.core.psi.RsModItem
+import org.rust.lang.core.psi.RsOuterAttr
+import org.rust.lang.core.psi.RsPsiImplUtil
 import org.rust.lang.core.stubs.RsModItemStub
 import org.rust.openapiext.findFileByMaybeRelativePath
 import javax.swing.Icon
@@ -52,7 +56,7 @@ abstract class RsModItemImplMixin : RsStubbedNamedElementImpl<RsModItemStub>,
     override val outerAttrList: List<RsOuterAttr>
         get() = stubChildrenOfType()
 
-    override fun getContext() = ExpansionResult.getContextImpl(this)
+    override fun getContext(): PsiElement? = ExpansionResult.getContextImpl(this)
 }
 
 val RsModItem.hasMacroUse: Boolean get() =

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsModificationTrackerOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsModificationTrackerOwner.kt
@@ -1,0 +1,30 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi.ext
+
+import com.intellij.openapi.util.ModificationTracker
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RsPsiManager
+
+/**
+ * A PSI element that holds modification tracker for some reason.
+ * This is mostly used to invalidate cached type inference results.
+ */
+interface RsModificationTrackerOwner : RsItemElement {
+    val modificationTracker: ModificationTracker
+
+    /**
+     * Increments local modification counter if needed.
+     *
+     * If and only if false returned,
+     * [RsPsiManager.rustStructureModificationTracker]
+     * will be incremented.
+     *
+     * @param element the changed psi element
+     * @see org.rust.lang.core.psi.RsPsiManagerImpl.updateModificationCount
+     */
+    fun incModificationCount(element: PsiElement): Boolean
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
@@ -38,5 +38,5 @@ abstract class RsPathImplMixin : RsStubbedElementImpl<RsPathStub>,
 
     override val referenceName: String get() = stub?.referenceName ?: referenceNameElement.text
 
-    override fun getContext(): RsElement = ExpansionResult.getContextImpl(this)
+    override fun getContext(): PsiElement? = ExpansionResult.getContextImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructItem.kt
@@ -11,8 +11,8 @@ import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.ExpansionResult
 import org.rust.lang.core.psi.RsElementTypes.UNION
-import org.rust.lang.core.psi.RsStructItem
 import org.rust.lang.core.psi.RsPsiImplUtil
+import org.rust.lang.core.psi.RsStructItem
 import org.rust.lang.core.stubs.RsStructItemStub
 import org.rust.lang.core.types.RsPsiTypeImplUtil
 import org.rust.lang.core.types.ty.Ty
@@ -47,5 +47,5 @@ abstract class RsStructItemImplMixin : RsStubbedNamedElementImpl<RsStructItemStu
 
     override val declaredType: Ty get() = RsPsiTypeImplUtil.declaredType(this)
 
-    override fun getContext(): RsElement = ExpansionResult.getContextImpl(this)
+    override fun getContext(): PsiElement? = ExpansionResult.getContextImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.psi.ext
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.Condition
+import com.intellij.psi.PsiElement
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.util.Query
@@ -110,7 +111,7 @@ abstract class RsTraitItemImplMixin : RsStubbedNamedElementImpl<RsTraitItemStub>
 
     override val declaredType: Ty get() = RsPsiTypeImplUtil.declaredType(this)
 
-    override fun getContext() = ExpansionResult.getContextImpl(this)
+    override fun getContext(): PsiElement? = ExpansionResult.getContextImpl(this)
 }
 
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
@@ -37,5 +37,5 @@ abstract class RsTypeAliasImplMixin : RsStubbedNamedElementImpl<RsTypeAliasStub>
 
     override val declaredType: Ty get() = RsPsiTypeImplUtil.declaredType(this)
 
-    override fun getContext() = ExpansionResult.getContextImpl(this)
+    override fun getContext(): PsiElement? = ExpansionResult.getContextImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseItem.kt
@@ -6,10 +6,11 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.lang.core.macros.ExpansionResult
-import org.rust.lang.core.psi.RsUseItem
 import org.rust.lang.core.psi.RsPsiImplUtil
+import org.rust.lang.core.psi.RsUseItem
 import org.rust.lang.core.stubs.RsUseItemStub
 
 abstract class RsUseItemImplMixin : RsStubbedElementImpl<RsUseItemStub>, RsUseItem {
@@ -19,5 +20,5 @@ abstract class RsUseItemImplMixin : RsStubbedElementImpl<RsUseItemStub>, RsUseIt
 
     override val isPublic: Boolean get() = RsPsiImplUtil.isPublic(this, stub)
 
-    override fun getContext() = ExpansionResult.getContextImpl(this)
+    override fun getContext(): PsiElement? = ExpansionResult.getContextImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -264,7 +264,7 @@ fun processPathResolveVariants(lookup: ImplLookup, path: RsPath, isCompletion: B
 
     if (isCompletion) {
         // Complete possible associated types in a case like `Trait</*caret*/>`
-        val possibleTypeArgs = parent.parent?.parent
+        val possibleTypeArgs = parent?.parent?.parent
         if (possibleTypeArgs is RsTypeArgumentList) {
             val trait = (possibleTypeArgs.parent as? RsPath)?.reference?.resolve() as? RsTraitItem
             if (trait != null && processAssocTypeVariants(trait, processor)) return true

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -55,6 +55,8 @@ class RsInferenceResult(
     private val resolvedFields: Map<RsFieldLookup, List<RsElement>>,
     val diagnostics: List<RsDiagnostic>
 ) {
+    private val timestamp: Long = System.nanoTime()
+
     fun getExprType(expr: RsExpr): Ty =
         exprTypes[expr] ?: TyUnknown
 
@@ -76,6 +78,9 @@ class RsInferenceResult(
     @TestOnly
     fun isExprTypeInferred(expr: RsExpr): Boolean =
         expr in exprTypes
+
+    @TestOnly
+    fun getTimestamp(): Long = timestamp
 }
 
 /**

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -635,6 +635,13 @@
         </component>
     </application-components>
 
+    <project-components>
+        <component>
+            <interface-class>org.rust.lang.core.psi.RsPsiManager</interface-class>
+            <implementation-class>org.rust.lang.core.psi.RsPsiManagerImpl</implementation-class>
+        </component>
+    </project-components>
+
     <actions>
         <action id="Rust.NewRustFile"
                 class="org.rust.ide.actions.RsCreateFileAction"

--- a/src/test/kotlin/org/rust/lang/core/psi/RsRustStructureModificationTrackerTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsRustStructureModificationTrackerTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+import com.intellij.psi.PsiDocumentManager
+import org.intellij.lang.annotations.Language
+import org.rust.lang.RsTestBase
+import org.rust.lang.core.psi.RsRustStructureModificationTrackerTest.TestAction.INC
+import org.rust.lang.core.psi.RsRustStructureModificationTrackerTest.TestAction.NOT_INC
+
+class RsRustStructureModificationTrackerTest : RsTestBase() {
+    private enum class TestAction(val function: (Long, Long) -> Boolean, val comment: String) {
+        INC({ a, b -> a > b }, "Modification counter expected to be incremented, but it remained the same"),
+        NOT_INC({ a, b -> a == b }, "Modification counter expected to remain the same, but it was incremented")
+    }
+
+    private fun checkModCount(op: TestAction, @Language("Rust") code: String, text: String) {
+        InlineFile(code).withCaret()
+        PsiDocumentManager.getInstance(project).commitAllDocuments()
+        val modTracker = project.rustStructureModificationTracker
+        val oldCount = modTracker.modificationCount
+        myFixture.type(text)
+        PsiDocumentManager.getInstance(project).commitAllDocuments()
+        check(op.function(modTracker.modificationCount, oldCount)) { op.comment }
+    }
+
+    private fun doTest(op: TestAction, @Language("Rust") code: String, text: String = "a") {
+        checkModCount(op, code, text)
+        checkModCount(op, """
+            fn wrapped() {
+                $code
+            }
+        """, text)
+    }
+
+    fun `test comment`() = doTest(NOT_INC, """
+        // /*caret*/
+    """)
+
+    //
+
+    fun `test fn`() = doTest(INC, """
+        /*caret*/
+    """, "fn foo() {}")
+
+    fun `test fn vis`() = doTest(INC, """
+        /*caret*/fn foo() {}
+    """, "pub ")
+
+    fun `test fn name`() = doTest(INC, """
+        fn foo/*caret*/() {}
+    """)
+
+    fun `test fn params`() = doTest(INC, """
+        fn foo(/*caret*/) {}
+    """)
+
+    fun `test fn return type 1`() = doTest(INC, """
+        fn foo()/*caret*/ {}
+    """, "-> u8")
+
+    fun `test fn return type 2`() = doTest(INC, """
+        fn foo() -> u/*caret*/ {}
+    """, "-> 8")
+
+    fun `test fn body`() = doTest(NOT_INC, """
+        fn foo() { /*caret*/ }
+    """)
+
+    //
+
+    fun `test struct vis`() = doTest(INC, """
+        /*caret*/struct Foo;
+    """, "pub ")
+
+    fun `test struct name`() = doTest(INC, """
+        struct Foo/*caret*/;
+    """)
+
+    fun `test struct body`() = doTest(INC, """
+        struct Foo { /*caret*/ }
+    """)
+
+    //
+
+    fun `test const vis`() = doTest(INC, """
+        /*caret*/const FOO: u8 = 0;
+    """, "pub ")
+
+    fun `test const name`() = doTest(INC, """
+        const FOO/*caret*/: u8 = 0;
+    """)
+
+    fun `test const body`() = doTest(INC, """
+        const FOO: u8 = 0/*caret*/;
+    """, "1")
+
+    //
+
+    fun `test impl type`() = doTest(INC, """
+        impl Foo/*caret*/ {}
+    """)
+
+    fun `test impl for`() = doTest(INC, """
+        impl Foo/*caret*/ {}
+    """, " for")
+
+    fun `test impl for trait`() = doTest(INC, """
+        impl Foo for/*caret*/ {}
+    """, " Bar")
+
+    fun `test impl body`() = doTest(INC, """
+        impl Foo { /*caret*/ }
+    """, "fn foo() {}")
+
+    fun `test impl fn`() = doTest(INC, """
+        impl Foo { fn foo(/*caret*/) {} }
+    """, "&self")
+
+    fun `test impl fn body`() = doTest(NOT_INC, """
+        impl Foo { fn foo() { /*caret*/ } }
+    """)
+
+    //
+
+    fun `test macro`() = doTest(INC, """
+        macro_rules! foo { () => { /*caret*/ } }
+    """)
+
+    fun `test macro call`() = doTest(INC, """
+        foo! { /*caret*/ }
+    """)
+}

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeInferenceCachingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeInferenceCachingTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.type
+
+import com.intellij.psi.PsiDocumentManager
+import org.intellij.lang.annotations.Language
+import org.rust.lang.RsTestBase
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.ext.childrenOfType
+import org.rust.lang.core.types.inference
+
+class RsTypeInferenceCachingTest : RsTestBase() {
+    private val TYPE: () -> Unit = { myFixture.type("a") }
+    private val COMPLETE: () -> Unit = { myFixture.completeBasic() }
+
+    private fun List<RsFunction>.collectStamps(): Map<String, Long> =
+        associate { it.name!! to it.inference.getTimestamp() }
+
+
+    private fun checkReinferred(action: () -> Unit, @Language("Rust") code: String, vararg names: String) {
+        InlineFile(code).withCaret()
+        val fns = myFixture.file.childrenOfType<RsFunction>()
+        val oldStamps = fns.collectStamps()
+        action()
+        PsiDocumentManager.getInstance(project).commitAllDocuments() // process PSI modification events
+        val changed = fns.collectStamps().entries
+            .filter { oldStamps[it.key] != it.value }
+            .map { it.key }
+        check(changed == names.toList()) {
+            "Expected to reinfer types in ${names.asList()}, reinferred in $changed instead"
+        }
+    }
+
+    fun `test reinferred only current function`() = checkReinferred(TYPE, """
+        fn foo() { /*caret*/ }
+        fn bar() {  }
+    """, "foo")
+
+    fun `test nothing reinferred after completion invocation`() = checkReinferred(COMPLETE, """
+        fn foo() { /*caret*/ }
+        fn bar() {  }
+    """)
+
+    fun `test reinferred everything on structure change 1`() = checkReinferred(TYPE, """
+        struct S { /*caret*/ }
+        fn foo() {  }
+        fn bar() {  }
+    """, "foo", "bar")
+
+    fun `test reinferred everything on structure change 2`() = checkReinferred(TYPE, """
+        fn foo() { struct S { /*caret*/ } }
+        fn bar() {  }
+    """, "foo", "bar")
+}


### PR DESCRIPTION
Now we will invalidate type inference cache only if a current function or program structure was changed. I.e. if we type in some function, inferred types of other functions will not be flushed.

Should fix most of "high CPU usage" issues