### PR TITLE
ACT: add context menu action to create a new Cargo (sub)crate

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -57,7 +57,11 @@ class Cargo(private val cargoExecutable: Path) {
      * runs for too long.
      */
     @Throws(ExecutionException::class)
-    fun fullProjectDescription(owner: Project, projectDirectory: Path, listener: ProcessListener? = null): CargoWorkspace {
+    fun fullProjectDescription(
+        owner: Project,
+        projectDirectory: Path,
+        listener: ProcessListener? = null
+    ): CargoWorkspace {
         val additionalArgs = mutableListOf("--verbose", "--format-version", "1", "--all-features")
         if (owner.rustSettings.useOffline) {
             additionalArgs += "-Zoffline"
@@ -78,14 +82,25 @@ class Cargo(private val cargoExecutable: Path) {
     }
 
     @Throws(ExecutionException::class)
-    fun init(owner: Disposable, directory: VirtualFile, createBinary: Boolean) {
+    fun init(
+        owner: Disposable,
+        directory: VirtualFile,
+        createBinary: Boolean,
+        vcs: String? = null
+    ) {
         val path = directory.pathAsPath
         val name = path.fileName.toString().replace(' ', '_')
         val crateType = if (createBinary) "--bin" else "--lib"
-        CargoCommandLine(
-            "init", path,
-            listOf(crateType, "--name", name, path.toString())
-        ).execute(owner)
+
+        val args = mutableListOf(crateType, "--name", name)
+
+        vcs?.let {
+            args.addAll(listOf("--vcs", vcs))
+        }
+
+        args.add(path.toString())
+
+        CargoCommandLine("init", path, args).execute(owner)
         check(File(directory.path, RustToolchain.CARGO_TOML).exists())
         fullyRefreshDirectory(directory)
     }

--- a/src/main/kotlin/org/rust/ide/actions/RsCreateCrateAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsCreateCrateAction.kt
@@ -1,0 +1,63 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import org.rust.cargo.icons.CargoIcons
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.runconfig.command.RunCargoCommandActionBase
+import org.rust.cargo.toolchain.RustToolchain
+import org.rust.ide.actions.ui.showCargoNewCrateUI
+import org.rust.openapiext.pathAsPath
+
+
+class RsCreateCrateAction : RunCargoCommandActionBase(CargoIcons.ICON) {
+    override fun actionPerformed(e: AnActionEvent) {
+        val dataContext = e.dataContext
+        val project = CommonDataKeys.PROJECT.getData(dataContext) ?: return
+        val root = getRootFolder(dataContext) ?: return
+        val toolchain = project.toolchain ?: return
+
+        val ui = showCargoNewCrateUI(project, root)
+        ui.selectCargoCrateSettings()?.let {
+            createProject(project, toolchain, root, it.crateName, it.binary)
+        }
+    }
+
+    private fun getRootFolder(dataContext: DataContext): VirtualFile? {
+        val file = CommonDataKeys.VIRTUAL_FILE.getData(dataContext) ?: return null
+        return if (!file.isDirectory) {
+            file.parent
+        } else file
+    }
+
+    private fun createProject(
+        project: Project,
+        toolchain: RustToolchain,
+        root: VirtualFile,
+        name: String,
+        binary: Boolean
+    ) {
+        val cargo = toolchain.cargoOrWrapper(
+            project.cargoProjects.findProjectForFile(root)?.workspaceRootDir?.pathAsPath)
+
+        val targetDir = runWriteAction {
+            root.createChildDirectory(this, name)
+        }
+        cargo.init(project, targetDir, binary, "none")
+
+        val manifest = targetDir.findChild(RustToolchain.CARGO_TOML)
+        manifest?.let {
+            project.cargoProjects.attachCargoProject(it.pathAsPath)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/actions/ui/CargoNewCrateDialog.kt
+++ b/src/main/kotlin/org/rust/ide/actions/ui/CargoNewCrateDialog.kt
@@ -1,0 +1,90 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.actions.ui
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.components.JBTextField
+import org.jetbrains.annotations.TestOnly
+import org.rust.ide.newProject.RsPackageNameValidator
+import org.rust.ide.ui.layout
+import org.rust.openapiext.isUnitTestMode
+import javax.swing.JComponent
+
+data class CargoNewCrateSettings(val binary: Boolean, val crateName: String)
+
+interface CargoNewCrateUI {
+    fun selectCargoCrateSettings(): CargoNewCrateSettings?
+}
+
+private var MOCK: CargoNewCrateUI? = null
+
+fun showCargoNewCrateUI(
+    project: Project,
+    root: VirtualFile
+): CargoNewCrateUI {
+    return if (isUnitTestMode) {
+        MOCK ?: error("You should set mock ui via `withMockCargoNewCrateUi`")
+    } else {
+        CargoNewCrateDialog(project, root)
+    }
+}
+
+@TestOnly
+fun withMockCargoNewCrateUi(mockUi: CargoNewCrateUI, action: () -> Unit) {
+    MOCK = mockUi
+    try {
+        action()
+    } finally {
+        MOCK = null
+    }
+}
+
+class CargoNewCrateDialog(project: Project, private val root: VirtualFile) : DialogWrapper(project), CargoNewCrateUI {
+    private val typeCombobox = ComboBox<String>(arrayOf("Binary", "Library"))
+    private val name = JBTextField(20)
+
+    val binary get() = this.typeCombobox.selectedIndex == 0
+    val crateName get() = name.text.trim()
+
+    init {
+        title = "New Cargo crate"
+        init()
+    }
+
+    override fun selectCargoCrateSettings(): CargoNewCrateSettings? {
+        val result = showAndGet()
+        if (!result) return null
+        return CargoNewCrateSettings(binary, crateName)
+    }
+
+    override fun createCenterPanel(): JComponent {
+
+        return layout {
+            row("Name", name)
+            row("Type", typeCombobox)
+        }
+    }
+
+    override fun getPreferredFocusedComponent(): JComponent? {
+        return name
+    }
+
+    override fun doValidate(): ValidationInfo? {
+        val name = crateName
+
+        val validationError = RsPackageNameValidator.validate(name, binary)
+        validationError?.let {
+            return ValidationInfo(it, this.name)
+        }
+
+        if (root.findChild(name) != null) return ValidationInfo("Directory $name already exists.", this.name)
+        return null
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -800,6 +800,11 @@
             <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFile"/>
         </action>
 
+        <action id="Rust.NewCargoCrate" class="org.rust.ide.actions.RsCreateCrateAction"
+                text="Cargo Crate" description="Create new Cargo crate">
+            <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFile"/>
+        </action>
+
         <action id="Rust.Build"
                 class="org.rust.ide.actions.RsBuildAction"
                 text="Build"

--- a/src/test/kotlin/org/rust/ide/actions/RsCreateCrateActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/RsCreateCrateActionTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.actions
+
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.MapDataContext
+import com.intellij.testFramework.TestActionEvent
+import junit.framework.Assert
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.fileTree
+import org.rust.ide.actions.ui.CargoNewCrateSettings
+import org.rust.ide.actions.ui.CargoNewCrateUI
+import org.rust.ide.actions.ui.withMockCargoNewCrateUi
+
+class RsCreateCrateActionTest : RsWithToolchainTestBase() {
+    fun `test create with file context`() {
+        createProjectScaffold()
+
+        val main = cargoProjectDirectory.findFileByRelativePath("Cargo.toml") ?: error("Main file was not found")
+        createCrate(main, "crate1")
+    }
+
+    fun `test create binary crate`() {
+        createProjectScaffold()
+        createCrate(cargoProjectDirectory, "crate1")
+    }
+
+    fun `test create library crate`() {
+        createProjectScaffold()
+        createCrate(cargoProjectDirectory, "crate1", binary = false)
+    }
+
+    private fun createCrate(file: VirtualFile, name: String, binary: Boolean = true) {
+        val action = RsCreateCrateAction()
+
+        val dataContext = MapDataContext(mapOf(
+            CommonDataKeys.PROJECT to project,
+            CommonDataKeys.VIRTUAL_FILE to file
+        ))
+        val e = TestActionEvent(dataContext, action)
+        action.beforeActionPerformedUpdate(e)
+        check(e.presentation.isEnabledAndVisible) {
+            "Failed to run `${RsCreateCrateAction::class.java.simpleName}` action"
+        }
+
+        withMockCargoNewCrateUi(object : CargoNewCrateUI {
+            override fun selectCargoCrateSettings(): CargoNewCrateSettings? {
+                return CargoNewCrateSettings(binary, name)
+            }
+        }) {
+            action.actionPerformed(e)
+        }
+
+        val src = if (binary) "main" else "lib"
+
+        val main = cargoProjectDirectory.findFileByRelativePath("$name/src/$src.rs")
+            ?: error("Source file was not found for crate $name")
+        val pkg = project.cargoProjects.findPackageForFile(main) ?: error("Package was not found for file $main")
+        Assert.assertEquals(pkg.targets.size, 1)
+    }
+
+    private fun createProjectScaffold() {
+        fileTree {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("src") {
+                rust("main.rs", """
+                    fn main() {
+                        println!("Hello, world!");
+                    }
+                """)
+            }
+        }.create()
+    }
+}


### PR DESCRIPTION
Hi, I tried implementing an action that would create a new Cargo crate in a project (as described here: https://github.com/intellij-rust/intellij-rust/issues/2944).

It's my first time making a non-trivial contribution to IntelliJ, so please let me know if I made any obvious mistakes.

- [x] Create new cargo project using `cargo init`
- [x] Tests
~~Workspace modification - it would be nice to add the new crate to an existing Cargo workspace, if there is one in the project~~
```toml
[workspace]

members = [
    "main",
    "new-crate" # this would get added automatically by the action
]
```