### PR TITLE
TY: fixed wrong `Self` substitution inside traits

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -496,7 +496,7 @@ class ImplLookup(
                     be.element == ref.trait.element && ctx.probe { ctx.combinePairs(be.subst.zipTypeValues(ref.trait.subst)) }
                 }
                 combineBoundElements(impl, ref.trait)
-                Selection(impl.element, emptyList())
+                Selection(impl.element, emptyList(), mapOf(TyTypeParameter.self() to ref.selfTy).toTypeSubst())
             }
         }
     }
@@ -602,9 +602,8 @@ class ImplLookup(
             is TyTraitObject -> selfTy.trait.assoc[assocType]
             is TyAnon -> lookupAssocTypeInBounds(selfTy.getTraitBoundsTransitively(), res.impl, assocType)
             else -> {
-                val ty = lookupAssocTypeInSelection(res, assocType)
+                lookupAssocTypeInSelection(res, assocType)
                     ?: lookupAssocTypeInBounds(getHardcodedImpls(selfTy), res.impl, assocType)
-                ty?.substitute(mapOf(TyTypeParameter.self() to selfTy).toTypeSubst())
             }
         }
     }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1448,4 +1448,18 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ u8
     """)
+
+    fun `test Self substitution inside traits`() = testExpr("""
+        struct S<T>(T);
+        impl<T> Tr for S<T> { type Item = T; }
+        trait Tr: Sized {
+            type Item;
+            fn wrap<T>(mut self) -> S<Self> { unimplemented!() }
+            fn unwrap(self) -> Self::Item { unimplemented!() }
+
+            fn bar(&self) {
+                self.wrap().unwrap()
+            }               //^ Self
+        }
+    """)
 }

--- a/src/test/kotlin/org/rustSlowTests/RsHighlightingPerformanceTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsHighlightingPerformanceTest.kt
@@ -31,6 +31,9 @@ class RsHighlightingPerformanceTest : RustWithToolchainTestBase() {
     fun `test highlighting mysql_async`() =
         repeatTest { highlightProjectFile("mysql_async", "https://github.com/blackbeam/mysql_async", "src/conn/mod.rs") }
 
+    fun `test highlighting mysql_async 2`() =
+        repeatTest { highlightProjectFile("mysql_async", "https://github.com/blackbeam/mysql_async", "src/connection_like/mod.rs") }
+
     private fun repeatTest(f: () -> Timings) {
         var result = Timings()
         println("${name.substring("test ".length)}:")


### PR DESCRIPTION
This bug led to extremely deep types and IDE freeze/OOME