### PR TITLE
T: testAssert function

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -26,6 +26,7 @@ import org.rust.lang.core.types.ty.TyFloat.F64
 import org.rust.lang.core.types.ty.TyInteger.*
 import org.rust.lang.core.types.type
 import org.rust.openapiext.ProjectCache
+import org.rust.openapiext.testAssert
 import org.rust.stdext.buildSet
 import org.rust.stdext.zipValues
 import kotlin.LazyThreadSafetyMode.NONE
@@ -458,8 +459,8 @@ class ImplLookup(
         val newRecDepth = recursionDepth + 1
         return when (candidate) {
             is SelectionCandidate.Impl -> {
-                assert(!candidate.formalSelfTy.containsTyOfClass(TyInfer::class.java))
-                assert(!candidate.formalTrait.containsTyOfClass(TyInfer::class.java))
+                testAssert { !candidate.formalSelfTy.containsTyOfClass(TyInfer::class.java) }
+                testAssert { !candidate.formalTrait.containsTyOfClass(TyInfer::class.java) }
                 val (subst, preparedRef) = candidate.prepareSubstAndTraitRef(ctx, ref.selfTy)
                 ctx.combineTraitRefs(ref, preparedRef)
                 // pre-resolve type vars to simplify caching of already inferred obligation on fulfillment
@@ -476,7 +477,7 @@ class ImplLookup(
                 Selection(trait, emptyList())
             }
             is SelectionCandidate.TypeParameter -> {
-                assert(!candidate.bound.containsTyOfClass(TyInfer::class.java))
+                testAssert { !candidate.bound.containsTyOfClass(TyInfer::class.java) }
                 ctx.combinePairs(zipValues(candidate.bound.subst, ref.trait.subst))
                 ctx.combinePairs(zipValues(candidate.bound.assoc, ref.trait.assoc))
                 Selection(candidate.bound.element, emptyList())

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -113,3 +113,14 @@ class CachedVirtualFile(private val url: String?) {
 val isUnitTestMode: Boolean get() = ApplicationManager.getApplication().isUnitTestMode
 
 fun saveAllDocuments() = FileDocumentManager.getInstance().saveAllDocuments()
+
+inline fun testAssert(action: () -> Boolean) {
+    testAssert(action) { "Assertion failed" }
+}
+
+inline fun testAssert(action: () -> Boolean, lazyMessage: () -> Any) {
+    if (isUnitTestMode && !action()) {
+        val message = lazyMessage()
+        throw AssertionError(message)
+    }
+}


### PR DESCRIPTION
Use own `testAssert` function instead of kotlin stdlib `assert` to throw assert error only in unit tests.
Also it allows us to calculate test action only if needed