### PR TITLE
RES: make "go to declaration" works with items defined with a macro

### DIFF
--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsTargetElementEvaluator.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsTargetElementEvaluator.kt
@@ -1,0 +1,33 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.navigation.goto
+
+import com.intellij.codeInsight.TargetElementEvaluatorEx2
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReference
+import org.rust.lang.core.macros.findMacroCallExpandedFrom
+
+class RsTargetElementEvaluator : TargetElementEvaluatorEx2() {
+    /**
+     * Allows to intercept platform calls to [PsiReference.resolve]
+     *
+     * Note that if this method returns null, it means
+     * "use default logic", i.e. call `ref.resolve()`
+     */
+    override fun getElementByReference(ref: PsiReference, flags: Int): PsiElement? = null
+
+    /**
+     * Allows to refine GotoDeclaration target
+     *
+     * Note that if this method returns null, it means
+     * "use default logic", i.e. just use `navElement`
+     *
+     * @param element the resolved element (basically via `element.reference.resolve()`)
+     * @param navElement the element we going to navigate to ([PsiElement.getNavigationElement])
+     */
+    override fun getGotoDeclarationTarget(element: PsiElement, navElement: PsiElement?): PsiElement? =
+        element.findMacroCallExpandedFrom()?.referenceNameElement
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/ExpansionResult.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpansionResult.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.StubBasedPsiElement
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.ancestors
 
 /**
  *  [ExpansionResult]s are those elements which exist in temporary,
@@ -40,7 +41,10 @@ fun ExpansionResult.setExpandedFrom(call: RsMacroCall) {
     putUserData(RS_EXPANSION_MACRO_CALL, call)
 }
 
-/** The [RsMacroCall] that expanded to this element or null if this element is not produced by a macro */
+/**
+ * The [RsMacroCall] that directly expanded to this element or
+ * null if this element is not directly produced by a macro
+ */
 val ExpansionResult.expandedFrom: RsMacroCall?
     get() = getUserData(RS_EXPANSION_MACRO_CALL) as RsMacroCall?
 
@@ -53,6 +57,14 @@ val ExpansionResult.expandedFromRecursively: RsMacroCall?
 
         return call
     }
+
+fun PsiElement.findMacroCallExpandedFrom(): RsMacroCall? {
+    val found = ancestors
+        .filterIsInstance<ExpansionResult>()
+        .mapNotNull { it.expandedFromRecursively }
+        .firstOrNull()
+    return found?.findMacroCallExpandedFrom() ?: found
+}
 
 
 private val RS_EXPANSION_CONTEXT = Key.create<RsElement>("org.rust.lang.core.psi.CODE_FRAGMENT_FILE")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -120,6 +120,9 @@
         // `ctrl+shift+b`
         <typeDeclarationProvider implementation="org.rust.ide.navigation.goto.RsTypeDeclarationProvider"/>
 
+        <targetElementEvaluator language="Rust"
+                                implementationClass="org.rust.ide.navigation.goto.RsTargetElementEvaluator"/>
+
         <!-- Hints -->
 
         <codeInsight.typeInfo language="Rust" implementationClass="org.rust.ide.hints.RsExpressionTypeProvider"/>

--- a/src/test/kotlin/org/rust/ide/docs/RsDocumentationProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsDocumentationProviderTest.kt
@@ -13,7 +13,7 @@ import org.rust.openapiext.Testmark
 
 abstract class RsDocumentationProviderTest : RsTestBase() {
 
-    protected inline fun doTest(
+    protected fun doTest(
         @Language("Rust") code: String,
         @Language("Html") expected: String,
         block: RsDocumentationProvider.(PsiElement, PsiElement?) -> String?
@@ -34,7 +34,7 @@ abstract class RsDocumentationProviderTest : RsTestBase() {
     protected fun doUrlTestByFileTree(@Language("Rust") text: String, expectedUrl: String?, testmark: Testmark? = null) =
         doUrlTest(text, expectedUrl, testmark, this::configureByFileTree)
 
-    private inline fun doUrlTest(
+    private fun doUrlTest(
         @Language("Rust") text: String,
         expectedUrl: String?,
         testmark: Testmark?,

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
@@ -688,6 +688,16 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
         <b>crate</b> [lib.rs]
     """)
 
+    fun `test item defined with a macro`() = doTest("""
+        macro_rules! foo { ($ i:item) => { $ i } }
+        foo! { struct S; }
+        type T = S;
+               //^
+    """, """
+        test_package
+        struct <b>S</b>
+    """)
+
     private fun doTest(@Language("Rust") code: String, @Language("Html") expected: String)
         = doTest(code, expected, RsDocumentationProvider::getQuickNavigateInfo)
 }

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoDeclarationTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoDeclarationTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.navigation.goto
+
+import com.intellij.openapi.actionSystem.IdeActions
+import org.intellij.lang.annotations.Language
+import org.rust.lang.RsTestBase
+
+class RsGotoDeclarationTest : RsTestBase() {
+    fun `test struct declaration`() = doTest("""
+        struct S;
+        type T = /*caret*/S;
+    """, """
+        struct /*caret*/S;
+        type T = S;
+    """)
+
+    fun `test defined with a macro`() = doTest("""
+        macro_rules! foo { ($ i:item) => { $ i } }
+        foo! { struct S; }
+        type T = /*caret*/S;
+    """, """
+        macro_rules! foo { ($ i:item) => { $ i } }
+        /*caret*/foo! { struct S; }
+        type T = S;
+    """)
+
+    fun `test defined with a macro with doc comment`() = doTest("""
+        macro_rules! foo { ($ i:item) => { $ i } }
+        /// docs
+        foo! { struct S; }
+        type T = /*caret*/S;
+    """, """
+        macro_rules! foo { ($ i:item) => { $ i } }
+        /// docs
+        /*caret*/foo! { struct S; }
+        type T = S;
+    """)
+
+    fun `test defined with nested macros`() = doTest("""
+        macro_rules! foo { ($ i:item) => { $ i } }
+        foo! { foo! { struct S; } }
+        type T = /*caret*/S;
+    """, """
+        macro_rules! foo { ($ i:item) => { $ i } }
+        /*caret*/foo! { foo! { struct S; } }
+        type T = S;
+    """)
+
+    fun `test defined with a macro indirectly`() = doTest("""
+        macro_rules! foo { ($ i:item) => { $ i } }
+        foo! { mod a { struct S; } }
+        use a::S;
+        type T = /*caret*/S;
+    """, """
+        macro_rules! foo { ($ i:item) => { $ i } }
+        /*caret*/foo! { mod a { struct S; } }
+        use a::S;
+        type T = S;
+    """)
+
+    private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) = checkByText(before, after) {
+        myFixture.performEditorAction(IdeActions.ACTION_GOTO_DECLARATION)
+    }
+}


### PR DESCRIPTION
Actually resolve items defined with a macro to the corresponding
macro call