### PR TITLE
Fix ClassCastException in derefRefPathFromActualToExpected

### DIFF
--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -202,7 +202,10 @@ sealed class RsDiagnostic(
             val derefs = actualCoercionSeq.indexOfFirst { refSeqEnd = tyToExpectedRefSeq[it]; refSeqEnd != null }
             val refs = expectedRefSeq.subList(0, refSeqEnd?: return null)
             // check that mutability of references would not contradict the `element`
-            val isSuitableMutability = refs.isEmpty() || !refs.last().isMut || (element as RsExpr).isMutable &&
+            val isSuitableMutability = refs.isEmpty() ||
+                !refs.last().isMut ||
+                element is RsExpr &&
+                element.isMutable &&
                 // covers cases like `let mut x: &T = ...`
                 actualCoercionSeq.subList(0, derefs + 1).all {
                     it !is TyReference || it.mutability.isMut


### PR DESCRIPTION
Fixes
```
java.lang.ClassCastException: org.rust.lang.core.psi.impl.RsStructLiteralFieldImpl cannot be cast to org.rust.lang.core.psi.RsExpr
	at org.rust.lang.utils.RsDiagnostic$TypeError.derefRefPathFromActualToExpected(RsDiagnostic.kt:202)
	at org.rust.lang.utils.RsDiagnostic$TypeError.prepare(RsDiagnostic.kt:119)
	at org.rust.lang.utils.RsDiagnosticKt.addToHolder(RsDiagnostic.kt:915)
	at org.rust.ide.inspections.RsDiagnosticBasedInspection.collectDiagnostics(RsDiagnosticBasedInspection.kt:24)
	at org.rust.ide.inspections.RsDiagnosticBasedInspection.access$collectDiagnostics(RsDiagnosticBasedInspection.kt:14)
	at org.rust.ide.inspections.RsDiagnosticBasedInspection$buildVisitor$1.visitFunction(RsDiagnosticBasedInspection.kt:16)
	at org.rust.lang.core.psi.impl.RsFunctionImpl.accept(RsFunctionImpl.java:27)
	at org.rust.lang.core.psi.impl.RsFunctionImpl.accept(RsFunctionImpl.java:31)
	at com.intellij.codeInspection.InspectionEngine.acceptElements(InspectionEngine.java:75)
	at com.intellij.codeInspection.InspectionEngine.createVisitorAndAcceptElements(InspectionEngine.java:63)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.runToolOnElements(LocalInspectionsPass.java:295)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.lambda$null$5(LocalInspectionsPass.java:263)
	at com.intellij.util.AstLoadingFilter.forceAllowTreeLoading(AstLoadingFilter.java:156)
	at com.intellij.util.AstLoadingFilter.forceAllowTreeLoading(AstLoadingFilter.java:148)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.lambda$null$6(LocalInspectionsPass.java:260)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:127)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:116)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.lambda$visitPriorityElementsAndInit$7(LocalInspectionsPass.java:260)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:133)
	at com.intellij.concurrency.ApplierCompleter.tryToExecAllList(ApplierCompleter.java:231)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:159)
	at com.intellij.concurrency.ApplierCompleter.tryToExecAllList(ApplierCompleter.java:231)
	at com.intellij.concurrency.ApplierCompleter.execAndForkSubTasks(ApplierCompleter.java:159)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1166)
	at com.intellij.concurrency.ApplierCompleter.lambda$wrapInReadActionAndIndicator$1(ApplierCompleter.java:105)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:586)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:532)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:86)
	at com.intellij.concurrency.ApplierCompleter.wrapInReadActionAndIndicator(ApplierCompleter.java:116)
	at com.intellij.concurrency.ApplierCompleter.lambda$compute$0(ApplierCompleter.java:96)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:164)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:218)
	at com.intellij.concurrency.ApplierCompleter.compute(ApplierCompleter.java:96)
	at java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:731)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
```

bors r+