### PR TITLE
CARGO: Add a dependency visitor

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/CargoTomlDependencyVisitor.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoTomlDependencyVisitor.kt
@@ -1,0 +1,44 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import org.toml.lang.psi.*
+
+abstract class CargoTomlDependencyVisitor : PsiElementVisitor() {
+    override fun visitElement(element: PsiElement?) {
+        val table = element as? TomlTable ?: return
+        if ((element.parent as? TomlFile)?.virtualFile?.name?.equals("cargo.toml", /*ignoreCase*/ true) == true) {
+            val headerNames = table.header.names
+            // Thanks to this dependencyNameIndex tactic we can also successfully match some less standard declarations
+            // such as [target.x86_64-pc-windows-gnu.dependencies], or [target."x86_64/linux.json".dependencies.serde]
+            val dependencyNameIndex = headerNames.indexOfFirst { it.isDependencyKey }
+            if (dependencyNameIndex != -1) {
+                val crate = headerNames.getOrNull(dependencyNameIndex + 1)
+                if (crate != null) {
+                    // Matches [dependencies.'crate'], [dev-dependencies.'crate'], etc
+                    val version = table.entries.find { it.key.text == "version" }
+                    visitDependency(crate, version?.value)
+                } else {
+                    // Matches [dependencies], [dev-dependencies], etc
+                    for (dependency in table.entries) {
+                        val version = when (val value = dependency.value) {
+                            // crate = { version = "x.y.z" }
+                            is TomlInlineTable -> value.entries.find { it.key.text == "version" }?.value
+                            // crate = "x.y.z"
+                            is TomlValue -> value
+                            else -> null
+                        }
+                        visitDependency(dependency.key, version)
+                    }
+                }
+            }
+        }
+    }
+
+    open fun visitDependency(name: TomlKey, version: TomlValue?) {}
+}


### PR DESCRIPTION
4th out of 4 groundwork PRs (#3783, #3785, #3786) thanks to which there will be in turn added support for newer crate version intention and an error annotator detecting common mistakes in dependencies. The PRs are divided so that it's easier to review them. *This PR does not depend on the other ones*

Final effect once the groundwork and 2 feature (new version intention, error checking) PRs will be merged:
![version-404](https://user-images.githubusercontent.com/5672750/57158549-05df4480-6de4-11e9-84bd-3442a0548633.png)
![name-404](https://user-images.githubusercontent.com/5672750/57158564-0bd52580-6de4-11e9-8776-225d7d9a4097.png)
![404](https://user-images.githubusercontent.com/5672750/57158573-0d065280-6de4-11e9-8249-5d9bfd1c7f1e.png)
![update](https://user-images.githubusercontent.com/5672750/57161774-b0f3fc00-6dec-11e9-91e5-970c0a7e019f.gif)

Question: Should we limit visiting dependencies to only those in `Cargo.toml` or should we also check other files?