### PR TITLE
MACRO: fix file attributes in VFS batch

### DIFF
--- a/src/191/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
+++ b/src/191/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
@@ -5,7 +5,7 @@
 
 package org.rust.lang.core.macros
 
-import com.intellij.openapi.util.io.FileAttributes
+import com.intellij.openapi.util.io.FileSystemUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
 import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
@@ -24,15 +24,7 @@ private class EventBasedVfsBatch191 : EventBasedVfsBatch() {
     override fun Event.toVFileEvent(): VFileEvent? = when (this) {
         is Event.Create -> {
             val vParent = LocalFileSystem.getInstance().findFileByPath(parent.toString())!!
-            val attributes = FileAttributes(
-                /* directory = */ false,
-                /* special = */ false,
-                /* symlink = */ false,
-                /* hidden = */ false,
-                /* length = */ length.toLong(),
-                /* lastModified = */ lastModified,
-                /* writable = */ true
-            )
+            val attributes = FileSystemUtil.getAttributes(parent.resolve(name).toString())
             VFileCreateEvent(null, vParent, name, false, attributes, null, true, false)
         }
         is Event.Write -> {

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
@@ -98,7 +98,7 @@ abstract class VfsBatch {
         val data = content.toByteArray() // UTF-8
         Files.write(child, data)
 
-        fileEvents.add(Event.Create(parent, name, child.lastModified().toMillis(), data.size))
+        fileEvents.add(Event.Create(parent, name))
         return child
     }
 
@@ -142,7 +142,7 @@ abstract class VfsBatch {
     protected class DirCreateEvent(val parent: Path, val name: String)
 
     protected sealed class Event {
-        class Create(val parent: Path, val name: String, val lastModified: Long, val length: Int): Event()
+        class Create(val parent: Path, val name: String): Event()
         class Write(val file: Path): Event()
         class Delete(val file: Path): Event()
     }


### PR DESCRIPTION
The platform VFS uses more precise last-modified file attribute
than java default. We should use `FileSystemUtil.getAttributes()`
or after refresh we will think that expansion files are changed