### PR TITLE
MACRO: allow to expand std macros (outside of std)

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -95,14 +95,12 @@ private data class WithParent(
         subst.variables[name] ?: parent?.getVar(name)
 }
 
-private val STD_MACRO_WHITELIST = setOf("write", "writeln")
-
 class MacroExpander(val project: Project) {
     private val psiFactory = RsPsiFactory(project, markGenerated = false)
 
     fun expandMacro(def: RsMacro, call: RsMacroCall): MacroExpansion? {
         // All std macros contain the only `impl`s which are not supported for now, so ignoring them
-        if (def.containingCargoTarget?.pkg?.origin == PackageOrigin.STDLIB && def.name !in STD_MACRO_WHITELIST) {
+        if (call.containingCargoTarget?.pkg?.origin == PackageOrigin.STDLIB) {
             return null
         }
 

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -6,6 +6,8 @@
 package org.rust.lang.core.macros
 
 import com.intellij.psi.tree.TokenSet
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.core.psi.RS_KEYWORDS
 import org.rust.lang.core.psi.RsElementTypes.CRATE
 import org.rust.lang.core.psi.tokenSetOf
@@ -612,6 +614,15 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
        vec!(i32);
     """, """
         fn foo() -> i32 {}
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test standard "vec!"`() = checkSingleMacro("""
+        fn main() {
+            vec![1, 2, 3];
+        } //^
+    """, """
+        <[_]>::into_vec(box [(1), (2), (3)])
     """)
 
     fun `test expend macro definition`() = doTest("""


### PR DESCRIPTION
(was blocked unintentionally)