### PR TITLE
MACRO&PERF: Store macro expansions as stubs

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -99,7 +99,11 @@ class MacroExpander(val project: Project) {
         val expandedText = expandMacroAsText(def, call) ?: return null
         return when (call.context) {
             is RsMacroExpr -> listOfNotNull(psiFactory.tryCreateExpression(expandedText))
-            else -> psiFactory.createFile(expandedText).childrenOfType()
+            else -> {
+                val psi = MacroExpansionPsiManager.instance.createPsiFromText(project, expandedText.toString())
+                check(psi.stub != null)
+                psi.stubChildrenOfType()
+            }
         }
     }
 

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionPsiManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionPsiManager.kt
@@ -1,0 +1,66 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiManager
+import com.intellij.util.io.createDirectories
+import com.intellij.util.io.delete
+import com.intellij.util.io.write
+import org.apache.commons.lang3.RandomStringUtils
+import org.rust.lang.core.psi.RsFile
+import org.rust.openapiext.ObjectGcTracker
+import org.rust.openapiext.pathAsPath
+import java.nio.file.Paths
+
+private const val RUST_EXPANDED_MACROS = "rust_expanded_macros"
+
+class MacroExpansionPsiManager : Disposable {
+    private val tempDir = Paths.get(PathManager.getTempPath())
+        .resolve(RUST_EXPANDED_MACROS)
+
+    init {
+        tempDir.delete()
+    }
+
+    override fun dispose() {
+        tempDir.delete()
+    }
+
+    /**
+     * Creates a temporary file filled with [content] and loads its PSI.
+     * Unlike [com.intellij.psi.PsiFileFactory], it creates stub-based PSI tree
+     */
+    fun createPsiFromText(project: Project, content: String): RsFile {
+        val file = createTempFileWithContent(content)
+        val psi = PsiManager.getInstance(project).findFile(file) as RsFile
+
+        // We will delete the file after the psi is GCed
+        ObjectGcTracker.instance.registerObjectGcHook(psi) {
+            file.pathAsPath.delete()
+        }
+
+        return psi
+    }
+
+    private fun createTempFileWithContent(content: String): VirtualFile {
+        // We creating the file bypass VFS because we don't want to perform write action and fire events
+        tempDir.createDirectories()
+        val file = tempDir.resolve(RandomStringUtils.randomAlphabetic(16) + ".rs")
+        file.write(content)
+        return LocalFileSystem.getInstance().findFileByIoFile(file.toFile())!!
+    }
+
+    companion object {
+        val instance: MacroExpansionPsiManager
+            get() = ServiceManager.getService(MacroExpansionPsiManager::class.java)
+    }
+}

--- a/src/main/kotlin/org/rust/openapiext/ObjectGcTracker.kt
+++ b/src/main/kotlin/org/rust/openapiext/ObjectGcTracker.kt
@@ -1,0 +1,98 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.openapiext
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.util.containers.ContainerUtil
+import java.lang.ref.ReferenceQueue
+import java.lang.ref.WeakReference
+
+/** Allows to track garbage collection of java objects */
+interface ObjectGcTracker {
+    /**
+     * Allows to track garbage collection of [obj] object. [hook] will be called
+     * not earlier than [obj] is garbage collected. [hook] will be called using
+     * [com.intellij.openapi.application.Application.executeOnPooledThread].
+     *
+     * Note: [hook] must NOT refer to [obj]. If you do so, [obj] will never be GCed.
+     *
+     * Note: It is not guaranteed that [hook] will be called.
+     */
+    fun registerObjectGcHook(obj: Any, hook: Runnable)
+
+    fun registerObjectGcHook(obj: Any, hook: () -> Unit) =
+        registerObjectGcHook(obj, Runnable { hook() })
+
+    companion object {
+        val instance: ObjectGcTracker
+            get() = ServiceManager.getService(ObjectGcTracker::class.java)
+    }
+}
+
+/**
+ * Implementation details:
+ *
+ * We use JVM magic from [java.lang.ref] package. See
+ * [documentation](https://docs.oracle.com/javase/8/docs/api/java/lang/ref/package-summary.html)
+ *
+ * The main part is [ReferenceWithCallback]. It extends JVMs [WeakReference], which
+ * has one useful feature: when referenced object is GCed, the [WeakReference] will
+ * be enqueued to [ReferenceQueue]. In our case, [ReferenceWithCallback] will be
+ * enqueued to [clearedReferencesQueue]. Then we can poll [ReferenceWithCallback]
+ * from the queue and do anything with a data attached to it. The interesting
+ * thing is that [ReferenceWithCallback] can be GCed itself, so we must provide
+ * a strong reference to it until it is placed to queue. We use
+ * [anchoredReferences] to provide such strong references.
+ */
+class ObjectGcTrackerImpl : ObjectGcTracker, Disposable {
+    private val clearedReferencesQueue = ReferenceQueue<Any>()
+    private val anchoredReferences = ContainerUtil.newConcurrentSet<ReferenceWithCallback>()
+    private val thread = Thread(::processQueue, "ObjectGcTrackerImpl callback caller")
+
+    init {
+        thread.isDaemon = true
+        thread.start()
+    }
+
+    override fun registerObjectGcHook(obj: Any, hook: Runnable) {
+        anchoredReferences.add(ReferenceWithCallback(obj, clearedReferencesQueue, hook))
+    }
+
+    private fun processQueue() {
+        while (!Thread.interrupted()) {
+            val ref = try {
+                // `remove()` method is like `.poll()`, but instead of returning null
+                // it awaits new entry if queue is empty
+                clearedReferencesQueue.remove() as ReferenceWithCallback
+            } catch (e: InterruptedException) {
+                break
+            }
+
+            anchoredReferences.remove(ref)
+
+            try {
+                ApplicationManager.getApplication().executeOnPooledThread(ref.callback)
+            } catch (t: Throwable) {
+                LOG.error(t)
+            }
+        }
+    }
+
+    override fun dispose() {
+        thread.interrupt()
+    }
+
+    private class ReferenceWithCallback(
+        referent: Any,
+        q: ReferenceQueue<Any>,
+        val callback: Runnable
+    ) : WeakReference<Any>(referent, q)
+}
+
+private val LOG = Logger.getInstance("org.rust.openapiext.ObjectGcTrackerImpl")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -631,6 +631,14 @@
         <statementUpDownMover implementation="org.rust.ide.actions.mover.RsMatchArmUpDownMover"/>
         <statementUpDownMover implementation="org.rust.ide.actions.mover.RsItemUpDownMover"/>
 
+        <!-- Macro Expansion -->
+
+        <applicationService serviceImplementation="org.rust.lang.core.macros.MacroExpansionPsiManager"/>
+
+        <applicationService serviceInterface="org.rust.openapiext.ObjectGcTracker"
+                            serviceImplementation="org.rust.openapiext.ObjectGcTrackerImpl"/>
+
+        <!-- Language Injections -->
 
         <multiHostInjector implementation="org.rust.ide.injected.RsRegExpInjector"/>
 


### PR DESCRIPTION
I want to store results of macro expansion in memory as stubs instead of AST. This will **significantly** reduce memory consumption.