### PR TITLE
INSP: do not provide auto import quick fix for names which are already in scope

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/lang/RsDebuggerTypesHelper.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/lang/RsDebuggerTypesHelper.kt
@@ -36,14 +36,14 @@ private fun resolveToDeclaration(ctx: PsiElement?, name: String): PsiElement? {
     val composite = ctx?.ancestorOrSelf<RsElement>() ?: return null
 
     var resolved: PsiElement? = null
-    processNestedScopesUpwards(composite, { entry ->
+    processNestedScopesUpwards(composite, VALUES) { entry ->
         if (entry.name == name) {
             resolved = entry.element
             true
         } else {
             false
         }
-    }, VALUES)
+    }
 
     return resolved
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemElement.kt
@@ -13,9 +13,9 @@ interface RsItemElement : RsVisibilityOwner, RsOuterAttributeOwner, RsExpandedEl
 
 fun <T : RsItemElement> Iterable<T>.filterInScope(scope: RsElement): List<T> {
     val set = toMutableSet()
-    processNestedScopesUpwards(scope, {
+    processNestedScopesUpwards(scope, TYPES) {
         set.remove(it.element)
         set.isEmpty()
-    }, TYPES)
+    }
     return if (set.isEmpty()) toList() else toMutableList().apply { removeAll(set) }
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.inspections
 
 import org.intellij.lang.annotations.Language
+import org.rust.ide.inspections.import.AutoImportFix
 
 class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection()) {
 
@@ -101,6 +102,18 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
             123.foo();
         }
     """)
+
+    fun `test do not highlight unresolved path references if name is in scope`() = checkByText("""
+        use foo::Foo;
+
+        mod foo {
+            pub struct Foo {}
+        }
+
+        fn main() {
+            Foo
+        }
+    """, testmark = AutoImportFix.Testmarks.nameInScope)
 
     private fun checkByText(@Language("Rust") text: String, ignoreWithoutQuickFix: Boolean) {
         val defaultValue = (inspection as RsUnresolvedReferenceInspection).ignoreWithoutQuickFix


### PR DESCRIPTION
Before these changes "Unresolved reference" inspection added auto import quick fix when path name is already in scope but namespace of psi element prevents correct name resolution. It led to unexpected auto import quick for incomplete code like `let map = HashMap` that can be easily created during typing.

Now the inspection checks the corresponding name is in scope for any namespace in addition to "fair" name resolution not to provide the fix in such cases.
Also, with "Ignore unresolved references without quick fix" property it removes "Unresolved reference" error annotations from unresolved but in scope names.