### PR TITLE
Improve dependencies completion in Cargo.toml

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -163,7 +163,7 @@ private fun appendSemicolon(context: InsertionContext, curUseItem: RsUseItem?) {
     }
 }
 
-private inline fun <reified T : PsiElement> InsertionContext.getElementOfType(strict: Boolean = false): T? =
+inline fun <reified T : PsiElement> InsertionContext.getElementOfType(strict: Boolean = false): T? =
     PsiTreeUtil.findElementOfClassAtOffset(file, tailOffset - 1, T::class.java, strict)
 
 private val InsertionContext.isInUseGroup: Boolean

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -106,7 +106,7 @@ fun PsiElement?.getPrevNonCommentSibling(): PsiElement? =
 fun PsiElement?.getNextNonCommentSibling(): PsiElement? =
     PsiTreeUtil.skipSiblingsForward(this, PsiWhiteSpace::class.java, PsiComment::class.java)
 
-fun RsElement.isAncestorOf(child: PsiElement): Boolean =
+fun PsiElement.isAncestorOf(child: PsiElement): Boolean =
     child.ancestors.contains(this)
 
 val PsiElement.endOffsetInParent: Int

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -6,10 +6,12 @@
 package org.rust.openapiext
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ex.ApplicationUtil
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.JDOMUtil
@@ -115,3 +117,6 @@ inline fun testAssert(action: () -> Boolean, lazyMessage: () -> Any) {
         throw AssertionError(message)
     }
 }
+
+fun <T> runWithCheckCanceled(callable: () -> T): T =
+    ApplicationUtil.runWithCheckCanceled(callable, ProgressManager.getInstance().progressIndicator)

--- a/src/main/kotlin/org/rust/toml/CargoTomlCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/toml/CargoTomlCompletionContributor.kt
@@ -6,12 +6,19 @@
 package org.rust.toml
 
 import com.intellij.codeInsight.completion.CompletionContributor
-import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.completion.CompletionType.BASIC
+import org.rust.toml.CargoTomlPsiPattern.inDependencyKeyValue
+import org.rust.toml.CargoTomlPsiPattern.inKey
+import org.rust.toml.CargoTomlPsiPattern.inSpecificDependencyHeaderKey
+import org.rust.toml.CargoTomlPsiPattern.inSpecificDependencyKeyValue
 
 class CargoTomlCompletionContributor : CompletionContributor() {
     init {
         if (tomlPluginIsAbiCompatible()) {
-            extend(CompletionType.BASIC, CargoTomlKeysCompletionProvider.elementPattern, CargoTomlKeysCompletionProvider())
+            extend(BASIC, inKey, CargoTomlKeysCompletionProvider())
+            extend(BASIC, inDependencyKeyValue, CargoTomlDependencyCompletionProvider())
+            extend(BASIC, inSpecificDependencyHeaderKey, CargoTomlSpecificDependencyHeaderCompletionProvider())
+            extend(BASIC, inSpecificDependencyKeyValue, CargoTomlSpecificDependencyVersionCompletionProvider())
         }
     }
 }

--- a/src/main/kotlin/org/rust/toml/CargoTomlDependencyCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/toml/CargoTomlDependencyCompletionProvider.kt
@@ -1,0 +1,136 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml
+
+import com.intellij.codeInsight.completion.*
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.tree.IElementType
+import com.intellij.util.ProcessingContext
+import org.rust.lang.core.completion.getElementOfType
+import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psi.ext.elementType
+import org.rust.lang.core.psi.ext.isAncestorOf
+import org.toml.lang.psi.*
+
+abstract class TomlKeyValueCompletionProviderBase : CompletionProvider<CompletionParameters>() {
+    override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+        val parent = parameters.position.parent ?: return
+        if (parent is TomlKey) {
+            val keyValue = parent.parent as? TomlKeyValue
+                ?: error("PsiElementPattern must not allow keys outside of TomlKeyValues")
+            completeKey(keyValue, result)
+        } else {
+            val keyValue = parent.ancestorOrSelf<TomlKeyValue>()
+                ?: error("PsiElementPattern must not allow values outside of TomlKeyValues")
+            // If a value is already present we should ensure that the value is a literal
+            // and the caret is inside the value to forbid completion in cases like
+            // `key = "" <caret>`
+            val value = keyValue.value
+            if (value != null && (value !is TomlLiteral || !value.isAncestorOf(parameters.position))) return
+
+            completeValue(keyValue, result)
+        }
+    }
+
+    protected abstract fun completeKey(keyValue: TomlKeyValue, result: CompletionResultSet)
+
+    protected abstract fun completeValue(keyValue: TomlKeyValue, result: CompletionResultSet)
+}
+
+/** @see CargoTomlPsiPattern.inDependencyKeyValue */
+class CargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProviderBase() {
+    override fun completeKey(keyValue: TomlKeyValue, result: CompletionResultSet) {
+        val variants = searchCrate(keyValue.key).map { it.dependencyLine }
+        result.addAllElements(variants.map(LookupElementBuilder::create))
+    }
+
+    override fun completeValue(keyValue: TomlKeyValue, result: CompletionResultSet) {
+        val version = getCrateLastVersion(keyValue.key) ?: return
+
+        result.addElement(
+            LookupElementBuilder.create(version)
+                .withInsertHandler(StringValueInsertionHandler(keyValue))
+        )
+    }
+}
+
+/** @see CargoTomlPsiPattern.inSpecificDependencyHeaderKey */
+class CargoTomlSpecificDependencyHeaderCompletionProvider : CompletionProvider<CompletionParameters>() {
+    override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+        val key = parameters.position.parent as? TomlKey ?: return
+        val variants = searchCrate(key)
+
+        val elements = variants.map { variant ->
+            LookupElementBuilder.create(variant.name)
+                .withPresentableText(variant.dependencyLine)
+                .withInsertHandler { context, _ ->
+                    val table = key.ancestorStrict<TomlTable>() ?: return@withInsertHandler
+                    if (table.entries.isEmpty()) {
+                        context.document.insertString(
+                            context.selectionEndOffset + 1,
+                            "\nversion = \"${variant.maxVersion}\""
+                        )
+                    }
+                }
+        }
+
+        result.addAllElements(elements)
+    }
+}
+
+/** @see CargoTomlPsiPattern.inSpecificDependencyKeyValue */
+class CargoTomlSpecificDependencyVersionCompletionProvider : TomlKeyValueCompletionProviderBase() {
+    override fun completeKey(keyValue: TomlKeyValue, result: CompletionResultSet) {
+        val dependencyNameKey = getDependencyKeyFromTableHeader(keyValue)
+
+        val version = getCrateLastVersion(dependencyNameKey) ?: return
+        result.addElement(LookupElementBuilder.create("version = \"$version\""))
+    }
+
+    override fun completeValue(keyValue: TomlKeyValue, result: CompletionResultSet) {
+        val dependencyNameKey = getDependencyKeyFromTableHeader(keyValue)
+        val version = getCrateLastVersion(dependencyNameKey) ?: return
+
+        result.addElement(
+            LookupElementBuilder.create(version)
+                .withInsertHandler(StringValueInsertionHandler(keyValue))
+        )
+    }
+
+    private fun getDependencyKeyFromTableHeader(keyValue: TomlKeyValue): TomlKey {
+        val table = keyValue.parent as? TomlTable
+            ?: error("PsiElementPattern must not allow keys outside of TomlTable")
+        return table.header.names.lastOrNull()
+            ?: error("PsiElementPattern must not allow KeyValues in tables without header")
+    }
+}
+
+/** Inserts `=` between key and value if missed and wraps inserted string with quotes if needed */
+private class StringValueInsertionHandler(val keyValue: TomlKeyValue) : InsertHandler<LookupElement> {
+    override fun handleInsert(context: InsertionContext, item: LookupElement) {
+        var startOffset = context.startOffset
+        val value = context.getElementOfType<TomlValue>()
+        val hasEq = keyValue.children.any { it.elementType == TomlElementTypes.EQ }
+        val hasQuotes = value != null && (value !is TomlLiteral || value.literalType != TomlElementTypes.NUMBER)
+
+        if (!hasEq) {
+            context.document.insertString(startOffset - if (hasQuotes) 1 else 0, "= ")
+            PsiDocumentManager.getInstance(context.project).commitDocument(context.document)
+            startOffset += 2
+        }
+
+        if (!hasQuotes) {
+            context.document.insertString(startOffset, "\"")
+            context.document.insertString(context.selectionEndOffset, "\"")
+        }
+    }
+}
+
+private val TomlLiteral.literalType: IElementType
+    get() = children.first().elementType

--- a/src/main/kotlin/org/rust/toml/CargoTomlKeyReferenceContributor.kt
+++ b/src/main/kotlin/org/rust/toml/CargoTomlKeyReferenceContributor.kt
@@ -6,50 +6,20 @@
 package org.rust.toml
 
 import com.intellij.openapi.util.TextRange
-import com.intellij.patterns.PsiElementPattern
 import com.intellij.psi.*
 import com.intellij.util.ProcessingContext
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.lang.core.or
 import org.rust.lang.core.psi.RsFile
-import org.rust.lang.core.psiElement
-import org.rust.lang.core.with
+import org.rust.toml.CargoTomlPsiPattern.onDependencyKey
+import org.rust.toml.CargoTomlPsiPattern.onSpecificDependencyHeaderKey
 import org.toml.lang.psi.TomlKey
-import org.toml.lang.psi.TomlTable
-import org.toml.lang.psi.TomlTableHeader
 
 class CargoTomlKeyReferenceContributor : PsiReferenceContributor() {
 
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
-        registrar.registerReferenceProvider(dependencyKeyPattern or specificDependencyKeyPattern,
+        registrar.registerReferenceProvider(onDependencyKey or onSpecificDependencyHeaderKey,
             CargoDependencyReferenceProvider())
-    }
-
-    companion object {
-
-        private const val TOML_KEY_CONTEXT_NAME = "key"
-
-        // [dependencies]
-        // regex = "1"
-        //   ^
-        private val dependencyKeyPattern: PsiElementPattern.Capture<TomlKey> = psiElement<TomlKey>()
-            .withSuperParent(2, psiElement<TomlTable>()
-                .withChild(psiElement<TomlTableHeader>()
-                    .with("dependenciesCondition") { header ->
-                        header.names.lastOrNull()?.isDependencyKey == true
-                    }
-                )
-            )
-        // [dependencies.regex]
-        //                 ^
-        private val specificDependencyKeyPattern: PsiElementPattern.Capture<TomlKey> = psiElement<TomlKey>(TOML_KEY_CONTEXT_NAME)
-            .withParent(psiElement<TomlTableHeader>()
-                .with("specificDependencyCondition") { header, context ->
-                    val key = context?.get(TOML_KEY_CONTEXT_NAME) ?: return@with false
-                    val names = header.names
-                    names.getOrNull(names.size - 2)?.isDependencyKey == true && names.lastOrNull() == key
-                }
-            )
     }
 }
 

--- a/src/main/kotlin/org/rust/toml/CargoTomlPsiPattern.kt
+++ b/src/main/kotlin/org/rust/toml/CargoTomlPsiPattern.kt
@@ -1,0 +1,149 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml
+
+import com.intellij.patterns.PsiElementPattern
+import com.intellij.patterns.StandardPatterns
+import com.intellij.patterns.VirtualFilePattern
+import com.intellij.psi.PsiElement
+import org.rust.cargo.toolchain.RustToolchain
+import org.rust.lang.core.psiElement
+import org.rust.lang.core.with
+import org.toml.lang.psi.TomlKey
+import org.toml.lang.psi.TomlKeyValue
+import org.toml.lang.psi.TomlTable
+import org.toml.lang.psi.TomlTableHeader
+
+object CargoTomlPsiPattern {
+    private const val TOML_KEY_CONTEXT_NAME = "key"
+    private const val TOML_KEY_VALUE_CONTEXT_NAME = "keyValue"
+
+    private inline fun <reified I : PsiElement> cargoTomlPsiElement(): PsiElementPattern.Capture<I> {
+        return psiElement<I>().inVirtualFile(
+            StandardPatterns.or(
+                VirtualFilePattern().withName(RustToolchain.CARGO_TOML),
+                VirtualFilePattern().withName(RustToolchain.XARGO_TOML)
+            )
+        )
+    }
+
+    private inline fun <reified I : PsiElement> cargoTomlPsiElement(contextName: String): PsiElementPattern.Capture<I> {
+        return cargoTomlPsiElement<I>().with("putIntoContext") { e, context ->
+            context?.put(contextName, e)
+            true
+        }
+    }
+
+    /** Any element inside any TomlKey in Cargo.toml */
+    val inKey: PsiElementPattern.Capture<PsiElement> =
+        cargoTomlPsiElement<PsiElement>()
+            .withParent(TomlKey::class.java)
+
+    private val onDependencyTableHeader: PsiElementPattern.Capture<TomlTableHeader> =
+        cargoTomlPsiElement<TomlTableHeader>()
+            .with("dependenciesCondition") { header ->
+                header.isDependencyListHeader
+            }
+
+    private val onDependencyTable: PsiElementPattern.Capture<TomlTable> =
+        cargoTomlPsiElement<TomlTable>()
+            .withChild(onDependencyTableHeader)
+
+    /**
+     * ```
+     * [dependencies]
+     * regex = "1"
+     *   ^
+     * ```
+     */
+    val onDependencyKey: PsiElementPattern.Capture<TomlKey> =
+        cargoTomlPsiElement<TomlKey>()
+            .withSuperParent(
+                2,
+                onDependencyTable
+            )
+
+    private val onSpecificDependencyTable: PsiElementPattern.Capture<TomlTable> =
+        cargoTomlPsiElement<TomlTable>()
+            .withChild(
+                psiElement<TomlTableHeader>()
+                    .with("specificDependencyCondition") { header, context ->
+                        val names = header.names
+                        names.getOrNull(names.size - 2)?.isDependencyKey == true
+                    }
+            )
+
+    /**
+     * ```
+     * [dependencies.regex]
+     *                 ^
+     * ```
+     */
+    val onSpecificDependencyHeaderKey: PsiElementPattern.Capture<TomlKey> =
+        cargoTomlPsiElement<TomlKey>(TOML_KEY_CONTEXT_NAME)
+            .withParent(
+                psiElement<TomlTableHeader>()
+                    .with("specificDependencyCondition") { header, context ->
+                        val key = context?.get(TOML_KEY_CONTEXT_NAME) ?: return@with false
+                        val names = header.names
+                        names.getOrNull(names.size - 2)?.isDependencyKey == true && names.lastOrNull() == key
+                    }
+            )
+
+    /** Any element inside [onSpecificDependencyHeaderKey] */
+    val inSpecificDependencyHeaderKey: PsiElementPattern.Capture<PsiElement> =
+        cargoTomlPsiElement<PsiElement>()
+            .withParent(onSpecificDependencyHeaderKey)
+
+    /**
+     * Any element inside [onDependencyKeyValue].
+     * This pattern doesn't permit nested keyValues, e.g. false for
+     * ```
+     * [dependencies]
+     * regex = { version = "1" }
+     *                   ^
+     * ```
+     */
+    val inDependencyKeyValue: PsiElementPattern.Capture<PsiElement> =
+        cargoTomlPsiElement<PsiElement>()
+            .inside(psiElement<TomlKeyValue>(TOML_KEY_VALUE_CONTEXT_NAME))
+            .with("dependencyKeyValueCondition") { _, context ->
+                val keyValue = context?.get(TOML_KEY_VALUE_CONTEXT_NAME) ?: return@with false
+                onDependencyKeyValue.accepts(keyValue)
+            }
+
+    /**
+     * ```
+     * [dependencies]
+     * regex = "1"
+     *       ^
+     * ```
+     */
+    private val onDependencyKeyValue: PsiElementPattern.Capture<TomlKeyValue> =
+        cargoTomlPsiElement<TomlKeyValue>()
+            .withParent(onDependencyTable)
+
+    /** Any element inside [onSpecificDependencyKeyValue] */
+    val inSpecificDependencyKeyValue: PsiElementPattern.Capture<PsiElement> =
+        cargoTomlPsiElement<PsiElement>()
+            .inside(psiElement<TomlKeyValue>(TOML_KEY_VALUE_CONTEXT_NAME))
+            .with("specificDependencyKeyValueCondition") { _, context ->
+                val keyValue = context?.get(TOML_KEY_VALUE_CONTEXT_NAME) ?: return@with false
+                onSpecificDependencyKeyValue.accepts(keyValue)
+            }
+
+
+    /**
+     * ```
+     * [dependencies.regex]
+     * version = "1"
+     *         ^
+     * ```
+     */
+    private val onSpecificDependencyKeyValue: PsiElementPattern.Capture<TomlKeyValue> =
+        cargoTomlPsiElement<TomlKeyValue>()
+            .withParent(onSpecificDependencyTable)
+}

--- a/src/main/kotlin/org/rust/toml/CratesIoApi.kt
+++ b/src/main/kotlin/org/rust/toml/CratesIoApi.kt
@@ -1,0 +1,86 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml
+
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
+import com.google.gson.annotations.SerializedName
+import com.intellij.codeInsight.completion.CompletionUtil
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.psi.PsiElement
+import com.intellij.util.io.HttpRequests
+import org.jetbrains.annotations.TestOnly
+import org.rust.ide.notifications.showBalloon
+import org.rust.openapiext.isUnitTestMode
+import org.rust.openapiext.runWithCheckCanceled
+import org.toml.lang.psi.TomlKey
+import java.io.IOException
+
+data class SearchResult(val crates: List<CrateDescription>)
+
+data class CrateInfoResult(val crate: CrateDescription)
+
+data class CrateDescription(
+    val name: String,
+    @SerializedName("max_version")
+    val maxVersion: String
+)
+
+val CrateDescription.dependencyLine: String
+    get() = "$name = \"$maxVersion\""
+
+fun searchCrate(key: TomlKey): Collection<CrateDescription> {
+    if (isUnitTestMode) return MOCK!!
+
+    val name = CompletionUtil.getOriginalElement(key)?.text ?: ""
+    if (name.isEmpty()) return emptyList()
+
+    val response = requestCratesIo<SearchResult>(key, "crates?page=1&per_page=20&q=$name&sort=") ?: return emptyList()
+    return response.crates
+}
+
+fun getCrateLastVersion(key: TomlKey): String? {
+    if (isUnitTestMode) return MOCK!!.first().maxVersion
+
+    val name = CompletionUtil.getOriginalElement(key)?.text ?: ""
+    if (name.isEmpty()) return null
+
+    val response = requestCratesIo<CrateInfoResult>(key, "crates/$name") ?: return null
+    return response.crate.maxVersion
+}
+
+private inline fun <reified T> requestCratesIo(context: PsiElement, path: String): T? {
+    return requestCratesIo(context, path, T::class.java)
+}
+
+private fun <T> requestCratesIo(context: PsiElement, path: String, cls: Class<T>): T? {
+    return try {
+        runWithCheckCanceled {
+            val response = HttpRequests.request("https://crates.io/api/v1/$path")
+                .readString(ProgressManager.getInstance().progressIndicator)
+            Gson().fromJson(response, cls)
+        }
+    } catch (e: IOException) {
+        context.project.showBalloon("Could not reach crates.io", NotificationType.WARNING)
+        null
+    } catch (e: JsonSyntaxException) {
+        context.project.showBalloon("Bad answer from crates.io", NotificationType.WARNING)
+        null
+    }
+}
+
+private var MOCK: List<CrateDescription>? = null
+
+@TestOnly
+fun withMockedCrateSearch(mock: List<CrateDescription>, action: () -> Unit) {
+    MOCK = mock
+    try {
+        action()
+    } finally {
+        MOCK = null
+    }
+}

--- a/src/main/kotlin/org/rust/toml/Util.kt
+++ b/src/main/kotlin/org/rust/toml/Util.kt
@@ -42,7 +42,11 @@ private val computeOnce: Boolean by lazy {
 private inline fun <reified T : Any> load(): String = T::class.java.name
 private fun load(p: KProperty<*>): String = p.name
 
-val TomlKey.isDependencyKey: Boolean get() {
-    val text = text
-    return text == "dependencies" || text == "dev-dependencies" || text == "build-dependencies"
-}
+val TomlKey.isDependencyKey: Boolean
+    get() {
+        val text = text
+        return text == "dependencies" || text == "dev-dependencies" || text == "build-dependencies"
+    }
+
+val TomlTableHeader.isDependencyListHeader: Boolean
+    get() = names.lastOrNull()?.isDependencyKey == true

--- a/src/test/kotlin/org/rust/toml/CargoTomlCompletionContributorTest.kt
+++ b/src/test/kotlin/org/rust/toml/CargoTomlCompletionContributorTest.kt
@@ -5,10 +5,7 @@
 
 package org.rust.toml
 
-import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase
-
-
-class CargoTomlCompletionContributorTest : LightCodeInsightFixtureTestCase() {
+class CargoTomlCompletionContributorTest : CargoTomlCompletionTestBase() {
     fun `test complete top level`() {
         myFixture.configureByText("Cargo.toml", "[dep<caret>]")
         val completions = myFixture.completeBasic().map { it.lookupString }
@@ -18,22 +15,22 @@ class CargoTomlCompletionContributorTest : LightCodeInsightFixtureTestCase() {
         )
     }
 
-    fun `test complete hyphen 1`() = doTest(
+    fun `test complete hyphen 1`() = doSingleCompletion(
         "[dev<caret>]",
         "[dev-dependencies<caret>]"
     )
 
-    fun `test complete hyphen 2`() = doTest(
+    fun `test complete hyphen 2`() = doSingleCompletion(
         "[dev-<caret>]",
         "[dev-dependencies<caret>]"
     )
 
-    fun `test complete hyphen 3`() = doTest(
+    fun `test complete hyphen 3`() = doSingleCompletion(
         "[build-d<caret>]",
         "[build-dependencies<caret>]"
     )
 
-    fun `test complete key in table`() = doTest("""
+    fun `test complete key in table`() = doSingleCompletion("""
         [profile.release]
         opt<caret>
     """, """
@@ -41,10 +38,4 @@ class CargoTomlCompletionContributorTest : LightCodeInsightFixtureTestCase() {
         opt-level<caret>
     """
     )
-
-    private fun doTest(before: String, after: String) {
-        myFixture.configureByText("Cargo.toml", before)
-        myFixture.completeBasic()
-        myFixture.checkResult(after)
-    }
 }

--- a/src/test/kotlin/org/rust/toml/CargoTomlCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/toml/CargoTomlCompletionTestBase.kt
@@ -1,0 +1,59 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml
+
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase
+
+abstract class CargoTomlCompletionTestBase : LightCodeInsightFixtureTestCase() {
+    protected fun doSingleCompletion(before: String, after: String) {
+        checkByText(before, after) { executeSoloCompletion() }
+    }
+
+    private fun executeSoloCompletion() {
+        val variants = myFixture.completeBasic()
+
+        if (variants != null) {
+            if (variants.size == 1) {
+                // for cases like `frob/*caret*/nicate()`,
+                // completion won't be selected automatically.
+                myFixture.type('\n')
+                return
+            }
+
+            fun LookupElement.debug(): String = "$lookupString ($psiElement)"
+
+            error("Expected a single completion, but got ${variants.size}\n"
+                + variants.joinToString("\n") { it.debug() })
+        }
+    }
+
+    protected fun checkByText(
+        before: String,
+        after: String,
+        action: () -> Unit
+    ) {
+        myFixture.configureByText("Cargo.toml", before)
+        action()
+        myFixture.checkResult(after)
+    }
+
+    protected fun checkNoCompletion(code: String) {
+        myFixture.configureByText("Cargo.toml", code)
+        noCompletionCheck()
+    }
+
+    private fun noCompletionCheck() {
+        val variants = myFixture.completeBasic()
+        checkNotNull(variants) {
+            val element = myFixture.file.findElementAt(myFixture.caretOffset - 1)
+            "Expected zero completions, but one completion was auto inserted: `${element?.text}`."
+        }
+        check(variants.isEmpty()) {
+            "Expected zero completions, got ${variants.size}: ${variants.map { it.lookupString }}."
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/toml/CargoTomlDependenciesCompletionTest.kt
+++ b/src/test/kotlin/org/rust/toml/CargoTomlDependenciesCompletionTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml
+
+import org.intellij.lang.annotations.Language
+
+class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
+    fun `test empty key`() = doTest("""
+        [dependencies]
+        <caret>
+    """, """
+        [dependencies]
+        dep = "1.0"
+    """, "dep" to "1.0")
+
+    fun `test empty key with complex dependency head`() = doTest("""
+        [target.'cfg(windows)'.dev-dependencies]
+        <caret>
+    """, """
+        [target.'cfg(windows)'.dev-dependencies]
+        dep = "1.0"
+    """, "dep" to "1.0")
+
+    fun `test partial key`() = doTest("""
+        [dependencies]
+        d<caret>
+    """, """
+        [dependencies]
+        dep = "1.0"
+    """, "app" to "1.0", "dep" to "1.0")
+
+    fun `test empty value complete without '=' and quotes 1_0`() = doTest("""
+        [dependencies]
+        dep <caret>
+    """, """
+        [dependencies]
+        dep = "1.0"
+    """, "dep" to "1.0")
+
+    fun `test empty value complete without quotes 1_0`() = doTest("""
+        [dependencies]
+        dep = <caret>
+    """, """
+        [dependencies]
+        dep = "1.0"
+    """, "dep" to "1.0")
+
+    fun `test empty value complete without quotes 1_0_0`() = doTest("""
+        [dependencies]
+        dep = <caret>
+    """, """
+        [dependencies]
+        dep = "1.0.0"
+    """, "dep" to "1.0.0")
+
+    fun `test empty value complete inside quotes`() = doTest("""
+        [dependencies]
+        dep = "<caret>"
+    """, """
+        [dependencies]
+        dep = "1.0"
+    """, "dep" to "1.0")
+
+    fun `test partial value complete inside quotes`() = doTest("""
+        [dependencies]
+        dep = "1.<caret>"
+    """, """
+        [dependencies]
+        dep = "1.0"
+    """, "dep" to "1.0")
+
+    fun `test empty value complete inside quotes without '='`() = doTest("""
+        [dependencies]
+        dep "<caret>"
+    """, """
+        [dependencies]
+        dep = "1.0"
+    """, "dep" to "1.0")
+
+    // TODO we may want to add a closing quotation mark
+    fun `test empty value complete after unclosed quote`() = doTest("""
+        [dependencies]
+        dep = "<caret>
+    """, """
+        [dependencies]
+        dep = "1.0
+    """, "dep" to "1.0")
+
+    fun `test no completion when caret after string literal`() = checkNoCompletion("""
+        [dependencies]
+        dep = "" <caret>
+    """, "dep" to "1.0")
+
+    fun `test no completion when caret after inline table`() = checkNoCompletion("""
+        [dependencies]
+        dep = { version = "1.0.0" } <caret>
+    """, "dep" to "1.0")
+
+    fun `test no completion when caret inside inline table`() = checkNoCompletion("""
+        [dependencies]
+        dep = { <caret> }
+    """, "dep" to "1.0")
+
+    fun `test no completion when caret inside inline table value`() = checkNoCompletion("""
+        [dependencies]
+        dep = { version = <caret> }
+    """, "dep" to "1.0")
+
+    fun `test complete specific dependency header empty key`() = doTest("""
+        [dependencies.<caret>]
+    """, """
+        [dependencies.dep]
+        version = "1.0"
+    """, "dep" to "1.0")
+
+    fun `test complete specific dependency header partial key`() = doTest("""
+        [dependencies.d<caret>]
+    """, """
+        [dependencies.dep]
+        version = "1.0"
+    """, "dep" to "1.0", "bar" to "2.0")
+
+    fun `test complete specific dependency version empty key`() = doTest("""
+        [dependencies.dep]
+        <caret>
+    """, """
+        [dependencies.dep]
+        version = "1.0"
+    """, "dep" to "1.0")
+
+    fun `test complete specific dependency version partial key`() = doTest("""
+        [dependencies.dep]
+        ver<caret>
+    """, """
+        [dependencies.dep]
+        version = "1.0"
+    """, "dep" to "1.0")
+
+    fun `test complete specific dependency empty version value`() = doTest("""
+        [dependencies.dep]
+        version <caret>
+    """, """
+        [dependencies.dep]
+        version = "1.0"
+    """, "dep" to "1.0")
+
+    fun `test complete specific dependency partial version value`() = doTest("""
+        [dependencies.dep]
+        version = "1.<caret>"
+    """, """
+        [dependencies.dep]
+        version = "1.0"
+    """, "dep" to "1.0")
+
+    private fun doTest(
+        @Language("TOML") before: String,
+        @Language("TOML") after: String,
+        vararg crates: Pair<String, String>
+    ) {
+        withMockedCrateSearch(crates.map { (name, version) -> CrateDescription(name, version) }) {
+            doSingleCompletion(before.trimIndent(), after.trimIndent())
+        }
+    }
+
+    private fun checkNoCompletion(@Language("TOML") code: String, vararg crates: Pair<String, String>) {
+        withMockedCrateSearch(crates.map { (name, version) -> CrateDescription(name, version) }) {
+            checkNoCompletion(code.trimIndent())
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/toml/CargoTomlPsiPatternTest.kt
+++ b/src/test/kotlin/org/rust/toml/CargoTomlPsiPatternTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml
+
+import com.intellij.patterns.ElementPattern
+import com.intellij.psi.PsiElement
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+import org.rust.toml.CargoTomlPsiPattern.inDependencyKeyValue
+import org.rust.toml.CargoTomlPsiPattern.inKey
+import org.rust.toml.CargoTomlPsiPattern.inSpecificDependencyHeaderKey
+import org.rust.toml.CargoTomlPsiPattern.inSpecificDependencyKeyValue
+import org.rust.toml.CargoTomlPsiPattern.onDependencyKey
+import org.rust.toml.CargoTomlPsiPattern.onSpecificDependencyHeaderKey
+
+class CargoTomlPsiPatternTest : RsTestBase() {
+
+    fun `test inKey header 1`() = testPattern(inKey, """
+        [key]
+        #^
+    """)
+
+    fun `test inKey header 2`() = testPattern(inKey, """
+        [key.key]
+            #^
+    """)
+
+    fun `test inKey header in Xargo toml file`() = testPattern(inKey, """
+        [key.key]
+            #^
+    """, fileName = "Xargo.toml")
+
+    fun `test inKey table keyValue`() = testPattern(inKey, """
+        [header]
+        key = ""
+        #^
+    """)
+
+    fun `test inKey inline table keyValue`() = testPattern(inKey, """
+        [header]
+        key = { key = "" }
+               #^
+    """)
+
+    fun `test onDependencyKey dependencies`() = testPattern(onDependencyKey, """
+        [dependencies]
+        key = ""
+        #^
+    """)
+
+    fun `test onDependencyKey dev-dependencies`() = testPattern(onDependencyKey, """
+        [dev-dependencies]
+        key = ""
+        #^
+    """)
+
+    fun `test onDependencyKey build-dependencies`() = testPattern(onDependencyKey, """
+        [build-dependencies]
+        key = ""
+        #^
+    """)
+
+    fun `test onDependencyKey target_'cfg(windows)'_dependencies`() = testPattern(onDependencyKey, """
+        [target.'cfg(windows)'.dependencies]
+        key = ""
+        #^
+    """)
+
+    fun `test inDependencyKeyValue 1`() = testPattern(inDependencyKeyValue, """
+        [dependencies]
+        key = ""
+           #^
+    """)
+
+    fun `test inDependencyKeyValue 2`() = testPattern(inDependencyKeyValue, """
+        [dependencies]
+        key = ""
+             #^
+    """)
+
+    fun `test inDependencyKeyValue 3`() = testPattern(inDependencyKeyValue, """
+        [dependencies]
+        key = "" ""
+                #^
+    """)
+
+    fun `test inDependencyKeyValue 4`() = testPatternNegative(inDependencyKeyValue, """
+        [dependencies]
+        key = { key = "" }
+                #^
+    """)
+
+    fun `test onSpecificDependencyHeaderKey 1`() = testPattern(onSpecificDependencyHeaderKey, """
+        [dependencies.key]
+                     #^
+    """)
+
+    fun `test onSpecificDependencyHeaderKey 2`() = testPatternNegative(onSpecificDependencyHeaderKey, """
+        [dependencies.key]
+              #^
+    """)
+
+    fun `test inSpecificDependencyHeaderKey`() = testPattern(inSpecificDependencyHeaderKey, """
+        [dependencies.key]
+                     #^
+    """)
+
+    fun `test inSpecificDependencyKeyValue 1`() = testPattern(inSpecificDependencyKeyValue, """
+        [dependencies.key]
+        version = ""
+        #^
+    """)
+
+    fun `test inSpecificDependencyKeyValue 2`() = testPattern(inSpecificDependencyKeyValue, """
+        [dependencies.key]
+        version = ""
+                 #^
+    """)
+
+    fun `test inSpecificDependencyKeyValue 3`() = testPatternNegative(inSpecificDependencyKeyValue, """
+        [dependencies]
+        version = ""
+        #^
+    """)
+
+    private inline fun <reified T : PsiElement> testPattern(
+        pattern: ElementPattern<T>,
+        @Language("Toml") code: String,
+        fileName: String = "Cargo.toml"
+    ) {
+        InlineFile(code, fileName)
+        val element = findElementInEditor<T>()
+        assertTrue(pattern.accepts(element))
+    }
+
+    private fun <T> testPatternNegative(pattern: ElementPattern<T>, @Language("Toml") code: String) {
+        InlineFile(code, "Cargo.toml")
+        val element = findElementInEditor<PsiElement>()
+        assertFalse(pattern.accepts(element))
+    }
+}


### PR DESCRIPTION
With this PR we should be able to complete versions of dependencies in cargo toml when caret is placed to toml value position, i.e.
```
[dependencies]
rand <caret>
rand = <caret>
rand = "<caret>"

[dependencies.<caret>]
<caret>
```

Fixes #2856