### PR TITLE
QDOC: show documentation of the corresponding trait item if element documentation is empty

### DIFF
--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -60,7 +60,12 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
             element.header(it)
             element.signature(it)
         }
-        val text = element.documentationAsHtml()
+        var text = element.documentationAsHtml()
+        if (text.isNullOrEmpty() && element is RsAbstractable && element.owner.isTraitImpl) {
+            // Show documentation of the corresponding trait item if own documentation is empty
+            val superElement = element.superItem as? RsDocAndAttributeOwner ?: return
+            text = superElement.documentationAsHtml()
+        }
         if (text.isNullOrEmpty()) return
         buffer += "\n" // Just for more pretty html text representation
         content(buffer) { it += text }

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -978,6 +978,41 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <div class='content'><p><a href="psi_element://test_package/struct.Foo.html#method.bar"><code>Foo::bar</code></a></p></div>
     """)
 
+    fun `test trait item doc 1`() = doTest("""
+        trait Foo {
+            /// Trait doc
+            fn foo();
+        }
+        struct Bar;
+
+        impl Foo for Bar {
+            /// Impl doc
+            fn foo() {}
+              //^
+        }
+    """, """
+        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Foo">Foo</a> for <a href="psi_element://Bar">Bar</a>
+        fn <b>foo</b>()</pre></div>
+        <div class='content'><p>Impl doc</p></div>
+    """)
+
+    fun `test trait item doc 2`() = doTest("""
+        trait Foo {
+            /// Trait doc
+            type Baz;
+        }
+        struct Bar;
+
+        impl Foo for Bar {
+            type Baz = ();
+               //^
+        }
+    """, """
+        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Foo">Foo</a> for <a href="psi_element://Bar">Bar</a>
+        type <b>Baz</b> = ()</pre></div>
+        <div class='content'><p>Trait doc</p></div>
+    """)
+
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test primitive type doc`() {
         InlineFile("""


### PR DESCRIPTION
Closes #3588