### PR TITLE
MACRO: some fixes in macro expansion

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -412,6 +412,8 @@ private class MacroPattern private constructor(
         private val IDENTIFIER_TOKENS = TokenSet.create(
             RsElementTypes.IDENTIFIER,
             RsElementTypes.SELF,
+            RsElementTypes.SUPER,
+            RsElementTypes.CRATE,
             RsElementTypes.CSELF
         )
     }

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -169,7 +169,7 @@ class MacroExpander(val project: Project) {
                 is RsMacroExpansion, is RsMacroExpansionContents ->
                     if (!substituteMacro(sb, child, subst)) return false
                 is RsMacroReference ->
-                    sb.append(subst.getVar(child.referenceName) ?: return false)
+                    sb.safeAppend(subst.getVar(child.referenceName) ?: return false)
                 is RsMacroExpansionReferenceGroup -> {
                     child.macroExpansionContents?.let { contents ->
                         val separator = child.macroExpansionGroupSeparator?.text ?: ""
@@ -184,13 +184,19 @@ class MacroExpander(val project: Project) {
                     }
                 }
                 else -> {
-                    sb.append(" ")
-                    sb.append(child.text)
-                    sb.append(" ")
+                    sb.safeAppend(child.text)
                 }
             }
         }
         return true
+    }
+
+    /** Ensures that the buffer ends (or [str] starts) with a whitespace and appends [str] to the buffer */
+    private fun StringBuilder.safeAppend(str: String) {
+        if (!isEmpty() && !last().isWhitespace() && !str.isEmpty() && !str.first().isWhitespace()) {
+            append(" ")
+        }
+        append(str)
     }
 
     private val RsMacro.macroBodyStubbed: RsMacroBody?

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -349,6 +349,12 @@ private class MacroPattern private constructor(
             }
         }
 
+        val isExpectedAtLeastOne = group.plus != null
+        if (isExpectedAtLeastOne && groups.isEmpty()) {
+            MacroExpansionMarks.failMatchGroupTooFewElements.hit()
+            return null
+        }
+
         return groups
     }
 
@@ -485,6 +491,7 @@ object MacroExpansionMarks {
     val failMatchPatternByExtraInput = Testmark("failMatchPatternByExtraInput")
     val failMatchPatternByBindingType = Testmark("failMatchPatternByBindingType")
     val failMatchGroupBySeparator = Testmark("failMatchGroupBySeparator")
+    val failMatchGroupTooFewElements = Testmark("failMatchGroupTooFewElements")
     val groupInputEnd1 = Testmark("groupInputEnd1")
     val groupInputEnd2 = Testmark("groupInputEnd2")
     val groupInputEnd3 = Testmark("groupInputEnd3")

--- a/src/test/kotlin/org/rust/lang/core/macros/RsErrorChainMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsErrorChainMacroExpansionTest.kt
@@ -828,12 +828,12 @@ class RsErrorChainMacroExpansionTest : RsMacroExpansionTestBase() {
         pub struct Error(
             pub ErrorKind,
             #[doc(hidden)]
-            pub ::State,
+            pub IntellijRustDollarCrate_self::State,
         );
-        impl ::ChainedError for Error {
+        impl IntellijRustDollarCrate_self::ChainedError for Error {
             type ErrorKind = ErrorKind;
 
-            fn new(kind: ErrorKind, state: ::State) -> Error {
+            fn new(kind: ErrorKind, state: IntellijRustDollarCrate_self::State) -> Error {
                 Error(kind, state)
             }
 
@@ -853,8 +853,8 @@ class RsErrorChainMacroExpansionTest : RsMacroExpansionTestBase() {
                 self.kind()
             }
 
-            fn iter(&self) -> ::Iter {
-                ::Iter::new(Some(self))
+            fn iter(&self) -> IntellijRustDollarCrate_self::Iter {
+                IntellijRustDollarCrate_self::Iter::new(Some(self))
             }
 
             fn chain_err<F, EK>(self, error: F) -> Self
@@ -863,13 +863,13 @@ class RsErrorChainMacroExpansionTest : RsMacroExpansionTestBase() {
                 self.chain_err(error)
             }
 
-            fn backtrace(&self) -> Option<&::Backtrace> {
+            fn backtrace(&self) -> Option<&IntellijRustDollarCrate_self::Backtrace> {
                 self.backtrace()
             }
 
             #[allow(unknown_lints, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
-            fn extract_backtrace(e: &(    ::std::error::Error + Send + 'static    ))
-                                 -> Option<::InternalBacktrace> {
+            fn extract_backtrace(e: &(   ::std::error::Error + Send + 'static   ))
+                                 -> Option<IntellijRustDollarCrate_self::InternalBacktrace> {
                 if let Some(e) = e.downcast_ref::<Error
                 >() {
                     return Some(e.1.backtrace.clone());
@@ -888,7 +888,7 @@ class RsErrorChainMacroExpansionTest : RsMacroExpansionTestBase() {
             pub fn from_kind(kind: ErrorKind) -> Error {
                 Error(
                     kind,
-                    ::State::default(),
+                    IntellijRustDollarCrate_self::State::default(),
                 )
             }
 
@@ -908,7 +908,7 @@ class RsErrorChainMacroExpansionTest : RsMacroExpansionTestBase() {
             {
                 Error(
                     kind.into(),
-                    ::State::new::<Error>(error, ),
+                    IntellijRustDollarCrate_self::State::new::<Error>(error, ),
                 )
             }
 
@@ -918,12 +918,12 @@ class RsErrorChainMacroExpansionTest : RsMacroExpansionTestBase() {
             }
 
 
-            pub fn iter(&self) -> ::Iter {
-                ::ChainedError::iter(self)
+            pub fn iter(&self) -> IntellijRustDollarCrate_self::Iter {
+                IntellijRustDollarCrate_self::ChainedError::iter(self)
             }
 
 
-            pub fn backtrace(&self) -> Option<&::Backtrace> {
+            pub fn backtrace(&self) -> Option<&IntellijRustDollarCrate_self::Backtrace> {
                 self.1.backtrace()
             }
 
@@ -1125,8 +1125,8 @@ class RsErrorChainMacroExpansionTest : RsMacroExpansionTestBase() {
                 where F: FnOnce() -> EK,
                       EK: Into<ErrorKind> {
                 self.map_err(move |e| {
-                    let state = ::State::new::<Error>(Box::new(e), );
-                    ::ChainedError::new(callback().into(), state)
+                    let state = IntellijRustDollarCrate_self::State::new::<Error>(Box::new(e), );
+                    IntellijRustDollarCrate_self::ChainedError::new(callback().into(), state)
                 })
             }
         }
@@ -1135,11 +1135,11 @@ class RsErrorChainMacroExpansionTest : RsMacroExpansionTestBase() {
                 where F: FnOnce() -> EK,
                       EK: Into<ErrorKind> {
                 self.ok_or_else(move || {
-                    ::ChainedError::from_kind(callback().into())
+                    IntellijRustDollarCrate_self::ChainedError::from_kind(callback().into())
                 })
             }
         }
         #[allow(unused)]
         pub type Result<T> = ::std::result::Result<T, Error>;
-""")
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -367,6 +367,23 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         struct Bar;
     """ to MacroExpansionMarks.failMatchPatternByExtraInput)
 
+    fun `test match * vs + group pattern`() = doTest("""
+        macro_rules! foo {
+            ($ ($ i:ident)+) => (
+                mod plus_matched {}
+            );
+            ($ ($ i:ident)*) => (
+                mod asterisk_matched {}
+            );
+        }
+        foo! {  }
+        foo! { foo }
+    """, """
+        mod asterisk_matched {}
+    """ to MacroExpansionMarks.failMatchGroupTooFewElements, """
+        mod plus_matched {}
+    """ to null)
+
     fun `test group pattern with collapsed token as a separator`() = doTest("""
         macro_rules! foo {
             ($ ($ i:ident)&&*) => ($ (

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -53,6 +53,20 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         impl S { fn foo() -> Self { S } }
     """)
 
+    // This test doesn't check result of '$crate' expansion because it's implementation detail.
+    // For example rustc expands '$crate' to synthetic token without text representation
+    fun `test '$crate' metavar is matched as identifier`() = doTest("""
+        macro_rules! foo {
+            () => { bar!($ crate); } // $ crate consumed as a single identifier by `bar`
+        }
+        macro_rules! bar {
+            ($ i:ident) => { mod a {} }
+        }
+        foo! {}
+    """, """
+        mod a {}
+    """)
+
     fun `test path`() = doTest("""
         macro_rules! foo {
             ($ i:path) => {
@@ -163,18 +177,6 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         foo! { fn foo() {} }
     """, """
         fn foo() {}
-    """)
-
-    fun `test 'crate' metavar`() = doTest("""
-        #[macro_use]
-        mod a {
-            macro_rules! foo {
-                ($ i:ident) => { fn $ i() { let a = $ crate::foo; } }
-            }
-        }
-        foo! { foo }
-    """, """
-        fn foo() { let a = ::foo; }
     """)
 
     fun `test empty group`() = doTest(MacroExpansionMarks.groupInputEnd1, """

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -17,7 +17,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         fn bar() {}
     """)
 
-    fun `test ident self`() = doTest("""
+    fun `test ident 'self'`() = doTest("""
         macro_rules! foo {
             ($ i:ident) => (
                 use foo::{$ i};
@@ -28,7 +28,21 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         use foo::{self};
     """)
 
-    fun `test ident Self`() = doTest("""
+    fun `test ident 'super', 'crate'`() = doTest("""
+        macro_rules! foo {
+            ($ i:ident) => (
+                use $ i::foo;
+            )
+        }
+        foo! { super }
+        foo! { crate }
+    """, """
+        use super::foo;
+    """, """
+        use crate::foo;
+    """)
+
+    fun `test ident 'Self'`() = doTest("""
         macro_rules! foo {
             ($ i:ident) => (
                 impl S { fn foo() -> $ i { S } }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
@@ -283,7 +283,7 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
 
         fn main() {
             foo().bar()
-        }       //^ lib.rs
+        }       //^
     """)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
@@ -292,7 +292,7 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
         pub struct Foo;
         impl Foo {
             pub fn bar(&self) {}
-        }     //X
+        }
         #[macro_export]
         macro_rules! foo {
             () => { fn foo() -> $ crate::Foo { unimplemented!() } }
@@ -314,7 +314,7 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
         pub struct Foo;
         impl Foo {
             pub fn bar(&self) {}
-        }     //X
+        }
         #[macro_export]
         macro_rules! foo {
             () => { fn foo() -> $ crate::Foo { unimplemented!() } }
@@ -336,7 +336,7 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
         pub struct Foo;
         impl Foo {
             pub fn bar(&self) {}
-        }     //X
+        }
         #[macro_export]
         macro_rules! foo {
             () => { fn foo() -> $ crate::Foo { unimplemented!() } }


### PR DESCRIPTION
These fixes allows to almost completely expand `table!` macro from diesel.

Note that this PR brings extremely awful hacks around $crate metavar expansion.