### PR TITLE
Clean up error annotation handling.

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspection.kt
@@ -14,6 +14,8 @@ import org.rust.lang.core.types.isMutable
 import org.rust.lang.core.types.ty.TyPointer
 import org.rust.lang.core.types.ty.TyReference
 import org.rust.lang.core.types.type
+import org.rust.lang.utils.RsDiagnostic
+import org.rust.lang.utils.addToHolder
 
 class RsAssignToImmutableInspection : RsLocalInspectionTool() {
 
@@ -43,6 +45,6 @@ class RsAssignToImmutableInspection : RsLocalInspectionTool() {
     }
 
     private fun registerProblem(holder: ProblemsHolder, expr: RsExpr, message: String) {
-        holder.registerProblem(expr, "Cannot assign to $message [E0594]")
+        RsDiagnostic.CannotAssignToImmutable(expr, message).addToHolder(holder)
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt
@@ -11,6 +11,8 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psi.ext.isAssignBinaryExpr
 import org.rust.lang.core.types.isMutable
+import org.rust.lang.utils.RsDiagnostic
+import org.rust.lang.utils.addToHolder
 
 class RsReassignImmutableInspection : RsLocalInspectionTool() {
 
@@ -33,8 +35,8 @@ class RsReassignImmutableInspection : RsLocalInspectionTool() {
         }
 
     private fun registerProblem(holder: ProblemsHolder, expr: RsExpr, nameExpr: RsExpr) {
-        val fix = AddMutableFix.createIfCompatible(nameExpr).let { if (it == null) emptyArray() else arrayOf(it) }
-        holder.registerProblem(expr, "Re-assignment of immutable variable [E0384]", *fix)
+        val fix = AddMutableFix.createIfCompatible(nameExpr)
+        RsDiagnostic.CannotReassignToImmutable(expr, fix).addToHolder(holder)
     }
 
 }

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -783,15 +783,38 @@ sealed class RsDiagnostic(
             return "Wrong number of lifetime arguments: expected $expectedLifetimes, found $actualLifetimes"
         }
     }
+
+    class CannotAssignToImmutable(
+        element: PsiElement,
+        private val message: String
+    ) : RsDiagnostic(element) {
+        override fun prepare(): PreparedAnnotation = PreparedAnnotation(
+            ERROR,
+            E0594,
+            "Cannot assign to $message"
+        )
+    }
+
+    class CannotReassignToImmutable(
+        element: PsiElement,
+        private val fix: AddMutableFix?
+    ) : RsDiagnostic(element) {
+        override fun prepare(): PreparedAnnotation = PreparedAnnotation(
+            ERROR,
+            E0384,
+            "Cannot assign twice to immutable variable",
+            fixes = listOfNotNull(fix)
+        )
+    }
 }
 
 enum class RsErrorCode {
     E0046, E0050, E0060, E0061, E0069,
     E0106, E0107, E0121, E0124, E0133, E0185, E0186, E0198, E0199,
     E0200, E0201, E0202, E0261, E0262, E0263, E0277,
-    E0308, E0379,
+    E0308, E0379, E0384,
     E0403, E0404, E0407, E0415, E0424, E0426, E0428, E0433, E0449, E0463,
-    E0569,
+    E0569, E0594,
     E0603, E0614, E0616, E0624, E0658;
 
     val code: String

--- a/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt
@@ -10,7 +10,7 @@ class RsReassignImmutableInspectionTest : RsInspectionsTestBase(RsReassignImmuta
     fun `test E0384 reassign immutable binding`() = checkByText("""
         fn main() {
             let x = 5;
-            <error descr="Re-assignment of immutable variable [E0384]">x = 3</error>;
+            <error descr="Cannot assign twice to immutable variable [E0384]">x = 3</error>;
         }
     """)
 
@@ -72,7 +72,7 @@ class RsReassignImmutableInspectionTest : RsInspectionsTestBase(RsReassignImmuta
     fun `test E0384 in pattern`() = checkByText("""
         fn main() {
             let (x, mut y) = (92, 62);
-            <error descr="Re-assignment of immutable variable [E0384]">x = 42</error>;
+            <error descr="Cannot assign twice to immutable variable [E0384]">x = 42</error>;
             y = 42;
         }
     """)
@@ -85,13 +85,13 @@ class RsReassignImmutableInspectionTest : RsInspectionsTestBase(RsReassignImmuta
 
     fun `test E0384 immutable used at mutable function definition`() = checkByText("""
         fn test(test: i32) {
-            <error descr="Re-assignment of immutable variable [E0384]">test = 10</error>;
+            <error descr="Cannot assign twice to immutable variable [E0384]">test = 10</error>;
         }
     """)
 
     fun `test E0384 immutable used at mutable function definition (pattern)`() = checkByText("""
         fn foo((x, y): (i32, i32)) {
-            <error descr="Re-assignment of immutable variable [E0384]">x = 92</error>;
+            <error descr="Cannot assign twice to immutable variable [E0384]">x = 92</error>;
         }
     """)
 
@@ -103,7 +103,7 @@ class RsReassignImmutableInspectionTest : RsInspectionsTestBase(RsReassignImmuta
 
     fun `test E0384 immutable used at mutable function definition (pattern) 2`() = checkByText("""
         fn foo((x, y): (i32, i32)) {
-            <error descr="Re-assignment of immutable variable [E0384]">y = 92</error>;
+            <error descr="Cannot assign twice to immutable variable [E0384]">y = 92</error>;
         }
     """)
 


### PR DESCRIPTION
Just some small cleanup. I hope this is allowed.

Related to #1732, I believe. I think this handles the last cases of hard coded "[E0000]" strings. There are a few other cases in `RsWrongLifetimeParametersNumberInspection.kt`, which I handled in #2937.

I've also changed the error message of E0384 to match the output by Rust.