### PR TITLE
INT: handle conversion of module to self in nest use intention

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -47,6 +47,7 @@ johnthagen
 jonas-schievink
 Keats
 king6cong
+Kobzol
 kumbayo
 la10736
 LiamClark

--- a/src/main/kotlin/org/rust/ide/intentions/NestUseStatementsIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/NestUseStatementsIntention.kt
@@ -86,6 +86,7 @@ class NestUseStatementsIntention : RsElementBaseIntentionAction<NestUseStatement
 
     private fun deleteBasePath(fullPath: String, basePath: String): String {
         return when {
+            fullPath == basePath -> "self"
             fullPath.startsWith(basePath) -> fullPath.removePrefix("$basePath::")
             else -> fullPath
         }

--- a/src/test/kotlin/org/rust/ide/intentions/NestUseStatementsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/NestUseStatementsIntentionTest.kt
@@ -251,4 +251,17 @@ class NestUseStatementsIntentionTest : RsIntentionTestBase(NestUseStatementsInte
         use ::a1/*caret*/::b::c;
         use a1::b::c;
     """)
+
+    fun `test converts module to self`() = doAvailableTest("""
+        use foo/*caret*/;
+        use foo::foo;
+        use foo::bar;
+    """, """
+        use foo::{
+            self,
+            foo,
+            bar
+        };
+
+    """)
 }


### PR DESCRIPTION
This PR fixes an error in the `Nest use statements` intention mentioned here: https://github.com/intellij-rust/intellij-rust/issues/2577#issuecomment-469150465.

Before the intention would change this code:
```
use foo;
use foo::bar;
```
into
```
use foo::{foo, bar}`;
```
which is incorrect.

Now it checks if the grouped path is the same as the base path and converts it to `self` if necessary.