### PR TITLE
Fix compatibility with 182 IDE sources

### DIFF
--- a/src/main/kotlin/org/rust/ide/formatter/blocks/RsFmtBlock.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/blocks/RsFmtBlock.kt
@@ -71,7 +71,7 @@ class RsFmtBlock(
         // We are using dot as our representative.
         // The idea is nearly copy-pasted from Kotlin's formatter.
         if (node.elementType == DOT_EXPR) {
-            val dotIndex = children.indexOfFirst { it.node.elementType == DOT }
+            val dotIndex = children.indexOfFirst { it.node?.elementType == DOT }
             if (dotIndex != -1) {
                 val dotBlock = children[dotIndex]
                 val syntheticBlock = SyntheticRsFmtBlock(
@@ -101,7 +101,7 @@ class RsFmtBlock(
         // so we have to manually decide whether new child is before (no indent)
         // or after (normal indent) left brace node.
             node.isFlatBraceBlock -> {
-                val lbraceIndex = subBlocks.indexOfFirst { it is ASTBlock && it.node.elementType == LBRACE }
+                val lbraceIndex = subBlocks.indexOfFirst { it is ASTBlock && it.node?.elementType == LBRACE }
                 if (lbraceIndex != -1 && lbraceIndex < newChildIndex) {
                     Indent.getNormalIndent()
                 } else {

--- a/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt
@@ -151,7 +151,7 @@ fun createSpacingBuilder(commonSettings: CommonCodeStyleSettings, rustSettings: 
 }
 
 fun Block.computeSpacing(child1: Block?, child2: Block, ctx: RsFmtContext): Spacing? {
-    if (child1 is ASTBlock && child2 is ASTBlock) SpacingContext.create(child1, child2, ctx).apply {
+    if (child1 is ASTBlock && child2 is ASTBlock) SpacingContext.create(child1, child2, ctx)?.apply {
         when {
             elementType2 == RustParserDefinition.EOL_COMMENT ->
                 return createKeepingFirstColumnSpacing(1, Int.MAX_VALUE, true, ctx.commonSettings.KEEP_BLANK_LINES_IN_CODE)
@@ -211,9 +211,9 @@ private data class SpacingContext(val node1: ASTNode,
                                   val ncPsi2: PsiElement,
                                   val ctx: RsFmtContext) {
     companion object {
-        fun create(child1: ASTBlock, child2: ASTBlock, ctx: RsFmtContext): SpacingContext {
-            val node1 = child1.node
-            val node2 = child2.node
+        fun create(child1: ASTBlock, child2: ASTBlock, ctx: RsFmtContext): SpacingContext? {
+            val node1 = child1.node ?: return null
+            val node2 = child2.node ?: return null
             val psi1 = node1.psi
             val psi2 = node2.psi
             val elementType1 = psi1.node.elementType


### PR DESCRIPTION
`Nullable` annotation was added on `com.intellij.formatting.ASTBlock#getNode()` recently.
It brokes kotlin source compatibility because now kotlin considers that `ASTBlock#getNode()` returns nullable type instead of platform type.