### PR TITLE
MACROS: Make macro expansion intentions start not in write actions

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentions.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentions.kt
@@ -29,6 +29,9 @@ abstract class RsShowMacroExpansionIntentionBase(private val expandRecursively: 
         showExpansion(project, editor, expansionDetails)
     }
 
+    /** Progress window cannot be shown in the write action, so it have to be disabled. **/
+    override fun startInWriteAction(): Boolean = false
+
     /**
      * This method is required for testing to avoid actually creating popup and editor.
      * Inspired by [com.intellij.codeInsight.hint.actions.ShowImplementationsAction].


### PR DESCRIPTION
Macro expansion can take some time, that is why we run it in background with progress window.

However, progress window cannot be shown in write action, so we have to disable write action mode for macro expansion intentions.