### PR TITLE
RUN: Support `--nocapture` option

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducerBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducerBase.kt
@@ -104,7 +104,7 @@ sealed class TestConfig {
     fun cargoCommandLine(): CargoCommandLine {
         var commandLine = CargoCommandLine.forTargets(targets, commandName, listOf(path))
         if (exact) {
-            commandLine = commandLine.addArgToBinary("--exact")
+            commandLine = commandLine.withBinaryArgument("--exact")
         }
         return commandLine
     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
@@ -95,11 +95,13 @@ class CargoCommandConfigurationEditor(private val project: Project) : SettingsEd
 
     private val environmentVariables = EnvironmentVariablesComponent()
     private val allFeatures = CheckBox("Use all features in tests", true)
+    private val nocapture = CheckBox("Show stdout/stderr in tests", false)
 
     override fun resetEditorFrom(configuration: CargoCommandConfiguration) {
         channel.selectedIndex = configuration.channel.index
         command.text = configuration.command
         allFeatures.isSelected = configuration.allFeatures
+        nocapture.isSelected = configuration.nocapture
         backtraceMode.selectedIndex = configuration.backtrace.index
         workingDirectory.component.text = configuration.workingDirectory?.toString() ?: ""
         environmentVariables.envData = configuration.env
@@ -119,6 +121,7 @@ class CargoCommandConfigurationEditor(private val project: Project) : SettingsEd
         configuration.channel = configChannel
         configuration.command = command.text
         configuration.allFeatures = allFeatures.isSelected
+        configuration.nocapture = nocapture.isSelected
         configuration.backtrace = BacktraceMode.fromIndex(backtraceMode.selectedIndex)
         configuration.workingDirectory = currentWorkingDirectory
         configuration.env = environmentVariables.envData
@@ -139,6 +142,7 @@ class CargoCommandConfigurationEditor(private val project: Project) : SettingsEd
         }
 
         row { allFeatures() }
+        row { nocapture() }
 
         row(environmentVariables.label) { environmentVariables.apply { makeWide() }() }
         row(workingDirectory.label) {

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -108,8 +108,15 @@ class Cargo(private val cargoExecutable: Path) {
         generalCommandLine(commandLine, false)
 
     private fun generalCommandLine(rawCommandLine: CargoCommandLine, colors: Boolean): GeneralCommandLine {
-        val commandLine = if (rawCommandLine.command == "test" && rawCommandLine.allFeatures) {
-            rawCommandLine.addArgToCargo("--all-features")
+        val commandLine = if (rawCommandLine.command == "test") {
+            var tmpCommandLine = rawCommandLine
+            if (rawCommandLine.allFeatures) {
+                tmpCommandLine = tmpCommandLine.withCargoArgument("--all-features")
+            }
+            if (rawCommandLine.nocapture) {
+                tmpCommandLine = tmpCommandLine.withBinaryArgument("--nocapture")
+            }
+            tmpCommandLine
         } else {
             rawCommandLine
         }

--- a/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
@@ -26,11 +26,12 @@ data class CargoCommandLine(
     val backtraceMode: BacktraceMode = BacktraceMode.DEFAULT,
     val channel: RustChannel = RustChannel.DEFAULT,
     val environmentVariables: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT,
-    val allFeatures: Boolean = true
+    val allFeatures: Boolean = true,
+    val nocapture: Boolean = false
 ) {
 
     /** Appends [arg] to Cargo options, in other words, inserts [arg] before `--` arg in [additionalArguments]. */
-    fun addArgToCargo(arg: String): CargoCommandLine {
+    fun withCargoArgument(arg: String): CargoCommandLine {
         val (cargoArgs, binaryArgs) = splitOnDoubleDash()
         if (arg in cargoArgs) return this
         return if (binaryArgs.isEmpty()) {
@@ -41,7 +42,7 @@ data class CargoCommandLine(
     }
 
     /** Appends [arg] to binary options, in other words, inserts [arg] after `--` arg in [additionalArguments]. */
-    fun addArgToBinary(arg: String): CargoCommandLine {
+    fun withBinaryArgument(arg: String): CargoCommandLine {
         val (cargoArgs, binaryArgs) = splitOnDoubleDash()
         if (arg in binaryArgs) return this
         return copy(additionalArguments = cargoArgs + "--" + arg + binaryArgs)

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench configuration uses default environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench configuration uses default environment.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="bench --package test-package --lib bench_foo -- --exact" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench fn is more specific than main or test mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench fn is more specific than main or test mod.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="bench --package test-package --bin foo bench_foo -- --exact" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer adds bin name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer adds bin name.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="bench --package test-package --bin foo bench_foo -- --exact" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer ignores selected files that contain no benches.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer ignores selected files that contain no benches.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="bench --package test-package --bench foo &quot;&quot;" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer uses complete function path.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer uses complete function path.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="bench --package test-package --lib foo_mod::bench_foo -- --exact" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for annotated functions.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for annotated functions.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="bench --package test-package --lib bench_foo -- --exact" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for files.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="bench --package test-package --bench foo &quot;&quot;" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for modules.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for modules.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="bench --package test-package --lib foo" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for multiple files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for multiple files.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="bench --package test-package --bench foo --bench baz &quot;&quot;" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for nested modules 1.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for nested modules 1.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="bench --package test-package --lib foo::bar" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for nested modules 2.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for nested modules 2.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="bench --package test-package --lib foo" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for root module.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for root module.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="bench --package test-package --lib &quot;&quot;" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable configuration uses default environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable configuration uses default environment.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="run --package test-package --bin hello" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable producer works for bin.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable producer works for bin.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="run --package test-package --bin hello" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable producer works for example.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable producer works for example.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="run --package test-package --example hello" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ hyphen in name works.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ hyphen in name works.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="run --package test-package --example hello-world" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than bench fn.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than bench fn.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="run --package test-package --bin foo" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than bench mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than bench mod.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="run --package test-package --bin foo" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than test fn.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than test fn.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="run --package test-package --bin foo" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than test mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than test mod.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="run --package test-package --bin foo" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main mod is more specific than test mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main mod is more specific than test mod.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="run --package test-package --bin foo" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ meaningful bench configuration name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ meaningful bench configuration name.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="bench --package test-package --lib bar::tests" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ meaningful test configuration name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ meaningful test configuration name.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib bar::tests" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ take into account path attribute.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ take into account path attribute.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib test::foo -- --exact" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test configuration uses default environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test configuration uses default environment.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib test_foo -- --exact" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test fn is more specific than main mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test fn is more specific than main mod.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --bin foo test_foo -- --exact" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test mod is more specific than bench mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test mod is more specific than bench mod.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib &quot;&quot;" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer adds bin name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer adds bin name.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --bin foo test_foo -- --exact" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer ignores selected files that contain no tests.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer ignores selected files that contain no tests.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --test foo &quot;&quot;" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer uses complete function path.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer uses complete function path.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib foo_mod::test_foo -- --exact" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for annotated functions.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for annotated functions.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib test_foo -- --exact" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for files.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --test foo &quot;&quot;" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for modules.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for modules.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib foo" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for multiple files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for multiple files.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --test foo --test baz &quot;&quot;" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for nested modules 1.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for nested modules 1.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib foo::bar" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for nested modules 2.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for nested modules 2.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib foo" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for root module.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for root module.xml
@@ -3,6 +3,7 @@
     <option name="channel" value="DEFAULT" />
     <option name="command" value="test --package test-package --lib &quot;&quot;" />
     <option name="allFeatures" value="true" />
+    <option name="nocapture" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />


### PR DESCRIPTION
Closes https://github.com/intellij-rust/intellij-rust/issues/2979.

Restores a checkbox in the `Edit Configurations` that has been removed in [this PR](https://github.com/intellij-rust/intellij-rust/pull/2901).

If this checkbox is selected, the `--nocapture` option will be used in the tests. The checkbox not selected by default.

At the moment, the test window can't work with `--nocapture` (see https://github.com/rust-lang/rust/issues/54669), so when the checkbox is activated, the test results will be displayed in the old-style console.

<img width="500" alt="Edit Configuration Menu" src="https://user-images.githubusercontent.com/6079006/47786381-add46200-dd1c-11e8-946a-6c4e6f1cdf1f.png">