### PR TITLE
QDOC: correct doc urls for primitive and primitive methods

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsQualifiedName.ChildItemType.*
 import org.rust.lang.core.psi.ext.RsQualifiedName.ParentItemType.*
@@ -194,8 +195,12 @@ data class RsQualifiedName private constructor(
                 val parentItem = element.toParentItem() ?: return null
                 parentItem to null
             }
+            val crateName = if (parentItem.type == PRIMITIVE) {
+                AutoInjectedCrates.STD
+            } else {
+                element.containingCargoTarget?.normName ?: return null
+            }
 
-            val crateName = element.containingCargoTarget?.normName ?: return null
             val modSegments = if (parentItem.type == PRIMITIVE) {
                 listOf()
             } else {

--- a/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlStdTest.kt
@@ -72,7 +72,7 @@ class RsExternalDocUrlStdTest : RsDocumentationProviderTest() {
             let x = ptr.is_null();
                           //^
         }
-    """, "https://doc.rust-lang.org/core/primitive.pointer.html#method.is_null")
+    """, "https://doc.rust-lang.org/std/primitive.pointer.html#method.is_null")
 
     fun `test tymethod`() = doUrlTestByText("""
         fn foo<T: Default>() -> T {


### PR DESCRIPTION
Fixes #3313