### PR TITLE
MACRO: Fix OOM when expanding incorrect macro with group if `vis`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -338,8 +338,13 @@ private class MacroPattern private constructor(
                 break
             }
 
+            val lastOffset = macroCallBody.currentOffset
             val result = pattern.matchPartial(macroCallBody)
             if (result != null) {
+                if (macroCallBody.currentOffset == lastOffset) {
+                    MacroExpansionMarks.groupMatchedEmptyTT.hit()
+                    return null
+                }
                 groups += result
             } else {
                 MacroExpansionMarks.groupInputEnd2.hit()
@@ -500,4 +505,5 @@ object MacroExpansionMarks {
     val groupInputEnd1 = Testmark("groupInputEnd1")
     val groupInputEnd2 = Testmark("groupInputEnd2")
     val groupInputEnd3 = Testmark("groupInputEnd3")
+    val groupMatchedEmptyTT = Testmark("groupMatchedEmptyTT")
 }

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -736,4 +736,14 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
     """, """
         fn foo() {}
     """ to NameResolutionTestmarks.dollarCrateMagicIdentifier)
+
+    fun `test incorrect "vis" group does not cause OOM`() = doTest("""
+        // error: repetition matches empty token tree
+        macro_rules! foo {
+            ($($ p:vis)*) => {}
+        }
+        foo!(a);
+    """, """
+        foo!(a);
+    """ to MacroExpansionMarks.groupMatchedEmptyTT)
 }


### PR DESCRIPTION
bors r+