### PR TITLE
ANN: Don't show empty parameter hints

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -93,6 +93,7 @@ ThoseGrapefruits
 tov
 ttaomae
 Turbo87
+tuxxi
 ujpv
 Undin
 vasily-kirichenko

--- a/src/main/kotlin/org/rust/ide/hints/RsInlayParameterHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/RsInlayParameterHintsProvider.kt
@@ -91,6 +91,9 @@ enum class HintType(desc: String, enabled: Boolean) {
                         return emptyList()
                     }
                 }
+                if (hints.all { (hint, _) -> hint == "_"}) {
+                    return emptyList()
+                }
                 return hints
                     .filter { (hint, arg) -> !arg.text.endsWith(hint) }
                     .map { (hint, arg) -> InlayInfo("$hint:", arg.startOffset) }

--- a/src/test/kotlin/org/rust/ide/hints/RsInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RsInlayParameterHintsProviderTest.kt
@@ -184,6 +184,13 @@ class RsInlayParameterHintsProviderTest : RsTestBase() {
         }
     """, enabledHints = HintType.LET_BINDING_HINT)
 
+    fun `test smart should not annotate tuple structs`() = checkByText("""
+        struct TS(i32, f32);
+        fn main() {
+            let s = TS(5i32, 10.0f32);
+        }
+    """, enabledHints = HintType.PARAMETER_HINT)
+
     private val fnTypes = """
         #[lang = "fn_once"]
         trait FnOnce<Args> { type Output; }


### PR DESCRIPTION
Tuple structs (and perhaps maybe other constructs too) previously showed empty parameter hints when being instantiated. This PR adds a condition so that if all the hints are empty, it don't bother to show any. 

Before:
![Before image showing empty hints](https://i.imgur.com/5eIr5Zz.png)

After: 
![After image showing no hints](https://i.imgur.com/eIMTiQS.png)