### PR TITLE
COMP: filter associated types from completion where they aren't allowed

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -286,6 +286,7 @@ fun processPathResolveVariants(lookup: ImplLookup, path: RsPath, isCompletion: B
         val selfSubst = mapOf(TyTypeParameter.self() to typeQual.typeReference.type).toTypeSubst()
         val subst = trait.subst.substituteInValues(selfSubst) + selfSubst
         if (processAllWithSubst(trait.element.members?.typeAliasList.orEmpty(), subst, processor)) return true
+        return false
     }
 
     if (isCompletion) {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
@@ -78,19 +78,19 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
 
     fun `test unsatisfied bound path filtering`() = doSingleCompletion("""
         trait Bound {}
-        trait Trait1 { type Foo = (); }
-        trait Trait2 { type Bar = (); }
+        trait Trait1 { fn foo(){} }
+        trait Trait2 { fn bar() {} }
         impl<T: Bound> Trait1 for T {}
         impl<T> Trait2 for T {}
         struct S;
         fn main() { S::/*caret*/ }
     """, """
         trait Bound {}
-        trait Trait1 { type Foo = (); }
-        trait Trait2 { type Bar = (); }
+        trait Trait1 { fn foo(){} }
+        trait Trait2 { fn bar() {} }
         impl<T: Bound> Trait1 for T {}
         impl<T> Trait2 for T {}
         struct S;
-        fn main() { S::Bar/*caret*/ }
+        fn main() { S::bar()/*caret*/ }
     """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
@@ -40,16 +40,16 @@ class RsCompletionSortingTest : RsTestBase() {
         RsFunction::class to "foo"
     ))
 
-    fun `test enum variants before associated types`() = doTest("""
+    fun `test enum variants before associated constants`() = doTest("""
         enum E { A, B }
-        trait T { type A; }
-        impl T for E { type A = (); }
+        trait T { const A: i32; }
+        impl T for E { const A: i32 = 0; }
 
         fn main() { E::/*caret*/ }
     """, listOf(
         RsEnumVariant::class to "A",
         RsEnumVariant::class to "B",
-        RsTypeAlias::class to "A"
+        RsConstant::class to "A"
     ))
 
     fun `test inherent impl methods before trait impl methods`() = doTest("""

--- a/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt
@@ -203,4 +203,16 @@ class RsTypeAwareCompletionTest : RsCompletionTestBase() {
         struct S;
         fn main() { let a: S::/*caret*/; }
     """)
+
+    fun `test associated type in explicit UFCS form`() = doSingleCompletion("""
+        trait Tr { type Item; }
+        impl<T> Tr for T { type Item = (); }
+        struct S;
+        fn main() { let a: <S as Tr>::/*caret*/; }
+    """, """
+        trait Tr { type Item; }
+        impl<T> Tr for T { type Item = (); }
+        struct S;
+        fn main() { let a: <S as Tr>::Item/*caret*/; }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt
@@ -195,4 +195,12 @@ class RsTypeAwareCompletionTest : RsCompletionTestBase() {
         struct S<A>(A);
         impl<B: Tr> S<B> { fn foo(self) -> <B as Tr>::Item/*caret*/ }
     """)
+
+    // https://doc.rust-lang.org/error-index.html#E0223
+    fun `test no completion for associated type of type other then type parameter`() = checkNoCompletion("""
+        trait Tr { type Item; }
+        impl<T> Tr for T { type Item = (); }
+        struct S;
+        fn main() { let a: S::/*caret*/; }
+    """)
 }


### PR DESCRIPTION
```rust
trait Tr { type Item; }
impl<T> Tr for T { type Item = (); }
struct S;
fn main() { let a: S::/*caret*/; }
```
In this case associated types aren't allowed ([E0223](https://doc.rust-lang.org/error-index.html#E0223)). I think we should remove them from completion, but resolve them as previously. It allows to simply implement E0223 analysis in future