### PR TITLE
Improved completion filtering by visibility

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -150,8 +150,13 @@ fun processAllWithSubst(
 
 fun filterCompletionVariantsByVisibility(processor: RsResolveProcessor, mod: RsMod): RsResolveProcessor {
     return fun(it: ScopeEntry): Boolean {
-        val visible = it.element as? RsVisible ?: return processor(it)
-        if (visible.isVisibleFrom(mod)) return processor(it)
-        return false
+        val element = it.element
+        if (element is RsVisible && !element.isVisibleFrom(mod)) return false
+
+        val isHidden = element is RsOuterAttributeOwner && element.queryAttributes.isDocHidden &&
+            element.containingMod != mod
+        if (isHidden) return false
+
+        return processor(it)
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
@@ -55,7 +55,14 @@ class RsFieldLookupReferenceImpl(
         val lookup = ImplLookup.relativeTo(element)
         val receiver = element.receiver.type
         return collectCompletionVariants {
-            processDotExprResolveVariants(lookup, receiver, filterMethodCompletionVariantsByTraitBounds(it, lookup, receiver))
+            processDotExprResolveVariants(
+                lookup,
+                receiver,
+                filterCompletionVariantsByVisibility(
+                    filterMethodCompletionVariantsByTraitBounds(it, lookup, receiver),
+                    element.containingMod
+                )
+            )
         }
     }
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
@@ -140,4 +140,25 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
             foo::S.b/*caret*/()
         }
     """)
+
+    fun `test private method 2`() = checkNoCompletion("""
+        mod foo {
+            pub struct S;
+            impl S { fn bar(&self) {} }
+        }
+        fn main() {
+            foo::S.b/*caret*/
+        }
+    """)
+
+    fun `test private field`() = checkNoCompletion("""
+        mod foo {
+            pub struct S {
+                field: i32
+            }
+        }
+        fn bar(s: S) {
+            s.f/*caret*/
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
@@ -109,4 +109,25 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
         impl<T: Sync + Send> Trait for T {}
         fn main() { S.foo()/*caret*/ }
     """)
+
+    fun `test private function`() = checkNoCompletion("""
+        mod foo { fn bar() {} }
+        fn main() {
+            foo::ba/*caret*/
+        }
+    """)
+
+    fun `test private mod`() = checkNoCompletion("""
+        mod foo { mod bar {} }
+        fn main() {
+            foo::ba/*caret*/
+        }
+    """)
+
+    fun `test private enum`() = checkNoCompletion("""
+        mod foo { enum MyEnum {} }
+        fn main() {
+            foo::MyEn/*caret*/
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
@@ -161,4 +161,28 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
             s.f/*caret*/
         }
     """)
+
+    fun `test doc(hidden) item`() = checkNoCompletion("""
+        mod foo {
+            #[doc(hidden)]
+            pub struct MyStruct;
+        }
+        fn main() {
+            foo::My/*caret*/
+        }
+    """)
+
+    fun `test doc(hidden) item from the same module isn't filtered`() = doSingleCompletion("""
+        #[doc(hidden)]
+        struct MyStruct;
+        fn main() {
+            My/*caret*/
+        }
+    """, """
+        #[doc(hidden)]
+        struct MyStruct;
+        fn main() {
+            MyStruct/*caret*/
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
@@ -130,4 +130,14 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
             foo::MyEn/*caret*/
         }
     """)
+
+    fun `test private method 1`() = checkNoCompletion("""
+        mod foo {
+            pub struct S;
+            impl S { fn bar(&self) {} }
+        }
+        fn main() {
+            foo::S.b/*caret*/()
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -657,27 +657,6 @@ class RsCompletionTest : RsCompletionTestBase() {
         }
     """)
 
-    fun `test private function`() = checkNoCompletion("""
-        mod foo { fn bar() {} }
-        fn main() {
-            foo::ba/*caret*/
-        }
-    """)
-
-    fun `test private mod`() = checkNoCompletion("""
-        mod foo { mod bar {} }
-        fn main() {
-            foo::ba/*caret*/
-        }
-    """)
-
-    fun `test private enum`() = checkNoCompletion("""
-        mod foo { enum MyEnum {} }
-        fn main() {
-            foo::MyEn/*caret*/
-        }
-    """)
-
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test private extern crate`() = checkNoCompletion("""
         mod foo { extern crate std; }


### PR DESCRIPTION
1. Filter private fields
2. Filter `#[doc(hidden)]` items