### PR TITLE
Expand the builtin include macro (WIP)

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/Include.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/Include.kt
@@ -1,0 +1,39 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import org.rust.lang.core.psi.RsLitExpr
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.RsMacroExpr
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.ext.stringLiteralValue
+import org.rust.lang.core.resolve.DEFAULT_RECURSION_LIMIT
+import java.nio.ByteBuffer
+
+fun expandInclude(call: RsMacroCall): List<RsExpandedElement>? {
+    val psiFactory = RsPsiFactory(call.project)
+    val args = call.includeMacroArgument?.expr ?: return null
+    val path = expandStringArgument(args) ?: return null
+    val file = call.containingFile.virtualFile.parent.findFileByRelativePath(path) ?: return null
+    val content = file.charset.decode(ByteBuffer.wrap(file.contentsToByteArray()))
+    return psiFactory.parseExpandedTextWithContext(call, content)
+}
+
+private tailrec fun expandStringArgument(args: RsExpandedElement, depth: Int = 0): String? {
+    if (depth > DEFAULT_RECURSION_LIMIT) return null
+    return when (args) {
+        is RsLitExpr -> args.stringLiteralValue
+        is RsMacroExpr -> {
+            val expansion = org.rust.lang.core.macros.expandMacro(args.macroCall).value.orEmpty()
+            if (expansion.size != 1) {
+                null
+            } else {
+                expandStringArgument(expansion.first(), depth + 1)
+            }
+        }
+        else -> null
+    }
+}


### PR DESCRIPTION
I'd like to get code completion support for generated sources.

This is related to the issue: https://github.com/intellij-rust/intellij-rust/issues/1908

The approach taken here is to expand the builtin `include!` macro. When something similar is done for `concat!` and `env!` that should provide code completion for the usual code generation case.

Is this the right approach?

--
I'm new to Kotlin and the IntelliJ internals, so any hints with regards to code style etc. are also welcome.