### PR TITLE
RUN: Support doc-tests by test runner

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsAsyncRunner.kt
@@ -53,12 +53,13 @@ abstract class RsAsyncRunner(private val executorId: String, private val errorMe
         if (executorId != this.executorId || profile !is CargoCommandConfiguration) {
             return false
         }
-        val cleaned = profile.clean().ok ?: return false
-        if (cleaned.cmd.command !in listOf("run", "test")) {
-            return false
-        }
 
-        return true
+        val cleaned = profile.clean().ok ?: return false
+        return when (cleaned.cmd.command) {
+            "run" -> true
+            "test" -> RsTestRunner.canRunCommandLine(cleaned.cmd)
+            else -> false
+        }
     }
 
     open fun getRunContentDescriptor(

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsRunner.kt
@@ -16,7 +16,7 @@ class RsRunner : DefaultProgramRunner() {
             return false
         }
         val cleaned = profile.clean().ok ?: return false
-        return cleaned.cmd.command != "test"
+        return !RsTestRunner.canRunCommandLine(cleaned.cmd)
     }
 
     override fun getRunnerId(): String = "RustRunner"

--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestLocator.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestLocator.kt
@@ -15,9 +15,7 @@ import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.model.impl.allTargets
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.core.psi.RsFile
-import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsModDeclItem
-import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.RsQualifiedNamedElement
 import org.rust.lang.core.psi.ext.qualifiedName
 import org.rust.lang.core.stubs.index.RsNamedElementIndex
@@ -52,8 +50,8 @@ object CargoTestLocator : SMTestLocator {
             val name = qualifiedName.substringAfterLast(NAME_SEPARATOR)
             for (element in RsNamedElementIndex.findElementsByName(project, name, scope)) {
                 val sourceElement = when (element) {
-                    is RsFunction, is RsMod -> element as? RsQualifiedNamedElement
                     is RsModDeclItem -> element.reference.resolve() as? RsFile
+                    is RsQualifiedNamedElement -> element
                     else -> null
                 }
                 if (sourceElement?.qualifiedName == qualifiedName) {
@@ -66,7 +64,7 @@ object CargoTestLocator : SMTestLocator {
     fun getTestUrl(name: String): String = "$TEST_PROTOCOL://$name"
 
     fun getTestUrl(function: RsQualifiedNamedElement): String =
-        this.getTestUrl(function.qualifiedName ?: "")
+        getTestUrl(function.qualifiedName ?: "")
 
     private fun toQualifiedName(path: String): String {
         val targetName = path.substringBefore(NAME_SEPARATOR).substringBeforeLast("-")


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/3707. Fixes https://github.com/intellij-rust/intellij-rust/issues/3860.

Fixes:
```
java.lang.Throwable: [Cargo Test]: Illegal nodeId: TestSuiteStartedEvent{name='0', id='0', parentId='0', locationUrl='cargo:test://0', running=true}
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:145)
	at com.intellij.execution.testframework.sm.runner.GeneralTestEventsProcessor.logProblem(GeneralTestEventsProcessor.java:323)
	at com.intellij.execution.testframework.sm.runner.GeneralTestEventsProcessor.logProblem(GeneralTestEventsProcessor.java:309)
	at com.intellij.execution.testframework.sm.runner.GeneralIdBasedToSMTRunnerEventsConvertor.validateAndGetNodeId(GeneralIdBasedToSMTRunnerEventsConvertor.java:375)
	at com.intellij.execution.testframework.sm.runner.GeneralIdBasedToSMTRunnerEventsConvertor.findNode(GeneralIdBasedToSMTRunnerEventsConvertor.java:382)
	at com.intellij.execution.testframework.sm.runner.GeneralIdBasedToSMTRunnerEventsConvertor.doStartNode(GeneralIdBasedToSMTRunnerEventsConvertor.java:120)
	at com.intellij.execution.testframework.sm.runner.GeneralIdBasedToSMTRunnerEventsConvertor.onSuiteStarted(GeneralIdBasedToSMTRunnerEventsConvertor.java:113)
	at com.intellij.execution.testframework.sm.runner.OutputToGeneralTestEventsConverter.fireOnSuiteStarted(OutputToGeneralTestEventsConverter.java:279)
	at com.intellij.execution.testframework.sm.runner.OutputToGeneralTestEventsConverter.access$100(OutputToGeneralTestEventsConverter.java:30)
	at com.intellij.execution.testframework.sm.runner.OutputToGeneralTestEventsConverter$MyServiceMessageVisitor.visitTestSuiteStarted(OutputToGeneralTestEventsConverter.java:375)
	at jetbrains.buildServer.messages.serviceMessages.TestSuiteStarted.visit(TestSuiteStarted.java:32)
	at com.intellij.execution.testframework.sm.runner.OutputToGeneralTestEventsConverter.processServiceMessages(OutputToGeneralTestEventsConverter.java:126)
	at org.rust.cargo.runconfig.test.CargoTestEventsConverter.handleSuiteMessage(CargoTestEventsConverter.kt:87)
	at org.rust.cargo.runconfig.test.CargoTestEventsConverter.processServiceMessages(CargoTestEventsConverter.kt:47)
	at com.intellij.execution.testframework.sm.runner.OutputToGeneralTestEventsConverter.processConsistentText(OutputToGeneralTestEventsConverter.java:102)
	at com.intellij.execution.testframework.sm.runner.OutputToGeneralTestEventsConverter$1.onTextAvailable(OutputToGeneralTestEventsConverter.java:59)
	at com.intellij.execution.testframework.sm.runner.OutputEventSplitter.flushInternal(OutputEventSplitter.kt:149)
	at com.intellij.execution.testframework.sm.runner.OutputEventSplitter.processInternal(OutputEventSplitter.kt:94)
	at com.intellij.execution.testframework.sm.runner.OutputEventSplitter.process(OutputEventSplitter.kt:68)
	at com.intellij.execution.testframework.sm.runner.OutputToGeneralTestEventsConverter.process(OutputToGeneralTestEventsConverter.java:85)
	at com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil$2.onTextAvailable(SMTestRunnerConnectionUtil.java:213)
	at jdk.internal.reflect.GeneratedMethodAccessor37.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.intellij.execution.process.ProcessHandler$2.invoke(ProcessHandler.java:214)
	at com.sun.proxy.$Proxy22.onTextAvailable(Unknown Source)
	at com.intellij.execution.process.ProcessHandler.notifyTextAvailable(ProcessHandler.java:188)
	at org.rust.cargo.runconfig.RsKillableColoredProcessHandler.coloredTextAvailable(RsKillableColoredProcessHandler.kt:29)
	at com.intellij.execution.process.AnsiEscapeDecoder.processTextChunk(AnsiEscapeDecoder.java:99)
	at com.intellij.execution.process.AnsiEscapeDecoder.escapeText(AnsiEscapeDecoder.java:63)
	at org.rust.cargo.runconfig.RsAnsiEscapeDecoder.escapeText(RsAnsiEscapeDecoder.kt:25)
	at org.rust.cargo.runconfig.RsKillableColoredProcessHandler.notifyTextAvailable(RsKillableColoredProcessHandler.kt:25)
	at com.intellij.execution.process.BaseOSProcessHandler$SimpleOutputReader.onTextAvailable(BaseOSProcessHandler.java:179)
	at com.intellij.util.io.BaseOutputReader.sendText(BaseOutputReader.java:211)
	at com.intellij.util.io.BaseOutputReader.processInput(BaseOutputReader.java:195)
	at com.intellij.util.io.BaseOutputReader.readAvailableNonBlocking(BaseOutputReader.java:114)
	at com.intellij.util.io.BaseDataReader.readAvailable(BaseDataReader.java:77)
	at com.intellij.util.io.BaseDataReader.doRun(BaseDataReader.java:155)
	at com.intellij.util.ConcurrencyUtil.runUnderThreadName(ConcurrencyUtil.java:208)
	at com.intellij.util.io.BaseDataReader.lambda$start$0(BaseDataReader.java:61)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

Depends on https://github.com/intellij-rust/intellij-rust/pull/3734, https://github.com/intellij-rust/intellij-rust/pull/3735 and https://github.com/intellij-rust/intellij-rust/pull/3752.