### PR TITLE
TY: TyTraitObject region

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -381,7 +381,11 @@ WherePred ::= Lifetime LifetimeParamBounds | ForLifetimes? TypeReference TypePar
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
-ForLifetimes ::= for '<' LifetimesParams '>'
+ForLifetimes ::= for '<' LifetimesParams '>' {
+  extends = "org.rust.lang.core.psi.ext.RsStubbedElementImpl<?>"
+  stubClass = "org.rust.lang.core.stubs.RsPlaceholderStub"
+  elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
+}
 
 ExternAbi ::= extern STRING_LITERAL?
 

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -33,7 +33,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 142
+        override fun getStubVersion(): Int = 143
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)
@@ -121,6 +121,7 @@ fun factory(name: String): RsStubElementType<*, *> = when (name) {
     "TYPE_PARAMETER" -> RsTypeParameterStub.Type
     "LIFETIME" -> RsLifetimeStub.Type
     "LIFETIME_PARAMETER" -> RsLifetimeParameterStub.Type
+    "FOR_LIFETIMES" -> RsPlaceholderStub.Type("FOR_LIFETIMES", ::RsForLifetimesImpl)
     "TYPE_ARGUMENT_LIST" -> RsPlaceholderStub.Type("TYPE_ARGUMENT_LIST", ::RsTypeArgumentListImpl)
     "ASSOC_TYPE_BINDING" -> RsAssocTypeBindingStub.Type
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
@@ -15,13 +15,18 @@ import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.mergeFlags
 import org.rust.lang.core.types.regions.ReEarlyBound
+import org.rust.lang.core.types.regions.ReUnknown
+import org.rust.lang.core.types.regions.Region
 
 /**
  * A "trait object" type should not be confused with a trait.
  * Though you use the same path to denote both traits and trait objects,
  * only the latter are ty.
  */
-data class TyTraitObject(val trait: BoundElement<RsTraitItem>) : Ty(mergeFlags(trait)) {
+class TyTraitObject(
+    val trait: BoundElement<RsTraitItem>,
+    val region: Region = ReUnknown
+) : Ty(mergeFlags(trait) or region.flags) {
 
     val typeArguments: List<Ty>
         get() = trait.element.typeParameters.map { typeParameterValues[it] ?: TyUnknown }
@@ -30,10 +35,20 @@ data class TyTraitObject(val trait: BoundElement<RsTraitItem>) : Ty(mergeFlags(t
         get() = trait.subst
 
     override fun superFoldWith(folder: TypeFolder): TyTraitObject =
-        TyTraitObject(trait.foldWith(folder))
+        TyTraitObject(trait.foldWith(folder), region.foldWith(folder))
 
     override fun superVisitWith(visitor: TypeVisitor): Boolean =
-        trait.visitWith(visitor)
+        trait.visitWith(visitor) || region.visitWith(visitor)
+
+    override fun equals(other: Any?): Boolean = when {
+        this === other -> true
+        javaClass != other?.javaClass -> false
+        other !is TyTraitObject -> false
+        trait != other.trait -> false
+        else -> true
+    }
+
+    override fun hashCode(): Int = trait.hashCode()
 
     companion object {
         fun valueOf(trait: RsTraitItem): TyTraitObject {

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
@@ -11,21 +11,28 @@ import org.rust.lang.core.psi.RsTypeParameter
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.HAS_TY_TYPE_PARAMETER_MASK
+import org.rust.lang.core.types.infer.resolve
+import org.rust.lang.core.types.regions.Region
 import org.rust.lang.core.types.type
 
 class TyTypeParameter private constructor(
     val parameter: TypeParameter,
     val isSized: Boolean,
-    boundsSupplier: () -> Collection<BoundElement<RsTraitItem>>
+    traitBoundsSupplier: () -> Collection<BoundElement<RsTraitItem>>,
+    regionBoundsSupplier: () -> Collection<Region>
 ) : Ty(HAS_TY_TYPE_PARAMETER_MASK) {
 
-    private val bounds: Collection<BoundElement<RsTraitItem>> by lazy(LazyThreadSafetyMode.NONE, boundsSupplier)
+    private val traitBounds: Collection<BoundElement<RsTraitItem>>
+        by lazy(LazyThreadSafetyMode.NONE, traitBoundsSupplier)
+
+    val regionBounds: Collection<Region>
+        by lazy(LazyThreadSafetyMode.NONE, regionBoundsSupplier)
 
     override fun equals(other: Any?): Boolean = other is TyTypeParameter && other.parameter == parameter
     override fun hashCode(): Int = parameter.hashCode()
 
     fun getTraitBoundsTransitively(): Collection<BoundElement<RsTraitItem>> =
-        bounds.flatMap { it.flattenHierarchy }
+        traitBounds.flatMap { it.flattenHierarchy }
 
     val name: String? get() = parameter.name
 
@@ -42,27 +49,40 @@ class TyTypeParameter private constructor(
     }
 
     companion object {
-        private val self = TyTypeParameter(Self, isSized = false) { emptyList() }
+        private val self = TyTypeParameter(Self, false, { emptyList() }, { emptyList() })
 
         fun self(): TyTypeParameter = self
 
         fun self(item: RsTraitOrImpl): TyTypeParameter {
             val isSized = when (item) {
-                is RsTraitItem -> item.implementedTrait?.flattenHierarchy.orEmpty().any { it.element.isSizedTrait  }
+                is RsTraitItem -> item.implementedTrait?.flattenHierarchy.orEmpty().any { it.element.isSizedTrait }
                 is RsImplItem -> item.typeReference?.type?.isSized() == true
                 else -> error("item must be instance of `RsTraitItem` or `RsImplItem`")
             }
-            return TyTypeParameter(Self, isSized) { listOfNotNull(item.implementedTrait) }
+            return TyTypeParameter(
+                Self,
+                isSized,
+                { listOfNotNull(item.implementedTrait) },
+                { emptyList() }
+            )
         }
 
         fun named(parameter: RsTypeParameter): TyTypeParameter =
-            TyTypeParameter(Named(parameter), parameter.isSized) { bounds(parameter) }
+            TyTypeParameter(
+                Named(parameter),
+                parameter.isSized,
+                { traitBounds(parameter) },
+                { regionBounds(parameter) }
+            )
     }
 }
 
-private fun bounds(parameter: RsTypeParameter): List<BoundElement<RsTraitItem>> =
+private fun traitBounds(parameter: RsTypeParameter): List<BoundElement<RsTraitItem>> =
     parameter.bounds.mapNotNull {
         val trait = it.bound.traitRef?.resolveToBoundTrait ?: return@mapNotNull null
         // if `T: ?Sized` then T doesn't have `Sized` bound
         if (!trait.element.isSizedTrait || parameter.isSized) trait else null
     }
+
+private fun regionBounds(parameter: RsTypeParameter): List<Region> =
+    parameter.bounds.mapNotNull { it.bound.lifetime?.resolve() }

--- a/src/main/kotlin/org/rust/stdext/Collections.kt
+++ b/src/main/kotlin/org/rust/stdext/Collections.kt
@@ -141,3 +141,8 @@ fun <T : Any> Iterator<T>.nextOrNull(): T? =
     if (hasNext()) next() else null
 
 fun <T> MutableList<T>.removeLast(): T = removeAt(size - 1)
+
+fun <T> dequeOf(): Deque<T> = ArrayDeque<T>()
+
+fun <T> dequeOf(vararg elements: T): Deque<T> =
+    ArrayDeque<T>().apply { addAll(elements) }

--- a/src/test/kotlin/org/rust/lang/core/type/RsTyTraitObjectRegionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTyTraitObjectRegionTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.type
+
+import org.intellij.lang.annotations.Language
+import org.rust.ProjectDescriptor
+import org.rust.RsTestBase
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.core.psi.RsTypeReference
+import org.rust.lang.core.types.ty.TyTraitObject
+import org.rust.lang.core.types.ty.walk
+import org.rust.lang.core.types.type
+
+class RsTyTraitObjectRegionTest : RsTestBase() {
+    fun `test trait under ref`() = doTest("""
+        trait Trait {}
+        fn foo<'a>(x: &'a Trait) {}
+                    //^ 'a
+    """)
+
+    fun `test trait under refs`() = doTest("""
+        trait Trait {}
+        fn foo<'a, 'b>(x: &'a &'b Trait) {}
+                        //^ 'b
+    """)
+
+    fun `test 'static region bound in struct`() = doTest("""
+        trait Trait {}
+        struct Struct<T: 'static> {}
+        fn foo<'a>(x: Struct<Trait>) {}
+                    //^ 'static
+    """)
+
+    fun `test no region bound it struct`() = doTest("""
+        trait Trait {}
+        struct Struct<'a, T> {}
+        fn foo<'b>(x: Struct<'b, Trait>) {}
+                    //^ 'static
+    """)
+
+    fun `test region bound it struct`() = doTest("""
+        trait Trait {}
+        struct Struct<'a, T: 'a> {}
+        fn foo<'b>(x: Struct<'b, Trait>) {}
+                    //^ 'b
+    """)
+
+    fun `test ambiguity region bound it struct`() = doTest("""
+        trait Trait {}
+        struct Struct<'a, 'b, T: 'a + 'b> {}
+        fn foo<'c, 'd>(x: Struct<'c, 'd, Trait>) {}
+                        //^ '_
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test box`() = doTest("""
+        trait Trait {}
+        fn foo<'a>(x: Box<Trait>) {}
+                    //^ 'static
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test box under ref`() = doTest("""
+        trait Trait {}
+        fn foo<'a>(x: &'a Box<Trait>) {}
+                    //^ 'a
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test explicit 'static overrides ref's region`() = doTest("""
+        trait Trait {}
+        fn foo<'a>(x: &'a Box<Trait + 'static>) {}
+                    //^ 'static
+    """)
+
+    /** Checks the region of the trait object in [code] pointed to by `//^` marker. */
+    private fun doTest(@Language("Rust") code: String) {
+        InlineFile(code)
+        val (typeAtCaret, expectedRegion) = findElementAndDataInEditor<RsTypeReference>()
+        val ty = typeAtCaret.type
+        val traitObjectTy = ty.walk().asSequence().filterIsInstance<TyTraitObject>().first()
+        val actualRegion = traitObjectTy.region.toString()
+        check(actualRegion == expectedRegion) {
+            "$actualRegion != $expectedRegion"
+        }
+    }
+}


### PR DESCRIPTION
Provides a region for [TyTraitObject](https://github.com/intellij-rust/intellij-rust/blob/294ce3e58c853537404dbcd46bf2d804a7d7b5f3/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt#L28).

This is part of #2828.

For details, see [RFC#0599](https://github.com/rust-lang/rfcs/blob/master/text/0599-default-object-bound.md).