### PR TITLE
TY: fixed typecheck false-positive when matching with string literal

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
@@ -15,8 +15,12 @@ fun RsPat.extractBindings(fcx: RsFnInferenceContext, type: Ty, ignoreRef: Boolea
     when (this) {
         is RsPatWild -> {}
         is RsPatConst -> {
-            val (derefTy, _) = type.stripReferences()
-            fcx.inferTypeCoercableTo(expr, derefTy)
+            val expr = expr
+            val expectedTy = when {
+                expr is RsLitExpr && expr.kind is RsLiteralKind.String -> type
+                else -> type.stripReferences().first
+            }
+            fcx.inferTypeCoercableTo(expr, expectedTy)
         }
         is RsPatRef -> {
             pat.extractBindings(fcx, (type as? TyReference)?.referenced ?: TyUnknown)

--- a/src/test/kotlin/org/rust/ide/inspections/RsTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsTypeCheckInspectionTest.kt
@@ -140,4 +140,14 @@ class RsTypeCheckInspectionTest : RsInspectionsTestBase(RsTypeCheckInspection())
             let _: RefWrapper<u32> = RefWrapper(w);
         }
     """)
+
+    // issue 2670
+    fun `test no type mismatch E0308 when matching with string literal`() = checkByText("""
+        fn main() {
+            match "" {
+                "" => {}
+                _ => {}
+            }
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #2670