### PR TITLE
QDOC/LI: fixed block doc comments without infix in quickdoc and doctest

### DIFF
--- a/src/main/kotlin/org/rust/lang/doc/psi/RsDocKind.kt
+++ b/src/main/kotlin/org/rust/lang/doc/psi/RsDocKind.kt
@@ -78,11 +78,17 @@ enum class RsDocKind {
     }
 
     protected fun removeBlockDecoration(lines: Sequence<String>): Sequence<String> {
-        // Doing some patches we can "convert" block comment into eol one
         val ll = lines.toMutableList()
-        ll[0] = ll[0].replaceFirst(prefix, " $infix ")
-        ll[ll.lastIndex] = ll[ll.lastIndex].trimTrailingAsterisks()
-        return removeEolDecoration(ll.asSequence(), infix)
+        return if (lines.drop(1).all { it.trimStart(' ', '\t').startsWith("*") }) {
+            // Doing some patches we can "convert" block comment into eol one
+            ll[0] = ll[0].replaceFirst(prefix, " $infix ")
+            ll[ll.lastIndex] = ll[ll.lastIndex].trimTrailingAsterisks()
+            removeEolDecoration(ll.asSequence(), infix)
+        } else {
+            ll[0] = ll[0].removePrefix(prefix)
+            ll[ll.lastIndex] = ll[ll.lastIndex].trimTrailingAsterisks()
+            ll.asSequence()
+        }
     }
 
     companion object {

--- a/src/test/kotlin/org/rust/ide/annotator/RsDoctestAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsDoctestAnnotatorTest.kt
@@ -87,6 +87,23 @@ class RsDoctestAnnotatorTest : RsAnnotatorTestBase(RsDoctestAnnotator::class.jav
         |fn foo() {}
         |""")
 
+    fun `test no infix in block comment`() = doTest("""
+        |/** ```
+        |<info> <inject>let a = 0;
+        |</inject></info> ```*/
+        |fn foo() {}
+        |""")
+
+    fun `test no infix in block comment multiline`() = doTest("""
+        |/** ```
+        |<info> <inject>let a = 0;
+        |</inject></info><info> <inject>let b = 0;
+        |</inject></info>```
+        |*/
+        |fn foo() {}
+        |""")
+
+
     fun `test no injection in non-lib target`() = checkByText("""
         /// ```
         /// let a = 0;

--- a/src/test/kotlin/org/rust/lang/doc/RsDocRemoveDecorationTest.kt
+++ b/src/test/kotlin/org/rust/lang/doc/RsDocRemoveDecorationTest.kt
@@ -133,6 +133,13 @@ code {
                     *  bar */""",
                 "foo\nbar"),
 
+            arrayOf(OuterBlock,
+                //language=Rust
+                """/** foo
+                   |bar * bar
+                   |*/""".trimMargin(),
+                "foo\nbar * bar"),
+
             arrayOf(Attr, "foo\nbar", "foo\nbar")
         )
     }


### PR DESCRIPTION
Block documentation comments without `*` infix, e.g.
``` rust
/*!
foo
bar
*/
```
were incorrectly handled by quickdoc and doctest injection. See added tests for particular cases that failed before.  