### PR TITLE
Group syntax highlighting options into collapsible menus.

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -87,6 +87,7 @@ private fun colorFor(element: RsElement): RsColor? = when (element) {
     is RsEnumItem -> RsColor.ENUM
     is RsEnumVariant -> RsColor.ENUM_VARIANT
     is RsExternCrateItem -> RsColor.CRATE
+    is RsConstant -> RsColor.CONSTANT
     is RsFieldDecl -> RsColor.FIELD
     is RsFunction -> when (element.owner) {
         is RsAbstractableOwner.Foreign, is RsAbstractableOwner.Free -> RsColor.FUNCTION

--- a/src/main/kotlin/org/rust/ide/colors/RsColorSettingsPage.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RsColorSettingsPage.kt
@@ -15,8 +15,6 @@ class RsColorSettingsPage : ColorSettingsPage {
     private val ATTRS = RsColor.values().map { it.attributesDescriptor }.toTypedArray()
 
     // This tags should be kept in sync with RsHighlightingAnnotator highlighting logic
-    // TODO: Figure out how to namespace menu elements a la
-    //       https://github.com/JetBrains/kotlin/blob/8b30e7ef4e48494ba245b441a5b23142f1d6ae33/idea/idea-analysis/src/org/jetbrains/kotlin/idea/KotlinBundle.properties
     private val ANNOTATOR_TAGS = RsColor.values().associateBy({ it.name }, { it.textAttributesKey })
 
     private val DEMO_TEXT by lazy {

--- a/src/main/kotlin/org/rust/ide/colors/RsColors.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RsColors.kt
@@ -13,63 +13,59 @@ import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Default
  * See [RsColorSettingsPage] and [org.rust.ide.highlight.RsHighlighter]
  */
 enum class RsColor(humanName: String, val default: TextAttributesKey) {
-    IDENTIFIER("Identifier", Default.IDENTIFIER),
-    FUNCTION("Function", Default.FUNCTION_DECLARATION),
-    METHOD("Method", Default.INSTANCE_METHOD),
-    ASSOC_FUNCTION("Associated function", Default.STATIC_METHOD),
-    PARAMETER("Parameter", Default.PARAMETER),
-    MUT_PARAMETER("Mutable parameter", Default.PARAMETER),
-    SELF_PARAMETER("Self parameter", Default.KEYWORD),
-    Q_OPERATOR("? operator", Default.KEYWORD),
+    IDENTIFIER("Variables//Default", Default.IDENTIFIER),
+    MUT_BINDING("Variables//Mutable binding", Default.IDENTIFIER),
+    FIELD("Variables//Field", Default.INSTANCE_FIELD),
+    CONSTANT("Variables//Constant", Default.CONSTANT),
 
-    LIFETIME("Lifetime", Default.IDENTIFIER),
+    FUNCTION("Functions//Function", Default.FUNCTION_DECLARATION),
+    METHOD("Functions//Method", Default.INSTANCE_METHOD),
+    ASSOC_FUNCTION("Functions//Associated function", Default.STATIC_METHOD),
+    MACRO("Functions//Macro", Default.IDENTIFIER),
 
-    CHAR("Char", Default.STRING),
-    STRING("String", Default.STRING),
-    NUMBER("Number", Default.NUMBER),
+    PARAMETER("Parameters//Parameter", Default.PARAMETER),
+    MUT_PARAMETER("Parameters//Mutable parameter", Default.PARAMETER),
+    SELF_PARAMETER("Parameters//Self parameter", Default.KEYWORD),
+    LIFETIME("Parameters//Lifetime", Default.IDENTIFIER),
+    TYPE_PARAMETER("Parameters//Type parameter", Default.IDENTIFIER),
 
-    PRIMITIVE_TYPE("Primitive type", Default.KEYWORD),
+    PRIMITIVE_TYPE("Types//Primitive", Default.KEYWORD),
+    STRUCT("Types//Struct", Default.CLASS_NAME),
+    TRAIT("Types//Trait", Default.INTERFACE_NAME),
+    ENUM("Types//Enum", Default.CLASS_NAME),
+    ENUM_VARIANT("Types//Enum variant", Default.STATIC_FIELD),
+    TYPE_ALIAS("Types//Type alias", Default.CLASS_NAME),
+    CRATE("Types//Crate", Default.IDENTIFIER),
+    MODULE("Types//Module", Default.IDENTIFIER),
 
-    CRATE("Crate", Default.IDENTIFIER),
-    STRUCT("Struct", Default.CLASS_NAME),
-    TRAIT("Trait", Default.INTERFACE_NAME),
-    MODULE("Module", Default.IDENTIFIER),
-    ENUM("Enum", Default.CLASS_NAME),
-    ENUM_VARIANT("Enum variant", Default.STATIC_FIELD),
-    TYPE_ALIAS("Type alias", Default.CLASS_NAME),
+    KEYWORD("Keywords//Keyword", Default.KEYWORD),
+    KEYWORD_UNSAFE("Keywords//unsafe", Default.KEYWORD),
 
-    FIELD("Field", Default.INSTANCE_FIELD),
+    CHAR("Literals//Char", Default.STRING),
+    NUMBER("Literals//Number", Default.NUMBER),
+    STRING("Literals//Strings//String", Default.STRING),
+    VALID_STRING_ESCAPE("Literals//Strings//Escape sequence//Valid", Default.VALID_STRING_ESCAPE),
+    INVALID_STRING_ESCAPE("Literals//Strings//Escape sequence//Invalid", Default.INVALID_STRING_ESCAPE),
 
-    KEYWORD("Keyword", Default.KEYWORD),
+    BLOCK_COMMENT("Comments//Block comment", Default.BLOCK_COMMENT),
+    EOL_COMMENT("Comments//Line comment", Default.LINE_COMMENT),
 
-    BLOCK_COMMENT("Block comment", Default.BLOCK_COMMENT),
-    EOL_COMMENT("Line comment", Default.LINE_COMMENT),
+    DOC_COMMENT("Rustdoc//Comment", Default.DOC_COMMENT),
+    DOC_HEADING("Rustdoc//Heading", Default.DOC_COMMENT_TAG),
+    DOC_LINK("Rustdoc//Link", Default.DOC_COMMENT_TAG_VALUE),
+    DOC_CODE("Rustdoc//Code", Default.DOC_COMMENT_MARKUP),
 
-    DOC_COMMENT("Rustdoc comment", Default.DOC_COMMENT),
-    DOC_HEADING("Rustdoc heading", Default.DOC_COMMENT_TAG),
-    DOC_LINK("Rustdoc link", Default.DOC_COMMENT_TAG_VALUE),
-    DOC_CODE("Rustdoc code", Default.DOC_COMMENT_MARKUP),
-
-    PARENTHESIS("Parenthesis", Default.PARENTHESES),
-    BRACKETS("Brackets", Default.BRACKETS),
-    BRACES("Braces", Default.BRACES),
-
-    OPERATORS("Operator sign", Default.OPERATION_SIGN),
-
-    SEMICOLON("Semicolon", Default.SEMICOLON),
-    DOT("Dot", Default.DOT),
-    COMMA("Comma", Default.COMMA),
+    BRACES("Braces and Operators//Braces", Default.BRACES),
+    BRACKETS("Braces and Operators//Brackets", Default.BRACKETS),
+    OPERATORS("Braces and Operators//Operation sign", Default.OPERATION_SIGN),
+    Q_OPERATOR("Braces and Operators//? operator", Default.KEYWORD),
+    SEMICOLON("Braces and Operators//Semicolon", Default.SEMICOLON),
+    DOT("Braces and Operators//Dot", Default.DOT),
+    COMMA("Braces and Operators//Comma", Default.COMMA),
+    PARENTHESIS("Braces and Operators//Parenthesis", Default.PARENTHESES),
 
     ATTRIBUTE("Attribute", Default.METADATA),
 
-    MACRO("Macro", Default.IDENTIFIER),
-
-    TYPE_PARAMETER("Type parameter", Default.IDENTIFIER),
-
-    MUT_BINDING("Mutable binding", Default.IDENTIFIER),
-
-    VALID_STRING_ESCAPE("Valid escape sequence", Default.VALID_STRING_ESCAPE),
-    INVALID_STRING_ESCAPE("Invalid escape sequence", Default.INVALID_STRING_ESCAPE),
     ;
 
     val textAttributesKey = TextAttributesKey.createTextAttributesKey("org.rust.$name", default)

--- a/src/main/kotlin/org/rust/ide/colors/RsColors.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RsColors.kt
@@ -12,7 +12,7 @@ import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Default
 /**
  * See [RsColorSettingsPage] and [org.rust.ide.highlight.RsHighlighter]
  */
-enum class RsColor(humanName: String, val default: TextAttributesKey) {
+enum class RsColor(val humanName: String, val default: TextAttributesKey) {
     IDENTIFIER("Variables//Default", Default.IDENTIFIER),
     MUT_BINDING("Variables//Mutable binding", Default.IDENTIFIER),
     FIELD("Variables//Field", Default.INSTANCE_FIELD),

--- a/src/main/kotlin/org/rust/ide/colors/RsColors.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RsColors.kt
@@ -39,7 +39,7 @@ enum class RsColor(val humanName: String, val default: TextAttributesKey) {
     MODULE("Types//Module", Default.IDENTIFIER),
 
     KEYWORD("Keywords//Keyword", Default.KEYWORD),
-    KEYWORD_UNSAFE("Keywords//unsafe", Default.KEYWORD),
+    KEYWORD_UNSAFE("Keywords//Unsafe", Default.KEYWORD),
 
     CHAR("Literals//Char", Default.STRING),
     NUMBER("Literals//Number", Default.NUMBER),

--- a/src/main/kotlin/org/rust/ide/highlight/RsHighlighter.kt
+++ b/src/main/kotlin/org/rust/ide/highlight/RsHighlighter.kt
@@ -64,6 +64,7 @@ class RsHighlighter : SyntaxHighlighterBase() {
             INVALID_CHARACTER_ESCAPE_TOKEN -> RsColor.INVALID_STRING_ESCAPE
             INVALID_UNICODE_ESCAPE_TOKEN -> RsColor.INVALID_STRING_ESCAPE
 
+            UNSAFE -> RsColor.KEYWORD_UNSAFE
             in RS_KEYWORDS, BOOL_LITERAL -> RsColor.KEYWORD
             in RS_OPERATORS -> RsColor.OPERATORS
 

--- a/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
+++ b/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
@@ -62,7 +62,8 @@ fn <FUNCTION>main</FUNCTION>() {
 /// # Heading
 /// [Rust](https://www.rust-lang.org/)
 <ATTRIBUTE>#[cfg(target_os=</ATTRIBUTE>"linux"<ATTRIBUTE>)]</ATTRIBUTE>
-unsafe fn <FUNCTION>a_function</FUNCTION><<TYPE_PARAMETER>T</TYPE_PARAMETER>: <LIFETIME>'lifetime</LIFETIME>>() {
+<KEYWORD_UNSAFE>unsafe</KEYWORD_UNSAFE> fn <FUNCTION>a_function</FUNCTION><<TYPE_PARAMETER>T</TYPE_PARAMETER>: <LIFETIME>'lifetime</LIFETIME>>(<MUT_PARAMETER>count</MUT_PARAMETER>: &mut i64) -> ! {
+    <MUT_PARAMETER>count</MUT_PARAMETER> += 1;
     'label: loop {
         <MACRO>println!</MACRO>("Hello\x20W\u{f3}rld!\u{abcdef}");
     }

--- a/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
+++ b/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
@@ -12,6 +12,8 @@ pub enum <ENUM>Flag</ENUM> {
     <ENUM_VARIANT>Ugly</ENUM_VARIANT>
 }
 
+const <CONSTANT>QUALITY</CONSTANT>: <ENUM>Flag</ENUM> = <ENUM>Flag</ENUM>::<ENUM_VARIANT>Good</ENUM_VARIANT>;
+
 pub trait <TRAIT>Write</TRAIT> {
     fn <METHOD>write</METHOD>(&mut <SELF_PARAMETER>self</SELF_PARAMETER>, <PARAMETER>buf</PARAMETER>: &[<PRIMITIVE_TYPE>u8</PRIMITIVE_TYPE>]) -> <ENUM>Result</ENUM><usize>;
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt
@@ -7,30 +7,37 @@ package org.rust.ide.annotator
 
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.ide.colors.RsColor
 
 class RsHighlightingMutableAnnotatorTest : RsAnnotationTestBase() {
+
+    val MUT_PARAMETER = RsColor.MUT_PARAMETER.humanName
+    val MUT_BINDING = RsColor.MUT_BINDING.humanName
+
     fun `test mut self highlight`() = checkInfo("""
         struct <info>Foo</info> {}
         impl <info>Foo</info> {
-            fn <info>bar</info>(&mut <info><info descr="Mutable parameter">self</info></info>) {
-                <info descr="Mutable parameter">self</info>.<info>bar</info>();
+            fn <info>bar</info>(&mut <info><info descr="$MUT_PARAMETER">self</info></info>) {
+                <info descr="$MUT_PARAMETER">self</info>.<info>bar</info>();
             }
         }
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    fun `test mut binding`() = checkInfo("""
-        fn <info descr="null">main</info>() {
-            let mut <info descr="Mutable binding">a</info> = 1;
-            let b = <info descr="Mutable binding">a</info>;
-            let <info descr="null">Some</info>(ref mut <info descr="Mutable binding">c</info>) = <info descr="null">Some</info>(10);
-            let <info descr="Mutable binding">d</info> = <info descr="Mutable binding">c</info>;
-        }
-    """)
+    fun `test mut binding`() {
+        checkInfo("""
+            fn <info descr="null">main</info>() {
+                let mut <info descr="$MUT_BINDING">a</info> = 1;
+                let b = <info descr="$MUT_BINDING">a</info>;
+                let <info descr="null">Some</info>(ref mut <info descr="$MUT_BINDING">c</info>) = <info descr="null">Some</info>(10);
+                let <info descr="$MUT_BINDING">d</info> = <info descr="$MUT_BINDING">c</info>;
+            }
+        """)
+    }
 
     fun `test mut parameter`() = checkInfo("""
-        fn <info>test</info>(mut <info><info descr="Mutable parameter">para</info></info>: <info>i32</info>) {
-            let b = <info><info descr="Mutable parameter">para</info></info>;
+        fn <info>test</info>(mut <info><info descr="$MUT_PARAMETER">para</info></info>: <info>i32</info>) {
+            let b = <info><info descr="$MUT_PARAMETER">para</info></info>;
         }
     """)
 }


### PR DESCRIPTION
Resolves the TODO I left in 2 years ago; naming mostly follows java's color menu.
This also added highlighting for constants and unsafe (as requested by https://github.com/intellij-rust/intellij-rust/issues/2814).

`./gradlew :runIde` looks good, but `./gradlew :test` segfaults, so I'm banking on CI to cover this.

Figured out the syntax from [GroovyColorSettingsPage.kt](https://github.com/JetBrains/intellij-community/blob/4999f5293e4307870020f1d0d672a3d35a52f22d/plugins/groovy/src/org/jetbrains/plugins/groovy/highlighter/GroovyColorSettingsPage.kt)

Closes #2814