### PR TITLE
RES: Fix non-absolute std-qualified path resolution

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -572,4 +572,42 @@ class RsStdlibResolveTest : RsResolveTestBase() {
             a.store();
         }   //^ .../libcore/sync/atomic.rs
     """)
+
+    fun `test non-absolute std-qualified path in non-root module`() = stubOnlyResolve("""
+    //- main.rs
+        mod foo {
+            fn main() {
+                std::mem::size_of::<i32>();
+            }           //^ .../libcore/mem.rs
+        }
+    """)
+
+    fun `test local 'std' module wins`() = checkByCode("""
+        mod foo {
+            mod std {
+                pub mod mem {
+                    pub fn size_of<T>() {}
+                }         //X
+            }
+            fn main() {
+                std::mem::size_of::<i32>();
+            }           //^
+        }
+    """)
+
+    fun `test imported 'std' module wins`() = checkByCode("""
+        mod foo {
+            mod bar {
+                pub mod std {
+                    pub mod mem {
+                        pub fn size_of<T>() {}
+                    }         //X
+                }
+            }
+            use self::bar::std;
+            fn main() {
+                std::mem::size_of::<i32>();
+            }           //^
+        }
+    """)
 }


### PR DESCRIPTION
Related to "Extern Prelude" and 2018 edition (but should work in 2015 edition as well)
Fixes #3421