### PR TITLE
Support symlinks better

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - OLD_RUST_VERSION=1.25.0
     - CURRENT_RUST_VERSION=1.29.0
     - NIGHLY_RUST_VERSION=nightly-2018-10-21
+    - RUST_SRC_WITH_SYMLINK=$HOME/.rust-src
   matrix:
     # 182 platform
     - RUST_VERSION=$NIGHLY_RUST_VERSION ORG_GRADLE_PROJECT_platformVersion=182 ORG_GRADLE_PROJECT_sinceBuild=182 ORG_GRADLE_PROJECT_ideaVersion=182.4892.20 # modified by script
@@ -26,7 +27,9 @@ install: true
 before_script:
   - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $RUST_VERSION -y
   - export PATH=$HOME/.cargo/bin:$PATH
+  - rustup component add rust-src
   - rustup component add rustfmt-preview
+  - ln -s $(rustc --print sysroot)/lib/rustlib/src/rust/src $RUST_SRC_WITH_SYMLINK
   - ./check-license.sh
   - ./gradlew :resolveDependencies -Pkotlin.incremental=false --no-daemon
   - ./gradlew assemble testClasses -Pkotlin.incremental=false --no-daemon

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,12 +9,15 @@ environment:
   JAVA_HOME: C:\Program Files\Java\jdk1.8.0
   RUST_VERSION: 1.29.0
   JAVA_OPTS: -Xmx2g
+  RUST_SRC_WITH_SYMLINK: C:\Users\appveyor\.rust-src
 
 install:
   - appveyor-retry appveyor DownloadFile https://win.rustup.rs -FileName rustup-init.exe
   - rustup-init.exe --default-toolchain %RUST_VERSION% -y
   - set PATH=C:\Users\appveyor\.cargo\bin;%PATH%
+  - rustup component add rust-src
   - rustup component add rustfmt-preview
+  - for /f "delims=*" %%a in ('rustc --print sysroot') do (Mklink /D "C:\Users\appveyor\.rust-src" "%%a\lib\rustlib\src\rust\src\")
 
 build_script:
   - gradlew.bat -Dkotlin.compiler.execution.strategy="in-process" assemble testClasses --no-daemon

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -48,6 +48,7 @@ import org.rust.cargo.toolchain.Rustup
 import org.rust.ide.notifications.showBalloon
 import org.rust.openapiext.*
 import org.rust.stdext.AsyncValue
+import org.rust.stdext.applyWithSymlink
 import org.rust.stdext.joinAll
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -132,9 +133,10 @@ class CargoProjectsServiceImpl(
         get() = hasAtLeastOneValidProject(allProjects)
 
     override fun findProjectForFile(file: VirtualFile): CargoProject? =
-        directoryIndex.getInfoForFile(file).takeIf { it !== noProjectMarker }
+        file.applyWithSymlink { directoryIndex.getInfoForFile(it).takeIf { it !== noProjectMarker } }
 
-    override fun findPackageForFile(file: VirtualFile): CargoWorkspace.Package? = packageIndex.findPackageForFile(file)
+    override fun findPackageForFile(file: VirtualFile): CargoWorkspace.Package? =
+        file.applyWithSymlink(packageIndex::findPackageForFile)
 
     override fun attachCargoProject(manifest: Path): Boolean {
         if (isExistingProject(allProjects, manifest)) return false

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.vfs.VirtualFileManager
 import org.jetbrains.annotations.TestOnly
 import org.rust.cargo.util.StdLibType
 import org.rust.openapiext.CachedVirtualFile
+import org.rust.stdext.applyWithSymlink
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.*
@@ -128,10 +129,8 @@ private class WorkspaceImpl(
 
     val targetByCrateRootUrl = packages.flatMap { it.targets }.associateBy { it.crateRootUrl }
 
-    override fun findTargetByCrateRoot(root: VirtualFile): CargoWorkspace.Target? {
-        val canonicalFile = root.canonicalFile ?: return null
-        return targetByCrateRootUrl[canonicalFile.url]
-    }
+    override fun findTargetByCrateRoot(root: VirtualFile): CargoWorkspace.Target? =
+        root.applyWithSymlink { targetByCrateRootUrl[it.url] }
 
     override fun withStdlib(stdlib: StandardLibrary): CargoWorkspace {
         // This is a bit trickier than it seems required.

--- a/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
@@ -5,16 +5,10 @@
 
 package org.rust.cargo.project.workspace
 
-import com.intellij.notification.NotificationType
-import com.intellij.openapi.module.Module
-import com.intellij.openapi.progress.ProgressIndicator
-import com.intellij.openapi.progress.Task
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
-import org.rust.cargo.toolchain.Rustup
 import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.cargo.util.StdLibType
-import org.rust.ide.notifications.showBalloon
 
 class StandardLibrary private constructor(
     val crates: List<StdCrate>
@@ -36,11 +30,14 @@ class StandardLibrary private constructor(
 
         fun fromFile(sources: VirtualFile): StandardLibrary? {
             if (!sources.isDirectory) return null
-            val srcDir = if (sources.name == "src") sources else sources.findChild("src")
-                ?: return null
+            val srcDir = if (sources.name == "src") {
+                sources
+            } else {
+                sources.findChild("src") ?: sources
+            }
 
             val stdlib = AutoInjectedCrates.stdlibCrates.mapNotNull { libInfo ->
-                val packageSrcDir = srcDir.findFileByRelativePath(libInfo.srcDir)
+                val packageSrcDir = srcDir.findFileByRelativePath(libInfo.srcDir)?.canonicalFile
                 val libFile = packageSrcDir?.findChild("lib.rs")
                 if (packageSrcDir != null && libFile != null)
                     StdCrate(libInfo.name, libInfo.type, libFile.url, packageSrcDir.url, libInfo.dependencies)

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -211,7 +211,7 @@ object CargoMetadata {
     }
 
     private fun Package.clean(fs: LocalFileSystem, isWorkspaceMember: Boolean): CargoWorkspaceData.Package? {
-        val root = checkNotNull(fs.refreshAndFindFileByPath(PathUtil.getParentPath(manifest_path))) {
+        val root = checkNotNull(fs.refreshAndFindFileByPath(PathUtil.getParentPath(manifest_path))?.canonicalFile) {
             "`cargo metadata` reported a package which does not exist at `$manifest_path`"
         }
         return CargoWorkspaceData.Package(
@@ -227,9 +227,7 @@ object CargoMetadata {
     }
 
     private fun Target.clean(root: VirtualFile): CargoWorkspaceData.Target? {
-
-        val mainFile = root.findFileByMaybeRelativePath(src_path)
-
+        val mainFile = root.findFileByMaybeRelativePath(src_path)?.canonicalFile
         return mainFile?.let {
             CargoWorkspaceData.Target(it.url, name, cleanKind, cleanCrateTypes, edition.cleanEdition())
         }

--- a/src/main/kotlin/org/rust/stdext/Utils.kt
+++ b/src/main/kotlin/org/rust/stdext/Utils.kt
@@ -6,8 +6,14 @@
 
 package org.rust.stdext
 
+import com.intellij.openapi.vfs.VirtualFile
+
 /**
  * Just a way to nudge Kotlin's type checker in the right direction
  */
 @Suppress("NOTHING_TO_INLINE")
 inline fun <T> typeAscription(t: T): T = t
+
+inline fun <T> VirtualFile.applyWithSymlink(f: (VirtualFile) -> T?): T? {
+    return f(this) ?: f(canonicalFile ?: return null)
+}

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.resolve
 
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.WithStdlibWithSymlinkRustProjectDescriptor
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.lang.core.types.infer.TypeInferenceMarks
@@ -552,5 +553,12 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         fn main() {
             S.clone();
         }   //^
+    """)
+
+    @ProjectDescriptor(WithStdlibWithSymlinkRustProjectDescriptor::class)
+    fun `test path to stdlib contains symlink`() = stubOnlyResolve("""
+    //- main.rs
+        fn foo(x: std::rc::Rc<i32>) {}
+                         //^ .../liballoc/rc.rs
     """)
 }


### PR DESCRIPTION
Resolve all symlinks in packages and targets.

Also, resolve symlinks before any call of `LightDirectoryIndex` to use the same virtual files as we use while index creation

Should fix #2466, but I don't know how to create good tests for this case
Fixes #2633
