### PR TITLE
TY: Fix bindings extraction for pat struct

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt
@@ -41,11 +41,9 @@ val RsFieldsOwner.positionalFields: List<RsTupleFieldDecl>
  * ```
  */
 fun RsFieldsOwner.canBeInstantiatedIn(mod: RsMod): Boolean =
-    namedFields.all { it.isVisibleFrom(mod) } && positionalFields.all { it.isVisibleFrom(mod) }
+    fields.all { it.isVisibleFrom(mod) }
 
-val RsFieldsOwner.fieldTypes: List<Ty>
-    get() = blockFields?.namedFieldDeclList?.mapNotNull { it.typeReference?.type }
-        ?: tupleFields?.tupleFieldDeclList?.mapNotNull { it.typeReference.type }.orEmpty()
+val RsFieldsOwner.fieldTypes: List<Ty> get() = fields.mapNotNull { it.typeReference?.type }
 
 /**
  * True for:
@@ -62,5 +60,4 @@ val RsFieldsOwner.fieldTypes: List<Ty>
 val RsFieldsOwner.isFieldless: Boolean
     get() = blockFields == null && tupleFields == null
 
-val RsFieldsOwner.size: Int
-    get() = tupleFields?.tupleFieldDeclList?.size ?: blockFields?.namedFieldDeclList?.size ?: 0
+val RsFieldsOwner.size: Int get() = fields.size

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -986,14 +986,11 @@ private fun collect2segmentPaths(rootSpeck: RsUseSpeck): List<TwoSegmentPath> {
     return result
 }
 
-private fun processFieldDeclarations(struct: RsFieldsOwner, processor: RsResolveProcessor): Boolean {
-    if (processAll(struct.namedFields, processor)) return true
-
-    for ((idx, field) in struct.positionalFields.withIndex()) {
-        if (processor(idx.toString(), field)) return true
+private fun processFieldDeclarations(struct: RsFieldsOwner, processor: RsResolveProcessor): Boolean =
+    struct.fields.any { field ->
+        val name = field.name ?: return@any false
+        processor(name, field)
     }
-    return false
-}
 
 private fun processMethodDeclarationsWithDeref(lookup: ImplLookup, receiver: Ty, processor: RsMethodResolveProcessor): Boolean {
     return lookup.coercionSequence(receiver).withIndex().any { (i, ty) ->

--- a/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
@@ -66,7 +66,7 @@ fun RsPat.extractBindings(fcx: RsFnInferenceContext, type: Ty, ignoreRef: Boolea
                 ?: ((derefTy as? TyAdt)?.item as? RsStructItem)
                 ?: return
 
-            val structFields = item.namedFields.associateBy { it.name }
+            val structFields = item.fields.associateBy { it.name }
             for (patField in patFieldList) {
                 val kind = patField.kind
                 val fieldType = structFields[kind.fieldName]

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -1107,7 +1107,7 @@ class RsFnInferenceContext(
         // `struct S; S();`
         if (callee is RsPathExpr) {
             ctx.getResolvedPaths(callee).singleOrNull()?.let {
-                if (it is RsFieldsOwner && it.namedFields.isEmpty() && it.positionalFields.isEmpty()) {
+                if (it is RsFieldsOwner && it.fields.isEmpty()) {
                     return ty
                 }
             }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -7,8 +7,7 @@ package org.rust.lang.core.types.ty
 
 import org.rust.ide.presentation.tyToString
 import org.rust.lang.core.psi.RsStructItem
-import org.rust.lang.core.psi.ext.namedFields
-import org.rust.lang.core.psi.ext.positionalFields
+import org.rust.lang.core.psi.ext.fields
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.*
@@ -83,13 +82,7 @@ tailrec fun Ty.isSized(): Boolean {
         is TyTypeParameter -> isSized
         is TyAdt -> {
             val item = item as? RsStructItem ?: return true
-            val namedFields = item.namedFields
-            val tupleFields = item.positionalFields
-            val typeRef = when {
-                namedFields.isNotEmpty() -> namedFields.last().typeReference
-                tupleFields.isNotEmpty() -> tupleFields.last().typeReference
-                else -> null
-            }
+            val typeRef = item.fields.lastOrNull()?.typeReference
             val type = typeRef?.type?.substitute(typeParameterValues) ?: return true
             type.isSized()
         }

--- a/src/test/kotlin/org/rust/lang/core/type/RsPatternMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsPatternMatchingTest.kt
@@ -124,7 +124,7 @@ class RsPatternMatchingTest : RsTypificationTestBase() {
     """)
     }
 
-    fun `test nested struct pattern`() = testExpr("""
+    fun `test struct pattern`() = testExpr("""
         struct S;
         struct T {
             s: S
@@ -134,6 +134,29 @@ class RsPatternMatchingTest : RsTypificationTestBase() {
             let T { s: x } = T { s: S };
             x;
           //^ S
+        }
+    """)
+
+    fun `test tuple struct pattern 1`() = testExpr("""
+        struct S;
+        struct T(S);
+
+        fn main() {
+            let T(x) = T(S);
+            x;
+          //^ S
+        }
+    """)
+
+    fun `test tuple struct pattern 2`() = testExpr("""
+        struct S1;
+        struct S2;
+        struct T(S1, S2);
+
+        fn main() {
+            let T { 1: x, 0: y } = T { 0: S1, 1: S2 };
+            (x, y);
+          //^ (S2, S1)
         }
     """)
 


### PR DESCRIPTION
@ortem I didn't update the borrow checker, but I think it should also take into account [this](https://github.com/intellij-rust/intellij-rust/pull/3543) syntax.