### PR TITLE
TY&RES: Fully support trait bounds for complex types

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -18,11 +18,9 @@ import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.resolve.STD_DERIVABLE_TRAITS
 import org.rust.lang.core.stubs.RsTraitItemStub
-import org.rust.lang.core.types.BoundElement
-import org.rust.lang.core.types.RsPsiTypeImplUtil
-import org.rust.lang.core.types.emptySubstitution
+import org.rust.lang.core.types.*
 import org.rust.lang.core.types.infer.substitute
-import org.rust.lang.core.types.toTypeSubst
+import org.rust.lang.core.types.regions.ReEarlyBound
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyTypeParameter
 import org.rust.openapiext.filterIsInstanceQuery
@@ -99,6 +97,21 @@ fun RsTraitItem.withSubst(vararg subst: Ty): BoundElement<RsTraitItem> {
         }.toTypeSubst()
     }
     return BoundElement(this, substitution)
+}
+
+fun RsTraitItem.withDefaultSubst(): BoundElement<RsTraitItem> =
+    BoundElement(this, defaultSubstitution(this))
+
+private fun defaultSubstitution(item: RsTraitItem): Substitution {
+    val typeSubst = item.typeParameters.associate {
+        val parameter = TyTypeParameter.named(it)
+        parameter to parameter
+    }
+    val regionSubst = item.lifetimeParameters.associate {
+        val parameter = ReEarlyBound(it)
+        parameter to parameter
+    }
+    return Substitution(typeSubst, regionSubst)
 }
 
 abstract class RsTraitItemImplMixin : RsStubbedNamedElementImpl<RsTraitItemStub>, RsTraitItem {

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -937,7 +937,7 @@ private fun processAssociatedItems(
     ns: Set<Namespace>,
     processor: (AssocItemScopeEntry) -> Boolean
 ): Boolean {
-    val traitBounds = (type as? TyTypeParameter)?.getTraitBoundsTransitively()
+    val traitBounds = (type as? TyTypeParameter)?.let { lookup.getEnvBoundTransitivelyFor(it).toList() }
     val visitedInherent = mutableSetOf<String>()
     fun processTraitOrImpl(traitOrImpl: TraitImplSource, inherent: Boolean): Boolean {
         fun inherentProcessor(entry: RsNamedElement): Boolean {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -38,7 +38,8 @@ import org.rust.stdext.zipValues
 
 fun inferTypesIn(element: RsInferenceContextOwner): RsInferenceResult {
     val items = element.knownItems
-    val lookup = ImplLookup(element.project, items)
+    val paramEnv = if (element is RsGenericDeclaration) ParamEnv.buildFor(element) else ParamEnv.EMPTY
+    val lookup = ImplLookup(element.project, items, paramEnv)
     return recursionGuard(element, Computable { lookup.ctx.infer(element) })
         ?: error("Can not run nested type inference")
 }
@@ -1106,37 +1107,42 @@ class RsFnInferenceContext(
             return methodType.retType
         }
 
-        val impl = callee.source.impl
-        var typeParameters = if (impl != null) {
-            val typeParameters = instantiateBounds(impl)
-            impl.typeReference?.type?.substitute(typeParameters)?.let { ctx.combineTypes(callee.selfTy, it) }
-            if (callee.element.owner is RsAbstractableOwner.Trait) {
-                impl.traitRef?.resolveToBoundTrait?.substitute(typeParameters)?.subst ?: emptySubstitution
-            } else {
-                typeParameters
-            }
-        } else {
-            // Method has been resolved to a trait, so we should add a predicate
-            // `Self : Trait<Args>` to select args and also refine method path if possible.
-            // Method path refinement needed if there are multiple impls of the same trait to the same type
-            val trait = (callee.element.owner as RsAbstractableOwner.Trait).trait
-            when (callee.selfTy) {
-                // All these branches except `else` are optimization, they can be removed without loss of functionality
-                is TyTypeParameter -> callee.selfTy.getTraitBoundsTransitively()
-                    .find { it.element == trait }?.subst ?: emptySubstitution
-                is TyAnon -> callee.selfTy.getTraitBoundsTransitively()
-                    .find { it.element == trait }?.subst ?: emptySubstitution
-                is TyTraitObject -> callee.selfTy.trait.flattenHierarchy
-                    .find { it.element == trait }?.subst ?: emptySubstitution
-                else -> {
-                    val typeParameters = instantiateBounds(trait)
-                    val subst = trait.generics.associateBy { it }.toTypeSubst()
-                    val boundTrait = BoundElement(trait, subst).substitute(typeParameters)
-                    val traitRef = TraitRef(callee.selfTy, boundTrait)
-                    fulfill.registerPredicateObligation(Obligation(Predicate.Trait(traitRef)))
-                    ctx.registerMethodRefinement(methodCall, traitRef)
+        val source = callee.source
+        var typeParameters = when (source) {
+            is TraitImplSource.ExplicitImpl -> {
+                val impl = source.value
+                val typeParameters = instantiateBounds(impl)
+                impl.typeReference?.type?.substitute(typeParameters)?.let { ctx.combineTypes(callee.selfTy, it) }
+                if (callee.element.owner is RsAbstractableOwner.Trait) {
+                    impl.traitRef?.resolveToBoundTrait?.substitute(typeParameters)?.subst ?: emptySubstitution
+                } else {
                     typeParameters
                 }
+            }
+            is TraitImplSource.TraitBound -> lookup.getEnvBoundTransitivelyFor(callee.selfTy)
+                .find { it.element == source.value }?.subst ?: emptySubstitution
+
+            is TraitImplSource.Derived -> emptySubstitution
+
+            is TraitImplSource.Object -> when (callee.selfTy) {
+                is TyAnon -> callee.selfTy.getTraitBoundsTransitively()
+                    .find { it.element == source.value }?.subst ?: emptySubstitution
+                is TyTraitObject -> callee.selfTy.trait.flattenHierarchy
+                    .find { it.element == source.value }?.subst ?: emptySubstitution
+                else -> emptySubstitution
+            }
+            is TraitImplSource.Collapsed, is TraitImplSource.Hardcoded -> {
+                // Method has been resolved to a trait, so we should add a predicate
+                // `Self : Trait<Args>` to select args and also refine method path if possible.
+                // Method path refinement needed if there are multiple impls of the same trait to the same type
+                val trait = source.value as RsTraitItem
+                val typeParameters = instantiateBounds(trait)
+                val subst = trait.generics.associateBy { it }.toTypeSubst()
+                val boundTrait = BoundElement(trait, subst).substitute(typeParameters)
+                val traitRef = TraitRef(callee.selfTy, boundTrait)
+                fulfill.registerPredicateObligation(Obligation(Predicate.Trait(traitRef)))
+                ctx.registerMethodRefinement(methodCall, traitRef)
+                typeParameters
             }
         }
         // TODO: borrow adjustments for self parameter

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyProjection.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyProjection.kt
@@ -9,6 +9,7 @@ import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.psi.ext.RsAbstractableOwner
 import org.rust.lang.core.psi.ext.owner
+import org.rust.lang.core.psi.ext.withDefaultSubst
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.HAS_TY_PROJECTION_MASK
 import org.rust.lang.core.types.TraitRef

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTraitObject.kt
@@ -7,14 +7,13 @@ package org.rust.lang.core.types.ty
 
 import com.intellij.codeInsight.completion.CompletionUtil
 import org.rust.lang.core.psi.RsTraitItem
-import org.rust.lang.core.psi.ext.lifetimeParameters
 import org.rust.lang.core.psi.ext.typeParameters
+import org.rust.lang.core.psi.ext.withDefaultSubst
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.Substitution
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.mergeFlags
-import org.rust.lang.core.types.regions.ReEarlyBound
 import org.rust.lang.core.types.regions.ReUnknown
 import org.rust.lang.core.types.regions.Region
 
@@ -56,19 +55,4 @@ class TyTraitObject(
             return TyTraitObject(item.withDefaultSubst())
         }
     }
-}
-
-fun RsTraitItem.withDefaultSubst(): BoundElement<RsTraitItem> =
-    BoundElement(this, defaultSubstitution(this))
-
-private fun defaultSubstitution(item: RsTraitItem): Substitution {
-    val typeSubst = item.typeParameters.associate {
-        val parameter = TyTypeParameter.named(it)
-        parameter to parameter
-    }
-    val regionSubst = item.lifetimeParameters.associate {
-        val parameter = ReEarlyBound(it)
-        parameter to parameter
-    }
-    return Substitution(typeSubst, regionSubst)
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
@@ -32,6 +32,7 @@ class TyTypeParameter private constructor(
     override fun equals(other: Any?): Boolean = other is TyTypeParameter && other.parameter == parameter
     override fun hashCode(): Int = parameter.hashCode()
 
+    @Deprecated("Use ImplLookup.getEnvBoundTransitivelyFor")
     fun getTraitBoundsTransitively(): Collection<BoundElement<RsTraitItem>> =
         traitBounds.flatMap { it.flattenHierarchy }
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -163,6 +163,65 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }         //^
     """)
 
+    fun `test method call on trait from bound on reference type`() = checkByCode("""
+        struct S;
+        trait Foo { fn foo(&self) {} }
+                     //X
+        impl Foo for &S {}
+
+        fn foo<'a, T>(t: &'a T) where &'a T: Foo {
+            t.foo();
+        }   //^
+    """)
+
+    fun `test associated function call on trait from bound for type without type parameter`() = checkByCode("""
+        struct S1;
+        struct S2;
+        trait From<T> { fn from(_: T) -> Self; }
+                         //X
+        fn foo<T>(t: T) -> S2 where S2: From<T> {
+            S2::from(t)
+        }     //^
+    """)
+
+    fun `test method call on trait from bound for associated type`() = checkByCode("""
+        trait Foo {
+            type Item;
+            fn foo(&self) -> Self::Item;
+        }
+        trait Bar<A> { fn bar(&self); }
+                        //X
+        fn baz<T1, T2>(t: T1)
+            where T1: Foo,
+                  T1::Item: Bar<T2> {
+            t.foo().bar();
+        }         //^
+    """)
+
+    fun `test method call on Self trait from bound for Self`() = checkByCode("""
+        trait Foo {
+            fn foo(&self) -> i32;
+        }    //X
+
+        trait Bar: Sized {
+            fn bar(s: Self) where Self: Foo {
+                s.foo();
+            }   //^
+        }
+    """)
+
+    fun `test method call on self trait from bound for Self`() = checkByCode("""
+        trait Foo {
+            fn foo(&self) -> i32;
+        }    //X
+
+        trait Bar: Sized {
+            fn bar(&self) where Self: Foo {
+                self.foo();
+            }      //^
+        }
+    """)
+
     fun `test Result unwrap`() = checkByCode("""
         enum Result<T, E> { Ok(T), Err(E)}
 

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1013,6 +1013,21 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test associated type bound 2`() = testExpr("""
+        trait Foo {
+            type Item;
+            fn foo(&self) -> Self::Item;
+        }
+        trait Bar<A> {}
+        fn bar<A: Bar<B>, B>(t: A) -> B { unimplemented!() }
+        fn baz<C, D>(t: C)
+            where C: Foo,
+                  C::Item: Bar<D> {
+            let a = bar(t.foo());
+            a;
+        } //^ D
+    """)
+
     fun `test simple unification`() = testExpr("""
         struct S<T>(T);
 
@@ -1279,6 +1294,15 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         trait Tr1<A> { fn foo(&self) -> A { unimplemented!() } }
         trait Tr2<B>: Tr1<B> {}
         fn bar<T: Tr2<u8>>(t: T) {
+            let a = t.foo();
+            a;
+        } //^ u8
+    """)
+
+    fun `test inherited generic type parameter method with bound for reference type`() = testExpr("""
+        trait Tr1<A> { fn foo(&self) -> A { unimplemented!() } }
+        trait Tr2<B>: Tr1<B> {}
+        fn bar<'a, T>(t: &'a T) where &'a T: Tr2<u8> {
             let a = t.foo();
             a;
         } //^ u8


### PR DESCRIPTION
E.g. for associated types:
```rust
trait Foo {
    type Item;
    fn foo(&self) -> Self::Item;
}
trait Bar<A> { fn bar(&self); }
                //X
fn baz<T1, T2>(t: T1)
    where T1: Foo,
          T1::Item: Bar<T2> {
    t.foo().bar();
}         //^
```