### PR TITLE
MACRO: expand macros in stmt context

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1320,7 +1320,9 @@ private BlockElement ::= !'}' (Macro | ExprStmtOrLastExpr | Stmt | Item) {
 }
 private BlockElement_recover ::= !('}' | Item_first | Expr_first | let | ';')
 
-Stmt ::= LetDecl | EmptyStmt | never ';'
+Stmt ::= LetDecl | EmptyStmt | never ';' {
+  implements = "org.rust.lang.core.macros.RsExpandedElement"
+}
 
 ExprStmtOrLastExpr ::= StmtModeExpr (ExprStmtUpper | LastExprUpper) {
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
@@ -8,25 +8,27 @@ package org.rust.lang.core.macros
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.PsiModificationTracker
 import org.rust.cargo.project.settings.rustSettings
-import org.rust.lang.core.psi.RsMacro
-import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.childrenOfType
+import org.rust.lang.core.psi.ext.descendantOfTypeStrict
 import org.rust.lang.core.psi.ext.macroName
-import org.rust.lang.core.psi.rustStructureModificationTracker
 
-private val NULL_RESULT: CachedValueProvider.Result<List<RsExpandedElement>?> =
+private val NULL_RESULT: CachedValueProvider.Result<MacroExpansion?> =
     CachedValueProvider.Result.create(null, PsiModificationTracker.MODIFICATION_COUNT)
 
-fun expandMacro(call: RsMacroCall): CachedValueProvider.Result<List<RsExpandedElement>?> {
+fun expandMacro(call: RsMacroCall): CachedValueProvider.Result<MacroExpansion?> {
     val context = call.context as? RsElement ?: return NULL_RESULT
     return when {
         call.macroName == "lazy_static" -> {
             val result = expandLazyStatic(call)
-            result?.forEach {
+            if (result == null || result.isEmpty()) return NULL_RESULT
+            result.forEach {
                 it.setContext(context)
                 it.setExpandedFrom(call)
             }
-            CachedValueProvider.Result.create(result, call.containingFile)
+            val expansion = MacroExpansion.Items(result.first().containingFile as RsFile, result)
+            CachedValueProvider.Result.create(expansion, call.containingFile)
         }
         else -> {
             val project = context.project
@@ -34,11 +36,98 @@ fun expandMacro(call: RsMacroCall): CachedValueProvider.Result<List<RsExpandedEl
             val def = call.path.reference.resolve() as? RsMacro ?: return NULL_RESULT
             val expander = MacroExpander(project)
             val result = expander.expandMacro(def, call)
-            result?.forEach {
+            result?.elements?.forEach {
                 it.setContext(context)
                 it.setExpandedFrom(call)
             }
             CachedValueProvider.Result.create(result, project.rustStructureModificationTracker)
+        }
+    }
+}
+
+enum class MacroExpansionContext {
+    EXPR, PAT, TYPE, STMT, ITEM
+}
+
+val RsMacroCall.expansionContext: MacroExpansionContext
+    get() = when (val context = context) {
+        is RsMacroExpr -> when {
+            context.context is RsExprStmt -> MacroExpansionContext.STMT
+            else -> MacroExpansionContext.EXPR
+        }
+        is RsPatMacro -> MacroExpansionContext.PAT
+        is RsMacroType -> MacroExpansionContext.TYPE
+        else -> MacroExpansionContext.ITEM
+    }
+
+sealed class MacroExpansion(val file: RsFile) {
+
+    /** The list of expanded elements. Can be empty */
+    abstract val elements: List<RsExpandedElement>
+
+    class Expr(file: RsFile, val expr: RsExpr) : MacroExpansion(file) {
+        override val elements: List<RsExpandedElement>
+            get() = listOf(expr)
+    }
+
+    class Pat(file: RsFile, val pat: RsPat) : MacroExpansion(file) {
+        override val elements: List<RsExpandedElement>
+            get() = listOf(pat)
+    }
+
+    class Type(file: RsFile, val type: RsTypeReference) : MacroExpansion(file) {
+        override val elements: List<RsExpandedElement>
+            get() = listOf(type)
+    }
+
+    /** Can contains items, macros and macro calls */
+    class Items(file: RsFile, override val elements: List<RsExpandedElement>) : MacroExpansion(file)
+
+    /** Can contains items, statements and a tail expr */
+    class Stmts(file: RsFile, override val elements: List<RsExpandedElement>) : MacroExpansion(file)
+}
+
+fun parseExpandedTextWithContext(
+    context: MacroExpansionContext,
+    factory: RsPsiFactory,
+    expandedText: CharSequence
+): MacroExpansion? =
+    getExpansionFromExpandedFile(context, factory.createFile(prepareExpandedTextForParsing(context, expandedText)))
+
+private fun prepareExpandedTextForParsing(
+    context: MacroExpansionContext,
+    expandedText: CharSequence
+): CharSequence = when (context) {
+    MacroExpansionContext.EXPR -> "fn f() { $expandedText; }"
+    MacroExpansionContext.PAT -> "fn f($expandedText: ()) {}"
+    MacroExpansionContext.TYPE -> "fn f(_: $expandedText) {}"
+    MacroExpansionContext.STMT -> "fn f() { $expandedText }"
+    MacroExpansionContext.ITEM -> expandedText
+}
+
+/** If a call is previously expanded to [expandedFile], this function extract expanded elements from the file */
+fun getExpansionFromExpandedFile(context: MacroExpansionContext, expandedFile: RsFile): MacroExpansion? {
+    return when (context) {
+        MacroExpansionContext.EXPR -> {
+            val expr = expandedFile.descendantOfTypeStrict<RsExpr>() ?: return null
+            MacroExpansion.Expr(expandedFile, expr)
+        }
+        MacroExpansionContext.PAT -> {
+            val pat = expandedFile.descendantOfTypeStrict<RsPat>() ?: return null
+            MacroExpansion.Pat(expandedFile, pat)
+        }
+        MacroExpansionContext.TYPE -> {
+            val type = expandedFile.descendantOfTypeStrict<RsTypeReference>() ?: return null
+            MacroExpansion.Type(expandedFile, type)
+        }
+        MacroExpansionContext.STMT -> {
+            val block = expandedFile.descendantOfTypeStrict<RsBlock>() ?: return null
+            val itemsAndStatements = block.childrenOfType<RsExpandedElement>()
+            MacroExpansion.Stmts(expandedFile, itemsAndStatements)
+        }
+        MacroExpansionContext.ITEM -> {
+            val items = expandedFile.childrenOfType<RsExpandedElement>()
+            MacroExpansion.Items(expandedFile, items)
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -70,7 +70,7 @@ class RsPsiFactory(private val project: Project) {
         return result
     }
 
-    fun createBlockExpr(body: String): RsBlockExpr =
+    fun createBlockExpr(body: CharSequence): RsBlockExpr =
         createExpressionOfType("{ $body }")
 
     fun createUnsafeBlockExpr(body: String): RsBlockExpr =

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.CachedValuesManager
+import org.rust.lang.core.macros.MacroExpansion
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.macros.expandMacro
 import org.rust.lang.core.psi.RsMacroCall
@@ -46,7 +47,7 @@ val RsMacroCall.macroBody: String?
             ?: logMacroArgument?.braceListBodyText()?.toString()
     }
 
-val RsMacroCall.expansion: List<RsExpandedElement>?
+val RsMacroCall.expansion: MacroExpansion?
     get() = CachedValuesManager.getCachedValue(this) {
         expandMacro(this)
     }
@@ -64,7 +65,7 @@ private fun RsMacroCall.expandAllMacrosRecursively(depth: Int): String {
             else -> element.text
         }
 
-    return expansion?.joinToString(" ") { toExpandedText(it) } ?: text
+    return expansion?.elements?.joinToString(" ") { toExpandedText(it) } ?: text
 }
 
 fun RsMacroCall.processExpansionRecursively(processor: (RsExpandedElement) -> Boolean): Boolean =
@@ -72,7 +73,7 @@ fun RsMacroCall.processExpansionRecursively(processor: (RsExpandedElement) -> Bo
 
 private fun RsMacroCall.processExpansionRecursively(processor: (RsExpandedElement) -> Boolean, depth: Int): Boolean {
     if (depth > DEFAULT_RECURSION_LIMIT) return true
-    return expansion.orEmpty().any { it.processRecursively(processor, depth) }
+    return expansion?.elements.orEmpty().any { it.processRecursively(processor, depth) }
 }
 
 private fun RsExpandedElement.processRecursively(processor: (RsExpandedElement) -> Boolean, depth: Int): Boolean {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -13,6 +13,7 @@ import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.util.containers.isNullOrEmpty
 import org.jetbrains.annotations.TestOnly
+import org.rust.lang.core.macros.MacroExpansion
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.*
@@ -1601,7 +1602,7 @@ class RsFnInferenceContext(
             name == "cfg" -> TyBool
             name == "unimplemented" || name == "unreachable" || name == "panic" -> TyNever
             name == "write" || name == "writeln" -> {
-                (macroExpr.macroCall.expansion?.singleOrNull() as? RsExpr)?.inferType() ?: TyUnknown
+                (macroExpr.macroCall.expansion as? MacroExpansion.Expr)?.expr?.inferType() ?: TyUnknown
             }
             macroExpr.macroCall.formatMacroArgument != null || macroExpr.macroCall.logMacroArgument != null -> TyUnit
 

--- a/src/test/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActionsTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActionsTest.kt
@@ -91,7 +91,7 @@ class RsShowMacroExpansionActionsTest : RsTestBase() {
 
         val failingAction = object : RsShowMacroExpansionActionBase(expandRecursively = true) {
             override fun showExpansion(project: Project, editor: Editor, expansionDetails: MacroExpansionViewDetails) {
-                fail("No expansion should be showed, but ${expansionDetails.expansions.toText()} was shown!")
+                fail("No expansion should be showed, but ${expansionDetails.expansion.elements.toText()} was shown!")
             }
         }
 
@@ -117,7 +117,7 @@ class RsShowMacroExpansionActionsTest : RsTestBase() {
 
         val action = object : RsShowMacroExpansionActionBase(expandRecursively = expandRecursively) {
             override fun showExpansion(project: Project, editor: Editor, expansionDetails: MacroExpansionViewDetails) {
-                expansions = expansionDetails.expansions
+                expansions = expansionDetails.expansion.elements
             }
         }
 
@@ -143,7 +143,7 @@ class RsShowMacroExpansionActionsTest : RsTestBase() {
 
         val action = object : RsShowMacroExpansionActionBase(expandRecursively = expandRecursively) {
             override fun showExpansion(project: Project, editor: Editor, expansionDetails: MacroExpansionViewDetails) {
-                error("Expected expansion fail, but got expansion: `${expansionDetails.expansions.map { it.text }}`")
+                error("Expected expansion fail, but got expansion: `${expansionDetails.expansion.elements.map { it.text }}`")
             }
 
             override fun showError(editor: Editor) {

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -569,6 +569,24 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         Option<i32>
     """)
 
+    fun `test stmt context`() = checkSingleMacro("""
+        macro_rules! foo {
+            ($ i:ident, $ j:ident) => {
+                struct $ i;
+                let $ j = 0;
+                ($ i, $ j)
+            }
+        }
+
+        fn main() {
+            foo!(S, a);
+        } //^
+    """, """
+        struct S;
+        let a = 0;
+        (S, a)
+    """)
+
     // There was a problem with "debug" macro related to the fact that we parse macro call
     // with such name as a specific syntax construction
     fun `test macro with name "debug"`() = doTest("""

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
@@ -70,11 +70,12 @@ abstract class RsMacroExpansionTestBase : RsTestBase() {
         val expandedText = mark?.checkHit(expand) ?: expand()
 
         if (!StringUtil.equalsIgnoreWhitespaces(expectedExpansion, expandedText)) {
-            val formattedExpandedText = RsPsiFactory(project)
-                .parseExpandedTextWithContext(macroCall, expandedText)
-                .map {
-                    CodeStyleManager.getInstance(project).reformatRange(it, it.startOffset, it.endOffset, true)
-                }.joinToString("\n") { it.text }
+            val formattedExpandedText =
+                parseExpandedTextWithContext(macroCall.expansionContext, RsPsiFactory(project), expandedText)
+                    ?.elements.orEmpty()
+                    .map {
+                        CodeStyleManager.getInstance(project).reformatRange(it, it.startOffset, it.endOffset, true)
+                    }.joinToString("\n") { it.text }
 
             throw ComparisonFailure(
                 errorMessage,


### PR DESCRIPTION
Note: this is not about name resolution or type inference. We can only expand (e.g. show expansion) such macros.

Now we can expand statement-like macros. E.g.
```rust
macro_rules! foo {
    ($ i:ident, $ j:ident) => {
        struct $ i;
        let $ j = 0;
        ($ i, $ j)
    }
}
fn main() {
    foo!(S, a);
}
```
I've done it without touching the grammar, but I don't sure in it, may be it's better to create MacroStmt or a something.

Also introduced class MacroExpansion that abstracts macro expansion made in different contexts.

This is also a preparation for #3015