### PR TITLE
PSI: `ContributedReferenceHost` for `RsLitExp`

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1150,7 +1150,8 @@ LitExpr ::= OuterAttr*
   | INTEGER_LITERAL | FLOAT_LITERAL
   | BOOL_LITERAL) {
  elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
- implements = "com.intellij.psi.PsiLanguageInjectionHost"
+ implements = [ "com.intellij.psi.PsiLanguageInjectionHost"
+                "com.intellij.psi.ContributedReferenceHost" ]
  mixin = "org.rust.lang.core.psi.ext.RsLitExprMixin"
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsLitExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsLitExpr.kt
@@ -43,7 +43,7 @@ val RsLitExpr.stubType: RsStubLiteralType? get() {
 val RsLitExpr.integerLiteralValue: String? get() =
     (stub as? RsLitExprStub)?.integerLiteralValue ?: integerLiteral?.text
 
-abstract class RsLitExprMixin : RsExprImpl, RsLitExpr, ContributedReferenceHost, RegExpLanguageHost {
+abstract class RsLitExprMixin : RsExprImpl, RsLitExpr, RegExpLanguageHost {
 
     constructor(node: ASTNode) : super(node)
     constructor(stub: RsPlaceholderStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)


### PR DESCRIPTION
In fact, it changes nothing because `RsLitExprImpl` already implements `ContributedReferenceHost` via `RsLitExprMixin` but now it's part of our public API