### PR TITLE
Bundled pretty-printer for LLDB: fix Ref provider

### DIFF
--- a/prettyPrinters/providers.py
+++ b/prettyPrinters/providers.py
@@ -460,10 +460,16 @@ class StdRefSyntheticProvider:
     def __init__(self, valobj, dict, is_cell=False):
         # type: (SBValue, dict, bool) -> StdRefSyntheticProvider
         self.valobj = valobj
-        self.borrow = valobj.GetChildMemberWithName("borrow").GetChildAtIndex(0).GetChildAtIndex(0)
-        if not is_cell:
-            self.borrow = self.borrow.GetChildAtIndex(0)
-        self.value = valobj.GetChildMemberWithName("value").GetChildAtIndex(0)
+
+        borrow = valobj.GetChildMemberWithName("borrow")
+        value = valobj.GetChildMemberWithName("value")
+        if is_cell:
+            self.borrow = borrow.GetChildMemberWithName("value").GetChildMemberWithName("value")
+            self.value = value.GetChildMemberWithName("value")
+        else:
+            self.borrow = borrow.GetChildMemberWithName("borrow").GetChildMemberWithName(
+                "value").GetChildMemberWithName("value")
+            self.value = value.Dereference()
 
         self.value_builder = ValueBuilder(valobj)
 


### PR DESCRIPTION
Fix `StdRefSyntheticProvider`: `value` was computed incorrectly for `Ref` and `RefMut`.

The problem was that `valobj.GetChildAtIndex(0)` doesn't always correspond to `valobj.Dereference()`. For example, it was working for `Ref<i32>`, but not for `Ref<&str>`.