### PR TITLE
QDOC: Reexports in doc links

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/ui.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/ui.kt
@@ -69,7 +69,7 @@ private class PopupImportItemUi(private val project: Project, private val dataCo
             }
 
             override fun getTextFor(value: ImportCandidate): String = value.info.usePath
-            override fun getIconFor(value: ImportCandidate): Icon? = value.importItem.item.getIcon(0)
+            override fun getIconFor(value: ImportCandidate): Icon? = value.qualifiedNamedItem.item.getIcon(0)
         }
         val popup = object : ListPopupImpl(step) {
             override fun getListElementRenderer(): ListCellRenderer<*> {
@@ -104,20 +104,21 @@ private class RsElementCellRenderer : DefaultPsiElementCellRenderer() {
             // how to use functionality of `PsiElementListCellRenderer`
             // and pass additional info with psi element at same time
             importCandidate = value
-            value.importItem.item
+            value.qualifiedNamedItem.item
         } else {
             value
         }
         return super.getListCellRendererComponent(list, realValue, index, isSelected, cellHasFocus)
     }
 
-    override fun getElementText(element: PsiElement): String = importCandidate?.importItem?.itemName ?: super.getElementText(element)
+    override fun getElementText(element: PsiElement): String = importCandidate?.qualifiedNamedItem?.itemName
+        ?: super.getElementText(element)
 
     override fun getContainerText(element: PsiElement, name: String): String? {
         val importCandidate = importCandidate
         return if (importCandidate != null) {
             val crateName = (importCandidate.info as? ImportInfo.ExternCrateImportInfo)?.externCrateName
-            val parentPath = importCandidate.importItem.parentCrateRelativePath ?: return null
+            val parentPath = importCandidate.qualifiedNamedItem.parentCrateRelativePath ?: return null
             val container = when {
                 crateName == null -> parentPath
                 parentPath.isEmpty() -> crateName
@@ -147,7 +148,7 @@ private class RsElementCellRenderer : DefaultPsiElementCellRenderer() {
         }
 
         private fun textWithIcon(): Pair<String, Icon>? {
-            val pkg = importCandidate?.importItem?.containingCargoTarget?.pkg ?: return null
+            val pkg = importCandidate?.qualifiedNamedItem?.containingCargoTarget?.pkg ?: return null
             return when (pkg.origin) {
                 PackageOrigin.STDLIB -> pkg.normName to RsIcons.RUST
                 PackageOrigin.DEPENDENCY, PackageOrigin.TRANSITIVE_DEPENDENCY -> pkg.normName to CargoIcons.ICON

--- a/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
@@ -232,6 +232,34 @@ class RsResolveLinkTest : RsTestBase() {
               //^
     """, "test_package/foo/bar/struct.foo.html")
 
+    fun `test fqn link with direct reexports`() = doTest("""
+        mod foo {
+            pub mod bar {
+                pub struct Baz;
+                          //X
+            }
+            pub use foo::bar::Baz;
+        }
+
+        struct Foo;
+              //^
+    """, "test_package/foo/struct.Baz.html")
+
+    fun `test fqn link with module reexports`() = doTest("""
+        mod foo {
+            pub mod bar {
+                pub mod baz {
+                    pub struct Baz;
+                              //X
+                }
+            }
+            pub use foo::bar::baz;
+        }
+
+        struct Foo;
+              //^
+    """, "test_package/foo/baz/struct.Baz.html")
+
     private fun doTest(@Language("Rust") code: String, link: String) {
         InlineFile(code)
         val context = findElementInEditor<RsNamedElement>("^")

--- a/src/test/kotlin/org/rust/ide/docs/RsStdlibResolveLinkTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsStdlibResolveLinkTest.kt
@@ -14,29 +14,25 @@ import org.rust.lang.core.psi.ext.RsNamedElement
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsStdlibResolveLinkTest : RsTestBase() {
-    fun `test with import`() = doTest("""
+    fun `test with import`() = doTest("Hash", ".../hash/mod.rs", """
         use std::hash::Hash;
 
         fn foo<T: Hash>(t: T) {}
           //^
-    """, "Hash", ".../hash/mod.rs")
+    """)
 
-    fun `test item from prelude`() = doTest("""
+    fun `test item from prelude`() = doTest("String", ".../string.rs", """
         fn foo(s: String) {}
           //^
-    """, "String", ".../string.rs")
+    """)
 
-    fun `test crate fqn link`() = doTest("""
-        fn foo() {}
-          //^
-    """, "std/index.html", ".../libstd/lib.rs")
+    fun `test crate fqn link`() = doTest("std/index.html", ".../libstd/lib.rs")
+    fun `test mod fqn link`() = doTest("std/io/index.html", ".../libstd/io/mod.rs")
+    fun `test fqn link with reexport`() = doTest("std/cmp/trait.Eq.html", ".../libcore/cmp.rs")
+    fun `test mod fqn link with reexport`() = doTest("std/marker/index.html", ".../libcore/marker.rs")
+    fun `test method fqn link with reexport`() = doTest("std/result/enum.Result.html#method.unwrap", ".../libcore/result.rs")
 
-    fun `test mod fqn link`() = doTest("""
-        fn foo() {}
-          //^
-    """, "std/io/index.html", ".../libstd/io/mod.rs")
-
-    private fun doTest(@Language("Rust") code: String, link: String, expectedPath: String) {
+    private fun doTest(link: String, expectedPath: String, @Language("Rust") code: String = DEFAULT_TEXT) {
         check(expectedPath.startsWith("...")) {
             "Expected path should start with '...', but '$expectedPath' was found"
         }
@@ -51,5 +47,13 @@ class RsStdlibResolveLinkTest : RsTestBase() {
         check(actualFile.path.endsWith(expectedPath.drop(3))) {
             "Should resolve to $expectedPath, was ${actualFile.path} instead"
         }
+    }
+
+    companion object {
+        @Language("Rust")
+        private const val DEFAULT_TEXT = """
+            struct Foo;
+                  //^
+        """
     }
 }


### PR DESCRIPTION
* Move `ImportItem` class and related code from `AutoImportFix.kt` into `RsQualifiedNamedElement.kt` as `QualifiedNamedItem` to reuse logic with reexport in fully qualified links resolution
* Partially support resolution of fully qualified links in quick documentation. 