### PR TITLE
Support raw identifiers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,7 @@ change. Common tags are:
   * ANN for error highlighting and annotators
   * INSP for inspections
   * INT for intentions
+  * REF for refactorings
   * RUN for run configurations
   * QDOC for quick documentation
   * PERF for performance optimizations

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,6 +86,7 @@ allprojects {
             jvmTarget = "1.8"
             languageVersion = "1.2"
             apiVersion = "1.2"
+            freeCompilerArgs = listOf("-Xjvm-default=enable")
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsNamingInspection.kt
@@ -21,21 +21,21 @@ abstract class RsNamingInspection(
     val elementType: String,
     val styleName: String,
     val lint: RsLint,
-    elementTitle: String = elementType
+    private val elementTitle: String = elementType
 ) : RsLocalInspectionTool() {
-    val dispName = elementTitle + " naming convention"
-    override fun getDisplayName() = dispName
+    override fun getDisplayName() = "$elementTitle naming convention"
 
     fun inspect(id: PsiElement?, holder: ProblemsHolder, fix: Boolean = true) {
         if (id == null) return
-        val (isOk, suggestedName) = checkName(id.text)
+        val name = id.unescapedText
+        val (isOk, suggestedName) = checkName(name)
         if (isOk || suggestedName == null || lint.levelFor(id) == RsLintLevel.ALLOW) return
 
         val fixEl = id.parent
         val fixes = if (fix && fixEl is PsiNamedElement) arrayOf(RenameFix(fixEl, suggestedName)) else emptyArray()
         holder.registerProblem(
             id,
-            "$elementType `${id.text}` should have $styleName case name such as `$suggestedName`",
+            "$elementType `$name` should have $styleName case name such as `$suggestedName`",
             *fixes)
     }
 

--- a/src/main/kotlin/org/rust/ide/spelling/RsNameIdentifierOwnerTokenizer.kt
+++ b/src/main/kotlin/org/rust/ide/spelling/RsNameIdentifierOwnerTokenizer.kt
@@ -10,8 +10,9 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.spellchecker.inspections.IdentifierSplitter
 import com.intellij.spellchecker.tokenizer.TokenConsumer
 import com.intellij.spellchecker.tokenizer.Tokenizer
+import org.rust.lang.core.psi.RS_RAW_PREFIX
 import org.rust.lang.core.psi.ext.RsNameIdentifierOwner
-import org.rust.lang.core.psi.ext.unescapeIdentifier
+import org.rust.lang.core.psi.unescapeIdentifier
 
 // Inspired by `PsiIdentifierOwnerTokenizer`
 object RsNameIdentifierOwnerTokenizer : Tokenizer<RsNameIdentifierOwner>() {
@@ -31,7 +32,7 @@ object RsNameIdentifierOwnerTokenizer : Tokenizer<RsNameIdentifierOwner>() {
         }
         val text = identifier.text
         val unescapedText = text.unescapeIdentifier()
-        if (text.startsWith("r#")) {
+        if (text.startsWith(RS_RAW_PREFIX)) {
             offset += 2
         }
         consumer.consumeToken(parent, unescapedText, true, offset, TextRange.allOf(unescapedText), IdentifierSplitter.getInstance())

--- a/src/main/kotlin/org/rust/ide/spelling/RsNameIdentifierOwnerTokenizer.kt
+++ b/src/main/kotlin/org/rust/ide/spelling/RsNameIdentifierOwnerTokenizer.kt
@@ -1,0 +1,39 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.spelling
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.spellchecker.inspections.IdentifierSplitter
+import com.intellij.spellchecker.tokenizer.TokenConsumer
+import com.intellij.spellchecker.tokenizer.Tokenizer
+import org.rust.lang.core.psi.ext.RsNameIdentifierOwner
+import org.rust.lang.core.psi.ext.unescapeIdentifier
+
+// Inspired by `PsiIdentifierOwnerTokenizer`
+object RsNameIdentifierOwnerTokenizer : Tokenizer<RsNameIdentifierOwner>() {
+
+    override fun tokenize(element: RsNameIdentifierOwner, consumer: TokenConsumer) {
+        val identifier = element.nameIdentifier ?: return
+        val range = identifier.textRange
+        if (range.isEmpty) return
+
+        var offset = range.startOffset - element.textRange.startOffset
+        val parent = if (offset < 0) {
+            val commonParent = PsiTreeUtil.findCommonParent(identifier, element) ?: return
+            offset = range.startOffset - commonParent.textRange.startOffset
+            commonParent
+        } else {
+            element
+        }
+        val text = identifier.text
+        val unescapedText = text.unescapeIdentifier()
+        if (text.startsWith("r#")) {
+            offset += 2
+        }
+        consumer.consumeToken(parent, unescapedText, true, offset, TextRange.allOf(unescapedText), IdentifierSplitter.getInstance())
+    }
+}

--- a/src/main/kotlin/org/rust/ide/spelling/RsSpellcheckingStrategy.kt
+++ b/src/main/kotlin/org/rust/ide/spelling/RsSpellcheckingStrategy.kt
@@ -10,15 +10,15 @@ import com.intellij.spellchecker.tokenizer.SpellcheckingStrategy
 import com.intellij.spellchecker.tokenizer.Tokenizer
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.RsElementTypes.STRING_LITERAL
+import org.rust.lang.core.psi.ext.RsNameIdentifierOwner
 
 class RsSpellcheckingStrategy : SpellcheckingStrategy() {
 
     override fun isMyContext(element: PsiElement) = RsLanguage.`is`(element.language)
 
-    override fun getTokenizer(element: PsiElement?): Tokenizer<*> =
-        if (element?.node?.elementType == STRING_LITERAL)
-            StringLiteralTokenizer
-        else
-            super.getTokenizer(element)
+    override fun getTokenizer(element: PsiElement?): Tokenizer<*> = when {
+        element?.node?.elementType == STRING_LITERAL -> StringLiteralTokenizer
+        element is RsNameIdentifierOwner -> RsNameIdentifierOwnerTokenizer
+        else -> super.getTokenizer(element)
+    }
 }
-

--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.editor.EditorModificationUtil
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.icons.RsIcons
+import org.rust.ide.refactoring.isValidRustVariableIdentifier
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyUnknown
@@ -97,6 +98,9 @@ private fun getFieldsOwnerTailText(owner: RsFieldsOwner) = when {
 
 private fun getInsertHandler(element: RsElement, scopeName: String, context: InsertionContext) {
     val curUseItem = context.getElementOfType<RsUseItem>()
+    if (element is RsNameIdentifierOwner && !isValidRustVariableIdentifier(scopeName) && scopeName !in CAN_NOT_BE_ESCAPED) {
+        context.document.insertString(context.startOffset, RS_RAW_PREFIX)
+    }
     when (element) {
 
         is RsMod -> {

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -38,7 +38,7 @@ class RsPsiFactory(private val project: Project) {
     }
 
     fun createIdentifier(text: String): PsiElement =
-        createFromText<RsModDeclItem>("mod $text;")?.identifier
+        createFromText<RsModDeclItem>("mod ${text.escapeIdentifierIfNeeded()};")?.identifier
             ?: error("Failed to create identifier: `$text`")
 
     fun createQuoteIdentifier(text: String): PsiElement =

--- a/src/main/kotlin/org/rust/lang/core/psi/RsRawIdentifiers.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsRawIdentifiers.kt
@@ -1,0 +1,23 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+import com.intellij.psi.PsiElement
+import org.rust.ide.refactoring.isValidRustVariableIdentifier
+import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
+import org.rust.lang.core.psi.ext.elementType
+
+const val RS_RAW_PREFIX = "r#"
+val CAN_NOT_BE_ESCAPED = listOf("self", "super", "crate", "Self")
+
+fun String.unescapeIdentifier(): String = removePrefix(RS_RAW_PREFIX)
+fun String.escapeIdentifierIfNeeded(): String =
+    if (isValidRustVariableIdentifier(this) || this in CAN_NOT_BE_ESCAPED) this else "$RS_RAW_PREFIX$this"
+
+val PsiElement.unescapedText: String get() {
+    val text = text ?: return ""
+    return if (elementType == IDENTIFIER) text.unescapeIdentifier() else text
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -10,12 +10,12 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.impl.source.PsiFileImpl
+import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.PsiUtilCore
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.stubs.RsFileStub
-
 
 val PsiElement.ancestors: Sequence<PsiElement> get() = generateSequence(this) {
     if (it is PsiFile) null else it.parent
@@ -114,3 +114,10 @@ fun PsiElement.isAncestorOf(child: PsiElement): Boolean =
 
 val PsiElement.endOffsetInParent: Int
     get() = startOffsetInParent + textLength
+
+fun String.unescapeIdentifier(): String = removePrefix("r#")
+
+val PsiElement.unescapedText: String get() {
+    val text = text ?: return ""
+    return if (this is LeafPsiElement) text.unescapeIdentifier() else text
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -113,11 +113,3 @@ fun PsiElement.isAncestorOf(child: PsiElement): Boolean =
 
 val PsiElement.endOffsetInParent: Int
     get() = startOffsetInParent + textLength
-
-fun String.unescapeIdentifier(): String = removePrefix("r#")
-fun String.escapeIdentifierIfNeeded(): String = if (isValidRustVariableIdentifier(this)) this else "r#$this"
-
-val PsiElement.unescapedText: String get() {
-    val text = text ?: return ""
-    return if (this is LeafPsiElement) text.unescapeIdentifier() else text
-}

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -10,7 +10,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.impl.source.PsiFileImpl
-import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.PsiUtilCore
@@ -116,6 +115,7 @@ val PsiElement.endOffsetInParent: Int
     get() = startOffsetInParent + textLength
 
 fun String.unescapeIdentifier(): String = removePrefix("r#")
+fun String.escapeIdentifierIfNeeded(): String = if (isValidRustVariableIdentifier(this)) this else "r#$this"
 
 val PsiElement.unescapedText: String get() {
     val text = text ?: return ""

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAssocTypeBinding.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAssocTypeBinding.kt
@@ -30,5 +30,5 @@ abstract class RsAssocTypeBindingMixin : RsStubbedNamedElementImpl<RsAssocTypeBi
 
     override val referenceNameElement: PsiElement get() = identifier
 
-    override val referenceName: String get() = stub?.name ?: referenceNameElement.text
+    override val referenceName: String get() = stub?.name ?: super.referenceName
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsBinaryOp.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsBinaryOp.kt
@@ -29,7 +29,5 @@ abstract class RsBinaryOpImplMixin : RsStubbedElementImpl<RsBinaryOpStub>, RsBin
 
     override val referenceNameElement: PsiElement get() = operator
 
-    override val referenceName: String get() = referenceNameElement.text
-
     override fun getReference(): RsReference = RsBinaryOpReferenceImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldLookup.kt
@@ -20,8 +20,6 @@ val RsFieldLookup.receiver: RsExpr get() = parentDotExpr.expr
 abstract class RsFieldLookupImplMixin(node: ASTNode) : RsElementImpl(node), RsFieldLookup {
     override val referenceNameElement: PsiElement get() = (identifier ?: integerLiteral)!!
 
-    override val referenceName: String get() = referenceNameElement.text
-
     override fun getReference(): RsReference = RsFieldLookupReferenceImpl(this)
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsLabel.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsLabel.kt
@@ -15,8 +15,6 @@ abstract class RsLabelImplMixin (node: ASTNode) : RsElementImpl(node), RsLabel {
 
     override val referenceNameElement: PsiElement get() = quoteIdentifier
 
-    override val referenceName: String get() = referenceNameElement.text
-
     override fun getReference(): RsReference = RsLabelReferenceImpl(this)
 
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -39,7 +39,7 @@ val RsMacroCall.macroName: String
     get() {
         val stub = stub
         if (stub != null) return stub.macroName
-        return referenceNameElement.text
+        return referenceNameElement.unescapedText
     }
 
 val RsMacroCall.macroBody: String?

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -13,6 +13,7 @@ import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.macros.expandMacro
 import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.unescapedText
 import org.rust.lang.core.resolve.DEFAULT_RECURSION_LIMIT
 import org.rust.lang.core.resolve.ref.RsMacroCallReferenceImpl
 import org.rust.lang.core.resolve.ref.RsReference

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.PsiReference
 import com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.lang.core.psi.RsMetaItem
+import org.rust.lang.core.psi.unescapedText
 import org.rust.lang.core.resolve.ref.RsReference
 import org.rust.lang.core.stubs.RsMetaItemStub
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
@@ -16,7 +16,7 @@ import org.rust.lang.core.stubs.RsMetaItemStub
 
 val RsMetaItem.name: String? get() {
     val stub = stub
-    return if (stub != null) stub.name else identifier?.text
+    return if (stub != null) stub.name else identifier?.unescapedText
 }
 
 val RsMetaItem.value: String? get() {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMethodCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMethodCall.kt
@@ -20,7 +20,5 @@ val RsMethodCall.receiver: RsExpr get() = parentDotExpr.expr
 abstract class RsMethodCallImplMixin(node: ASTNode) : RsElementImpl(node), RsMethodCall {
     override val referenceNameElement: PsiElement get() = identifier
 
-    override val referenceName: String get() = referenceNameElement.text
-
     override fun getReference(): RsReference = RsMethodCallReferenceImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedElement.kt
@@ -27,7 +27,7 @@ abstract class RsNamedElementImpl(node: ASTNode) : RsElementImpl(node),
 
     override fun getNameIdentifier(): PsiElement? = findChildByType(IDENTIFIER)
 
-    override fun getName(): String? = nameIdentifier?.text
+    override fun getName(): String? = nameIdentifier?.unescapedText
 
     override fun setName(name: String): PsiElement? {
         nameIdentifier?.replace(RsPsiFactory(project).createIdentifier(name))
@@ -45,12 +45,11 @@ where StubT : RsNamedStub, StubT : StubElement<*> {
 
     constructor(stub: StubT, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
-    override fun getNameIdentifier(): PsiElement?
-        = findChildByType(IDENTIFIER)
+    override fun getNameIdentifier(): PsiElement? = findChildByType(IDENTIFIER)
 
     override fun getName(): String? {
         val stub = stub
-        return if (stub != null) stub.name else nameIdentifier?.text
+        return if (stub != null) stub.name else nameIdentifier?.unescapedText
     }
 
     override fun setName(name: String): PsiElement? {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedElement.kt
@@ -16,6 +16,7 @@ import com.intellij.psi.stubs.StubElement
 import org.rust.ide.presentation.getPresentation
 import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.unescapedText
 import org.rust.lang.core.stubs.RsNamedStub
 
 interface RsNamedElement : RsElement, PsiNamedElement, NavigatablePsiElement

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
@@ -61,7 +61,7 @@ abstract class RsPathImplMixin : RsStubbedElementImpl<RsPathStub>,
             "Path must contain identifier: $this ${this.text} at ${this.containingFile.virtualFile.path}"
         }
 
-    override val referenceName: String get() = stub?.referenceName ?: referenceNameElement.text
+    override val referenceName: String get() = stub?.referenceName ?: super.referenceName
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsReferenceElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsReferenceElement.kt
@@ -12,7 +12,8 @@ interface RsWeakReferenceElement : RsElement {
 
     val referenceNameElement: PsiElement?
 
-    val referenceName: String?
+    @JvmDefault
+    val referenceName: String? get() = referenceNameElement?.unescapedText
 
     override fun getReference(): RsReference?
 }
@@ -21,7 +22,8 @@ interface RsReferenceElement : RsWeakReferenceElement {
 
     override val referenceNameElement: PsiElement
 
-    override val referenceName: String
+    @JvmDefault
+    override val referenceName: String get() = referenceNameElement.unescapedText
 
     override fun getReference(): RsReference
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsReferenceElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsReferenceElement.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.unescapedText
 import org.rust.lang.core.resolve.ref.RsReference
 
 interface RsWeakReferenceElement : RsElement {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructLiteralField.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructLiteralField.kt
@@ -22,7 +22,5 @@ abstract class RsStructLiteralFieldImplMixin(node: ASTNode) : RsElementImpl(node
     override fun getReference(): RsReference = RsStructLiteralFieldReferenceImpl(this)
 
     override val referenceNameElement: PsiElement get() = identifier
-
-    override val referenceName: String get() = referenceNameElement.text
 }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceBase.kt
@@ -14,10 +14,10 @@ import org.rust.ide.refactoring.isValidRustVariableIdentifier
 import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 import org.rust.lang.core.psi.RsElementTypes.QUOTE_IDENTIFIER
 import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.escapeIdentifierIfNeeded
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.RsWeakReferenceElement
 import org.rust.lang.core.psi.ext.elementType
-import org.rust.lang.core.psi.ext.escapeIdentifierIfNeeded
 
 abstract class RsReferenceBase<T : RsWeakReferenceElement>(
     element: T

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceBase.kt
@@ -10,13 +10,14 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.PsiPolyVariantReferenceBase
 import com.intellij.psi.ResolveResult
-import org.rust.ide.refactoring.RsNamesValidator
+import org.rust.ide.refactoring.isValidRustVariableIdentifier
 import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 import org.rust.lang.core.psi.RsElementTypes.QUOTE_IDENTIFIER
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.RsWeakReferenceElement
 import org.rust.lang.core.psi.ext.elementType
+import org.rust.lang.core.psi.ext.escapeIdentifierIfNeeded
 
 abstract class RsReferenceBase<T : RsWeakReferenceElement>(
     element: T
@@ -57,8 +58,8 @@ abstract class RsReferenceBase<T : RsWeakReferenceElement>(
                 IDENTIFIER -> {
                     // Renaming files is tricky: we don't want to change `RenamePsiFileProcessor`,
                     // so we must be ready for invalid names here
-                    val name = newName.replace(".rs", "")
-                    if (!RsNamesValidator().isIdentifier(name, identifier.project)) return
+                    val name = newName.replace(".rs", "").escapeIdentifierIfNeeded()
+                    if (!isValidRustVariableIdentifier(name)) return
                     factory.createIdentifier(name)
 
                 }

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -33,7 +33,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 145
+        override fun getStubVersion(): Int = 146
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsFunctionNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsFunctionNamingInspectionTest.kt
@@ -34,4 +34,16 @@ class RsFunctionNamingInspectionTest : RsInspectionsTestBase(RsFunctionNamingIns
             fun_foo();
         }
     """)
+
+    fun `test function with raw identifier`() = checkFixByText("Rename to `extern`", """
+        fn <warning descr="Function `Extern` should have a snake case name such as `extern`">r#Extern/*caret*/</warning>() {}
+        fn main() {
+            r#Extern();
+        }
+    """, """
+        fn r#extern() {}
+        fn main() {
+            r#extern();
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsMacroNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsMacroNamingInspectionTest.kt
@@ -26,4 +26,12 @@ class RsMacroNamingInspectionTest : RsInspectionsTestBase(RsMacroNamingInspectio
         macro_rules! macro_foo { () => {}; }
         macro_foo!();
     """)
+
+    fun `test macros with raw identifier`() = checkFixByText("Rename to `macro_foo`", """
+        macro_rules! <warning descr="Macro `MacroFoo` should have a snake case name such as `macro_foo`">r#Macro/*caret*/Foo</warning> { () => {}; }
+        r#MacroFoo!();
+    """, """
+        macro_rules! macro_foo { () => {}; }
+        macro_foo!();
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsStructNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsStructNamingInspectionTest.kt
@@ -30,4 +30,16 @@ class RsStructNamingInspectionTest : RsInspectionsTestBase(RsStructNamingInspect
             let a = StructFoo {};
         }
     """)
+
+    fun `test struct with raw identifier`() = checkFixByText("Rename to `FooBar`", """
+        struct <warning descr="Type `foo_bar` should have a camel case name such as `FooBar`">r#foo_bar/*caret*/</warning>;
+        fn main() {
+            let a = foo_bar;
+        }
+    """, """
+        struct FooBar;
+        fn main() {
+            let a = FooBar;
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
@@ -159,8 +159,8 @@ class RenameTest : RsTestBase() {
         pub enum Spam { Quux, Eggs }
     """, """
     //- main.rs
-        use foo::Spam;
-        mod foo;
+        use r#mod::Spam;
+        mod r#mod;
 
         fn main() { let _ = Spam::Quux; }
     //- mod.rs
@@ -168,6 +168,31 @@ class RenameTest : RsTestBase() {
     """) {
         val file = myFixture.configureFromTempProjectFile("foo.rs")
         myFixture.renameElement(file, "mod.rs")
+    }
+
+    fun `test rename file to keyword`() = checkByDirectory("""
+    //- main.rs
+        mod foo;
+        use foo::bar;
+
+        fn main() {
+            bar();
+        }
+    //- foo.rs
+        pub fn bar() { println!("Bar"); }
+    """, """
+    //- main.rs
+        mod r#match;
+        use r#match::bar;
+
+        fn main() {
+            bar();
+        }
+    //- match.rs
+        pub fn bar() { println!("Bar"); }
+    """) {
+        val file = myFixture.configureFromTempProjectFile("foo.rs")
+        myFixture.renameElement(file, "match")
     }
 
     fun `test does not rename lambda parameter shadowed in an outer comment`() = doTest("new_name", """
@@ -187,6 +212,30 @@ class RenameTest : RsTestBase() {
                 // Prints out `new_name`.
             });
             // `param` printed out.
+        }
+    """)
+
+    fun `test rename raw identifier 1`() = doTest("bar", """
+        fn foo() {}
+        fn main() {
+            r#foo/*caret*/();
+        }
+    """, """
+        fn bar() {}
+        fn main() {
+            bar();
+        }
+    """)
+
+    fun `test rename raw identifier 2`() = doTest("match", """
+        fn foo() {}
+        fn main() {
+            foo/*caret*/();
+        }
+    """, """
+        fn r#match() {}
+        fn main() {
+            r#match();
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/spellchecker/RsSpellCheckerTest.kt
+++ b/src/test/kotlin/org/rust/ide/spellchecker/RsSpellCheckerTest.kt
@@ -34,6 +34,10 @@ class RsSpellCheckerTest : RsTestBase() {
         }
     """)
 
+    fun `test raw identifiers`() = doTest("""
+        fn r#<TYPO>wodrl</TYPO>() {}
+    """)
+
     private fun doTest(@Language("Rust") text: String, processComments: Boolean = true, processLiterals: Boolean = true) {
         val inspection = SpellCheckingInspection()
         inspection.processLiterals = processLiterals

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -676,4 +676,16 @@ class RsCompletionTest : RsCompletionTestBase() {
         extern crate dep_lib_target;
         pub use dep_lib_target::st/*caret*/
     """)
+
+    fun `test complete with identifier escaping`() = doSingleCompletion("""
+        fn r#else() {}
+        fn main() {
+            els/*caret*/
+        }
+    """, """
+        fn r#else() {}
+        fn main() {
+            r#else()/*caret*/
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
@@ -152,5 +152,19 @@ class RsMacroResolveTest : RsResolveTestBase() {
         }
     """, NameResolutionTestmarks.missingMacroUse)
 
+    fun `test raw identifier 1`() = checkByCode("""
+        macro_rules! r#match { () => () }
+                     //X
+        r#match!();
+           //^
+    """)
+
+    fun `test raw identifier 2`() = checkByCode("""
+        macro_rules! foo { () => () }
+                    //X
+        r#foo!();
+         //^
+    """)
+
     // More macro tests in [RsPackageLibraryResolveTest] and [RsStubOnlyResolveTest]
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -1070,12 +1070,30 @@ class RsResolveTest : RsResolveTestBase() {
         }         //^ unresolved
     """)
 
-    fun `test raw identifier`() = checkByCode("""
+    fun `test raw identifier 1`() = checkByCode("""
         fn foo() {
             let r#match = 42;
               //X
             r#match;
           //^
+        }
+    """)
+
+    fun `test raw identifier 2`() = checkByCode("""
+        fn foo() {}
+           //X
+        fn main() {
+            r#foo();
+             //^
+        }
+    """)
+
+    fun `test raw identifier 3`() = checkByCode("""
+        struct r#Foo;
+               //X
+        fn main() {
+            let f = Foo;
+                   //^
         }
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -416,6 +416,13 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }
     }
 
+    fun `test raw identifier in derive trait`() = stubOnlyResolve("""
+    //- main.rs
+        #[derive(r#Debug)]
+                 //^ ...libcore/fmt/mod.rs
+        struct Foo;
+    """)
+
     fun `test infer lambda expr`() = stubOnlyResolve("""
     //- main.rs
         struct S;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -436,4 +436,17 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         use crate::bar::Foo;
             //^ main.rs
     """)
+
+    fun `test raw identifier`() = stubOnlyResolve("""
+    //- main.rs
+        mod r#match;
+        use r#match::bar;
+
+        fn main() {
+            bar();
+           //^ match.rs
+        }
+    //- match.rs
+        pub fn bar() { println!("Bar"); }
+    """)
 }


### PR DESCRIPTION
The corresponding [RFC](https://github.com/rust-lang/rfcs/blob/master/text/2151-raw-identifiers.md)
* Name resolution takes into account raw identifiers
* Correctly rename module files
* Adjust spell checker and naming inspections
* Add `r#` prefix while completion if needed
* Provide `-Xjvm-default=enable` option to kotlin compiler so now we can use `@JvmDefault` annotation

TODO:
* Support renaming of any named item to keyword with the corresponding escaping. Although our tests work in this case, in real IDE rename dialog doesn't allow such renaming because it calls `RsNamesValidator` before all actions and rejects keywords