### PR TITLE
ANN: improve annotator highlighting

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsAnnotatorBase.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsAnnotatorBase.kt
@@ -1,0 +1,36 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.util.Disposer
+import com.intellij.psi.PsiElement
+import com.intellij.util.containers.ContainerUtil
+import org.jetbrains.annotations.TestOnly
+import org.rust.openapiext.isUnitTestMode
+
+abstract class RsAnnotatorBase : Annotator {
+
+    final override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        if (!isUnitTestMode || javaClass in enabledAnnotators) {
+            annotateInternal(element, holder)
+        }
+    }
+
+    protected abstract fun annotateInternal(element: PsiElement, holder: AnnotationHolder)
+
+    companion object {
+        private val enabledAnnotators: MutableSet<Class<out RsAnnotatorBase>> = ContainerUtil.newConcurrentSet()
+
+        @TestOnly
+        fun enableAnnotator(annotatorClass: Class<out RsAnnotatorBase>, parentDisposable: Disposable) {
+            enabledAnnotators += annotatorClass
+            Disposer.register(parentDisposable, Disposable { enabledAnnotators -= annotatorClass })
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotator.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.annotator
 
 import com.intellij.lang.annotation.AnnotationHolder
-import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.colors.RsColor
@@ -16,8 +15,8 @@ import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.elementType
 import org.rust.lang.core.psi.ext.isEdition2018
 
-class RsEdition2018KeywordsAnnotator : Annotator {
-    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+class RsEdition2018KeywordsAnnotator : RsAnnotatorBase() {
+    override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         if (!isEdition2018Keyword(element)) return
 
         val isEdition2018 = element.isEdition2018

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -9,7 +9,6 @@ import com.intellij.codeInsight.daemon.impl.HighlightRangeExtension
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.AnnotationSession
-import com.intellij.lang.annotation.Annotator
 import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -39,10 +38,10 @@ import org.rust.lang.utils.RsDiagnostic
 import org.rust.lang.utils.RsErrorCode
 import org.rust.lang.utils.addToHolder
 
-class RsErrorAnnotator : Annotator, HighlightRangeExtension {
+class RsErrorAnnotator : RsAnnotatorBase(), HighlightRangeExtension {
     override fun isForceHighlightParents(file: PsiFile): Boolean = file is RsFile
 
-    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+    override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         val visitor = object : RsVisitor() {
             override fun visitBaseType(o: RsBaseType) = checkBaseType(holder, o)
             override fun visitConstant(o: RsConstant) = checkConstant(holder, o)

--- a/src/main/kotlin/org/rust/ide/annotator/RsExpressionAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExpressionAnnotator.kt
@@ -7,7 +7,6 @@ package org.rust.ide.annotator
 
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.lang.annotation.AnnotationHolder
-import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import com.intellij.util.SmartList
 import org.rust.ide.annotator.fixes.AddStructFieldsFix
@@ -17,9 +16,8 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ref.deepResolve
 import java.util.*
 
-
-class RsExpressionAnnotator : Annotator {
-    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+class RsExpressionAnnotator : RsAnnotatorBase() {
+    override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         element.accept(RedundantParenthesisVisitor(holder))
         if (element is RsStructLiteral) {
             val decl = element.path.reference.deepResolve() as? RsFieldsOwner

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -7,6 +7,7 @@ package org.rust.ide.annotator
 
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import org.rust.ide.colors.RsColor
@@ -14,6 +15,7 @@ import org.rust.ide.highlight.RsHighlighter
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyPrimitive
+import org.rust.openapiext.isUnitTestMode
 
 // Highlighting logic here should be kept in sync with tags in RustColorSettingsPage
 class RsHighlightingAnnotator : Annotator {
@@ -26,7 +28,8 @@ class RsHighlightingAnnotator : Annotator {
             else -> highlightNotReference(element)
         } ?: return
 
-        holder.createInfoAnnotation(partToHighlight, null).textAttributes = color.textAttributesKey
+        val severity = if (isUnitTestMode) color.testSeverity else HighlightSeverity.INFORMATION
+        holder.createAnnotation(severity, partToHighlight, null).textAttributes = color.textAttributesKey
     }
 
     private fun highlightReference(element: RsReferenceElement): Pair<TextRange, RsColor>? {

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -24,6 +24,7 @@ class RsHighlightingAnnotator : Annotator {
         val (partToHighlight, color) = when {
             element is RsPatBinding && !element.isReferenceToConstant -> highlightNotReference(element)
             element is RsMacroCall -> highlightNotReference(element)
+            element is RsModDeclItem -> highlightNotReference(element)
             element is RsReferenceElement -> highlightReference(element)
             else -> highlightNotReference(element)
         } ?: return
@@ -101,7 +102,7 @@ private fun colorFor(element: RsElement): RsColor? = when (element) {
     }
     is RsMethodCall -> RsColor.METHOD
     is RsModDeclItem -> RsColor.MODULE
-    is RsModItem -> RsColor.MODULE
+    is RsMod -> if (element.isCrateRoot) RsColor.CRATE else RsColor.MODULE
     is RsPatBinding -> {
         if (element.ancestorStrict<RsValueParameter>() != null) RsColor.PARAMETER else null
     }

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.annotator
 
 import com.intellij.lang.annotation.AnnotationHolder
-import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
@@ -18,9 +17,9 @@ import org.rust.lang.core.types.ty.TyPrimitive
 import org.rust.openapiext.isUnitTestMode
 
 // Highlighting logic here should be kept in sync with tags in RustColorSettingsPage
-class RsHighlightingAnnotator : Annotator {
+class RsHighlightingAnnotator : RsAnnotatorBase() {
 
-    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+    override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         val (partToHighlight, color) = when {
             element is RsPatBinding && !element.isReferenceToConstant -> highlightNotReference(element)
             element is RsMacroCall -> highlightNotReference(element)

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotator.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.annotator
 
 import com.intellij.lang.annotation.AnnotationHolder
-import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.psi.PsiElement
 import org.rust.ide.colors.RsColor
@@ -21,9 +20,9 @@ import org.rust.lang.core.types.ty.TyReference
 import org.rust.lang.core.types.type
 import org.rust.openapiext.isUnitTestMode
 
-class RsHighlightingMutableAnnotator : Annotator {
+class RsHighlightingMutableAnnotator : RsAnnotatorBase() {
 
-    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+    override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         val ref = when (element) {
             is RsPath -> element.reference.resolve() ?: return
             is RsSelfParameter -> element

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotator.kt
@@ -22,13 +22,6 @@ import org.rust.lang.core.types.type
 import org.rust.openapiext.isUnitTestMode
 
 class RsHighlightingMutableAnnotator : Annotator {
-    companion object {
-        private val MUTABLE_HIGHTLIGHTING = HighlightSeverity(
-            "MUTABLE_HIGHTLIGHTING",
-            HighlightSeverity.INFORMATION.myVal + 3
-        )
-    }
-
 
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
         val ref = when (element) {
@@ -66,16 +59,16 @@ class RsHighlightingMutableAnnotator : Annotator {
     }
 
     private fun addHighlightingAnnotation(holder: AnnotationHolder, target: PsiElement, key: RsColor) {
-        // These following lines allow to test the mutable highlight for it own using INFORMATION and the description.
-        val annotationSeverity = if (isUnitTestMode) HighlightSeverity.INFORMATION else MUTABLE_HIGHTLIGHTING
-        val annotationText = if (isUnitTestMode) key.attributesDescriptor.displayName else null
-        holder.createAnnotation(
-            annotationSeverity,
-            target.textRange,
-            annotationText
-        ).textAttributes = key.textAttributesKey
+        val annotationSeverity = if (isUnitTestMode) key.testSeverity else MUTABLE_HIGHLIGHTING
+        holder.createAnnotation(annotationSeverity, target.textRange, null).textAttributes = key.textAttributesKey
     }
 
+    companion object {
+        private val MUTABLE_HIGHLIGHTING = HighlightSeverity(
+            "MUTABLE_HIGHLIGHTING",
+            HighlightSeverity.INFORMATION.myVal + 3
+        )
+    }
 }
 
 val RsElement.isMut: Boolean

--- a/src/main/kotlin/org/rust/ide/annotator/RsLiteralAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsLiteralAnnotator.kt
@@ -7,13 +7,12 @@ package org.rust.ide.annotator
 
 import com.intellij.lang.ASTNode
 import com.intellij.lang.annotation.AnnotationHolder
-import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.*
 
-class RsLiteralAnnotator : Annotator {
-    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+class RsLiteralAnnotator : RsAnnotatorBase() {
+    override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         if (element !is RsLitExpr) return
         val literal = element.kind
 

--- a/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
@@ -9,7 +9,6 @@ import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.lang.annotation.Annotation
 import com.intellij.lang.annotation.AnnotationHolder
-import com.intellij.lang.annotation.Annotator
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
@@ -19,9 +18,8 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.utils.RsDiagnostic
 import org.rust.lang.utils.addToHolder
 
-
-class RsSyntaxErrorsAnnotator : Annotator {
-    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+class RsSyntaxErrorsAnnotator : RsAnnotatorBase() {
+    override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         when (element) {
             is RsFunction -> checkFunction(holder, element)
             is RsStructItem -> checkStructItem(holder, element)

--- a/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
@@ -99,8 +99,8 @@ class RsUnsafeExpressionAnnotator : RsAnnotatorBase() {
 
         return parent is RsBlockExpr || (parent is RsFunction && parent.isUnsafe)
     }
-}
 
-fun AnnotationHolder.createUnsafeAnnotation(element: PsiElement, message: String) {
-    createWeakWarningAnnotation(element, message).textAttributes = RsColor.UNSAFE_CODE.textAttributesKey
+    private fun AnnotationHolder.createUnsafeAnnotation(element: PsiElement, message: String) {
+        createInfoAnnotation(element, message).textAttributes = RsColor.UNSAFE_CODE.textAttributesKey
+    }
 }

--- a/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.annotator
 
 import com.intellij.lang.annotation.AnnotationHolder
-import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import org.rust.ide.colors.RsColor
 import org.rust.lang.core.psi.*
@@ -16,8 +15,8 @@ import org.rust.lang.core.types.type
 import org.rust.lang.utils.RsDiagnostic
 import org.rust.lang.utils.addToHolder
 
-class RsUnsafeExpressionAnnotator : Annotator {
-    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+class RsUnsafeExpressionAnnotator : RsAnnotatorBase() {
+    override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         val visitor = object : RsVisitor() {
             override fun visitCallExpr(o: RsCallExpr) = checkCall(o, holder)
             override fun visitMethodCall(o: RsMethodCall) = checkMethodCall(o, holder)

--- a/src/main/kotlin/org/rust/ide/colors/RsColors.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RsColors.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.colors
 
+import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.options.colors.AttributesDescriptor
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Default
@@ -70,5 +71,6 @@ enum class RsColor(val humanName: String, val default: TextAttributesKey? = null
 
     val textAttributesKey = TextAttributesKey.createTextAttributesKey("org.rust.$name", default)
     val attributesDescriptor = AttributesDescriptor(humanName, textAttributesKey)
+    val testSeverity: HighlightSeverity = HighlightSeverity(name, HighlightSeverity.INFORMATION.myVal)
 }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -161,13 +161,13 @@
 
         <!-- Annotator -->
 
-        <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsHighlightingAnnotator"/>
-        <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsHighlightingMutableAnnotator"/>
-        <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsLiteralAnnotator"/>
-        <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsExpressionAnnotator"/>
-        <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsErrorAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsSyntaxErrorsAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsEdition2018KeywordsAnnotator"/>
+        <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsLiteralAnnotator"/>
+        <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsHighlightingAnnotator"/>
+        <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsHighlightingMutableAnnotator"/>
+        <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsExpressionAnnotator"/>
+        <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsErrorAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsUnsafeExpressionAnnotator"/>
         <externalAnnotator language="Rust" implementationClass="org.rust.ide.annotator.RsCargoCheckAnnotator"/>
         <highlightRangeExtension implementation="org.rust.ide.annotator.RsErrorAnnotator"/>

--- a/src/test/kotlin/org/rust/ide/annotator/RsAnnotatorTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAnnotatorTestBase.kt
@@ -1,0 +1,13 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+abstract class RsAnnotatorTestBase(private val annotatorClass: Class<out RsAnnotatorBase>) : RsAnnotationTestBase() {
+    override fun setUp() {
+        super.setUp()
+        RsAnnotatorBase.enableAnnotator(annotatorClass, testRootDisposable)
+    }
+}

--- a/src/test/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotatorTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.annotator
 import org.rust.MockEdition
 import org.rust.cargo.project.workspace.CargoWorkspace
 
-class RsEdition2018KeywordsAnnotatorTest : RsAnnotationTestBase() {
+class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018KeywordsAnnotator::class.java) {
 
     fun `test edition 2018 keywords in edition 2015`() = checkErrors("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -9,7 +9,7 @@ import org.rust.MockEdition
 import org.rust.MockRustcVersion
 import org.rust.cargo.project.workspace.CargoWorkspace
 
-class RsErrorAnnotatorTest : RsAnnotationTestBase() {
+class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class.java) {
 
     @MockRustcVersion("1.29.0")
     fun `test invalid module declarations`() = checkByFileTree("""

--- a/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsExpressionAnnotatorTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.annotator
 
-class RsExpressionAnnotatorTest : RsAnnotationTestBase() {
+class RsExpressionAnnotatorTest : RsAnnotatorTestBase(RsExpressionAnnotator::class.java) {
 
     fun `test unnecessary parens`() = checkWarnings("""
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -5,111 +5,116 @@
 
 package org.rust.ide.annotator
 
+import org.rust.ide.colors.RsColor
+
 class RsHighlightingAnnotatorTest : RsAnnotationTestBase() {
 
-    fun `test attributes`() = checkInfo("""
-        <info>#[cfg_attr(foo)]</info>
-        fn <info>main</info>() {
-            <info>#![crate_type = <info>"lib"</info>]</info>
+    override fun setUp() {
+        super.setUp()
+        registerSeverities(RsColor.values().map(RsColor::testSeverity))
+    }
+
+    fun `test attributes`() = checkHighlighting("""
+        <ATTRIBUTE>#[cfg_attr(foo)]</ATTRIBUTE>
+        fn <FUNCTION>main</FUNCTION>() {
+            <ATTRIBUTE>#![crate_type = <STRING>"lib"</STRING>]</ATTRIBUTE>
         }
     """)
 
-    fun `test fields and methods`() = checkInfo("""
-        struct <info>T</info>(<info>i32</info>);
-        struct <info>S</info>{ <info>field</info>: <info>T</info>}
-        fn <info>main</info>() {
-            let s = <info>S</info>{ <info>field</info>: <info>T</info>(92) };
-            s.<info>field</info>.0;
+    fun `test fields and methods`() = checkHighlighting("""
+        struct <STRUCT>T</STRUCT>(<PRIMITIVE_TYPE>i32</PRIMITIVE_TYPE>);
+        struct <STRUCT>S</STRUCT>{ <FIELD>field</FIELD>: <STRUCT>T</STRUCT>}
+        fn <FUNCTION>main</FUNCTION>() {
+            let s = <STRUCT>S</STRUCT>{ <FIELD>field</FIELD>: <STRUCT>T</STRUCT>(92) };
+            s.<FIELD>field</FIELD>.0;
         }
     """)
 
-    fun `test functions`() = checkInfo("""
-        fn <info>main</info>() {}
-        struct <info>S</info>;
-        impl <info>S</info> {
-            fn <info>foo</info>() {}
+    fun `test functions`() = checkHighlighting("""
+        fn <FUNCTION>main</FUNCTION>() {}
+        struct <STRUCT>S</STRUCT>;
+        impl <STRUCT>S</STRUCT> {
+            fn <ASSOC_FUNCTION>foo</ASSOC_FUNCTION>() {}
         }
-        trait <info>T</info> {
-            fn <info>foo</info>();
-            fn <info>bar</info>() {}
+        trait <TRAIT>T</TRAIT> {
+            fn <ASSOC_FUNCTION>foo</ASSOC_FUNCTION>();
+            fn <ASSOC_FUNCTION>bar</ASSOC_FUNCTION>() {}
         }
-        impl <info>T</info> for <info>S</info> {
-            fn <info>foo</info>() {}
+        impl <TRAIT><TRAIT>T</TRAIT></TRAIT> for <STRUCT>S</STRUCT> {
+            fn <ASSOC_FUNCTION>foo</ASSOC_FUNCTION>() {}
         }
     """)
 
-    fun `test macro`() = checkInfo("""
-        fn <info>main</info>() {
-            <info>println</info><info>!</info>["Hello, World!"];
-            <info>unreachable</info><info>!</info>();
-            std::<info>unreachable</info><info>!</info>();
+    fun `test macro`() = checkHighlighting("""
+        fn <FUNCTION>main</FUNCTION>() {
+            <MACRO>println</MACRO><MACRO>!</MACRO>["Hello, World!"];
+            <MACRO>unreachable</MACRO><MACRO>!</MACRO>();
         }
-        <info>macro_rules!</info> foo {
-            (x => $ <info>e</info>:expr) => (println!("mode X: {}", $ <info>e</info>));
-            (y => $ <info>e</info>:expr) => (println!("mode Y: {}", $ <info>e</info>));
+        <MACRO>macro_rules!</MACRO> foo {
+            (x => $ <FUNCTION>e</FUNCTION>:expr) => (println!("mode X: {}", $ <FUNCTION>e</FUNCTION>));
+            (y => $ <FUNCTION>e</FUNCTION>:expr) => (println!("mode Y: {}", $ <FUNCTION>e</FUNCTION>));
         }
         impl T {
-            <info>foo</info><info>!</info>();
+            <MACRO>foo</MACRO><MACRO>!</MACRO>();
+    """)
+
+    fun `test type parameters`() = checkHighlighting("""
+        trait <TRAIT>MyTrait</TRAIT> {
+            type <TYPE_ALIAS>AssocType</TYPE_ALIAS>;
+            fn <METHOD>some_fn</METHOD>(&<SELF_PARAMETER>self</SELF_PARAMETER>);
+        }
+        struct <STRUCT>MyStruct</STRUCT><<TYPE_PARAMETER>N</TYPE_PARAMETER>: ?<TRAIT>Sized</TRAIT>+<TRAIT>Debug</TRAIT>+<TRAIT>MyTrait</TRAIT>> {
+            <FIELD>N</FIELD>: my_field
         }
     """)
 
-    fun `test type parameters`() = checkInfo("""
-        trait <info>MyTrait</info> {
-            type <info>AssocType</info>;
-            fn <info>some_fn</info>(&<info>self</info>);
+    fun `test function arguments`() = checkHighlighting("""
+        struct <STRUCT>Foo</STRUCT> {}
+        impl <STRUCT>Foo</STRUCT> {
+            fn <METHOD>bar</METHOD>(&<SELF_PARAMETER>self</SELF_PARAMETER>, (<PARAMETER>i</PARAMETER>, <PARAMETER>j</PARAMETER>): (<PRIMITIVE_TYPE>i32</PRIMITIVE_TYPE>, <PRIMITIVE_TYPE>i32</PRIMITIVE_TYPE>)) {}
         }
-        struct <info>MyStruct</info><<info>N</info>: ?<info>Sized</info>+<info>Debug</info>+<info><info>MyTrait</info></info>> {
-            <info>N</info>: my_field
+        fn <FUNCTION>baz</FUNCTION>(<PARAMETER>u</PARAMETER>: <PRIMITIVE_TYPE>u32</PRIMITIVE_TYPE>) {}
+    """)
+
+    fun `test contextual keywords`() = checkHighlighting("""
+        trait <TRAIT>T</TRAIT> {
+            fn <ASSOC_FUNCTION>foo</ASSOC_FUNCTION>();
+        }
+        <KEYWORD>union</KEYWORD> <STRUCT>U</STRUCT> { }
+        impl <TRAIT>T</TRAIT> for <STRUCT>U</STRUCT> {
+            <KEYWORD>default</KEYWORD> fn <ASSOC_FUNCTION>foo</ASSOC_FUNCTION>() {}
         }
     """)
 
-    fun `test function arguments`() = checkInfo("""
-        struct <info>Foo</info> {}
-        impl <info>Foo</info> {
-            fn <info>bar</info>(&<info>self</info>, (<info>i</info>, <info>j</info>): (<info>i32</info>, <info>i32</info>)) {}
-        }
-        fn <info>baz</info>(<info>u</info>: <info>u32</info>) {}
-    """)
-
-    fun `test contextual keywords`() = checkInfo("""
-        trait <info>T</info> {
-            fn <info>foo</info>();
-        }
-        <info>union</info> <info>U</info> { }
-        impl <info>T</info> for <info>U</info> {
-            <info>default</info> fn <info>foo</info>() {}
+    fun `test ? operator`() = checkHighlighting("""
+        fn <FUNCTION>foo</FUNCTION>() -> Result<<PRIMITIVE_TYPE>i32</PRIMITIVE_TYPE>, ()>{
+            Ok(Ok(1)<Q_OPERATOR>?</Q_OPERATOR> * 2)
         }
     """)
 
-    fun `test ? operator`() = checkInfo("""
-        fn <info>foo</info>() -> Result<<info>i32</info>, ()>{
-            Ok(Ok(1)<info>?</info> * 2)
+    fun `test type alias`() = checkHighlighting("""
+        type <TYPE_ALIAS>Bar</TYPE_ALIAS> = <PRIMITIVE_TYPE>u32</PRIMITIVE_TYPE>;
+        fn <FUNCTION>main</FUNCTION>() {
+            let a: <TYPE_ALIAS>Bar</TYPE_ALIAS> = 10;
         }
     """)
 
-    fun `test type alias`() = checkInfo("""
-        type <info>Bar</info> = <info>u32</info>;
-        fn <info>main</info>() {
-            let a: <info>Bar</info> = 10;
+    fun `test self is not over annotated`() = checkHighlighting("""
+        pub use self::<MODULE>foo</MODULE>;
+
+        mod <MODULE>foo</MODULE> {
+            pub use self::<MODULE>bar</MODULE>;
+
+            pub mod <MODULE>bar</MODULE> {}
         }
     """)
 
-    fun `test self is not over annotated`() = checkInfo("""
-        pub use self::<info>foo</info>;
-
-        mod <info>foo</info> {
-            pub use self::<info>bar</info>;
-
-            pub mod <info>bar</info> {}
-        }
-    """)
-
-    fun `test primitive`() = checkInfo("""
-        fn <info>main</info>() -> <info>bool</info> {
-            let a: <info>u8</info> = 42;
-            let b: <info>f32</info> = 10.0;
-            let c: &<info>str</info> = "example";
-            <info>char</info>::is_lowercase('a');
+    fun `test primitive`() = checkHighlighting("""
+        fn <FUNCTION>main</FUNCTION>() -> <PRIMITIVE_TYPE>bool</PRIMITIVE_TYPE> {
+            let a: <PRIMITIVE_TYPE>u8</PRIMITIVE_TYPE> = 42;
+            let b: <PRIMITIVE_TYPE>f32</PRIMITIVE_TYPE> = 10.0;
+            let c: &<PRIMITIVE_TYPE>str</PRIMITIVE_TYPE> = "example";
+            <PRIMITIVE_TYPE>char</PRIMITIVE_TYPE>::is_lowercase('a');
             true
         }
     """)
@@ -118,13 +123,12 @@ class RsHighlightingAnnotatorTest : RsAnnotationTestBase() {
         //- main.rs
             mod aux;
 
-            fn <info>main</info>() {
-                let _ = aux::<info>S</info>;
+            fn <FUNCTION>main</FUNCTION>() {
+                let _ = aux::<STRUCT>S</STRUCT>;
             }
 
         //- aux.rs
             pub struct S;
-        """,
-        checkInfo = true
+        """
     )
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -9,7 +9,7 @@ import org.rust.ProjectDescriptor
 import org.rust.WithStdlibAndDependencyRustProjectDescriptor
 import org.rust.ide.colors.RsColor
 
-class RsHighlightingAnnotatorTest : RsAnnotationTestBase() {
+class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator::class.java) {
 
     override fun setUp() {
         super.setUp()

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.ide.annotator
 
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibAndDependencyRustProjectDescriptor
 import org.rust.ide.colors.RsColor
 
 class RsHighlightingAnnotatorTest : RsAnnotationTestBase() {
@@ -119,12 +121,19 @@ class RsHighlightingAnnotatorTest : RsAnnotationTestBase() {
         }
     """)
 
+    @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
+    fun `test crate`() = checkHighlighting("""
+        extern crate <CRATE>dep_lib_target</CRATE>;
+        
+        use <CRATE>std</CRATE>::<MODULE>io</MODULE>::<TRAIT>Read</TRAIT>;
+    """)
+
     fun `test dont touch ast in other files`() = checkDontTouchAstInOtherFiles("""
         //- main.rs
-            mod aux;
+            mod <MODULE>aux</MODULE>;
 
             fn <FUNCTION>main</FUNCTION>() {
-                let _ = aux::<STRUCT>S</STRUCT>;
+                let _ = <MODULE>aux</MODULE>::<STRUCT>S</STRUCT>;
             }
 
         //- aux.rs

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt
@@ -7,37 +7,38 @@ package org.rust.ide.annotator
 
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.ide.colors.RsColor
+import org.rust.ide.colors.RsColor.MUT_BINDING
+import org.rust.ide.colors.RsColor.MUT_PARAMETER
 
 class RsHighlightingMutableAnnotatorTest : RsAnnotationTestBase() {
 
-    val MUT_PARAMETER = RsColor.MUT_PARAMETER.humanName
-    val MUT_BINDING = RsColor.MUT_BINDING.humanName
+    override fun setUp() {
+        super.setUp()
+        registerSeverities(listOf(MUT_BINDING.testSeverity, MUT_PARAMETER.testSeverity))
+    }
 
-    fun `test mut self highlight`() = checkInfo("""
-        struct <info>Foo</info> {}
-        impl <info>Foo</info> {
-            fn <info>bar</info>(&mut <info><info descr="$MUT_PARAMETER">self</info></info>) {
-                <info descr="$MUT_PARAMETER">self</info>.<info>bar</info>();
+    fun `test mut self highlight`() = checkHighlighting("""
+        struct Foo {}
+        impl Foo {
+            fn bar(&mut <MUT_PARAMETER>self</MUT_PARAMETER>) {
+                <MUT_PARAMETER>self</MUT_PARAMETER>.bar();
             }
         }
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    fun `test mut binding`() {
-        checkInfo("""
-            fn <info descr="null">main</info>() {
-                let mut <info descr="$MUT_BINDING">a</info> = 1;
-                let b = <info descr="$MUT_BINDING">a</info>;
-                let <info descr="null">Some</info>(ref mut <info descr="$MUT_BINDING">c</info>) = <info descr="null">Some</info>(10);
-                let <info descr="$MUT_BINDING">d</info> = <info descr="$MUT_BINDING">c</info>;
-            }
-        """)
-    }
+    fun `test mut binding`() = checkHighlighting("""
+        fn main() {
+            let mut <MUT_BINDING>a</MUT_BINDING> = 1;
+            let b = <MUT_BINDING>a</MUT_BINDING>;
+            let Some(ref mut <MUT_BINDING>c</MUT_BINDING>) = Some(10);
+            let <MUT_BINDING>d</MUT_BINDING> = <MUT_BINDING>c</MUT_BINDING>;
+        }
+    """)
 
-    fun `test mut parameter`() = checkInfo("""
-        fn <info>test</info>(mut <info><info descr="$MUT_PARAMETER">para</info></info>: <info>i32</info>) {
-            let b = <info><info descr="$MUT_PARAMETER">para</info></info>;
+    fun `test mut parameter`() = checkHighlighting("""
+        fn test(mut <MUT_PARAMETER>para</MUT_PARAMETER>: i32) {
+            let b = <MUT_PARAMETER>para</MUT_PARAMETER>;
         }
     """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt
@@ -10,7 +10,7 @@ import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.colors.RsColor.MUT_BINDING
 import org.rust.ide.colors.RsColor.MUT_PARAMETER
 
-class RsHighlightingMutableAnnotatorTest : RsAnnotationTestBase() {
+class RsHighlightingMutableAnnotatorTest : RsAnnotatorTestBase(RsHighlightingMutableAnnotator::class.java) {
 
     override fun setUp() {
         super.setUp()

--- a/src/test/kotlin/org/rust/ide/annotator/RsLiteralAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsLiteralAnnotatorTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.annotator
 
-class RsLiteralAnnotatorTest : RsAnnotationTestBase() {
+class RsLiteralAnnotatorTest : RsAnnotatorTestBase(RsLiteralAnnotator::class.java) {
     fun `test char literal length`() = checkErrors("""
         fn main() {
             let ch1 = <error descr="empty char literal">''</error>;

--- a/src/test/kotlin/org/rust/ide/annotator/RsStdlibErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsStdlibErrorAnnotatorTest.kt
@@ -9,7 +9,7 @@ import org.rust.ProjectDescriptor
 import org.rust.WithStdlibAndDependencyRustProjectDescriptor
 
 @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
-class RsStdlibErrorAnnotatorTest : RsAnnotationTestBase() {
+class RsStdlibErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class.java) {
     fun `test E0428 respects crate aliases`() = checkErrors("""
         extern crate libc as libc_alias;
         mod libc {}

--- a/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.annotator
 
-class RsSyntaxErrorsAnnotatorTest : RsAnnotationTestBase() {
+class RsSyntaxErrorsAnnotatorTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator::class.java) {
     fun `test E0379 const trait function`() = checkErrors("""
         trait Foo {
             fn foo();

--- a/src/test/kotlin/org/rust/ide/annotator/RsTestSeverityProvider.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsTestSeverityProvider.kt
@@ -1,0 +1,25 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfoType
+import com.intellij.codeInsight.daemon.impl.SeveritiesProvider
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.psi.PsiElement
+
+class RsTestSeverityProvider(private val severities: List<HighlightSeverity>) : SeveritiesProvider() {
+    override fun getSeveritiesHighlightInfoTypes(): List<HighlightInfoType> = severities.map(::TestHighlightingInfoType)
+}
+
+private class TestHighlightingInfoType(private val severity: HighlightSeverity) : HighlightInfoType {
+    override fun getAttributesKey(): TextAttributesKey = DEFAULT_TEXT_ATTRIBUTES
+    override fun getSeverity(psiElement: PsiElement?): HighlightSeverity = severity
+
+    companion object {
+        private val DEFAULT_TEXT_ATTRIBUTES = TextAttributesKey.createTextAttributesKey("DEFAULT_TEXT_ATTRIBUTES")
+    }
+}

--- a/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotatorTest.kt
@@ -16,13 +16,13 @@ class RsUnsafeExpressionAnnotatorTest : RsAnnotatorTestBase(RsUnsafeExpressionAn
         }
     """)
 
-    fun `test extern static in unsafe block`() = checkWarnings("""
+    fun `test extern static in unsafe block`() = checkHighlighting("""
         extern {
             static C: i32;
         }
 
         fn main() {
-            unsafe { let a = <weak_warning descr="Use of unsafe extern static">C</weak_warning>; }
+            unsafe { let a = <info descr="Use of unsafe extern static">C</info>; }
         }
     """)
 
@@ -34,11 +34,11 @@ class RsUnsafeExpressionAnnotatorTest : RsAnnotatorTestBase(RsUnsafeExpressionAn
         }
     """)
 
-    fun `test mutable static in unsafe block`() = checkWarnings("""
+    fun `test mutable static in unsafe block`() = checkHighlighting("""
         static mut test : u8 = 0;
 
         fn main() {
-            unsafe { <weak_warning descr="Use of unsafe mutable static">test</weak_warning> += 1; }
+            unsafe { <info descr="Use of unsafe mutable static">test</info> += 1; }
         }
     """)
 
@@ -111,9 +111,9 @@ class RsUnsafeExpressionAnnotatorTest : RsAnnotatorTestBase(RsUnsafeExpressionAn
         }
     """)
 
-    fun `test unsafe call unsafe`() = checkWarnings("""
+    fun `test unsafe call unsafe`() = checkHighlighting("""
         unsafe fn foo() {}
-        unsafe fn bar() { <weak_warning descr="Call to unsafe function">foo</weak_warning>(); }
+        unsafe fn bar() { <info descr="Call to unsafe function">foo</info>(); }
     """)
 
     fun `test pointer dereference`() = checkErrors("""
@@ -123,19 +123,19 @@ class RsUnsafeExpressionAnnotatorTest : RsAnnotatorTestBase(RsUnsafeExpressionAn
         }
     """)
 
-    fun `test pointer dereference in unsafe block`() = checkWarnings("""
+    fun `test pointer dereference in unsafe block`() = checkHighlighting("""
         fn main() {
             let char_ptr: *const char = 42 as *const _;
-            let val = unsafe { <weak_warning descr="Unsafe dereference of raw pointer">*char_ptr</weak_warning> };
+            let val = unsafe { <info descr="Unsafe dereference of raw pointer">*char_ptr</info> };
         }
     """)
 
-    fun `test pointer dereference in unsafe fn`() = checkWarnings("""
+    fun `test pointer dereference in unsafe fn`() = checkHighlighting("""
         fn main() {
         }
         unsafe fn foo() {
             let char_ptr: *const char = 42 as *const _;
-            let val = <weak_warning descr="Unsafe dereference of raw pointer">*char_ptr</weak_warning>;
+            let val = <info descr="Unsafe dereference of raw pointer">*char_ptr</info>;
         }
     """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotatorTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.annotator
 
-class RsUnsafeExpressionAnnotatorTest : RsAnnotationTestBase() {
+class RsUnsafeExpressionAnnotatorTest : RsAnnotatorTestBase(RsUnsafeExpressionAnnotator::class.java) {
     fun `test extern static requires unsafe`() = checkErrors("""
         extern {
             static C: i32;

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddFeatureAttributeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddFeatureAttributeFixTest.kt
@@ -6,9 +6,10 @@
 package org.rust.ide.annotator.fixes
 
 import org.rust.MockRustcVersion
-import org.rust.ide.annotator.RsAnnotationTestBase
+import org.rust.ide.annotator.RsAnnotatorTestBase
+import org.rust.ide.annotator.RsErrorAnnotator
 
-class AddFeatureAttributeFixTest : RsAnnotationTestBase() {
+class AddFeatureAttributeFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class.java) {
 
     @MockRustcVersion("1.27.1")
     fun `test add crate_visibility_modifier feature is unavailable`() = checkFixIsUnavailable(

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddSelfTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddSelfTest.kt
@@ -5,9 +5,10 @@
 
 package org.rust.ide.annotator.fixes
 
-import org.rust.ide.annotator.RsAnnotationTestBase
+import org.rust.ide.annotator.RsAnnotatorTestBase
+import org.rust.ide.annotator.RsErrorAnnotator
 
-class AddSelfTest : RsAnnotationTestBase() {
+class AddSelfTest : RsAnnotatorTestBase(RsErrorAnnotator::class.java) {
     fun `test has no parameters`() = checkFixByText("Add self to function", """
         struct S;
 

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt
@@ -8,9 +8,10 @@ package org.rust.ide.annotator.fixes
 import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.ide.annotator.RsAnnotationTestBase
+import org.rust.ide.annotator.RsAnnotatorTestBase
+import org.rust.ide.annotator.RsExpressionAnnotator
 
-class AddStructFieldsFixTest : RsAnnotationTestBase() {
+class AddStructFieldsFixTest : RsAnnotatorTestBase(RsExpressionAnnotator::class.java) {
     fun `test no named fields`() = checkBothQuickFix("""
         struct S { foo: i32, bar: f64 }
 

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddTurbofishFixTest.kt
@@ -6,9 +6,10 @@
 package org.rust.ide.annotator.fixes
 
 import org.intellij.lang.annotations.Language
-import org.rust.ide.annotator.RsAnnotationTestBase
+import org.rust.ide.annotator.RsAnnotatorTestBase
+import org.rust.ide.annotator.RsErrorAnnotator
 
-class AddTurbofishFixTest : RsAnnotationTestBase() {
+class AddTurbofishFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class.java) {
     private val intention = "Add turbofish operator"
 
     fun `test trivial happy path`() = checkStatement(

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeTest.kt
@@ -5,9 +5,10 @@
 
 package org.rust.ide.annotator.fixes
 
-import org.rust.ide.annotator.RsAnnotationTestBase
+import org.rust.ide.annotator.RsAnnotatorTestBase
+import org.rust.ide.annotator.RsUnsafeExpressionAnnotator
 
-class AddUnsafeTest : RsAnnotationTestBase() {
+class AddUnsafeTest : RsAnnotatorTestBase(RsUnsafeExpressionAnnotator::class.java) {
     fun `test add unsafe to function`() = checkFixByText("Add unsafe to function", """
         unsafe fn foo() {}
 

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToSizedTypeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertToSizedTypeFixTest.kt
@@ -5,9 +5,10 @@
 
 package org.rust.ide.annotator.fixes
 
-import org.rust.ide.annotator.RsAnnotationTestBase
+import org.rust.ide.annotator.RsAnnotatorTestBase
+import org.rust.ide.annotator.RsErrorAnnotator
 
-class ConvertToSizedTypeFixTest : RsAnnotationTestBase() {
+class ConvertToSizedTypeFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class.java) {
 
     fun `test convert function arg to reference`() = checkFixByText("Convert to reference", """
         fn foo(slice: <error>[u8]/*caret*/</error>) {}

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/FixVisRestrictionTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/FixVisRestrictionTest.kt
@@ -5,9 +5,10 @@
 
 package org.rust.ide.annotator.fixes
 
-import org.rust.ide.annotator.RsAnnotationTestBase
+import org.rust.ide.annotator.RsAnnotatorTestBase
+import org.rust.ide.annotator.RsErrorAnnotator
 
-class FixVisRestrictionTest : RsAnnotationTestBase() {
+class FixVisRestrictionTest : RsAnnotatorTestBase(RsErrorAnnotator::class.java) {
 
     fun `test fix visibility restriction 1`() = checkFixByText("Fix visibility restriction", """
         mod foo {

--- a/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
@@ -54,7 +54,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
             type x;
         }
 
-        <error descr="Not all trait items implemented, missing: `x` [E0046]">/*caret*/impl Foo for ()</error> {
+        /*caret*/impl Foo for () {
         }
     """)
 
@@ -63,7 +63,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
         }
 
         /*caret*/impl Foo for () {
-            type <error descr="Method `x` is not a member of trait `Foo` [E0407]">x</error> = ();
+            type x = ();
         }
     """)
 
@@ -71,8 +71,8 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
         trait Foo {
             type x;
         }
-        <error descr="Not all trait items implemented, missing: `x` [E0046]">/*caret*/impl Foo for ()</error> {
-            type <error descr="Method `y` is not a member of trait `Foo` [E0407]">y</error> = ();
+        /*caret*/impl Foo for () {
+            type y = ();
         }
     """)
 
@@ -84,7 +84,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
         /*caret*/impl Foo for () {
             fn g() {}
             fn f() {}
-            fn <error descr="Method `h` is not a member of trait `Foo` [E0407]">h</error>() {}
+            fn h() {}
         }
     """, testmark = RsSortImplTraitMembersInspection.Testmarks.implMemberNotInTrait)
 
@@ -299,7 +299,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
 
         struct S;
 
-        <error descr="Not all trait items implemented, missing: `T` [E0046]"><weak_warning descr="Different impl member order from the trait">impl Foo for S/*caret*/</weak_warning></error> {
+        <weak_warning descr="Different impl member order from the trait">impl Foo for S/*caret*/</weak_warning> {
             fn foo() { unimplemented!() }
             const C: i32 = unimplemented!();
         }

--- a/src/test/kotlin/org/rust/ide/inspections/RsWhileTrueLoopInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsWhileTrueLoopInspectionTest.kt
@@ -52,7 +52,7 @@ class RsWhileTrueLoopInspectionTest : RsInspectionsTestBase(RsWhileTrueLoopInspe
 
     fun `test with unnecessary parentheses around while`() = checkFix("""
         fn main() {
-            <weak_warning descr="Denote infinite loops with `loop { ... }`">while/*caret*/ <weak_warning descr="Predicate expression has unnecessary parentheses">(true)</weak_warning></weak_warning> {
+            <weak_warning descr="Denote infinite loops with `loop { ... }`">while/*caret*/ (true)</weak_warning> {
                 let a = 42;
                 println!("{}", a);
             }

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -9,6 +9,8 @@ import com.intellij.openapi.actionSystem.ex.ActionManagerEx
 import junit.framework.TestCase
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
+import org.rust.ide.annotator.RsAnnotatorBase
+import org.rust.ide.annotator.RsErrorAnnotator
 
 
 class ImplementMembersHandlerTest : RsTestBase() {
@@ -16,9 +18,12 @@ class ImplementMembersHandlerTest : RsTestBase() {
         myFixture.performEditorAction("ImplementMethods")
     }
 
-    fun `test available via quick fix`() = invokeVia {
-        val action = myFixture.findSingleIntention("Implement members")
-        myFixture.launchAction(action)
+    fun `test available via quick fix`() {
+        RsAnnotatorBase.enableAnnotator(RsErrorAnnotator::class.java, testRootDisposable)
+        invokeVia {
+            val action = myFixture.findSingleIntention("Implement members")
+            myFixture.launchAction(action)
+        }
     }
 
     private fun invokeVia(actionInvoker: () -> Unit) {


### PR DESCRIPTION
* correctly highlight module declarations, module and crate references
* provide API to register custom severity to simplify highlighting tests
* provide API to test only particular annotator
* use `info` severity to highlight using of unsafe code by unsafe annotator
* reorder annotator declarations in `plugin.xml` to launch faster annotators first