### PR TITLE
COMP: change text attributes in completion for deprecated items

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -29,6 +29,7 @@ private const val FIELD_DECL_PRIORITY = 3.0
 private const val INHERENT_IMPL_MEMBER_PRIORITY = 2.0
 private const val DEFAULT_PRIORITY = 0.0
 private const val MACRO_PRIORITY = -0.1
+private const val DEPRECATED_PRIORITY = -1.0
 
 fun createLookupElement(
     element: RsElement,
@@ -41,6 +42,7 @@ fun createLookupElement(
         .let { if (locationString != null) it.appendTailText(" ($locationString)", true) else it }
 
     val priority = when {
+        element is RsDocAndAttributeOwner && element.queryAttributes.deprecatedAttribute != null -> DEPRECATED_PRIORITY
         element is RsMacro -> MACRO_PRIORITY
         element is RsEnumVariant -> ENUM_VARIANT_PRIORITY
         element is RsNamedFieldDecl -> FIELD_DECL_PRIORITY
@@ -57,6 +59,7 @@ fun LookupElementBuilder.withPriority(priority: Double): LookupElement =
 private fun RsElement.getLookupElementBuilder(scopeName: String): LookupElementBuilder {
     val base = LookupElementBuilder.createWithSmartPointer(scopeName, this)
         .withIcon(if (this is RsFile) RsIcons.MODULE else this.getIcon(0))
+        .withStrikeoutness(this is RsDocAndAttributeOwner && queryAttributes.deprecatedAttribute != null)
 
     return when (this) {
         is RsMod -> if (scopeName == "self" || scopeName == "super" || scopeName == "crate") {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsLookupElementTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsLookupElementTest.kt
@@ -37,7 +37,7 @@ class RsLookupElementTest : RsTestBase() {
         }
     """, tailText = "(&self, x: i32) of T", typeText = "()")
 
-    fun `test cons item`() = check("""
+    fun `test const item`() = check("""
         const C: S = unimplemented!();
             //^
     """, typeText = "S")
@@ -107,6 +107,24 @@ class RsLookupElementTest : RsTestBase() {
                      //^
     """, tailText = "!", typeText = null)
 
+    fun `test deprecated fn`() = check("""
+        #[deprecated]
+        fn foo() {}
+          //^
+    """, tailText = "()", typeText = "()", isStrikeout = true)
+
+    fun `test deprecated const item`() = check("""
+        #[deprecated]
+        const C: S = unimplemented!();
+            //^
+    """, typeText = "S", isStrikeout = true)
+
+    fun `test deprecated enum`() = check("""
+        #[deprecated]
+        enum E { X, Y }
+           //^
+    """, isStrikeout = true)
+
     fun `test mod`() {
         myFixture.configureByText("foo.rs", "")
         val lookup = createLookupElement((myFixture.file as RsFile), "foo")
@@ -117,7 +135,12 @@ class RsLookupElementTest : RsTestBase() {
         assertEquals("foo", presentation.itemText)
     }
 
-    private fun check(@Language("Rust") code: String, tailText: String? = null, typeText: String? = null) {
+    private fun check(
+        @Language("Rust") code: String,
+        tailText: String? = null,
+        typeText: String? = null,
+        isStrikeout: Boolean = false
+    ) {
         InlineFile(code)
         val element = findElementInEditor<RsNamedElement>()
         val lookup = createLookupElement(element, element.name!!)
@@ -127,5 +150,6 @@ class RsLookupElementTest : RsTestBase() {
         assertNotNull(presentation.icon)
         assertEquals(tailText, presentation.tailText)
         assertEquals(typeText, presentation.typeText)
+        assertEquals(isStrikeout, presentation.isStrikeout)
     }
 }


### PR DESCRIPTION
Fulfilled #3564 improvement (the last checkbox): change text attributes in completion for deprecated elements.

Example:
<img alt="deprecated-item-completion" src="https://user-images.githubusercontent.com/2528429/54982125-f995e980-4fe4-11e9-8c89-2abe0cd262ab.JPG">
