### PR TITLE
LI: inject Rust language to doctests

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
@@ -36,6 +36,9 @@ class RsProjectConfigurable(
     private val showTestToolWindowCheckbox: JBCheckBox = JBCheckBox()
     private var showTestToolWindow: Boolean by CheckboxDelegate(showTestToolWindowCheckbox)
 
+    private val doctestInjectionCheckbox: JBCheckBox = JBCheckBox()
+    private var doctestInjectionEnabled: Boolean by CheckboxDelegate(doctestInjectionCheckbox)
+
     private val hintProvider = InlayParameterHintsExtension.forLanguage(RsLanguage)
     private val hintCheckboxes: Map<String, JBCheckBox> =
         hintProvider.supportedOptions.associate { it.id to JBCheckBox() }
@@ -52,6 +55,7 @@ class RsProjectConfigurable(
             Show test results in run tool window when testing session begins
             instead of raw console.
         """)
+        row("Inject Rust language to documentation comments:", doctestInjectionCheckbox)
         val supportedHintOptions = hintProvider.supportedOptions
         if (supportedHintOptions.isNotEmpty()) {
             block("Hints") {
@@ -73,6 +77,7 @@ class RsProjectConfigurable(
         )
         expandMacros = settings.expandMacros
         showTestToolWindow = settings.showTestToolWindow
+        doctestInjectionEnabled = settings.doctestInjectionEnabled
 
         for (option in hintProvider.supportedOptions) {
             checkboxForOption(option).isSelected = option.get()
@@ -92,7 +97,8 @@ class RsProjectConfigurable(
             toolchain = rustProjectSettings.data.toolchain,
             explicitPathToStdlib = rustProjectSettings.data.explicitPathToStdlib,
             expandMacros = expandMacros,
-            showTestToolWindow = showTestToolWindow
+            showTestToolWindow = showTestToolWindow,
+            doctestInjectionEnabled = doctestInjectionEnabled
         )
     }
 
@@ -103,6 +109,7 @@ class RsProjectConfigurable(
             || data.explicitPathToStdlib != settings.explicitPathToStdlib
             || expandMacros != settings.expandMacros
             || showTestToolWindow != settings.showTestToolWindow
+            || doctestInjectionEnabled != settings.doctestInjectionEnabled
     }
 
     private fun checkboxForOption(opt: Option): JBCheckBox = hintCheckboxes[opt.id]!!

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -25,6 +25,7 @@ interface RustProjectSettingsService {
         val useOffline: Boolean,
         val expandMacros: Boolean,
         val showTestToolWindow: Boolean,
+        val doctestInjectionEnabled: Boolean,
         val useSkipChildren: Boolean
     )
 
@@ -44,6 +45,7 @@ interface RustProjectSettingsService {
     val useOffline: Boolean get() = data.useOffline
     val expandMacros: Boolean get() = data.expandMacros
     val showTestToolWindow: Boolean get() = data.showTestToolWindow
+    val doctestInjectionEnabled: Boolean get() = data.doctestInjectionEnabled
     val useSkipChildren: Boolean get() = data.useSkipChildren
 
     /*

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -33,6 +33,7 @@ class RustProjectSettingsServiceImpl(
         var useOffline: Boolean = false,
         var expandMacros: Boolean = true,
         var showTestToolWindow: Boolean = true,
+        var doctestInjectionEnabled: Boolean = true,
         var useSkipChildren: Boolean = false
     )
 
@@ -60,6 +61,7 @@ class RustProjectSettingsServiceImpl(
                 useOffline = state.useOffline,
                 expandMacros = state.expandMacros,
                 showTestToolWindow = state.showTestToolWindow,
+                doctestInjectionEnabled = state.doctestInjectionEnabled,
                 useSkipChildren = state.useSkipChildren
             )
         }
@@ -75,6 +77,7 @@ class RustProjectSettingsServiceImpl(
                 useOffline = value.useOffline,
                 expandMacros = value.expandMacros,
                 showTestToolWindow = value.showTestToolWindow,
+                doctestInjectionEnabled = value.doctestInjectionEnabled,
                 useSkipChildren = value.useSkipChildren
             )
             if (state != newState) {

--- a/src/main/kotlin/org/rust/ide/actions/RsEnterHandler.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsEnterHandler.kt
@@ -1,0 +1,47 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.actions
+
+import com.intellij.codeInsight.editorActions.EnterHandler
+import com.intellij.injected.editor.EditorWindow
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Caret
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.actionSystem.EditorActionHandler
+import com.intellij.openapi.editor.actions.EnterAction
+import com.intellij.psi.impl.source.tree.injected.InjectedCaret
+import org.rust.ide.injected.RsDoctestLanguageInjector
+import org.rust.ide.injected.isDoctestInjection
+import org.rust.lang.core.psi.RsFile
+
+/**
+ * This class is used to handle typing enter inside doctest language injection (see [RsDoctestLanguageInjector]).
+ * Enter handlers are piped:
+ * [EnterHandler] -> [RsEnterHandler] -> --------------------> [EnterAction.Handler]
+ *  |                 |             \ -> [EnterHandler] -> /    ^ just insert new line [originalHandler]
+ *  |                 this class          ^ (the case of injected psi) [injectionEnterHandler]
+ *  front platform handler (handles indents and other complex stuff)
+ */
+class RsEnterHandler(private val originalHandler: EditorActionHandler) : EditorActionHandler() {
+    private val injectionEnterHandler = EnterHandler(object : EditorActionHandler() {
+        override fun doExecute(editor: Editor, caret: Caret?, dataContext: DataContext) {
+            originalHandler.execute(editor, caret, dataContext)
+        }
+    })
+
+    public override fun isEnabledForCaret(editor: Editor, caret: Caret, dataContext: DataContext): Boolean {
+        return originalHandler.isEnabled(editor, caret, dataContext)
+    }
+
+    override fun doExecute(editor: Editor, caret: Caret?, dataContext: DataContext) {
+        if (editor is EditorWindow && caret is InjectedCaret &&
+            (editor.injectedFile as? RsFile)?.isDoctestInjection == true) {
+            injectionEnterHandler.execute(editor.delegate, caret.delegate, dataContext)
+        } else {
+            originalHandler.execute(editor, caret, dataContext)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/annotator/RsDoctestAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsDoctestAnnotator.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.editor.colors.EditorColors
+import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.tree.injected.InjectionBackgroundSuppressor
+import org.rust.cargo.project.settings.rustSettings
+import org.rust.ide.injected.RsDoctestLanguageInjector
+import org.rust.ide.injected.findDoctestInjectableRanges
+import org.rust.lang.core.psi.RsDocCommentImpl
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psi.ext.containingCargoTarget
+
+/**
+ * Adds missing background for injections from [RsDoctestLanguageInjector].
+ * Background is disabled by [InjectionBackgroundSuppressor] marker implemented for [RsDocCommentImpl].
+ *
+ * We have to do it this way because we want to highlight fully range inside ```backticks```
+ * but a real injections is shifted by 1 character and empty lines are skipped.
+ */
+class RsDoctestAnnotator : RsAnnotatorBase() {
+    override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
+        if (element !is RsDocCommentImpl) return
+        if (!element.project.rustSettings.doctestInjectionEnabled) return
+        // only library targets can have doctests
+        if (element.ancestorStrict<RsElement>()?.containingCargoTarget?.isLib != true) return
+
+        val startOffset = element.startOffset
+        findDoctestInjectableRanges(element).flatten().forEach {
+            holder.createAnnotation(HighlightSeverity.INFORMATION, it.shiftRight(startOffset), null)
+                .textAttributes = EditorColors.INJECTED_LANGUAGE_FRAGMENT
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
+++ b/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
@@ -1,0 +1,182 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.injected
+
+import com.intellij.injected.editor.VirtualFileWindow
+import com.intellij.lang.injection.MultiHostInjector
+import com.intellij.lang.injection.MultiHostRegistrar
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.tree.IElementType
+import com.intellij.util.text.CharArrayUtil
+import org.rust.cargo.project.settings.rustSettings
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.cargo.util.AutoInjectedCrates
+import org.rust.lang.RsLanguage
+import org.rust.lang.core.psi.RS_DOC_COMMENTS
+import org.rust.lang.core.psi.RsDocCommentImpl
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.doc.psi.RsDocKind
+import org.rust.openapiext.toPsiFile
+import org.rust.stdext.nextOrNull
+import java.util.regex.Pattern
+
+// See https://github.com/rust-lang/rust/blob/5182cc1c/src/librustdoc/html/markdown.rs#L646
+private val LANG_SPLIT_REGEX = Pattern.compile("[^\\w-]+", Pattern.UNICODE_CHARACTER_CLASS)
+private val RUST_LANG_ALIASES = listOf(
+    "rust",
+    "allow_fail",
+    "should_panic",
+    "no_run",
+    "test_harness",
+//    "compile_fail", // don't highlight code that is expected to contain errors
+    "edition2018",
+    "edition2015"
+)
+
+class RsDoctestLanguageInjector : MultiHostInjector {
+    private data class CodeRange(val start: Int, val end: Int, val codeStart: Int) {
+        fun isCodeNotEmpty(): Boolean = codeStart + 1 < end
+
+        val indent: Int = codeStart - start
+
+        fun offsetIndent(indent: Int): CodeRange? =
+            if (start + indent < end) CodeRange(start + indent, end, codeStart) else null
+    }
+
+    override fun elementsToInjectIn(): List<Class<out PsiElement>> =
+        listOf(RsDocCommentImpl::class.java)
+
+    override fun getLanguagesToInject(registrar: MultiHostRegistrar, context: PsiElement) {
+        if (context !is RsDocCommentImpl) return
+        if (!context.isValidHost || context.elementType !in RS_DOC_COMMENTS) return
+        if (!context.project.rustSettings.doctestInjectionEnabled) return
+
+        val rsElement = context.ancestorStrict<RsElement>() ?: return
+        val cargoTarget = rsElement.containingCargoTarget ?: return
+        if (!cargoTarget.isLib) return // only library targets can have doctests
+        val crateName = cargoTarget.normName
+        val text = context.text
+
+        findDoctestInjectableRanges(text, context.elementType).map { ranges ->
+            ranges.map {
+                CodeRange(
+                    it.startOffset,
+                    it.endOffset,
+                    CharArrayUtil.shiftForward(text, it.startOffset, it.endOffset, " \t")
+                )
+            }
+        }.map { ranges ->
+            val commonIndent = ranges.filter { it.isCodeNotEmpty() }.map { it.indent }.min()
+            val indentedRanges = if (commonIndent != null) ranges.mapNotNull { it.offsetIndent(commonIndent) } else ranges
+
+            indentedRanges.map { (start, end, codeStart) ->
+                // `cargo doc` has special rules for code lines which start with `#`:
+                //   * `# ` prefix is used to mark lines that should be skipped in rendered documentation.
+                //   * `##` prefix is converted to `#`
+                // See https://github.com/rust-lang/rust/blob/5182cc1c/src/librustdoc/html/markdown.rs#L114
+                when {
+                    text.startsWith("##", codeStart) -> TextRange(codeStart + 1, end)
+                    text.startsWith("# ", codeStart) -> TextRange(codeStart + 2, end)
+                    else -> TextRange(start, end)
+                }
+            }
+        }.forEach { ranges ->
+            val inj = registrar.startInjecting(RsLanguage)
+
+            ranges.forEachIndexed { index, range ->
+                val isFirstIteration = index == 0
+                val isLastIteration = index == ranges.size - 1
+
+                val prefix = if (isFirstIteration) {
+                    buildString {
+                        // Yes, we want to skip the only "std" crate. Not core/alloc/etc, the "std" only
+                        val isStdCrate = crateName == AutoInjectedCrates.STD &&
+                            cargoTarget.pkg.origin == PackageOrigin.STDLIB
+                        if (!isStdCrate) {
+                            append("extern crate ")
+                            append(crateName)
+                            append("; ")
+                        }
+                        append("fn main() {")
+                    }
+                } else {
+                    null
+                }
+                val suffix = if (isLastIteration) "}" else null
+
+                inj.addPlace(prefix, suffix, context, range)
+            }
+
+            inj.doneInjecting()
+        }
+    }
+}
+
+fun findDoctestInjectableRanges(comment: RsDocCommentImpl): Sequence<List<TextRange>> =
+    findDoctestInjectableRanges(comment.text, comment.elementType)
+
+private fun findDoctestInjectableRanges(text: String, elementType: IElementType): Sequence<List<TextRange>> {
+    // TODO use markdown parser
+    val tripleBacktickIndices = text.indicesOf("```").toList()
+    if (tripleBacktickIndices.size < 2) return emptySequence() // no code blocks in the comment
+
+    val infix = RsDocKind.of(elementType).infix
+
+    return tripleBacktickIndices.asSequence().chunked(2).mapNotNull { idx ->
+        // Contains code lines inside backticks including `///` at the start and `\n` at the end.
+        // It doesn't contain the last line with /// ```
+        val lines = run {
+            val codeBlockStart = idx[0] + 3 // skip ```
+            val codeBlockEnd = idx.getOrNull(1) ?: return@mapNotNull null
+            generateSequence(codeBlockStart) { text.indexOf("\n", it) + 1 }
+                .takeWhile { it != 0 && it < codeBlockEnd }
+                .zipWithNext()
+                .iterator()
+        }
+
+        // ```rust, should_panic, edition2018
+        //     ^ this text
+        val lang = lines.nextOrNull()?.let { text.substring(it.first, it.second - 1) } ?: return@mapNotNull null
+        if (lang.isNotEmpty()) {
+            val parts = lang.split(LANG_SPLIT_REGEX).filter { it.isNotBlank() }
+            if (parts.any { it !in RUST_LANG_ALIASES }) return@mapNotNull null
+        }
+
+        // skip doc comment infix (`///`, `//!` or ` * `)
+        val ranges = lines.asSequence().mapNotNull { (lineStart, lineEnd) ->
+            val index = text.indexOf(infix, lineStart)
+            if (index != -1 && index < lineEnd) {
+                val start = index + infix.length
+                TextRange(start, lineEnd)
+            } else {
+                null
+            }
+        }.toList()
+
+        if (ranges.isEmpty()) return@mapNotNull null
+        ranges
+    }
+}
+
+private fun String.indicesOf(s: String): Sequence<Int> =
+    generateSequence(indexOf(s)) { indexOf(s, it + s.length) }.takeWhile { it != -1 }
+
+fun VirtualFile.isDoctestInjection(project: Project): Boolean {
+    val virtualFileWindow = this as? VirtualFileWindow ?: return false
+    val hostFile = virtualFileWindow.delegate.toPsiFile(project) as? RsFile ?: return false
+    val hostElement = hostFile.findElementAt(virtualFileWindow.documentWindow.injectedToHost(0)) ?: return false
+    return hostElement.elementType in RS_DOC_COMMENTS
+}
+
+val RsFile.isDoctestInjection: Boolean
+    get() = virtualFile?.isDoctestInjection(project) == true
+
+val RsElement.isDoctestInjection: Boolean
+    get() = (contextualFile as? RsFile)?.isDoctestInjection == true

--- a/src/main/kotlin/org/rust/ide/injected/RsSimpleMultiLineEscaper.kt
+++ b/src/main/kotlin/org/rust/ide/injected/RsSimpleMultiLineEscaper.kt
@@ -1,0 +1,24 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.injected
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.LiteralTextEscaper
+import com.intellij.psi.PsiLanguageInjectionHost
+
+/** Same as [com.intellij.psi.LiteralTextEscaper.createSimple], but multi line */
+class RsSimpleMultiLineEscaper<T: PsiLanguageInjectionHost>(host: T) : LiteralTextEscaper<T>(host) {
+    override fun decode(rangeInsideHost: TextRange, outChars: java.lang.StringBuilder): Boolean {
+        outChars.append(rangeInsideHost.substring(myHost.text))
+        return true
+    }
+
+    override fun getOffsetInHost(offsetInDecoded: Int, rangeInsideHost: TextRange): Int {
+        return rangeInsideHost.startOffset + offsetInDecoded
+    }
+
+    override fun isOneLine(): Boolean = false
+}

--- a/src/main/kotlin/org/rust/ide/injected/RsStringLiteralEscaper.kt
+++ b/src/main/kotlin/org/rust/ide/injected/RsStringLiteralEscaper.kt
@@ -11,7 +11,6 @@ import org.rust.lang.core.psi.RS_ALL_STRING_LITERALS
 import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.psi.RsLitExpr
 import org.rust.lang.utils.parseRustStringCharacters
-import java.lang.StringBuilder
 
 /** See [com.intellij.psi.impl.source.tree.injected.StringLiteralEscaper] */
 private class RsNormalStringLiteralEscaper(host: RsLitExpr) : LiteralTextEscaper<RsLitExpr>(host) {
@@ -37,25 +36,11 @@ private class RsNormalStringLiteralEscaper(host: RsLitExpr) : LiteralTextEscaper
     override fun isOneLine(): Boolean = false
 }
 
-/** See [com.intellij.psi.LiteralTextEscaper.createSimple] */
-private class RsRawStringLiteralEscaper(host: RsLitExpr) : LiteralTextEscaper<RsLitExpr>(host) {
-    override fun decode(rangeInsideHost: TextRange, outChars: StringBuilder): Boolean {
-        outChars.append(rangeInsideHost.substring(myHost.text))
-        return true
-    }
-
-    override fun getOffsetInHost(offsetInDecoded: Int, rangeInsideHost: TextRange): Int {
-        return rangeInsideHost.startOffset + offsetInDecoded
-    }
-
-    override fun isOneLine(): Boolean = false
-}
-
 fun escaperForLiteral(lit: RsLitExpr): LiteralTextEscaper<RsLitExpr> {
     val elementType = lit.node.findChildByType(RS_ALL_STRING_LITERALS)?.elementType
     val isRaw = elementType == RAW_STRING_LITERAL || elementType == RAW_BYTE_STRING_LITERAL
     assert(isRaw || elementType == STRING_LITERAL || elementType == BYTE_STRING_LITERAL) {
         "`${lit.text}` is not a string literal"
     }
-    return if (isRaw) RsRawStringLiteralEscaper(lit) else RsNormalStringLiteralEscaper(lit)
+    return if (isRaw) RsSimpleMultiLineEscaper(lit) else RsNormalStringLiteralEscaper(lit)
 }

--- a/src/main/kotlin/org/rust/ide/typing/RsEnterInLineCommentHandler.kt
+++ b/src/main/kotlin/org/rust/ide/typing/RsEnterInLineCommentHandler.kt
@@ -7,6 +7,7 @@ package org.rust.ide.typing
 
 import com.intellij.codeInsight.editorActions.enter.EnterHandlerDelegate.Result
 import com.intellij.codeInsight.editorActions.enter.EnterHandlerDelegateAdapter
+import com.intellij.injected.editor.EditorWindow
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.actionSystem.EditorActionHandler
@@ -16,6 +17,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.TokenType.WHITE_SPACE
 import com.intellij.util.text.CharArrayUtil
+import org.rust.ide.injected.isDoctestInjection
 import org.rust.lang.core.parser.RustParserDefinition.Companion.EOL_COMMENT
 import org.rust.lang.core.parser.RustParserDefinition.Companion.INNER_EOL_DOC_COMMENT
 import org.rust.lang.core.parser.RustParserDefinition.Companion.OUTER_EOL_DOC_COMMENT
@@ -37,6 +39,9 @@ class RsEnterInLineCommentHandler : EnterHandlerDelegateAdapter() {
         if (file !is RsFile) {
             return Result.Continue
         }
+
+        // Any indent handling in doctest injections is disabled for now due to some bugs
+        if (editor is EditorWindow && file.isDoctestInjection) return Result.DefaultSkipIndent
 
         // get current document and commit any changes, so we'll get latest PSI
         val document = editor.document

--- a/src/main/kotlin/org/rust/lang/core/RsASTFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsASTFactory.kt
@@ -1,0 +1,20 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core
+
+import com.intellij.core.CoreASTFactory
+import com.intellij.psi.impl.source.tree.LeafElement
+import com.intellij.psi.impl.source.tree.PsiCommentImpl
+import com.intellij.psi.tree.IElementType
+import org.rust.lang.core.psi.RS_DOC_COMMENTS
+import org.rust.lang.core.psi.RsDocCommentImpl
+
+class RsASTFactory : CoreASTFactory() {
+    override fun createComment(type: IElementType, text: CharSequence): LeafElement {
+        return if (type in RS_DOC_COMMENTS) RsDocCommentImpl(type, text) else PsiCommentImpl(type, text)
+    }
+}
+

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -17,7 +17,7 @@ import com.intellij.util.ProcessingContext
 import org.rust.ide.inspections.import.AutoImportFix
 import org.rust.ide.inspections.import.ImportCandidate
 import org.rust.ide.inspections.import.ImportContext
-import org.rust.ide.inspections.import.importItem
+import org.rust.ide.inspections.import.import
 import org.rust.ide.settings.RsCodeInsightSettings
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -151,7 +151,7 @@ object RsCommonCompletionProvider : CompletionProvider<CompletionParameters>() {
                             super.handleInsert(element, scopeName, context, item)
                             context.commitDocument()
                             if (RsCodeInsightSettings.getInstance().importOutOfScopeItems) {
-                                context.containingMod?.importItem(candidate)
+                                context.containingMod?.let { candidate.import(it) }
                             }
                         }
                     })
@@ -264,7 +264,7 @@ private fun methodAndFieldCompletionProcessor(
                     super.handleInsert(element, scopeName, context, item)
                     context.commitDocument()
                     if (traitImportCandidate != null) {
-                        context.containingMod?.importItem(traitImportCandidate)
+                        context.containingMod?.let { traitImportCandidate.import(it) }
                     }
                 }
             }))

--- a/src/main/kotlin/org/rust/lang/core/psi/RsDocCommentImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsDocCommentImpl.kt
@@ -1,0 +1,83 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+import com.intellij.psi.LiteralTextEscaper
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.PsiLanguageInjectionHost
+import com.intellij.psi.impl.source.tree.PsiCoreCommentImpl
+import com.intellij.psi.impl.source.tree.injected.InjectionBackgroundSuppressor
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.text.CharArrayUtil
+import org.rust.ide.annotator.RsDoctestAnnotator
+import org.rust.ide.injected.RsDoctestLanguageInjector
+import org.rust.ide.injected.RsSimpleMultiLineEscaper
+import org.rust.lang.doc.psi.RsDocKind
+
+/**
+ * Psi element for rust documentation comments. Provides specific behavior for
+ * language injections (see [RsDoctestLanguageInjector]).
+ * [InjectionBackgroundSuppressor] is used to disable builtin background highlighting for injection.
+ * We create such background manually by [RsDoctestAnnotator] (see the class docs)
+ */
+class RsDocCommentImpl(type: IElementType, text: CharSequence) : PsiCoreCommentImpl(type, text),
+                                                                 PsiLanguageInjectionHost,
+                                                                 InjectionBackgroundSuppressor {
+    override fun isValidHost(): Boolean = true
+
+    /**
+     * Handles changes in PSI injected to the comment (see [RsDoctestLanguageInjector]).
+     * It is not used on typing. Instead, it's used on direct PSI changes (performed by
+     * intentions/quick fixes).
+     *
+     * Each line of doc comment should start with some prefix (see [RsDocKind.infix]). For example, with `///`.
+     * But if some intention inserts newline to PSI, there will not be such prefix after that newline.
+     * Here we insure that every comment line is started from appropriate prefix
+     */
+    override fun updateText(text: String): PsiLanguageInjectionHost {
+        val docKind = RsDocKind.of(elementType)
+        val infix = docKind.infix
+
+        val newText = StringBuilder()
+        var prevIndent = ""
+        var index = 0
+        while (index < text.length) {
+            val linebreakIndex = text.indexOf("\n", index)
+            if (linebreakIndex == -1) {
+                newText.append(text, index, text.length)
+                break
+            } else {
+                val nextLineStart = linebreakIndex + 1
+                newText.append(text, index, nextLineStart)
+                index = nextLineStart
+
+                val firstNonWhitespace = CharArrayUtil.shiftForward(text, nextLineStart, " \t")
+                if (firstNonWhitespace == text.length) continue
+                val isStartCorrect = text.startsWith(infix, firstNonWhitespace) ||
+                    docKind.isBlock && text.startsWith("*/", firstNonWhitespace)
+                if (!isStartCorrect) {
+                    newText.append(prevIndent)
+                    newText.append(infix)
+                    newText.append(" ")
+                } else {
+                    prevIndent = text.substring(nextLineStart, firstNonWhitespace)
+                }
+            }
+        }
+
+        // There are some problems with indentation if we just use replaceWithText(text).
+        // copied from PsiCommentManipulator
+        val type = containingFile.fileType
+        val fromText = PsiFileFactory.getInstance(project).createFileFromText("__." + type.defaultExtension, type, newText)
+        val newElement = PsiTreeUtil.getParentOfType(fromText.findElementAt(0), javaClass, false)
+            ?: error(type.toString() + " " + type.defaultExtension + " " + newText)
+        return replace(newElement) as RsDocCommentImpl
+    }
+
+    override fun createLiteralTextEscaper(): LiteralTextEscaper<RsDocCommentImpl> =
+        RsSimpleMultiLineEscaper(this)
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -15,6 +15,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiModificationTracker
+import org.rust.ide.injected.isDoctestInjection
 import org.rust.lang.RsConstants
 import org.rust.lang.RsFileType
 import org.rust.lang.RsLanguage
@@ -65,6 +66,11 @@ class RsFile(
 
     override val isCrateRoot: Boolean
         get() {
+            // Doctest injection file should be a crate root to resolve absolute paths inside injection.
+            // Doctest contains a single "extern crate $crateName;" declaration at the top level, so
+            // we should be able to resolve it by absolute path
+            if (originalFile.isDoctestInjection) return true
+
             val file = originalFile.virtualFile ?: return false
             return cargoWorkspace?.isCrateRoot(file) ?: false
         }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -46,11 +46,13 @@
 
         <lang.parserDefinition language="Rust" implementationClass="org.rust.lang.core.parser.RustParserDefinition"/>
         <stubElementTypeHolder class="org.rust.lang.core.psi.RsElementTypes"/>
+        <lang.ast.factory language="Rust" implementationClass="org.rust.lang.core.RsASTFactory"/>
 
         <!-- Code insight settings -->
 
         <applicationService serviceInterface="org.rust.ide.settings.RsCodeInsightSettings"
                             serviceImplementation="org.rust.ide.settings.RsCodeInsightSettings"/>
+        <editorActionHandler action="EditorEnter" implementationClass="org.rust.ide.actions.RsEnterHandler"/>
 
         <!-- Selection Handler -->
 
@@ -162,6 +164,7 @@
 
         <!-- Annotator -->
 
+        <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsDoctestAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsSyntaxErrorsAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsEdition2018KeywordsAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsLiteralAnnotator"/>
@@ -757,6 +760,7 @@
         <lang.elementManipulator forClass="org.rust.lang.core.psi.RsLitExpr"
                                  implementationClass="org.rust.ide.injected.RsStringLiteralManipulator"/>
         <multiHostInjector implementation="org.rust.ide.injected.RsRegExpInjector"/>
+        <multiHostInjector implementation="org.rust.ide.injected.RsDoctestLanguageInjector"/>
 
 
         <projectService serviceImplementation="org.rust.lang.core.resolve.ref.RsResolveCache"/>

--- a/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
@@ -25,6 +25,7 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
             <State>
               <option name="autoUpdateEnabled" value="false" />
               <option name="compileAllTargets" value="false" />
+              <option name="doctestInjectionEnabled" value="false" />
               <option name="expandMacros" value="false" />
               <option name="explicitPathToStdlib" value="/stdlib" />
               <option name="showTestToolWindow" value="false" />
@@ -52,6 +53,7 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
             useOffline = true,
             expandMacros = false,
             showTestToolWindow = false,
+            doctestInjectionEnabled = false,
             useSkipChildren = true
         ))
     }

--- a/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestBase.kt
@@ -101,6 +101,17 @@ abstract class RsAnnotationTestBase : RsTestBase() {
         checkAfter = this::checkByFileTree,
         testmark = testmark)
 
+    protected fun checkFixByFileTreeWithoutHighlighting(
+        fixName: String,
+        @Language("Rust") before: String,
+        @Language("Rust") after: String,
+        testmark: Testmark? = null
+    ) = checkFix(fixName, before, after,
+        configure = this::configureByFileTree,
+        checkBefore = {},
+        checkAfter = this::checkByFileTree,
+        testmark = testmark)
+
     protected fun checkFixIsUnavailable(
         fixName: String,
         @Language("Rust") text: String,

--- a/src/test/kotlin/org/rust/ide/annotator/RsDoctestAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsDoctestAnnotatorTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+import org.rust.ProjectDescriptor
+import org.rust.WithDependencyRustProjectDescriptor
+
+@ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+class RsDoctestAnnotatorTest : RsAnnotatorTestBase(RsDoctestAnnotator::class.java) {
+    fun `test no injection 1`() = doTest("""
+        |/// ``` ```
+        |fn foo() {}
+        |""")
+
+    fun `test no injection 2`() = doTest("""
+        |/// ```
+        |/// ```
+        |fn foo() {}
+        |""")
+
+    fun `test single line injection`() = doTest("""
+        |/// ```
+        |///<info> <inject>let a = 0;
+        |</inject></info>/// ```
+        |fn foo() {}
+        |""")
+
+    fun `test multi line injection`() = doTest("""
+        |/// ```
+        |///<info> <inject>let a = 0;
+        |</inject></info>///<info> <inject>let b = 0;
+        |</inject></info>/// ```
+        |fn foo() {}
+        |""")
+
+    fun `test multi line injection with empty line`() = doTest("""
+        |/// ```
+        |///<info> <inject>let a = 0;
+        |</inject></info>///<info>
+        |</info>///<info> <inject>let a = 0;
+        |</inject></info>/// ```
+        |fn foo() {}
+        |""")
+
+    fun `test acceptable "lang" string`() = doTest("""
+        |/// ```rust, allow_fail, should_panic, no_run, test_harness, edition2018, edition2015
+        |///<info> <inject>let a = 0;
+        |</inject></info>/// ```
+        |fn foo() {}
+        |""")
+
+    fun `test no injection with unacceptable "lang" string`() = doTest("""
+        |/// ```foobar
+        |///let a = 0;
+        |/// ```
+        |fn foo() {}
+        |""")
+
+    fun `test no injection with unacceptable "lang" string contain acceptable parts`() = doTest("""
+        |/// ```rust, foobar
+        |///let a = 0;
+        |/// ```
+        |fn foo() {}
+        |""")
+
+    fun `test no injection in non-lib target`() = checkByText("""
+        /// ```
+        /// let a = 0;
+        /// ```
+        fn foo() {}
+    """, checkInfo = true)
+
+    fun doTest(code: String) = checkByFileTree(
+        "//- lib.rs\n/*caret*/${code.trimMargin()}",
+        checkWarn = false,
+        checkInfo = true,
+        checkWeakWarn = false,
+        ignoreExtraHighlighting = false
+    )
+}

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt
@@ -27,6 +27,12 @@ abstract class AutoImportFixTestBase : RsInspectionsTestBase(RsUnresolvedReferen
         testmark: Testmark? = null
     ) = doTest { checkFixByFileTree(AutoImportFix.NAME, before, after, testmark = testmark) }
 
+    protected fun checkAutoImportFixByFileTreeWithouHighlighting(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String,
+        testmark: Testmark? = null
+    ) = doTest { checkFixByFileTreeWithoutHighlighting(AutoImportFix.NAME, before, after, testmark = testmark) }
+
     protected fun checkAutoImportFixByTextWithMultipleChoice(
         @Language("Rust") before: String,
         expectedElements: Set<String>,

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve
+
+import org.rust.ProjectDescriptor
+import org.rust.WithDependencyRustProjectDescriptor
+import org.rust.WithStdlibAndDependencyRustProjectDescriptor
+
+class RsDoctestInjectionResolveTest : RsResolveTestBase() {
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test resolve outer element`() = checkByCode("""
+        /// ```
+        /// use test_package::foo;
+        /// foo();
+        /// //^
+        /// ```
+        pub fn foo() {}
+         //X
+    """, "lib.rs")
+
+    @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
+    fun `test resolve std element`() = stubOnlyResolve("""
+    //- lib.rs
+        /// ```
+        /// Vec::new()
+        /// //^ ...vec.rs
+        /// ```
+        pub fn foo() {}
+    """)
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test outer crate dependency is not resolved`() = checkByCode("""
+        /// ```
+        /// extern crate dep_lib_target;
+        ///             //^ unresolved
+        /// ```
+        pub fn foo() {}
+    """, "lib.rs")
+}

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
@@ -22,12 +22,17 @@ import org.rust.lang.core.resolve.ref.RsReference
 import org.rust.openapiext.Testmark
 
 abstract class RsResolveTestBase : RsTestBase() {
-
     protected open fun checkByCode(@Language("Rust") code: String) =
-        checkByCodeGeneric<RsNamedElement>(code)
+        checkByCode(code, "main.rs")
 
-    protected inline fun <reified T : NavigatablePsiElement> checkByCodeGeneric(@Language("Rust") code: String) {
-        InlineFile(code)
+    protected open fun checkByCode(@Language("Rust") code: String, fileName: String) =
+        checkByCodeGeneric<RsNamedElement>(code, fileName)
+
+    protected inline fun <reified T : NavigatablePsiElement> checkByCodeGeneric(
+        @Language("Rust") code: String,
+        fileName: String = "main.rs"
+    ) {
+        InlineFile(code, fileName)
 
         val (refElement, data, offset) = findElementWithDataAndOffsetInEditor<RsWeakReferenceElement>("^")
 


### PR DESCRIPTION
We now thinking about code inside Rust doctests as if it is a valid Rust code, with all IDE intelligence like highlighting, completion, intentions, linting, etc.
![image](https://user-images.githubusercontent.com/3221931/49857141-d44ce900-fe02-11e8-82ca-1aed45472bf9.png)

Unresolved questions:
- postprocess reformatting is not work in injections. It means that after the most of intentions/quickfixes the code will not be formatted and so will looks ugly. Should we disable intentions/quickfixes inside injections because of this? (I think we can ignore it for now, and then fix something in the platform)
- some intentions/quickfixes can edit PSI outside of injection that leads to crashes. But I think it is smaller part of them, and we can disable specific actions if they will not work.
- Typing enter inside injections does not insert an indent at the next line. 

About testing: This is mostly manually tested. There are tests for reference resolution and auto-import inside injection. Injection ranges are not tested (looks too complex to test). RsEnterHandler is not tested too (fixture API ignores injections while typing).

Closes #618