### PR TITLE
Implement categorization of expressions

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -41,7 +41,7 @@ class RsPathReferenceImpl(
         advancedMultiResolve().singleOrNull()
 
     override fun advancedMultiResolve(): List<BoundElement<RsElement>> =
-        (element.parent as? RsPathExpr)?.let { it.inference?.getResolvedPath(it)?.map { BoundElement(it) } }
+        (element.parent as? RsPathExpr)?.let { it.inference?.getResolvedPaths(it)?.map { BoundElement(it) } }
             ?: advancedCachedMultiResolve()
 
     override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/MemoryCategorization.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/MemoryCategorization.kt
@@ -6,18 +6,117 @@
 package org.rust.lang.core.types.infer
 
 import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.containerExpr
+import org.rust.lang.core.psi.ext.descendantsOfType
 import org.rust.lang.core.psi.ext.mutability
+import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.types.builtinDeref
-import org.rust.lang.core.types.infer.Adjustment.Deref
-import org.rust.lang.core.types.inference
+import org.rust.lang.core.types.infer.Aliasability.FreelyAliasable
+import org.rust.lang.core.types.infer.Aliasability.NonAliasable
+import org.rust.lang.core.types.infer.AliasableReason.*
+import org.rust.lang.core.types.infer.BorrowKind.ImmutableBorrow
+import org.rust.lang.core.types.infer.BorrowKind.MutableBorrow
+import org.rust.lang.core.types.infer.Categorization.*
+import org.rust.lang.core.types.infer.ImmutabilityBlame.*
+import org.rust.lang.core.types.infer.InteriorKind.*
+import org.rust.lang.core.types.infer.MutabilityCategory.Declared
+import org.rust.lang.core.types.infer.PointerKind.BorrowedPointer
+import org.rust.lang.core.types.infer.PointerKind.UnsafePointer
 import org.rust.lang.core.types.isDereference
+import org.rust.lang.core.types.regions.ReStatic
+import org.rust.lang.core.types.regions.Region
 import org.rust.lang.core.types.ty.*
-import org.rust.lang.core.types.type
 import org.rust.stdext.nextOrNull
 
+/** [Categorization] is a subset of the full expression forms */
+sealed class Categorization {
+    /** Temporary value */
+    data class Rvalue(val region: Region) : Categorization()
 
+    /** Static value */
+    object StaticItem : Categorization()
+
+    /** Local variable */
+    data class Local(val element: RsElement) : Categorization()
+
+    /** Dereference of a pointer */
+    data class Deref(val cmt: Cmt, val pointerKind: PointerKind) : Categorization()
+
+    /** Something reachable from the base without a pointer dereference (e.g. field) */
+    data class Interior(val cmt: Cmt, val interiorKind: InteriorKind) : Categorization()
+
+    /** Selects a particular enum variant (if enum has more than one variant */
+    data class Downcast(val cmt: Cmt, val element: RsElement) : Categorization()
+}
+
+sealed class BorrowKind {
+    object ImmutableBorrow : BorrowKind()
+    object MutableBorrow : BorrowKind()
+
+    companion object {
+        fun from(mutability: Mutability): BorrowKind =
+            when (mutability) {
+                Mutability.IMMUTABLE -> ImmutableBorrow
+                Mutability.MUTABLE -> MutableBorrow
+            }
+
+        fun isCompatible(firstKind: BorrowKind, secondKind: BorrowKind): Boolean =
+            firstKind == ImmutableBorrow && secondKind == ImmutableBorrow
+    }
+}
+
+sealed class PointerKind {
+    data class BorrowedPointer(val borrowKind: BorrowKind, val region: Region) : PointerKind()
+    data class UnsafePointer(val mutability: Mutability) : PointerKind()
+}
+
+/** "interior" means "something reachable from the base without a pointer dereference" */
+sealed class InteriorKind {
+    /** e.g. `s.field` */
+    class InteriorField(val fieldName: String?) : InteriorKind()
+
+    /** e.g. `arr[0]` */
+    object InteriorIndex : InteriorKind()
+
+    /** e.g. `fn foo([_, a, _, _]: [A; 4]) { ... }` */
+    object InteriorPattern : InteriorKind()
+}
+
+/** Reason why something is immutable */
+sealed class ImmutabilityBlame {
+    /** Immutable as immutable variable */
+    class LocalDeref(val element: RsElement) : ImmutabilityBlame()
+
+    /** Immutable as dereference of immutable variable */
+    object AdtFieldDeref : ImmutabilityBlame()
+
+    /** Immutable as interior of immutable */
+    class ImmutableLocal(val element: RsElement) : ImmutabilityBlame()
+}
+
+/**
+ * Borrow checker have to never permit &mut-borrows of aliasable data.
+ * "Rules" of aliasability:
+ * - Local variables are never aliasable as they are accessible only within the stack frame;
+ * - Owned content is aliasable if it is found in an aliasable location;
+ * - `&T` is aliasable, and hence can only be borrowed immutably;
+ * - `&mut T` is aliasable if `T` is aliasable
+ */
+sealed class Aliasability {
+    class FreelyAliasable(val reason: AliasableReason) : Aliasability()
+    object NonAliasable : Aliasability()
+}
+
+enum class AliasableReason {
+    Borrowed,
+    Static,
+    StaticMut
+}
+
+/** Mutability of the expression address */
 enum class MutabilityCategory {
+    /** Any immutable */
     Immutable,
     /** Directly declared as mutable */
     Declared,
@@ -25,120 +124,249 @@ enum class MutabilityCategory {
     Inherited;
 
     companion object {
-        fun valueOf(mutability: Mutability): MutabilityCategory =
+        fun from(mutability: Mutability): MutabilityCategory =
             when (mutability) {
-                Mutability.IMMUTABLE -> MutabilityCategory.Immutable
-                Mutability.MUTABLE -> MutabilityCategory.Declared
+                Mutability.IMMUTABLE -> Immutable
+                Mutability.MUTABLE -> Declared
+            }
+
+        fun from(borrowKind: BorrowKind): MutabilityCategory =
+            when (borrowKind) {
+                is ImmutableBorrow -> Immutable
+                is MutableBorrow -> Declared
+            }
+
+        fun from(pointerKind: PointerKind): MutabilityCategory =
+            when (pointerKind) {
+                is BorrowedPointer -> from(pointerKind.borrowKind)
+                is UnsafePointer -> from(pointerKind.mutability)
             }
     }
 
     fun inherit(): MutabilityCategory =
         when (this) {
-            MutabilityCategory.Immutable -> MutabilityCategory.Immutable
-            MutabilityCategory.Declared, MutabilityCategory.Inherited -> MutabilityCategory.Inherited
+            Immutable -> Immutable
+            Declared, Inherited -> Inherited
         }
 
-    val isMutable: Boolean
-        get() = when (this) {
-            MutabilityCategory.Immutable -> false
-            MutabilityCategory.Declared, MutabilityCategory.Inherited -> true
-        }
+    val isMutable: Boolean get() = this != Immutable
 }
 
 /**
- * Category, MutabilityCategory, and Type
- * Currently supports only MutabilityCategory and Type
+ * [Cmt]: Category, MutabilityCategory, and Type
+ *
+ * Imagine a routine Address(Expr) that evaluates an expression and returns an
+ * address where the result is to be found.  If Expr is a place, then this
+ * is the address of the place.  If Expr is an rvalue, this is the address of
+ * some temporary spot in memory where the result is stored.
+ *
+ * [element]: Expr
+ * [category]: kind of Expr
+ * [mutabilityCategory]: mutability of Address(Expr)
+ * [ty]: the type of data found at Address(Expr)
  */
-class Cmt(val ty: Ty, val mutabilityCategory: MutabilityCategory? = null)
+class Cmt(
+    val element: RsElement,
+    val category: Categorization? = null,
+    val mutabilityCategory: MutabilityCategory = MutabilityCategory.from(Mutability.DEFAULT_MUTABILITY),
+    val ty: Ty
+) {
+    val immutabilityBlame: ImmutabilityBlame?
+        get() = when (category) {
+            is Deref -> {
+                // try to figure out where the immutable reference came from
+                val pointerKind = category.pointerKind
+                val baseCmt = category.cmt
+                if (pointerKind is BorrowedPointer && pointerKind.borrowKind is ImmutableBorrow) {
+                    when (baseCmt.category) {
+                        is Local -> LocalDeref(baseCmt.category.element)
+                        is Interior -> AdtFieldDeref
+                        else -> null
+                    }
+                } else if (pointerKind is UnsafePointer) {
+                    null
+                } else {
+                    baseCmt.immutabilityBlame
+                }
+            }
+            is Local -> ImmutableLocal(category.element)
+            is Interior -> category.cmt.immutabilityBlame
+            is Downcast -> category.cmt.immutabilityBlame
+            else -> null
+        }
 
-private fun processUnaryExpr(unaryExpr: RsUnaryExpr): Cmt {
-    val type = unaryExpr.type
-    if (!unaryExpr.isDereference) return Cmt(type)
-    val base = unaryExpr.expr ?: return Cmt(type)
+    val isMutable: Boolean get() = mutabilityCategory.isMutable
 
-    val baseCmt = processExpr(base)
-    return processDeref(baseCmt)
+    val aliasability: Aliasability
+        get() = when {
+            category is Deref && category.pointerKind is BorrowedPointer ->
+                when (category.pointerKind.borrowKind) {
+                    is MutableBorrow -> category.cmt.aliasability
+                    is ImmutableBorrow -> FreelyAliasable(Borrowed)
+                }
+            category is StaticItem -> FreelyAliasable(if (isMutable) StaticMut else Static)
+            category is Interior -> category.cmt.aliasability
+            category is Downcast -> category.cmt.aliasability
+            else -> NonAliasable
+        }
 }
 
-private fun processDotExpr(dotExpr: RsDotExpr): Cmt {
-    if (dotExpr.methodCall != null) {
-        return processRvalue(dotExpr)
+class MemoryCategorizationContext(val lookup: ImplLookup, val inference: RsInferenceData) {
+    fun processExpr(expr: RsExpr): Cmt {
+        val adjustments = inference.getExprAdjustments(expr)
+        return processExprAdjustedWith(expr, adjustments.asReversed().iterator())
     }
-    val type = dotExpr.type
-    val base = dotExpr.expr
-    val baseCmt = processExpr(base)
-    return Cmt(type, baseCmt.mutabilityCategory?.inherit())
-}
 
-private fun processIndexExpr(indexExpr: RsIndexExpr): Cmt {
-    val type = indexExpr.type
-    val base = indexExpr.containerExpr ?: return Cmt(type)
-    val baseCmt = processExpr(base)
-    return Cmt(type, baseCmt.mutabilityCategory?.inherit())
-}
+    private fun processExprAdjustedWith(expr: RsExpr, adjustments: Iterator<Adjustment>): Cmt =
+        when (adjustments.nextOrNull()) {
+            is Adjustment.Deref -> {
+                // TODO: overloaded deref
+                processDeref(expr, processExprAdjustedWith(expr, adjustments))
+            }
+            else -> processExprUnadjusted(expr)
+        }
 
-private fun processPathExpr(pathExpr: RsPathExpr): Cmt {
-    val type = pathExpr.type
-    val declaration = pathExpr.path.reference.resolve() ?: return Cmt(type)
+    private fun processExprUnadjusted(expr: RsExpr): Cmt =
+        when (expr) {
+            is RsUnaryExpr -> processUnaryExpr(expr)
+            is RsDotExpr -> processDotExpr(expr)
+            is RsIndexExpr -> processIndexExpr(expr)
+            is RsPathExpr -> processPathExpr(expr)
+            is RsParenExpr -> processParenExpr(expr)
+            else -> processRvalue(expr)
+        }
 
-    return when (declaration) {
-        is RsConstant, is RsEnumVariant, is RsStructItem, is RsFunction -> Cmt(type, MutabilityCategory.Declared)
+    private fun processUnaryExpr(unaryExpr: RsUnaryExpr): Cmt {
+        if (!unaryExpr.isDereference) return processRvalue(unaryExpr)
+        val base = unaryExpr.expr ?: return Cmt(unaryExpr, ty = inference.getExprType(unaryExpr))
+        val baseCmt = processExpr(base)
+        return processDeref(unaryExpr, baseCmt)
+    }
 
-        is RsPatBinding -> {
-            if (declaration.mutability.isMut) {
-                Cmt(type, MutabilityCategory.Declared)
-            } else {
-                Cmt(type, MutabilityCategory.Immutable)
+    private fun processDotExpr(dotExpr: RsDotExpr): Cmt {
+        if (dotExpr.methodCall != null) return processRvalue(dotExpr)
+        val type = inference.getExprType(dotExpr)
+        val base = dotExpr.expr
+        val baseCmt = processExpr(base)
+        val fieldName = dotExpr.fieldLookup?.identifier?.text
+        return cmtOfField(dotExpr, baseCmt, fieldName, type)
+    }
+
+    private fun processIndexExpr(indexExpr: RsIndexExpr): Cmt {
+        val type = inference.getExprType(indexExpr)
+        val base = indexExpr.containerExpr ?: return Cmt(indexExpr, ty = type)
+        val baseCmt = processExpr(base)
+        return Cmt(indexExpr, Interior(baseCmt, InteriorIndex), baseCmt.mutabilityCategory.inherit(), type)
+    }
+
+    private fun processPathExpr(pathExpr: RsPathExpr): Cmt {
+        val type = inference.getExprType(pathExpr)
+        // TODO: infcx.getResolvedPaths
+        val declaration = inference.getResolvedPaths(pathExpr).singleOrNull() ?: return Cmt(pathExpr, ty = type)
+        return when (declaration) {
+            is RsConstant -> {
+                if (declaration.static != null) {
+                    Cmt(pathExpr, StaticItem, MutabilityCategory.from(declaration.mutability), type)
+                } else {
+                    processRvalue(pathExpr)
+                }
+            }
+
+            is RsEnumVariant, is RsStructItem, is RsFunction -> processRvalue(pathExpr)
+
+            is RsPatBinding -> Cmt(pathExpr, Local(declaration), MutabilityCategory.from(declaration.mutability), type)
+
+            is RsSelfParameter -> Cmt(pathExpr, Local(declaration), MutabilityCategory.from(declaration.mutability), type)
+
+            else -> Cmt(pathExpr, ty = type)
+        }
+    }
+
+    private fun processParenExpr(parenExpr: RsParenExpr): Cmt =
+        processExpr(parenExpr.expr)
+
+    private fun processDeref(expr: RsExpr, baseCmt: Cmt): Cmt {
+        val baseType = baseCmt.ty
+        val (derefType, derefMut) = baseType.builtinDeref() ?: Pair(TyUnknown, Mutability.DEFAULT_MUTABILITY)
+
+        val pointerKind = when (baseType) {
+            is TyReference -> BorrowedPointer(BorrowKind.from(baseType.mutability), baseType.region)
+            is TyPointer -> UnsafePointer(baseType.mutability)
+            else -> UnsafePointer(derefMut)
+        }
+
+        return Cmt(expr, Deref(baseCmt, pointerKind), MutabilityCategory.from(pointerKind), derefType)
+    }
+
+    // `rvalue_promotable_map` is needed to distinguish rvalues with static region and rvalue with temporary region,
+    // so now all rvalues have static region
+    fun processRvalue(expr: RsExpr, ty: Ty = inference.getExprType(expr)): Cmt =
+        Cmt(expr, Rvalue(ReStatic), Declared, ty)
+
+    fun processRvalue(element: RsElement, tempScope: Region, ty: Ty): Cmt =
+        Cmt(element, Rvalue(tempScope), Declared, ty)
+
+    fun walkPat(cmt: Cmt, pat: RsPat, callback: (Cmt, RsPat) -> Unit) {
+        fun processTuplePats(pats: List<RsPat>) {
+            for ((index, subPat) in pats.withIndex()) {
+                val subBinding = subPat.descendantsOfType<RsPatBinding>().firstOrNull() ?: continue
+                val subType = inference.getBindingType(subBinding)
+                val interior = InteriorField(index.toString())
+                val subCmt = Cmt(pat, Interior(cmt, interior), cmt.mutabilityCategory.inherit(), subType)
+                walkPat(subCmt, subPat, callback)
             }
         }
 
-        is RsSelfParameter -> Cmt(type, MutabilityCategory.valueOf(declaration.mutability))
+        callback(cmt, pat)
 
-        else -> Cmt(type)
-    }
-}
+        when (pat) {
+            is RsPatIdent -> {
+                if (pat.patBinding.reference.resolve() !is RsEnumVariant) {
+                    pat.pat?.let { walkPat(cmt, it, callback) }
+                }
+            }
 
-private fun processParenExpr(parenExpr: RsParenExpr): Cmt =
-    Cmt(parenExpr.type, parenExpr.expr.mutabilityCategory)
+            is RsPatTupleStruct -> processTuplePats(pat.patList)
 
-private fun processExpr(expr: RsExpr): Cmt {
-    val adjustments = expr.inference?.adjustments?.get(expr) ?: emptyList()
-    return processExprAdjustedWith(expr, adjustments.asReversed().iterator())
-}
+            is RsPatTup -> processTuplePats(pat.patList)
 
-private fun processExprAdjustedWith(expr: RsExpr, adjustments: Iterator<Adjustment>): Cmt =
-    when (adjustments.nextOrNull()) {
-        is Deref -> {
-            // TODO: overloaded deref
-            processDeref(processExprAdjustedWith(expr, adjustments))
+            is RsPatStruct -> {
+                for (patField in pat.patFieldList) {
+                    val binding = patField.patBinding ?: continue
+                    val fieldType = inference.getBindingType(binding)
+                    val fieldName = patField.identifier?.text ?: continue
+                    val fieldPat = patField.pat ?: continue
+                    val fieldCmt = cmtOfField(pat, cmt, fieldName, fieldType)
+                    walkPat(fieldCmt, fieldPat, callback)
+                }
+            }
+
+            is RsPatSlice -> {
+                val elementCmt = cmtOfSliceElement(pat, cmt)
+                pat.patList.forEach { walkPat(elementCmt, it, callback) }
+            }
         }
-        else -> processExprUnadjusted(expr)
     }
 
-private fun processDeref(baseCmt: Cmt): Cmt {
-    val baseType = baseCmt.ty
-    val (derefType, derefMut) = baseType.builtinDeref() ?: Pair(TyUnknown, Mutability.DEFAULT_MUTABILITY)
+    private fun cmtOfField(element: RsElement, baseCmt: Cmt, fieldName: String?, fieldType: Ty): Cmt =
+        Cmt(
+            element,
+            Interior(baseCmt, InteriorField(fieldName)),
+            baseCmt.mutabilityCategory.inherit(),
+            fieldType
+        )
 
-    return when (baseType) {
-        is TyReference -> Cmt(derefType, MutabilityCategory.valueOf(derefMut))
-        is TyPointer -> Cmt(derefType, MutabilityCategory.valueOf(derefMut))
-        else -> Cmt(derefType)
-    }
+    private fun cmtOfSliceElement(element: RsElement, baseCmt: Cmt): Cmt =
+        Cmt(
+            element,
+            Interior(baseCmt, InteriorPattern),
+            baseCmt.mutabilityCategory.inherit(),
+            baseCmt.ty
+        )
+
+    fun isTypeMovesByDefault(ty: Ty): Boolean =
+        when (ty) {
+            is TyUnknown, is TyPrimitive, is TyTuple, is TyReference, is TyPointer, is TyFunction -> false
+            else -> lookup.isCopy(ty).not()
+        }
 }
-
-private fun processRvalue(expr: RsExpr): Cmt =
-    Cmt(expr.type, MutabilityCategory.Declared)
-
-private fun processExprUnadjusted(expr: RsExpr): Cmt =
-    when (expr) {
-        is RsUnaryExpr -> processUnaryExpr(expr)
-        is RsDotExpr -> processDotExpr(expr)
-        is RsIndexExpr -> processIndexExpr(expr)
-        is RsPathExpr -> processPathExpr(expr)
-        is RsParenExpr -> processParenExpr(expr)
-        else -> processRvalue(expr)
-    }
-
-
-val RsExpr.mutabilityCategory: MutabilityCategory?
-    get() = processExpr(this).mutabilityCategory

--- a/src/test/kotlin/org/rust/lang/core/type/RsMemoryCategorizationTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsMemoryCategorizationTest.kt
@@ -10,7 +10,7 @@ import org.rust.lang.ProjectDescriptor
 import org.rust.lang.RsTestBase
 import org.rust.lang.WithStdlibRustProjectDescriptor
 import org.rust.lang.core.psi.RsExpr
-import org.rust.lang.core.types.infer.mutabilityCategory
+import org.rust.lang.core.types.cmt
 
 class RsMemoryCategorizationTest : RsTestBase() {
     private fun testExpr(@Language("Rust") code: String, description: String = "") {
@@ -21,9 +21,10 @@ class RsMemoryCategorizationTest : RsTestBase() {
     private fun check(description: String) {
         val (expr, expectedCategory) = findElementAndDataInEditor<RsExpr>()
 
-        val category = expr.mutabilityCategory
-        check(category.toString() == expectedCategory) {
-            "Category mismatch. Expected: $expectedCategory, found: $category. $description"
+        val cmt = expr.cmt
+        val actual = "${cmt?.category?.javaClass?.simpleName}, ${cmt?.mutabilityCategory}"
+        check(actual == expectedCategory) {
+            "Category mismatch. Expected: $expectedCategory, found: $actual. $description"
         }
     }
 
@@ -31,7 +32,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
         fn main() {
             let x = 42;
             x;
-          //^ Immutable
+          //^ Local, Immutable
         }
     """)
 
@@ -39,7 +40,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
         fn main() {
             let mut x = 42;
             x;
-          //^ Declared
+          //^ Local, Declared
         }
     """)
 
@@ -48,7 +49,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
             let y = 42;
             let x = &y;
             (*x);
-             //^ Immutable
+             //^ Deref, Immutable
         }
     """)
 
@@ -57,7 +58,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
             let mut y = 42;
             let x = &y;
             (*x);
-             //^ Immutable
+             //^ Deref, Immutable
         }
     """)
 
@@ -66,7 +67,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
             let mut y = 42;
             let x = &mut y;
             (*x);
-             //^ Declared
+             //^ Deref, Declared
         }
     """)
 
@@ -74,7 +75,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
         fn main() {
             let a: [i32; 3] = [0; 3];
             a[1];
-             //^ Immutable
+             //^ Interior, Immutable
         }
     """)
 
@@ -82,7 +83,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
         fn main() {
             let mut a: [i32; 3] = [0; 3];
             a[1];
-             //^ Inherited
+             //^ Interior, Inherited
         }
     """)
 
@@ -91,7 +92,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
         fn main() {
             let x = Foo { a: 1 };
             (x.a);
-              //^ Immutable
+              //^ Interior, Immutable
         }
     """)
 
@@ -100,7 +101,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
         fn main() {
             let mut x = Foo { a: 1 };
             (x.a);
-              //^ Inherited
+              //^ Interior, Inherited
         }
     """)
 
@@ -110,7 +111,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
             let mut foo = Foo { a: 1 };
             let x = &foo;
             (x.a);
-              //^ Immutable
+              //^ Interior, Immutable
         }
     """)
 
@@ -120,7 +121,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
             let mut foo = Foo { a: 1 };
             let x = &mut foo;
             (x.a);
-              //^ Inherited
+              //^ Interior, Inherited
         }
     """)
 
@@ -130,7 +131,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
             let mut foo = Foo { a: 1 };
             let x = &mut &mut &foo;
             (x.a);
-              //^ Immutable
+              //^ Interior, Immutable
         }
     """)
 
@@ -140,7 +141,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
             let mut foo = Foo { a: 1 };
             let x = & & &mut foo;
             (x.a);
-              //^ Inherited
+              //^ Interior, Inherited
         }
     """)
 
@@ -150,7 +151,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
             let x = 5;
             let p = &x as *const i32;
             (*p);
-             //^ Immutable
+             //^ Deref, Immutable
         }
     """)
 
@@ -160,7 +161,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
             let mut x = 5;
             let p = &mut x as *mut i32;
             (*p);
-             //^ Declared
+             //^ Deref, Declared
         }
     """)
 
@@ -169,7 +170,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
         impl Foo {
             fn f(&self) {
                 self;
-                 //^ Immutable
+                 //^ Local, Immutable
             }
         }
     """)
@@ -179,17 +180,33 @@ class RsMemoryCategorizationTest : RsTestBase() {
         impl Foo {
             fn f(&mut self) {
                 self;
-                 //^ Declared
+                 //^ Local, Declared
             }
         }
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test static`() = testExpr("""
+        static N: i32 = 42;
+        fn main() {
+            N;
+          //^ StaticItem, Immutable
+        }
+    """)
+
+    fun `test const`() = testExpr("""
+        const N: i32 = 42;
+        fn main() {
+            N;
+          //^ Rvalue, Declared
+        }
+    """)
+
     fun `test rvalue method call`() = testExpr("""
         fn main() {
           let v = vec![1];
           v.iter();
-               //^ Declared
+               //^ Rvalue, Declared
         }
     """)
 
@@ -197,7 +214,28 @@ class RsMemoryCategorizationTest : RsTestBase() {
         struct S {}
         fn main() {
           (if true { S } else { S });
-                                 //^ Declared
+                                 //^ Rvalue, Declared
+        }
+    """)
+
+    fun `test rvalue closure`() = testExpr("""
+        fn main() {
+          (|x: i32| x + 1);
+                       //^ Rvalue, Declared
+        }
+    """)
+
+    fun `test immutable closure parameter`() = testExpr("""
+        fn main() {
+          (|x: i32| x + 1);
+                  //^ Local, Immutable
+        }
+    """)
+
+    fun `test mutable closure parameter`() = testExpr("""
+        fn main() {
+          (|mut x: i32| x + 1);
+                      //^ Local, Declared
         }
     """)
 
@@ -205,7 +243,7 @@ class RsMemoryCategorizationTest : RsTestBase() {
     fun `test array`() = testExpr("""
         fn f(buf: &mut [u8]) {
             (buf[0]);
-                 //^ Inherited
+                 //^ Interior, Inherited
         }
     """)
 }


### PR DESCRIPTION
Add `category` to `Cmt` (category, mutability, and type); implement memory categorization cache.
Some parts of memory categorization are unused now, but they will be necessary for borrow checking.