### PR TITLE
RUN: Run rustfmt with UTF-8 charset

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/Rustfmt.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Rustfmt.kt
@@ -54,6 +54,7 @@ class Rustfmt(private val rustfmtExecutable: Path) {
             GeneralCommandLine(rustfmtExecutable)
                 .withWorkDirectory(cargoProject.workingDirectory)
                 .withParameters(arguments)
+                .withCharset(Charsets.UTF_8)
                 .execute(owner, false, stdIn = stdIn)
         } catch (e: ExecutionException) {
             if (isUnitTestMode) throw e else null

--- a/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
+++ b/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
@@ -30,7 +30,7 @@ class RustfmtTest : RsWithToolchainTestBase() {
             dir("src") {
                 rust("main.rs", """
                     fn main() {
-                    println!("Hello, world!");
+                    println!("Hello, ΣΠ∫!");
                     }
                 """)
             }
@@ -52,7 +52,7 @@ class RustfmtTest : RsWithToolchainTestBase() {
             dir("src") {
                 rust("main.rs", """
                     fn main() {/*caret*/
-                        println!("Hello, world!");
+                        println!("Hello, ΣΠ∫!");
                     }
                 """)
             }
@@ -81,7 +81,7 @@ class RustfmtTest : RsWithToolchainTestBase() {
             dir("src") {
                 rust("main.rs", """
                     fn main() {/*caret*/
-                        println!("Hello, world!");
+                        println!("Hello, ΣΠ∫!");
                     }
                 """)
             }


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/3570.