### PR TITLE
Support `#[macro_export(local_inner_macros)]`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -78,11 +78,12 @@ interface MacroExpansionManager {
 }
 
 inline fun MacroExpansionManager.withResolvingMacro(action: () -> Boolean): Boolean {
+    val old = isResolvingMacro
     isResolvingMacro = true
     try {
         if (action()) return true
     } finally {
-        isResolvingMacro = false
+        isResolvingMacro = old
     }
     return false
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
@@ -51,6 +51,10 @@ abstract class RsMacroImplMixin : RsStubbedNamedElementImpl<RsMacroStub>,
 val RsMacro.hasMacroExport: Boolean
     get() = queryAttributes.hasAttribute("macro_export")
 
+/** `#[macro_export(local_inner_macros)]` */
+val RsMacro.hasMacroExportLocalInnerMacros: Boolean
+    get() = queryAttributes.hasAttributeWithArg("macro_export", "local_inner_macros")
+
 val RsMacro.isRustcDocOnlyMacro: Boolean
     get() = queryAttributes.hasAttribute("rustc_doc_only_macro")
 

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.codeStyle.CodeStyleManager
 import junit.framework.ComparisonFailure
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
+import org.rust.fileTreeFromText
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.descendantsOfType
@@ -61,6 +62,12 @@ abstract class RsMacroExpansionTestBase : RsTestBase() {
 
     fun checkSingleMacro(@Language("Rust") code: String, @Language("Rust") expectedExpansion: String) {
         InlineFile(code)
+        val call = findElementInEditor<RsMacroCall>("^")
+        checkMacroExpansion(call, expectedExpansion, "Macro comparision failed")
+    }
+
+    fun checkSingleMacroByTree(@Language("Rust") code: String, @Language("Rust") expectedExpansion: String) {
+        fileTreeFromText(code).createAndOpenFileWithCaretMarker()
         val call = findElementInEditor<RsMacroCall>("^")
         checkMacroExpansion(call, expectedExpansion, "Macro comparision failed")
     }


### PR DESCRIPTION
Enables support for [`#[macro_export(local_inner_macros)]`](https://doc.rust-lang.org/edition-guide/rust-2018/macros/macro-changes.html#macros-using-local_inner_macros). Works only with the new macro expansion engine (see #3628).
Part of #3611