### PR TITLE
MACRO: support `?`-groups

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -369,6 +369,12 @@ private class MacroPattern private constructor(
                 break
             }
 
+            if (group.q != null) {
+                // `$(...)?` means "0 or 1 occurrences"
+                MacroExpansionMarks.questionMarkGroupEnd.hit()
+                break
+            }
+
             if (separator != null) {
                 mark?.drop()
                 mark = macroCallBody.mark()
@@ -506,6 +512,7 @@ object MacroExpansionMarks {
     val failMatchPatternByBindingType = Testmark("failMatchPatternByBindingType")
     val failMatchGroupBySeparator = Testmark("failMatchGroupBySeparator")
     val failMatchGroupTooFewElements = Testmark("failMatchGroupTooFewElements")
+    val questionMarkGroupEnd = Testmark("questionMarkGroupEnd")
     val groupInputEnd1 = Testmark("groupInputEnd1")
     val groupInputEnd2 = Testmark("groupInputEnd2")
     val groupInputEnd3 = Testmark("groupInputEnd3")

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -401,6 +401,28 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         mod plus_matched {}
     """ to null)
 
+    // TODO should work only on 2018 edition
+    fun `test match * vs ? group pattern`() = doTest(MacroExpansionMarks.questionMarkGroupEnd, """
+        macro_rules! foo {
+            ($ ($ i:ident)?) => (
+                mod question_matched {}
+            );
+            ($ ($ i:ident)*) => (
+                mod asterisk_matched {}
+            );
+        }
+
+        foo! {  }
+        foo! { foo }
+        foo! { foo bar }
+    """, """
+        mod question_matched {}
+    """, """
+        mod question_matched {}
+    """, """
+        mod asterisk_matched {}
+    """)
+
     fun `test group pattern with collapsed token as a separator`() = doTest("""
         macro_rules! foo {
             ($ ($ i:ident)&&*) => ($ (


### PR DESCRIPTION
Fixes #3521

bors r+