### PR TITLE
RES: duplicated `#[macro_export]` macros now unresolved

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -50,6 +50,21 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         macro_rules! foo_bar { () => {} }
     """)
 
+    fun `test duplicated macro_export macro`() = stubOnlyResolve("""
+    //- main.rs
+        #[macro_use]
+        extern crate test_package;
+
+        fn main() {
+            foo_bar!();
+        }  //^ unresolved
+    //- lib.rs
+        #[macro_export]
+        macro_rules! foo_bar { () => {} }
+        #[macro_export]
+        macro_rules! foo_bar { () => {} }
+    """)
+
     fun `test macro rules missing macro_export`() = stubOnlyResolve("""
     //- main.rs
         #[macro_use]


### PR DESCRIPTION
We had a problem that if we have multiple `#[macro_export]`
with the same name we resolved to some of them randomly
(really randomly!). Ideally it should be multiresolve.