### PR TITLE
TY: Do not mark `'_` as undeclared lifetime

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -31,6 +31,7 @@ import org.rust.lang.core.stubs.index.RsFeatureIndex
 import org.rust.lang.core.types.inference
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
+import org.rust.lang.refactoring.RsNamesValidator.Companion.RESERVED_LIFETIME_NAMES
 import org.rust.lang.utils.RsDiagnostic
 import org.rust.lang.utils.RsErrorCode
 import org.rust.lang.utils.addToHolder
@@ -451,10 +452,6 @@ class RsErrorAnnotator : Annotator, HighlightRangeExtension {
 
     private fun hasResolve(el: RsReferenceElement): Boolean =
         !(el.reference.resolve() != null || el.reference.multiResolve().size > 1)
-
-    companion object {
-        private val RESERVED_LIFETIME_NAMES: Set<String> = setOf("'_", "'static")
-    }
 }
 
 private fun RsExpr?.isComparisonBinaryExpr(): Boolean {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsLifetime.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsLifetime.kt
@@ -15,7 +15,7 @@ import org.rust.lang.core.stubs.RsLifetimeStub
 import org.rust.lang.refactoring.RsNamesValidator
 
 
-val RsLifetime.isPredefined: Boolean get() = referenceName in RsNamesValidator.PredefinedLifetimes
+val RsLifetime.isPredefined: Boolean get() = referenceName in RsNamesValidator.RESERVED_LIFETIME_NAMES
 
 abstract class RsLifetimeImplMixin : RsStubbedNamedElementImpl<RsLifetimeStub>, RsLifetime {
 

--- a/src/main/kotlin/org/rust/lang/refactoring/RsNamesValidator.kt
+++ b/src/main/kotlin/org/rust/lang/refactoring/RsNamesValidator.kt
@@ -28,7 +28,7 @@ class RsNamesValidator : NamesValidator {
 
 
     companion object {
-        val PredefinedLifetimes = arrayOf("'static")
+        val RESERVED_LIFETIME_NAMES: Set<String> = setOf("'static", "'_")
     }
 }
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -436,13 +436,25 @@ class RsErrorAnnotatorTest : RsAnnotationTestBase() {
         fn foo(a: &'static str) {}
     """)
 
-    fun `test reserved lifetime names E0262`() = checkErrors("""
-        fn foo<<error descr="`'_` is a reserved lifetime name [E0262]">'_</error>>(x: &'_ str) {}
-        fn bar<<error descr="`'static` is a reserved lifetime name [E0262]">'static</error>>(x: &'static str) {}
-        struct Str<<error>'static</error>> { a: &'static u32 }
-        impl<<error>'static</error>> Str<'static> {}
-        enum En<<error>'static</error>> { A(&'static str) }
-        trait Tr<<error>'static</error>> {}
+    fun `test not applied to underscore lifetimes E0261`() = checkErrors("""
+        const ZERO: &'_ u32 = &0;
+        fn foo(a: &'_ str) {}
+    """)
+
+    fun `test reserved lifetime name ('static) E0262`() = checkErrors("""
+        fn foo1<<error descr="`'static` is a reserved lifetime name [E0262]">'static</error>>(x: &'static str) {}
+        struct Str1<<error>'static</error>> { a: &'static u32 }
+        impl<<error>'static</error>> Str1<'static> {}
+        enum En1<<error>'static</error>> { A(&'static str) }
+        trait Tr1<<error>'static</error>> {}
+    """)
+
+    fun `test reserved lifetime name ('_) E0262`() = checkErrors("""
+        fn foo2<<error descr="`'_` is a reserved lifetime name [E0262]">'_</error>>(x: &'_ str) {}
+        struct Str2<<error>'_</error>> { a: &'_ u32 }
+        impl<<error>'_</error>> Str2<'_> {}
+        enum En2<<error>'_</error>> { A(&'_ str) }
+        trait Tr2<<error>'_</error>> {}
     """)
 
     fun `test lifetime name duplication in generic params E0263`() = checkErrors("""


### PR DESCRIPTION
Part of https://github.com/intellij-rust/intellij-rust/issues/2550.