### PR TITLE
PERF: use recursion guard only for type aliases

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.types
 
 import com.intellij.injected.editor.VirtualFileWindow
-import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.CachedValue
@@ -24,7 +23,6 @@ import org.rust.lang.core.types.ty.Mutability
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyTypeParameter
 import org.rust.lang.core.types.ty.TyUnknown
-import org.rust.openapiext.recursionGuard
 
 
 private fun <T> RsInferenceContextOwner.createResult(value: T): Result<T> {
@@ -46,8 +44,7 @@ private fun <T> RsInferenceContextOwner.createResult(value: T): Result<T> {
 }
 
 val RsTypeReference.type: Ty
-    get() = recursionGuard(this, Computable { inferTypeReferenceType(this) })
-        ?: TyUnknown
+    get() = inferTypeReferenceType(this)
 
 val RsTypeElement.lifetimeElidable: Boolean
     get() {

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -343,6 +343,48 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
                             //^ &Struct<'_, Struct<'_, &'a str>>
     """, renderLifetimes = true)
 
+    fun `test no infinite recursion on "impl Self 1"`() = testType("""
+        impl Self {}
+           //^ <unknown>
+    """)
+
+    fun `test no infinite recursion on "impl Self 2"`() = testType("""
+        struct S<T>(T);
+        impl S<Self> {}
+           //^ S<<unknown>>
+    """)
+
+    fun `test no infinite recursion on cyclic type`() = testType("""
+        type A = B;
+        type B = A;
+               //^ <unknown>
+    """)
+
+    fun `test no infinite recursion on cyclic type array`() = testType("""
+        type A = [B; 2];
+        type B = A;
+               //^ [<unknown>; 2]
+    """)
+
+    fun `test no infinite recursion on cyclic type tuple`() = testType("""
+        type A = (B, B);
+        type B = A;
+               //^ (<unknown>, <unknown>)
+    """)
+
+    fun `test no infinite recursion on cyclic type fn pointer`() = testType("""
+        type A = fn(B);
+        type B = A;
+               //^ fn(<unknown>)
+    """)
+
+    fun `test no infinite recursion on cyclic type with type argument`() = testType("""
+        struct S<T>(T);
+        type A = S<B>;
+        type B = A;
+               //^ S<<unknown>>
+    """)
+
     /**
      * Checks the type of the element in [code] pointed to by `//^` marker.
      */


### PR DESCRIPTION
Slightly optimizes type resolution & also simplifies stacktraces/profiling