### PR TITLE
RES: Don't search std/core crates in workspace in 2018 Edition

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -174,7 +174,11 @@ private class WorkspaceImpl(
         val result = WorkspaceImpl(
             manifestPath,
             workspaceRootPath,
-            packages.map { it.asPackageData(edition) }
+            packages.map { pkg ->
+                // Currently, stdlib doesn't use 2018 edition
+                val packageEdition = if (pkg.origin == PackageOrigin.STDLIB) pkg.edition else edition
+                pkg.asPackageData(packageEdition)
+            }
         )
 
         val oldIdToPackage = packages.associateBy { it.id }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -307,7 +307,17 @@ fun processPathResolveVariants(lookup: ImplLookup, path: RsPath, isCompletion: B
             if (crateRoot != null && processor("crate", crateRoot)) return true
             if (path.kind == PathKind.IDENTIFIER &&
                 path.containingCargoTarget?.edition == CargoWorkspace.Edition.EDITION_2018) {
-                if (processExternCrateResolveVariants(path, isCompletion, processor)) return true
+                val attributes = (crateRoot as? RsFile)?.attributes
+                val implicitExternCrate = when (attributes) {
+                    NONE -> "std"
+                    NO_STD -> "core"
+                    else -> null
+                }
+                // We shouldn't process implicit extern crate here
+                // because we add it in `ItemResolutionKt.processItemDeclarations`
+                if (path.referenceName != implicitExternCrate) {
+                    if (processExternCrateResolveVariants(path, isCompletion, processor)) return true
+                }
             }
         }
     }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2015.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2015.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve
+
+import org.rust.MockEdition
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.cargo.project.workspace.CargoWorkspace
+
+@MockEdition(CargoWorkspace.Edition.EDITION_2015)
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+class RsStdlibResolveTestEdition2015 : RsResolveTestBase() {
+
+    fun `test try! macro`() = checkByCode("""
+        struct S { field: u32 }
+                    //X
+        fn foo() -> Result<S, ()> { unimplemented!() }
+
+        //noinspection RsTryMacro
+        fn main() {
+            let s = try!(foo());
+            s.field;
+            //^
+        }
+    """)
+
+    fun `test resolve with no_std attribute 2`() = stubOnlyResolve("""
+    //- main.rs
+        #![no_std]
+
+        extern crate alloc;
+
+        use alloc::vec::Vec;
+
+        fn foo(v: Vec) {}
+                 //^ .../liballoc/vec.rs
+    """)
+}


### PR DESCRIPTION
Our implementation already processes std/core crates so with lookup into workspace
it leads to multiple resolution results and prevents from success resolution of all items in std/core crates

Fixes #2877