### PR TITLE
Fix cache invalidation in language injections

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
@@ -40,7 +40,7 @@ fun expandMacro(call: RsMacroCall): CachedValueProvider.Result<MacroExpansion?> 
                 it.setContext(context)
                 it.setExpandedFrom(call)
             }
-            CachedValueProvider.Result.create(result, project.rustStructureModificationTracker)
+            CachedValueProvider.Result.create(result, call.rustStructureOrAnyPsiModificationTracker)
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
@@ -61,7 +61,7 @@ val RsItemsOwner.expandedItemsExceptImpls: List<RsItemElement>
         }
         CachedValueProvider.Result.create(
             if (items.isNotEmpty()) items else emptyList(),
-            project.rustStructureModificationTracker
+            rustStructureOrAnyPsiModificationTracker
         )
     }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -789,7 +789,7 @@ private class MacroResolver private constructor() {
         private fun visibleMacros(scope: RsItemsOwner): List<RsMacro> =
             CachedValuesManager.getCachedValue(scope) {
                 val macros = MacroResolver().collectMacrosInScopeDownward(scope)
-                CachedValueProvider.Result.create(macros, scope.project.rustStructureModificationTracker)
+                CachedValueProvider.Result.create(macros, scope.rustStructureOrAnyPsiModificationTracker)
             }
 
         private fun <T> processAll(elements: Collection<T>, processor: (T) -> Boolean): Boolean =
@@ -811,7 +811,7 @@ private fun exportedMacros(scope: RsFile): List<RsMacro> {
     }
     return CachedValuesManager.getCachedValue(scope) {
         val macros = exportedMacrosInternal(scope)
-        CachedValueProvider.Result.create(macros, scope.project.rustStructureModificationTracker)
+        CachedValueProvider.Result.create(macros, scope.rustStructureOrAnyPsiModificationTracker)
     }
 }
 


### PR DESCRIPTION
TODO do something with `rustStructureModificationTracker` usage in `ProjectCache` and `RsMacroIndex`