### PR TITLE
Revert "INT: Take into account defaulted type parameters during `Implement members`"

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -114,27 +114,9 @@ fun resolvePath(path: RsPath, lookup: ImplLookup = ImplLookup.relativeTo(path)):
         }
 
         val typeParameters = element.typeParameters.map { TyTypeParameter.named(it) }
-        val typeSubst = buildMap<TyTypeParameter, Ty> {
-            putAll(typeParameters.zip(typeParameters).toMap())
-            val typeDefaults = element.typeParameters.mapNotNull {
-                val param = TyTypeParameter.named(it)
-                val default = it.typeReference?.type ?: return@mapNotNull null
-                param to default
-            }.toMap()
-            putAll(typeDefaults)
-            if (typeArguments != null) {
-                putAll(typeParameters.zip(typeArguments).toMap())
-            }
-        }
-
         val regionParameters = element.lifetimeParameters.map { ReEarlyBound(it) }
-        val regionSubst = buildMap<ReEarlyBound, Region> {
-            putAll(regionParameters.zip(regionParameters).toMap())
-            if (regionArguments != null) {
-                putAll(regionParameters.zip(regionArguments).toMap())
-            }
-        }
-
+        val typeSubst = typeParameters.zip(typeArguments ?: typeParameters).toMap()
+        val regionSubst = regionParameters.zip(regionArguments ?: regionParameters).toMap()
         val newSubst = Substitution(typeSubst, regionSubst)
         BoundElement(element, subst + newSubst, assocTypes)
     }

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -269,13 +269,11 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """)
 
     fun `test implement generic trait`() = doTest("""
-        trait T<A, B = i16, C = u32> {
+        trait T<A, B> {
             fn f1(_: A) -> A;
             const C1: A;
             fn f2(_: B) -> B;
             const C2: B;
-            fn f3(_: C) -> C;
-            const C3: C;
         }
         struct S;
         impl T<u8, u16> for S {/*caret*/}
@@ -283,17 +281,13 @@ class ImplementMembersHandlerTest : RsTestBase() {
         ImplementMemberSelection("f1(_: A) -> A", true),
         ImplementMemberSelection("C1: A", true),
         ImplementMemberSelection("f2(_: B) -> B", true),
-        ImplementMemberSelection("C2: B", true),
-        ImplementMemberSelection("f3(_: C) -> C", true),
-        ImplementMemberSelection("C3: C", true)
+        ImplementMemberSelection("C2: B", true)
     ), """
-        trait T<A, B = i16, C = u32> {
+        trait T<A, B> {
             fn f1(_: A) -> A;
             const C1: A;
             fn f2(_: B) -> B;
             const C2: B;
-            fn f3(_: C) -> C;
-            const C3: C;
         }
         struct S;
         impl T<u8, u16> for S {
@@ -308,12 +302,6 @@ class ImplementMembersHandlerTest : RsTestBase() {
             }
 
             const C2: u16 = unimplemented!();
-
-            fn f3(_: u32) -> u32 {
-                unimplemented!()
-            }
-
-            const C3: u32 = unimplemented!();
         }
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -795,7 +795,9 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }                   //^
     """, NameResolutionTestmarks.selfRelatedTypeSpecialCase)
 
-    fun `test Self-qualified path in trait impl is resolved to assoc type of super trait (generic trait 2)`() = checkByCode("""
+    // TODO support default type parameters
+    fun `test Self-qualified path in trait impl is resolved to assoc type of super trait (generic trait 2)`() = expect<IllegalStateException> {
+        checkByCode("""
         struct S;
         trait Trait1<T=u8> { type Item; }
         trait Trait2<T>: Trait1<T> { fn foo() -> i32; }
@@ -809,7 +811,8 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         impl Trait2<i32> for S {
             fn foo() -> Self::Item { unreachable!() }
         }                   //^
-    """, NameResolutionTestmarks.selfRelatedTypeSpecialCase)
+        """, NameResolutionTestmarks.selfRelatedTypeSpecialCase)
+    }
 
     fun `test explicit UFCS-like type-qualified path`() = checkByCode("""
         struct S;


### PR DESCRIPTION
This reverts commit ccc5f54d

Fixes https://github.com/intellij-rust/intellij-rust/issues/3635. Reopens https://github.com/intellij-rust/intellij-rust/issues/3470.
