### PR TITLE
INT: don't show "remove unnecessary parens" for struct literals in for-loop iterator

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/RemoveParenthesesFromExprIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/RemoveParenthesesFromExprIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorStrict
 
@@ -16,8 +17,14 @@ class RemoveParenthesesFromExprIntention : RsElementBaseIntentionAction<RsParenE
     override fun getFamilyName(): String = text
 
     fun isAvailable(expr: RsParenExpr?): Boolean {
-        if (expr?.ancestorStrict<RsCondition>() == null && expr?.ancestorStrict<RsMatchExpr>() == null) return true
-        val child = expr.children.singleOrNull()
+        if (PsiTreeUtil.getContextOfType(
+                expr,
+                false,
+                RsCondition::class.java,
+                RsMatchExpr::class.java,
+                RsForExpr::class.java
+            ) == null) return true
+        val child = expr?.children?.singleOrNull()
         return when (child) {
             is RsStructLiteral -> false
             is RsBinaryExpr -> child.exprList.all { it !is RsStructLiteral }

--- a/src/test/kotlin/org/rust/ide/intentions/RemoveParenthesesFromExprIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RemoveParenthesesFromExprIntentionTest.kt
@@ -15,4 +15,20 @@ class RemoveParenthesesFromExprIntentionTest : RsIntentionTestBase(RemoveParenth
             let a = 4 + 3/*caret*/;
         }
     """)
+
+
+    fun `test remove parentheses from expr - struct literal in for-loop iterator`() = doUnavailableTest("""
+        struct SomeIter {
+            foo: ()
+        }
+        impl Iterator for SomeIter {
+            type Item = u32;
+            fn next(&mut self) -> Option<<Self as Iterator>::Item> {
+                Some(1)
+            }
+        }
+        fn test() {
+            for val in (SomeIter { foo: () }/*caret*/) {}
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #3039