### PR TITLE
INSP: insert use items after outer attributes in auto import quick fix

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -480,7 +480,7 @@ private val RsPath.namespaceFilter: (RsQualifiedNamedElement) -> Boolean get() =
 
 private val RsElement.stdlibAttributes: RsFile.Attributes
     get() = (crateRoot?.containingFile as? RsFile)?.attributes ?: RsFile.Attributes.NONE
-private val RsItemsOwner.firstItem: RsElement get() = itemsAndMacros.first { it !is RsInnerAttr }
+private val RsItemsOwner.firstItem: RsElement get() = itemsAndMacros.first { it !is RsAttr }
 private val <T: RsElement> List<T>.lastElement: T? get() = maxBy { it.textOffset }
 
 private val CargoWorkspace.Target.isStd: Boolean

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -202,6 +202,32 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
+    fun `test insert use item after outer attributes`() = checkAutoImportFixByText("""
+        mod foo {
+            pub struct Foo;
+        }
+
+        #[cfg(test)]
+        mod tests {
+            fn foo() {
+                let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
+            }
+        }
+    """, """
+        mod foo {
+            pub struct Foo;
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use foo::Foo;
+
+            fn foo() {
+                let f = Foo/*caret*/;
+            }
+        }
+    """)
+
     fun `test import item from nested module`() = checkAutoImportFixByText("""
         mod foo {
             pub mod bar {


### PR DESCRIPTION
Fixes #2889