### PR TITLE
Fix "Incorrect CachedValue use" error in resolve cache

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsResolveCache.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsResolveCache.kt
@@ -101,13 +101,16 @@ class RsResolveCache(messageBus: MessageBus) {
             ResolveCacheDependency.LOCAL, ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE -> {
                 val owner = element.findModificationTrackerOwner()
                 return if (owner != null) {
-                    CachedValuesManager.getCachedValue(owner, LOCAL_CACHE_KEY) {
-                        if (dep == ResolveCacheDependency.LOCAL) {
+                    if (dep == ResolveCacheDependency.LOCAL) {
+                        CachedValuesManager.getCachedValue(owner, LOCAL_CACHE_KEY) {
                             CachedValueProvider.Result.create(
                                 createWeakMap(),
                                 owner.modificationTracker
                             )
-                        } else {
+                        }
+
+                    } else {
+                        CachedValuesManager.getCachedValue(owner, LOCAL_CACHE_KEY2) {
                             CachedValueProvider.Result.create(
                                 createWeakMap(),
                                 owner.project.rustStructureModificationTracker,
@@ -255,6 +258,7 @@ private val EMPTY_RESOLVE_RESULT = StrongValueReference<Any, Array<ResolveResult
 private val EMPTY_LIST = StrongValueReference<Any, List<Any>>(emptyList())
 
 private val LOCAL_CACHE_KEY: Key<CachedValue<ConcurrentMap<PsiElement, Any?>>> = Key.create("LOCAL_CACHE_KEY")
+private val LOCAL_CACHE_KEY2: Key<CachedValue<ConcurrentMap<PsiElement, Any?>>> = Key.create("LOCAL_CACHE_KEY2")
 
 private fun ensureValidResult(result: Any?): Unit = when (result) {
     is ResolveResult -> ensureValidPsi(result)


### PR DESCRIPTION
Fixes
```
java.lang.Throwable: Incorrect CachedValue use: same CV with different captured context, this can cause unstable results and invalid PSI access.
Field $dep in class org.rust.lang.core.resolve.ref.RsResolveCache$getCacheFor$1 has non-equivalent values:
  LOCAL and
  LOCAL_AND_RUST_STRUCTURE
Either make equals() hold for these values, or avoid this dependency, e.g. by extracting CV provider into a static method.
  at com.intellij.openapi.diagnostic.Logger.error(Logger.java:145)
  at com.intellij.util.CachedValueStabilityChecker.complain(CachedValueStabilityChecker.java:158)
  at com.intellij.util.CachedValueStabilityChecker.checkFieldEquivalence(CachedValueStabilityChecker.java:129)
  at com.intellij.util.CachedValueStabilityChecker.checkFieldEquivalence(CachedValueStabilityChecker.java:125)
  at com.intellij.util.CachedValueStabilityChecker.checkProvidersEquivalent(CachedValueStabilityChecker.java:86)
  at com.intellij.util.CachedValuesManagerImpl.getCachedValueFromExHolder(CachedValuesManagerImpl.java:60)
  at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:45)
  at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:147)
  at org.rust.lang.core.resolve.ref.RsResolveCache.getCacheFor(RsResolveCache.kt:104)
  at org.rust.lang.core.resolve.ref.RsResolveCache.resolveWithCaching(RsResolveCache.kt:86)
  at org.rust.lang.core.resolve.ref.RsReferenceCached.cachedMultiResolve(RsReferenceCached.kt:28)
  at org.rust.lang.core.resolve.ref.RsReferenceCached.multiResolve(RsReferenceCached.kt:21)
  at com.intellij.psi.PsiPolyVariantReferenceBase.resolve(PsiPolyVariantReferenceBase.java:47)
  at org.rust.lang.core.resolve.ref.RsReferenceBase.resolve(RsReferenceBase.kt:28)
  at org.rust.ide.annotator.RsHighlightingAnnotator.highlightReference(RsHighlightingAnnotator.kt:45)
  at org.rust.ide.annotator.RsHighlightingAnnotator.annotateInternal(RsHighlightingAnnotator.kt:27)
  at org.rust.ide.annotator.RsAnnotatorBase.annotate(RsAnnotatorBase.kt:21)
```

(Really I think everything was OK and it was just a false-positive of CachedValueStabilityChecker)

bors r+