### PR TITLE
TY: Fix isMovesByDefault on copyable type parameter

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -160,8 +160,8 @@ fun Ty.isMovesByDefault(lookup: ImplLookup): Boolean =
     when (this) {
         is TyUnknown, is TyReference, is TyPointer, is TyFunction -> false
         is TyTuple -> types.any { it.isMovesByDefault(lookup) }
-        is TyTypeParameter -> parameter != TyTypeParameter.Self
-        else -> lookup.isCopy(this).not()
+        is TyTypeParameter -> !(parameter == TyTypeParameter.Self || lookup.isCopy(this))
+        else -> !lookup.isCopy(this)
     }
 
 val Ty.isBox: Boolean

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
@@ -269,4 +269,12 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
             }
         }
     """, checkWarn = false)
+
+    /** Issue [#3093](https://github.com/intellij-rust/intellij-rust/issues/3093) */
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test no move error E0507 on copyable type parameter`() = checkByText("""
+        fn foo<X: Copy>(x: &[X]) -> X {
+            x[0]
+        }
+    """, checkWarn = false)
 }


### PR DESCRIPTION
Fixes #3093 