### PR TITLE
PERF: Don't mark macro expansions as generated code

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -98,7 +98,7 @@ private data class WithParent(
 private val STD_MACRO_WHITELIST = setOf("write", "writeln")
 
 class MacroExpander(val project: Project) {
-    private val psiFactory = RsPsiFactory(project)
+    private val psiFactory = RsPsiFactory(project, markGenerated = false)
 
     fun expandMacro(def: RsMacro, call: RsMacroCall): MacroExpansion? {
         // All std macros contain the only `impl`s which are not supported for now, so ignoring them

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactory.kt
@@ -17,7 +17,7 @@ import org.rust.openapiext.toPsiFile
 
 
 class RsCodeFragmentFactory(val project: Project) {
-    private val psiFactory = RsPsiFactory(project)
+    private val psiFactory = RsPsiFactory(project, markGenerated = false)
 
     fun createCrateRelativePath(pathText: String, target: CargoWorkspace.Target): RsPath? {
         check(pathText.startsWith("::"))

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiParserFacade
+import com.intellij.util.LocalTimeCounter
 import org.rust.ide.presentation.insertionSafeText
 import org.rust.ide.presentation.insertionSafeTextWithLifetimes
 import org.rust.lang.RsFileType
@@ -25,10 +26,17 @@ import org.rust.lang.core.types.ty.Mutability.IMMUTABLE
 import org.rust.lang.core.types.ty.Mutability.MUTABLE
 import org.rust.lang.core.types.type
 
-class RsPsiFactory(private val project: Project) {
+class RsPsiFactory(private val project: Project, private val markGenerated: Boolean = true) {
     fun createFile(text: CharSequence): RsFile =
         PsiFileFactory.getInstance(project)
-            .createFileFromText("DUMMY.rs", RsFileType, text) as RsFile
+            .createFileFromText(
+                "DUMMY.rs",
+                RsFileType,
+                text,
+                /*modificationStamp =*/ LocalTimeCounter.currentTime(), // default value
+                /*eventSystemEnabled =*/ false, // default value
+                /*markAsCopy =*/ markGenerated // `true` by default
+            ) as RsFile
 
     fun createMacroBody(text: String): RsMacroBody? = createFromText(
         "macro_rules! m $text"

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
@@ -53,7 +53,7 @@ val RsMacro.macroBodyStubbed: RsMacroBody?
         val text = stub.macroBody ?: return null
         return CachedValuesManager.getCachedValue(this) {
             CachedValueProvider.Result.create(
-                RsPsiFactory(project).createMacroBody(text),
+                RsPsiFactory(project, markGenerated = false).createMacroBody(text),
                 modificationTracker
             )
         }


### PR DESCRIPTION
This marking is needed for generated code that will be inserted to real PSI by intentions/etc. Then postprocess formatting will be invoked on marked code only. In macro expansions (and other generated code that is not intended to be used in intentions/etc) we totally don't need it. It just consumes additional memory for storing such marks in user data of each PSI element.