### PR TITLE
ACT: add ability to group imports by semantics for import optimizer

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -36,6 +36,7 @@ HeyLey
 himikof
 HybridEidolon
 idubrov
+isamborskiy
 JakubAdamWieczorek
 johnthagen
 jonas-schievink
@@ -60,7 +61,6 @@ mrhota
 msmorgan
 netvl
 nicholastmosher
-Nilera
 ninjabear
 oistein
 oleg-semenov


### PR DESCRIPTION
Fulfilled #2259 improvement (the last checkbox).

Add the ability to group imports by semantics (std, crates, inner mods, etc.)
Groups order: [here](https://github.com/isamborskiy/intellij-rust/blob/ce89a6cb41477c480edf0dfdb2d9285fc394084e/src/main/kotlin/org/rust/lang/refactoring/RsImportOptimizer.kt#L113)
Examples: [here](https://github.com/isamborskiy/intellij-rust/blob/ce89a6cb41477c480edf0dfdb2d9285fc394084e/src/test/kotlin/org/rust/lang/refactoring/RsImportOptimizerTest.kt#L293) and [here](https://github.com/isamborskiy/intellij-rust/blob/ce89a6cb41477c480edf0dfdb2d9285fc394084e/src/test/kotlin/org/rust/lang/refactoring/RsImportOptimizerTest.kt#L317)
