### PR TITLE
QDOC: improvements in macro quick documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jdk: oraclejdk8
 
 env:
   global:
-    - OLD_RUST_VERSION=1.26.0
+    - OLD_RUST_VERSION=1.28.0
     - CURRENT_RUST_VERSION=1.33.0
     - NIGHLY_RUST_VERSION=nightly-2019-03-08
     - RUST_SRC_WITH_SYMLINK=$HOME/.rust-src

--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -19,6 +19,7 @@ import org.rust.lang.core.types.type
 import org.rust.lang.doc.documentationAsHtml
 import org.rust.openapiext.Testmark
 import org.rust.openapiext.escaped
+import org.rust.openapiext.hitOnFalse
 import org.rust.openapiext.isUnitTestMode
 import org.rust.stdext.joinToWithBuffer
 
@@ -130,9 +131,8 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
         }
 
         // macros without #[macro_export] are not public and don't have external documentation
-        if (this is RsMacro && !hasMacroExport) {
-            Testmarks.notExportedMacro.hit()
-            return false
+        if (this is RsMacro) {
+            return Testmarks.notExportedMacro.hitOnFalse(hasMacroExport)
         }
         // TODO: we should take into account real path of item for user, i.e. take into account reexports
         // instead of already resolved item path

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
@@ -218,13 +218,15 @@ data class RsQualifiedName private constructor(
         fun from(qualifiedNamedItem: QualifiedNamedItem): RsQualifiedName? {
             val crateName = qualifiedNamedItem.containingCargoTarget?.normName ?: return null
             val modSegments = mutableListOf<String>()
-            qualifiedNamedItem.superMods
-                ?.asReversed()
-                ?.drop(1)
-                ?.mapTo(modSegments) { it.modName ?: return null }
-                ?: return null
 
             val (parentItem, childItem) = qualifiedNamedItem.item.toItems() ?: return null
+            if (parentItem.type != MACRO) {
+                qualifiedNamedItem.superMods
+                    ?.asReversed()
+                    ?.drop(1)
+                    ?.mapTo(modSegments) { it.modName ?: return null }
+                    ?: return null
+            }
             if (parentItem.type == MOD) {
                 modSegments += parentItem.name
             }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
@@ -201,7 +201,7 @@ data class RsQualifiedName private constructor(
                 element.containingCargoTarget?.normName ?: return null
             }
 
-            val modSegments = if (parentItem.type == PRIMITIVE) {
+            val modSegments = if (parentItem.type == PRIMITIVE || parentItem.type == MACRO) {
                 listOf()
             } else {
                 val mod = element as? RsMod ?: element.containingMod

--- a/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlStdTest.kt
@@ -50,14 +50,12 @@ class RsExternalDocUrlStdTest : RsDocumentationProviderTest() {
         }
     """, "https://doc.rust-lang.org/core/f64/consts/constant.E.html")
 
-    fun `test macro`() = expect<AssertionFailedError> {
-        doUrlTestByText("""
-            fn main() {
-                println!("Hello!");
-                //^
-            }
-        """, "https://doc.rust-lang.org/std/macro.println.html")
-    }
+    fun `test macro`() = doUrlTestByText("""
+        fn main() {
+            println!("Hello!");
+            //^
+        }
+    """, "https://doc.rust-lang.org/std/macro.println.html")
 
     fun `test method`() = doUrlTestByText("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
@@ -121,7 +121,7 @@ class RsResolveLinkTest : RsTestBase() {
               //^
     """, "test_package/foo/index.html")
 
-    fun `test macro fqn link`() = doTest("""
+    fun `test macro fqn link 1`() = doTest("""
         macro_rules! foo {
                     //X
             () => {};
@@ -130,6 +130,17 @@ class RsResolveLinkTest : RsTestBase() {
         struct Bar;
               //^
     """, "test_package/macro.foo.html")
+
+    fun `test macro fqn link 2`() = doTest("""
+        mod foo {
+            macro_rules! bar {
+                       //X
+                () => {};
+            }
+        }
+        struct Foo;
+             //^
+    """, "test_package/macro.bar.html")
 
     fun `test method fqn link`() = doTest("""
         struct Foo;

--- a/src/test/kotlin/org/rust/ide/docs/RsStdlibResolveLinkTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsStdlibResolveLinkTest.kt
@@ -31,6 +31,8 @@ class RsStdlibResolveLinkTest : RsTestBase() {
     fun `test fqn link with reexport`() = doTest("std/cmp/trait.Eq.html", ".../libcore/cmp.rs")
     fun `test mod fqn link with reexport`() = doTest("std/marker/index.html", ".../libcore/marker.rs")
     fun `test method fqn link with reexport`() = doTest("std/result/enum.Result.html#method.unwrap", ".../libcore/result.rs")
+    fun `test macro fqn link`() = doTest("std/macro.println.html", ".../libstd/macros.rs")
+    fun `test macro fqn link with reexport`() = doTest("std/macro.assert_eq.html", ".../libcore/macros.rs")
 
     private fun doTest(link: String, expectedPath: String, @Language("Rust") code: String = DEFAULT_TEXT) {
         check(expectedPath.startsWith("...")) {

--- a/src/test/kotlin/org/rustSlowTests/RsCargoCheckAnnotatorPassTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsCargoCheckAnnotatorPassTest.kt
@@ -7,6 +7,7 @@ package org.rustSlowTests
 
 import com.intellij.lang.annotation.HighlightSeverity
 import org.intellij.lang.annotations.Language
+import org.rust.cargo.MinRustcVersion
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.rustSettings
@@ -67,6 +68,11 @@ class RsCargoCheckAnnotatorPassTest : RsWithToolchainTestBase() {
     }
 
     // https://github.com/intellij-rust/intellij-rust/issues/1497
+    //
+    // We don't want to run this test with rust below 1.30.0
+    // because the corresponding cargo can fail to run `metadata` command
+    // due to `edition` property in `Cargo.toml` in some dependency of `rand` crate
+    @MinRustcVersion("1.30.0")
     fun `test don't try to highlight non project files`() {
         fileTree {
             toml("Cargo.toml", """


### PR DESCRIPTION
* fix external doc URLs generation for macros defined in non crate root (like `assert_eq` or `write`)
* fix documentation link resolution when link refers to a macro defined in non crate root

Note, `OLD_RUST_VERSION` was increased to 1.28 because:
* before 1.28 stdlib uses special attribute to reexport macros. It fails the corresponding test
* we also need 1.28 as minimal rustc version because of #3490