### PR TITLE
ANN: Non't show E0583 "File not found for module" if syntax error in declaration

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -269,7 +269,7 @@ class RsErrorAnnotator : RsAnnotatorBase(), HighlightRangeExtension {
             }
         }
 
-        if (modDecl.reference.resolve() == null) {
+        if (modDecl.reference.resolve() == null && modDecl.semicolon != null) {
             RsDiagnostic.ModuleNotFound(modDecl).addToHolder(holder)
         }
     }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -59,6 +59,11 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class.java) {
     //- bar/foo.rs
     """)
 
+    fun `test no E0583 if no semicolon after module declaration`() = checkByText("""
+        mod foo<error descr="';' or '{' expected"> </error>
+        // often happens during typing `mod foo {}`
+    """)
+
     @MockRustcVersion("1.29.0")
     fun `test create file and expand module quick fix`() = checkFixByFileTree("Create module file", """
     //- main.rs


### PR DESCRIPTION
When typing `mod foo {}` this construction can be incomplete and
so will be parsed as module declaration `mod foo` with missed
semicolon. In this case it tries to find "foo.rs" file and
shows E0583 "File not found for module" because it doesn't exist.

I think we should not show this error if semicolon is missed.
We should let user to fix the syntax error or complete inline
module declaration first.