### PR TITLE
PERF: make RsResolveCache invalidation a bit more precise

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
@@ -24,6 +24,12 @@ val RUST_STRUCTURE_CHANGE_TOPIC: Topic<RustStructureChangeListener> = Topic.crea
     Topic.BroadcastDirection.TO_PARENT
 )
 
+val RUST_PSI_CHANGE_TOPIC: Topic<RustPsiChangeListener> = Topic.create(
+    "RUST_PSI_CHANGE_TOPIC",
+    RustPsiChangeListener::class.java,
+    Topic.BroadcastDirection.TO_PARENT
+)
+
 interface RsPsiManager {
     /**
      * A project-global modification tracker that increments on each PSI change that can affect
@@ -35,6 +41,10 @@ interface RsPsiManager {
 
 interface RustStructureChangeListener {
     fun rustStructureChanged()
+}
+
+interface RustPsiChangeListener {
+    fun rustPsiChanged(element: PsiElement)
 }
 
 class RsPsiManagerImpl(val project: Project) : ProjectComponent, RsPsiManager {
@@ -94,6 +104,7 @@ class RsPsiManagerImpl(val project: Project) : ProjectComponent, RsPsiManager {
         if (owner == null || !owner.incModificationCount(psi)) {
             incRustStructureModificationCount()
         }
+        project.messageBus.syncPublisher(RUST_PSI_CHANGE_TOPIC).rustPsiChanged(psi)
     }
 
     private fun incRustStructureModificationCount() {

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsBinaryOpReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsBinaryOpReferenceImpl.kt
@@ -20,6 +20,8 @@ class RsBinaryOpReferenceImpl(
 
     override val RsBinaryOp.referenceAnchor: PsiElement get() = referenceNameElement
 
+    override val cacheDependency: ResolveCacheDependency get() = ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE
+
     override fun resolveInner(): List<RsElement> {
         val operator = element.operatorType as? OverloadableBinaryOperator ?: return emptyList()
         return collectResolveVariants(operator.fnName) { processBinaryOpVariants(element, operator, it) }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLabelReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLabelReferenceImpl.kt
@@ -19,6 +19,8 @@ class RsLabelReferenceImpl(
 
     override val RsLabel.referenceAnchor: PsiElement get() = quoteIdentifier
 
+    override val cacheDependency: ResolveCacheDependency get() = ResolveCacheDependency.LOCAL
+
     override fun resolveInner(): List<RsElement> =
         collectResolveVariants(element.referenceName) { processLabelResolveVariants(element, it) }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLifetimeReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLifetimeReferenceImpl.kt
@@ -19,6 +19,8 @@ class RsLifetimeReferenceImpl(
 
     override val RsLifetime.referenceAnchor: PsiElement get() = quoteIdentifier
 
+    override val cacheDependency: ResolveCacheDependency get() = ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE
+
     override fun resolveInner(): List<RsElement> =
         collectResolveVariants(element.referenceName) { processLifetimeResolveVariants(element, it) }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroReferenceImpl.kt
@@ -17,6 +17,8 @@ class RsMacroReferenceImpl(pattern: RsMacroReference) : RsReferenceCached<RsMacr
     override val RsMacroReference.referenceAnchor: PsiElement
         get() = referenceNameElement
 
+    override val cacheDependency: ResolveCacheDependency get() = ResolveCacheDependency.LOCAL
+
     override fun getVariants(): Array<out Any> =
         collectCompletionVariants { processMacroReferenceVariants(element, it) }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -70,7 +70,7 @@ class RsPathReferenceImpl(
 
     private fun advancedCachedMultiResolve(): List<BoundElement<RsElement>> {
         return RsResolveCache.getInstance(element.project)
-            .resolveWithCaching(element, Resolver)
+            .resolveWithCaching(element, ResolveCacheDependency.RUST_STRUCTURE, Resolver)
             .orEmpty()
             // We can store a fresh `TyInfer.TyVar` to the cache for `_` path parameter (like `Vec<_>`), but
             // TyVar is mutable type, so we must copy it after retrieving from the cache

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceCached.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceCached.kt
@@ -26,8 +26,10 @@ abstract class RsReferenceCached<T : RsWeakReferenceElement>(
 
     private fun cachedMultiResolve(): List<PsiElementResolveResult> {
         return RsResolveCache.getInstance(element.project)
-            .resolveWithCaching(element, Resolver).orEmpty()
+            .resolveWithCaching(element, cacheDependency, Resolver).orEmpty()
     }
+
+    protected open val cacheDependency: ResolveCacheDependency get() = ResolveCacheDependency.RUST_STRUCTURE
 
     private object Resolver : (RsWeakReferenceElement) -> List<PsiElementResolveResult> {
         override fun invoke(ref: RsWeakReferenceElement): List<PsiElementResolveResult> {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveCacheTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveCacheTest.kt
@@ -22,7 +22,7 @@ class RsResolveCacheTest : RsTestBase() {
         use a/*caret*/::S;
         type T = S;
                //^
-    """, "\bb", Testmarks.cacheCleared)
+    """, "\bb", Testmarks.rustStructureDependentCacheCleared)
 
     fun `test resolve correctly without global cache invalidation 1`() = checkResolvedToXY("""
         struct S1;
@@ -32,7 +32,7 @@ class RsResolveCacheTest : RsTestBase() {
         fn main() {
             let a: S1/*caret*/;
         }        //^
-    """, "\b2")
+    """, "\b2", Testmarks.removeChangedElement)
 
     fun `test resolve correctly without global cache invalidation 2`() = checkResolvedToXY("""
         mod a { pub struct S; }
@@ -44,7 +44,7 @@ class RsResolveCacheTest : RsTestBase() {
                 ::S;
                 //^
         }
-    """, "\bb")
+    """, "\bb", Testmarks.removeChangedElement)
 
     fun `test resolve correctly without global cache invalidation 3`() = checkResolvedToXY("""
         struct S;
@@ -59,7 +59,7 @@ class RsResolveCacheTest : RsTestBase() {
                 ::Item;
                 //^
         }
-    """, "\b2")
+    """, "\b2", Testmarks.removeChangedElement)
 
     fun `test edit local pat binding`() = checkResolvedAndThenUnresolved("""
         fn main() {


### PR DESCRIPTION
The most important thing is that this change opens the way
for even more precise cache invalidation. For example, we can make
specific cache for macro resolve, which is invalidated only
by changes that can affect macro resolve (e.g. module structure)