### PR TITLE
Provide binary compatible API for Rust project settings

### DIFF
--- a/idea/src/main/kotlin/org/rust/ide/idea/CargoConfigurationWizardStep.kt
+++ b/idea/src/main/kotlin/org/rust/ide/idea/CargoConfigurationWizardStep.kt
@@ -61,10 +61,10 @@ class CargoConfigurationWizardStep private constructor(
         override fun update(module: Module, rootModel: ModifiableRootModel) {
             val data = data
             if (data != null) {
-                module.project.rustSettings.data = module.project.rustSettings.data.copy(
-                    toolchain = data.toolchain,
-                    explicitPathToStdlib = data.explicitPathToStdlib
-                )
+                module.project.rustSettings.modify {
+                    it.toolchain = data.toolchain
+                    it.explicitPathToStdlib = data.explicitPathToStdlib
+                }
             }
             // We don't use SDK, but let's inherit one to reduce the amount of
             // "SDK not configured" errors

--- a/src/main/kotlin/org/rust/cargo/project/configurable/CargoConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/CargoConfigurable.kt
@@ -69,15 +69,14 @@ class CargoConfigurable(project: Project) : RsConfigurableBase(project) {
     }
 
     override fun apply() {
-        val currentData = settings.data
-        settings.data = currentData.copy(
-            autoUpdateEnabled = autoUpdateEnabled,
-            useCargoCheckForBuild = useCargoCheckForBuild,
-            useCargoCheckAnnotator = useCargoCheckAnnotator,
-            cargoCheckArguments = cargoCheckArguments.text,
-            compileAllTargets = compileAllTargets,
-            useOffline = useOffline
-        )
+        settings.modify {
+            it.autoUpdateEnabled = autoUpdateEnabled
+            it.useCargoCheckForBuild = useCargoCheckForBuild
+            it.useCargoCheckAnnotator = useCargoCheckAnnotator
+            it.cargoCheckArguments = cargoCheckArguments.text
+            it.compileAllTargets = compileAllTargets
+            it.useOffline = useOffline
+        }
     }
 
     override fun reset() {

--- a/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
@@ -92,14 +92,13 @@ class RsProjectConfigurable(
             option.set(checkboxForOption(option).isSelected)
         }
 
-        val currentData = settings.data
-        settings.data = currentData.copy(
-            toolchain = rustProjectSettings.data.toolchain,
-            explicitPathToStdlib = rustProjectSettings.data.explicitPathToStdlib,
-            expandMacros = expandMacros,
-            showTestToolWindow = showTestToolWindow,
-            doctestInjectionEnabled = doctestInjectionEnabled
-        )
+        settings.modify {
+            it.toolchain = rustProjectSettings.data.toolchain
+            it.explicitPathToStdlib = rustProjectSettings.data.explicitPathToStdlib
+            it.expandMacros = expandMacros
+            it.showTestToolWindow = showTestToolWindow
+            it.doctestInjectionEnabled = doctestInjectionEnabled
+        }
     }
 
     override fun isModified(): Boolean {

--- a/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
@@ -28,8 +28,7 @@ class RustfmtConfigurable(project: Project) : RsConfigurableBase(project) {
     override fun isModified(): Boolean = settings.useSkipChildren != useSkipChildren
 
     override fun apply() {
-        val currentData = settings.data
-        settings.data = currentData.copy(useSkipChildren = useSkipChildren)
+        settings.modify { it.useSkipChildren = useSkipChildren }
     }
 
     override fun reset() {

--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -148,7 +148,7 @@ private fun discoverToolchain(project: Project) {
         }
 
         runWriteAction {
-            project.rustSettings.data = project.rustSettings.data.copy(toolchain = toolchain)
+            project.rustSettings.modify { it.toolchain = toolchain }
         }
 
         val tool = if (toolchain.isRustupAvailable) "rustup" else "Cargo at ${toolchain.presentableLocation}"

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -7,46 +7,58 @@ package org.rust.cargo.project.settings
 
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
+import com.intellij.util.io.systemIndependentPath
 import com.intellij.util.messages.Topic
+import com.intellij.util.xmlb.annotations.Transient
 import org.rust.cargo.toolchain.RustToolchain
+import java.nio.file.Paths
 
 interface RustProjectSettingsService {
-    data class Data(
-        val toolchain: RustToolchain?,
-        val autoUpdateEnabled: Boolean,
+
+    data class State(
+        var toolchainHomeDirectory: String? = null,
+        var autoUpdateEnabled: Boolean = true,
         // Usually, we use `rustup` to find stdlib automatically,
         // but if one does not use rustup, it's possible to
         // provide path to stdlib explicitly.
-        val explicitPathToStdlib: String?,
-        val useCargoCheckForBuild: Boolean,
-        val useCargoCheckAnnotator: Boolean,
-        val cargoCheckArguments: String,
-        val compileAllTargets: Boolean,
-        val useOffline: Boolean,
-        val expandMacros: Boolean,
-        val showTestToolWindow: Boolean,
-        val doctestInjectionEnabled: Boolean,
-        val useSkipChildren: Boolean
-    )
+        var explicitPathToStdlib: String? = null,
+        var useCargoCheckForBuild: Boolean = false,
+        var useCargoCheckAnnotator: Boolean = false,
+        var cargoCheckArguments: String = "",
+        var compileAllTargets: Boolean = true,
+        var useOffline: Boolean = false,
+        var expandMacros: Boolean = true,
+        var showTestToolWindow: Boolean = true,
+        var doctestInjectionEnabled: Boolean = true,
+        var useSkipChildren: Boolean = false
+    ) {
+        @get:Transient
+        @set:Transient
+        var toolchain: RustToolchain?
+            get() = toolchainHomeDirectory?.let { RustToolchain(Paths.get(it)) }
+            set(value) {
+                toolchainHomeDirectory = value?.location?.systemIndependentPath
+            }
+    }
 
-    var data: Data
+    /**
+     * Allows to modify settings.
+     * After setting change,
+     */
+    fun modify(action: (State) -> Unit)
 
-    val toolchain: RustToolchain? get() = data.toolchain
-    var explicitPathToStdlib: String?
-        get() = data.explicitPathToStdlib
-        set(value) {
-            data = data.copy(explicitPathToStdlib = value)
-        }
-    val autoUpdateEnabled: Boolean get() = data.autoUpdateEnabled
-    val useCargoCheckForBuild: Boolean get() = data.useCargoCheckForBuild
-    val useCargoCheckAnnotator: Boolean get() = data.useCargoCheckAnnotator
-    val cargoCheckArguments: String get() = data.cargoCheckArguments
-    val compileAllTargets: Boolean get() = data.compileAllTargets
-    val useOffline: Boolean get() = data.useOffline
-    val expandMacros: Boolean get() = data.expandMacros
-    val showTestToolWindow: Boolean get() = data.showTestToolWindow
-    val doctestInjectionEnabled: Boolean get() = data.doctestInjectionEnabled
-    val useSkipChildren: Boolean get() = data.useSkipChildren
+    val toolchain: RustToolchain?
+    val explicitPathToStdlib: String?
+    val autoUpdateEnabled: Boolean
+    val useCargoCheckForBuild: Boolean
+    val useCargoCheckAnnotator: Boolean
+    val cargoCheckArguments: String
+    val compileAllTargets: Boolean
+    val useOffline: Boolean
+    val expandMacros: Boolean
+    val showTestToolWindow: Boolean
+    val doctestInjectionEnabled: Boolean
+    val useSkipChildren: Boolean
 
     /*
      * Show a dialog for toolchain configuration

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -6,36 +6,32 @@
 package org.rust.cargo.project.settings.impl
 
 import com.intellij.openapi.components.PersistentStateComponent
-import com.intellij.openapi.components.State
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
-import com.intellij.util.io.systemIndependentPath
 import org.rust.cargo.project.configurable.RsProjectConfigurable
 import org.rust.cargo.project.settings.RustProjectSettingsService
+import org.rust.cargo.project.settings.RustProjectSettingsService.State
 import org.rust.cargo.toolchain.RustToolchain
-import java.nio.file.Paths
 
-@State(name = "RustProjectSettings")
+@com.intellij.openapi.components.State(name = "RustProjectSettings")
 class RustProjectSettingsServiceImpl(
     private val project: Project
-) : PersistentStateComponent<RustProjectSettingsServiceImpl.State>, RustProjectSettingsService {
+) : PersistentStateComponent<State>, RustProjectSettingsService {
     @Volatile
     private var state: State = State()
 
-    data class State(
-        var toolchainHomeDirectory: String? = null,
-        var autoUpdateEnabled: Boolean = true,
-        var explicitPathToStdlib: String? = null,
-        var useCargoCheckForBuild: Boolean = false,
-        var useCargoCheckAnnotator: Boolean = false,
-        var cargoCheckArguments: String = "",
-        var compileAllTargets: Boolean = true,
-        var useOffline: Boolean = false,
-        var expandMacros: Boolean = true,
-        var showTestToolWindow: Boolean = true,
-        var doctestInjectionEnabled: Boolean = true,
-        var useSkipChildren: Boolean = false
-    )
+    override val toolchain: RustToolchain? get() = state.toolchain
+    override val explicitPathToStdlib: String? get() = state.explicitPathToStdlib
+    override val autoUpdateEnabled: Boolean get() = state.autoUpdateEnabled
+    override val useCargoCheckForBuild: Boolean get() = state.useCargoCheckForBuild
+    override val useCargoCheckAnnotator: Boolean get() = state.useCargoCheckAnnotator
+    override val cargoCheckArguments: String get() = state.cargoCheckArguments
+    override val compileAllTargets: Boolean get() = state.compileAllTargets
+    override val useOffline: Boolean get() = state.useOffline
+    override val expandMacros: Boolean get() = state.expandMacros
+    override val showTestToolWindow: Boolean get() = state.showTestToolWindow
+    override val doctestInjectionEnabled: Boolean get() = state.doctestInjectionEnabled
+    override val useSkipChildren: Boolean get() = state.useSkipChildren
 
     override fun getState(): State = state
 
@@ -43,48 +39,18 @@ class RustProjectSettingsServiceImpl(
         state = newState
     }
 
+    override fun modify(action: (State) -> Unit) {
+        val copy = state.copy()
+        action(copy)
+        if (state != copy) {
+            state = copy.copy()
+            notifyToolchainChanged()
+        }
+    }
+
     override fun configureToolchain() {
         ShowSettingsUtil.getInstance().editConfigurable(project, RsProjectConfigurable(project))
     }
-
-    override var data: RustProjectSettingsService.Data
-        get() {
-            val state = state
-            return RustProjectSettingsService.Data(
-                toolchain = state.toolchainHomeDirectory?.let { RustToolchain(Paths.get(it)) },
-                autoUpdateEnabled = state.autoUpdateEnabled,
-                explicitPathToStdlib = state.explicitPathToStdlib,
-                useCargoCheckForBuild = state.useCargoCheckForBuild,
-                useCargoCheckAnnotator = state.useCargoCheckAnnotator,
-                cargoCheckArguments = state.cargoCheckArguments,
-                compileAllTargets = state.compileAllTargets,
-                useOffline = state.useOffline,
-                expandMacros = state.expandMacros,
-                showTestToolWindow = state.showTestToolWindow,
-                doctestInjectionEnabled = state.doctestInjectionEnabled,
-                useSkipChildren = state.useSkipChildren
-            )
-        }
-        set(value) {
-            val newState = State(
-                toolchainHomeDirectory = value.toolchain?.location?.systemIndependentPath,
-                autoUpdateEnabled = value.autoUpdateEnabled,
-                explicitPathToStdlib = value.explicitPathToStdlib,
-                useCargoCheckForBuild = value.useCargoCheckForBuild,
-                useCargoCheckAnnotator = value.useCargoCheckAnnotator,
-                cargoCheckArguments = value.cargoCheckArguments,
-                compileAllTargets = value.compileAllTargets,
-                useOffline = value.useOffline,
-                expandMacros = value.expandMacros,
-                showTestToolWindow = value.showTestToolWindow,
-                doctestInjectionEnabled = value.doctestInjectionEnabled,
-                useSkipChildren = value.useSkipChildren
-            )
-            if (state != newState) {
-                state = newState
-                notifyToolchainChanged()
-            }
-        }
 
     private fun notifyToolchainChanged() {
         project.messageBus.syncPublisher(RustProjectSettingsService.TOOLCHAIN_TOPIC).toolchainChanged()

--- a/src/main/kotlin/org/rust/ide/actions/ToggleCargoCheckAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/ToggleCargoCheckAction.kt
@@ -32,6 +32,6 @@ class ToggleCargoCheckAction : AnAction() {
         val project = e.project ?: return
         val settings = project.rustSettings
         val before = settings.useCargoCheckAnnotator
-        settings.data = settings.data.copy(useCargoCheckAnnotator = !before)
+        settings.modify { it.useCargoCheckAnnotator = !before }
     }
 }

--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -119,7 +119,7 @@ class MissingToolchainNotificationProvider(
                 val descriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
                 val stdlib = FileChooser.chooseFile(descriptor, this, project, null) ?: return@createActionLabel
                 if (StandardLibrary.fromFile(stdlib) != null) {
-                    project.rustSettings.explicitPathToStdlib = stdlib.path
+                    project.rustSettings.modify { it.explicitPathToStdlib = stdlib.path }
                 } else {
                     project.showBalloon(
                         "Invalid Rust standard library source path: `${stdlib.presentableUrl}`",

--- a/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
@@ -69,12 +69,12 @@ abstract class RsWithToolchainTestBase : CodeInsightFixtureTestCase<ModuleFixtur
         super.setUp()
 
         if (toolchain != null) {
-            project.rustSettings.data = project.rustSettings.data.copy(toolchain = toolchain)
+            project.rustSettings.modify { it.toolchain = toolchain }
         }
     }
 
     override fun tearDown() {
-        project.rustSettings.data = project.rustSettings.data.copy(toolchain = null)
+        project.rustSettings.modify { it.toolchain = null }
         super.tearDown()
     }
 

--- a/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
@@ -9,7 +9,6 @@ import com.intellij.configurationStore.deserialize
 import com.intellij.configurationStore.serialize
 import com.intellij.testFramework.LightPlatformTestCase
 import org.intellij.lang.annotations.Language
-import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.settings.impl.RustProjectSettingsServiceImpl
 import org.rust.cargo.toolchain.RustToolchain
 import org.rust.openapiext.elementFromXmlString
@@ -24,6 +23,7 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
         val text = """
             <State>
               <option name="autoUpdateEnabled" value="false" />
+              <option name="cargoCheckArguments" value="--no-default-features" />
               <option name="compileAllTargets" value="false" />
               <option name="doctestInjectionEnabled" value="false" />
               <option name="expandMacros" value="false" />
@@ -38,23 +38,19 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
         """.trimIndent()
         service.loadState(elementFromXmlString(text).deserialize())
         val actual = service.state.serialize()!!.toXmlString()
-        check(actual == text.trimIndent()) {
-            "Expected:\n$text\nActual:\n$actual"
-        }
+        assertEquals(text.trimIndent(), actual)
 
-        check(service.data == RustProjectSettingsService.Data(
-            toolchain = RustToolchain(Paths.get("/")),
-            autoUpdateEnabled = false,
-            explicitPathToStdlib = "/stdlib",
-            useCargoCheckForBuild = true,
-            useCargoCheckAnnotator = true,
-            cargoCheckArguments = "",
-            compileAllTargets = false,
-            useOffline = true,
-            expandMacros = false,
-            showTestToolWindow = false,
-            doctestInjectionEnabled = false,
-            useSkipChildren = true
-        ))
+        assertEquals(RustToolchain(Paths.get("/")), service.toolchain)
+        assertEquals(false, service.autoUpdateEnabled)
+        assertEquals("/stdlib", service.explicitPathToStdlib)
+        assertEquals(true, service.useCargoCheckForBuild)
+        assertEquals(true, service.useCargoCheckAnnotator)
+        assertEquals("--no-default-features", service.cargoCheckArguments)
+        assertEquals(false, service.compileAllTargets)
+        assertEquals(true, service.useOffline)
+        assertEquals(false, service.expandMacros)
+        assertEquals(false, service.showTestToolWindow)
+        assertEquals(false, service.doctestInjectionEnabled)
+        assertEquals(true, service.useSkipChildren)
     }
 }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ApplySuggestionFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ApplySuggestionFixTest.kt
@@ -15,7 +15,7 @@ class ApplySuggestionFixTest : RsWithToolchainTestBase() {
 
     override fun setUp() {
         super.setUp()
-        project.rustSettings.data = project.rustSettings.data.copy(useCargoCheckAnnotator = true)
+        project.rustSettings.modify { it.useCargoCheckAnnotator = true }
     }
 
     fun `test rustc suggestion (machine applicable)`() = checkFixByText("""

--- a/src/test/kotlin/org/rustSlowTests/RsCargoCheckAnnotatorPassTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsCargoCheckAnnotatorPassTest.kt
@@ -18,7 +18,7 @@ class RsCargoCheckAnnotatorPassTest : RsWithToolchainTestBase() {
 
     override fun setUp() {
         super.setUp()
-        project.rustSettings.data = project.rustSettings.data.copy(useCargoCheckAnnotator = true)
+        project.rustSettings.modify { it.useCargoCheckAnnotator = true }
     }
 
     fun `test no errors if everything is ok`() = doTest("""


### PR DESCRIPTION
Before these changes, there was only one way to change almost all properties of `RustProjectSettingsService`:
get `data`, create new one with necessary changes and set new instance to the settings.
Because of `RustProjectSettingsService.Data` is immutable, you have to create new instance via constructor or `copy` method.
But any changes in class lead to `java.lang.NoSuchMethodError` in external code
because signatures of constructor and `copy` method are changing accordingly

These changes provide setter for each property (i.e. make each property mutable)
It should be enough to change any property and do not touch `RustProjectSettingsService.Data` class