### PR TITLE
Add CLion's Valgrind support

### DIFF
--- a/clion/src/191/main/kotlin/org/rust/clion/profiler/dtrace/RsDTraceConfigurationExtension.kt
+++ b/clion/src/191/main/kotlin/org/rust/clion/profiler/dtrace/RsDTraceConfigurationExtension.kt
@@ -35,12 +35,11 @@ class RsDTraceConfigurationExtension : CargoCommandConfigurationExtension() {
 
     override fun patchCommandLine(
         configuration: CargoCommandConfiguration,
-        runnerSettings: RunnerSettings?,
+        environment: ExecutionEnvironment,
         cmdLine: GeneralCommandLine,
-        runnerId: String,
         context: ConfigurationExtensionContext
     ) {
-        if (RsProfilerRunner.RUNNER_ID != runnerId) return
+        if (RsProfilerRunner.RUNNER_ID != environment.runner.runnerId) return
         val starterPath = profilerStarterPath()
         if (!starterPath.exists()) throw ExecutionException("Internal error: Can't find process starter")
         cmdLine.withEnvironment(DYLD_INSERT_LIBRARIES, starterPath.absolutePath)
@@ -50,11 +49,9 @@ class RsDTraceConfigurationExtension : CargoCommandConfigurationExtension() {
         configuration: CargoCommandConfiguration,
         handler: ProcessHandler,
         environment: ExecutionEnvironment,
-        runnerSettings: RunnerSettings?,
-        runnerId: String,
         context: ConfigurationExtensionContext
     ) {
-        if (RsProfilerRunner.RUNNER_ID != runnerId) return
+        if (RsProfilerRunner.RUNNER_ID != environment.runner.runnerId) return
 
         val targetProcess = (handler as? BaseProcessHandler<*>)?.process
             ?: throw ExecutionException("Profiler connection error: can't detect target process id")

--- a/clion/src/191/main/kotlin/org/rust/clion/profiler/perf/RsPerfConfigurationExtension.kt
+++ b/clion/src/191/main/kotlin/org/rust/clion/profiler/perf/RsPerfConfigurationExtension.kt
@@ -39,12 +39,11 @@ class RsPerfConfigurationExtension : CargoCommandConfigurationExtension() {
 
     override fun patchCommandLine(
         configuration: CargoCommandConfiguration,
-        runnerSettings: RunnerSettings?,
+        environment: ExecutionEnvironment,
         cmdLine: GeneralCommandLine,
-        runnerId: String,
         context: ConfigurationExtensionContext
     ) {
-        if (RsProfilerRunner.RUNNER_ID != runnerId) return
+        if (RsProfilerRunner.RUNNER_ID != environment.runner.runnerId) return
         val project = configuration.project
         val settings = CPPProfilerSettings.instance.state
         val perfPath = settings.executablePath.orEmpty()
@@ -61,11 +60,9 @@ class RsPerfConfigurationExtension : CargoCommandConfigurationExtension() {
         configuration: CargoCommandConfiguration,
         handler: ProcessHandler,
         environment: ExecutionEnvironment,
-        runnerSettings: RunnerSettings?,
-        runnerId: String,
         context: ConfigurationExtensionContext
     ) {
-        if (RsProfilerRunner.RUNNER_ID != runnerId) return
+        if (RsProfilerRunner.RUNNER_ID != environment.runner.runnerId) return
         if (handler !is BaseProcessHandler<*>)
             throw ExecutionException("Can't detect target process id")
         val outputFile = context.getUserData(PERF_OUTPUT_FILE_KEY)

--- a/clion/src/191/main/kotlin/org/rust/clion/valgrind/RsValgrindConfigurationExtension.kt
+++ b/clion/src/191/main/kotlin/org/rust/clion/valgrind/RsValgrindConfigurationExtension.kt
@@ -1,0 +1,198 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.valgrind
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.CommandLineState
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.RunnerSettings
+import com.intellij.execution.configurations.SearchScopeProvider
+import com.intellij.execution.filters.TextConsoleBuilderImpl
+import com.intellij.execution.process.ProcessAdapter
+import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.execution.ui.ConsoleView
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.util.ArrayUtil
+import com.intellij.util.ui.StatusText
+import com.jetbrains.cidr.cpp.CPPBundle
+import com.jetbrains.cidr.cpp.profiling.*
+import com.jetbrains.cidr.cpp.profiling.ui.MemoryProfileOutputPanel
+import com.jetbrains.cidr.cpp.valgrind.*
+import com.jetbrains.cidr.lang.toolchains.CidrToolEnvironment
+import org.rust.cargo.runconfig.CargoCommandConfigurationExtension
+import org.rust.cargo.runconfig.ConfigurationExtensionContext
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import java.io.File
+import java.io.IOException
+
+private val LOG = Logger.getInstance(RsValgrindConfigurationExtension::class.java.name)
+
+class RsValgrindConfigurationExtension : CargoCommandConfigurationExtension() {
+    override fun isApplicableFor(configuration: CargoCommandConfiguration): Boolean {
+        return true
+    }
+
+    override fun isEnabledFor(applicableConfiguration: CargoCommandConfiguration, runnerSettings: RunnerSettings?): Boolean =
+        SystemInfo.isLinux || SystemInfo.isMac
+
+    override fun patchCommandLine(
+        configuration: CargoCommandConfiguration,
+        environment: ExecutionEnvironment,
+        cmdLine: GeneralCommandLine,
+        context: ConfigurationExtensionContext
+    ) {
+        if (RsValgrindRunner.RUNNER_ID != environment.runner.runnerId) return
+
+        val programPath = cmdLine.exePath
+        val valgrindPath = ValgrindSettings.getInstance().valgrindPath
+        if (!File(programPath).exists()) {
+            throw ExecutionException("File not found: $programPath")
+        }
+        val project = configuration.project
+        if (StringUtil.isEmpty(valgrindPath) || !File(valgrindPath).exists()) {
+            ShowSettingsUtil.getInstance().showSettingsDialog(project, ValgrindConfigurable::class.java)
+            return
+        }
+        try {
+            val outputFile = FileUtil.createTempFile("valgrind", null, true)
+            val outputFilePath = outputFile.absolutePath
+            cmdLine.exePath = valgrindPath
+            // scheme of command line arguments
+            // <valgrind-arguments> <program> <program-arguments>
+            val parametersBuilder = ValgrindCommandLineParametersBuilder()
+            val valgrindParameters = parametersBuilder.build(outputFilePath)
+            valgrindParameters.add(programPath)
+            cmdLine.parametersList.prependAll(*ArrayUtil.toStringArray(valgrindParameters))
+            putUserData<File>(OUTPUT_FILE_PATH_KEY, outputFile, configuration, context)
+        } catch (e: IOException) {
+            throw ExecutionException(e)
+        }
+    }
+
+    override fun patchCommandLineState(
+        configuration: CargoCommandConfiguration,
+        environment: ExecutionEnvironment,
+        state: CommandLineState,
+        context: ConfigurationExtensionContext
+    ) {
+        if (RsValgrindRunner.RUNNER_ID != environment.runner.runnerId) return
+
+        val project = configuration.project
+        val treeDataModel = MemoryProfileTreeDataModel("Valgrind", project)
+        val outputPanel = MemoryProfileOutputPanel(treeDataModel, ValgrindUtil.EDIT_SETTINGS_ACTION_ID, ValgrindUtil.TREE_POPUP_ID, project)
+        putUserData(DATA_MODEL_KEY, treeDataModel, configuration, context)
+        putUserData(OUTPUT_PANEL_KEY, outputPanel, configuration, context)
+        val console = state.consoleBuilder.console
+        state.consoleBuilder = object : TextConsoleBuilderImpl(project, SearchScopeProvider.createSearchScope(environment.project, environment.runProfile)) {
+            override fun getConsole(): ConsoleView {
+                val icon = ValgrindExecutor.getExecutorInstance().icon
+                return MemoryProfileConsoleViewWrapper(ValgrindUtil.PROFILER_NAME, console, outputPanel, project, icon)
+            }
+        }
+    }
+
+    override fun attachToProcess(
+        configuration: CargoCommandConfiguration,
+        handler: ProcessHandler,
+        environment: ExecutionEnvironment,
+        context: ConfigurationExtensionContext
+    ) {
+        if (RsValgrindRunner.RUNNER_ID != environment.runner.runnerId) return
+
+        val outputFile = getUserData<File>(OUTPUT_FILE_PATH_KEY, configuration, context) ?: return
+        val treeDataModel = getUserData<MemoryProfileTreeDataModel>(DATA_MODEL_KEY, configuration, context) ?: return
+        val outputPanel = getUserData<MemoryProfileOutputPanel>(OUTPUT_PANEL_KEY, configuration, context) ?: return
+        try {
+            val valgrindHandler = ValgrindHandler(treeDataModel, CidrToolEnvironment())
+            val outputFileConsumer = ValgrindOutputConsumer(valgrindHandler)
+            val accumulator = MemoryProfileStringAccumulator()
+            val compositeConsumer = MemoryProfileCompositeConsumer(outputFileConsumer, accumulator)
+            val fileReader = MemoryProfileFileReader(outputFile, compositeConsumer, ValgrindUtil.PROFILER_NAME)
+            handler.addProcessListener(object : ProcessAdapter() {
+                override fun processTerminated(event: ProcessEvent) {
+                    try {
+                        fileReader.stop()
+                        Disposer.dispose(compositeConsumer)
+                        deleteFile(outputFile)
+                    } finally {
+                        fileReader.close()
+                    }
+                }
+            })
+            configureUIListeners(outputPanel, handler, accumulator, configuration.project)
+        } catch (e: IOException) {
+            LOG.warn("Exception during processListener setup: $e")
+        }
+
+    }
+
+    private fun configureUIListeners(
+        outputPanel: MemoryProfileOutputPanel,
+        handler: ProcessHandler,
+        accumulator: MemoryProfileStringAccumulator,
+        project: Project
+    ) {
+        val application = ApplicationManager.getApplication()
+        val expiredCondition = { _: Any -> !project.isOpen || project.isDisposed }
+        val tree = outputPanel.tree
+        handler.addProcessListener(object : ProcessAdapter() {
+            override fun startNotified(event: ProcessEvent) {
+                application.invokeLater({
+                    tree.setPaintBusy(true)
+                    tree.emptyText.text = CPPBundle.message("valgrind.progress")
+                }, expiredCondition)
+            }
+
+            override fun processTerminated(event: ProcessEvent) {
+                application.invokeLater({
+                    tree.setPaintBusy(false)
+                    tree.emptyText.text = StatusText.DEFAULT_EMPTY_TEXT
+                    outputPanel.setExportContent(accumulator.toString())
+                }, expiredCondition)
+            }
+        })
+    }
+
+    private fun deleteFile(file: File) {
+        val application = ApplicationManager.getApplication()
+        if (!application.isUnitTestMode && !application.isInternal) {
+            FileUtil.delete(file)
+        }
+    }
+
+    private fun <T> putUserData(key: Key<T>, value: T, configuration: CargoCommandConfiguration, context: ConfigurationExtensionContext) {
+        if (configuration.getUserData<Boolean>(STORE_DATA_IN_RUN_CONFIGURATION) == true) {
+            configuration.putUserData(key, value)
+        } else {
+            context.putUserData(key, value)
+        }
+    }
+
+    private fun <T> getUserData(key: Key<T>, configuration: CargoCommandConfiguration, context: ConfigurationExtensionContext): T? {
+        return if (configuration.getUserData(STORE_DATA_IN_RUN_CONFIGURATION) == true)
+            configuration.getUserData(key)
+        else
+            context.getUserData(key)
+    }
+
+    companion object {
+        val OUTPUT_FILE_PATH_KEY = Key.create<File>("valgrind.output_file_path_key")
+        val DATA_MODEL_KEY = Key.create<MemoryProfileTreeDataModel>("valgrind.data_model_key")
+        val OUTPUT_PANEL_KEY = Key.create<MemoryProfileOutputPanel>("valgrind.output_panel_key")
+
+        val STORE_DATA_IN_RUN_CONFIGURATION = Key.create<Boolean>("valgrind.store_data_in_run_configuration")
+    }
+}

--- a/clion/src/191/main/kotlin/org/rust/clion/valgrind/RsValgrindRunner.kt
+++ b/clion/src/191/main/kotlin/org/rust/clion/valgrind/RsValgrindRunner.kt
@@ -1,0 +1,23 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.valgrind
+
+import com.intellij.openapi.util.SystemInfo
+import com.jetbrains.cidr.cpp.valgrind.ValgrindExecutor
+import org.rust.cargo.runconfig.RsAsyncRunner
+
+private const val ERROR_MESSAGE_TITLE: String = "Valgrind is not possible"
+
+class RsValgrindRunner : RsAsyncRunner(ValgrindExecutor.EXECUTOR_ID, ERROR_MESSAGE_TITLE) {
+    override fun getRunnerId(): String = RUNNER_ID
+
+    override fun isApplicable(): Boolean =
+        SystemInfo.isMac || SystemInfo.isLinux
+
+    companion object {
+        const val RUNNER_ID: String = "RsValgrindRunner"
+    }
+}

--- a/clion/src/191/main/resources/META-INF/platform-clion-only.xml
+++ b/clion/src/191/main/resources/META-INF/platform-clion-only.xml
@@ -6,10 +6,14 @@
     <extensions defaultExtensionNs="com.intellij">
         <programRunner implementation="org.rust.clion.profiler.RsProfilerRunner"/>
         <projectService serviceImplementation="org.rust.clion.profiler.RsCachingStackElementReader"/>
+
+        <programRunner implementation="org.rust.clion.valgrind.RsValgrindRunner"/>
     </extensions>
 
     <extensions defaultExtensionNs="org.rust">
         <runConfigurationExtension implementation="org.rust.clion.profiler.perf.RsPerfConfigurationExtension"/>
         <runConfigurationExtension implementation="org.rust.clion.profiler.dtrace.RsDTraceConfigurationExtension"/>
+
+        <runConfigurationExtension implementation="org.rust.clion.valgrind.RsValgrindConfigurationExtension"/>
     </extensions>
 </idea-plugin>

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandConfigurationExtension.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandConfigurationExtension.kt
@@ -6,6 +6,7 @@
 package org.rust.cargo.runconfig
 
 import com.intellij.execution.configuration.RunConfigurationExtensionBase
+import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.RunnerSettings
 import com.intellij.execution.process.ProcessHandler
@@ -24,18 +25,23 @@ abstract class CargoCommandConfigurationExtension : RunConfigurationExtensionBas
         configuration: CargoCommandConfiguration,
         handler: ProcessHandler,
         environment: ExecutionEnvironment,
-        runnerSettings: RunnerSettings?,
-        runnerId: String,
         context: ConfigurationExtensionContext
     )
 
     abstract fun patchCommandLine(
         configuration: CargoCommandConfiguration,
-        runnerSettings: RunnerSettings?,
+        environment: ExecutionEnvironment,
         cmdLine: GeneralCommandLine,
-        runnerId: String,
         context: ConfigurationExtensionContext
     )
+
+    open fun patchCommandLineState(
+        configuration: CargoCommandConfiguration,
+        environment: ExecutionEnvironment,
+        state: CommandLineState,
+        context: ConfigurationExtensionContext
+    ) {
+    }
 
     override fun patchCommandLine(
         configuration: CargoCommandConfiguration,

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsAsyncRunner.kt
@@ -76,11 +76,12 @@ abstract class RsAsyncRunner(private val executorId: String, private val errorMe
 
         RsRunConfigurationExtensionManager.getInstance().patchCommandLine(
             runConfiguration,
-            environment.runnerSettings,
+            environment,
             cmd,
-            environment.runner.runnerId,
             context
         )
+
+        RsRunConfigurationExtensionManager.getInstance().patchCommandLineState(runConfiguration, environment, state, context)
 
         val handler = RsKillableColoredProcessHandler(cmd)
         ProcessTerminatedListener.attach(handler) // shows exit code upon termination
@@ -89,8 +90,6 @@ abstract class RsAsyncRunner(private val executorId: String, private val errorMe
             runConfiguration,
             handler,
             environment,
-            environment.runnerSettings,
-            environment.runner.runnerId,
             context
         )
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsRunConfigurationExtensionManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsRunConfigurationExtensionManager.kt
@@ -6,8 +6,8 @@
 package org.rust.cargo.runconfig
 
 import com.intellij.execution.configuration.RunConfigurationExtensionsManager
+import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.execution.configurations.RunnerSettings
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.components.service
@@ -18,24 +18,32 @@ class RsRunConfigurationExtensionManager : RunConfigurationExtensionsManager<Car
         configuration: CargoCommandConfiguration,
         handler: ProcessHandler,
         environment: ExecutionEnvironment,
-        runnerSettings: RunnerSettings?,
-        runnerId: String,
         context: ConfigurationExtensionContext
     ) {
-        processEnabledExtensions(configuration, runnerSettings) {
-            it.attachToProcess(configuration, handler, environment, runnerSettings, runnerId, context)
+        processEnabledExtensions(configuration, environment.runnerSettings) {
+            it.attachToProcess(configuration, handler, environment, context)
         }
     }
 
     fun patchCommandLine(
         configuration: CargoCommandConfiguration,
-        runnerSettings: RunnerSettings?,
+        environment: ExecutionEnvironment,
         cmdLine: GeneralCommandLine,
-        runnerId: String,
         context: ConfigurationExtensionContext
     ) {
-        processEnabledExtensions(configuration, runnerSettings) {
-            it.patchCommandLine(configuration, runnerSettings, cmdLine, runnerId, context)
+        processEnabledExtensions(configuration, environment.runnerSettings) {
+            it.patchCommandLine(configuration, environment, cmdLine, context)
+        }
+    }
+
+    fun patchCommandLineState(
+        configuration: CargoCommandConfiguration,
+        environment: ExecutionEnvironment,
+        state: CommandLineState,
+        context: ConfigurationExtensionContext
+    ) {
+        processEnabledExtensions(configuration, environment.runnerSettings) {
+            it.patchCommandLineState(configuration, environment, state, context)
         }
     }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/console/CargoConsoleBuilder.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/console/CargoConsoleBuilder.kt
@@ -17,7 +17,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import org.rust.cargo.runconfig.test.CargoTestConsoleProperties
 import org.rust.cargo.runconfig.test.CargoTestConsoleProperties.Companion.TEST_FRAMEWORK_NAME
 
-class CargoConsoleBuilder(project: Project, scope: GlobalSearchScope) : TextConsoleBuilderImpl(project, scope) {
+open class CargoConsoleBuilder(project: Project, scope: GlobalSearchScope) : TextConsoleBuilderImpl(project, scope) {
     override fun createConsole(): ConsoleView = CargoConsoleView(project, scope, isViewer, true)
 }
 


### PR DESCRIPTION
Add [CLion's Valgrind Memcheck](https://www.jetbrains.com/help/clion/memory-profiling-with-valgrind.html) support. Works on Linux and on MacOS.

I don't know how to properly install Valgrind on MacOS Mojave, but you can try [this solution](https://stackoverflow.com/a/54818930/10445191).

Merge after #3529 

<img width="906" alt="Screenshot 2019-03-14 at 19 20 07" src="https://user-images.githubusercontent.com/4854600/54435325-45bd7000-4741-11e9-8e0d-68b8039fa83d.png">
