### PR TITLE
COMP: Don't filter completion for partially unknown type

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
@@ -15,8 +15,10 @@ import org.rust.lang.core.psi.ext.receiver
 import org.rust.lang.core.resolve.*
 import org.rust.lang.core.types.Substitution
 import org.rust.lang.core.types.emptySubstitution
+import org.rust.lang.core.types.infer.containsTyOfClass
 import org.rust.lang.core.types.inference
 import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.type
 
 
@@ -129,6 +131,9 @@ private fun filterMethodCompletionVariants(
     lookup: ImplLookup,
     receiver: Ty
 ): RsResolveProcessor {
+    // Don't filter partially unknown types
+    if (receiver.containsTyOfClass(TyUnknown::class.java)) return processor
+
     val cache = mutableMapOf<RsImplItem, Boolean>()
     return fun(it: ScopeEntry): Boolean {
         // 1. If not a method (actually a field) or a trait method - just process it

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -380,7 +380,7 @@ class RsInferenceContext(
             return when (ty) {
                 is TyInfer.IntVar -> intUnificationTable.findValue(ty) ?: TyInteger.DEFAULT
                 is TyInfer.FloatVar -> floatUnificationTable.findValue(ty) ?: TyFloat.DEFAULT
-                is TyInfer.TyVar -> varUnificationTable.findValue(ty)?.let(::go) ?: ty.origin ?: TyUnknown
+                is TyInfer.TyVar -> varUnificationTable.findValue(ty)?.let(::go) ?: TyUnknown
             }
         }
 

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
@@ -665,13 +665,13 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
 
     fun `test match if let`() = doTest("""
         fn foo() {
-            if let Some(ref foo) = None {
-                *foo
+            if let Some(ref foo) = Some(0) {
+                *foo;
                  //^
             }
         }
     """, """
-        condition binding <b>foo</b>: &amp;T
+        condition binding <b>foo</b>: &amp;i32
     """)
 
     fun `test file 1`() = doTest("""

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
@@ -45,4 +45,34 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
         impl Bound1 for S {}
         fn main() { S.foo()/*caret*/ }
     """)
+
+    fun `test unsatisfied bound not filtered for unknown type`() = doSingleCompletion("""
+        trait Bound {}
+        trait Trait { fn foo(&self) {} }
+        impl<T: Bound> Trait for S1<T> {}
+        struct S1<T>(T);
+        fn main() { S1(SomeUnknownType).f/*caret*/ }
+    """, """
+        trait Bound {}
+        trait Trait { fn foo(&self) {} }
+        impl<T: Bound> Trait for S1<T> {}
+        struct S1<T>(T);
+        fn main() { S1(SomeUnknownType).foo()/*caret*/ }
+    """)
+
+    fun `test unsatisfied bound not filtered for unconstrained type var`() = doSingleCompletion("""
+        trait Bound {}
+        trait Trait { fn foo(&self) {} }
+        impl<T: Bound> Trait for S1<T> {}
+        struct S1<T>(T);
+        fn ty_var<T>() -> T { unimplemented!() }
+        fn main() { S1(ty_var()).f/*caret*/ }
+    """, """
+        trait Bound {}
+        trait Trait { fn foo(&self) {} }
+        impl<T: Bound> Trait for S1<T> {}
+        struct S1<T>(T);
+        fn ty_var<T>() -> T { unimplemented!() }
+        fn main() { S1(ty_var()).foo()/*caret*/ }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -863,7 +863,7 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
         fn main() {
             let a = UnknownStruct { f1: 1, ..Default::default() };
-        }                                                  //^ Self
+        }                                                  //^ <unknown>
     """)
 
     fun `test index expr of unresolved path`() = testExpr("""


### PR DESCRIPTION
This works for `"33".to_owned().parse().un<caret>`

This change may also affect the current results of type inference failures. Previously we can often see something like `<T as Iterator>::Item` in types and it mostly meant that type is inferred incorrectly. Now we will show only `<unknown>`

Fixes #2425
