### PR TITLE
GRD: setup resources for additional source sets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -147,10 +147,17 @@ project(":") {
     }
 
     sourceSets {
-        getByName("main").kotlin.srcDirs("src/$platformVersion/main/kotlin")
-        getByName("test").kotlin.srcDirs("src/$platformVersion/test/kotlin")
+        getByName("main").apply {
+            kotlin.srcDirs("src/$platformVersion/main/kotlin")
+            resources.srcDirs("src/$platformVersion/main/resources")
+        }
+        getByName("test").apply {
+            kotlin.srcDirs("src/$platformVersion/test/kotlin")
+            resources.srcDirs("src/$platformVersion/test/resources")
+        }
         create("debugger") {
             kotlin.srcDirs("debugger/src/main/kotlin", "debugger/src/$platformVersion/main/kotlin")
+            resources.srcDirs("debugger/src/main/resources", "debugger/src/$platformVersion/main/resources")
             compileClasspath += getByName("main").compileClasspath +
                 getByName("main").output +
                 files("deps/clion-$clionVersion/lib/clion.jar")

--- a/src/182/main/resources/META-INF/platform-plugin.xml
+++ b/src/182/main/resources/META-INF/platform-plugin.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/src/183/main/resources/META-INF/platform-plugin.xml
+++ b/src/183/main/resources/META-INF/platform-plugin.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,4 +1,4 @@
-<idea-plugin>
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude" allow-bundled-update="true">
     <id>org.rust.lang</id>
     <name>Rust</name>
 
@@ -18,6 +18,8 @@
          on how to target different products -->
 
     <depends>com.intellij.modules.lang</depends>
+
+    <xi:include href="/META-INF/platform-plugin.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <depends optional="true" config-file="idea-only.xml">com.intellij.modules.java</depends>
     <depends optional="true" config-file="clion-only.xml">com.intellij.modules.clion</depends>
     <depends optional="true" config-file="toml-only.xml">org.toml.lang</depends>


### PR DESCRIPTION
Also, create an additional xml file for each platform version to support features only for a specific platform version. It should be useful when some extension point or other code is not available in some old (but still supported) platform and it's impossible to declare this features in plugin.xml