### PR TITLE
QDOC: Highlight code in quick documentation

### DIFF
--- a/src/182/main/kotlin/org/rust/lang/doc/RsCodeFenceProvider.kt
+++ b/src/182/main/kotlin/org/rust/lang/doc/RsCodeFenceProvider.kt
@@ -1,0 +1,11 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.doc
+
+import com.intellij.psi.PsiElement
+import org.intellij.markdown.html.GeneratingProvider
+
+fun createCodeFenceProvider(element: PsiElement): GeneratingProvider? = null

--- a/src/183/main/kotlin/org/rust/lang/doc/RsCodeFenceProvider.kt
+++ b/src/183/main/kotlin/org/rust/lang/doc/RsCodeFenceProvider.kt
@@ -1,0 +1,69 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.doc
+
+import com.intellij.codeEditor.printing.HTMLTextPainter
+import com.intellij.psi.PsiElement
+import org.intellij.markdown.MarkdownTokenTypes
+import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.ast.getTextInNode
+import org.intellij.markdown.html.GeneratingProvider
+import org.intellij.markdown.html.HtmlGenerator
+import java.lang.StringBuilder
+
+fun createCodeFenceProvider(element: PsiElement): GeneratingProvider = RsCodeFenceProvider(element)
+
+// Inspired by org.intellij.markdown.html.CodeFenceGeneratingProvider
+private class RsCodeFenceProvider(private val context: PsiElement) : GeneratingProvider {
+
+    override fun processNode(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
+        val indentBefore = node.getTextInNode(text).commonPrefixWith(" ".repeat(10)).length
+
+        val codeText = StringBuilder()
+
+        var childrenToConsider = node.children
+        if (childrenToConsider.last().type == MarkdownTokenTypes.CODE_FENCE_END) {
+            childrenToConsider = childrenToConsider.subList(0, childrenToConsider.size - 1)
+        }
+
+        var isContentStarted = false
+        var skipNextEOL = false
+        var lastChildWasContent = false
+
+        loop@for (child in childrenToConsider) {
+            if (isContentStarted && child.type in listOf(MarkdownTokenTypes.CODE_FENCE_CONTENT, MarkdownTokenTypes.EOL)) {
+                if (skipNextEOL && child.type == MarkdownTokenTypes.EOL) {
+                    skipNextEOL = false
+                    continue
+                }
+                val rawLine = HtmlGenerator.trimIndents(child.getTextInNode(text), indentBefore)
+                // `cargo doc` has special rules for code lines which start with `#`:
+                //   * `# ` prefix is used to mark lines that should be skipped in rendered documentation.
+                //   * `##` prefix is converted to `#`
+                // See https://github.com/rust-lang/rust/blob/5182cc1ca65d05f16ee5e1529707ac6f63233ca9/src/librustdoc/html/markdown.rs#L114 for more details
+                val codeLine = when {
+                    rawLine.startsWith("# ") -> {
+                        skipNextEOL = true
+                        continue@loop
+                    }
+                    rawLine.startsWith("##") -> rawLine.removePrefix("#")
+                    else -> rawLine
+                }
+
+                codeText.append(codeLine)
+                lastChildWasContent = child.type == MarkdownTokenTypes.CODE_FENCE_CONTENT
+            }
+            if (!isContentStarted && child.type == MarkdownTokenTypes.EOL) {
+                isContentStarted = true
+            }
+        }
+        if (lastChildWasContent) {
+            codeText.appendln()
+        }
+        val htmlCodeText = HTMLTextPainter.convertCodeFragmentToHTMLFragmentWithInlineStyles(context, codeText.toString())
+        visitor.consumeHtml(htmlCodeText)
+    }
+}

--- a/src/183/test/kotlin/org/rust/ide/docs/RsCodeHighlightingInQuickDocumentationTest.kt
+++ b/src/183/test/kotlin/org/rust/ide/docs/RsCodeHighlightingInQuickDocumentationTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.docs
+
+import org.intellij.lang.annotations.Language
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+
+class RsCodeHighlightingInQuickDocumentationTest : RsDocumentationProviderTest() {
+
+    fun `test code highlighting`() = doTest("""
+        /// Adds one to the number given.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// let five = 5;
+        ///
+        /// assert_eq!(6, add_one(5));
+        /// ```
+        fn add_one(x: i32) -> i32 {
+            x + 1
+        }
+
+        fn main() {
+            add_one(91)
+             //^
+        }
+    """, """
+        <div class='definition'><pre>test_package
+        fn <b>add_one</b>(x: i32) -&gt; i32</pre></div>
+        <div class='content'><p>Adds one to the number given.</p><h2>Examples</h2><pre><span style="...">let </span>five = <span style="...">5</span>;
+
+        assert_eq!(<span style="...">6</span>, add_one(<span style="...">5</span>));
+        </pre>
+        </div>
+    """)
+
+    // https://github.com/intellij-rust/intellij-rust/issues/495
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test issue495`() = doTest("""
+        /// A cheap, reference-to-reference conversion.
+        ///
+        /// `AsRef` is very similar to, but different than, `Borrow`. See
+        /// [the book][book] for more.
+        ///
+        /// [book]: ../../book/borrow-and-asref.html
+        ///
+        /// **Note: this trait must not fail**. If the conversion can fail, use a dedicated method which
+        /// returns an `Option<T>` or a `Result<T, E>`.
+        ///
+        /// # Examples
+        ///
+        /// Both `String` and `&str` implement `AsRef<str>`:
+        ///
+        /// ```
+        /// fn is_hello<T: AsRef<str>>(s: T) {
+        ///    assert_eq!("hello", s.as_ref());
+        /// }
+        ///
+        /// let s = "hello";
+        /// is_hello(s);
+        ///
+        /// let s = "hello".to_string();
+        /// is_hello(s);
+        /// ```
+        ///
+        /// # Generic Impls
+        ///
+        /// - `AsRef` auto-dereference if the inner type is a reference or a mutable
+        /// reference (eg: `foo.as_ref()` will work the same if `foo` has type `&mut Foo` or `&&mut Foo`)
+        ///
+        #[stable(feature = "rust1", since = "1.0.0")]
+        pub trait AsRef<T: ?Sized> {
+            /// Performs the conversion.
+            #[stable(feature = "rust1", since = "1.0.0")]
+            fn as_ref(&self) -> &T;
+        }
+
+        impl <T> AsRef<T> {}
+                  //^
+    """, """
+        <div class='definition'><pre>test_package
+        pub trait <b>AsRef</b>&lt;T: ?<a href="psi_element://Sized">Sized</a>&gt;</pre></div>
+        <div class='content'><p>A cheap, reference-to-reference conversion.</p><p><code>AsRef</code> is very similar to, but different than, <code>Borrow</code>. See
+        <a href="psi_element://../book/borrow-and-asref.html">the book</a> for more.</p><p><strong>Note: this trait must not fail</strong>. If the conversion can fail, use a dedicated method which
+        returns an <code>Option&lt;T&gt;</code> or a <code>Result&lt;T, E&gt;</code>.</p><h2>Examples</h2><p>Both <code>String</code> and <code>&amp;str</code> implement <code>AsRef&lt;str&gt;</code>:</p><pre><span style="...">fn </span>is_hello&lt;T: AsRef&lt;str&gt;&gt;(s: T) {
+           assert_eq!(<span style="...">&quot;hello&quot;</span>, s.as_ref());
+        }
+
+        <span style="...">let </span>s = <span style="...">&quot;hello&quot;</span>;
+        is_hello(s);
+
+        <span style="...">let </span>s = <span style="...">&quot;hello&quot;</span>.to_string();
+        is_hello(s);
+        </pre>
+        <h2>Generic Impls</h2><ul><li><code>AsRef</code> auto-dereference if the inner type is a reference or a mutable
+        reference (eg: <code>foo.as_ref()</code> will work the same if <code>foo</code> has type <code>&amp;mut Foo</code> or <code>&amp;&amp;mut Foo</code>)</li></ul></div>
+    """)
+
+    fun `test process code lines start with #`() = doTest("""
+        /// Some doc.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// #[attr1]
+        /// ##[attr2]
+        /// let foo = Foo;
+        /// # let foo2 = Foo;
+        /// ```
+        struct Foo;
+              //^
+    """, """
+        <div class='definition'><pre>test_package
+        struct <b>Foo</b></pre></div>
+        <div class='content'><p>Some doc.</p><h2>Example</h2><pre>#[attr1]
+        #[attr2]
+        <span style="...">let </span>foo = Foo;
+        </pre>
+        </div>
+    """)
+
+    private fun doTest(@Language("Rust") code: String, @Language("Html") expected: String)
+        = doTest(code, expected) { element, context -> generateDoc(element, context)?.hideSpecificStyles() }
+
+    private fun String.hideSpecificStyles(): String = replace(SPAN_REGEX, """<span style="...">""")
+
+    companion object {
+        private val SPAN_REGEX = Regex("""<span style=".*?">""")
+    }
+}

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -15,11 +15,8 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         ///
         /// # Examples
         ///
-        /// ```
-        /// let five = 5;
+        /// Some text
         ///
-        /// assert_eq!(6, add_one(5));
-        /// ```
         fn add_one(x: i32) -> i32 {
             x + 1
         }
@@ -31,10 +28,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
     """, """
         <div class='definition'><pre>test_package
         fn <b>add_one</b>(x: i32) -&gt; i32</pre></div>
-        <div class='content'><p>Adds one to the number given.</p><h2>Examples</h2><pre><code>let five = 5;
-
-        assert_eq!(6, add_one(5));
-        </code></pre></div>
+        <div class='content'><p>Adds one to the number given.</p><h2>Examples</h2><p>Some text</p></div>
     """)
 
     fun `test pub fn`() = doTest("""
@@ -692,67 +686,6 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <div class='definition'><pre>test_package::q
         fn <b>foo</b>()</pre></div>
         <div class='content'><p>Blurb.</p></div>
-    """)
-
-    // https://github.com/intellij-rust/intellij-rust/issues/495
-    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    fun `test issue495`() = doTest("""
-        /// A cheap, reference-to-reference conversion.
-        ///
-        /// `AsRef` is very similar to, but different than, `Borrow`. See
-        /// [the book][book] for more.
-        ///
-        /// [book]: ../../book/borrow-and-asref.html
-        ///
-        /// **Note: this trait must not fail**. If the conversion can fail, use a dedicated method which
-        /// returns an `Option<T>` or a `Result<T, E>`.
-        ///
-        /// # Examples
-        ///
-        /// Both `String` and `&str` implement `AsRef<str>`:
-        ///
-        /// ```
-        /// fn is_hello<T: AsRef<str>>(s: T) {
-        ///    assert_eq!("hello", s.as_ref());
-        /// }
-        ///
-        /// let s = "hello";
-        /// is_hello(s);
-        ///
-        /// let s = "hello".to_string();
-        /// is_hello(s);
-        /// ```
-        ///
-        /// # Generic Impls
-        ///
-        /// - `AsRef` auto-dereference if the inner type is a reference or a mutable
-        /// reference (eg: `foo.as_ref()` will work the same if `foo` has type `&mut Foo` or `&&mut Foo`)
-        ///
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub trait AsRef<T: ?Sized> {
-            /// Performs the conversion.
-            #[stable(feature = "rust1", since = "1.0.0")]
-            fn as_ref(&self) -> &T;
-        }
-
-        impl <T> AsRef<T> {}
-                  //^
-    """, """
-        <div class='definition'><pre>test_package
-        pub trait <b>AsRef</b>&lt;T: ?<a href="psi_element://Sized">Sized</a>&gt;</pre></div>
-        <div class='content'><p>A cheap, reference-to-reference conversion.</p><p><code>AsRef</code> is very similar to, but different than, <code>Borrow</code>. See
-        <a href="psi_element://../book/borrow-and-asref.html">the book</a> for more.</p><p><strong>Note: this trait must not fail</strong>. If the conversion can fail, use a dedicated method which
-        returns an <code>Option&lt;T&gt;</code> or a <code>Result&lt;T, E&gt;</code>.</p><h2>Examples</h2><p>Both <code>String</code> and <code>&amp;str</code> implement <code>AsRef&lt;str&gt;</code>:</p><pre><code>fn is_hello&lt;T: AsRef&lt;str&gt;&gt;(s: T) {
-           assert_eq!(&quot;hello&quot;, s.as_ref());
-        }
-
-        let s = &quot;hello&quot;;
-        is_hello(s);
-
-        let s = &quot;hello&quot;.to_string();
-        is_hello(s);
-        </code></pre><h2>Generic Impls</h2><ul><li><code>AsRef</code> auto-dereference if the inner type is a reference or a mutable
-        reference (eg: <code>foo.as_ref()</code> will work the same if <code>foo</code> has type <code>&amp;mut Foo</code> or <code>&amp;&amp;mut Foo</code>)</li></ul></div>
     """)
 
     fun `test fn arg`() = doTest("""


### PR DESCRIPTION
Implement code highlighting in rust quick documentation.
In fact, it uses rust lexer to wrap some code tokens into `span` tag with the same styles as `RsHighlighter` provides. So, if you change color settings, it will also change code highlighting in quick documentation window.

![image](https://user-images.githubusercontent.com/2539310/49300317-f1182100-f4d2-11e8-89a7-09e34c64a877.png)

Note, it's available since 2018.3 because the corresponding platform code appeared only in 2018.3

Closes #2501