### PR TITLE
Fixed crash on typecheck error from expanded macro (like `write!()`)

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -228,7 +228,9 @@ class RsInferenceContext(
     }
 
     fun addDiagnostic(diagnostic: RsDiagnostic) {
-        diagnostics.add(diagnostic)
+        if (diagnostic.element.containingFile.isPhysical) {
+            diagnostics.add(diagnostic)
+        }
     }
 
     fun addAdjustment(expression: RsExpr, adjustment: Adjustment) {


### PR DESCRIPTION
bors r+