### PR TITLE
TY: Add tests for ignoring values in tuple destructuring

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/type/RsPatternMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsPatternMatchingTest.kt
@@ -49,6 +49,61 @@ class RsPatternMatchingTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test let remaining front single`() = expect<IllegalStateException> {
+        testExpr("""
+        struct S;
+        struct T;
+        struct U;
+
+        fn main() {
+            let (.., t, u) = (S, T, U);
+            u;
+          //^ U
+        }
+    """)
+    }
+
+    fun `test let remaining front multiple`() = expect<IllegalStateException> {
+        testExpr("""
+        struct S;
+        struct T;
+        struct U;
+
+        fn main() {
+            let (.., u) = (S, T, U);
+            u;
+          //^ U
+        }
+    """)
+    }
+
+    fun `test let remaining back single`() = testExpr("""
+        struct S;
+        struct T;
+        struct U;
+
+        fn main() {
+            let (s, t, ..) = (S, T, U);
+            t;
+          //^ T
+        }
+    """)
+
+    fun `test let remaining middle multiple`() = expect<IllegalStateException> {
+        testExpr("""
+        struct S;
+        struct T;
+        struct U;
+        struct V;
+
+        fn main() {
+            let (s, .., v) = (S, T, U, V);
+            v;
+          //^ V
+        }
+    """)
+    }
+
     fun `test nested struct pattern`() = testExpr("""
         struct S;
         struct T {


### PR DESCRIPTION
When the `..` is placed at the start or the middle of the pattern,
we assign types as if the `..` was not there at all.
When the `..` is placed ad the end, types are already correct.

See: https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html#ignoring-remaining-parts-of-a-value-with-

CC #3281
