### PR TITLE
RES: fix private reexport with starts with `crate::`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -1183,8 +1183,10 @@ private fun walkUp(
 }
 
 fun isSuperChain(path: RsPath): Boolean {
-    val qual = path.path
-    return (path.referenceName == "super" || path.referenceName == "self") && (qual == null || isSuperChain(qual))
+    val qualifier = path.path
+    val referenceName = path.referenceName
+    return (referenceName == "super" || referenceName == "self" || referenceName == "crate") &&
+        (qualifier == null || isSuperChain(qualifier))
 }
 
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
@@ -557,6 +557,18 @@ class RsUseResolveTest : RsResolveTestBase() {
         }                                   //^
     """)
 
+    fun `test private reexport with crate keyword`() = checkByCode("""
+        mod a {
+            pub struct Foo;
+        }            //X
+        use a::Foo;
+        mod b {
+            use crate::Foo;
+
+            type T = Foo;
+        }          //^
+    """)
+
     fun `test can't import methods`() = checkByCode("""
         mod m {
             pub enum E {}


### PR DESCRIPTION
Fix #3151