### PR TITLE
add references from pattern fields,fix pattern parsing

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -489,7 +489,12 @@ PatBinding ::= BindingMode? identifier !'...' !'::' {
   mixin = "org.rust.lang.core.psi.ext.RsPatBindingImplMixin"
 }
 
-PatField ::= identifier ':' Pat | box? PatBinding
+PatFieldFull ::= (identifier | INTEGER_LITERAL ) ':' Pat {
+  implements = [ "org.rust.lang.core.psi.ext.RsReferenceElement" ]
+  mixin = "org.rust.lang.core.psi.ext.RsPatFieldFullImplMixin"
+}
+
+PatField ::= PatFieldFull | box? PatBinding
 
 BindingMode ::= ref mut? | mut
 

--- a/src/main/kotlin/org/rust/ide/inspections/checkMatch/CheckMatchUtils.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/checkMatch/CheckMatchUtils.kt
@@ -95,9 +95,9 @@ private val RsPat.kind: PatternKind
             val indices = item.namedFields.withIndex().associateBy({ it.value.name }, { it.index })
 
             val subPatterns = patFieldList
-                .sortedBy { indices[it.identifier?.text] }
+                .sortedBy { indices[it.patFieldFull?.referenceNameElement?.text] }
                 .map { patField ->
-                    val pat = patField.pat
+                    val pat = patField.patFieldFull?.pat
                     val binding = patField.patBinding
                     pat?.lower
                         ?: binding?.type?.let { ty -> Pattern(ty, PatternKind.Binding(ty, binding.name.orEmpty())) }

--- a/src/main/kotlin/org/rust/lang/core/cfg/CFGBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/cfg/CFGBuilder.kt
@@ -173,7 +173,7 @@ class CFGBuilder(val graph: Graph<CFGNodeData, CFGEdgeData>, val entry: CFGNode,
         finishWith { processSubPats(patTupleStruct, patTupleStruct.patList) }
 
     override fun visitPatStruct(patStruct: RsPatStruct) =
-        finishWith { processSubPats(patStruct, patStruct.patFieldList.mapNotNull { it.pat }) }
+        finishWith { processSubPats(patStruct, patStruct.patFieldList.mapNotNull { it.patFieldFull?.pat }) }
 
     override fun visitPatSlice(patSlice: RsPatSlice) =
         finishWith { processSubPats(patSlice, patSlice.patList) }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPat.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPat.kt
@@ -19,7 +19,9 @@ val RsPat.isIrrefutable: Boolean
         is RsPatRef ->
             pat.pat.isIrrefutable
         is RsPatStruct ->
-            pat.path.isIrrefutable && pat.patFieldList.all { it.pat?.isIrrefutable ?: (it.patBinding != null) }
+            pat.path.isIrrefutable && pat.patFieldList.all {
+                it.patFieldFull?.pat?.isIrrefutable ?: (it.patBinding != null)
+            }
         is RsPatTupleStruct ->
             pat.path.isIrrefutable && pat.patList.all { it.isIrrefutable }
         is RsPatIdent ->

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatField.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatField.kt
@@ -11,7 +11,8 @@ import org.rust.lang.core.psi.RsPatBinding
 import org.rust.lang.core.psi.RsPatField
 
 val RsPatField.kind: RsPatFieldKind
-    get() = patBinding?.let { RsPatFieldKind.Shorthand(it, box != null) } ?: RsPatFieldKind.Full(identifier!!, pat!!)
+    get() = patBinding?.let { RsPatFieldKind.Shorthand(it, box != null) }
+        ?: RsPatFieldKind.Full(patFieldFull!!.referenceNameElement, patFieldFull!!.pat)
 
 // PatField ::= identifier ':' Pat | box? PatBinding
 sealed class RsPatFieldKind {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatFieldFull.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatFieldFull.kt
@@ -1,0 +1,37 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi.ext
+
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RsPatFieldFull
+import org.rust.lang.core.psi.RsPatStruct
+import org.rust.lang.core.resolve.collectResolveVariants
+import org.rust.lang.core.resolve.processStructPatternFieldResolveVariants
+import org.rust.lang.core.resolve.ref.ResolveCacheDependency
+import org.rust.lang.core.resolve.ref.RsReference
+import org.rust.lang.core.resolve.ref.RsReferenceCached
+
+
+val RsPatFieldFull.parentStructPattern: RsPatStruct
+    get() = ancestorStrict()!!
+
+
+abstract class RsPatFieldFullImplMixin(node: ASTNode) : RsElementImpl(node), RsPatFieldFull {
+    override val referenceNameElement: PsiElement
+        get() = identifier ?: integerLiteral!!
+
+    override fun getReference(): RsReference = object : RsReferenceCached<RsPatFieldFull>(this@RsPatFieldFullImplMixin) {
+        override fun resolveInner(): List<RsElement> =
+            collectResolveVariants(element.referenceName) { processStructPatternFieldResolveVariants(element, it) }
+
+        override val RsPatFieldFull.referenceAnchor: PsiElement?
+            get() = referenceNameElement
+
+        override val cacheDependency: ResolveCacheDependency
+            get() = ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -135,6 +135,15 @@ fun processStructLiteralFieldResolveVariants(
     return false
 }
 
+fun processStructPatternFieldResolveVariants(
+    field: RsPatFieldFull,
+    processor: RsResolveProcessor
+): Boolean {
+    val resolved = field.parentStructPattern.path.reference.deepResolve()
+    val resolvedStruct = resolved as? RsFieldsOwner ?: return false
+    return processFieldDeclarations(resolvedStruct, processor)
+}
+
 fun processMethodCallExprResolveVariants(lookup: ImplLookup, receiverType: Ty, processor: RsMethodResolveProcessor): Boolean =
     processMethodDeclarationsWithDeref(lookup, receiverType, processor)
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/MemoryCategorization.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/MemoryCategorization.kt
@@ -332,8 +332,8 @@ class MemoryCategorizationContext(val lookup: ImplLookup, val inference: RsInfer
                 for (patField in pat.patFieldList) {
                     val binding = patField.patBinding ?: continue
                     val fieldType = inference.getBindingType(binding)
-                    val fieldName = patField.identifier?.text ?: continue
-                    val fieldPat = patField.pat ?: continue
+                    val fieldName = patField.patFieldFull?.referenceName ?: continue
+                    val fieldPat = patField.patFieldFull?.pat ?: continue
                     val fieldCmt = cmtOfField(pat, cmt, fieldName, fieldType)
                     walkPat(fieldCmt, fieldPat, callback)
                 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.lang.core.resolve
 
+import org.rust.lang.core.psi.RsTupleFieldDecl
+
 class RsTypeAwareResolveTest : RsResolveTestBase() {
     fun `test self method call expr`() = checkByCode("""
         struct S;
@@ -265,6 +267,50 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
                 x;
               //^
             }
+        }
+    """)
+
+    fun `test let struct literal field`() = checkByCode("""
+        struct S { x: f32 }
+                 //X
+        impl S {
+            fn foo(&self) {
+                let S { x: x } = S { x: 0. };
+                                   //^
+                x;
+            }
+        }
+    """)
+
+    fun `test let decl pat struct field`() = checkByCode("""
+        struct S { x: f32 }
+                 //X
+        impl S {
+            fn foo(&self) {
+                let S { x: x } = S { x: 0. };
+                      //^
+                x;
+            }
+        }
+    """)
+
+    fun `test let tuple literal field`() = checkByCodeGeneric<RsTupleFieldDecl>("""
+        struct S (f32);
+                 //X
+        fn foo() {
+            let S { 0: x } = S { 0: 0. };
+                               //^
+            x;
+        }
+    """)
+
+    fun `test let decl pat tuple field`() = checkByCodeGeneric<RsTupleFieldDecl>("""
+        struct S (f32);
+                //X
+        fn foo() {
+            let S { 0: x } = S { 0: 0. };
+                  //^
+            x;
         }
     """)
 


### PR DESCRIPTION
This is fix for some minor problems I have found while working on another issue  
- added references/highlighting of full structure pattern fields(see added test)
- Fixed parser error for tuple being destructured as block struct. Here is valid example that resulted in error in plugin:
```rust
struct A(i32,i32);
fn main(){
    let A{0:a,1:b} = A(0,0);
}
  ``` 
<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
