### PR TITLE
Add println postfix template

### DIFF
--- a/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
@@ -27,7 +27,8 @@ class RsPostfixTemplateProvider : PostfixTemplateProvider {
         LambdaPostfixTemplate(this),
         NotPostfixTemplate(this),
         LetPostfixTemplate(this),
-        IterPostfixTemplate(this)
+        IterPostfixTemplate(this),
+        PrintlnPostfixTemplate(this)
     )
 
     override fun getTemplates(): Set<PostfixTemplate> = templates

--- a/src/main/resources/postfixTemplates/PrintlnPostfixTemplate/after.rs.template
+++ b/src/main/resources/postfixTemplates/PrintlnPostfixTemplate/after.rs.template
@@ -1,0 +1,3 @@
+pub fn main() {
+    println!("{:?}", 44);
+}

--- a/src/main/resources/postfixTemplates/PrintlnPostfixTemplate/before.rs.template
+++ b/src/main/resources/postfixTemplates/PrintlnPostfixTemplate/before.rs.template
@@ -1,0 +1,3 @@
+pub fn main() {
+    <spot>44</spot>.println
+}

--- a/src/main/resources/postfixTemplates/PrintlnPostfixTemplate/description.html
+++ b/src/main/resources/postfixTemplates/PrintlnPostfixTemplate/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Surrounds expression with println! macro.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplateTest.kt
@@ -1,0 +1,278 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.template.postfix
+
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate(RsPostfixTemplateProvider())) {
+    fun `test string`() = doTest("""
+       fn main() {
+           "Arbitrary string".println/*caret*/
+       }
+    """, """
+       fn main() {
+           println!("Arbitrary string");/*caret*/
+       }
+    """)
+
+    fun `test method returning Debug`() = doTest("""
+        #[derive(Debug)]
+        enum E { A }
+
+        fn test() { E::A }
+
+        fn main() {
+            test().println/*caret*/
+        }
+    """, """
+        #[derive(Debug)]
+        enum E { A }
+
+        fn test() { E::A }
+
+        fn main() {
+            println!("{:?}", test());/*caret*/
+        }
+    """)
+
+    fun `test method returning no Debug`() = doTestNotApplicable("""
+        struct S {}
+
+        fn test() -> S { S {} }
+
+        fn main() {
+            test().println/*caret*/
+        }
+    """)
+
+    fun `test macro`() = doTest("""
+        fn main() {
+            assert_eq!(2, 2).println/*caret*/
+        }
+    """, """
+        fn main() {
+            println!("{:?}", assert_eq!(2, 2));/*caret*/
+        }
+    """)
+
+    fun `test struct implementing Display`() = doTest("""
+        use std::fmt::Display;
+        use std::fmt::Formatter;
+        use std::fmt::Error;
+
+        struct S { }
+        impl Display for S { fn fmt(&self, f: &mut Formatter) -> Result<(), Error> { unimplemented!() } }
+
+        fn main() {
+            &&S {}.println/*caret*/
+        }
+    """, """
+        use std::fmt::Display;
+        use std::fmt::Formatter;
+        use std::fmt::Error;
+
+        struct S { }
+        impl Display for S { fn fmt(&self, f: &mut Formatter) -> Result<(), Error> { unimplemented!() } }
+
+        fn main() {
+            println!("{}", &&S {});/*caret*/
+        }
+    """)
+
+    fun `test ignored let expression`() = doTestNotApplicable("""
+        fn main() {
+            let _ = 4.println/*caret*/;
+        }
+    """)
+
+    fun `test let expression`() = doTest("""
+        fn main() {
+            let test = 4.println/*caret*/;
+        }
+    """.trimIndent(), """
+        fn main() {
+            let test = 4;
+            println!("{:?}", test);/*caret*/
+        }
+    """.trimIndent())
+
+    fun `test let expression without semicolon`() = doTest("""
+        fn main() {
+            let test = 4.println/*caret*/
+        }
+    """.trimIndent(), """
+        fn main() {
+            let test = 4;
+            println!("{:?}", test);/*caret*/
+        }
+    """.trimIndent())
+
+    fun `test let expression with a comment not in the end of a block`() = doTest("""
+        fn main() {
+            let a = 123;
+            let b = a - 42 * 3.println/*caret*/; // this is a comment
+            let c = a + b;
+        }
+    """.trimIndent(), """
+        fn main() {
+            let a = 123;
+            let b = a - 42 * 3; // this is a comment
+            println!("{:?}", b);/*caret*/
+            let c = a + b;
+        }
+    """.trimIndent())
+
+    fun `test inner println in the let expression`() = doTest("""
+        fn main() {
+            let a = 123;
+            let b = a - 42.println/*caret*/ * 3; // this is a comment
+            let c = a + b;
+        }
+    """.trimIndent(), """
+        fn main() {
+            let a = 123;
+            let b = a - 42 * 3; // this is a comment
+            println!("{:?}", 42);/*caret*/
+            let c = a + b;
+        }
+    """.trimIndent())
+
+    fun `test inner println in the match expression`() = doTest("""
+        enum E<T> { A(T), B }
+
+        fn main() {
+            let a = 123;
+            match E::A(22) {
+                E::A(value) => a - 42.println/*caret*/ * 3 // this is a comment
+                _ => -1
+            };
+        }
+    """, """
+        enum E<T> { A(T), B }
+
+        fn main() {
+            let a = 123;
+            match E::A(22) {
+                E::A(value) => {
+                    println!("{:?}", 42);/*caret*/
+                    a - 42 * 3
+                } // this is a comment
+                _ => -1
+            };
+        }
+    """)
+
+    fun `test match expression`() = doTest("""
+        enum E<T> { A(T), B }
+
+        fn main() {
+            match E::A(22) {
+                E::A(value) => value,
+                _ => -1
+            }.println/*caret*/
+        }
+    """, """
+        enum E<T> { A(T), B }
+
+        fn main() {
+            println!("{:?}", match E::A(22) {
+                E::A(value) => value,
+                _ => -1
+            });/*caret*/
+        }
+    """)
+
+    fun `test multi line match arm`() = doTest("""
+        enum E<T> { A(T), B }
+
+        fn main() {
+            match E::A(22) {
+                E::A(value) => {
+                    value.println/*caret*/
+                }
+                _ => ()
+            }
+        }
+    """, """
+        enum E<T> { A(T), B }
+
+        fn main() {
+            match E::A(22) {
+                E::A(value) => {
+                    println!("{:?}", value);/*caret*/
+                }
+                _ => ()
+            }
+        }
+    """)
+
+    fun `test match arm with not empty type`() = doTest("""
+        enum E<T> { A(T), B }
+
+        fn main() {
+            match E::A(22) {
+                E::A(value) => value.println/*caret*/
+                _ => -1
+            };
+        }
+    """, """
+        enum E<T> { A(T), B }
+
+        fn main() {
+            match E::A(22) {
+                E::A(value) => {
+                    println!("{:?}", value);/*caret*/
+                    value
+                }
+                _ => -1
+            };
+        }
+    """)
+
+    fun `test match arm with empty type`() = doTest("""
+        enum E<T> { A(T), B }
+
+        fn main() {
+            match E::A(22) {
+                E::A(value) => value.println/*caret*/
+                _ => ()
+            };
+        }
+    """, """
+        enum E<T> { A(T), B }
+
+        fn main() {
+            match E::A(22) {
+                E::A(value) => println!("{:?}", value),/*caret*/
+                _ => ()
+            };
+        }
+    """)
+
+    fun `test generic parameter with no Debug`() = doTestNotApplicable("""
+        fn test<T>(variable: T) {
+            variable.println/*caret*/
+        }
+    """)
+
+    fun `test generic parameter with Debug + Display`() = doTest("""
+        use std::fmt::Debug;
+        use std::fmt::Display;
+
+        fn test<T>(variable: T) where T: Debug + Display {
+            variable.println/*caret*/
+        }
+    """, """
+        use std::fmt::Debug;
+        use std::fmt::Display;
+
+        fn test<T>(variable: T) where T: Debug + Display {
+            println!("{:?}", variable);/*caret*/
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateTest.kt
@@ -8,6 +8,7 @@ package org.rust.ide.template.postfix
 import com.intellij.codeInsight.template.postfix.templates.LanguagePostfixTemplate
 import com.intellij.codeInsight.template.postfix.templates.PostfixLiveTemplate
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplate
+import com.intellij.openapi.application.runReadAction
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.lang.RsLanguage
@@ -59,14 +60,16 @@ abstract class RsPostfixTemplateTest(val postfixTemplate: PostfixTemplate) : RsT
                 }
             }
 
-        check(
+        val result = runReadAction {
             PostfixLiveTemplate.isApplicableTemplate(
                 provider,
                 postfixTemplate.key,
                 myFixture.file,
                 myFixture.editor
-            ) == isApplicable
-        ) {
+            )
+        }
+
+        check(result == isApplicable) {
             "postfixTemplate ${if (isApplicable) "should" else "shouldn't"} be applicable to given case:\n\n$testCase"
         }
     }


### PR DESCRIPTION
I've decided to add a postfix template for creating a `println` macro for the expression applicable.
I've kept the implementation as generic as possible so that similar macros as `eprintln`, `format` would be easy to add, but this can be done later in a separate PR, after the current one is considered to be normal.

There are two minor issues I've faced when writing the tests:
1. One is the commented out test with a  `fixme` commend in it - looks like type resolution does not work as intended in this case hence macro template is not applicable.
The case seems to be rather minor though and can be fixed separately.

2. I've failed to use `Parameterized` test, so I had to leave the tests as they are now. Does not seem to be a big issue also, since all the tests are still there, but I have no idea how to fix it.

Here's the snippet: https://gist.github.com/SomeoneToIgnore/65d2328c7a3d65ba9a5fc5b0f9e917a4
When I run it, I receive the following error:
`ERROR: Read access is allowed from event dispatch thread or inside read-action only (see com.intellij.openapi.application.Application.runReadAction())`