### PR TITLE
INSP: Crate in path inspections

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -47,6 +47,9 @@ interface CargoProjectsService {
     fun setRustcInfo(rustcInfo: RustcInfo)
 
     @TestOnly
+    fun setEdition(edition: CargoWorkspace.Edition)
+
+    @TestOnly
     fun discoverAndRefreshSync(): List<CargoProject> {
         val projects = discoverAndRefresh().get(1, TimeUnit.MINUTES)
             ?: error("Timeout when refreshing a test Cargo project")

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
@@ -31,13 +31,15 @@ data class CargoWorkspaceData(
         val version: String,
         val targets: Collection<Target>,
         val source: String?,
-        val origin: PackageOrigin
+        val origin: PackageOrigin,
+        val edition: CargoWorkspace.Edition
     )
 
     data class Target(
         val crateRootUrl: String,
         val name: String,
         val kind: CargoWorkspace.TargetKind,
-        val crateTypes: List<CargoWorkspace.CrateType>
+        val crateTypes: List<CargoWorkspace.CrateType>,
+        val edition: CargoWorkspace.Edition
     )
 }

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddCrateKeywordFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddCrateKeywordFix.kt
@@ -1,0 +1,27 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.RsPsiFactory
+
+class AddCrateKeywordFix(path: RsPath) : LocalQuickFixAndIntentionActionOnPsiElement(path) {
+
+    override fun getFamilyName(): String = text
+    override fun getText(): String = "Add `crate` at the beginning of path"
+
+    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
+        if (startElement !is RsPath) return
+        val originalPathText = startElement.text.removePrefix("::")
+        val newPath = RsPsiFactory(project).tryCreatePath("crate::$originalPathText") ?: return
+        startElement.replace(newPath)
+    }
+}

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -706,6 +706,25 @@ sealed class RsDiagnostic(
             fixes = listOfNotNull(fix)
         )
     }
+
+    class UndeclaredTypeOrModule(
+        element: PsiElement
+    ) : RsDiagnostic(element) {
+        override fun prepare(): PreparedAnnotation = PreparedAnnotation(
+            ERROR,
+            E0433,
+            header = escapeString(errorText())
+        )
+
+        private fun errorText(): String {
+            val elementType = element.elementType
+            // TODO: support other cases
+            return when (elementType) {
+                RsElementTypes.CRATE -> "`crate` in paths can only be used in start position"
+                else -> error("Unexpected element type: `$elementType`")
+            }
+        }
+    }
 }
 
 enum class RsErrorCode {
@@ -713,7 +732,7 @@ enum class RsErrorCode {
     E0121, E0124, E0133, E0185, E0186, E0198, E0199,
     E0200, E0201, E0202, E0261, E0262, E0263, E0277,
     E0308, E0379,
-    E0403, E0407, E0415, E0424, E0426, E0428, E0449, E0463,
+    E0403, E0407, E0415, E0424, E0426, E0428, E0433, E0449, E0463,
     E0569,
     E0603, E0614, E0616, E0624, E0658;
 

--- a/src/test/kotlin/org/rust/MockEdition.kt
+++ b/src/test/kotlin/org/rust/MockEdition.kt
@@ -1,0 +1,19 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust
+
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.model.CargoProjectsService
+
+/**
+ * Allows to set certain edition for all [CargoProject]s in test case.
+ *
+ * @see CargoProjectsService.setEdition
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MockEdition(val edition: CargoWorkspace.Edition)

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -23,6 +23,7 @@ import junit.framework.AssertionFailedError
 import org.intellij.lang.annotations.Language
 import org.rust.cargo.project.model.RustcInfo
 import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.toolchain.RustChannel
 import org.rust.cargo.toolchain.RustcVersion
 import org.rust.lang.core.psi.ext.ancestorOrSelf
@@ -51,6 +52,7 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
         (projectDescriptor as? RustProjectDescriptorBase)?.setUp(myFixture)
 
         setupMockRustcVersion()
+        setupMockEdition()
     }
 
     private fun setupMockRustcVersion() {
@@ -58,6 +60,11 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
         val (semVer, channel) = parse(annotation.rustcVersion)
         val rustcInfo = RustcInfo("", RustcVersion(semVer, "", channel))
         project.cargoProjects.setRustcInfo(rustcInfo)
+    }
+
+    private fun setupMockEdition() {
+        val edition = findAnnotationInstance<MockEdition>()?.edition ?: CargoWorkspace.Edition.EDITION_2015
+        project.cargoProjects.setEdition(edition)
     }
 
     private fun parse(version: String): Pair<SemVer, RustChannel> {

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -14,8 +14,7 @@ import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import org.rust.cargo.project.model.RustcInfo
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
-import org.rust.cargo.project.workspace.CargoWorkspace.CrateType
-import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
+import org.rust.cargo.project.workspace.CargoWorkspace.*
 import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.cargo.project.workspace.CargoWorkspaceData.Package
 import org.rust.cargo.project.workspace.CargoWorkspaceData.Target
@@ -53,17 +52,18 @@ open class RustProjectDescriptorBase : LightProjectDescriptor() {
         return CargoWorkspace.deserialize(Paths.get("/my-crate/Cargo.toml"), CargoWorkspaceData(packages, emptyMap()))
     }
 
-    protected fun testCargoPackage(contentRoot: String, name: String = "test-package") = Package(
+    protected fun testCargoPackage(contentRoot: String, name: String = "test-package") = CargoWorkspaceData.Package(
         id = "$name 0.0.1",
         contentRootUrl = contentRoot,
         name = name,
         version = "0.0.1",
         targets = listOf(
-            Target("$contentRoot/main.rs", name, TargetKind.BIN, listOf(CrateType.BIN)),
-            Target("$contentRoot/lib.rs", name, TargetKind.LIB, listOf(CrateType.LIB))
+            Target("$contentRoot/main.rs", name, TargetKind.BIN, listOf(CrateType.BIN), edition = Edition.EDITION_2015),
+            Target("$contentRoot/lib.rs", name, TargetKind.LIB, listOf(CrateType.LIB), edition = Edition.EDITION_2015)
         ),
         source = null,
-        origin = PackageOrigin.WORKSPACE
+        origin = PackageOrigin.WORKSPACE,
+        edition = Edition.EDITION_2015
     )
 }
 
@@ -115,10 +115,12 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
             targets = listOf(
                 // don't use `FileUtil.join` here because it uses `File.separator`
                 // which is system dependent although all other code uses `/` as separator
-                Target(source?.let { "$contentRoot/$it" } ?: "", targetName, TargetKind.LIB, listOf(CrateType.BIN))
+                Target(source?.let { "$contentRoot/$it" } ?: "", targetName,
+                    TargetKind.LIB, listOf(CrateType.BIN), Edition.EDITION_2015)
             ),
             source = source,
-            origin = origin
+            origin = origin,
+            edition = Edition.EDITION_2015
         )
     }
 

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTest.kt
@@ -25,6 +25,7 @@ import org.rust.RsTestBase
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.CrateType
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
 import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.cargo.project.workspace.PackageOrigin
@@ -394,7 +395,8 @@ class RunConfigurationProducerTest : RsTestBase() {
             val name: String,
             val file: File,
             val kind: CargoWorkspace.TargetKind,
-            val crateTypes: List<CargoWorkspace.CrateType>
+            val crateTypes: List<CargoWorkspace.CrateType>,
+            val edition: CargoWorkspace.Edition
         )
 
         private var targets = arrayListOf<Target>()
@@ -405,22 +407,22 @@ class RunConfigurationProducerTest : RsTestBase() {
         private val hello = """pub fn hello() -> String { return "Hello, World!".to_string() }"""
 
         fun bin(name: String, path: String, @Language("Rust") code: String = helloWorld): TestProjectBuilder {
-            addTarget(name, TargetKind.BIN, CrateType.BIN, path, code)
+            addTarget(name, TargetKind.BIN, CrateType.BIN, Edition.EDITION_2015, path, code)
             return this
         }
 
         fun example(name: String, path: String, @Language("Rust") code: String = helloWorld): TestProjectBuilder {
-            addTarget(name, TargetKind.EXAMPLE, CrateType.BIN, path, code)
+            addTarget(name, TargetKind.EXAMPLE, CrateType.BIN, Edition.EDITION_2015, path, code)
             return this
         }
 
         fun test(name: String, path: String, @Language("Rust") code: String = simpleTest): TestProjectBuilder {
-            addTarget(name, TargetKind.TEST, CrateType.BIN, path, code)
+            addTarget(name, TargetKind.TEST, CrateType.BIN, Edition.EDITION_2015, path, code)
             return this
         }
 
         fun lib(name: String, path: String, @Language("Rust") code: String = hello): TestProjectBuilder {
-            addTarget(name, TargetKind.LIB, CrateType.LIB, path, code)
+            addTarget(name, TargetKind.LIB, CrateType.LIB, Edition.EDITION_2015, path, code)
             return this
         }
 
@@ -463,11 +465,13 @@ class RunConfigurationProducerTest : RsTestBase() {
                                     myFixture.tempDirFixture.getFile(it.file.path)!!.url,
                                     it.name,
                                     it.kind,
-                                    it.crateTypes
+                                    it.crateTypes,
+                                    it.edition
                                 )
                             },
                             source = null,
-                            origin = PackageOrigin.WORKSPACE
+                            origin = PackageOrigin.WORKSPACE,
+                            edition = Edition.EDITION_2015
                         )
                     ),
                     dependencies = emptyMap()
@@ -477,9 +481,16 @@ class RunConfigurationProducerTest : RsTestBase() {
             project.cargoProjects.createTestProject(myFixture.findFileInTempDir("."), projectDescription)
         }
 
-        private fun addTarget(name: String, kind: CargoWorkspace.TargetKind, crateType: CargoWorkspace.CrateType, path: String, code: String) {
+        private fun addTarget(
+            name: String,
+            kind: CargoWorkspace.TargetKind,
+            crateType: CargoWorkspace.CrateType,
+            edition: CargoWorkspace.Edition,
+            path: String,
+            code: String
+        ) {
             val file = addFile(path, code)
-            targets.add(Target(name, file, kind, listOf(crateType)))
+            targets.add(Target(name, file, kind, listOf(crateType), edition))
         }
 
         private fun addFile(path: String, code: String): File {

--- a/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
@@ -9,8 +9,7 @@ import com.intellij.codeInsight.completion.PlainPrefixMatcher
 import org.rust.RsTestBase
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
-import org.rust.cargo.project.workspace.CargoWorkspace.CrateType
-import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
+import org.rust.cargo.project.workspace.CargoWorkspace.*
 import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.cargo.project.workspace.PackageOrigin
 import java.nio.file.Paths
@@ -98,17 +97,24 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
     }
 
     private val TEST_WORKSPACE = run {
-        fun target(name: String, kind: TargetKind, crateType: CrateType): CargoWorkspaceData.Target = CargoWorkspaceData.Target(
+        fun target(
+            name: String,
+            kind: TargetKind,
+            crateType: CrateType,
+            edition: Edition = Edition.EDITION_2015
+        ): CargoWorkspaceData.Target = CargoWorkspaceData.Target(
             crateRootUrl = "/tmp/lib/rs",
             name = name,
             kind = kind,
-            crateTypes = listOf(crateType)
+            crateTypes = listOf(crateType),
+            edition = edition
         )
 
         fun pkg(
             name: String,
             isWorkspaceMember: Boolean,
-            targets: List<CargoWorkspaceData.Target>
+            targets: List<CargoWorkspaceData.Target>,
+            edition: Edition = Edition.EDITION_2015
         ): CargoWorkspaceData.Package = CargoWorkspaceData.Package(
             name = name,
             id = "$name 1.0.0",
@@ -116,7 +122,8 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
             version = "1.0.0",
             targets = targets,
             source = null,
-            origin = if (isWorkspaceMember) PackageOrigin.WORKSPACE else PackageOrigin.DEPENDENCY
+            origin = if (isWorkspaceMember) PackageOrigin.WORKSPACE else PackageOrigin.DEPENDENCY,
+            edition = edition
         )
 
         val pkgs = listOf(

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -5,7 +5,9 @@
 
 package org.rust.ide.annotator
 
+import org.rust.MockEdition
 import org.rust.MockRustcVersion
+import org.rust.cargo.project.workspace.CargoWorkspace
 
 class RsErrorAnnotatorTest : RsAnnotationTestBase() {
     override val dataPath = "org/rust/ide/annotator/fixtures/errors"
@@ -1179,7 +1181,40 @@ class RsErrorAnnotatorTest : RsAnnotationTestBase() {
         }
     """)
 
-    fun `test crate keyword not at the beginning`() = checkErrors("""
-       use crate::foo::<error descr="`crate` is allowed only at the beginning">crate</error>::Foo;
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test crate keyword not at the beginning E0433`() = checkErrors("""
+        use crate::foo::<error descr="`crate` in paths can only be used in start position [E0433]">crate</error>::Foo;
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test crate keyword not at the beginning in use group E0433`() = checkErrors("""
+        use crate::foo::{<error descr="`crate` in paths can only be used in start position [E0433]">crate</error>::Foo};
+    """)
+
+    @MockRustcVersion("1.28.0")
+    fun `test crate in path feature E0658`() = checkErrors("""
+        mod foo {
+            pub struct Foo;
+        }
+
+        use <error descr="`crate` in paths is experimental [E0658]">crate</error>::foo::Foo;
+    """)
+
+    @MockRustcVersion("1.29.0-nightly")
+    fun `test crate in path feature E0658 2`() = checkErrors("""
+        mod foo {
+            pub struct Foo;
+        }
+
+        use <error descr="`crate` in paths is experimental [E0658]">crate</error>::foo::Foo;
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test crate in path feature E0658 3`() = checkErrors("""
+        mod foo {
+            pub struct Foo;
+        }
+
+        use crate::foo::Foo;
     """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddFeatureAttributeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddFeatureAttributeFixTest.kt
@@ -37,4 +37,18 @@ class AddFeatureAttributeFixTest : RsAnnotationTestBase() {
 
             crate/*caret*/ type Foo = i128;
         """)
+
+    @MockRustcVersion("1.28.0")
+    fun `test add crate_in_paths feature is unavailable`() = checkFixIsUnavailable("Add `crate_in_paths` feature", """
+        use <error>crate/*caret*/</error>::foo::Foo;
+    """)
+
+    @MockRustcVersion("1.30.0-nightly")
+    fun `test add crate_in_paths feature`() = checkFixByText("Add `crate_in_paths` feature", """
+        use <error>crate/*caret*/</error>::foo::Foo;
+    """, """
+        #![feature(crate_in_paths)]
+
+        use crate/*caret*/::foo::Foo;
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/FixUsePathsFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/FixUsePathsFixTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ide.annotator.RsAnnotationTestBase
+import org.rust.MockEdition
+
+@MockEdition(CargoWorkspace.Edition.EDITION_2018)
+class FixUsePathsFixTest : RsAnnotationTestBase() {
+
+    fun `test add crate keyword 1`() = checkFixByText("Add `crate` at the beginning of path", """
+        mod foo {
+            pub struct Foo;
+        }
+
+        use <error descr="Paths in `use` declarations should start with a crate name, or with `crate`, `super`, or `self`">foo::Foo/*caret*/</error>;
+    """, """
+        mod foo {
+            pub struct Foo;
+        }
+
+        use crate::foo::Foo/*caret*/;
+    """)
+
+    fun `test add crate keyword 2`() = checkFixByText("Add `crate` at the beginning of path", """
+        mod foo {
+            pub struct Foo;
+        }
+
+        use <error descr="Paths in `use` declarations should start with a crate name, or with `crate`, `super`, or `self`">::foo::Foo/*caret*/</error>;
+    """, """
+        mod foo {
+            pub struct Foo;
+        }
+
+        use crate::foo::Foo/*caret*/;
+    """)
+
+    fun `test add crate keyword with use group`() = checkFixByText("Add `crate` at the beginning of path", """
+        mod foo {
+            pub struct Foo;
+            pub struct Bar;
+        }
+
+        use <error descr="Paths in `use` declarations should start with a crate name, or with `crate`, `super`, or `self`">foo/*caret*/</error>::{Foo, Bar};
+    """, """
+        mod foo {
+            pub struct Foo;
+            pub struct Bar;
+        }
+
+        use crate::foo/*caret*/::{Foo, Bar};
+    """)
+
+    fun `test add crate keyword in use group`() = checkFixByText("Add `crate` at the beginning of path", """
+        mod foo {
+            pub struct Foo;
+        }
+
+        use {<error descr="Paths in `use` declarations should start with a crate name, or with `crate`, `super`, or `self`">foo::Foo</error>/*caret*/};
+    """, """
+        mod foo {
+            pub struct Foo;
+        }
+
+        use {crate::foo::Foo/*caret*/};
+    """)
+
+    fun `test do not insert crate keyword for unknown items`() = checkFixIsUnavailable("Add `crate` at the beginning of path", """
+        use <error descr="Paths in `use` declarations should start with a crate name, or with `crate`, `super`, or `self`">foo::Foo/*caret*/</error>;
+    """)
+
+    fun `test do not insert crate keyword for`() = checkFixIsUnavailable("Add `crate` at the beginning of path", """
+        mod bar {
+            pub mod foo {
+                pub struct Foo;
+            }
+        }
+
+        use crate::bar::foo;
+        use <error descr="Paths in `use` declarations should start with a crate name, or with `crate`, `super`, or `self`">foo::Foo/*caret*/</error>;
+    """)
+}


### PR DESCRIPTION
* check and quick fix to use the corresponding feature (edition 2015)
* check and quick fix if `crate` keyword is missed (edition 2018)
* improve "`crate` is allowed only at the beginning" annotation to highlight using `crate` keyword in non root use group