### PR TITLE
RES: fix disambiguating primitive type qualified paths

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -374,13 +374,14 @@ private fun processQualifiedPathResolveVariants(
     parent: PsiElement?,
     processor: RsResolveProcessor
 ): Boolean {
-    val primitiveType = TyPrimitive.fromPath(qualifier)
-    if (primitiveType != null) {
-        val selfSubst = mapOf(TyTypeParameter.self() to primitiveType).toTypeSubst()
-        if (processAssociatedItemsWithSelfSubst(lookup, primitiveType, ns, selfSubst, processor)) return true
+    val (base, subst) = qualifier.reference.advancedResolve() ?: run {
+        val primitiveType = TyPrimitive.fromPath(qualifier)
+        if (primitiveType != null) {
+            val selfSubst = mapOf(TyTypeParameter.self() to primitiveType).toTypeSubst()
+            if (processAssociatedItemsWithSelfSubst(lookup, primitiveType, ns, selfSubst, processor)) return true
+        }
+        return false
     }
-
-    val (base, subst) = qualifier.reference.advancedResolve() ?: return false
     val isSuperChain = isSuperChain(qualifier)
     if (base is RsMod) {
         val s = base.`super`

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -624,4 +624,12 @@ class RsStdlibResolveTest : RsResolveTestBase() {
             std::format_args!(true);
         }        //^ ...libstd/macros.rs
     """)
+
+    fun `test f64 INFINITY`() = stubOnlyResolve("""
+    //- main.rs
+        use std::f64;
+        fn main() {
+            let a = f64::INFINITY;
+        }              //^ ...num/f64.rs
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -823,4 +823,15 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
             <S>::foo;
         }      //^
     """)
+
+    fun `test module wins over primitive type`() = checkByCode("""
+        mod f64 {
+            pub const INFINITY: f64 = 0.0;
+        }            //X
+        trait T { const INFINITY: Self; }
+        impl T for f64 { const INFINITY: Self = 17.0; }
+        fn main() {
+            let a = f64::INFINITY;
+        }              //^
+    """)
 }


### PR DESCRIPTION
Works for 
```rust
use std::f64;
fn main() {
    let a = f64::INFINITY;
}              //^ ...num/f64.rs
```

Fixes #2667