### PR TITLE
TY&RES: Take into account super traits defined with where clause

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -368,7 +368,7 @@ TypeParamBounds ::= ':' [ Polybound ('+' Polybound)* '+'? ] {
 
 Polybound ::= '(' PolyboundInner ')' | PolyboundInner {
   extends = "org.rust.lang.core.psi.ext.RsStubbedElementImpl<?>"
-  stubClass = "org.rust.lang.core.stubs.RsPlaceholderStub"
+  stubClass = "org.rust.lang.core.stubs.RsPolyboundStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPolybound.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPolybound.kt
@@ -1,0 +1,18 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi.ext
+
+import org.rust.lang.core.psi.RsPolybound
+
+/**
+ * Return true if there is a question mark before a bound:
+ * ```
+ * fn foo<T: ?Sized>() {}
+ *         //^
+ * ```
+ */
+val RsPolybound.hasQ: Boolean
+    get() = stub?.hasQ ?: (q != null)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -78,7 +78,9 @@ private val RsTraitItem.superTraits: Sequence<BoundElement<RsTraitItem>> get() {
         .flatMap { it.typeParamBounds?.polyboundList.orEmpty().asSequence() }
     // trait Foo: Bar {}
     val bounds = typeParamBounds?.polyboundList.orEmpty().asSequence() + whereBounds
-    return bounds.mapNotNull { it.bound.traitRef?.resolveToBoundTrait }
+    return bounds
+        .filter { !it.hasQ } // ignore `?Sized`
+        .mapNotNull { it.bound.traitRef?.resolveToBoundTrait }
 }
 
 val RsTraitItem.isSized: Boolean get() {

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -33,7 +33,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 151
+        override fun getStubVersion(): Int = 152
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)
@@ -126,7 +126,7 @@ fun factory(name: String): RsStubElementType<*, *> = when (name) {
     "ASSOC_TYPE_BINDING" -> RsAssocTypeBindingStub.Type
 
     "TYPE_PARAM_BOUNDS" -> RsPlaceholderStub.Type("TYPE_PARAM_BOUNDS", ::RsTypeParamBoundsImpl)
-    "POLYBOUND" -> RsPlaceholderStub.Type("POLYBOUND", ::RsPolyboundImpl)
+    "POLYBOUND" -> RsPolyboundStub.Type
     "BOUND" -> RsPlaceholderStub.Type("BOUND", ::RsBoundImpl)
     "WHERE_CLAUSE" -> RsPlaceholderStub.Type("WHERE_CLAUSE", ::RsWhereClauseImpl)
     "WHERE_PRED" -> RsPlaceholderStub.Type("WHERE_PRED", ::RsWherePredImpl)
@@ -1237,6 +1237,30 @@ class RsAssocTypeBindingStub(
 
         override fun createStub(psi: RsAssocTypeBinding, parentStub: StubElement<*>?) =
             RsAssocTypeBindingStub(parentStub, this, psi.identifier.text)
+    }
+}
+
+class RsPolyboundStub(
+    parent: StubElement<*>?, elementType: IStubElementType<*, *>,
+    val hasQ: Boolean
+) : StubBase<RsPolybound>(parent, elementType) {
+
+    object Type : RsStubElementType<RsPolyboundStub, RsPolybound>("POLYBOUND") {
+        override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
+            RsPolyboundStub(parentStub, this,
+                dataStream.readBoolean()
+            )
+
+        override fun serialize(stub: RsPolyboundStub, dataStream: StubOutputStream) =
+            with(dataStream) {
+                writeBoolean(stub.hasQ)
+            }
+
+        override fun createPsi(stub: RsPolyboundStub): RsPolybound =
+            RsPolyboundImpl(stub, this)
+
+        override fun createStub(psi: RsPolybound, parentStub: StubElement<*>?) =
+            RsPolyboundStub(parentStub, this, psi.hasQ)
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -1741,8 +1741,8 @@ private fun RsGenericDeclaration.doGetBounds(): List<TraitRef> {
 }
 
 private fun List<RsPolybound>?.toTraitRefs(selfTy: Ty): Sequence<TraitRef> = orEmpty().asSequence()
+    .filter { !it.hasQ } // ignore `?Sized`
     .mapNotNull { it.bound.traitRef?.resolveToBoundTrait }
-    .filter { !it.element.isSizedTrait }
     .map { TraitRef(selfTy, it) }
 
 private fun Sequence<Ty>.infiniteWithTyUnknown(): Sequence<Ty> =

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
@@ -56,7 +56,7 @@ class TyTypeParameter private constructor(
 
         fun self(item: RsTraitOrImpl): TyTypeParameter {
             val isSized = when (item) {
-                is RsTraitItem -> item.implementedTrait?.flattenHierarchy.orEmpty().any { it.element.isSizedTrait }
+                is RsTraitItem -> item.isSized
                 is RsImplItem -> item.typeReference?.type?.isSized() == true
                 else -> error("item must be instance of `RsTraitItem` or `RsImplItem`")
             }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -7,6 +7,8 @@ package org.rust.ide.annotator
 
 import org.rust.MockEdition
 import org.rust.MockRustcVersion
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace
 
 class RsErrorAnnotatorTest : RsAnnotationTestBase() {
@@ -1230,6 +1232,20 @@ class RsErrorAnnotatorTest : RsAnnotationTestBase() {
         trait Foo {
             fn foo() -> Self;
         }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test Self type inside trait is sized if have Sized bound E0277`() = checkErrors("""
+        trait Foo: Sized {
+            fn foo() -> (Self, Self);
+        }
+        trait Bar where Self: Sized {
+            fn foo() -> (Self, Self);
+        }
+        // TODO
+//        trait Baz {
+//            fn foo() -> (Self, Self) where Self: Sized;
+//        }
     """)
 
     @MockRustcVersion("1.27.1")

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -391,6 +391,16 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }
     """)
 
+    fun `test self implements trait from where clause bound`() = checkByCode("""
+        trait Bar {
+            fn bar(&self);
+             //X
+        }
+        trait Foo where Self : Bar {
+            fn foo(&self) { self.bar(); }
+        }                      //^
+    """)
+
     fun `test match enum tuple variant`() = checkByCode("""
         enum E { V(S) }
         struct S;

--- a/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
@@ -124,6 +124,13 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test Self is Sized if trait is Sized (vie where clause)`() = doTest("""
+        trait Foo where Self: Sized {
+            fn foo(self: Self);
+                        //^ Sized
+        }
+    """)
+
     fun `test Self is Sized in Sized type impl`() = doTest("""
         trait Foo {
             fn foo(self: Self);


### PR DESCRIPTION
Co-Authored-By: vlad9486 <vlad9486@gmail.com> (#3049)

```rust
trait Bar {
    fn bar(&self);
     //X
}
trait Foo where Self : Bar {
    fn foo(&self) { self.bar(); }
}                      //^
```

This is NOT a fix for #2530 b/c we still ignore fn-level Self bounds