### PR TITLE
ACT: Fix AutoImportHintFix for single import-candidate case

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -57,7 +57,9 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
         }
 
         if (candidates.size == 1) {
-            candidates.first().import(element)
+            project.runWriteCommandAction {
+                candidates.first().import(element)
+            }
         } else {
             DataManager.getInstance().dataContextFromFocusAsync.onSuccess {
                 chooseItemAndImport(project, it, candidates, element)


### PR DESCRIPTION
### Steps to reproduce
1. Enable `Show import popup` option for Rust.
2. Create file with the following code:
```rust
mod a { pub struct S; }
fn main() { let s = S; }
```
3. Try to import `S` via popup hint.