### PR TITLE
TY: enforce builtin binop operand types

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -177,3 +177,18 @@ fun Ty.isMovesByDefault(lookup: ImplLookup): Boolean =
 
 val Ty.isBox: Boolean
     get() = this is TyAdt && item == item.knownItems.Box
+
+val Ty.isIntegral: Boolean
+    get() = this is TyInteger || this is TyInfer.IntVar
+
+val Ty.isFloat: Boolean
+    get() = this is TyFloat || this is TyInfer.FloatVar
+
+val Ty.isScalar: Boolean
+    get() = isIntegral ||
+        isFloat ||
+        this == TyBool ||
+        this == TyChar ||
+        this == TyUnit ||
+        this is TyFunction || // really TyFnDef & TyFnPtr
+        this is TyPointer

--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
@@ -67,9 +67,9 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
         }
     """, listOf("10", "5 + 10", "foo(5 + 10)"), 1, """
         fn hello() {
-            let x = 5 + 10;
-            foo(x);
-            foo(x);
+            let i = 5 + 10;
+            foo(i);
+            foo(i);
         }
     """, replaceAll = true)
 
@@ -82,9 +82,9 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
     """, listOf("1", "a + 1"), 1, """
         fn main() {
             let a = 1;
-            let x = a + 1;
-            let b = x;
-            let c = x;
+            let i = a + 1;
+            let b = i;
+            let c = i;
         }
     """, replaceAll = true)
 

--- a/src/test/kotlin/org/rust/ide/template/postfix/LetPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/LetPostfixTemplateTest.kt
@@ -28,7 +28,7 @@ class LetPostfixTemplateTest : RsPostfixTemplateTest(LetPostfixTemplate(RsPostfi
         }
     """, """
         fn foo() {
-            let /*caret*/x = (1 + 2);
+            let /*caret*/i = (1 + 2);
         }
     """)
 


### PR DESCRIPTION
Very internal stuff related to #3015. After removal of hardcoded macros surfaced some shortcomings of our type inference. This PR currently affects nothing.

// Some tests changed only because they was written without stdlib dependency and so worked wrongly