### PR TITLE
Literal stubs & const expr evaluation

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -90,11 +90,11 @@ class RsErrorAnnotator : RsAnnotatorBase(), HighlightRangeExtension {
     private fun checkDuplicateEnumVariants(holder: AnnotationHolder, o: RsEnumBody) {
         data class VariantInfo(val variant: RsEnumVariant, val alreadyReported: Boolean)
 
-        var discrCounter = 0
-        val indexToVariantMap = hashMapOf<Int, VariantInfo>()
+        var discrCounter = 0L
+        val indexToVariantMap = hashMapOf<Long, VariantInfo>()
         for (variant in o.enumVariantList) {
             val literal = variant.variantDiscriminant?.expr as? RsLitExpr
-            val int = literal?.integerLiteralValue?.toIntOrNull()
+            val int = literal?.integerValue
             val idx = int ?: discrCounter
             discrCounter = idx + 1
 

--- a/src/main/kotlin/org/rust/ide/inspections/checkMatch/Constructor.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/checkMatch/Constructor.kt
@@ -106,3 +106,14 @@ sealed class Constructor {
             }
     }
 }
+
+private operator fun ExprValue.compareTo(other: ExprValue): Int {
+    return when {
+        this is ExprValue.Bool && other is ExprValue.Bool -> value.compareTo(other.value)
+        this is ExprValue.Integer && other is ExprValue.Integer -> value.compareTo(other.value)
+        this is ExprValue.Float && other is ExprValue.Float -> value.compareTo(other.value)
+        this is ExprValue.Str && other is ExprValue.Str -> value.compareTo(other.value)
+        this is ExprValue.Char && other is ExprValue.Char -> value.compareTo(other.value)
+        else -> throw CheckMatchException("Comparison of incompatible types: $javaClass and ${other.javaClass}")
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsLiteralKind.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsLiteralKind.kt
@@ -36,6 +36,22 @@ sealed class RsLiteralKind(val node: ASTNode) {
             get() = listOf("u8", "i8", "u16", "i16", "u32", "i32", "u64", "i64", "u128", "i128", "isize", "usize")
 
         override val offsets: LiteralOffsets by lazy { offsetsForNumber(node) }
+
+        val value: Long? get() {
+            val textValue = offsets.value?.substring(node.text) ?: return null
+            val (start, radix) = when (textValue.take(2)) {
+                "0x" -> 2 to 16
+                "0o" -> 2 to 8
+                "0b" -> 2 to 2
+                else -> 0 to 10
+            }
+            val cleanTextValue = textValue.substring(start).filter { it != '_' }
+            return try {
+                java.lang.Long.parseLong(cleanTextValue, radix)
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
     }
 
     class Float(node: ASTNode) : RsLiteralKind(node), RsLiteralWithSuffix {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExpr.kt
@@ -14,11 +14,6 @@ import org.rust.lang.core.resolve.KnownItems
 import org.rust.lang.core.stubs.RsPlaceholderStub
 import org.rust.lang.core.stubs.RsUnaryExprStub
 
-/**
- * Extracts [RsLitExpr] raw value
- */
-val RsLitExpr.stringLiteralValue: String? get() = (kind as? RsTextLiteral)?.value
-
 enum class UnaryOperator {
     REF, // `&a`
     REF_MUT, // `&mut a`

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsLitExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsLitExpr.kt
@@ -25,26 +25,29 @@ import org.rust.lang.core.psi.impl.RsExprImpl
 import org.rust.lang.core.psi.kind
 import org.rust.lang.core.stubs.RsLitExprStub
 import org.rust.lang.core.stubs.RsPlaceholderStub
-import org.rust.lang.core.stubs.RsStubLiteralType
+import org.rust.lang.core.stubs.RsStubLiteralKind
 import org.rust.lang.core.types.ty.TyFloat
 import org.rust.lang.core.types.ty.TyInteger
 
-val RsLitExpr.stubType: RsStubLiteralType? get() {
-    val stub = (greenStub as? RsLitExprStub)
-    if (stub != null) return stub.type
-    val kind = kind
-    return when (kind) {
-        is RsLiteralKind.Boolean ->  RsStubLiteralType.Boolean
-        is RsLiteralKind.Char -> RsStubLiteralType.Char(kind.isByte)
-        is RsLiteralKind.String -> RsStubLiteralType.String(kind.value?.length?.toLong(), kind.isByte)
-        is RsLiteralKind.Integer -> RsStubLiteralType.Integer(TyInteger.fromSuffixedLiteral(integerLiteral!!))
-        is RsLiteralKind.Float -> RsStubLiteralType.Float(TyFloat.fromSuffixedLiteral(floatLiteral!!))
-        else -> null
+val RsLitExpr.stubKind: RsStubLiteralKind?
+    get() {
+        val stub = (greenStub as? RsLitExprStub)
+        if (stub != null) return stub.kind
+        return when (val kind = kind) {
+            is RsLiteralKind.Boolean -> RsStubLiteralKind.Boolean(kind.value)
+            is RsLiteralKind.Char -> RsStubLiteralKind.Char(kind.value, kind.isByte)
+            is RsLiteralKind.String -> RsStubLiteralKind.String(kind.value, kind.isByte)
+            is RsLiteralKind.Integer -> RsStubLiteralKind.Integer(kind.value, TyInteger.fromSuffixedLiteral(integerLiteral!!))
+            is RsLiteralKind.Float -> RsStubLiteralKind.Float(kind.value, TyFloat.fromSuffixedLiteral(floatLiteral!!))
+            else -> null
+        }
     }
-}
 
-val RsLitExpr.integerLiteralValue: String? get() =
-    (greenStub as? RsLitExprStub)?.integerLiteralValue ?: integerLiteral?.text
+val RsLitExpr.booleanValue: Boolean? get() = (stubKind as? RsStubLiteralKind.Boolean)?.value
+val RsLitExpr.integerValue: Long? get() = (stubKind as? RsStubLiteralKind.Integer)?.value
+val RsLitExpr.floatValue: Double? get() = (stubKind as? RsStubLiteralKind.Float)?.value
+val RsLitExpr.charValue: String? get() = (stubKind as? RsStubLiteralKind.Char)?.value
+val RsLitExpr.stringValue: String? get() = (stubKind as? RsStubLiteralKind.String)?.value
 
 abstract class RsLitExprMixin : RsExprImpl, RsLitExpr, RegExpLanguageHost {
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
@@ -22,10 +22,7 @@ val RsMetaItem.name: String? get() {
     return if (stub != null) stub.name else identifier?.unescapedText
 }
 
-val RsMetaItem.value: String? get() {
-    val stub = greenStub
-    return if (stub != null) stub.value else litExpr?.stringLiteralValue
-}
+val RsMetaItem.value: String? get() = litExpr?.stringValue
 
 val RsMetaItem.hasEq: Boolean get() = greenStub?.hasEq ?: (eq != null)
 

--- a/src/main/kotlin/org/rust/lang/doc/RsDocPipeline.kt
+++ b/src/main/kotlin/org/rust/lang/doc/RsDocPipeline.kt
@@ -109,7 +109,7 @@ private fun RsDocAndAttributeOwner.innerDocs(): Sequence<Pair<RsDocKind, String>
 }
 
 private val RsMetaItem.docAttr: String?
-    get() = if (name == "doc") litExpr?.stringLiteralValue else null
+    get() = if (name == "doc") litExpr?.stringValue else null
 
 private class RustDocMarkdownFlavourDescriptor(
     private val context: PsiElement,

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -531,7 +531,7 @@ sealed class RsDiagnostic(
 
     class DuplicateEnumDiscriminant(
         element: PsiElement,
-        private val id: Int
+        private val id: Long
     ) : RsDiagnostic(element) {
         override fun prepare(): PreparedAnnotation = PreparedAnnotation(
             ERROR,

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/ExprValue.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/ExprValue.kt
@@ -25,15 +25,4 @@ sealed class ExprValue {
     data class Char(val value: String) : ExprValue() {
         override fun toString(): String = value
     }
-
-    operator fun compareTo(other: ExprValue): Int {
-        return when {
-            this is Bool && other is Bool -> value.compareTo(other.value)
-            this is Integer && other is Integer -> value.compareTo(other.value)
-            this is Float && other is Float -> value.compareTo(other.value)
-            this is Str && other is Str -> value.compareTo(other.value)
-            this is Char && other is Char -> value.compareTo(other.value)
-            else -> -1
-        }
-    }
 }

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/RsConstExprEvaluator.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/RsConstExprEvaluator.kt
@@ -7,110 +7,175 @@ package org.rust.lang.utils.evaluation
 
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
-import org.rust.lang.core.types.ty.Ty
-import org.rust.lang.core.types.ty.TyInteger
-import org.rust.lang.core.types.ty.TyPrimitive
+import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
 
-object RsConstExprEvaluator {
+private val STR_REF_TYPE: TyReference = TyReference(TyStr, Mutability.IMMUTABLE)
 
-    private const val MAX_EXPR_DEPTH: Int = 64
+object RsConstExprEvaluator {
 
     private val defaultExprPathResolver: (RsPathExpr) -> RsElement? = { it.path.reference.resolve() }
 
     fun evaluate(
         expr: RsExpr,
         expectedTy: Ty = expr.type,
-        pathExprResolver: ((RsPathExpr) -> RsElement?) = defaultExprPathResolver
+        pathExprResolver: ((RsPathExpr) -> RsElement?)? = defaultExprPathResolver
     ): ExprValue? {
-        return when (expectedTy) {
-            is TyInteger -> evaluateInteger(expr, expectedTy, pathExprResolver)
-            else -> {
-                val kind = (expr as? RsLitExpr)?.kind
-                when (kind) {
-                    is RsLiteralKind.Boolean -> ExprValue.Bool(kind.value)
-                    is RsLiteralKind.Float -> ExprValue.Float(kind.value ?: return null)
-                    is RsLiteralKind.String -> ExprValue.Str(kind.value ?: return null)
-                    is RsLiteralKind.Char -> ExprValue.Char(kind.value ?: return null)
-                    else -> null
-                }
+        val evaluation = when (expectedTy) {
+            is TyInteger -> IntegerExprEvaluation(expectedTy, pathExprResolver)
+            is TyBool -> BoolExprEvaluation(pathExprResolver)
+            is TyFloat -> FloatExprEvaluation(expectedTy, pathExprResolver)
+            is TyChar -> CharExprEvaluation(pathExprResolver)
+            // TODO: type should be "wider"
+            STR_REF_TYPE -> StrExprEvaluation(pathExprResolver)
+            else -> null
+        }
+        return evaluation?.evaluate(expr)
+    }
+}
+
+private open class ExprEvaluation<T: Ty, V>(
+    protected val expectedTy: T,
+    private val pathExprResolver: ((RsPathExpr) -> RsElement?)?,
+    private val evalLitExpr: RsLitExpr.() -> V?,
+    private val exprValueCtr: (V) -> ExprValue
+) {
+
+    fun evaluate(expr: RsExpr?): ExprValue? = evaluate(expr, 0)?.let(exprValueCtr)
+
+    protected fun evaluate(expr: RsExpr?, depth: Int): V? {
+        // To prevent SO we restrict max depth of expression
+        if (depth >= MAX_EXPR_DEPTH) return null
+        return evaluateInner(expr, depth)
+    }
+
+    protected open fun evaluateInner(expr: RsExpr?, depth: Int): V? {
+        return when (expr) {
+            is RsLitExpr -> expr.evalLitExpr()
+            is RsParenExpr -> evaluate(expr.expr, depth + 1)
+            is RsPathExpr -> {
+                val const = pathExprResolver?.invoke(expr) as? RsConstant ?: return null
+                if (!const.isConst) return null
+                val path = (const.typeReference?.typeElement as? RsBaseType)?.path ?: return null
+                if (TyPrimitive.fromPath(path) != expectedTy) return null
+                evaluate(const.expr, depth + 1)
             }
+            else -> null
         }
     }
 
-    private fun evaluateInteger(
-        expr: RsExpr,
-        expectedTy: TyInteger,
-        pathExprResolver: ((RsPathExpr) -> RsElement?)
-    ): ExprValue.Integer? {
+    companion object {
+        private const val MAX_EXPR_DEPTH: Int = 64
+    }
+}
 
-        fun eval(expr: RsExpr?, depth: Int): Long? {
-            // To prevent SO we restrict max depth of expression
-            if (depth >= MAX_EXPR_DEPTH) return null
-            return when (expr) {
-                is RsLitExpr -> expr.integerValue?.validValueOrNull(expectedTy)
-                is RsPathExpr -> {
-                    val const = pathExprResolver(expr) as? RsConstant ?: return null
-                    if (!const.isConst) return null
-                    val path = (const.typeReference?.typeElement as? RsBaseType)?.path ?: return null
-                    val integerType = TyPrimitive.fromPath(path) as? TyInteger ?: return null
-                    if (integerType == expectedTy) eval(const.expr, depth + 1) else null
+private class IntegerExprEvaluation(
+    expectedTy: TyInteger,
+    pathExprResolver: ((RsPathExpr) -> RsElement?)?
+) : ExprEvaluation<TyInteger, Long>(expectedTy, pathExprResolver, RsLitExpr::integerValue, ExprValue::Integer) {
+
+    override fun evaluateInner(expr: RsExpr?, depth: Int): Long? {
+        return when (expr) {
+            is RsUnaryExpr -> {
+                if (expr.operatorType != UnaryOperator.MINUS) return null
+                val value = evaluate(expr.expr, depth + 1) ?: return null
+                (-value).validValueOrNull(expectedTy)
+            }
+            is RsBinaryExpr -> {
+                val op = expr.operatorType as? ArithmeticOp ?: return null
+                val leftValue = evaluate(expr.left, depth + 1) ?: return null
+                val rightValue = evaluate(expr.right, depth + 1) ?: return null
+                // TODO: check overflow
+                val result = when (op) {
+                    ArithmeticOp.ADD -> leftValue + rightValue
+                    ArithmeticOp.SUB -> leftValue - rightValue
+                    ArithmeticOp.MUL -> leftValue * rightValue
+                    ArithmeticOp.DIV -> if (rightValue == 0L) null else leftValue / rightValue
+                    ArithmeticOp.REM -> if (rightValue == 0L) null else leftValue % rightValue
+                    ArithmeticOp.BIT_AND -> leftValue and rightValue
+                    ArithmeticOp.BIT_OR -> leftValue or rightValue
+                    ArithmeticOp.BIT_XOR -> leftValue xor rightValue
+                    // We can't simply convert `rightValue` to Int
+                    // because after conversion of quite large Long values (> 2^31 - 1)
+                    // we can get any Int value including negative one
+                    // so it can lead to incorrect result.
+                    // But if `rightValue` >= `java.lang.Long.BYTES`
+                    // we know result without computation:
+                    // overflow in 'shl' case and 0 in 'shr' case.
+                    ArithmeticOp.SHL -> if (rightValue >= java.lang.Long.BYTES) null else leftValue shl rightValue.toInt()
+                    ArithmeticOp.SHR -> if (rightValue >= java.lang.Long.BYTES) 0 else leftValue shr rightValue.toInt()
                 }
-                is RsParenExpr -> eval(expr.expr, depth + 1)
-                is RsUnaryExpr -> {
-                    if (expr.operatorType != UnaryOperator.MINUS) return null
-                    val value = eval(expr.expr, depth + 1) ?: return null
-                    (-value).validValueOrNull(expectedTy)
+                result?.validValueOrNull(expectedTy)
+            }
+            else -> super.evaluateInner(expr, depth)
+        }
+    }
+
+    // It returns wrong values for large types like `i128` or `usize`
+    // But looks like like it's enough for real cases
+    private val TyInteger.validValuesRange: LongRange
+        get() = when (this) {
+            TyInteger.U8 -> LongRange(0, 1L shl 8)
+            TyInteger.U16 -> LongRange(0, 1L shl 16)
+            TyInteger.U32 -> LongRange(0, 1L shl 32)
+            TyInteger.U64 -> LongRange(0, Long.MAX_VALUE)
+            TyInteger.U128 -> LongRange(0, Long.MAX_VALUE)
+            TyInteger.USize -> LongRange(0, Long.MAX_VALUE)
+            TyInteger.I8 -> LongRange(-(1L shl 7), (1L shl 7) - 1)
+            TyInteger.I16 -> LongRange(-(1L shl 15), (1L shl 15) - 1)
+            TyInteger.I32 -> LongRange(-(1L shl 31), (1L shl 31) - 1)
+            TyInteger.I64 -> LongRange(Long.MIN_VALUE, Long.MAX_VALUE)
+            TyInteger.I128 -> LongRange(Long.MIN_VALUE, Long.MAX_VALUE)
+            TyInteger.ISize -> LongRange(Long.MIN_VALUE, Long.MAX_VALUE)
+        }
+
+    private fun Long.validValueOrNull(ty: TyInteger): Long? = if (this in ty.validValuesRange) this else null
+}
+
+private class BoolExprEvaluation(
+    pathExprResolver: ((RsPathExpr) -> RsElement?)?
+) : ExprEvaluation<TyBool, Boolean>(TyBool, pathExprResolver, RsLitExpr::booleanValue, ExprValue::Bool) {
+
+    override fun evaluateInner(expr: RsExpr?, depth: Int): Boolean? {
+        return when (expr) {
+            is RsBinaryExpr -> when (expr.operatorType) {
+                LogicOp.AND -> {
+                    val lhs = evaluate(expr.left, depth + 1) ?: return null
+                    if (!lhs) return false // false && _ --> false
+                    val rhs = evaluate(expr.right, depth + 1) ?: return null
+                    lhs && rhs
                 }
-                is RsBinaryExpr -> {
-                    val op = expr.operatorType as? ArithmeticOp ?: return null
-                    val leftValue = eval(expr.left, depth + 1) ?: return null
-                    val rightValue = eval(expr.right, depth + 1) ?: return null
-                    // TODO: check overflow
-                    val result = when (op) {
-                        ArithmeticOp.ADD -> leftValue + rightValue
-                        ArithmeticOp.SUB -> leftValue - rightValue
-                        ArithmeticOp.MUL -> leftValue * rightValue
-                        ArithmeticOp.DIV -> if (rightValue == 0L) null else leftValue / rightValue
-                        ArithmeticOp.REM -> if (rightValue == 0L) null else leftValue % rightValue
-                        ArithmeticOp.BIT_AND -> leftValue and rightValue
-                        ArithmeticOp.BIT_OR -> leftValue or rightValue
-                        ArithmeticOp.BIT_XOR -> leftValue xor rightValue
-                        // We can't simply convert `rightValue` to Int
-                        // because after conversion of quite large Long values (> 2^31 - 1)
-                        // we can get any Int value including negative one
-                        // so it can lead to incorrect result.
-                        // But if `rightValue` >= `java.lang.Long.BYTES`
-                        // we know result without computation:
-                        // overflow in 'shl' case and 0 in 'shr' case.
-                        ArithmeticOp.SHL -> if (rightValue >= java.lang.Long.BYTES) null else leftValue shl rightValue.toInt()
-                        ArithmeticOp.SHR -> if (rightValue >= java.lang.Long.BYTES) 0 else leftValue shr rightValue.toInt()
-                    }
-                    result?.validValueOrNull(expectedTy)
+                LogicOp.OR -> {
+                    val lhs = evaluate(expr.left, depth + 1) ?: return null
+                    if (lhs) return true // true || _ --> true
+                    val rhs = evaluate(expr.right, depth + 1) ?: return null
+                    lhs || rhs
+                }
+                ArithmeticOp.BIT_XOR -> {
+                    val lhs = evaluate(expr.left, depth + 1) ?: return null
+                    val rhs = evaluate(expr.right, depth + 1) ?: return null
+                    lhs xor rhs
                 }
                 else -> null
             }
+            is RsUnaryExpr -> when (expr.operatorType) {
+                UnaryOperator.NOT -> evaluate(expr.expr, depth + 1)?.let { !it }
+                else -> null
+            }
+            else -> super.evaluateInner(expr, depth)
         }
-
-        return eval(expr, 0)?.let(ExprValue::Integer)
     }
 }
 
-// It returns wrong values for large types like `i128` or `usize`
-// But looks like like it's enough for real cases
-private val TyInteger.validValuesRange: LongRange get() = when (this) {
-    TyInteger.U8 -> LongRange(0, 1L shl 8)
-    TyInteger.U16 -> LongRange(0, 1L shl 16)
-    TyInteger.U32 -> LongRange(0, 1L shl 32)
-    TyInteger.U64 -> LongRange(0, Long.MAX_VALUE)
-    TyInteger.U128 -> LongRange(0, Long.MAX_VALUE)
-    TyInteger.USize -> LongRange(0, Long.MAX_VALUE)
-    TyInteger.I8 -> LongRange(-(1L shl 7), (1L shl 7) - 1)
-    TyInteger.I16 -> LongRange(-(1L shl 15), (1L shl 15) - 1)
-    TyInteger.I32 -> LongRange(-(1L shl 31), (1L shl 31) - 1)
-    TyInteger.I64 -> LongRange(Long.MIN_VALUE, Long.MAX_VALUE)
-    TyInteger.I128 -> LongRange(Long.MIN_VALUE, Long.MAX_VALUE)
-    TyInteger.ISize -> LongRange(Long.MIN_VALUE, Long.MAX_VALUE)
-}
+private class FloatExprEvaluation(
+    expectedTy: TyFloat,
+    pathExprResolver: ((RsPathExpr) -> RsElement?)?
+) : ExprEvaluation<TyFloat, Double>(expectedTy, pathExprResolver, RsLitExpr::floatValue, ExprValue::Float)
 
-private fun Long.validValueOrNull(ty: TyInteger): Long? = if (this in ty.validValuesRange) this else null
+private class CharExprEvaluation(
+    pathExprResolver: ((RsPathExpr) -> RsElement?)?
+) : ExprEvaluation<TyChar, String>(TyChar, pathExprResolver, RsLitExpr::charValue, ExprValue::Char)
+
+private class StrExprEvaluation(
+    pathExprResolver: ((RsPathExpr) -> RsElement?)?
+) : ExprEvaluation<TyReference, String>(STR_REF_TYPE, pathExprResolver, RsLitExpr::stringValue, ExprValue::Str)

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/RsConstExprEvaluator.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/RsConstExprEvaluator.kt
@@ -44,27 +44,11 @@ object RsConstExprEvaluator {
         pathExprResolver: ((RsPathExpr) -> RsElement?)
     ): ExprValue.Integer? {
 
-        fun RsLitExpr.eval(expectedTy: TyInteger): Long? {
-            val textValue = integerLiteralValue?.removeSuffix(expectedTy.name) ?: return null
-            val (start, radix) = when (textValue.take(2)) {
-                "0x" -> 2 to 16
-                "0o" -> 2 to 8
-                "0b" -> 2 to 2
-                else -> 0 to 10
-            }
-            val cleanTextValue = textValue.substring(start).filter { it != '_' }
-            return try {
-                java.lang.Long.parseLong(cleanTextValue, radix).validValueOrNull(expectedTy)
-            } catch (e: NumberFormatException) {
-                null
-            }
-        }
-
         fun eval(expr: RsExpr?, depth: Int): Long? {
             // To prevent SO we restrict max depth of expression
             if (depth >= MAX_EXPR_DEPTH) return null
             return when (expr) {
-                is RsLitExpr -> expr.eval(expectedTy)
+                is RsLitExpr -> expr.integerValue?.validValueOrNull(expectedTy)
                 is RsPathExpr -> {
                     val const = pathExprResolver(expr) as? RsConstant ?: return null
                     if (!const.isConst) return null


### PR DESCRIPTION
* Save values of literals into stubs when needed. It's useful not only for const expr evaluation but for `include` macro support in future
* Provide common API for const expr evaluation
* Drop confusing `compareTo` method from `ExprValue` public API