### PR TITLE
INSP: don't search initial items for auto import in transitive dependencies

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -31,9 +31,11 @@ import java.util.concurrent.TimeUnit
  * Cargo itself via `cargo metadata` command.
  */
 interface CargoProjectsService {
-    fun findProjectForFile(file: VirtualFile): CargoProject?
     val allProjects: Collection<CargoProject>
     val hasAtLeastOneValidProject: Boolean
+
+    fun findProjectForFile(file: VirtualFile): CargoProject?
+    fun findPackageForFile(file: VirtualFile): CargoWorkspace.Package?
 
     fun attachCargoProject(manifest: Path): Boolean
     fun detachCargoProject(cargoProject: CargoProject)

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoPackageIndex.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoPackageIndex.kt
@@ -1,0 +1,63 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.model.impl
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.Consumer
+import com.intellij.util.indexing.LightDirectoryIndex
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.model.CargoProjectsService
+import org.rust.cargo.project.workspace.CargoWorkspace.Package
+import org.rust.openapiext.checkReadAccessAllowed
+import org.rust.openapiext.checkWriteAccessAllowed
+import java.util.*
+
+class CargoPackageIndex(
+    private val project: Project,
+    private val service: CargoProjectsService
+) : CargoProjectsService.CargoProjectsListener {
+
+    private val indices: MutableMap<CargoProject, LightDirectoryIndex<Optional<Package>>> = hashMapOf()
+    private var indexDisposable: Disposable? = null
+
+    init {
+        project.messageBus.connect(project).subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, this)
+    }
+
+    override fun cargoProjectsUpdated(projects: Collection<CargoProject>) {
+        checkWriteAccessAllowed()
+        resetIndex()
+        val disposable = Disposer.newDisposable("CargoPackageIndexDisposable")
+        Disposer.register(project, disposable)
+        for (cargoProject in projects) {
+            val packages = cargoProject.workspace?.packages.orEmpty()
+            indices[cargoProject] = LightDirectoryIndex(disposable, Optional.empty(), Consumer { index ->
+                for (pkg in packages) {
+                    index.putInfo(pkg.contentRoot, Optional.of(pkg))
+                }
+            })
+        }
+        indexDisposable = disposable
+    }
+
+    fun findPackageForFile(file: VirtualFile): Package? {
+        checkReadAccessAllowed()
+        val cargoProject = service.findProjectForFile(file) ?: return null
+        return indices[cargoProject]?.getInfoForFile(file)?.orElse(null)
+    }
+
+    private fun resetIndex() {
+        val disposable = indexDisposable
+        if (disposable != null) {
+            Disposer.dispose(disposable)
+        }
+        indexDisposable = null
+        indices.clear()
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -118,14 +118,18 @@ class CargoProjectsServiceImpl(
             }
         })
 
-    override fun findProjectForFile(file: VirtualFile): CargoProject? =
-        directoryIndex.getInfoForFile(file).takeIf { it !== noProjectMarker }
+    private val packageIndex: CargoPackageIndex = CargoPackageIndex(project, this)
 
     override val allProjects: Collection<CargoProject>
         get() = projects.currentState
 
     override val hasAtLeastOneValidProject: Boolean
         get() = hasAtLeastOneValidProject(allProjects)
+
+    override fun findProjectForFile(file: VirtualFile): CargoProject? =
+        directoryIndex.getInfoForFile(file).takeIf { it !== noProjectMarker }
+
+    override fun findPackageForFile(file: VirtualFile): CargoWorkspace.Package? = packageIndex.findPackageForFile(file)
 
     override fun attachCargoProject(manifest: Path): Boolean {
         if (isExistingProject(allProjects, manifest)) return false
@@ -177,10 +181,10 @@ class CargoProjectsServiceImpl(
                         directoryIndex.resetIndex()
                         ProjectRootManagerEx.getInstanceEx(project)
                             .makeRootsChange(EmptyRunnable.getInstance(), false, true)
+                        project.messageBus.syncPublisher(CargoProjectsService.CARGO_PROJECTS_TOPIC)
+                            .cargoProjectsUpdated(projects)
                     }
                 }
-                project.messageBus.syncPublisher(CargoProjectsService.CARGO_PROJECTS_TOPIC)
-                    .cargoProjectsUpdated(projects)
 
                 projects
             }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -101,12 +101,13 @@ interface CargoWorkspace {
     }
 
     companion object {
-        fun deserialize(manifestPath: Path, data: CargoWorkspaceData): CargoWorkspace = WorkspaceImpl.deserialize(manifestPath, data)
+        fun deserialize(manifestPath: Path, data: CargoWorkspaceData): CargoWorkspace =
+            WorkspaceImpl.deserialize(manifestPath, data)
     }
 }
 
 
-private class WorkspaceImpl constructor(
+private class WorkspaceImpl(
     override val manifestPath: Path,
     override val workspaceRootPath: Path?,
     packagesData: Collection<CargoWorkspaceData.Package>
@@ -126,6 +127,7 @@ private class WorkspaceImpl constructor(
     }
 
     val targetByCrateRootUrl = packages.flatMap { it.targets }.associateBy { it.crateRootUrl }
+
     override fun findTargetByCrateRoot(root: VirtualFile): CargoWorkspace.Target? {
         val canonicalFile = root.canonicalFile ?: return null
         return targetByCrateRootUrl[canonicalFile.url]

--- a/src/main/kotlin/org/rust/ide/search/RsCargoProjectScope.kt
+++ b/src/main/kotlin/org/rust/ide/search/RsCargoProjectScope.kt
@@ -1,0 +1,24 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.search
+
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.DelegatingGlobalSearchScope
+import com.intellij.psi.search.GlobalSearchScope
+import org.rust.cargo.project.model.CargoProjectsService
+import org.rust.cargo.project.workspace.PackageOrigin
+
+class RsCargoProjectScope(
+    private val service: CargoProjectsService,
+    baseScope: GlobalSearchScope
+) : DelegatingGlobalSearchScope(baseScope) {
+
+    override fun contains(file: VirtualFile): Boolean {
+        if (!myBaseScope.contains(file)) return false
+        val pkg = service.findPackageForFile(file) ?: return false
+        return pkg.origin != PackageOrigin.TRANSITIVE_DEPENDENCY
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsNamedElementIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsNamedElementIndex.kt
@@ -38,7 +38,10 @@ class RsNamedElementIndex : StringStubIndexExtension<RsNamedElement>() {
                     }
             }
 
-        fun findElementsByName(project: Project, target: String): Collection<RsNamedElement> =
-            getElements(KEY, target, project, GlobalSearchScope.allScope(project))
+        fun findElementsByName(
+            project: Project,
+            target: String,
+            scope: GlobalSearchScope = GlobalSearchScope.allScope(project)
+        ): Collection<RsNamedElement> = getElements(KEY, target, project, scope)
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsReexportIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsReexportIndex.kt
@@ -34,7 +34,10 @@ class RsReexportIndex : StringStubIndexExtension<RsUseSpeck>() {
             sink.occurrence(KEY, name)
         }
 
-        fun findReexportsByName(project: Project, target: String): Collection<RsUseSpeck> =
-            getElements(KEY, target, project, GlobalSearchScope.allScope(project))
+        fun findReexportsByName(
+            project: Project,
+            target: String,
+            scope: GlobalSearchScope = GlobalSearchScope.allScope(project)
+        ): Collection<RsUseSpeck> = getElements(KEY, target, project, scope)
     }
 }

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -109,7 +109,7 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
     ): Package {
         return Package(
             id = "$name $version",
-            contentRootUrl = "",
+            contentRootUrl = contentRoot,
             name = name,
             version = version,
             targets = listOf(
@@ -134,10 +134,11 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
     override fun testCargoProject(module: Module, contentRoot: String): CargoWorkspace {
         val packages = listOf(
             testCargoPackage(contentRoot),
-            externalPackage(contentRoot, "dep-lib/lib.rs", "dep-lib", "dep-lib-target"),
-            externalPackage(contentRoot, null, "nosrc-lib", "nosrc-lib-target"),
-            externalPackage(contentRoot, "trans-lib/lib.rs", "trans-lib"),
-            externalPackage(contentRoot, "dep-lib-new/lib.rs", "dep-lib", "dep-lib-target",
+            externalPackage("$contentRoot/dep-lib", "lib.rs", "dep-lib", "dep-lib-target"),
+            externalPackage("", null, "nosrc-lib", "nosrc-lib-target"),
+            externalPackage("$contentRoot/trans-lib", "lib.rs", "trans-lib",
+                origin = PackageOrigin.TRANSITIVE_DEPENDENCY),
+            externalPackage("$contentRoot/dep-lib-new", "lib.rs", "dep-lib", "dep-lib-target",
                 version = "0.0.2", origin = PackageOrigin.TRANSITIVE_DEPENDENCY)
         )
 

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
@@ -388,4 +388,36 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
             f.read_to_string/*caret*/(&mut s);
         }
     """)
+
+    fun `test do not suggest items from transitive dependencies`() = checkAutoImportFixByFileTree("""
+        //- dep-lib-new/lib.rs
+        pub struct Foo;
+
+        //- dep-lib/lib.rs
+        extern crate dep_lib_target;
+
+        pub use dep_lib_target::Foo;
+
+        //- main.rs
+        fn main() {
+            let foo = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
+        }
+    """, """
+        //- dep-lib-new/lib.rs
+        pub struct Foo;
+
+        //- dep-lib/lib.rs
+        extern crate dep_lib_target;
+
+        pub use dep_lib_target::Foo;
+
+        //- main.rs
+        extern crate dep_lib_target;
+
+        use dep_lib_target::Foo;
+
+        fn main() {
+            let foo = Foo/*caret*/;
+        }
+    """)
 }


### PR DESCRIPTION
* Introduce cargo project search scope
* Use this scope to exclude transitive dependencies' items from auto import candidates