### PR TITLE
TY: Use name 'lifetime' when it comes to RsLifetime or RsLifetimeParameter, and name 'region' in other cases

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -123,13 +123,13 @@ private data class TypeRenderer(
     }
 
     private fun formatGenerics(adt: TyAdt, render: (Ty) -> String): String {
-        val typeArguments = adt.typeArguments.map(render)
-        val lifetimeArguments = if (includeLifetimeArguments) {
-            adt.lifetimeArguments.map { render(it) }
+        val typeArgumentNames = adt.typeArguments.map(render)
+        val regionArgumentNames = if (includeLifetimeArguments) {
+            adt.regionArguments.map { render(it) }
         } else {
             emptyList()
         }
-        val generics = lifetimeArguments + typeArguments
+        val generics = regionArgumentNames + typeArgumentNames
         return if (generics.isEmpty()) "" else generics.joinToString(", ", "<", ">")
     }
 
@@ -139,7 +139,7 @@ private data class TypeRenderer(
         includeAssoc: Boolean = true
     ): String {
         val tySubst = trait.element.typeParameters.map { render(trait.subst[it] ?: TyUnknown) }
-        val reSubst = if (includeLifetimeArguments) {
+        val regionSubst = if (includeLifetimeArguments) {
             trait.element.lifetimeParameters.map { render(trait.subst[it] ?: ReUnknown) }
         } else {
             emptyList()
@@ -152,7 +152,7 @@ private data class TypeRenderer(
         } else {
             emptyList()
         }
-        val visibleTypes = reSubst + tySubst + assoc
+        val visibleTypes = regionSubst + tySubst + assoc
         return if (visibleTypes.isEmpty()) "" else visibleTypes.joinToString(", ", "<", ">")
     }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -196,7 +196,7 @@ class RsPsiFactory(private val project: Project) {
         typeBounds: List<RsTypeParameter>
     ): RsWhereClause {
 
-        val lifetimes = lifetimeBounds
+        val lifetimeConstraints = lifetimeBounds
             .filter { it.lifetimeParamBounds != null }
             .mapNotNull { it.text }
 
@@ -204,7 +204,7 @@ class RsPsiFactory(private val project: Project) {
             .filter { it.typeParamBounds != null }
             .mapNotNull { it.text }
 
-        val whereClauseConstraints = (lifetimes + typeConstraints).joinToString(", ")
+        val whereClauseConstraints = (lifetimeConstraints + typeConstraints).joinToString(", ")
 
         val text = "where $whereClauseConstraints"
         return createFromText("fn main() $text {}")
@@ -357,8 +357,8 @@ private fun RsTypeReference.substAndGetText(subst: Substitution): String =
 private fun RsSelfParameter.substAndGetText(subst: Substitution): String =
     buildString {
         append(and?.text ?: "")
-        val lifetime = lifetime.resolve().substitute(subst)
-        if (lifetime != ReUnknown) append("$lifetime ")
+        val region = lifetime.resolve().substitute(subst)
+        if (region != ReUnknown) append("$region ")
         if (mutability == MUTABLE) append("mut ")
         append(self.text)
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -84,7 +84,7 @@ fun resolvePath(path: RsPath, lookup: ImplLookup = ImplLookup.relativeTo(path)):
         }
     }
 
-    val lifetimeArguments: List<Region>? = path.typeArgumentList?.lifetimeList?.map { it.resolve() }
+    val regionArguments: List<Region>? = path.typeArgumentList?.lifetimeList?.map { it.resolve() }
 
     val outputArg = path.retType?.typeReference?.type
 
@@ -117,10 +117,10 @@ fun resolvePath(path: RsPath, lookup: ImplLookup = ImplLookup.relativeTo(path)):
         }
 
         val typeParameters = element.typeParameters.map { TyTypeParameter.named(it) }
-        val lifetimeParameters = element.lifetimeParameters.map { ReEarlyBound(it) }
+        val regionParameters = element.lifetimeParameters.map { ReEarlyBound(it) }
         val typeSubst = typeParameters.zip(typeArguments ?: typeParameters).toMap()
-        val lifetimeSubst = lifetimeParameters.zip(lifetimeArguments ?: lifetimeParameters).toMap()
-        val newSubst = Substitution(typeSubst, lifetimeSubst)
+        val regionSubst = regionParameters.zip(regionArguments ?: regionParameters).toMap()
+        val newSubst = Substitution(typeSubst, regionSubst)
         BoundElement(element, subst + newSubst, assocTypes)
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
@@ -49,6 +49,6 @@ data class BoundElement<out E : RsElement>(
         )
 
     override fun superVisitWith(visitor: TypeVisitor): Boolean = assoc.values.any { visitor.visitTy(it) } ||
-        subst.types.any { visitor.visitTy(it) } && subst.lifetimes.any { visitor.visitRegion(it) }
+        subst.types.any { visitor.visitTy(it) } && subst.regions.any { visitor.visitRegion(it) }
 
 }

--- a/src/main/kotlin/org/rust/lang/core/types/Substitution.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Substitution.kt
@@ -18,19 +18,19 @@ import org.rust.stdext.zipValues
 
 open class Substitution(
     val typeSubst: Map<TyTypeParameter, Ty> = emptyMap(),
-    val lifetimeSubst: Map<ReEarlyBound, Region> = emptyMap()
+    val regionSubst: Map<ReEarlyBound, Region> = emptyMap()
 ) {
     val types: Collection<Ty> get() = typeSubst.values
-    val lifetimes: Collection<Region> get() = lifetimeSubst.values
-    val kinds: Collection<Kind> get() = types + lifetimes
+    val regions: Collection<Region> get() = regionSubst.values
+    val kinds: Collection<Kind> get() = types + regions
 
     operator fun plus(other: Substitution): Substitution =
-        Substitution(mergeMaps(typeSubst, other.typeSubst), mergeMaps(lifetimeSubst, other.lifetimeSubst))
+        Substitution(mergeMaps(typeSubst, other.typeSubst), mergeMaps(regionSubst, other.regionSubst))
 
     operator fun get(key: TyTypeParameter) = typeSubst[key]
-    operator fun get(key: ReEarlyBound) = lifetimeSubst[key]
+    operator fun get(key: ReEarlyBound) = regionSubst[key]
     operator fun get(psi: RsTypeParameter) = typeSubst[TyTypeParameter.named((psi))]
-    operator fun get(psi: RsLifetimeParameter) = lifetimeSubst[ReEarlyBound((psi))]
+    operator fun get(psi: RsLifetimeParameter) = regionSubst[ReEarlyBound((psi))]
 
     fun typeByName(name: String): Ty =
         typeSubst.entries.find { it.key.toString() == name }?.value ?: TyUnknown
@@ -41,19 +41,19 @@ open class Substitution(
     fun substituteInValues(map: Substitution): Substitution =
         Substitution(
             typeSubst.mapValues { (_, value) -> value.substitute(map) },
-            lifetimeSubst.mapValues { (_, value) -> value.substitute(map) }
+            regionSubst.mapValues { (_, value) -> value.substitute(map) }
         )
 
     fun foldValues(folder: TypeFolder): Substitution =
         Substitution(
             typeSubst.mapValues { (_, value) -> value.foldWith(folder) },
-            lifetimeSubst.mapValues { (_, value) -> value.foldWith(folder) }
+            regionSubst.mapValues { (_, value) -> value.foldWith(folder) }
         )
 
     fun zipTypeValues(other: Substitution): List<Pair<Ty, Ty>> = zipValues(typeSubst, other.typeSubst)
 
     fun mapTypeValues(transform: (Map.Entry<TyTypeParameter, Ty>) -> Ty): Substitution =
-        Substitution(typeSubst.mapValues(transform), lifetimeSubst)
+        Substitution(typeSubst.mapValues(transform), regionSubst)
 
     override fun equals(other: Any?): Boolean = when {
         this === other -> true

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
@@ -51,9 +51,9 @@ private fun defaultSubstitution(item: RsTraitItem): Substitution {
         val parameter = TyTypeParameter.named(it)
         parameter to parameter
     }
-    val lifetimeSubst = item.lifetimeParameters.associate {
+    val regionSubst = item.lifetimeParameters.associate {
         val parameter = ReEarlyBound(it)
         parameter to parameter
     }
-    return Substitution(typeSubst, lifetimeSubst)
+    return Substitution(typeSubst, regionSubst)
 }


### PR DESCRIPTION
Just few renames.

Part of #2828.