### PR TITLE
 DBG: Use code fragment instead of plain text

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/lang/RsDebuggerEditorsExtension.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/lang/RsDebuggerEditorsExtension.kt
@@ -5,9 +5,27 @@
 
 package org.rust.debugger.lang
 
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.xdebugger.XSourcePosition
+import com.intellij.xdebugger.evaluation.EvaluationMode
 import com.jetbrains.cidr.execution.debugger.CidrDebuggerEditorsExtensionBase
 import org.rust.lang.RsLanguage
+import org.rust.lang.core.psi.RsExpressionCodeFragment
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.ancestorOrSelf
 
 class RsDebuggerEditorsExtension : CidrDebuggerEditorsExtensionBase() {
+    override fun getContext(project: Project, sourcePosition: XSourcePosition): PsiElement? =
+        super.getContext(project, sourcePosition)?.ancestorOrSelf<RsElement>()
+
+    override fun createExpressionCodeFragment(project: Project, text: String, context: PsiElement, mode: EvaluationMode): PsiFile =
+        if (context is RsElement) {
+            RsExpressionCodeFragment(project, text, context)
+        } else {
+            super.createExpressionCodeFragment(project, text, context, mode)
+        }
+
     override fun getSupportedLanguage() = RsLanguage
 }


### PR DESCRIPTION
Add resolve/inference/completion support for `Evaluate expression` and `New watch`.

Merge after #3753 

![dbg_codefragment](https://user-images.githubusercontent.com/4854600/56658565-9a8ac980-66a3-11e9-9b80-71e2f9c258e4.gif)
