### PR TITLE
TYPE: display notification panel when a file is not included in the module tree

### DIFF
--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -13,6 +13,8 @@ import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.ui.EditorNotificationPanel
 import com.intellij.ui.EditorNotifications
 import org.rust.cargo.project.model.CargoProject
@@ -23,6 +25,8 @@ import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.StandardLibrary
+import org.rust.lang.core.psi.RUST_STRUCTURE_CHANGE_TOPIC
+import org.rust.lang.core.psi.RustStructureChangeListener
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.isNotRustFile
 import org.rust.openapiext.toPsiFile
@@ -49,6 +53,11 @@ class MissingToolchainNotificationProvider(
 
             subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsService.CargoProjectsListener {
                 override fun cargoProjectsUpdated(projects: Collection<CargoProject>) {
+                    notifications.updateAllNotifications()
+                }
+            })
+            subscribe(RUST_STRUCTURE_CHANGE_TOPIC, object : RustStructureChangeListener {
+                override fun rustStructureChanged(file: PsiFile?, changedElement: PsiElement?) {
                     notifications.updateAllNotifications()
                 }
             })

--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -23,7 +23,9 @@ import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.StandardLibrary
+import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.isNotRustFile
+import org.rust.openapiext.toPsiFile
 
 /**
  * Warn user if rust toolchain or standard library is not properly configured.
@@ -73,6 +75,11 @@ class MissingToolchainNotificationProvider(
             //TODO: more precise check here
             return createNoCargoProjectForFilePanel()
 
+        val psiFile = file.toPsiFile(project) as RsElement
+        if (psiFile.crateRoot == null) {
+            return createFileNotIncludedInModulesPanel()
+        }
+
         val workspace = cargoProject.workspace ?: return null
         if (!workspace.hasStandardLibrary) {
             // If rustup is not null, the WorkspaceService will use it
@@ -83,6 +90,11 @@ class MissingToolchainNotificationProvider(
 
         return null
     }
+
+    private fun createFileNotIncludedInModulesPanel(): EditorNotificationPanel =
+        EditorNotificationPanel().apply {
+            setText("File is not included in module tree, analysis is not available")
+        }
 
     private fun createBadToolchainPanel(): EditorNotificationPanel =
         EditorNotificationPanel().apply {


### PR DESCRIPTION
This PR adds a notification panel that warns about files which are not included in any module tree.
Currently the file has to be re-opened for the notification bar to update.

Corresponding issue: https://github.com/intellij-rust/intellij-rust/issues/1675