### PR TITLE
COMP: Fix import duplication when multiple carets are used

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -551,6 +551,7 @@ private fun RsUseItem.tryGroupWith(
     val parentPath = parentPath ?: return false
     if (parentPath != newParentPath) return false
     val importingNames = importingNames ?: return false
+    if (importingNames.contains(newImportingName)) return true
     val newUsePath = parentPath.joinToString("::", postfix = "::") +
         (importingNames + newImportingName).joinToString(", ", "{", "}")
     val newUseSpeck = psiFactory.createUseSpeck(newUsePath)
@@ -564,17 +565,17 @@ private val RsUseItem.parentPath: List<String>?
         return if (useSpeck?.useGroup != null) path else path.dropLast(1)
     }
 
-private val RsUseItem.importingNames: List<String>?
+private val RsUseItem.importingNames: Set<String>?
     get() {
         if (useSpeck?.isStarImport == true) return null
         val path = pathAsList ?: return null
-        val groupedNames = useSpeck?.useGroup?.useSpeckList?.map { it.text }
+        val groupedNames = useSpeck?.useGroup?.useSpeckList?.asSequence()?.map { it.text }?.toSet()
         val lastName = path.lastOrNull()
         val alias = useSpeck?.alias?.identifier?.text
         return when {
             groupedNames != null -> groupedNames
-            lastName != null && alias != null -> listOf("$lastName as $alias")
-            lastName != null -> listOf(lastName)
+            lastName != null && alias != null -> setOf("$lastName as $alias")
+            lastName != null -> setOf(lastName)
             else -> null
         }
     }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPathCompletionFromIndexTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPathCompletionFromIndexTest.kt
@@ -152,6 +152,30 @@ class RsPathCompletionFromIndexTest : RsCompletionTestBase() {
         }
     """)
 
+    fun `test insert handler for multiple carets`() = doTest("""
+        mod foo {
+            pub fn bar(x: i32) {}
+        }
+
+        fn main() {
+            ba/*caret*/
+            ba/*caret*/
+            ba/*caret*/
+        }
+    """, """
+        use foo::bar;
+
+        mod foo {
+            pub fn bar(x: i32) {}
+        }
+
+        fn main() {
+            bar(/*caret*/)
+            bar(/*caret*/)
+            bar(/*caret*/)
+        }
+    """)
+
     fun `test do not import out of scope items when setting disabled`() = doTest("""
         mod collections {
             pub struct BTreeMap;

--- a/src/test/kotlin/org/rust/lang/core/completion/RsTraitMethodCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsTraitMethodCompletionTest.kt
@@ -124,6 +124,48 @@ class RsTraitMethodCompletionTest : RsCompletionTestBase() {
         }
     """)
 
+    fun `test auto import trait while method completion for multiple carets`() = doTest("""
+        mod baz {
+            pub trait Foo {
+                fn foo(&self);
+            }
+
+            pub struct Bar;
+
+            impl Foo for Bar {
+                fn foo(&self) {}
+            }
+        }
+
+        use baz::Bar;
+
+        fn main() {
+            Bar.fo/*caret*/
+            Bar.fo/*caret*/
+            Bar.fo/*caret*/
+        }
+    """, """
+        mod baz {
+            pub trait Foo {
+                fn foo(&self);
+            }
+
+            pub struct Bar;
+
+            impl Foo for Bar {
+                fn foo(&self) {}
+            }
+        }
+
+        use baz::{Bar, Foo};
+
+        fn main() {
+            Bar.foo()/*caret*/
+            Bar.foo()/*caret*/
+            Bar.foo()/*caret*/
+        }
+    """)
+
     fun `test do not insert trait import while method completion when trait in scope`() = doTest("""
         mod baz {
             pub trait Foo {


### PR DESCRIPTION
Currently, if I have multiple carets that get autocompleted with automatic imports included:
<img width="595" alt="image" src="https://user-images.githubusercontent.com/2690773/55264986-033a7e00-527f-11e9-8de9-77b0a4456982.png">

imports are duplicated for each caret: 

<img width="409" alt="image" src="https://user-images.githubusercontent.com/2690773/55265018-19483e80-527f-11e9-8d58-f91056ee0715.png">