### PR TITLE
Don't jump over multi-line whitespaces in up/down mover

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -6,10 +6,7 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.openapi.util.TextRange
-import com.intellij.psi.PsiComment
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.*
 import com.intellij.psi.impl.source.PsiFileImpl
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
@@ -128,3 +125,21 @@ fun PsiElement.rangeWithPrevSpace(prev: PsiElement?) = when (prev) {
 
 val PsiElement.rangeWithPrevSpace: TextRange
     get() = rangeWithPrevSpace(prevSibling)
+
+private fun PsiElement.getLineCount(): Int {
+    val doc = containingFile?.let { file -> PsiDocumentManager.getInstance(project).getDocument(file) }
+    if (doc != null) {
+        val spaceRange = textRange ?: TextRange.EMPTY_RANGE
+
+        if (spaceRange.endOffset <= doc.textLength) {
+            val startLine = doc.getLineNumber(spaceRange.startOffset)
+            val endLine = doc.getLineNumber(spaceRange.endOffset)
+
+            return endLine - startLine
+        }
+    }
+
+    return (text ?: "").count { it == '\n' } + 1
+}
+
+fun PsiWhiteSpace.isMultiLine(): Boolean = getLineCount() > 1

--- a/src/test/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMoverTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMoverTest.kt
@@ -408,4 +408,88 @@ class RsStatementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
             }
         }
     """)
+
+    fun `test up empty line`() = moveUp("""
+        fn main() {
+            1;
+
+            2/*caret*/;
+        }
+    """, """
+        fn main() {
+            1;
+            2/*caret*/;
+
+        }
+    """)
+
+    fun `test down empty line`() = moveDown("""
+        fn main() {
+            1/*caret*/;
+
+            2;
+        }
+    """, """
+        fn main() {
+
+            1/*caret*/;
+            2;
+        }
+    """)
+
+    fun `test down empty line block`() = moveDown("""
+        fn main() {
+            1/*caret*/;
+
+            if cond {
+            }
+        }
+    """, """
+        fn main() {
+
+            1/*caret*/;
+            if cond {
+            }
+        }
+    """)
+
+    fun `test up empty line block`() = moveUp("""
+        fn main() {
+            if cond {
+            }
+
+            1/*caret*/;
+        }
+    """, """
+        fn main() {
+            if cond {
+            }
+            1/*caret*/;
+
+        }
+    """)
+
+    fun `test up empty line at start`() = moveUp("""
+        fn main() {
+
+            1/*caret*/;
+        }
+    """, """
+        fn main() {
+            1/*caret*/;
+
+        }
+    """)
+
+    fun `test up empty line at end`() = moveDown("""
+        fn main() {
+            1/*caret*/;
+
+        }
+    """, """
+        fn main() {
+
+            1/*caret*/;
+        }
+    """)
 }


### PR DESCRIPTION
Fixes such behavior for `RsStatementUpDownMover`:

![problem](https://user-images.githubusercontent.com/4854600/54190597-30d4a880-44c5-11e9-9f25-dc0cd67eb6c5.gif)
