### PR TITLE
add mut fix

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -31,6 +31,7 @@ FatalCatharsis
 Filippok
 framlog
 garyttierney
+gfreezy
 greg-kargin
 Guillaume Eveillard
 harrisjt

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -80,6 +80,7 @@ val RsExpr.type: Ty
 val RsExpr.declaration: RsElement?
     get() = when (this) {
         is RsPathExpr -> path.reference.resolve()
+        is RsDotExpr -> expr.declaration
         is RsCallExpr -> expr.declaration
         is RsStructLiteral -> path.reference.resolve()
         else -> null

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddMutableFixText.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddMutableFixText.kt
@@ -1,0 +1,68 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+
+import org.rust.ide.inspections.RsBorrowCheckerInspection
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class AddMutableFixText : RsInspectionsTestBase(RsBorrowCheckerInspection()) {
+    fun `test add mutable fix to self`() = checkFixByText("Make `self` mutable", """
+        struct A {}
+
+        impl A {
+            fn foo(&mut self) {  }
+
+            fn bar (&self) {
+                <error>self/*caret*/</error>.foo();
+            }
+        }
+    """, """
+        struct A {}
+
+        impl A {
+            fn foo(&mut self) {  }
+
+            fn bar (&mut self) {
+                self.foo();
+            }
+        }
+    """)
+
+    fun `test add mutable fix to self2`() = checkFixByText("Make `self` mutable", """
+        struct A {}
+
+        impl A {
+            fn foo(&mut self) {  }
+        }
+
+        struct V {
+            a: A
+        }
+
+        impl V {
+            fn foo(&self) {
+                <error>self.a/*caret*/</error>.foo()
+            }
+        }
+    """, """
+        struct A {}
+
+        impl A {
+            fn foo(&mut self) {  }
+        }
+
+        struct V {
+            a: A
+        }
+
+        impl V {
+            fn foo(&mut self) {
+                self.a.foo()
+            }
+        }
+    """)
+}


### PR DESCRIPTION
fixed #3184

This test failed on my computer which is macos 10.14.1 with rust stable 1.31.0 .

```
org.rustSlowTests.CargoProjectResolveTest > test resolve feature gated crate FAILED
    java.lang.IllegalStateException: Failed to resolve the reference `libc` in `src/main.rs`.
        at org.rustSlowTests.CargoProjectResolveTest.test resolve feature gated crate(CargoProjectResolveTest.kt:323)
```