### PR TITLE
PERF&MACRO: optimize `getExpandedFrom`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -45,10 +45,7 @@ import org.rust.ide.search.RsWithMacrosScope
 import org.rust.lang.RsFileType
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsPsiTreeChangeEvent.*
-import org.rust.lang.core.psi.ext.RsElement
-import org.rust.lang.core.psi.ext.containingCargoTarget
-import org.rust.lang.core.psi.ext.resolveToMacro
-import org.rust.lang.core.psi.ext.stubDescendantOfTypeOrSelf
+import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.indexes.RsMacroCallIndex
 import org.rust.openapiext.*
 import org.rust.stdext.ThreadLocalDelegate
@@ -586,13 +583,14 @@ private class MacroExpansionServiceImplInner(
 
     fun getExpandedFrom(element: RsExpandedElement): RsMacroCall? {
         checkReadAccessAllowed()
-        if (!element.isValid) return null
-        val file = element.containingFile.virtualFile ?: return null
-        return if (isExpansionFile(file) && element.parent is RsFile /*TODO*/) {
-            storage.getInfoForExpandedFile(file)?.getMacroCall()
-        } else {
-            null
+        if (element.stubParent is RsFile /*TODO*/) {
+            val file = element.containingFile.virtualFile ?: return null
+            if (isExpansionFile(file)) {
+                return storage.getInfoForExpandedFile(file)?.getMacroCall()
+            }
         }
+
+        return null
     }
 
     @TestOnly

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -33,6 +33,15 @@ val PsiElement.ancestorPairs: Sequence<Pair<PsiElement, PsiElement>> get() {
     }
 }
 
+val PsiElement.stubParent: PsiElement
+    get() {
+        if (this is StubBasedPsiElement<*>) {
+            val stub = this.stub
+            if (stub != null) return stub.parentStub.psi
+        }
+        return parent
+    }
+
 val PsiElement.leftLeaves: Sequence<PsiElement>
     get() = generateSequence(this, PsiTreeUtil::prevLeaf).drop(1)
 


### PR DESCRIPTION
`MacroExpansionManager.getExpandedFrom()` is used in `getContext()` which is very hot spot.
Interesting thing is that `VirtualFile.getUrl()` is slow.

Now name resolution isn't slower when new macro expansion engine is enabled