### PR TITLE
DBG: add support for printing Enums directly in debugger

### DIFF
--- a/prettyPrinters/gdb_lookup.py
+++ b/prettyPrinters/gdb_lookup.py
@@ -23,12 +23,10 @@ def lookup(valobj):
 
     if rust_type == RustType.STRUCT:
         return StructProvider(valobj)
-    if rust_type == RustType.STRUCT_VARIANT:
-        return StructProvider(valobj, is_variant=True)
     if rust_type == RustType.TUPLE:
         return TupleProvider(valobj)
-    if rust_type == RustType.TUPLE_VARIANT:
-        return TupleProvider(valobj, is_variant=True)
+    if rust_type == RustType.ENUM:
+        return EnumProvider(valobj)
 
     if rust_type == RustType.STD_STRING:
         return StdStringProvider(valobj)

--- a/prettyPrinters/gdb_providers.py
+++ b/prettyPrinters/gdb_providers.py
@@ -15,23 +15,22 @@ def unwrap_unique_or_non_null(unique_or_nonnull):
 
 
 class StructProvider:
-    def __init__(self, valobj, is_variant=False):
+    def __init__(self, valobj):
         self.valobj = valobj
-        self.is_variant = is_variant
-        fields = self.valobj.type.fields()
-        self.fields = fields[1:] if is_variant else fields
+        self.fields = self.valobj.type.fields()
+
+    def to_string(self):
+        return self.valobj.type.name
 
     def children(self):
-        for i, field in enumerate(self.fields):
-            yield ((field.name, self.valobj[field.name]))
+        for field in self.fields:
+            yield (field.name, self.valobj[field.name])
 
 
 class TupleProvider:
-    def __init__(self, valobj, is_variant=False):
+    def __init__(self, valobj):
         self.valobj = valobj
-        self.is_variant = is_variant
-        fields = self.valobj.type.fields()
-        self.fields = fields[1:] if is_variant else fields
+        self.fields = self.valobj.type.fields()
 
     def to_string(self):
         return "size={}".format(len(self.fields))
@@ -43,6 +42,30 @@ class TupleProvider:
     @staticmethod
     def display_hint():
         return "array"
+
+
+class EnumProvider:
+    def __init__(self, valobj):
+        content = valobj[valobj.type.fields()[0]]
+        fields = content.type.fields()
+        self.empty = len(fields) == 0
+        if not self.empty:
+            if len(fields) == 1:
+                discriminant = 0
+            else:
+                discriminant = int(content[fields[0]]) + 1
+            self.active_variant = content[fields[discriminant]]
+            self.name = fields[discriminant].name
+            self.full_name = "{}::{}".format(valobj.type.name, self.name)
+        else:
+            self.full_name = valobj.type.name
+
+    def to_string(self):
+        return self.full_name
+
+    def children(self):
+        if not self.empty:
+            yield (self.name, self.active_variant)
 
 
 class StdStringProvider:

--- a/prettyPrinters/rust_types.py
+++ b/prettyPrinters/rust_types.py
@@ -8,6 +8,7 @@ class RustType(object):
     CSTYLE_VARIANT = "CStyleVariant"
     TUPLE_VARIANT = "TupleVariant"
     STRUCT_VARIANT = "StructVariant"
+    ENUM = "Enum"
     EMPTY = "Empty"
     SINGLETON_ENUM = "SingletonEnum"
     REGULAR_ENUM = "RegularEnum"
@@ -50,7 +51,7 @@ STD_REF_CELL_REGEX = re.compile(r"^(core::(\w+::)+)RefCell<.+>$")
 TUPLE_ITEM_REGEX = re.compile(r"__\d+$")
 
 ENCODED_ENUM_PREFIX = "RUST$ENCODED$ENUM$"
-ENUM_DISR_FIELD_NAME = "RUST$ENUM$DISR"
+ENUM_DISR_FIELD_NAME = "<<variant>>"
 
 STD_TYPE_TO_REGEX = {
     RustType.STD_STRING: STD_STRING_REGEX,
@@ -84,12 +85,7 @@ def classify_struct(name, fields):
             return ty
 
     if fields[0].name == ENUM_DISR_FIELD_NAME:
-        if len(fields) == 1:
-            return RustType.CSTYLE_VARIANT
-        if is_tuple_fields(fields[1:]):
-            return RustType.TUPLE_VARIANT
-        else:
-            return RustType.STRUCT_VARIANT
+        return RustType.ENUM
 
     if is_tuple_fields(fields):
         return RustType.TUPLE

--- a/pretty_printers_tests/tests/enum.rs
+++ b/pretty_printers_tests/tests/enum.rs
@@ -1,0 +1,39 @@
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+
+// gdb-command:print a
+// gdbg-check:[...]$1 = enum::EnumA::Var3 = {Var3 = enum::EnumA::Var3 = {a = 5, b = enum::TestEnumB::Var2 = {Var2 = enum::TestEnumB::Var2 = {a = 5, b = "hello", c = enum::EnumC::Var1 = {Var1 = size=1 = {8}}}}}}
+
+// gdb-command:print d
+// gdbg-check:[...]$2 = enum::EnumD
+
+enum EnumA {
+    Var1 { a: u32 },
+    Var2(u64),
+    Var3 { a: u32, b: TestEnumB },
+}
+
+enum TestEnumB {
+    Var1(u64),
+    Var2 { a: u32, b: String, c: EnumC },
+}
+
+enum EnumC {
+    Var1(u64),
+}
+
+enum EnumD {}
+
+fn main() {
+    let a = EnumA::Var3 {
+        a: 5,
+        b: TestEnumB::Var2 {
+            a: 5,
+            b: "hello".to_owned(),
+            c: EnumC::Var1(8),
+        },
+    };
+    let d: EnumD;
+    print!(""); // #break
+}


### PR DESCRIPTION
Hi, using the latest versions of Rust and the bundled GDB (Rust 1.34 and GDB 8.2), enums are visualized in a weird way in the synthetic debugger view (it basically prints the discriminant and then all of the possible variants as children). I changed the output so that only the correct enum variant is printed.

The name of the variant is outputted as a child field, since to change the type name of the enum variable itself I would have to change its type and I don't know how to do that (if it's even possible in the GDB API, doesn't seem like so).

Code:
![enum-gdb](https://user-images.githubusercontent.com/4539057/56131720-80a50480-5f88-11e9-8220-c63d64dcdef2.png)

Original output:
![enum-gdb-vis-orig](https://user-images.githubusercontent.com/4539057/56131951-1fc9fc00-5f89-11e9-8d23-5832832e0d21.png)

New output:
![enum-gdb-vis](https://user-images.githubusercontent.com/4539057/56131661-60754580-5f88-11e9-8e8d-d59db3f7091a.png)

So far I only added support for GDB and there are no tests, I'd like to know what you think about this change and if I implemented it correctly before I go forward. From the code it looked like it already tried supporting enums, but it seems that the code involving `is_variant` in structs and tuples was not working in the current Rust/GDB combination, the variant versions of struct and enum were not created at all.

TODO:
- [ ] LLDB support
- [x] Tests

This falls under pretty printer improvements umbrella issue (https://github.com/intellij-rust/intellij-rust/issues/3000).