### PR TITLE
Fix cache invalidation bugs; Partially revert of #3059

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -50,7 +50,7 @@ class RsPathReferenceImpl(
 
     private fun advancedCachedMultiResolve(): List<BoundElement<RsElement>> {
         return RsResolveCache.getInstance(element.project)
-            .resolveWithCaching(element, ResolveCacheDependency.RUST_STRUCTURE, Resolver)
+            .resolveWithCaching(element, ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE, Resolver)
             .orEmpty()
             // We can store a fresh `TyInfer.TyVar` to the cache for `_` path parameter (like `Vec<_>`), but
             // TyVar is mutable type, so we must copy it after retrieving from the cache

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceCached.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferenceCached.kt
@@ -28,7 +28,7 @@ abstract class RsReferenceCached<T : RsWeakReferenceElement>(
             .resolveWithCaching(element, cacheDependency, Resolver).orEmpty()
     }
 
-    protected open val cacheDependency: ResolveCacheDependency get() = ResolveCacheDependency.RUST_STRUCTURE
+    protected open val cacheDependency: ResolveCacheDependency get() = ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE
 
     private object Resolver : (RsWeakReferenceElement) -> List<PsiElementResolveResult> {
         override fun invoke(ref: RsWeakReferenceElement): List<PsiElementResolveResult> {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveCacheTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveCacheTest.kt
@@ -61,6 +61,21 @@ class RsResolveCacheTest : RsTestBase() {
         }
     """, "\b2", Testmarks.removeChangedElement)
 
+    fun `test resolve correctly without global cache invalidation 4`() = checkResolvedToXY("""
+        mod foo { pub struct S; }
+           //Y
+        mod bar {
+            mod foo { pub struct S; }
+               //X
+            fn baz() {
+                /*caret*/
+                foo
+                //^
+                ::S;
+            }
+        }
+    """, "::")
+
     fun `test edit local pat binding`() = checkResolvedAndThenUnresolved("""
         fn main() {
             let a/*caret*/ = 0;


### PR DESCRIPTION
I have to admit that #3059 was a bad idea. We should not rely on PSI modification events. It is an infinite source of bugs. I think we'll use the default `ResolveCache` after rewriting of name resolution engine