### PR TITLE
Make `RsResolveProcessor.lazy()` non thread safe

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -115,7 +115,7 @@ operator fun RsResolveProcessor.invoke(name: String, e: RsElement, subst: Substi
     this(SimpleScopeEntry(name, e, subst))
 
 fun RsResolveProcessor.lazy(name: String, e: () -> RsElement?): Boolean =
-    this(LazyScopeEntry(name, lazy(e)))
+    this(LazyScopeEntry(name, lazy(LazyThreadSafetyMode.NONE, e)))
 
 operator fun RsResolveProcessor.invoke(e: RsNamedElement): Boolean {
     val name = e.name ?: return false


### PR DESCRIPTION
Lazy `ScopeEntry.element` is never accessed from different thread,
so we don't need synchronization here
