### PR TITLE
Handle 8-bit and 24-bit ANSI color escapes in console

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
@@ -12,7 +12,10 @@ import com.intellij.execution.configurations.RunProfile
 import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.configurations.RunnerSettings
 import com.intellij.execution.executors.DefaultDebugExecutor
-import com.intellij.execution.process.*
+import com.intellij.execution.process.CapturingProcessAdapter
+import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.execution.process.ProcessOutput
+import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.AsyncProgramRunner
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.ui.RunContentDescriptor
@@ -36,6 +39,7 @@ import org.jetbrains.concurrency.Promise
 import org.rust.cargo.project.workspace.CargoWorkspace.CrateType
 import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
 import org.rust.cargo.runconfig.CargoRunStateBase
+import org.rust.cargo.runconfig.RsKillableColoredProcessHandler
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.toolchain.Cargo
 import org.rust.cargo.toolchain.CargoCommandLine
@@ -137,7 +141,7 @@ private fun buildProjectAndGetBinaryArtifactPath(
     val cargo = state.cargo()
 
     val processForUserOutput = ProcessOutput()
-    val processForUser = KillableColoredProcessHandler(cargo.toColoredCommandLine(command))
+    val processForUser = RsKillableColoredProcessHandler(cargo.toColoredCommandLine(command))
 
     processForUser.addProcessListener(CapturingProcessAdapter(processForUserOutput))
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunStateBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunStateBase.kt
@@ -7,7 +7,6 @@ package org.rust.cargo.runconfig
 
 import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.filters.Filter
-import com.intellij.execution.process.KillableColoredProcessHandler
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
@@ -59,7 +58,7 @@ abstract class CargoRunStateBase(
     public override fun startProcess(): ProcessHandler {
         val cmd = toolchain.cargoOrWrapper(cargoProject?.manifest?.parent)
             .toColoredCommandLine(prepareCommandLine())
-        val handler = KillableColoredProcessHandler(cmd)
+        val handler = RsKillableColoredProcessHandler(cmd)
         ProcessTerminatedListener.attach(handler) // shows exit code upon termination
         return handler
     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsAnsiEscapeDecoder.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsAnsiEscapeDecoder.kt
@@ -1,0 +1,160 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig
+
+import com.intellij.execution.process.AnsiEscapeDecoder
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.text.StringUtil
+import org.rust.stdext.nextOrNull
+import java.awt.Color
+import kotlin.math.roundToInt
+
+/**
+ * Currently IntelliJ Platform supports only 16 ANSI colors (standard colors and high intensity colors). The base
+ * [AnsiEscapeDecoder] class simply ignores 8-bit and 24-bit ANSI color escapes. This class converts (quantizes) such
+ * escapes to supported 3/4-bit ANSI color escapes. Note that the user can configure color mapping in editor settings
+ * (Preferences > Editor > Console Scheme > Console Colors > ANSI Colors). In addition, the themes also set the colors.
+ * So, this solution gives us interoperability with existing themes.
+ */
+class RsAnsiEscapeDecoder : AnsiEscapeDecoder() {
+    override fun escapeText(text: String, outputType: Key<*>, textAcceptor: ColoredTextAcceptor) {
+        super.escapeText(quantizeAnsiColors(text), outputType, textAcceptor)
+    }
+
+    companion object {
+        const val CSI: String = "\u001B[" // "Control Sequence Initiator"
+        private val ANSI_CONTROL_SEQUENCE_REGEX: Regex = """${StringUtil.escapeToRegexp(CSI)}([^m]*;[^m]*)m""".toRegex()
+
+        private const val ANSI_SET_FOREGROUND_ATTR: Int = 38
+        private const val ANSI_SET_BACKGROUND_ATTR: Int = 48
+
+        const val ANSI_24_BIT_COLOR_FORMAT: Int = 2
+        const val ANSI_8_BIT_COLOR_FORMAT: Int = 5
+
+        /**
+         * Parses ANSI-value codes from text and replaces 8-bit and 24-bit colors with nearest (in Euclidean space)
+         * 4-bit value.
+         *
+         * @param text a string with ANSI escape sequences
+         */
+        private fun quantizeAnsiColors(text: String): String = text
+            .replace(ANSI_CONTROL_SEQUENCE_REGEX) {
+                val rawAttributes = it.destructured.component1().split(";").iterator()
+                val result = mutableListOf<Int>()
+                while (rawAttributes.hasNext()) {
+                    val attribute = rawAttributes.parseAttribute() ?: continue
+                    if (attribute !in listOf(ANSI_SET_FOREGROUND_ATTR, ANSI_SET_BACKGROUND_ATTR)) {
+                        result.add(attribute)
+                        continue
+                    }
+                    val color = parseColor(rawAttributes) ?: continue
+                    val ansiColor = getNearestAnsiColor(color) ?: continue
+                    val colorAttribute = getColorAttribute(ansiColor, attribute == ANSI_SET_FOREGROUND_ATTR)
+                    result.add(colorAttribute)
+                }
+                result.joinToString(separator = ";", prefix = CSI, postfix = "m") { attr -> attr.toString() }
+            }
+
+        private fun Iterator<String>.parseAttribute(): Int? = nextOrNull()?.toIntOrNull()
+
+        private fun parseColor(rawAttributes: Iterator<String>): Color? {
+            val format = rawAttributes.parseAttribute() ?: return null
+            return when (format) {
+                ANSI_24_BIT_COLOR_FORMAT -> parse24BitColor(rawAttributes)
+                ANSI_8_BIT_COLOR_FORMAT -> parse8BitColor(rawAttributes)
+                else -> null
+            }
+        }
+
+        private fun parse24BitColor(rawAttributes: Iterator<String>): Color? {
+            val red = rawAttributes.parseAttribute() ?: return null
+            val green = rawAttributes.parseAttribute() ?: return null
+            val blue = rawAttributes.parseAttribute() ?: return null
+            return Color(red, green, blue)
+        }
+
+        private fun parse8BitColor(rawAttributes: Iterator<String>): Color? {
+            val attribute = rawAttributes.parseAttribute() ?: return null
+            return when (attribute) {
+                // Standard colors or high intensity colors
+                in 0..15 -> Ansi4BitColor[attribute]?.value
+
+                // 6 × 6 × 6 cube (216 colors): 16 + 36 × r + 6 × g + b (0 ≤ r, g, b ≤ 5)
+                in 16..231 -> {
+                    val red = (attribute - 16) / 36 * 51
+                    val green = (attribute - 16) % 36 / 6 * 51
+                    val blue = (attribute - 16) % 6 * 51
+                    Color(red, green, blue)
+                }
+
+                // Grayscale from black to white in 24 steps
+                in 232..255 -> {
+                    val value = (attribute - 232) * 10 + 8
+                    Color(value, value, value)
+                }
+
+                else -> null
+            }
+        }
+
+        private fun getNearestAnsiColor(color: Color): Ansi4BitColor? =
+            Ansi4BitColor.values().minBy { calcEuclideanDistance(it.value, color) }
+
+        private fun calcEuclideanDistance(from: Color, to: Color): Int {
+            val redDiff = from.red.toDouble() - to.red
+            val greenDiff = from.green.toDouble() - to.green
+            val blueDiff = from.blue.toDouble() - to.blue
+            return Math.sqrt(redDiff * redDiff + greenDiff * greenDiff + blueDiff * blueDiff).roundToInt()
+        }
+
+        private fun getColorAttribute(realAnsiColor: Ansi4BitColor, isForeground: Boolean): Int {
+            // Rude hack for Windows: map the bright white foreground color to black.
+            // See https://github.com/intellij-rust/intellij-rust/pull/3312#issue-249111003
+            val ansiColor = if (realAnsiColor == Ansi4BitColor.BRIGHT_WHITE && isForeground && SystemInfo.isWindows) {
+                Ansi4BitColor.BLACK
+            } else {
+                realAnsiColor
+            }
+            val colorIndex = ansiColor.index
+            return when {
+                colorIndex in 0..7 && isForeground -> colorIndex + 30
+                colorIndex in 0..7 && !isForeground -> colorIndex + 40
+                colorIndex in 8..15 && isForeground -> colorIndex + 82
+                colorIndex in 8..15 && !isForeground -> colorIndex + 92
+                else -> error("impossible")
+            }
+        }
+
+        private enum class Ansi4BitColor(val value: Color) {
+            BLACK(Color(0, 0, 0)),
+            RED(Color(128, 0, 0)),
+            GREEN(Color(0, 128, 0)),
+            YELLOW(Color(128, 128, 0)),
+            BLUE(Color(0, 0, 128)),
+            MAGENTA(Color(128, 0, 128)),
+            CYAN(Color(0, 128, 128)),
+            WHITE(Color(192, 192, 192)),
+            BRIGHT_BLACK(Color(128, 128, 128)),
+            BRIGHT_RED(Color(255, 0, 0)),
+            BRIGHT_GREEN(Color(0, 255, 0)),
+            BRIGHT_YELLOW(Color(255, 255, 0)),
+            BRIGHT_BLUE(Color(0, 0, 255)),
+            BRIGHT_MAGENTA(Color(255, 0, 255)),
+            BRIGHT_CYAN(Color(0, 255, 255)),
+            BRIGHT_WHITE(Color(255, 255, 255));
+
+            val index: Int get() = values().indexOf(this)
+
+            companion object {
+                operator fun get(index: Int): Ansi4BitColor? {
+                    val values = values()
+                    return if (index >= 0 && index < values.size) values[index] else null
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsKillableColoredProcessHandler.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsKillableColoredProcessHandler.kt
@@ -1,0 +1,31 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.AnsiEscapeDecoder
+import com.intellij.execution.process.KillableProcessHandler
+import com.intellij.openapi.util.Key
+
+/**
+ * Same as [com.intellij.execution.process.KillableColoredProcessHandler], but uses [RsAnsiEscapeDecoder].
+ */
+class RsKillableColoredProcessHandler(commandLine: GeneralCommandLine)
+    : KillableProcessHandler(mediate(commandLine, false, false)), AnsiEscapeDecoder.ColoredTextAcceptor {
+    private val ansiEscapeDecoder: AnsiEscapeDecoder = RsAnsiEscapeDecoder()
+
+    init {
+        setShouldKillProcessSoftly(true)
+    }
+
+    override fun notifyTextAvailable(text: String, outputType: Key<*>) {
+        ansiEscapeDecoder.escapeText(text, outputType, this)
+    }
+
+    override fun coloredTextAvailable(text: String, attributes: Key<*>) {
+        super.notifyTextAvailable(text, attributes)
+    }
+}

--- a/src/test/kotlin/org/rust/cargo/runconfig/RsAnsiEscapeDecoderTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/RsAnsiEscapeDecoderTest.kt
@@ -1,0 +1,305 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig
+
+import com.intellij.execution.process.AnsiEscapeDecoder
+import com.intellij.execution.process.ProcessOutputTypes
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.testFramework.PlatformTestCase
+import org.rust.cargo.runconfig.RsAnsiEscapeDecoder.Companion.ANSI_24_BIT_COLOR_FORMAT
+import org.rust.cargo.runconfig.RsAnsiEscapeDecoder.Companion.ANSI_8_BIT_COLOR_FORMAT
+import org.rust.cargo.runconfig.RsAnsiEscapeDecoder.Companion.CSI
+
+class RsAnsiEscapeDecoderTest : PlatformTestCase() {
+
+    fun `test standard 24-bit colors foreground`() = check(
+        ColoredText(
+            make24BitColorCtrlSeq(0, 0, 0, isForeground = true) + "BLACK" +
+                make24BitColorCtrlSeq(129, 0, 0, isForeground = true) + "RED" +
+                make24BitColorCtrlSeq(0, 129, 0, isForeground = true) + "GREEN" +
+                make24BitColorCtrlSeq(129, 129, 0, isForeground = true) + "YELLOW" +
+                make24BitColorCtrlSeq(0, 0, 129, isForeground = true) + "BLUE" +
+                make24BitColorCtrlSeq(129, 0, 129, isForeground = true) + "MAGENTA" +
+                make24BitColorCtrlSeq(0, 129, 129, isForeground = true) + "CYAN" +
+                make24BitColorCtrlSeq(193, 193, 193, isForeground = true) + "WHITE"
+        )
+            .addExpected("BLACK", makeSimpleCtrlSeq(30))
+            .addExpected("RED", makeSimpleCtrlSeq(31))
+            .addExpected("GREEN", makeSimpleCtrlSeq(32))
+            .addExpected("YELLOW", makeSimpleCtrlSeq(33))
+            .addExpected("BLUE", makeSimpleCtrlSeq(34))
+            .addExpected("MAGENTA", makeSimpleCtrlSeq(35))
+            .addExpected("CYAN", makeSimpleCtrlSeq(36))
+            .addExpected("WHITE", makeSimpleCtrlSeq(37))
+    )
+
+    fun `test standard 24-bit colors background`() = check(
+        ColoredText(
+            make24BitColorCtrlSeq(0, 0, 0, isForeground = false) + "BLACK" +
+                make24BitColorCtrlSeq(129, 0, 0, isForeground = false) + "RED" +
+                make24BitColorCtrlSeq(0, 129, 0, isForeground = false) + "GREEN" +
+                make24BitColorCtrlSeq(129, 129, 0, isForeground = false) + "YELLOW" +
+                make24BitColorCtrlSeq(0, 0, 129, isForeground = false) + "BLUE" +
+                make24BitColorCtrlSeq(129, 0, 129, isForeground = false) + "MAGENTA" +
+                make24BitColorCtrlSeq(0, 129, 129, isForeground = false) + "CYAN" +
+                make24BitColorCtrlSeq(193, 193, 193, isForeground = false) + "WHITE"
+        )
+            .addExpected("BLACK", makeSimpleCtrlSeq(40))
+            .addExpected("RED", makeSimpleCtrlSeq(41))
+            .addExpected("GREEN", makeSimpleCtrlSeq(42))
+            .addExpected("YELLOW", makeSimpleCtrlSeq(43))
+            .addExpected("BLUE", makeSimpleCtrlSeq(44))
+            .addExpected("MAGENTA", makeSimpleCtrlSeq(45))
+            .addExpected("CYAN", makeSimpleCtrlSeq(46))
+            .addExpected("WHITE", makeSimpleCtrlSeq(47))
+    )
+
+    fun `test bright 24-bit colors foreground`() = check(
+        ColoredText(
+            make24BitColorCtrlSeq(127, 127, 127, isForeground = true) + "BRIGHT BLACK" +
+                make24BitColorCtrlSeq(254, 0, 0, isForeground = true) + "BRIGHT RED" +
+                make24BitColorCtrlSeq(0, 254, 0, isForeground = true) + "BRIGHT GREEN" +
+                make24BitColorCtrlSeq(254, 254, 0, isForeground = true) + "BRIGHT YELLOW" +
+                make24BitColorCtrlSeq(0, 0, 254, isForeground = true) + "BRIGHT BLUE" +
+                make24BitColorCtrlSeq(254, 0, 254, isForeground = true) + "BRIGHT MAGENTA" +
+                make24BitColorCtrlSeq(0, 254, 254, isForeground = true) + "BRIGHT CYAN" +
+                make24BitColorCtrlSeq(254, 254, 254, isForeground = true) + "BRIGHT WHITE"
+        )
+            .addExpected("BRIGHT BLACK", makeSimpleCtrlSeq(90))
+            .addExpected("BRIGHT RED", makeSimpleCtrlSeq(91))
+            .addExpected("BRIGHT GREEN", makeSimpleCtrlSeq(92))
+            .addExpected("BRIGHT YELLOW", makeSimpleCtrlSeq(93))
+            .addExpected("BRIGHT BLUE", makeSimpleCtrlSeq(94))
+            .addExpected("BRIGHT MAGENTA", makeSimpleCtrlSeq(95))
+            .addExpected("BRIGHT CYAN", makeSimpleCtrlSeq(96))
+            .addExpected("BRIGHT WHITE", if (SystemInfo.isWindows) makeSimpleCtrlSeq(30) else makeSimpleCtrlSeq(97))
+    )
+
+    fun `test bright 24-bit colors background`() = check(
+        ColoredText(
+            make24BitColorCtrlSeq(127, 127, 127, isForeground = false) + "BRIGHT BLACK" +
+                make24BitColorCtrlSeq(254, 0, 0, isForeground = false) + "BRIGHT RED" +
+                make24BitColorCtrlSeq(0, 254, 0, isForeground = false) + "BRIGHT GREEN" +
+                make24BitColorCtrlSeq(254, 254, 0, isForeground = false) + "BRIGHT YELLOW" +
+                make24BitColorCtrlSeq(0, 0, 254, isForeground = false) + "BRIGHT BLUE" +
+                make24BitColorCtrlSeq(254, 0, 254, isForeground = false) + "BRIGHT MAGENTA" +
+                make24BitColorCtrlSeq(0, 254, 254, isForeground = false) + "BRIGHT CYAN" +
+                make24BitColorCtrlSeq(254, 254, 254, isForeground = false) + "BRIGHT WHITE"
+        )
+            .addExpected("BRIGHT BLACK", makeSimpleCtrlSeq(100))
+            .addExpected("BRIGHT RED", makeSimpleCtrlSeq(101))
+            .addExpected("BRIGHT GREEN", makeSimpleCtrlSeq(102))
+            .addExpected("BRIGHT YELLOW", makeSimpleCtrlSeq(103))
+            .addExpected("BRIGHT BLUE", makeSimpleCtrlSeq(104))
+            .addExpected("BRIGHT MAGENTA", makeSimpleCtrlSeq(105))
+            .addExpected("BRIGHT CYAN", makeSimpleCtrlSeq(106))
+            .addExpected("BRIGHT WHITE", makeSimpleCtrlSeq(107))
+    )
+
+    fun `test standard 8-bit colors foreground`() = check(
+        ColoredText(
+            make8BitColorCtrlSeq(0, isForeground = true) + "BLACK" +
+                make8BitColorCtrlSeq(1, isForeground = true) + "RED" +
+                make8BitColorCtrlSeq(2, isForeground = true) + "GREEN" +
+                make8BitColorCtrlSeq(3, isForeground = true) + "YELLOW" +
+                make8BitColorCtrlSeq(4, isForeground = true) + "BLUE" +
+                make8BitColorCtrlSeq(5, isForeground = true) + "MAGENTA" +
+                make8BitColorCtrlSeq(6, isForeground = true) + "CYAN" +
+                make8BitColorCtrlSeq(7, isForeground = true) + "WHITE"
+        )
+            .addExpected("BLACK", makeSimpleCtrlSeq(30))
+            .addExpected("RED", makeSimpleCtrlSeq(31))
+            .addExpected("GREEN", makeSimpleCtrlSeq(32))
+            .addExpected("YELLOW", makeSimpleCtrlSeq(33))
+            .addExpected("BLUE", makeSimpleCtrlSeq(34))
+            .addExpected("MAGENTA", makeSimpleCtrlSeq(35))
+            .addExpected("CYAN", makeSimpleCtrlSeq(36))
+            .addExpected("WHITE", makeSimpleCtrlSeq(37))
+    )
+
+    fun `test standard 8-bit colors background`() = check(
+        ColoredText(
+            make8BitColorCtrlSeq(0, isForeground = false) + "BLACK" +
+                make8BitColorCtrlSeq(1, isForeground = false) + "RED" +
+                make8BitColorCtrlSeq(2, isForeground = false) + "GREEN" +
+                make8BitColorCtrlSeq(3, isForeground = false) + "YELLOW" +
+                make8BitColorCtrlSeq(4, isForeground = false) + "BLUE" +
+                make8BitColorCtrlSeq(5, isForeground = false) + "MAGENTA" +
+                make8BitColorCtrlSeq(6, isForeground = false) + "CYAN" +
+                make8BitColorCtrlSeq(7, isForeground = false) + "WHITE"
+        )
+            .addExpected("BLACK", makeSimpleCtrlSeq(40))
+            .addExpected("RED", makeSimpleCtrlSeq(41))
+            .addExpected("GREEN", makeSimpleCtrlSeq(42))
+            .addExpected("YELLOW", makeSimpleCtrlSeq(43))
+            .addExpected("BLUE", makeSimpleCtrlSeq(44))
+            .addExpected("MAGENTA", makeSimpleCtrlSeq(45))
+            .addExpected("CYAN", makeSimpleCtrlSeq(46))
+            .addExpected("WHITE", makeSimpleCtrlSeq(47))
+    )
+
+    fun `test bright 8-bit colors foreground`() = check(
+        ColoredText(
+            make8BitColorCtrlSeq(8, isForeground = true) + "BRIGHT BLACK" +
+                make8BitColorCtrlSeq(9, isForeground = true) + "BRIGHT RED" +
+                make8BitColorCtrlSeq(10, isForeground = true) + "BRIGHT GREEN" +
+                make8BitColorCtrlSeq(11, isForeground = true) + "BRIGHT YELLOW" +
+                make8BitColorCtrlSeq(12, isForeground = true) + "BRIGHT BLUE" +
+                make8BitColorCtrlSeq(13, isForeground = true) + "BRIGHT MAGENTA" +
+                make8BitColorCtrlSeq(14, isForeground = true) + "BRIGHT CYAN" +
+                make8BitColorCtrlSeq(15, isForeground = true) + "BRIGHT WHITE"
+        )
+            .addExpected("BRIGHT BLACK", makeSimpleCtrlSeq(90))
+            .addExpected("BRIGHT RED", makeSimpleCtrlSeq(91))
+            .addExpected("BRIGHT GREEN", makeSimpleCtrlSeq(92))
+            .addExpected("BRIGHT YELLOW", makeSimpleCtrlSeq(93))
+            .addExpected("BRIGHT BLUE", makeSimpleCtrlSeq(94))
+            .addExpected("BRIGHT MAGENTA", makeSimpleCtrlSeq(95))
+            .addExpected("BRIGHT CYAN", makeSimpleCtrlSeq(96))
+            .addExpected("BRIGHT WHITE", if (SystemInfo.isWindows) makeSimpleCtrlSeq(30) else makeSimpleCtrlSeq(97))
+    )
+
+    fun `test bright 8-bit colors background`() = check(
+        ColoredText(
+            make8BitColorCtrlSeq(8, isForeground = false) + "BRIGHT BLACK" +
+                make8BitColorCtrlSeq(9, isForeground = false) + "BRIGHT RED" +
+                make8BitColorCtrlSeq(10, isForeground = false) + "BRIGHT GREEN" +
+                make8BitColorCtrlSeq(11, isForeground = false) + "BRIGHT YELLOW" +
+                make8BitColorCtrlSeq(12, isForeground = false) + "BRIGHT BLUE" +
+                make8BitColorCtrlSeq(13, isForeground = false) + "BRIGHT MAGENTA" +
+                make8BitColorCtrlSeq(14, isForeground = false) + "BRIGHT CYAN" +
+                make8BitColorCtrlSeq(15, isForeground = false) + "BRIGHT WHITE"
+        )
+            .addExpected("BRIGHT BLACK", makeSimpleCtrlSeq(100))
+            .addExpected("BRIGHT RED", makeSimpleCtrlSeq(101))
+            .addExpected("BRIGHT GREEN", makeSimpleCtrlSeq(102))
+            .addExpected("BRIGHT YELLOW", makeSimpleCtrlSeq(103))
+            .addExpected("BRIGHT BLUE", makeSimpleCtrlSeq(104))
+            .addExpected("BRIGHT MAGENTA", makeSimpleCtrlSeq(105))
+            .addExpected("BRIGHT CYAN", makeSimpleCtrlSeq(106))
+            .addExpected("BRIGHT WHITE", makeSimpleCtrlSeq(107))
+    )
+
+    fun `test rgb 8-bit colors foreground`() = check(
+        ColoredText(
+            make8BitColorCtrlSeq(232, isForeground = true) + "BLACK" +
+                make8BitColorCtrlSeq(88, isForeground = true) + "RED" +
+                make8BitColorCtrlSeq(28, isForeground = true) + "GREEN" +
+                make8BitColorCtrlSeq(142, isForeground = true) + "YELLOW" +
+                make8BitColorCtrlSeq(18, isForeground = true) + "BLUE" +
+                make8BitColorCtrlSeq(90, isForeground = true) + "MAGENTA" +
+                make8BitColorCtrlSeq(30, isForeground = true) + "CYAN" +
+                make8BitColorCtrlSeq(250, isForeground = true) + "WHITE" +
+                make8BitColorCtrlSeq(240, isForeground = true) + "BRIGHT BLACK" +
+                make8BitColorCtrlSeq(196, isForeground = true) + "BRIGHT RED" +
+                make8BitColorCtrlSeq(46, isForeground = true) + "BRIGHT GREEN" +
+                make8BitColorCtrlSeq(226, isForeground = true) + "BRIGHT YELLOW" +
+                make8BitColorCtrlSeq(21, isForeground = true) + "BRIGHT BLUE" +
+                make8BitColorCtrlSeq(201, isForeground = true) + "BRIGHT MAGENTA" +
+                make8BitColorCtrlSeq(51, isForeground = true) + "BRIGHT CYAN" +
+                make8BitColorCtrlSeq(255, isForeground = true) + "BRIGHT WHITE"
+        )
+            .addExpected("BLACK", makeSimpleCtrlSeq(30))
+            .addExpected("RED", makeSimpleCtrlSeq(31))
+            .addExpected("GREEN", makeSimpleCtrlSeq(32))
+            .addExpected("YELLOW", makeSimpleCtrlSeq(33))
+            .addExpected("BLUE", makeSimpleCtrlSeq(34))
+            .addExpected("MAGENTA", makeSimpleCtrlSeq(35))
+            .addExpected("CYAN", makeSimpleCtrlSeq(36))
+            .addExpected("WHITE", makeSimpleCtrlSeq(37))
+            .addExpected("BRIGHT BLACK", makeSimpleCtrlSeq(90))
+            .addExpected("BRIGHT RED", makeSimpleCtrlSeq(91))
+            .addExpected("BRIGHT GREEN", makeSimpleCtrlSeq(92))
+            .addExpected("BRIGHT YELLOW", makeSimpleCtrlSeq(93))
+            .addExpected("BRIGHT BLUE", makeSimpleCtrlSeq(94))
+            .addExpected("BRIGHT MAGENTA", makeSimpleCtrlSeq(95))
+            .addExpected("BRIGHT CYAN", makeSimpleCtrlSeq(96))
+            .addExpected("BRIGHT WHITE", if (SystemInfo.isWindows) makeSimpleCtrlSeq(30) else makeSimpleCtrlSeq(97))
+    )
+
+    fun `test rgb 8-bit colors background`() = check(
+        ColoredText(
+            make8BitColorCtrlSeq(232, isForeground = false) + "BLACK" +
+                make8BitColorCtrlSeq(88, isForeground = false) + "RED" +
+                make8BitColorCtrlSeq(28, isForeground = false) + "GREEN" +
+                make8BitColorCtrlSeq(142, isForeground = false) + "YELLOW" +
+                make8BitColorCtrlSeq(18, isForeground = false) + "BLUE" +
+                make8BitColorCtrlSeq(90, isForeground = false) + "MAGENTA" +
+                make8BitColorCtrlSeq(30, isForeground = false) + "CYAN" +
+                make8BitColorCtrlSeq(250, isForeground = false) + "WHITE" +
+                make8BitColorCtrlSeq(240, isForeground = false) + "BRIGHT BLACK" +
+                make8BitColorCtrlSeq(196, isForeground = false) + "BRIGHT RED" +
+                make8BitColorCtrlSeq(46, isForeground = false) + "BRIGHT GREEN" +
+                make8BitColorCtrlSeq(226, isForeground = false) + "BRIGHT YELLOW" +
+                make8BitColorCtrlSeq(21, isForeground = false) + "BRIGHT BLUE" +
+                make8BitColorCtrlSeq(201, isForeground = false) + "BRIGHT MAGENTA" +
+                make8BitColorCtrlSeq(51, isForeground = false) + "BRIGHT CYAN" +
+                make8BitColorCtrlSeq(255, isForeground = false) + "BRIGHT WHITE"
+        )
+            .addExpected("BLACK", makeSimpleCtrlSeq(40))
+            .addExpected("RED", makeSimpleCtrlSeq(41))
+            .addExpected("GREEN", makeSimpleCtrlSeq(42))
+            .addExpected("YELLOW", makeSimpleCtrlSeq(43))
+            .addExpected("BLUE", makeSimpleCtrlSeq(44))
+            .addExpected("MAGENTA", makeSimpleCtrlSeq(45))
+            .addExpected("CYAN", makeSimpleCtrlSeq(46))
+            .addExpected("WHITE", makeSimpleCtrlSeq(47))
+            .addExpected("BRIGHT BLACK", makeSimpleCtrlSeq(100))
+            .addExpected("BRIGHT RED", makeSimpleCtrlSeq(101))
+            .addExpected("BRIGHT GREEN", makeSimpleCtrlSeq(102))
+            .addExpected("BRIGHT YELLOW", makeSimpleCtrlSeq(103))
+            .addExpected("BRIGHT BLUE", makeSimpleCtrlSeq(104))
+            .addExpected("BRIGHT MAGENTA", makeSimpleCtrlSeq(105))
+            .addExpected("BRIGHT CYAN", makeSimpleCtrlSeq(106))
+            .addExpected("BRIGHT WHITE", makeSimpleCtrlSeq(107))
+    )
+
+    fun `test multiple attributes 1`() = check(
+        ColoredText(
+            makeSimpleCtrlSeq(0) +
+                make24BitColorCtrlSeq(0, 0, 0, isForeground = false) +
+                make8BitColorCtrlSeq(255, isForeground = true) +
+                "TEXT"
+        ).addExpected("TEXT", "${CSI}0;40;${if (SystemInfo.isWindows) 30 else 97}m")
+    )
+
+    fun `test multiple attributes 2`() = check(
+        ColoredText("${CSI}0m${CSI}48;$ANSI_24_BIT_COLOR_FORMAT;0;0;0m${CSI}38;$ANSI_8_BIT_COLOR_FORMAT;255mTEXT")
+            .addExpected("TEXT", "${CSI}0;40;${if (SystemInfo.isWindows) 30 else 97}m")
+    )
+
+    private class ColoredText(val rawText: String, val outputType: Key<*> = ProcessOutputTypes.STDOUT) {
+        val expectedColoredChunks: MutableList<Pair<String, String>> = mutableListOf()
+
+        fun addExpected(text: String, colorKey: String): ColoredText {
+            expectedColoredChunks.add(Pair(text, colorKey))
+            return this
+        }
+    }
+
+    companion object {
+        private fun check(text: ColoredText) {
+            val decoder = RsAnsiEscapeDecoder()
+            val actualColoredChunks = mutableListOf<Pair<String, String>>()
+            val acceptor = AnsiEscapeDecoder.ColoredTextAcceptor { s, attrs ->
+                actualColoredChunks.add(Pair(s, attrs.toString()))
+            }
+            decoder.escapeText(text.rawText, text.outputType, acceptor)
+            val expectedColoredChunks = mutableListOf<Pair<String, String>>()
+            expectedColoredChunks.addAll(text.expectedColoredChunks)
+            assertEquals(expectedColoredChunks, actualColoredChunks)
+        }
+
+        private fun makeSimpleCtrlSeq(n: Int): String = "$CSI${n}m"
+
+        private fun make24BitColorCtrlSeq(r: Int, g: Int, b: Int, isForeground: Boolean): String =
+            "$CSI${if (isForeground) "38;" else "48;"}$ANSI_24_BIT_COLOR_FORMAT;$r;$g;${b}m"
+
+        private fun make8BitColorCtrlSeq(n: Int, isForeground: Boolean): String =
+            "$CSI${if (isForeground) "38;" else "48;"}$ANSI_8_BIT_COLOR_FORMAT;${n}m"
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/1261 (already fixed?)
Closes https://github.com/intellij-rust/intellij-rust/issues/1630 (?)
Fixes https://github.com/intellij-rust/intellij-rust/issues/1966
Fixes https://github.com/intellij-rust/intellij-rust/issues/2463
Fixes https://github.com/intellij-rust/intellij-rust/issues/1842 (does it work as expected?)

Thanks @kumbayo for [this](https://github.com/intellij-rust/intellij-rust/issues/1966#issuecomment-445550757) comment!

TODO:
* Fix issue with white color on Windows
#### Update

Looks like a Rustc issue.

macOS Mojave:
```
^[[0m^[[1mFor more information about this error, try `rustc --explain E0369`.^[[0m
```

Windows 10:
```
^[[0m^[[1m^[[38;5;15mFor more information about this error, try `rustc --explain E0369`.^[[0m^M
```

As you can see, on Windows, Rustc prepends `^[[38;5;15m` control sequence to some chunks of text, which forces console use white color for the foreground. This is a problem, as the default background in IDEA is also white.

Not sure how to fix it (and whether to do it at all). The user can configure color mapping in the console (`Preferences > Editor > Console Scheme > Console Colors > ANSI Colors`).