### PR TITLE
MACRO: expand multiple `lazy_static` definitions in the same call

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -55,6 +55,7 @@ mhaessig
 mitchhentges
 mkaput
 mrhota
+msmorgan
 netvl
 Nilera
 ninjabear

--- a/src/main/kotlin/org/rust/lang/core/macros/LazyStatic.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/LazyStatic.kt
@@ -8,51 +8,64 @@ package org.rust.lang.core.macros
 import com.intellij.psi.PsiElement
 import com.intellij.psi.tree.IElementType
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.descendantOfTypeStrict
+import org.rust.lang.core.psi.ext.descendantsOfType
 import org.rust.lang.core.psi.ext.elementType
 
-fun expandLazyStatic(call: RsMacroCall): RsExpandedElement? {
+fun expandLazyStatic(call: RsMacroCall): List<RsExpandedElement>? {
     val arg = call.macroArgument?.compactTT ?: return null
-    val lazyStaticCall = parseLazyStaticCall(arg) ?: return null
-    val text = "${if (lazyStaticCall.pub) "pub " else ""}static ${lazyStaticCall.identifier}: ${lazyStaticCall.type} = &${lazyStaticCall.expr};"
+    val lazyStaticRefs = parseLazyStaticCall(arg)
+    val texts = lazyStaticRefs.map { "${if (it.pub) "pub " else ""}static ${it.identifier}: ${it.type} = &${it.expr};" }
     return RsPsiFactory(call.project)
-        .createFile(text)
-        .descendantOfTypeStrict<RsConstant>()
+        .createFile(texts.joinToString("\n"))
+        .descendantsOfType<RsConstant>()
+        .toList()
 }
 
-private data class LazyStaticCall(
+private data class LazyStaticRef(
     val pub: Boolean,
     val identifier: String,
     val type: String,
     val expr: String
 )
 
-private fun parseLazyStaticCall(tt: RsCompactTT): LazyStaticCall? {
-    // static ref FOO: Foo = Foo::new();
-    val pub = tt.firstToken(RsElementTypes.PUB) != null
-    val ident = tt.firstToken(RsElementTypes.IDENTIFIER) ?: return null
-    val colon = tt.firstToken(RsElementTypes.COLON) ?: return null
-    val eq = tt.firstToken(RsElementTypes.EQ) ?: return null
-    val semi = tt.firstToken(RsElementTypes.SEMICOLON) ?: return null
+private fun parseLazyStaticCall(tt: RsCompactTT): List<LazyStaticRef> {
+    val calls = mutableListOf<LazyStaticRef>()
 
-    val typeStart = colon.textRange.endOffset - tt.textRange.startOffset
-    val typeEnd = eq.textRange.startOffset - tt.textRange.startOffset
-    if (typeStart >= typeEnd) return null
-    val typeText = tt.text.substring(typeStart, typeEnd)
+    var start = tt.firstChild
+    while (start != null) {
+        parseLazyStaticRef(start, tt)?.let { calls.add(it) }
+        start = start.firstSibling(RsElementTypes.SEMICOLON)?.nextSibling
+    }
 
-    val exprStart = eq.textRange.endOffset - tt.textRange.startOffset
-    val exprEnd = semi.textRange.startOffset - tt.textRange.startOffset
-    if (exprStart >= exprEnd) return null
-    val exprText = tt.text.substring(exprStart, exprEnd)
-
-    return LazyStaticCall(pub, ident.text, typeText, exprText)
+    return calls
 }
 
-private fun RsCompactTT.firstToken(type: IElementType): PsiElement? {
-    var child = firstChild
-    while (child != null) {
-        if (child.elementType == type) return child
-        child = child.nextSibling
+private fun parseLazyStaticRef(start: PsiElement, parent: RsCompactTT): LazyStaticRef? {
+    // static ref FOO: Foo = Foo::new();
+    val pub = start.firstSibling(RsElementTypes.PUB) != null
+    val ident = start.firstSibling(RsElementTypes.IDENTIFIER) ?: return null
+    val colon = start.firstSibling(RsElementTypes.COLON) ?: return null
+    val eq = start.firstSibling(RsElementTypes.EQ) ?: return null
+    val semi = start.firstSibling(RsElementTypes.SEMICOLON) ?: return null
+
+    val typeStart = colon.textRange.endOffset - parent.textRange.startOffset
+    val typeEnd = eq.textRange.startOffset - parent.textRange.startOffset
+    if (typeStart >= typeEnd) return null
+    val typeText = parent.text.substring(typeStart, typeEnd)
+
+    val exprStart = eq.textRange.endOffset - parent.textRange.startOffset
+    val exprEnd = semi.textRange.startOffset - parent.textRange.startOffset
+    if (exprStart >= exprEnd) return null
+    val exprText = parent.text.substring(exprStart, exprEnd)
+
+    return LazyStaticRef(pub, ident.text, typeText, exprText)
+}
+
+private fun PsiElement.firstSibling(type: IElementType): PsiElement? {
+    var element: PsiElement? = this
+    while (element != null) {
+        if (element.elementType == type) return element
+        element = element.nextSibling
     }
     return null
 }

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
@@ -21,7 +21,7 @@ fun expandMacro(call: RsMacroCall): CachedValueProvider.Result<List<RsExpandedEl
     val context = call.context as? RsElement ?: return NULL_RESULT
     return when {
         call.macroName == "lazy_static" -> {
-            val result = expandLazyStatic(call)?.let { listOf(it) }
+            val result = expandLazyStatic(call)
             result?.forEach {
                 it.setContext(context)
                 it.setExpandedFrom(call)

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
@@ -23,6 +23,48 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
         }      //^
     """)
 
+    fun `test multiple lazy static 1`() = checkByCode("""
+        #[macro_use]
+        extern crate lazy_static;
+
+        struct Foo {}
+        impl Foo {
+            fn new() -> Foo { Foo {} }
+            fn bar (&self) {}
+        }     //X
+
+        lazy_static! {
+            static ref FOO_1: Foo = Foo::new();
+            static ref FOO_2: Foo = Foo::new();
+        }
+
+        fn main() {
+            FOO_1.bar();
+                 //^
+        }
+    """)
+
+    fun `test multiple lazy static 2`() = checkByCode("""
+        #[macro_use]
+        extern crate lazy_static;
+
+        struct Foo {}
+        impl Foo {
+            fn new() -> Foo { Foo {} }
+            fn bar (&self) {}
+        }     //X
+
+        lazy_static! {
+            static ref FOO_1: Foo = Foo::new();
+            static ref FOO_2: Foo = Foo::new();
+        }
+
+        fn main() {
+            FOO_2.bar();
+                 //^
+        }
+    """)
+
     fun `test expand item`() = checkByCode("""
         macro_rules! if_std {
             ($ i:item) => (


### PR DESCRIPTION
Adds macro expansion support for multiple `lazy_static` declarations in the same block.

I'm not sure how to go about writing a new test for this, since it seems that `RsResolveTestBase#checkByCode()` does not support resolving multiple symbols.