### PR TITLE
INSP: Do not highlight comments and attributes for impl...

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
@@ -11,10 +11,7 @@ import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.RsItemElement
-import org.rust.lang.core.psi.ext.RsTraitOrImpl
-import org.rust.lang.core.psi.ext.elementType
-import org.rust.lang.core.psi.ext.resolveToTrait
+import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.Testmark
 
 class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
@@ -23,7 +20,10 @@ class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
             val trait = impl.traitRef?.resolveToTrait ?: return
             val typeRef = impl.typeReference ?: return
             if (sortedImplItems(impl.items(), trait.items()) == null) return
-            val textRange = TextRange(0, typeRef.startOffsetInParent + typeRef.textLength)
+            val textRange = TextRange(
+                (impl.vis ?: impl.default ?: impl.unsafe ?: impl.impl).startOffsetInParent,
+                typeRef.startOffsetInParent + typeRef.textLength
+            )
             holder.registerProblem(
                 impl, textRange,
                 "Different impl member order from the trait",

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -15,6 +15,7 @@ import com.intellij.psi.util.PsiModificationTracker
 import org.rust.ide.icons.RsIcons
 import org.rust.ide.presentation.getPresentation
 import org.rust.lang.core.macros.RsExpandedElement
+import org.rust.lang.core.psi.RsElementTypes.DEFAULT
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsInnerAttr
 import org.rust.lang.core.psi.RsTraitItem
@@ -23,6 +24,9 @@ import org.rust.lang.core.stubs.RsImplItemStub
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.RsPsiTypeImplUtil
 import org.rust.lang.core.types.ty.Ty
+
+val RsImplItem.default: PsiElement?
+    get() = node.findChildByType(DEFAULT)?.psi
 
 abstract class RsImplItemImplMixin : RsStubbedElementImpl<RsImplItemStub>, RsImplItem {
 

--- a/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
@@ -179,6 +179,50 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
         }
     """, checkWeakWarn = true)
 
+    fun `test highlight unsafe keyword`() = checkByText("""
+        unsafe trait Foo {
+            fn foo();
+            fn bar();
+        }
+
+        <weak_warning descr="Different impl member order from the trait">/*caret*/unsafe impl Foo for ()</weak_warning> {
+            fn bar() {
+            }
+            fn foo() {
+            }
+        }
+    """, checkWeakWarn = true)
+
+    fun `test highlight default keyword`() = checkByText("""
+        unsafe trait Foo {
+            fn foo();
+            fn bar();
+        }
+
+        <weak_warning descr="Different impl member order from the trait">/*caret*/default unsafe impl Foo for ()</weak_warning> {
+            fn bar() {
+            }
+            fn foo() {
+            }
+        }
+    """, checkWeakWarn = true)
+
+    fun `test do not highlight comments and attributes for impl`() = checkByText("""
+        trait Foo {
+            fn foo();
+            fn bar();
+        }
+
+        // Some comment
+        #[cfg(some_attr = "value")]
+        <weak_warning descr="Different impl member order from the trait">/*caret*/impl Foo for ()</weak_warning> {
+            fn bar() {
+            }
+            fn foo() {
+            }
+        }
+    """, checkWeakWarn = true)
+
     fun `test different order with different files`() = checkFixByFileTree("Apply same member order", """
         //- foo.rs
         pub trait Trait {


### PR DESCRIPTION
...by `Different impl member order from the trait` inspection.

The problem:
<img width="532" alt="screen shot 2018-08-28 at 18 06 41" src="https://user-images.githubusercontent.com/6079006/44732083-3ea87a80-aaed-11e8-9bcb-8037460b86b0.png">

