### PR TITLE
Unify types of shorthand struct fields

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -334,6 +334,16 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test struct field shorthand`() = testExpr("""
+        enum E<T> { A, B(T) }
+        struct S<T> { item: E<T> }
+        fn foo() -> S<u8> {
+            let item = E::A;
+                     //^ E<u8>
+            S { item }
+        }
+    """)
+
     fun `test struct expr with 2 fields of same type 1`() = testExpr("""
         struct X;
         struct S<T> { a: T, b: T }


### PR DESCRIPTION
I need some help with this. I believe I have found the correct place to perform this type
inference, but I'm not sure how to proceed. I believe what needs to happen is to look up
a declaration that matches the struct field's name, and then if it matches, tell the type
inference system that the type of the variable is coercible to the field's type, but I
could not figure out how to do this.