### PR TITLE
Add support for lifetime and literal macro token types.

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -344,6 +344,8 @@ private class MacroPattern private constructor(
                 "meta" -> RustParser.MetaItemWithoutTT(adaptBuilder, 0)
                 "vis" -> RustParser.Vis(adaptBuilder, 0)
                 "tt" -> RustParser.TT(adaptBuilder, 0)
+                "lifetime" -> RustParser.Lifetime(adaptBuilder, 0)
+                "literal" -> RustParser.LitExpr(adaptBuilder, 0)
                 else -> false
             }
             GeneratedParserUtilBase.exit_section_(adaptBuilder, 0, marker, root, parsed, true) { _, _ -> false }

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -627,6 +627,30 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         pub(in a::b) fn baz() {}
     """)
 
+    fun `test expand lifetime matcher`() = doTest("""
+        macro_rules! foo {
+            ($ lt:lifetime) => { struct Ref<$ lt>(&$ lt str);};
+        }
+        foo!('a);
+        foo!('lifetime);
+    """, """
+        struct Ref<'a>(&'a str);
+    """, """
+        struct Ref<'lifetime>(&'lifetime str);
+    """)
+
+    fun `test expand literal matcher`() = doTest("""
+        macro_rules! foo {
+            ($ type:ty $ lit:literal) => { const VALUE: $ type = $ lit;};
+        }
+        foo!(u8 0);
+        foo!(&'static str "value");
+    """, """
+        const VALUE: u8 = 0;
+    """, """
+        const VALUE: &'static str = "value";
+    """)
+
     fun `test expand macro defined in function`() = doTest("""
         fn main() {
             macro_rules! foo {


### PR DESCRIPTION
Heyo, just thought I'd add the other two macro token types.
They weren't supported, as so macro expansion doesn't work at all in intellij, but with this it should be as good as it was before.

[rust macro parser](https://github.com/rust-lang/rust/blob/master/src/libsyntax/ext/tt/macro_parser.rs#L900)