### PR TITLE
Fix substitution in pattern matching

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
@@ -55,7 +55,7 @@ fun RsPat.extractBindings(fcx: RsFnInferenceContext, type: Ty, ignoreRef: Boolea
                     .getOrNull(idx)
                     ?.typeReference
                     ?.type
-                    ?.substitute(derefTy.typeParameterValues)
+                    ?.substituteOrUnknown(derefTy.typeParameterValues)
                     ?: TyUnknown
                 p.extractBindings(fcx, fieldType.toRefIfNeeded(mut), mut != null)
             }
@@ -72,7 +72,7 @@ fun RsPat.extractBindings(fcx: RsFnInferenceContext, type: Ty, ignoreRef: Boolea
                 val fieldType = structFields[kind.fieldName]
                     ?.typeReference
                     ?.type
-                    ?.substitute(derefTy.typeParameterValues)
+                    ?.substituteOrUnknown(derefTy.typeParameterValues)
                     ?: TyUnknown
 
                 when (kind) {

--- a/src/test/kotlin/org/rust/lang/core/type/RsPatternMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsPatternMatchingTest.kt
@@ -327,4 +327,17 @@ class RsPatternMatchingTest : RsTypificationTestBase() {
             a;
         } //^ &&i32
     """)
+
+    fun `test unknown`() = testExpr("""
+        fn main() {
+            let x = unknown;
+            match x {
+                Some(n) => {
+                    n;
+                  //^ <unknown>
+                },
+                _ => {}
+            };
+        }
+    """)
 }


### PR DESCRIPTION
Use `TyUnknown` instead of original type parameter.