### PR TITLE
ANN: don't treat fns in wasm_bindgen extern block as unsafe

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
@@ -54,7 +54,7 @@ class RsUnsafeExpressionAnnotator : RsAnnotatorBase() {
     fun checkMethodCall(o: RsMethodCall, holder: AnnotationHolder) {
         val fn = o.reference.resolve() as? RsFunction ?: return
 
-        if (fn.isUnsafe) {
+        if (fn.isActuallyUnsafe) {
             annotateUnsafeCall(o.parentDotExpr, holder)
         }
     }
@@ -63,7 +63,7 @@ class RsUnsafeExpressionAnnotator : RsAnnotatorBase() {
         val path = (element.expr as? RsPathExpr)?.path ?: return
         val fn = path.reference.resolve() as? RsFunction ?: return
 
-        if (fn.isUnsafe) {
+        if (fn.isActuallyUnsafe) {
             annotateUnsafeCall(element, holder)
         }
     }
@@ -97,7 +97,7 @@ class RsUnsafeExpressionAnnotator : RsAnnotatorBase() {
                 }
             } ?: return false
 
-        return parent is RsBlockExpr || (parent is RsFunction && parent.isUnsafe)
+        return parent is RsBlockExpr || (parent is RsFunction && parent.isActuallyUnsafe)
     }
 
     private fun AnnotationHolder.createUnsafeAnnotation(element: PsiElement, message: String) {

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -33,7 +33,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 154
+        override fun getStubVersion(): Int = 155
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)

--- a/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotatorTest.kt
@@ -138,4 +138,15 @@ class RsUnsafeExpressionAnnotatorTest : RsAnnotatorTestBase(RsUnsafeExpressionAn
             let val = <info descr="Unsafe dereference of raw pointer">*char_ptr</info>;
         }
     """)
+
+    fun `test function defined in wasm_bindgen extern block is not unsafe`() = checkErrors("""
+        #[wasm_bindgen]
+        extern {
+            fn foo();
+        }
+
+        fn main() {
+            foo();
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -62,7 +62,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         }
     """, """
         <div class='definition'><pre>test_package
-        unsafe extern fn <b>foo</b>()</pre></div>
+        extern fn <b>foo</b>()</pre></div>
     """)
 
     fun `test fn in extern block with abi name`() = doTest("""
@@ -72,7 +72,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         }
     """, """
         <div class='definition'><pre>test_package
-        unsafe extern "C" fn <b>foo</b>()</pre></div>
+        extern "C" fn <b>foo</b>()</pre></div>
     """)
 
     fun `test extern fn`() = doTest("""


### PR DESCRIPTION
Part of #3129

Also it will be useful if we will start to expand macros in
extern blocks (macros_in_extern)