### PR TITLE
TY: Do not implement the trait `Sized` for `str`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -414,6 +414,8 @@ class ImplLookup(
     private fun assembleCandidates(ref: TraitRef): List<SelectionCandidate> {
         val element = ref.trait.element
         return when {
+            // The `Sized` trait is hardcoded in the compiler. It cannot be implemented in source code.
+            // Trying to do so would result in a E0322.
             element == items.Sized -> sizedTraitCandidates(ref.selfTy, element)
             ref.selfTy is TyTypeParameter -> {
                 ref.selfTy.getTraitBoundsTransitively().asSequence()

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -65,14 +65,21 @@ fun Ty.getTypeParameter(name: String): TyTypeParameter? {
     return typeParameterValues.typeParameterByName(name)
 }
 
+/**
+ * See [org.rust.lang.core.type.RsImplicitTraitsTest]
+ */
 tailrec fun Ty.isSized(): Boolean {
     return when (this) {
-        is TyPrimitive,
+        is TyNumeric,
+        is TyBool,
+        is TyChar,
+        is TyUnit,
+        is TyNever,
         is TyReference,
         is TyPointer,
         is TyArray,
         is TyFunction -> true
-        is TySlice, is TyTraitObject -> false
+        is TyStr, is TySlice, is TyTraitObject -> false
         is TyTypeParameter -> isSized
         is TyAdt -> {
             val item = item as? RsStructItem ?: return true

--- a/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
@@ -8,10 +8,7 @@ package org.rust.lang.core.type
 import org.intellij.lang.annotations.Language
 import org.rust.lang.core.psi.RsTypeReference
 import org.rust.lang.core.resolve.ImplLookup
-import org.rust.lang.core.types.ty.TyBool
-import org.rust.lang.core.types.ty.TyChar
-import org.rust.lang.core.types.ty.TyFloat
-import org.rust.lang.core.types.ty.TyInteger
+import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
 
 class RsImplicitTraitsTest : RsTypificationTestBase() {
@@ -25,6 +22,11 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
 
     fun `test slice is not Sized`() = doTest("""
         fn foo() -> Box<[i32]> { unimplemented!() }
+                      //^ !Sized
+    """)
+
+    fun `test str is not Sized`() = doTest("""
+        fn foo() -> Box<str> { unimplemented!() }
                       //^ !Sized
     """)
 
@@ -145,7 +147,7 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
     private fun checkPrimitiveTypes(traitName: String) {
         val allIntegers = TyInteger.VALUES.toTypedArray()
         val allFloats = TyFloat.VALUES.toTypedArray()
-        for (ty in listOf(TyBool, TyChar, *allIntegers, *allFloats)) {
+        for (ty in listOf(TyBool, TyChar, TyUnit, TyNever, *allIntegers, *allFloats)) {
             doTest("""
                 fn foo() -> $ty { unimplemented!() }
                           //^ $traitName


### PR DESCRIPTION
This allows us to to correctly report an error `E0277` for the following code:
```rust
    fn foo(a: str) { }
```
