### PR TITLE
Improve simplify boolean expression

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/SimplifyBooleanExpressionFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/SimplifyBooleanExpressionFix.kt
@@ -1,0 +1,27 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.ide.utils.BooleanExprSimplifier
+import org.rust.ide.utils.isPure
+import org.rust.lang.core.psi.RsExpr
+
+class SimplifyBooleanExpressionFix(expr: RsExpr) : LocalQuickFixOnPsiElement(expr) {
+    override fun getText(): String = "Simplify boolean expression"
+    override fun getFamilyName() = text
+
+    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+        val expr = startElement as? RsExpr ?: return
+        if (expr.isPure() == true && BooleanExprSimplifier.canBeSimplified(expr)) {
+            val simplified = BooleanExprSimplifier(project).simplify(expr) ?: return
+            expr.replace(simplified)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntention.kt
@@ -8,10 +8,10 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import org.rust.ide.utils.simplifyBooleanExpression
+import org.rust.ide.utils.BooleanExprSimplifier
 import org.rust.lang.core.psi.RsExpr
-import org.rust.lang.core.psi.ext.ancestors
 import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psi.ext.ancestors
 
 class SimplifyBooleanExpressionIntention : RsElementBaseIntentionAction<RsExpr>() {
     override fun getText() = "Simplify boolean expression"
@@ -22,15 +22,10 @@ class SimplifyBooleanExpressionIntention : RsElementBaseIntentionAction<RsExpr>(
             ?.ancestors
             ?.takeWhile { it is RsExpr }
             ?.map { it as RsExpr }
-            ?.findLast { isSimplifiableExpression(it) }
-
-    private fun isSimplifiableExpression(psi: RsExpr): Boolean {
-        return (psi.copy() as RsExpr).simplifyBooleanExpression().second
-    }
+            ?.findLast { BooleanExprSimplifier.canBeSimplified(it) }
 
     override fun invoke(project: Project, editor: Editor, ctx: RsExpr) {
-        val (expr, isSimplified) = ctx.simplifyBooleanExpression()
-        if (isSimplified)
-            ctx.replace(expr)
+        val simplified = BooleanExprSimplifier(project).simplify(ctx) ?: return
+        ctx.replace(simplified)
     }
 }

--- a/src/main/kotlin/org/rust/ide/utils/BooleanExprSimplifier.kt
+++ b/src/main/kotlin/org/rust/ide/utils/BooleanExprSimplifier.kt
@@ -1,0 +1,128 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.utils
+
+import com.intellij.openapi.project.Project
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.utils.negate
+
+class BooleanExprSimplifier(val project: Project) {
+    private val factory = RsPsiFactory(project)
+
+    /**
+     * Simplifies a boolean expression if can.
+     *
+     * @returns `null` if expr cannot be simplified, `expr` otherwise
+     */
+    fun simplify(expr: RsExpr): RsExpr? {
+        if (expr is RsLitExpr) return null
+
+        val value = eval(expr)
+        if (value != null) {
+            return factory.createExpression(value.toString())
+        }
+
+        return when (expr) {
+            is RsBinaryExpr -> {
+                val left = expr.left
+                val right = expr.right ?: return null
+                val op = expr.operatorType
+
+                val lhs = simplify(left) ?: left
+                val rhs = simplify(right) ?: right
+
+                when {
+                    lhs is RsLitExpr -> simplifyBinaryOperation(op, lhs, rhs)
+                    rhs is RsLitExpr -> simplifyBinaryOperation(op, rhs, lhs)
+                    else -> factory.createExpression("${lhs.text} ${expr.binaryOp.text} ${rhs.text}")
+                }
+            }
+
+            is RsParenExpr -> {
+                val interiorSimplified = simplify(expr.expr)
+                interiorSimplified?.let { factory.createExpression("(${it.text})") }
+            }
+
+            else -> null
+        }
+    }
+
+    private fun simplifyBinaryOperation(op: BinaryOperator, const: RsLitExpr, expr: RsExpr): RsExpr? {
+        val literal = const.boolLiteral?.text ?: return null
+        return when (op) {
+            LogicOp.AND -> if (literal == "false") factory.createExpression("false") else expr
+            LogicOp.OR -> if (literal == "true") factory.createExpression("true") else expr
+            EqualityOp.EQ -> if (literal == "false") factory.createExpression("!${expr.text}") else expr
+            EqualityOp.EXCLEQ -> if (literal == "true") factory.createExpression("!${expr.text}") else expr
+            else -> null
+        }
+    }
+
+    companion object {
+        fun canBeSimplified(expr: RsExpr): Boolean {
+            if (expr is RsLitExpr) return false
+
+            if (canBeEvaluated(expr)) return true
+
+            when (expr) {
+                is RsBinaryExpr -> {
+                    val left = expr.left
+                    val right = expr.right ?: return false
+
+                    if (expr.operatorType in setOf(LogicOp.AND, LogicOp.OR, EqualityOp.EQ, EqualityOp.EXCLEQ)) {
+                        if (canBeSimplified(left) || canBeSimplified(right)) return true
+                        if (canBeEvaluated(left) || canBeEvaluated(right)) return true
+                    }
+                }
+
+                is RsParenExpr -> return canBeSimplified(expr.expr)
+            }
+
+            return false
+        }
+
+        private fun canBeEvaluated(expr: RsExpr): Boolean =
+            eval(expr) != null
+
+        private fun eval(expr: RsExpr?): Boolean? {
+            return when (expr) {
+                is RsLitExpr ->
+                    (expr.kind as? RsLiteralKind.Boolean)?.value
+
+                is RsBinaryExpr -> when (expr.operatorType) {
+                    LogicOp.AND -> {
+                        val lhs = eval(expr.left) ?: return null
+                        if (!lhs) return false // false && _ --> false
+                        val rhs = eval(expr.right) ?: return null
+                        lhs && rhs
+                    }
+                    LogicOp.OR -> {
+                        val lhs = eval(expr.left) ?: return null
+                        if (lhs) return true // true || _ --> true
+                        val rhs = eval(expr.right) ?: return null
+                        lhs || rhs
+                    }
+                    ArithmeticOp.BIT_XOR -> {
+                        val lhs = eval(expr.left) ?: return null
+                        val rhs = eval(expr.right) ?: return null
+                        lhs xor rhs
+                    }
+                    else -> null
+                }
+
+                is RsUnaryExpr -> when (expr.operatorType) {
+                    UnaryOperator.NOT -> eval(expr.expr)?.let { !it }
+                    else -> null
+                }
+
+                is RsParenExpr -> eval(expr.expr)
+
+                else -> null
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/ide/intentions/InvertIfIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/InvertIfIntentionTest.kt
@@ -6,7 +6,7 @@
 package org.rust.ide.intentions
 
 class InvertIfIntentionTest : RsIntentionTestBase(InvertIfIntention()) {
-    fun `test if let unavailable`() = doUnavailableTest(""""
+    fun `test if let unavailable`() = doUnavailableTest("""
         fn foo(a: Option<i32>) {
             if/*caret*/ let Some(x) = a {} else {}
         }
@@ -18,7 +18,7 @@ class InvertIfIntentionTest : RsIntentionTestBase(InvertIfIntention()) {
         }
     """)
 
-    fun `test if without else branch unavailable`() = doUnavailableTest(""""
+    fun `test if without else branch unavailable`() = doUnavailableTest("""
         fn foo(a: i32) {
             if/*caret*/ a == 10  {}
         }
@@ -32,29 +32,22 @@ class InvertIfIntentionTest : RsIntentionTestBase(InvertIfIntention()) {
 
     fun `test simple inversion`() = doAvailableTest("""
         fn foo() {
-            if/*caret*/ 2 == 2 {
-                Ok(())
-            } else {
-                Err(())
-            }
-        }
-    """, """
-        fn foo() {
-            if 2 != 2 {
-                Err(())
-            } else {
-                Ok(())
-            }
-        }
-    """)
-
-    fun `test simple inversion on one line`() = doAvailableTest("""
-        fn foo() {
             if/*caret*/ 2 == 2 { Ok(()) } else { Err(()) }
         }
     """, """
         fn foo() {
             if 2 != 2 { Err(()) } else { Ok(()) }
+        }
+    """)
+
+    // `!(2 == 2)` can be later simplified to `2 != 2` by user via `Simplify boolean expression` intention
+    fun `test simple inversion parens`() = doAvailableTest("""
+        fn foo() {
+            if/*caret*/ (2 == 2) { Ok(()) } else { Err(()) }
+        }
+    """, """
+        fn foo() {
+            if !(2 == 2) { Err(()) } else { Ok(()) }
         }
     """)
 
@@ -70,11 +63,11 @@ class InvertIfIntentionTest : RsIntentionTestBase(InvertIfIntention()) {
 
     fun `test complex condition`() = doAvailableTest("""
         fn foo() {
-            if/*caret*/ 2 == 2 && (3 == 3 || 4 == 4) { Ok(()) } else { Err(()) }
+            if/*caret*/ 2 == 2 && (3 == 3 || 4 == 4) && (5 == 5) { Ok(()) } else { Err(()) }
         }
     """, """
         fn foo() {
-            if 2 != 2 || !(3 == 3 || 4 == 4) { Err(()) } else { Ok(()) }
+            if 2 != 2 || !(3 == 3 || 4 == 4) || (5 != 5) { Err(()) } else { Ok(()) }
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntentionTest.kt
@@ -283,6 +283,16 @@ class SimplifyBooleanExpressionIntentionTest : RsIntentionTestBase(SimplifyBoole
         }
     """)
 
+    fun `test negation parens`() = doAvailableTest("""
+        fn main() {
+            if !(1 == 2/*caret*/) {}
+        }
+    """, """
+        fn main() {
+            if 1 != 2 {}
+        }
+    """)
+
     fun `test incomplete code`() = doUnavailableTest("""
         fn main() {
             xs.iter()


### PR DESCRIPTION
* Extract `SimplifyBooleanExpressionFix` from `RsSimplifyBooleanExpressionInspection`
* Extract `BooleanExprSimplifier` from `ExprUtils.kt`
* Split `RsExpr.simplifyBooleanExpression(peek: Boolean): Pair<RsExpr, Boolean>` into two functions:
  - `simplify(expr: RsExpr): RsExpr?`
  - `canBeSimplified(expr: RsExpr): Boolean`
* Now `simplify` doesn't perform any changes on existing PSI (unlike old `simplifyBooleanExpression`)
* Now `simplify` translates `!(1 == 2)` into `1 != 2`
* Add more tests for "Invert if" intention to specify that user can simplify resulted expression manually
 