### PR TITLE
Improve content roots detection

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -11,9 +11,12 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ContentEntry
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.messages.Topic
 import org.jetbrains.annotations.TestOnly
+import org.rust.cargo.CargoConstants
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.toolchain.RustToolchain
@@ -142,4 +145,15 @@ private fun discoverToolchain(project: Project) {
         project.showBalloon("Using $tool", NotificationType.INFORMATION)
         project.cargoProjects.discoverAndRefresh()
     }
+}
+
+fun ContentEntry.setup(contentRoot: VirtualFile) {
+    val makeVfsUrl = { dirName: String -> FileUtil.join(contentRoot.url, dirName) }
+    CargoConstants.ProjectLayout.sources.map(makeVfsUrl).forEach {
+        addSourceFolder(it, /* test = */ false)
+    }
+    CargoConstants.ProjectLayout.tests.map(makeVfsUrl).forEach {
+        addSourceFolder(it, /* test = */ true)
+    }
+    addExcludeFolder(makeVfsUrl(CargoConstants.ProjectLayout.target))
 }

--- a/src/main/kotlin/org/rust/ide/idea/CargoConfigurationWizardStep.kt
+++ b/src/main/kotlin/org/rust/ide/idea/CargoConfigurationWizardStep.kt
@@ -13,9 +13,8 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.util.Disposer
-import com.intellij.openapi.util.io.FileUtil
-import org.rust.cargo.CargoConstants
 import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.model.setup
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.ui.RustProjectSettingsPanel
 import org.rust.cargo.toolchain.RustToolchain
@@ -80,14 +79,7 @@ class CargoConfigurationWizardStep private constructor(
                 }
 
                 val projectRoot = contentEntry.file ?: return
-                val makeVfsUrl = { dirName: String -> FileUtil.join(projectRoot.url, dirName) }
-                CargoConstants.ProjectLayout.sources.map(makeVfsUrl).forEach {
-                    contentEntry.addSourceFolder(it, /* test = */ false)
-                }
-                CargoConstants.ProjectLayout.tests.map(makeVfsUrl).forEach {
-                    contentEntry.addSourceFolder(it, /* test = */ true)
-                }
-                contentEntry.addExcludeFolder(makeVfsUrl(CargoConstants.ProjectLayout.target))
+                contentEntry.setup(projectRoot)
             }
         }
     }

--- a/src/test/kotlin/org/rust/cargo/RustWithToolchainTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/RustWithToolchainTestBase.kt
@@ -9,10 +9,12 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.builders.ModuleFixtureBuilder
 import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase
 import org.rust.FileTree
+import org.rust.FileTreeBuilder
 import org.rust.TestProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.toolchain.RustToolchain
+import org.rust.fileTree
 
 // This class allows to execute real Cargo during the tests.
 // Unlike `RustTestCaseBase` it does not use in-memory temporary VFS
@@ -53,4 +55,7 @@ abstract class RustWithToolchainTestBase : CodeInsightFixtureTestCase<ModuleFixt
         project.rustSettings.data = project.rustSettings.data.copy(toolchain = null)
         super.tearDown()
     }
+
+    protected fun buildProject(builder: FileTreeBuilder.() -> Unit): TestProject =
+        fileTree { builder() }.create()
 }

--- a/src/test/kotlin/org/rustSlowTests/CargoProjectResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/CargoProjectResolveTest.kt
@@ -6,10 +6,7 @@
 package org.rustSlowTests
 
 import com.intellij.openapi.util.SystemInfo
-import org.rust.FileTreeBuilder
-import org.rust.TestProject
 import org.rust.cargo.RustWithToolchainTestBase
-import org.rust.fileTree
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.resolve.NameResolutionTestmarks
 
@@ -299,7 +296,4 @@ class CargoProjectResolveTest : RustWithToolchainTestBase() {
         checkReferenceIsResolved<RsPath>("hello/src/main.rs", toCrate = "rand 0.3.14")
         checkReferenceIsResolved<RsPath>("bar/src/lib.rs", toCrate = "rand 54.0.0")
     }
-
-    private fun buildProject(builder: FileTreeBuilder.() -> Unit): TestProject =
-        fileTree { builder() }.create()
 }

--- a/src/test/kotlin/org/rustSlowTests/RsContentRootsTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsContentRootsTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rustSlowTests
+
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.vfs.VirtualFile
+import org.rust.TestProject
+import org.rust.cargo.RustWithToolchainTestBase
+
+class RsContentRootsTest : RustWithToolchainTestBase() {
+
+    fun test() {
+        val project = buildProject {
+            toml("Cargo.toml", """
+                [package]
+                name = "intellij-rust-test"
+                version = "0.1.0"
+                authors = []
+
+                [workspace]
+                members = ["subproject"]
+            """)
+            dir("src") {
+                rust("main.rs", "")
+            }
+            dir("examples") {}
+            dir("tests") {}
+            dir("benches") {}
+            dir("target") {}
+
+            dir("subproject") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "subproject"
+                    version = "0.1.0"
+                    authors = []
+                """)
+                dir("src") {
+                    rust("main.rs", "")
+                }
+                dir("examples") {}
+                dir("tests") {}
+                dir("benches") {}
+                dir("target") {}
+            }
+        }
+
+        val projectFolders = listOf(
+            ProjectFolder.Source(project.findFile("src"), false),
+            ProjectFolder.Source(project.findFile("examples"), false),
+            ProjectFolder.Source(project.findFile("tests"), true),
+            ProjectFolder.Source(project.findFile("benches"), true),
+            ProjectFolder.Excluded(project.findFile("target")),
+            ProjectFolder.Source(project.findFile("subproject/src"), false),
+            ProjectFolder.Source(project.findFile("subproject/examples"), false),
+            ProjectFolder.Source(project.findFile("subproject/tests"), true),
+            ProjectFolder.Source(project.findFile("subproject/benches"), true),
+            ProjectFolder.Excluded(project.findFile("subproject/target"))
+        )
+
+        check(projectFolders)
+    }
+
+    private fun check(projectFolders: List<ProjectFolder>) {
+        ModuleRootModificationUtil.updateModel(myModule) { model ->
+            val contentEntry = model.contentEntries.firstOrNull() ?: error("")
+            val sourceFiles = contentEntry.sourceFolders.associateBy { it.file }
+            val excludedFiles = contentEntry.excludeFolders.associateBy { it.file }
+
+            for (projectFolder in projectFolders) {
+                when (projectFolder) {
+                    is ProjectFolder.Source -> {
+                        val sourceFile = sourceFiles[projectFolder.file]
+                            ?: error("Can't find `${projectFolder.file}` folder in source folders")
+                        check(sourceFile.isTestSource == projectFolder.isTest)
+                    }
+                    is ProjectFolder.Excluded -> {
+                        if (excludedFiles[projectFolder.file] == null) {
+                            error("Can't find `${projectFolder.file}` folder in excluded folders")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun TestProject.findFile(path: String): VirtualFile =
+        root.findFileByRelativePath(path) ?: error("Can't find `$path` in `$root`")
+
+    private sealed class ProjectFolder {
+        data class Source(val file: VirtualFile, val isTest: Boolean) : ProjectFolder()
+        data class Excluded(val file: VirtualFile) : ProjectFolder()
+    }
+}


### PR DESCRIPTION
After each refresh add `src`, `examples`, `tests` and `benches` folders
of each workspace package as source roots and `target` folder as excluded folder

Fixes #2493
Fixes #2869