### PR TITLE
`Add mut` quick-fix now retains the reference's declared lifetime.

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt
@@ -54,7 +54,7 @@ fun updateMutable(project: Project, binding: RsNamedElement, mutable: Boolean = 
             val type = parameter?.typeReference?.typeElement
             if (type is RsRefLikeType) {
                 val newParameterExpr = RsPsiFactory(project)
-                    .createValueParameter(parameter.pat?.text!!, type.typeReference, mutable)
+                    .createValueParameter(parameter.pat?.text!!, type.typeReference, mutable, type.lifetime)
                 parameter.replace(newParameterExpr)
                 return
             }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -286,8 +286,8 @@ class RsPsiFactory(private val project: Project) {
         createFromText<RsImplItem>("impl $name {\n${functions.joinToString(separator = "\n", transform = { it.text })}\n}")
             ?: error("Failed to create RsImplItem element")
 
-    fun createValueParameter(name: String, type: RsTypeReference, mutable: Boolean = false): RsValueParameter {
-        return createFromText<RsFunction>("fn main($name: ${if (mutable) "&mut " else ""}${type.text}){}")
+    fun createValueParameter(name: String, type: RsTypeReference, mutable: Boolean = false, lifetime: RsLifetime? = null): RsValueParameter {
+        return createFromText<RsFunction>("fn main($name: &${if (lifetime != null) lifetime.text + " " else ""}${if (mutable) "mut " else ""}${type.text}){}")
             ?.valueParameterList?.valueParameterList?.get(0)
             ?: error("Failed to create parameter element")
     }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddMutableFixText.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddMutableFixText.kt
@@ -65,4 +65,26 @@ class AddMutableFixText : RsInspectionsTestBase(RsBorrowCheckerInspection()) {
             }
         }
     """)
+
+    fun `test add mutable fix to parameter with lifetime`() = checkFixByText("Make `obj` mutable", """
+        struct A {}
+
+        impl A {
+            fn foo(&mut self) {  }
+
+            fn bar<'a>(&self, obj: &'a A) {
+                <error>obj/*caret*/</error>.foo()
+            }
+        }
+    """, """
+        struct A {}
+
+        impl A {
+            fn foo(&mut self) {  }
+
+            fn bar<'a>(&self, obj: &'a mut A) {
+                obj.foo()
+            }
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #3186.

T: Added a test for this behaviour.