### PR TITLE
WIP: INT: Generate accessors.

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/GenerateAccessorIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/GenerateAccessorIntention.kt
@@ -1,0 +1,63 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.types.ty.TyAdt
+import org.rust.lang.core.types.ty.TyPrimitive
+import org.rust.lang.core.types.type
+
+class GenerateAccessorIntention : RsElementBaseIntentionAction<GenerateAccessorIntention.Context>() {
+    data class Context(val structItem: RsStructItem, val implItem: RsImplItem)
+
+    override fun getText() = "Generate accessor for fields struct"
+    override fun getFamilyName() = text
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        // Must be in members of an `impl` block
+        if (element.parent !is RsMembers) return null
+        val implItem = element.ancestorStrict<RsImplItem>() ?: return null
+
+        // Must be implementing a struct.
+        val implType = (implItem.typeReference?.type) as? TyAdt ?: return null
+        val structItem = implType.item as? RsStructItem ?: return null
+
+        // Must not be implementing a trait.
+        return if (implItem.traitRef == null) Context(structItem, implItem) else null
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val functionNames = ctx.implItem.members?.functionList
+            ?.map { it.identifier.text }
+            ?: listOf()
+
+        // Get fields in struct.
+        val fields = ctx.structItem.blockFields?.fieldDeclList ?: return
+
+        // Generate accessors for each field if there is no method name conflict.
+        fields.filter { it.identifier.text !in functionNames }.forEach { field ->
+            // Skip public fields since those can be accessed directly.
+            if (field.isPublic) return@forEach
+
+            val fieldName = field.identifier.text
+            val fieldType = field.typeReference?.type ?: return@forEach
+
+            val borrow = if (fieldType is TyPrimitive) "" else "&"
+            val fnSignature = "fn $fieldName(&self) -> $borrow$fieldType"
+            val fnBody = "${borrow}self.$fieldName"
+
+            val accessor = RsPsiFactory(project).createTraitMethodMember(
+                "$fnSignature {\n$fnBody\n}")
+
+            ctx.implItem.members?.addBefore(accessor, ctx.implItem.members?.rbrace)
+        }
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -613,6 +613,10 @@
             <className>org.rust.ide.intentions.NestUseStatementsIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.GenerateAccessorIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 

--- a/src/main/resources/intentionDescriptions/GenerateAccessorIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/GenerateAccessorIntention/before.rs.template
@@ -1,0 +1,13 @@
+struct S {
+    b: bool,
+    s: String
+}
+
+impl S {<spot>
+    fn b(&self) -> bool {
+        self.b
+    }
+    fn s(&self) -> &String {
+        self.s
+    }</spot>
+}

--- a/src/main/resources/intentionDescriptions/GenerateAccessorIntention/description.html
+++ b/src/main/resources/intentionDescriptions/GenerateAccessorIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention adds accessors for struct fields to an impl block.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/GenerateAccessorIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/GenerateAccessorIntentionTest.kt
@@ -1,0 +1,215 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+
+class GenerateAccessorIntentionTest : RsIntentionTestBase(GenerateAccessorIntention()) {
+    fun `test primitive fields`() = doAvailableTest("""
+        struct S {
+            a: i32,
+            b: bool,
+        }
+
+        impl S {
+            /*caret*/
+        }
+    """, """
+        struct S {
+            a: i32,
+            b: bool,
+        }
+
+        impl S {
+            fn a(&self) -> i32 {
+                self.a
+            }
+            fn b(&self) -> bool {
+                self.b
+            }
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test enum and struct fields`() = doAvailableTest("""
+        enum E {
+            E1, E2
+        }
+
+        struct S1 {
+            a: i32,
+        }
+
+        struct S2 {
+            e: E,
+            s1: S1,
+            s2: String,
+        }
+
+        impl S2 {
+            /*caret*/
+        }
+    """, """
+        enum E {
+            E1, E2
+        }
+
+        struct S1 {
+            a: i32,
+        }
+
+        struct S2 {
+            e: E,
+            s1: S1,
+            s2: String,
+        }
+
+        impl S2 {
+            fn e(&self) -> &E {
+                &self.e
+            }
+            fn s1(&self) -> &S1 {
+                &self.s1
+            }
+            fn s2(&self) -> &String {
+                &self.s2
+            }
+        }
+    """)
+
+    fun `test getter exists`() = doAvailableTest("""
+        struct S {
+            a: i32,
+            b: i32,
+        }
+
+        impl S {
+            fn a(&self) -> i32 {
+                self.a
+            }
+            /*caret*/
+        }
+    """, """
+        struct S {
+            a: i32,
+            b: i32,
+        }
+
+        impl S {
+            fn a(&self) -> i32 {
+                self.a
+            }
+
+            fn b(&self) -> i32 {
+                self.b
+            }
+        }
+    """)
+
+    fun `test unrelated method exists`() = doAvailableTest("""
+        struct S {
+            a: i32,
+        }
+
+        impl S {
+            fn foo() -> i32 {
+                42
+            }
+            /*caret*/
+        }
+    """, """
+        struct S {
+            a: i32,
+        }
+
+        impl S {
+            fn foo() -> i32 {
+                42
+            }
+
+            fn a(&self) -> i32 {
+                self.a
+            }
+        }
+    """)
+
+    fun `test unrelated method name conflict`() = doAvailableTest("""
+        struct S {
+            a: i32,
+            b: i32,
+        }
+
+        impl S {
+            fn a() -> i32 {
+                42
+            }
+            /*caret*/
+        }
+    """, """
+        struct S {
+            a: i32,
+            b: i32,
+        }
+
+        impl S {
+            fn a() -> i32 {
+                42
+            }
+
+            fn b(&self) -> i32 {
+                self.b
+            }
+        }
+    """)
+
+    fun `test skip pub field`() = doAvailableTest("""
+        struct S {
+            a: i32,
+            pub b: i32,
+            c: i32,
+        }
+
+        impl S {
+            /*caret*/
+        }
+    ""","""
+        struct S {
+            a: i32,
+            pub b: i32,
+            c: i32,
+        }
+
+        impl S {
+            fn a(&self) -> i32 {
+                self.a
+            }
+            fn c(&self) -> i32 {
+                self.c
+            }
+        }
+    """)
+
+    fun `test impl trait block`() = doAvailableTest("""
+        trait T {}
+
+        struct S {
+            a: i32,
+            b: i32,
+        }
+
+        impl T for S {/*caret*/}
+    """, """
+        trait T {}
+
+        struct S {
+            a: i32,
+            b: i32,
+        }
+
+        impl T for S {}
+    """)
+}


### PR DESCRIPTION
My attempt at #2471. 

This is my first attempt at implementing an intention. This is still a work in progress, but hopefully I'm at least on the right track. Any feedback is welcome.

I also had some questions.

> Ideally, it should be able to fix all call-site as well!

I don't quite understand what this means. Does this mean to replace field access with calls to the getter? e.g. `spam.eggs` becomes `spam.eggs()`

> * which impl block to add method to?

Currently I just check that it is an `impl` block that is not implementing a trait. Where else might you want to put getters?


> * fixup return type (Foo -> &Foo, u64 -> u64, String -> &str)

I currently return primitive types as-is and return a reference to non-primitive types. Since `String` is non-primitive the getter returns `&String`. Is it considered idiomatic Rust to return `&str` instead?
