### PR TITLE
Fix inc rust structure mod tracker on element replacement

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
@@ -52,13 +52,14 @@ class RsPsiManagerImpl(val project: Project) : ProjectComponent, RsPsiManager {
 
     inner class CacheInvalidator : PsiTreeChangeAdapter() {
         override fun beforeChildRemoval(event: PsiTreeChangeEvent) = onPsiChange(event)
+        override fun beforeChildReplacement(event: PsiTreeChangeEvent) = onPsiChange(event, event.oldChild)
         override fun childReplaced(event: PsiTreeChangeEvent) = onPsiChange(event)
         override fun childAdded(event: PsiTreeChangeEvent) = onPsiChange(event)
         override fun childrenChanged(event: PsiTreeChangeEvent) = onPsiChange(event)
         override fun childMoved(event: PsiTreeChangeEvent) = onPsiChange(event)
         override fun propertyChanged(event: PsiTreeChangeEvent) = onPsiChange(event)
 
-        private fun onPsiChange(event: PsiTreeChangeEvent) {
+        private fun onPsiChange(event: PsiTreeChangeEvent, child: PsiElement? = event.child) {
             // `GenericChange` event means that "something changed in the file" and sends
             // after all events for concrete PSI changes in a file.
             // We handle more concrete events and so should ignore generic event
@@ -69,7 +70,6 @@ class RsPsiManagerImpl(val project: Project) : ProjectComponent, RsPsiManager {
             val file = event.file ?: event.child as? PsiFile
             if (file?.fileType != RsFileType) return
 
-            val child = event.child
             if (child is PsiComment || child is PsiWhiteSpace) return
 
             updateModificationCount(child ?: event.parent)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -9,6 +9,7 @@ import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.icons.RsIcons
 import org.rust.ide.icons.addTestMark
 import org.rust.lang.core.macros.RsExpandedElement
@@ -106,7 +107,13 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
         SimpleModificationTracker()
 
     override fun incModificationCount(element: PsiElement): Boolean {
-        val shouldInc = element !is RsItemElement && block?.isAncestorOf(element) == true
+        val shouldInc = block?.isAncestorOf(element) == true && PsiTreeUtil.findChildOfAnyType(
+            element,
+            false,
+            RsItemElement::class.java,
+            RsMacro::class.java,
+            RsMacroCall::class.java
+        ) == null
         if (shouldInc) modificationTracker.incModificationCount()
         return shouldInc
     }

--- a/src/test/kotlin/org/rust/lang/core/psi/RsRustStructureModificationTrackerTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsRustStructureModificationTrackerTest.kt
@@ -174,4 +174,22 @@ class RsRustStructureModificationTrackerTest : RsTestBase() {
             }
         }
     }
+
+    //
+
+    fun `test replace function with comment`() = doTest(INC, """
+        /*caret*/fn foo() {}
+    """, "//")
+
+    fun `test replace expr with block with item`() = doTest(INC, """
+        fn foo() { 2/*caret*/; }
+    """, "\b{ fn bar() {} }")
+
+    fun `test replace expr with block with macro definition`() = doTest(INC, """
+        fn foo() { 2/*caret*/; }
+    """, "\b{ macro_rules! foo { () => {} } }")
+
+    fun `test replace expr with block with call`() = doTest(INC, """
+        fn foo() { 2/*caret*/; }
+    """, "\b{ foo!() }")
 }


### PR DESCRIPTION
This fixes cache invalidation after replacing a line with comment
(`ctrl+/`)