### PR TITLE
TYPE: don't move use items before `{` in inline modules while import optimization

### DIFF
--- a/src/test/kotlin/org/rust/lang/refactoring/RsImportOptimizerTest.kt
+++ b/src/test/kotlin/org/rust/lang/refactoring/RsImportOptimizerTest.kt
@@ -220,6 +220,18 @@ class RsImportOptimizerTest: RsTestBase() {
         }
     """)
 
+    fun `test do not move use items before mod block`() = doTest("""
+        pub mod foo {
+            use std::time;
+            use std::io;
+        }
+    """, """
+        pub mod foo {
+            use std::io;
+            use std::time;
+        }
+    """)
+
     private fun doTest(@Language("Rust") code: String, @Language("Rust") excepted: String){
         checkByText(code.trimIndent(), excepted.trimIndent()) {
             myFixture.performEditorAction("OptimizeImports")


### PR DESCRIPTION
Fixes #2929