### PR TITLE
Fix expressions replacing inside introduce refactorings

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/RsInPlaceVariableIntroducer.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsInPlaceVariableIntroducer.kt
@@ -1,0 +1,20 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
+import com.intellij.refactoring.introduce.inplace.InplaceVariableIntroducer
+
+class RsInPlaceVariableIntroducer(
+    elementToRename: PsiNamedElement,
+    editor: Editor,
+    project: Project,
+    title: String,
+    occurrences: Array<PsiElement>
+) : InplaceVariableIntroducer<PsiElement>(elementToRename, editor, project, title, occurrences, null)

--- a/src/main/kotlin/org/rust/ide/refactoring/extraxtExpressionUi.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extraxtExpressionUi.kt
@@ -55,7 +55,6 @@ fun showErrorMessageForExtractParameter(project: Project, editor: Editor, messag
     val title = RefactoringBundle.message("introduce.parameter.title")
     val helpId = "refactoring.extractParameter"
     CommonRefactoringUtil.showErrorHint(project, editor, message, title, helpId)
-
 }
 
 private val <T> ((T) -> Unit).asPass: Pass<T>

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceParameter/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceParameter/impl.kt
@@ -15,7 +15,10 @@ import com.intellij.refactoring.RefactoringBundle
 import com.intellij.refactoring.rename.inplace.MemberInplaceRenamer
 import com.intellij.refactoring.util.CommonRefactoringUtil
 import org.rust.ide.presentation.insertionSafeText
-import org.rust.ide.refactoring.*
+import org.rust.ide.refactoring.findOccurrences
+import org.rust.ide.refactoring.moveEditorToNameElement
+import org.rust.ide.refactoring.showOccurrencesChooser
+import org.rust.ide.refactoring.suggestedNames
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyNever
@@ -101,7 +104,7 @@ private class ParamIntroducer(
                     .forEach { introduceParam(it, suggestedNames.default, typeRef) }
             }
             val newParam = introduceParam(function, suggestedNames.default, typeRef)
-            val name = psiFactory.createIdentifier(suggestedNames.default)
+            val name = psiFactory.createExpression(suggestedNames.default)
             exprs.forEach { it.replace(name) }
             moveEditorToNameElement(editor, newParam)
         }

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceParameter/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceParameter/impl.kt
@@ -14,11 +14,7 @@ import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.refactoring.RefactoringBundle
 import com.intellij.refactoring.util.CommonRefactoringUtil
 import org.rust.ide.presentation.insertionSafeText
-import org.rust.ide.refactoring.findOccurrences
-import org.rust.ide.refactoring.introduceVariable.RustInPlaceVariableIntroducer
-import org.rust.ide.refactoring.moveEditorToNameElement
-import org.rust.ide.refactoring.showOccurrencesChooser
-import org.rust.ide.refactoring.suggestedNames
+import org.rust.ide.refactoring.*
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyNever
@@ -114,7 +110,7 @@ private class ParamIntroducer(
         documentManager.doPostponedOperationsAndUnblockDocument(editor.document)
 
         if (newParameter != null) {
-            RustInPlaceVariableIntroducer(newParameter, editor, project, "choose a parameter", emptyArray())
+            RsInPlaceVariableIntroducer(newParameter, editor, project, "choose a parameter", emptyArray())
                 .performInplaceRefactoring(suggestedNames.all)
         }
     }

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceParameter/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceParameter/impl.kt
@@ -12,10 +12,10 @@ import com.intellij.psi.PsiReference
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.refactoring.RefactoringBundle
-import com.intellij.refactoring.rename.inplace.MemberInplaceRenamer
 import com.intellij.refactoring.util.CommonRefactoringUtil
 import org.rust.ide.presentation.insertionSafeText
 import org.rust.ide.refactoring.findOccurrences
+import org.rust.ide.refactoring.introduceVariable.RustInPlaceVariableIntroducer
 import org.rust.ide.refactoring.moveEditorToNameElement
 import org.rust.ide.refactoring.showOccurrencesChooser
 import org.rust.ide.refactoring.suggestedNames
@@ -114,7 +114,8 @@ private class ParamIntroducer(
         documentManager.doPostponedOperationsAndUnblockDocument(editor.document)
 
         if (newParameter != null) {
-            MemberInplaceRenamer(newParameter, newParameter, editor).performInplaceRename()
+            RustInPlaceVariableIntroducer(newParameter, editor, project, "choose a parameter", emptyArray())
+                .performInplaceRefactoring(suggestedNames.all)
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceVariable/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceVariable/impl.kt
@@ -133,7 +133,7 @@ private fun findAnchor(expr: PsiElement): PsiElement? {
     return anchor
 }
 
-private class RustInPlaceVariableIntroducer(
+class RustInPlaceVariableIntroducer(
     elementToRename: PsiNamedElement,
     editor: Editor,
     project: Project,

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceVariable/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceVariable/impl.kt
@@ -7,12 +7,17 @@ package org.rust.ide.refactoring.introduceVariable
 
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.*
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.PsiParserFacade
 import com.intellij.refactoring.introduce.inplace.InplaceVariableIntroducer
-import org.rust.ide.refactoring.*
+import org.rust.ide.refactoring.findOccurrences
+import org.rust.ide.refactoring.moveEditorToNameElement
+import org.rust.ide.refactoring.showOccurrencesChooser
+import org.rust.ide.refactoring.suggestedNames
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorOrSelf
-import org.rust.lang.core.psi.ext.ancestors
 import org.rust.lang.core.psi.ext.startOffset
 import org.rust.openapiext.runWriteCommandAction
 
@@ -80,7 +85,8 @@ private class ExpressionReplacer(
             ?: return
 
         val suggestedNames = chosenExpr.suggestedNames()
-        val (let, name) = createLet(suggestedNames.default) ?: return
+        val let = createLet(suggestedNames.default)
+        val name = psiFactory.createExpression(suggestedNames.default)
 
         val nameElem: RsPatBinding? = project.runWriteCommandAction {
             val newElement = introduceLet(project, anchor, let)
@@ -97,18 +103,11 @@ private class ExpressionReplacer(
 
     /**
      * Creates a let binding for the found expression.
-     * Returning handles to the complete let expr and the identifier inside the newly created let binding.
      */
-    private fun createLet(name: String): Pair<RsLetDecl, PsiElement>? {
+    private fun createLet(name: String): RsLetDecl {
         val parent = chosenExpr.parent
-
         val mutable = parent is RsUnaryExpr && parent.mut != null
-        val let = psiFactory.createLetDeclaration(name, chosenExpr, mutable = mutable)
-
-        val binding = let.findBinding()
-            ?: error("Failed to create a proper let expression: `${let.text}`")
-
-        return let to binding.identifier
+        return psiFactory.createLetDeclaration(name, chosenExpr, mutable)
     }
 
     private fun introduceLet(project: Project, anchor: PsiElement, let: RsLetDecl): PsiElement? {

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceVariable/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceVariable/impl.kt
@@ -9,13 +9,8 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.PsiParserFacade
-import com.intellij.refactoring.introduce.inplace.InplaceVariableIntroducer
-import org.rust.ide.refactoring.findOccurrences
-import org.rust.ide.refactoring.moveEditorToNameElement
-import org.rust.ide.refactoring.showOccurrencesChooser
-import org.rust.ide.refactoring.suggestedNames
+import org.rust.ide.refactoring.*
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorOrSelf
 import org.rust.lang.core.psi.ext.startOffset
@@ -74,7 +69,7 @@ private class ExpressionReplacer(
 
         PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
         if (nameElem != null) {
-            RustInPlaceVariableIntroducer(nameElem, editor, project, "choose a variable", emptyArray())
+            RsInPlaceVariableIntroducer(nameElem, editor, project, "choose a variable", emptyArray())
                 .performInplaceRefactoring(suggestedNames.all)
         }
     }
@@ -96,7 +91,7 @@ private class ExpressionReplacer(
 
         PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
         if (nameElem != null) {
-            RustInPlaceVariableIntroducer(nameElem, editor, project, "choose a variable", emptyArray())
+            RsInPlaceVariableIntroducer(nameElem, editor, project, "choose a variable", emptyArray())
                 .performInplaceRefactoring(suggestedNames.all)
         }
     }
@@ -132,11 +127,3 @@ private fun findAnchor(expr: PsiElement): PsiElement? {
 
     return anchor
 }
-
-class RustInPlaceVariableIntroducer(
-    elementToRename: PsiNamedElement,
-    editor: Editor,
-    project: Project,
-    title: String,
-    occurrences: Array<PsiElement>
-) : InplaceVariableIntroducer<PsiElement>(elementToRename, editor, project, title, occurrences, null)


### PR DESCRIPTION
1. Replacing `RsExpr` with `PsiIdentifier` leads to problems with parsing result, so now it uses `createExpression`.
2. `MemberInplaceRenamer` may not work correctly when the user starts typing right after introducing a parameter. So it was replaced with `RustInPlaceVariableIntroducer` (also providing all suggested names).