### PR TITLE
RES: fix extern crate resolution with several versions of the same crate in dependencies

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -229,4 +229,18 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         use bar::S;
                //^ lib.rs
     """)
+
+    fun `test transitive dependency on the same crate`() = stubOnlyResolve("""
+    //- dep-lib-new/lib.rs
+        pub struct Foo;
+    //- dep-lib/lib.rs
+        extern crate dep_lib_target;
+
+        pub use dep_lib_target::Foo;
+    //- lib.rs
+        extern crate dep_lib_target;
+
+        use dep_lib_target::Foo;
+                            //^ dep-lib-new/lib.rs
+    """, NameResolutionTestmarks.otherVersionOfSameCrate)
 }


### PR DESCRIPTION
Some crates depend on another version of the same crate. For example, `rand 0.3` and `num-traits 0.1`.
And currently, name resolution of `extern crate` item for such transitive dependencies returns two items: `lib.rs` of the current crate (it's wrong) and `lib.rs` of transitive dependency (correct resolution). It leads to broken resolution and completion for a user because such crates actively use reexports from their transitive dependencies which we fail to resolve.

These changes fix this bug. Now we don't add a lib target of the current crate to resolve results while extern crate resolution inside the lib target, i.e. we ignore `lib.rs` of `rand 0.3` while resolution `extern crate rand` inside `lib.rs` of `rand 0.3` because it refers to `lib.rs` of `rand 0.4` (transitive dependency of `rand 0.3`)

Fixes #2439
Fixes #2793
Fixes resolution/completion part of  #2817