### PR TITLE
MACRO: add range mappings between macro call and expansion

### DIFF
--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsGeneratedSourcesFilter.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsGeneratedSourcesFilter.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.GeneratedSourcesFilter
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
-import org.rust.lang.core.macros.findMacroCallExpandedFrom
+import org.rust.lang.core.macros.findNavigationTargetIfMacroExpansion
 import org.rust.lang.core.macros.macroExpansionManager
 
 class RsGeneratedSourcesFilter : GeneratedSourcesFilter() {
@@ -18,7 +18,7 @@ class RsGeneratedSourcesFilter : GeneratedSourcesFilter() {
     }
 
     override fun getOriginalElements(element: PsiElement): List<PsiElement> {
-        val macroCall = element.findMacroCallExpandedFrom() ?: return emptyList()
-        return listOf(macroCall.path)
+        val result = element.findNavigationTargetIfMacroExpansion() ?: return emptyList()
+        return listOf(result)
     }
 }

--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsTargetElementEvaluator.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsTargetElementEvaluator.kt
@@ -10,7 +10,7 @@ import com.intellij.codeInsight.TargetElementUtil
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
 import com.intellij.util.BitUtil
-import org.rust.lang.core.macros.findMacroCallExpandedFrom
+import org.rust.lang.core.macros.findNavigationTargetIfMacroExpansion
 import org.rust.lang.core.psi.RsBinaryExpr
 import org.rust.lang.core.psi.RsBinaryOp
 import org.rust.lang.core.psi.RsMethodCall
@@ -69,5 +69,5 @@ class RsTargetElementEvaluator : TargetElementEvaluatorEx2() {
      * @param navElement the element we going to navigate to ([PsiElement.getNavigationElement])
      */
     override fun getGotoDeclarationTarget(element: PsiElement, navElement: PsiElement?): PsiElement? =
-        element.findMacroCallExpandedFrom()?.path
+        element.findNavigationTargetIfMacroExpansion()
 }

--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -664,7 +664,7 @@ private fun calcStubIndex(psi: StubBasedPsiElement<*>): Int {
 private val VirtualFile.fileId: Int
     get() = (this as VirtualFileWithId).id
 
-// Use WeakReference it's relatively easy to load RangeMap again
+/** We use [WeakReference] because uncached [loadRangeMap] is quite cheap */
 private val MACRO_RANGE_MAP_CACHE_KEY: Key<WeakReference<RangeMap>> = Key.create("MACRO_RANGE_MAP_CACHE_KEY")
 private val RANGE_MAP_ATTRIBUTE = FileAttribute(
     "org.rust.macro.RangeMap",

--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -10,9 +10,11 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.vfs.VirtualFileWithId
+import com.intellij.openapi.vfs.newvfs.FileAttribute
 import com.intellij.psi.PsiAnchor
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiManager
@@ -37,6 +39,7 @@ import org.rust.stdext.HashCode
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import java.io.FileNotFoundException
+import java.lang.ref.WeakReference
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.zip.DeflaterOutputStream
@@ -110,7 +113,8 @@ class ExpandedMacroStorage(val project: Project) {
         oldInfo: ExpandedMacroInfo,
         callHash: HashCode?,
         defHash: HashCode?,
-        expansionFile: VirtualFile?
+        expansionFile: VirtualFile?,
+        ranges: RangeMap?
     ): ExpandedMacroInfo {
         checkWriteAccessAllowed()
 
@@ -135,6 +139,10 @@ class ExpandedMacroStorage(val project: Project) {
         }
 
         newInfo.expansionFile?.let { getOrCreateSourceFile(it) }
+
+        if (newInfo.expansionFile != null && ranges != null) {
+            newInfo.expansionFile.writeRangeMap(ranges)
+        }
 
         return newInfo
     }
@@ -190,13 +198,15 @@ class ExpandedMacroStorage(val project: Project) {
 
     companion object {
         private val LOG = Logger.getInstance(ExpandedMacroStorage::class.java)
-        private const val STORAGE_VERSION = 5
+        private const val STORAGE_VERSION = 6
+        const val RANGE_MAP_ATTRIBUTE_VERSION = 2
 
         fun load(project: Project, dataFile: Path): ExpandedMacroStorage? {
             return try {
                 DataInputStream(InflaterInputStream(Files.newInputStream(dataFile))).use { data ->
                     if (data.readInt() != STORAGE_VERSION) return null
                     if (data.readInt() != RsFileStub.Type.stubVersion) return null
+                    if (data.readInt() != RANGE_MAP_ATTRIBUTE_VERSION) return null
 
                     val sourceFilesSize = data.readInt()
                     val sourceFiles = ArrayList<SourceFile>(sourceFilesSize)
@@ -223,6 +233,7 @@ class ExpandedMacroStorage(val project: Project) {
             DataOutputStream(DeflaterOutputStream(Files.newOutputStream(dataFile))).use { data ->
                 data.writeInt(STORAGE_VERSION)
                 data.writeInt(RsFileStub.Type.stubVersion)
+                data.writeInt(RANGE_MAP_ATTRIBUTE_VERSION)
 
                 data.writeInt(storage.sourceFiles.size())
                 storage.sourceFiles.forEachValue { it.writeTo(data); true }
@@ -652,3 +663,34 @@ private fun calcStubIndex(psi: StubBasedPsiElement<*>): Int {
 
 private val VirtualFile.fileId: Int
     get() = (this as VirtualFileWithId).id
+
+// Use WeakReference it's relatively easy to load RangeMap again
+private val MACRO_RANGE_MAP_CACHE_KEY: Key<WeakReference<RangeMap>> = Key.create("MACRO_RANGE_MAP_CACHE_KEY")
+private val RANGE_MAP_ATTRIBUTE = FileAttribute(
+    "org.rust.macro.RangeMap",
+    ExpandedMacroStorage.RANGE_MAP_ATTRIBUTE_VERSION,
+    /*fixedSize = */ true // don't allocate extra space for each record
+)
+
+private fun VirtualFile.writeRangeMap(ranges: RangeMap) {
+    checkWriteAccessAllowed()
+
+    RANGE_MAP_ATTRIBUTE.writeAttribute(this).use {
+        ranges.writeTo(it)
+    }
+
+    if (getUserData(MACRO_RANGE_MAP_CACHE_KEY)?.get() != null) {
+        putUserData(MACRO_RANGE_MAP_CACHE_KEY, WeakReference(ranges))
+    }
+}
+
+fun VirtualFile.loadRangeMap(): RangeMap? {
+    checkReadAccessAllowed()
+
+    getUserData(MACRO_RANGE_MAP_CACHE_KEY)?.get()?.let { return it }
+
+    val data = RANGE_MAP_ATTRIBUTE.readAttribute(this) ?: return null
+    val ranges = RangeMap.readFrom(data)
+    putUserData(MACRO_RANGE_MAP_CACHE_KEY, WeakReference(ranges))
+    return ranges
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.util.io.storage.HeavyProcessLatch
 import org.rust.lang.core.psi.RsMacroCall
@@ -323,25 +324,40 @@ object ExpansionPipeline {
             if (info.isUpToDate(call, def)) {
                 return EmptyPipeline // old expansion is up-to-date
             }
-            val expansion = expander.expandMacroAsText(def, call)?.toString()
+            val expansion = expander.expandMacroAsText(def, call)
             if (expansion == null) {
                 MACRO_LOG.debug("Failed to expand macro: `${call.path.referenceName}!(${call.macroBody})`")
                 return if (oldExpansionFile == null) EmptyPipeline else nextStageFail(callHash, defHash)
             }
 
-            if (oldExpansionFile != null && oldExpansionFile.isValid &&
-                VfsUtil.loadText(oldExpansionFile) == expansion) {
-                return EmptyPipeline
+            val expansionText = expansion.first.toString()
+            val ranges = expansion.second
+
+            if (oldExpansionFile != null && oldExpansionFile.isValid) {
+                val oldExpansionText = VfsUtil.loadText(oldExpansionFile)
+                if (expansionText == oldExpansionText) {
+                    val oldRanges = oldExpansionFile.loadRangeMap()
+                    return if (ranges != oldRanges) {
+                        Stage2OkRangesOnly(call, info, callHash, defHash, oldExpansionFile, ranges)
+                    } else {
+                        EmptyPipeline
+                    }
+                }
             }
 
-            return nextStageOk(callHash, defHash, expansion)
+            return nextStageOk(callHash, defHash, expansionText, ranges)
         }
 
         private fun nextStageFail(callHash: HashCode?, defHash: HashCode?): Pipeline.Stage2WriteToFs =
             Stage2Fail(call, info, callHash, defHash)
 
-        private fun nextStageOk(callHash: HashCode?, defHash: HashCode?, expansionText: String): Pipeline.Stage2WriteToFs =
-            Stage2Ok(call, info, callHash, defHash, expansionText)
+        private fun nextStageOk(
+            callHash: HashCode?,
+            defHash: HashCode?,
+            expansionText: String,
+            ranges: RangeMap
+        ): Pipeline.Stage2WriteToFs =
+            Stage2Ok(call, info, callHash, defHash, expansionText, ranges)
 
         override fun toString(): String =
             "ExpansionPipeline.Stage1(call=${call.path.referenceName}!(${call.macroBody}))"
@@ -352,19 +368,34 @@ object ExpansionPipeline {
         private val info: ExpandedMacroInfo,
         private val callHash: HashCode?,
         private val defHash: HashCode?,
-        private val expansion: String
+        private val expansionText: String,
+        private val ranges: RangeMap
     ) : Pipeline.Stage2WriteToFs {
         override fun writeExpansionToFs(fs: MacroExpansionVfsBatch): Pipeline.Stage3SaveToStorage {
             val oldExpansionFile = info.expansionFile
             val file = if (oldExpansionFile != null) {
                 check(oldExpansionFile.isValid) { "VirtualFile is not valid ${oldExpansionFile.url}" }
                 val file = fs.resolve(oldExpansionFile)
-                fs.writeFile(file, expansion)
+                fs.writeFile(file, expansionText)
                 file
             } else {
-                fs.createFileWithContent(expansion)
+                fs.createFileWithContent(expansionText)
             }
-            return Stage3(call, info, callHash, defHash, file)
+            return Stage3(call, info, callHash, defHash, file, ranges)
+        }
+    }
+
+    class Stage2OkRangesOnly(
+        private val call: RsMacroCall,
+        private val info: ExpandedMacroInfo,
+        private val callHash: HashCode?,
+        private val defHash: HashCode?,
+        private val oldExpansionFile: VirtualFile,
+        private val ranges: RangeMap
+    ) : Pipeline.Stage2WriteToFs {
+        override fun writeExpansionToFs(fs: MacroExpansionVfsBatch): Pipeline.Stage3SaveToStorage {
+            val file = fs.resolve(oldExpansionFile)
+            return Stage3(call, info, callHash, defHash, file, ranges)
         }
     }
 
@@ -379,7 +410,7 @@ object ExpansionPipeline {
             if (oldExpansionFile != null && oldExpansionFile.isValid) {
                 fs.deleteFile(fs.resolve(oldExpansionFile))
             }
-            return Stage3(call, info, callHash, defHash, null)
+            return Stage3(call, info, callHash, defHash, null, null)
         }
     }
 
@@ -388,12 +419,13 @@ object ExpansionPipeline {
         private val info: ExpandedMacroInfo,
         private val callHash: HashCode?,
         private val defHash: HashCode?,
-        private val expansionFile: MacroExpansionVfsBatch.Path?
+        private val expansionFile: MacroExpansionVfsBatch.Path?,
+        private val ranges: RangeMap?
     ) : Pipeline.Stage3SaveToStorage {
         override fun save(storage: ExpandedMacroStorage) {
             checkWriteAccessAllowed()
             val virtualFile = expansionFile?.toVirtualFile()
-            storage.addExpandedMacro(call, info, callHash, defHash, virtualFile)
+            storage.addExpandedMacro(call, info, callHash, defHash, virtualFile, ranges)
             // If a document exists for expansion file (e.g. when AST tree is loaded), the changes in
             // a virtual file will not be committed to the PSI immediately. We have to commit it manually
             // to see the changes (or somehow wait for DocumentCommitThread, but it isn't possible for now)

--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -139,6 +139,16 @@ private fun Int.fromBodyRelativeOffset(call: RsMacroCall): Int? {
     return elementOffset
 }
 
+/**
+ * If receiver element is inside a macro expansion, returns the element inside the macro call
+ * we should navigate to (or the macro call itself if there isn't such element inside a macro call).
+ * Returns null if the element isn't inside a macro expansion
+ */
+fun PsiElement.findNavigationTargetIfMacroExpansion(): PsiElement? {
+    /** @see RsNamedElementImpl.getTextOffset */
+    val element = (this as? RsNameIdentifierOwner)?.nameIdentifier ?: this
+    return element.findElementExpandedFrom() ?: findMacroCallExpandedFrom()?.path
+}
 
 private val RS_EXPANSION_CONTEXT = Key.create<RsElement>("org.rust.lang.core.psi.CODE_FRAGMENT_FILE")
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -294,7 +294,7 @@ fun processExternCrateResolveVariants(
 
 private fun findDependencyCrateByName(context: RsElement, name: String): RsFile? {
     val refinedName = when {
-        name.startsWith(MACRO_CRATE_IDENTIFIER_PREFIX) && context.findMacroCallExpandedFrom() != null -> {
+        name.startsWith(MACRO_CRATE_IDENTIFIER_PREFIX) && context.isExpandedFromMacro -> {
             NameResolutionTestmarks.dollarCrateMagicIdentifier.hit()
             val refinedName = name.removePrefix(MACRO_CRATE_IDENTIFIER_PREFIX)
             if (refinedName == "self") {
@@ -463,7 +463,7 @@ private fun processUnqualifiedPathResolveVariants(
         run {
             // hacks around $crate macro metavar. See `expandDollarCrateVar` function docs
             val referenceName = path.referenceName
-            if (referenceName.startsWith(MACRO_CRATE_IDENTIFIER_PREFIX) && path.findMacroCallExpandedFrom() != null) {
+            if (referenceName.startsWith(MACRO_CRATE_IDENTIFIER_PREFIX) && path.isExpandedFromMacro) {
                 val crate = referenceName.removePrefix(MACRO_CRATE_IDENTIFIER_PREFIX)
                 val result = if (crate == "self") {
                     processor.lazy(referenceName) { path.crateRoot }

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -215,6 +215,9 @@ fun <T> Project.computeWithCancelableProgress(title: String, supplier: () -> T):
     return ProgressManager.getInstance().runProcessWithProgressSynchronously<T, Exception>(supplier, title, true, this)
 }
 
+inline fun <T> UserDataHolderEx.getOrPut(key: Key<T>, defaultValue: () -> T): T =
+    getUserData(key) ?: putUserDataIfAbsent(key, defaultValue())
+
 inline fun <T> UserDataHolderEx.getOrPutSoft(key: Key<SoftReference<T>>, defaultValue: () -> T): T =
     getUserData(key)?.get() ?: run {
         val value = defaultValue()

--- a/src/main/kotlin/org/rust/stdext/Collections.kt
+++ b/src/main/kotlin/org/rust/stdext/Collections.kt
@@ -5,6 +5,7 @@
 
 package org.rust.stdext
 
+import com.intellij.util.SmartList
 import java.util.*
 
 @Suppress("UNCHECKED_CAST")
@@ -48,7 +49,7 @@ inline fun <K, V> buildMap(builder: (MapBuilder<K, V>).() -> Unit): Map<K, V> {
         }
     }.builder()
 
-    return replaceTrivialMap(result)
+    return result.replaceTrivialMap()
 }
 
 interface MapBuilder<K, in V> {
@@ -56,13 +57,22 @@ interface MapBuilder<K, in V> {
     fun putAll(map: Map<K, V>)
 }
 
-fun <K, V> replaceTrivialMap(map: Map<K, V>): Map<K, V> = when (map.size) {
+fun <K, V> Map<K, V>.replaceTrivialMap(): Map<K, V> = when (size) {
     0 -> emptyMap()
     1 -> {
-        val entry = map.entries.single()
+        val entry = entries.single()
         Collections.singletonMap(entry.key, entry.value)
     }
-    else -> map
+    else -> this
+}
+
+fun <T> SmartList<T>.optimizeList(): List<T> = when (size) {
+    0 -> emptyList()
+    1 -> Collections.singletonList(single())
+    else -> {
+        trimToSize()
+        this
+    }
 }
 
 private const val INT_MAX_POWER_OF_TWO: Int = Int.MAX_VALUE / 2 + 1

--- a/src/main/kotlin/org/rust/stdext/io.kt
+++ b/src/main/kotlin/org/rust/stdext/io.kt
@@ -1,0 +1,19 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.stdext
+
+import com.intellij.util.io.DataInputOutputUtil
+import java.io.DataInput
+import java.io.DataOutput
+import java.io.IOException
+
+@Throws(IOException::class)
+fun DataInput.readVarInt(): Int =
+    DataInputOutputUtil.readINT(this)
+
+@Throws(IOException::class)
+fun DataOutput.writeVarInt(value: Int): Unit =
+    DataInputOutputUtil.writeINT(this, value)

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoDeclarationTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoDeclarationTest.kt
@@ -26,7 +26,7 @@ class RsGotoDeclarationTest : RsTestBase() {
         type T = /*caret*/S;
     """, """
         macro_rules! foo { ($ i:item) => { $ i } }
-        /*caret*/foo! { struct S; }
+        foo! { struct /*caret*/S; }
         type T = S;
     """)
 
@@ -38,7 +38,7 @@ class RsGotoDeclarationTest : RsTestBase() {
     """, """
         macro_rules! foo { ($ i:item) => { $ i } }
         /// docs
-        /*caret*/foo! { struct S; }
+        foo! { struct /*caret*/S; }
         type T = S;
     """)
 
@@ -48,7 +48,7 @@ class RsGotoDeclarationTest : RsTestBase() {
         type T = /*caret*/S;
     """, """
         macro_rules! foo { ($ i:item) => { $ i } }
-        /*caret*/foo! { foo! { struct S; } }
+        foo! { foo! { struct /*caret*/S; } }
         type T = S;
     """)
 
@@ -59,8 +59,18 @@ class RsGotoDeclarationTest : RsTestBase() {
         type T = /*caret*/S;
     """, """
         macro_rules! foo { ($ i:item) => { $ i } }
-        /*caret*/foo! { mod a { struct S; } }
+        foo! { mod a { struct /*caret*/S; } }
         use a::S;
+        type T = S;
+    """)
+
+    fun `test defined with a macro with struct inside macro definition`() = doTest("""
+        macro_rules! foo { () => { struct S; } }
+        foo!();
+        type T = /*caret*/S;
+    """, """
+        macro_rules! foo { () => { struct S; } }
+        /*caret*/foo!();
         type T = S;
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionRangeMappingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionRangeMappingTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.intellij.lang.annotations.Language
+import org.rust.ExpandMacros
+import org.rust.RsTestBase
+import org.rust.lang.core.psi.RsBinaryExpr
+import org.rust.lang.core.psi.ext.*
+
+@ExpandMacros
+class RsMacroExpansionRangeMappingTest : RsTestBase() {
+    fun `test struct name`() = checkOffset("""
+        macro_rules! foo {
+            ($ i:item) => { $ i };
+        }
+        foo! {
+            struct /*caret*/Foo;
+        }
+        type T = Foo;
+               //^
+    """, SELECT_NAME)
+
+    fun `test struct name from nested macro 1`() = checkOffset("""
+        macro_rules! foo {
+            ($ i:item) => { $ i };
+        }
+        foo! {
+            foo! { pub struct /*caret*/Foo; }
+        }
+        type T = Foo;
+               //^
+    """, SELECT_NAME)
+
+    fun `test struct name from nested macro 2`() = checkOffset("""
+        macro_rules! foo {
+            ($ i:item) => { $ i };
+        }
+        foo! {
+            mod a {
+                foo! { pub struct /*caret*/Foo; }
+            }
+        }
+        type T = a::Foo;
+                  //^
+    """, SELECT_NAME)
+
+    fun `test struct name from nested macro 3`() = checkOffset("""
+        macro_rules! foo {
+            ($ i:item) => { $ i };
+        }
+        macro_rules! bar {
+            ($ i:item) => { mod a { $ i } };
+        }
+        bar! {
+            foo! { pub struct /*caret*/Foo; }
+        }
+        type T = a::Foo;
+                  //^
+    """, SELECT_NAME)
+
+    fun `test struct name passed via tt`() = checkOffset("""
+        macro_rules! foo {
+            ($($ i:tt)*) => { $($ i)* };
+        }
+        foo! {
+            struct /*caret*/Foo;
+        }
+        type T = Foo;
+               //^
+    """, SELECT_NAME)
+
+    fun `test struct`() = checkOffset("""
+        macro_rules! foo {
+            ($ i:item) => { $ i };
+        }
+        foo! {
+            /*caret*/struct Foo;
+        }
+        type T = Foo;
+               //^
+    """)
+
+    fun `test struct passed via tt`() = checkOffset("""
+        macro_rules! foo {
+            ($($ i:tt)*) => { $($ i)* };
+        }
+        foo! {
+            /*caret*/struct Foo;
+        }
+        type T = Foo;
+               //^
+    """)
+
+    fun `test struct field passed via tt`() = checkOffset("""
+        macro_rules! foo {
+            ($($ i:tt)*) => { $($ i)* };
+        }
+        foo! {
+            struct Foo {
+                /*caret*/bar: i32
+            }
+        }
+        fn foo(foo: Foo) {
+            foo.bar;
+        }     //^
+    """)
+
+    fun `test expression`() = checkOffset("""
+        macro_rules! foo {
+            ($ e:expr) => { fn foo() { $ e } };
+        }
+        foo! {
+            /*caret*/2 + 2
+        }
+        use self::foo;
+                //^
+    """) { it.descendantOfTypeStrict<RsBinaryExpr>()!! }
+
+    fun `test not found when expanded from macro definition`() = checkNotFound("""
+        macro_rules! foo {
+            ($ i:item) => { $ i };
+        }
+        macro_rules! bar {
+            () => { foo! { struct Foo; } };
+        }
+        bar!();
+        type T = Foo;
+               //^
+    """)
+
+    fun `test not found when expanded from nested macro definition`() = checkNotFound("""
+        macro_rules! foo {
+            () => { struct Foo; };
+        }
+        foo!();
+        type T = Foo;
+               //^
+    """)
+
+    private fun checkOffset(@Language("Rust") code: String, refiner: (RsElement) -> PsiElement = { it }) {
+        InlineFile(code).withCaret()
+        val ref = findElementInEditor<RsReferenceElement>("^")
+        val resolved = ref.reference.resolve() ?: error("Failed to resolve ${ref.text}")
+        val elementInExpansion = refiner(resolved)
+        check(elementInExpansion.isExpandedFromMacro) { "Must resolve to macro expansion" }
+        val elementInCallBody = elementInExpansion.findElementExpandedFrom()
+            ?: error("Failed to find element expanded from")
+        assertEquals(myFixture.editor.caretModel.currentCaret.offset, elementInCallBody.startOffset)
+
+        // do reverse translation of offsets and check that they are equal to original
+        val recoveredElementsInExpansion = elementInCallBody.findExpansionElements()
+            ?: error("recoveredElementsInExpansion must not be null")
+        check(recoveredElementsInExpansion.size == 1) { "Expected list of 1 element, got: $recoveredElementsInExpansion" }
+        val recoveredElementInExpansion = recoveredElementsInExpansion.single()
+        assertEquals(elementInExpansion.startOffset, recoveredElementInExpansion.startOffset)
+        check(recoveredElementInExpansion is LeafPsiElement)
+    }
+
+    private fun checkNotFound(@Language("Rust") code: String, refiner: (RsElement) -> PsiElement = { it }) {
+        InlineFile(code)
+        val ref = findElementInEditor<RsReferenceElement>("^")
+        val resolved = ref.reference.resolve() ?: error("Failed to resolve ${ref.text}")
+        val elementInExpansion = refiner(resolved)
+        check(elementInExpansion.isExpandedFromMacro) { "Must resolve to macro expansion" }
+        val elementInCallBody = elementInExpansion.findElementExpandedFrom()
+        assertNull(elementInCallBody)
+    }
+
+    companion object {
+        private val SELECT_NAME = { e: RsElement -> (e as RsNameIdentifierOwner).nameIdentifier!! }
+    }
+}


### PR DESCRIPTION
Now we know which element in macro call is expanded to which (real) element in expansion.
Currently it is used only to provide more precise navigation target when navigating to something expanded from a macro:
![Peek 2019-04-03 23-36](https://user-images.githubusercontent.com/3221931/55512388-addde280-566b-11e9-8f43-c4c490fed0d6.gif)

But soon I'll use it to support go-to-declaration from macro call #2898 (and for other navigation actions), and then this will be used to support hygiene (and so type inference for custom expression-like macros), and in the future this will allow to support highlighting and completion inside macro calls!

This works only if new macro expansion engine is enabled (see #3628 for details).