### PR TITLE
Fix output in graph description written in the DOT language

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/cfg/ControlFlowGraph.kt
+++ b/src/main/kotlin/org/rust/lang/core/cfg/ControlFlowGraph.kt
@@ -114,8 +114,10 @@ class ControlFlowGraph private constructor(
                 val target = edge.target
                 val sourceNode = source.data
                 val targetNode = target.data
+                val escapedSourceText = sourceNode.text.replace("\"", "\\\"")
+                val escapedTargetText = targetNode.text.replace("\"", "\\\"")
 
-                append("    \"${source.index}: ${sourceNode.text}\" -> \"${target.index}: ${targetNode.text}\";\n")
+                append("    \"${source.index}: $escapedSourceText\" -> \"${target.index}: $escapedTargetText\";\n")
             }
 
             append("}\n")


### PR DESCRIPTION
If the elements of the graph contain string, for example `print!("Hello");`, then the output becomes syntactically incorrect.
Escaping solves this problem.