### PR TITLE
PSI: Introduce RsCodeFragment

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -87,6 +87,8 @@
     elementType(".+BinExpr") = BinaryExpr
     elementType(".+BinOp") = BinaryOp
 
+    elementTypeFactory("ExprCodeFragment") = "org.rust.lang.core.psi.RsCodeFragmentElementTypeBaseKt.factory"
+
     extends("Pat(Wild|Ref|Tup|Slice|Macro|Struct|TupleStruct|Ident|Range|Box|Const)") = Pat
 
     generateTokenAccessors=true
@@ -1406,3 +1408,7 @@ private never ::= !()
 // Trailing commas are allowed
 private meta comma_separated_list ::= <<param>> ( ',' <<param>> )* ','?
 private meta list_element ::= <<param>> !'+' (',' | &'>') { pin = 2 }
+
+// This parsing rule is used directly from the code
+//noinspection BnfUnusedRule
+ExprCodeFragment ::= Expr?

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
@@ -1,0 +1,91 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.project.Project
+import com.intellij.psi.*
+import com.intellij.psi.impl.PsiManagerEx
+import com.intellij.psi.impl.source.PsiFileImpl
+import com.intellij.psi.impl.source.tree.FileElement
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.LightVirtualFile
+import org.rust.lang.RsFileType
+import org.rust.lang.RsLanguage
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsInferenceContextOwner
+import org.rust.lang.core.psi.ext.RsMod
+
+abstract class RsCodeFragment(
+    project: Project,
+    text: CharSequence,
+    private val context: RsElement,
+    contentElementType: IElementType
+) : RsFileBase(
+    PsiManagerEx.getInstanceEx(project).fileManager.createFileViewProvider(
+        LightVirtualFile(
+            "fragment.rs",
+            RsLanguage,
+            text
+        ), true)
+), PsiCodeFragment {
+    override val containingMod: RsMod
+        get() = context.containingMod
+
+    override val crateRoot: RsMod?
+        get() = context.crateRoot
+
+    override fun accept(visitor: PsiElementVisitor) {
+        visitor.visitFile(this)
+    }
+
+    override fun getFileType(): FileType = RsFileType
+
+    private var viewProvider = super.getViewProvider() as SingleRootFileViewProvider
+    private var forcedResolveScope: GlobalSearchScope? = null
+    private var isPhysical = true
+
+    init {
+        getViewProvider().forceCachedPsi(this)
+        init(TokenType.CODE_FRAGMENT, contentElementType)
+    }
+
+    final override fun init(elementType: IElementType, contentElementType: IElementType?) {
+        super.init(elementType, contentElementType)
+    }
+
+    override fun isPhysical() = isPhysical
+
+    override fun forceResolveScope(scope: GlobalSearchScope?) {
+        forcedResolveScope = scope
+    }
+
+    override fun getForcedResolveScope(): GlobalSearchScope? = forcedResolveScope
+
+    override fun getContext(): PsiElement? = context
+
+    final override fun getViewProvider(): SingleRootFileViewProvider = viewProvider
+
+    override fun isValid() = true
+
+    override fun clone(): PsiFileImpl {
+        val clone = cloneImpl(calcTreeElement().clone() as FileElement) as RsCodeFragment
+        clone.isPhysical = false
+        clone.myOriginalFile = this
+        clone.viewProvider =
+            SingleRootFileViewProvider(PsiManager.getInstance(project), LightVirtualFile(name, RsLanguage, text), false)
+        clone.viewProvider.forceCachedPsi(clone)
+        return clone
+    }
+}
+
+class RsExpressionCodeFragment(project: Project, text: CharSequence, context: RsElement)
+    : RsCodeFragment(project, text, context, RsElementTypes.EXPR_CODE_FRAGMENT),
+      RsInferenceContextOwner {
+    val expr: RsExpr? get() = PsiTreeUtil.getChildOfType(this, RsExpr::class.java)
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentElementTypeBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentElementTypeBase.kt
@@ -1,0 +1,28 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.PsiBuilderFactory
+import com.intellij.psi.impl.source.tree.ICodeFragmentElementType
+import com.intellij.psi.tree.IElementType
+import org.rust.lang.RsLanguage
+import org.rust.lang.core.parser.RustParser
+
+abstract class RsCodeFragmentElementTypeBase(debugName: String) : ICodeFragmentElementType(debugName, RsLanguage) {
+    protected abstract val elementType: IElementType
+    override fun parseContents(chameleon: ASTNode): ASTNode? {
+        val project = chameleon.psi.project
+        val builder = PsiBuilderFactory.getInstance().createBuilder(project, chameleon)
+        val root = RustParser().parse(elementType, builder)
+        return root.firstChildNode
+    }
+}
+
+fun factory(name: String): IElementType = when (name) {
+    "EXPR_CODE_FRAGMENT" -> RsExprCodeFragmentElementType()
+    else -> error("Unknown element $name")
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsExprCodeFragmentElementType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsExprCodeFragmentElementType.kt
@@ -1,0 +1,13 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+import com.intellij.psi.tree.IElementType
+
+class RsExprCodeFragmentElementType : RsCodeFragmentElementTypeBase("RS_EXPR_CODE_FRAGMENT") {
+    override val elementType: IElementType
+        get() = RsElementTypes.EXPR_CODE_FRAGMENT
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsInferenceContextOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsInferenceContextOwner.kt
@@ -21,5 +21,6 @@ val RsInferenceContextOwner.body: RsElement?
         is RsConstant -> expr
         is RsFunction -> block
         is RsVariantDiscriminant -> expr
+        is RsExpressionCodeFragment -> expr
         else -> null
     }

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -35,6 +35,9 @@ private fun <T> RsInferenceContextOwner.createResult(value: T): Result<T> {
         // So we have to invalidate the cached value on any PSI change
         containingFile.virtualFile is VirtualFileWindow -> Result.create(value, PsiModificationTracker.MODIFICATION_COUNT)
 
+        // Invalidate cached value of code fragment on any PSI change
+        this is RsCodeFragment -> Result.create(value, PsiModificationTracker.MODIFICATION_COUNT)
+
         // CachedValueProvider.Result can accept a ModificationTracker as a dependency, so the
         // cached value will be invalidated if the modification counter is incremented.
         this is RsModificationTrackerOwner -> Result.create(value, structureModificationTracker, modificationTracker)

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -72,8 +72,8 @@ interface RsInferenceData {
  * from expressions to their types.
  */
 class RsInferenceResult(
-    private val bindings: Map<RsPatBinding, Ty>,
-    private val exprTypes: Map<RsExpr, Ty>,
+    val bindings: Map<RsPatBinding, Ty>,
+    val exprTypes: Map<RsExpr, Ty>,
     private val expectedPathExprTypes: Map<RsPathExpr, Ty>,
     private val expectedDotExprTypes: Map<RsDotExpr, Ty>,
     private val resolvedPaths: Map<RsPathExpr, List<RsElement>>,
@@ -180,6 +180,13 @@ class RsInferenceContext(
                         ?: TyInteger.ISize
 
                     reprType to element.expr
+                }
+                is RsExpressionCodeFragment -> {
+                    element.context?.inference?.let {
+                        bindings.putAll(it.bindings)
+                        exprTypes.putAll(it.exprTypes)
+                    }
+                    null to element.expr
                 }
                 else -> error("Type inference is not implemented for PSI element of type " +
                     "`${element.javaClass}` that implement `RsInferenceContextOwner`")


### PR DESCRIPTION
This PR introduces `RsCodeFragment` to be used in `Add format string argument` intention, `Evaluate expression`, and other future stuff.