### PR TITLE
PERF: use green stubs everywhere

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -87,7 +87,7 @@ class RsFile(
 
     val attributes: Attributes
         get() {
-            val stub = stub
+            val stub = greenStub as RsFileStub?
             if (stub != null) return stub.attributes
             if (queryAttributes.hasAtomAttribute("no_core")) return Attributes.NO_CORE
             if (queryAttributes.hasAtomAttribute("no_std")) return Attributes.NO_STD

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.psi.ext
 
+import com.intellij.extapi.psi.StubBasedPsiElementBase
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.VirtualFile
@@ -36,7 +37,7 @@ val PsiElement.ancestorPairs: Sequence<Pair<PsiElement, PsiElement>> get() {
 val PsiElement.stubParent: PsiElement
     get() {
         if (this is StubBasedPsiElement<*>) {
-            val stub = this.stub
+            val stub = this.greenStub
             if (stub != null) return stub.parentStub.psi
         }
         return parent
@@ -128,8 +129,8 @@ fun <T : PsiElement> getStubDescendantsOfType(
     aClass: Class<T>
 ): Collection<T> {
     if (element == null) return emptyList()
-    val stub = (element as? PsiFileImpl)?.stub
-        ?: (element as? StubBasedPsiElement<*>)?.stub
+    val stub = (element as? PsiFileImpl)?.greenStub
+        ?: (element as? StubBasedPsiElement<*>)?.greenStub
         ?: return PsiTreeUtil.findChildrenOfAnyType<T>(element, strict, aClass)
 
     val result = SmartList<T>()
@@ -161,8 +162,8 @@ fun <T : PsiElement> getStubDescendantOfType(
     aClass: Class<T>
 ): T? {
     if (element == null) return null
-    val stub = (element as? PsiFileImpl)?.stub
-        ?: (element as? StubBasedPsiElement<*>)?.stub
+    val stub = (element as? PsiFileImpl)?.greenStub
+        ?: (element as? StubBasedPsiElement<*>)?.greenStub
         ?: return PsiTreeUtil.findChildOfType<T>(element, aClass, strict)
 
     fun go(childrenStubs: List<StubElement<PsiElement>>): T? {
@@ -240,3 +241,7 @@ private fun PsiElement.getLineCount(): Int {
 }
 
 fun PsiWhiteSpace.isMultiLine(): Boolean = getLineCount() > 1
+
+@Suppress("UNCHECKED_CAST")
+inline val <T: StubElement<*>> StubBasedPsiElement<T>.greenStub: T?
+    get() = (this as? StubBasedPsiElementBase<T>)?.greenStub

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt
@@ -10,7 +10,7 @@ import org.rust.lang.core.types.ty.TyInteger
 import org.rust.lang.utils.evaluation.ExprValue
 import org.rust.lang.utils.evaluation.RsConstExprEvaluator
 
-val RsArrayType.isSlice: Boolean get() = stub?.isSlice ?: (expr == null)
+val RsArrayType.isSlice: Boolean get() = greenStub?.isSlice ?: (expr == null)
 
 val RsArrayType.arraySize: Long?
     get() {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAssocTypeBinding.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAssocTypeBinding.kt
@@ -30,5 +30,5 @@ abstract class RsAssocTypeBindingMixin : RsStubbedNamedElementImpl<RsAssocTypeBi
 
     override val referenceNameElement: PsiElement get() = identifier
 
-    override val referenceName: String get() = stub?.name ?: super.referenceName
+    override val referenceName: String get() = greenStub?.name ?: super.referenceName
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsBaseType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsBaseType.kt
@@ -30,7 +30,7 @@ sealed class RsBaseTypeKind {
 private val RS_BASE_TYPE_KINDS = tokenSetOf(LPAREN, EXCL, UNDERSCORE, PATH)
 
 val RsBaseType.stubKind: RsBaseTypeStubKind get() {
-    val stub = stub
+    val stub = greenStub
     if (stub != null) return stub.kind
 
     val child = node.findChildByType(RS_BASE_TYPE_KINDS)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsBinaryOp.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsBinaryOp.kt
@@ -17,7 +17,7 @@ import org.rust.lang.core.stubs.RsBinaryOpStub
 val RsBinaryOp.operator: PsiElement
     get() = requireNotNull(node.findChildByType(RS_BINARY_OPS)) { "guaranteed to be not-null by parser" }.psi
 
-val RsBinaryOp.op: String get() = stub?.op ?: operator.text
+val RsBinaryOp.op: String get() = greenStub?.op ?: operator.text
 
 val RsBinaryOp.isLazy: Boolean get() = andand != null || this.oror != null
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
@@ -22,9 +22,9 @@ enum class RsConstantKind {
     CONST
 }
 
-val RsConstant.isMut: Boolean get() = stub?.isMut ?: (mut != null)
+val RsConstant.isMut: Boolean get() = greenStub?.isMut ?: (mut != null)
 
-val RsConstant.isConst: Boolean get() = stub?.isConst ?: (const != null)
+val RsConstant.isConst: Boolean get() = greenStub?.isConst ?: (const != null)
 
 val RsConstant.kind: RsConstantKind get() = when {
     isMut -> RsConstantKind.MUT_STATIC

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -86,7 +86,7 @@ class QueryAttributes(
     // #[cfg(test)], #[cfg(target_has_atomic = "ptr")], #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
     fun hasCfgAttr(): Boolean {
         if (psi is RsFunction) {
-            val stub = psi.stub
+            val stub = psi.greenStub
             if (stub != null) return stub.isCfg
         }
         return hasAttribute("cfg")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
@@ -30,7 +30,7 @@ enum class UnaryOperator {
 
 val RsUnaryExpr.operatorType: UnaryOperator
     get() {
-        val stub = stub as? RsUnaryExprStub
+        val stub = greenStub as? RsUnaryExprStub
         if (stub != null) return stub.operatorType
         return when {
             mut != null -> UnaryOperator.REF_MUT

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt
@@ -33,7 +33,7 @@ abstract class RsExternCrateItemImplMixin : RsStubbedNamedElementImpl<RsExternCr
         "Extern crate must contain identifier: $this $text at ${containingFile.virtualFile.path}"
     }
 
-    override val referenceName: String get() = stub?.name ?: super.referenceName
+    override val referenceName: String get() = greenStub?.name ?: super.referenceName
 
     override fun getIcon(flags: Int) = RsIcons.CRATE
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -24,32 +24,32 @@ import javax.swing.Icon
 val RsFunction.isAssocFn: Boolean get() = selfParameter == null && owner.isImplOrTrait
 
 val RsFunction.isTest: Boolean get() {
-    val stub = stub
+    val stub = greenStub
     return stub?.isTest ?: (queryAttributes.hasAtomAttribute("test") || queryAttributes.hasAtomAttribute("quickcheck"))
 }
 
 val RsFunction.isBench: Boolean get() {
-    val stub = stub
+    val stub = greenStub
     return stub?.isBench ?: queryAttributes.hasAtomAttribute("bench")
 }
 
 val RsFunction.isConst: Boolean get() {
-    val stub = stub
+    val stub = greenStub
     return stub?.isConst ?: (const != null)
 }
 
 val RsFunction.isExtern: Boolean get() {
-    val stub = stub
+    val stub = greenStub
     return stub?.isExtern ?: (abi != null)
 }
 
 val RsFunction.isVariadic: Boolean get() {
-    val stub = stub
+    val stub = greenStub
     return stub?.isVariadic ?: (valueParameterList?.variadic != null)
 }
 
 val RsFunction.abiName: String? get() {
-    val stub = stub
+    val stub = greenStub
     return stub?.abiName ?: abi?.stringLiteral?.text
 }
 
@@ -63,7 +63,7 @@ val RsFunction.default: PsiElement?
     get() = node.findChildByType(RsElementTypes.DEFAULT)?.psi
 
 val RsFunction.isAsync: Boolean
-    get() = stub?.isAsync ?: (node.findChildByType(RsElementTypes.ASYNC) != null)
+    get() = greenStub?.isAsync ?: (node.findChildByType(RsElementTypes.ASYNC) != null)
 
 val RsFunction.title: String
     get() = when (owner) {
@@ -107,9 +107,9 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
 
     constructor(stub: RsFunctionStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
-    override val isAbstract: Boolean get() = stub?.isAbstract ?: (block == null)
+    override val isAbstract: Boolean get() = greenStub?.isAbstract ?: (block == null)
 
-    override val isUnsafe: Boolean get() = this.stub?.isUnsafe ?: (unsafe != null)
+    override val isUnsafe: Boolean get() = this.greenStub?.isUnsafe ?: (unsafe != null)
 
     override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
@@ -6,12 +6,16 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.openapi.util.Key
+import com.intellij.psi.StubBasedPsiElement
 import com.intellij.psi.stubs.StubElement
 import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.util.SmartList
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.RsImplItem
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.rustStructureOrAnyPsiModificationTracker
 
 interface RsItemsOwner : RsElement
 
@@ -20,16 +24,12 @@ val RsItemsOwner.itemsAndMacros: Sequence<RsElement>
         val stubChildren: List<StubElement<*>>? = run {
             when (this) {
                 is RsFile -> {
-                    val stub = stub
+                    val stub = greenStub
                     if (stub != null) return@run stub.childrenStubs
                 }
-                is RsModItem -> {
-                    val stub = stub
+                is StubBasedPsiElement<*> -> {
+                    val stub = this.greenStub
                     if (stub != null) return@run stub.childrenStubs
-                }
-                is RsBlock -> {
-                    val stub = stub
-                    if(stub != null) return@run stub.childrenStubs
                 }
             }
             null

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsLifetime.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsLifetime.kt
@@ -27,7 +27,7 @@ abstract class RsLifetimeImplMixin : RsStubbedNamedElementImpl<RsLifetimeStub>, 
 
     override val referenceNameElement: PsiElement get() = quoteIdentifier
 
-    override val referenceName: String get() = stub?.name ?: referenceNameElement.text
+    override val referenceName: String get() = greenStub?.name ?: referenceNameElement.text
 }
 
 sealed class LifetimeName {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsLitExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsLitExpr.kt
@@ -6,7 +6,10 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
-import com.intellij.psi.*
+import com.intellij.psi.LiteralTextEscaper
+import com.intellij.psi.PsiLanguageInjectionHost
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceService
 import com.intellij.psi.impl.source.tree.LeafElement
 import com.intellij.psi.stubs.IStubElementType
 import org.intellij.lang.regexp.DefaultRegExpPropertiesProvider
@@ -27,7 +30,7 @@ import org.rust.lang.core.types.ty.TyFloat
 import org.rust.lang.core.types.ty.TyInteger
 
 val RsLitExpr.stubType: RsStubLiteralType? get() {
-    val stub = (stub as? RsLitExprStub)
+    val stub = (greenStub as? RsLitExprStub)
     if (stub != null) return stub.type
     val kind = kind
     return when (kind) {
@@ -41,7 +44,7 @@ val RsLitExpr.stubType: RsStubLiteralType? get() {
 }
 
 val RsLitExpr.integerLiteralValue: String? get() =
-    (stub as? RsLitExprStub)?.integerLiteralValue ?: integerLiteral?.text
+    (greenStub as? RsLitExprStub)?.integerLiteralValue ?: integerLiteral?.text
 
 abstract class RsLitExprMixin : RsExprImpl, RsLitExpr, RegExpLanguageHost {
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
@@ -64,7 +64,7 @@ val RsMacro.macroBodyStubbed: RsMacroBody?
 
 val RsMacro.bodyHash: HashCode?
     get() = CachedValuesManager.getCachedValue(this) {
-        val body = stub?.macroBody ?: macroBody?.text
+        val body = greenStub?.macroBody ?: macroBody?.text
         val hash = body?.let { HashCode.compute(it) }
         CachedValueProvider.Result.create(hash, modificationTracker)
     }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -45,7 +45,7 @@ val RsMacroCall.macroName: String
 
 val RsMacroCall.macroBody: String?
     get() {
-        val stub = stub
+        val stub = greenStub
         if (stub != null) return stub.macroBody
         return macroArgument?.compactTT?.text
             ?: formatMacroArgument?.braceListBodyText()?.toString()

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMembers.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMembers.kt
@@ -24,7 +24,7 @@ val RsMembers.expandedMembers: List<RsAbstractable>
     }
 
 private val StubBasedPsiElement<*>.childrenSequence
-    get() = (stub?.childrenStubs?.asSequence()?.map { it.psi } ?: generateSequence(firstChild) { it.nextSibling })
+    get() = (greenStub?.childrenStubs?.asSequence()?.map { it.psi } ?: generateSequence(firstChild) { it.nextSibling })
         .filterIsInstance<RsElement>()
 
 private fun RsMacroCall.collectAbstractableMembersRecursively(members: MutableList<RsAbstractable>) {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
@@ -18,16 +18,16 @@ import org.rust.lang.core.resolve.ref.deriveReference
 import org.rust.lang.core.stubs.RsMetaItemStub
 
 val RsMetaItem.name: String? get() {
-    val stub = stub
+    val stub = greenStub
     return if (stub != null) stub.name else identifier?.unescapedText
 }
 
 val RsMetaItem.value: String? get() {
-    val stub = stub
+    val stub = greenStub
     return if (stub != null) stub.value else litExpr?.stringLiteralValue
 }
 
-val RsMetaItem.hasEq: Boolean get() = stub?.hasEq ?: (eq != null)
+val RsMetaItem.hasEq: Boolean get() = greenStub?.hasEq ?: (eq != null)
 
 fun RsMetaItem.resolveToDerivedTrait(): RsTraitItem? =
     deriveReference?.resolve() as? RsTraitItem

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt
@@ -27,7 +27,7 @@ fun RsModDeclItem.getOrCreateModuleFile(): PsiFile? {
 }
 
 val RsModDeclItem.isLocal: Boolean
-    get() = stub?.isLocal ?: (ancestorStrict<RsBlock>() != null)
+    get() = greenStub?.isLocal ?: (ancestorStrict<RsBlock>() != null)
 
 
 //TODO: use explicit path if present.

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
@@ -20,10 +20,10 @@ import org.rust.lang.core.stubs.RsPathStub
 
 private val RS_PATH_KINDS = tokenSetOf(IDENTIFIER, SELF, SUPER, CSELF, CRATE)
 
-val RsPath.hasColonColon: Boolean get() = stub?.hasColonColon ?: (coloncolon != null)
+val RsPath.hasColonColon: Boolean get() = greenStub?.hasColonColon ?: (coloncolon != null)
 val RsPath.hasCself: Boolean get() = kind == PathKind.CSELF
 val RsPath.kind: PathKind get() {
-    val stub = stub
+    val stub = greenStub
     if (stub != null) return stub.kind
     val child = node.findChildByType(RS_PATH_KINDS)
     return when (child?.elementType) {
@@ -66,7 +66,7 @@ abstract class RsPathImplMixin : RsStubbedElementImpl<RsPathStub>,
             "Path must contain identifier: $this ${this.text} at ${this.containingFile.virtualFile.path}"
         }
 
-    override val referenceName: String get() = stub?.referenceName ?: super.referenceName
+    override val referenceName: String get() = greenStub?.referenceName ?: super.referenceName
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPolybound.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPolybound.kt
@@ -15,4 +15,4 @@ import org.rust.lang.core.psi.RsPolybound
  * ```
  */
 val RsPolybound.hasQ: Boolean
-    get() = stub?.hasQ ?: (q != null)
+    get() = greenStub?.hasQ ?: (q != null)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsRefLikeType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsRefLikeType.kt
@@ -8,6 +8,6 @@ package org.rust.lang.core.psi.ext
 import org.rust.lang.core.psi.RsRefLikeType
 import org.rust.lang.core.types.ty.Mutability
 
-val RsRefLikeType.mutability: Mutability get() = Mutability.valueOf(stub?.isMut ?: (mut != null))
-val RsRefLikeType.isRef: Boolean get() = stub?.isRef ?: (and != null)
-val RsRefLikeType.isPointer: Boolean get() = stub?.isPointer ?: (mul != null)
+val RsRefLikeType.mutability: Mutability get() = Mutability.valueOf(greenStub?.isMut ?: (mut != null))
+val RsRefLikeType.isRef: Boolean get() = greenStub?.isRef ?: (and != null)
+val RsRefLikeType.isPointer: Boolean get() = greenStub?.isPointer ?: (mul != null)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsSelfParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsSelfParameter.kt
@@ -15,9 +15,9 @@ import org.rust.lang.core.stubs.RsSelfParameterStub
 import org.rust.lang.core.types.ty.Mutability
 
 
-val RsSelfParameter.mutability: Mutability get() = Mutability.valueOf(stub?.isMut ?: (mut != null))
-val RsSelfParameter.isRef: Boolean get() = stub?.isRef ?: (and != null)
-val RsSelfParameter.isExplicitType get() = stub?.isExplicitType ?: (colon != null)
+val RsSelfParameter.mutability: Mutability get() = Mutability.valueOf(greenStub?.isMut ?: (mut != null))
+val RsSelfParameter.isRef: Boolean get() = greenStub?.isRef ?: (and != null)
+val RsSelfParameter.isExplicitType get() = greenStub?.isExplicitType ?: (colon != null)
 val RsSelfParameter.parentFunction: RsFunction get() = ancestorStrict()!!
 
 abstract class RsSelfParameterImplMixin : RsStubbedElementImpl<RsSelfParameterStub>, RsSelfParameter {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructItem.kt
@@ -28,7 +28,7 @@ enum class RsStructKind {
 }
 
 val RsStructItem.kind: RsStructKind get() {
-    val hasUnion = stub?.isUnion ?: (union != null)
+    val hasUnion = greenStub?.isUnion ?: (union != null)
     return if (hasUnion) RsStructKind.UNION else RsStructKind.STRUCT
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -35,7 +35,7 @@ val RsTraitItem.langAttribute: String? get() = queryAttributes.langAttribute
 val RsTraitItem.isSizedTrait: Boolean get() = langAttribute == "sized"
 
 val RsTraitItem.isAuto: Boolean
-    get() = stub?.isAuto ?: (node.findChildByType(RsElementTypes.AUTO) != null)
+    get() = greenStub?.isAuto ?: (node.findChildByType(RsElementTypes.AUTO) != null)
 
 val RsTraitItem.isKnownDerivable: Boolean get() {
     val derivableTrait = KNOWN_DERIVABLE_TRAITS[name] ?: return false
@@ -139,7 +139,7 @@ abstract class RsTraitItemImplMixin : RsStubbedNamedElementImpl<RsTraitItemStub>
         get() = BoundElement(this).associatedTypesTransitively
 
     override val isUnsafe: Boolean get() {
-        val stub = stub
+        val stub = greenStub
         return stub?.isUnsafe ?: (unsafe != null)
     }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitType.kt
@@ -7,4 +7,4 @@ package org.rust.lang.core.psi.ext
 
 import org.rust.lang.core.psi.RsTraitType
 
-val RsTraitType.isImpl: Boolean get() = (stub?.isImpl) ?: (impl != null)
+val RsTraitType.isImpl: Boolean get() = (greenStub?.isImpl) ?: (impl != null)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeParameter.kt
@@ -30,7 +30,7 @@ val RsTypeParameter.bounds: List<RsPolybound> get() {
 }
 
 val RsTypeParameter.isSized: Boolean get() {
-    val stub = stub
+    val stub = greenStub
     if (stub != null) return stub.isSized
 
     // We can't use `resolve` here to find `?Sized` bound because it causes `IndexNotReadyException` while indexing.

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseSpeck.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseSpeck.kt
@@ -12,7 +12,7 @@ import org.rust.lang.core.psi.RsUseGroup
 import org.rust.lang.core.psi.RsUseSpeck
 import org.rust.lang.core.stubs.RsUseSpeckStub
 
-val RsUseSpeck.isStarImport: Boolean get() = stub?.isStarImport ?: (mul != null) // I hate operator precedence
+val RsUseSpeck.isStarImport: Boolean get() = greenStub?.isStarImport ?: (mul != null) // I hate operator precedence
 val RsUseSpeck.qualifier: RsPath? get() {
     val parentUseSpeck = (context as? RsUseGroup)?.parentUseSpeck ?: return null
     return parentUseSpeck.pathOrQualifier

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsValueParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsValueParameter.kt
@@ -9,6 +9,6 @@ import org.rust.lang.core.psi.RsValueParameter
 
 
 val RsValueParameter.patText: String? get() {
-    val stub = stub
+    val stub = greenStub
     return if (stub != null) stub.patText else pat?.text
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
@@ -56,7 +56,7 @@ enum class RsVisStubKind {
 }
 
 val RsVis.stubKind: RsVisStubKind
-    get() = stub?.kind ?: when {
+    get() = greenStub?.kind ?: when {
         crate != null -> RsVisStubKind.CRATE
         visRestriction != null -> RsVisStubKind.RESTRICTED
         else -> RsVisStubKind.PUB

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -751,7 +751,7 @@ private class MacroResolver private constructor() {
         startElement: PsiElement,
         processor: (PsiElement) -> Boolean
     ): Boolean {
-        val stub = (startElement as? StubBasedPsiElement<*>)?.stub
+        val stub = (startElement as? StubBasedPsiElement<*>)?.greenStub
         return if (stub != null) {
             stubBasedProcessScopesInLexicalOrderUpward(stub, processor)
         } else {


### PR DESCRIPTION
"Green stub" can co-exists with AST. I think we should mostly use
green stubs (just like Java does) because almost all operations
are faster on stubs then on AST