### PR TITLE
PRJ: make stdlib selection button inactive when if rustup available

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
@@ -105,6 +105,7 @@ class RustProjectSettingsPanel(
                 downloadStdlibLink.isVisible = hasRustup && stdlibLocation == null
 
                 pathToStdlibField.isEditable = !hasRustup
+                pathToStdlibField.button.isEnabled = !hasRustup
                 if (hasRustup) {
                     pathToStdlibField.text = stdlibLocation ?: ""
                 }


### PR DESCRIPTION
bors r+