### PR TITLE
INSP: filter out redundant auto import candidates better

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -330,10 +330,6 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
         }
 
         private fun filterInPackage(candidates: List<ImportCandidate>): List<ImportCandidate> {
-            val (simpleImports, compositeImports) = candidates.partition {
-                it.qualifiedNamedItem !is QualifiedNamedItem.CompositeItem
-            }
-
             // If there is item reexport from some parent module of current import path
             // we want to drop this import candidate
             //
@@ -345,15 +341,14 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
             // we have `mod_a::mod_b::Item` and `mod_a::Item` import candidates.
             // `mod_a::Item` is reexport of `Item` so we don't want to add `mod_a::mod_b::Item`
             // into final import list
-            val candidatesWithSuperMods = simpleImports.mapNotNull {
+            val candidatesWithSuperMods = candidates.mapNotNull {
                 val superMods = it.qualifiedNamedItem.superMods ?: return@mapNotNull null
                 it to superMods
             }
             val parents = candidatesWithSuperMods.mapTo(HashSet()) { (_, superMods) -> superMods[0] }
-            val filteredSimpleImports = candidatesWithSuperMods.mapNotNull { (candidate, superMods) ->
+            return candidatesWithSuperMods.mapNotNull { (candidate, superMods) ->
                 if (superMods.asSequence().drop(1).none { it in parents }) candidate else null
             }
-            return filteredSimpleImports + compositeImports
         }
     }
 

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
@@ -437,4 +437,16 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
 
         fn foo(t: Bar/*caret*/) {}
     """)
+
+    fun `test import HashMap`() = checkAutoImportFixByText("""
+        fn main() {
+            let a = <error descr="Unresolved reference: `HashMap`">HashMap::new</error>/*caret*/();
+        }
+    """, """
+        use std::collections::HashMap;
+
+        fn main() {
+            let a = HashMap::new/*caret*/();
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -908,7 +908,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         fn main() {
             let x = <error descr="Unresolved reference: `Z`">Z/*caret*/</error>;
         }
-    """, setOf("x::Z", "y::x::Z", "x::y::x::Z"), "x::Z", """
+    """, setOf("x::Z", "y::x::Z"), "x::Z", """
         use x::Z;
 
         pub mod x {
@@ -948,12 +948,8 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         "x::y::Z",
         "x::u::y::Z",
         "x::u::v::x::y::Z",
-        "x::u::y::v::x::y::Z",
-        "x::y::v::x::u::y::Z",
-        "x::y::v::x::y::Z",
         "u::y::Z",
         "u::v::x::y::Z",
-        "u::y::v::x::y::Z",
         "u::v::x::u::y::Z"
     ), "u::y::Z", """
         use u::y::Z;


### PR DESCRIPTION
From user side, it fixes multiple variants suggested by auto import quick fix for `HashSet` and `HashMap` structs