### PR TITLE
INSP: Using a function that is going to be deprecated should warn

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -333,7 +333,7 @@ project(":") {
             exclude(module = "kotlin-stdlib")
             exclude(module = "kotlin-stdlib-common")
         }
-        implementation("com.vdurmont:semver4j:3.1.0")
+        api("com.vdurmont:semver4j:3.1.0")
         testImplementation(project(":common", "testOutput"))
         testImplementation("com.squareup.okhttp3:mockwebserver:4.9.0")
     }
@@ -446,7 +446,6 @@ project(":toml") {
     }
     dependencies {
         implementation("org.eclipse.jgit:org.eclipse.jgit:5.9.0.202009080501-r") { exclude("org.slf4j") }
-        implementation("com.vdurmont:semver4j:3.1.0")
 
         implementation(project(":"))
         implementation(project(":common"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -333,6 +333,7 @@ project(":") {
             exclude(module = "kotlin-stdlib")
             exclude(module = "kotlin-stdlib-common")
         }
+        implementation("com.vdurmont:semver4j:3.1.0")
         testImplementation(project(":common", "testOutput"))
         testImplementation("com.squareup.okhttp3:mockwebserver:4.9.0")
     }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspection.kt
@@ -48,7 +48,12 @@ class RsDeprecationInspection : RsLintInspection() {
         if (original is RsOuterAttributeOwner) {
             val attr = original.queryAttributes.deprecatedAttribute ?: return
             val (message, highlightType) = attr.extractDeprecatedMessage(identifier.text)
-            holder.registerProblem(identifier, message, highlightType)
+            holder.registerLintProblem(identifier, message, { level ->
+                when (level) {
+                    RsLint.Deprecated.defaultLevel -> highlightType
+                    else -> null
+                }
+            })
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -16,7 +16,7 @@ import org.rust.lang.core.psi.ext.*
 enum class RsLint(
     val id: String,
     private val groupIds: List<String> = emptyList(),
-    private val defaultLevel: RsLintLevel = WARN
+    val defaultLevel: RsLintLevel = WARN
 ) {
     NonSnakeCase("non_snake_case", listOf("bad_style", "nonstandard_style")),
     NonCamelCaseTypes("non_camel_case_types", listOf("bad_style", "nonstandard_style")),


### PR DESCRIPTION
Fixes: #3681

changelog: Deprecated item inspection now correctly handles items that will be deprecated in a future version.