### PR TITLE
TY: better type inference for overloaded binops

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -613,7 +613,7 @@ class ImplLookup(
     fun findArithmeticBinaryExprOutputType(lhsType: Ty, rhsType: Ty, op: ArithmeticOp): TyWithObligations<Ty>? {
         val trait = op.findTrait(items) ?: return null
         val assocType = trait.findAssociatedType("Output") ?: return null
-        return selectProjection(TraitRef(lhsType, trait.withSubst(rhsType)), assocType).ok()
+        return ctx.normalizeAssociatedTypesIn(TyProjection.valueOf(lhsType, trait.withSubst(rhsType), assocType))
     }
 
     private fun selectProjection(

--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
@@ -7,7 +7,9 @@ package org.rust.ide.refactoring
 
 import junit.framework.TestCase
 import org.intellij.lang.annotations.Language
+import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.refactoring.introduceVariable.IntroduceVariableTestmarks
 import org.rust.lang.core.psi.RsExpr
 import org.rust.openapiext.Testmark
@@ -60,6 +62,7 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
         }
     """)
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test replace occurrences forward`() = doTest("""
         fn hello() {
             foo(5 + /*caret*/10);
@@ -73,6 +76,7 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
         }
     """, replaceAll = true)
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test replace occurrences backward`() = doTest("""
         fn main() {
             let a = 1;

--- a/src/test/kotlin/org/rust/ide/template/postfix/LetPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/LetPostfixTemplateTest.kt
@@ -5,6 +5,9 @@
 
 package org.rust.ide.template.postfix
 
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+
 class LetPostfixTemplateTest : RsPostfixTemplateTest(LetPostfixTemplate(RsPostfixTemplateProvider())) {
     fun `test not expr`() = doTestNotApplicable("""
         fn foo() {
@@ -22,6 +25,7 @@ class LetPostfixTemplateTest : RsPostfixTemplateTest(LetPostfixTemplate(RsPostfi
         }
     """)
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test par expr`() = doTest("""
         fn foo() {
             (1 + 2).let/*caret*/;

--- a/src/test/kotlin/org/rust/lang/core/type/RsArithmeticOpsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsArithmeticOpsTest.kt
@@ -109,6 +109,36 @@ class RsArithmeticOpsTest : RsTypificationTestBase() {
         """
     }
 
+    fun `test with rhs reference coercion`() = testExprWithAllOps { traitName, itemName, fnName, sign ->
+        """
+        #[lang = "deref"]
+        trait Deref { type Target; }
+
+        #[lang = "$itemName"]
+        pub trait $traitName<RHS=Self> {
+            type Output;
+            fn $fnName(self, rhs: RHS) -> Self::Output;
+        }
+
+        struct Foo;
+        struct Bar;
+
+        struct X; struct Y;
+        impl Deref for X { type Target = Y; }
+
+        impl $traitName<&Y> for Foo {
+            type Output = Bar;
+            fn $fnName(self, rhs: &Y) -> Bar { unimplemented!() }
+        }
+
+        fn foo(lhs: Foo, rhs: X) {
+            let x = lhs $sign &rhs;
+            x;
+          //^ Bar
+        }
+        """
+    }
+
     fun `test generic lhs and output`() = testExprWithAllOps { traitName, itemName, fnName, sign ->
         """
         #[lang = "$itemName"]

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -441,8 +441,8 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         fn main() {
             let test: Vec<i32> = Vec::new();
             let a = test.into_iter()
-                .filter(|x| x < 30)
-                .filter(|x| x > 10)
+                .filter(|x| *x < 30)
+                .filter(|x| *x > 10)
                 .filter(|x| x % 2 == 0)
                 .next().unwrap();
             a;
@@ -711,5 +711,15 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
             a;
           //^ String
         }
+    """)
+
+    fun `test overloaded add String + &String`() = stubOnlyTypeInfer("""
+    //- main.rs
+        fn main() {
+            let a = String::new();
+            let b = String::new();
+            let c = a + &b;
+            c;
+        } //^ String
     """)
 }


### PR DESCRIPTION
This now works:
```rust
fn main() {
    let a = String::new();
    let b = String::new();
    let c = a + &b;
    c;
} //^ String
```

TODO:
- [x] add more tests