### PR TITLE
TY: more precise trait pick in type inference

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -1212,7 +1212,12 @@ class RsFnInferenceContext(
             traitToCallee.keys.filterInScope(methodCall).forEach {
                 filtered += traitToCallee.getValue(it)
             }
-            filtered
+            if (filtered.isNotEmpty()) {
+                filtered
+            } else {
+                TypeInferenceMarks.methodPickTraitsOutOfScope.hit()
+                list
+            }
         }.singleOrFilter { callee ->
             // 2. Filter methods by trait bounds (try to select all obligations for each impl)
             TypeInferenceMarks.methodPickCheckBounds.hit()
@@ -1873,6 +1878,7 @@ object TypeInferenceMarks {
     val cyclicType = Testmark("cyclicType")
     val questionOperator = Testmark("questionOperator")
     val methodPickTraitScope = Testmark("methodPickTraitScope")
+    val methodPickTraitsOutOfScope = Testmark("methodPickTraitsOutOfScope")
     val methodPickCheckBounds = Testmark("methodPickCheckBounds")
     val methodPickDerefOrder = Testmark("methodPickDerefOrder")
     val methodPickCollapseTraits = Testmark("methodPickCollapseTraits")

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -1372,6 +1372,68 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
+    fun `test suggest single method`() = checkAutoImportFixByText("""
+        struct Foo;
+        struct Bar;
+
+        #[lang="deref"]
+        trait Deref {
+            type Target;
+        }
+
+        impl Deref for Bar {
+            type Target = Foo;
+        }
+        mod a {
+            pub trait X {
+                fn do_x(&self);
+            }
+
+            impl X for ::Foo {
+                fn do_x(&self) {}
+            }
+
+            impl X for ::Bar {
+                fn do_x(&self) {}
+            }
+        }
+
+        fn main() {
+            Bar.<error>do_x/*caret*/</error>();
+        }
+    """, """
+        use a::X;
+
+        struct Foo;
+        struct Bar;
+
+        #[lang="deref"]
+        trait Deref {
+            type Target;
+        }
+
+        impl Deref for Bar {
+            type Target = Foo;
+        }
+        mod a {
+            pub trait X {
+                fn do_x(&self);
+            }
+
+            impl X for ::Foo {
+                fn do_x(&self) {}
+            }
+
+            impl X for ::Bar {
+                fn do_x(&self) {}
+            }
+        }
+
+        fn main() {
+            Bar.do_x/*caret*/();
+        }
+    """)
+
     /** Issue [2822](https://github.com/intellij-rust/intellij-rust/issues/2822) */
     fun `test do not try to import trait object method`() = checkAutoImportFixIsUnavailable("""
         mod foo {
@@ -1536,5 +1598,4 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             let a = A;
         }
     """)
-
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -263,4 +263,37 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
             S.foo();
         }   //^
     """, TypeInferenceMarks.traitSelectionSpecialization)
+
+    fun `test pick correct method from out of scope traits`() = checkByCode("""
+        struct Foo;
+        struct Bar;
+
+        #[lang="deref"]
+        trait Deref {
+            type Target;
+        }
+
+        impl Deref for Bar {
+            type Target = Foo;
+        }
+        mod a {
+            pub trait X {
+                fn do_x(&self);
+            }
+
+            impl X for ::Foo {
+                fn do_x(&self) {}
+            }
+
+            impl X for ::Bar {
+                fn do_x(&self) {}
+                   //X
+            }
+        }
+
+        fn main() {
+            Bar.do_x();
+               //^
+        }
+    """, TypeInferenceMarks.methodPickTraitsOutOfScope)
 }


### PR DESCRIPTION
In case, when there isn't any trait in scope, we add all potential variants as resolve variants. But sometimes we can filter out some obviously wrong variants. 

These changes don't affect type inference/name resolution for correct code but should improve name resolution/auto import for incorrect code (when all traits are out of scope)

Fixes #3344
