### PR TITLE
Expand macros in trait and impl bodies

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/ExpansionResult.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpansionResult.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.macros
 import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
 import com.intellij.psi.StubBasedPsiElement
+import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.ext.RsElement
 
 /**
@@ -35,6 +36,25 @@ fun ExpansionResult.setContext(context: RsElement) {
     putUserData(RS_EXPANSION_CONTEXT, context)
 }
 
+fun ExpansionResult.setExpandedFrom(call: RsMacroCall) {
+    putUserData(RS_EXPANSION_MACRO_CALL, call)
+}
+
+/** The [RsMacroCall] that expanded to this element or null if this element is not produced by a macro */
+val ExpansionResult.expandedFrom: RsMacroCall?
+    get() = getUserData(RS_EXPANSION_MACRO_CALL) as RsMacroCall?
+
+val ExpansionResult.expandedFromRecursively: RsMacroCall?
+    get() {
+        var call: RsMacroCall = expandedFrom ?: return null
+        while (true) {
+            call = call.expandedFrom ?: break
+        }
+
+        return call
+    }
+
 
 private val RS_EXPANSION_CONTEXT = Key.create<RsElement>("org.rust.lang.core.psi.CODE_FRAGMENT_FILE")
+private val RS_EXPANSION_MACRO_CALL = Key.create<RsElement>("org.rust.lang.core.psi.RS_EXPANSION_MACRO_CALL")
 

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
@@ -8,8 +8,8 @@ package org.rust.lang.core.macros
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.PsiModificationTracker
 import org.rust.cargo.project.settings.rustSettings
-import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.RsMacro
+import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.macroName
 
@@ -21,7 +21,10 @@ fun expandMacro(call: RsMacroCall): CachedValueProvider.Result<List<ExpansionRes
     return when {
         call.macroName == "lazy_static" -> {
             val result = expandLazyStatic(call)?.let { listOf(it) }
-            result?.forEach { it.setContext(context) }
+            result?.forEach {
+                it.setContext(context)
+                it.setExpandedFrom(call)
+            }
             CachedValueProvider.Result.create(result, call.containingFile)
         }
         else -> {
@@ -30,7 +33,10 @@ fun expandMacro(call: RsMacroCall): CachedValueProvider.Result<List<ExpansionRes
             val project = context.project
             val expander = MacroExpander(project)
             val result = expander.expandMacro(def, call)
-            result?.forEach { it.setContext(context) }
+            result?.forEach {
+                it.setContext(context)
+                it.setExpandedFrom(call)
+            }
             // We can use a files instead of `MODIFICATION_COUNT`, so cached value will be depends
             // on modification count of these files. See [PsiCachedValue.getTimeStamp]
             CachedValueProvider.Result.create(result, def.containingFile, call.containingFile)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
@@ -6,9 +6,10 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.psi.PsiNameIdentifierOwner
+import org.rust.lang.core.macros.ExpansionResult
 import org.rust.lang.core.psi.*
 
-interface RsAbstractable : RsNamedElement, PsiNameIdentifierOwner {
+interface RsAbstractable : RsNamedElement, PsiNameIdentifierOwner, ExpansionResult {
     val isAbstract: Boolean
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMembers.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMembers.kt
@@ -1,0 +1,48 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi.ext
+
+import com.intellij.psi.StubBasedPsiElement
+import org.rust.lang.core.psi.*
+
+/** Returns all members including those produced by macros */
+val RsMembers.expandedMembers: List<RsAbstractable>
+    get() {
+        val members = mutableListOf<RsAbstractable>()
+
+        for (member in childrenSequence) {
+            when (member) {
+                is RsAbstractable -> members.add(member)
+                is RsMacroCall -> member.collectAbstractableMembersRecursively(members)
+            }
+        }
+
+        return members
+    }
+
+private val StubBasedPsiElement<*>.childrenSequence
+    get() = (stub?.childrenStubs?.asSequence()?.map { it.psi } ?: generateSequence(firstChild) { it.nextSibling })
+        .filterIsInstance<RsElement>()
+
+private fun RsMacroCall.collectAbstractableMembersRecursively(members: MutableList<RsAbstractable>) {
+    processExpansionRecursively {
+        if (it is RsAbstractable) {
+            members.add(it)
+        }
+
+        false
+    }
+}
+
+val List<RsAbstractable>.functions: List<RsFunction>
+    get() = filterIsInstance<RsFunction>()
+val List<RsAbstractable>.constants: List<RsConstant>
+    get() = filterIsInstance<RsConstant>()
+val List<RsAbstractable>.types: List<RsTypeAlias>
+    get() = filterIsInstance<RsTypeAlias>()
+
+val List<RsAbstractable>.functionsAndConstants: List<RsAbstractable>
+    get() = filter { it is RsFunction || it is RsConstant }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -147,7 +147,7 @@ class TraitImplementationInfo private constructor(
 
 
     private fun RsMembers.abstractable(): List<RsAbstractable> =
-        stubChildrenOfType<RsAbstractable>().filter { it.name != null }
+        expandedMembers.filter { it.name != null }
 
     companion object {
         fun create(trait: RsTraitItem, impl: RsImplItem): TraitImplementationInfo? {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -119,9 +119,7 @@ class TraitImplementationInfo private constructor(
     val trait: RsTraitItem,
     val traitName: String,
     traitMembers: RsMembers,
-    implMembers: RsMembers,
-    // Macros can add methods
-    hasMacros: Boolean
+    implMembers: RsMembers
 ) {
     val declared = traitMembers.abstractable()
     private val implemented = implMembers.abstractable()
@@ -129,13 +127,11 @@ class TraitImplementationInfo private constructor(
     private val implementedByNameAndType = implemented.associateBy { it.name!! to it.elementType }
 
 
-    val missingImplementations: List<RsAbstractable> = if (!hasMacros)
+    val missingImplementations: List<RsAbstractable> =
         declared.filter { it.isAbstract }.filter { it.name to it.elementType !in implementedByNameAndType }
-    else emptyList()
 
-    val alreadyImplemented: List<RsAbstractable> =  if (!hasMacros)
+    val alreadyImplemented: List<RsAbstractable> =
         declared.filter { it.isAbstract }.filter { it.name to it.elementType in implementedByNameAndType }
-    else emptyList()
 
     val nonExistentInTrait: List<RsAbstractable> = implemented.filter { it.name !in declaredByName }
 
@@ -154,8 +150,7 @@ class TraitImplementationInfo private constructor(
             val traitName = trait.name ?: return null
             val traitMembers = trait.members ?: return null
             val implMembers = impl.members ?: return null
-            val hasMacros = implMembers.macroCallList.isNotEmpty()
-            return TraitImplementationInfo(trait, traitName, traitMembers, implMembers, hasMacros)
+            return TraitImplementationInfo(trait, traitName, traitMembers, implMembers)
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitOrImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitOrImpl.kt
@@ -5,7 +5,9 @@
 
 package org.rust.lang.core.psi.ext
 
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsMembers
+import org.rust.lang.core.psi.RsTraitItem
+import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.types.BoundElement
 
 interface RsTraitOrImpl : RsItemElement, RsGenericDeclaration {
@@ -15,3 +17,6 @@ interface RsTraitOrImpl : RsItemElement, RsGenericDeclaration {
 
     val associatedTypesTransitively: Collection<RsTypeAlias>
 }
+
+val RsTraitOrImpl.expandedMembers: List<RsAbstractable>
+    get() = members?.expandedMembers.orEmpty()

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -658,11 +658,10 @@ private fun processAssociatedItems(
         }
 
         if (Namespace.Values in ns) {
-            if (processMembersWithDefaults({ it.functionList })) return true
-            if (processMembersWithDefaults({ it.constantList })) return true
+            if (processMembersWithDefaults { it.expandedMembers.functionsAndConstants }) return true
         }
         if (Namespace.Types in ns) {
-            if (processMembersWithDefaults({ it.typeAliasList })) return true
+            if (processMembersWithDefaults { it.expandedMembers.types }) return true
         }
         return false
     }

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -33,7 +33,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 133
+        override fun getStubVersion(): Int = 134
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -470,6 +470,18 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase() {
         }
     """)
 
+    fun `test no E0407 for method defined with a macro`() = checkErrors("""
+        macro_rules! foo {
+            ($ i:ident, $ j:ty) => { fn $ i(&self) -> $ j { unimplemented!() } }
+        }
+        trait T {
+            foo!(foo, ());
+        }
+        impl T for () {
+            fn foo(&self) {}
+        }
+    """)
+
     fun `test name duplication in param list E0415`() = checkErrors("""
         fn foo(x: u32, X: u32) {}
         fn bar<T>(T: T) {}

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -461,4 +461,23 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
     """, """
          fn foo() {}
     """)
+
+    fun `test impl members`() = checkSingleMacro("""
+        macro_rules! foo {
+            () => {
+                fn foo() {}
+                type Bar = u8;
+                const BAZ: u8 = 0;
+            }
+        }
+
+        struct S;
+        impl S {
+            foo!();
+        }  //^
+    """, """
+        fn foo() {}
+        type Bar = u8;
+        const BAZ: u8 = 0;
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
@@ -61,4 +61,19 @@ abstract class RsMacroExpansionTestBase : RsTestBase() {
     ) {
         doTest(code, *expectedExpansions.map { Pair<String, Testmark?>(it, null) }.toTypedArray())
     }
+
+    fun checkSingleMacro(@Language("Rust") code: String, @Language("Rust") expectedExpansion: String) {
+        InlineFile(code)
+        val call = findElementInEditor<RsMacroCall>("^")
+        val expansion = call.expansion ?: error("Macro expansion failed `${call.text}`")
+        val expandedText = expansion.joinToString("\n") { it.text }
+
+        if (StringUtils.deleteWhitespace(expandedText) != StringUtils.deleteWhitespace(expectedExpansion)) {
+            throw ComparisonFailure(
+                "Macro comparision failed",
+                expectedExpansion,
+                expandedText
+            )
+        }
+    }
 }

--- a/src/test/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -481,6 +481,43 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
     """)
 
+    fun `test with members defined by a macro`() = doTest("""
+        macro_rules! foo {
+            ($ i:ident, $ j:tt) => { fn $ i() $ j }
+        }
+        trait T {
+            foo!(foo, ;);
+            foo!(bar, ;);
+            foo!(baz, ;);
+        }
+        struct S;
+        impl T for S {
+            foo!(foo, {});
+            fn baz() {}/*caret*/
+        }
+    """, listOf(
+        ImplementMemberSelection("bar()", true, isSelected = true)
+    ), """
+        macro_rules! foo {
+            ($ i:ident, $ j:tt) => { fn $ i() $ j }
+        }
+        trait T {
+            foo!(foo, ;);
+            foo!(bar, ;);
+            foo!(baz, ;);
+        }
+        struct S;
+        impl T for S {
+            foo!(foo, {});
+
+            fn bar() {
+                unimplemented!()
+            }
+
+            fn baz() {}
+        }
+    """)
+
     private data class ImplementMemberSelection(val member: String, val byDefault: Boolean, val isSelected: Boolean = byDefault)
 
     private fun doTest(@Language("Rust") code: String,


### PR DESCRIPTION
Now we can expand macros in this context:
```rust
impl Foo {
    foo!();
    bar!();
}
```
and can resolve method generated by these macros.
Also fixed some inspections to work properly with members defined by a macro.