### PR TITLE
TY&RES: hardcode `serde` and `failure` custom derives

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt
@@ -20,9 +20,10 @@ import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.psi.ext.RsStructOrEnumItemElement
 import org.rust.lang.core.psi.ext.ancestorStrict
-import org.rust.lang.core.psi.ext.isStdDerivable
+import org.rust.lang.core.psi.ext.isKnownDerivable
 import org.rust.lang.core.resolve.ImplLookup
-import org.rust.lang.core.resolve.StdDerivableTrait
+import org.rust.lang.core.resolve.KnownDerivableTrait
+import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.resolve.withDependencies
 
 object RsDeriveCompletionProvider : CompletionProvider<CompletionParameters>() {
@@ -40,11 +41,12 @@ object RsDeriveCompletionProvider : CompletionProvider<CompletionParameters>() {
             .findImplsAndTraits(owner.declaredType)
             .mapNotNull {
                 val (trait, _) = it.value.implementedTrait ?: return@mapNotNull null
-                if (trait.isStdDerivable) trait.name else null
+                if (trait.isKnownDerivable) trait.name else null
             }
 
-        StdDerivableTrait.values()
+        KnownDerivableTrait.values()
             .filter { it.name !in alreadyDerived }
+            .filter { it.findTrait(owner.knownItems) != null } // check available
             .forEach { trait ->
                 val traitWithDependencies = trait.withDependencies
                     .filter { it.name !in alreadyDerived }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt
@@ -20,11 +20,12 @@ import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.psi.ext.RsStructOrEnumItemElement
 import org.rust.lang.core.psi.ext.ancestorStrict
-import org.rust.lang.core.psi.ext.isKnownDerivable
+import org.rust.lang.core.psi.ext.withDefaultSubst
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.KnownDerivableTrait
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.resolve.withDependencies
+import org.rust.lang.core.types.TraitRef
 
 object RsDeriveCompletionProvider : CompletionProvider<CompletionParameters>() {
 
@@ -37,28 +38,30 @@ object RsDeriveCompletionProvider : CompletionProvider<CompletionParameters>() {
 
         val owner = parameters.position.ancestorStrict<RsStructOrEnumItemElement>()
             ?: return
-        val alreadyDerived = ImplLookup.relativeTo(owner)
-            .findImplsAndTraits(owner.declaredType)
-            .mapNotNull {
-                val (trait, _) = it.value.implementedTrait ?: return@mapNotNull null
-                if (trait.isKnownDerivable) trait.name else null
-            }
+        val ownerType = owner.declaredType
+        val lookup = ImplLookup.relativeTo(owner)
 
-        KnownDerivableTrait.values()
-            .filter { it.name !in alreadyDerived }
-            .filter { it.findTrait(owner.knownItems) != null } // check available
-            .forEach { trait ->
-                val traitWithDependencies = trait.withDependencies
-                    .filter { it.name !in alreadyDerived }
+        /** Filter unavailable and already derived */
+        fun Sequence<KnownDerivableTrait>.filterDerivables() = filter {
+            val trait = it.findTrait(owner.knownItems)
+            trait != null && !lookup.canSelect(TraitRef(ownerType, trait.withDefaultSubst()))
+        }
+
+        KnownDerivableTrait.values().asSequence()
+            .filterDerivables()
+            .forEach { derivable ->
+                val traitWithDependencies = derivable.withDependencies.asSequence()
+                    .filterDerivables()
+                    .toList()
                 // if 'traitWithDependencies' contains only one element
-                // then all trait dependencies are already satisfied
-                // and 'traitWithDependencies' contains only 'trait' element
+                // then all derivable dependencies are already satisfied
+                // and 'traitWithDependencies' contains only 'derivable' element
                 if (traitWithDependencies.size > 1) {
                     val element = LookupElementBuilder.create(traitWithDependencies.joinToString(", "))
                         .withIcon(RsIcons.TRAIT.multiple())
                     result.addElement(element.withPriority(GROUP_PRIORITY))
                 }
-                val element = LookupElementBuilder.create(trait.name)
+                val element = LookupElementBuilder.create(derivable.name)
                     .withIcon(RsIcons.TRAIT)
                 result.addElement(element.withPriority(DEFAULT_PRIORITY))
             }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -12,11 +12,11 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.util.Query
-import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.resolve.STD_DERIVABLE_TRAITS
+import org.rust.lang.core.resolve.KNOWN_DERIVABLE_TRAITS
+import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.stubs.RsTraitItemStub
 import org.rust.lang.core.types.*
 import org.rust.lang.core.types.infer.substitute
@@ -37,10 +37,9 @@ val RsTraitItem.isSizedTrait: Boolean get() = langAttribute == "sized"
 val RsTraitItem.isAuto: Boolean
     get() = stub?.isAuto ?: (node.findChildByType(RsElementTypes.AUTO) != null)
 
-val RsTraitItem.isStdDerivable: Boolean get() {
-    val derivableTrait = STD_DERIVABLE_TRAITS[name] ?: return false
-    return containingCargoPackage?.origin == PackageOrigin.STDLIB &&
-        containingMod.modName == derivableTrait.modName
+val RsTraitItem.isKnownDerivable: Boolean get() {
+    val derivableTrait = KNOWN_DERIVABLE_TRAITS[name] ?: return false
+    return derivableTrait.findTrait(knownItems) == this
 }
 
 val BoundElement<RsTraitItem>.flattenHierarchy: Collection<BoundElement<RsTraitItem>> get() {

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -23,22 +23,6 @@ import org.rust.openapiext.testAssert
 import org.rust.stdext.buildList
 import kotlin.LazyThreadSafetyMode.NONE
 
-enum class StdDerivableTrait(val modName: String, val dependencies: Array<StdDerivableTrait> = emptyArray()) {
-    Clone("clone"),
-    Copy("marker", arrayOf(Clone)),
-    Debug("fmt"),
-    Default("default"),
-    Hash("hash"),
-    PartialEq("cmp"),
-    Eq("cmp", arrayOf(PartialEq)),
-    PartialOrd("cmp", arrayOf(PartialEq)),
-    Ord("cmp", arrayOf(PartialOrd, Eq, PartialEq))
-}
-
-val StdDerivableTrait.withDependencies: List<StdDerivableTrait> get() = listOf(this, *dependencies)
-
-val STD_DERIVABLE_TRAITS: Map<String, StdDerivableTrait> = StdDerivableTrait.values().associate { it.name to it }
-
 private val RsTraitItem.typeParamSingle: TyTypeParameter?
     get() =
         typeParameterList?.typeParameterList?.singleOrNull()?.let { TyTypeParameter.named(it) }
@@ -252,7 +236,7 @@ class ImplLookup(
         return (ty as? TyAdt)?.item?.derivedTraits.orEmpty()
             // select only std traits because we are sure
             // that they are resolved correctly
-            .filter { it.isStdDerivable }
+            .filter { it.isKnownDerivable }
     }
 
     private fun getHardcodedImpls(ty: Ty): Collection<BoundElement<RsTraitItem>> {
@@ -508,7 +492,7 @@ class ImplLookup(
         return (ref.selfTy as? TyAdt)?.item?.derivedTraits.orEmpty()
             // select only std traits because we are sure
             // that they are resolved correctly
-            .filter { it.isStdDerivable }
+            .filter { it.isKnownDerivable }
             .filter { it == ref.trait.element }
             .map { SelectionCandidate.DerivedTrait(it) }
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
@@ -128,3 +128,25 @@ private class RealKnownItemsLookup(
         }.orElse(null)
     }
 }
+
+enum class KnownDerivableTrait(
+    private val resolver: (KnownItems) -> RsTraitItem?,
+    val dependencies: Array<KnownDerivableTrait> = emptyArray()
+) {
+    Clone(KnownItems::Clone),
+    Copy(KnownItems::Copy, arrayOf(Clone)),
+    Debug(KnownItems::Debug),
+    Default(KnownItems::Default),
+    Hash(KnownItems::Hash),
+    PartialEq(KnownItems::PartialEq),
+    Eq(KnownItems::Eq, arrayOf(PartialEq)),
+    PartialOrd(KnownItems::PartialOrd, arrayOf(PartialEq)),
+    Ord(KnownItems::Ord, arrayOf(PartialOrd, Eq, PartialEq)),
+    ;
+
+    fun findTrait(items: KnownItems): RsTraitItem? = resolver(items)
+}
+
+val KnownDerivableTrait.withDependencies: List<KnownDerivableTrait> get() = listOf(this, *dependencies)
+
+val KNOWN_DERIVABLE_TRAITS: Map<String, KnownDerivableTrait> = KnownDerivableTrait.values().associate { it.name to it }

--- a/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
@@ -142,6 +142,12 @@ enum class KnownDerivableTrait(
     Eq(KnownItems::Eq, arrayOf(PartialEq)),
     PartialOrd(KnownItems::PartialOrd, arrayOf(PartialEq)),
     Ord(KnownItems::Ord, arrayOf(PartialOrd, Eq, PartialEq)),
+
+    Serialize({ it.findTrait("serde::Serialize") }),
+    Deserialize({ it.findTrait("serde::Deserialize") }),
+
+    // TODO Fail also derives `Display`. Ignore it for now
+    Fail({ it.findTrait("failure::Fail") }, arrayOf(Debug)),
     ;
 
     fun findTrait(items: KnownItems): RsTraitItem? = resolver(items)

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -567,8 +567,14 @@ fun processMacroReferenceVariants(ref: RsMacroReference, processor: RsResolvePro
 }
 
 fun processDeriveTraitResolveVariants(element: RsMetaItem, traitName: String, processor: RsResolveProcessor): Boolean {
-    val traits = RsNamedElementIndex.findDerivableTraits(element.project, traitName)
-    return processAll(traits, processor)
+    val knownDerive = KNOWN_DERIVABLE_TRAITS[traitName]?.findTrait(element.knownItems)
+    return if (knownDerive != null) {
+        processor(knownDerive)
+    } else {
+        val traits = RsNamedElementIndex.findElementsByName(element.project, traitName)
+            .filterIsInstance<RsTraitItem>()
+        processAll(traits, processor)
+    }
 }
 
 fun processBinaryOpVariants(element: RsBinaryOp, operator: OverloadableBinaryOperator,

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsNamedElementIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsNamedElementIndex.kt
@@ -9,13 +9,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StringStubIndexExtension
 import com.intellij.psi.stubs.StubIndexKey
-import org.rust.cargo.project.workspace.PackageOrigin
-import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.ext.RsNamedElement
-import org.rust.lang.core.psi.ext.containingCargoPackage
-import org.rust.lang.core.resolve.STD_DERIVABLE_TRAITS
 import org.rust.lang.core.stubs.RsFileStub
-import org.rust.openapiext.ProjectCache
 import org.rust.openapiext.getElements
 
 class RsNamedElementIndex : StringStubIndexExtension<RsNamedElement>() {
@@ -25,18 +20,6 @@ class RsNamedElementIndex : StringStubIndexExtension<RsNamedElement>() {
     companion object {
         val KEY: StubIndexKey<String, RsNamedElement> =
             StubIndexKey.createIndexKey("org.rust.lang.core.stubs.index.RustNamedElementIndex")
-
-        private val derivableTraitsCache = ProjectCache<String, Collection<RsTraitItem>>("derivableTraitsCache")
-        fun findDerivableTraits(project: Project, target: String): Collection<RsTraitItem> =
-            derivableTraitsCache.getOrPut(project, target) {
-                val stdTrait = STD_DERIVABLE_TRAITS[target]
-                getElements(KEY, target, project, GlobalSearchScope.allScope(project))
-                    .mapNotNull { it as? RsTraitItem }
-                    .filter { e ->
-                        if (stdTrait == null) return@filter true
-                        e.containingCargoPackage?.origin == PackageOrigin.STDLIB && e.containingMod.modName == stdTrait.modName
-                    }
-            }
 
         fun findElementsByName(
             project: Project,

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -1135,4 +1135,18 @@ class RsResolveTest : RsResolveTestBase() {
                                  //^
         }
     """)
+
+    fun `test derive serde Serialize`() = checkByCode("""
+    //- main.rs
+        #[lang = "serde::Serialize"]
+        trait Serialize { fn serialize(&self); }
+                           //X
+        #[derive(Serialize)]
+        struct Foo;
+
+        fn bar(foo: Foo) {
+            foo.serialize();
+              //^
+        }
+    """)
 }


### PR DESCRIPTION
Now derive for Serialize, Deserialize and Fail work as well as builtin derives.

I think this makes sense even if we'll support procedural macros. Just as an optimization - serde custom derives are very widespread