### PR TITLE
Bundled pretty-printer for LLDB: tuple and enum support

### DIFF
--- a/prettyPrinters/lookup.py
+++ b/prettyPrinters/lookup.py
@@ -5,22 +5,47 @@ from providers import *
 
 
 class RustType:
-    OTHER = 0
-    STD_VEC = 1
-    STD_STRING = 2
-    STD_STR = 3
+    OTHER = "Other"
+    STRUCT = "Struct"
+    TUPLE = "Tuple"
+    CSTYLE_VARIANT = "CStyleVariant"
+    TUPLE_VARIANT = "TupleVariant"
+    STRUCT_VARIANT = "StructVariant"
+    EMPTY = "Empty"
+    SINGLETON_ENUM = "SingletonEnum"
+    REGULAR_ENUM = "RegularEnum"
+    COMPRESSED_ENUM = "CompressedEnum"
+    REGULAR_UNION = "RegularUnion"
+
+    STD_VEC = "StdVec"
+    STD_STRING = "StdString"
+    STD_STR = "StdStr"
 
 
 STD_VEC_REGEX = re.compile(r"^(alloc::([a-zA-Z]+::)+)Vec<.+>$")
 STD_STRING_REGEX = re.compile(r"^(alloc::([a-zA-Z]+::)+)String$")
 STD_STR_REGEX = re.compile(r"^&str$")
 
+TUPLE_ITEM_REGEX = re.compile(r"__\d+$")
+
+ENCODED_ENUM_PREFIX = "RUST$ENCODED$ENUM$"
+ENUM_DISR_FIELD_NAME = "RUST$ENUM$DISR"
+
+
+def is_tuple_fields(fields):
+    # type: (list) -> bool
+    return all(re.match(TUPLE_ITEM_REGEX, str(field.name)) for field in fields)
+
 
 def classify_rust_type(type):
-    # type: (SBType) -> int
+    # type: (SBType) -> str
     type_class = type.GetTypeClass()
+    fields = type.fields
 
     if type_class == lldb.eTypeClassStruct:
+        if len(fields) == 0:
+            return RustType.EMPTY
+
         name = type.GetName()
         if re.match(STD_VEC_REGEX, name):
             return RustType.STD_VEC
@@ -28,6 +53,36 @@ def classify_rust_type(type):
             return RustType.STD_STRING
         if re.match(STD_STR_REGEX, name):
             return RustType.STD_STR
+
+        if fields[0].name == ENUM_DISR_FIELD_NAME:
+            if len(fields) == 1:
+                return RustType.CSTYLE_VARIANT
+            if is_tuple_fields(fields[1:]):
+                return RustType.TUPLE_VARIANT
+            else:
+                return RustType.STRUCT_VARIANT
+
+        if is_tuple_fields(fields):
+            return RustType.TUPLE
+
+        else:
+            return RustType.STRUCT
+
+    if type_class == lldb.eTypeClassUnion:
+        if len(fields) == 0:
+            return RustType.EMPTY
+
+        first_variant_name = fields[0].name
+        if first_variant_name is None:
+            if len(fields) == 1:
+                return RustType.SINGLETON_ENUM
+            else:
+                return RustType.REGULAR_ENUM
+        elif first_variant_name.startswith(ENCODED_ENUM_PREFIX):
+            assert len(fields) == 1
+            return RustType.COMPRESSED_ENUM
+        else:
+            return RustType.REGULAR_UNION
 
     return RustType.OTHER
 
@@ -54,5 +109,21 @@ def synthetic_lookup(valobj, dict):
 
     if rust_type == RustType.STD_VEC:
         return StdVecSyntheticProvider(valobj, dict)
+    if rust_type == RustType.STRUCT:
+        return StructSyntheticProvider(valobj, dict)
+    if rust_type == RustType.STRUCT_VARIANT:
+        return StructSyntheticProvider(valobj, dict, is_variant=True)
+    if rust_type == RustType.TUPLE:
+        return TupleSyntheticProvider(valobj, dict)
+    if rust_type == RustType.TUPLE_VARIANT:
+        return TupleSyntheticProvider(valobj, dict, is_variant=True)
+    if rust_type == RustType.EMPTY:
+        return EmptySyntheticProvider(valobj, dict)
+
+    if rust_type == RustType.REGULAR_ENUM:
+        discriminant = valobj.GetChildAtIndex(0).GetChildAtIndex(0).GetValueAsUnsigned()
+        return synthetic_lookup(valobj.GetChildAtIndex(discriminant), dict)
+    if rust_type == RustType.SINGLETON_ENUM:
+        return synthetic_lookup(valobj.GetChildAtIndex(0), dict)
 
     return DefaultSynthteticProvider(valobj, dict)


### PR DESCRIPTION
This PR adds  `tuple` and `enum` support to LLDB pretty-printers.

<img width="495" alt="screen shot 2018-11-01 at 19 31 07" src="https://user-images.githubusercontent.com/4854600/47865325-f10dfe00-de0c-11e8-9911-21b583baba1e.png">
<img width="272" alt="screen shot 2018-11-01 at 19 31 21" src="https://user-images.githubusercontent.com/4854600/47865326-f10dfe00-de0c-11e8-88b9-2dd671223aa4.png">


This implementation still doesn't work in some cases due to compilers' (debuggers'?) bugs. I've opened the corresponding [issue](https://github.com/rust-lang/rust/issues/55586).