### PR TITLE
Add CLion's CPU profiler support

### DIFF
--- a/clion/src/191/main/kotlin/org/rust/clion/profiler/RsCachedPerfFlameChartBuilder.kt
+++ b/clion/src/191/main/kotlin/org/rust/clion/profiler/RsCachedPerfFlameChartBuilder.kt
@@ -1,0 +1,108 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.profiler
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.profiler.DummyFlameChartBuilder
+import com.intellij.profiler.api.BaseCallStackElement
+import com.intellij.profiler.clion.perf.*
+import com.intellij.profiler.fastRemoveCppFunctionArgs
+import com.intellij.profiler.model.NativeThread
+import com.intellij.profiler.model.ThreadInfo
+import org.rust.clion.profiler.perf.RsPerfNavigatableNativeCall
+import java.io.File
+
+class RsCachedPerfFlameChartBuilder(
+    cacheSize: Int,
+    private val addressSymbolizer: AddressSymbolizer?,
+    private val indicator: ProgressIndicator
+) {
+    private val samplesCache: Array<PerfSample?>
+    private val addressSymbolizerCache: MutableMap<PerfFrame, AddressSymbolizerItem>
+    private var cacheIndex = 0
+    private val flameChartBuilder = DummyFlameChartBuilder<ThreadInfo, BaseCallStackElement>()
+
+    init {
+        check(cacheSize > 0)
+        samplesCache = arrayOfNulls(cacheSize)
+        addressSymbolizerCache = PerfUtils.createLRUCache(cacheSize, 0.75f)
+    }
+
+    fun add(sample: PerfSample) {
+        samplesCache[cacheIndex++] = sample
+        if (cacheIndex == samplesCache.size) {
+            addChunksToFlameChartBuilder()
+            cacheIndex = 0
+        }
+    }
+
+    fun getFlameChartBuilder(): DummyFlameChartBuilder<ThreadInfo, BaseCallStackElement> {
+        if (cacheIndex != 0) {
+            addChunksToFlameChartBuilder()
+            cacheIndex = 0
+        }
+        return flameChartBuilder
+    }
+
+    private fun addChunksToFlameChartBuilder() {
+        ProgressManager.checkCanceled()
+        val symbolizerMap = buildAddressSymbolizerMap()
+        for (index in 0 until cacheIndex) {
+            val sample = samplesCache[index]
+            flameChartBuilder.add(NativeThread(sample!!.threadId, sample.threadName),
+                sample.frames.asReversed().map { createNavigatableNativeCall(it, symbolizerMap) },
+                1)
+        }
+    }
+
+    private fun createNavigatableNativeCall(
+        frame: PerfFrame,
+        symbolizerMap: Map<PerfFrame, AddressSymbolizerItem>?
+    ): RsPerfNavigatableNativeCall {
+        val symbolizerItem = symbolizerMap?.get(frame)
+        val binaryName = File(frame.binary).name
+        if (symbolizerItem != null && symbolizerItem.isNotEmpty()) {
+            return RsPerfNavigatableNativeCall(binaryName, symbolizerItem.deMangledFunction,
+                symbolizerItem.filePath, symbolizerItem.line)
+        }
+        return RsPerfNavigatableNativeCall(binaryName, fastRemoveCppFunctionArgs(frame.function, true))
+    }
+
+    private fun buildAddressSymbolizerMap(): Map<PerfFrame, AddressSymbolizerItem>? {
+        if (addressSymbolizer == null) return null
+
+        val result = HashMap<PerfFrame, AddressSymbolizerItem>()
+        val allFrames = samplesCache.slice(0 until cacheIndex).flatMap { it!!.frames }
+        val cachedFrames = allFrames.filter { addressSymbolizerCache.containsKey(it) }
+        cachedFrames.forEach { result[it] = addressSymbolizerCache[it]!! }
+        val uncachedFrames = allFrames.filter { !addressSymbolizerCache.containsKey(it) }
+        val framesGroupedByBinary = uncachedFrames.groupBy { it.binary }
+        for (binaryToFramesPair in framesGroupedByBinary) {
+            ProgressManager.checkCanceled()
+            val binary = binaryToFramesPair.key
+            val binaryFrames = binaryToFramesPair.value
+            val addressesToConvert = binaryFrames.map { it.instructionPointer }
+            val symbolizerItems = addressSymbolizer.execute(binary, addressesToConvert, indicator)
+            if (addressesToConvert.size == symbolizerItems.size) {
+                binaryFrames.forEachIndexed { index, frame ->
+                    run {
+                        addressSymbolizerCache[frame] = symbolizerItems[index]
+                        result[frame] = symbolizerItems[index]
+                    }
+                }
+            } else {
+                LOG.warn("Skipping symbolizer output for: $binary: output is incorrect")
+            }
+        }
+        return result
+    }
+
+    companion object {
+        private val LOG = Logger.getInstance(CachedPerfFlameChartBuilder::class.java)
+    }
+}

--- a/clion/src/191/main/kotlin/org/rust/clion/profiler/RsCachingStackElementReader.kt
+++ b/clion/src/191/main/kotlin/org/rust/clion/profiler/RsCachingStackElementReader.kt
@@ -1,0 +1,30 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.profiler
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.profiler.api.BaseCallStackElement
+import com.intellij.profiler.model.BaseCachingStackElementReader
+import com.intellij.profiler.model.CantBeParsedCall
+import org.rust.clion.profiler.dtrace.RsDTraceNavigatableNativeCall
+
+class RsCachingStackElementReader : BaseCachingStackElementReader() {
+    fun parseStackElement(string: String): BaseCallStackElement {
+        return intern(
+            try {
+                RsDTraceNavigatableNativeCall.read(string, stringsInterner)
+            } catch (e: Exception) {
+                CantBeParsedCall(string)
+            }
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        fun getInstance(project: Project) = project.service<RsCachingStackElementReader>()
+    }
+}

--- a/clion/src/191/main/kotlin/org/rust/clion/profiler/RsProfilerRunner.kt
+++ b/clion/src/191/main/kotlin/org/rust/clion/profiler/RsProfilerRunner.kt
@@ -1,0 +1,19 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.profiler
+
+import com.intellij.profiler.clion.ProfilerExecutor
+import org.rust.cargo.runconfig.RsAsyncRunner
+
+const val ERROR_MESSAGE_TITLE: String = "Profiling is not possible"
+
+class RsProfilerRunner : RsAsyncRunner(ProfilerExecutor.EXECUTOR_ID, ERROR_MESSAGE_TITLE) {
+    override fun getRunnerId(): String = RUNNER_ID
+
+    companion object {
+        const val RUNNER_ID: String = "RsProfilerRunner"
+    }
+}

--- a/clion/src/191/main/kotlin/org/rust/clion/profiler/RsSymbolSearcher.kt
+++ b/clion/src/191/main/kotlin/org/rust/clion/profiler/RsSymbolSearcher.kt
@@ -1,0 +1,52 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.profiler
+
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.project.Project
+import com.intellij.profiler.model.NativeCall
+import com.intellij.psi.search.GlobalSearchScope
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.ext.qualifiedName
+import org.rust.lang.core.stubs.index.RsNamedElementIndex
+import org.rust.openapiext.getElements
+
+class RsSymbolSearcher(private val project: Project) {
+    fun find(nativeCall: NativeCall): Array<RsFunction> {
+        val elements = mutableListOf<RsFunction>()
+        val searchScope = GlobalSearchScope.allScope(project)
+        val qualifiedPath = extractPath(nativeCall.className)
+
+        runReadAction {
+            val allDeclarations = getElements(RsNamedElementIndex.KEY, nativeCall.methodOrFunction, project, searchScope)
+                .filterIsInstance<RsFunction>()
+            val appropriateDeclarations = allDeclarations
+                .filter { it.qualifiedName?.substringBeforeLast("::") == qualifiedPath }
+
+            if (appropriateDeclarations.isNotEmpty()) {
+                elements.addAll(appropriateDeclarations)
+            } else {
+                // TODO: return all or nothing?
+                elements.addAll(allDeclarations)
+            }
+        }
+
+        return elements.toTypedArray()
+    }
+
+
+    /**
+     * `_<foo::bar123::foo_bar::Qux as baz>::qux` -> `foo::bar123::foo_bar`
+     *
+     * It doesn't work for crates/modules with inappropriate names (e.g. upper-case)
+     *
+     * TODO: add tests
+     */
+    private fun extractPath(signature: String): String = signature
+        .dropWhile { !it.isLetter() }
+        .takeWhile { (it.isLetterOrDigit() && it.isLowerCase()) || it == '_' || it == ':' }
+        .removeSuffix("::")
+}

--- a/clion/src/191/main/kotlin/org/rust/clion/profiler/dtrace/RsDTraceConfigurationExtension.kt
+++ b/clion/src/191/main/kotlin/org/rust/clion/profiler/dtrace/RsDTraceConfigurationExtension.kt
@@ -1,0 +1,83 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.profiler.dtrace
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.RunnerSettings
+import com.intellij.execution.impl.ExecutionManagerImpl
+import com.intellij.execution.process.BaseProcessHandler
+import com.intellij.execution.process.OSProcessUtil
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.process.UnixProcessManager
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.progress.PerformInBackgroundOption
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.profiler.ProfilerToolWindowManager
+import com.intellij.profiler.clion.NativeTargetProcess
+import com.intellij.profiler.installErrorHandlers
+import org.rust.cargo.runconfig.CargoCommandConfigurationExtension
+import org.rust.cargo.runconfig.ConfigurationExtensionContext
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.clion.profiler.RsProfilerRunner
+import java.io.File
+
+
+class RsDTraceConfigurationExtension : CargoCommandConfigurationExtension() {
+    override fun isApplicableFor(configuration: CargoCommandConfiguration): Boolean = true
+
+    override fun isEnabledFor(applicableConfiguration: CargoCommandConfiguration, runnerSettings: RunnerSettings?): Boolean =
+        SystemInfo.isMac
+
+    override fun patchCommandLine(
+        configuration: CargoCommandConfiguration,
+        runnerSettings: RunnerSettings?,
+        cmdLine: GeneralCommandLine,
+        runnerId: String,
+        context: ConfigurationExtensionContext
+    ) {
+        if (RsProfilerRunner.RUNNER_ID != runnerId) return
+        val starterPath = profilerStarterPath()
+        if (!starterPath.exists()) throw ExecutionException("Internal error: Can't find process starter")
+        cmdLine.withEnvironment(DYLD_INSERT_LIBRARIES, starterPath.absolutePath)
+    }
+
+    override fun attachToProcess(
+        configuration: CargoCommandConfiguration,
+        handler: ProcessHandler,
+        environment: ExecutionEnvironment,
+        runnerSettings: RunnerSettings?,
+        runnerId: String,
+        context: ConfigurationExtensionContext
+    ) {
+        if (RsProfilerRunner.RUNNER_ID != runnerId) return
+
+        val targetProcess = (handler as? BaseProcessHandler<*>)?.process
+            ?: throw ExecutionException("Profiler connection error: can't detect target process id")
+        val namedProcess = NativeTargetProcess(OSProcessUtil.getProcessID(targetProcess), configuration.name)
+        val project = configuration.project
+        RsDTraceProfilerProcess.attach(namedProcess, PerformInBackgroundOption.ALWAYS_BACKGROUND, 10000, project)
+            .installErrorHandlers(project)
+            .onError { ExecutionManagerImpl.stopProcess(handler) }
+            .onSuccess { process ->
+                UnixProcessManager.sendSigIntToProcessTree(targetProcess) //wakeup starter and finally run targetProcess code
+                ProfilerToolWindowManager.getInstance(project).addProfilerProcessTab(process)
+            }
+    }
+
+    companion object {
+        private const val DYLD_INSERT_LIBRARIES = "DYLD_INSERT_LIBRARIES"
+        private const val BUNDLED_STARTER_PATH = "profiler/macosx/libosx-starter.dylib"
+        private const val STARTER_PATH_PROPERTY = "clion.profiler.osx.starter.path"
+        private fun profilerStarterPath(): File {
+            System.getProperty(STARTER_PATH_PROPERTY)?.let {
+                return File(it) //develop
+            }
+            return File(PathManager.getLibPath(), BUNDLED_STARTER_PATH) //production
+        }
+    }
+}

--- a/clion/src/191/main/kotlin/org/rust/clion/profiler/dtrace/RsDTraceNavigatableNativeCall.kt
+++ b/clion/src/191/main/kotlin/org/rust/clion/profiler/dtrace/RsDTraceNavigatableNativeCall.kt
@@ -1,0 +1,43 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.profiler.dtrace
+
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.profiler.api.BaseCallStackElement
+import com.intellij.profiler.model.NativeCall
+import com.intellij.psi.NavigatablePsiElement
+import com.intellij.util.containers.WeakStringInterner
+import com.intellij.util.containers.stream
+import org.rust.clion.profiler.RsSymbolSearcher
+
+data class RsDTraceNavigatableNativeCall(private val nativeCall: NativeCall) : BaseCallStackElement() {
+    override fun fullName(): String = nativeCall.fullName()
+
+    override val isNavigatable: Boolean get() = true
+
+    override fun calcNavigatables(project: Project): Array<out NavigatablePsiElement> {
+        val searcher = RsSymbolSearcher(project)
+        val symbols = searcher.find(nativeCall)
+        val navigatables = runReadAction {
+            symbols.stream()
+                .filter { it.isValid }
+                .toArray<NavigatablePsiElement> { length -> arrayOfNulls(length) }
+        }
+        if (navigatables.isEmpty()) {
+            LOG.warn("Failed to navigate: ${nativeCall.methodWithClassOrFunction()}")
+        }
+        return navigatables
+    }
+
+    companion object {
+        private val LOG = logger<RsDTraceNavigatableNativeCall>()
+
+        fun read(string: String, interner: WeakStringInterner? = null): RsDTraceNavigatableNativeCall =
+            RsDTraceNavigatableNativeCall(NativeCall.read(string, interner))
+    }
+}

--- a/clion/src/191/main/kotlin/org/rust/clion/profiler/dtrace/RsDTraceProfilerProcess.kt
+++ b/clion/src/191/main/kotlin/org/rust/clion/profiler/dtrace/RsDTraceProfilerProcess.kt
@@ -1,0 +1,118 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.profiler.dtrace
+
+import com.intellij.openapi.progress.PerformInBackgroundOption
+import com.intellij.openapi.project.Project
+import com.intellij.profiler.DummyFlameChartBuilder
+import com.intellij.profiler.api.AttachableTargetProcess
+import com.intellij.profiler.api.BaseCallStackElement
+import com.intellij.profiler.api.CollapsedProfilerDumpWriter
+import com.intellij.profiler.api.ProfilerData
+import com.intellij.profiler.clion.CPPProfilerSettings
+import com.intellij.profiler.dtrace.DTraceProfilerProcessBase
+import com.intellij.profiler.dtrace.FullDumpParser
+import com.intellij.profiler.dtrace.SimpleProfilerSettingsState
+import com.intellij.profiler.dtrace.cpuProfilerScript
+import com.intellij.profiler.model.NativeCall
+import com.intellij.profiler.model.NativeThread
+import com.intellij.profiler.model.ThreadInfo
+import com.intellij.profiler.sudo.SudoProcessHandler
+import com.intellij.profiler.ui.flamechart.NativeCallChartNodeRenderer
+import com.intellij.util.xmlb.XmlSerializer
+import org.jetbrains.concurrency.Promise
+import org.rust.cargo.toolchain.Cargo
+import org.rust.clion.profiler.RsCachingStackElementReader
+import java.io.IOException
+
+
+class RsDTraceProfilerProcess private constructor(
+    project: Project,
+    targetProcess: AttachableTargetProcess,
+    attachedTimestamp: Long,
+    dtraceProcessHandler: SudoProcessHandler
+) : DTraceProfilerProcessBase(project, targetProcess, attachedTimestamp, dtraceProcessHandler) {
+
+    override fun createDumpParser(): FullDumpParser<ThreadInfo, BaseCallStackElement> {
+        val cachingStackElementReader = RsCachingStackElementReader.getInstance(project)
+        return FullDumpParser(NativeThread.Companion::fromId, cachingStackElementReader::parseStackElement)
+    }
+
+    override fun createProfilerData(builder: DummyFlameChartBuilder<ThreadInfo, BaseCallStackElement>) =
+        ProfilerData(
+            builder, NativeCallChartNodeRenderer.factory, null,
+            CollapsedProfilerDumpWriter(builder, targetProcess.fullName, attachedTimestamp, { it.fullName() }, { it.name })
+        )
+
+    override fun postProcessData(builder: DummyFlameChartBuilder<ThreadInfo, BaseCallStackElement>): DummyFlameChartBuilder<ThreadInfo, BaseCallStackElement> {
+        readIndicator.checkCanceled()
+
+        val pb = ProcessBuilder("rustfilt")
+        val process = try {
+            pb.start()
+        } catch (e: IOException) {
+            return builder
+        }
+
+        val writer = process.outputStream.bufferedWriter()
+        val reader = process.inputStream.bufferedReader()
+
+        return try {
+            builder.mapTreeElements {
+                if (it is RsDTraceNavigatableNativeCall) {
+                    val fullName = it.fullName()
+                    writer.write(fullName + "\n")
+                    writer.flush()
+
+                    val demangledName = reader.readLine()
+                    if (demangledName != null) {
+                        val library = demangledName.substringBeforeLast('`')
+                        val qualifiedMethod = demangledName.substringAfterLast('`')
+                        val path = qualifiedMethod.substringBeforeLast("::")
+                        val method = qualifiedMethod.substringAfterLast("::")
+                        val nativeCall = NativeCall(library, path, method)
+                        RsDTraceNavigatableNativeCall(nativeCall)
+                    } else {
+                        it
+                    }
+                } else {
+                    it
+                }
+            }
+        } catch (e: IOException) {
+            builder
+        } finally {
+            process.destroy()
+        }
+    }
+
+    companion object {
+        fun attach(
+            targetProcess: AttachableTargetProcess,
+            backgroundOption: PerformInBackgroundOption,
+            timeoutInMilliseconds: Int,
+            project: Project
+        ): Promise<RsDTraceProfilerProcess> {
+            val settings = CPPProfilerSettings.instance.state
+
+            // WARNING: Do not use such solution for other needs!
+            // We want to always use -xmangled option because DTrace cannot demangle Rust symbols correctly
+            val element = XmlSerializer.serialize(settings)
+            val settingsCopy = XmlSerializer.deserialize(element, SimpleProfilerSettingsState::class.java)
+            settingsCopy.defaultCmdArgs.add("-xmangled")
+
+            Cargo.checkNeedInstallRustfilt(project)
+
+            return DTraceProfilerProcessBase.attachBase(
+                targetProcess,
+                backgroundOption,
+                settingsCopy.cpuProfilerScript(),
+                timeoutInMilliseconds,
+                project
+            ) { handler, _ -> RsDTraceProfilerProcess(project, targetProcess, System.currentTimeMillis(), handler) }
+        }
+    }
+}

--- a/clion/src/191/main/kotlin/org/rust/clion/profiler/perf/RsPerfConfigurationExtension.kt
+++ b/clion/src/191/main/kotlin/org/rust/clion/profiler/perf/RsPerfConfigurationExtension.kt
@@ -1,0 +1,111 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.profiler.perf
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.RunnerSettings
+import com.intellij.execution.process.BaseProcessHandler
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.profiler.ProfilerToolWindowManager
+import com.intellij.profiler.clion.CPPProfilerSettings
+import com.intellij.profiler.clion.perf.Addr2LineProcess
+import com.intellij.profiler.clion.perf.AddressSymbolizer
+import com.intellij.profiler.keepTempProfilerFiles
+import com.intellij.profiler.linux.HasInvalidVariables
+import com.intellij.profiler.linux.KernelVariable
+import com.intellij.profiler.linux.KernelVariablesChangeRequiredException
+import com.intellij.profiler.linux.checkKernelVariables
+import org.rust.cargo.runconfig.CargoCommandConfigurationExtension
+import org.rust.cargo.runconfig.ConfigurationExtensionContext
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.clion.profiler.RsProfilerRunner
+import java.io.File
+
+class RsPerfConfigurationExtension : CargoCommandConfigurationExtension() {
+    private val PERF_OUTPUT_FILE_KEY = Key.create<File>("perf.output")
+
+    override fun isApplicableFor(configuration: CargoCommandConfiguration): Boolean = true
+
+    override fun isEnabledFor(applicableConfiguration: CargoCommandConfiguration, runnerSettings: RunnerSettings?): Boolean =
+        SystemInfo.isLinux
+
+    override fun patchCommandLine(
+        configuration: CargoCommandConfiguration,
+        runnerSettings: RunnerSettings?,
+        cmdLine: GeneralCommandLine,
+        runnerId: String,
+        context: ConfigurationExtensionContext
+    ) {
+        if (RsProfilerRunner.RUNNER_ID != runnerId) return
+        val project = configuration.project
+        val settings = CPPProfilerSettings.instance.state
+        val perfPath = settings.executablePath.orEmpty()
+        val validationResult = checkKernelVariables(requiredKernelVariables)
+        if (validationResult is HasInvalidVariables) {
+            throw KernelVariablesChangeRequiredException(validationResult, project)
+        }
+        val outputFile = FileUtil.createTempFile("perf", null, !keepTempProfilerFiles())
+        cmdLine.addPerfStarter(perfPath, settings.samplingFrequency, settings.defaultCmdArgs, outputFile.absolutePath)
+        context.putUserData(PERF_OUTPUT_FILE_KEY, outputFile)
+    }
+
+    override fun attachToProcess(
+        configuration: CargoCommandConfiguration,
+        handler: ProcessHandler,
+        environment: ExecutionEnvironment,
+        runnerSettings: RunnerSettings?,
+        runnerId: String,
+        context: ConfigurationExtensionContext
+    ) {
+        if (RsProfilerRunner.RUNNER_ID != runnerId) return
+        if (handler !is BaseProcessHandler<*>)
+            throw ExecutionException("Can't detect target process id")
+        val outputFile = context.getUserData(PERF_OUTPUT_FILE_KEY)
+            ?: throw ExecutionException("Can't get output perf data file")
+
+        val project = configuration.project
+        val profilerProcess = RsPerfProfilerProcess(
+            handler,
+            outputFile.path,
+            createAddressSymbolizer(),
+            configuration.name,
+            project,
+            System.currentTimeMillis()
+        )
+        ProfilerToolWindowManager.getInstance(project).addProfilerProcessTab(profilerProcess)
+    }
+
+    private fun createAddressSymbolizer(): AddressSymbolizer? {
+        return if (Addr2LineProcess.isAvailable) {
+            Addr2LineProcess()
+        } else {
+            null
+        }
+    }
+
+    companion object {
+        private val requiredKernelVariables = listOf(
+            KernelVariable("perf_event_paranoid", "1") { it.toInt() <= 1 }, //required, error otherwise
+            KernelVariable("kptr_restrict", "0") { it == "0" } //useful, warning otherwise
+        )
+
+        private fun GeneralCommandLine.addPerfStarter(
+            perfPath: String,
+            samplingFrequency: Int,
+            defaultArgs: List<String>,
+            outputPath: String
+        ): GeneralCommandLine = this.apply {
+            parametersList.prependAll("record", "--freq=$samplingFrequency", *defaultArgs.toTypedArray(), "-o", outputPath, exePath)
+            exePath = perfPath
+        }
+    }
+
+}

--- a/clion/src/191/main/kotlin/org/rust/clion/profiler/perf/RsPerfNavigatableNativeCall.kt
+++ b/clion/src/191/main/kotlin/org/rust/clion/profiler/perf/RsPerfNavigatableNativeCall.kt
@@ -1,0 +1,68 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.profiler.perf
+
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.profiler.api.BaseCallStackElement
+import com.intellij.profiler.model.NativeCall
+import com.intellij.psi.NavigatablePsiElement
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.DocumentUtil
+import org.rust.lang.core.psi.RsFunction
+import java.nio.file.Paths
+
+data class RsPerfNavigatableNativeCall(
+    private val library: String,
+    private val methodWithClassOrFunction: String
+) : BaseCallStackElement() {
+
+    constructor(library: String, methodWithClassOrFunction: String, filePath: String, line: Int)
+        : this(library, methodWithClassOrFunction) {
+        this.filePath = filePath
+        this.line = line
+    }
+
+    private val nativeCall = NativeCall(library, methodWithClassOrFunction)
+    private var filePath: String = ""
+    private var line: Int = -1
+
+    override fun fullName(): String = nativeCall.fullName()
+
+    override val isNavigatable: Boolean
+        get() = filePath.isNotBlank() && line >= 0
+
+    override fun calcNavigatables(project: Project): Array<out NavigatablePsiElement> {
+        val element = getNavigatablePsiElement(project)
+        if (element == null) {
+            LOG.warn("Failed to navigate: $filePath:$line")
+            return emptyArray()
+        }
+        return arrayOf(element)
+    }
+
+    private fun getNavigatablePsiElement(project: Project): NavigatablePsiElement? {
+        if (!isNavigatable) return null
+
+        val virtualFile = VfsUtil.findFile(Paths.get(filePath), true) ?: return null
+        return runReadAction {
+            val document = FileDocumentManager.getInstance().getDocument(virtualFile) ?: return@runReadAction null
+            val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(document) ?: return@runReadAction null
+            val offset = document.getLineStartOffset(line)
+            if (!DocumentUtil.isValidOffset(offset, document)) return@runReadAction null
+            val element = psiFile.findElementAt(offset)
+            return@runReadAction PsiTreeUtil.getNonStrictParentOfType(element, RsFunction::class.java)
+        }
+    }
+
+    companion object {
+        private val LOG = Logger.getInstance(RsPerfNavigatableNativeCall::class.java)
+    }
+}

--- a/clion/src/191/main/kotlin/org/rust/clion/profiler/perf/RsPerfProfilerProcess.kt
+++ b/clion/src/191/main/kotlin/org/rust/clion/profiler/perf/RsPerfProfilerProcess.kt
@@ -1,0 +1,72 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.profiler.perf
+
+import com.intellij.execution.process.BaseProcessHandler
+import com.intellij.execution.process.OSProcessUtil
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.profiler.ProfilerProcessBase
+import com.intellij.profiler.api.*
+import com.intellij.profiler.clion.NativeTargetProcess
+import com.intellij.profiler.clion.perf.AddressSymbolizer
+import com.intellij.profiler.clion.perf.PerfScriptProcess
+import com.intellij.profiler.ui.flamechart.NativeCallChartNodeRenderer
+import org.rust.clion.profiler.RsCachedPerfFlameChartBuilder
+
+class RsPerfProfilerProcess(
+    perfProcessHandler: BaseProcessHandler<*>,
+    private val outputPerfDataPath: String,
+    private val addressSymbolizer: AddressSymbolizer?,
+    processName: String,
+    project: Project,
+    override val attachedTimestamp: Long
+) : ProfilerProcessBase<NativeTargetProcess>(
+    project,
+    NativeTargetProcess(OSProcessUtil.getProcessID(perfProcessHandler.process), processName)
+) {
+    init {
+        initAlreadyAttached(perfProcessHandler)
+    }
+
+    override fun onTargetProcessTerminated() {
+        if (state !== Attached) return
+        ApplicationManager.getApplication().executeOnPooledThread {
+            if (state !== Attached) return@executeOnPooledThread
+            ProgressManager.getInstance().runProcess({
+                try {
+                    val builder = RsCachedPerfFlameChartBuilder(10000, addressSymbolizer, readIndicator)
+                    changeStateAndNotifyAsync(ReadingData)
+                    PerfScriptProcess.execute(outputPerfDataPath, builder::add, readIndicator)
+                    val data = ProfilerData(builder.getFlameChartBuilder(), NativeCallChartNodeRenderer.factory, null)
+                    readIndicator.checkCanceled()
+                    profilerData = data
+                    changeStateAndNotifyAsync(DataReady(data))
+                } catch (e: Throwable) {
+                    if (e !is ProcessCanceledException) {
+                        changeStateAndNotifyAsync(ProfilerError(e.message.orEmpty()))
+                    }
+                }
+            }, readIndicator)
+        }
+    }
+
+    override fun canBeStopped(): Boolean = false
+
+    override fun stop(): Boolean {
+        LOG.warn("Perf profiler process can't be stopped yet")
+        return false
+    }
+
+    override val LOG = staticLogger
+
+    companion object {
+        private val staticLogger = Logger.getInstance(RsPerfProfilerProcess::class.java)
+    }
+}

--- a/clion/src/191/main/resources/META-INF/platform-clion-only.xml
+++ b/clion/src/191/main/resources/META-INF/platform-clion-only.xml
@@ -2,4 +2,14 @@
     <extensions defaultExtensionNs="clion">
         <buildConfigurationProvider implementation="org.rust.clion.cargo.CargoBuildConfigurationProvider"/>
     </extensions>
+
+    <extensions defaultExtensionNs="com.intellij">
+        <programRunner implementation="org.rust.clion.profiler.RsProfilerRunner"/>
+        <projectService serviceImplementation="org.rust.clion.profiler.RsCachingStackElementReader"/>
+    </extensions>
+
+    <extensions defaultExtensionNs="org.rust">
+        <runConfigurationExtension implementation="org.rust.clion.profiler.perf.RsPerfConfigurationExtension"/>
+        <runConfigurationExtension implementation="org.rust.clion.profiler.dtrace.RsDTraceConfigurationExtension"/>
+    </extensions>
 </idea-plugin>

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
@@ -5,24 +5,12 @@
 
 package org.rust.debugger.runconfig
 
-import com.google.gson.JsonParser
-import com.google.gson.JsonSyntaxException
-import com.intellij.execution.RunContentExecutor
-import com.intellij.execution.configurations.RunProfile
-import com.intellij.execution.configurations.RunProfileState
-import com.intellij.execution.configurations.RunnerSettings
+import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.executors.DefaultDebugExecutor
-import com.intellij.execution.process.CapturingProcessAdapter
-import com.intellij.execution.process.CapturingProcessHandler
-import com.intellij.execution.process.ProcessOutput
 import com.intellij.execution.process.ProcessTerminatedListener
-import com.intellij.execution.runners.AsyncProgramRunner
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.ui.RunContentDescriptor
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.options.ShowSettingsUtil
-import com.intellij.openapi.progress.ProgressIndicator
-import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.xdebugger.XDebugProcess
@@ -32,120 +20,39 @@ import com.intellij.xdebugger.impl.XDebugProcessConfiguratorStarter
 import com.intellij.xdebugger.impl.ui.XDebugSessionData
 import com.jetbrains.cidr.cpp.toolchains.CPPToolchains
 import com.jetbrains.cidr.cpp.toolchains.CPPToolchainsConfigurable
-import com.jetbrains.cidr.toolchains.OSType
-import org.jetbrains.concurrency.AsyncPromise
-import org.jetbrains.concurrency.Promise
-import org.rust.cargo.project.workspace.CargoWorkspace.CrateType
-import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
 import org.rust.cargo.runconfig.CargoRunStateBase
-import org.rust.cargo.runconfig.RsKillableColoredProcessHandler
-import org.rust.cargo.runconfig.command.CargoCommandConfiguration
-import org.rust.cargo.toolchain.Cargo
-import org.rust.cargo.toolchain.CargoCommandLine
-import org.rust.cargo.toolchain.impl.CargoMetadata
-import org.rust.cargo.toolchain.prependArgument
-import org.rust.cargo.util.CargoArgsParser
+import org.rust.cargo.runconfig.RsAsyncRunner
 import org.rust.debugger.settings.RsDebuggerSettings
-import org.rust.openapiext.saveAllDocuments
-import java.nio.file.Path
-import java.nio.file.Paths
 
-private const val ERROR_MESSAGE_TITLE: String = "Debugging is not possible"
+const val ERROR_MESSAGE_TITLE: String = "Debugging is not possible"
 
-class RsDebugRunner : AsyncProgramRunner<RunnerSettings>() {
+
+class RsDebugRunner : RsAsyncRunner(DefaultDebugExecutor.EXECUTOR_ID, ERROR_MESSAGE_TITLE) {
     override fun getRunnerId(): String = "RsDebugRunner"
 
-    override fun canRun(executorId: String, profile: RunProfile): Boolean {
-        if (executorId != DefaultDebugExecutor.EXECUTOR_ID || profile !is CargoCommandConfiguration) {
-            return false
-        }
-        val cleaned = profile.clean().ok ?: return false
-        if (cleaned.cmd.command !in listOf("run", "test")) {
-            return false
-        }
+    override fun getRunContentDescriptor(
+        state: CargoRunStateBase,
+        environment: ExecutionEnvironment,
+        runCommand: GeneralCommandLine
+    ): RunContentDescriptor? {
+        val sysroot = state.computeSysroot()
+        val runParameters = RsDebugRunParameters(environment.project, runCommand)
+        return XDebuggerManager.getInstance(environment.project)
+            .startSession(environment, object : XDebugProcessConfiguratorStarter() {
+                override fun start(session: XDebugSession): XDebugProcess =
+                    RsLocalDebugProcess(runParameters, session, state.consoleBuilder).apply {
+                        ProcessTerminatedListener.attach(processHandler, environment.project)
+                        val settings = RsDebuggerSettings.getInstance()
+                        loadPrettyPrinters(sysroot, settings.lldbRenderers, settings.gdbRenderers)
+                        start()
+                    }
 
-        return true
+                override fun configure(data: XDebugSessionData?) {}
+            })
+            .runContentDescriptor
     }
 
-    override fun execute(environment: ExecutionEnvironment, state: RunProfileState): Promise<RunContentDescriptor?> {
-        saveAllDocuments()
-        state as CargoRunStateBase
-        val cmd = Cargo.patchArgs(state.prepareCommandLine(), true)
-        val (commandArguments, executableArguments) = CargoArgsParser.parseArgs(cmd.command, cmd.additionalArguments)
-
-        val isTestRun = cmd.command == "test"
-        val cmdHasNoRun = "--no-run" in cmd.additionalArguments
-        val buildCommand = if (isTestRun) {
-            if (cmdHasNoRun) cmd else cmd.prependArgument("--no-run")
-        } else {
-            cmd.copy(command = "build", additionalArguments = commandArguments)
-        }
-
-        val getRunCommand = { executablePath: Path ->
-            with(buildCommand) {
-                Cargo.createGeneralCommandLine(
-                    executablePath,
-                    workingDirectory,
-                    backtraceMode,
-                    environmentVariables,
-                    executableArguments
-                )
-            }
-        }
-
-        return buildProjectAndGetBinaryArtifactPath(environment.project, buildCommand, state, isTestRun)
-            .then { binary ->
-                if (isTestRun && cmdHasNoRun) return@then null
-                val path = binary?.path ?: return@then null
-                val runCommand = getRunCommand(path)
-                val sysroot = state.computeSysroot()
-                val runParameters = RsDebugRunParameters(environment.project, runCommand)
-                XDebuggerManager.getInstance(environment.project)
-                    .startSession(environment, object : XDebugProcessConfiguratorStarter() {
-                        override fun start(session: XDebugSession): XDebugProcess =
-                            RsLocalDebugProcess(runParameters, session, state.consoleBuilder).apply {
-                                ProcessTerminatedListener.attach(processHandler, environment.project)
-                                val settings = RsDebuggerSettings.getInstance()
-                                loadPrettyPrinters(sysroot, settings.lldbRenderers, settings.gdbRenderers)
-                                start()
-                            }
-
-                        override fun configure(data: XDebugSessionData?) {}
-                    })
-                    .runContentDescriptor
-            }
-
-    }
-}
-
-private class Binary(val path: Path)
-
-private sealed class DebugBuildResult {
-    data class Binaries(val paths: List<String>) : DebugBuildResult()
-    object MSVCToolchain : DebugBuildResult()
-}
-
-/**
- * Runs `command` twice:
- *   * once to show console with errors
- *   * the second time to get json output
- * See https://github.com/rust-lang/cargo/issues/3855
- */
-private fun buildProjectAndGetBinaryArtifactPath(
-    project: Project,
-    command: CargoCommandLine,
-    state: CargoRunStateBase,
-    testsOnly: Boolean
-): Promise<Binary?> {
-    val promise = AsyncPromise<Binary?>()
-    val cargo = state.cargo()
-
-    val processForUserOutput = ProcessOutput()
-    val processForUser = RsKillableColoredProcessHandler(cargo.toColoredCommandLine(command))
-
-    processForUser.addProcessListener(CapturingProcessAdapter(processForUserOutput))
-
-    ApplicationManager.getApplication().invokeLater {
+    override fun checkToolchain(project: Project): Boolean {
         val toolchains = CPPToolchains.getInstance()
         val toolchain = toolchains.defaultToolchain
         if (toolchain == null) {
@@ -154,102 +61,8 @@ private fun buildProjectAndGetBinaryArtifactPath(
             if (option == 0) {
                 ShowSettingsUtil.getInstance().showSettingsDialog(project, CPPToolchainsConfigurable::class.java, null)
             }
-            promise.setResult(null)
-            return@invokeLater
+            return false
         }
-
-        RunContentExecutor(project, processForUser)
-            .apply { state.createFilters().forEach { withFilter(it) } }
-            .withAfterCompletion {
-                if (processForUserOutput.exitCode != 0) {
-                    promise.setResult(null)
-                    return@withAfterCompletion
-                }
-
-                object : Task.Backgroundable(project, "Building Cargo project") {
-                    var result: DebugBuildResult? = null
-
-                    override fun run(indicator: ProgressIndicator) {
-                        indicator.isIndeterminate = true
-                        if (toolchains.osType == OSType.WIN && "msvc" in state.rustVersion().rustc?.host.orEmpty()) {
-                            result = DebugBuildResult.MSVCToolchain
-                            return
-                        }
-
-                        val processForJson = CapturingProcessHandler(cargo.toGeneralCommandLine(command.prependArgument("--message-format=json")))
-                        val output = processForJson.runProcessWithProgressIndicator(indicator)
-                        if (output.isCancelled || output.exitCode != 0) {
-                            promise.setResult(null)
-                            return
-                        }
-
-                        val parser = JsonParser()
-                        result = output.stdoutLines
-                            .mapNotNull {
-                                try {
-                                    val jsonElement = parser.parse(it)
-                                    val jsonObject = if (jsonElement.isJsonObject) {
-                                        jsonElement.asJsonObject
-                                    } else {
-                                        return@mapNotNull null
-                                    }
-                                    CargoMetadata.Artifact.fromJson(jsonObject)
-                                } catch (e: JsonSyntaxException) {
-                                    null
-                                }
-                            }
-                            .filter { (target, profile) ->
-                                val isSuitableTarget = when (target.cleanKind) {
-                                    TargetKind.BIN -> true
-                                    TargetKind.EXAMPLE -> {
-                                        // TODO: support cases when crate types list contains not only binary
-                                        target.cleanCrateTypes.singleOrNull() == CrateType.BIN
-                                    }
-                                    TargetKind.TEST -> true
-                                    TargetKind.LIB -> profile.test
-                                    else -> false
-                                }
-                                isSuitableTarget && (!testsOnly || profile.test)
-                            }
-                            .flatMap { it.filenames.filter { !it.endsWith(".dSYM") } } // FIXME: correctly launch debug binaries for macos
-                            .let(DebugBuildResult::Binaries)
-                    }
-
-                    override fun onSuccess() {
-                        when (val result = result!!) {
-                            DebugBuildResult.MSVCToolchain -> {
-                                project.showErrorDialog("MSVC toolchain is not supported for debugging. Please use GNU toolchain.")
-                                promise.setResult(null)
-                            }
-                            is DebugBuildResult.Binaries -> {
-                                val binaries = result.paths
-                                when {
-                                    binaries.isEmpty() -> {
-                                        project.showErrorDialog("Can't find a binary to debug")
-                                        promise.setResult(null)
-                                    }
-                                    binaries.size > 1 -> {
-                                        project.showErrorDialog("More than one binary produced. " +
-                                            "Please specify `--bin`, `--lib`, `--test` or `--example` flag explicitly.")
-                                        promise.setResult(null)
-                                    }
-                                    else -> promise.setResult(Binary(Paths.get(binaries.single())))
-                                }
-                            }
-                        }
-                    }
-
-                    override fun onThrowable(error: Throwable) {
-                        promise.setResult(null)
-                    }
-                }.queue()
-            }
-            .run()
+        return true
     }
-
-    return promise
-}
-
-private fun Project.showErrorDialog(message: String) {
-    Messages.showErrorDialog(this, message, ERROR_MESSAGE_TITLE)
 }

--- a/gradle-191.properties
+++ b/gradle-191.properties
@@ -2,5 +2,5 @@ ideaVersion=IC-191.6183-EAP-CANDIDATE-SNAPSHOT
 clionVersion=CL-191.6183-EAP-CANDIDATE-SNAPSHOT
 
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
-sinceBuild=191.6014
+sinceBuild=191.6183
 untilBuild=191.*

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -44,6 +44,7 @@ import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.project.workspace.StandardLibrary
 import org.rust.cargo.toolchain.RustToolchain
 import org.rust.cargo.toolchain.Rustup
+import org.rust.cargo.util.DownloadResult
 import org.rust.ide.notifications.showBalloon
 import org.rust.openapiext.*
 import org.rust.stdext.AsyncValue
@@ -430,7 +431,7 @@ private fun fetchStdlib(
         progress.isIndeterminate = true
         val download = rustup.downloadStdlib()
         when (download) {
-            is Rustup.DownloadResult.Ok -> {
+            is DownloadResult.Ok -> {
                 val lib = StandardLibrary.fromFile(download.value)
                 if (lib == null) {
                     err("" +
@@ -440,7 +441,7 @@ private fun fetchStdlib(
                     ok(lib)
                 }
             }
-            is Rustup.DownloadResult.Err -> err(
+            is DownloadResult.Err -> err(
                 "download failed: ${download.error}"
             )
         }

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandConfigurationExtension.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandConfigurationExtension.kt
@@ -1,0 +1,48 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig
+
+import com.intellij.execution.configuration.RunConfigurationExtensionBase
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.RunnerSettings
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.openapi.util.UserDataHolderBase
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+
+class ConfigurationExtensionContext : UserDataHolderBase()
+
+abstract class CargoCommandConfigurationExtension : RunConfigurationExtensionBase<CargoCommandConfiguration>() {
+    private val LOG: Logger = Logger.getInstance(CargoCommandConfigurationExtension::class.java)
+
+    abstract fun attachToProcess(configuration: CargoCommandConfiguration,
+                                 handler: ProcessHandler,
+                                 environment: ExecutionEnvironment,
+                                 runnerSettings: RunnerSettings?,
+                                 runnerId: String,
+                                 context: ConfigurationExtensionContext)
+
+    abstract fun patchCommandLine(
+        configuration: CargoCommandConfiguration,
+        runnerSettings: RunnerSettings?,
+        cmdLine: GeneralCommandLine,
+        runnerId: String,
+        context: ConfigurationExtensionContext
+    )
+
+    override fun patchCommandLine(configuration: CargoCommandConfiguration,
+                                  runnerSettings: RunnerSettings?,
+                                  cmdLine: GeneralCommandLine,
+                                  runnerId: String) {
+        LOG.error("use the other overload of 'patchCommandLine' method")
+    }
+
+    companion object {
+        val EP_NAME = ExtensionPointName.create<CargoCommandConfigurationExtension>("org.rust.runConfigurationExtension")
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandConfigurationExtension.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandConfigurationExtension.kt
@@ -20,12 +20,14 @@ class ConfigurationExtensionContext : UserDataHolderBase()
 abstract class CargoCommandConfigurationExtension : RunConfigurationExtensionBase<CargoCommandConfiguration>() {
     private val LOG: Logger = Logger.getInstance(CargoCommandConfigurationExtension::class.java)
 
-    abstract fun attachToProcess(configuration: CargoCommandConfiguration,
-                                 handler: ProcessHandler,
-                                 environment: ExecutionEnvironment,
-                                 runnerSettings: RunnerSettings?,
-                                 runnerId: String,
-                                 context: ConfigurationExtensionContext)
+    abstract fun attachToProcess(
+        configuration: CargoCommandConfiguration,
+        handler: ProcessHandler,
+        environment: ExecutionEnvironment,
+        runnerSettings: RunnerSettings?,
+        runnerId: String,
+        context: ConfigurationExtensionContext
+    )
 
     abstract fun patchCommandLine(
         configuration: CargoCommandConfiguration,
@@ -35,10 +37,12 @@ abstract class CargoCommandConfigurationExtension : RunConfigurationExtensionBas
         context: ConfigurationExtensionContext
     )
 
-    override fun patchCommandLine(configuration: CargoCommandConfiguration,
-                                  runnerSettings: RunnerSettings?,
-                                  cmdLine: GeneralCommandLine,
-                                  runnerId: String) {
+    override fun patchCommandLine(
+        configuration: CargoCommandConfiguration,
+        runnerSettings: RunnerSettings?,
+        cmdLine: GeneralCommandLine,
+        runnerId: String
+    ) {
         LOG.error("use the other overload of 'patchCommandLine' method")
     }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
@@ -12,8 +12,9 @@ import org.rust.cargo.runconfig.console.CargoConsoleBuilder
 
 class CargoRunState(
     environment: ExecutionEnvironment,
+    runConfiguration: CargoCommandConfiguration,
     config: CargoCommandConfiguration.CleanConfiguration.Ok
-) : CargoRunStateBase(environment, config) {
+) : CargoRunStateBase(environment, runConfiguration, config) {
     init {
         val scope = SearchScopeProvider.createSearchScope(environment.project, environment.runProfile)
         consoleBuilder = CargoConsoleBuilder(environment.project, scope)

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunStateBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunStateBase.kt
@@ -22,6 +22,7 @@ import org.rust.cargo.toolchain.RustToolchain
 
 abstract class CargoRunStateBase(
     environment: ExecutionEnvironment,
+    val runConfiguration: CargoCommandConfiguration,
     val config: CargoCommandConfiguration.CleanConfiguration.Ok
 ) : CommandLineState(environment) {
     private val toolchain: RustToolchain = config.toolchain

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoTestRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoTestRunState.kt
@@ -19,8 +19,9 @@ import org.rust.cargo.toolchain.CargoCommandLine
 
 class CargoTestRunState(
     environment: ExecutionEnvironment,
+    runConfiguration: CargoCommandConfiguration,
     config: CargoCommandConfiguration.CleanConfiguration.Ok
-) : CargoRunStateBase(environment, config) {
+) : CargoRunStateBase(environment, runConfiguration, config) {
 
     init {
         consoleBuilder = CargoTestConsoleBuilder(environment.runProfile as RunConfiguration, environment.executor)

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsAsyncRunner.kt
@@ -1,0 +1,245 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig
+
+import com.google.gson.JsonParser
+import com.google.gson.JsonSyntaxException
+import com.intellij.execution.DefaultExecutionResult
+import com.intellij.execution.RunContentExecutor
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.RunProfile
+import com.intellij.execution.configurations.RunProfileState
+import com.intellij.execution.configurations.RunnerSettings
+import com.intellij.execution.process.CapturingProcessAdapter
+import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.execution.process.ProcessOutput
+import com.intellij.execution.process.ProcessTerminatedListener
+import com.intellij.execution.runners.AsyncProgramRunner
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.execution.runners.showRunContent
+import com.intellij.execution.ui.RunContentDescriptor
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import org.jetbrains.concurrency.AsyncPromise
+import org.jetbrains.concurrency.Promise
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.toolchain.Cargo
+import org.rust.cargo.toolchain.CargoCommandLine
+import org.rust.cargo.toolchain.impl.CargoMetadata
+import org.rust.cargo.toolchain.prependArgument
+import org.rust.cargo.util.CargoArgsParser
+import org.rust.openapiext.saveAllDocuments
+import java.nio.file.Path
+import java.nio.file.Paths
+
+abstract class RsAsyncRunner(private val executorId: String, private val errorMessageTitle: String) : AsyncProgramRunner<RunnerSettings>() {
+    class Binary(val path: Path)
+    sealed class BuildResult {
+        data class Binaries(val paths: List<String>) : BuildResult()
+        object MSVCToolchain : BuildResult()
+    }
+
+    override fun canRun(executorId: String, profile: RunProfile): Boolean {
+        if (executorId != this.executorId || profile !is CargoCommandConfiguration) {
+            return false
+        }
+        val cleaned = profile.clean().ok ?: return false
+        if (cleaned.cmd.command !in listOf("run", "test")) {
+            return false
+        }
+
+        return true
+    }
+
+    open fun getRunContentDescriptor(
+        state: CargoRunStateBase,
+        environment: ExecutionEnvironment,
+        runCommand: GeneralCommandLine
+    ): RunContentDescriptor? {
+        return showRunContent(executeCmd(state, runCommand, environment), environment)
+    }
+
+    private fun executeCmd(state: CargoRunStateBase, cmd: GeneralCommandLine, environment: ExecutionEnvironment): DefaultExecutionResult {
+        val runConfiguration = state.runConfiguration
+        val context = ConfigurationExtensionContext()
+
+        RsRunConfigurationExtensionManager.getInstance().patchCommandLine(
+            runConfiguration,
+            environment.runnerSettings,
+            cmd,
+            environment.runner.runnerId,
+            context
+        )
+
+        val handler = RsKillableColoredProcessHandler(cmd)
+        ProcessTerminatedListener.attach(handler) // shows exit code upon termination
+
+        RsRunConfigurationExtensionManager.getInstance().attachExtensionsToProcess(
+            runConfiguration,
+            handler,
+            environment,
+            environment.runnerSettings,
+            environment.runner.runnerId,
+            context
+        )
+
+        val console = state.consoleBuilder.console
+        console.attachToProcess(handler)
+        return DefaultExecutionResult(console, handler)
+    }
+
+    override fun execute(environment: ExecutionEnvironment, state: RunProfileState): Promise<RunContentDescriptor?> {
+        saveAllDocuments()
+        state as CargoRunStateBase
+        val cmd = Cargo.patchArgs(state.prepareCommandLine(), true)
+        val (commandArguments, executableArguments) = CargoArgsParser.parseArgs(cmd.command, cmd.additionalArguments)
+
+        val isTestRun = cmd.command == "test"
+        val cmdHasNoRun = "--no-run" in cmd.additionalArguments
+        val buildCommand = if (isTestRun) {
+            if (cmdHasNoRun) cmd else cmd.prependArgument("--no-run")
+        } else {
+            cmd.copy(command = "build", additionalArguments = commandArguments)
+        }
+
+        val getRunCommand = { executablePath: Path ->
+            with(buildCommand) {
+                Cargo.createGeneralCommandLine(
+                    executablePath,
+                    workingDirectory,
+                    backtraceMode,
+                    environmentVariables,
+                    executableArguments
+                )
+            }
+        }
+
+        return buildProjectAndGetBinaryArtifactPath(environment.project, buildCommand, state, isTestRun)
+            .then { binary ->
+                if (isTestRun && cmdHasNoRun) return@then null
+                val path = binary?.path ?: return@then null
+                val runCommand = getRunCommand(path)
+
+                getRunContentDescriptor(state, environment, runCommand)
+            }
+    }
+
+    open fun checkToolchain(project: Project): Boolean = true
+
+
+    private fun buildProjectAndGetBinaryArtifactPath(
+        project: Project,
+        command: CargoCommandLine,
+        state: CargoRunStateBase,
+        testsOnly: Boolean
+    ): Promise<Binary?> {
+        val promise = AsyncPromise<Binary?>()
+        val cargo = state.cargo()
+
+        val processForUserOutput = ProcessOutput()
+        val processForUser = RsKillableColoredProcessHandler(cargo.toColoredCommandLine(command))
+
+        processForUser.addProcessListener(CapturingProcessAdapter(processForUserOutput))
+
+        ApplicationManager.getApplication().invokeLater {
+            RunContentExecutor(project, processForUser)
+                .apply { state.createFilters().forEach { withFilter(it) } }
+                .withAfterCompletion {
+                    if (processForUserOutput.exitCode != 0) {
+                        promise.setResult(null)
+                        return@withAfterCompletion
+                    }
+
+                    object : Task.Backgroundable(project, "Building Cargo project") {
+                        var result: RsAsyncRunner.BuildResult? = null
+
+                        override fun run(indicator: ProgressIndicator) {
+                            indicator.isIndeterminate = true
+                            if (!checkToolchain(project)) {
+                                promise.setResult(null)
+                                return
+                            }
+                            val processForJson = CapturingProcessHandler(cargo.toGeneralCommandLine(command.prependArgument("--message-format=json")))
+                            val output = processForJson.runProcessWithProgressIndicator(indicator)
+                            if (output.isCancelled || output.exitCode != 0) {
+                                promise.setResult(null)
+                                return
+                            }
+
+                            val parser = JsonParser()
+                            result = output.stdoutLines
+                                .mapNotNull {
+                                    try {
+                                        val jsonElement = parser.parse(it)
+                                        val jsonObject = if (jsonElement.isJsonObject) {
+                                            jsonElement.asJsonObject
+                                        } else {
+                                            return@mapNotNull null
+                                        }
+                                        CargoMetadata.Artifact.fromJson(jsonObject)
+                                    } catch (e: JsonSyntaxException) {
+                                        null
+                                    }
+                                }
+                                .filter { (target, profile) ->
+                                    val isSuitableTarget = when (target.cleanKind) {
+                                        CargoWorkspace.TargetKind.BIN -> true
+                                        CargoWorkspace.TargetKind.EXAMPLE -> {
+                                            // TODO: support cases when crate types list contains not only binary
+                                            target.cleanCrateTypes.singleOrNull() == CargoWorkspace.CrateType.BIN
+                                        }
+                                        CargoWorkspace.TargetKind.TEST -> true
+                                        CargoWorkspace.TargetKind.LIB -> profile.test
+                                        else -> false
+                                    }
+                                    isSuitableTarget && (!testsOnly || profile.test)
+                                }
+                                .flatMap { it.filenames.filter { !it.endsWith(".dSYM") } } // FIXME: correctly launch binaries for macos
+                                .let(RsAsyncRunner.BuildResult::Binaries)
+                        }
+
+                        override fun onSuccess() {
+                            when (val result = result!!) {
+                                is RsAsyncRunner.BuildResult.MSVCToolchain -> {
+                                    project.showErrorDialog("MSVC toolchain is not supported. Please use GNU toolchain.")
+                                    promise.setResult(null)
+                                }
+                                is RsAsyncRunner.BuildResult.Binaries -> {
+                                    val binaries = result.paths
+                                    when {
+                                        binaries.isEmpty() -> {
+                                            project.showErrorDialog("Can't find a binary")
+                                            promise.setResult(null)
+                                        }
+                                        binaries.size > 1 -> {
+                                            project.showErrorDialog("More than one binary produced. " +
+                                                "Please specify `--bin`, `--lib`, `--test` or `--example` flag explicitly.")
+                                            promise.setResult(null)
+                                        }
+                                        else -> promise.setResult(RsAsyncRunner.Binary(Paths.get(binaries.single())))
+                                    }
+                                }
+                            }
+                        }
+
+                        override fun onThrowable(error: Throwable) {
+                            promise.setResult(null)
+                        }
+                    }.queue()
+                }.run()
+        }
+
+        return promise
+    }
+
+    private fun Project.showErrorDialog(message: String) {
+        Messages.showErrorDialog(this, message, errorMessageTitle)
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsRunConfigurationExtensionManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsRunConfigurationExtensionManager.kt
@@ -41,7 +41,6 @@ class RsRunConfigurationExtensionManager : RunConfigurationExtensionsManager<Car
 
     companion object {
         @JvmStatic
-        val instance: RsRunConfigurationExtensionManager
-            get() = service()
+        fun getInstance(): RsRunConfigurationExtensionManager = service()
     }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsRunConfigurationExtensionManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsRunConfigurationExtensionManager.kt
@@ -1,0 +1,47 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig
+
+import com.intellij.execution.configuration.RunConfigurationExtensionsManager
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.RunnerSettings
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.components.service
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+
+class RsRunConfigurationExtensionManager : RunConfigurationExtensionsManager<CargoCommandConfiguration, CargoCommandConfigurationExtension>(CargoCommandConfigurationExtension.EP_NAME) {
+    fun attachExtensionsToProcess(
+        configuration: CargoCommandConfiguration,
+        handler: ProcessHandler,
+        environment: ExecutionEnvironment,
+        runnerSettings: RunnerSettings?,
+        runnerId: String,
+        context: ConfigurationExtensionContext
+    ) {
+        processEnabledExtensions(configuration, runnerSettings) {
+            it.attachToProcess(configuration, handler, environment, runnerSettings, runnerId, context)
+        }
+    }
+
+    fun patchCommandLine(
+        configuration: CargoCommandConfiguration,
+        runnerSettings: RunnerSettings?,
+        cmdLine: GeneralCommandLine,
+        runnerId: String,
+        context: ConfigurationExtensionContext
+    ) {
+        processEnabledExtensions(configuration, runnerSettings) {
+            it.patchCommandLine(configuration, runnerSettings, cmdLine, runnerId, context)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        val instance: RsRunConfigurationExtensionManager
+            get() = service()
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsTestRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsTestRunner.kt
@@ -48,7 +48,7 @@ private fun buildTests(project: Project, state: CargoRunStateBase, cmdHasNoRun: 
     val buildProcessHandler = run {
         val buildCmd = if (cmdHasNoRun) state.commandLine else state.commandLine.prependArgument("--no-run")
         val buildConfig = CargoCommandConfiguration.CleanConfiguration.Ok(buildCmd, state.config.toolchain)
-        val buildState = CargoRunState(state.environment, buildConfig)
+        val buildState = CargoRunState(state.environment, state.runConfiguration, buildConfig)
         buildState.startProcess()
     }
     val exitCode = AsyncPromise<Int?>()

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -103,9 +103,9 @@ class CargoCommandConfiguration(
                 project.rustSettings.showTestToolWindow &&
                 !command.contains("--nocapture") &&
                 !nocapture) {
-                CargoTestRunState(environment, it)
+                CargoTestRunState(environment, this, it)
             } else {
-                CargoRunState(environment, it)
+                CargoRunState(environment, this, it)
             }
         }
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.util.DownloadResult
 import org.rust.ide.actions.InstallComponentAction
 import org.rust.ide.notifications.showBalloon
 import org.rust.openapiext.*
@@ -27,12 +28,6 @@ class Rustup(
     private val rustup: Path,
     private val projectDirectory: Path
 ) {
-    @Suppress("unused")
-    sealed class DownloadResult<out T> {
-        class Ok<T>(val value: T) : DownloadResult<T>()
-        class Err(val error: String) : DownloadResult<Nothing>()
-    }
-
     data class Component(val name: String, val isInstalled: Boolean) {
         companion object {
             fun from(line: String): Component {

--- a/src/main/kotlin/org/rust/cargo/util/InstallUtils.kt
+++ b/src/main/kotlin/org/rust/cargo/util/InstallUtils.kt
@@ -1,0 +1,12 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.util
+
+@Suppress("unused")
+sealed class DownloadResult<out T> {
+    class Ok<T>(val value: T) : DownloadResult<T>()
+    class Err(val error: String) : DownloadResult<Nothing>()
+}

--- a/src/main/kotlin/org/rust/ide/actions/InstallCargoPackageAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/InstallCargoPackageAction.kt
@@ -14,20 +14,18 @@ import com.intellij.openapi.project.DumbAwareAction
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.util.DownloadResult
 import org.rust.ide.notifications.showBalloon
-import java.nio.file.Path
 
-class InstallComponentAction(
-    private val projectDirectory: Path,
-    private val componentName: String
+class InstallCargoPackageAction(
+    private val packageName: String
 ) : DumbAwareAction("Install") {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        val rustup = project.toolchain?.rustup(projectDirectory) ?: return
+        val cargo = project.toolchain?.rawCargo() ?: return
         Notification.get(e).expire()
-        object : Task.Backgroundable(project, "Installing $componentName...") {
+        object : Task.Backgroundable(project, "Installing $packageName...") {
             override fun shouldStartInBackground(): Boolean = false
             override fun run(indicator: ProgressIndicator) {
-                val result = rustup.downloadComponent(myProject, componentName) as? DownloadResult.Err ?: return
+                val result = cargo.installPackage(myProject, packageName) as? DownloadResult.Err ?: return
                 myProject.showBalloon(result.error, NotificationType.ERROR)
             }
         }.queue()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -54,6 +54,9 @@
                             serviceImplementation="org.rust.ide.settings.RsCodeInsightSettings"/>
         <editorActionHandler action="EditorEnter" implementationClass="org.rust.ide.actions.RsEnterHandler"/>
 
+        <applicationService serviceInterface="org.rust.cargo.runconfig.RsRunConfigurationExtensionManager"
+                            serviceImplementation="org.rust.cargo.runconfig.RsRunConfigurationExtensionManager"/>
+
         <!-- Selection Handler -->
 
         <extendWordSelectionHandler implementation="org.rust.ide.wordSelection.RsBlockSelectionHandler"/>
@@ -780,6 +783,11 @@
         <projectService serviceImplementation="org.rust.lang.core.resolve.ref.RsResolveCache"/>
 
     </extensions>
+
+    <extensionPoints>
+        <extensionPoint qualifiedName="org.rust.runConfigurationExtension"
+                        interface="org.rust.cargo.runconfig.CargoCommandConfigurationExtension"/>
+    </extensionPoints>
 
     <application-components>
         <component>

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -22,7 +22,7 @@ import org.rust.cargo.project.workspace.CargoWorkspaceData.Target
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.project.workspace.StandardLibrary
 import org.rust.cargo.toolchain.RustToolchain
-import org.rust.cargo.toolchain.Rustup
+import org.rust.cargo.util.DownloadResult
 import java.nio.file.Paths
 
 object DefaultDescriptor : RustProjectDescriptorBase()
@@ -78,7 +78,7 @@ open class WithRustup(private val delegate: RustProjectDescriptorBase) : RustPro
     private val toolchain: RustToolchain? by lazy { RustToolchain.suggest() }
 
     private val rustup by lazy { toolchain?.rustup(Paths.get(".")) }
-    val stdlib by lazy { (rustup?.downloadStdlib() as? Rustup.DownloadResult.Ok)?.value }
+    val stdlib by lazy { (rustup?.downloadStdlib() as? DownloadResult.Ok)?.value }
 
     override val skipTestReason: String?
         get() {


### PR DESCRIPTION
Add [CLion's CPU profiler](https://www.jetbrains.com/help/clion/cpu-profiler.html) support (perf on Linux and DTrace on MacOS).

Huge thanks to @KirillTim for help!

### Perf
<img width="1167" alt="Screenshot 2019-03-14 at 11 41 04" src="https://user-images.githubusercontent.com/4854600/54342739-4fb27680-464e-11e9-9071-e5804959579f.png">
<img width="1167" alt="Screenshot 2019-03-14 at 11 42 38" src="https://user-images.githubusercontent.com/4854600/54342865-9607d580-464e-11e9-94eb-256b0d51118a.png">


### DTrace
<img width="965" alt="Screenshot 2019-03-19 at 19 09 08" src="https://user-images.githubusercontent.com/4854600/54622422-a23ec900-4a7a-11e9-81fd-5ce1937d1436.png">
<img width="965" alt="Screenshot 2019-03-19 at 19 10 03" src="https://user-images.githubusercontent.com/4854600/54622424-a23ec900-4a7a-11e9-82b7-6d3e91d9ecef.png">

