### PR TITLE
STUB&RES: fix scoped resolve inside stubbed fn body

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/stubs/RsPlaceholderStub.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/RsPlaceholderStub.kt
@@ -12,7 +12,7 @@ import org.rust.lang.core.psi.ext.RsElement
 open class RsPlaceholderStub(parent: StubElement<*>?, elementType: IStubElementType<*, *>)
     : StubBase<RsElement>(parent, elementType) {
 
-    class Type<PsiT : RsElement>(
+    open class Type<PsiT : RsElement>(
         debugName: String,
         private val psiCtor: (RsPlaceholderStub, IStubElementType<*, *>) -> PsiT
     ) : RsStubElementType<RsPlaceholderStub, PsiT>(debugName) {

--- a/src/main/kotlin/org/rust/lang/core/stubs/RsStubElementType.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/RsStubElementType.kt
@@ -20,11 +20,11 @@ abstract class RsStubElementType<StubT : StubElement<*>, PsiT : RsElement>(
     final override fun getExternalId(): String = "rust.${super.toString()}"
 
     override fun indexStub(stub: StubT, sink: IndexSink) {}
+}
 
-    protected fun createStubIfParentIsStub(node: ASTNode): Boolean {
-        val parent = node.treeParent
-        val parentType = parent.elementType
-        return (parentType is IStubElementType<*, *> && parentType.shouldCreateStub(parent)) ||
-            parentType is IStubFileElementType<*>
-    }
+fun createStubIfParentIsStub(node: ASTNode): Boolean {
+    val parent = node.treeParent
+    val parentType = parent.elementType
+    return (parentType is IStubElementType<*, *> && parentType.shouldCreateStub(parent)) ||
+        parentType is IStubFileElementType<*>
 }

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -36,7 +36,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 166
+        override fun getStubVersion(): Int = 167
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)
@@ -150,35 +150,35 @@ fun factory(name: String): RsStubElementType<*, *> = when (name) {
 
     "BINARY_OP" -> RsBinaryOpStub.Type
 
-    "ARRAY_EXPR" -> RsExprStub.Type("ARRAY_EXPR", ::RsArrayExprImpl)
-    "BINARY_EXPR" -> RsExprStub.Type("BINARY_EXPR", ::RsBinaryExprImpl)
-    "BLOCK_EXPR" -> RsExprStub.Type("BLOCK_EXPR", ::RsBlockExprImpl)
-    "BREAK_EXPR" -> RsExprStub.Type("BREAK_EXPR", ::RsBreakExprImpl)
-    "CALL_EXPR" -> RsExprStub.Type("CALL_EXPR", ::RsCallExprImpl)
-    "CAST_EXPR" -> RsExprStub.Type("CAST_EXPR", ::RsCastExprImpl)
-    "CONT_EXPR" -> RsExprStub.Type("CONT_EXPR", ::RsContExprImpl)
-    "DOT_EXPR" -> RsExprStub.Type("DOT_EXPR", ::RsDotExprImpl)
-    "EXPR_STMT_OR_LAST_EXPR" -> RsExprStub.Type("EXPR_STMT_OR_LAST_EXPR", ::RsExprStmtOrLastExprImpl)
-    "FOR_EXPR" -> RsExprStub.Type("FOR_EXPR", ::RsForExprImpl)
-    "IF_EXPR" -> RsExprStub.Type("IF_EXPR", ::RsIfExprImpl)
-    "INDEX_EXPR" -> RsExprStub.Type("INDEX_EXPR", ::RsIndexExprImpl)
-    "LAMBDA_EXPR" -> RsExprStub.Type("LAMBDA_EXPR", ::RsLambdaExprImpl)
+    "ARRAY_EXPR" -> RsExprStubType("ARRAY_EXPR", ::RsArrayExprImpl)
+    "BINARY_EXPR" -> RsExprStubType("BINARY_EXPR", ::RsBinaryExprImpl)
+    "BLOCK_EXPR" -> RsExprStubType("BLOCK_EXPR", ::RsBlockExprImpl)
+    "BREAK_EXPR" -> RsExprStubType("BREAK_EXPR", ::RsBreakExprImpl)
+    "CALL_EXPR" -> RsExprStubType("CALL_EXPR", ::RsCallExprImpl)
+    "CAST_EXPR" -> RsExprStubType("CAST_EXPR", ::RsCastExprImpl)
+    "CONT_EXPR" -> RsExprStubType("CONT_EXPR", ::RsContExprImpl)
+    "DOT_EXPR" -> RsExprStubType("DOT_EXPR", ::RsDotExprImpl)
+    "EXPR_STMT_OR_LAST_EXPR" -> RsExprStubType("EXPR_STMT_OR_LAST_EXPR", ::RsExprStmtOrLastExprImpl)
+    "FOR_EXPR" -> RsExprStubType("FOR_EXPR", ::RsForExprImpl)
+    "IF_EXPR" -> RsExprStubType("IF_EXPR", ::RsIfExprImpl)
+    "INDEX_EXPR" -> RsExprStubType("INDEX_EXPR", ::RsIndexExprImpl)
+    "LAMBDA_EXPR" -> RsExprStubType("LAMBDA_EXPR", ::RsLambdaExprImpl)
     "LIT_EXPR" -> RsLitExprStub.Type
-    "LOOP_EXPR" -> RsExprStub.Type("LOOP_EXPR", ::RsLoopExprImpl)
-    "MACRO_EXPR" -> RsExprStub.Type("MACRO_EXPR", ::RsMacroExprImpl)
-    "MATCH_EXPR" -> RsExprStub.Type("MATCH_EXPR", ::RsMatchExprImpl)
-    "PAREN_EXPR" -> RsExprStub.Type("PAREN_EXPR", ::RsParenExprImpl)
-    "PATH_EXPR" -> RsExprStub.Type("PATH_EXPR", ::RsPathExprImpl)
-    "RANGE_EXPR" -> RsExprStub.Type("RANGE_EXPR", ::RsRangeExprImpl)
-    "RET_EXPR" -> RsExprStub.Type("RET_EXPR", ::RsRetExprImpl)
-    "YIELD_EXPR" -> RsExprStub.Type("YIELD_EXPR", ::RsYieldExprImpl)
-    "STRUCT_LITERAL" -> RsExprStub.Type("STRUCT_LITERAL", ::RsStructLiteralImpl)
-    "TRY_EXPR" -> RsExprStub.Type("TRY_EXPR", ::RsTryExprImpl)
-    "TUPLE_EXPR" -> RsExprStub.Type("TUPLE_EXPR", ::RsTupleExprImpl)
-    "TUPLE_OR_PAREN_EXPR" -> RsExprStub.Type("TUPLE_OR_PAREN_EXPR", ::RsTupleOrParenExprImpl)
+    "LOOP_EXPR" -> RsExprStubType("LOOP_EXPR", ::RsLoopExprImpl)
+    "MACRO_EXPR" -> RsExprStubType("MACRO_EXPR", ::RsMacroExprImpl)
+    "MATCH_EXPR" -> RsExprStubType("MATCH_EXPR", ::RsMatchExprImpl)
+    "PAREN_EXPR" -> RsExprStubType("PAREN_EXPR", ::RsParenExprImpl)
+    "PATH_EXPR" -> RsExprStubType("PATH_EXPR", ::RsPathExprImpl)
+    "RANGE_EXPR" -> RsExprStubType("RANGE_EXPR", ::RsRangeExprImpl)
+    "RET_EXPR" -> RsExprStubType("RET_EXPR", ::RsRetExprImpl)
+    "YIELD_EXPR" -> RsExprStubType("YIELD_EXPR", ::RsYieldExprImpl)
+    "STRUCT_LITERAL" -> RsExprStubType("STRUCT_LITERAL", ::RsStructLiteralImpl)
+    "TRY_EXPR" -> RsExprStubType("TRY_EXPR", ::RsTryExprImpl)
+    "TUPLE_EXPR" -> RsExprStubType("TUPLE_EXPR", ::RsTupleExprImpl)
+    "TUPLE_OR_PAREN_EXPR" -> RsExprStubType("TUPLE_OR_PAREN_EXPR", ::RsTupleOrParenExprImpl)
     "UNARY_EXPR" -> RsUnaryExprStub.Type
-    "UNIT_EXPR" -> RsExprStub.Type("UNIT_EXPR", ::RsUnitExprImpl)
-    "WHILE_EXPR" -> RsExprStub.Type("WHILE_EXPR", ::RsWhileExprImpl)
+    "UNIT_EXPR" -> RsExprStubType("UNIT_EXPR", ::RsUnitExprImpl)
+    "WHILE_EXPR" -> RsExprStubType("WHILE_EXPR", ::RsWhileExprImpl)
 
     "VIS" -> RsVisStub.Type
     "VIS_RESTRICTION" -> RsPlaceholderStub.Type("VIS_RESTRICTION", ::RsVisRestrictionImpl)
@@ -1114,26 +1114,12 @@ object RsBlockStubType : RsPlaceholderStub.Type<RsBlock>("BLOCK", ::RsBlockImpl)
         createStubIfParentIsStub(node) || PsiTreeUtil.getChildOfType(node.psi, RsItemElement::class.java) != null
 }
 
-class RsExprStub(
-    parent: StubElement<*>?, elementType: IStubElementType<*, *>
-) : RsPlaceholderStub(parent, elementType) {
-    class Type<PsiT : RsElement>(
-        debugName: String,
-        private val psiCtor: (RsPlaceholderStub, IStubElementType<*, *>) -> PsiT
-    ) : RsStubElementType<RsPlaceholderStub, PsiT>(debugName) {
-
-        override fun shouldCreateStub(node: ASTNode): Boolean =
-            shouldCreateExprStub(node)
-
-        override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?)
-            = RsPlaceholderStub(parentStub, this)
-
-        override fun serialize(stub: RsPlaceholderStub, dataStream: StubOutputStream) {}
-
-        override fun createPsi(stub: RsPlaceholderStub) = psiCtor(stub, this)
-
-        override fun createStub(psi: PsiT, parentStub: StubElement<*>?) = RsPlaceholderStub(parentStub, this)
-    }
+class RsExprStubType<PsiT : RsElement>(
+    debugName: String,
+    psiCtor: (RsPlaceholderStub, IStubElementType<*, *>) -> PsiT
+) : RsPlaceholderStub.Type<PsiT>(debugName, psiCtor) {
+    override fun shouldCreateStub(node: ASTNode): Boolean =
+        shouldCreateExprStub(node)
 }
 
 class RsLitExprStub(

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -561,4 +561,24 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
     //- main/foo.rs
         pub struct Bar;
     """, NameResolutionTestmarks.crateRootModule)
+
+    fun `test scoped resolve inside stubbed function body`() = stubOnlyResolve("""
+    //- main.rs
+        mod foo;
+        fn main() {
+            foo::S.baz();
+        }        //^ foo.rs
+    //- foo.rs
+        pub struct S;
+
+        fn foobar() {
+            if true {
+                impl S {
+                    pub fn baz(&self) {}
+                }
+            } else {
+                struct S;
+            }
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt
@@ -155,6 +155,59 @@ class RsStubTest : RsTestBase() {
                   LIT_EXPR:RsLitExprStub
     """)
 
+    fun `test nested block is stubbed if contains items`() = doTest("""
+        fn foo() {
+            if true {
+                struct S;
+            } else {
+                foobar();
+            }
+        }
+    """, """
+        RsFileStub
+          FUNCTION:RsFunctionStub
+            VALUE_PARAMETER_LIST:RsPlaceholderStub
+            BLOCK:RsPlaceholderStub
+              BLOCK:RsPlaceholderStub
+                STRUCT_ITEM:RsStructItemStub
+    """)
+
+    fun `test literal is not stubbed inside nested block tail expr`() = doTest("""
+        fn foo() {
+            if true {
+                struct S;
+                0
+            } else {
+                0
+            };
+        }
+    """, """
+        RsFileStub
+          FUNCTION:RsFunctionStub
+            VALUE_PARAMETER_LIST:RsPlaceholderStub
+            BLOCK:RsPlaceholderStub
+              BLOCK:RsPlaceholderStub
+                STRUCT_ITEM:RsStructItemStub
+    """)
+
+    fun `test expression is not stubbed inside nested block tail expr`() = doTest("""
+        fn foo() {
+            if true {
+                struct S;
+                2 + 2
+            } else {
+                2 + 2
+            };
+        }
+    """, """
+        RsFileStub
+          FUNCTION:RsFunctionStub
+            VALUE_PARAMETER_LIST:RsPlaceholderStub
+            BLOCK:RsPlaceholderStub
+              BLOCK:RsPlaceholderStub
+                STRUCT_ITEM:RsStructItemStub
+    """)
+
     private fun doTest(@Language("Rust") code: String, expectedStubText: String) {
         val fileName = "main.rs"
         fileTreeFromText("//- $fileName\n$code").create()


### PR DESCRIPTION
```rust
//- main.rs
    mod foo;
    fn main() {
        foo::S.baz();
    }        //^ foo.rs
//- foo.rs
    pub struct S;

    fn foobar() {
        if true {
            impl S {
                pub fn baz(&self) {}
            }
        } else {
            struct S;
        }
    }
```

Works when `foo.rs` is stubbed