### PR TITLE
INSP: Fix `Unresolved Reference` error highlighting

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
@@ -19,6 +19,8 @@ import org.rust.lang.core.psi.RsMethodCall
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.endOffsetInParent
+import org.rust.lang.core.psi.ext.getPrevNonCommentSibling
 import javax.swing.JComponent
 
 class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
@@ -36,7 +38,10 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
 
                 val referenceName = basePath.identifier?.text
                 // Don't highlight generic parameters
-                val range = TextRange(0, path.typeArgumentList?.startOffsetInParent ?: path.textLength)
+                val range = TextRange(
+                    0,
+                    path.typeArgumentList?.getPrevNonCommentSibling()?.endOffsetInParent ?: path.textLength
+                )
                 holder.registerProblem(path, candidates, referenceName, range)
             }
 


### PR DESCRIPTION
Fixes error highlighting in this case:

<img width="600" alt="screen shot" src="https://user-images.githubusercontent.com/6079006/51482110-98645680-1da6-11e9-9577-85f1fef1736d.png">
