### PR TITLE
RUN: Enable `--all-features` option in run configuration

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducer.kt
@@ -155,7 +155,7 @@ sealed class TestConfig {
     fun cargoCommandLine(): CargoCommandLine {
         var commandLine = CargoCommandLine.forTargets(targets, "test", listOf(path))
         if (exact) {
-            commandLine = commandLine.withDoubleDashFlag("--exact")
+            commandLine = commandLine.addArgToBinary("--exact")
         }
         return commandLine
     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
@@ -94,11 +94,12 @@ class CargoCommandConfigurationEditor(private val project: Project) : SettingsEd
     }
 
     private val environmentVariables = EnvironmentVariablesComponent()
-
+    private val allFeatures = CheckBox("Use all features in tests", true)
 
     override fun resetEditorFrom(configuration: CargoCommandConfiguration) {
         channel.selectedIndex = configuration.channel.index
         command.text = configuration.command
+        allFeatures.isSelected = configuration.allFeatures
         backtraceMode.selectedIndex = configuration.backtrace.index
         workingDirectory.component.text = configuration.workingDirectory?.toString() ?: ""
         environmentVariables.envData = configuration.env
@@ -117,6 +118,7 @@ class CargoCommandConfigurationEditor(private val project: Project) : SettingsEd
 
         configuration.channel = configChannel
         configuration.command = command.text
+        configuration.allFeatures = allFeatures.isSelected
         configuration.backtrace = BacktraceMode.fromIndex(backtraceMode.selectedIndex)
         configuration.workingDirectory = currentWorkingDirectory
         configuration.env = environmentVariables.envData
@@ -135,6 +137,8 @@ class CargoCommandConfigurationEditor(private val project: Project) : SettingsEd
             channelLabel()
             channel()
         }
+
+        row { allFeatures() }
 
         row(environmentVariables.label) { environmentVariables.apply { makeWide() }() }
         row(workingDirectory.label) {

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -107,7 +107,13 @@ class Cargo(private val cargoExecutable: Path) {
     fun toGeneralCommandLine(commandLine: CargoCommandLine): GeneralCommandLine =
         generalCommandLine(commandLine, false)
 
-    private fun generalCommandLine(commandLine: CargoCommandLine, colors: Boolean): GeneralCommandLine {
+    private fun generalCommandLine(rawCommandLine: CargoCommandLine, colors: Boolean): GeneralCommandLine {
+        val commandLine = if (rawCommandLine.command == "test" && rawCommandLine.allFeatures) {
+            rawCommandLine.addArgToCargo("--all-features")
+        } else {
+            rawCommandLine
+        }
+
         val cmdLine = GeneralCommandLine(cargoExecutable)
             .withCharset(Charsets.UTF_8)
             .withWorkDirectory(commandLine.workingDirectory)

--- a/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
@@ -25,14 +25,26 @@ data class CargoCommandLine(
     val additionalArguments: List<String> = emptyList(),
     val backtraceMode: BacktraceMode = BacktraceMode.DEFAULT,
     val channel: RustChannel = RustChannel.DEFAULT,
-    val environmentVariables: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
+    val environmentVariables: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT,
+    val allFeatures: Boolean = true
 ) {
 
+    /** Appends [arg] to Cargo options, in other words, inserts [arg] before `--` arg in [additionalArguments]. */
+    fun addArgToCargo(arg: String): CargoCommandLine {
+        val (cargoArgs, binaryArgs) = splitOnDoubleDash()
+        if (arg in cargoArgs) return this
+        return if (binaryArgs.isEmpty()) {
+            copy(additionalArguments = cargoArgs + arg)
+        } else {
+            copy(additionalArguments = cargoArgs + arg + "--" + binaryArgs)
+        }
+    }
 
-    fun withDoubleDashFlag(arg: String): CargoCommandLine {
-        val (pre, post) = splitOnDoubleDash()
-        if (arg in post) return this
-        return copy(additionalArguments = pre + "--" + arg + post)
+    /** Appends [arg] to binary options, in other words, inserts [arg] after `--` arg in [additionalArguments]. */
+    fun addArgToBinary(arg: String): CargoCommandLine {
+        val (cargoArgs, binaryArgs) = splitOnDoubleDash()
+        if (arg in binaryArgs) return this
+        return copy(additionalArguments = cargoArgs + "--" + arg + binaryArgs)
     }
 
     /**

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt
@@ -24,10 +24,10 @@ class CargoTest : RsTestBase() {
 
     fun `test basic command`() = checkCommandLine(
         cargo.toGeneralCommandLine(CargoCommandLine("test", wd, listOf("--all"))), """
-        cmd: /usr/bin/cargo test --all
+        cmd: /usr/bin/cargo test --all --all-features
         env: RUST_BACKTRACE=short, TERM=ansi
         """, """
-        cmd: C:/usr/bin/cargo.exe test --all
+        cmd: C:/usr/bin/cargo.exe test --all --all-features
         env: RUST_BACKTRACE=short, TERM=ansi
     """)
 

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable configuration uses default environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable configuration uses default environment.xml
@@ -2,6 +2,7 @@
   <configuration name="Run hello" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="run --package test-package --bin hello" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable producer works for bin.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable producer works for bin.xml
@@ -2,6 +2,7 @@
   <configuration name="Run hello" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="run --package test-package --bin hello" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable producer works for example.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable producer works for example.xml
@@ -2,6 +2,7 @@
   <configuration name="Run hello" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="run --package test-package --example hello" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ hyphen in name works.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ hyphen in name works.xml
@@ -2,6 +2,7 @@
   <configuration name="Run hello-world" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="run --package test-package --example hello-world" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than test mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than test mod.xml
@@ -2,6 +2,7 @@
   <configuration name="Run foo" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="run --package test-package --bin foo" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main mod and test mod have same specificity.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main mod and test mod have same specificity.xml
@@ -2,6 +2,7 @@
   <configuration name="Run foo" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="run --package test-package --bin foo" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />
@@ -9,6 +10,7 @@
   <configuration name="Test main" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --bin foo &quot;&quot;" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ meaningful configuration name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ meaningful configuration name.xml
@@ -2,6 +2,7 @@
   <configuration name="Test bar::tests" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib bar::tests" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ producer use complete function path.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ producer use complete function path.xml
@@ -2,6 +2,7 @@
   <configuration name="Test foo_mod::test_foo" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib foo_mod::test_foo -- --exact" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ take into account path attribute.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ take into account path attribute.xml
@@ -2,6 +2,7 @@
   <configuration name="Test test::foo" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib test::foo -- --exact" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test configuration uses default environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test configuration uses default environment.xml
@@ -2,6 +2,7 @@
   <configuration name="Test test_foo" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib test_foo -- --exact" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer adds bin name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer adds bin name.xml
@@ -2,6 +2,7 @@
   <configuration name="Test test_foo" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --bin foo test_foo -- --exact" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer ignores selected files that contain no tests.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer ignores selected files that contain no tests.xml
@@ -2,6 +2,7 @@
   <configuration name="Test foo" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --test foo &quot;&quot;" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for annotated functions.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for annotated functions.xml
@@ -2,6 +2,7 @@
   <configuration name="Test test_foo" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib test_foo -- --exact" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for files.xml
@@ -2,6 +2,7 @@
   <configuration name="Test foo" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --test foo &quot;&quot;" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for modules.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for modules.xml
@@ -2,6 +2,7 @@
   <configuration name="Test foo" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib foo" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for multiple files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for multiple files.xml
@@ -2,6 +2,7 @@
   <configuration name="Test multiple selected files" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --test foo --test baz &quot;&quot;" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for root module.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for root module.xml
@@ -2,6 +2,7 @@
   <configuration name="Test lib" class="CargoCommandConfiguration">
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib &quot;&quot;" />
+    <option name="allFeatures" value="true" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />


### PR DESCRIPTION
Closes https://github.com/intellij-rust/intellij-rust/issues/2812.

Makes the `--all-features` option enabled by default and applies it only to tests.

<img width="525" alt="Edit Configuration Menu" src="https://user-images.githubusercontent.com/6079006/46963792-37462c00-d0af-11e8-8a81-507c6434a8f3.png">
