### PR TITLE
RES: fix underscore import shouldn't bring name to the scope

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -555,6 +555,7 @@ private UseSpeck_recover ::= !('}' | '{' | self | identifier | '::' | '*' )
 Alias ::= as ('_' | identifier) {
   implements = [ "org.rust.lang.core.psi.ext.RsNameIdentifierOwner" ]
   extends = "org.rust.lang.core.psi.ext.RsStubbedNamedElementImpl<?>"
+  mixin = "org.rust.lang.core.psi.ext.RsAliasImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsAliasStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAlias.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAlias.kt
@@ -1,0 +1,24 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi.ext
+
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.IStubElementType
+import org.rust.lang.core.psi.RsAlias
+import org.rust.lang.core.stubs.RsAliasStub
+
+abstract class RsAliasImplMixin : RsStubbedNamedElementImpl<RsAliasStub>, RsAlias {
+
+    constructor(node: ASTNode) : super(node)
+
+    constructor(stub: RsAliasStub, elementType: IStubElementType<*, *>) : super(stub, elementType)
+
+    override fun getNameIdentifier(): PsiElement? {
+        // `use Foo as _;` really should be unnamed, but "_" is not a valid name in rust, so I think it's ok
+        return identifier ?: underscore
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -33,7 +33,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 159
+        override fun getStubVersion(): Int = 160
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -1485,6 +1485,22 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
+    fun `test do not try to import underscore aliased trait`() = checkAutoImportFixIsUnavailable("""
+        mod foo {
+            pub trait Foo {
+                fn foo(&self) {}
+            }
+
+            impl<T> Foo for T {}
+        }
+
+        use foo::Foo as _;
+
+        fn main() {
+            123.foo/*caret*/();
+        }
+    """)
+
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import item in root module (edition 2018)`() = checkAutoImportFixByText("""
         mod foo {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -253,6 +253,54 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
         }   //^
     """, TypeInferenceMarks.methodPickTraitScope)
 
+    fun `test method defined in out of scope trait (with underscore import)`() = checkByCode("""
+        struct S;
+
+        mod a {
+            use super::S;
+            pub trait A { fn foo(&self){} }
+                           //X
+            impl A for S {}
+        }
+
+        mod b {
+            use super::S;
+            pub trait B { fn foo(&self){} }
+            impl B for S {}
+        }
+
+        fn main() {
+            use a::A as _;
+            S.foo();
+        }   //^
+    """, TypeInferenceMarks.methodPickTraitScope)
+
+    fun `test method defined in out of scope trait (with underscore re-export)`() = checkByCode("""
+        struct S;
+
+        mod a {
+            use super::S;
+            pub trait A { fn foo(&self){} }
+                           //X
+            impl A for S {}
+        }
+
+        mod b {
+            use super::S;
+            pub trait B { fn foo(&self){} }
+            impl B for S {}
+        }
+
+        mod c {
+            pub use super::a::A as _;
+        }
+
+        fn main() {
+            use c::*;
+            S.foo();
+        }   //^
+    """, TypeInferenceMarks.methodPickTraitScope)
+
     fun `test specialization simple`() = checkByCode("""
         trait Tr { fn foo(&self); }
         struct S;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
@@ -637,4 +637,13 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
     """)
     }
+
+    fun `test underscore import doesn't bring a name into scope`() = checkByCode("""
+        pub mod foo {
+            pub trait Foo {}
+        }
+        use foo::Foo as _;
+        fn bar(a: &Foo) {}
+                  //^ unresolved
+    """)
 }


### PR DESCRIPTION
```rust
pub mod foo {
    pub trait Foo {}
}
use foo::Foo as _;
fn bar(a: &Foo) {}
          //^ unresolved
```