### PR TITLE
MACRO: navigate to macro call during all nav actions

### DIFF
--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsGeneratedSourcesFilter.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsGeneratedSourcesFilter.kt
@@ -1,0 +1,23 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.navigation.goto
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.GeneratedSourcesFilter
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.macros.findMacroCallExpandedFrom
+
+class RsGeneratedSourcesFilter : GeneratedSourcesFilter() {
+    override fun isGeneratedSource(file: VirtualFile, project: Project): Boolean {
+        return false
+    }
+
+    override fun getOriginalElements(element: PsiElement): List<PsiElement> {
+        val macroCall = element.findMacroCallExpandedFrom() ?: return emptyList()
+        return listOf(macroCall.path)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsTargetElementEvaluator.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsTargetElementEvaluator.kt
@@ -58,6 +58,8 @@ class RsTargetElementEvaluator : TargetElementEvaluatorEx2() {
         return item?.derivedTraitsToMetaItems?.get(trait)
     }
 
+    // TODO remove it when all macro expansions will become physical files
+    //  (then they will be handled with RsGeneratedSourcesFilter)
     /**
      * Allows to refine GotoDeclaration target
      *

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -137,6 +137,7 @@
 
         <targetElementEvaluator language="Rust"
                                 implementationClass="org.rust.ide.navigation.goto.RsTargetElementEvaluator"/>
+        <generatedSourcesFilter implementation="org.rust.ide.navigation.goto.RsGeneratedSourcesFilter"/>
 
         <!-- Hints -->
 


### PR DESCRIPTION
(including go-to-super and go-to-implementation)
I've used GeneratedSourcesFilter extension which also
allows to refine navigation target