### PR TITLE
RES: use correct prelude module

### DIFF
--- a/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
@@ -35,14 +35,14 @@ data class StdLibInfo (
 )
 
 object AutoInjectedCrates {
-    const val std: String = "std"
-    const val core: String = "core"
+    const val STD: String = "std"
+    const val CORE: String = "core"
     val stdlibCrates = listOf(
         // Roots
-        StdLibInfo(std, StdLibType.ROOT, dependencies = listOf("alloc_jemalloc", "alloc_system", "panic_abort", "rand",
+        StdLibInfo(STD, StdLibType.ROOT, dependencies = listOf("alloc_jemalloc", "alloc_system", "panic_abort", "rand",
             "compiler_builtins", "unwind", "rustc_asan", "rustc_lsan", "rustc_msan", "rustc_tsan",
             "build_helper")),
-        StdLibInfo(core, StdLibType.ROOT),
+        StdLibInfo(CORE, StdLibType.ROOT),
         StdLibInfo("alloc", StdLibType.ROOT),
         StdLibInfo("collections", StdLibType.ROOT),
         StdLibInfo("libc", StdLibType.ROOT, srcDir = "liblibc/src"),

--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -310,8 +310,8 @@ class AutoImportFix(path: RsPath) : LocalQuickFixOnPsiElement(path), HighPriorit
             val candidateToAttributes = stdlibCandidates.map { candidate ->
                 val pkg = candidate.second
                 val attributes = when (pkg.normName) {
-                    AutoInjectedCrates.std -> RsFile.Attributes.NONE
-                    AutoInjectedCrates.core -> RsFile.Attributes.NO_STD
+                    AutoInjectedCrates.STD -> RsFile.Attributes.NONE
+                    AutoInjectedCrates.CORE -> RsFile.Attributes.NO_STD
                     else -> RsFile.Attributes.NO_CORE
                 }
                 hasImportWithSameAttributes = hasImportWithSameAttributes || attributes == fileAttributes
@@ -508,7 +508,7 @@ private val RsItemsOwner.firstItem: RsElement get() = itemsAndMacros.first { it 
 private val <T: RsElement> List<T>.lastElement: T? get() = maxBy { it.textOffset }
 
 private val CargoWorkspace.Target.isStd: Boolean
-    get() = pkg.origin == PackageOrigin.STDLIB && normName == AutoInjectedCrates.std
+    get() = pkg.origin == PackageOrigin.STDLIB && normName == AutoInjectedCrates.STD
 
 private val CargoWorkspace.Target.isCore: Boolean
-    get() = pkg.origin == PackageOrigin.STDLIB && normName == AutoInjectedCrates.core
+    get() = pkg.origin == PackageOrigin.STDLIB && normName == AutoInjectedCrates.CORE

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -15,6 +15,8 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.util.*
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.cargo.util.AutoInjectedCrates.CORE
+import org.rust.cargo.util.AutoInjectedCrates.STD
 import org.rust.lang.RsConstants
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsFile.Attributes.*
@@ -526,14 +528,9 @@ private fun exportedMacrosInternal(scope: RsFile): List<RsMacro> {
             }
         }
 
-        // Implicit extern crate from stdlib
-        val (name, prelude) = when (scope.attributes) {
-            NO_CORE -> null to null
-            NO_STD -> "core" to scope.findDependencyCrateRoot("core")
-            NONE -> "std" to scope.findDependencyCrateRoot("std")
-        }
-        if (name != null && prelude != null) {
-            exportingMacrosCrates[name] = prelude
+        val implicitStdlibCrate = implicitStdlibCrate(scope)
+        if (implicitStdlibCrate != null) {
+            exportingMacrosCrates[implicitStdlibCrate.name] = implicitStdlibCrate.crateRoot
         }
 
         if (exportingMacrosCrates.isNotEmpty()) {
@@ -838,13 +835,40 @@ private fun processNestedScopesUpwards(scopeStart: RsElement, processor: RsResol
         false
     }
 
-    val prelude = scopeStart.containingCargoPackage?.findDependency("std")?.crateRoot
-        ?.findFileByRelativePath("../prelude/v1.rs")
-        ?.toPsiFile(scopeStart.project)
-        ?.rustFile
+    val prelude = findPrelude(scopeStart)
     if (prelude != null && processItemDeclarations(prelude, ns, { v -> v.name !in prevScope && processor(v) }, false)) return true
 
     return false
+}
+
+private fun findPrelude(element: RsElement): RsFile? {
+    val crateRoot = element.crateRoot as? RsFile ?: return null
+    val cargoPackage = crateRoot.containingCargoPackage
+    val isStdlib = cargoPackage?.origin == PackageOrigin.STDLIB
+    val packageName = cargoPackage?.normName
+
+    // `std` and `core` crates explicitly add their prelude
+    val stdlibCrateRoot = if (isStdlib && (packageName == STD || packageName == CORE)) {
+        crateRoot
+    } else {
+        implicitStdlibCrate(crateRoot)?.crateRoot
+    }
+
+    return stdlibCrateRoot
+        ?.virtualFile
+        ?.findFileByRelativePath("../prelude/v1.rs")
+        ?.toPsiFile(element.project)
+        ?.rustFile
+}
+
+// Implicit extern crate from stdlib
+private fun implicitStdlibCrate(scope: RsFile): ImplicitStdlibCrate? {
+    val (name, crateRoot) = when (scope.attributes) {
+        NO_CORE -> return null
+        NO_STD -> CORE to scope.findDependencyCrateRoot(CORE)
+        NONE -> STD to scope.findDependencyCrateRoot(STD)
+    }
+    return if (crateRoot == null) null else ImplicitStdlibCrate(name, crateRoot)
 }
 
 // There's already similar functions in TreeUtils, should use it
@@ -883,3 +907,5 @@ object NameResolutionTestmarks {
     val missingMacroUse = Testmark("missingMacroUse")
     val selfInGroup = Testmark("selfInGroup")
 }
+
+private data class ImplicitStdlibCrate(val name: String, val crateRoot: RsFile)

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -5,7 +5,6 @@
 
 package org.rust.lang.core.resolve
 
-import com.intellij.util.text.SemVer
 import org.rust.lang.core.types.infer.TypeInferenceMarks
 
 class RsStdlibResolveTest : RsResolveTestBase() {
@@ -537,7 +536,23 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }                    //^ ...convert.rs
     """)
 
-    companion object {
-        private val RUST_1_25 = SemVer.parseFromText("1.25.0")!!
-    }
+    fun `test resolve with no_std attribute`() = stubOnlyResolve("""
+    //- main.rs
+        #![no_std]
+
+        fn foo(v: Vec) {}
+                 //^ unresolved
+    """)
+
+    fun `test resolve with no_std attribute 2`() = stubOnlyResolve("""
+    //- main.rs
+        #![no_std]
+
+        extern crate alloc;
+
+        use alloc::Vec;
+
+        fn foo(v: Vec) {}
+                 //^ .../liballoc/vec.rs
+    """)
 }


### PR DESCRIPTION
Currently, we add prelude from `std` crate to all modules.
But if crate has `#![no_std]` or `#![no_core]` attributes we shouldn't do it.
In the case of `#![no_std]` compiler implicitly adds prelude from `core` crate and
in the case of `#![no_core]` compiler does nothing.

Also, there is unstable `#[prelude_import]` attribute that used in `std` and `core`
to explicitly add some custom prelude (actually, it is used to add prelude of `std` and `core`
to the corresponding crate because they use `#![no_std]` and `#![no_core]` respectively)

These changes implement similar logic as compiler uses. Note, we don't search
`#[prelude_import]` and just add `std::prelude` to `std` and `core::prelude` to `core` crates.

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
