### PR TITLE
INT: Make "unelide lifetimes" intention unavailable in doc comments

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/UnElideLifetimesIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/UnElideLifetimesIntention.kt
@@ -16,6 +16,7 @@ class UnElideLifetimesIntention : RsElementBaseIntentionAction<RsFunction>() {
     override fun getFamilyName(): String = text
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsFunction? {
+        if (element is RsDocCommentImpl) return null
         val fn = element.ancestorOrSelf<RsFunction>(stopAt = RsBlock::class.java) ?: return null
 
         if ((fn.retType?.typeReference as? RsRefLikeType)?.lifetime != null) return null

--- a/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt
@@ -18,6 +18,15 @@ class UnElideLifetimesIntentionTest : RsIntentionTestBase(UnElideLifetimesIntent
         """
     )
 
+    fun `test unavailable doc comment`() = doUnavailableTest(
+        """
+        /// ```
+        /// /*caret*/
+        /// ```
+        fn bar(x: &i32) {}
+        """
+    )
+
     fun `test unavailable no args`() = doUnavailableTest(
         """
         fn bar(/*caret*/) {}


### PR DESCRIPTION
It can be too annoying that this intention is available
inside all doctest injections