### PR TITLE
INSP: Assign to immutable inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspection.kt
@@ -1,0 +1,48 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.isAssignBinaryExpr
+import org.rust.lang.core.psi.ext.unwrapParenExprs
+import org.rust.lang.core.types.isDereference
+import org.rust.lang.core.types.isMutable
+import org.rust.lang.core.types.ty.TyPointer
+import org.rust.lang.core.types.ty.TyReference
+import org.rust.lang.core.types.type
+
+class RsAssignToImmutableInspection : RsLocalInspectionTool() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        object : RsVisitor() {
+            override fun visitBinaryExpr(expr: RsBinaryExpr) {
+                if (expr.isAssignBinaryExpr) checkAssignment(expr, holder)
+            }
+        }
+
+    private fun checkAssignment(expr: RsBinaryExpr, holder: ProblemsHolder) {
+        val left = unwrapParenExprs(expr.left)
+        if (left.isMutable) return
+
+        when (left) {
+            is RsDotExpr -> registerProblem(holder, expr, "field of immutable binding")
+            is RsIndexExpr -> registerProblem(holder, expr, "indexed content of immutable binding")
+            is RsUnaryExpr -> if (left.isDereference) registerDereferenceProblem(left, holder, expr)
+        }
+    }
+
+    private fun registerDereferenceProblem(left: RsUnaryExpr, holder: ProblemsHolder, expr: RsBinaryExpr) {
+        when (left.expr?.type) {
+            is TyReference -> registerProblem(holder, expr, "immutable borrowed content")
+            is TyPointer -> registerProblem(holder, expr, "immutable dereference of raw pointer")
+        }
+    }
+
+    private fun registerProblem(holder: ProblemsHolder, expr: RsExpr, message: String) {
+        holder.registerProblem(expr, "Cannot assign to $message [E0594]")
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt
@@ -8,9 +8,8 @@ package org.rust.ide.inspections
 import com.intellij.codeInspection.ProblemsHolder
 import org.rust.ide.annotator.fixes.AddMutableFix
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.AssignmentOp
 import org.rust.lang.core.psi.ext.ancestorStrict
-import org.rust.lang.core.psi.ext.operatorType
+import org.rust.lang.core.psi.ext.isAssignBinaryExpr
 import org.rust.lang.core.types.isMutable
 
 class RsReassignImmutableInspection : RsLocalInspectionTool() {
@@ -19,8 +18,8 @@ class RsReassignImmutableInspection : RsLocalInspectionTool() {
         object : RsVisitor() {
             override fun visitBinaryExpr(expr: RsBinaryExpr) {
                 val left = expr.left
-                if (expr.isAssignBinaryExpr() && left is RsPathExpr && !left.isMutable) {
-                    // todo: perform some kind of data-flow analysis
+                if (expr.isAssignBinaryExpr && left is RsPathExpr && !left.isMutable) {
+                    // TODO: perform some kind of data-flow analysis
                     val declaration = left.path.reference.resolve()
                     val letExpr = declaration?.ancestorStrict<RsLetDecl>()
                     if (letExpr == null) registerProblem(holder, expr, left)
@@ -38,9 +37,4 @@ class RsReassignImmutableInspection : RsLocalInspectionTool() {
         holder.registerProblem(expr, "Re-assignment of immutable variable [E0384]", *fix)
     }
 
-}
-
-private fun RsExpr?.isAssignBinaryExpr(): Boolean {
-    val op = this as? RsBinaryExpr ?: return false
-    return op.operatorType is AssignmentOp
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
@@ -191,3 +191,9 @@ abstract class RsExprMixin : RsStubbedElementImpl<RsPlaceholderStub>, RsExpr {
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 }
+
+tailrec fun unwrapParenExprs(expr: RsExpr): RsExpr =
+    if (expr is RsParenExpr) unwrapParenExprs(expr.expr) else expr
+
+val RsExpr.isAssignBinaryExpr: Boolean
+    get() = this is RsBinaryExpr && this.operatorType is AssignmentOp

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -78,7 +78,6 @@ fun Ty.builtinDeref(explicit: Boolean = true): Pair<Ty, Mutability>? =
         else -> null
     }
 
-val RsExpr.isDereference: Boolean get() = this is RsUnaryExpr && this.mul != null
-
+val RsUnaryExpr.isDereference: Boolean get() = this.mul != null
 
 val RsExpr.isMutable: Boolean get() = mutabilityCategory?.isMutable ?: Mutability.DEFAULT_MUTABILITY.isMut

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -1612,14 +1612,6 @@ private fun List<RsPolybound>?.toTraitRefs(selfTy: Ty): Sequence<TraitRef> = orE
 private fun Sequence<Ty>.infiniteWithTyUnknown(): Sequence<Ty> =
     this + generateSequence { TyUnknown }
 
-private fun unwrapParenExprs(expr: RsExpr): RsExpr {
-    var child = expr
-    while (child is RsParenExpr) {
-        child = child.expr
-    }
-    return child
-}
-
 data class TyWithObligations<out T>(
     val value: T,
     val obligations: List<Obligation> = emptyList()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -438,6 +438,11 @@
                          enabledByDefault="true" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.RsNeedlessLifetimesInspection"/>
 
+        <localInspection language="Rust" groupName="Rust"
+                         displayName="Assign to immutable"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.rust.ide.inspections.RsAssignToImmutableInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsAssignToImmutable.html
+++ b/src/main/resources/inspectionDescriptions/RsAssignToImmutable.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+Detects assignments to immutable.
+
+Corresponds to <a href="https://doc.rust-lang.org/error-index.html#E0594">E0594</a> Rust error.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspectionTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+class RsAssignToImmutableInspectionTest : RsInspectionsTestBase(RsAssignToImmutableInspection()) {
+
+    fun `test E0594 assign to immutable borrowed content`() = checkByText("""
+        fn main() {
+            let mut y = 1;
+            let x = &y;
+            <error descr="Cannot assign to immutable borrowed content [E0594]">*x = 2</error>;
+        }
+    """)
+
+    fun `test E0594 assign to immutable borrowed content with parentheses`() = checkByText("""
+        fn main() {
+            let mut y = 1;
+            let x = &y;
+            <error descr="Cannot assign to immutable borrowed content [E0594]">((*x)) = 2</error>;
+        }
+    """)
+
+    fun `test E0594 assign to immutable borrowed content of literal`() = checkByText("""
+        fn main() {
+            let foo = &16;
+            <error descr="Cannot assign to immutable borrowed content [E0594]">*foo = 32</error>;
+        }
+    """)
+
+    fun `test E0594 assign to mutable field of immutable binding`() = checkByText("""
+        struct Foo { a: i32 }
+        fn main() {
+            let mut foo = Foo { a: 1 };
+            let x = &foo;
+            <error descr="Cannot assign to field of immutable binding [E0594]">x.a = 2</error>;
+        }
+    """)
+
+    fun `test E0594 assign to immutable field of immutable binding`() = checkByText("""
+        struct Foo { a: i32 }
+        fn main() {
+            let foo = Foo { a: 1 };
+            let x = &foo;
+            <error descr="Cannot assign to field of immutable binding [E0594]">x.a = 2</error>;
+        }
+    """)
+
+    fun `test E0594 assign to field of immutable binding`() = checkByText("""
+        struct Foo { a: i32 }
+        fn main() {
+            let foo = Foo { a: 1 };
+            <error descr="Cannot assign to field of immutable binding [E0594]">foo.a = 2</error>;
+        }
+    """)
+
+    fun `test E0594 assign to field of immutable binding while iterating`() = checkByText("""
+        struct Foo { a: i32 }
+        fn main() {
+            let mut foos: [Foo; 1] = [Foo { a: 1 }];
+            for foo in foos.iter() {
+                <error descr="Cannot assign to field of immutable binding [E0594]">foo.a = 2</error>;
+            }
+        }
+    """)
+
+    fun `test E0594 assign to indexed content of immutable binding`() = checkByText("""
+        fn main() {
+            let a: [i32; 3] = [0; 3];
+            <error descr="Cannot assign to indexed content of immutable binding [E0594]">a[1] = 5</error>;
+        }
+    """)
+
+    fun `test E0594 assign to immutable dereference of raw pointer`() = checkByText("""
+        struct Foo { a: i32 }
+        fn main() {}
+        unsafe fn f() {
+            let x = 5;
+            let p = &x as *const i32;
+            <error descr="Cannot assign to immutable dereference of raw pointer [E0594]">*p = 1</error>;
+        }
+    """)
+}


### PR DESCRIPTION
Add `RsAssignToImmutableInspection` corresponds to [E0594](https://doc.rust-lang.org/error-index.html#E0594) Rust error.
<img width="404" alt="1" src="https://user-images.githubusercontent.com/4854600/43310641-d2aaf36e-9190-11e8-9a2d-db087f44f7d9.png">
<img width="386" alt="2" src="https://user-images.githubusercontent.com/4854600/43310655-dcbb93b8-9190-11e8-9fc3-facef9cd9c11.png">
<img width="456" alt="3" src="https://user-images.githubusercontent.com/4854600/43310658-de3434c0-9190-11e8-94ea-03aaecddc645.png">
<img width="449" alt="4" src="https://user-images.githubusercontent.com/4854600/43310659-dfee401c-9190-11e8-987c-65b6a1324331.png">
