### PR TITLE
ANN: fix highlighting of const/static

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -138,6 +138,7 @@ private fun partToHighlight(element: RsElement): TextRange? {
         is RsEnumItem -> element.identifier
         is RsEnumVariant -> element.identifier
         is RsExternCrateItem -> element.identifier
+        is RsConstant -> element.identifier
         is RsNamedFieldDecl -> element.identifier
         is RsFunction -> element.identifier
         is RsMethodCall -> element.referenceNameElement

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -143,4 +143,13 @@ class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator:
             pub struct S;
         """
     )
+
+    fun `test const and static`() = checkHighlighting("""
+        const <CONST>FOO</CONST>: i32 = 0;
+        static <CONST>BAR</CONST>: i32 = 0;
+        fn main() {
+            <CONST>FOO</CONST>;
+            <CONST>BAR</CONST>;
+        }
+    """)
 }


### PR DESCRIPTION
```rust
const FOO: i32 = 0;
     //^ should be highlighted
```