### PR TITLE
Copyright plugin support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -132,7 +132,7 @@ project(":") {
     intellij {
         pluginName = "intellij-rust"
 //        alternativeIdePath = "deps/clion-$clionVersion"
-        setPlugins(project(":intellij-toml"), "IntelliLang")
+        setPlugins(project(":intellij-toml"), "IntelliLang", "copyright")
     }
 
     repositories {

--- a/src/main/resources/META-INF/copyright-only.xml
+++ b/src/main/resources/META-INF/copyright-only.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij.copyright">
+        <updater filetype="Rust"
+                 implementationClass="com.maddyhome.idea.copyright.psi.UpdateAnyFileCopyright$Provider"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -23,6 +23,7 @@
     <depends optional="true" config-file="idea-only.xml">com.intellij.modules.java</depends>
     <depends optional="true" config-file="clion-only.xml">com.intellij.modules.clion</depends>
     <depends optional="true" config-file="toml-only.xml">org.toml.lang</depends>
+    <depends optional="true" config-file="copyright-only.xml">com.intellij.copyright</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- although Rust module type is only created by IDEA, we need it in other IDEs as well


### PR DESCRIPTION
Closes https://github.com/intellij-rust/intellij-rust/issues/2524.

Also provides copyright formatting settings for Rust files.

Note, Copyright plugin is not available in CLion (see the corresponding [issue](https://youtrack.jetbrains.com/issue/CPP-10423))