### PR TITLE
INSP: move checks for anchored paths to separate inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -15,7 +15,6 @@ import com.intellij.psi.PsiFile
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.toolchain.RustChannel
-import org.rust.ide.annotator.fixes.AddCrateKeywordFix
 import org.rust.ide.annotator.fixes.AddFeatureAttributeFix
 import org.rust.ide.annotator.fixes.AddModuleFileFix
 import org.rust.ide.annotator.fixes.AddTurbofishFix
@@ -25,8 +24,6 @@ import org.rust.lang.core.CompilerFeature
 import org.rust.lang.core.FeatureState.ACCEPTED
 import org.rust.lang.core.FeatureState.ACTIVE
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.RsElementTypes.CSELF
-import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.Namespace
 import org.rust.lang.core.resolve.namespaces
@@ -226,25 +223,7 @@ class RsErrorAnnotator : Annotator, HighlightRangeExtension {
             }
         }
 
-        if (edition == Edition.EDITION_2018 && parent is RsUseSpeck && parent.qualifier == null) {
-            checkPathInUseItem(path, holder)
-        }
-
         checkReferenceIsPublic(path, path, holder)
-    }
-
-    private fun checkPathInUseItem(path: RsPath, holder: AnnotationHolder) {
-        val basePath = path.basePath()
-        basePath.node.findChildByType(tokenSetOf(IDENTIFIER, CSELF)) ?: return
-
-        val element = basePath.reference.resolve()
-        if (element is RsMod && element.isCrateRoot) return
-        val annotation = holder.createErrorAnnotation(path,
-            "Paths in `use` declarations should start with a crate name, or with `crate`, `super`, or `self`")
-        // TODO: add fixes for other cases
-        if (element != null && element.crateRoot == path.crateRoot && element.containingMod.isCrateRoot) {
-            annotation.registerFix(AddCrateKeywordFix(path))
-        }
     }
 
     private fun checkLifetimeParameter(holder: AnnotationHolder, lifetimeParameter: RsLifetimeParameter) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsAnchoredPathsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAnchoredPathsInspection.kt
@@ -1,0 +1,50 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ide.inspections.fixes.AddCrateKeywordFix
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.basePath
+import org.rust.lang.core.psi.ext.containingCargoTarget
+import org.rust.lang.core.psi.ext.qualifier
+
+class RsAnchoredPathsInspection : RsLocalInspectionTool() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = object : RsVisitor() {
+        override fun visitPath(path: RsPath) {
+            val parent = path.parent
+            val edition = path.containingCargoTarget?.edition
+
+            if (edition == CargoWorkspace.Edition.EDITION_2018 && parent is RsUseSpeck && parent.qualifier == null) {
+                checkPathInUseItem(path, holder)
+            }
+        }
+    }
+
+    private fun checkPathInUseItem(path: RsPath, holder: ProblemsHolder) {
+        val basePath = path.basePath()
+        basePath.node.findChildByType(tokenSetOf(RsElementTypes.IDENTIFIER, RsElementTypes.CSELF)) ?: return
+
+        val element = basePath.reference.resolve()
+        if (element is RsMod && element.isCrateRoot) return
+
+        val fixes = if (element != null && element.crateRoot == path.crateRoot && element.containingMod.isCrateRoot) {
+            arrayOf(AddCrateKeywordFix(path))
+        } else {
+            emptyArray()
+        }
+
+        holder.registerProblem(
+            path,
+            "Paths in `use` declarations should start with a crate name, or with `crate`, `super`, or `self`",
+            *fixes
+        )
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AddCrateKeywordFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AddCrateKeywordFix.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.annotator.fixes
+package org.rust.ide.inspections.fixes
 
 import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -462,6 +462,11 @@
                          enabledByDefault="true" level="ERROR"
                          implementationClass="org.rust.ide.inspections.RsAssignToImmutableInspection"/>
 
+        <localInspection language="Rust" groupPath="Rust" groupName="Edition 2018"
+                         displayName="Anchored paths"
+                         enabledByDefault="false" level="ERROR"
+                         implementationClass="org.rust.ide.inspections.RsAnchoredPathsInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsAnchoredPaths.html
+++ b/src/main/resources/inspectionDescriptions/RsAnchoredPaths.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+Checks that all paths in <code>use</code> items start with a crate name, or with <code>crate</code>,
+<code>super</code>, or <code>self</code>.<br>
+
+Related to "anchored paths" variant in Edition 2018.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/RsAnchoredPathsInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsAnchoredPathsInspectionTest.kt
@@ -3,14 +3,13 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.annotator.fixes
+package org.rust.ide.inspections
 
 import org.rust.cargo.project.workspace.CargoWorkspace
-import org.rust.ide.annotator.RsAnnotationTestBase
 import org.rust.MockEdition
 
 @MockEdition(CargoWorkspace.Edition.EDITION_2018)
-class FixUsePathsFixTest : RsAnnotationTestBase() {
+class RsAnchoredPathsInspectionTest : RsInspectionsTestBase(RsAnchoredPathsInspection()) {
 
     fun `test add crate keyword 1`() = checkFixByText("Add `crate` at the beginning of path", """
         mod foo {


### PR DESCRIPTION
Because there isn't a final decision about paths in `use` items, it was decided to move related code annotation into separate inspection and disable it by default not to generate false positive annotations.

When new path design will be fixed, we will adopt inspection (if it is necessary) and enable it