### PR TITLE
INSP: Needless lifetimes inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsNeedlessLifetimesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsNeedlessLifetimesInspection.kt
@@ -1,0 +1,228 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.util.TextRange
+import org.rust.ide.inspections.ReferenceLifetime.*
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.openapiext.forEachChild
+import org.rust.stdext.chain
+
+/**
+ * Checks for lifetime annotations which can be removed by relying on lifetime elision.
+ * Corresponds to needless_lifetimes lint from Rust Clippy.
+ */
+class RsNeedlessLifetimesInspection : RsLocalInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
+        override fun visitFunction(fn: RsFunction) {
+            if (couldUseElision(fn)) registerProblem(holder, fn)
+        }
+    }
+}
+
+/**
+ * There are two scenarios where elision works:
+ * - no output references, all input references have different LT
+ * - output references, exactly one input reference with same LT
+ * All lifetimes must be unnamed, 'static or defined without bounds on the level of the current item.
+ */
+private fun couldUseElision(fn: RsFunction): Boolean {
+    if (hasWhereLifetimes(fn.whereClause)) return false
+
+    val typeParametersBounds = fn.typeParameters.flatMap { it.bounds }.map { it.bound }
+    if (typeParametersBounds.any { hasNamedReferenceLifetime(it) }) return false
+
+    val (inputLifetimes, outputLifetimes) = collectLifetimesFromFnSignature(fn)
+
+    // no input lifetimes? easy case!
+    if (inputLifetimes.isEmpty()) return false
+
+    if (checkLifetimesUsedInBody(fn.block)) return false
+
+    // check for lifetimes from higher scopes
+    val allowedLifetimes = allowedLifetimesFrom(fn.lifetimeParameters)
+    if (!inputLifetimes.chain(outputLifetimes).all { allowedLifetimes.contains(it) }) return false
+
+    val areInputsDistinct = inputLifetimes.size == inputLifetimes.distinct().size
+
+    // no output lifetimes, check distinctness of input lifetimes
+    if (outputLifetimes.isEmpty()) {
+        // only unnamed and static, ok
+        if (inputLifetimes.none { it is Named }) return false
+        // we have no output reference, so we only need all distinct lifetimes
+        return areInputsDistinct
+    }
+
+    return when {
+        outputLifetimes.distinct().size > 1 -> false
+        inputLifetimes.size == 1 || fn.selfParameter?.isRef == true && areInputsDistinct -> {
+            val input = inputLifetimes.first()
+            val output = outputLifetimes.first()
+            when {
+                input is Named && output is Named && input.name == output.name -> true
+                input is Named && output === Unnamed -> true
+                input === Unnamed && output === Unnamed && inputLifetimes.any { it is Named } -> true
+                else -> false  // different named lifetimes or something static going on
+            }
+        }
+        else -> false
+    }
+}
+
+private class LifetimesCollector : RsVisitor() {
+    val lifetimes = mutableListOf<ReferenceLifetime>()
+
+    override fun visitSelfParameter(selfParameter: RsSelfParameter) {
+        selfParameter.lifetime?.let { visitLifetime(it) }
+        if (selfParameter.isRef && selfParameter.lifetime.isElided) record(null)
+        selfParameter.typeReference?.let { visitTypeReference(it) }
+    }
+
+    override fun visitRefLikeType(refLike: RsRefLikeType) {
+        if (refLike.isRef && refLike.lifetime.isElided) record(null)
+        super.visitRefLikeType(refLike)
+    }
+
+    override fun visitPath(path: RsPath) {
+        collectAnonymousLifetimes(path)
+        super.visitPath(path)
+    }
+
+    override fun visitLifetime(lifetime: RsLifetime) = record(lifetime)
+
+    override fun visitElement(element: RsElement) {
+        if (element is RsItemElement /* ignore nested items */) return
+        element.forEachChild { it.accept(this) }
+    }
+
+    private fun record(lifetime: RsLifetime?) {
+        lifetimes.add(lifetime.name.toReferenceLifetime())
+    }
+
+    private fun collectAnonymousLifetimes(path: RsPath) {
+        if (path.typeArgumentList != null) return
+        val resolved = path.reference.resolve()
+        when (resolved) {
+            is RsStructItem, is RsTraitItem, is RsTypeAlias -> {
+                val declaration = resolved as RsGenericDeclaration
+                val genericsCount = declaration.lifetimeParameters.size + declaration.typeParameters.size
+                repeat(genericsCount) { record(null) }
+            }
+        }
+    }
+}
+
+private class BodyLifetimeChecker : RsVisitor() {
+    var lifetimesUsedInBody: Boolean = false
+        private set
+
+    override fun visitLifetime(lifetime: RsLifetime) {
+        if (lifetime.name is LifetimeName.Parameter) {
+            lifetimesUsedInBody = true
+        }
+    }
+
+    override fun visitElement(element: RsElement) {
+        if (lifetimesUsedInBody || element is RsItemElement /* ignore nested items */) return
+        element.forEachChild { it.accept(this) }
+    }
+}
+
+private fun collectLifetimesFromFnSignature(fn: RsFunction): Pair<List<ReferenceLifetime>, List<ReferenceLifetime>> {
+    // these will collect all the lifetimes for references in arg/return types
+    val inputCollector = LifetimesCollector()
+    val outputCollector = LifetimesCollector()
+
+    // extract lifetimes in input argument types
+    fn.valueParameterList?.let {
+        it.selfParameter?.accept(inputCollector)
+        it.valueParameterList.forEach { it.typeReference?.accept(inputCollector) }
+    }
+
+    // extract lifetimes in output type
+    fn.retType?.typeReference?.accept(outputCollector)
+
+    return Pair(inputCollector.lifetimes, outputCollector.lifetimes)
+}
+
+private fun allowedLifetimesFrom(lifetimeParameters: List<RsLifetimeParameter>): Set<ReferenceLifetime> {
+    val allowedLifetimes = HashSet<ReferenceLifetime>()
+    lifetimeParameters
+        .filter { it.bounds.isEmpty() }
+        .mapNotNull { it.name }
+        .map { Named(it) }
+        .toCollection(allowedLifetimes)
+    allowedLifetimes.add(Unnamed)
+    allowedLifetimes.add(Static)
+    return allowedLifetimes
+}
+
+/** Are any lifetimes mentioned in the `where` clause? If yes, we don't try to reason about elision. */
+private fun hasWhereLifetimes(whereClause: RsWhereClause?): Boolean {
+    if (whereClause == null) return false
+    for (predicate in whereClause.wherePredList) {
+        if (predicate.lifetime != null) return true
+
+        // a predicate like F: Trait or F: for<'a> Trait<'a>
+
+        // check the type F, it may not contain LT refs
+        val collector = LifetimesCollector()
+        predicate.typeReference?.accept(collector)
+        if (collector.lifetimes.isNotEmpty()) return true
+
+        // if the bounds define new lifetimes, they are fine to occur
+        val boundLifetimeParams = predicate.forLifetimes?.lifetimeParameterList.orEmpty()
+        val allowedLifetimes = allowedLifetimesFrom(boundLifetimeParams)
+        // now walk the bounds
+        predicate.typeParamBounds?.polyboundList?.map { it.bound }?.forEach { it.accept(collector) }
+        // and check that all lifetimes are allowed
+        if (!allowedLifetimes.containsAll(collector.lifetimes)) return false
+    }
+    return false
+}
+
+private fun hasNamedReferenceLifetime(bound: RsBound): Boolean {
+    val collector = LifetimesCollector()
+    bound.accept(collector)
+    return collector.lifetimes.any { it is Named }
+}
+
+/** @return true if an lifetime is used in the [body] */
+private fun checkLifetimesUsedInBody(body: RsBlock?): Boolean {
+    if (body == null) return false
+    val checker = BodyLifetimeChecker()
+    body.accept(checker)
+    return checker.lifetimesUsedInBody
+}
+
+private fun registerProblem(holder: ProblemsHolder, fn: RsFunction) {
+    holder.registerProblem(
+        fn,
+        "Explicit lifetimes given in parameter types where they could be elided",
+        ProblemHighlightType.WEAK_WARNING,
+        TextRange(
+            fn.fn.startOffsetInParent,
+            fn.block?.getPrevNonCommentSibling()?.endOffsetInParent ?: fn.identifier.endOffsetInParent
+        )
+    )
+}
+
+/** The lifetime of a &-reference. */
+private sealed class ReferenceLifetime {
+    object Unnamed : ReferenceLifetime()
+    object Static : ReferenceLifetime()
+    data class Named(val name: String) : ReferenceLifetime()
+}
+
+private fun LifetimeName.toReferenceLifetime(): ReferenceLifetime =
+    when (this) {
+        is LifetimeName.Parameter -> ReferenceLifetime.Named(name)
+        LifetimeName.Static -> ReferenceLifetime.Static
+        LifetimeName.Implicit, LifetimeName.Underscore -> ReferenceLifetime.Unnamed
+    }

--- a/src/main/kotlin/org/rust/ide/inspections/RsNeedlessLifetimesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsNeedlessLifetimesInspection.kt
@@ -9,6 +9,7 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.util.TextRange
 import org.rust.ide.inspections.ReferenceLifetime.*
+import org.rust.ide.inspections.fixes.ElideLifetimesFix
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.forEachChild
@@ -209,7 +210,8 @@ private fun registerProblem(holder: ProblemsHolder, fn: RsFunction) {
         TextRange(
             fn.fn.startOffsetInParent,
             fn.block?.getPrevNonCommentSibling()?.endOffsetInParent ?: fn.identifier.endOffsetInParent
-        )
+        ),
+        ElideLifetimesFix()
     )
 }
 

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/ElideLifetimesFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/ElideLifetimesFix.kt
@@ -1,0 +1,84 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.childrenOfType
+import org.rust.lang.core.psi.ext.isRef
+import org.rust.lang.core.psi.ext.mutability
+
+class ElideLifetimesFix : LocalQuickFix {
+    override fun getName() = "Elide lifetimes"
+    override fun getFamilyName() = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val fn = descriptor.psiElement as? RsFunction ?: return
+        LifetimeRemover().visitFunction(fn)
+    }
+}
+
+private class LifetimeRemover : RsVisitor() {
+    private val boundsLifetimes = mutableListOf<RsLifetimeParameter>()
+
+    override fun visitFunction(fn: RsFunction) {
+        fn.typeParameterList?.let { visitTypeParameterList(it) }
+        fn.valueParameterList?.let { visitValueParameterList(it) }
+        fn.retType?.let { visitRetType(it) }
+    }
+
+    override fun visitTypeParameterList(typeParameters: RsTypeParameterList) {
+        boundsLifetimes.addAll(typeParameters.lifetimeParameterList)
+        val typeNames = typeParameters.typeParameterList.map { it.text }
+        if (typeNames.isEmpty()) {
+            typeParameters.delete()
+        } else {
+            val types = RsPsiFactory(typeParameters.project).createTypeParameterList(typeNames)
+            typeParameters.replace(types)
+        }
+    }
+
+    override fun visitTypeArgumentList(typeArguments: RsTypeArgumentList) {
+        super.visitTypeArgumentList(typeArguments)
+        val restNames = typeArguments.typeReferenceList.map { it.text } +
+            typeArguments.assocTypeBindingList.map { it.text }
+        if (restNames.isEmpty()) {
+            typeArguments.delete()
+        } else {
+            val newTypeArguments = RsPsiFactory(typeArguments.project).createTypeArgumentList(restNames)
+            typeArguments.replace(newTypeArguments)
+        }
+    }
+
+    override fun visitValueParameterList(valueParameters: RsValueParameterList) {
+        valueParameters.selfParameter?.let { visitSelfParameter(it) }
+        valueParameters.valueParameterList.forEach { visitValueParameter(it) }
+    }
+
+    override fun visitSelfParameter(selfParameter: RsSelfParameter) {
+        if (selfParameter.lifetime != null) {
+            val newSelfParameter = RsPsiFactory(selfParameter.project).createSelf(selfParameter.mutability.isMut)
+            selfParameter.replace(newSelfParameter)
+        }
+        selfParameter.typeReference?.let { visitTypeReference(it) }
+    }
+
+    override fun visitRefLikeType(refLike: RsRefLikeType) {
+        visitTypeReference(refLike.typeReference)
+        if (refLike.isRef && refLike.lifetime != null) {
+            val ref = RsPsiFactory(refLike.project)
+                .createReferenceType(refLike.typeReference.text, refLike.mutability.isMut)
+            refLike.replace(ref)
+        }
+    }
+
+    override fun visitElement(element: RsElement) {
+        element.childrenOfType<RsElement>().forEach { it.accept(this) }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -217,6 +217,13 @@ class RsPsiFactory(private val project: Project) {
             ?: error("Failed to create type from text: `$text`")
     }
 
+    fun createTypeArgumentList(
+        params: Iterable<String>
+    ): RsTypeArgumentList {
+        val text = params.joinToString(prefix = "<", separator = ", ", postfix = ">")
+        return createFromText("type T = a$text") ?: error("Failed to create type argument from text: `$text`")
+    }
+
     fun createOuterAttr(text: String): RsOuterAttr =
         createFromText("#[$text] struct Dummy;")
             ?: error("Failed to create an outer attribute from text: `$text`")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -108,3 +108,6 @@ fun PsiElement?.getNextNonCommentSibling(): PsiElement? =
 
 fun RsElement.isAncestorOf(child: PsiElement): Boolean =
     child.ancestors.contains(this)
+
+val PsiElement.endOffsetInParent: Int
+    get() = startOffsetInParent + textLength

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -431,6 +431,11 @@
                          enabledByDefault="true" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.RsSortImplTraitMembersInspection"/>
 
+        <localInspection language="Rust" groupName="Rust"
+                         displayName="Needless lifetimes"
+                         enabledByDefault="true" level="WEAK WARNING"
+                         implementationClass="org.rust.ide.inspections.RsNeedlessLifetimesInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsNeedlessLifetimes.html
+++ b/src/main/resources/inspectionDescriptions/RsNeedlessLifetimes.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+Checks for lifetime annotations which can be removed by relying on lifetime elision.
+Corresponds to <a href="https://rust-lang-nursery.github.io/rust-clippy/master/index.html#needless_lifetimes">needless_lifetimes</a>
+lint from Rust Clippy.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/RsNeedlessLifetimesInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsNeedlessLifetimesInspectionTest.kt
@@ -1,0 +1,292 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import org.intellij.lang.annotations.Language
+
+class RsNeedlessLifetimesInspectionTest : RsInspectionsTestBase(RsNeedlessLifetimesInspection()) {
+
+    fun `test no output lifetimes 1`() = doTest("""
+        <weak_warning>fn <caret>foo<'a>(s: &'a str)</weak_warning> { unimplemented!() }
+    """, """
+        fn <caret>foo(s: &str) { unimplemented!() }
+    """)
+
+    fun `test no output lifetimes 2`() = doTest("""
+        <weak_warning>fn <caret>foo<'a>(i: i32, s: &'a str)</weak_warning> { unimplemented!() }
+    """, """
+        fn <caret>foo(i: i32, s: &str) { unimplemented!() }
+    """)
+
+    fun `test one input lifetime 1`() = doTest("""
+        <weak_warning>fn <caret>foo<'a>(s: &'a str, i: i32) -> &'a str</weak_warning> { unimplemented!() }
+    """, """
+        fn <caret>foo(s: &str, i: i32) -> &str { unimplemented!() }
+    """)
+
+    fun `test one input lifetime 2`() = doTest("""
+        struct S<'a>(&'a str);
+        <weak_warning>fn <caret>foo<'a>(x: &'a str) -> S<'a></weak_warning> { unimplemented!() }
+    """, """
+        struct S<'a>(&'a str);
+        fn <caret>foo(x: &str) -> S { unimplemented!() }
+    """)
+
+    fun `test one input lifetime 3`() = doTest("""
+        <weak_warning>fn <caret>foo<'a>(x: &'a str) -> Box<&'a str></weak_warning> { unimplemented!() }
+    """, """
+        fn <caret>foo(x: &str) -> Box<&str> { unimplemented!() }
+    """)
+
+    fun `test no input lifetimes`() = doTest("""
+        fn foo() -> &str { unimplemented!() }
+    """)
+
+    fun `test assoc param`() = doTest("""
+        <weak_warning>fn <caret>foo<'a>(x: &'a str) -> Box<Iterator<Item=&'a str>></weak_warning> { unimplemented!() }
+    """, """
+        fn <caret>foo(x: &str) -> Box<Iterator<Item=&str>> { unimplemented!() }
+    """)
+
+    fun `test two input lifetimes no output lifetimes 1`() = doTest("""
+        <weak_warning>fn <caret>foo<'a>(a: &'a str, b: &str)</weak_warning> { unimplemented!() }
+    """, """
+        fn foo(a: &str, b: &str) { unimplemented!() }
+    """)
+
+    fun `test two input lifetimes no output lifetimes 2`() = doTest("""
+        struct S<'s>(&'s str);
+        fn foo<'a>(s: &'a str, t: S<'a>) { unimplemented!() }
+    """)
+
+    fun `test two input lifetimes one output lifetime`() = doTest("""
+        fn foo<'a>(s: &'a str, t: &str) -> &str { unimplemented!() }
+    """)
+
+    fun `test output trait type`() = doTest("""
+        trait T<'a> {}
+        impl <'a> T<'a> for () {}
+        <weak_warning>fn <caret>foo<'a>(a: &'a str) -> impl T<'a></weak_warning> { unimplemented!() }
+    """, """
+        trait T<'a> {}
+        impl <'a> T<'a> for () {}
+        fn <caret>foo(a: &str) -> impl T { unimplemented!() }
+    """)
+
+    fun `test input struct with implicit lifetime`() = doTest("""
+        struct S<'s>(&'s str);
+        <weak_warning>fn <caret>foo<'a>(s: &'a str, t: S)</weak_warning> { unimplemented!() }
+    """, """
+        struct S<'s>(&'s str);
+        fn <caret>foo(s: &str, t: S) { unimplemented!() }
+    """)
+
+    fun `test input struct with type argument and implicit lifetime`() = doTest("""
+        struct S<'s, T: 's>(&'s T);
+        <weak_warning>fn <caret>foo<'a>(s: &'a S<i32>)</weak_warning> { unimplemented!(); }
+    """, """
+        struct S<'s, T: 's>(&'s T);
+        fn <caret>foo(s: &S<i32>) { unimplemented!(); }
+    """)
+
+    fun `test self 1`() = doTest("""
+        struct S;
+        impl S {
+            <weak_warning>fn <caret>foo<'a>(&'a mut self) -> &'a mut S</weak_warning> { unimplemented!() }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn <caret>foo(&mut self) -> &mut S { unimplemented!() }
+        }
+    """)
+
+    fun `test self 2`() = doTest("""
+        struct S;
+        impl S {
+            <weak_warning>fn <caret>foo<'a, 'b>(&'a self, x: &'b str) -> &'a str</weak_warning> { unimplemented!() }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn <caret>foo(&self, x: &str) -> &str { unimplemented!() }
+        }
+    """)
+
+    fun `test self 3`() = doTest("""
+        struct S;
+        impl S {
+            <weak_warning>fn <caret>foo<'a, 'b>(&'a self, b: &'b str) -> &'a str</weak_warning> { unimplemented!() }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn <caret>foo(&self, b: &str) -> &str { unimplemented!() }
+        }
+    """)
+
+    fun `test self 4`() = doTest("""
+        struct S;
+        impl S {
+            <weak_warning>fn <caret>foo<'a, 'b, 'c>(&'a self, b: &'b str, c: &'c str) -> &'a str</weak_warning> { unimplemented!() }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn <caret>foo(&self, b: &str, c: &str) -> &str { unimplemented!() }
+        }
+    """)
+
+    fun `test self 5`() = doTest("""
+        struct S;
+        impl S {
+            <weak_warning>fn <caret>foo<'a, 'b, 'c>(&'a self, b: &'b str, c: &'c str) -> &str</weak_warning> { unimplemented!() }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn <caret>foo(&self, b: &str, c: &str) -> &str { unimplemented!() }
+        }
+    """)
+
+    fun `test self 6`() = doTest("""
+        struct S;
+        impl S {
+            fn foo<'b, 'c>(self, b: &'b str, c: &'c str) -> &str { unimplemented!() }
+        }
+    """)
+
+    fun `test inside impl`() = doTest("""
+        struct S<'a>(&'a str);
+        <weak_warning>fn <caret>foo<'a>(x: &'a mut [u8]) -> S<'a></weak_warning> { unimplemented!() }
+    """, """
+        struct S<'a>(&'a str);
+        fn <caret>foo(x: &mut [u8]) -> S { unimplemented!() }
+    """)
+
+    fun `test inside trait`() = doTest("""
+        trait T<'a> {
+            fn foo(&'a self) -> &'a str { unimplemented!() }
+            <weak_warning>fn <caret>bar<'b>(&'b self) -> &'b str</weak_warning> { unimplemented!() }
+        }
+    """, """
+        trait T<'a> {
+            fn foo(&'a self) -> &'a str { unimplemented!() }
+            fn <caret>bar(&self) -> &str { unimplemented!() }
+        }
+    """)
+
+    fun `test inside impl trait`() = doTest("""
+        trait T<'a> {
+            fn foo(&'a self) -> &'a str;
+            fn bar(&self) -> &str;
+        }
+        impl<'a> T<'a> for &'a str {
+            fn foo(&'a self) -> &'a str { unimplemented!() }
+            <weak_warning>fn <caret>bar<'b>(&'b self) -> &'b str</weak_warning> { unimplemented!() }
+        }
+    """, """
+        trait T<'a> {
+            fn foo(&'a self) -> &'a str;
+            fn bar(&self) -> &str;
+        }
+        impl<'a> T<'a> for &'a str {
+            fn foo(&'a self) -> &'a str { unimplemented!() }
+            fn <caret>bar(&self) -> &str { unimplemented!() }
+        }
+    """)
+
+    fun `test no refs only structs 1`() = doTest("""
+        struct S<'s>(&'s str);
+        <weak_warning>fn <caret>foo<'a>(t: S<'a>) -> S<'a></weak_warning> { unimplemented!() }
+    """, """
+        struct S<'s>(&'s str);
+        fn <caret>foo(t: S) -> S { unimplemented!() }
+    """)
+
+    fun `test no refs only structs 2`() = doTest("""
+        struct S<'s, T: 's>(&'s T);
+        <weak_warning>fn <caret>foo<'a>(t: S<'a, i32>) -> S<'a, i32></weak_warning> { unimplemented!() }
+    """, """
+        struct S<'s, T: 's>(&'s T);
+        fn <caret>foo(t: S<i32>) -> S<i32> { unimplemented!() }
+    """)
+
+    fun `test no elision for struct and impl`() = doTest("""
+        struct S<'a>(&'a str);
+        trait T {}
+        impl<'a> T for S<'a> {}
+    """)
+
+    fun `test no elision input struct with lifetime`() = doTest("""
+        struct S<'s>(&'s str);
+        fn foo<'a>(s: &'a str, t: S<'a>) { unimplemented!() }
+    """)
+
+    fun `test no elision when lifetime in bound 1`() = doTest("""
+        struct S<'s>(&'s str);
+        fn foo<'a>(s: &'a str, t: S<'a>) { unimplemented!() }
+    """)
+
+    fun `test no elision when lifetime in bound 2`() = doTest("""
+        trait S<'s> {}
+        fn foo<'a, T: S<'a>>(s: &'a str, t: T) { unimplemented!() }
+    """)
+
+    fun `test no elision when lifetime in where 1`() = doTest("""
+        fn foo<'a, 'b>(s: &'a str, t: &'b str) where 'b: 'a { unimplemented!() }
+    """)
+
+    fun `test no elision when lifetime in where 2`() = doTest("""
+        trait S<'s> {}
+        fn foo<'a, T>(s: &'a str, t: T) where T: S<'a> { unimplemented!() }
+    """)
+
+    fun `test no elision when lifetime in body`() = doTest("""
+        fn foo<'a>(s: &'a str) { let x: &'a str = unimplemented!(); }
+    """)
+
+    fun `test no elision for 'static`() = doTest("""
+        fn foo(s: &'static str) { unimplemented!(); }
+    """)
+
+    fun `test no elision for for`() = doTest("""
+        fn foo(x: for<'a> fn(&'a str)) { unimplemented!(); }
+    """)
+
+    fun `test no elision for bounded LT parameters`() = doTest("""
+        fn foo<'a, 'b: 'a>(a: &'a str, b: &'b str) { unimplemented!() }
+    """)
+
+    fun `test ignore 'static in body`() = doTest("""
+        <weak_warning>fn <caret>foo<'a>(s: &'a str)</weak_warning> { let x: &'static str = unimplemented!(); }
+    """, """
+        fn <caret>foo(s: &str) { let x: &'static str = unimplemented!(); }
+    """)
+
+    fun `test ignore items in body`() = doTest("""
+        <weak_warning>fn <caret>foo<'a>(s: &'a str)</weak_warning> {
+            fn bar<'b>(s: &'b str, t: &str) -> &str { unimplemented!(); }
+        }
+    """, """
+        fn <caret>foo(s: &str) {
+            fn bar<'b>(s: &'b str, t: &str) -> &str { unimplemented!(); }
+        }
+    """)
+
+    private fun doTest(
+        @Language("Rust") text: String
+    ) = checkFixIsUnavailable(FIX_NAME, text, checkWeakWarn = true)
+
+    private fun doTest(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String
+    ) = checkFixByText(FIX_NAME, before, after, checkWeakWarn = true)
+
+    companion object {
+        private const val FIX_NAME: String = "Elide lifetimes"
+    }
+}


### PR DESCRIPTION
Checks for lifetime annotations which can be removed by relying on lifetime elision.
<img src="https://user-images.githubusercontent.com/6079006/42790517-30529c08-8974-11e8-952e-43b4389d9c5c.png" width="80%">

Corresponds to [needless_lifetimes](https://github.com/rust-lang-nursery/rust-clippy/wiki#needless_lifetimes) lint from Rust Clippy (see [lifetimes.rs](https://github.com/rust-lang-nursery/rust-clippy/blob/master/clippy_lints/src/lifetimes.rs)).

Also implements quickfix for removing needless lifetimes.
