### PR TITLE
INT: Fix 'if let to match' intention

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/FillMatchArmsIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/FillMatchArmsIntention.kt
@@ -11,7 +11,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.util.containers.isNullOrEmpty
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorStrict
-import org.rust.lang.core.resolve.knownItems
+import org.rust.lang.core.psi.ext.isStdOptionOrResult
 import org.rust.lang.core.types.ty.TyAdt
 import org.rust.lang.core.types.type
 
@@ -25,7 +25,7 @@ class FillMatchArmsIntention : RsElementBaseIntentionAction<FillMatchArmsIntenti
         if (!matchExpr.matchBody?.matchArmList.isNullOrEmpty()) return null
         val item = (matchExpr.expr?.type as? TyAdt)?.item as? RsEnumItem ?: return null
         // TODO: check enum variants can be used without enum name qualifier
-        val name = if (!isStdOptionOrResult(item)) {
+        val name = if (!item.isStdOptionOrResult) {
             item.name ?: return null
         } else null
         val variants = item.enumBody?.enumVariantList ?: return null
@@ -49,13 +49,6 @@ class FillMatchArmsIntention : RsElementBaseIntentionAction<FillMatchArmsIntenti
         val lbraceOffset = (body.matchArmList.firstOrNull()?.expr as? RsBlockExpr)
             ?.block?.lbrace?.textOffset ?: return
         editor.caretModel.moveToOffset(lbraceOffset + 1)
-    }
-
-    private fun isStdOptionOrResult(element: RsEnumItem): Boolean {
-        val knownItems = element.knownItems
-        val option = knownItems.Option
-        val result = knownItems.Result
-        return element == option || element == result
     }
 
     data class Context(

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumItem.kt
@@ -12,6 +12,7 @@ import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.RsEnumItem
 import org.rust.lang.core.psi.RsPsiImplUtil
+import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.stubs.RsEnumItemStub
 import org.rust.lang.core.types.RsPsiTypeImplUtil
 import org.rust.lang.core.types.ty.Ty
@@ -34,4 +35,11 @@ abstract class RsEnumItemImplMixin : RsStubbedNamedElementImpl<RsEnumItemStub>, 
     override val declaredType: Ty get() = RsPsiTypeImplUtil.declaredType(this)
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
+}
+
+val RsEnumItem.isStdOptionOrResult: Boolean get() {
+    val knownItems = knownItems
+    val option = knownItems.Option
+    val result = knownItems.Result
+    return this == option || this == result
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPat.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPat.kt
@@ -1,0 +1,20 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi.ext
+
+import org.rust.lang.core.psi.*
+
+val RsPat.isIrrefutable: Boolean
+    get() = when (this) {
+        is RsPatTupleStruct -> patList.all { it.isIrrefutable }
+        is RsPatSlice -> patList.all { it.isIrrefutable }
+        is RsPatTup -> patList.all { it.isIrrefutable }
+        is RsPatBox -> pat.isIrrefutable
+        is RsPatRef -> pat.isIrrefutable
+        is RsPatStruct -> patFieldList.all { it.pat?.isIrrefutable ?: it.patBinding != null }
+        is RsPatConst, is RsPatRange -> false
+        else -> true
+    }

--- a/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt
@@ -5,104 +5,555 @@
 
 package org.rust.ide.intentions
 
-class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention()) {
-    fun `test simple`() = doAvailableTest("""
-    fn main() {
-        if let Some(value) = x {/*caret*/
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention()) {
+    fun `test option with some`() = doAvailableTest("""
+        fn main() {
+            let x = Some(42);
+            if let Some(value) = x {/*caret*/
+                println!("some")
+            }
         }
-    }
     """, """
-    fn main() {
-        match x {
-            Some(value) => {}
+        fn main() {
+            let x = Some(42);
+            match x {
+                Some(value) => {
+                    println!("some")
+                }
+                None => {}
+            }
         }
-    }
+    """)
+
+    fun `test option with refutable some`() = doAvailableTest("""
+        fn main() {
+            let x = Some(42);
+            if let Some(42) = x {/*caret*/
+                println!("some")
+            }
+        }
+    """, """
+        fn main() {
+            let x = Some(42);
+            match x {
+                Some(42) => {
+                    println!("some")
+                }
+                _ => {}
+            }
+        }
+    """)
+
+    fun `test option with wild some`() = doAvailableTest("""
+        fn main() {
+            let x = Some(42);
+            if let Some(_) = x {/*caret*/
+                println!("some")
+            }
+        }
+    """, """
+        fn main() {
+            let x = Some(42);
+            match x {
+                Some(_) => {
+                    println!("some")
+                }
+                None => {}
+            }
+        }
+    """)
+
+    fun `test option with range`() = doAvailableTest("""
+        fn main() {
+            let x = Some(42);
+            if let Some(1..=5) = x {/*caret*/
+                println!("some")
+            }
+        }
+    """, """
+        fn main() {
+            let x = Some(42);
+            match x {
+                Some(1..=5) => {
+                    println!("some")
+                }
+                _ => {}
+            }
+        }
+    """)
+
+    fun `test option with none`() = doAvailableTest("""
+        fn main() {
+            let x = Some(42);
+            if let None = x {/*caret*/
+                println!("none")
+            }
+        }
+    """, """
+        fn main() {
+            let x = Some(42);
+            match x {
+                None => {
+                    println!("none")
+                }
+                Some(..) => {}
+            }
+        }
+    """)
+
+    fun `test option full 1`() = doAvailableTest("""
+        fn main() {
+            let x = Some(42);
+            if let Some(value) = x {/*caret*/
+                println!("some")
+            } else {
+                println!("none")
+            }
+        }
+    """, """
+        fn main() {
+            let x = Some(42);
+            match x {
+                Some(value) => {
+                    println!("some")
+                }
+                None => {
+                    println!("none")
+                }
+            }
+        }
+    """)
+
+    fun `test option full 2`() = doAvailableTest("""
+        fn main() {
+            let x = Some(42);
+            if let None = x {/*caret*/
+                println!("none")
+            } else {
+                println!("some")
+            }
+        }
+    """, """
+        fn main() {
+            let x = Some(42);
+            match x {
+                None => {
+                    println!("none")
+                }
+                Some(..) => {
+                    println!("some")
+                }
+            }
+        }
+    """)
+
+    fun `test result with ok`() = doAvailableTest("""
+        fn main() {
+            let x: Result<i32, i32> = Ok(42);
+            if let Ok(value) = x {/*caret*/
+                println!("ok")
+            }
+        }
+    """, """
+        fn main() {
+            let x: Result<i32, i32> = Ok(42);
+            match x {
+                Ok(value) => {
+                    println!("ok")
+                }
+                Err(..) => {}
+            }
+        }
+    """)
+
+    fun `test result with err`() = doAvailableTest("""
+        fn main() {
+            let x: Result<i32, i32> = Err(42);
+            if let Err(e) = x {/*caret*/
+                println!("err")
+            }
+        }
+    """, """
+        fn main() {
+            let x: Result<i32, i32> = Err(42);
+            match x {
+                Err(e) => {
+                    println!("err")
+                }
+                Ok(..) => {}
+            }
+        }
+    """)
+
+    fun `test result full 1`() = doAvailableTest("""
+        fn main() {
+            let x: Result<i32, i32> = Ok(42);
+            if let Ok(value) = x {/*caret*/
+                println!("ok")
+            } else {
+                println!("err")
+            }
+        }
+    """, """
+        fn main() {
+            let x: Result<i32, i32> = Ok(42);
+            match x {
+                Ok(value) => {
+                    println!("ok")
+                }
+                Err(..) => {
+                    println!("err")
+                }
+            }
+        }
+    """)
+
+    fun `test result full 2`() = doAvailableTest("""
+        fn main() {
+            let x: Result<i32, i32> = Ok(42);
+            if let Err(e) = x {/*caret*/
+                println!("err")
+            } else {
+                println!("ok")
+            }
+        }
+    """, """
+        fn main() {
+            let x: Result<i32, i32> = Ok(42);
+            match x {
+                Err(e) => {
+                    println!("err")
+                }
+                Ok(..) => {
+                    println!("ok")
+                }
+            }
+        }
     """)
 
     fun `test simple else`() = doAvailableTest("""
-    fn main() {
-        if let Some(val) = x {
+        fn main() {
+            let x = Some(42);
+            if let Some(val) = x {
 
-        } else {
-            /*caret*/
+            } else {/*caret*/
+                println!("it work")
+            }
         }
-    }
     """, """
-    fn main() {
-        match x {
-            Some(val) => {},
-            _ => {}
+        fn main() {
+            let x = Some(42);
+            match x {
+                Some(val) => {}
+                None => {
+                    println!("it work")
+                }
+            }
         }
-    }
     """)
 
     fun `test else if`() = doAvailableTest("""
-    fn main() {
-        if let A(value) = x {
+        fn main() {
+            if let A(value) = x {
 
-        } else if let B(value) = x {
-            /*caret*/
+            } else if let B(value) = x {
+                /*caret*/
+            }
         }
-    }
     """, """
-    fn main() {
-        match x {
-            A(value) => {},
-            B(value) => {}
+        fn main() {
+            match x {
+                A(value) => {}
+                B(value) => {}
+                _ => {}
+            }
         }
-    }
+    """)
+
+    fun `test full option else if`() = doAvailableTest("""
+        fn main() {
+            let x = Some(42);
+            if let Some(value) = x {
+                println!("some")
+            } else if let None = x {
+                /*caret*/println!("none")
+            }
+        }
+    """, """
+        fn main() {
+            let x = Some(42);
+            match x {
+                Some(value) => {
+                    println!("some")
+                }
+                None => {
+                    println!("none")
+                }
+            }
+        }
+    """)
+
+    fun `test full result else if`() = doAvailableTest("""
+        fn main() {
+            let x: Result<i32, i32> = Ok(42);
+            if let Ok(value) = x {
+                println!("ok")
+            } else if let Err(e) = x {
+                /*caret*/println!("err")
+            }
+        }
+    """, """
+        fn main() {
+            let x: Result<i32, i32> = Ok(42);
+            match x {
+                Ok(value) => {
+                    println!("ok")
+                }
+                Err(e) => {
+                    println!("err")
+                }
+            }
+        }
     """)
 
     fun `test else if else`() = doAvailableTest("""
-    fn main() {
-        if let A(value) = x {
-            /*caret*/
-        } else if let B(value) = x {
+        fn main() {
+            if let A(value) = x {
+                /*caret*/
+            } else if let B(value) = x {
 
-        } else {
+            } else {
 
+            }
         }
-    }
     """, """
-    fn main() {
-        match x {
-            A(value) => {},
-            B(value) => {},
-            _ => {}
+        fn main() {
+            match x {
+                A(value) => {}
+                B(value) => {}
+                _ => {}
+            }
         }
-    }
-    """
-    )
+    """)
 
     fun `test trackback if`() = doAvailableTest("""
-    fn main() {
-        if let A(value) = x {
+        fn main() {
+            if let A(value) = x {
 
-        } else if let B(value) = x {
-            /*caret*/
-        } else {
+            } else if let B(value) = x {
+                /*caret*/
+            } else {
 
+            }
         }
-    }
     """, """
-    fn main() {
-        match x {
-            A(value) => {},
-            B(value) => {},
-            _ => {}
+        fn main() {
+            match x {
+                A(value) => {}
+                B(value) => {}
+                _ => {}
+            }
         }
-    }
-    """
-    )
+    """)
 
     fun `test apply on same target`() = doUnavailableTest("""
-    fn main() {
-        if let A(value) = x {
+        fn main() {
+            if let A(value) = x {
 
-        } else if let B(value) = y {
-            /*caret*/
+            } else if let B(value) = y {
+                /*caret*/
+            }
         }
-    }
+    """)
+
+    fun `test available with range`() = doAvailableTest("""
+        fn main() {
+            let e = 4;
+            if let 1..=5 = e {/*caret*/
+                println!("got {}", e)
+            };
+        }
+    """, """
+        fn main() {
+            let e = 4;
+            match e {
+                1..=5 => {
+                    println!("got {}", e)
+                }
+                _ => {}
+            };
+        }
+    """)
+
+    fun `test available with const`() = doAvailableTest("""
+        fn main() {
+            let e = 4;
+            if let 4 = e {/*caret*/
+                println!("got {}", e)
+            };
+        }
+    """, """
+        fn main() {
+            let e = 4;
+            match e {
+                4 => {
+                    println!("got {}", e)
+                }
+                _ => {}
+            };
+        }
+    """)
+
+    fun `test available with struct`() = doAvailableTest("""
+        struct Point {
+            x: bool,
+            y: bool,
+        }
+        fn main() {
+            let point = Point { x: false, y: true };
+            if let Point { x: true, .. } = point {/*caret*/
+                println!("42")
+            }
+        }
+    """, """
+        struct Point {
+            x: bool,
+            y: bool,
+        }
+        fn main() {
+            let point = Point { x: false, y: true };
+            match point {
+                Point { x: true, .. } => {
+                    println!("42")
+                }
+                _ => {}
+            }
+        }
+    """)
+
+    fun `test available with struct 2`() = doAvailableTest("""
+        struct Point {
+            x: bool,
+            y: bool,
+        }
+        fn main() {
+            let point = Point { x: false, y: true };
+            if let Point { x: true, y: f } = point {/*caret*/
+                println!("42")
+            }
+        }
+    """, """
+        struct Point {
+            x: bool,
+            y: bool,
+        }
+        fn main() {
+            let point = Point { x: false, y: true };
+            match point {
+                Point { x: true, y: f } => {
+                    println!("42")
+                }
+                _ => {}
+            }
+        }
+    """)
+
+    fun `test available pattern with tup`() = doAvailableTest("""
+        fn main() {
+            let e = Some(32);
+            if let (Some(42)) = e {/*caret*/
+                println!("got {:?}", a)
+            }
+        }
+    """, """
+        fn main() {
+            let e = Some(32);
+            match e {
+                (Some(42)) => {
+                    println!("got {:?}", a)
+                }
+                _ => {}
+            }
+        }
+    """)
+
+    fun `test available pattern with tup 2`() = doAvailableTest("""
+        fn main() {
+            let e = (42, 50);
+            if let (a, 50) = e {/*caret*/
+                println!("got {:?}", a)
+            }
+        }
+    """, """
+        fn main() {
+            let e = (42, 50);
+            match e {
+                (a, 50) => {
+                    println!("got {:?}", a)
+                }
+                _ => {}
+            }
+        }
+    """)
+
+    fun `test available with slice`() = doAvailableTest("""
+        fn main() {
+            let x = [1, 2];
+            if let [1, ..] = x {/*caret*/
+                println!("42")
+            }
+        }
+    """, """
+        fn main() {
+            let x = [1, 2];
+            match x {
+                [1, ..] => {
+                    println!("42")
+                }
+                _ => {}
+            }
+        }
+    """)
+
+    fun `test available with box`() = doAvailableTest("""
+        fn main() {
+            let x = box 42;
+            if let box 42 = x {/*caret*/
+                println!("42")
+            }
+        }
+    """, """
+        fn main() {
+            let x = box 42;
+            match x {
+                box 42 => {
+                    println!("42")
+                }
+                _ => {}
+            }
+        }
+    """)
+
+    fun `test available with ref`() = doAvailableTest("""
+        fn main() {
+            let x = &42;
+            if let &42 = x {/*caret*/
+                println!("42")
+            }
+        }
+    """, """
+        fn main() {
+            let x = &42;
+            match x {
+                &42 => {
+                    println!("42")
+                }
+                _ => {}
+            }
+        }
     """)
 }


### PR DESCRIPTION
Maybe we should generate a wild arm in the absence of else branch? Now the absence of this arm leads to an error [E0004](https://doc.rust-lang.org/error-index.html#E0004). 