### PR TITLE
COMP: Index proc_macro_derive functions and provide completion for derive

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -506,15 +506,16 @@ fun ImportCandidate.import(context: RsElement) {
     insertionScope.insertUseItem(psiFactory, "$prefix${info.usePath}")
 }
 
-private fun RsMod.insertExternCrateItem(psiFactory: RsPsiFactory, crateName: String) {
+fun RsMod.insertExternCrateItem(psiFactory: RsPsiFactory, crateName: String): RsExternCrateItem {
     val externCrateItem = psiFactory.createExternCrateItem(crateName)
     val lastExternCrateItem = childrenOfType<RsExternCrateItem>().lastElement
-    if (lastExternCrateItem != null) {
+    return if (lastExternCrateItem != null) {
         addAfter(externCrateItem, lastExternCrateItem)
     } else {
-        addBefore(externCrateItem, firstItem)
-        addAfter(psiFactory.createNewline(), firstItem)
-    }
+        addBefore(externCrateItem, firstItem).also {
+            addAfter(psiFactory.createNewline(), firstItem)
+        }
+    } as RsExternCrateItem
 }
 
 private fun RsItemsOwner.insertUseItem(psiFactory: RsPsiFactory, usePath: String) {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProvider.kt
@@ -16,16 +16,21 @@ import com.intellij.psi.PsiElement
 import com.intellij.util.ProcessingContext
 import org.rust.ide.icons.RsIcons
 import org.rust.ide.icons.multiple
+import org.rust.ide.inspections.import.insertExternCrateItem
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.RsElementTypes.*
-import org.rust.lang.core.psi.ext.RsStructOrEnumItemElement
-import org.rust.lang.core.psi.ext.ancestorStrict
-import org.rust.lang.core.psi.ext.withDefaultSubst
+import org.rust.lang.core.psi.RsExternCrateItem
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsTraitItem
+import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.KnownDerivableTrait
+import org.rust.lang.core.resolve.indexes.RsDeriveIndex
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.resolve.withDependencies
+import org.rust.lang.core.stubs.index.RsNamedElementIndex
 import org.rust.lang.core.types.TraitRef
+import org.rust.lang.core.types.ty.Ty
 
 object RsDeriveCompletionProvider : CompletionProvider<CompletionParameters>() {
 
@@ -41,17 +46,12 @@ object RsDeriveCompletionProvider : CompletionProvider<CompletionParameters>() {
         val ownerType = owner.declaredType
         val lookup = ImplLookup.relativeTo(owner)
 
-        /** Filter unavailable and already derived */
-        fun Sequence<KnownDerivableTrait>.filterDerivables() = filter {
-            val trait = it.findTrait(owner.knownItems)
-            trait != null && !lookup.canSelect(TraitRef(ownerType, trait.withDefaultSubst()))
-        }
-
-        KnownDerivableTrait.values().asSequence()
-            .filterDerivables()
+        KnownDerivableTrait.values()
+            .asSequence()
+            .filter { it.findTrait(owner.knownItems)?.isImplementedFor(ownerType, lookup) == false }
             .forEach { derivable ->
                 val traitWithDependencies = derivable.withDependencies.asSequence()
-                    .filterDerivables()
+                    .filter { it.findTrait(owner.knownItems)?.isImplementedFor(ownerType, lookup) == false }
                     .toList()
                 // if 'traitWithDependencies' contains only one element
                 // then all derivable dependencies are already satisfied
@@ -65,7 +65,46 @@ object RsDeriveCompletionProvider : CompletionProvider<CompletionParameters>() {
                     .withIcon(RsIcons.TRAIT)
                 result.addElement(element.withPriority(DEFAULT_PRIORITY))
             }
+        RsDeriveIndex.allDeriverableTraits(owner.project)
+            .associate {
+                // Find trait by it's name
+                RsNamedElementIndex.findElementsByName(owner.project, it.name, it.deriver.resolveScope)
+                    .filterIsInstance<RsTraitItem>().firstOrNull() to it.deriver
+            }
+            .filterKeys {
+                // Past this point, trait can't be null (but the inference doesn't understand that)
+                it?.isImplementedFor(ownerType, lookup) == false
+            }
+            .forEach { (trait, deriver) ->
+                val mainFile = owner.crateRoot
+                val deriverCrateName = deriver.containingCargoPackage?.name
+
+                val name = trait!!.name ?: return@forEach
+                val element = LookupElementBuilder.create(name)
+                    .withIcon(RsIcons.TRAIT)
+                    .withInsertHandler { context, item ->
+                        // If #[macro_use] extern crate <deriver's crate> is not present, add it
+                        if (mainFile != null) {
+                            val externCrates = mainFile.childrenOfType<RsExternCrateItem>()
+                            val externCrate = externCrates.find {
+                                it.identifier?.text == deriverCrateName
+                            } ?: deriverCrateName?.let {
+                                mainFile.insertExternCrateItem(RsPsiFactory(context.project), it)
+                            }
+
+                            if (externCrate?.hasOuterAttr("macro_use") == false) {
+                                externCrate.addOuterAttribute(Attribute("macro_use"))
+                            }
+                            context.commitDocument()
+                            // FIXME: for some reason even though this is invoked, it actually doesnt do anything
+                        }
+                    }
+                result.addElement(element.withPriority(DEFAULT_PRIORITY))
+            }
     }
+
+    private fun RsTraitItem.isImplementedFor(owner: Ty, lookup: ImplLookup): Boolean =
+        lookup.canSelect(TraitRef(owner, this.withDefaultSubst()))
 
     val elementPattern: ElementPattern<PsiElement>
         get() {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -42,6 +42,9 @@ interface RsOuterAttributeOwner : RsDocAndAttributeOwner {
     val outerAttrList: List<RsOuterAttr>
 }
 
+fun RsOuterAttributeOwner.hasOuterAttr(name: String): Boolean =
+    outerAttrList.any { it.metaItem.name == name }
+
 /**
  * Find the first outer attribute with the given identifier.
  */
@@ -49,14 +52,28 @@ fun RsOuterAttributeOwner.findOuterAttr(name: String): RsOuterAttr? =
     outerAttrList.find { it.metaItem.name == name }
 
 
-fun RsOuterAttributeOwner.addOuterAttribute(attribute: Attribute, anchor: PsiElement): RsOuterAttr {
-    val attr = RsPsiFactory(project).createOuterAttr(attribute.text)
-    return addBefore(attr, anchor) as RsOuterAttr
+fun RsOuterAttributeOwner.addOuterAttribute(attribute: Attribute, anchor: PsiElement? = null): RsOuterAttr {
+    val factory = RsPsiFactory(project)
+    val attr = factory.createOuterAttr(attribute.text)
+    return if (anchor != null) {
+        addBefore(attr, anchor)
+    } else {
+        addBefore(attr, firstChild).also {
+            addAfter(factory.createNewline(), firstChild)
+        }
+    } as RsOuterAttr
 }
 
-fun RsInnerAttributeOwner.addInnerAttribute(attribute: Attribute, anchor: PsiElement): RsInnerAttr {
-    val attr = RsPsiFactory(project).createInnerAttr(attribute.text)
-    return addBefore(attr, anchor) as RsInnerAttr
+fun RsInnerAttributeOwner.addInnerAttribute(attribute: Attribute, anchor: PsiElement? = null): RsInnerAttr {
+    val factory = RsPsiFactory(project)
+    val attr = factory.createInnerAttr(attribute.text)
+    return if (anchor != null) {
+        addBefore(attr, anchor)
+    } else {
+        addBefore(attr, firstChild).also {
+            addAfter(factory.createNewline(), firstChild)
+        }
+    } as RsInnerAttr
 }
 
 data class Attribute(val name: String, val argText: String? = null) {

--- a/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
@@ -67,6 +67,7 @@ class KnownItems(
     val Arguments: RsStructOrEnumItemElement? get() = findItem("core::fmt::Arguments")
     val Option: RsStructOrEnumItemElement? get() = findItem("core::option::Option")
     val Result: RsStructOrEnumItemElement? get() = findItem("core::result::Result")
+    val TokenStream: RsStructOrEnumItemElement? get() = findItem("proc_macro::TokenStream")
 
     val Iterator: RsTraitItem? get() = findItem("core::iter::Iterator")
     val IntoIterator: RsTraitItem? get() = findItem("core::iter::IntoIterator")

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsDeriveIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsDeriveIndex.kt
@@ -1,0 +1,123 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve.indexes
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.stubs.IndexSink
+import com.intellij.psi.stubs.StringStubIndexExtension
+import com.intellij.psi.stubs.StubIndex
+import com.intellij.psi.stubs.StubIndexKey
+import org.rust.ide.search.RsWithMacrosProjectScope
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.ext.isPublic
+import org.rust.lang.core.psi.ext.name
+import org.rust.lang.core.psi.ext.returnType
+import org.rust.lang.core.psi.ext.valueParameters
+import org.rust.lang.core.resolve.knownItems
+import org.rust.lang.core.stubs.RsFileStub
+import org.rust.lang.core.types.type
+import org.rust.openapiext.getElements
+
+
+data class DeriverableTrait(val name: String, val deriver: RsFunction)
+
+/**
+ * Index of functions that can be used to `#[derive]` traits.
+ */
+class RsDeriveIndex : StringStubIndexExtension<RsFunction>() {
+    override fun getVersion(): Int = RsFileStub.Type.stubVersion
+    override fun getKey(): StubIndexKey<String, RsFunction> = KEY
+
+    companion object {
+        val KEY: StubIndexKey<String, RsFunction> =
+            StubIndexKey.createIndexKey("org.rust.lang.core.stubs.index.RustDeriveIndex")
+
+        fun index(fn: RsFunction, sink: IndexSink) {
+            fn.potentiallyDeriverableTraitName?.let { traitName ->
+                sink.occurrence(KEY, traitName)
+            }
+        }
+
+        fun allDeriverableTraits(
+            project: Project
+        ): Collection<DeriverableTrait> =
+            StubIndex.getInstance().getAllKeys(KEY, project).flatMap { name ->
+                getElements(KEY, name, project, RsWithMacrosProjectScope(project)).map { deriver ->
+                    DeriverableTrait(name, deriver)
+                }
+            }.filter {
+                // TODO Can I remove elements from the index if they aren't actually derivers?
+                it.deriver.isDeriver
+            }
+
+        fun findDeriversByTraitName(
+            project: Project,
+            target: String,
+            scope: GlobalSearchScope = RsWithMacrosProjectScope(project)
+        ): Collection<RsFunction> = getElements(KEY, target, project, scope)
+            .filter {
+                it.isDeriver
+            }
+    }
+}
+
+/**
+ * A deriver is a function that can be used to `#[derive]` traits.
+ * For a function to be a deriver it must be public, have a
+ * `proc_macro_derive` attribute with the name of the trait it can
+ * derive specified, a single input parameter of type `proc_macro::TokenStream`
+ * and a return type of `proc_macro::TokenStream`.
+ * E.g. deriver function:
+ * ```rust
+ * #[proc_macro_derive(Trait)]
+ * pub fn trait_deriver(input: proc_macro::TokenStream) -> proc_macro::TokenStream { /* code */ }
+ * ```
+ * E.g. invalid functions:
+ * ```rust
+ * #[proc_macro_derive] // no trait name
+ * pub fn trait_deriver(input: proc_macro::TokenStream) -> proc_macro::TokenStream { /* code */ }
+ *
+ * #[proc_macro_derive(Trait)} // fn must be `pub`
+ * fn trait_deriver(input: proc_macro::TokenStream) -> proc_macro::TokenStream { /* code */ }
+ * ```
+ *
+ */
+val RsFunction.isDeriver: Boolean
+    get() = deriverableTraitName != null
+
+/**
+ * Checks if a given function could be a deriver function. Omits checking for return type
+ * and parameter type as it's not possible to do so when indexing
+ */
+private val RsFunction.potentiallyDeriverableTraitName: String?
+    get() = this.outerAttrList
+        .map { it.metaItem }
+        .find { it.name == "proc_macro_derive" }
+        ?.metaItemArgs
+        ?.metaItemList
+        ?.getOrNull(0)
+        ?.name
+        ?.takeIf {
+            this.isPublic && this.valueParameters.size == 1
+        }
+
+
+val RsFunction.deriverableTraitName: String?
+    get() = this.outerAttrList
+        .map { it.metaItem }
+        .find { it.name == "proc_macro_derive" }
+        ?.metaItemArgs
+        ?.metaItemList
+        ?.getOrNull(0)
+        ?.name
+        ?.takeIf {
+            this.isPublic
+                && this.returnType == this.knownItems.TokenStream?.declaredType
+                && this.valueParameters.size == 1
+                && this.valueParameters[0].typeReference?.type == this.knownItems.TokenStream?.declaredType
+        }
+

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
@@ -8,10 +8,7 @@ package org.rust.lang.core.stubs
 import com.intellij.psi.stubs.IndexSink
 import org.rust.lang.core.psi.ext.RsAbstractableOwner
 import org.rust.lang.core.psi.ext.owner
-import org.rust.lang.core.resolve.indexes.RsImplIndex
-import org.rust.lang.core.resolve.indexes.RsLangItemIndex
-import org.rust.lang.core.resolve.indexes.RsMacroCallIndex
-import org.rust.lang.core.resolve.indexes.RsMacroIndex
+import org.rust.lang.core.resolve.indexes.*
 import org.rust.lang.core.stubs.index.*
 
 fun IndexSink.indexExternCrate(stub: RsExternCrateItemStub) {
@@ -54,6 +51,7 @@ fun IndexSink.indexImplItem(stub: RsImplItemStub) {
 
 fun IndexSink.indexFunction(stub: RsFunctionStub) {
     indexNamedStub(stub)
+    RsDeriveIndex.index(stub.psi, this)
 }
 
 fun IndexSink.indexConstant(stub: RsConstantStub) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -752,6 +752,7 @@
         <stubIndex implementation="org.rust.lang.core.stubs.index.RsGotoClassIndex"/>
         <stubIndex implementation="org.rust.lang.core.stubs.index.RsReexportIndex"/>
         <stubIndex implementation="org.rust.lang.core.stubs.index.RsFeatureIndex"/>
+        <stubIndex implementation="org.rust.lang.core.resolve.indexes.RsDeriveIndex"/>
 
         <stubIndex implementation="org.rust.lang.core.resolve.indexes.RsImplIndex"/>
         <stubIndex implementation="org.rust.lang.core.resolve.indexes.RsLangItemIndex"/>

--- a/src/test/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProviderTest.kt
@@ -123,4 +123,22 @@ class RsDeriveCompletionProviderTest : RsCompletionTestBase() {
         #[derive(Ser/*caret*/)]
         struct S;
     """)
+
+
+    // TODO add more tests
+    fun `test custom completion`() = doSingleCompletion("""
+        trait Foo {}
+        #[proc_macro_derive(Foo)]
+        pub fn foo_deriver(input: u32 /* todo fix, see RsDeriveIndex:~100 */) { }
+
+        #[derive(Fo/*caret*/)]
+        struct Bar;
+    """, """
+        trait Foo {}
+        #[proc_macro_derive(Foo)]
+        pub fn foo_deriver(input: u32 /* todo fix, see RsDeriveIndex:~100 */) { }
+
+        #[derive(Foo/*caret*/)]
+        struct Bar;
+    """)
 }


### PR DESCRIPTION
Closes #3690. This is a *work in progress* PR for indexing `proc_macro_derive` functions and adding completions for `#[derive]` attribute. At the moment there are 3 unresolved issues - type resolving during indexing, how to index macro expansions and `LookupElementBuilder`'s `InsertionHandler` not working (I've looked at `RsCommonCompletionContributor` and then `AutoImportFix` for help but as far as I understand it just happily modifies the PSI without any problems). I'd appreciate any help with resolving them.

Currently, the completion works correctly but some tests are missing, and auto-importing the crates, as well as, just adding `#[macro_use]` if the import is present, is not yet working. Also, does not yet work for macro generates `proc_macro_derive` functions.