### PR TITLE
Bundled pretty-printer for LLDB: fix empty &str printing

### DIFF
--- a/prettyPrinters/providers.py
+++ b/prettyPrinters/providers.py
@@ -135,6 +135,9 @@ def StdStrSummaryProvider(valobj, dict):
     logger >> "[StdStrSummaryProvider] for " + str(valobj.GetName())
 
     length = valobj.GetChildMemberWithName("length").GetValueAsUnsigned()
+    if length == 0:
+        return '""'
+
     data_ptr = valobj.GetChildMemberWithName("data_ptr")
 
     start = data_ptr.GetValueAsUnsigned()


### PR DESCRIPTION
Fix printer's failure on empty `&str`.