### PR TITLE
INSP: improve inspection suppression

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -938,6 +938,7 @@ StmtModeExpr ::= <<structLiterals 'ON' <<stmtMode 'ON' Expr>> >> { elementType =
 StmtModeExprOff ::= <<stmtMode 'OFF' Expr>> { elementType = Expr }
 
 BlockExpr ::= OuterAttr* [ (unsafe | asyncBlock move? | try) &'{' ] SimpleBlock {
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
@@ -1010,14 +1011,17 @@ TryExpr ::= Expr '?' {
 }
 
 UnaryExpr ::= OuterAttr* (box | '-' | '*' | '!' | '&' mut?) Expr {
- elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
+  elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
 LambdaExpr ::= OuterAttr* asyncBlock? move? LambdaParameters RetType? AnyExpr {
- elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
+  elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
 StructLiteral ::= <<checkStructAllowed>> OuterAttr* PathGenericArgsWithColonsNoTypeQual StructLiteralBody {
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
@@ -1025,7 +1029,8 @@ StructLiteralBody ::= '{' StructLiteralField_with_recover* ('..'  AnyExpr)? '}' 
 
 StructLiteralField ::= OuterAttr* (identifier | INTEGER_LITERAL) [ ':' AnyExpr ] {
   pin = 2
-  implements = [ "org.rust.lang.core.psi.ext.RsReferenceElement" ]
+  implements = [ "org.rust.lang.core.psi.ext.RsReferenceElement"
+                 "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   mixin = "org.rust.lang.core.psi.ext.RsStructLiteralFieldImplMixin"
 }
 
@@ -1043,28 +1048,33 @@ PathExpr ::= OuterAttr* PathGenericArgsWithColons {
 
 WhileExpr ::= OuterAttr* LabelDecl? while Condition SimpleBlock {
   pin = 'while'
-  implements = [ "org.rust.lang.core.psi.ext.RsLabeledExpression" ]
+  implements = [ "org.rust.lang.core.psi.ext.RsLabeledExpression" 
+                 "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 Condition ::= [ let OrPats '=' ] NoStructLitExpr
 
 LoopExpr ::= OuterAttr* LabelDecl? loop SimpleBlock {
   pin = 'loop'
-  implements = [ "org.rust.lang.core.psi.ext.RsLabeledExpression" ]
+  implements = [ "org.rust.lang.core.psi.ext.RsLabeledExpression" 
+                 "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
 ContExpr ::= OuterAttr* continue Label? {
- elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
+  elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
 BreakExpr ::= OuterAttr* break Label? AnyExpr? {
- elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
+  elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
 ForExpr ::= OuterAttr* LabelDecl? for Pat in NoStructLitExpr SimpleBlock {
   pin = 'for'
-  implements = [ "org.rust.lang.core.psi.ext.RsLabeledExpression" ]
+  implements = [ "org.rust.lang.core.psi.ext.RsLabeledExpression" 
+                 "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
@@ -1079,11 +1089,13 @@ Label ::= QUOTE_IDENTIFIER {
 
 MatchExpr ::= OuterAttr* match NoStructLitExpr MatchBody {
   pin = 'match'
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 MatchBody ::= '{' MatchArm* '}' { pin = 1 }
 MatchArm ::= OuterAttr* OrPats MatchArmGuard? '=>' StmtModeExpr (',' | (&'}' | <<isBlock>>)) {
   pin = 2
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   recoverWhile = MatchArm_recover
 }
 private MatchArm_recover ::= !(Pat_first | OuterAttr_first | '}' | '|')
@@ -1091,15 +1103,18 @@ MatchArmGuard ::= if AnyExpr
 
 IfExpr ::= OuterAttr* if Condition SimpleBlock ElseBranch? {
   pin = 'if'
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 ElseBranch ::= else ( IfExpr | SimpleBlock )
 
 RetExpr ::= OuterAttr* return Expr? {
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
 UnitExpr ::= OuterAttr* '(' ')' {
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
@@ -1115,6 +1130,7 @@ fake ParenExpr ::= '(' AnyExpr ')' {
 // https://github.com/JetBrains/Grammar-Kit/blob/d716ade658c1f8e1f84bd0d61764c9949a7df5f2/src/org/intellij/grammar/parser/GeneratedParserUtilBase.java#L656
 TupleOrParenExpr ::= OuterAttr* '(' AnyExpr (TupleExprUpper | ParenExprUpper) {
   pin = 2
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 upper TupleExprUpper ::= ',' [ AnyExpr (',' AnyExpr)* ','? ] ')' { elementType = TupleExpr }
@@ -1122,6 +1138,7 @@ upper ParenExprUpper ::= ')' { elementType = ParenExpr }
 
 ArrayExpr ::= OuterAttr* '[' ArrayInitializer ']' {
   pin = 2
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 private ArrayInitializer ::= [ AnyExpr ( ';' AnyExpr | (',' AnyExpr)* ','? ) ]
@@ -1168,11 +1185,13 @@ LitExpr ::= OuterAttr*
   | BOOL_LITERAL) {
  elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
  implements = [ "com.intellij.psi.PsiLanguageInjectionHost"
-                "com.intellij.psi.ContributedReferenceHost" ]
+                "com.intellij.psi.ContributedReferenceHost"
+                "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
  mixin = "org.rust.lang.core.psi.ext.RsLitExprMixin"
 }
 
 YieldExpr ::= OuterAttr* yield Expr? {
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
@@ -1356,6 +1375,7 @@ fake ExprStmt ::= AnyExpr ';'? { extends = Stmt }
 
 LetDecl ::= OuterAttr* let Pat TypeAscription? [ '=' AnyExpr ] ';' {
   extends = Stmt
+  implements = [ "org.rust.lang.core.psi.ext.RsOuterAttributeOwner" ]
   pin = "let"
 }
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsInspectionSuppressor.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsInspectionSuppressor.kt
@@ -40,7 +40,7 @@ class RsInspectionSuppressor : InspectionSuppressor {
     ) : AbstractBatchSuppressByNoInspectionCommentFix(ID, /* replaceOthers = */ ID == SuppressionUtil.ALL) {
 
         init {
-            text = if (ID == SuppressionUtil.ALL) "Suppress all inspections for item" else "Suppress for item"
+            text = if (ID == SuppressionUtil.ALL) "Suppress all inspections for item" else "Suppress for item with comment"
         }
 
         override fun getContainer(context: PsiElement?): PsiElement? {

--- a/src/main/kotlin/org/rust/ide/inspections/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLint.kt
@@ -18,7 +18,8 @@ enum class RsLint(
 ) {
     NonSnakeCase("non_snake_case", "bad_style"),
     NonCamelCaseTypes("non_camel_case_types", "bad_style"),
-    NonUpperCaseGlobals("non_upper_case_globals", "bad_style");
+    NonUpperCaseGlobals("non_upper_case_globals", "bad_style"),
+    Deprecated("deprecated");
 
     /**
      * Returns the level of the lint for the given PSI element.

--- a/src/main/kotlin/org/rust/ide/inspections/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLint.kt
@@ -13,31 +13,29 @@ import org.rust.lang.core.psi.ext.*
  */
 enum class RsLint(
     val id: String,
+    val groupId: String? = null,
     val defaultLevel: RsLintLevel = RsLintLevel.WARN
 ) {
-    NonSnakeCase("non_snake_case"),
-    NonCamelCaseTypes("non_camel_case_types"),
-    NonUpperCaseGlobals("non_upper_case_globals"),
-    BadStyle("bad_style");
+    NonSnakeCase("non_snake_case", "bad_style"),
+    NonCamelCaseTypes("non_camel_case_types", "bad_style"),
+    NonUpperCaseGlobals("non_upper_case_globals", "bad_style");
 
     /**
      * Returns the level of the lint for the given PSI element.
      */
-    fun levelFor(el: PsiElement)
-        = explicitLevel(el) ?: superModsLevel(el) ?: defaultLevel
+    fun levelFor(el: PsiElement) = explicitLevel(el) ?: superModsLevel(el) ?: defaultLevel
 
-    private fun explicitLevel(el: PsiElement)
-        = el.ancestors
+    private fun explicitLevel(el: PsiElement): RsLintLevel? = el.ancestors
         .filterIsInstance<RsDocAndAttributeOwner>()
         .flatMap { it.queryAttributes.metaItems }
-        .filter { it.metaItemArgs?.metaItemList.orEmpty().any { it.name == id || it.name == BadStyle.id } }
+        .filter { it.metaItemArgs?.metaItemList.orEmpty().any { it.name == id || it.name == groupId } }
         .mapNotNull { it.name?.let { RsLintLevel.valueForId(it) } }
         .firstOrNull()
 
-    private fun superModsLevel(el: PsiElement)
-        = el.ancestors
+    private fun superModsLevel(el: PsiElement): RsLintLevel? = el.ancestors
         .filterIsInstance<RsMod>()
         .lastOrNull()
         ?.superMods
-        ?.mapNotNull { explicitLevel(it) }?.firstOrNull()
+        ?.mapNotNull { explicitLevel(it) }
+        ?.firstOrNull()
 }

--- a/src/main/kotlin/org/rust/ide/inspections/RsLintInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLintInspection.kt
@@ -1,0 +1,24 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import com.intellij.codeInspection.CustomSuppressableInspectionTool
+import com.intellij.codeInspection.SuppressIntentionAction
+import com.intellij.psi.PsiElement
+
+abstract class RsLintInspection : RsLocalInspectionTool(), CustomSuppressableInspectionTool {
+
+    protected abstract val lint: RsLint
+
+    override fun isSuppressedFor(element: PsiElement): Boolean {
+        if (super.isSuppressedFor(element)) return true
+        return lint.levelFor(element) == RsLintLevel.ALLOW
+    }
+
+    override fun getSuppressActions(element: PsiElement?): Array<SuppressIntentionAction>? {
+        return emptyArray()
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/RsLintInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLintInspection.kt
@@ -5,11 +5,17 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.CustomSuppressableInspectionTool
-import com.intellij.codeInspection.SuppressIntentionAction
+import com.intellij.codeInspection.ContainerBasedSuppressQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.SuppressQuickFix
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
 
-abstract class RsLintInspection : RsLocalInspectionTool(), CustomSuppressableInspectionTool {
+abstract class RsLintInspection : RsLocalInspectionTool() {
 
     protected abstract val lint: RsLint
 
@@ -18,7 +24,83 @@ abstract class RsLintInspection : RsLocalInspectionTool(), CustomSuppressableIns
         return lint.levelFor(element) == RsLintLevel.ALLOW
     }
 
-    override fun getSuppressActions(element: PsiElement?): Array<SuppressIntentionAction>? {
-        return emptyArray()
+    // TODO: fix quick fix order in UI
+    override fun getBatchSuppressActions(element: PsiElement?): Array<SuppressQuickFix> {
+        val fixes = super.getBatchSuppressActions(element).toMutableList()
+        if (element == null) return fixes.toTypedArray()
+        element.ancestors.forEach {
+            val action = when (it) {
+                is RsLetDecl,
+                is RsFieldDecl,
+                is RsEnumVariant,
+                is RsItemElement,
+                is RsFile -> {
+                    var target = when (it) {
+                        is RsLetDecl -> "statement"
+                        is RsFieldDecl -> "field"
+                        is RsEnumVariant -> "enum variant"
+                        is RsStructItem -> "struct"
+                        is RsEnumItem -> "enum"
+                        is RsFunction -> "fn"
+                        is RsTypeAlias -> "type"
+                        is RsConstant -> "const"
+                        is RsModItem -> "mod"
+                        is RsImplItem -> "impl"
+                        is RsTraitItem -> "trait"
+                        is RsUseItem -> "use"
+                        is RsFile -> "file"
+                        else -> null
+                    }
+                    if (target != null) {
+                        val name = (it as? PsiNamedElement)?.name
+                        if (name != null) {
+                            target += " $name"
+                        }
+                        RsSuppressQuickFix(it as RsDocAndAttributeOwner, lint, target)
+                    } else {
+                        null
+                    }
+                }
+                is RsExprStmt-> {
+                    val expr = it.expr
+                    if (expr is RsOuterAttributeOwner) RsSuppressQuickFix(expr, lint, "statement") else null
+                }
+                else -> null
+            }
+            if (action != null) {
+                fixes += action
+            }
+        }
+        return fixes.toTypedArray()
+    }
+}
+
+private class RsSuppressQuickFix(
+    private val suppressAt: RsDocAndAttributeOwner,
+    private val lint: RsLint,
+    private val target: String
+) : ContainerBasedSuppressQuickFix {
+
+    override fun getFamilyName(): String = "Suppress Warnings"
+    override fun getName(): String = "Suppress `${lint.id}` for $target"
+
+    override fun isAvailable(project: Project, context: PsiElement): Boolean = context.isValid
+
+    override fun isSuppressAll(): Boolean = false
+
+    override fun getContainer(context: PsiElement?): PsiElement? = suppressAt.takeIf { it !is RsFile }
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val attr = Attribute("allow", lint.id)
+        when (suppressAt) {
+            is RsOuterAttributeOwner -> {
+                val anchor = suppressAt.outerAttrList.firstOrNull() ?: suppressAt.firstChild
+                suppressAt.addOuterAttribute(attr, anchor)
+            }
+            is RsInnerAttributeOwner -> {
+                val anchor = suppressAt.children.first { it !is RsInnerAttr && it !is PsiComment } ?: return
+                suppressAt.addInnerAttribute(attr, anchor)
+            }
+        }
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/RsLintLevel.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLintLevel.kt
@@ -22,11 +22,11 @@ enum class RsLintLevel(
     WARN("warn"),
 
     /**
-     * Compliler errors.
+     * Compiler errors.
      */
     DENY("deny");
 
     companion object {
-        fun valueForId(id: String) = RsLintLevel.values().filter { it.id == id }.firstOrNull()
+        fun valueForId(id: String) = values().firstOrNull { it.id == id }
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/RsNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsNamingInspection.kt
@@ -23,16 +23,15 @@ import org.rust.lang.core.psi.ext.owner
 abstract class RsNamingInspection(
     val elementType: String,
     val styleName: String,
-    val lint: RsLint,
     private val elementTitle: String = elementType
-) : RsLocalInspectionTool() {
+) : RsLintInspection() {
     override fun getDisplayName() = "$elementTitle naming convention"
 
     fun inspect(id: PsiElement?, holder: ProblemsHolder, fix: Boolean = true) {
         if (id == null) return
         val name = id.unescapedText
         val (isOk, suggestedName) = checkName(name)
-        if (isOk || suggestedName == null || lint.levelFor(id) == RsLintLevel.ALLOW) return
+        if (isOk || suggestedName == null) return
 
         val fixEl = id.parent
         val fixes = if (fix && fixEl is PsiNamedElement) arrayOf(RenameFix(fixEl, suggestedName)) else emptyArray()
@@ -51,7 +50,9 @@ abstract class RsNamingInspection(
 open class RsCamelCaseNamingInspection(
     elementType: String,
     elementTitle: String = elementType
-) : RsNamingInspection(elementType, "a camel", RsLint.NonCamelCaseTypes, elementTitle) {
+) : RsNamingInspection(elementType, "a camel", elementTitle) {
+
+    override val lint: RsLint = RsLint.NonCamelCaseTypes
 
     override fun checkName(name: String): Pair<Boolean, String?> {
         val str = name.trim('_')
@@ -88,7 +89,10 @@ open class RsCamelCaseNamingInspection(
 /**
  * Checks if the name is snake_case.
  */
-open class RsSnakeCaseNamingInspection(elementType: String) : RsNamingInspection(elementType, "a snake", RsLint.NonSnakeCase) {
+open class RsSnakeCaseNamingInspection(elementType: String) : RsNamingInspection(elementType, "a snake") {
+
+    override val lint: RsLint = RsLint.NonSnakeCase
+
     override fun checkName(name: String): Pair<Boolean, String?> {
         val str = name.trim('_')
         if (!str.isEmpty() && str.all { !it.isLetter() || it.isLowerCase() }) {
@@ -101,7 +105,10 @@ open class RsSnakeCaseNamingInspection(elementType: String) : RsNamingInspection
 /**
  * Checks if the name is UPPER_CASE.
  */
-open class RsUpperCaseNamingInspection(elementType: String) : RsNamingInspection(elementType, "an upper", RsLint.NonUpperCaseGlobals) {
+open class RsUpperCaseNamingInspection(elementType: String) : RsNamingInspection(elementType, "an upper") {
+
+    override val lint: RsLint = RsLint.NonUpperCaseGlobals
+
     override fun checkName(name: String): Pair<Boolean, String?> {
         val str = name.trim('_')
         if (!str.isEmpty() && str.all { !it.isLetter() || it.isUpperCase() }) {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.psi.NavigatablePsiElement
+import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.*
 
 interface RsDocAndAttributeOwner : RsElement, NavigatablePsiElement
@@ -46,6 +47,21 @@ interface RsOuterAttributeOwner : RsDocAndAttributeOwner {
  */
 fun RsOuterAttributeOwner.findOuterAttr(name: String): RsOuterAttr? =
     outerAttrList.find { it.metaItem.name == name }
+
+
+fun RsOuterAttributeOwner.addOuterAttribute(attribute: Attribute, anchor: PsiElement): RsOuterAttr {
+    val attr = RsPsiFactory(project).createOuterAttr(attribute.text)
+    return addBefore(attr, anchor) as RsOuterAttr
+}
+
+fun RsInnerAttributeOwner.addInnerAttribute(attribute: Attribute, anchor: PsiElement): RsInnerAttr {
+    val attr = RsPsiFactory(project).createInnerAttr(attribute.text)
+    return addBefore(attr, anchor) as RsInnerAttr
+}
+
+data class Attribute(val name: String, val argText: String? = null) {
+    val text: String get() = if (argText == null) name else "$name($argText)"
+}
 
 /**
  * Returns [QueryAttributes] for given PSI element.

--- a/src/test/kotlin/org/rust/ide/inspections/RsDeprecationInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDeprecationInspectionTest.kt
@@ -247,4 +247,109 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         #[deprecated(since="1.0.0", note="here could be your reason")]
         pub fn bar() {}
     """)
+
+    fun `test suppression quick fix for statement 1`() = expect<AssertionError> {
+        checkFixByText("Suppress `deprecated` for statement", """
+            #[deprecated]
+            pub fn foo() {}
+
+            fn main() {
+                <warning descr="`foo` is deprecated">foo/*caret*/</warning>();
+            }
+        """, """
+            #[deprecated]
+            pub fn foo() {}
+
+            fn main() {
+                #[allow(deprecated)]
+                foo/*caret*/();
+            }
+        """)
+    }
+
+    fun `test suppression quick fix for statement 2`() = checkFixByText("Suppress `deprecated` for statement", """
+        #[deprecated]
+        pub struct Foo;
+
+        fn main() {
+            let foo = <warning descr="`Foo` is deprecated">Foo/*caret*/</warning>;
+        }
+    """, """
+        #[deprecated]
+        pub struct Foo;
+
+        fn main() {
+            #[allow(deprecated)] let foo = Foo/*caret*/;
+        }
+    """)
+
+    // TODO: fix field attribute formatting
+    fun `test suppression quick fix for field`() = checkFixByText("Suppress `deprecated` for field x", """
+        #[deprecated]
+        pub struct Foo;
+
+        pub struct Bar {
+            x: <warning descr="`Foo` is deprecated">/*caret*/Foo</warning>
+        }
+    """, """
+        #[deprecated]
+        pub struct Foo;
+
+        pub struct Bar {
+            #[allow(deprecated)]x: /*caret*/Foo
+        }
+    """)
+
+    fun `test suppression quick fix for struct`() = checkFixByText("Suppress `deprecated` for struct Bar", """
+        #[deprecated]
+        pub struct Foo;
+
+        pub struct Bar {
+            x: <warning descr="`Foo` is deprecated">Foo/*caret*/</warning>
+        }
+    """, """
+        #[deprecated]
+        pub struct Foo;
+
+        #[allow(deprecated)]
+        pub struct Bar {
+            x: Foo/*caret*/
+        }
+    """)
+
+    fun `test suppression quick fix for fn`() = checkFixByText("Suppress `deprecated` for fn main", """
+        #[deprecated]
+        pub fn foo() {}
+
+        fn main() {
+            <warning descr="`foo` is deprecated">foo/*caret*/</warning>();
+        }
+    """, """
+        #[deprecated]
+        pub fn foo() {}
+
+        #[allow(deprecated)]
+        fn main() {
+            foo/*caret*/();
+        }
+    """)
+
+    fun `test suppression quick fix for file`() = checkFixByText("Suppress `deprecated` for file main.rs", """
+        #[deprecated]
+        pub fn foo() {}
+
+        fn main() {
+            <warning descr="`foo` is deprecated">foo/*caret*/</warning>();
+        }
+    """, """
+        #![allow(deprecated)]
+
+        #[deprecated]
+        pub fn foo() {}
+
+        fn main() {
+            foo/*caret*/();
+        }
+    """)
+
 }

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsModuleNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsModuleNamingInspectionTest.kt
@@ -19,9 +19,18 @@ class RsModuleNamingInspectionTest : RsInspectionsTestBase(RsModuleNamingInspect
         mod moduleA {}
     """)
 
-    fun `test modules suppression bad style`() = checkByText("""
+    fun `test modules suppression bad style 1`() = checkByText("""
         #[allow(bad_style)]
         mod moduleA {}
+    """)
+
+    fun `test modules suppression bad style 2`() = checkByFileTree("""
+    //- main.rs
+        #![allow(bad_style)]
+
+        mod x;
+    //- x.rs
+        mod moduleA/*caret*/ {}
     """)
 
     fun `test modules fix`() = checkFixByText("Rename to `mod_foo`", """

--- a/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
@@ -47,19 +47,19 @@ class RsAttributeTest : RsTestBase() {
     fun `test file`() = doTest("""
         //^
         #![inner]
-        """, Inner)
+    """, Inner)
 
     fun `test extern crate`() = doTest("""
         #[outer]
         extern crate foo;
         //^
-        """, Outer)
+    """, Outer)
 
     fun `test use`() = doTest("""
         #[outer]
         use foo;
         //^
-        """, Outer)
+    """, Outer)
 
     fun `test mod`() = doTest("""
         #[outer]
@@ -67,13 +67,13 @@ class RsAttributeTest : RsTestBase() {
         //^
             #![inner]
         }
-        """, Both)
+    """, Both)
 
     fun `test mod separate file`() = doTest("""
         #[outer]
         mod m;
         //^
-        """, Outer)
+    """, Outer)
 
     fun `test extern`() = doTest2<RsForeignModItem>("""
         #[outer]
@@ -81,7 +81,7 @@ class RsAttributeTest : RsTestBase() {
         //^
             #![inner]
         }
-        """, Both)
+    """, Both)
 
     fun `test trait`() = doTest("""
         #[outer]
@@ -89,13 +89,13 @@ class RsAttributeTest : RsTestBase() {
         //^
             #![inner]
         }
-        """, Outer)
+    """, Outer)
 
     fun `test struct`() = doTest("""
         #[outer]
         struct S { }
         //^
-        """, Outer)
+    """, Outer)
 
     fun `test struct item`() = doTest("""
         struct S {
@@ -103,7 +103,7 @@ class RsAttributeTest : RsTestBase() {
             s: u16,
           //^
         }
-        """, Outer)
+    """, Outer)
 
     fun `test union`() = doTest("""
         #[outer]
@@ -111,7 +111,7 @@ class RsAttributeTest : RsTestBase() {
         //^
             u1: u16,
         }
-        """, Outer)
+    """, Outer)
 
     fun `test union field`() = doTest("""
         union U {
@@ -120,13 +120,13 @@ class RsAttributeTest : RsTestBase() {
           //^
             u2: i16,
         }
-        """, Outer)
+    """, Outer)
 
     fun `test enum`() = doTest("""
         #[outer]
         enum E { }
         //^
-        """, Outer)
+    """, Outer)
 
     fun `test enum variant`() = doTest("""
         enum E {
@@ -134,7 +134,7 @@ class RsAttributeTest : RsTestBase() {
             EV,
           //^
         }
-        """, Outer)
+    """, Outer)
 
     fun `test impl`() = doTest("""
         struct S { }
@@ -143,7 +143,7 @@ class RsAttributeTest : RsTestBase() {
         //^
             #![inner]
         }
-        """, Both)
+    """, Both)
 
     fun `test impl trait`() = doTest("""
         struct S { }
@@ -153,7 +153,7 @@ class RsAttributeTest : RsTestBase() {
         //^
             #![inner]
         }
-        """, Both)
+    """, Both)
 
     fun `test fn`() = doTest("""
         #[outer]
@@ -161,37 +161,37 @@ class RsAttributeTest : RsTestBase() {
          //^
             #![inner]
         }
-        """, Both)
+    """, Both)
 
     fun `test fn type parameter`() = doTest("""
         fn foo<#[outer] T>( a: u16) {
                       //^
         }
-        """, Outer)
+    """, Outer)
 
     fun `test fn lifetime parameter`() = doTest("""
         fn foo<#[outer] 'a>( a: u16) {
                       //^
         }
-        """, Outer)
+    """, Outer)
 
     fun `test type alias`() = doTest("""
         #[outer]
         type T = u16;
         //^
-        """, Outer)
+    """, Outer)
 
     fun `test const`() = doTest("""
         #[outer]
         const C: u16 = 1;
         //^
-        """, Outer)
+    """, Outer)
 
     fun `test static`() = doTest("""
         #[outer]
         static S: u16 = 1;
         //^
-        """, Outer)
+    """, Outer)
 
     fun `test macro`() = doTest("""
         #[outer]
@@ -199,7 +199,7 @@ class RsAttributeTest : RsTestBase() {
         //^
             () => { };
         }
-        """, Outer)
+    """, Outer)
 
     fun `test macro call`() = doTest("""
         macro_rules! makro {
@@ -209,17 +209,15 @@ class RsAttributeTest : RsTestBase() {
         #[outer]
         makro!();
            //^
-        """, Outer)
+    """, Outer)
 
-    fun `test let statement`() = expect<IllegalStateException> {
-        doTest2<RsStmt>("""
+    fun `test let statement`() = doTest2<RsStmt>("""
         fn main() {
             #[outer]
             let a = 1u16;
             //^
         }
-        """, Outer)
-    }
+    """, Outer)
 
     fun `test fn call expr as statement`() = expect<IllegalStateException> {
         doTest2<RsStmt>("""
@@ -233,13 +231,11 @@ class RsAttributeTest : RsTestBase() {
         """, Outer)
     }
 
-    fun `test literal expr as statement`() = expect<IllegalStateException> {
-        doTest("""
+    fun `test literal expr as statement`() = doTest("""
         fn main() {
             #[outer]
             "Hello Rust!";
             //^
         }
-        """, Outer)
-    }
+    """, Outer)
 }


### PR DESCRIPTION
These changes provide `RsLintInspection` - base class for all inspections that should be suppressed by `allow` attribute. This class uses the correct API to suppress warning annotations. Also, it provides suppression quick fixes to add `allow(lint)` attribute to the chosen item. 

Now naming convention and deprecated inspections extend `RsLintInspection` and provide suppression quick fixes.

Note, our parser doesn't correctly parse expressions with outer attributes like
```rust
#[allow(lint)]
foo();
```
so, statement suppression quick fix is not provided in some cases. Should be fixed from grammar side

Fixes #2308