### PR TITLE
REF: Auto-import unresolved types during implement members [WIP]

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
@@ -11,10 +11,16 @@ import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
+import org.rust.ide.inspections.import.ImportCandidate
 import org.rust.lang.core.macros.expandedFromRecursively
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.types.canBeImported
+import org.rust.lang.core.types.importItem
+import org.rust.lang.core.types.ty.TyAdt
+import org.rust.lang.core.types.ty.TyTraitObject
+import org.rust.lang.core.types.type
 import org.rust.openapiext.checkReadAccessAllowed
 import org.rust.openapiext.checkWriteAccessAllowed
 
@@ -49,6 +55,59 @@ private fun insertNewTraitMembers(selected: Collection<RsAbstractable>, existing
     if (selected.isEmpty()) return
 
     val templateImpl = RsPsiFactory(existingMembers.project).createMembers(selected, trait.subst)
+    val mod = existingMembers.containingMod
+    val superMods = LinkedHashSet(mod.superMods)
+
+    val importCandidates = mutableListOf<ImportCandidate>()
+    val importCandidateVisitor = object : RsVisitor() {
+        override fun visitFunction(o: RsFunction) {
+            o.typeParameterList?.let(this::visitTypeParameterList)
+            o.valueParameterList?.let(this::visitValueParameterList)
+
+            o.whereClause?.wherePredList?.forEach {
+                it.typeReference?.let(this::visitTypeReference)
+            }
+        }
+
+        override fun visitValueParameterList(o: RsValueParameterList) {
+            o.valueParameterList.forEach { it.typeReference?.accept(this) }
+        }
+
+        override fun visitTypeParameterList(o: RsTypeParameterList) {
+            o.typeParameterList.forEach { it.typeReference?.accept(this) }
+        }
+
+        override fun visitRetType(o: RsRetType) {
+            o.typeReference?.let(::visitTypeReference)
+        }
+
+        override fun visitTypeReference(o: RsTypeReference) {
+            val ty = o.type
+            val item: RsQualifiedNamedElement = when (ty) {
+                is TyAdt -> ty.item
+                is TyTraitObject -> ty.trait.element
+                else -> return
+            }
+
+            val candidate = QualifiedNamedItem.ExplicitItem(item)
+                .withModuleReexports(mod.project)
+                .mapNotNull { ImportCandidate(it, it.canBeImported(superMods) ?: return@mapNotNull null) }
+                .firstOrNull() ?: return
+
+            importCandidates.add(candidate)
+        }
+    }
+
+    // Visit the existing trait functions to determine the types that need to be imported.
+    selected.forEach { it.accept(importCandidateVisitor) }
+
+    // Determine which of the type references we found are already in scope.
+    val inScopeItems: Set<RsElement> = importCandidates
+        .mapNotNull { it.qualifiedNamedItem.item as? RsItemElement }
+        .filterInScope(existingMembers)
+        .toSet()
+
+    importCandidates.filter { !inScopeItems.contains(it.qualifiedNamedItem.item) }.forEach(mod::importItem)
 
     val traitMembers = trait.element.expandedMembers
     val newMembers = templateImpl.childrenOfType<RsAbstractable>()


### PR DESCRIPTION
Extracts out the code used for the Auto-Import fix to make it reusable by other intentions. 

I've added a visitor that finds all type references in the selected members to implement, and finds import candidates for each.  I'm not sure if this is the best approach, but it seems to work insofar as my testing.  I'll make sure the tests are passing and add a few more that verifies this functionality works.  

Is there anything else that needs covered in https://github.com/intellij-rust/intellij-rust/commit/f26633f0b3fb9388ad177b82d5dffef6344ee7f9#diff-5347552d7d8c8a383193d5925797806fR86 or a better way to do this?
