### PR TITLE
PERF: Added several `ProgressManager.checkCanceled()` calls

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -10,6 +10,7 @@ import com.intellij.lang.PsiBuilder
 import com.intellij.lang.PsiBuilderFactory
 import com.intellij.lang.PsiBuilderUtil
 import com.intellij.lang.parser.GeneratedParserUtilBase
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
@@ -208,6 +209,7 @@ private class MacroPattern private constructor(
     private fun isEmpty() = pattern.firstOrNull() == null
 
     private fun matchPartial(macroCallBody: PsiBuilder): MacroSubstitution? {
+        ProgressManager.checkCanceled()
         val map = HashMap<String, String>()
         val groups = mutableListOf<List<MacroSubstitution>>()
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -7,6 +7,7 @@
 
 package org.rust.lang.core.resolve
 
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.psi.PsiElement
@@ -838,6 +839,7 @@ private fun walkUp(
     var cameFrom = start
     var scope = start.context as RsElement?
     while (scope != null) {
+        ProgressManager.checkCanceled()
         if (processor(cameFrom, scope)) return true
         if (stopAfter(scope)) break
         cameFrom = scope

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Fulfillment.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.types.infer
 
+import com.intellij.openapi.progress.ProgressManager
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.SelectionResult
 import org.rust.lang.core.types.TraitRef
@@ -111,6 +112,7 @@ class ObligationForest {
         var hasErrors = false
         var stalled = true
         for (index in 0 until nodes.size) {
+            ProgressManager.checkCanceled()
             val node = nodes[index]
             if (node.state != NodeState.Pending) continue
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.types.infer
 
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.util.Computable
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.CachedValueProvider
@@ -611,6 +612,7 @@ private class RsFnInferenceContext(
     }
 
     private fun RsExpr.inferType(expected: Ty? = null): Ty {
+        ProgressManager.checkCanceled()
         if (ctx.isTypeInferred(this)) error("Trying to infer expression type twice")
 
         val ty = when (this) {


### PR DESCRIPTION
`ProgressManager.checkCanceled()` is used to cancel (by throwing an
an exception) the current task. I.e. if user requested completion
and then canceled it. This call is often found in the platform (e.g.
in ResolveCache we call `checkCanceled()` on each cache lookup),
so we can decide that it is cheap and its use is good practice.

In this commit I've added `checkCanceled()` to some possible
long recursive/loop operations like type inference.