### PR TITLE
MACRO: allow macro definitions in macro expansions

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1158,7 +1158,8 @@ YieldExpr ::= OuterAttr* yield Expr? {
 Macro ::= AttrsAndVis "macro_rules" '!' identifier MacroBody <<macroSemicolon>>{
   implements = [ "org.rust.lang.core.psi.ext.RsNameIdentifierOwner"
                  "org.rust.lang.core.psi.ext.RsOuterAttributeOwner"
-                 "org.rust.lang.core.psi.ext.RsQualifiedNamedElement" ]
+                 "org.rust.lang.core.psi.ext.RsQualifiedNamedElement"
+                 "org.rust.lang.core.macros.RsExpandedElement" ]
   extends = "org.rust.lang.core.psi.ext.RsMacroImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsMacroStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -541,4 +541,15 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
     """, """
         Option<i32>
     """)
+
+    fun `test expend macro definition`() = doTest("""
+       macro_rules! foo {
+           () => {
+               macro_rules! bar { () => {} }
+           }
+       }
+       foo!();
+    """, """
+        macro_rules! bar { () => {} }
+    """)
 }


### PR DESCRIPTION
This allow macro definitions to be expanded from macros.
Resolve isn't supported, only expansion for now

bors r+