### PR TITLE
ANN: [DRAFT] highlighting emphasis text in RustDoc

### DIFF
--- a/src/main/kotlin/org/rust/ide/colors/RsColors.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RsColors.kt
@@ -55,6 +55,8 @@ enum class RsColor(val humanName: String, val default: TextAttributesKey? = null
     DOC_HEADING("Rustdoc//Heading", Default.DOC_COMMENT_TAG),
     DOC_LINK("Rustdoc//Link", Default.DOC_COMMENT_TAG_VALUE),
     DOC_CODE("Rustdoc//Code", Default.DOC_COMMENT_MARKUP),
+    DOC_EMPHASIS("Rustdoc//Emphasis regular"),
+    DOC_EMPHASIS_STRONG("Rustdoc//Emphasis strong"),
 
     BRACES("Braces and Operators//Braces", Default.BRACES),
     BRACKETS("Braces and Operators//Brackets", Default.BRACKETS),

--- a/src/main/kotlin/org/rust/ide/utils/RustDocUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/RustDocUtils.kt
@@ -1,0 +1,71 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.utils
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiComment
+import org.intellij.markdown.IElementType
+import org.intellij.markdown.MarkdownElementTypes.EMPH
+import org.intellij.markdown.MarkdownElementTypes.STRONG
+import org.intellij.markdown.MarkdownTokenTypes.Companion.EOL
+import org.intellij.markdown.MarkdownTokenTypes.Companion.TEXT
+import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.ast.CompositeASTNode
+import org.intellij.markdown.ast.LeafASTNode
+import org.intellij.markdown.parser.MarkdownParser
+import org.rust.lang.core.psi.ext.startOffset
+import org.rust.lang.doc.RustDocMarkdownFlavourDescriptor
+import org.rust.lang.doc.psi.RsDocKind
+
+fun getAllRegularEmphasis(docComment: PsiComment): List<TextRange> {
+    return getMarkdownElementRangesOfType(docComment, EMPH)
+}
+
+fun getAllStrongEmphasis(docComment: PsiComment): List<TextRange> {
+    return getMarkdownElementRangesOfType(docComment, STRONG)
+}
+
+private fun getMarkdownElementRangesOfType(docComment: PsiComment, type: IElementType): List<TextRange> {
+    val root = buildMarkdownASTTree(docComment)
+    return getCompositeNodesOfType(root, type)
+        .flatMap { getTextNodes(it) }
+        .map { TextRange(it.startOffset, it.endOffset).shiftRight(docComment.startOffset) }
+}
+
+private fun buildMarkdownASTTree(docComment: PsiComment): ASTNode {
+    val text = docComment.text /*RsDocKind.of(docComment.tokenType)
+        .removeDecoration(docComment.text.splitToSequence("\r\n", "\r", "\n"))
+        .joinToString("\n")*/
+    val flavour = RustDocMarkdownFlavourDescriptor(docComment)
+    return MarkdownParser(flavour).buildMarkdownTreeFromString(text)
+}
+
+// fixme
+private fun getCompositeNodesOfType(root: ASTNode, type: IElementType): List<ASTNode> {
+    val result = mutableListOf<ASTNode>()
+    root.children.forEach {
+        if (it is CompositeASTNode) {
+            if (it.type == type) result += it
+            result.addAll(getCompositeNodesOfType(it, type))
+        }
+    }
+    return result
+}
+
+// fixme
+private fun getTextNodes(root: ASTNode): List<ASTNode> {
+    val result = mutableListOf<ASTNode>()
+    root.children.forEachIndexed { index, it ->
+        (
+            if (it is LeafASTNode) {
+                if (it.type == TEXT && root.children[index - 1].type != EOL) result += it
+            } else {
+                result.addAll(getTextNodes(it))
+            }
+            )
+    }
+    return result
+}

--- a/src/main/kotlin/org/rust/lang/doc/RsDocPipeline.kt
+++ b/src/main/kotlin/org/rust/lang/doc/RsDocPipeline.kt
@@ -111,7 +111,7 @@ private fun RsDocAndAttributeOwner.innerDocs(): Sequence<Pair<RsDocKind, String>
 private val RsMetaItem.docAttr: String?
     get() = if (name == "doc") litExpr?.stringLiteralValue else null
 
-private class RustDocMarkdownFlavourDescriptor(
+class RustDocMarkdownFlavourDescriptor(
     private val context: PsiElement,
     private val uri: URI? = null,
     private val gfm: MarkdownFlavourDescriptor = GFMFlavourDescriptor()

--- a/src/main/resources/org/rust/ide/colors/RustDarcula.xml
+++ b/src/main/resources/org/rust/ide/colors/RustDarcula.xml
@@ -38,4 +38,14 @@
             <option name="BACKGROUND" value="4D3E3E" />
         </value>
     </option>
+    <option name="org.rust.DOC_EMPHASIS">
+        <value>
+            <option name="FONT_TYPE" value="3"/>
+        </value>
+    </option>
+    <option name="org.rust.DOC_EMPHASIS_STRONG">
+        <value>
+            <option name="FONT_TYPE" value="1"/>
+        </value>
+    </option>
 </list>

--- a/src/main/resources/org/rust/ide/colors/RustDefault.xml
+++ b/src/main/resources/org/rust/ide/colors/RustDefault.xml
@@ -33,6 +33,16 @@
             <option name="FOREGROUND" value="404040"/>
         </value>
     </option>
+    <option name="org.rust.DOC_EMPHASIS">
+        <value>
+            <option name="FONT_TYPE" value="3"/>
+        </value>
+    </option>
+    <option name="org.rust.DOC_EMPHASIS_STRONG">
+        <value>
+            <option name="FONT_TYPE" value="1"/>
+        </value>
+    </option>
     <option name="org.rust.DIMMED_TEXT">
         <value>
             <option name="FOREGROUND" value="CBCBCB" />

--- a/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
+++ b/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
@@ -59,6 +59,7 @@ fn <FUNCTION>main</FUNCTION>() {
 }
 
 /// Some documentation `with code`
+/// Emphasis *<DOC_EMPHASIS>regular</DOC_EMPHASIS>* and **<DOC_EMPHASIS_STRONG>strong</DOC_EMPHASIS_STRONG>**
 /// # Heading
 /// [Rust](https://www.rust-lang.org/)
 <ATTRIBUTE>#[cfg(target_os=</ATTRIBUTE>"linux"<ATTRIBUTE>)]</ATTRIBUTE>


### PR DESCRIPTION
**Do not merge to master!**
Draft for discussion and bits of advice for *///highlighting **\*emphasis text\*** in RustDoc*.
Work in progress. Definitely, need to be better coded (see `//fixme` at least) and tested. Would be great to have comments and advice from maintainers.

PS Will be away for a couple of weeks but should have mobile internet to read comments and answer.
PSS Potentially that might be implemented as a separate module to reuse in Dart, Kotlin, etc. plugins to make doc comments better highlighted.