### PR TITLE
PERF: optimize VFS batch (macro expansion)

### DIFF
--- a/src/183/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
+++ b/src/183/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
@@ -1,0 +1,37 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+
+fun createEventBasedVfsBatch(): EventBasedVfsBatch =
+    EventBasedVfsBatch183()
+
+private class EventBasedVfsBatch183 : EventBasedVfsBatch() {
+    override fun DirCreateEvent.toVFileEvent(): VFileEvent? {
+        val vParent = LocalFileSystem.getInstance().findFileByPath(parent.toString()) ?: return null
+        return VFileCreateEvent(null, vParent, name, true, true)
+    }
+
+    override fun Event.toVFileEvent(): VFileEvent? = when (this) {
+        is Event.Create -> {
+            val vParent = LocalFileSystem.getInstance().findFileByPath(parent.toString())!!
+            VFileCreateEvent(null, vParent, name, false, true)
+        }
+        is Event.Write -> {
+            val vFile = LocalFileSystem.getInstance().findFileByPath(file.toString())!!
+            VFileContentChangeEvent(null, vFile, vFile.modificationStamp, -1, true)
+        }
+        is Event.Delete -> {
+            val vFile = LocalFileSystem.getInstance().findFileByPath(file.toString())!!
+            VFileDeleteEvent(null, vFile, true)
+        }
+    }
+}

--- a/src/191/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
+++ b/src/191/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
@@ -1,0 +1,47 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.openapi.util.io.FileAttributes
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+
+fun createEventBasedVfsBatch(): EventBasedVfsBatch =
+    EventBasedVfsBatch191()
+
+private class EventBasedVfsBatch191 : EventBasedVfsBatch() {
+    override fun DirCreateEvent.toVFileEvent(): VFileEvent? {
+        val vParent = LocalFileSystem.getInstance().findFileByPath(parent.toString()) ?: return null
+        return VFileCreateEvent(null, vParent, name, true, null, null, true, false)
+    }
+
+    override fun Event.toVFileEvent(): VFileEvent? = when (this) {
+        is Event.Create -> {
+            val vParent = LocalFileSystem.getInstance().findFileByPath(parent.toString())!!
+            val attributes = FileAttributes(
+                /* directory = */ false,
+                /* special = */ false,
+                /* symlink = */ false,
+                /* hidden = */ false,
+                /* length = */ length.toLong(),
+                /* lastModified = */ lastModified,
+                /* writable = */ true
+            )
+            VFileCreateEvent(null, vParent, name, false, attributes, null, true, false)
+        }
+        is Event.Write -> {
+            val vFile = LocalFileSystem.getInstance().findFileByPath(file.toString())!!
+            VFileContentChangeEvent(null, vFile, vFile.modificationStamp, -1, true)
+        }
+        is Event.Delete -> {
+            val vFile = LocalFileSystem.getInstance().findFileByPath(file.toString())!!
+            VFileDeleteEvent(null, vFile, true)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -21,6 +21,7 @@ import org.rust.lang.core.psi.ext.macroBody
 import org.rust.lang.core.psi.ext.resolveToMacro
 import org.rust.lang.core.resolve.DEFAULT_RECURSION_LIMIT
 import org.rust.openapiext.*
+import org.rust.stdext.executeSequentially
 import org.rust.stdext.nextOrNull
 import org.rust.stdext.supplyAsync
 import java.nio.file.Path
@@ -121,18 +122,18 @@ abstract class MacroExpansionTaskBase(
             realTaskIndicator.text2 = "Writing expansion results"
 
             if (stages2.isNotEmpty()) {
-                val fs = LocalFsMacroExpansionVfsBatch(realFsExpansionContentRoot)
                 // TODO support cancellation here
-                val stages3 = stages2.map { stage2 ->
-                    val result = stage2.writeExpansionToFs(fs)
-                    doneStages.incrementAndGet()
-                    result
+                val stages3fs = stages2.chunked(VFS_BATCH_SIZE).map { stages2c ->
+                    val fs = LocalFsMacroExpansionVfsBatch(realFsExpansionContentRoot)
+                    val stages3 = stages2c.map { stage2 ->
+                        val result = stage2.writeExpansionToFs(fs)
+                        doneStages.incrementAndGet()
+                        result
+                    }
+                    stages3 to fs
                 }
 
-                supplyAsync(transactionExecutor) {
-                    // All changes should be applied in a single write action. Otherwise we'll run into
-                    // dumb mode between two write actions. Also changes applied to vfs should be consistent
-                    // with the changes applied to the storage
+                executeSequentially(transactionExecutor, stages3fs) { (stages3, fs) ->
                     runWriteAction {
                         fs.applyToVfs()
                         for (stage3 in stages3) {
@@ -142,7 +143,7 @@ abstract class MacroExpansionTaskBase(
                     }
                     totalExpanded.addAndGet(stages3.size)
                     Unit
-                }
+                }.thenApply { Unit }
             } else {
                 CompletableFuture.completedFuture(Unit)
             }
@@ -189,6 +190,13 @@ abstract class MacroExpansionTaskBase(
     open fun canEat(other: MacroExpansionTaskBase): Boolean = false
 
     open val isProgressBarDelayed: Boolean get() = true
+
+    companion object {
+        /**
+         * Higher values leads to better throughput (overall expansion time), but worse latency (UI freezes)
+         */
+        private const val VFS_BATCH_SIZE = 50
+    }
 }
 
 interface Extractable {


### PR DESCRIPTION
1. Optimize VFS batch
That was an original implementation of VFS batch which I removed because of API difference between 183 and 191 (and 192). But this implementation works faster. So if there will be any problems (including porting on 192), we can roll back to RefreshBasedVfsBatch

2. Split expansion writing into several batches
Now we produce fewer UI freezes

Part of #3628