### PR TITLE
MACRO: expand log macros

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -46,7 +46,9 @@ val RsMacroCall.macroBody: String?
     get() {
         val stub = stub
         if (stub != null) return stub.macroBody
-        return macroArgument?.compactTT?.text ?: formatMacroArgument?.braceListBodyText()?.toString()
+        return macroArgument?.compactTT?.text
+            ?: formatMacroArgument?.braceListBodyText()?.toString()
+            ?: logMacroArgument?.braceListBodyText()?.toString()
     }
 
 val RsMacroCall.expansion: List<RsExpandedElement>?

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -575,6 +575,17 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         Option<i32>
     """)
 
+    // There was a problem with "debug" macro related to the fact that we parse macro call
+    // with such name as a specific syntax construction
+    fun `test macro with name "debug"`() = doTest("""
+       macro_rules! debug {
+           ($ t:ty) => { fn foo() -> $ t {} }
+       }
+       debug!(i32);
+    """, """
+        fn foo() -> i32 {}
+    """)
+
     fun `test expend macro definition`() = doTest("""
        macro_rules! foo {
            () => {


### PR DESCRIPTION
Currently log macros are hardcoded in our grammar and we
can't really expand them. The problem is that std contains
macro with name `debug` that is not "log" macro, and we should
be able to expand it