### PR TITLE
DBG: disable `buildSearchableOptions` by default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,9 +73,15 @@ allprojects {
         instrumentCode = false
         ideaDependencyCachePath = dependencyCachePath
 
-        tasks.withType<PatchPluginXmlTask> {
-            sinceBuild(prop("sinceBuild"))
-            untilBuild(prop("untilBuild"))
+        tasks {
+            withType<PatchPluginXmlTask> {
+                sinceBuild(prop("sinceBuild"))
+                untilBuild(prop("untilBuild"))
+            }
+
+            "buildSearchableOptions" {
+                enabled = prop("enableBuildSearchableOptions").toBoolean()
+            }
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,6 @@ publishPassword=password
 publishChannel=
 
 showTestStatus=false
+enableBuildSearchableOptions=false
 
 org.gradle.jvmargs=-Xmx2g


### PR DESCRIPTION
It should speed up CI tests and local builds