### PR TITLE
ACT: make "New | Rust File" action less cocky

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/RsCreateFileAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsCreateFileAction.kt
@@ -7,9 +7,13 @@ package org.rust.ide.actions
 
 import com.intellij.ide.actions.CreateFileFromTemplateAction
 import com.intellij.ide.actions.CreateFileFromTemplateDialog
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.psi.PsiDirectory
+import org.rust.cargo.project.model.cargoProjects
 import org.rust.ide.icons.RsIcons
 
 
@@ -18,6 +22,16 @@ class RsCreateFileAction : CreateFileFromTemplateAction(RsCreateFileAction.CAPTI
 
     override fun getActionName(directory: PsiDirectory?, newName: String, templateName: String?): String = CAPTION
 
+    override fun isAvailable(dataContext: DataContext): Boolean {
+        if (!super.isAvailable(dataContext)) return false
+        val project = CommonDataKeys.PROJECT.getData(dataContext) ?: return false
+        val vFile = CommonDataKeys.VIRTUAL_FILE.getData(dataContext) ?: return false
+        return project.cargoProjects.allProjects.any {
+            val rootDir = it.rootDir ?: return@any false
+            VfsUtil.isAncestor(rootDir, vFile, false)
+        }
+    }
+
     override fun buildDialog(project: Project?, directory: PsiDirectory?,
                              builder: CreateFileFromTemplateDialog.Builder) {
         builder.setTitle(CAPTION)
@@ -25,6 +39,6 @@ class RsCreateFileAction : CreateFileFromTemplateAction(RsCreateFileAction.CAPTI
     }
 
     private companion object {
-        private val CAPTION = "New Rust File"
+        private const val CAPTION = "New Rust File"
     }
 }


### PR DESCRIPTION
Before these changes new Rust file creation action was always before "New File" action
regardless of context. It can be annoying for some users.
Now it's available only inside cargo project directory.