### PR TITLE
Fix Usage grouping in the "Find" window

### DIFF
--- a/src/183/test/kotlin/org/rust/ide/search/RsUsageViewTreeTest.kt
+++ b/src/183/test/kotlin/org/rust/ide/search/RsUsageViewTreeTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.search
+
+import com.intellij.usages.UsageViewSettings
+import com.intellij.util.xmlb.XmlSerializerUtil
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+import org.rust.lang.core.psi.ext.RsNamedElement
+
+class RsUsageViewTreeTest : RsTestBase() {
+
+    fun `test grouping function usages`() = doTestByText("""
+        fn foo() {}
+          //^
+
+        fn bar() {
+            foo();
+        }
+
+        fn baz() {
+            foo();
+        }
+    """, """
+        Usage (2 usages)
+         Function
+          foo
+         Found usages (2 usages)
+          function call (2 usages)
+           main.rs (2 usages)
+            6foo();
+            10foo();
+    """)
+
+    fun `test grouping struct usages`() = doTestByText("""
+        struct S {
+             //^
+            a: usize,
+        }
+
+        impl S {}
+        impl S {}
+
+        fn foo(s1: &S) {}
+
+        fn bar() {
+            let s1 = S { a: 1 };
+            let a = 1;
+            let s2 = S { a };
+        }
+    """, """
+        Usage (5 usages)
+         Struct
+          S
+         Found usages (5 usages)
+          impl (2 usages)
+           main.rs (2 usages)
+            7impl S {}
+            8impl S {}
+          init struct (2 usages)
+           main.rs (2 usages)
+            13let s1 = S { a: 1 };
+            15let s2 = S { a };
+          type reference (1 usage)
+           main.rs (1 usage)
+            10fn foo(s1: &S) {}
+    """)
+
+    private fun doTestByText(@Language("Rust") code: String, representation: String) {
+        InlineFile(code)
+        val source = findElementInEditor<RsNamedElement>()
+
+        val textRepresentation = myFixture.getUsageViewTreeTextRepresentation(source)
+        assertEquals(representation.trimIndent(), textRepresentation.trimIndent())
+    }
+
+    private val originalSettings = UsageViewSettings()
+    override fun setUp() {
+        super.setUp()
+        val settings = UsageViewSettings.instance
+        XmlSerializerUtil.copyBean(settings.state, originalSettings)
+
+        settings.isGroupByFileStructure = false
+        settings.isGroupByModule = false
+        settings.isGroupByPackage = false
+        settings.isGroupByUsageType = true
+        settings.isGroupByScope = false
+    }
+
+    override fun tearDown() {
+        UsageViewSettings.instance.loadState(originalSettings)
+        super.tearDown()
+    }
+}

--- a/src/main/kotlin/org/rust/ide/search/RsUsageTypeProvider.kt
+++ b/src/main/kotlin/org/rust/ide/search/RsUsageTypeProvider.kt
@@ -12,6 +12,31 @@ import com.intellij.usages.impl.rules.UsageTypeProviderEx
 import org.rust.lang.core.psi.*
 
 object RsUsageTypeProvider : UsageTypeProviderEx {
+    // Instantiate each UsageType only once, so that the equality check in UsageTypeGroup.equals() works correctly
+    private val IMPL = UsageType("impl")
+
+    private val TYPE_REFERENCE = UsageType("type reference")
+    private val TRAIT_REF = UsageType("trait ref")
+
+    private val EXPR = UsageType("expr")
+    private val DOT_EXPR = UsageType("dot expr")
+
+    private val FUNCTION_CALL = UsageType("function call")
+    private val METHOD_CALL = UsageType("method call")
+    private val ARGUMENT = UsageType("argument")
+
+    private val MACRO_ARGUMENT = UsageType("macro argument")
+
+    private val INIT_STRUCT = UsageType("init struct")
+    private val INIT_FIELD = UsageType("init field")
+
+    private val FIELD = UsageType("field")
+
+    private val META_ITEM = UsageType("meta item")
+
+    private val USE = UsageType("use")
+    private val MOD = UsageType("mod")
+
     override fun getUsageType(element: PsiElement?): UsageType? = getUsageType(element, UsageTarget.EMPTY_ARRAY)
 
     override fun getUsageType(element: PsiElement?, targets: Array<out UsageTarget>): UsageType? {
@@ -21,8 +46,8 @@ object RsUsageTypeProvider : UsageTypeProviderEx {
             return when (context) {
                 is RsTypeReference -> {
                     when (context.parent) {
-                        is RsImplItem -> UsageType("impl")
-                        else -> UsageType("type reference")
+                        is RsImplItem -> IMPL
+                        else -> TYPE_REFERENCE
                     }
                 }
                 else -> null
@@ -31,26 +56,26 @@ object RsUsageTypeProvider : UsageTypeProviderEx {
         if (parent is RsPathExpr) {
             val context = parent.goUp<RsPathExpr>()
             return when (context) {
-                is RsDotExpr -> UsageType("dot expr")
-                is RsCallExpr -> UsageType("function call")
-                is RsValueArgumentList -> UsageType("argument")
-                is RsFormatMacroArg -> UsageType("macro argument")
-                is RsExpr -> UsageType("expr")
+                is RsDotExpr -> DOT_EXPR
+                is RsCallExpr -> FUNCTION_CALL
+                is RsValueArgumentList -> ARGUMENT
+                is RsFormatMacroArg -> MACRO_ARGUMENT
+                is RsExpr -> EXPR
                 else -> null
             }
         }
         return when (parent) {
-            is RsUseSpeck -> UsageType("use")
-            is RsStructLiteral -> UsageType("init struct")
-            is RsStructLiteralField -> UsageType("init field")
-            is RsTraitRef -> UsageType("trait ref")
-            is RsMethodCall -> UsageType("method call")
-            is RsMetaItem -> UsageType("meta item")
-            is RsFieldLookup -> UsageType("field")
+            is RsUseSpeck -> USE
+            is RsStructLiteral -> INIT_STRUCT
+            is RsStructLiteralField -> INIT_FIELD
+            is RsTraitRef -> TRAIT_REF
+            is RsMethodCall -> METHOD_CALL
+            is RsMetaItem -> META_ITEM
+            is RsFieldLookup -> FIELD
             else -> {
                 val context = parent.parent
                 when (context) {
-                    is RsModDeclItem -> UsageType("mod")
+                    is RsModDeclItem -> MOD
                     else -> null
                 }
             }

--- a/src/main/kotlin/org/rust/ide/search/RsUsageTypeProvider.kt
+++ b/src/main/kotlin/org/rust/ide/search/RsUsageTypeProvider.kt
@@ -25,6 +25,7 @@ object RsUsageTypeProvider : UsageTypeProviderEx {
     private val METHOD_CALL = UsageType("method call")
     private val ARGUMENT = UsageType("argument")
 
+    private val MACRO_CALL = UsageType("macro call")
     private val MACRO_ARGUMENT = UsageType("macro argument")
 
     private val INIT_STRUCT = UsageType("init struct")
@@ -72,6 +73,7 @@ object RsUsageTypeProvider : UsageTypeProviderEx {
             is RsMethodCall -> METHOD_CALL
             is RsMetaItem -> META_ITEM
             is RsFieldLookup -> FIELD
+            is RsMacroCall -> MACRO_CALL
             else -> {
                 val context = parent.parent
                 when (context) {

--- a/src/main/kotlin/org/rust/ide/search/RsUsageTypeProvider.kt
+++ b/src/main/kotlin/org/rust/ide/search/RsUsageTypeProvider.kt
@@ -16,7 +16,7 @@ object RsUsageTypeProvider : UsageTypeProviderEx {
     private val IMPL = UsageType("impl")
 
     private val TYPE_REFERENCE = UsageType("type reference")
-    private val TRAIT_REF = UsageType("trait ref")
+    private val TRAIT_REFERENCE = UsageType("trait reference")
 
     private val EXPR = UsageType("expr")
     private val DOT_EXPR = UsageType("dot expr")
@@ -69,7 +69,7 @@ object RsUsageTypeProvider : UsageTypeProviderEx {
             is RsUseSpeck -> USE
             is RsStructLiteral -> INIT_STRUCT
             is RsStructLiteralField -> INIT_FIELD
-            is RsTraitRef -> TRAIT_REF
+            is RsTraitRef -> TRAIT_REFERENCE
             is RsMethodCall -> METHOD_CALL
             is RsMetaItem -> META_ITEM
             is RsFieldLookup -> FIELD

--- a/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt
+++ b/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt
@@ -98,9 +98,9 @@ class RsFindUsagesTest : RsTestBase() {
         trait B {}
             //^
         struct A;
-        impl B for A {}// - trait ref
+        impl B for A {}// - trait reference
 
-        fn bar<T: B>() {}// - trait ref
+        fn bar<T: B>() {}// - trait reference
 
         mod a {
             use super::B;// - use

--- a/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt
+++ b/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt
@@ -150,6 +150,14 @@ class RsFindUsagesTest : RsTestBase() {
         }
     """)
 
+    fun `test macro call`() = doTestByText("""
+        macro_rules! foo {
+                   //^
+            () => { }
+        }
+        foo!();// - macro call
+    """)
+
     private fun doTestByText(@Language("Rust") code: String) {
         InlineFile(code)
         val source = findElementInEditor<RsNamedElement>()


### PR DESCRIPTION
Currently the "Group by usage type" option in the Find window is broken.
Each result is placed in its own group.
![image](https://user-images.githubusercontent.com/1041267/48674330-2fb0f180-eb4b-11e8-800a-f194bfd622e6.png)

Fix this problem
![image](https://user-images.githubusercontent.com/1041267/48674360-769ee700-eb4b-11e8-818b-356d36185806.png)

This also includes the following smaller changes:
- Support `macro call` usage.
- Change `trait ref` to `trait reference` to it better align with the `type reference` usage type.

This fixes #2672