### PR TITLE
DBG: Load Rust stdlib sources

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
@@ -44,6 +44,10 @@ class RsDebugRunner : RsAsyncRunner(DefaultDebugExecutor.EXECUTOR_ID, ERROR_MESS
                         ProcessTerminatedListener.attach(processHandler, environment.project)
                         val settings = RsDebuggerSettings.getInstance()
                         loadPrettyPrinters(sysroot, settings.lldbRenderers, settings.gdbRenderers)
+                        val commitHash = state.cargoProject?.rustcInfo?.version?.commitHash
+                        if (sysroot != null && commitHash != null) {
+                            loadRustcSources(sysroot, commitHash)
+                        }
                         start()
                     }
 

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsLocalDebugProcess.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsLocalDebugProcess.kt
@@ -33,6 +33,20 @@ class RsLocalDebugProcess(
         }
     }
 
+    fun loadRustcSources(sysroot: String, commitHash: String) {
+        postCommand { driver ->
+            val sourceMapCommand = when (driver) {
+                is LLDBDriver -> "settings set target.source-map"
+                is GDBDriver -> "set substitute-path"
+                else -> return@postCommand
+            }
+            val rustcHash = "/rustc/$commitHash/".systemDependentAndEscaped()
+            val rustcSources = "$sysroot/lib/rustlib/src/rust/".systemDependentAndEscaped()
+            val fullCommand = """$sourceMapCommand "$rustcHash" "$rustcSources" """
+            driver.executeConsoleCommand(currentThreadId, currentFrameIndex, fullCommand)
+        }
+    }
+
     private fun LLDBDriver.loadPrettyPrinters(threadId: Long, frameIndex: Int, sysroot: String?, renderers: LLDBRenderers) {
         when (renderers) {
             LLDBRenderers.COMPILER -> {

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunStateBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunStateBase.kt
@@ -27,7 +27,7 @@ abstract class CargoRunStateBase(
 ) : CommandLineState(environment) {
     private val toolchain: RustToolchain = config.toolchain
     val commandLine: CargoCommandLine = config.cmd
-    private val cargoProject: CargoProject? = CargoCommandConfiguration.findCargoProject(
+    val cargoProject: CargoProject? = CargoCommandConfiguration.findCargoProject(
         environment.project,
         commandLine.additionalArguments,
         commandLine.workingDirectory

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -66,7 +66,7 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
     private fun setupMockRustcVersion() {
         val annotation = findAnnotationInstance<MockRustcVersion>() ?: return
         val (semVer, channel) = parse(annotation.rustcVersion)
-        val rustcInfo = RustcInfo("", RustcVersion(semVer, "", channel))
+        val rustcInfo = RustcInfo("", RustcVersion(semVer, "", channel, null))
         project.cargoProjects.setRustcInfo(rustcInfo)
     }
 
@@ -162,7 +162,7 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
         fail("No ${X::class.java} was thrown during the test")
     }
 
-    inner class InlineFile(private @Language("Rust") val code: String, val name: String = "main.rs") {
+    inner class InlineFile(@Language("Rust") private val code: String, val name: String = "main.rs") {
         private val hasCaretMarker = "/*caret*/" in code
 
         init {


### PR DESCRIPTION
Now it's possible to jump into Rust stdlib sources while debugging.

![debug_stdlib](https://user-images.githubusercontent.com/4854600/55635499-843acd80-57c9-11e9-8d1b-1eb4ab6de529.gif)
