### PR TITLE
TY: force to <unknown> type of multi-resolved PathExpr

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -806,7 +806,7 @@ class RsFnInferenceContext(
                 return instantiatePath(BoundElement(resolved, variants.first().subst), expr, tryRefinePath = true)
             }
         }
-        val first = variants.firstOrNull() ?: return TyUnknown
+        val first = variants.singleOrNull() ?: return TyUnknown
         return instantiatePath(first, expr, tryRefinePath = variants.size == 1)
     }
 

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -1048,11 +1048,20 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ i32
     """)
 
-    fun `test type of ambiguously resolved paths is unknown`() = testExpr("""
+    fun `test type of ambiguously resolved paths is unknown 1`() = testExpr("""
         struct S;
         struct S;
         fn main() {
             let a: S;
+            a;
+        } //^ <unknown>
+    """)
+
+    fun `test type of ambiguously resolved paths is unknown 2`() = testExpr("""
+        struct S;
+        struct S;
+        fn main() {
+            let a = S;
             a;
         } //^ <unknown>
     """)


### PR DESCRIPTION
Partially fixes #2876
(at least it fixes typechecker false-positive)