### PR TITLE
PERF: don't invalidate caches when edition expression contains hardcoded macros

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -139,7 +139,7 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
             false,
             RsItemElement::class.java,
             RsMacro::class.java,
-            RsMacroCall::class.java
+            RsMacroArgument::class.java
         ) == null
         if (shouldInc) modificationTracker.incModificationCount()
         return shouldInc


### PR DESCRIPTION
This speeds up completion in the case of `vec![]./*caret*/;`