### PR TITLE
T: test our analysis on real rust projects

### DIFF
--- a/src/test/kotlin/org/rustSlowTests/RsHighlightingPerformanceTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsHighlightingPerformanceTest.kt
@@ -5,34 +5,27 @@
 
 package org.rustSlowTests
 
-import com.intellij.openapi.application.runWriteAction
-import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.VfsUtil
-import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.util.PsiModificationTracker
-import com.intellij.util.ui.UIUtil
-import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.RsReferenceElement
 import org.rust.lang.core.psi.ext.descendantsOfType
-import org.rust.openapiext.fullyRefreshDirectory
 import org.rust.stdext.Timings
 
 
-class RsHighlightingPerformanceTest : RsWithToolchainTestBase() {
+class RsHighlightingPerformanceTest : RsRealProjectTestBase() {
     // It is a performance test, but we don't want to waste time
     // measuring CPU performance
     override fun isPerformanceTest(): Boolean = false
 
     fun `test highlighting Cargo`() =
-        repeatTest { highlightProjectFile("cargo", "https://github.com/rust-lang/cargo", "src/cargo/core/resolver/mod.rs") }
+        repeatTest { highlightProjectFile(CARGO, "src/cargo/core/resolver/mod.rs") }
 
     fun `test highlighting mysql_async`() =
-        repeatTest { highlightProjectFile("mysql_async", "https://github.com/blackbeam/mysql_async", "src/conn/mod.rs") }
+        repeatTest { highlightProjectFile(MYSQL_ASYNC, "src/conn/mod.rs") }
 
     fun `test highlighting mysql_async 2`() =
-        repeatTest { highlightProjectFile("mysql_async", "https://github.com/blackbeam/mysql_async", "src/connection_like/mod.rs") }
+        repeatTest { highlightProjectFile(MYSQL_ASYNC, "src/connection_like/mod.rs") }
 
     private fun repeatTest(f: () -> Timings) {
         var result = Timings()
@@ -45,13 +38,9 @@ class RsHighlightingPerformanceTest : RsWithToolchainTestBase() {
         result.report()
     }
 
-    private fun highlightProjectFile(name: String, gitUrl: String, filePath: String): Timings {
+    private fun highlightProjectFile(info: RealProjectInfo, filePath: String): Timings {
         val timings = Timings()
-        val base = openRealProject("testData/$name")
-        if (base == null) {
-            println("SKIP $name: git clone $gitUrl testData/$name")
-            return timings
-        }
+        val base = openRealProject(info) ?: return timings
 
         myFixture.configureFromTempProjectFile(filePath)
 
@@ -107,22 +96,5 @@ class RsHighlightingPerformanceTest : RsWithToolchainTestBase() {
 
     private fun currentPsiModificationCount() =
         PsiModificationTracker.SERVICE.getInstance(project).modificationCount
-
-    private fun openRealProject(path: String): VirtualFile? {
-        val projectDir = LocalFileSystem.getInstance().refreshAndFindFileByPath(path)
-            ?: return null
-        runWriteAction {
-            VfsUtil.copyDirectory(
-                this,
-                projectDir,
-                cargoProjectDirectory
-            ) { true }
-            fullyRefreshDirectory(cargoProjectDirectory)
-        }
-
-        refreshWorkspace()
-        UIUtil.dispatchAllInvocationEvents()
-        return cargoProjectDirectory
-    }
 }
 

--- a/src/test/kotlin/org/rustSlowTests/RsRealProjectAnalysisTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsRealProjectAnalysisTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rustSlowTests
+
+import com.intellij.codeInspection.ex.InspectionToolRegistrar
+import org.junit.ComparisonFailure
+import org.rust.ide.inspections.RsLocalInspectionTool
+import org.rust.lang.RsFileType
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.ext.cargoWorkspace
+import org.rust.openapiext.toPsiFile
+import java.lang.reflect.Field
+
+class RsRealProjectAnalysisTest : RsRealProjectTestBase() {
+
+    /** Don't run it on Rustc! It's a kind of stress-test */
+    fun `test analyze rustc`() = doTest(RUSTC)
+
+    fun `test analyze Cargo`() = doTest(CARGO, failOnFirstFileWithErrors = true)
+    fun `test analyze mysql_async`() = doTest(MYSQL_ASYNC)
+    fun `test analyze tokio`() = doTest(TOKIO)
+
+    private fun doTest(info: RealProjectInfo, failOnFirstFileWithErrors: Boolean = false) {
+        val inspections = InspectionToolRegistrar.getInstance().createTools()
+            .map { it.tool }
+            .filter { it is RsLocalInspectionTool }
+        myFixture.enableInspections(*inspections.toTypedArray())
+
+        println("Opening the project")
+        val base = openRealProject(info) ?: return
+
+        println("Collecting files to analyze")
+        val filesToCheck = base.findDescendants {
+            it.fileType == RsFileType && run {
+                val file = it.toPsiFile(project)
+                file is RsFile && file.crateRoot != null && file.cargoWorkspace != null
+            }
+        }
+
+        if (failOnFirstFileWithErrors) {
+            println("Analyzing...")
+            myFixture.testHighlightingAllFiles(
+                /* checkWarnings = */ false,
+                /* checkInfos = */ false,
+                /* checkWeakWarnings = */ false,
+                *filesToCheck.toTypedArray()
+            )
+        } else {
+            val exceptions = filesToCheck.mapNotNull { file ->
+                val path = file.path.substring(base.path.length + 1)
+                println("Analyzing $path")
+                try {
+                    myFixture.testHighlighting(
+                        /* checkWarnings = */ false,
+                        /* checkInfos = */ false,
+                        /* checkWeakWarnings = */ false,
+                        file
+                    )
+                    null
+                } catch (e: ComparisonFailure) {
+                    e to path
+                }
+            }
+
+            if (exceptions.isNotEmpty()) {
+                error("Error annotations found:\n\n" + exceptions.joinToString("\n\n") { (e, path) ->
+                    "$path:\n${e.detailMessage}"
+                })
+            }
+        }
+    }
+}
+
+private val THROWABLE_DETAILED_MESSAGE_FIELD: Field = run {
+    val field = Throwable::class.java.getDeclaredField("detailMessage")
+    field.isAccessible = true
+    field
+}
+
+/**
+ * Retrieves original value of detailMessage field of [Throwable] class.
+ * It is needed because [ComparisonFailure] overrides [Throwable.message]
+ * method so we can't get the original value without reflection
+ */
+private val Throwable.detailMessage: CharSequence
+    get() = THROWABLE_DETAILED_MESSAGE_FIELD.get(this) as CharSequence

--- a/src/test/kotlin/org/rustSlowTests/RsRealProjectTestBase.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsRealProjectTestBase.kt
@@ -1,0 +1,95 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rustSlowTests
+
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.vfs.*
+import com.intellij.util.ui.UIUtil
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.cargo.toolchain.RustToolchain
+import org.rust.openapiext.fullyRefreshDirectory
+
+abstract class RsRealProjectTestBase : RsWithToolchainTestBase() {
+    protected fun openRealProject(info: RealProjectInfo): VirtualFile? {
+        val base = openRealProject("testData/${info.path}", info.exclude)
+        if (base == null) {
+            val name = info.name
+            println("SKIP $name: git clone ${info.gitUrl} testData/$name")
+            return null
+        }
+        return base
+    }
+
+    private fun openRealProject(path: String, exclude: List<String> = emptyList()): VirtualFile? {
+        val projectDir = LocalFileSystem.getInstance().refreshAndFindFileByPath(path)
+            ?: return null
+
+        fun isAppropriate(file: VirtualFile): Boolean {
+            val relativePath = file.path.substring(projectDir.path.length + 1)
+            // 1. Ignore excluded files
+            if (exclude.any { relativePath.startsWith(it) }) return false
+            // 2. Ignore hidden files
+            if (file.name.startsWith(".")) return false
+            // 3. Ignore excluded directories in the root of the project
+            if (file.isDirectory &&
+                file.name in EXCLUDED_DIRECTORY_NAMES &&
+                file.parent.findChild(RustToolchain.CARGO_TOML) != null) return false
+
+            // Otherwise, analyse it
+            return true
+        }
+
+        runWriteAction {
+            fullyRefreshDirectoryInUnitTests(projectDir)
+            VfsUtil.copyDirectory(this, projectDir, cargoProjectDirectory, ::isAppropriate)
+            fullyRefreshDirectoryInUnitTests(cargoProjectDirectory)
+        }
+
+        refreshWorkspace()
+        UIUtil.dispatchAllInvocationEvents()
+        return cargoProjectDirectory
+    }
+
+    class RealProjectInfo(
+        val name: String,
+        val path: String,
+        val gitUrl: String,
+        val exclude: List<String> = emptyList()
+    )
+
+    companion object {
+        val RUSTC = RealProjectInfo(
+            name = "rust",
+            path = "rust/src",
+            gitUrl = "https://github.com/rust-lang/rust",
+            exclude = listOf("llvm", "llvm-emscripten", "binaryen", "test", "ci", "rt", "compiler-rt", "jemalloc")
+        )
+        val CARGO = RealProjectInfo("cargo", "cargo", "https://github.com/rust-lang/cargo")
+        val MYSQL_ASYNC = RealProjectInfo("mysql_async", "mysql_async", "https://github.com/blackbeam/mysql_async")
+        val TOKIO = RealProjectInfo("tokio", "tokio", "https://github.com/tokio-rs/tokio")
+
+        private val EXCLUDED_DIRECTORY_NAMES = setOf("target")
+    }
+}
+
+fun VirtualFile.findDescendants(filter: (VirtualFile) -> Boolean): ArrayList<VirtualFile> {
+    val result = ArrayList<VirtualFile>()
+    VfsUtilCore.visitChildrenRecursively(this,
+        object : VirtualFileVisitor<ArrayList<VirtualFile>>() {
+            override fun visitFile(file: VirtualFile): Boolean {
+                if (!file.isDirectory && filter(file)) result.add(file)
+                return true
+            }
+        })
+    return result
+}
+
+fun fullyRefreshDirectoryInUnitTests(directory: VirtualFile) {
+    // It's very weird, but real refresh occurs only if
+    // we touch file names. At least in the test environment
+    VfsUtilCore.iterateChildrenRecursively(directory, null) { it.name; true }
+    fullyRefreshDirectory(directory)
+}


### PR DESCRIPTION
This PR adds new test `RsRealProjectAnalysisTest` for testing our inspections and error annotators on real rust projects. It allows to easy find possible false positives produced by some new analysis. Currently, we have a LOT of false positives with existing analysis. These false positives should be fixed eventually. 

These tests are disabled on CI because they are very slow and because they are always fails (due to existing false-positives). Use it manually when adding some new analysis or changing behavior of an existing one.