### PR TITLE
Do not add extra lifetimes for the methods implemented 

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -82,7 +82,7 @@ class RsPsiFactory(private val project: Project) {
     }
 
     fun createStructLiteral(name: String): RsStructLiteral =
-        createExpressionOfType<RsStructLiteral>("$name { }")
+        createExpressionOfType("$name { }")
 
     fun createStructLiteralField(name: String, value: RsExpr? = null): RsStructLiteralField {
         val structLiteralField = createExpressionOfType<RsStructLiteral>("S { $name: () }")
@@ -124,7 +124,7 @@ class RsPsiFactory(private val project: Project) {
     fun createMethodParam(text: String): PsiElement {
         val fnItem: RsFunction = createTraitMethodMember("fn foo($text);")
         return fnItem.selfParameter ?: fnItem.valueParameters.firstOrNull()
-            ?: error("Failed to create method param from text: `$text`")
+        ?: error("Failed to create method param from text: `$text`")
     }
 
     fun createReferenceType(innerTypeText: String, mutable: Boolean): RsRefLikeType =
@@ -155,24 +155,26 @@ class RsPsiFactory(private val project: Project) {
     }
 
     fun createMembers(members: Collection<RsAbstractable>, subst: Substitution = emptySubstitution): RsMembers {
-        val body = members.joinToString(separator = "\n", transform = { when (it) {
-            is RsConstant ->
-                "    const ${it.identifier.text}: ${it.typeReference?.substAndGetText(subst)} = unimplemented!();"
-            is RsTypeAlias ->
-                "    type ${it.name} = ();"
-            is RsFunction ->
-                "    ${it.getSignatureText(subst) ?: ""}{\n        unimplemented!()\n    }"
-            else ->
-                error("Unknown trait member")
-        } })
+        val body = members.joinToString(separator = "\n", transform = {
+            when (it) {
+                is RsConstant ->
+                    "    const ${it.identifier.text}: ${it.typeReference?.substAndGetText(subst)} = unimplemented!();"
+                is RsTypeAlias ->
+                    "    type ${it.name} = ();"
+                is RsFunction ->
+                    "    ${it.getSignatureText(subst) ?: ""}{\n        unimplemented!()\n    }"
+                else ->
+                    error("Unknown trait member")
+            }
+        })
 
         val text = "impl T for S {$body}"
         return createFromText(text) ?: error("Failed to create an impl from text: `$text`")
     }
 
     fun createTraitMethodMember(text: String): RsFunction {
-        val members: RsMembers = createFromText("trait Foo { $text }") ?:
-            error("Failed to create an method member from text: `$text`")
+        val members: RsMembers = createFromText("trait Foo { $text }")
+            ?: error("Failed to create an method member from text: `$text`")
         return members.functionList.first()
     }
 
@@ -264,8 +266,8 @@ class RsPsiFactory(private val project: Project) {
         createFromText<RsConstant>("const C: () = ();")!!.colon!!
 
     fun createIn(): PsiElement =
-        createFromText<RsConstant>("pub(in self) const C: () = ();")?.vis?.visRestriction?.`in` ?:
-            error("Failed to create `in` element")
+        createFromText<RsConstant>("pub(in self) const C: () = ();")?.vis?.visRestriction?.`in`
+            ?: error("Failed to create `in` element")
 
     fun createNewline(): PsiElement = createWhitespace("\n")
 
@@ -279,11 +281,11 @@ class RsPsiFactory(private val project: Project) {
     fun createFunction(
         config: RsExtractFunctionConfig
     ): RsFunction =
-        createFromText<RsFunction>(config.signature)
+        createFromText(config.signature)
             ?: error("Failed to create function element: ${config.name}")
 
     fun createImpl(name: String, functions: List<RsFunction>): RsImplItem =
-        createFromText<RsImplItem>("impl $name {\n${functions.joinToString(separator = "\n", transform = { it.text })}\n}")
+        createFromText("impl $name {\n${functions.joinToString(separator = "\n", transform = { it.text })}\n}")
             ?: error("Failed to create RsImplItem element")
 
     fun createSimpleValueParameterList(name: String, type: RsTypeReference): RsValueParameterList {

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiParserFacade
+import org.rust.ide.presentation.insertionSafeText
 import org.rust.ide.presentation.insertionSafeTextWithLifetimes
 import org.rust.ide.refactoring.extractFunction.RsExtractFunctionConfig
 import org.rust.lang.RsFileType
@@ -370,8 +371,11 @@ private fun RsFunction.getSignatureText(subst: Substitution): String? {
 
 private fun String.iff(cond: Boolean) = if (cond) this + " " else " "
 
-private fun RsTypeReference.substAndGetText(subst: Substitution): String =
-    type.substitute(subst).insertionSafeTextWithLifetimes
+private fun RsTypeReference.substAndGetText(subst: Substitution): String {
+    val substitutedType = type.substitute(subst)
+    val hasLifetime = refLikeType?.lifetime != null
+    return if (hasLifetime) substitutedType.insertionSafeTextWithLifetimes else substitutedType.insertionSafeText
+}
 
 private fun RsSelfParameter.substAndGetText(subst: Substitution): String =
     buildString {

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -8,7 +8,9 @@ package org.rust.ide.refactoring.implementMembers
 import com.intellij.openapi.actionSystem.ex.ActionManagerEx
 import junit.framework.TestCase
 import org.intellij.lang.annotations.Language
+import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.annotator.RsAnnotatorBase
 import org.rust.ide.annotator.RsErrorAnnotator
 
@@ -646,6 +648,27 @@ class ImplementMembersHandlerTest : RsTestBase() {
             }
 
             fn baz() {}
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test Debug implementation`() = doTest("""
+        use std::fmt::Debug;
+
+        struct DebugImpl {}
+
+        impl Debug for DebugImpl {
+            /*caret*/
+        }
+    """, listOf(ImplementMemberSelection("fmt(&self, f: &mut Formatter) -> Result", true, isSelected = true)), """
+        use std::fmt::Debug;
+
+        struct DebugImpl {}
+
+        impl Debug for DebugImpl {
+            fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+                unimplemented!()
+            }
         }
     """)
 


### PR DESCRIPTION
Currently the plugin adds extra lifetimes when processing the functions with reference types with no parameters.

Example: [`Debug` trait, `fmt` method](https://doc.rust-lang.org/std/fmt/trait.Debug.html#tymethod.fmt): `fn fmt(&self, f: &mut Formatter) -> Result<(), Error>`

When the implementation is generated by the plugin, the following code is created:
```
fn fmt(&self, f: &mut Formatter<'a>) -> Result<(), Error> {
	unimplemented!()
}
```

It seems like the generation should not add lifetimes at all, if they are not defined in the original method, that's what I've tried to achieve with the PR.