### PR TITLE
Add support for spacing between assoc type bindings.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -40,6 +40,7 @@ HybridEidolon
 idubrov
 isamborskiy
 JakubAdamWieczorek
+Jezza
 johnthagen
 jonas-schievink
 Keats

--- a/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt
@@ -114,6 +114,8 @@ fun createSpacingBuilder(commonSettings: CommonCodeStyleSettings, rustSettings: 
         .betweenInside(IDENTIFIER, TUPLE_FIELDS, ENUM_VARIANT).spaces(0)
         .betweenInside(IDENTIFIER, VARIANT_DISCRIMINANT, ENUM_VARIANT).spaces(1)
 
+    val spacesAroundAssocTypeBinding = if (rustSettings.SPACE_AROUND_ASSOC_TYPE_BINDING) 1 else 0
+
     return sb2
         //== types
         .afterInside(LIFETIME, REF_LIKE_TYPE).spaceIf(true)
@@ -123,7 +125,7 @@ fun createSpacingBuilder(commonSettings: CommonCodeStyleSettings, rustSettings: 
         .after(TYPE_QUAL).spaces(0)
         .betweenInside(FOR, LT, FOR_LIFETIMES).spacing(0, 0, 0, true, 0)
         .around(FOR_LIFETIMES).spacing(1, 1, 0, true, 0)
-        .aroundInside(EQ, ASSOC_TYPE_BINDING).spaces(0)
+        .aroundInside(EQ, ASSOC_TYPE_BINDING).spaces(spacesAroundAssocTypeBinding)
 
         //?Sized
         .betweenInside(ts(Q), ts(BOUND), POLYBOUND).spaces(0)

--- a/src/main/kotlin/org/rust/ide/formatter/settings/RsCodeStyleSettings.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/settings/RsCodeStyleSettings.kt
@@ -19,4 +19,6 @@ class RsCodeStyleSettings(container: CodeStyleSettings) :
     @JvmField var ALLOW_ONE_LINE_MATCH = false
     @JvmField var MIN_NUMBER_OF_BLANKS_BETWEEN_ITEMS = 1
     @JvmField var PRESERVE_PUNCTUATION = false
+
+    @JvmField var SPACE_AROUND_ASSOC_TYPE_BINDING = false
 }

--- a/src/main/kotlin/org/rust/ide/formatter/settings/RsCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/settings/RsCodeStyleSettingsProvider.kt
@@ -27,6 +27,7 @@ class RsCodeStyleSettingsProvider : CodeStyleSettingsProvider() {
 
         override fun initTabs(settings: CodeStyleSettings?) {
             addIndentOptionsTab(settings)
+            addSpacesTab(settings)
             addWrappingAndBracesTab(settings)
             addBlankLinesTab(settings)
         }

--- a/src/main/kotlin/org/rust/ide/formatter/settings/RsLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/settings/RsLanguageCodeStyleSettingsProvider.kt
@@ -21,6 +21,7 @@ class RsLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider() 
     override fun getCodeSample(settingsType: SettingsType): String =
         when (settingsType) {
             INDENT_SETTINGS -> INDENT_SAMPLE
+            SPACING_SETTINGS -> SPACING_SAMPLE
             WRAPPING_AND_BRACES_SETTINGS -> WRAPPING_AND_BRACES_SAMPLE
             BLANK_LINES_SETTINGS -> BLANK_LINES_SAMPLE
             else -> ""
@@ -39,6 +40,13 @@ class RsLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider() 
                     "MIN_NUMBER_OF_BLANKS_BETWEEN_ITEMS",
                     "Between declarations:",
                     CodeStyleSettingsCustomizable.BLANK_LINES)
+            }
+
+            SPACING_SETTINGS -> {
+                consumer.showCustomOption(RsCodeStyleSettings::class.java,
+                    "SPACE_AROUND_ASSOC_TYPE_BINDING",
+                    "Around associated type bindings",
+                    CodeStyleSettingsCustomizable.SPACES_IN_TYPE_PARAMETERS)
             }
 
             WRAPPING_AND_BRACES_SETTINGS -> {
@@ -127,6 +135,16 @@ impl Vector {
         }
     }
 }
+""")
+
+private val SPACING_SAMPLE = sample("""
+trait Trait0<A, B, T: Trait1<A>> {
+    type Output;
+}
+
+trait Trait1<T> {}
+
+fn method<A, B, T, C>(value: T) where T: Trait0<A, B, T, Output=C> {}
 """)
 
 


### PR DESCRIPTION
Added some basic spacing support for associated type bindings.
While useful, the bigger part is definitely that spacings can now be added.
Granted, having seen the spacing builder... I don't think I wanna do that all at once.

So, this is, hopefully, the start of the migration towards giving the user the option to change the spacing settings.