### PR TITLE
PERF: macro resolve cache invalidation

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -495,7 +495,7 @@ private fun exportedMacros(scope: RsFile): List<RsMacro> {
     check(scope.isCrateRoot)
     return CachedValuesManager.getCachedValue(scope) {
         val macros = exportedMacrosInternal(scope)
-        CachedValueProvider.Result.create(macros, PsiModificationTracker.MODIFICATION_COUNT)
+        CachedValueProvider.Result.create(macros, scope.project.rustStructureModificationTracker)
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsMacroIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsMacroIndex.kt
@@ -13,10 +13,10 @@ import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
-import com.intellij.psi.util.PsiModificationTracker
 import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.hasMacroExport
+import org.rust.lang.core.psi.rustStructureModificationTracker
 import org.rust.lang.core.resolve.NameResolutionTestmarks
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsMacroStub
@@ -50,7 +50,7 @@ class RsMacroIndex : StringStubIndexExtension<RsMacro>() {
                         }
                     }
                 }
-                CachedValueProvider.Result.create(result, PsiModificationTracker.MODIFICATION_COUNT)
+                CachedValueProvider.Result.create(result, project.rustStructureModificationTracker)
             }
         }
     }

--- a/src/test/kotlin/org/rustSlowTests/RsHighlightingPerformanceTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsHighlightingPerformanceTest.kt
@@ -73,15 +73,18 @@ class RsHighlightingPerformanceTest : RustWithToolchainTestBase() {
             refs.forEach { it.reference.resolve() }
         }
 
-        val stmt = myFixture.file.descendantsOfType<RsFunction>().asSequence()
-            .mapNotNull { it.block?.stmtList?.lastOrNull() }.first()
-        myFixture.editor.caretModel.moveToOffset(stmt.textOffset)
-        myFixture.type("2+2;")
-        PsiDocumentManager.getInstance(project).commitAllDocuments() // process PSI modification events
+        myFixture.file.descendantsOfType<RsFunction>()
+            .asSequence()
+            .mapNotNull { it.block?.stmtList?.lastOrNull() }
+            .forEach { stmt ->
+                myFixture.editor.caretModel.moveToOffset(stmt.textOffset)
+                myFixture.type("2+2;")
+                PsiDocumentManager.getInstance(project).commitAllDocuments() // process PSI modification events
 
-        timings.measure("resolve_after_typing") {
-            refs.forEach { it.reference.resolve() }
-        }
+                timings.measureAverage("resolve_after_typing") {
+                    refs.forEach { it.reference.resolve() }
+                }
+            }
 
         return timings
     }


### PR DESCRIPTION
Use `rustStructureModificationTracker` for macro resolve cache invalidaiton.

Also measure average time of references resolution after typing over all functions in file.
It should show more representative result because resolution in single function can depend on not all
cases and such measurement can mislead us