### PR TITLE
Allow choosing which cargo project features are enabled

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -28,6 +28,8 @@ interface RustProjectSettingsService {
         var runExternalLinterOnTheFly: Boolean = false,
         var externalLinterArguments: String = "",
         var compileAllTargets: Boolean = true,
+        var cargoFeatures: FeaturesSetting = FeaturesSetting.Default,
+        var cargoFeaturesAdditional: List<String> = mutableListOf(),//TODO: Mutable?
         var useOffline: Boolean = false,
         var macroExpansionEngine: MacroExpansionEngine = MacroExpansionEngine.OLD,
         var showTestToolWindow: Boolean = true,
@@ -48,6 +50,13 @@ interface RustProjectSettingsService {
         DISABLED, OLD, NEW
     }
 
+    // We cannot add a toString() method, as the enum serialization/deserialization in XmlSerializerImpl uses toString()
+    enum class FeaturesSetting {
+        All,
+        Default,
+        NoDefault,
+    }
+
     /**
      * Allows to modify settings.
      * After setting change,
@@ -62,6 +71,8 @@ interface RustProjectSettingsService {
     val runExternalLinterOnTheFly: Boolean
     val externalLinterArguments: String
     val compileAllTargets: Boolean
+    val cargoFeatures: FeaturesSetting
+    val cargoFeaturesAdditional: List<String>
     val useOffline: Boolean
     val macroExpansionEngine: MacroExpansionEngine
     val showTestToolWindow: Boolean

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -18,6 +18,7 @@ import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.settings.RustProjectSettingsService.MacroExpansionEngine
 import org.rust.cargo.project.settings.RustProjectSettingsService.State
 import org.rust.cargo.toolchain.ExternalLinter
+import org.rust.cargo.project.settings.RustProjectSettingsService.FeaturesSetting
 import org.rust.cargo.toolchain.RustToolchain
 
 private const val serviceName: String = "RustProjectSettings"
@@ -40,6 +41,8 @@ class RustProjectSettingsServiceImpl(
     override val runExternalLinterOnTheFly: Boolean get() = state.runExternalLinterOnTheFly
     override val externalLinterArguments: String get() = state.externalLinterArguments
     override val compileAllTargets: Boolean get() = state.compileAllTargets
+    override val cargoFeatures: FeaturesSetting get() = state.cargoFeatures
+    override val cargoFeaturesAdditional: List<String> get() = state.cargoFeaturesAdditional
     override val useOffline: Boolean get() = state.useOffline
     override val macroExpansionEngine: MacroExpansionEngine get() = state.macroExpansionEngine
     override val showTestToolWindow: Boolean get() = state.showTestToolWindow

--- a/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructure.kt
+++ b/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructure.kt
@@ -56,42 +56,49 @@ class CargoProjectStructure(private var cargoProjects: List<CargoProject> = empt
         object Root : Node() {
             override fun toString(): String = "Root"
         }
+
         data class Project(val cargoProject: CargoProject) : Node() {
             override fun toString(): String = "Project"
         }
+
         data class WorkspaceMember(val pkg: CargoWorkspace.Package) : Node() {
             override fun toString(): String = "WorkspaceMember($name)"
         }
+
         data class Targets(val targets: Collection<CargoWorkspace.Target>) : Node() {
             override fun toString(): String = "Targets"
         }
+
         data class Target(val target: CargoWorkspace.Target) : Node() {
             override fun toString(): String = "Target($name[${target.kind.name.toLowerCase()}])"
         }
 
-        val name: String get() = when (this) {
-            Root -> ""
-            is Project -> cargoProject.presentableName
-            is WorkspaceMember -> pkg.name
-            is Targets -> "targets"
-            is Target -> target.name
-        }
+        val name: String
+            get() = when (this) {
+                Root -> ""
+                is Project -> cargoProject.presentableName
+                is WorkspaceMember -> pkg.name
+                is Targets -> "targets"
+                is Target -> target.name
+            }
 
-        val icon: Icon? get() = when (this) {
-            is Project -> CargoIcons.ICON
-            is WorkspaceMember -> CargoIcons.ICON
-            is Targets -> CargoIcons.TARGETS
-            is Target -> target.icon
-            else -> null
-        }
+        val icon: Icon?
+            get() = when (this) {
+                is Project -> CargoIcons.ICON
+                is WorkspaceMember -> CargoIcons.ICON
+                is Targets -> CargoIcons.TARGETS
+                is Target -> target.icon
+                else -> null
+            }
 
-        private val CargoWorkspace.Target.icon: Icon? get() = when (kind) {
-            is Lib -> CargoIcons.LIB_TARGET
-            Bin -> CargoIcons.BIN_TARGET
-            Test -> CargoIcons.TEST_TARGET
-            Bench -> CargoIcons.BENCH_TARGET
-            ExampleBin, is ExampleLib -> CargoIcons.EXAMPLE_TARGET
-            Unknown -> null
-        }
+        private val CargoWorkspace.Target.icon: Icon?
+            get() = when (kind) {
+                is Lib -> CargoIcons.LIB_TARGET
+                Bin -> CargoIcons.BIN_TARGET
+                Test -> CargoIcons.TEST_TARGET
+                Bench -> CargoIcons.BENCH_TARGET
+                ExampleBin, is ExampleLib -> CargoIcons.EXAMPLE_TARGET
+                Unknown -> null
+            }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructureTree.kt
+++ b/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructureTree.kt
@@ -18,12 +18,13 @@ import javax.swing.tree.TreeSelectionModel
 
 class CargoProjectStructureTree(model: CargoProjectStructure) : SimpleTree(model) {
 
-    val selectedProject: CargoProject? get() {
-        val path = selectionPath ?: return null
-        if (path.pathCount < 2) return null
-        val treeNode = path.getPathComponent(1) as? DefaultMutableTreeNode ?: return null
-        return (treeNode.userObject as? CargoProjectStructure.Node.Project)?.cargoProject
-    }
+    val selectedProject: CargoProject?
+        get() {
+            val path = selectionPath ?: return null
+            if (path.pathCount < 2) return null
+            val treeNode = path.getPathComponent(1) as? DefaultMutableTreeNode ?: return null
+            return (treeNode.userObject as? CargoProjectStructure.Node.Project)?.cargoProject
+        }
 
     init {
         isRootVisible = false

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -59,6 +59,8 @@ interface CargoWorkspace {
 
         val dependencies: Collection<Dependency>
 
+        val features: Collection<Feature>
+
         val workspace: CargoWorkspace
 
         val edition: Edition
@@ -119,6 +121,17 @@ interface CargoWorkspace {
         EDITION_2015, EDITION_2018
     }
 
+    class Feature(
+        val name: String,
+        val state: FeatureState
+    )
+
+    enum class FeatureState {
+        Unknown,
+        Enabled,
+        Disabled
+    }
+
     companion object {
         fun deserialize(manifestPath: Path, data: CargoWorkspaceData): CargoWorkspace =
             WorkspaceImpl.deserialize(manifestPath, data)
@@ -141,7 +154,8 @@ private class WorkspaceImpl(
             pkg.targets,
             pkg.source,
             pkg.origin,
-            pkg.edition
+            pkg.edition,
+            pkg.features
         )
     }
 
@@ -265,7 +279,8 @@ private class PackageImpl(
     targetsData: Collection<CargoWorkspaceData.Target>,
     override val source: String?,
     override var origin: PackageOrigin,
-    override val edition: CargoWorkspace.Edition
+    override val edition: CargoWorkspace.Edition,
+    override val features: Collection<CargoWorkspace.Feature>
 ) : CargoWorkspace.Package {
     override val targets = targetsData.map {
         TargetImpl(
@@ -327,7 +342,8 @@ private fun PackageImpl.asPackageData(edition: CargoWorkspace.Edition? = null): 
         },
         source = source,
         origin = origin,
-        edition = edition ?: this.edition
+        edition = edition ?: this.edition,
+        features = features
     )
 
 private fun StandardLibrary.StdCrate.asPackageData(rustcInfo: RustcInfo?): CargoWorkspaceData.Package {
@@ -358,7 +374,8 @@ private fun StandardLibrary.StdCrate.asPackageData(rustcInfo: RustcInfo?): Cargo
         )),
         source = null,
         origin = PackageOrigin.STDLIB,
-        edition = edition
+        edition = edition,
+        features = emptyList()
     )
 }
 

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
@@ -27,7 +27,8 @@ data class CargoWorkspaceData(
         val targets: Collection<Target>,
         val source: String?,
         val origin: PackageOrigin,
-        val edition: CargoWorkspace.Edition
+        val edition: CargoWorkspace.Edition,
+        val features: Collection<CargoWorkspace.Feature>
     )
 
     data class Target(

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -24,6 +24,7 @@ import com.intellij.util.text.SemVer
 import org.jetbrains.annotations.TestOnly
 import org.rust.cargo.CargoConstants.RUST_BACTRACE_ENV_VAR
 import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.settings.RustProjectSettingsService.FeaturesSetting
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.CargoWorkspace
@@ -97,9 +98,31 @@ class Cargo(private val cargoExecutable: Path) {
         projectDirectory: Path,
         listener: ProcessListener? = null
     ): CargoWorkspace {
-        val additionalArgs = mutableListOf("--verbose", "--format-version", "1", "--all-features")
+        val additionalArgs = mutableListOf("--verbose", "--format-version", "1")
         if (owner.rustSettings.useOffline) {
             additionalArgs += "-Zoffline"
+        }
+
+        val featuresAdditional = owner.rustSettings.cargoFeaturesAdditional
+        when (owner.rustSettings.cargoFeatures) {
+            FeaturesSetting.All -> {
+                additionalArgs += "--all-features"
+                // Passing --features is not necessary in this case
+                // cargo will just ignore them anyway
+            }
+            FeaturesSetting.Default -> {
+                if (!featuresAdditional.isEmpty()) {
+                    additionalArgs += "--features"
+                    additionalArgs += featuresAdditional.joinToString(separator = " ")
+                }
+            }
+            FeaturesSetting.NoDefault -> {
+                additionalArgs += "--no-default-features"
+                if (!featuresAdditional.isEmpty()) {
+                    additionalArgs += "--features"
+                    additionalArgs += featuresAdditional.joinToString(separator = " ")
+                }
+            }
         }
 
         val json = CargoCommandLine("metadata", projectDirectory, additionalArgs)

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -239,7 +239,7 @@ object CargoMetadata {
     fun clean(project: Project): CargoWorkspaceData {
         val fs = LocalFileSystem.getInstance()
         val members = project.workspace_members
-            ?: error("No `members` key in the `cargo metadata` output.\n" +
+            ?: error("No `workspace_members` key in the `cargo metadata` output.\n" +
                 "Your version of Cargo is no longer supported, please upgrade Cargo.")
         return CargoWorkspaceData(
             project.packages.mapNotNull { it.clean(fs, it.id in members) },

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -240,7 +240,7 @@ object CargoMetadata {
         val fs = LocalFileSystem.getInstance()
         val members = project.workspace_members
             ?: error("No `members` key in the `cargo metadata` output.\n" +
-            "Your version of Cargo is no longer supported, please upgrade Cargo.")
+                "Your version of Cargo is no longer supported, please upgrade Cargo.")
         return CargoWorkspaceData(
             project.packages.mapNotNull { it.clean(fs, it.id in members) },
             project.resolve.nodes.associate { (id, dependencies, deps) ->

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -34,6 +34,11 @@ object CargoMetadata {
         val packages: List<Package>,
 
         /**
+         * Ids of packages that are members of the cargo workspace
+         */
+        val workspace_members: List<String>?,
+
+        /**
          * A graph of dependencies
          */
         val resolve: Resolve,
@@ -42,11 +47,6 @@ object CargoMetadata {
          * Version of the format (currently 1)
          */
         val version: Int,
-
-        /**
-         * Ids of packages that are members of the cargo workspace
-         */
-        val workspace_members: List<String>?,
 
         /**
          * Path to workspace root folder. Can be null for old cargo version
@@ -65,13 +65,6 @@ object CargoMetadata {
         val version: String,
 
         /**
-         * Where did this package comes from? Local file system, crates.io, github repository.
-         *
-         * Will be `null` for the root package and path dependencies.
-         */
-        val source: String?,
-
-        /**
          * A unique id.
          * There may be several packages with the same name, but different version/source.
          * The triple (name, version, source) is unique.
@@ -79,15 +72,22 @@ object CargoMetadata {
         val id: PackageId,
 
         /**
-         * Path to Cargo.toml
+         * Where did this package comes from? Local file system, crates.io, github repository.
+         *
+         * Will be `null` for the root package and path dependencies.
          */
-        val manifest_path: String,
+        val source: String?,
 
         /**
          * Artifacts that can be build from this package.
          * This is a list of crates that can be build from the package.
          */
         val targets: List<Target>,
+
+        /**
+         * Path to Cargo.toml
+         */
+        val manifest_path: String,
 
         /**
          * Code edition of current package.
@@ -109,6 +109,13 @@ object CargoMetadata {
         val kind: List<String>,
 
         /**
+         * List of crate types
+         *
+         * See [linkage](https://doc.rust-lang.org/reference/linkage.html)
+         */
+        val crate_types: List<String>,
+
+        /**
          * Name
          */
         val name: String,
@@ -117,13 +124,6 @@ object CargoMetadata {
          * Path to the root module of the crate (aka crate root)
          */
         val src_path: String,
-
-        /**
-         * List of crate types
-         *
-         * See [linkage](https://doc.rust-lang.org/reference/linkage.html)
-         */
-        val crate_types: List<String>,
 
         /**
          * Code edition of current target.

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -34,7 +34,8 @@ object CargoMetadata {
         val packages: List<Package>,
 
         /**
-         * Ids of packages that are members of the cargo workspace
+         * Ids of packages that are members of the cargo workspace.
+         * Since: Rust 1.13.0
          */
         val workspace_members: List<String>?,
 
@@ -49,9 +50,9 @@ object CargoMetadata {
         val version: Int,
 
         /**
-         * Path to workspace root folder. Can be null for old cargo version
+         * Path to workspace root folder.
+         * Since: Rust 1.24.0
          */
-        // BACKCOMPAT: Rust 1.23: use not nullable type here
         val workspace_root: String?
     )
 
@@ -94,6 +95,7 @@ object CargoMetadata {
          *
          * Can be "2015", "2018" or null. Null value can be got from old version of cargo
          * so it is the same as "2015"
+         * Since: Rust 1.29.0
          */
         val edition: String?
     )
@@ -112,6 +114,7 @@ object CargoMetadata {
          * List of crate types
          *
          * See [linkage](https://doc.rust-lang.org/reference/linkage.html)
+         * Since: Rust 1.17.0
          */
         val crate_types: List<String>,
 
@@ -130,6 +133,7 @@ object CargoMetadata {
          *
          * Can be "2015", "2018" or null. Null value can be got from old version of cargo
          * so it is the same as "2015"
+         * Since: Rust 1.29.0
          */
         val edition: String?,
 
@@ -198,11 +202,14 @@ object CargoMetadata {
          * List of dependency info
          *
          * Contains additional info compared with [dependencies] like custom package name.
-         * Can be null for old cargo version
+         * Since: Rust 1.30.0
          */
         val deps: List<Dep>?
     )
 
+    /**
+     *  Since: Rust 1.30.0
+     */
     data class Dep(
         /**
          * Id of dependent package

--- a/src/main/kotlin/org/rust/ide/intentions/UnwrapToTryIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/UnwrapToTryIntention.kt
@@ -12,7 +12,6 @@ import org.rust.lang.core.psi.RsMethodCall
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.ancestorOrSelf
 import org.rust.lang.core.psi.ext.parentDotExpr
-import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psi.ext.receiver
 
 class UnwrapToTryIntention : RsElementBaseIntentionAction<RsMethodCall>() {

--- a/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
@@ -17,7 +17,6 @@ import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsStructItem
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.ext.searchForImplementations
-import org.rust.lang.core.psi.ext.union
 
 /**
  * Annotates trait declaration with an icon on the gutter that allows to jump to

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -70,7 +70,8 @@ open class RustProjectDescriptorBase : LightProjectDescriptor() {
         ),
         source = null,
         origin = PackageOrigin.WORKSPACE,
-        edition = Edition.EDITION_2015
+        edition = Edition.EDITION_2015,
+        features = emptyList()
     )
 }
 
@@ -151,7 +152,8 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
             ),
             source = source,
             origin = origin,
-            edition = Edition.EDITION_2015
+            edition = Edition.EDITION_2015,
+            features = emptyList()
         )
     }
 

--- a/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
@@ -25,6 +25,13 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
         val text = """
             <RustProjectSettings>
               <option name="autoUpdateEnabled" value="false" />
+              <option name="cargoFeatures" value="NoDefault" />
+              <option name="cargoFeaturesAdditional">
+                <list>
+                  <option value="foo" />
+                  <option value="bar" />
+                </list>
+              </option>
               <option name="compileAllTargets" value="false" />
               <option name="doctestInjectionEnabled" value="false" />
               <option name="explicitPathToStdlib" value="/stdlib" />
@@ -59,6 +66,8 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
         assertEquals(false, service.doctestInjectionEnabled)
         assertEquals(true, service.runRustfmtOnSave)
         assertEquals(true, service.useSkipChildren)
+        assertEquals(RustProjectSettingsService.FeaturesSetting.NoDefault, service.cargoFeatures)
+        assertEquals(listOf("foo", "bar"), service.cargoFeaturesAdditional)
     }
 
     fun `test update from version 1`() {

--- a/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
@@ -7,6 +7,7 @@ package org.rust.cargo.project
 
 import com.intellij.testFramework.LightPlatformTestCase
 import org.intellij.lang.annotations.Language
+import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.settings.RustProjectSettingsService.MacroExpansionEngine
 import org.rust.cargo.project.settings.impl.RustProjectSettingsServiceImpl
 import org.rust.cargo.project.settings.impl.XML_FORMAT_VERSION
@@ -99,5 +100,32 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
         assertEquals(true, service.runExternalLinterOnTheFly)
         assertEquals("", service.externalLinterArguments)
         assertEquals(MacroExpansionEngine.DISABLED, service.macroExpansionEngine)
+    }
+
+    fun `test defaults`() {
+        val service = RustProjectSettingsServiceImpl(LightPlatformTestCase.getProject())
+        @Language("XML")
+        val text = """
+            <State>
+            </State>
+        """.trimIndent()
+        service.loadState(elementFromXmlString(text))
+
+        assertEquals(XML_FORMAT_VERSION, service.version)
+        assertEquals(null, service.toolchain)
+        assertEquals(true, service.autoUpdateEnabled)
+        assertEquals(ExternalLinter.CARGO_CHECK, service.externalLinter)
+        assertEquals(null, service.explicitPathToStdlib)
+        assertEquals(false, service.runExternalLinterOnTheFly)
+        assertEquals("", service.externalLinterArguments)
+        assertEquals(true, service.compileAllTargets)
+        assertEquals(false, service.useOffline)
+        assertEquals(MacroExpansionEngine.OLD, service.macroExpansionEngine)
+        assertEquals(true, service.showTestToolWindow)
+        assertEquals(true, service.doctestInjectionEnabled)
+        assertEquals(false, service.runRustfmtOnSave)
+        assertEquals(false, service.useSkipChildren)
+        assertEquals(RustProjectSettingsService.FeaturesSetting.Default, service.cargoFeatures)
+        assertEquals(listOf<String>(), service.cargoFeaturesAdditional)
     }
 }

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestBase.kt
@@ -219,7 +219,8 @@ abstract class RunConfigurationProducerTestBase : RsTestBase() {
                             },
                             source = null,
                             origin = PackageOrigin.WORKSPACE,
-                            edition = Edition.EDITION_2015
+                            edition = Edition.EDITION_2015,
+                            features = emptyList()
                         )
                     ),
                     dependencies = emptyMap()

--- a/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
@@ -121,7 +121,8 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
             targets = targets,
             source = null,
             origin = if (isWorkspaceMember) PackageOrigin.WORKSPACE else PackageOrigin.DEPENDENCY,
-            edition = edition
+            edition = edition,
+            features = emptyList()
         )
 
         val pkgs = listOf(


### PR DESCRIPTION
Allow choosing per project which cargo project features are enabled:
- All features (`--all-features`)
- Default features + custom features
- No default features (`--no-default-features`) + custom features

Custom features are passed via `--features xxx`

The default is changed from `All features` to `Default features`.

This currently only influences calls to `cargo metadata` which influences crate resolution and thus available crates.

In a next step this information about features can be used for analysis/evaluation of `#[cfg(feature="foo")]` attributes (#2166)