### PR TITLE
INSP: use stub in inspections if possible

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
@@ -10,6 +10,7 @@ import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
+import com.intellij.psi.tree.IElementType
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.Testmark
@@ -33,7 +34,7 @@ class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
     }
 
     companion object {
-        private fun sortedImplItems(implItems: List<RsItemElement>, traitItems: List<RsItemElement>): List<RsItemElement>? {
+        private fun sortedImplItems(implItems: List<RsAbstractable>, traitItems: List<RsAbstractable>): List<RsAbstractable>? {
             val traitItemMap = traitItems.withIndex().associate { it.value.key() to it.index }
             if (implItems.any { it.key() !in traitItemMap }) {
                 Testmarks.implMemberNotInTrait.hit()
@@ -68,8 +69,8 @@ class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
     }
 }
 
-private fun RsTraitOrImpl.items(): List<RsItemElement> = members?.children?.mapNotNull {
-    if (it is RsFunction || it is RsConstant || it is RsTypeAlias) it as? RsItemElement else null
-} ?: emptyList()
+private fun RsTraitOrImpl.items(): List<RsAbstractable> {
+    return members?.stubChildrenOfType<RsAbstractable>().orEmpty()
+}
 
-private fun RsItemElement.key() = name to elementType
+private fun RsAbstractable.key(): Pair<String?, IElementType> = name to elementType

--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -230,7 +230,7 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
                 val externCrateMod = ourSuperMods.last()
 
                 val externCrateWithDepth = superMods.withIndex().mapNotNull { (index, superMod) ->
-                    val externCrateItem = superMod.childrenOfType<RsExternCrateItem>()
+                    val externCrateItem = superMod.stubChildrenOfType<RsExternCrateItem>()
                         .find { it.reference.resolve() == externCrateMod } ?: return@mapNotNull null
                     val depth = if (superMod.isCrateRoot) null else index
                     externCrateItem to depth

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -246,8 +246,8 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
         InlineFile(text.trimIndent())
     }
 
-    protected open fun configureByFileTree(text: String) {
-        fileTreeFromText(text).createAndOpenFileWithCaretMarker()
+    protected open fun configureByFileTree(text: String): TestProject {
+        return fileTreeFromText(text).createAndOpenFileWithCaretMarker()
     }
 
     companion object {

--- a/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestBase.kt
@@ -78,13 +78,14 @@ abstract class RsAnnotationTestBase : RsTestBase() {
         checkInfo: Boolean = false,
         checkWeakWarn: Boolean = false,
         ignoreExtraHighlighting: Boolean = false,
+        stubOnly: Boolean = true,
         testmark: Testmark? = null
     ) = check(text,
         checkWarn = checkWarn,
         checkInfo = checkInfo,
         checkWeakWarn = checkWeakWarn,
         ignoreExtraHighlighting = ignoreExtraHighlighting,
-        configure = this::configureByFileTree,
+        configure = { configureByFileTree(it, stubOnly) },
         testmark = testmark)
 
     protected fun checkFixByFileTree(
@@ -94,9 +95,10 @@ abstract class RsAnnotationTestBase : RsTestBase() {
         checkWarn: Boolean = true,
         checkInfo: Boolean = false,
         checkWeakWarn: Boolean = false,
+        stubOnly: Boolean = true,
         testmark: Testmark? = null
     ) = checkFix(fixName, before, after,
-        configure = this::configureByFileTree,
+        configure = { configureByFileTree(it, stubOnly) },
         checkBefore = { myFixture.checkHighlighting(checkWarn, checkInfo, checkWeakWarn) },
         checkAfter = this::checkByFileTree,
         testmark = testmark)
@@ -105,9 +107,10 @@ abstract class RsAnnotationTestBase : RsTestBase() {
         fixName: String,
         @Language("Rust") before: String,
         @Language("Rust") after: String,
+        stubOnly: Boolean = true,
         testmark: Testmark? = null
     ) = checkFix(fixName, before, after,
-        configure = this::configureByFileTree,
+        configure = { configureByFileTree(it, stubOnly) },
         checkBefore = {},
         checkAfter = this::checkByFileTree,
         testmark = testmark)
@@ -135,13 +138,14 @@ abstract class RsAnnotationTestBase : RsTestBase() {
         checkInfo: Boolean = false,
         checkWeakWarn: Boolean = false,
         ignoreExtraHighlighting: Boolean = false,
+        stubOnly: Boolean = true,
         testmark: Testmark? = null
     ) = checkFixIsUnavailable(fixName, text,
         checkWarn = checkWarn,
         checkInfo = checkInfo,
         checkWeakWarn = checkWeakWarn,
         ignoreExtraHighlighting = ignoreExtraHighlighting,
-        configure = this::configureByFileTree,
+        configure = { configureByFileTree(it, stubOnly) },
         testmark = testmark)
 
     private fun check(
@@ -191,6 +195,14 @@ abstract class RsAnnotationTestBase : RsTestBase() {
         check(text, checkWarn, checkInfo, checkWeakWarn, ignoreExtraHighlighting, configure, testmark)
         check(myFixture.filterAvailableIntentions(fixName).isEmpty()) {
             "Fix $fixName should not be possible to apply."
+        }
+    }
+
+    private fun configureByFileTree(text: String, stubOnly: Boolean) {
+        val testProject = configureByFileTree(text)
+        if (stubOnly) {
+            (myFixture as CodeInsightTestFixtureImpl)
+                .setVirtualFileFilter { !it.path.endsWith(testProject.fileWithCaret) }
         }
     }
 

--- a/src/test/kotlin/org/rust/ide/docs/RsDocumentationProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsDocumentationProviderTest.kt
@@ -33,7 +33,7 @@ abstract class RsDocumentationProviderTest : RsTestBase() {
         doUrlTest(text, expectedUrl, testmark, this::configureByText)
 
     protected fun doUrlTestByFileTree(@Language("Rust") text: String, expectedUrl: String?, testmark: Testmark? = null) =
-        doUrlTest(text, expectedUrl, testmark, this::configureByFileTree)
+        doUrlTest(text, expectedUrl, testmark) { configureByFileTree(it) }
 
     private fun doUrlTest(
         @Language("Rust") text: String,

--- a/src/test/kotlin/org/rust/ide/inspections/RsDeprecationInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDeprecationInspectionTest.kt
@@ -5,8 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
-
 /**
  * Tests for Deprecated Attribute inspection.
  */
@@ -238,18 +236,15 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         }
     """)
 
-    fun `test AST is not loaded when deprecated item in another file`() {
-        (myFixture as CodeInsightTestFixtureImpl).setVirtualFileFilter { !it.path.endsWith("main.rs") }
-        checkByFileTree("""
-        //- main.rs
-            mod foo;
+    fun `test AST is not loaded when deprecated item in another file`() = checkByFileTree("""
+    //- main.rs
+        mod foo;
 
-            fn main() {/*caret*/
-                foo::<warning descr="`bar` is deprecated since 1.0.0: here could be your reason">bar</warning>();
-            }
-        //- foo.rs
-            #[deprecated(since="1.0.0", note="here could be your reason")]
-            pub fn bar() {}
-        """)
-    }
+        fn main() {/*caret*/
+            foo::<warning descr="`bar` is deprecated since 1.0.0: here could be your reason">bar</warning>();
+        }
+    //- foo.rs
+        #[deprecated(since="1.0.0", note="here could be your reason")]
+        pub fn bar() {}
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections
 
+import org.rust.TestProject
 import org.rust.ide.annotator.RsAnnotationTestBase
 
 abstract class RsInspectionsTestBase(
@@ -25,8 +26,9 @@ abstract class RsInspectionsTestBase(
         enableInspection()
     }
 
-    override fun configureByFileTree(text: String) {
-        super.configureByFileTree(text)
+    override fun configureByFileTree(text: String): TestProject {
+        val testProject = super.configureByFileTree(text)
         enableInspection()
+        return testProject
     }
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsMultipleInspectionsTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsMultipleInspectionsTestBase.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.inspections
 
+import org.rust.TestProject
 import org.rust.ide.annotator.RsAnnotationTestBase
 
 abstract class RsMultipleInspectionsTestBase(
@@ -18,8 +19,9 @@ abstract class RsMultipleInspectionsTestBase(
         enableInspections()
     }
 
-    override fun configureByFileTree(text: String) {
-        super.configureByFileTree(text)
+    override fun configureByFileTree(text: String): TestProject {
+        val testProject = super.configureByFileTree(text)
         enableInspections()
+        return testProject
     }
 }


### PR DESCRIPTION
Before these changes, `Unresolved reference` and `Different impl member order from the trait` inspections always used AST instead of stubs that led to reparsing all files required for analysis
Now, they use stub in these cases.
Also, file tree based annotation tests check that inspections don't load files (except opened one, of course) while analysis by default