### PR TITLE
RES: Fixed use items with nested groups without paths `use {{foo}};`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseSpeck.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseSpeck.kt
@@ -13,8 +13,10 @@ import org.rust.lang.core.psi.RsUseSpeck
 import org.rust.lang.core.stubs.RsUseSpeckStub
 
 val RsUseSpeck.isStarImport: Boolean get() = stub?.isStarImport ?: (mul != null) // I hate operator precedence
-val RsUseSpeck.qualifier: RsPath? get() =
-    (context as? RsUseGroup)?.parentUseSpeck?.path
+val RsUseSpeck.qualifier: RsPath? get() {
+    val parentUseSpeck = (context as? RsUseGroup)?.parentUseSpeck ?: return null
+    return parentUseSpeck.path ?: parentUseSpeck.qualifier
+}
 
 val RsUseSpeck.nameInScope: String? get() {
     if (useGroup != null) return null

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
@@ -333,6 +333,18 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
     """)
 
+    fun `test nested braces`() = checkByCode("""
+        mod foo {
+            pub fn bar() {}
+        }        //X
+
+        use {{foo::{{bar}}}};
+
+        fn main() {
+            bar();
+        } //^
+    """)
+
     fun `test colon braces`() = checkByCode("""
         struct Spam;
               //X


### PR DESCRIPTION
Fixes this case:
```rust
mod foo {
    pub fn bar() {}
}        //X

use {{foo::{{bar}}}};

fn main() {
    bar();
} //^
```