### PR TITLE
Add mutability categories

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -60,6 +60,7 @@ ninjabear
 oistein
 oleg-semenov
 orium
+ortem
 osialr
 pasa
 pavel-v-chernykh

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotator.kt
@@ -10,7 +10,10 @@ import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.psi.PsiElement
 import org.rust.ide.colors.RsColor
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsPatBinding
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.RsSelfParameter
+import org.rust.lang.core.psi.RsValueParameter
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psi.ext.mutability

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt
@@ -11,9 +11,11 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsBindingModeKind.BindByReference
+import org.rust.lang.core.psi.ext.RsBindingModeKind.BindByValue
 import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.ancestorStrict
-import org.rust.lang.core.psi.ext.isRef
+import org.rust.lang.core.psi.ext.kind
 import org.rust.lang.core.psi.ext.typeElement
 import org.rust.lang.core.types.declaration
 
@@ -30,7 +32,7 @@ class AddMutableFix(binding: RsNamedElement) : LocalQuickFixAndIntentionActionOn
     companion object {
         fun createIfCompatible(expr: RsExpr): AddMutableFix? {
             val declaration = expr.declaration
-            return if (declaration is RsSelfParameter || declaration is RsPatBinding) {
+            return if (declaration is RsSelfParameter || (declaration is RsPatBinding && declaration.kind is BindByValue)) {
                 AddMutableFix(declaration as RsNamedElement)
             } else {
                 null
@@ -56,7 +58,7 @@ fun updateMutable(project: Project, binding: RsNamedElement, mutable: Boolean = 
                 parameter.replace(newParameterExpr)
                 return
             }
-            val newPatBinding = RsPsiFactory(project).createPatBinding(binding.identifier.text, mutable = mutable, ref = binding.isRef)
+            val newPatBinding = RsPsiFactory(project).createPatBinding(binding.identifier.text, mutable = mutable, ref = binding.kind is BindByReference)
             binding.replace(newPatBinding)
         }
         is RsSelfParameter -> {

--- a/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt
@@ -7,10 +7,9 @@ package org.rust.ide.inspections
 
 import com.intellij.codeInspection.ProblemsHolder
 import org.rust.ide.annotator.fixes.AddMutableFix
-import org.rust.lang.core.psi.RsBinaryExpr
-import org.rust.lang.core.psi.RsExpr
-import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.AssignmentOp
+import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psi.ext.operatorType
 import org.rust.lang.core.types.isMutable
 
@@ -19,8 +18,17 @@ class RsReassignImmutableInspection : RsLocalInspectionTool() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitBinaryExpr(expr: RsBinaryExpr) {
-                if (expr.isAssignBinaryExpr() && !expr.left.isMutable) {
-                    registerProblem(holder, expr, expr.left)
+                val left = expr.left
+                if (expr.isAssignBinaryExpr() && left is RsPathExpr && !left.isMutable) {
+                    // todo: perform some kind of data-flow analysis
+                    val declaration = left.path.reference.resolve()
+                    val letExpr = declaration?.ancestorStrict<RsLetDecl>()
+                    if (letExpr == null) registerProblem(holder, expr, left)
+
+                    // this brings false-negative, because it doesn't check initialization properly:
+                    // let x; x = 1;
+                    // x = 2; <-- reassignment of immutable `x`, but the problem did not register
+                    else if (letExpr.eq != null) registerProblem(holder, expr, left)
                 }
             }
         }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatBinding.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatBinding.kt
@@ -16,9 +16,30 @@ import org.rust.lang.core.resolve.ref.RsPatBindingReferenceImpl
 import org.rust.lang.core.resolve.ref.RsReference
 import org.rust.lang.core.types.ty.Mutability
 
-val RsPatBinding.isRef: Boolean get() = bindingMode?.ref != null
-val RsPatBinding.mutability: Mutability get() = Mutability.valueOf(bindingMode?.mut != null)
+sealed class RsBindingModeKind {
+    class BindByReference(val mutability: Mutability) : RsBindingModeKind()
+    class BindByValue(val mutability: Mutability) : RsBindingModeKind()
+}
+
+val RsPatBinding.mutability: Mutability
+    get() {
+        val kind = kind
+        return when (kind) {
+            is RsBindingModeKind.BindByValue -> kind.mutability
+            is RsBindingModeKind.BindByReference -> Mutability.IMMUTABLE
+        }
+    }
+
 val RsPatBinding.isArg: Boolean get() = parent?.parent is RsValueParameter
+
+val RsPatBinding.kind: RsBindingModeKind
+    get() {
+        val bindingMode = bindingMode
+        val ref = bindingMode?.ref != null
+        val mutability = Mutability.valueOf(bindingMode?.mut != null)
+
+        return if (ref) RsBindingModeKind.BindByReference(mutability) else RsBindingModeKind.BindByValue(mutability)
+    }
 
 val RsPatBinding.topLevelPattern: RsPat
     get() = ancestors

--- a/src/main/kotlin/org/rust/lang/core/types/infer/MemoryCategorization.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/MemoryCategorization.kt
@@ -1,0 +1,138 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.types.infer
+
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.containerExpr
+import org.rust.lang.core.psi.ext.mutability
+import org.rust.lang.core.types.builtinDeref
+import org.rust.lang.core.types.infer.Adjustment.Deref
+import org.rust.lang.core.types.inference
+import org.rust.lang.core.types.isDereference
+import org.rust.lang.core.types.ty.*
+import org.rust.lang.core.types.type
+import org.rust.stdext.nextOrNull
+
+
+enum class MutabilityCategory {
+    Immutable,
+    /** Directly declared as mutable */
+    Declared,
+    /** Inherited from the fact that owner is mutable */
+    Inherited;
+
+    companion object {
+        fun valueOf(mutability: Mutability): MutabilityCategory =
+            when (mutability) {
+                Mutability.IMMUTABLE -> MutabilityCategory.Immutable
+                Mutability.MUTABLE -> MutabilityCategory.Declared
+            }
+    }
+
+    fun inherit(): MutabilityCategory =
+        when (this) {
+            MutabilityCategory.Immutable -> MutabilityCategory.Immutable
+            MutabilityCategory.Declared, MutabilityCategory.Inherited -> MutabilityCategory.Inherited
+        }
+
+    val isMutable: Boolean
+        get() = when (this) {
+            MutabilityCategory.Immutable -> false
+            MutabilityCategory.Declared, MutabilityCategory.Inherited -> true
+        }
+}
+
+/**
+ * Category, MutabilityCategory, and Type
+ * Currently supports only MutabilityCategory and Type
+ */
+class Cmt(val ty: Ty, val mutabilityCategory: MutabilityCategory? = null)
+
+private fun processUnaryExpr(unaryExpr: RsUnaryExpr): Cmt {
+    val type = unaryExpr.type
+    if (!unaryExpr.isDereference) return Cmt(type)
+    val base = unaryExpr.expr ?: return Cmt(type)
+
+    val baseCmt = processExpr(base)
+    return processDeref(baseCmt)
+}
+
+private fun processDotExpr(dotExpr: RsDotExpr): Cmt {
+    val type = dotExpr.type
+    val base = dotExpr.expr
+    val baseCmt = processExpr(base)
+    return Cmt(type, baseCmt.mutabilityCategory?.inherit())
+}
+
+private fun processIndexExpr(indexExpr: RsIndexExpr): Cmt {
+    val type = indexExpr.type
+    val base = indexExpr.containerExpr ?: return Cmt(type)
+    val baseCmt = processExpr(base)
+    return Cmt(type, baseCmt.mutabilityCategory?.inherit())
+}
+
+private fun processPathExpr(pathExpr: RsPathExpr): Cmt {
+    val type = pathExpr.type
+    val declaration = pathExpr.path.reference.resolve() ?: return Cmt(type)
+
+    return when (declaration) {
+        is RsConstant, is RsEnumVariant, is RsStructItem, is RsFunction -> Cmt(type, MutabilityCategory.Declared)
+
+        is RsPatBinding -> {
+            if (declaration.mutability.isMut) {
+                Cmt(type, MutabilityCategory.Declared)
+            } else {
+                Cmt(type, MutabilityCategory.Immutable)
+            }
+        }
+
+        is RsSelfParameter -> Cmt(type, MutabilityCategory.valueOf(declaration.mutability))
+
+        else -> Cmt(type)
+    }
+}
+
+private fun processParenExpr(parenExpr: RsParenExpr): Cmt =
+    Cmt(parenExpr.type, parenExpr.expr.mutabilityCategory)
+
+private fun processExpr(expr: RsExpr): Cmt {
+    val adjustments = expr.inference?.adjustments?.get(expr) ?: emptyList()
+    return processExprAdjustedWith(expr, adjustments.asReversed().iterator())
+}
+
+private fun processExprAdjustedWith(expr: RsExpr, adjustments: Iterator<Adjustment>): Cmt =
+    when (adjustments.nextOrNull()) {
+        is Deref -> {
+            // TODO: overloaded deref
+            processDeref(processExprAdjustedWith(expr, adjustments))
+        }
+        else -> processExprUnadjusted(expr)
+    }
+
+private fun processDeref(baseCmt: Cmt): Cmt {
+    val baseType = baseCmt.ty
+    val (derefType, derefMut) = baseType.builtinDeref() ?: Pair(TyUnknown, Mutability.DEFAULT_MUTABILITY)
+
+    return when (baseType) {
+        is TyReference -> Cmt(derefType, MutabilityCategory.valueOf(derefMut))
+        is TyPointer -> Cmt(derefType, MutabilityCategory.valueOf(derefMut))
+        else -> Cmt(derefType)
+    }
+}
+
+private fun processExprUnadjusted(expr: RsExpr): Cmt =
+    when (expr) {
+        is RsUnaryExpr -> processUnaryExpr(expr)
+        is RsDotExpr -> processDotExpr(expr)
+        is RsIndexExpr -> processIndexExpr(expr)
+        is RsPathExpr -> processPathExpr(expr)
+        is RsParenExpr -> processParenExpr(expr)
+        else -> Cmt(expr.type)
+    }
+
+
+val RsExpr.mutabilityCategory: MutabilityCategory?
+    get() = processExpr(this).mutabilityCategory

--- a/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.types.infer
 
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.RsBindingModeKind.BindByReference
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
 
@@ -26,7 +27,8 @@ fun RsPat.extractBindings(fcx: RsFnInferenceContext, type: Ty, ignoreRef: Boolea
         }
         is RsPatIdent -> {
             val patBinding = patBinding
-            val bindingType = if (patBinding.isRef && !ignoreRef) TyReference(type, patBinding.mutability) else type
+            val kind = patBinding.kind
+            val bindingType = if (kind is BindByReference && !ignoreRef) TyReference(type, kind.mutability) else type
             fcx.writeBindingTy(patBinding, bindingType)
             pat?.extractBindings(fcx, type)
         }
@@ -72,7 +74,8 @@ fun RsPat.extractBindings(fcx: RsFnInferenceContext, type: Ty, ignoreRef: Boolea
                 when (kind) {
                     is RsPatFieldKind.Full -> kind.pat.extractBindings(fcx, fieldType.toRefIfNeeded(mut), mut != null)
                     is RsPatFieldKind.Shorthand -> {
-                        val bindingType = fieldType.toRefIfNeeded(if (kind.binding.isRef) kind.binding.mutability else mut)
+                        val bindingKind = kind.binding.kind
+                        val bindingType = fieldType.toRefIfNeeded(if (bindingKind is BindByReference) bindingKind.mutability else mut)
                         fcx.writeBindingTy(kind.binding, bindingType)
                     }
                 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -53,6 +53,8 @@ enum class Mutability {
     companion object {
         fun valueOf(mutable: Boolean): Mutability =
             if (mutable) MUTABLE else IMMUTABLE
+
+        val DEFAULT_MUTABILITY = MUTABLE
     }
 }
 

--- a/src/main/kotlin/org/rust/stdext/Collections.kt
+++ b/src/main/kotlin/org/rust/stdext/Collections.kt
@@ -91,3 +91,6 @@ fun <T> List<T>.chain(other: List<T>): Sequence<T> =
         this.isEmpty() -> other.asSequence()
         else -> this.asSequence() + other.asSequence()
     }
+
+fun <T : Any> Iterator<T>.nextOrNull(): T? =
+    if (hasNext()) next() else null

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt
@@ -5,7 +5,11 @@
 
 package org.rust.ide.annotator
 
+import com.intellij.testFramework.LightProjectDescriptor
+
 class RsHighlightingMutableAnnotatorTest : RsAnnotatorTestBase() {
+
+    override fun getProjectDescriptor(): LightProjectDescriptor = WithStdlibRustProjectDescriptor
 
     fun `test mut self highlight`() = checkInfo("""
         struct <info>Foo</info> {}
@@ -17,11 +21,11 @@ class RsHighlightingMutableAnnotatorTest : RsAnnotatorTestBase() {
     """)
 
     fun `test mut binding`() = checkInfo("""
-        fn <info>main</info>() {
+        fn <info descr="null">main</info>() {
             let mut <info descr="Mutable binding">a</info> = 1;
             let b = <info descr="Mutable binding">a</info>;
-            let Some(ref mut <info descr="Mutable binding">c</info>) = Some(10);
-            let d = <info descr="Mutable binding">c</info>;
+            let <info descr="null">Some</info>(ref mut <info descr="Mutable binding">c</info>) = <info descr="null">Some</info>(10);
+            let <info descr="Mutable binding">d</info> = <info descr="Mutable binding">c</info>;
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt
@@ -113,13 +113,21 @@ class RsReassignImmutableInspectionTest : RsInspectionsTestBase(RsReassignImmuta
         }
     """)
 
-    fun `test E0384 no error in for loop over mutable`() = checkByText("""
-        struct Foo { a: u32 }
+    fun `test E0384 mut struct field`() = checkByText("""
+        struct Foo { a: i32 }
         fn main() {
-            let mut vec: Vec<Foo> = Vec::new();
-            for v in &mut vec {
-                v.a = 15;           // Must not be annotated
-            }
+            let mut foo = Foo { a: 1 };
+            let x = &mut foo;
+            x.a = 2;
+        }
+    """)
+
+    fun `test E0384 reassign ref mut`() = checkByText("""
+        fn main() {
+            let mut a = 5;
+            let mut b = 6;
+            let ref mut test = a;
+            <error>test<caret> = &mut b</error>;
         }
     """)
 
@@ -168,20 +176,4 @@ class RsReassignImmutableInspectionTest : RsInspectionsTestBase(RsReassignImmuta
             test = 32;
         }
     """)
-
-    fun `test E0384 fix let ref at reassign `() = checkFixByText("Make `test` mutable", """
-        fn main() {
-            let mut a = 5;
-            let mut b = 6;
-            let ref test = a;
-            <error>test<caret> = &b</error>;
-        }
-            """, """
-        fn main() {
-            let mut a = 5;
-            let mut b = 6;
-            let ref mut test = a;
-            test = &b;
-        }
-            """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsMemoryCategorizationTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsMemoryCategorizationTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.type
+
+import org.intellij.lang.annotations.Language
+import org.rust.lang.RsTestBase
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.types.infer.mutabilityCategory
+
+class RsMemoryCategorizationTest : RsTestBase() {
+    private fun testExpr(@Language("Rust") code: String, description: String = "", allowErrors: Boolean = false) {
+        InlineFile(code)
+        check(description)
+    }
+
+    private fun check(description: String) {
+        val (expr, expectedCategory) = findElementAndDataInEditor<RsExpr>()
+
+        val category = expr.mutabilityCategory
+        check(category.toString() == expectedCategory) {
+            "Category mismatch. Expected: $expectedCategory, found: $category. $description"
+        }
+    }
+
+    fun `test declared immutable`() = testExpr("""
+        fn main() {
+            let x = 42;
+            x;
+          //^ Immutable
+        }
+    """)
+
+    fun `test declared mutable`() = testExpr("""
+        fn main() {
+            let mut x = 42;
+            x;
+          //^ Declared
+        }
+    """)
+
+    fun `test declared immutable with immutable deref`() = testExpr("""
+        fn main() {
+            let y = 42;
+            let x = &y;
+            (*x);
+             //^ Immutable
+        }
+    """)
+
+    fun `test declared mutable with immutable deref`() = testExpr("""
+        fn main() {
+            let mut y = 42;
+            let x = &y;
+            (*x);
+             //^ Immutable
+        }
+    """)
+
+    fun `test declared mutable with mutable deref`() = testExpr("""
+        fn main() {
+            let mut y = 42;
+            let x = &mut y;
+            (*x);
+             //^ Declared
+        }
+    """)
+
+    fun `test immutable array`() = testExpr("""
+        fn main() {
+            let a: [i32; 3] = [0; 3];
+            a[1];
+             //^ Immutable
+        }
+    """)
+
+    fun `test mutable array`() = testExpr("""
+        fn main() {
+            let mut a: [i32; 3] = [0; 3];
+            a[1];
+             //^ Inherited
+        }
+    """)
+
+    fun `test immutable struct`() = testExpr("""
+        struct Foo { a: i32 }
+        fn main() {
+            let x = Foo { a: 1 };
+            (x.a);
+              //^ Immutable
+        }
+    """)
+
+    fun `test mutable struct`() = testExpr("""
+        struct Foo { a: i32 }
+        fn main() {
+            let mut x = Foo { a: 1 };
+            (x.a);
+              //^ Inherited
+        }
+    """)
+
+    fun `test mutable struct with immutable reference`() = testExpr("""
+        struct Foo { a: i32 }
+        fn main() {
+            let mut foo = Foo { a: 1 };
+            let x = &foo;
+            (x.a);
+              //^ Immutable
+        }
+    """)
+
+    fun `test mutable struct with mutable reference`() = testExpr("""
+        struct Foo { a: i32 }
+        fn main() {
+            let mut foo = Foo { a: 1 };
+            let x = &mut foo;
+            (x.a);
+              //^ Inherited
+        }
+    """)
+
+    fun `test mutable struct with multiple references to immutable reference`() = testExpr("""
+        struct Foo { a: i32 }
+        fn main() {
+            let mut foo = Foo { a: 1 };
+            let x = &mut &mut &foo;
+            (x.a);
+              //^ Immutable
+        }
+    """)
+
+    fun `test mutable struct with multiple references to mutable reference`() = testExpr("""
+        struct Foo { a: i32 }
+        fn main() {
+            let mut foo = Foo { a: 1 };
+            let x = & & &mut foo;
+            (x.a);
+              //^ Inherited
+        }
+    """)
+
+    fun `test const raw pointer`() = testExpr("""
+        struct Foo { a: i32 }
+        fn main() {
+            let x = 5;
+            let p = &x as *const i32;
+            (*p);
+             //^ Immutable
+        }
+    """)
+
+    fun `test mut raw pointer`() = testExpr("""
+        struct Foo { a: i32 }
+        fn main() {
+            let mut x = 5;
+            let p = &mut x as *mut i32;
+            (*p);
+             //^ Declared
+        }
+    """)
+
+    fun `test immutable self`() = testExpr("""
+        struct Foo {}
+        impl Foo {
+            fn f(&self) {
+                self;
+                 //^ Immutable
+            }
+        }
+    """)
+
+    fun `test mutable self`() = testExpr("""
+        struct Foo {}
+        impl Foo {
+            fn f(&mut self) {
+                self;
+                 //^ Declared
+            }
+        }
+    """)
+}


### PR DESCRIPTION
Add mutability categories support for checking assignments to immutable memory (see [mem_categorization.rs](https://github.com/rust-lang/rust/blob/master/src/librustc/middle/mem_categorization.rs)).