### PR TITLE
 RUN: fix backtrace hyperlinks on 2018 edition

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -27,7 +27,7 @@ interface CargoWorkspace {
     val workspaceRootPath: Path?
 
     val packages: Collection<Package>
-    fun findPackage(name: String): Package? = packages.find { it.name == name }
+    fun findPackage(name: String): Package? = packages.find { it.name == name || it.normName == name }
 
     fun findTargetByCrateRoot(root: VirtualFile): Target?
     fun isCrateRoot(root: VirtualFile) = findTargetByCrateRoot(root) != null

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactory.kt
@@ -20,7 +20,7 @@ class RsCodeFragmentFactory(val project: Project) {
     private val psiFactory = RsPsiFactory(project, markGenerated = false)
 
     fun createCrateRelativePath(pathText: String, target: CargoWorkspace.Target): RsPath? {
-        check(pathText.startsWith("::"))
+        check(!pathText.startsWith("::"))
         val vFile = target.crateRoot ?: return null
         val crateRoot = vFile.toPsiFile(project) as? RsFile ?: return null
         return psiFactory.tryCreatePath(pathText)

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -609,7 +609,7 @@ fun resolveStringPath(path: String, workspace: CargoWorkspace, project: Project)
     }
 
     val el = pkg.targets.asSequence()
-        .mapNotNull { RsCodeFragmentFactory(project).createCrateRelativePath("::${parts[1]}", it) }
+        .mapNotNull { RsCodeFragmentFactory(project).createCrateRelativePath(parts[1], it) }
         .mapNotNull { it.reference.resolve() }
         .filterIsInstance<RsNamedElement>()
         .firstOrNull() ?: return null

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -31,6 +31,7 @@ import org.rust.cargo.toolchain.RustcVersion
 import org.rust.lang.core.macros.macroExpansionManager
 import org.rust.lang.core.psi.ext.ancestorOrSelf
 import org.rust.openapiext.saveAllDocuments
+import org.rust.stdext.BothEditions
 
 abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCase {
 
@@ -99,6 +100,26 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
             System.err.println("SKIP $name: $reason")
             return
         }
+
+        if (findAnnotationInstance<BothEditions>() != null) {
+            if (findAnnotationInstance<MockEdition>() != null) {
+                error("Can't mix `BothEditions` and `MockEdition` annotations")
+            }
+            // These functions exist to simplify stacktrace analyzing
+            runTestEdition2015()
+            runTestEdition2018()
+        } else {
+            super.runTest()
+        }
+    }
+
+    private fun runTestEdition2015() {
+        project.cargoProjects.setEdition(CargoWorkspace.Edition.EDITION_2015)
+        super.runTest()
+    }
+
+    private fun runTestEdition2018() {
+        project.cargoProjects.setEdition(CargoWorkspace.Edition.EDITION_2018)
         super.runTest()
     }
 

--- a/src/test/kotlin/org/rust/cargo/runconfig/filters/HighlightFilterTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/filters/HighlightFilterTestBase.kt
@@ -10,6 +10,7 @@ import com.intellij.execution.filters.OpenFileHyperlinkInfo
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VirtualFile
+import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import java.util.*
 
@@ -36,6 +37,17 @@ abstract class HighlightFilterTestBase : RsTestBase() {
         }
     }
 
+    protected fun checkHighlights(
+        filter: Filter,
+        @Language("Rust") code: String,
+        before: String,
+        after: String,
+        lineIndex: Int = 0
+    ) {
+        configureByFileTree(code)
+        checkHighlights(filter, before, after, lineIndex)
+    }
+
     protected fun checkHighlights(filter: Filter, before: String, after: String, lineIndex: Int = 0) {
         val line = before.splitLinesKeepSeparators()[lineIndex]
         val result = checkNotNull(filter.applyFilter(line, before.length)) {
@@ -53,7 +65,7 @@ abstract class HighlightFilterTestBase : RsTestBase() {
             checkText = checkText.replaceRange(range, "[$itemText]")
         }
         checkText = checkText.splitLinesKeepSeparators()[lineIndex]
-        check(checkText == after)
+        assertEquals(after, checkText)
     }
 
     private fun String.splitLinesKeepSeparators() = split("(?<=\n)".toRegex())

--- a/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterTest.kt
@@ -7,12 +7,15 @@ package org.rust.cargo.runconfig.filters
 
 import com.intellij.openapi.util.SystemInfo
 import org.rust.ProjectDescriptor
+import org.rust.WithDependencyRustProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.cargo.project.model.cargoProjects
+import org.rust.stdext.BothEditions
 
 /**
  * Tests for RustBacktraceFilter
  */
+@BothEditions
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsBacktraceFilterTest : HighlightFilterTestBase() {
     private val filter: RsBacktraceFilter
@@ -24,7 +27,7 @@ class RsBacktraceFilterTest : HighlightFilterTestBase() {
             "          at src/main.rs:24",
             "          at [src/main.rs -> main.rs]:24")
 
-    fun `test rustc source code link wIth absolute path`() {
+    fun `test rustc source code link with absolute path`() {
         // Windows does not handle abs paths on the tmpfs
         if (SystemInfo.isWindows) return
         val absPath = "${projectDir.canonicalPath}/src/main.rs"
@@ -83,5 +86,13 @@ stack backtrace:
                         at src/main.rs:22""",
             "                        at [src/main.rs -> main.rs]:22", 14)
 
-
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test crate with "-" in name`() =
+        checkHighlights(filter,
+            """
+                //- dep-lib/lib.rs
+                fn foo() {}/*caret*/
+            """,
+            "  6: dep_lib::foo",
+            "  6: [dep_lib::foo -> lib.rs]")
 }

--- a/src/test/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactoryTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactoryTest.kt
@@ -7,12 +7,14 @@ package org.rust.lang.core.psi
 
 import org.rust.RsTestBase
 import org.rust.cargo.project.model.cargoProjects
+import org.rust.stdext.BothEditions
 
+@BothEditions
 class RsCodeFragmentFactoryTest : RsTestBase() {
     fun `test resolve string path`() {
         InlineFile("mod foo { struct S; }")
         val target = project.cargoProjects.allProjects.single().workspace!!.packages.single().targets.first()
-        val path = RsCodeFragmentFactory(project).createCrateRelativePath("::foo::S", target)
+        val path = RsCodeFragmentFactory(project).createCrateRelativePath("foo::S", target)
         val declaration = path!!.reference.resolve()
         check((declaration as RsStructItem).name == "S")
     }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -5,26 +5,17 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.*
-import org.rust.cargo.project.model.cargoProjects
-import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ExpandMacros
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.WithStdlibWithSymlinkRustProjectDescriptor
 import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.types.infer.TypeInferenceMarks
+import org.rust.stdext.BothEditions
 
+@BothEditions
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsStdlibResolveTest : RsResolveTestBase() {
-
-    override fun runTest() {
-        if (javaClass.getMethod(name).getAnnotation(MockEdition::class.java) != null) {
-            return super.runTest()
-        }
-
-        for (edition in CargoWorkspace.Edition.values()) {
-            project.cargoProjects.setEdition(edition)
-            super.runTest()
-        }
-    }
-
     fun `test resolve fs`() = stubOnlyResolve("""
     //- main.rs
         use std::fs::File;
@@ -642,21 +633,4 @@ class RsStdlibResolveTest : RsResolveTestBase() {
             let a = f64::INFINITY;
         }              //^ ...num/f64.rs
     """)
-
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
-    fun `test extern crate std is not injected on 2018 edition`() = stubOnlyResolve("""
-    //- main.rs
-        use crate::std::mem;
-                 //^ unresolved
-    """)
-
-    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
-    fun `test extra use of prelude item`() = stubOnlyResolve("""
-    //- main.rs
-        use Vec;
-
-        fn main() {
-            let a = Vec::<i32>::new();
-        }         //^ .../vec.rs
-    """, ItemResolutionTestmarks.extraAtomUse)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2018.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2018.kt
@@ -1,0 +1,30 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve
+
+import org.rust.MockEdition
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.cargo.project.workspace.CargoWorkspace
+
+@MockEdition(CargoWorkspace.Edition.EDITION_2018)
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+class RsStdlibResolveTestEdition2018 : RsResolveTestBase() {
+    fun `test extern crate std is not injected on 2018 edition`() = stubOnlyResolve("""
+    //- main.rs
+        use crate::std::mem;
+                 //^ unresolved
+    """)
+
+    fun `test extra use of prelude item`() = stubOnlyResolve("""
+    //- main.rs
+        use Vec;
+
+        fn main() {
+            let a = Vec::<i32>::new();
+        }         //^ .../vec.rs
+    """, ItemResolutionTestmarks.extraAtomUse)
+}

--- a/src/test/kotlin/org/rust/stdext/BothEditions.kt
+++ b/src/test/kotlin/org/rust/stdext/BothEditions.kt
@@ -1,0 +1,19 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.stdext
+
+import org.rust.cargo.project.model.CargoProjectsService
+import java.lang.annotation.Inherited
+
+/**
+ * Like [org.rust.MockEdition], but makes the test run 2 times with both edition
+ *
+ * @see CargoProjectsService.setEdition
+ */
+@Inherited
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class BothEditions


### PR DESCRIPTION
Fixes such hyperlinks in 2018 edition crates or crates containing "-" in the name
![image](https://user-images.githubusercontent.com/3221931/57533969-a2a36400-7347-11e9-986b-2279ae459cf3.png)
