### PR TITLE
CARGO: Improve accessing creates.io API

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/CargoTomlDependencyCompletionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoTomlDependencyCompletionProvider.kt
@@ -41,7 +41,7 @@ class CargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProviderBase
     }
 
     override fun completeValue(keyValue: TomlKeyValue, result: CompletionResultSet) {
-        val version = getCrateLastVersion(keyValue.key) ?: return
+        val version = getCrateFullDescription(keyValue.key)?.maxVersion ?: return
 
         result.addElement(
             LookupElementBuilder.create(version)
@@ -79,13 +79,13 @@ class CargoTomlSpecificDependencyVersionCompletionProvider : TomlKeyValueComplet
     override fun completeKey(keyValue: TomlKeyValue, result: CompletionResultSet) {
         val dependencyNameKey = getDependencyKeyFromTableHeader(keyValue)
 
-        val version = getCrateLastVersion(dependencyNameKey) ?: return
+        val version = getCrateFullDescription(dependencyNameKey)?.maxVersion ?: return
         result.addElement(LookupElementBuilder.create("version = \"$version\""))
     }
 
     override fun completeValue(keyValue: TomlKeyValue, result: CompletionResultSet) {
         val dependencyNameKey = getDependencyKeyFromTableHeader(keyValue)
-        val version = getCrateLastVersion(dependencyNameKey) ?: return
+        val version = getCrateFullDescription(dependencyNameKey)?.maxVersion ?: return
 
         result.addElement(
             LookupElementBuilder.create(version)

--- a/toml/src/main/kotlin/org/rust/toml/CratesIoApi.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CratesIoApi.kt
@@ -22,8 +22,6 @@ import java.io.IOException
 
 data class SearchResult(val crates: List<CrateDescription>)
 
-data class CrateInfoResult(val crate: CrateDescription)
-
 data class CrateDescription(
     val name: String,
     @SerializedName("max_version")
@@ -36,22 +34,46 @@ val CrateDescription.dependencyLine: String
 fun searchCrate(key: TomlKey): Collection<CrateDescription> {
     if (isUnitTestMode) return MOCK!!
 
-    val name = CompletionUtil.getOriginalElement(key)?.text ?: ""
+    val name = key.escapedText ?: ""
     if (name.isEmpty()) return emptyList()
 
     val response = requestCratesIo<SearchResult>(key, "crates?page=1&per_page=20&q=$name&sort=") ?: return emptyList()
     return response.crates
 }
 
-fun getCrateLastVersion(key: TomlKey): String? {
-    if (isUnitTestMode) return MOCK!!.first().maxVersion
+data class CrateFullDescription(
+    val name: String,
+    @SerializedName("max_version")
+    val maxVersion: String,
+    val versions: List<CrateVersionDescription>
+)
 
-    val name = CompletionUtil.getOriginalElement(key)?.text ?: ""
-    if (name.isEmpty()) return null
+data class CrateVersionDescription(val id: Int, val num: String, val yanked: Boolean)
 
-    val response = requestCratesIo<CrateInfoResult>(key, "crates/$name") ?: return null
-    return response.crate.maxVersion
+private class CratesIoApiResponse(val crate: CrateDescription, val versions: List<CrateVersionDescription>)
+
+fun getCrateFullDescription(crateName: TomlKey): CrateFullDescription? {
+    return getCrateFullDescription(crateName, crateName.escapedText ?: return null)
 }
+
+fun getCrateFullDescription(context: PsiElement, name: String): CrateFullDescription? {
+    if (isUnitTestMode) return MOCK2
+
+    val response = requestCratesIo<CratesIoApiResponse>(context, "crates/$name") ?: return null
+    return CrateFullDescription(response.crate.name, response.crate.maxVersion, response.versions)
+}
+
+/**
+ * Stuff like [dependencies.'crate'] can contain (single ' or double ") quotes which we need to remove or otherwise the
+ * crates API request would not work.
+ */
+private val TomlKey.escapedText: String?
+    get() {
+        val text = CompletionUtil.getOriginalElement(this)?.text ?: text
+        if (text.startsWith('\'')) return text.removeSurrounding("'")
+        if (text.startsWith('"')) return text.removeSurrounding("\'")
+        return text
+    }
 
 private inline fun <reified T> requestCratesIo(context: PsiElement, path: String): T? {
     return requestCratesIo(context, path, T::class.java)
@@ -75,7 +97,24 @@ private fun <T> requestCratesIo(context: PsiElement, path: String, cls: Class<T>
 }
 
 private var MOCK: List<CrateDescription>? = null
+private var MOCK2: CrateFullDescription? = null
 
+/**
+ * Use when underlying code requests information about a particular crate
+ */
+@TestOnly
+fun withMockedFullCrateDescription(mock: CrateFullDescription, action: () -> Unit) {
+    MOCK2 = mock
+    try {
+        action()
+    } finally {
+        MOCK2 = null
+    }
+}
+
+/**
+ * Use when underlying code requests information about multiple crates
+ */
 @TestOnly
 fun withMockedCrateSearch(mock: List<CrateDescription>, action: () -> Unit) {
     MOCK = mock

--- a/toml/src/test/kotlin/org/rust/toml/CargoTomlDependenciesCompletionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoTomlDependenciesCompletionTest.kt
@@ -8,7 +8,7 @@ package org.rust.toml
 import org.intellij.lang.annotations.Language
 
 class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
-    fun `test empty key`() = doTest("""
+    fun `test empty key`() = doSearchTest("""
         [dependencies]
         <caret>
     """, """
@@ -16,7 +16,7 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
         dep = "1.0"
     """, "dep" to "1.0")
 
-    fun `test empty key with complex dependency head`() = doTest("""
+    fun `test empty key with complex dependency head`() = doSearchTest("""
         [target.'cfg(windows)'.dev-dependencies]
         <caret>
     """, """
@@ -24,7 +24,7 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
         dep = "1.0"
     """, "dep" to "1.0")
 
-    fun `test partial key`() = doTest("""
+    fun `test partial key`() = doSearchTest("""
         [dependencies]
         d<caret>
     """, """
@@ -32,7 +32,7 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
         dep = "1.0"
     """, "app" to "1.0", "dep" to "1.0")
 
-    fun `test empty value complete without '=' and quotes 1_0`() = doTest("""
+    fun `test empty value complete without '=' and quotes 1_0`() = doCompletionTest("""
         [dependencies]
         dep <caret>
     """, """
@@ -40,7 +40,7 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
         dep = "1.0"
     """, "dep" to "1.0")
 
-    fun `test empty value complete without quotes 1_0`() = doTest("""
+    fun `test empty value complete without quotes 1_0`() = doCompletionTest("""
         [dependencies]
         dep = <caret>
     """, """
@@ -48,7 +48,7 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
         dep = "1.0"
     """, "dep" to "1.0")
 
-    fun `test empty value complete without quotes 1_0_0`() = doTest("""
+    fun `test empty value complete without quotes 1_0_0`() = doCompletionTest("""
         [dependencies]
         dep = <caret>
     """, """
@@ -56,7 +56,7 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
         dep = "1.0.0"
     """, "dep" to "1.0.0")
 
-    fun `test empty value complete inside quotes`() = doTest("""
+    fun `test empty value complete inside quotes`() = doCompletionTest("""
         [dependencies]
         dep = "<caret>"
     """, """
@@ -64,7 +64,7 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
         dep = "1.0"
     """, "dep" to "1.0")
 
-    fun `test partial value complete inside quotes`() = doTest("""
+    fun `test partial value complete inside quotes`() = doCompletionTest("""
         [dependencies]
         dep = "1.<caret>"
     """, """
@@ -72,7 +72,7 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
         dep = "1.0"
     """, "dep" to "1.0")
 
-    fun `test empty value complete inside quotes without '='`() = doTest("""
+    fun `test empty value complete inside quotes without '='`() = doCompletionTest("""
         [dependencies]
         dep "<caret>"
     """, """
@@ -81,7 +81,7 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
     """, "dep" to "1.0")
 
     // TODO we may want to add a closing quotation mark
-    fun `test empty value complete after unclosed quote`() = doTest("""
+    fun `test empty value complete after unclosed quote`() = doCompletionTest("""
         [dependencies]
         dep = "<caret>
     """, """
@@ -109,21 +109,21 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
         dep = { version = <caret> }
     """, "dep" to "1.0")
 
-    fun `test complete specific dependency header empty key`() = doTest("""
+    fun `test complete specific dependency header empty key`() = doSearchTest("""
         [dependencies.<caret>]
     """, """
         [dependencies.dep]
         version = "1.0"
     """, "dep" to "1.0")
 
-    fun `test complete specific dependency header partial key`() = doTest("""
+    fun `test complete specific dependency header partial key`() = doSearchTest("""
         [dependencies.d<caret>]
     """, """
         [dependencies.dep]
         version = "1.0"
     """, "dep" to "1.0", "bar" to "2.0")
 
-    fun `test complete specific dependency version empty key`() = doTest("""
+    fun `test complete specific dependency version empty key`() = doCompletionTest("""
         [dependencies.dep]
         <caret>
     """, """
@@ -131,7 +131,7 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
         version = "1.0"
     """, "dep" to "1.0")
 
-    fun `test complete specific dependency version partial key`() = doTest("""
+    fun `test complete specific dependency version partial key`() = doCompletionTest("""
         [dependencies.dep]
         ver<caret>
     """, """
@@ -139,7 +139,7 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
         version = "1.0"
     """, "dep" to "1.0")
 
-    fun `test complete specific dependency empty version value`() = doTest("""
+    fun `test complete specific dependency empty version value`() = doCompletionTest("""
         [dependencies.dep]
         version <caret>
     """, """
@@ -147,7 +147,7 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
         version = "1.0"
     """, "dep" to "1.0")
 
-    fun `test complete specific dependency partial version value`() = doTest("""
+    fun `test complete specific dependency partial version value`() = doCompletionTest("""
         [dependencies.dep]
         version = "1.<caret>"
     """, """
@@ -155,12 +155,29 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
         version = "1.0"
     """, "dep" to "1.0")
 
-    private fun doTest(
+    /**
+     * Use when underlying code requests information about multiple crates.
+     */
+    private fun doSearchTest(
         @Language("TOML") before: String,
         @Language("TOML") after: String,
         vararg crates: Pair<String, String>
     ) {
         withMockedCrateSearch(crates.map { (name, version) -> CrateDescription(name, version) }) {
+            doSingleCompletion(before.trimIndent(), after.trimIndent())
+        }
+    }
+
+    /**
+     * Use when underlying code requests information about a particular crate.
+     */
+    private fun doCompletionTest(
+        @Language("TOML") before: String,
+        @Language("TOML") after: String,
+        crate: Pair<String, String>
+    ) {
+        val version = CrateVersionDescription(0, crate.second, false)
+        withMockedFullCrateDescription(CrateFullDescription(crate.first, crate.second, listOf(version))) {
             doSingleCompletion(before.trimIndent(), after.trimIndent())
         }
     }


### PR DESCRIPTION
3rd out of 4 groundwork PRs (#3783, #3785) thanks to which there will be in turn added support for newer crate version intention and an error annotator detecting common mistakes in dependencies. The PRs are divided so that it's easier to review them. *This PR does not depend on the other ones*

Final effect once the groundwork and 2 feature (new version intention, error checking) PRs will be merged:
![version-404](https://user-images.githubusercontent.com/5672750/57158549-05df4480-6de4-11e9-84bd-3442a0548633.png)
![name-404](https://user-images.githubusercontent.com/5672750/57158564-0bd52580-6de4-11e9-8776-225d7d9a4097.png)
![404](https://user-images.githubusercontent.com/5672750/57158573-0d065280-6de4-11e9-8249-5d9bfd1c7f1e.png)
![update](https://user-images.githubusercontent.com/5672750/57161774-b0f3fc00-6dec-11e9-91e5-970c0a7e019f.gif)