### PR TITLE
TYPE: insert pair brace before ']'

### DIFF
--- a/src/main/kotlin/org/rust/ide/typing/RsBraceMatcher.kt
+++ b/src/main/kotlin/org/rust/ide/typing/RsBraceMatcher.kt
@@ -146,7 +146,7 @@ private class RsBaseBraceMatcher : PairedBraceMatcher {
                 SEMICOLON,
                 COMMA,
                 RPAREN,
-                RBRACE,
+                RBRACK,
                 RBRACE, LBRACE
             )
         )

--- a/src/test/kotlin/org/rust/ide/typing/RsBraceMatcherTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/RsBraceMatcherTest.kt
@@ -30,6 +30,12 @@ class RsBraceMatcherTest : RsTestBase() {
         "fn foo(<caret>){}"
     )
 
+    fun `test pair parenthesis before bracket`() = doTest(
+        "fn main() { let _ = &[foo<caret>]; }",
+        '(',
+        "fn main() { let _ = &[foo(<caret>)]; }"
+    )
+
     fun `test match parenthesis`() = doMatch("fn foo<caret>(x: (i32, ()) ) {}", ")")
 
     fun `test match square brackets`() = doMatch("fn foo(x: <caret>[i32; 192]) {}", "]")


### PR DESCRIPTION
Looks like there was a typo inside the `InsertPairBraceBefore` set: there was no `RBRACK`, but two `RBRACE`s 😄 