### PR TITLE
DOC: formatting RustDoc for #trimTrailingAsterisks

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -10,6 +10,7 @@ alygin
 amakeev
 andruhon
 anton-okolelov
+ArtsiomCh
 ashleysommer
 AtomicInteger
 atsky

--- a/src/main/kotlin/org/rust/lang/doc/psi/RsDocKind.kt
+++ b/src/main/kotlin/org/rust/lang/doc/psi/RsDocKind.kt
@@ -112,7 +112,7 @@ enum class RsDocKind {
         }
 
         /**
-         * Get rid of trailing (pseudo-regexp): [ ]+ [*]* * /
+         * Get rid of trailing (pseudo-regexp): `[ ]+ [*]* * /`
          */
         private fun String.trimTrailingAsterisks(): String {
             if (length < 2) return this


### PR DESCRIPTION
Put `...*]*...` in code spans to not be parsed as markdown emphasis.

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
