### PR TITLE
Attribute parenthesis completion

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -57,6 +57,7 @@ mkaput
 mrhota
 msmorgan
 netvl
+nicholastmosher
 Nilera
 ninjabear
 oistein

--- a/src/main/kotlin/org/rust/ide/typing/RsAngleBraceHandlers.kt
+++ b/src/main/kotlin/org/rust/ide/typing/RsAngleBraceHandlers.kt
@@ -5,149 +5,82 @@
 
 package org.rust.ide.typing
 
-import com.intellij.codeInsight.CodeInsightSettings
-import com.intellij.codeInsight.editorActions.TypedHandlerDelegate
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.EditorModificationUtil
 import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.editor.highlighter.HighlighterIterator
-import com.intellij.openapi.fileTypes.FileType
-import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsElementTypes.*
-import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.tokenSetOf
 
 private val GENERIC_NAMED_ENTITY_KEYWORDS = tokenSetOf(FN, STRUCT, ENUM, TRAIT, TYPE_KW)
 
 private val INVALID_INSIDE_TOKENS = tokenSetOf(LBRACE, RBRACE, SEMICOLON)
 
-class RsAngleBraceTypedHandler : TypedHandlerDelegate() {
+class RsAngleBraceTypedHandler : RsBraceTypedHandler(AngleBraceHandler)
 
-    private var rsLTTyped = false
+class RsAngleBraceBackspaceHandler : RsBraceBackspaceHandler(AngleBraceHandler)
 
-    override fun beforeCharTyped(c: Char, project: Project, editor: Editor, file: PsiFile, fileType: FileType): Result {
-        if (file !is RsFile) return Result.CONTINUE
+object AngleBraceHandler : TypingPairHandler {
+    override val opening: TypingPairAtom
+        get() = TypingPairAtom('<', LT)
 
-        if (CodeInsightSettings.getInstance().AUTOINSERT_PAIR_BRACKET) {
-            when (c) {
-                '<' -> rsLTTyped = isStartOfGenericBraces(editor)
-                '>' -> {
-                    val lexer = editor.createLexer(editor.caretModel.offset)
-                        ?: return Result.CONTINUE
-                    val tokenType = lexer.tokenType
-                    if (tokenType == GT && calculateBalance(editor) == 0) {
-                        EditorModificationUtil.moveCaretRelatively(editor, 1)
-                        return Result.STOP
-                    }
+    override val closing: TypingPairAtom
+        get() = TypingPairAtom('>', GT)
+
+    override fun shouldComplete(editor: Editor): Boolean {
+        val offset = editor.caretModel.offset
+        val lexer = editor.createLexer(offset - 1)
+            ?: return false
+
+        return when (lexer.tokenType) {
+            // manual function type specification
+            COLONCOLON -> true
+            // generic implementation block
+            IMPL -> true
+            IDENTIFIER -> {
+                // don't complete angle braces inside identifier
+                if (lexer.end != offset) return false
+                // it considers that typical case is only one whitespace character
+                // between keyword (fn, enum, etc.) and identifier
+                if (lexer.start > 1) {
+                    lexer.retreat()
+                    lexer.retreat()
+                    if (lexer.tokenType in GENERIC_NAMED_ENTITY_KEYWORDS) return true
+                    lexer.advance()
+                    lexer.advance()
                 }
+                isTypeLikeIdentifier(offset, editor, lexer)
             }
+            else -> false
         }
-
-        return Result.CONTINUE
     }
 
-    override fun charTyped(c: Char, project: Project, editor: Editor, file: PsiFile): Result {
-        if (file !is RsFile) return Result.CONTINUE
+    override fun calculateBalance(editor: Editor): Int {
+        val offset = editor.caretModel.offset
+        val iterator = (editor as EditorEx).highlighter.createIterator(offset)
+        while (iterator.start > 0 && iterator.tokenType !in INVALID_INSIDE_TOKENS) {
+            iterator.retreat()
+        }
 
-        if (rsLTTyped) {
-            rsLTTyped = false
-            val balance = calculateBalance(editor)
-            if (balance == 1) {
-                val offset = editor.caretModel.offset
-                editor.document.insertString(offset, ">")
+        if (iterator.tokenType in INVALID_INSIDE_TOKENS) {
+            iterator.advance()
+        }
+
+        var balance = 0
+        while (!iterator.atEnd() && balance >= 0 && iterator.tokenType !in INVALID_INSIDE_TOKENS) {
+            when (iterator.tokenType) {
+                LT -> balance++
+                GT -> balance--
             }
-            return Result.STOP
-
+            iterator.advance()
         }
-        return Result.CONTINUE
-    }
-}
-
-class RsAngleBraceBackspaceHandler : RsEnableableBackspaceHandlerDelegate() {
-
-    override fun deleting(c: Char, file: PsiFile, editor: Editor): Boolean {
-        if (c == '<' && file is RsFile) {
-            val offset = editor.caretModel.offset
-            val iterator = (editor as EditorEx).highlighter.createIterator(offset)
-            return iterator.tokenType == GT
-        }
-        return false
+        return balance
     }
 
-    override fun deleted(c: Char, file: PsiFile, editor: Editor): Boolean {
-        val balance = calculateBalance(editor)
-        if (balance < 0) {
-            val offset = editor.caretModel.offset
-            editor.document.deleteString(offset, offset + 1)
-            return true
-        }
-        return true
+    private fun isTypeLikeIdentifier(offset: Int, editor: Editor, iterator: HighlighterIterator): Boolean {
+        if (iterator.end != offset) return false
+        val chars = editor.document.charsSequence
+        if (!Character.isUpperCase(chars[iterator.start])) return false
+        if (iterator.end == iterator.start + 1) return true
+        return (iterator.start + 1 until iterator.end).any { Character.isLowerCase(chars[it]) }
     }
-}
-
-private fun isStartOfGenericBraces(editor: Editor): Boolean {
-    val offset = editor.caretModel.offset
-    val lexer = editor.createLexer(offset - 1)
-        ?: return false
-
-    return when (lexer.tokenType) {
-        // manual function type specification
-        COLONCOLON -> true
-        // generic implementation block
-        IMPL -> true
-        IDENTIFIER -> {
-            // don't complete angle braces inside identifier
-            if (lexer.end != offset) return false
-            // it considers that typical case is only one whitespace character
-            // between keyword (fn, enum, etc.) and identifier
-            if (lexer.start > 1) {
-                lexer.retreat()
-                lexer.retreat()
-                if (lexer.tokenType in GENERIC_NAMED_ENTITY_KEYWORDS) return true
-                lexer.advance()
-                lexer.advance()
-            }
-            isTypeLikeIdentifier(offset, editor, lexer)
-        }
-        else -> false
-    }
-}
-
-private fun Editor.createLexer(offset: Int): HighlighterIterator? {
-    if (!isValidOffset(offset, document.charsSequence)) return null
-    val lexer = (this as EditorEx).highlighter.createIterator(offset)
-    if (lexer.atEnd()) return null
-    return lexer
-}
-
-private fun isTypeLikeIdentifier(offset: Int, editor: Editor, iterator: HighlighterIterator): Boolean {
-    if (iterator.end != offset) return false
-    val chars = editor.document.charsSequence
-    if (!Character.isUpperCase(chars[iterator.start])) return false
-    if (iterator.end == iterator.start + 1) return true
-    return (iterator.start + 1 until iterator.end).any { Character.isLowerCase(chars[it]) }
-}
-
-private fun calculateBalance(editor: Editor): Int {
-    val offset = editor.caretModel.offset
-    val iterator = (editor as EditorEx).highlighter.createIterator(offset)
-    while (iterator.start > 0 && iterator.tokenType !in INVALID_INSIDE_TOKENS) {
-        iterator.retreat()
-    }
-
-    if (iterator.tokenType in INVALID_INSIDE_TOKENS) {
-        iterator.advance()
-    }
-
-    var balance = 0
-    while (!iterator.atEnd() && balance >= 0 && iterator.tokenType !in INVALID_INSIDE_TOKENS) {
-        when (iterator.tokenType) {
-            LT -> balance++
-            GT -> balance--
-        }
-        iterator.advance()
-    }
-
-    return balance
 }

--- a/src/main/kotlin/org/rust/ide/typing/RsAttributeParenthesisHandler.kt
+++ b/src/main/kotlin/org/rust/ide/typing/RsAttributeParenthesisHandler.kt
@@ -1,0 +1,78 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.typing
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.ex.EditorEx
+import org.rust.lang.core.psi.RsElementTypes.*
+
+class RsAttributeParenthesisHandler : RsBraceTypedHandler(AttributeHandler)
+
+class RsAttributeParenthesisBackspaceHandler : RsBraceBackspaceHandler(AttributeHandler)
+
+object AttributeHandler : TypingPairHandler {
+    override val opening: TypingPairAtom
+        get() = TypingPairAtom('(', LPAREN)
+
+    override val closing: TypingPairAtom
+        get() = TypingPairAtom(')', RPAREN)
+
+    override fun shouldComplete(editor: Editor): Boolean {
+        val offset = editor.caretModel.offset
+        val lexer = editor.createLexer(offset - 1) ?: return false
+
+        // Don't complete parenthesis inside of an identifier
+        if (lexer.tokenType == IDENTIFIER && lexer.end != offset) return false
+
+        // Walk backwards to the nearest meta-attribute start
+        while (lexer.start > 0 && !isStartOfMetaAttribute(editor, lexer.start)) {
+            // If we hit a "]" on the way, we're outside a meta attribute
+            if (lexer.tokenType == RBRACK) return false
+            lexer.retreat()
+        }
+        return isStartOfMetaAttribute(editor, lexer.start)
+    }
+
+    override fun calculateBalance(editor: Editor): Int {
+        val offset = editor.caretModel.offset
+        val iterator = (editor as EditorEx).highlighter.createIterator(offset)
+
+        // Walk backwards to the start of the nearest meta attribute
+        while (iterator.start > 0 && !isStartOfMetaAttribute(editor, iterator.start)) {
+            iterator.retreat()
+        }
+
+        var balance = 0
+        while (!iterator.atEnd() && balance >= 0 && iterator.tokenType != RBRACK) {
+            when (iterator.tokenType) {
+                LPAREN -> balance++
+                RPAREN -> balance--
+            }
+            iterator.advance()
+        }
+        return balance
+    }
+
+    /** Meta attributes begin with "#[" or "#![" */
+    private fun isStartOfMetaAttribute(editor: Editor, offset: Int): Boolean {
+        val lexer = editor.createLexer(offset) ?: return false
+
+        // Check for "#" token
+        if (lexer.tokenType != SHA) return false
+        lexer.advance()
+
+        return when (lexer.tokenType) {
+            // "#[" -> true
+            LBRACK -> true
+            EXCL -> {
+                lexer.advance()
+                // "#![" -> true
+                lexer.tokenType == LBRACK
+            }
+            else -> false
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/typing/RsBraceTypedHandler.kt
+++ b/src/main/kotlin/org/rust/ide/typing/RsBraceTypedHandler.kt
@@ -1,0 +1,103 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.typing
+
+import com.intellij.codeInsight.CodeInsightSettings
+import com.intellij.codeInsight.editorActions.TypedHandlerDelegate
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorModificationUtil
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.editor.highlighter.HighlighterIterator
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import com.intellij.psi.tree.IElementType
+import org.rust.lang.core.psi.RsFile
+
+data class TypingPairAtom(val char: Char, val token: IElementType)
+
+interface TypingPairHandler {
+    val opening: TypingPairAtom
+    val closing: TypingPairAtom
+    fun shouldComplete(editor: Editor): Boolean
+    fun calculateBalance(editor: Editor): Int
+
+    fun Editor.createLexer(offset: Int): HighlighterIterator? {
+        if (!isValidOffset(offset, document.charsSequence)) return null
+        val lexer = (this as EditorEx).highlighter.createIterator(offset)
+        if (lexer.atEnd()) return null
+        return lexer
+    }
+}
+
+abstract class RsBraceTypedHandler(private val handler: TypingPairHandler) : TypedHandlerDelegate() {
+
+    private var openingTyped = false
+
+    override fun beforeCharTyped(c: Char, project: Project, editor: Editor, file: PsiFile, fileType: FileType): Result {
+        if (file !is RsFile) return Result.CONTINUE
+
+        if (CodeInsightSettings.getInstance().AUTOINSERT_PAIR_BRACKET) {
+            when (c) {
+                handler.opening.char -> openingTyped = handler.shouldComplete(editor)
+                handler.closing.char -> {
+                    val lexer = editor.createLexer(editor.caretModel.offset) ?: return Result.CONTINUE
+                    val tokenType = lexer.tokenType
+                    if (tokenType == handler.closing.token && handler.calculateBalance(editor) == 0) {
+                        EditorModificationUtil.moveCaretRelatively(editor, 1)
+                        return Result.STOP
+                    }
+                }
+            }
+        }
+
+        return Result.CONTINUE
+    }
+
+    override fun charTyped(c: Char, project: Project, editor: Editor, file: PsiFile): Result {
+        if (file !is RsFile) return Result.CONTINUE
+
+        if (openingTyped) {
+            openingTyped = false
+            val balance = handler.calculateBalance(editor)
+            if (balance == 1) {
+                val offset = editor.caretModel.offset
+                editor.document.insertString(offset, handler.closing.char.toString())
+            }
+        }
+
+        return super.charTyped(c, project, editor, file)
+    }
+}
+
+abstract class RsBraceBackspaceHandler(private val handler: TypingPairHandler) : RsEnableableBackspaceHandlerDelegate() {
+
+    override fun deleting(c: Char, file: PsiFile, editor: Editor): Boolean {
+        if (c == handler.opening.char && file is RsFile) {
+            val offset = editor.caretModel.offset
+            val iterator = (editor as EditorEx).highlighter.createIterator(offset)
+            return iterator.tokenType == handler.closing.token
+        }
+        return false
+    }
+
+    override fun deleted(c: Char, file: PsiFile, editor: Editor): Boolean {
+        val balance = handler.calculateBalance(editor)
+        if (balance < 0) {
+            val offset = editor.caretModel.offset
+            editor.document.deleteString(offset, offset + 1)
+            return true
+        }
+        return true
+    }
+}
+
+private fun Editor.createLexer(offset: Int): HighlighterIterator? {
+    if (!isValidOffset(offset, document.charsSequence)) return null
+    val lexer = (this as EditorEx).highlighter.createIterator(offset)
+    if (lexer.atEnd()) return null
+    return lexer
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -222,11 +222,15 @@
                       id="RsAngleBraceTypedHandler"/>
         <typedHandler implementation="org.rust.ide.typing.RsDotTypedHandler"
                       id="RsDotTypedHandler"/>
+        <typedHandler implementation="org.rust.ide.typing.RsAttributeParenthesisHandler"
+                      id="RsAttributeParenthesisHandler"/>
 
         <backspaceHandlerDelegate implementation="org.rust.ide.typing.RsRawLiteralHashesDeleter"
                                   id="RsRawLiteralHashesDeleter"/>
         <backspaceHandlerDelegate implementation="org.rust.ide.typing.RsAngleBraceBackspaceHandler"
                                   id="RsAngleBraceBackspaceHandler"/>
+        <backspaceHandlerDelegate implementation="org.rust.ide.typing.RsAttributeParenthesisBackspaceHandler"
+                                  id="RsAttributeParenthesisBackspaceHandler"/>
 
         <joinLinesHandler implementation="org.rust.ide.actions.RsJoinLinesHandler"
                           id="RsJoinLinesHandler"/>

--- a/src/test/kotlin/org/rust/ide/typing/RsAttributeParenthesisTypedHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/RsAttributeParenthesisTypedHandlerTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.typing
+
+import org.intellij.lang.annotations.Language
+
+class RsAttributeParenthesisTypedHandlerTest : RsTypingTestBase() {
+    fun `test pair parenthesis in struct attribute`() = doComplexTest("#[derive<caret>] struct Foo")
+
+    fun `test pair parenthesis in inner attribute`() =
+        doTestByText("#[derive<caret>]", "#[derive(<caret>)]", '(')
+
+    fun `test pair parenthesis in outer attribute`() =
+        doTestByText("#![feature<caret>]", "#![feature(<caret>)]", '(')
+
+    fun `test pair parenthesis in unclosed inner attribute block`() =
+        doTestByText("#[derive<caret>", "#[derive(<caret>)", '(')
+
+    fun `test pair parenthesis in unclosed outer attribute block`() =
+        doTestByText("#![derive<caret>", "#![derive(<caret>)", '(')
+
+    fun `test pair parenthesis with nested attributes`() =
+        doTestByText("#[foo(bar<caret>)]", "#[foo(bar(<caret>))]", '(')
+
+    fun `test pair parenthesis with multiple nested attributes`() =
+        doTestByText("""#[foo(bar("hi"), baz<caret>)]""", """#[foo(bar("hi"), baz(<caret>))]""", '(')
+
+    fun `test advance cursor when closing balanced parenthesis`() =
+        doTestByText("#[foo(<caret>)]", "#[foo()<caret>]", ')')
+
+    fun `test no advancing cursor when closing unbalanced parenthesis`() =
+        doTestByText("#[foo(<caret>]", "#[foo()<caret>]", ')')
+
+    fun `test no pair parenthesis inside identifier`() =
+        doTestByText("#![plu<caret>gin]", "#![plu(<caret>gin]", '(')
+
+    fun `test empty close`() =
+        doTestByText("<caret>", ")<caret>", ')')
+
+    private fun doComplexTest(@Language("Rust") before: String) {
+        val afterWithRPAREN = before.replace("<caret>", "(<caret>)")
+        // check completion at the end of file
+        doTypeDeleteTest(before, afterWithRPAREN)
+        // check completion in the middle of file
+        doTypeDeleteTest(before, afterWithRPAREN, "mod Foo { <code> }")
+
+        val afterWithoutRPAREN = before.replace("<caret>", "(<caret>")
+        // check completion in string literal
+        doTypeDeleteTest(before, afterWithoutRPAREN, """fn main() { let _ = "<code>" }""")
+        // check completion in comments
+        doTypeDeleteTest(before, afterWithoutRPAREN, """fn main() { /* <code> */ }""")
+    }
+
+    private fun doTypeDeleteTest(@Language("Rust") before: String, @Language("Rust") after: String, @Language("Rust") surroundings: String) = doTypeDeleteTest(
+        surroundings.replace("<code>", before),
+        surroundings.replace("<code>", after)
+    )
+
+    private fun doTypeDeleteTest(before: String, after: String) {
+        // First type a '('...
+        doTestByText(before, after, '(')
+        // ...then delete it.
+        doTestByText(after, before, '\b')
+    }
+}


### PR DESCRIPTION
This PR implements issue #2715 for completing parentheses typed inside of attributes (`#[]` and `#![]`).

Please let me know if there are any edge cases I may have missed or extra tests that I should add! :)

@Undin 