### PR TITLE
CARGO: improve cargo project and toolchains api

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
@@ -51,7 +51,7 @@ class CargoRunState(
 
     fun computeSysroot(): String? {
         val projectDirectory = cargoProject?.manifest?.parent ?: return null
-        return toolchain.rustup(projectDirectory)?.getSysroot()
+        return toolchain.getSysroot(projectDirectory)
     }
 
     fun rustVersion(): RustToolchain.VersionInfo = toolchain.queryVersions()

--- a/src/main/kotlin/org/rust/cargo/toolchain/CommandLineExt.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CommandLineExt.kt
@@ -1,0 +1,34 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.toolchain
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.execution.process.ProcessOutput
+import com.intellij.openapi.diagnostic.Logger
+
+private val LOG = Logger.getInstance("org.rust.cargo.toolchain.CommandLineExt")
+
+fun GeneralCommandLine.exec(timeoutInMilliseconds: Int? = null): ProcessOutput {
+    val handler = CapturingProcessHandler(this)
+
+    LOG.info("Executing `$commandLineString`")
+    val output = if (timeoutInMilliseconds != null)
+        handler.runProcess(timeoutInMilliseconds)
+    else
+        handler.runProcess()
+
+    if (output.exitCode != 0) {
+        LOG.warn("Failed to execute `$commandLineString`" +
+            "\ncode  : ${output.exitCode}" +
+            "\nstdout:\n${output.stdout}" +
+            "\nstderr:\n${output.stderr}")
+    }
+
+    return output
+}
+
+val ProcessOutput.isSuccess: Boolean get() = !isTimeout && !isCancelled && exitCode == 0

--- a/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
@@ -5,9 +5,6 @@
 
 package org.rust.cargo.toolchain
 
-import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.execution.process.CapturingProcessHandler
-import com.intellij.execution.process.ProcessOutput
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
@@ -20,8 +17,8 @@ import java.nio.file.Path
 private val LOG = Logger.getInstance(Rustup::class.java)
 
 class Rustup(
+    private val toolchain: RustToolchain,
     private val rustup: Path,
-    private val rustc: Path,
     private val projectDirectory: Path
 ) {
     sealed class DownloadResult {
@@ -36,7 +33,9 @@ class Rustup(
             .exec()
 
         return if (downloadProcessOutput.exitCode != 0) {
-            DownloadResult.Err("rustup failed: `${downloadProcessOutput.stderr}`")
+            val message = "rustup failed: `${downloadProcessOutput.stderr}`"
+            LOG.warn(message)
+            DownloadResult.Err(message)
         } else {
             val sources = getStdlibFromSysroot() ?: return DownloadResult.Err("Failed to find stdlib in sysroot")
             fullyRefreshDirectory(sources)
@@ -45,37 +44,8 @@ class Rustup(
     }
 
     fun getStdlibFromSysroot(): VirtualFile? {
-        val sysroot = getSysroot()
+        val sysroot = toolchain.getSysroot(projectDirectory) ?: return null
         val fs = LocalFileSystem.getInstance()
         return fs.refreshAndFindFileByPath(FileUtil.join(sysroot, "lib/rustlib/src/rust/src"))
-    }
-
-    fun getSysroot(): String {
-        val timeoutMs = 10000
-        return GeneralCommandLine(rustc)
-            .withCharset(Charsets.UTF_8)
-            .withWorkDirectory(projectDirectory)
-            .withParameters("--print", "sysroot")
-            .exec(timeoutMs)
-            .stdout.trim()
-    }
-
-    private fun GeneralCommandLine.exec(timeoutInMilliseconds: Int? = null): ProcessOutput {
-        val handler = CapturingProcessHandler(this)
-
-        LOG.info("Executing `$commandLineString`")
-        val output = if (timeoutInMilliseconds != null)
-            handler.runProcess(timeoutInMilliseconds)
-        else
-            handler.runProcess()
-
-        if (output.exitCode != 0) {
-            LOG.warn("Failed to execute `$commandLineString`" +
-                "\ncode  : ${output.exitCode}" +
-                "\nstdout:\n${output.stdout}" +
-                "\nstderr:\n${output.stderr}")
-        }
-
-        return output
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -10,8 +10,10 @@ import com.intellij.extapi.psi.StubBasedPsiElementBase
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.stubs.StubElement
+import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.lang.core.psi.RsFile
@@ -28,12 +30,21 @@ interface RsElement : PsiElement {
 }
 
 val CARGO_WORKSPACE = Key.create<CargoWorkspace>("CARGO_WORKSPACE")
+
+val RsElement.cargoProject: CargoProject?
+    get() = contextualFile.originalFile.cargoProject
+
 val RsElement.cargoWorkspace: CargoWorkspace?
     get() {
         val psiFile = contextualFile.originalFile
         psiFile.getUserData(CARGO_WORKSPACE)?.let { return it }
-        val vFile = psiFile.virtualFile ?: return null
-        return project.cargoProjects.findProjectForFile(vFile)?.workspace
+        return psiFile.cargoProject?.workspace
+    }
+
+private val PsiFile.cargoProject: CargoProject?
+    get() {
+        val vFile = virtualFile ?: return null
+        return project.cargoProjects.findProjectForFile(vFile)
     }
 
 


### PR DESCRIPTION
* Add `RustcInfo` property to `CargoProject` object which contains rustc sysroot and version
* Move sysroot computation from `Rustup` to `RustToolchain` because we should have ability
to get sysroot without rustup