### PR TITLE
TY: better coerce types in generic function args

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -1299,8 +1299,10 @@ class RsFnInferenceContext(
                 selectObligationsWherePossible()
             }
 
-            // extending argument definitions to be sure that type inference launched for each arg expr
-            val argDefsExt = argDefs.asSequence().infiniteWithTyUnknown()
+            val argDefsExt = argDefs.asSequence()
+                .map(ctx::resolveTypeVarsIfPossible)
+                // extending argument definitions to be sure that type inference launched for each arg expr
+                .infiniteWithTyUnknown()
             for ((type, expr) in argDefsExt.zip(argExprs.asSequence().map(::unwrapParenExprs))) {
                 val isLambda = expr is RsLambdaExpr
                 if (isLambda != checkLambdas) continue

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1539,4 +1539,24 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ i32
     """)
+
+    fun `test type coercion in generic associates function args`() = testExpr("""
+        #[lang = "deref"]
+        trait Deref { type Target; }
+
+        struct Foo;
+        struct Bar;
+
+        impl Deref for Foo {
+            type Target = Bar;
+        }
+
+        struct Box<T>(T);
+        impl<T> Box<T> {
+            pub fn new(x: T) -> Box<T> { unimplemented!() }
+        }
+        fn main() {
+            let _: Box<[&Bar; 1]> = (Box::new([&Foo]));
+        }                         //^ Box<[&Bar; 1]>
+    """)
 }


### PR DESCRIPTION
(fixes false-possible E0308 in some rare cases)