### PR TITLE
INSP: make auto import works for path with type params

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -16,8 +16,8 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.util.ProcessingContext
 import org.rust.ide.inspections.import.AutoImportFix
+import org.rust.ide.inspections.import.ImportContext
 import org.rust.ide.inspections.import.importItem
-import org.rust.ide.inspections.import.toImportContext
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psiElement
@@ -118,7 +118,7 @@ object RsCommonCompletionProvider : CompletionProvider<CompletionParameters>() {
         Testmarks.pathCompletionFromIndex.hit()
 
         val project = parameters.originalFile.project
-        val importContext = path.toImportContext(project)
+        val importContext = ImportContext.from(project, path)
         val pathMod = path.containingMod
 
         val keys = hashSetOf<String>().apply {

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactory.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.psi
 import com.intellij.openapi.project.Project
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.lang.core.macros.setContext
+import org.rust.lang.core.psi.RsPsiFactory.PathNamespace
 import org.rust.lang.core.psi.ext.CARGO_WORKSPACE
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.RsMod
@@ -26,13 +27,19 @@ class RsCodeFragmentFactory(val project: Project) {
             ?.apply { setContext(crateRoot) }
     }
 
-    fun createPath(path: String, context: RsElement): RsPath? =
-        psiFactory.tryCreatePath(path)?.apply {
+    fun createPath(path: String, context: RsElement, ns: PathNamespace = PathNamespace.TYPES): RsPath? =
+        psiFactory.tryCreatePath(path, ns)?.apply {
             setContext(context)
             containingFile?.putUserData(CARGO_WORKSPACE, context.cargoWorkspace)
         }
 
-    fun createPathInTmpMod(context: RsMod, importingPathName: String, usePath: String, crateName: String?): RsPath? {
+    fun createPathInTmpMod(
+        importingPathName: String,
+        context: RsMod,
+        ns: PathNamespace,
+        usePath: String,
+        crateName: String?
+    ): RsPath? {
         val (externCrateItem, useItem) = if (crateName != null) {
             "extern crate $crateName;" to "use self::$usePath;"
         } else {
@@ -44,6 +51,6 @@ class RsCodeFragmentFactory(val project: Project) {
             $useItem
             """)
         mod.setContext(context)
-        return createPath(importingPathName, mod)
+        return createPath(importingPathName, mod, ns)
     }
 }

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -132,6 +132,98 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         fn f<T>(foo: Foo/*caret*/<T>) {}
     """)
 
+    fun `test import item with type params (struct literal)`() = checkAutoImportFixByText("""
+        mod foo {
+            pub struct Foo<T> { x: T }
+        }
+
+        fn main() {
+            let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>::<i32> {};
+        }
+    """, """
+        use foo::Foo;
+
+        mod foo {
+            pub struct Foo<T> { x: T }
+        }
+
+        fn main() {
+            let f = Foo/*caret*/::<i32> {};
+        }
+    """)
+
+    fun `test import item with type params (tuple struct literal)`() = checkAutoImportFixByText("""
+        mod foo {
+            pub struct Foo<T>(T);
+            impl<T> Foo<T> {
+                fn bar() {}
+            }
+        }
+
+        fn main() {
+            let f = <error descr="Unresolved reference: `Foo`">Foo::/*caret*/<i32>::bar</error>();
+        }
+    """, """
+        use foo::Foo;
+
+        mod foo {
+            pub struct Foo<T>(T);
+            impl<T> Foo<T> {
+                fn bar() {}
+            }
+        }
+
+        fn main() {
+            let f = Foo::/*caret*/<i32>::bar();
+        }
+    """)
+
+    fun `test import item with type params (pat struct)`() = checkAutoImportFixByText("""
+        mod foo {
+            pub struct Foo<T> { x: T }
+        }
+
+        fn main() {
+            let <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>::<i32> { x } = ();
+        }
+    """, """
+        use foo::Foo;
+
+        mod foo {
+            pub struct Foo<T> { x: T }
+        }
+
+        fn main() {
+            let Foo/*caret*/::<i32> { x } = ();
+        }
+    """)
+
+    fun `test import item with type params (pat tuple struct)`() = checkAutoImportFixByText("""
+        mod foo {
+            pub struct Foo<T>(T);
+            impl<T> Foo<T> {
+                fn bar() {}
+            }
+        }
+
+        fn main() {
+            let <error descr="Unresolved reference: `Foo`">Foo::/*caret*/<i32>::bar</error>(x) = ();
+        }
+    """, """
+        use foo::Foo;
+
+        mod foo {
+            pub struct Foo<T>(T);
+            impl<T> Foo<T> {
+                fn bar() {}
+            }
+        }
+
+        fn main() {
+            let Foo::/*caret*/<i32>::bar(x) = ();
+        }
+    """)
+
     fun `test import module`() = checkAutoImportFixByText("""
         mod foo {
             pub mod bar {


### PR DESCRIPTION
The main reason why it didn't work before is wrong intermediate path creation.
`AutoImportFix#canBeResolvedToSuitableItem` didn't take into account namespace of path
and always tried to create intermediate path via `fn foo(t: $pathText) {}`.
But for paths like `Foo::<i32>::bar` it doesn't work because of syntax error.

Now, it's possible to pass namespace to `RsPsiFactory#tryCreatePath` to correctly create necessary path element

Fixes #3269