### PR TITLE
ACT: Added self parameter support to type declaration provider

### DIFF
--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsTypeDeclarationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsTypeDeclarationProvider.kt
@@ -7,11 +7,11 @@ package org.rust.ide.navigation.goto
 
 import com.intellij.codeInsight.navigation.actions.TypeDeclarationProvider
 import com.intellij.psi.PsiElement
-import org.rust.lang.core.psi.RsConstant
-import org.rust.lang.core.psi.RsFunction
-import org.rust.lang.core.psi.RsNamedFieldDecl
-import org.rust.lang.core.psi.RsPatBinding
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsAbstractableOwner
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.owner
+import org.rust.lang.core.psi.ext.parentFunction
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
 
@@ -23,6 +23,11 @@ class RsTypeDeclarationProvider : TypeDeclarationProvider {
             is RsNamedFieldDecl -> element.typeReference?.type
             is RsConstant -> element.typeReference?.type
             is RsPatBinding -> element.type
+            is RsSelfParameter -> when (val owner = element.parentFunction.owner) {
+                is RsAbstractableOwner.Trait -> owner.trait.declaredType
+                is RsAbstractableOwner.Impl -> owner.impl.typeReference?.type
+                else -> null
+            }
             else -> null
         } ?: return null
 

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoTypeDeclarationTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoTypeDeclarationTest.kt
@@ -245,6 +245,94 @@ class RsGotoTypeDeclarationTest : RsTestBase() {
         }
     """)
 
+    fun `test self param in impl`() = doTest("""
+        struct Foo;
+        impl Foo {
+            fn bar(se/*caret*/lf) {}
+        }
+    """, """
+        struct /*caret*/Foo;
+        impl Foo {
+            fn bar(self) {}
+        }
+    """)
+
+    fun `test &self param in impl`() = doTest("""
+        struct Foo;
+        impl Foo {
+            fn bar(&s/*caret*/elf) {}
+        }
+    """, """
+        struct /*caret*/Foo;
+        impl Foo {
+            fn bar(&self) {}
+        }
+    """)
+
+    fun `test &mut self param in impl`() = doTest("""
+        struct Foo;
+        impl Foo {
+            fn bar(&mut /*caret*/self) {}
+        }
+    """, """
+        struct /*caret*/Foo;
+        impl Foo {
+            fn bar(&mut self) {}
+        }
+    """)
+
+    fun `test &mut self param in impl with spacing`() = doTest("""
+        struct Foo;
+        impl Foo {
+            fn bar(  &  mut /*caret*/self) {}
+        }
+    """, """
+        struct /*caret*/Foo;
+        impl Foo {
+            fn bar(  &  mut self) {}
+        }
+    """)
+
+    fun `test self param in trait`() = doTest("""
+        trait Foo {
+            fn bar(se/*caret*/lf) {}
+        }
+    """, """
+        trait /*caret*/Foo {
+            fn bar(self) {}
+        }
+    """)
+
+    fun `test &self param in trait`() = doTest("""
+        trait Foo {
+            fn bar(&self/*caret*/) {}
+        }
+    """, """
+        trait /*caret*/Foo {
+            fn bar(&self) {}
+        }
+    """)
+
+    fun `test &mut self param in trait`() = doTest("""
+        trait Foo {
+            fn bar(&mut /*caret*/self) {}
+        }
+    """, """
+        trait /*caret*/Foo {
+            fn bar(&mut self) {}
+        }
+    """)
+
+    fun `test &mut self param in trait with spacing`() = doTest("""
+        trait Foo {
+            fn bar(  &  mut /*caret*/self) {}
+        }
+    """, """
+        trait /*caret*/Foo {
+            fn bar(  &  mut self) {}
+        }
+    """)
+
     private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) = checkByText(before, after) {
         myFixture.performEditorAction(ACTION_GOTO_TYPE_DECLARATION)
     }


### PR DESCRIPTION
<details><summary>Fixed issue. Thanks to @vlad20012 and his PR #3804</summary>Currently, for reasons I believe are unrelated to my changes, it only works with the leftmost element of the self parameter (see gif below). I tried to figure out the reason for this, and so far I've discovered that the `getSymbolTypeDeclaration` function is not even invoked for elements other than the leftmost one. I'd appreciate some help on this.

![goto-is-weird-2](https://user-images.githubusercontent.com/5672750/57197743-3e5d5a80-6f6b-11e9-95a8-0f9bc2636b0d.gif)
</details>

This closes #3665.