### PR TITLE
INSP: Adjust auto import to edition 2018

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -84,6 +84,7 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
         // we uses this info to create correct relative use item path if needed
         var relativeDepth: Int? = null
 
+        val isEdition2018 = originalElement.containingCargoTarget?.edition == CargoWorkspace.Edition.EDITION_2018
         val info = candidate.info
         // if crate of importing element differs from current crate
         // we need to add new extern crate item
@@ -100,7 +101,7 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
                 // we don't add corresponding extern crate item manually for the same reason
                 attributes == RsFile.Attributes.NO_STD && target.isCore -> Testmarks.autoInjectedCoreCrate.hit()
                 else -> {
-                    if (info.needInsertExternCrateItem) {
+                    if (info.needInsertExternCrateItem && !isEdition2018) {
                         crateRoot?.insertExternCrateItem(psiFactory, info.externCrateName)
                     } else {
                         if (info.depth != null) {
@@ -113,7 +114,7 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
         }
 
         val prefix = when (relativeDepth) {
-            null -> ""
+            null -> if (info is ImportInfo.LocalImportInfo && isEdition2018) "crate::" else ""
             0 -> "self::"
             else -> "super::".repeat(relativeDepth)
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -5,13 +5,12 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.cargo.project.workspace.CargoWorkspace.Edition.EDITION_2018
 import org.rust.cargo.util.AutoInjectedCrates.CORE
 import org.rust.cargo.util.AutoInjectedCrates.STD
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
-import org.rust.lang.core.resolve.ItemResolutionTestmarks.externCrateItemWithoutAlias
 import org.rust.lang.core.resolve.ItemResolutionTestmarks.externCrateItemAliasWithSameName
+import org.rust.lang.core.resolve.ItemResolutionTestmarks.externCrateItemWithoutAlias
 import org.rust.lang.core.resolve.ref.RsReference
 import org.rust.openapiext.Testmark
 import java.util.*
@@ -20,14 +19,15 @@ fun processItemOrEnumVariantDeclarations(
     scope: RsElement,
     ns: Set<Namespace>,
     processor: RsResolveProcessor,
-    withPrivateImports: Boolean = false
+    withPrivateImports: Boolean = false,
+    withPlainExternCrateItems: Boolean = true
 ): Boolean {
     when (scope) {
         is RsEnumItem -> {
             if (processAll(scope.enumBody?.enumVariantList.orEmpty(), processor)) return true
         }
         is RsMod -> {
-            if (processItemDeclarations(scope, ns, processor, withPrivateImports)) return true
+            if (processItemDeclarations(scope, ns, processor, withPrivateImports, withPlainExternCrateItems)) return true
         }
     }
 
@@ -39,7 +39,8 @@ fun processItemDeclarations(
     scope: RsItemsOwner,
     ns: Set<Namespace>,
     originalProcessor: RsResolveProcessor,
-    withPrivateImports: Boolean
+    withPrivateImports: Boolean,
+    withPlainExternCrateItems: Boolean = true
 ): Boolean {
     val starImports = mutableListOf<RsUseSpeck>()
     val itemImports = mutableListOf<RsUseSpeck>()
@@ -84,12 +85,12 @@ fun processItemDeclarations(
                     val itemName = item.name
                     val aliasName = item.alias?.name
                     val name = aliasName ?: itemName ?: return false
-                    val edition = item.containingCargoTarget?.edition
 
-                    if (edition == EDITION_2018) {
-                        // For edition 2018 we should process only extern crate item
+                    if (!withPlainExternCrateItems) {
+                        // In some situations (for example, absolute paths in edition 2018)
+                        // we should process only extern crate item
                         // which brings new name into the scope, i.e. with alias,
-                        // because otherwise this item is already processed in `NameResolutionKt#processPathResolveVariants`
+                        // because otherwise this item is already processed in other place
                         if (aliasName == null) {
                             externCrateItemWithoutAlias.hit()
                             return false
@@ -156,7 +157,8 @@ fun processItemDeclarations(
 
         val found = processItemOrEnumVariantDeclarations(mod, ns,
             { it.name !in directlyDeclaredNames && originalProcessor(it) },
-            withPrivateImports = basePath != null && isSuperChain(basePath)
+            withPrivateImports = basePath != null && isSuperChain(basePath),
+            withPlainExternCrateItems = withPlainExternCrateItems
         )
         if (found) return true
     }

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
@@ -5,8 +5,10 @@
 
 package org.rust.ide.inspections.import
 
+import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibAndDependencyRustProjectDescriptor
+import org.rust.cargo.project.workspace.CargoWorkspace
 
 @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
 class AutoImportFixStdTest : AutoImportFixTestBase() {
@@ -419,5 +421,20 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         fn main() {
             let foo = Foo/*caret*/;
         }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test import item from not std crate (edition 2018)`() = checkAutoImportFixByFileTree("""
+        //- dep-lib/lib.rs
+        pub mod foo {
+            pub struct Bar;
+        }
+        //- main.rs
+        fn foo(t: <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>) {}
+    """, """
+        //- main.rs
+        use dep_lib_target::foo::Bar;
+
+        fn foo(t: Bar/*caret*/) {}
     """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -5,6 +5,9 @@
 
 package org.rust.ide.inspections.import
 
+import org.rust.MockEdition
+import org.rust.cargo.project.workspace.CargoWorkspace
+
 class AutoImportFixTest : AutoImportFixTestBase() {
 
     fun `test import struct`() = checkAutoImportFixByText("""
@@ -1299,6 +1302,27 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
         fn bar<T: foo::Foo>(t: T) {
             t.foo/*caret*/();
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test import item in root module (edition 2018)`() = checkAutoImportFixByText("""
+        mod foo {
+            pub struct Foo;
+        }
+
+        fn main() {
+            let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
+        }
+    """, """
+        use crate::foo::Foo;
+
+        mod foo {
+            pub struct Foo;
+        }
+
+        fn main() {
+            let f = Foo/*caret*/;
         }
     """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -307,4 +307,16 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         fn foo() -> dep_lib_target::Foo { unimplemented!() }
                                    //^ dep-lib/lib.rs
     """, ItemResolutionTestmarks.externCrateItemAliasWithSameName)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test extern crate in super chain (edition 2018)`() = stubOnlyResolve("""
+    //- dep-lib/lib.rs
+        pub struct Foo;
+    //- lib.rs
+        mod foo {
+            extern crate dep_lib_target;
+            use self::dep_lib_target::Foo;
+                                     //^ dep-lib/lib.rs
+        }
+    """)
 }


### PR DESCRIPTION
* fix extern crate name resolution in relative paths in edition 2018
* adjust auto import to edition 2018
  * don't add `extern crate` item while importing items from other crates
  * add `crate::` prefix for local absolute paths