### PR TITLE
INT: Auto-import unresolved types in generated code

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/RustfmtFileAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RustfmtFileAction.kt
@@ -8,7 +8,6 @@ package org.rust.ide.actions
 import com.intellij.execution.ExecutionException
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -21,10 +20,7 @@ import org.rust.cargo.runconfig.command.workingDirectory
 import org.rust.cargo.toolchain.Rustfmt
 import org.rust.cargo.toolchain.Rustup.Companion.checkNeedInstallRustfmt
 import org.rust.lang.core.psi.isRustFile
-import org.rust.openapiext.computeWithCancelableProgress
-import org.rust.openapiext.isUnitTestMode
-import org.rust.openapiext.runWriteCommandAction
-import org.rust.openapiext.virtualFile
+import org.rust.openapiext.*
 
 class RustfmtFileAction : DumbAwareAction() {
 
@@ -35,7 +31,7 @@ class RustfmtFileAction : DumbAwareAction() {
 
     override fun actionPerformed(e: AnActionEvent) {
         val (cargoProject, rustfmt, document) = getContext(e) ?: return
-        check(!ApplicationManager.getApplication().isWriteAccessAllowed)
+        checkWriteAccessNotAllowed()
         val formattedText = cargoProject.project.computeWithCancelableProgress("Reformatting File with Rustfmt...") {
             reformatDocumentAndGetText(cargoProject, rustfmt, document)
         } ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AddRemainingArmsFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AddRemainingArmsFix.kt
@@ -10,8 +10,10 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.rust.ide.inspections.checkMatch.Pattern
+import org.rust.ide.inspections.import.RsImportHelper.importTypeReferencesFromTy
 import org.rust.lang.core.psi.RsMatchExpr
 import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.types.type
 
 class AddRemainingArmsFix(match: RsMatchExpr, val patterns: List<Pattern>) : LocalQuickFixOnPsiElement(match) {
     override fun getFamilyName() = "Add remaining patterns"
@@ -25,5 +27,8 @@ class AddRemainingArmsFix(match: RsMatchExpr, val patterns: List<Pattern>) : Loc
         for (arm in newArms) {
             oldMatchBody.addBefore(arm, oldMatchBody.rbrace)
         }
+
+        val ty = startElement.expr?.type ?: return
+        importTypeReferencesFromTy(startElement, ty)
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -56,7 +56,7 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
         val element = startElement as? RsElement ?: return
         val (_, candidates) = when (element) {
             is RsPath -> findApplicableContext(project, element) ?: return
-            is RsMethodCall -> findApplicableContext(project, element)  ?: return
+            is RsMethodCall -> findApplicableContext(project, element) ?: return
             else -> return
         }
 
@@ -389,10 +389,10 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
                 candidate to attributes
             }
 
-            val condition: (RsFile.Attributes) -> Boolean = if (hasImportWithSameAttributes) {
-                attributes -> attributes == fileAttributes
-            } else {
-                attributes -> attributes < fileAttributes
+            val condition: (RsFile.Attributes) -> Boolean = if (hasImportWithSameAttributes) { attributes ->
+                attributes == fileAttributes
+            } else { attributes ->
+                attributes < fileAttributes
             }
             return candidateToAttributes.mapNotNull { (candidate, attributes) ->
                 if (condition(attributes)) candidate else null
@@ -442,7 +442,7 @@ sealed class ImportInfo {
 
     abstract val usePath: String
 
-    class LocalImportInfo(override val usePath: String): ImportInfo()
+    class LocalImportInfo(override val usePath: String) : ImportInfo()
 
     class ExternCrateImportInfo(
         val target: CargoWorkspace.Target,
@@ -674,17 +674,18 @@ data class ImportContext private constructor(
     }
 }
 
-private val RsPath.pathParsingMode: PathParsingMode get() = when (parent) {
-    is RsPathExpr,
-    is RsStructLiteral,
-    is RsPatStruct,
-    is RsPatTupleStruct -> PathParsingMode.COLONS
-    else -> PathParsingMode.NO_COLONS
-}
+private val RsPath.pathParsingMode: PathParsingMode
+    get() = when (parent) {
+        is RsPathExpr,
+        is RsStructLiteral,
+        is RsPatStruct,
+        is RsPatTupleStruct -> PathParsingMode.COLONS
+        else -> PathParsingMode.NO_COLONS
+    }
 private val RsElement.stdlibAttributes: RsFile.Attributes
     get() = (crateRoot?.containingFile as? RsFile)?.attributes ?: RsFile.Attributes.NONE
 private val RsItemsOwner.firstItem: RsElement get() = itemsAndMacros.first { it !is RsAttr && it !is RsVis }
-private val <T: RsElement> List<T>.lastElement: T? get() = maxBy { it.textOffset }
+private val <T : RsElement> List<T>.lastElement: T? get() = maxBy { it.textOffset }
 
 private val CargoWorkspace.Target.isStd: Boolean
     get() = pkg.origin == PackageOrigin.STDLIB && normName == AutoInjectedCrates.STD

--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -671,6 +671,16 @@ data class ImportContext private constructor(
             attributes = path.stdlibAttributes,
             namespaceFilter = path.namespaceFilter(isCompletion)
         )
+
+        fun from(project: Project, element: RsElement): ImportContext = ImportContext(
+            project = project,
+            mod = element.containingMod,
+            superMods = LinkedHashSet(element.containingMod.superMods),
+            scope = RsWithMacrosScope(project, GlobalSearchScope.allScope(project)),
+            pathParsingMode = PathParsingMode.NO_COLONS,
+            attributes = element.stdlibAttributes,
+            namespaceFilter = { true }
+        )
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/inspections/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/RsImportHelper.kt
@@ -1,0 +1,162 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.import
+
+import org.rust.ide.settings.RsCodeInsightSettings
+import org.rust.lang.core.psi.RsMembers
+import org.rust.lang.core.psi.RsModDeclItem
+import org.rust.lang.core.psi.RsTypeReference
+import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.RsQualifiedNamedElement
+import org.rust.lang.core.resolve.TYPES
+import org.rust.lang.core.resolve.processNestedScopesUpwards
+import org.rust.lang.core.types.Substitution
+import org.rust.lang.core.types.emptySubstitution
+import org.rust.lang.core.types.infer.TypeVisitor
+import org.rust.lang.core.types.infer.substitute
+import org.rust.lang.core.types.ty.*
+import org.rust.lang.core.types.type
+
+object RsImportHelper {
+    fun importTypeReferencesFromElements(
+        context: RsElement,
+        elements: Collection<RsElement>,
+        subst: Substitution = emptySubstitution,
+        useAliases: Boolean = false
+    ) {
+        val (toImport, _) = getTypeReferencesInfoFromElements(context, elements, subst, useAliases)
+        importElements(context, toImport)
+    }
+
+    fun importTypeReferencesFromTy(context: RsElement, ty: Ty, useAliases: Boolean = false) {
+        val (toImport, _) = getTypeReferencesInfoFromTy(context, ty, useAliases)
+        importElements(context, toImport)
+    }
+
+    private fun importElements(context: RsElement, elements: Set<RsQualifiedNamedElement>) {
+        if (!RsCodeInsightSettings.getInstance().importOutOfScopeItems) return
+        val importContext = ImportContext.from(context.project, context)
+        for (element in elements) {
+            val name = element.name ?: continue
+            val candidates = AutoImportFix.getImportCandidates(importContext, name, name) {
+                !(it.item is RsMod || it.item is RsModDeclItem || it.item.parent is RsMembers)
+            }
+            val candidate = candidates.firstOrNull { it.qualifiedNamedItem.item in elements }
+            candidate?.import(context)
+        }
+    }
+
+    /**
+     * Traverses type references in `elements` and collects all items that unresolved in current context.
+     */
+    private fun getTypeReferencesInfoFromElements(
+        context: RsElement,
+        elements: Collection<RsElement>,
+        subst: Substitution,
+        useAliases: Boolean
+    ): TypeReferencesInfo = getTypeReferencesInfo(context, elements) { ty, result ->
+        collectImportSubjectsFromTypeReferences(ty, subst, result, useAliases)
+    }
+
+    /**
+     * Traverse types in `elemTy` and collects all items that unresolved in current context.
+     */
+    private fun getTypeReferencesInfoFromTy(
+        context: RsElement,
+        elemTy: Ty,
+        useAliases: Boolean
+    ): TypeReferencesInfo = getTypeReferencesInfo(context, listOf(elemTy)) { ty, result ->
+        collectImportSubjectsFromTy(ty, emptySubstitution, result, useAliases)
+    }
+
+    private fun <T> getTypeReferencesInfo(
+        context: RsElement,
+        elements: Collection<T>,
+        collector: (T, MutableSet<RsQualifiedNamedElement>) -> Unit
+    ): TypeReferencesInfo {
+        val result = hashSetOf<RsQualifiedNamedElement>()
+        elements.forEach { collector(it, result) }
+        return processRawImportSubjects(context, result)
+    }
+
+    private fun collectImportSubjectsFromTypeReferences(
+        context: RsElement,
+        subst: Substitution,
+        result: MutableSet<RsQualifiedNamedElement>,
+        useAliases: Boolean
+    ) {
+        context.accept(object : RsVisitor() {
+            override fun visitTypeReference(reference: RsTypeReference) =
+                collectImportSubjectsFromTy(reference.type, subst, result, useAliases)
+
+            override fun visitElement(element: RsElement) =
+                element.acceptChildren(this)
+        })
+    }
+
+    private fun collectImportSubjectsFromTy(
+        ty: Ty,
+        subst: Substitution,
+        result: MutableSet<RsQualifiedNamedElement>,
+        useAliases: Boolean
+    ) {
+        ty.substitute(subst).visitWith(object : TypeVisitor {
+            override fun visitTy(ty: Ty): Boolean {
+                when (ty) {
+                    is TyAdt -> {
+                        val alias = ty.aliasedBy?.element.takeIf { useAliases } as? RsQualifiedNamedElement
+                        result += alias ?: ty.item
+                    }
+                    is TyAnon -> result += ty.traits.map { it.element }
+                    is TyTraitObject -> result += ty.trait.element
+                    is TyProjection -> {
+                        result += ty.trait.element
+                        result += ty.target
+                    }
+                }
+                return ty.superVisitWith(this)
+            }
+        })
+    }
+
+    /**
+     * Takes `rawImportSubjects` and filters items that are unresolved in the current `context`.
+     * Then splits the items into two sets:
+     * - Items that should be imported
+     * - Items that can't be imported
+     */
+    private fun processRawImportSubjects(
+        context: RsElement,
+        rawImportSubjects: Set<RsQualifiedNamedElement>
+    ): TypeReferencesInfo {
+        val importSubjects = hashMapOf<String, MutableSet<RsQualifiedNamedElement>>()
+        for (element in rawImportSubjects) {
+            val name = element.name ?: continue
+            importSubjects.getOrPut(name, ::hashSetOf) += element
+        }
+
+        val toQualifiedName = hashSetOf<RsQualifiedNamedElement>()
+        processNestedScopesUpwards(context, TYPES) { entry ->
+            val group = importSubjects.remove(entry.name) ?: return@processNestedScopesUpwards false
+            group.remove(entry.element)
+            toQualifiedName.addAll(group)
+            importSubjects.isEmpty()
+        }
+
+        return TypeReferencesInfo(importSubjects.flatMap { it.value }.toSet(), toQualifiedName)
+    }
+
+    /**
+     * @param toImport  Set of unresolved items that should be imported
+     * @param toQualify Set of unresolved items that can't be imported
+     */
+    private data class TypeReferencesInfo(
+        val toImport: Set<RsQualifiedNamedElement>,
+        val toQualify: Set<RsQualifiedNamedElement>
+    )
+}

--- a/src/main/kotlin/org/rust/ide/intentions/DestructureIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/DestructureIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.inspections.import.RsImportHelper.importTypeReferencesFromTy
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyAdt
@@ -53,7 +54,11 @@ class DestructureIntention : RsElementBaseIntentionAction<DestructureIntention.C
         } else {
             factory.createPatStruct(struct)
         }
-        val newPatStruct = patIdent.replace(patStruct) as? RsPatTupleStruct ?: return
+        val newPatStruct = patIdent.replace(patStruct) as? RsPat ?: return
+
+        importTypeReferencesFromTy(newPatStruct, struct.declaredType)
+
+        if (newPatStruct !is RsPatTupleStruct) return
         if (struct.positionalFields.isNotEmpty()) {
             replaceFieldPatsWithPlaceholders(editor, newPatStruct)
         }

--- a/src/main/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntention.kt
@@ -44,6 +44,7 @@ class SpecifyTypeExplicitlyIntention : RsElementBaseIntentionAction<SpecifyTypeE
         val letDecl = ctx.letDecl
         val colon = letDecl.addAfter(factory.createColon(), letDecl.pat)
         letDecl.addAfter(createdType, colon)
+        importTypeReferencesFromTy(ctx.letDecl, ctx.type, useAliases = true)
     }
 
 

--- a/src/main/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntention.kt
@@ -8,6 +8,7 @@ package org.rust.ide.intentions
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import org.rust.ide.inspections.import.RsImportHelper.importTypeReferencesFromTy
 import org.rust.ide.presentation.insertionSafeTextWithAliases
 import org.rust.lang.core.psi.RsLetDecl
 import org.rust.lang.core.psi.RsPatIdent
@@ -28,9 +29,7 @@ class SpecifyTypeExplicitlyIntention : RsElementBaseIntentionAction<SpecifyTypeE
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
         val letDecl = element.ancestorStrict<RsLetDecl>() ?: return null
-        if(letDecl.typeReference != null) {
-            return null
-        }
+        if (letDecl.typeReference != null) return null
         val ident = letDecl.pat as? RsPatIdent ?: return null
         val type = ident.patBinding.type
         if (type.containsTyOfClass(listOf(TyUnknown::class.java, TyInfer::class.java, TyAnon::class.java))) {

--- a/src/main/kotlin/org/rust/ide/refactoring/generateConstructor/GenerateConstructorHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generateConstructor/GenerateConstructorHandler.kt
@@ -9,7 +9,6 @@ package org.rust.ide.refactoring.generateConstructor
 import com.intellij.codeInsight.CodeInsightActionHandler
 import com.intellij.codeInsight.actions.CodeInsightAction
 import com.intellij.lang.LanguageCodeInsightActionHandler
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
@@ -20,6 +19,7 @@ import org.rust.lang.core.psi.ext.isTupleStruct
 import org.rust.lang.core.psi.ext.namedFields
 import org.rust.lang.core.psi.ext.positionalFields
 import org.rust.openapiext.checkWriteAccessAllowed
+import org.rust.openapiext.checkWriteAccessNotAllowed
 
 class GenerateConstructorAction : CodeInsightAction() {
 
@@ -44,7 +44,7 @@ class GenerateConstructorHandler : LanguageCodeInsightActionHandler {
     }
 
     private fun generateConstructorBody(structItem: RsStructItem, editor: Editor) {
-        check(!ApplicationManager.getApplication().isWriteAccessAllowed)
+        checkWriteAccessNotAllowed()
         val chosenFields = showConstructorArgumentsChooser(structItem.project, structItem) ?: return
         runWriteAction {
             insertNewConstructor(structItem, chosenFields, editor)

--- a/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
@@ -6,26 +6,21 @@
 package org.rust.ide.refactoring.implementMembers
 
 import com.intellij.codeInsight.hint.HintManager
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
-import org.rust.ide.inspections.import.ImportCandidate
-import org.rust.ide.inspections.import.canBeImported
-import org.rust.ide.inspections.import.import
+import org.rust.ide.inspections.import.RsImportHelper.importTypeReferencesFromElements
 import org.rust.lang.core.macros.expandedFromRecursively
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.BoundElement
-import org.rust.lang.core.types.ty.TyAdt
-import org.rust.lang.core.types.ty.TyTraitObject
-import org.rust.lang.core.types.type
 import org.rust.openapiext.checkReadAccessAllowed
 import org.rust.openapiext.checkWriteAccessAllowed
+import org.rust.openapiext.checkWriteAccessNotAllowed
 
 fun generateTraitMembers(impl: RsImplItem, editor: Editor?) {
-    check(!ApplicationManager.getApplication().isWriteAccessAllowed)
+    checkWriteAccessNotAllowed()
     val (implInfo, trait) = findMembersToImplement(impl) ?: run {
         if (editor != null) {
             HintManager.getInstance().showErrorHint(editor, "No members to implement have been found")
@@ -50,7 +45,11 @@ private fun findMembersToImplement(impl: RsImplItem): Pair<TraitImplementationIn
     return implInfo to trait
 }
 
-private fun insertNewTraitMembers(selected: Collection<RsAbstractable>, existingMembers: RsMembers, trait: BoundElement<RsTraitItem>) {
+private fun insertNewTraitMembers(
+    selected: Collection<RsAbstractable>,
+    existingMembers: RsMembers,
+    trait: BoundElement<RsTraitItem>
+) {
     checkWriteAccessAllowed()
     if (selected.isEmpty()) return
 
@@ -98,8 +97,8 @@ private fun insertNewTraitMembers(selected: Collection<RsAbstractable>, existing
 
     // [1] First, check if the order of the existingMembers already implemented
     // matches the order of existingMembers in the trait declaration.
-    val existingMembersWithPosInTrait = existingMembers.expandedMembers.map {
-        existingMember -> Pair(existingMember, traitMembers.indexOfFirst {
+    val existingMembersWithPosInTrait = existingMembers.expandedMembers.map { existingMember ->
+        Pair(existingMember, traitMembers.indexOfFirst {
             it.elementType == existingMember.elementType && it.name == existingMember.name
         })
     }.toMutableList()
@@ -143,6 +142,8 @@ private fun insertNewTraitMembers(selected: Collection<RsAbstractable>, existing
             existingMembers.addAfter(whitespaces, addedMember)
         }
     }
+
+    importTypeReferencesFromElements(existingMembers, selected, trait.subst)
 }
 
 private fun createExtraWhitespacesAroundFunction(left: PsiElement, right: PsiElement): PsiElement {

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -695,7 +695,7 @@ private class MacroExpansionTaskQueue(val project: Project) {
 
     fun ensureUpToDate() {
         if (isUnitTestMode && ApplicationManager.getApplication().isDispatchThread && !processor.isEmpty) {
-            check(!ApplicationManager.getApplication().isWriteAccessAllowed)
+            checkWriteAccessNotAllowed()
             while (!processor.isEmpty && !project.isDisposed) {
                 LaterInvocator.dispatchPendingFlushes()
                 Thread.sleep(10)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -25,35 +25,42 @@ import javax.swing.Icon
 val RsFunction.isAssocFn: Boolean get() = !hasSelfParameters && owner.isImplOrTrait
 val RsFunction.isMethod: Boolean get() = hasSelfParameters && owner.isImplOrTrait
 
-val RsFunction.isTest: Boolean get() {
-    val stub = greenStub
-    return stub?.isTest ?: (queryAttributes.hasAtomAttribute("test") || queryAttributes.hasAtomAttribute("quickcheck"))
-}
+val RsFunction.isTest: Boolean
+    get() {
+        val stub = greenStub
+        return stub?.isTest
+            ?: (queryAttributes.hasAtomAttribute("test") || queryAttributes.hasAtomAttribute("quickcheck"))
+    }
 
-val RsFunction.isBench: Boolean get() {
-    val stub = greenStub
-    return stub?.isBench ?: queryAttributes.hasAtomAttribute("bench")
-}
+val RsFunction.isBench: Boolean
+    get() {
+        val stub = greenStub
+        return stub?.isBench ?: queryAttributes.hasAtomAttribute("bench")
+    }
 
-val RsFunction.isConst: Boolean get() {
-    val stub = greenStub
-    return stub?.isConst ?: (const != null)
-}
+val RsFunction.isConst: Boolean
+    get() {
+        val stub = greenStub
+        return stub?.isConst ?: (const != null)
+    }
 
-val RsFunction.isExtern: Boolean get() {
-    val stub = greenStub
-    return stub?.isExtern ?: (abi != null)
-}
+val RsFunction.isExtern: Boolean
+    get() {
+        val stub = greenStub
+        return stub?.isExtern ?: (abi != null)
+    }
 
-val RsFunction.isVariadic: Boolean get() {
-    val stub = greenStub
-    return stub?.isVariadic ?: (valueParameterList?.variadic != null)
-}
+val RsFunction.isVariadic: Boolean
+    get() {
+        val stub = greenStub
+        return stub?.isVariadic ?: (valueParameterList?.variadic != null)
+    }
 
-val RsFunction.abiName: String? get() {
-    val stub = greenStub
-    return stub?.abiName ?: abi?.stringLiteral?.text
-}
+val RsFunction.abiName: String?
+    get() {
+        val stub = greenStub
+        return stub?.abiName ?: abi?.stringLiteral?.text
+    }
 
 val RsFunction.valueParameters: List<RsValueParameter>
     get() = valueParameterList?.valueParameterList.orEmpty()
@@ -78,10 +85,11 @@ val RsFunction.title: String
             if (isAssocFn) "Associated function `$name`" else "Method `$name`"
     }
 
-val RsFunction.returnType: Ty get() {
-    val retType = retType ?: return TyUnit
-    return retType.typeReference?.type ?: TyUnknown
-}
+val RsFunction.returnType: Ty
+    get() {
+        val retType = retType ?: return TyUnit
+        return retType.typeReference?.type ?: TyUnknown
+    }
 
 val RsFunction.abi: RsExternAbi? get() = externAbi ?: (parent as? RsForeignModItem)?.externAbi
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
@@ -25,11 +25,12 @@ interface RsQualifiedNamedElement : RsNamedElement {
     val crateRelativePath: String?
 }
 
-val RsQualifiedNamedElement.qualifiedName: String? get() {
-    val inCratePath = crateRelativePath ?: return null
-    val cargoTarget = containingCargoTarget?.normName ?: return null
-    return "$cargoTarget$inCratePath"
-}
+val RsQualifiedNamedElement.qualifiedName: String?
+    get() {
+        val inCratePath = crateRelativePath ?: return null
+        val cargoTarget = containingCargoTarget?.normName ?: return null
+        return "$cargoTarget$inCratePath"
+    }
 
 @Suppress("DataClassPrivateConstructor")
 data class RsQualifiedName private constructor(
@@ -82,7 +83,8 @@ data class RsQualifiedName private constructor(
             // if any variant has the same `RsQualifiedName`
             result = lookupInIndex(project, RsReexportIndex.KEY) { useSpeck ->
                 if (useSpeck.isStarImport) return@lookupInIndex null
-                val candidate = useSpeck.path?.reference?.resolve() as? RsQualifiedNamedElement ?: return@lookupInIndex null
+                val candidate = useSpeck.path?.reference?.resolve() as? RsQualifiedNamedElement
+                    ?: return@lookupInIndex null
                 QualifiedNamedItem.ReexportedItem.from(useSpeck, candidate)
             }
         }
@@ -415,21 +417,23 @@ sealed class QualifiedNamedItem(val item: RsQualifiedNamedElement) {
     abstract val superMods: List<ModWithName>?
     abstract val containingCargoTarget: CargoWorkspace.Target?
 
-    val parentCrateRelativePath: String? get() {
-        val path = superMods
-            ?.map { it.modName ?: return null }
-            ?.asReversed()
-            ?.drop(1)
-            ?.joinToString("::") ?: return null
-        return if (item is RsEnumVariant) item.parentEnum.name?.let { "$path::$it" } else path
-    }
+    val parentCrateRelativePath: String?
+        get() {
+            val path = superMods
+                ?.map { it.modName ?: return null }
+                ?.asReversed()
+                ?.drop(1)
+                ?.joinToString("::") ?: return null
+            return if (item is RsEnumVariant) item.parentEnum.name?.let { "$path::$it" } else path
+        }
 
-    val crateRelativePath: String? get() {
-        val name = itemName ?: return null
-        val parentPath = parentCrateRelativePath ?: return null
-        if (parentPath.isEmpty()) return name
-        return "$parentPath::$name".removePrefix("::")
-    }
+    val crateRelativePath: String?
+        get() {
+            val name = itemName ?: return null
+            val parentPath = parentCrateRelativePath ?: return null
+            if (parentPath.isEmpty()) return name
+            return "$parentPath::$name".removePrefix("::")
+        }
 
     override fun toString(): String {
         return "${containingCargoTarget?.normName}::$crateRelativePath"
@@ -438,8 +442,8 @@ sealed class QualifiedNamedItem(val item: RsQualifiedNamedElement) {
     class ExplicitItem(item: RsQualifiedNamedElement) : QualifiedNamedItem(item) {
         override val itemName: String? get() = item.name
         override val isPublic: Boolean get() = (item as? RsVisible)?.isPublic == true
-        override val superMods: List<ModWithName>? get() =
-            (if (item is RsMod) item.`super` else item.containingMod)?.superMods?.map { ModWithName(it) }
+        override val superMods: List<ModWithName>?
+            get() = (if (item is RsMod) item.`super` else item.containingMod)?.superMods?.map { ModWithName(it) }
         override val containingCargoTarget: CargoWorkspace.Target? get() = item.containingCargoTarget
     }
 
@@ -472,11 +476,12 @@ sealed class QualifiedNamedItem(val item: RsQualifiedNamedElement) {
         item: RsQualifiedNamedElement
     ) : QualifiedNamedItem(item) {
 
-        override val superMods: List<ModWithName>? get() {
-            val mods = ArrayList(explicitSuperMods)
-            mods += reexportedModItem.superMods.orEmpty()
-            return mods
-        }
+        override val superMods: List<ModWithName>?
+            get() {
+                val mods = ArrayList(explicitSuperMods)
+                mods += reexportedModItem.superMods.orEmpty()
+                return mods
+            }
         override val containingCargoTarget: CargoWorkspace.Target? get() = reexportedModItem.containingCargoTarget
     }
 

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -146,7 +146,7 @@ sealed class RsDiagnostic(
         private fun errTyOfTryFromActualImplForTy(ty: Ty, items: KnownItems, lookup: ImplLookup): Ty? {
             val fromTrait = items.TryFrom ?: return null
             val result = lookup.selectProjectionStrict(TraitRef(ty, fromTrait.withSubst(actualTy)),
-                fromTrait.associatedTypesTransitively.find { it.name == "Error"} ?: return null)
+                fromTrait.associatedTypesTransitively.find { it.name == "Error" } ?: return null)
             return result.ok()?.value
         }
 
@@ -208,7 +208,7 @@ sealed class RsDiagnostic(
             // for the first type X in the "actual sequence" that is also in the "expected sequence"; get the number of
             // dereferences we need to apply to get to X from `actualTy` and number of references to get to `expectedTy`
             val derefs = actualCoercionSeq.indexOfFirst { refSeqEnd = tyToExpectedRefSeq[it]; refSeqEnd != null }
-            val refs = expectedRefSeq.subList(0, refSeqEnd?: return null)
+            val refs = expectedRefSeq.subList(0, refSeqEnd ?: return null)
             // check that mutability of references would not contradict the `element`
             val isSuitableMutability = refs.isEmpty() ||
                 !refs.last().isMut ||

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -68,6 +68,10 @@ fun checkWriteAccessAllowed() {
     }
 }
 
+fun checkWriteAccessNotAllowed() {
+    check(!ApplicationManager.getApplication().isWriteAccessAllowed)
+}
+
 fun checkReadAccessAllowed() {
     check(ApplicationManager.getApplication().isReadAccessAllowed) {
         "Needs read action"

--- a/src/test/kotlin/org/rust/ide/inspections/RsMatchCheckInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsMatchCheckInspectionTest.kt
@@ -984,4 +984,35 @@ class RsMatchCheckInspectionTest : RsInspectionsTestBase(RsMatchCheckInspection:
             }
         }
     """)
+
+    fun `test import unresolved type`() = checkFixByText("Add remaining patterns", """
+        use a::foo;
+        use a::E::A;
+
+        mod a {
+            pub enum E { A, B }
+            pub fn foo() -> E { E::A }
+        }
+
+        fn main() {
+            <error descr="Match must be exhaustive [E0004]">match/*caret*/</error> foo() {
+                A => {}
+            };
+        }
+    """, """
+        use a::{foo, E};
+        use a::E::A;
+
+        mod a {
+            pub enum E { A, B }
+            pub fn foo() -> E { E::A }
+        }
+
+        fn main() {
+            match foo() {
+                A => {}
+                E::B => {}
+            };
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/DestructureIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/DestructureIntentionTest.kt
@@ -109,4 +109,55 @@ class DestructureIntentionTest : RsIntentionTestBase(DestructureIntention()) {
             let /*caret*/x = S { x: 0, y: 1 };
         }
     """)
+
+    fun `test import unresolved type`() = doAvailableTest("""
+        use a::foo;
+
+        mod a {
+            pub struct S;
+            pub fn foo() -> S { S }
+        }
+
+        fn main() {
+            let /*caret*/x = foo();
+        }
+    """, """
+        use a::{foo, S};
+
+        mod a {
+            pub struct S;
+            pub fn foo() -> S { S }
+        }
+
+        fn main() {
+            let S {} = foo();
+        }
+    """)
+
+    // TODO: Support type aliases
+    fun `test import unresolved type alias`() = doAvailableTest("""
+        use a::foo;
+
+        mod a {
+            pub struct S;
+            pub type R = S;
+            pub fn foo() -> R { S }
+        }
+
+        fn main() {
+            let /*caret*/x = foo();
+        }
+    """, """
+        use a::{foo, S};
+
+        mod a {
+            pub struct S;
+            pub type R = S;
+            pub fn foo() -> R { S }
+        }
+
+        fn main() {
+            let S {} = foo();
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionTest.kt
@@ -238,4 +238,31 @@ class FillMatchArmsIntentionTest : RsIntentionTestBase(FillMatchArmsIntention())
             }
         }
     """)
+
+    fun `test import unresolved type`() = doAvailableTest("""
+        use a::foo;
+
+        mod a {
+            pub enum FooBar { Foo, Bar }
+            pub fn foo() -> FooBar { FooBar::Foo }
+        }
+
+        fn main() {
+            match/*caret*/ foo() {};
+        }
+    """, """
+        use a::{foo, FooBar};
+
+        mod a {
+            pub enum FooBar { Foo, Bar }
+            pub fn foo() -> FooBar { FooBar::Foo }
+        }
+
+        fn main() {
+            match foo() {
+                FooBar::Foo => {},
+                FooBar::Bar => {},
+            };
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
@@ -5,6 +5,9 @@
 
 package org.rust.ide.intentions
 
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+
 class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplicitlyIntention()) {
     fun `test inferred type`() = doAvailableTest(
         """ fn main() { let var/*caret*/ = 42; } """,
@@ -46,5 +49,97 @@ class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplic
         fn main() {
             let var/*caret*/ = foo();
         }
+    """)
+
+    fun `test import unresolved type`() = doAvailableTest("""
+            use a::foo;
+            mod a {
+                pub struct S;
+                pub fn foo() -> S { S }
+            }
+            fn main() { let var/*caret*/ = foo(); }
+    """, """
+            use a::{foo, S};
+            mod a {
+                pub struct S;
+                pub fn foo() -> S { S }
+            }
+            fn main() { let var: S = foo(); }
+    """)
+
+    fun `test try import unresolved type`() = doAvailableTest("""
+            use a::foo;
+            mod a {
+                struct S;
+                pub fn foo() -> S { S }
+            }
+            fn main() { let var/*caret*/ = foo(); }
+    """, """
+            use a::foo;
+            mod a {
+                struct S;
+                pub fn foo() -> S { S }
+            }
+            fn main() { let var: S = foo(); }
+    """)
+
+    fun `test import type parameter`() = doAvailableTest("""
+            use a::foo;
+            mod a {
+                pub struct S<T>(T);
+                pub struct P;
+                pub fn foo() -> S<P> { S(P) }
+            }
+            fn main() { let var/*caret*/ = foo(); }
+    """, """
+            use a::{foo, P, S};
+            mod a {
+                pub struct S<T>(T);
+                pub struct P;
+                pub fn foo() -> S<P> { S(P) }
+            }
+            fn main() { let var: S<P> = foo(); }
+    """)
+
+    fun `test import type alias`() = doAvailableTest("""
+            use a::{foo, A};
+            mod a {
+                pub struct S;
+                pub type A = S;
+                pub type B = A;
+                pub fn foo() -> B { S }
+            }
+            fn main() { let var/*caret*/ = foo(); }
+    """, """
+            use a::{foo, A, B};
+            mod a {
+                pub struct S;
+                pub type A = S;
+                pub type B = A;
+                pub fn foo() -> B { S }
+            }
+            fn main() { let var: B = foo(); }
+    """)
+
+    // TODO: Don't render default values of type parameters
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test import std type`() = doAvailableTest("""
+            use a::foo;
+
+            mod a {
+                use std::collections::HashMap;
+                pub fn foo() -> HashMap<i32, i32> { HashMap::new() }
+            }
+            fn main() { let var/*caret*/ = foo(); }
+    """, """
+            use a::foo;
+            use std::collections::hash_map::RandomState;
+            use std::collections::HashMap;
+
+            mod a {
+                use std::collections::HashMap;
+                pub fn foo() -> HashMap<i32, i32> { HashMap::new() }
+            }
+            fn main() { let var: HashMap<i32, i32, RandomState> = foo(); }
     """)
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -94,6 +94,37 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
     """)
 
+    // TODO: Support type aliases
+    fun `test import unresolved types`() = doTest("""
+        use a::T;
+        mod a {
+            pub struct R;
+            pub type U = R;
+            pub trait T {
+                fn f() -> (R, U);
+            }
+        }
+        struct S;
+        impl T for S {/*caret*/}
+    """, listOf(
+        ImplementMemberSelection("f() -> (R, U)", true, true)
+    ), """
+        use a::{T, R};
+        mod a {
+            pub struct R;
+            pub type U = R;
+            pub trait T {
+                fn f() -> (R, U);
+            }
+        }
+        struct S;
+        impl T for S {
+            fn f() -> (R, R) {
+                unimplemented!()
+            }
+        }
+    """)
+
     fun `test implement unsafe methods`() = doTest("""
         trait T {
             unsafe fn f1();


### PR DESCRIPTION
Auto-import unresolved types in intentions:
  - Implement members
  - Specify type explicitly
  - Fill match arms
  - Add remaining patterns
  - Use destructuring declaration

![1](https://user-images.githubusercontent.com/6079006/65974332-71057380-e475-11e9-8bb2-314bd02e9118.gif)

This PR doesn't affect:
  - Add missing fields / Recursively add missing fields
  - Initialize with a default value

because `RsDefaultValueBuilder.buildFor` can't use unresolved types.

Based on https://github.com/intellij-rust/intellij-rust/pull/3099.
Closes https://github.com/intellij-rust/intellij-rust/issues/3586. Closes https://github.com/intellij-rust/intellij-rust/issues/3495.
Relates to https://github.com/intellij-rust/intellij-rust/pull/3520.