### PR TITLE
DBG: Add HashMap/HashSet formatter for gdb

### DIFF
--- a/prettyPrinters/gdb_lookup.py
+++ b/prettyPrinters/gdb_lookup.py
@@ -45,6 +45,10 @@ def lookup(valobj):
         return StdBTreeSetProvider(valobj)
     if rust_type == RustType.STD_BTREE_MAP:
         return StdBTreeMapProvider(valobj)
+    if rust_type == RustType.STD_HASH_MAP:
+        return StdHashMapProvider(valobj)
+    if rust_type == RustType.STD_HASH_SET:
+        return StdHashMapProvider(valobj["map"], show_values=False)
 
     if rust_type == RustType.STD_RC:
         return StdRcProvider(valobj)

--- a/prettyPrinters/gdb_providers.py
+++ b/prettyPrinters/gdb_providers.py
@@ -1,11 +1,13 @@
+from sys import version_info
+
 import gdb
 from gdb import lookup_type
-from sys import version_info
 
 if version_info[0] >= 3:
     xrange = range
 
 ZERO_FIELD = "__0"
+FIRST_FIELD = "__1"
 
 
 def unwrap_unique_or_non_null(unique_or_nonnull):
@@ -249,3 +251,60 @@ class StdBTreeMapProvider:
     @staticmethod
     def display_hint():
         return "map"
+
+
+class StdHashMapProvider:
+    def __init__(self, valobj, show_values=True):
+        self.valobj = valobj
+        self.show_values = show_values
+
+        self.table = self.valobj["table"]
+        self.size = int(self.table["size"])
+        self.hashes = self.table["hashes"]
+        self.hash_uint_type = self.hashes.type
+        self.hash_uint_size = self.hashes.type.sizeof
+        self.modulo = 2 ** self.hash_uint_size
+        self.data_ptr = self.hashes[ZERO_FIELD]["pointer"]
+
+        self.capacity_mask = int(self.table["capacity_mask"])
+        self.capacity = (self.capacity_mask + 1) % self.modulo
+
+        marker = self.table["marker"].type
+        self.pair_type = marker.template_argument(0)
+        self.pair_type_size = self.pair_type.sizeof
+
+        self.valid_indices = []
+        for idx in range(self.capacity):
+            data_ptr = self.data_ptr.cast(self.hash_uint_type.pointer())
+            address = data_ptr + idx
+            hash_uint = address.dereference()
+            hash_ptr = hash_uint[ZERO_FIELD]["pointer"]
+            if int(hash_ptr) != 0:
+                self.valid_indices.append(idx)
+
+    def to_string(self):
+        return "size={}".format(self.size)
+
+    def children(self):
+        start = int(self.data_ptr) & ~1
+
+        hashes = self.hash_uint_size * self.capacity
+        align = self.pair_type_size
+        len_rounded_up = (((((hashes + align) % self.modulo - 1) % self.modulo) & ~(
+                (align - 1) % self.modulo)) % self.modulo - hashes) % self.modulo
+
+        pairs_offset = hashes + len_rounded_up
+        pairs_start = gdb.Value(start + pairs_offset).cast(self.pair_type.pointer())
+
+        for index in range(self.size):
+            table_index = self.valid_indices[index]
+            idx = table_index & self.capacity_mask
+            element = (pairs_start + idx).dereference()
+            if self.show_values:
+                yield ("key{}".format(index), element[ZERO_FIELD])
+                yield ("val{}".format(index), element[FIRST_FIELD])
+            else:
+                yield ("[{}]".format(index), element[ZERO_FIELD])
+
+    def display_hint(self):
+        return "map" if self.show_values else "array"

--- a/pretty_printers_tests/tests/hash_map.rs
+++ b/pretty_printers_tests/tests/hash_map.rs
@@ -7,6 +7,15 @@
 // lldb-command:print ys
 // lldbg-check:[...]$1 = size=4 { [0] = 10 [1] = 20 [2] = 30 [3] = 40 }
 
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+
+// gdb-command:print xs
+// gdbg-check:[...]$1 = size=4 = {[1] = 10, [2] = 20, [3] = 30, [4] = 40}
+// gdb-command:print ys
+// gdbg-check:[...]$2 = size=4 = {10, 20, 30, 40}
+
 
 use std::collections::{HashMap, HashSet};
 use std::hash::{BuildHasherDefault, Hasher};


### PR DESCRIPTION
`HashMap`

<img width="811" alt="Screenshot 2019-04-11 at 21 42 47" src="https://user-images.githubusercontent.com/4854600/55983010-cd47c180-5ca2-11e9-987d-b2ce38af9149.png">


`HashSet`

<img width="575" alt="Screenshot 2019-04-11 at 21 44 20" src="https://user-images.githubusercontent.com/4854600/55983092-fc5e3300-5ca2-11e9-818c-5ecbd09025c0.png">
