### PR TITLE
STUB: bump stub version

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -33,7 +33,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 149
+        override fun getStubVersion(): Int = 150
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)


### PR DESCRIPTION
Two previous PRs (#3133 and #3103) increased stub version independently to the same value.
It can lead to stub parsing error if stubs were created by code of one of these PRs.
