### PR TITLE
ANN: fix highlighting of keywords in paths (`crate`/`Self`)

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -34,7 +34,7 @@ class RsHighlightingAnnotator : RsAnnotatorBase() {
 
     private fun highlightReference(element: RsReferenceElement): Pair<TextRange, RsColor>? {
         // These should be highlighted as keywords by the lexer
-        if (element is RsPath && (element.self != null || element.`super` != null)) return null
+        if (element is RsPath && element.kind != PathKind.IDENTIFIER) return null
 
         val isPrimitiveType = element is RsPath && TyPrimitive.fromPath(element) != null
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -101,15 +101,18 @@ class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator:
         }
     """)
 
-    fun `test self is not over annotated`() = checkHighlighting("""
+    fun `test keyword paths are not over annotated`() = checkByText("""
         pub use self::<MODULE>foo</MODULE>;
+        pub use crate::foobar;
 
         mod <MODULE>foo</MODULE> {
             pub use self::<MODULE>bar</MODULE>;
 
             pub mod <MODULE>bar</MODULE> {}
         }
-    """)
+
+        trait <TRAIT>Foo</TRAIT> { fn <ASSOC_FUNCTION>foo</ASSOC_FUNCTION>(_: Self) -> Self; }
+    """, checkWarn = false, ignoreExtraHighlighting = false)
 
     fun `test primitive`() = checkHighlighting("""
         fn <FUNCTION>main</FUNCTION>() -> <PRIMITIVE_TYPE>bool</PRIMITIVE_TYPE> {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/3221931/54930427-51224f80-4f28-11e9-9ed9-1aee0d75a08b.png)
After:
![image](https://user-images.githubusercontent.com/3221931/54930596-98a8db80-4f28-11e9-850c-1d94c33d47cf.png)
