### PR TITLE
RES: more precise namespace for paths in use items

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -225,7 +225,16 @@ fun processPathResolveVariants(lookup: ImplLookup, path: RsPath, isCompletion: B
     val parent = path.context
     val ns = when (parent) {
         is RsPath, is RsTypeElement, is RsTraitRef, is RsStructLiteral -> TYPES
-        is RsUseSpeck -> if (parent.isStarImport) TYPES_N_MACROS else TYPES_N_VALUES_N_MACROS
+        is RsUseSpeck -> when {
+            // use foo::bar::{self, baz};
+            //     ~~~~~~~~
+            // use foo::bar::*;
+            //     ~~~~~~~~
+            parent.useGroup != null || parent.isStarImport -> TYPES
+            // use foo::bar;
+            //     ~~~~~~~~
+            else -> TYPES_N_VALUES_N_MACROS
+        }
         is RsPathExpr -> if (isCompletion) TYPES_N_VALUES else VALUES
         else -> TYPES_N_VALUES
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
@@ -22,7 +22,6 @@ val VALUES: Set<Namespace> = EnumSet.of(Namespace.Values)
 val LIFETIMES: Set<Namespace> = EnumSet.of(Namespace.Lifetimes)
 val MACROS: Set<Namespace> = EnumSet.of(Namespace.Macros)
 val TYPES_N_VALUES: Set<Namespace> = EnumSet.of(Namespace.Types, Namespace.Values)
-val TYPES_N_MACROS: Set<Namespace> = EnumSet.of(Namespace.Types, Namespace.Macros)
 val TYPES_N_VALUES_N_MACROS: Set<Namespace> = EnumSet.of(Namespace.Types, Namespace.Values, Namespace.Macros)
 
 val RsNamedElement.namespaces: Set<Namespace> get() = when (this) {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
@@ -119,12 +119,10 @@ class RsUseResolveTest : RsResolveTestBase() {
 
     fun `test view path glob self fn`() = checkByCode("""
         fn f() {}
-         //X
 
         mod foo {
-            // This looks strange, but is allowed by the Rust Language
             use f::{self};
-                   //^
+                   //^ unresolved
         }
     """)
 
@@ -570,5 +568,30 @@ class RsUseResolveTest : RsResolveTestBase() {
         fn main() {
             let a: A = X;
         }            //^
+    """)
+
+    fun `test do not resolve use item inner path to value items 1`() = checkByCode("""
+        pub mod foo {
+            pub fn bar() {}
+                  //X
+        }
+        pub fn foo() {}
+
+        use self::foo::{bar};
+                       //^
+    """)
+
+    fun `test do not resolve use item inner path to value items 2`() = checkByCode("""
+        pub mod foo {
+            pub fn bar() {}
+                  //X
+        }
+        pub const foo: i32 = 123;
+
+        use self::foo::{bar};
+
+        fn main() {
+            bar();
+        }  //^
     """)
 }


### PR DESCRIPTION
The current implementation of name resolution doesn't take into account the following use group in use items while path resolve.
It leads to multiple resolution results for paths before use group when there are several items with the same name but different namespace.

In the following case
```rust
mod foo {
    pub fn bar() {}
}

fn foo() {}

use self::foo::{bar};
```
we get multiple resolution for `self::foo` path and fail to resolve `bar` because of it.

Current changes fix wrong namespace for such paths and fix multiple name resolution.

Fixes #2864
Fixes #2981