### PR TITLE
Some doctest injection fixes

### DIFF
--- a/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
+++ b/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
@@ -84,6 +84,7 @@ class RsDoctestLanguageInjector : MultiHostInjector {
                 when {
                     text.startsWith("##", codeStart) -> TextRange(codeStart + 1, end)
                     text.startsWith("# ", codeStart) -> TextRange(codeStart + 2, end)
+                    text.startsWith("#\n", codeStart) -> TextRange(codeStart + 1, end)
                     else -> TextRange(start, end)
                 }
             }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -256,7 +256,6 @@ fun processExternCrateResolveVariants(element: RsElement, isCompletion: Boolean,
         if (otherVersionOfSameCrate.hitOnFalse(libTarget == target) && !isDoctestInjection) return false
 
         if (pkg.origin == PackageOrigin.STDLIB && pkg.name in visitedDeps) return false
-        if (isDoctestInjection && pkg.origin != PackageOrigin.STDLIB && libTarget != target) return false
         visitedDeps += pkg.name
         return processor.lazy(dependencyName ?: libTarget.normName) {
             libTarget.crateRoot?.toPsiFile(element.project)?.rustFile

--- a/src/test/kotlin/org/rust/ide/annotator/RsDoctestAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsDoctestAnnotatorTest.kt
@@ -66,6 +66,27 @@ class RsDoctestAnnotatorTest : RsAnnotatorTestBase(RsDoctestAnnotator::class.jav
         |fn foo() {}
         |""")
 
+    fun `test "# " escape`() = doTest("""
+        |/// ```
+        |///<info> # <inject>extern crate foobar;
+        |</inject></info>/// ```
+        |fn foo() {}
+        |""")
+
+    fun `test "##" escape`() = doTest("""
+        |/// ```
+        |///<info> #<inject>#![allow(deprecated)]
+        |</inject></info>/// ```
+        |fn foo() {}
+        |""")
+
+    fun `test "#" escape`() = doTest("""
+        |/// ```
+        |///<info> #<inject>
+        |</inject></info>/// ```
+        |fn foo() {}
+        |""")
+
     fun `test no injection in non-lib target`() = checkByText("""
         /// ```
         /// let a = 0;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
@@ -30,12 +30,17 @@ class RsDoctestInjectionResolveTest : RsResolveTestBase() {
         /// ```
         pub fn foo() {}
     """)
+
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    fun `test outer crate dependency is not resolved`() = checkByCode("""
+    fun `test outer crate dependency`() = stubOnlyResolve("""
+    //- lib.rs
         /// ```
         /// extern crate dep_lib_target;
-        ///             //^ unresolved
+        /// use dep_lib_target::bar;
+        ///                   //^ dep-lib/lib.rs
         /// ```
         pub fn foo() {}
-    """, "lib.rs")
+    //- dep-lib/lib.rs
+        pub fn bar() {}
+    """)
 }


### PR DESCRIPTION
1. Resolve dependencies inside doctests
2. Fix single `#` excape (when newline after `#`)