### PR TITLE
TY: support trait bounds for complex types

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -349,6 +349,12 @@ class ImplLookup(
     }
 
     private fun selectCandidate(ref: TraitRef, recursionDepth: Int): SelectionResult<SelectionCandidate> {
+        if (ref.selfTy is TyReference && ref.selfTy.referenced is TyInfer.TyVar) {
+            // This condition is related to TyFingerprint internals: TyFingerprint should not be created for
+            // TyInfer.TyVar, and TyReference is a single special case: it unwraps during TyFingerprint creation
+            return SelectionResult.Ambiguous()
+        }
+
         val candidates = assembleCandidates(ref)
 
         return when (candidates.size) {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -1724,20 +1724,16 @@ val RsGenericDeclaration.bounds: List<TraitRef>
     }
 
 private fun RsGenericDeclaration.doGetBounds(): List<TraitRef> {
-    val whereBounds = this.whereClause?.wherePredList.orEmpty().asSequence()
+    val whereBounds = whereClause?.wherePredList.orEmpty().asSequence()
         .flatMap {
-            val (element, subst) = (it.typeReference?.typeElement as? RsBaseType)?.path?.reference?.advancedResolve()
-                ?: return@flatMap emptySequence<TraitRef>()
-            val selfTy = ((element as? RsTypeDeclarationElement)?.declaredType)
-                ?.substitute(subst)
-                ?: return@flatMap emptySequence<TraitRef>()
+            val selfTy = it.typeReference?.type ?: return@flatMap emptySequence<TraitRef>()
             it.typeParamBounds?.polyboundList.toTraitRefs(selfTy)
         }
-
-    return (typeParameters.asSequence().flatMap {
+    val bounds = typeParameters.asSequence().flatMap {
         val selfTy = TyTypeParameter.named(it)
         it.typeParamBounds?.polyboundList.toTraitRefs(selfTy)
-    } + whereBounds).toList()
+    }
+    return (bounds + whereBounds).toList()
 }
 
 private fun List<RsPolybound>?.toTraitRefs(selfTy: Ty): Sequence<TraitRef> = orEmpty().asSequence()

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1485,4 +1485,15 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             (a, s);
         } //^ (u64, S)
     """)
+
+    fun `test trait bound for reference type`() = testExpr("""
+        struct S;
+        trait Foo<T> {}
+        impl Foo<i32> for &S {}
+        fn foo<'a, T1, T2>(t: &'a T1) -> T2 where &'a T1: Foo<T2> { unimplemented!() }
+        fn main() {
+            let a = foo(&S);
+            a;
+        } //^ i32
+    """)
 }


### PR DESCRIPTION
Trait bounds for non-base types (e.g. references) was ignored for a some reason.
```rust
struct S;
trait Foo<T> {}
impl Foo<i32> for &S {}
fn foo<'a, T1, T2>(t: &'a T1) -> T2 where &'a T1: Foo<T2> { unimplemented!() }
fn main() {
    let a = foo(&S);
    a;
} //^ i32
```