### PR TITLE
Fix Incorrect CachedValue use report on 2019.1

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -197,18 +197,6 @@ class MacroExpander(val project: Project) {
         }
         append(str)
     }
-
-    private val RsMacro.macroBodyStubbed: RsMacroBody?
-        get() {
-            val stub = stub ?: return macroBody
-            val text = stub.macroBody ?: return null
-            return CachedValuesManager.getCachedValue(this) {
-                CachedValueProvider.Result.create(
-                    psiFactory.createMacroBody(text),
-                    modificationTracker
-                )
-            }
-        }
 }
 
 /**

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
@@ -9,9 +9,13 @@ import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.psi.RsElementTypes
 import org.rust.lang.core.psi.RsMacro
+import org.rust.lang.core.psi.RsMacroBody
+import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.stubs.RsMacroStub
 import javax.swing.Icon
 
@@ -41,3 +45,16 @@ abstract class RsMacroImplMixin : RsStubbedNamedElementImpl<RsMacroStub>,
 
 val RsMacro.hasMacroExport: Boolean
     get() = queryAttributes.hasAttribute("macro_export")
+
+
+val RsMacro.macroBodyStubbed: RsMacroBody?
+    get() {
+        val stub = stub ?: return macroBody
+        val text = stub.macroBody ?: return null
+        return CachedValuesManager.getCachedValue(this) {
+            CachedValueProvider.Result.create(
+                RsPsiFactory(project).createMacroBody(text),
+                modificationTracker
+            )
+        }
+    }


### PR DESCRIPTION
2019.1 platform brings dynamic analyzer of incorrect CachedValue usages, which generate crashes on EAPs. This case is false positive, but it's easy to "fix" it anyway, so let's do it.

bors r+