### PR TITLE
ANN: implement members qfux: use `Self::` instead of `<Self as T>::`

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -30,7 +30,10 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.Namespace
 import org.rust.lang.core.resolve.namespaces
 import org.rust.lang.core.types.inference
-import org.rust.lang.core.types.ty.*
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyUnit
+import org.rust.lang.core.types.ty.isSelf
+import org.rust.lang.core.types.ty.isSized
 import org.rust.lang.core.types.type
 import org.rust.lang.utils.RsDiagnostic
 import org.rust.lang.utils.RsErrorCode
@@ -529,7 +532,7 @@ private fun checkTypesAreSized(holder: AnnotationHolder, fn: RsFunction) {
 
     fun isError(ty: Ty): Boolean = !ty.isSized() &&
         // Self type in trait method is not an error
-        !(owner is RsAbstractableOwner.Trait && ty is TyTypeParameter && ty.parameter is TyTypeParameter.Self)
+        !(owner is RsAbstractableOwner.Trait && ty.isSelf)
 
     for (arg in arguments) {
         val typeReference = arg.typeReference ?: continue

--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -100,12 +100,16 @@ private data class TypeRenderer(
             is TyTypeParameter -> ty.name ?: anonymous
             is TyProjection -> buildString {
                 val traitName = ty.trait.element.name ?: return anonymous
-                append("<")
-                append(ty.type)
-                append(" as ")
-                append(traitName)
-                if (includeTypeArguments) append(formatTraitGenerics(ty.trait, render, false))
-                append(">::")
+                if (ty.type.isSelf) {
+                    append("Self::")
+                } else {
+                    append("<")
+                    append(ty.type)
+                    append(" as ")
+                    append(traitName)
+                    if (includeTypeArguments) append(formatTraitGenerics(ty.trait, render, false))
+                    append(">::")
+                }
                 append(ty.target.name)
             }
             is TyTraitObject -> formatTrait(ty.trait, render)

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -91,6 +91,9 @@ tailrec fun Ty.isSized(): Boolean {
     }
 }
 
+val Ty.isSelf: Boolean
+    get() = this is TyTypeParameter && this.parameter is TyTypeParameter.Self
+
 fun Ty.walk(): TypeIterator = TypeIterator(this)
 
 class TypeIterator(root: Ty) : Iterator<Ty> {

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -580,6 +580,33 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
     """)
 
+    fun `test self associated type`() = doTest("""
+        trait T {
+            type Item;
+            fn foo() -> Self::Item;
+        }
+        struct S;
+        impl T for S {
+            /*caret*/
+        }
+    """, listOf(
+        ImplementMemberSelection("Item", true, isSelected = true),
+        ImplementMemberSelection("foo() -> Self::Item", true, isSelected = true)
+    ), """
+        trait T {
+            type Item;
+            fn foo() -> Self::Item;
+        }
+        struct S;
+        impl T for S {
+            type Item = ();
+
+            fn foo() -> Self::Item {
+                unimplemented!()
+            }
+        }
+    """)
+
     fun `test with members defined by a macro`() = doTest("""
         macro_rules! foo {
             ($ i:ident, $ j:tt) => { fn $ i() $ j }


### PR DESCRIPTION
![peek 2018-12-27 12-01](https://user-images.githubusercontent.com/3221931/50473731-3561e880-09cf-11e9-871c-79511fc6720f.gif)
