### PR TITLE
MACRO: Macro expansion actions and intentions

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/macroExpansion/MacroExpansionViewUtils.kt
+++ b/src/main/kotlin/org/rust/ide/actions/macroExpansion/MacroExpansionViewUtils.kt
@@ -1,0 +1,158 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.actions.macroExpansion
+
+import com.intellij.ide.highlighter.HighlighterFactory
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.editor.highlighter.EditorHighlighter
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.psi.PsiElement
+import com.intellij.psi.codeStyle.CodeStyleManager
+import com.intellij.ui.popup.PopupPositionManager
+import org.rust.lang.RsFileType
+import org.rust.lang.core.macros.RsExpandedElement
+import org.rust.lang.core.macros.parseExpandedTextWithContext
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.ext.expandAllMacrosRecursively
+import org.rust.lang.core.psi.ext.expansion
+import java.awt.BorderLayout
+import javax.swing.JPanel
+
+/** Data class to group title and expansions of macro to show them in the view. */
+data class MacroExpansionViewDetails(val title: String, val expansions: List<RsExpandedElement>)
+
+/**
+ * This method expands macro in background thread with progress bar showing on, allowing user to close it if expansion
+ * takes too long.
+ */
+fun expandMacroForViewWithProgress(
+    project: Project,
+    ctx: RsMacroCall,
+    expandRecursively: Boolean
+): MacroExpansionViewDetails {
+    val progressTitle = "${if (expandRecursively) "Recursive" else "Single step"} expansion progress..."
+
+    return project.computeWithCancelableProgress(progressTitle) {
+        runReadAction { expandMacroForView(ctx, expandRecursively) }
+    }
+}
+
+
+/** This function shows macro expansion in floating popup. */
+fun showMacroExpansionPopup(project: Project, editor: Editor, expansionDetails: MacroExpansionViewDetails) {
+    if (expansionDetails.expansions.isEmpty()) return
+
+    val component = MacroExpansionViewComponent(expansionDetails.expansions)
+
+    val popup = JBPopupFactory.getInstance().createComponentPopupBuilder(component, component)
+        .setProject(project)
+        .setResizable(true)
+        .setMovable(true)
+        .setRequestFocus(true)
+        .setTitle(expansionDetails.title)
+        .createPopup()
+
+    PopupPositionManager.positionPopupInBestPosition(popup, editor, null)
+}
+
+private fun expandMacroForView(macroToExpand: RsMacroCall, expandRecursively: Boolean): MacroExpansionViewDetails =
+    MacroExpansionViewDetails(
+        getMacroExpansionViewTitle(macroToExpand, expandRecursively),
+        getMacroExpansions(macroToExpand, expandRecursively)
+    )
+
+private fun<T> Project.computeWithCancelableProgress(title: String, supplier: () -> T): T {
+    val manager = ProgressManager.getInstance()
+
+    return manager.runProcessWithProgressSynchronously<T, Exception>(supplier, title, true, this)
+}
+
+private fun getMacroExpansionViewTitle(macroToExpand: RsMacroCall, expandRecursively: Boolean): String =
+    if (expandRecursively) {
+        "Recursive expansion of ${macroToExpand.referenceName}! macro"
+    } else {
+        "First level expansion of ${macroToExpand.referenceName}! macro"
+    }
+
+private fun getMacroExpansions(macroToExpand: RsMacroCall, expandRecursively: Boolean): List<RsExpandedElement> {
+    if (!expandRecursively) {
+        return macroToExpand.expansion ?: listOf(macroToExpand)
+    }
+
+    val expansionText = macroToExpand.expandAllMacrosRecursively()
+    val expansionElements = RsPsiFactory(macroToExpand.project)
+        .parseExpandedTextWithContext(macroToExpand, expansionText)
+
+    return expansionElements
+}
+
+/** Simple view to show some code. Inspired by [com.intellij.codeInsight.hint.ImplementationViewComponent] */
+private class MacroExpansionViewComponent(expansions: List<RsExpandedElement>) : JPanel(BorderLayout()) {
+
+    private val editor: EditorEx
+
+    init {
+        require(expansions.isNotEmpty()) { "Must be at least one expansion!" }
+
+        val firstExpansion = expansions.first()
+        val project = firstExpansion.project
+
+        val reformatted = expansions.map { project.formatPsiElement(it) }
+        editor = project.createReadOnlyEditorWithElements(reformatted)
+
+        setupSimpleEditorLook(editor)
+        editor.highlighter = project.createRustHighlighter()
+
+        add(editor.component)
+    }
+
+    private fun setupSimpleEditorLook(editor: EditorEx) {
+        with(editor.settings) {
+            additionalLinesCount = 1
+            additionalColumnsCount = 1
+            isLineMarkerAreaShown = false
+            isIndentGuidesShown = false
+            isLineNumbersShown = false
+            isFoldingOutlineShown = false
+        }
+    }
+
+    /**
+     * Every editor, created by [EditorFactory], should be released
+     * (see docs for [EditorFactory.createEditor] method).
+     */
+    override fun removeNotify() {
+        super.removeNotify()
+
+        EditorFactory.getInstance().releaseEditor(editor)
+    }
+}
+
+private fun Project.formatPsiElement(element: PsiElement): PsiElement =
+    CodeStyleManager.getInstance(this).reformatRange(
+        element,
+        element.textRange.startOffset,
+        element.textRange.endOffset
+    )
+
+private fun Project.createReadOnlyEditorWithElements(expansions: List<PsiElement>): EditorEx {
+    val factory = EditorFactory.getInstance()
+
+    val text = expansions.joinToString("\n") { it.text }
+    val doc = factory.createDocument(text)
+    doc.setReadOnly(true)
+
+    return factory.createEditor(doc, this) as EditorEx
+}
+
+fun Project.createRustHighlighter(): EditorHighlighter =
+    HighlighterFactory.createHighlighter(this, RsFileType)

--- a/src/main/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActions.kt
+++ b/src/main/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActions.kt
@@ -1,0 +1,80 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.actions.macroExpansion
+
+import com.google.common.annotations.VisibleForTesting
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.parentOfType
+import org.rust.lang.core.psi.RsMacroCall
+
+abstract class RsShowMacroExpansionActionBase(private val expandRecursively: Boolean) : AnAction() {
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = getMacroUnderCaret(e.dataContext) != null
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        performForContext(e.dataContext)
+    }
+
+    @VisibleForTesting
+    fun performForContext(e: DataContext) {
+        val project = e.project ?: return
+        val editor = e.editor ?: return
+        val macroToExpand = getMacroUnderCaret(e) ?: return
+
+        val expansionDetails = expandMacroForViewWithProgress(project, macroToExpand, expandRecursively)
+
+        showExpansion(project, editor, expansionDetails)
+    }
+
+    /**
+     * This method is required for testing to avoid actually creating popup and editor.
+     * Inspired by [com.intellij.codeInsight.hint.actions.ShowImplementationsAction].
+     */
+    @VisibleForTesting
+    protected open fun showExpansion(project: Project, editor: Editor, expansionDetails: MacroExpansionViewDetails) {
+        showMacroExpansionPopup(project, editor, expansionDetails)
+    }
+
+}
+
+/** Action for showing recursive expansion of ordinary macros (not procedural or custom derives). */
+class RsShowRecursiveMacroExpansionAction : RsShowMacroExpansionActionBase(expandRecursively = true)
+
+/** Action for showing first-level expansion of ordinary macros (not procedural or custom derives). */
+class RsShowSingleStepMacroExpansionAction : RsShowMacroExpansionActionBase(expandRecursively = false)
+
+/** Returns closest [RsMacroCall] under cursor in the [DataContext.editor] if it's present. */
+fun getMacroUnderCaret(event: DataContext): RsMacroCall? {
+    val elementUnderCaret = event.elementUnderCaretInEditor ?: return null
+
+    return elementUnderCaret.parentOfType<RsMacroCall>()
+}
+
+private val DataContext.psiFile: PsiFile?
+    get() = getData(CommonDataKeys.PSI_FILE)
+
+private val DataContext.editor: Editor?
+    get() = getData(CommonDataKeys.EDITOR)
+
+private val DataContext.project: Project?
+    get() = getData(CommonDataKeys.PROJECT)
+
+private val DataContext.elementUnderCaretInEditor: PsiElement?
+    get() {
+        val psiFile = psiFile ?: return null
+        val editor = editor ?: return null
+
+        return psiFile.findElementAt(editor.caretModel.offset)
+    }

--- a/src/main/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionGroup.kt
+++ b/src/main/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionGroup.kt
@@ -1,0 +1,21 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.actions.macroExpansion
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import org.rust.lang.core.psi.RsMacroCall
+
+/**
+ * Action group for showing macros expansion actions in context menu.
+ *
+ * It is required to show those actions only on certain elements (like [RsMacroCall]s).
+ */
+class RsShowMacroExpansionGroup : DefaultActionGroup() {
+    override fun update(event: AnActionEvent) {
+        event.presentation.isEnabledAndVisible = getMacroUnderCaret(event.dataContext) != null
+    }
+}

--- a/src/main/kotlin/org/rust/ide/intentions/RsElementBaseIntentionAction.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/RsElementBaseIntentionAction.kt
@@ -41,7 +41,11 @@ abstract class RsElementBaseIntentionAction<Ctx> : BaseElementAtCaretIntentionAc
 
     final override fun invoke(project: Project, editor: Editor, element: PsiElement) {
         val ctx = findApplicableContext(project, editor, element) ?: return
-        checkWriteAccessAllowed()
+
+        if (startInWriteAction()) {
+            checkWriteAccessAllowed()
+        }
+
         invoke(project, editor, ctx)
     }
 

--- a/src/main/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentions.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentions.kt
@@ -1,0 +1,49 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.google.common.annotations.VisibleForTesting
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import org.rust.ide.actions.macroExpansion.MacroExpansionViewDetails
+import org.rust.ide.actions.macroExpansion.expandMacroForViewWithProgress
+import org.rust.ide.actions.macroExpansion.showMacroExpansionPopup
+import org.rust.lang.core.psi.RsMacroCall
+
+abstract class RsShowMacroExpansionIntentionBase(private val expandRecursively: Boolean) :
+    RsElementBaseIntentionAction<RsMacroCall>() {
+
+    override fun getFamilyName() = text
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsMacroCall? =
+        element.parentOfType<RsMacroCall>()
+
+    override fun invoke(project: Project, editor: Editor, ctx: RsMacroCall) {
+        val expansionDetails = expandMacroForViewWithProgress(project, ctx, expandRecursively)
+
+        showExpansion(project, editor, expansionDetails)
+    }
+
+    /**
+     * This method is required for testing to avoid actually creating popup and editor.
+     * Inspired by [com.intellij.codeInsight.hint.actions.ShowImplementationsAction].
+     */
+    @VisibleForTesting
+    protected open fun showExpansion(project: Project, editor: Editor, expansionDetails: MacroExpansionViewDetails) {
+        showMacroExpansionPopup(project, editor, expansionDetails)
+    }
+
+}
+
+class RsShowRecursiveMacroExpansionIntention : RsShowMacroExpansionIntentionBase(expandRecursively = true) {
+    override fun getText() = "Show recursive macro expansion"
+}
+
+class RsShowSingleStepMacroExpansionIntention : RsShowMacroExpansionIntentionBase(expandRecursively = false) {
+    override fun getText() = "Show single step macro expansion"
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -64,7 +64,8 @@
         <postFormatProcessor implementation="org.rust.ide.formatter.processors.RsTrailingCommaFormatProcessor"/>
         <preFormatProcessor implementation="org.rust.ide.formatter.processors.RsMatchArmCommaFormatProcessor"/>
         <preFormatProcessor implementation="org.rust.ide.formatter.processors.RsStatementSemicolonFormatProcessor"/>
-        <preFormatProcessor implementation="org.rust.ide.formatter.processors.RsSingleImportRemoveBracesFormatProcessor"/>
+        <preFormatProcessor
+            implementation="org.rust.ide.formatter.processors.RsSingleImportRemoveBracesFormatProcessor"/>
 
         <!-- Refactoring support -->
 
@@ -569,6 +570,14 @@
             <className>org.rust.ide.intentions.FlipBinaryExpressionIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.RsShowRecursiveMacroExpansionIntention</className>
+            <category>Rust</category>
+        </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.RsShowSingleStepMacroExpansionIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 
@@ -733,6 +742,23 @@
                 text="Detach Cargo project"
                 icon="AllIcons.ToolbarDecorator.Remove"
                 use-shortcut-of="$Delete"/>
+
+        <action id="Rust.ShowSingleStepMacroExpansionAction"
+                class="org.rust.ide.actions.macroExpansion.RsShowSingleStepMacroExpansionAction"
+                text="Show expanded macro">
+        </action>
+        <action id="Rust.ShowRecursiveMacroExpansionAction"
+                class="org.rust.ide.actions.macroExpansion.RsShowRecursiveMacroExpansionAction"
+                text="Show recursively expanded macro">
+        </action>
+        <group id="Rust.MacroExpansionActions"
+               text="Show Macro Expansion"
+               class="org.rust.ide.actions.macroExpansion.RsShowMacroExpansionGroup">
+            <add-to-group group-id="EditorPopupMenu"/>
+            <separator/>
+            <reference id="Rust.ShowRecursiveMacroExpansionAction"/>
+            <reference id="Rust.ShowSingleStepMacroExpansionAction"/>
+        </group>
 
         <group id="Rust.Cargo">
             <reference id="Rust.RefreshCargoProject"/>

--- a/src/main/resources/intentionDescriptions/RsShowMacroExpansionIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/RsShowMacroExpansionIntention/after.rs.template
@@ -1,0 +1,1 @@
+// no text here

--- a/src/main/resources/intentionDescriptions/RsShowMacroExpansionIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/RsShowMacroExpansionIntention/before.rs.template
@@ -1,0 +1,1 @@
+// no text here

--- a/src/main/resources/intentionDescriptions/RsShowMacroExpansionIntention/description.html
+++ b/src/main/resources/intentionDescriptions/RsShowMacroExpansionIntention/description.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+Those two intentions show the expansion of the macro under the cursor.
+They do not change file in any way.
+
+There are two intentions -- for simple, single-step expansion, and for full-blown recursive expansion.
+
+Currently only simple (non-procedural) actions are supported.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActionsTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActionsTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.actions.macroExpansion
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.project.Project
+import org.intellij.lang.annotations.Language
+import org.rust.lang.RsTestBase
+import org.rust.lang.core.macros.RsExpandedElement
+
+class RsShowMacroExpansionActionsTest : RsTestBase() {
+
+    fun `test no expansion available when macro is not under caret`() = testNoExpansionHappens("""
+        let a = /*caret*/boo();
+        foo!();
+    """)
+
+    fun `test single level expansion is performed by recursive action`() = testRecursiveExpansion("""
+        macro_rules! foo {
+            () => { println!(); }
+        }
+        /*caret*/foo!();
+    """, """
+        println!();
+    """)
+
+    fun `test single level expansion is performed by single step action`() = testSingleStepExpansion("""
+            macro_rules! foo {
+                () => { println!(); }
+            }
+            /*caret*/foo!();
+        """, """
+            println!();
+        """)
+
+    fun `test two leveled expansion is preformed with recursive expansion`() = testRecursiveExpansion("""
+        macro_rules! boo {
+            () => { println!(); }
+        }
+
+        macro_rules! foo {
+            () => { boo!(); }
+        }
+
+        /*caret*/foo!();
+    """, """
+        println!();
+    """)
+
+    fun `test no second level expansion is preformed with single step expansion`() = testSingleStepExpansion("""
+        macro_rules! boo {
+            () => { println!(); }
+        }
+
+        macro_rules! foo {
+            () => { boo!(); }
+        }
+
+        /*caret*/foo!();
+    """, """
+        boo!();
+    """)
+
+    fun `test macros correctly recursively expands to itself`() = testRecursiveExpansion("""
+        macro_rules! foo {
+            () => { println!(); }
+            (${'$'}i: expr) => { foo!(); }
+        }
+
+        /*caret*/foo!(boo);
+    """, """
+        println!();
+    """)
+
+    fun `test that recursive expansion of macro without body is just its name`() = testRecursiveExpansion("""
+            /*caret*/foo!();
+        """, """
+            foo!();
+        """)
+
+    fun `test that single step expansion of macro without body is just its name`() = testSingleStepExpansion("""
+        /*caret*/foo!();
+    """, """
+        foo!();
+    """)
+
+    private fun testNoExpansionHappens(@Language("Rust") code: String) {
+        InlineFile(code)
+
+        val failingAction = object : RsShowMacroExpansionActionBase(expandRecursively = true) {
+            override fun showExpansion(project: Project, editor: Editor, expansionDetails: MacroExpansionViewDetails) {
+                fail("No expansion should be showed, but ${expansionDetails.expansions.toText()} was shown!")
+            }
+        }
+
+        failingAction.performForContext(dataContext)
+    }
+
+    private fun testRecursiveExpansion(@Language("Rust") code: String, @Language("Rust") expectedRaw: String) {
+        testMacroExpansion(code, expectedRaw, expandRecursively = true)
+    }
+
+    private fun testSingleStepExpansion(@Language("Rust") code: String, @Language("Rust") expectedRaw: String) {
+        testMacroExpansion(code, expectedRaw, expandRecursively = false)
+    }
+
+    private fun testMacroExpansion(
+        @Language("Rust") code: String,
+        @Language("Rust") expectedRaw: String,
+        expandRecursively: Boolean
+    ) {
+        InlineFile(code)
+
+        lateinit var expansions: List<RsExpandedElement>
+
+        val action = object : RsShowMacroExpansionActionBase(expandRecursively = expandRecursively) {
+            override fun showExpansion(project: Project, editor: Editor, expansionDetails: MacroExpansionViewDetails) {
+                expansions = expansionDetails.expansions
+            }
+        }
+
+        action.performForContext(dataContext)
+
+        val expandedMacroText = expansions.toText().removeWhitespace()
+        val expected = expectedRaw.removeWhitespace()
+
+        assertEquals(
+            "${if (expandRecursively) "Recursive" else "Single step"} expansion went wrong!",
+            expected,
+            expandedMacroText
+        )
+    }
+
+    private val dataContext
+        get() = (myFixture.editor as EditorEx).dataContext
+
+}
+
+private fun List<RsExpandedElement>.toText(): String =
+    joinToString("\n") { it.text }
+
+private fun String.removeWhitespace(): String =
+    filter { !it.isWhitespace() }

--- a/src/test/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentionBaseTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentionBaseTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import org.rust.ide.actions.macroExpansion.MacroExpansionViewDetails
+
+class RsShowMacroExpansionIntentionBaseTest : RsIntentionTestBase(RsShowMacroExpansionIntention) {
+
+    fun `test that intention is not available outside of the macros`() {
+        doUnavailableTest("""
+            foo!();
+            /*caret*/foo();
+        """)
+    }
+
+    fun `test that intention is available on the macros, but does not change it`() {
+        doAvailableTest("""
+            /*caret*/foo!();
+            foo();
+        """, """
+            foo!();
+            foo();
+        """)
+    }
+
+}
+
+object RsShowMacroExpansionIntention : RsShowMacroExpansionIntentionBase(expandRecursively = true) {
+    override fun showExpansion(project: Project, editor: Editor, expansionDetails: MacroExpansionViewDetails) {
+        // do not show anything
+    }
+}


### PR DESCRIPTION
Add actions and intentions for expanding simple (non-procedural) macros. 

Actions are available via right-click context menu.

~~WIP: no test yet.~~
UPD: Simple tests are added.