### PR TITLE
RUN: Run rustfmt on the document before saving

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
@@ -20,7 +20,6 @@ import com.intellij.execution.runners.AsyncProgramRunner
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
@@ -47,6 +46,7 @@ import org.rust.cargo.toolchain.impl.CargoMetadata
 import org.rust.cargo.toolchain.prependArgument
 import org.rust.cargo.util.CargoArgsParser
 import org.rust.debugger.settings.RsDebuggerSettings
+import org.rust.openapiext.saveAllDocuments
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -68,7 +68,7 @@ class RsDebugRunner : AsyncProgramRunner<RunnerSettings>() {
     }
 
     override fun execute(environment: ExecutionEnvironment, state: RunProfileState): Promise<RunContentDescriptor?> {
-        FileDocumentManager.getInstance().saveAllDocuments()
+        saveAllDocuments()
         state as CargoRunStateBase
         val cmd = Cargo.patchArgs(state.prepareCommandLine(), true)
         val (commandArguments, executableArguments) = CargoArgsParser.parseArgs(cmd.command, cmd.additionalArguments)

--- a/src/main/kotlin/org/rust/cargo/RustfmtWatcher.kt
+++ b/src/main/kotlin/org/rust/cargo/RustfmtWatcher.kt
@@ -1,0 +1,93 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo
+
+import com.intellij.AppTopics
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.BaseComponent
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.fileEditor.FileDocumentManagerListener
+import com.intellij.openapi.project.guessProjectForFile
+import com.intellij.util.containers.ContainerUtil
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.settings.rustSettings
+import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.runconfig.command.workingDirectory
+import org.rust.cargo.toolchain.Rustup.Companion.checkNeedInstallRustfmt
+import org.rust.lang.core.psi.isNotRustFile
+import org.rust.openapiext.virtualFile
+
+class RustfmtWatcher : BaseComponent {
+    private val documentsToReformatLater: MutableSet<Document> = ContainerUtil.newConcurrentSet()
+    private var isSuppressed: Boolean = false
+
+    override fun initComponent() {
+        ApplicationManager.getApplication()
+            .messageBus
+            .connect()
+            .subscribe(AppTopics.FILE_DOCUMENT_SYNC, RustfmtListener())
+    }
+
+    fun withoutReformatting(action: () -> Unit) {
+        val oldStatus = isSuppressed
+        try {
+            isSuppressed = true
+            action()
+        } finally {
+            isSuppressed = oldStatus
+        }
+    }
+
+    fun reformatDocumentLater(document: Document): Boolean {
+        val file = document.virtualFile ?: return false
+        if (file.isNotRustFile) return false
+        val project = guessProjectForFile(file) ?: return false
+        if (!project.rustSettings.runRustfmtOnSave) return false
+        return documentsToReformatLater.add(document)
+    }
+
+    private inner class RustfmtListener : FileDocumentManagerListener {
+
+        override fun beforeAllDocumentsSaving() {
+            val documentsToReformat = HashSet(documentsToReformatLater)
+            documentsToReformatLater.clear()
+            documentsToReformat.groupBy(::findCargoProject).forEach(::reformatDocuments)
+        }
+
+        override fun beforeDocumentSaving(document: Document) {
+            if (!isSuppressed) {
+                reformatDocuments(findCargoProject(document), listOf(document))
+            }
+        }
+
+        override fun unsavedDocumentsDropped() {
+            documentsToReformatLater.clear()
+        }
+    }
+
+    companion object {
+
+        fun getInstance(): RustfmtWatcher =
+            ApplicationManager.getApplication().getComponent(RustfmtWatcher::class.java)
+
+        private fun findCargoProject(document: Document): CargoProject? {
+            val file = document.virtualFile ?: return null
+            val project = guessProjectForFile(file) ?: return null
+            return project.cargoProjects.findProjectForFile(file)
+        }
+
+        private fun reformatDocuments(cargoProject: CargoProject?, documents: List<Document>) {
+            if (cargoProject == null) return
+            val project = cargoProject.project
+            if (!project.rustSettings.runRustfmtOnSave) return
+            val rustfmt = project.toolchain?.rustfmt() ?: return
+            if (checkNeedInstallRustfmt(cargoProject.project, cargoProject.workingDirectory)) return
+            val skipChildren = rustfmt.checkSupportForSkipChildrenFlag(cargoProject)
+            documents.forEach { rustfmt.reformatDocument(cargoProject, it, skipChildren = skipChildren) }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
@@ -12,6 +12,8 @@ import org.rust.openapiext.CheckboxDelegate
 import javax.swing.JComponent
 
 class RustfmtConfigurable(project: Project) : RsConfigurableBase(project) {
+    private val runRustfmtOnSaveCheckbox: JBCheckBox = JBCheckBox()
+    private var runRustfmtOnSave: Boolean by CheckboxDelegate(runRustfmtOnSaveCheckbox)
 
     private val useSkipChildrenCheckbox: JBCheckBox = JBCheckBox()
     private var useSkipChildren: Boolean by CheckboxDelegate(useSkipChildrenCheckbox)
@@ -19,19 +21,25 @@ class RustfmtConfigurable(project: Project) : RsConfigurableBase(project) {
     override fun getDisplayName(): String = "Rustfmt"
 
     override fun createComponent(): JComponent? = layout {
+        row("Run rustfmt on Save:", runRustfmtOnSaveCheckbox)
         row("Don't reformat child modules (nightly only):", useSkipChildrenCheckbox, """
             Pass `--skip-children` option to rustfmt not to reformat child modules.
             Used only for nightly toolchain.
         """)
     }
 
-    override fun isModified(): Boolean = settings.useSkipChildren != useSkipChildren
+    override fun isModified(): Boolean =
+        settings.runRustfmtOnSave != runRustfmtOnSave || settings.useSkipChildren != useSkipChildren
 
     override fun apply() {
-        settings.modify { it.useSkipChildren = useSkipChildren }
+        settings.modify {
+            it.runRustfmtOnSave = runRustfmtOnSave
+            it.useSkipChildren = useSkipChildren
+        }
     }
 
     override fun reset() {
+        runRustfmtOnSave = settings.runRustfmtOnSave
         useSkipChildren = settings.useSkipChildren
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -31,6 +31,7 @@ interface RustProjectSettingsService {
         var expandMacros: Boolean = true,
         var showTestToolWindow: Boolean = true,
         var doctestInjectionEnabled: Boolean = true,
+        var runRustfmtOnSave: Boolean = false,
         var useSkipChildren: Boolean = false
     ) {
         @get:Transient
@@ -59,6 +60,7 @@ interface RustProjectSettingsService {
     val expandMacros: Boolean
     val showTestToolWindow: Boolean
     val doctestInjectionEnabled: Boolean
+    val runRustfmtOnSave: Boolean
     val useSkipChildren: Boolean
 
     /*

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -32,6 +32,7 @@ class RustProjectSettingsServiceImpl(
     override val expandMacros: Boolean get() = state.expandMacros
     override val showTestToolWindow: Boolean get() = state.showTestToolWindow
     override val doctestInjectionEnabled: Boolean get() = state.doctestInjectionEnabled
+    override val runRustfmtOnSave: Boolean get() = state.runRustfmtOnSave
     override val useSkipChildren: Boolean get() = state.useSkipChildren
 
     override fun getState(): State = state

--- a/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoToolWindow.kt
+++ b/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoToolWindow.kt
@@ -89,7 +89,7 @@ class CargoToolWindow(
                     return
                 }
                 val cargoProject = selectedProject ?: return
-                CargoCommandLine.forTarget(target, command).run(project, cargoProject)
+                CargoCommandLine.forTarget(target, command).run(cargoProject)
             }
         })
     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsTestRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsTestRunner.kt
@@ -14,12 +14,12 @@ import com.intellij.execution.runners.AsyncProgramRunner
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.showRunContent
 import com.intellij.execution.ui.RunContentDescriptor
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.toolchain.prependArgument
+import org.rust.openapiext.saveAllDocuments
 
 class RsTestRunner : AsyncProgramRunner<RunnerSettings>() {
     override fun canRun(executorId: String, profile: RunProfile): Boolean {
@@ -31,7 +31,7 @@ class RsTestRunner : AsyncProgramRunner<RunnerSettings>() {
     }
 
     override fun execute(environment: ExecutionEnvironment, state: RunProfileState): Promise<RunContentDescriptor?> {
-        FileDocumentManager.getInstance().saveAllDocuments()
+        saveAllDocuments()
         state as CargoRunStateBase
         val onlyBuild = "--no-run" in state.commandLine.additionalArguments
         return buildTests(environment.project, state, onlyBuild)

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandAction.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/RunCargoCommandAction.kt
@@ -12,14 +12,12 @@ import org.rust.cargo.runconfig.ui.RunCargoCommandDialog
 import org.rust.cargo.toolchain.run
 
 class RunCargoCommandAction : RunCargoCommandActionBase(CargoIcons.ICON) {
-
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val cargoProject = getAppropriateCargoProject(e.dataContext) ?: return
         val dialog = RunCargoCommandDialog(project, cargoProject)
         if (!dialog.showAndGet()) return
 
-        dialog.getCargoCommandLine().run(project, cargoProject)
+        dialog.getCargoCommandLine().run(cargoProject)
     }
-
 }

--- a/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
@@ -109,7 +109,8 @@ fun CargoWorkspace.Target.launchCommand(): String? {
     }
 }
 
-fun CargoCommandLine.run(project: Project, cargoProject: CargoProject) {
+fun CargoCommandLine.run(cargoProject: CargoProject) {
+    val project = cargoProject.project
     val runConfiguration =
         if (project.cargoProjects.allProjects.size > 1)
             createRunConfiguration(project, this, name = command + " [" + cargoProject.presentableName + "]")

--- a/src/main/kotlin/org/rust/cargo/toolchain/Rustfmt.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Rustfmt.kt
@@ -8,52 +8,77 @@ package org.rust.cargo.toolchain
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.process.ProcessOutput
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.project.Project
+import com.intellij.openapi.editor.Document
 import com.intellij.openapi.vfs.VirtualFile
-import org.rust.cargo.project.model.cargoProjects
+import com.intellij.util.DocumentUtil.writeInRunUndoTransparentAction
+import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.settings.rustSettings
-import org.rust.openapiext.GeneralCommandLine
-import org.rust.openapiext.execute
-import org.rust.openapiext.pathAsPath
-import org.rust.openapiext.withWorkDirectory
+import org.rust.cargo.runconfig.command.workingDirectory
+import org.rust.lang.core.psi.isNotRustFile
+import org.rust.openapiext.*
+import org.rust.stdext.buildList
 import java.nio.file.Path
 
 class Rustfmt(private val rustfmtExecutable: Path) {
 
     @Throws(ExecutionException::class)
     fun reformatFile(
-        project: Project,
+        cargoProject: CargoProject,
         file: VirtualFile,
-        owner: Disposable = project
-    ): ProcessOutput {
-        val channel = project.cargoProjects.findProjectForFile(file)
-            ?.rustcInfo?.version?.channel
-
-        val arguments = mutableListOf<String>()
-        val (emit, skipChildren) = checkSupportForRustfmtFlags(file.parent.pathAsPath)
-        arguments += if (emit) "--emit=files" else "--write-mode=overwrite"
-        if (project.rustSettings.useSkipChildren && channel == RustChannel.NIGHTLY && skipChildren) {
-            arguments += "--unstable-features"
-            arguments += "--skip-children"
+        owner: Disposable = cargoProject.project,
+        stdIn: ByteArray? = null,
+        overwriteFile: Boolean = true,
+        skipChildren: Boolean = checkSupportForSkipChildrenFlag(cargoProject)
+    ): ProcessOutput? {
+        if (file.isNotRustFile || !file.isValid) return null
+        val arguments = buildList<String> {
+            add("--emit=${if (overwriteFile) "files" else "stdout"}")
+            if (skipChildren) {
+                add("--unstable-features")
+                add("--skip-children")
+            }
+            if (stdIn == null) add(file.path)
         }
-        arguments += file.path
-        return GeneralCommandLine(rustfmtExecutable)
-            .withWorkDirectory(file.parent.pathAsPath)
-            .withParameters(arguments)
-            .execute(owner, false)
+
+        return try {
+            GeneralCommandLine(rustfmtExecutable)
+                .withWorkDirectory(cargoProject.workingDirectory)
+                .withParameters(arguments)
+                .execute(owner, false, stdIn = stdIn)
+        } catch (e: ExecutionException) {
+            if (isUnitTestMode) throw e else null
+        }
     }
 
-    private fun checkSupportForRustfmtFlags(workingDirectory: Path): RustfmtFlags {
-        val lines = GeneralCommandLine(rustfmtExecutable)
+    @Throws(ExecutionException::class)
+    fun reformatDocument(
+        cargoProject: CargoProject,
+        document: Document,
+        owner: Disposable = cargoProject.project,
+        skipChildren: Boolean = checkSupportForSkipChildrenFlag(cargoProject)
+    ) {
+        if (!document.isWritable) return
+        val processOutput = reformatFile(
+            cargoProject = cargoProject,
+            file = document.virtualFile ?: return,
+            owner = owner,
+            stdIn = document.text.toByteArray(),
+            overwriteFile = false,
+            skipChildren = skipChildren
+        ) ?: return
+        writeInRunUndoTransparentAction { document.setText(processOutput.stdout) }
+    }
+
+    fun checkSupportForSkipChildrenFlag(cargoProject: CargoProject): Boolean {
+        if (!cargoProject.project.rustSettings.useSkipChildren) return false
+        val channel = cargoProject.rustcInfo?.version?.channel
+        if (channel != RustChannel.NIGHTLY) return false
+        return GeneralCommandLine(rustfmtExecutable)
             .withParameters("-h")
-            .withWorkDirectory(workingDirectory)
+            .withWorkDirectory(cargoProject.workingDirectory)
             .execute()
             ?.stdoutLines
-            ?: return RustfmtFlags(false, false)
-
-        return RustfmtFlags(lines.any { it.contains(" --emit ") },
-            lines.any { it.contains(" --skip-children ") })
+            ?.contains(" --skip-children ")
+            ?: false
     }
-
-    private data class RustfmtFlags(val emit: Boolean, val skipChildren: Boolean)
 }

--- a/src/main/kotlin/org/rust/ide/actions/macroExpansion/MacroExpansionViewUtils.kt
+++ b/src/main/kotlin/org/rust/ide/actions/macroExpansion/MacroExpansionViewUtils.kt
@@ -12,7 +12,6 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.editor.highlighter.EditorHighlighter
-import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.psi.PsiElement
@@ -27,6 +26,7 @@ import org.rust.lang.core.macros.parseExpandedTextWithContext
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.*
+import org.rust.openapiext.computeWithCancelableProgress
 import java.awt.BorderLayout
 import javax.swing.JPanel
 
@@ -49,7 +49,6 @@ fun expandMacroForViewWithProgress(
     expandRecursively: Boolean
 ): MacroExpansionViewDetails? {
     val progressTitle = "${if (expandRecursively) "Recursive" else "Single step"} expansion progress..."
-
     return project.computeWithCancelableProgress(progressTitle) {
         runReadAction { expandMacroForView(ctx, expandRecursively) }
     }
@@ -82,12 +81,6 @@ private fun expandMacroForView(macroToExpand: RsMacroCall, expandRecursively: Bo
         getMacroExpansionViewTitle(macroToExpand, expandRecursively),
         expansions
     )
-}
-
-private fun<T> Project.computeWithCancelableProgress(title: String, supplier: () -> T): T {
-    val manager = ProgressManager.getInstance()
-
-    return manager.runProcessWithProgressSynchronously<T, Exception>(supplier, title, true, this)
 }
 
 private fun getMacroExpansionViewTitle(macroToExpand: RsMacroCall, expandRecursively: Boolean): String =

--- a/src/main/kotlin/org/rust/ide/actions/runAnything/CargoRunAnythingProvider.kt
+++ b/src/main/kotlin/org/rust/ide/actions/runAnything/CargoRunAnythingProvider.kt
@@ -50,7 +50,7 @@ class CargoRunAnythingProvider : RunAnythingProviderBase<String>() {
             params.firstOrNull() ?: "--help",
             params.drop(1)
         )
-        commandLine.run(project, cargoProject)
+        commandLine.run(cargoProject)
     }
 
     override fun getCommand(value: String): String = value

--- a/src/main/kotlin/org/rust/ide/update/UpdateComponent.kt
+++ b/src/main/kotlin/org/rust/ide/update/UpdateComponent.kt
@@ -15,7 +15,6 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.event.EditorFactoryEvent
 import com.intellij.openapi.editor.event.EditorFactoryListener
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.util.JDOMUtil
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.io.HttpRequests
@@ -23,6 +22,7 @@ import org.jdom.JDOMException
 import org.rust.lang.core.psi.isRustFile
 import org.rust.openapiext.isUnitTestMode
 import org.rust.openapiext.plugin
+import org.rust.openapiext.virtualFile
 import java.io.IOException
 import java.net.URLEncoder
 import java.net.UnknownHostException
@@ -42,7 +42,7 @@ class UpdateComponent : BaseComponent, Disposable {
     object EDITOR_LISTENER : EditorFactoryListener {
         override fun editorCreated(event: EditorFactoryEvent) {
             val document = event.editor.document
-            val file = FileDocumentManager.getInstance().getFile(document)
+            val file = document.virtualFile
             if (file != null && file.isRustFile) {
                 update()
             }

--- a/src/main/kotlin/org/rust/openapiext/CommandLineExt.kt
+++ b/src/main/kotlin/org/rust/openapiext/CommandLineExt.kt
@@ -50,6 +50,7 @@ fun GeneralCommandLine.execute(timeoutInMilliseconds: Int? = 1000): ProcessOutpu
 fun GeneralCommandLine.execute(
     owner: Disposable,
     ignoreExitCode: Boolean = true,
+    stdIn: ByteArray? = null,
     listener: ProcessListener? = null
 ): ProcessOutput {
 
@@ -81,6 +82,11 @@ fun GeneralCommandLine.execute(
     }
 
     listener?.let { handler.addProcessListener(it) }
+
+    if (stdIn != null) {
+        handler.processInput?.use { it.write(stdIn) }
+    }
+
     val output = try {
         val indicator = ProgressManager.getGlobalProgressIndicator()
         if (indicator != null) {

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -90,6 +90,12 @@ val VirtualFile.pathAsPath: Path get() = Paths.get(path)
 fun VirtualFile.toPsiFile(project: Project): PsiFile? =
     PsiManager.getInstance(project).findFile(this)
 
+val Document.virtualFile: VirtualFile?
+    get() = FileDocumentManager.getInstance().getFile(this)
+
+val VirtualFile.document: Document?
+    get() = FileDocumentManager.getInstance().getDocument(this)
+
 inline fun <Key, reified Psi : PsiElement> getElements(
     indexKey: StubIndexKey<Key, Psi>,
     key: Key, project: Project,
@@ -175,6 +181,9 @@ inline fun testAssert(action: () -> Boolean, lazyMessage: () -> Any) {
 
 fun <T> runWithCheckCanceled(callable: () -> T): T =
     ApplicationUtil.runWithCheckCanceled(callable, ProgressManager.getInstance().progressIndicator)
+
+fun<T> Project.computeWithCancelableProgress(title: String, supplier: () -> T): T =
+    ProgressManager.getInstance().runProcessWithProgressSynchronously<T, Exception>(supplier, title, true, this)
 
 inline fun <T> UserDataHolderEx.getOrPutSoft(key: Key<SoftReference<T>>, defaultValue: () -> T): T =
     getUserData(key)?.get() ?: run {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -780,6 +780,9 @@
         <component>
             <implementation-class>org.rust.ide.update.UpdateComponent</implementation-class>
         </component>
+        <component>
+            <implementation-class>org.rust.cargo.RustfmtWatcher</implementation-class>
+        </component>
     </application-components>
 
     <project-components>

--- a/src/test/kotlin/org/rust/FileTree.kt
+++ b/src/test/kotlin/org/rust/FileTree.kt
@@ -6,7 +6,6 @@
 package org.rust
 
 import com.intellij.openapi.application.runWriteAction
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.text.StringUtil.convertLineSeparators
 import com.intellij.openapi.vfs.VfsUtil
@@ -18,6 +17,7 @@ import org.rust.lang.core.psi.ext.RsReferenceElement
 import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psi.ext.containingCargoPackage
 import org.rust.openapiext.fullyRefreshDirectory
+import org.rust.openapiext.saveAllDocuments
 import org.rust.openapiext.toPsiFile
 import kotlin.text.Charsets.UTF_8
 
@@ -112,7 +112,7 @@ class FileTree(private val rootDirectory: Entry.Directory) {
             }
         }
 
-        FileDocumentManager.getInstance().saveAllDocuments()
+        saveAllDocuments()
         go(rootDirectory, baseDir)
     }
 

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -9,7 +9,6 @@ import com.intellij.injected.editor.VirtualFileWindow
 import com.intellij.lang.LanguageCommenters
 import com.intellij.lang.injection.InjectedLanguageManager
 import com.intellij.openapi.editor.LogicalPosition
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.util.io.StreamUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
@@ -29,6 +28,7 @@ import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.toolchain.RustChannel
 import org.rust.cargo.toolchain.RustcVersion
 import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.rust.openapiext.saveAllDocuments
 
 abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCase {
 
@@ -124,7 +124,7 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
     protected fun checkByDirectory(@Language("Rust") before: String, @Language("Rust") after: String, action: () -> Unit) {
         fileTreeFromText(before).create()
         action()
-        FileDocumentManager.getInstance().saveAllDocuments()
+        saveAllDocuments()
         fileTreeFromText(after).assertEquals(myFixture.findFileInTempDir("."))
     }
 

--- a/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
+++ b/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
@@ -6,13 +6,13 @@
 package org.rust.cargo.commands
 
 import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.MapDataContext
 import com.intellij.testFramework.TestActionEvent
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.fileTree
 import org.rust.ide.actions.RustfmtFileAction
+import org.rust.openapiext.document
 
 class RustfmtTest : RsWithToolchainTestBase() {
 
@@ -57,7 +57,7 @@ class RustfmtTest : RsWithToolchainTestBase() {
         }.create().fileWithCaret
 
         val file = myFixture.configureFromTempProjectFile(fileWithCaret).virtualFile
-        val document = FileDocumentManager.getInstance().getDocument(file)!!
+        val document = file.document!!
         val prevText = document.text
         myFixture.type("\n\n\n")
 

--- a/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
+++ b/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
@@ -10,9 +10,11 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.MapDataContext
 import com.intellij.testFramework.TestActionEvent
 import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.cargo.project.settings.rustSettings
 import org.rust.fileTree
 import org.rust.ide.actions.RustfmtFileAction
 import org.rust.openapiext.document
+import org.rust.openapiext.saveAllDocuments
 
 class RustfmtTest : RsWithToolchainTestBase() {
 
@@ -62,6 +64,35 @@ class RustfmtTest : RsWithToolchainTestBase() {
         myFixture.type("\n\n\n")
 
         reformat(file)
+        assertEquals(prevText.trim(), document.text.trim())
+    }
+
+    fun `test rustfmt on save`() {
+        project.rustSettings.modify { it.runRustfmtOnSave = true }
+
+        val fileWithCaret = fileTree {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("src") {
+                rust("main.rs", """
+                    fn main() {/*caret*/
+                        println!("Hello, world!");
+                    }
+                """)
+            }
+        }.create().fileWithCaret
+
+        val file = myFixture.configureFromTempProjectFile(fileWithCaret).virtualFile
+        val document = file.document!!
+        val prevText = document.text
+        myFixture.type("\n\n\n")
+
+        saveAllDocuments()
         assertEquals(prevText.trim(), document.text.trim())
     }
 

--- a/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
@@ -16,7 +16,6 @@ import org.rust.openapiext.elementFromXmlString
 import org.rust.openapiext.toXmlString
 import java.nio.file.Paths
 
-
 class RustProjectSettingsServiceTest : LightPlatformTestCase() {
     fun `test serialization`() {
         val service = RustProjectSettingsServiceImpl(LightPlatformTestCase.getProject())
@@ -31,6 +30,7 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
               <option name="externalLinter" value="Clippy" />
               <option name="externalLinterArguments" value="--no-default-features" />
               <option name="runExternalLinterOnTheFly" value="true" />
+              <option name="runRustfmtOnSave" value="true" />
               <option name="showTestToolWindow" value="false" />
               <option name="toolchainHomeDirectory" value="/" />
               <option name="useOffline" value="true" />
@@ -52,6 +52,7 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
         assertEquals(false, service.expandMacros)
         assertEquals(false, service.showTestToolWindow)
         assertEquals(false, service.doctestInjectionEnabled)
+        assertEquals(true, service.runRustfmtOnSave)
         assertEquals(true, service.useSkipChildren)
     }
 }


### PR DESCRIPTION
`Preferences > Languages & Frameworks > Rust > Rustfmt > Run rustfmt on Save`

Also, now rustfmt uses the `rustfmt.toml` from the corresponding cargo project root.

Relates to https://github.com/intellij-rust/intellij-rust/issues/1087.
