### PR TITLE
Add formatter setting for indenting where clauses

### DIFF
--- a/src/main/kotlin/org/rust/ide/formatter/impl/indent.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/impl/indent.kt
@@ -25,7 +25,8 @@ fun RsFmtBlock.computeIndent(child: ASTNode, childCtx: RsFmtContext): Indent? {
     // fn moo(...)
     //     -> ...
     //     where ... {}
-        childType == RET_TYPE || childType == WHERE_CLAUSE -> Indent.getNormalIndent()
+        childType == RET_TYPE ||
+            (childType == WHERE_CLAUSE && ctx.rustSettings.INDENT_WHERE_CLAUSE) -> Indent.getNormalIndent()
 
     // Indent blocks excluding braces
         node.isDelimitedBlock -> getIndentIfNotDelim(child, node)

--- a/src/main/kotlin/org/rust/ide/formatter/settings/RsCodeStyleSettings.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/settings/RsCodeStyleSettings.kt
@@ -15,6 +15,7 @@ class RsCodeStyleSettings(container: CodeStyleSettings) :
     @JvmField var ALIGN_WHERE_CLAUSE = false
     @JvmField var ALIGN_TYPE_PARAMS = false
     @JvmField var ALIGN_WHERE_BOUNDS = true
+    @JvmField var INDENT_WHERE_CLAUSE = true
     @JvmField var ALLOW_ONE_LINE_MATCH = false
     @JvmField var MIN_NUMBER_OF_BLANKS_BETWEEN_ITEMS = 1
     @JvmField var PRESERVE_PUNCTUATION = false

--- a/src/main/kotlin/org/rust/ide/formatter/settings/RsLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/settings/RsLanguageCodeStyleSettingsProvider.kt
@@ -74,6 +74,11 @@ class RsLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider() 
                     "Type parameters")
 
                 consumer.showCustomOption(RsCodeStyleSettings::class.java,
+                    "INDENT_WHERE_CLAUSE",
+                    "Indent where clause",
+                    "Type parameters")
+
+                consumer.showCustomOption(RsCodeStyleSettings::class.java,
                     "ALIGN_WHERE_BOUNDS",
                     "Align where clause bounds",
                     "Type parameters")

--- a/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt
@@ -90,6 +90,28 @@ class RsFormatterTest : RsFormatterTestBase() {
         """)
     }
 
+    fun `test indent where clause on`() {
+        custom().INDENT_WHERE_CLAUSE = true
+        doTextTest("""
+            pub fn do_stuff<T>(&self, item: &T)
+                        where T: ToString {}
+        """, """
+            pub fn do_stuff<T>(&self, item: &T)
+                where T: ToString {}
+        """)
+    }
+
+    fun `test indent where clause off`() {
+        custom().INDENT_WHERE_CLAUSE = false
+        doTextTest("""
+            pub fn do_stuff<T>(&self, item: &T)
+                        where T: ToString {}
+        """, """
+            pub fn do_stuff<T>(&self, item: &T)
+            where T: ToString {}
+        """)
+    }
+
     fun `test align type params on`() {
         custom().ALIGN_TYPE_PARAMS = true
         doTest()


### PR DESCRIPTION
This allows the intellij-rust formatter to better approximate the rustfmt formatter,
which by default aligns where clauses with the parent declaration.