### PR TITLE
TY&RES: Fix UFCS-like type-qualified paths (`<T as Foo>::bar`)

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -328,8 +328,7 @@ class RsErrorAnnotator : RsAnnotatorBase(), HighlightRangeExtension {
     }
 
     private fun checkValueArgumentList(holder: AnnotationHolder, args: RsValueArgumentList) {
-        val parent = args.parent
-        val (expectedCount, variadic) = when (parent) {
+        val (expectedCount, variadic) = when (val parent = args.parent) {
             is RsCallExpr -> parent.expectedParamsCount()
             is RsMethodCall -> parent.expectedParamsCount()
             else -> null
@@ -500,8 +499,7 @@ private fun RsCallExpr.expectedParamsCount(): Pair<Int, Boolean>? {
             val owner = el.owner
             if (owner.isTraitImpl) return null
             val count = el.valueParameterList?.valueParameterList?.size ?: return null
-            // We can call foo.method(1), or Foo::method(&foo, 1), so need to take coloncolon into account
-            val s = if (path.coloncolon != null && el.selfParameter != null) 1 else 0
+            val s = if (el.selfParameter != null) 1 else 0
             Pair(count + s, el.isVariadic)
         }
         else -> null

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -270,6 +270,14 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class.java) {
         }
     """)
 
+    fun `test type-qualified UFCS path E0061`() = checkErrors("""
+        struct S;
+        impl S { fn foo(self) { } }
+        fn main() {
+            <S>::foo(S);
+        }
+    """)
+
     fun `test empty return E0069`() = checkErrors("""
         fn ok1() { return; }
         fn ok2() -> () { return; }

--- a/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
@@ -58,7 +58,6 @@ class RsResolveLinkTest : RsTestBase() {
     fun `test assoc type with type qual`() = doTest("""
         trait Foo1 {
             type Bar;
-               //X
         }
 
         trait Foo2 {
@@ -69,7 +68,7 @@ class RsResolveLinkTest : RsTestBase() {
 
         impl Foo1 for S {
             type Bar = ();
-        }
+        }      //X
 
         impl Foo2 for S {
             type Bar = <Self as Foo1>::Bar;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveCacheTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveCacheTest.kt
@@ -49,11 +49,11 @@ class RsResolveCacheTest : RsTestBase() {
     fun `test resolve correctly without global cache invalidation 3`() = checkResolvedToXY("""
         struct S;
         trait Trait1 { type Item; }
-                            //X
         trait Trait2 { type Item; }
-                            //Y
         impl Trait1 for S { type Item = (); }
+                               //X
         impl Trait2 for S { type Item = (); }
+                               //Y
         fn main() {
             let _: <S as Trait1/*caret*/>
                 ::Item;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -180,13 +180,11 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                        //^ .../f32.rs
     """)
 
-    fun `test inherent impl f32 3`() = expect<IllegalStateException> {
-        stubOnlyResolve("""
+    fun `test inherent impl f32 3`() = stubOnlyResolve("""
     //- main.rs
         fn main() { <f32>::sqrt(0.0f32); }
                          //^ .../f32.rs
     """)
-    }
 
     fun `test inherent impl f64 1`() = stubOnlyResolve("""
     //- main.rs
@@ -209,8 +207,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }
     """)
 
-    fun `test inherent impl const ptr 2`() = expect<IllegalStateException> {
-        stubOnlyResolve("""
+    fun `test inherent impl const ptr 2`() = stubOnlyResolve("""
     //- main.rs
         fn main() {
             let p: *const char;
@@ -218,10 +215,8 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                          //^ ...libcore/ptr.rs
         }
     """)
-    }
 
-    fun `test inherent impl const ptr 3`() = expect<IllegalStateException> {
-        stubOnlyResolve("""
+    fun `test inherent impl const ptr 3`() = stubOnlyResolve("""
     //- main.rs
         fn main() {
             let p: *mut char;
@@ -229,7 +224,6 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                          //^ ...libcore/ptr.rs
         }
     """)
-    }
 
     fun `test inherent impl mut ptr 1`() = stubOnlyResolve("""
     //- main.rs
@@ -240,8 +234,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }
     """)
 
-    fun `test inherent impl mut ptr 2`() = expect<IllegalStateException> {
-        stubOnlyResolve("""
+    fun `test inherent impl mut ptr 2`() = stubOnlyResolve("""
     //- main.rs
         fn main() {
             let p: *mut char;
@@ -249,7 +242,6 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                        //^ ...libcore/ptr.rs
         }
     """)
-    }
 
     fun `test println macro`() = stubOnlyResolve("""
     //- main.rs

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -451,8 +451,7 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }
     """)
 
-    fun `test slice resolve UFCS`() = expect<IllegalStateException> {
-        checkByCode("""
+    fun `test slice resolve UFCS`() = checkByCode("""
         impl<T> [T] {
             fn foo(&self) {}
               //X
@@ -464,7 +463,6 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
                     //^
         }
     """)
-    }
 
     fun `test array coercing to slice resolve`() = checkByCode("""
         impl<T> [T] {
@@ -766,4 +764,14 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
             fn foo() -> Self::Item { unreachable!() }
         }                   //^
     """, NameResolutionTestmarks.selfRelatedTypeSpecialCase)
+
+    fun `test explicit UFCS-like type-qualified path`() = checkByCode("""
+        struct S;
+        impl S {
+            fn foo() {}
+        }    //X
+        fn main () {
+            <S>::foo;
+        }      //^
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -50,7 +50,7 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
 
         fn main() {
             let _: <S as T>::Assoc = S;
-                 //^ <S as T>::Assoc
+                 //^ S
         }
     """)
 


### PR DESCRIPTION
```rust
struct S;
impl S {
    fn foo() {}
}    //X
fn main () {
    <S>::foo;
}      //^
```

(the first commit is only refactoring)