### PR TITLE
TY: filter impls from dangling (not attached to some crate) files

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -309,7 +309,7 @@ class ImplLookup(
         return impls
     }
 
-    private fun findSimpleImpls(selfTy: Ty): Collection<RsImplItem> {
+    private fun findSimpleImpls(selfTy: Ty): Sequence<RsImplItem> {
         return RsImplIndex.findPotentialImpls(project, selfTy).mapNotNull { impl ->
             val subst = impl.generics.associate { it to ctx.typeVarForParam(it) }.toTypeSubst()
             // TODO: take into account the lifetimes (?)
@@ -452,7 +452,7 @@ class ImplLookup(
                     prepareSubstAndTraitRefRaw(ctx, impl.generics, formalSelfTy, formalTraitRef, ref.selfTy)
                 if (!ctx.probe { ctx.combineTraitRefs(implTraitRef, ref) }) return@mapNotNull null
                 SelectionCandidate.Impl(impl, formalSelfTy, formalTraitRef)
-            }
+            }.toList()
     }
 
     private fun assembleDerivedCandidates(ref: TraitRef): List<SelectionCandidate> {

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
@@ -29,13 +29,14 @@ class RsImplIndex : AbstractStubIndex<TyFingerprint, RsImplItem>() {
          * Note this method may return false positives
          * @see TyFingerprint
          */
-        fun findPotentialImpls(project: Project, target: Ty): Collection<RsImplItem> {
+        fun findPotentialImpls(project: Project, target: Ty): Sequence<RsImplItem> {
             val fingerprint = TyFingerprint.create(target)
-                ?: return emptyList()
+                ?: return emptySequence()
 
             val impls = getElements(KEY, fingerprint, project, GlobalSearchScope.allScope(project))
             val freeImpls = getElements(KEY, TyFingerprint.TYPE_PARAMETER_FINGERPRINT, project, GlobalSearchScope.allScope(project))
-            return impls + freeImpls
+            // filter dangling (not attached to some crate) rust files, e.g. tests, generated source
+            return (impls.asSequence() + freeImpls.asSequence()).filter { it.crateRoot != null }
         }
 
         fun index(stub: RsImplItemStub, sink: IndexSink) {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -5,8 +5,6 @@
 
 package org.rust.lang.core.resolve
 
-import junit.framework.AssertionFailedError
-
 class RsTypeAwareResolveTest : RsResolveTestBase() {
     fun `test self method call expr`() = checkByCode("""
         struct S;
@@ -662,5 +660,14 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
             foo().baz();
                 //^
         }
+    """)
+
+    fun `test filter methods from dangling (not attached to some crate) rust files`() = stubOnlyResolve("""
+    //- dangling.rs
+        impl u8 { fn foo(self){} }
+    //- main.rs
+        fn main() {
+            0u8.foo();
+        }     //^ unresolved
     """)
 }


### PR DESCRIPTION
Sometimes you can see in completion methods from surprising locations (like tests). This PR should finally fix the issue.

Also fixes #2876