### PR TITLE
TY: infer box expr `box Foo`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -1397,8 +1397,8 @@ class RsFnInferenceContext(
             UnaryOperator.MINUS -> innerExpr.inferType(expected)
             UnaryOperator.NOT -> innerExpr.inferType(expected)
             UnaryOperator.BOX -> {
-                innerExpr.inferType()
-                TyUnknown
+                val expectedInner = (expected as? TyAdt)?.takeIf { it.item == items.Box }?.typeArguments?.getOrNull(0)
+                items.makeBox(innerExpr.inferType(expectedInner))
             }
         }
     }
@@ -1861,6 +1861,12 @@ private fun KnownItems.findRangeTy(rangeName: String, indexType: Ty?): Ty {
 
     val typeParameter = ty.getTypeParameter("Idx") ?: return ty
     return ty.substitute(mapOf(typeParameter to indexType).toTypeSubst())
+}
+
+fun KnownItems.makeBox(innerTy: Ty): Ty {
+    val box = Box ?: return TyUnknown
+    val boxTy = TyAdt.valueOf(box)
+    return boxTy.substitute(mapOf(boxTy.typeArguments[0] as TyTypeParameter to innerTy).toTypeSubst())
 }
 
 object TypeInferenceMarks {

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -643,4 +643,13 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
             for x in foo() { x; }
         }                  //^ u8
     """)
+
+    fun `test box expr`() = stubOnlyTypeInfer("""
+    //- main.rs
+        struct S;
+        fn main() {
+            let a = box S;
+            a;
+        } //^ Box<S>
+    """)
 }


### PR DESCRIPTION
```rust
struct S;
fn main() {
    let a = box S;
    a;
} //^ Box<S>
```