### PR TITLE
GRD: build the rust lexer in addition to parser by IDEA run config

### DIFF
--- a/.idea/runConfigurations/Generate_Parser.xml
+++ b/.idea/runConfigurations/Generate_Parser.xml
@@ -10,6 +10,7 @@
       </option>
       <option name="taskNames">
         <list>
+          <option value=":generateRustLexer" />
           <option value=":generateRustParser" />
         </list>
       </option>


### PR DESCRIPTION
We had problems with the fact that the lexer did not re-compile
by "Generate Parser" IDEA run configuration.