### PR TITLE
RES: fix StackOverflow in name resolution

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
@@ -618,4 +618,23 @@ class RsUseResolveTest : RsResolveTestBase() {
             bar();
         }  //^
     """)
+
+    fun `test cyclic dependent imports`() = expect<IllegalStateException> {
+        checkByCode("""
+        mod a {
+            pub use b::*;
+
+            pub mod c {
+                pub struct Foo;
+            }            //X
+
+            type T = self::Foo;
+        }                //^
+
+        mod b {
+            pub use a::*;
+            pub use self::c::*;
+        }
+    """)
+    }
 }


### PR DESCRIPTION
<details><summary>stacktrace</summary>
<p>

```stacktrace
java.lang.StackOverflowError
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt:134)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt:134)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt:134)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt:134)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt:134)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt:134)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt:134)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt:134)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt:134)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt:134)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt:134)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt:134)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt)
	at org.rust.lang.core.resolve.ItemResolutionKt$processItemDeclarations$found$1.invoke(ItemResolution.kt:134)
```
</p>
</details>