### PR TITLE
RES&MACRO: fix import macros with wildcard use item

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -869,15 +869,16 @@ private fun collect2segmentPaths(rootSpeck: RsUseSpeck): List<TwoSegmentPath> {
     val result = mutableListOf<TwoSegmentPath>()
 
     fun go(speck: RsUseSpeck) {
+        val starImport = speck.isStarImport
         val path = speck.path
-        val qualifier = path?.qualifier
+        val qualifier = path?.qualifier ?: speck.qualifier
         val group = speck.useGroup
         if (path != null && qualifier != null && qualifier.qualifier != null) return
         val firstSegment = qualifier ?: path
         val lastSegment = path ?: qualifier
         when {
-            group == null && firstSegment != null && (path != null || speck.isStarImport) -> {
-                result += TwoSegmentPath(firstSegment.referenceName, path?.referenceName)
+            group == null && firstSegment != null && (path != null || starImport) -> {
+                result += TwoSegmentPath(firstSegment.referenceName, if (starImport) null else path?.referenceName)
             }
             group != null && firstSegment == lastSegment -> {
                 group.useSpeckList.forEach { go(it) }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -203,6 +203,20 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """, NameResolutionTestmarks.missingMacroUse)
 
+    fun `test import macro by use item wildcard`() = stubOnlyResolve("""
+    //- lib.rs
+        extern crate dep_lib_target;
+        use dep_lib_target::*;
+        fn bar() {
+            foo!();
+        } //^ dep-lib/lib.rs
+    //- dep-lib/lib.rs
+        #[macro_export]
+        macro_rules! foo {
+            () => {};
+        }
+    """, NameResolutionTestmarks.missingMacroUse)
+
     fun `test import macro by use item without extern crate`() = stubOnlyResolve("""
     //- lib.rs
         use dep_lib_target::foo;
@@ -216,9 +230,35 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
+    fun `test import macro by use item wildcard without extern crate`() = stubOnlyResolve("""
+    //- lib.rs
+        use dep_lib_target::*;
+        fn bar() {
+            foo!();
+        } //^ dep-lib/lib.rs
+    //- dep-lib/lib.rs
+        #[macro_export]
+        macro_rules! foo {
+            () => {};
+        }
+    """)
+
     fun `test import macro by complex use item without extern crate`() = stubOnlyResolve("""
     //- lib.rs
         use {{dep_lib_target::{{foo}}}};
+        fn bar() {
+            foo!();
+        } //^ dep-lib/lib.rs
+    //- dep-lib/lib.rs
+        #[macro_export]
+        macro_rules! foo {
+            () => {};
+        }
+    """)
+
+    fun `test import macro by complex use item wildcard without extern crate`() = stubOnlyResolve("""
+    //- lib.rs
+        use {{dep_lib_target::{{*}}}};
         fn bar() {
             foo!();
         } //^ dep-lib/lib.rs


### PR DESCRIPTION
The case of wildcard macro import `use foo::*` was untested for a some reason and did not work =/
Fixes #3210