### PR TITLE
INT: add support for smart pointers, Default implementation, struct init shorthand and local variable to Add struct fields fix

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFix.kt
@@ -12,11 +12,14 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.rust.ide.annotator.calculateMissingFields
 import org.rust.lang.core.psi.RsDefaultValueBuilder
+import org.rust.lang.core.psi.RsPatBinding
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsStructLiteral
+import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.RsFieldsOwner
 import org.rust.lang.core.psi.ext.fields
 import org.rust.lang.core.resolve.knownItems
+import org.rust.lang.core.resolve.processLocalVariables
 import org.rust.lang.core.resolve.ref.deepResolve
 import org.rust.openapiext.buildAndRunTemplate
 import org.rust.openapiext.createSmartPointer
@@ -50,7 +53,13 @@ class AddStructFieldsFix(
         val body = structLiteral.structLiteralBody
         val fieldsToAdd = calculateMissingFields(body, decl)
         val defaultValueBuilder = RsDefaultValueBuilder(decl.knownItems, body.containingMod, RsPsiFactory(project), recursive)
-        val addedFields = defaultValueBuilder.fillStruct(body, decl.fields, fieldsToAdd)
+
+        val addedFields = defaultValueBuilder.fillStruct(
+            body,
+            decl.fields,
+            fieldsToAdd,
+            RsDefaultValueBuilder.getVisibleBindings(startElement)
+        )
         editor?.buildAndRunTemplate(body, addedFields.mapNotNull { it.expr?.createSmartPointer() })
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspection.kt
@@ -28,12 +28,18 @@ class RsFieldInitShorthandInspection : RsLocalInspectionTool() {
                     override fun getFamilyName(): String = "Use initialization shorthand"
 
                     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-                        val field = descriptor.psiElement as RsStructLiteralField
-                        field.expr?.delete()
-                        field.colon?.delete()
+                        applyShorthandInit(descriptor.psiElement as RsStructLiteralField)
                     }
                 }
             )
+        }
+    }
+
+    companion object {
+        fun applyShorthandInit(field: RsStructLiteralField)
+        {
+            field.expr?.delete()
+            field.colon?.delete()
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/InitializeWithDefaultValueFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/InitializeWithDefaultValueFix.kt
@@ -14,6 +14,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.ancestorOrSelf
 import org.rust.lang.core.resolve.knownItems
+import org.rust.lang.core.resolve.processLocalVariables
 import org.rust.lang.core.types.declaration
 import org.rust.lang.core.types.type
 import org.rust.openapiext.buildAndRunTemplate
@@ -29,7 +30,8 @@ class InitializeWithDefaultValueFix(element: RsElement) : LocalQuickFixAndIntent
         val declaration = patBinding.ancestorOrSelf<RsLetDecl>() ?: return
         val semicolon = declaration.semicolon ?: return
         val psiFactory = RsPsiFactory(project)
-        val initExpr = RsDefaultValueBuilder(declaration.knownItems, declaration.containingMod, psiFactory).buildFor(patBinding.type)
+        val initExpr = RsDefaultValueBuilder(declaration.knownItems, declaration.containingMod, psiFactory, true)
+            .buildFor(patBinding.type, RsDefaultValueBuilder.getVisibleBindings(startElement as RsElement))
 
         if (declaration.eq == null) {
             declaration.addBefore(psiFactory.createEq(), semicolon)

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -725,6 +725,7 @@ class ImplLookup(
     fun isClone(ty: Ty): Boolean = ty.isTraitImplemented(items.Clone)
     fun isSized(ty: Ty): Boolean = ty.isTraitImplemented(items.Sized)
     fun isDebug(ty: Ty): Boolean = ty.isTraitImplemented(items.Debug)
+    fun isDefault(ty: Ty): Boolean = ty.isTraitImplemented(items.Default)
     fun isPartialEq(ty: Ty, rhsType: Ty = ty): Boolean = ty.isTraitImplemented(items.PartialEq, rhsType)
     fun isIntoIterator(ty: Ty): Boolean = ty.isTraitImplemented(items.IntoIterator)
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
@@ -107,7 +107,13 @@ class KnownItems(
     // Some old versions of stdlib contain `Ord` trait without lang attribute
     val Ord: RsTraitItem? get() = findItem("core::cmp::Ord")
     val Debug: RsTraitItem? get() = findLangItem("debug_trait")
-    val Box: RsStructItem? get() = findLangItem("owned_box", "alloc")
+    val Box: RsStructOrEnumItemElement? get() = findLangItem("owned_box", "alloc")
+    val Rc: RsStructOrEnumItemElement? get() = findItem("alloc::rc::Rc")
+    val Arc: RsStructOrEnumItemElement? get() = findItem("alloc::sync::Arc") ?: findItem("alloc::arc::Arc")
+    val Cell: RsStructOrEnumItemElement? get() = findItem("core::cell::Cell")
+    val RefCell: RsStructOrEnumItemElement? get() = findItem("core::cell::RefCell")
+    val UnsafeCell: RsStructOrEnumItemElement? get() = findItem("core::cell::UnsafeCell")
+    val Mutex: RsStructOrEnumItemElement? get() = findItem("std::sync::mutex::Mutex")
 }
 
 interface KnownItemsLookup {

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -593,7 +593,7 @@ fun processLocalVariables(place: RsElement, processor: (RsPatBinding) -> Unit) {
         processLexicalDeclarations(scope, cameFrom, VALUES) { v ->
             val el = v.element
             if (el is RsPatBinding) processor(el)
-            true
+            false
         }
     }
 }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt
@@ -7,6 +7,7 @@ package org.rust.ide.annotator.fixes
 
 import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
+import org.rust.WithStdlibAndDependencyRustProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsExpressionAnnotator
@@ -286,6 +287,196 @@ class AddStructFieldsFixTest : RsAnnotatorTestBase(RsExpressionAnnotator::class.
                 empty_struct: EmptyStruct {},
                 unsupported_type_field: ()
             };
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test smart pointers`() = checkBothQuickFix("""
+        use std::rc::Rc;
+        use std::sync::{Arc, Mutex};
+        use std::cell::{Cell, RefCell, UnsafeCell};
+
+        struct S<'a> {
+            a: Box<Box<u32>>,
+            b: Rc<&'a u64>,
+            c: Arc<String>,
+            d: Cell<f32>,
+            e: RefCell<u32>,
+            f: UnsafeCell<u64>,
+            g: Mutex<String>
+        }
+
+        fn main() {
+            <error>S</error>{/*caret*/};
+        }
+    """, """
+        use std::rc::Rc;
+        use std::sync::{Arc, Mutex};
+        use std::cell::{Cell, RefCell, UnsafeCell};
+
+        struct S<'a> {
+            a: Box<Box<u32>>,
+            b: Rc<&'a u64>,
+            c: Arc<String>,
+            d: Cell<f32>,
+            e: RefCell<u32>,
+            f: UnsafeCell<u64>,
+            g: Mutex<String>
+        }
+
+        fn main() {
+            S{
+                a: Box::new(Box::new(0)),
+                b: Rc::new(&0),
+                c: Arc::new("".to_string()),
+                d: Cell::new(0.0),
+                e: RefCell::new(0),
+                f: UnsafeCell::new(0),
+                g: Mutex::new("".to_string())
+            };
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test default`() = checkBothQuickFix("""
+        #[derive(Default)]
+        struct A {
+            a: u64
+        }
+
+        struct B {
+            b: u64
+        }
+
+        impl Default for B {
+            fn default() -> Self {
+                Self { b: 1 }
+            }
+        }
+
+        struct S {
+            a: A,
+            b: B
+        }
+
+        fn main() {
+            <error>S</error>{/*caret*/};
+        }
+    """, """
+        #[derive(Default)]
+        struct A {
+            a: u64
+        }
+
+        struct B {
+            b: u64
+        }
+
+        impl Default for B {
+            fn default() -> Self {
+                Self { b: 1 }
+            }
+        }
+
+        struct S {
+            a: A,
+            b: B
+        }
+
+        fn main() {
+            S{ a: Default::default(), b: Default::default() };
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test local variable`() = checkBothQuickFix("""
+        struct A {
+            x: u64
+        }
+        struct S<'a> {
+            a: u64,
+            b: &'a u64,
+            c: &'a &'a mut u64,
+            d: u32,
+            e: u64,
+            f: String,
+            obj: A
+        }
+
+        fn test(a: u64) {
+            let b = 3 as u64;
+            let mut c: u64 = 1;
+            let d: u64 = 5;
+            {
+                let e: u64 = 5;
+            }
+            let f = "".to_string();
+            let obj = A { x: 5 };
+
+            <error>S</error>{/*caret*/};
+        }
+    """, """
+        struct A {
+            x: u64
+        }
+        struct S<'a> {
+            a: u64,
+            b: &'a u64,
+            c: &'a &'a mut u64,
+            d: u32,
+            e: u64,
+            f: String,
+            obj: A
+        }
+
+        fn test(a: u64) {
+            let b = 3 as u64;
+            let mut c: u64 = 1;
+            let d: u64 = 5;
+            {
+                let e: u64 = 5;
+            }
+            let f = "".to_string();
+            let obj = A { x: 5 };
+
+            S{
+                a,
+                b: &b,
+                c: &&mut c,
+                d: 0,
+                e: 0,
+                f,
+                obj
+            };
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test local variable recursive`() = checkRecursiveQuickFix("""
+        struct A {
+            a: u64
+        }
+
+        struct B {
+            a: A
+        }
+
+        fn main() {
+            let a: u64 = 5;
+            <error>B</error>{/*caret*/};
+        }
+    """, """
+        struct A {
+            a: u64
+        }
+
+        struct B {
+            a: A
+        }
+
+        fn main() {
+            let a: u64 = 5;
+            B{ a: A { a } };
         }
     """)
 


### PR DESCRIPTION
Hi,
I implemented support for smart pointers, Default impl and shorthand init syntax using local variables with same name and type for the Add struct fields fix (https://github.com/intellij-rust/intellij-rust/issues/2311), .

It would be also nice to auto-import the smart pointers if they are not in scope (if we prefill `Rc::new(0)` and `Rc` is not in scope, the user will have to use autoimport after the fix). Any hint on how could I do that? I guess I could run the autoimport action after the fix, but that seems like a heavyweight solution to me.

- [x] smart pointers
- [x] ? use Default impl
- [x] use local variables for initialization
- [ ] automatically import missing types for filled fields
- [ ] ? make the whole analysis dumber/simpler