### PR TITLE
CARGO: improve rustfmt formating

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
@@ -1,0 +1,38 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.configurable
+
+import com.intellij.openapi.project.Project
+import com.intellij.ui.components.JBCheckBox
+import org.rust.ide.ui.layout
+import org.rust.openapiext.CheckboxDelegate
+import javax.swing.JComponent
+
+class RustfmtConfigurable(project: Project) : RsConfigurableBase(project) {
+
+    private val useSkipChildrenCheckbox: JBCheckBox = JBCheckBox()
+    private var useSkipChildren: Boolean by CheckboxDelegate(useSkipChildrenCheckbox)
+
+    override fun getDisplayName(): String = "Rustfmt"
+
+    override fun createComponent(): JComponent? = layout {
+        row("Don't reformat child modules (nightly only):", useSkipChildrenCheckbox, """
+            Pass `--skip-children` option to rustfmt not to reformat child modules.
+            Used only for nightly toolchain.
+        """)
+    }
+
+    override fun isModified(): Boolean = settings.useSkipChildren != useSkipChildren
+
+    override fun apply() {
+        val currentData = settings.data
+        settings.data = currentData.copy(useSkipChildren = useSkipChildren)
+    }
+
+    override fun reset() {
+        useSkipChildren = settings.useSkipChildren
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -382,10 +382,10 @@ private fun fetchStdlib(
         val download = rustup.downloadStdlib()
         when (download) {
             is Rustup.DownloadResult.Ok -> {
-                val lib = StandardLibrary.fromFile(download.library)
+                val lib = StandardLibrary.fromFile(download.value)
                 if (lib == null) {
                     err("" +
-                        "corrupted standard library: ${download.library.presentableUrl}"
+                        "corrupted standard library: ${download.value.presentableUrl}"
                     )
                 } else {
                     ok(lib)

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -22,7 +22,8 @@ interface RustProjectSettingsService {
         val useCargoCheckAnnotator: Boolean,
         val compileAllTargets: Boolean,
         val useOfflineForCargoCheck: Boolean,
-        val expandMacros: Boolean
+        val expandMacros: Boolean,
+        val useSkipChildren: Boolean
     )
 
     var data: Data
@@ -39,6 +40,7 @@ interface RustProjectSettingsService {
     val compileAllTargets: Boolean get() = data.compileAllTargets
     val useOfflineForCargoCheck: Boolean get() = data.useOfflineForCargoCheck
     val expandMacros: Boolean get() = data.expandMacros
+    val useSkipChildren: Boolean get() = data.useSkipChildren
 
     /*
      * Show a dialog for toolchain configuration

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -30,7 +30,8 @@ class RustProjectSettingsServiceImpl(
         var useCargoCheckAnnotator: Boolean = false,
         var compileAllTargets: Boolean = true,
         var useOfflineForCargoCheck: Boolean = false,
-        var expandMacros: Boolean = true
+        var expandMacros: Boolean = true,
+        var useSkipChildren: Boolean = false
     )
 
     override fun getState(): State = state
@@ -54,7 +55,8 @@ class RustProjectSettingsServiceImpl(
                 useCargoCheckAnnotator = state.useCargoCheckAnnotator,
                 compileAllTargets = state.compileAllTargets,
                 useOfflineForCargoCheck = state.useOfflineForCargoCheck,
-                expandMacros = state.expandMacros
+                expandMacros = state.expandMacros,
+                useSkipChildren = state.useSkipChildren
             )
         }
         set(value) {
@@ -66,7 +68,8 @@ class RustProjectSettingsServiceImpl(
                 useCargoCheckAnnotator = value.useCargoCheckAnnotator,
                 compileAllTargets = value.compileAllTargets,
                 useOfflineForCargoCheck = value.useOfflineForCargoCheck,
-                expandMacros = value.expandMacros
+                expandMacros = value.expandMacros,
+                useSkipChildren = value.useSkipChildren
             )
             if (state != newState) {
                 state = newState
@@ -78,4 +81,3 @@ class RustProjectSettingsServiceImpl(
         project.messageBus.syncPublisher(RustProjectSettingsService.TOOLCHAIN_TOPIC).toolchainChanged()
     }
 }
-

--- a/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
@@ -5,38 +5,17 @@
 
 package org.rust.cargo.runconfig
 
-import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.execution.ExecutionException
 import com.intellij.execution.ExecutorRegistry
-import com.intellij.execution.process.CapturingProcessHandler
 import com.intellij.execution.ProgramRunnerUtil
 import com.intellij.execution.RunManager
 import com.intellij.execution.RunnerAndConfigurationSettings
 import com.intellij.execution.executors.DefaultRunExecutor
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.runconfig.command.CargoCommandConfigurationType
 import org.rust.cargo.toolchain.CargoCommandLine
-
-private val LOG_GENERAL_COMMAND_LINE = Logger.getInstance(GeneralCommandLine::class.java)
-
-fun GeneralCommandLine.runExecutable(): List<String>? {
-    val procOut = try {
-        val timeoutMs = 1000
-        CapturingProcessHandler(this).runProcess(timeoutMs)
-    } catch (e: ExecutionException) {
-        LOG_GENERAL_COMMAND_LINE.warn("Failed to run executable!", e)
-        return null
-    }
-
-    if (procOut.exitCode != 0 || procOut.isCancelled || procOut.isTimeout)
-        return null
-
-    return procOut.stdoutLines
-}
 
 fun CargoCommandLine.mergeWithDefault(default: CargoCommandConfiguration): CargoCommandLine =
     if (environmentVariables.envs.isEmpty())

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -9,27 +9,22 @@ import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.execution.process.CapturingProcessHandler
 import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.process.ProcessOutput
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.runReadAction
-import com.intellij.openapi.fileEditor.FileDocumentManager
-import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.SystemInfo
-import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.net.HttpConfigurable
 import org.jetbrains.annotations.TestOnly
 import org.rust.cargo.CargoConstants.RUST_BACTRACE_ENV_VAR
-import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.workspace.CargoWorkspace
-import org.rust.cargo.runconfig.runExecutable
 import org.rust.cargo.toolchain.impl.CargoMetadata
-import org.rust.openapiext.*
+import org.rust.openapiext.GeneralCommandLine
+import org.rust.openapiext.fullyRefreshDirectory
+import org.rust.openapiext.pathAsPath
+import org.rust.openapiext.withWorkDirectory
 import org.rust.stdext.buildList
 import java.io.File
 import java.nio.file.Path
@@ -43,31 +38,15 @@ import java.nio.file.Path
  * It is impossible to guarantee that paths to the project or executables are valid,
  * because the user can always just `rm ~/.cargo/bin -rf`.
  */
-class Cargo(
-    private val cargoExecutable: Path,
-    private val rustExecutable: Path,
-    private val rustfmtExecutable: Path
-) {
+class Cargo(private val cargoExecutable: Path) {
     fun checkSupportForBuildCheckAllTargets(): Boolean {
         val lines = GeneralCommandLine(cargoExecutable)
             .withParameters("help", "check")
-            .runExecutable()
+            .execute()
+            ?.stdoutLines
             ?: return false
 
         return lines.any { it.contains(" --all-targets ") }
-    }
-
-    data class RustfmtFlags(val emit: Boolean, val skipChildren: Boolean)
-
-    private fun checkSupportForRustfmtFlags(workingDirectory: Path): RustfmtFlags {
-        val lines = GeneralCommandLine(rustfmtExecutable)
-            .withParameters("-h")
-            .withWorkDirectory(workingDirectory)
-            .runExecutable()
-            ?: return RustfmtFlags(false, false)
-
-        return RustfmtFlags(lines.any { it.contains(" --emit ") },
-            lines.any { it.contains(" --skip-children ") })
     }
 
     /**
@@ -107,37 +86,6 @@ class Cargo(
         ).execute(owner)
         check(File(directory.path, RustToolchain.CARGO_TOML).exists())
         fullyRefreshDirectory(directory)
-    }
-
-    @Throws(ExecutionException::class)
-    fun reformatFile(
-        project: Project,
-        file: VirtualFile,
-        owner: Disposable = project,
-        listener: ProcessListener? = null
-    ): ProcessOutput {
-        FileDocumentManager.getInstance().saveAllDocuments()
-
-        val channel = project.cargoProjects.findProjectForFile(file)
-            ?.rustcInfo?.version?.channel
-
-        val result = ProgressManager.getInstance().runProcessWithProgressSynchronously<ProcessOutput, ExecutionException>({
-            val arguments = mutableListOf("--all", "--")
-            val (emit, skipChildren) = checkSupportForRustfmtFlags(file.parent.pathAsPath)
-            arguments += if (emit) "--emit=files" else "--write-mode=overwrite"
-            if (project.rustSettings.useSkipChildren && channel == RustChannel.NIGHTLY && skipChildren) {
-                arguments += "--unstable-features"
-                arguments += "--skip-children"
-            }
-            arguments += file.path
-            CargoCommandLine("fmt", file.parent.pathAsPath, arguments)
-                .execute(owner, listener)
-        }, "Reformat File with Rustfmt", true, project)
-
-        // We want to refresh file synchronously only in unit test
-        // to get new text right after `reformatFile` call
-        VfsUtil.markDirtyAndRefresh(!isUnitTestMode, true, true, file)
-        return result
     }
 
     @Throws(ExecutionException::class)
@@ -201,51 +149,10 @@ class Cargo(
         return cmdLine.withParameters(parameters)
     }
 
-
+    @Throws(ExecutionException::class)
     private fun CargoCommandLine.execute(owner: Disposable, listener: ProcessListener? = null,
                                          ignoreExitCode: Boolean = false): ProcessOutput {
-        val command = toGeneralCommandLine(this)
-        val handler = CapturingProcessHandler(command)
-        val cargoKiller = Disposable {
-            // Don't attempt a graceful termination, Cargo can be SIGKILLed safely.
-            // https://github.com/rust-lang/cargo/issues/3566
-            handler.destroyProcess()
-        }
-
-        val alreadyDisposed = runReadAction {
-            if (Disposer.isDisposed(owner)) {
-                true
-            } else {
-                Disposer.register(owner, cargoKiller)
-                false
-            }
-        }
-
-        if (alreadyDisposed) {
-            // On the one hand, this seems fishy,
-            // on the other hand, this is isomorphic
-            // to the scenario where cargoKiller triggers.
-            if (ignoreExitCode) {
-                return ProcessOutput().apply { setCancelled() }
-            } else {
-                throw ExecutionException("Cargo command failed to start")
-            }
-        }
-
-        listener?.let { handler.addProcessListener(it) }
-        val output = try {
-            handler.runProcess()
-        } finally {
-            Disposer.dispose(cargoKiller)
-        }
-        if (!ignoreExitCode && output.exitCode != 0) {
-            throw ExecutionException("""
-            Cargo execution failed (exit code ${output.exitCode}).
-            ${command.commandLineString}
-            stdout : ${output.stdout}
-            stderr : ${output.stderr}""".trimIndent())
-        }
-        return output
+        return toGeneralCommandLine(this).execute(owner, ignoreExitCode, listener)
     }
 
     private var _http: HttpConfigurable? = null

--- a/src/main/kotlin/org/rust/cargo/toolchain/CommandLineExt.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CommandLineExt.kt
@@ -5,30 +5,90 @@
 
 package org.rust.cargo.toolchain
 
+import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.process.ProcessOutput
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.util.Disposer
 
 private val LOG = Logger.getInstance("org.rust.cargo.toolchain.CommandLineExt")
 
-fun GeneralCommandLine.exec(timeoutInMilliseconds: Int? = null): ProcessOutput {
-    val handler = CapturingProcessHandler(this)
+fun GeneralCommandLine.execute(timeoutInMilliseconds: Int? = 1000): ProcessOutput? {
+    val output = try {
+        val handler = CapturingProcessHandler(this)
 
-    LOG.info("Executing `$commandLineString`")
-    val output = if (timeoutInMilliseconds != null)
-        handler.runProcess(timeoutInMilliseconds)
-    else
-        handler.runProcess()
+        LOG.info("Executing `$commandLineString`")
+        if (timeoutInMilliseconds != null)
+            handler.runProcess(timeoutInMilliseconds)
+        else
+            handler.runProcess()
+    } catch (e: ExecutionException) {
+        LOG.warn("Failed to run executable", e)
+        return null
+    }
 
-    if (output.exitCode != 0) {
-        LOG.warn("Failed to execute `$commandLineString`" +
-            "\ncode  : ${output.exitCode}" +
-            "\nstdout:\n${output.stdout}" +
-            "\nstderr:\n${output.stderr}")
+    if (!output.isSuccess) {
+        LOG.warn(errorMessage(this, output))
     }
 
     return output
 }
+
+@Throws(ExecutionException::class)
+fun GeneralCommandLine.execute(
+    owner: Disposable,
+    ignoreExitCode: Boolean = true,
+    listener: ProcessListener? = null
+): ProcessOutput {
+
+    val handler = CapturingProcessHandler(this)
+    val cargoKiller = Disposable {
+        // Don't attempt a graceful termination, Cargo can be SIGKILLed safely.
+        // https://github.com/rust-lang/cargo/issues/3566
+        handler.destroyProcess()
+    }
+
+    val alreadyDisposed = runReadAction {
+        if (Disposer.isDisposed(owner)) {
+            true
+        } else {
+            Disposer.register(owner, cargoKiller)
+            false
+        }
+    }
+
+    if (alreadyDisposed) {
+        // On the one hand, this seems fishy,
+        // on the other hand, this is isomorphic
+        // to the scenario where cargoKiller triggers.
+        if (ignoreExitCode) {
+            return ProcessOutput().apply { setCancelled() }
+        } else {
+            throw ExecutionException("Command failed to start")
+        }
+    }
+
+    listener?.let { handler.addProcessListener(it) }
+    val output = try {
+        handler.runProcess()
+    } finally {
+        Disposer.dispose(cargoKiller)
+    }
+    if (!ignoreExitCode && output.exitCode != 0) {
+        throw ExecutionException(errorMessage(this, output))
+    }
+    return output
+}
+
+private fun errorMessage(commandLine: GeneralCommandLine, output: ProcessOutput): String = """
+        Execution failed (exit code ${output.exitCode}).
+        ${commandLine.commandLineString}
+        stdout : ${output.stdout}
+        stderr : ${output.stderr}
+    """.trimIndent()
 
 val ProcessOutput.isSuccess: Boolean get() = !isTimeout && !isCancelled && exitCode == 0

--- a/src/main/kotlin/org/rust/cargo/toolchain/Rustfmt.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Rustfmt.kt
@@ -1,0 +1,58 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.toolchain
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.process.ProcessOutput
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.settings.rustSettings
+import org.rust.openapiext.GeneralCommandLine
+import org.rust.openapiext.pathAsPath
+import org.rust.openapiext.withWorkDirectory
+import java.nio.file.Path
+
+class Rustfmt(private val rustfmtExecutable: Path) {
+
+    @Throws(ExecutionException::class)
+    fun reformatFile(
+        project: Project,
+        file: VirtualFile,
+        owner: Disposable = project
+    ): ProcessOutput {
+        val channel = project.cargoProjects.findProjectForFile(file)
+            ?.rustcInfo?.version?.channel
+
+        val arguments = mutableListOf<String>()
+        val (emit, skipChildren) = checkSupportForRustfmtFlags(file.parent.pathAsPath)
+        arguments += if (emit) "--emit=files" else "--write-mode=overwrite"
+        if (project.rustSettings.useSkipChildren && channel == RustChannel.NIGHTLY && skipChildren) {
+            arguments += "--unstable-features"
+            arguments += "--skip-children"
+        }
+        arguments += file.path
+        return GeneralCommandLine(rustfmtExecutable)
+            .withWorkDirectory(file.parent.pathAsPath)
+            .withParameters(arguments)
+            .execute(owner, false)
+    }
+
+    private fun checkSupportForRustfmtFlags(workingDirectory: Path): RustfmtFlags {
+        val lines = GeneralCommandLine(rustfmtExecutable)
+            .withParameters("-h")
+            .withWorkDirectory(workingDirectory)
+            .execute()
+            ?.stdoutLines
+            ?: return RustfmtFlags(false, false)
+
+        return RustfmtFlags(lines.any { it.contains(" --emit ") },
+            lines.any { it.contains(" --skip-children ") })
+    }
+
+    private data class RustfmtFlags(val emit: Boolean, val skipChildren: Boolean)
+}

--- a/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
@@ -30,16 +30,16 @@ class Rustup(
         val downloadProcessOutput = GeneralCommandLine(rustup)
             .withWorkDirectory(projectDirectory)
             .withParameters("component", "add", "rust-src")
-            .exec()
+            .execute(null)
 
-        return if (downloadProcessOutput.exitCode != 0) {
-            val message = "rustup failed: `${downloadProcessOutput.stderr}`"
-            LOG.warn(message)
-            DownloadResult.Err(message)
-        } else {
+        return if (downloadProcessOutput?.isSuccess == true) {
             val sources = getStdlibFromSysroot() ?: return DownloadResult.Err("Failed to find stdlib in sysroot")
             fullyRefreshDirectory(sources)
             DownloadResult.Ok(sources)
+        } else {
+            val message = "rustup failed: `${downloadProcessOutput?.stderr ?: ""}`"
+            LOG.warn(message)
+            DownloadResult.Err(message)
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/actions/RustfmtFileAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RustfmtFileAction.kt
@@ -7,20 +7,26 @@ package org.rust.ide.actions
 
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.process.ProcessOutput
+import com.intellij.notification.Notification
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
+import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.toolchain.RustToolchain
+import org.rust.cargo.toolchain.Rustup
 import org.rust.ide.notifications.showBalloon
 import org.rust.lang.core.psi.isRustFile
 import org.rust.openapiext.isUnitTestMode
+import java.nio.file.Path
 
 class RustfmtFileAction : DumbAwareAction() {
     override fun update(e: AnActionEvent) {
@@ -46,9 +52,11 @@ class RustfmtFileAction : DumbAwareAction() {
             if (isUnitTestMode) throw e
             val message = e.message ?: ""
 
-            // #1131 - Check if we get a `no such subcommand: fmt` and let the user know to install fmt
-            if ("no such subcommand: fmt" in message) {
-                project.showBalloon("Install rustfmt: https://github.com/rust-lang-nursery/rustfmt", NotificationType.ERROR)
+            // #1131 - Check if we get a "does not have the binary `rustfmt`" and let the user know to install fmt
+            if ("does not have the binary `rustfmt`" in message) {
+                val projectDir = project.cargoProjects.findProjectForFile(file)?.manifest?.parent
+                val action = if (projectDir != null) InstallRustfmtAction(projectDir) else null
+                project.showBalloon("Rustfmt is not installed", NotificationType.ERROR, action)
             } else {
                 project.showBalloon(message, NotificationType.ERROR)
             }
@@ -61,5 +69,22 @@ class RustfmtFileAction : DumbAwareAction() {
         val file = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return null
         if (!(file.isInLocalFileSystem && file.isRustFile)) return null
         return Triple(project, toolchain, file)
+    }
+}
+
+private class InstallRustfmtAction(private val projectDirectory: Path) : DumbAwareAction("Install") {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val rustup = project.toolchain?.rustup(projectDirectory) ?: return
+
+        Notification.get(e).expire()
+        object : Task.Backgroundable(project, "Installing Rustfmt...") {
+            override fun shouldStartInBackground(): Boolean = false
+            override fun run(indicator: ProgressIndicator) {
+                val result = rustup.downloadRustfmt(myProject) as? Rustup.DownloadResult.Err ?: return
+                myProject.showBalloon(result.error, NotificationType.ERROR)
+            }
+        }.queue()
     }
 }

--- a/src/main/kotlin/org/rust/ide/actions/RustfmtFileAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RustfmtFileAction.kt
@@ -6,16 +6,21 @@
 package org.rust.ide.actions
 
 import com.intellij.execution.ExecutionException
+import com.intellij.execution.process.ProcessOutput
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.toolchain.RustToolchain
 import org.rust.ide.notifications.showBalloon
 import org.rust.lang.core.psi.isRustFile
+import org.rust.openapiext.isUnitTestMode
 
 class RustfmtFileAction : DumbAwareAction() {
     override fun update(e: AnActionEvent) {
@@ -26,10 +31,19 @@ class RustfmtFileAction : DumbAwareAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val (project, toolchain, file) = getContext(e) ?: return
 
-        val cargo = toolchain.rawCargo()
+        FileDocumentManager.getInstance().saveAllDocuments()
+
+        val rustfmt = toolchain.rustfmt()
         try {
-            cargo.reformatFile(project, file)
+            ProgressManager.getInstance().runProcessWithProgressSynchronously<ProcessOutput, ExecutionException>({
+                rustfmt.reformatFile(project, file)
+            }, "Reformatting File with Rustfmt...", true, project)
+            // We want to refresh file synchronously only in unit test
+            // to get new text right after `reformatFile` call
+            VfsUtil.markDirtyAndRefresh(!isUnitTestMode, true, true, file)
         } catch (e: ExecutionException) {
+            // Just easy way to know that something wrong happened
+            if (isUnitTestMode) throw e
             val message = e.message ?: ""
 
             // #1131 - Check if we get a `no such subcommand: fmt` and let the user know to install fmt

--- a/src/main/kotlin/org/rust/ide/notifications/Utils.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/Utils.kt
@@ -8,12 +8,16 @@ package org.rust.ide.notifications
 import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
+import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.project.Project
 
 private val pluginNotifications = NotificationGroup.balloonGroup("Rust Plugin")
 
-fun Project.showBalloon(content: String, type: NotificationType) {
+fun Project.showBalloon(content: String, type: NotificationType, action: AnAction? = null) {
     val notification = pluginNotifications.createNotification(content, type)
+    if (action != null) {
+        notification.addAction(action)
+    }
     Notifications.Bus.notify(notification, this)
 }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -601,6 +601,11 @@
                              parentId="language.rust"
                              id="language.rust.cargo"/>
 
+        <projectConfigurable instance="org.rust.cargo.project.configurable.RustfmtConfigurable"
+                             displayName="Rustfmt"
+                             parentId="language.rust"
+                             id="language.rust.rustfmt"/>
+
         <projectService serviceInterface="org.rust.cargo.project.settings.RustProjectSettingsService"
                         serviceImplementation="org.rust.cargo.project.settings.impl.RustProjectSettingsServiceImpl"/>
         <projectService serviceInterface="org.rust.cargo.project.model.CargoProjectsService"
@@ -722,7 +727,7 @@
 
         <action id="Rust.CargoFmtFile"
                 class="org.rust.ide.actions.RustfmtFileAction"
-                text="Reformat file with rustfmt"
+                text="Reformat File with Rustfmt"
                 description="Reformat current file with rustfmt">
             <add-to-group group-id="CodeMenu" anchor="last"/>
         </action>

--- a/src/test/kotlin/org/rust/cargo/commands/CargoFmtTest.kt
+++ b/src/test/kotlin/org/rust/cargo/commands/CargoFmtTest.kt
@@ -64,7 +64,7 @@ class CargoFmtTest : RustWithToolchainTestBase() {
 
     private fun reformat(file: VirtualFile) {
         val cargo = project.toolchain!!.rawCargo()
-        val result = cargo.reformatFile(testRootDisposable, file)
+        val result = cargo.reformatFile(project, file, testRootDisposable)
         check(result.exitCode == 0)
     }
 }

--- a/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
+++ b/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
@@ -5,15 +5,18 @@
 
 package org.rust.cargo.commands
 
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.MapDataContext
+import com.intellij.testFramework.TestActionEvent
 import org.rust.cargo.RustWithToolchainTestBase
-import org.rust.cargo.project.settings.toolchain
 import org.rust.fileTree
+import org.rust.ide.actions.RustfmtFileAction
 
-class CargoFmtTest : RustWithToolchainTestBase() {
+class RustfmtTest : RustWithToolchainTestBase() {
 
-    fun `test cargo fmt`() {
+    fun `test rustfmt action`() {
         fileTree {
             toml("Cargo.toml", """
                 [package]
@@ -63,8 +66,17 @@ class CargoFmtTest : RustWithToolchainTestBase() {
     }
 
     private fun reformat(file: VirtualFile) {
-        val cargo = project.toolchain!!.rawCargo()
-        val result = cargo.reformatFile(project, file, testRootDisposable)
-        check(result.exitCode == 0)
+        val dataContext = MapDataContext(mapOf(
+            CommonDataKeys.PROJECT to project,
+            CommonDataKeys.VIRTUAL_FILE to file
+        ))
+        val action = RustfmtFileAction()
+        val e = TestActionEvent(dataContext, action)
+        action.beforeActionPerformedUpdate(e)
+        check(e.presentation.isEnabledAndVisible) {
+            "Failed to run `${RustfmtFileAction::class.java.simpleName}` action"
+        }
+
+        action.actionPerformed(e)
     }
 }

--- a/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
@@ -31,6 +31,7 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
               <option name="useCargoCheckAnnotator" value="true" />
               <option name="useCargoCheckForBuild" value="false" />
               <option name="useOfflineForCargoCheck" value="true" />
+              <option name="useSkipChildren" value="true" />
             </State>
         """.trimIndent()
         service.loadState(elementFromXmlString(text).deserialize())
@@ -47,7 +48,8 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
             useCargoCheckAnnotator = true,
             compileAllTargets = false,
             useOfflineForCargoCheck = true,
-            expandMacros = false
+            expandMacros = false,
+            useSkipChildren = true
         ))
     }
 }

--- a/src/test/kotlin/org/rust/lang/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/RsTestBase.kt
@@ -254,7 +254,7 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
         private val toolchain: RustToolchain? by lazy { RustToolchain.suggest() }
 
         private val rustup by lazy { toolchain?.rustup(Paths.get(".")) }
-        val stdlib by lazy { (rustup?.downloadStdlib() as? Rustup.DownloadResult.Ok)?.library }
+        val stdlib by lazy { (rustup?.downloadStdlib() as? Rustup.DownloadResult.Ok)?.value }
 
         override val skipTestReason: String?
             get() {


### PR DESCRIPTION
* Add panel for rustfmt with options to use `--skip-children` flag
* Use `rustfmt` directly instead of `cargo fmt` to reformat only one file
* Allow a user to install `rustfmt` from IDE

Fixes #2761 