### PR TITLE
TY: derive auto traits (Sync/Send) to all types

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -36,6 +36,9 @@ val RsTraitItem.langAttribute: String? get() = queryAttributes.langAttribute
 
 val RsTraitItem.isSizedTrait: Boolean get() = langAttribute == "sized"
 
+val RsTraitItem.isAuto: Boolean
+    get() = stub?.isAuto ?: (node.findChildByType(RsElementTypes.AUTO) != null)
+
 val RsTraitItem.isStdDerivable: Boolean get() {
     val derivableTrait = STD_DERIVABLE_TRAITS[name] ?: return false
     return containingCargoPackage?.origin == PackageOrigin.STDLIB &&

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -420,6 +420,7 @@ class ImplLookup(
                 ref.selfTy.getTraitBoundsTransitively().find { it.element == element }
                     ?.let { listOf(SelectionCandidate.TraitObject) } ?: emptyList()
             }
+            element.isAuto -> autoTraitCandidates(ref.selfTy, element)
             else -> buildList {
                 addAll(assembleImplCandidates(ref))
                 addAll(assembleDerivedCandidates(ref))
@@ -465,6 +466,12 @@ class ImplLookup(
             SelectionCandidate.DerivedTrait(sizedTrait)
         }
         return listOf(candidate)
+    }
+
+    private fun autoTraitCandidates(ty: Ty, trait: RsTraitItem): List<SelectionCandidate> {
+        // FOr now, just think that any type is Sync + Send
+        // TODO implement auto trait logic
+        return listOf(SelectionCandidate.DerivedTrait(trait))
     }
 
     private fun confirmCandidate(

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
@@ -5,6 +5,9 @@
 
 package org.rust.lang.core.completion
 
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+
 class RsCompletionFilteringTest: RsCompletionTestBase() {
     fun `test unsatisfied bound filtered 1`() = doSingleCompletion("""
         trait Bound {}
@@ -92,5 +95,18 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
         impl<T> Trait2 for T {}
         struct S;
         fn main() { S::Bar/*caret*/ }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test method is not filtered by Sync+Send bounds`() = doSingleCompletion("""
+        struct S;
+        trait Trait { fn foo(&self) {} }
+        impl<T: Sync + Send> Trait for T {}
+        fn main() { S.fo/*caret*/ }
+    """, """
+        struct S;
+        trait Trait { fn foo(&self) {} }
+        impl<T: Sync + Send> Trait for T {}
+        fn main() { S.foo()/*caret*/ }
     """)
 }


### PR DESCRIPTION
Due to the fact that completion results are now filtered by trait bounds, the fact that IJ-Rust don't understand auto traits (Sync/Send) may be awkward. I think it's better to temporary make any type Sync/Send and then see more completion than less.