### PR TITLE
MACRO: Allow custom macros with name "vec"

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -45,6 +45,9 @@ val RsMacroCall.macroBody: String?
         return macroArgument?.compactTT?.text
             ?: formatMacroArgument?.braceListBodyText()?.toString()
             ?: logMacroArgument?.braceListBodyText()?.toString()
+            ?: assertMacroArgument?.braceListBodyText()?.toString()
+            ?: exprMacroArgument?.braceListBodyText()?.toString()
+            ?: vecMacroArgument?.braceListBodyText()?.toString()
     }
 
 val RsMacroCall.expansion: MacroExpansion?

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -598,6 +598,15 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         fn foo() -> i32 {}
     """)
 
+    fun `test macro with name "vec"`() = doTest("""
+       macro_rules! vec {
+           ($ t:ty) => { fn foo() -> $ t {} }
+       }
+       vec!(i32);
+    """, """
+        fn foo() -> i32 {}
+    """)
+
     fun `test expend macro definition`() = doTest("""
         macro_rules! foo {
             () => {


### PR DESCRIPTION
We parse `vec![]` macro as a specific syntax construction
and previously it was not able to expand custom (non-std)
macros with such name
