### PR TITLE
Test that Sized win ?Sized if they both are listed

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -20,6 +20,7 @@ chriskrycho
 contradictioned
 d9n
 daschl
+dem1tris
 devurandom
 Dimonchik0036
 Falkenfighter

--- a/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
@@ -110,6 +110,28 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
                          //^ !Sized
     """)
 
+    fun `test type parameter with ?Sized and Sized bounds is Sized`() = doTest("""
+        fn foo<T: Sized + ?Sized>() -> T { unimplemented!() }
+                                     //^ Sized
+    """)
+
+    fun `test type parameter with ?Sized and Sized bounds is Sized 2`() = doTest("""
+        fn foo<T>() -> T where T: Sized + ?Sized { unimplemented!() }
+                     //^ Sized
+    """)
+
+    fun `test type parameter with ?Sized and implicit Sized bounds is Sized`() = doTest("""
+        trait Derived: Sized {}
+        fn foo<T: Derived + ?Sized>() -> T { unimplemented!() }
+                                       //^ Sized
+    """)
+
+    fun `test type parameter with ?Sized and implicit Sized bounds is Sized 2`() = doTest("""
+        trait Derived: Sized {}
+        fn foo<T>() -> T where T: Derived + ?Sized { unimplemented!() }
+                     //^ Sized
+    """)
+
     fun `test Self is ?Sized by default`() = doTest("""
         trait Foo {
             fn foo(self: Self);


### PR DESCRIPTION
Hello! Just added a couple of tests for case when both of `Sized` (itself or as a supertrait) and `?Sized` are bounds for type parameter. They can't be passed for now, but should be.

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
