### PR TITLE
REF/INT:add refactoring to convert struct and its usages between block and tuple representation

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/RsConvertToNamedFieldsProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsConvertToNamedFieldsProcessor.kt
@@ -1,0 +1,134 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring
+
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiReference
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.refactoring.BaseRefactoringProcessor
+import com.intellij.usageView.BaseUsageViewDescriptor
+import com.intellij.usageView.UsageInfo
+import com.intellij.usageView.UsageViewDescriptor
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsFieldsOwner
+import org.rust.lang.core.psi.ext.RsWeakReferenceElement
+import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.rust.lang.core.psi.ext.descendantOfTypeStrict
+
+class RsConvertToNamedFieldsProcessor(
+    project: Project,
+    val element: RsFieldsOwner,
+    private val convertUsages: Boolean
+) : BaseRefactoringProcessor(project) {
+    constructor(project: Project,
+                element: RsFieldsOwner,
+                convertUsages: Boolean,
+                newNames: List<String>
+    ) : this(project, element, convertUsages) {
+        this.newNames = newNames
+    }
+
+    private val rsPsiFactory: RsPsiFactory = RsPsiFactory(project)
+
+    private val types = element.tupleFields!!.tupleFieldDeclList
+    private var newNames: List<String> = (0..types.size).map { "_$it" }
+
+    override fun findUsages(): Array<UsageInfo> {
+        if (!convertUsages) return arrayOf()
+        var usages = ReferencesSearch
+            .search(element, element.useScope)
+            .asSequence()
+            .map { MyUsageInfo(it) }
+
+        usages += types
+            .mapIndexed { index, rsTupleFieldDecl ->
+                ProgressManager.checkCanceled()
+                ReferencesSearch.search(rsTupleFieldDecl, rsTupleFieldDecl.useScope)
+                    .map { MyUsageInfo(it, newNames[index]) }
+            }.flatten()
+
+        return usages
+            .toCollection(ArrayList())
+            .toTypedArray()
+    }
+
+    private class MyUsageInfo(psiReference: PsiReference, val fieldName: String? = null) : UsageInfo(psiReference)
+
+    override fun performRefactoring(usages: Array<out UsageInfo>) {
+        loop@ for (usage in usages) {
+            val usageParent = usage.element!!.parent
+            when (usageParent) {
+                is RsDotExpr,
+                is RsStructLiteralBody,
+                is RsPatField -> {
+                    val nameElement = (usage.element!! as RsWeakReferenceElement).referenceNameElement!!
+                    nameElement.replace(rsPsiFactory.createIdentifier((usage as MyUsageInfo).fieldName!!))
+                }
+                is RsPatTupleStruct -> {
+                    //for tuples `..` can be in the middle
+                    var dotdotPos = 0
+                    PsiTreeUtil.findSiblingForward(usageParent.lparen, RsElementTypes.DOTDOT) { el -> if (el is RsPat) dotdotPos += 1 }
+
+                    val text = "let ${usageParent.path.text}{" +
+                        usageParent.patList.withIndex().joinToString(", ") { (index, pat) ->
+                            val fieldNumber = if (index < dotdotPos) index else (index + types.size - usageParent.patList.size)
+                            "${newNames[fieldNumber]}:${pat.text}"
+                        } +
+                        " ${if (usageParent.dotdot != null) ", .." else ""}} = 0;"
+
+                    val patternPsiElement = rsPsiFactory
+                        .createStatement(text)
+                        .descendantOfTypeStrict<RsPatStruct>()!!
+                    usageParent.replace(patternPsiElement)
+                }
+                //first parent doesn't work in case of RsCallExpr
+                else -> {
+                    val callExpr = usageParent
+                        .ancestorOrSelf<RsCallExpr>(RsValueArgumentList::class.java)
+                        ?: continue@loop
+                    val values = callExpr.valueArgumentList.exprList
+                    val text = "let a = ${callExpr.expr.text}" +
+                        values.zip(newNames)
+                            .joinToString(",\n", "{", "};") { (expr, name) ->
+                                "$name:${expr.text}"
+                            }
+
+                    val structCreationElement = rsPsiFactory
+                        .createStatement(text)
+                        .descendantOfTypeStrict<RsStructLiteral>()!!
+                    callExpr.replace(structCreationElement)
+                }
+            }
+        }
+
+        //convert struct itself
+        val fields = types
+            .zip(newNames)
+            .joinToString(",\n", "{", "}") { (tupleField, name) ->
+                "${tupleField.text.substring(0, tupleField.typeReference.startOffsetInParent)}$name: ${tupleField.typeReference.text}"
+            }
+        val newFieldsElement = rsPsiFactory.createStruct("struct A$fields")
+
+        element.tupleFields!!.replace(newFieldsElement.blockFields!!)
+        (element as? RsStructItem)?.semicolon?.delete()
+
+    }
+
+    override fun getCommandName(): String {
+        return "Converting ${element.name} to named fields"
+    }
+
+    override fun createUsageViewDescriptor(usages: Array<UsageInfo>): UsageViewDescriptor {
+        return BaseUsageViewDescriptor(element)
+    }
+
+    override fun getRefactoringId(): String? {
+        return "refactoring.convertToNamedFields"
+    }
+
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -124,6 +124,10 @@ class RsPsiFactory(private val project: Project, private val markGenerated: Bool
             .blockFields!!
     }
 
+    fun createEnum(text: String): RsEnumItem =
+        createFromText(text)
+            ?: error("Failed to create enum from text: `$text`")
+
     fun createStruct(text: String): RsStructItem =
         createFromText(text)
             ?: error("Failed to create struct from text: `$text`")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldDecl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldDecl.kt
@@ -5,10 +5,9 @@
 
 package org.rust.lang.core.psi.ext
 
-import org.rust.lang.core.psi.RsStructItem
 import org.rust.lang.core.psi.RsTypeReference
 
-val RsFieldDecl.parentStruct: RsStructItem? get() = stubAncestorStrict()
+val RsFieldDecl.parentStruct: RsFieldsOwner? get() = stubAncestorStrict()
 
 interface RsFieldDecl : RsOuterAttributeOwner, RsVisibilityOwner {
     val typeReference: RsTypeReference?

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt
@@ -12,7 +12,7 @@ import org.rust.lang.core.psi.RsTupleFields
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.type
 
-interface RsFieldsOwner : RsElement {
+interface RsFieldsOwner : RsElement, RsNameIdentifierOwner, RsQualifiedNamedElement {
     val blockFields: RsBlockFields?
     val tupleFields: RsTupleFields?
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferencesSearchExtensionImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferencesSearchExtensionImpl.kt
@@ -1,0 +1,25 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve.ref
+
+import com.intellij.openapi.application.QueryExecutorBase
+import com.intellij.psi.search.UsageSearchContext
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.util.Processor
+import org.rust.lang.core.psi.RsTupleFieldDecl
+import org.rust.lang.core.psi.ext.RsFieldsOwner
+import org.rust.lang.core.psi.ext.ancestorStrict
+
+class RsReferencesSearchExtensionImpl : QueryExecutorBase<RsReference, ReferencesSearch.SearchParameters>(true) {
+    override fun processQuery(queryParameters: ReferencesSearch.SearchParameters, consumer: Processor<in RsReference>) {
+        val element = queryParameters.elementToSearch as? RsTupleFieldDecl ?: return
+        val elementOwnerStruct = element.ancestorStrict<RsFieldsOwner>()!!
+        val elementIndex = elementOwnerStruct.tupleFields!!.tupleFieldDeclList.indexOf(element)
+        queryParameters.optimizer.searchWord(elementIndex.toString(), elementOwnerStruct.useScope, UsageSearchContext.IN_CODE, false, element)
+
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -212,6 +212,7 @@
                                   implementation="org.rust.lang.core.resolve.ref.RsMetaItemReferenceContributor"/>
         <psi.referenceContributor language="Rust"
                                   implementation="org.rust.lang.core.resolve.ref.RsLitExprReferenceContributor"/>
+        <referencesSearch implementation="org.rust.lang.core.resolve.ref.RsReferencesSearchExtensionImpl"/>
 
         <!-- Completion -->
 

--- a/src/test/kotlin/org/rust/ide/refactoring/ConvertToNamedFieldsRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/ConvertToNamedFieldsRefactoringTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring
+
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+
+class ConvertToNamedFieldsRefactoringTest : RsTestBase() {
+
+    fun `test simple`() = doAvailableTest("""
+        struct Test(pub usize,/*caret*/ i32);
+    """, """
+        struct Test {
+            pub _0: usize,
+            _1: i32
+        }
+    """)
+
+    fun `test simple enum`() = doAvailableTest("""
+        enum Test{
+            A(usize,/*caret*/ i32),
+            B
+        }
+        fn main(){
+            let Test::A(a, b) = Test::A(0, 0);
+        }
+    """, """
+        enum Test{
+            A {
+                _0: usize,
+                _1: i32
+            },
+            B
+        }
+        fn main(){
+            let Test::A { _0: a, _1: b } = Test::A {
+                _0: 0,
+                _1: 0
+            };
+        }
+    """)
+
+    fun `test convert tuple literal`() = doAvailableTest("""
+        struct Test(pub usize,/*caret*/ i32);
+        fn main (){
+            let a = Test(0, 0);
+            let Test{0: a, 1: b}= Test{0: 0, 1: 0};
+        }
+    """, """
+        struct Test {
+            pub _0: usize,
+            _1: i32
+        }
+
+        fn main (){
+            let a = Test {
+                _0: 0,
+                _1: 0
+            };
+            let Test{ _0: a, _1: b}= Test{ _0: 0, _1: 0};
+        }
+    """)
+
+    fun `test convert field access`() = doAvailableTest("""
+        struct Test(pub usize,/*caret*/ i32);
+        fn main (){
+            let var = Test(0, 0);
+            let x = var.0;
+            let x = var.1;
+        }
+    """, """
+        struct Test {
+            pub _0: usize,
+            _1: i32
+        }
+
+        fn main (){
+            let var = Test {
+                _0: 0,
+                _1: 0
+            };
+            let x = var._0;
+            let x = var._1;
+        }
+    """)
+
+    fun `test convert destructuring`() = doAvailableTest("""
+        struct Test(pub usize,/*caret*/ i32);
+        fn main (){
+            let var = Test(0, 0);
+            let Test(a, b) = &var;
+            let Test(ref a, mut b) = &var;
+            let Test(a, _) = &var;
+            let Test(a, ..) = &var;
+            let Test(.. ,b) = &var;
+            let Test(_, b) = &var;
+        }
+    """, """
+        struct Test {
+            pub _0: usize,
+            _1: i32
+        }
+
+        fn main (){
+            let var = Test {
+                _0: 0,
+                _1: 0
+            };
+            let Test { _0: a, _1: b } = &var;
+            let Test { _0: ref a, _1: mut b } = &var;
+            let Test { _0: a, _1: _ } = &var;
+            let Test { _0: a, .. } = &var;
+            let Test { _1: b, .. } = &var;
+            let Test { _0: _, _1: b } = &var;
+        }
+    """)
+
+    protected fun doAvailableTest(@Language("Rust") before: String, @Language("Rust") after: String) {
+        InlineFile(before.trimIndent()).withCaret()
+        myFixture.testAction(RsConvertToNamedFieldsAction())
+        myFixture.checkResult(replaceCaretMarker(after.trimIndent()))
+    }
+}


### PR DESCRIPTION
This is implementation for #3180. I wasn't sure what exactly i was expected to do because no one has answered me in the issue, so I have implemented it in the way i thought would be best. I think usages conversion should not harm but I have added checkbox to disable it. For now i have done only conversion to block struct. And if you like my implementation, I will add other way conversion later.

When I thought that it might be better to implement it as refactoring, I found that there was already a draft implementation in `RsConvertToNamedFieldsAction.kt`. So I just extended it.

