### PR TITLE
 PERF: optimize macro resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
@@ -88,7 +88,7 @@ class RsPsiManagerImpl(val project: Project) : ProjectComponent, RsPsiManager {
             if (file == null) {
                 if (element is RsFile ||
                     element is PsiDirectory && project.cargoProjects.findPackageForFile(element.virtualFile) != null) {
-                    incRustStructureModificationCount()
+                    incRustStructureModificationCount(element as? RsFile, element as? RsFile)
                 }
             } else {
                 if (file.fileType != RsFileType) return

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt
@@ -66,4 +66,4 @@ abstract class RsModDeclItemImplMixin : RsStubbedNamedElementImpl<RsModDeclItemS
 }
 
 val RsModDeclItem.hasMacroUse: Boolean get() =
-    queryAttributes.hasAttribute("macro_use")
+    stub?.hasMacroUse ?: queryAttributes.hasAttribute("macro_use")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
@@ -11,10 +11,12 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.RsElementTypes.*
+import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.RsUseSpeck
 import org.rust.lang.core.psi.RsVis
 import org.rust.lang.core.psi.tokenSetOf
+import org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl
 import org.rust.lang.core.resolve.ref.RsPathReference
 import org.rust.lang.core.resolve.ref.RsPathReferenceImpl
 import org.rust.lang.core.stubs.RsPathStub
@@ -70,7 +72,8 @@ abstract class RsPathImplMixin : RsStubbedElementImpl<RsPathStub>,
 
     constructor(stub: RsPathStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
-    override fun getReference(): RsPathReference = RsPathReferenceImpl(this)
+    override fun getReference(): RsPathReference =
+        if (parent is RsMacroCall) RsMacroPathReferenceImpl(this) else RsPathReferenceImpl(this)
 
     override val referenceNameElement: PsiElement
         get() = checkNotNull(identifier ?: self ?: `super` ?: cself ?: crate) {

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -320,7 +320,7 @@ private fun findDependencyCrateByName(context: RsElement, name: String): RsFile?
 fun processPathResolveVariants(lookup: ImplLookup, path: RsPath, isCompletion: Boolean, processor: RsResolveProcessor): Boolean {
     val parent = path.context
     if (parent is RsMacroCall) {
-        return processMacroCallPathResolveVariants(path, isCompletion, processor)
+        error("Tried to use `processPathResolveVariants` for macro path. See `RsMacroPathReferenceImpl`")
     }
     val qualifier = path.qualifier
     val typeQual = path.typeQual
@@ -676,7 +676,7 @@ fun processAssocTypeVariants(trait: RsTraitItem, processor: RsResolveProcessor):
     return false
 }
 
-private fun processMacroCallPathResolveVariants(path: RsPath, isCompletion: Boolean, processor: RsResolveProcessor): Boolean {
+fun processMacroCallPathResolveVariants(path: RsPath, isCompletion: Boolean, processor: RsResolveProcessor): Boolean {
     // Allowed only 1 or 2-segment paths: `foo!()` or `foo::bar!()`, but not foo::bar::baz!();
     val qualifier = path.qualifier
     if (qualifier?.path != null) return false

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroPathReferenceImpl.kt
@@ -56,10 +56,17 @@ class RsMacroPathReferenceImpl(
         listOfNotNull(resolve())
 
     override fun resolve(): RsNamedElement? {
-        val dep = if (isBatchMode) ResolveCacheDependency.MACRO else ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE
         return RsResolveCache.getInstance(element.project)
-            .resolveWithCaching(element, dep, Resolver)
+            .resolveWithCaching(element, cacheDep, Resolver)
     }
+
+    fun resolveIfCached(): RsNamedElement? {
+        return RsResolveCache.getInstance(element.project)
+            .getCached(element, cacheDep) as? RsNamedElement
+    }
+
+    private val cacheDep: ResolveCacheDependency
+        get() = if (isBatchMode) ResolveCacheDependency.MACRO else ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE
 
     private object Resolver : (RsPath) -> RsNamedElement? {
         override fun invoke(element: RsPath): RsNamedElement? {

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroPathReferenceImpl.kt
@@ -1,0 +1,85 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve.ref
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementResolveResult
+import com.intellij.psi.ResolveResult
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsMacro
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsNamedElement
+import org.rust.lang.core.resolve.pickFirstResolveVariant
+import org.rust.lang.core.resolve.processMacroCallPathResolveVariants
+import org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl.Companion.resolveInBatchMode
+import org.rust.lang.core.types.BoundElement
+import org.rust.stdext.ThreadLocalDelegate
+
+/**
+ * A reference for path of macro call:
+ * ```rust
+ * foo!();
+ * //^ this path
+ * foo::bar!();
+ *     //^ or this path
+ * ```
+ *
+ * Some differences from [RsPathReferenceImpl]:
+ * 1. It always points to a macro (declarative of procedural)
+ * 2. Macro path can't have generic arguments, so we don't store [BoundElement] to the cache (to save memory)
+ * 3. In the current implementation macros can't be multiresolved, so we store single nullable element in
+ * |  the cache instead of a list (to save memory)
+ * 4. This reference introduces "batch mode" ([resolveInBatchMode]) in which another cache dependency is used.
+ * |  See [ResolveCacheDependency.MACRO] for more info
+ */
+class RsMacroPathReferenceImpl(
+    element: RsPath
+) : RsReferenceBase<RsPath>(element),
+    RsPathReference {
+    override val RsPath.referenceAnchor: PsiElement get() = referenceNameElement
+
+    override fun isReferenceTo(element: PsiElement): Boolean =
+        (element is RsMacro || element is RsFunction /* proc macro */) && super.isReferenceTo(element)
+
+    override fun advancedResolve(): BoundElement<RsElement>? =
+        resolve()?.let { BoundElement(it) }
+
+    override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> {
+        return resolve()?.let { arrayOf(PsiElementResolveResult(it)) } ?: ResolveResult.EMPTY_ARRAY
+    }
+
+    override fun multiResolve(): List<RsNamedElement> =
+        listOfNotNull(resolve())
+
+    override fun resolve(): RsNamedElement? {
+        val dep = if (isBatchMode) ResolveCacheDependency.MACRO else ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE
+        return RsResolveCache.getInstance(element.project)
+            .resolveWithCaching(element, dep, Resolver)
+    }
+
+    private object Resolver : (RsPath) -> RsNamedElement? {
+        override fun invoke(element: RsPath): RsNamedElement? {
+            return pickFirstResolveVariant(element.referenceName) {
+                processMacroCallPathResolveVariants(element, false, it)
+            } as? RsNamedElement
+        }
+    }
+
+    companion object {
+        var isBatchMode by ThreadLocalDelegate { false }
+
+        /** @see ResolveCacheDependency.MACRO */
+        inline fun <T> resolveInBatchMode(action: () -> T): T {
+            isBatchMode = true
+            return try {
+                action()
+            } finally {
+                isBatchMode = false
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsResolveCache.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsResolveCache.kt
@@ -25,6 +25,7 @@ import com.intellij.psi.util.PsiUtilCore
 import com.intellij.util.containers.ConcurrentWeakKeySoftValueHashMap
 import com.intellij.util.containers.ContainerUtil
 import com.intellij.util.messages.MessageBus
+import org.rust.lang.core.macros.macroExpansionManager
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsModificationTrackerOwner
 import org.rust.lang.core.psi.ext.RsWeakReferenceElement
@@ -47,24 +48,23 @@ class RsResolveCache(messageBus: MessageBus) {
     private val _rustStructureDependentCache: AtomicReference<ConcurrentMap<PsiElement, Any?>?> = AtomicReference(null)
     /** The cache is cleared on [ANY_PSI_CHANGE_TOPIC] event */
     private val _anyPsiChangeDependentCache: AtomicReference<ConcurrentMap<PsiElement, Any?>?> = AtomicReference(null)
+    private val _macroCache: AtomicReference<ConcurrentMap<PsiElement, Any?>?> = AtomicReference(null)
     private val guard = RecursionGuardWrapper.createGuard("RsResolveCache")
 
     private val rustStructureDependentCache: ConcurrentMap<PsiElement, Any?>
-        get() = _rustStructureDependentCache.get()
-            ?: createWeakMap<PsiElement, Any?>()
-                .takeIf { _rustStructureDependentCache.compareAndSet(null, it) }
-            ?: _rustStructureDependentCache.get()!! // can be set to null in write action only
+        get() = _rustStructureDependentCache.getOrCreateMap()
 
     private val anyPsiChangeDependentCache: ConcurrentMap<PsiElement, Any?>
-        get() = _anyPsiChangeDependentCache.get()
-            ?: createWeakMap<PsiElement, Any?>()
-                .takeIf { _anyPsiChangeDependentCache.compareAndSet(null, it) }
-            ?: _anyPsiChangeDependentCache.get()!! // can be set to null in write action only
+        get() = _anyPsiChangeDependentCache.getOrCreateMap()
+
+    private val macroCache: ConcurrentMap<PsiElement, Any?>
+        get() = _macroCache.getOrCreateMap()
 
     init {
         val connection = messageBus.connect()
         connection.subscribe(RUST_STRUCTURE_CHANGE_TOPIC, object : RustStructureChangeListener {
-            override fun rustStructureChanged(file: PsiFile?, changedElement: PsiElement?) = onRustStructureChanged()
+            override fun rustStructureChanged(file: PsiFile?, changedElement: PsiElement?) =
+                onRustStructureChanged(file)
         })
         connection.subscribe(ANY_PSI_CHANGE_TOPIC, object : AnyPsiChangeListener {
             override fun afterPsiChanged(isPhysical: Boolean) {
@@ -141,6 +141,7 @@ class RsResolveCache(messageBus: MessageBus) {
             }
             ResolveCacheDependency.RUST_STRUCTURE -> rustStructureDependentCache
             ResolveCacheDependency.ANY_PSI_CHANGE -> anyPsiChangeDependentCache
+            ResolveCacheDependency.MACRO -> macroCache
         }
     }
 
@@ -152,9 +153,16 @@ class RsResolveCache(messageBus: MessageBus) {
         map[element] = result ?: NULL_RESULT as V
     }
 
-    private fun onRustStructureChanged() {
+    private fun onRustStructureChanged(file: PsiFile?) {
         Testmarks.rustStructureDependentCacheCleared.hit()
         _rustStructureDependentCache.set(null)
+        if (file != null && _macroCache.get() != null) {
+            val viFile = file.virtualFile
+            if (viFile != null && !file.project.macroExpansionManager.isExpansionFile(viFile)) {
+                // Invalidate cache only on changes OUTSIDE of expansion files
+                _macroCache.set(null)
+            }
+        }
     }
 
     private fun onRustPsiChanged(element: PsiElement) {
@@ -178,6 +186,10 @@ class RsResolveCache(messageBus: MessageBus) {
                 rustStructureDependentCache.remove(it)
             }
         }
+    }
+
+    fun endExpandingMacros() {
+        _macroCache.set(null)
     }
 
     companion object {
@@ -216,6 +228,29 @@ enum class ResolveCacheDependency {
      * any PSI change, not only in rust files
      */
     ANY_PSI_CHANGE,
+
+    /**
+     * Very specific to the new macro expansion engine. The cache is valid during macro expansion
+     * process (see [org.rust.lang.core.macros.MacroExpansionTaskBase]) and invalidates at the end
+     * of expansion process (see [RsResolveCache.endExpandingMacros]).
+     *
+     * During macro resolve we can multiple times change expansion files and so increment
+     * [RsPsiManager.rustStructureModificationTracker]. But these changes can't affect the values
+     * that stored in the cache previously because of specific order of macro expansion we use.
+     * This dependency should be used only in macro expansion task and only when we call resolve
+     * in the correct order.
+     *
+     * @see RsMacroPathReferenceImpl.resolveInBatchMode
+     */
+    MACRO,
+}
+
+private fun AtomicReference<ConcurrentMap<PsiElement, Any?>?>.getOrCreateMap(): ConcurrentMap<PsiElement, Any?> {
+    while (true) {
+        get()?.let { return it }
+        val map = createWeakMap<PsiElement, Any?>()
+        if (compareAndSet(null, map)) return map
+    }
 }
 
 private fun <K, V> createWeakMap(): ConcurrentMap<K, V> {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
@@ -128,6 +128,23 @@ class RsMacroResolveTest : RsResolveTestBase() {
         }
     """)
 
+    fun `test resolve macro in lexical order 3`() = checkByCode("""
+        macro_rules! foo { () => () }
+        #[macro_use]
+        mod a {
+            macro_rules! bar { () => () }
+            #[macro_use]
+            mod b {
+                macro_rules! foo { () => () }
+                //X
+                macro_rules! bar { () => () }
+            }
+        }
+        fn main() {
+            foo!();
+        } //^
+    """)
+
     fun `test resolve macro missing macro_use`() = checkByCode("""
         // Missing #[macro_use] here
         mod a {


### PR DESCRIPTION
Initially I've tried to support [`#[macro_export(local_inner_macros)]`](https://doc.rust-lang.org/edition-guide/rust-2018/macros/macro-changes.html#macros-using-local_inner_macros) (#3750), but implementation was too slow, so I've tried to cache macro resolution better and accidentally sped it up 3 times... 
`local_inner_macros` is implemented in a separate RP #3750