### PR TITLE
Bundled pretty-printer for LLDB: fix Rc provider (weak_count)

### DIFF
--- a/prettyPrinters/providers.py
+++ b/prettyPrinters/providers.py
@@ -408,7 +408,7 @@ class StdRcSyntheticProvider:
     def update(self):
         # type: () -> None
         self.strong_count = self.strong.GetValueAsUnsigned()
-        self.weak_count = self.weak.GetValueAsUnsigned()
+        self.weak_count = self.weak.GetValueAsUnsigned() - 1
 
     def has_children(self):
         # type: () -> bool


### PR DESCRIPTION
`weak_count` should be `weak - 1` in `Rc` and `Arc`.