### PR TITLE
MACRO: Fix expansion of macros containing $crate metavar inside a group

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -475,7 +475,7 @@ private fun PsiBuilder.isSameToken(psi: PsiElement): Boolean {
 private fun RsMacroBindingGroup.matches(contents: RsMacroExpansionContents): Boolean {
     val available = availableVars
     val used = contents.descendantsOfType<RsMacroReference>()
-    return used.all { it.referenceName in available }
+    return used.all { it.referenceName in available || it.referenceName == "crate" }
 }
 
 /**

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -192,6 +192,13 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         fn foo() {}
     """)
 
+    fun `test group with $crate usage`() = doTest(MacroExpansionMarks.groupInputEnd1, """
+        macro_rules! foo {
+            ($ ($ i:item)*; $ ($ j:item)*) => ($ ( use $ crate::$ i; )* $ ( use $ crate::$ i; )*)
+        }
+        foo! {;}
+    """, "")
+
     fun `test all items`() = doTest("""
         macro_rules! foo {
             ($ ($ i:item)*) => ($ (


### PR DESCRIPTION
bors r+
