### PR TITLE
INSP: add deprecated attribute inspection

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1029,7 +1029,8 @@ private StructLiteralField_with_recover ::= StructLiteralField (',' | &'}') {
 private StructLiteralField_recover ::= !(identifier | INTEGER_LITERAL | ',' | '}' | '..' | '#')
 
 PathExpr ::= OuterAttr* PathGenericArgsWithColons {
- elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
+  elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
 WhileExpr ::= OuterAttr* LabelDecl? while Condition SimpleBlock {

--- a/src/main/kotlin/org/rust/ide/inspections/RsDeprecationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDeprecationInspection.kt
@@ -1,0 +1,82 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+
+class RsDeprecationInspection : RsLocalInspectionTool() {
+    override fun getDisplayName() = "Deprecated item"
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = object : RsVisitor() {
+        override fun visitElement(ref: RsElement) {
+            // item is non-inline module declaration or not reference element
+            if (ref is RsModDeclItem || ref !is RsWeakReferenceElement) return
+
+            var original = ref.reference?.resolve() ?: return
+
+            val identifier = ref.referenceNameElement ?: ref
+            original = when (original) {
+                is RsFile -> original.declaration
+                is RsAbstractable -> original.superItem
+                else -> original
+            } ?: original
+
+            if (original is RsOuterAttributeOwner &&
+                checkAndRegisterAsDeprecated(identifier, original, holder)) return
+        }
+    }
+
+    private fun checkAndRegisterAsDeprecated(identifier: PsiElement, original: RsOuterAttributeOwner, holder: ProblemsHolder): Boolean =
+        original.outerAttrList
+            .mapNotNull { DeprecatedAttribute.from(it) }
+            .firstOrNull()
+            ?.let { deprecatedAttr ->
+                holder.registerProblem(identifier, deprecatedAttr.getMessage(identifier.text), ProblemHighlightType.LIKE_DEPRECATED)
+                true
+            } ?: false
+}
+
+private class DeprecatedAttribute(val note: String?, val since: String?) {
+
+    fun getMessage(item: String): String = buildString {
+        append("'$item' is marked as deprecated")
+        if (since != null) append(" since version $since")
+        if (note != null) append(" ($note)")
+    }
+
+    companion object {
+        private const val DEPRECATED_ATTR_NAME: String = "deprecated"
+        private const val RUSTC_DEPRECATED_ATTR_NAME: String = "rustc_deprecated"
+
+        private const val SINCE_PARAM_NAME: String = "since"
+        private const val NOTE_PARAM_NAME: String = "note"
+        private const val REASON_PARAM_NAME: String = "reason"
+
+        fun from(attr: RsOuterAttr): DeprecatedAttribute? {
+            fun List<RsMetaItem>.getByName(name: String): String? =
+                firstOrNull { name == it.identifier?.text }?.litExpr?.stringLiteralValue
+
+            fun RsOuterAttr.extract(noteParamName: String, sinceParamName: String): DeprecatedAttribute {
+                val params = metaItem.metaItemArgs?.metaItemList
+                val note = params?.getByName(noteParamName)
+                val since = params?.getByName(sinceParamName)
+                return DeprecatedAttribute(note, since)
+            }
+
+            val identifier = attr.metaItem.identifier?.text
+            return when (identifier) {
+                DEPRECATED_ATTR_NAME -> attr.extract(NOTE_PARAM_NAME, SINCE_PARAM_NAME)
+                RUSTC_DEPRECATED_ATTR_NAME -> attr.extract(REASON_PARAM_NAME, SINCE_PARAM_NAME)
+                else -> null
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/RsDeprecationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDeprecationInspection.kt
@@ -5,11 +5,15 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemHighlightType.LIKE_DEPRECATED
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
-import org.rust.lang.core.psi.*
+import com.intellij.psi.util.parents
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.RsMetaItem
+import org.rust.lang.core.psi.RsModDeclItem
+import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.*
 
 class RsDeprecationInspection : RsLocalInspectionTool() {
@@ -20,63 +24,64 @@ class RsDeprecationInspection : RsLocalInspectionTool() {
             // item is non-inline module declaration or not reference element
             if (ref is RsModDeclItem || ref !is RsWeakReferenceElement) return
 
-            var original = ref.reference?.resolve() ?: return
+            val original = ref.reference?.resolve() ?: return
+            val identifier = ref.referenceNameElement ?: return
 
-            val identifier = ref.referenceNameElement ?: ref
-            original = when (original) {
+            val targetElement = when (original) {
                 is RsFile -> original.declaration
-                is RsAbstractable -> original.superItem
+                is RsAbstractable -> if (original.owner.isTraitImpl) original.superItem else original
                 else -> original
-            } ?: original
+            } ?: return
 
-            if (original is RsOuterAttributeOwner &&
-                checkAndRegisterAsDeprecated(identifier, original, holder)) return
+            if (ref.parents().none { it.hasAllowDeprecatedAttribute() }) {
+                checkAndRegisterAsDeprecated(identifier, targetElement, holder)
+            }
         }
     }
 
-    private fun checkAndRegisterAsDeprecated(identifier: PsiElement, original: RsOuterAttributeOwner, holder: ProblemsHolder): Boolean =
-        original.outerAttrList
-            .mapNotNull { DeprecatedAttribute.from(it) }
-            .firstOrNull()
-            ?.let { deprecatedAttr ->
-                holder.registerProblem(identifier, deprecatedAttr.getMessage(identifier.text), ProblemHighlightType.LIKE_DEPRECATED)
-                true
-            } ?: false
-}
-
-private class DeprecatedAttribute(val note: String?, val since: String?) {
-
-    fun getMessage(item: String): String = buildString {
-        append("'$item' is marked as deprecated")
-        if (since != null) append(" since version $since")
-        if (note != null) append(" ($note)")
+    private fun checkAndRegisterAsDeprecated(identifier: PsiElement, original: PsiElement, holder: ProblemsHolder) {
+        if (original is RsOuterAttributeOwner) {
+            val attr = original.queryAttributes.deprecatedAttribute ?: return
+            holder.registerProblem(identifier, attr.extractDeprecatedMessage(identifier.text), LIKE_DEPRECATED)
+        }
     }
 
+    private fun PsiElement.hasAllowDeprecatedAttribute(): Boolean = this is RsDocAndAttributeOwner &&
+        queryAttributes.hasAttributeWithArg(ALLOW_ATTR_NAME, DEPRECATED_ARG_NAME)
+
+    private fun RsMetaItem.extractDeprecatedMessage(item: String): String {
+        val (note, since) = if (DEPRECATED_ATTR_NAME == identifier?.text) {
+            extract(NOTE_PARAM_NAME, SINCE_PARAM_NAME)
+        } else {
+            extract(REASON_PARAM_NAME, SINCE_PARAM_NAME)
+        }
+
+        return buildString {
+            append("`$item` is deprecated")
+            if (since != null) append(" since $since")
+            if (note != null) append(": $note")
+        }
+    }
+
+    private fun RsMetaItem.extract(noteParamName: String, sinceParamName: String): DeprecatedAttribute {
+        val params = metaItemArgs?.metaItemList
+        val note = params?.getByName(noteParamName)
+        val since = params?.getByName(sinceParamName)
+        return DeprecatedAttribute(note, since)
+    }
+
+    private fun List<RsMetaItem>.getByName(name: String): String? = firstOrNull { name == it.name }?.value
+
+    private data class DeprecatedAttribute(val note: String?, val since: String?)
+
     companion object {
+        private const val ALLOW_ATTR_NAME: String = "allow"
         private const val DEPRECATED_ATTR_NAME: String = "deprecated"
-        private const val RUSTC_DEPRECATED_ATTR_NAME: String = "rustc_deprecated"
+
+        private const val DEPRECATED_ARG_NAME: String = "deprecated"
 
         private const val SINCE_PARAM_NAME: String = "since"
         private const val NOTE_PARAM_NAME: String = "note"
         private const val REASON_PARAM_NAME: String = "reason"
-
-        fun from(attr: RsOuterAttr): DeprecatedAttribute? {
-            fun List<RsMetaItem>.getByName(name: String): String? =
-                firstOrNull { name == it.identifier?.text }?.litExpr?.stringLiteralValue
-
-            fun RsOuterAttr.extract(noteParamName: String, sinceParamName: String): DeprecatedAttribute {
-                val params = metaItem.metaItemArgs?.metaItemList
-                val note = params?.getByName(noteParamName)
-                val since = params?.getByName(sinceParamName)
-                return DeprecatedAttribute(note, since)
-            }
-
-            val identifier = attr.metaItem.identifier?.text
-            return when (identifier) {
-                DEPRECATED_ATTR_NAME -> attr.extract(NOTE_PARAM_NAME, SINCE_PARAM_NAME)
-                RUSTC_DEPRECATED_ATTR_NAME -> attr.extract(REASON_PARAM_NAME, SINCE_PARAM_NAME)
-                else -> null
-            }
-        }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -120,6 +120,10 @@ class QueryAttributes(
     val reprAttributes: Sequence<RsMetaItem>
         get() = attrsByName("repr")
 
+    // #[deprecated(since, note)], #[rustc_deprecated(since, reason)]
+    val deprecatedAttribute: RsMetaItem?
+        get() = (attrsByName("deprecated") + attrsByName("rustc_deprecated")).firstOrNull()
+
     // `#[attributeName = "Xxx"]`
     private fun getStringAttributes(attributeName: String): Sequence<String?> = attrsByName(attributeName).map { it.value }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -276,6 +276,11 @@
                                    implementationClass="org.rust.ide.inspections.RsInspectionSuppressor"/>
 
         <localInspection language="Rust" groupName="Rust"
+                         displayName="Deprecated element"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RsDeprecationInspection"/>
+
+        <localInspection language="Rust" groupName="Rust"
                          displayName="Approximate Constants"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RsApproxConstantInspection"/>

--- a/src/main/resources/inspectionDescriptions/RsDeprecation.html
+++ b/src/main/resources/inspectionDescriptions/RsDeprecation.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+Detects the item marked with <code>#[deprecated(...)]</code> attribute, which is discouraged from using,
+typically because it is dangerous, or because a better alternative exists.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/RsDeprecationInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDeprecationInspectionTest.kt
@@ -1,0 +1,194 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+/**
+ * Tests for Deprecated Attribute inspection.
+ */
+class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspection()) {
+
+    fun `test deprecated function without params`() = checkByText("""
+        #[deprecated()]
+        pub fn foo() {
+        }
+
+        fn main() {
+            <warning descr="'foo' is marked as deprecated">foo</warning>();
+        }
+    """)
+
+    fun `test deprecated function with since param only`() = checkByText("""
+        #[deprecated(since="1.0.0")]
+        pub fn foo() {
+        }
+
+        fn main() {
+            <warning descr="'foo' is marked as deprecated since version 1.0.0">foo</warning>();
+        }
+    """)
+
+    fun `test deprecated function with note param only`() = checkByText("""
+        #[deprecated(note="here could be your reason")]
+        pub fn foo() {
+        }
+
+        fn main() {
+            <warning descr="'foo' is marked as deprecated (here could be your reason)">foo</warning>();
+        }
+    """)
+
+    fun `test deprecated function with since and note params`() = checkByText("""
+        #[deprecated(since="1.0.0", note="here could be your reason")]
+        pub fn foo() {
+        }
+
+        fn main() {
+            <warning descr="'foo' is marked as deprecated since version 1.0.0 (here could be your reason)">foo</warning>();
+        }
+    """)
+
+    fun `test rustc_deprecated attribute`() = checkByText("""
+        #[rustc_deprecated(since="1.0.0", reason="here could be your reason")]
+        pub fn foo() {
+        }
+
+        fn main() {
+            <warning descr="'foo' is marked as deprecated since version 1.0.0 (here could be your reason)">foo</warning>();
+        }
+    """)
+
+    fun `test deprecated struct`() = checkByText("""
+        #[deprecated]
+        struct Foo;
+
+        fn main() {
+            let foo = <warning descr="'Foo' is marked as deprecated">Foo</warning>{};
+        }
+    """)
+
+    fun `test deprecated struct method`() = checkByText("""
+        struct Foo;
+
+        impl Foo {
+            #[deprecated]
+            fn new() -> Foo {
+                Foo { }
+            }
+        }
+
+        fn main() {
+            let foo = Foo::<warning descr="'new' is marked as deprecated">new</warning>();
+        }
+    """)
+
+    fun `test deprecated trait`() = checkByText("""
+        #[deprecated]
+        trait Bar {}
+
+        struct Foo;
+
+        impl <warning descr="'Bar' is marked as deprecated">Bar</warning> for Foo {
+        }
+    """)
+
+    fun `test deprecated trait method`() = checkByText("""
+        trait Bar {
+            #[deprecated]
+            fn foo(&self);
+        }
+
+        struct Foo;
+
+        impl Bar for Foo {
+            fn foo(&self) {
+                println("foo")
+            }
+        }
+
+        fn main() {
+            let foo = Foo;
+            foo.<warning descr="'foo' is marked as deprecated">foo</warning>();
+        }
+    """)
+
+    fun `test deprecated enum`() = checkByText("""
+        #[deprecated]
+        enum Numbers {
+            One,
+            Two,
+            Three
+        }
+
+        fn main() {
+            <warning descr="'Numbers' is marked as deprecated">Numbers</warning>::One;
+        }
+    """)
+
+    fun `test deprecated enum item`() = checkByText("""
+        enum Numbers {
+            #[deprecated]
+            One,
+            Two,
+            Three
+        }
+
+        fn main() {
+            Numbers::<warning descr="'One' is marked as deprecated">One</warning>;
+        }
+    """)
+
+    fun `test deprecated type alias`() = checkByText("""
+        #[deprecated]
+        type Name = String;
+
+        fn main() {
+            let name: <warning descr="'Name' is marked as deprecated">Name</warning> = "test".to_string();
+        }
+    """)
+
+    fun `test deprecated variable`() = checkByText("""
+        #[deprecated]
+        static SOME_INT: i32 = 5;
+
+        fn main() {
+            let a = <warning descr="'SOME_INT' is marked as deprecated">SOME_INT</warning>;
+        }
+    """)
+
+    fun `test deprecated inline module`() = checkByText("""
+        #[deprecated]
+        mod foo {
+            pub static SOME_INT: i32 = 5;
+        }
+
+        fn main() {
+            let a = <warning descr="'foo' is marked as deprecated">foo</warning>::SOME_INT;
+        }
+    """)
+
+    fun `test deprecated variable in struct`() = checkByText("""
+        struct Foo {
+            #[deprecated]
+            pub x: i32
+        }
+
+        fn main() {
+            let a = Foo { <warning descr="'x' is marked as deprecated">x</warning>: 123 };
+        }
+    """)
+
+    fun `test deprecated non-inline module`() = checkByFileTree("""
+        //- main.rs
+            #[deprecated]
+            mod foo;
+
+            fn main() {
+                let a = /*caret*/<warning descr="'foo' is marked as deprecated">foo</warning>::SOME_INT;
+            }
+        //- foo.rs
+            pub static SOME_INT: i32 = 5;
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/inspections/RsDeprecationInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDeprecationInspectionTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.ide.inspections
 
+import com.intellij.openapi.vfs.VirtualFileFilter
+
 /**
  * Tests for Deprecated Attribute inspection.
  */
@@ -16,7 +18,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         }
 
         fn main() {
-            <warning descr="'foo' is marked as deprecated">foo</warning>();
+            <warning descr="`foo` is deprecated">foo</warning>();
         }
     """)
 
@@ -26,7 +28,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         }
 
         fn main() {
-            <warning descr="'foo' is marked as deprecated since version 1.0.0">foo</warning>();
+            <warning descr="`foo` is deprecated since 1.0.0">foo</warning>();
         }
     """)
 
@@ -36,7 +38,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         }
 
         fn main() {
-            <warning descr="'foo' is marked as deprecated (here could be your reason)">foo</warning>();
+            <warning descr="`foo` is deprecated: here could be your reason">foo</warning>();
         }
     """)
 
@@ -46,7 +48,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         }
 
         fn main() {
-            <warning descr="'foo' is marked as deprecated since version 1.0.0 (here could be your reason)">foo</warning>();
+            <warning descr="`foo` is deprecated since 1.0.0: here could be your reason">foo</warning>();
         }
     """)
 
@@ -56,7 +58,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         }
 
         fn main() {
-            <warning descr="'foo' is marked as deprecated since version 1.0.0 (here could be your reason)">foo</warning>();
+            <warning descr="`foo` is deprecated since 1.0.0: here could be your reason">foo</warning>();
         }
     """)
 
@@ -65,7 +67,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         struct Foo;
 
         fn main() {
-            let foo = <warning descr="'Foo' is marked as deprecated">Foo</warning>{};
+            let foo = <warning descr="`Foo` is deprecated">Foo</warning>{};
         }
     """)
 
@@ -80,7 +82,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         }
 
         fn main() {
-            let foo = Foo::<warning descr="'new' is marked as deprecated">new</warning>();
+            let foo = Foo::<warning descr="`new` is deprecated">new</warning>();
         }
     """)
 
@@ -90,7 +92,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
 
         struct Foo;
 
-        impl <warning descr="'Bar' is marked as deprecated">Bar</warning> for Foo {
+        impl <warning descr="`Bar` is deprecated">Bar</warning> for Foo {
         }
     """)
 
@@ -110,7 +112,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
 
         fn main() {
             let foo = Foo;
-            foo.<warning descr="'foo' is marked as deprecated">foo</warning>();
+            foo.<warning descr="`foo` is deprecated">foo</warning>();
         }
     """)
 
@@ -123,7 +125,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         }
 
         fn main() {
-            <warning descr="'Numbers' is marked as deprecated">Numbers</warning>::One;
+            <warning descr="`Numbers` is deprecated">Numbers</warning>::One;
         }
     """)
 
@@ -136,7 +138,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         }
 
         fn main() {
-            Numbers::<warning descr="'One' is marked as deprecated">One</warning>;
+            Numbers::<warning descr="`One` is deprecated">One</warning>;
         }
     """)
 
@@ -145,7 +147,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         type Name = String;
 
         fn main() {
-            let name: <warning descr="'Name' is marked as deprecated">Name</warning> = "test".to_string();
+            let name: <warning descr="`Name` is deprecated">Name</warning> = "test".to_string();
         }
     """)
 
@@ -154,7 +156,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         static SOME_INT: i32 = 5;
 
         fn main() {
-            let a = <warning descr="'SOME_INT' is marked as deprecated">SOME_INT</warning>;
+            let a = <warning descr="`SOME_INT` is deprecated">SOME_INT</warning>;
         }
     """)
 
@@ -165,7 +167,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         }
 
         fn main() {
-            let a = <warning descr="'foo' is marked as deprecated">foo</warning>::SOME_INT;
+            let a = <warning descr="`foo` is deprecated">foo</warning>::SOME_INT;
         }
     """)
 
@@ -176,7 +178,7 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         }
 
         fn main() {
-            let a = Foo { <warning descr="'x' is marked as deprecated">x</warning>: 123 };
+            let a = Foo { <warning descr="`x` is deprecated">x</warning>: 123 };
         }
     """)
 
@@ -186,9 +188,68 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
             mod foo;
 
             fn main() {
-                let a = /*caret*/<warning descr="'foo' is marked as deprecated">foo</warning>::SOME_INT;
+                let a = /*caret*/<warning descr="`foo` is deprecated">foo</warning>::SOME_INT;
             }
         //- foo.rs
             pub static SOME_INT: i32 = 5;
     """)
+
+    fun `test allow deprecated function`() = checkByText("""
+        #[deprecated]
+        pub fn foo() {
+        }
+
+        #[allow(deprecated)]
+        fn main() {
+            foo();
+        }
+    """)
+
+    fun `test allow deprecated statement`() = checkByText("""
+        #[deprecated]
+        pub fn foo() {
+        }
+
+        fn main() {
+            #[allow(deprecated)]
+            foo();
+        }
+    """)
+
+    fun `test allow deprecated item in module`() = checkByText("""
+        #[allow(deprecated)]
+        mod foo {
+            #[deprecated]
+            static SOME_INT: i32 = 5;
+            static OTHER_INT: i32 = SOME_INT;
+        }
+    """)
+
+    fun `test allow deprecated inner attribute`() = checkByText("""
+        #![allow(deprecated)]
+
+        #[deprecated]
+        fn foo() {
+            println!("TEST")
+        }
+
+        fn main() {
+            foo();
+        }
+    """)
+
+    fun `test AST is not loaded when deprecated item in another file`() {
+        checkAstNotLoaded(VirtualFileFilter { "foo.rs" == it.name })
+        checkByFileTree("""
+        //- main.rs
+            mod foo;
+
+            fn main() {/*caret*/
+                foo::<warning descr="`bar` is deprecated since 1.0.0: here could be your reason">bar</warning>();
+            }
+        //- foo.rs
+            #[deprecated(since="1.0.0", note="here could be your reason")]
+            pub fn bar() {}
+        """)
+    }
 }


### PR DESCRIPTION
Fulfilled #3564 improvement (the first and second checkboxes):

* Implement [deprecated attribute](https://github.com/rust-lang/rfcs/blob/master/text/1270-deprecation.md) inspection (for both `#[deprecated]` and `#[rustc_deprecated]` attributes)
* Support `#[allow(deprecated)]` attribute to suppress the corresponding warnings

Example:
<img alt="deprecated-std-fun" src="https://user-images.githubusercontent.com/2528429/54508067-5fe49180-497f-11e9-809b-8b436c07cd28.JPG">
<img height="180" alt="deprecated-fun" src="https://user-images.githubusercontent.com/2528429/54507859-5149aa80-497e-11e9-9171-fb2f483ee630.JPG">

**Note:** update `PathExpr` in RustParser by adding implementation of `RsOuterAttributeOwner` interface