### PR TITLE
CARGO: Support crate version and version requirements parsing

### DIFF
--- a/intellij-toml/src/main/kotlin/org/toml/lang/CrateVersion.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/CrateVersion.kt
@@ -1,0 +1,161 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.lang
+
+// Based on https://github.com/steveklabnik/semver/blob/master/src/version.rs
+sealed class Identifier : Comparable<Identifier> {
+    companion object {
+        fun parse(input: String): Identifier {
+            // Strings such as 0851523 should be parsed as AlphaNumeric because Numeric would lose the 0 in front
+            val int = if (input.startsWith("0")) null else input.toIntOrNull()
+            return if (int != null) {
+                Numeric(int)
+            } else {
+                AlphaNumeric(input)
+            }
+        }
+    }
+
+    data class Numeric(val num: Int) : Identifier() {
+        override fun compareTo(other: Identifier): Int {
+            if (other is Numeric) {
+                return this.num.compareTo(other.num)
+            }
+
+            return 0
+        }
+
+        override fun toString() = "$num"
+    }
+
+    data class AlphaNumeric(val string: String) : Identifier() {
+        init {
+            require(string.isNotEmpty()) { "Identifier can't be empty" }
+        }
+
+        override fun compareTo(other: Identifier): Int {
+            if (other is AlphaNumeric) {
+                return this.string.compareTo(other.string)
+            }
+
+            return 0
+        }
+
+        override fun toString() = string
+    }
+}
+
+data class IncompleteCrateVersion(val major: Int?, val minor: Int?, val patch: Int?, val pre: List<Identifier> = emptyList(), val build: List<Identifier> = emptyList()) {
+    companion object {
+        fun parse(string: String): IncompleteCrateVersion {
+            val input = string.trim()
+            val majorBound = input.indexOf('.').takeUnless { it == -1 }
+                ?: return IncompleteCrateVersion(input.toIntOrNull(), null, null)
+            val major = input.substring(0, majorBound).toIntOrNull() ?: return IncompleteCrateVersion(null, null, null)
+
+            val minorBound = input.indexOf('.', majorBound + 1).takeUnless { it == -1 }
+                ?: return IncompleteCrateVersion(major, input.substring(majorBound + 1).toIntOrNull(), null)
+            val minor = input.substring(majorBound + 1, minorBound).toIntOrNull()
+                ?: return IncompleteCrateVersion(major, null, null)
+
+            val patchBound = input.indexOfAny(charArrayOf('-', '+'), minorBound + 1).takeUnless { it == -1 }
+                ?: return IncompleteCrateVersion(major, minor, input.substring(minorBound + 1).toIntOrNull())
+            val patch = input.substring(minorBound + 1, patchBound).toIntOrNull()
+                ?: return IncompleteCrateVersion(major, minor, null)
+
+            val preStartBound = if (input.getOrNull(patchBound) == '-') patchBound else -1
+            val preBound = input.indexOf('+', preStartBound + 1).takeUnless { it == -1 } ?: input.length
+            val pres = if (preStartBound != -1 && preStartBound != preBound) input.substring(preStartBound + 1, preBound).split('.').map { Identifier.parse(it) } else listOf()
+
+            val builds = if (preBound + 1 < input.length) input.substring(preBound + 1).split('.').map { Identifier.parse(it) } else listOf()
+
+            return IncompleteCrateVersion(major, minor, patch, pres, builds)
+        }
+    }
+}
+
+data class CrateVersion(val major: Int, val minor: Int, val patch: Int, val pre: List<Identifier> = emptyList(), val build: List<Identifier> = emptyList()) : Comparable<CrateVersion> {
+    companion object {
+        /**
+         * Requires all 3 components (major, minor, patch) to be present.
+         */
+        fun parse(string: String): CrateVersion {
+            val input = string.trim()
+            val majorBound = input.indexOf('.').takeUnless { it == -1 }
+                ?: throw IllegalArgumentException("Major not provided")
+            val major = input.substring(0, majorBound).toInt()
+
+            val minorBound = input.indexOf('.', majorBound + 1).takeUnless { it == -1 }
+                ?: throw IllegalArgumentException("Minor not provided")
+            val minor = input.substring(majorBound + 1, minorBound).toInt()
+
+            val patchBound = input.indexOfAny(charArrayOf('-', '+'), minorBound + 1).takeUnless { it == -1 }
+                ?: input.length
+            val patch = input.substring(minorBound + 1, patchBound).toInt()
+
+            val preStartBound = if (input.getOrNull(patchBound) == '-') patchBound else -1
+            val preBound = input.indexOf('+', preStartBound + 1).takeUnless { it == -1 } ?: input.length
+            val pres = if (preStartBound != -1 && preStartBound != preBound) input.substring(preStartBound + 1, preBound).split('.').map { Identifier.parse(it) } else listOf()
+
+            val builds = if (preBound + 1 < input.length) input.substring(preBound + 1).split('.').map { Identifier.parse(it) } else listOf()
+
+            return CrateVersion(major, minor, patch, pres, builds)
+        }
+
+        fun tryParse(string: String): CrateVersion? = try {
+            parse(string)
+        } catch (e: IllegalArgumentException) {
+            null
+        }
+    }
+
+    fun isPrerelease() = pre.isNotEmpty()
+
+    override fun compareTo(other: CrateVersion): Int {
+        val majorCmp = this.major.compareTo(other.major)
+        if (majorCmp != 0) return majorCmp
+
+        val minorCmp = this.minor.compareTo(other.minor)
+        if (minorCmp != 0) return minorCmp
+
+        val patchCmp = this.patch.compareTo(other.patch)
+        if (patchCmp != 0) return patchCmp
+
+        val preCmp = this.pre.withIndex().firstOrNull { (i, own) -> other.pre.getOrNull(i)?.compareTo(own) != 0 }?.let {
+            val (preI, preOwn) = it
+            // 1. times(-1) because this expr compares the other way (other > this ? instead of this > other ?)
+            // 2. if other.pre[preI] == null, it means that this.pre.size > other.pre.size which means this > other
+            other.pre.getOrNull(preI)?.compareTo(preOwn)?.times(-1) ?: -1
+        } ?: if (this.pre.isEmpty()) {
+            if (other.pre.isEmpty()) 0
+            else 1
+        } else {
+            if (other.pre.isEmpty()) -1
+            else this.pre.size.compareTo(other.pre.size)
+        }
+        if (preCmp != 0) return preCmp
+
+
+        val buildCmp = this.build.withIndex().firstOrNull { (i, own) -> other.build.getOrNull(i)?.compareTo(own) != 0 }?.let {
+            val (buildI, buildOwn) = it
+            // 1. times(-1) because this expr compares the other way (other > this ? instead of this > other ?)
+            // 2. if other.build[buildI] == null, it means that this.build.size > other.build.size which means this > other
+            other.build.getOrNull(buildI)?.compareTo(buildOwn)?.times(-1) ?: -1
+        } ?: if (this.build.isEmpty()) {
+            if (other.build.isEmpty()) 0
+            else 1
+        } else {
+            if (other.build.isEmpty()) -1
+            else this.build.size.compareTo(other.build.size)
+        }
+        return buildCmp
+    }
+
+    override fun toString() =
+        "$major.$minor.$patch" +
+            (if (pre.isNotEmpty()) pre.joinToString(".", prefix = "-") else "") +
+            (if (build.isNotEmpty()) build.joinToString(".", prefix = "+") else "")
+}

--- a/intellij-toml/src/main/kotlin/org/toml/lang/CrateVersionReq.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/CrateVersionReq.kt
@@ -40,7 +40,7 @@ class CrateVersionReq private constructor(private val predicates: List<Predicate
                     else -> null to 0
                 }
 
-                val (major, minor, patch, pre, _) = IncompleteCrateVersion.parse(req.substring(len))
+                val (major, minor, patch, pre, _) = CrateVersion.tryParse(req.substring(len))
                 predicates += Predicate(op ?: Op.Compatible, major, minor, patch, pre)
             }
 

--- a/intellij-toml/src/main/kotlin/org/toml/lang/CrateVersionReq.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/CrateVersionReq.kt
@@ -1,0 +1,216 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.lang
+
+// Based on https://github.com/steveklabnik/semver/blob/master/src/version_req.rs
+class CrateVersionReq private constructor(private val predicates: List<Predicate>) {
+    companion object {
+        fun any(): CrateVersionReq =
+            CrateVersionReq(emptyList())
+
+        fun exact(version: CrateVersion) =
+            CrateVersionReq(listOf(Predicate.exact(version)))
+
+        fun parse(input: String): CrateVersionReq {
+            val requirements = input.split(",")
+            val predicates = mutableListOf<Predicate>()
+            for (requirement in requirements) {
+                val req = requirement.trim()
+                val (op, len) = when {
+                    req.startsWith(">=") -> Op.GtEq to 2
+                    req.startsWith(">") -> Op.Gt to 1
+                    req.startsWith("<=") -> Op.LtEq to 2
+                    req.startsWith("<") -> Op.Lt to 1
+                    req.startsWith("=") -> Op.Eq to 1
+                    req.startsWith("~") -> Op.Tilde to 1
+                    req.startsWith("^") -> Op.Compatible to 1
+                    req.contains('*') -> {
+                        val starPos = req.indexOf('*')
+                        val dotCount = req.dropLast(req.length - starPos).count { it == '.' }
+                        when (dotCount) {
+                            0 -> Op.WildcardMajor
+                            1 -> Op.WildcardMinor
+                            2 -> Op.WildcardPatch
+                            else -> throw IllegalArgumentException("Couldn't parse wildcard. Unrecognizable position")
+                        } to 0
+                    }
+                    else -> null to 0
+                }
+
+                val (major, minor, patch, pre, _) = IncompleteCrateVersion.parse(req.substring(len))
+                predicates += Predicate(op ?: Op.Compatible, major, minor, patch, pre)
+            }
+
+            return CrateVersionReq(predicates)
+        }
+    }
+
+    /**
+     * Is this a simple requirement that specifies a single version, such as `1.0.0` or `1.3.2`
+     */
+    val isSimple: Boolean = this.predicates.size == 1 &&
+        (this.predicates[0].op == Op.Eq ||
+            this.predicates[0].op == Op.Compatible)
+
+    fun matches(version: CrateVersion): Boolean =
+        this.predicates.isEmpty() ||
+            (this.predicates.all { it.matches(version) } &&
+                this.predicates.any { it.preTagIsCompatible(version) })
+
+    override fun toString(): String =
+        if (predicates.isEmpty()) "any"
+        else predicates.joinToString()
+}
+
+private enum class Op(val literal: String) {
+    Eq("="),
+    Gt(">"),
+    GtEq(">="),
+    Lt("<"),
+    LtEq("<="),
+    Tilde("~"),
+    Compatible("^"),
+    WildcardMajor("*"),
+    WildcardMinor(""),
+    WildcardPatch("")
+}
+
+private data class Predicate(val op: Op, private val major: Int?, private val minor: Int?, private val patch: Int?, private val pre: List<Identifier>) {
+    companion object {
+        fun exact(version: CrateVersion) = Predicate(
+            Op.Eq,
+            version.major,
+            version.minor,
+            version.patch,
+            ArrayList(version.pre)
+        )
+    }
+
+    fun matches(version: CrateVersion): Boolean = when (this.op) {
+        Op.Eq -> this.isExact(version)
+        Op.Gt -> this.isGreater(version)
+        Op.GtEq -> this.isGreater(version) || this.isExact(version)
+        Op.Lt -> !this.isExact(version) && !this.isGreater(version)
+        Op.LtEq -> !this.isGreater(version)
+        Op.Tilde -> this.matchesTilde(version)
+        Op.Compatible -> this.isCompatible(version)
+        Op.WildcardMajor, Op.WildcardMinor, Op.WildcardPatch -> this.matchesWildcard(version)
+    }
+
+    private fun isExact(version: CrateVersion): Boolean {
+        if (this.major != version.major) return false
+        if (this.minor != null) {
+            if (this.minor != version.minor) {
+                return false
+            }
+        } else {
+            return true
+        }
+
+        if (this.patch != null) {
+            if (this.patch != version.patch) {
+                return false
+            }
+        } else {
+            return true
+        }
+
+        if (this.pre != version.pre) return false
+
+        return true
+    }
+
+    fun preTagIsCompatible(version: CrateVersion): Boolean =
+        !version.isPrerelease()
+            || (this.major == version.major
+            && this.minor == version.minor
+            && this.patch == version.patch
+            && this.pre.isNotEmpty())
+
+    private fun isGreater(version: CrateVersion): Boolean {
+        if (this.major == null) return true
+        if (this.major != version.major) return version.major > this.major
+        if (this.minor != null) {
+            if (this.minor != version.minor) {
+                return version.minor > this.minor
+            }
+        } else {
+            return false
+        }
+
+        if (this.patch != null) {
+            if (this.patch != version.patch) {
+                return version.patch > this.patch
+            }
+        }
+
+        if (this.pre.isNotEmpty()) {
+            return version.pre.isEmpty() || version.pre.zip(this.pre).all { (a, b) -> a > b }
+        }
+
+        return false
+    }
+
+    private fun matchesTilde(version: CrateVersion): Boolean {
+        this.minor ?: return this.major == version.major
+
+        return if (this.patch != null) {
+            this.major == version.major &&
+                this.minor == version.minor &&
+                (version.patch > patch || (version.patch == patch && this.preIsCompatible(version)))
+        } else {
+            this.major == version.major && this.minor == version.minor
+        }
+    }
+
+    private fun isCompatible(version: CrateVersion): Boolean {
+        if (version.major != this.major) return this.major == null
+
+        val minor = this.minor ?: return version.major == this.major
+
+        if (this.patch != null) {
+            return if (this.major == 0) {
+                if (minor == 0) {
+                    version.minor == minor && version.patch == patch && this.preIsCompatible(version)
+                } else {
+                    version.minor == minor && (version.patch > patch || (version.patch == patch && this.preIsCompatible(version)))
+                }
+            } else {
+                version.minor > minor || (version.minor == minor && (version.patch > patch || (version.patch == patch && this.preIsCompatible(version))))
+            }
+        } else {
+            return if (this.major == 0) {
+                // When in pre 1.0 stage, the minor version acts as major
+                this.minor == version.minor
+            } else {
+                version.minor >= minor
+            }
+        }
+
+    }
+
+    private fun preIsCompatible(version: CrateVersion) =
+        version.pre.isEmpty() || version.pre.zip(this.pre).all { (a, b) -> a >= b }
+
+    private fun matchesWildcard(version: CrateVersion) = when (op) {
+        Op.WildcardMajor -> true
+        Op.WildcardMinor -> this.major == version.major
+        Op.WildcardPatch -> this.minor == version.minor
+        else -> throw IllegalStateException("Tried to check if matches wildcard but there's no wildcard")
+    }
+
+    override fun toString() =
+        "CrateVersionReq(" + when (op) {
+            Op.WildcardMajor -> "*"
+            Op.WildcardMinor -> "$major.*"
+            Op.WildcardPatch -> "$major.$minor.*"
+            else -> op.literal +
+                "$major" +
+                (if (minor != null) ".$minor" else "") +
+                (if (patch != null) ".$patch" else "") +
+                (if (pre.isNotEmpty()) "-" + pre.joinToString() else "")
+        } + ")"
+}

--- a/intellij-toml/src/test/kotlin/org/toml/lang/CrateVersionReqTest.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/lang/CrateVersionReqTest.kt
@@ -1,0 +1,254 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.lang
+
+import org.junit.Test
+
+// Based on https://github.com/steveklabnik/semver/blob/master/src/version_req.rs
+class CrateVersionReqTest {
+    private fun assertMatches(req: CrateVersionReq, vararg matchingVersions: String) {
+        for (version in matchingVersions) {
+            assert(req.matches(CrateVersion.parse(version))) { "Crate version requirements $req should have matched version $version" }
+        }
+    }
+
+    private fun assertNotMatches(req: CrateVersionReq, vararg matchingVersions: String) {
+        for (version in matchingVersions) {
+            assert(!req.matches(CrateVersion.parse(version))) { "Crate version requirements $req shouldn't have matched version $version" }
+        }
+    }
+
+    @Test
+    fun `test parsing default`() {
+        val req = CrateVersionReq.parse("1.0.0")
+
+        assertMatches(req, "1.0.0", "1.0.1")
+        assertNotMatches(req, "0.9.9", "0.10.0", "0.1.0")
+    }
+
+    @Test
+    fun `test parsing exact #1`() {
+        val req = CrateVersionReq.parse("=1.0.0")
+
+        assertMatches(req, "1.0.0")
+        assertNotMatches(req, "1.0.1", "0.9.9", "0.10.0", "0.1.0")
+    }
+
+    @Test
+    fun `test parsing exact #2`() {
+        val req = CrateVersionReq.parse("=0.9.0")
+
+        assertMatches(req, "0.9.0")
+        assertNotMatches(req, "1.0.1", "0.9.9", "0.10.0", "0.1.0")
+    }
+
+    @Test
+    fun `test parsing greater than #1`() {
+        val req = CrateVersionReq.parse(">=1.0.0")
+
+        assertMatches(req, "1.0.0", "2.0.0")
+        assertNotMatches(req, "0.1.0", "0.0.1", "1.0.0-pre", "2.0.0-pre")
+    }
+
+    @Test
+    fun `test parsing greater than #2`() {
+        val req = CrateVersionReq.parse(">= 2.1.0-alpha2")
+
+        assertMatches(req, "2.1.0-alpha2", "2.1.0-alpha3", "2.1.0", "3.1.0")
+        assertNotMatches(req, "2.0.0", "2.1.0-alpha1", "3.0.0-alpha2")
+    }
+
+    @Test
+    fun `test parsing less than #1`() {
+        val req = CrateVersionReq.parse("< 1.0.0")
+
+        assertMatches(req, "0.1.0", "0.0.1")
+        assertNotMatches(req, "1.0.0", "1.0.0-beta", "1.0.1", "0.9.9-alpha")
+    }
+
+    @Test
+    fun `test parsing less than #2`() {
+        val req = CrateVersionReq.parse("<= 2.1.0-alpha2")
+
+        assertMatches(req, "2.1.0-alpha2", "2.1.0-alpha1", "2.0.0", "1.0.0")
+        assertNotMatches(req, "2.1.0", "2.2.0-alpha1", "2.0.0-alpha2", "1.0.0-alpha2")
+    }
+
+    @Test
+    fun `test parsing multiple #1`() {
+        val req = CrateVersionReq.parse("> 0.0.9, <= 2.5.3")
+
+        assertMatches(req, "0.0.10", "1.0.0", "2.5.3")
+        assertNotMatches(req, "0.0.8", "2.5.4")
+    }
+
+    @Test
+    fun `test parsing multiple #2`() {
+        val req = CrateVersionReq.parse("0.3.0, 0.4.0")
+
+        assertNotMatches(req, "0.0.8", "0.3.0", "0.4.0")
+    }
+
+    @Test
+    fun `test parsing multiple #3`() {
+        val req = CrateVersionReq.parse("<= 0.2.0, >= 0.5.0")
+
+        assertNotMatches(req, "0.0.8", "0.3.0", "0.5.1")
+    }
+
+    @Test
+    fun `test parsing multiple #4`() {
+        val req = CrateVersionReq.parse("0.1.0, 0.1.4, 0.1.6")
+
+        assertMatches(req, "0.1.6", "0.1.9")
+        assertNotMatches(req, "0.1.0", "0.1.4", "0.2.0")
+    }
+
+    @Test
+    fun `test parsing multiple #5`() {
+        val req = CrateVersionReq.parse(">=0.5.1-alpha3, <0.6")
+
+        assertMatches(req, "0.5.1-alpha3", "0.5.1-alpha4", "0.5.1-beta", "0.5.1", "0.5.5")
+        assertNotMatches(req, "0.5.1-alpha1", "0.5.2-alpha2", "0.5.5-pre", "0.5.0-pre")
+    }
+
+    @Test
+    fun `test parsing tilde #1`() {
+        val req = CrateVersionReq.parse("~1")
+
+        assertMatches(req, "1.0.0", "1.0.1", "1.1.1")
+        assertNotMatches(req, "0.9.1", "2.9.0", "0.0.9")
+    }
+
+    @Test
+    fun `test parsing tilde #2`() {
+        val req = CrateVersionReq.parse("~1.2")
+
+        assertMatches(req, "1.2.0", "1.2.1")
+        assertNotMatches(req, "1.1.1", "1.3.0", "0.0.9")
+    }
+
+    @Test
+    fun `test parsing tilde #3`() {
+        val req = CrateVersionReq.parse("~1.2.2")
+
+        assertMatches(req, "1.2.2", "1.2.4")
+        assertNotMatches(req, "1.2.1", "1.9.0", "1.0.9", "2.0.1", "0.1.3")
+    }
+
+    @Test
+    fun `test parsing tilde #4`() {
+        val req = CrateVersionReq.parse("~1.2.3-beta.2")
+
+        assertMatches(req, "1.2.3", "1.2.3-beta.2", "1.2.3-beta.4", "1.2.4")
+        assertNotMatches(req, "1.3.3", "1.1.4", "1.2.3-beta.1", "1.2.4-beta.2")
+    }
+
+    @Test
+    fun `test parsing compatible #1`() {
+        val req = CrateVersionReq.parse("^1")
+
+        assertMatches(req, "1.1.2", "1.1.0", "1.2.1", "1.0.1")
+        assertNotMatches(req, "0.9.1", "2.9.0", "0.1.4", "1.0.0-beta1", "0.1.0-alpha", "1.0.1-pre")
+    }
+
+    @Test
+    fun `test parsing compatible #2`() {
+        val req = CrateVersionReq.parse("^1.1")
+
+        assertMatches(req, "1.1.2", "1.1.0", "1.2.1")
+        assertNotMatches(req, "1.0.1", "0.9.1", "2.9.0", "0.1.4", "1.0.0-beta1", "0.1.0-alpha", "1.0.1-pre")
+    }
+
+    @Test
+    fun `test parsing compatible #3`() {
+        val req = CrateVersionReq.parse("^1.1.2")
+
+        assertMatches(req, "1.1.2", "1.1.4", "1.2.1")
+        assertNotMatches(req, "0.9.1", "2.9.0", "1.1.1", "0.0.1", "1.1.2-alpha1", "1.1.3-alpha1", "2.9.0-alpha1")
+    }
+
+    @Test
+    fun `test parsing compatible #4`() {
+        val req = CrateVersionReq.parse("^0.1.2")
+
+        assertMatches(req, "0.1.2", "0.1.4")
+        assertNotMatches(req, "0.9.1", "2.9.0", "1.1.1", "0.0.1", "0.1.2-beta", "0.1.3-alpha", "0.2.0-pre")
+    }
+
+    @Test
+    fun `test parsing compatible #5`() {
+        val req = CrateVersionReq.parse("^0.5.1-alpha3")
+
+        assertMatches(req, "0.5.1-alpha3", "0.5.1-alpha4", "0.5.1-beta", "0.5.1", "0.5.5")
+        assertNotMatches(req, "0.5.1-alpha1", "0.5.2-alpha3", "0.5.5-pre", "0.5.0-pre", "0.6.0")
+    }
+
+    @Test
+    fun `test parsing compatible #6`() {
+        val req = CrateVersionReq.parse("^0.0.2")
+
+        assertMatches(req, "0.0.2")
+        assertNotMatches(req, "0.9.1", "2.9.0", "1.1.1", "0.0.1", "0.1.4")
+    }
+
+    @Test
+    fun `test parsing compatible #7`() {
+        val req = CrateVersionReq.parse("^0.0")
+
+        assertMatches(req, "0.0.2", "0.0.0")
+        assertNotMatches(req, "0.9.1", "2.9.0", "1.1.1", "0.1.4")
+    }
+
+    @Test
+    fun `test parsing compatible #8`() {
+        val req = CrateVersionReq.parse("^0")
+
+        assertMatches(req, "0.9.1", "0.0.2", "0.0.0")
+        assertNotMatches(req, "2.9.0", "1.1.1")
+    }
+
+    @Test
+    fun `test parsing compatible #9`() {
+        val req = CrateVersionReq.parse("^1.4.2-beta.5")
+
+        assertMatches(req, "1.4.2", "1.4.3", "1.4.2-beta.5", "1.4.2-beta.6", "1.4.2-c")
+        assertNotMatches(req, "0.9.9", "2.0.0", "1.4.2-alpha", "1.4.2-beta.4", "1.4.3-beta.5")
+    }
+
+    @Test
+    fun `test parsing wildcard #1`() {
+        val req = CrateVersionReq.parse("")
+
+        assertMatches(req, "0.9.1", "2.9.0", "0.0.9", "1.0.1", "1.1.1")
+        assertNotMatches(req)
+    }
+
+    @Test
+    fun `test parsing wildcard #2`() {
+        val req = CrateVersionReq.parse("*")
+
+        assertMatches(req, "0.9.1", "2.9.0", "0.0.9", "1.0.1", "1.1.1")
+        assertNotMatches(req)
+    }
+
+
+    @Test
+    fun `test parsing wildcard #3`() {
+        val req = CrateVersionReq.parse("1.*")
+
+        assertMatches(req, "1.2.0", "1.2.1", "1.1.1", "1.3.0")
+        assertNotMatches(req, "0.0.9")
+    }
+
+    @Test
+    fun `test parsing wildcard #4`() {
+        val req = CrateVersionReq.parse("1.2.*")
+
+        assertMatches(req, "1.2.0", "1.2.2", "1.2.4")
+        assertNotMatches(req, "1.9.0", "1.0.9", "2.0.1", "0.1.3")
+    }
+}

--- a/intellij-toml/src/test/kotlin/org/toml/lang/CrateVersionTest.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/lang/CrateVersionTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.lang
+
+import org.junit.Test
+import org.toml.lang.CrateVersion.Companion.parse
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// Based on https://github.com/steveklabnik/semver/blob/master/src/version.rs
+class CrateVersionTest {
+    @Test
+    fun `test parse`() {
+        assertEquals(CrateVersion(1, 2, 3), parse("1.2.3"))
+        assertEquals(CrateVersion(1, 2, 3), parse("  1.2.3  "))
+        assertEquals(CrateVersion(1, 2, 3, listOf(Identifier.AlphaNumeric("alpha1"))), parse("1.2.3-alpha1"))
+        assertEquals(CrateVersion(1, 2, 3, listOf(Identifier.AlphaNumeric("alpha1"))), parse("  1.2.3-alpha1  "))
+        assertEquals(CrateVersion(1, 2, 3, emptyList(), listOf(Identifier.AlphaNumeric("build5"))), parse("1.2.3+build5"))
+        assertEquals(CrateVersion(1, 2, 3, emptyList(), listOf(Identifier.AlphaNumeric("build5"))), parse("  1.2.3+build5  "))
+        assertEquals(CrateVersion(1, 2, 3, listOf(Identifier.Numeric(1), Identifier.AlphaNumeric("alpha1"), Identifier.Numeric(9)), listOf(Identifier.AlphaNumeric("build5"), Identifier.Numeric(7), Identifier.AlphaNumeric("3aedf"))), parse("1.2.3-1.alpha1.9+build5.7.3aedf  "))
+        assertEquals(CrateVersion(0, 4, 0, listOf(Identifier.AlphaNumeric("beta"), Identifier.Numeric(1)), listOf(Identifier.AlphaNumeric("0851523"))), parse("0.4.0-beta.1+0851523"))
+        assertEquals(CrateVersion(1, 0, 0, emptyList(), listOf(Identifier.Numeric(1))), parse("1.0.0+1"))
+    }
+
+    @Test
+    fun `test lt`() {
+        assertTrue(parse("0.0.0") < parse("1.2.3-alpha2"))
+        assertTrue(parse("1.0.0") < parse("1.2.3-alpha2"))
+        assertTrue(parse("1.2.0") < parse("1.2.3-alpha2"))
+        assertTrue(parse("1.2.3-alpha1") < parse("1.2.3"))
+        assertTrue(parse("1.2.3-alpha1") < parse("1.2.3-alpha2"))
+        assertTrue(parse("1.2.3-alpha2") >= parse("1.2.3-alpha2"))
+        assertTrue(parse("1.2.3+23") < parse("1.2.3+42"))
+    }
+
+    @Test
+    fun `test le`() {
+        assertTrue(parse("0.0.0") <= parse("1.2.3-alpha2"))
+        assertTrue(parse("1.0.0") <= parse("1.2.3-alpha2"))
+        assertTrue(parse("1.2.0") <= parse("1.2.3-alpha2"))
+        assertTrue(parse("1.2.3-alpha1") <= parse("1.2.3-alpha2"))
+        assertTrue(parse("1.2.3-alpha2") <= parse("1.2.3-alpha2"))
+        assertTrue(parse("1.2.3+23") <= parse("1.2.3+42"))
+    }
+
+    @Test
+    fun `test gt`() {
+        assertTrue(parse("1.2.3-alpha2") > parse("0.0.0"))
+        assertTrue(parse("1.2.3-alpha2") > parse("1.0.0"))
+        assertTrue(parse("1.2.3-alpha2") > parse("1.2.0"))
+        assertTrue(parse("1.2.3-alpha2") > parse("1.2.3-alpha1"))
+        assertTrue(parse("1.2.3") > parse("1.2.3-alpha2"))
+        assertTrue(parse("1.2.3-alpha2") <= parse("1.2.3-alpha2"))
+        assertTrue(parse("1.2.3+23") <= parse("1.2.3+42"))
+    }
+
+    @Test
+    fun `test ge`() {
+        assertTrue(parse("1.2.3-alpha2") >= parse("0.0.0"))
+        assertTrue(parse("1.2.3-alpha2") >= parse("1.0.0"))
+        assertTrue(parse("1.2.3-alpha2") >= parse("1.2.0"))
+        assertTrue(parse("1.2.3-alpha2") >= parse("1.2.3-alpha1"))
+        assertTrue(parse("1.2.3-alpha2") >= parse("1.2.3-alpha2"))
+        assertTrue(parse("1.2.3+23") < parse("1.2.3+42"))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `test parse empty`() {
+        parse("")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `test parse empty 2`() {
+        parse("   ")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `test parse major only`() {
+        parse("1")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `test parse without patch`() {
+        parse("1.2")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `test parse invalid pre`() {
+        parse("1.2.3-")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `test parse invalid identifiers`() {
+        parse("a.b.c")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `test parse with junk after version`() {
+        parse("1.2.3 abc")
+    }
+}


### PR DESCRIPTION
2nd out of 4 (#3783) groundwork PRs thanks to which there will be in turn added support for newer crate version intention and an error annotator detecting common mistakes in dependencies. The PRs are divided so that it's 
easier to review them.

Final effect once the groundwork and 3 feature (new version intention, error checking, warn on future deprecation) PRs will be merged:
![version-404](https://user-images.githubusercontent.com/5672750/57158549-05df4480-6de4-11e9-84bd-3442a0548633.png)
![name-404](https://user-images.githubusercontent.com/5672750/57158564-0bd52580-6de4-11e9-8776-225d7d9a4097.png)
![404](https://user-images.githubusercontent.com/5672750/57158573-0d065280-6de4-11e9-8249-5d9bfd1c7f1e.png)
![update](https://user-images.githubusercontent.com/5672750/57161774-b0f3fc00-6dec-11e9-91e5-970c0a7e019f.gif)

Edit: I've moved `CrateVersion` and `CrateVersionReq` from the `toml` module to `intellij-toml` as I need these classes in a Rust inspection
Edit 2: Fixed a small parsing bug and properly implemented `compareTo` for `CrateVersion`
Edit 3: Added `tryParse` convenience function
Edit 4: Rebased