### PR TITLE
TOML: Support hexadecimal, binary, octal integers and nan/inf floats

### DIFF
--- a/intellij-toml/src/main/grammars/TomlLexer.flex
+++ b/intellij-toml/src/main/grammars/TomlLexer.flex
@@ -26,10 +26,18 @@ BOOLEAN=true|false
 BARE_KEY_OR_NUMBER=-?[0-9]+
 BARE_KEY_OR_DATE={DATE}[Zz]?
 
-NUMBER=[-+]?
- (0|[1-9](_?[0-9])*) // no leading zeros
- (\.[0-9](_?[0-9])*)?
- ([eE][-+]?[1-9](_?[0-9])*)?
+DEC_INT=[-+]?(0|[1-9](_?[0-9])*) // no leading zeros
+HEX_INT=0x[0-9a-fA-F](_?[0-9a-fA-F])*
+OCT_INT=0o[0-7](_?[0-7])*
+BIN_INT=0b[01](_?[01])*
+INTEGER={DEC_INT}|{HEX_INT}|{OCT_INT}|{BIN_INT}
+
+EXP=[eE]{DEC_INT}
+FRAC=\.[0-9](_?[0-9])*
+SPECIAL_FLOAT=[-+]?(inf|nan)
+FLOAT={DEC_INT}({EXP}|{FRAC}{EXP}?)|{SPECIAL_FLOAT}
+
+NUMBER={FLOAT}|{INTEGER}
 
 DATE=[0-9]{4}-[0-9]{2}-[0-9]{2}
 TIME=[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/numbers.toml
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/numbers.toml
@@ -6,6 +6,15 @@ int5 = 1_000
 int6 = 5_349_221
 int7 = 1_2_3_4_5
 
+hex1 = 0xDEADBEEF
+hex2 = 0xdeadbeef
+hex3 = 0xdead_beef
+
+oct1 = 0o01234567
+oct2 = 0o755
+
+bin1 = 0b11010110
+
 flt1 = +1.0
 flt2 = 3.1415
 flt3 = -0.01
@@ -14,3 +23,11 @@ flt5 = 1e6
 flt6 = -2E-2
 flt7 = 6.626e-34
 flt8 = 9_224_617.445_991_228_313
+
+sf1 = inf
+sf2 = +inf
+sf3 = -inf
+
+sf4 = nan
+sf5 = +nan
+sf6 = -nan

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/numbers.txt
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/numbers.txt
@@ -64,6 +64,60 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
+      PsiElement(BARE_KEY)('hex1')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlLiteral
+      PsiElement(NUMBER)('0xDEADBEEF')
+  PsiWhiteSpace('\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('hex2')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlLiteral
+      PsiElement(NUMBER)('0xdeadbeef')
+  PsiWhiteSpace('\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('hex3')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlLiteral
+      PsiElement(NUMBER)('0xdead_beef')
+  PsiWhiteSpace('\n\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('oct1')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlLiteral
+      PsiElement(NUMBER)('0o01234567')
+  PsiWhiteSpace('\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('oct2')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlLiteral
+      PsiElement(NUMBER)('0o755')
+  PsiWhiteSpace('\n\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('bin1')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlLiteral
+      PsiElement(NUMBER)('0b11010110')
+  PsiWhiteSpace('\n\n')
+  TomlKeyValue
+    TomlKey
       PsiElement(BARE_KEY)('flt1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
@@ -133,3 +187,57 @@ TOML File
     PsiWhiteSpace(' ')
     TomlLiteral
       PsiElement(NUMBER)('9_224_617.445_991_228_313')
+  PsiWhiteSpace('\n\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('sf1')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlLiteral
+      PsiElement(NUMBER)('inf')
+  PsiWhiteSpace('\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('sf2')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlLiteral
+      PsiElement(NUMBER)('+inf')
+  PsiWhiteSpace('\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('sf3')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlLiteral
+      PsiElement(NUMBER)('-inf')
+  PsiWhiteSpace('\n\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('sf4')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlLiteral
+      PsiElement(NUMBER)('nan')
+  PsiWhiteSpace('\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('sf5')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlLiteral
+      PsiElement(NUMBER)('+nan')
+  PsiWhiteSpace('\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('sf6')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlLiteral
+      PsiElement(NUMBER)('-nan')


### PR DESCRIPTION
Closes https://github.com/intellij-rust/intellij-rust/issues/3118.
