### PR TITLE
PERF: significantly optimize "find usages" (in the broad sense)

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
@@ -5,9 +5,9 @@
 
 package org.rust.lang.core.psi
 
-import org.rust.lang.core.psi.ext.RsMod
-import org.rust.lang.core.psi.ext.RsNamedElement
-import org.rust.lang.core.psi.ext.superMods
+import com.intellij.psi.search.LocalSearchScope
+import com.intellij.psi.search.SearchScope
+import org.rust.lang.core.psi.ext.*
 
 /**
  * Mixin methods to implement PSI interfaces without copy pasting and
@@ -27,6 +27,17 @@ object RsPsiImplUtil {
         }
         if (segments.isEmpty()) return ""
         return "::" + segments.joinToString("::")
+    }
+
+    /**
+     * Used by [RsTypeParameter] and [RsLifetimeParameter].
+     * @return null if default scope should be used
+     */
+    fun getParameterUseScope(element: RsElement): SearchScope? {
+        val owner = element.contextStrict<RsGenericDeclaration>()
+        if (owner != null) return LocalSearchScope(owner)
+
+        return null
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.psi
 
 import com.intellij.psi.search.LocalSearchScope
 import com.intellij.psi.search.SearchScope
+import com.intellij.psi.util.PsiTreeUtil
 import org.rust.lang.core.psi.ext.*
 
 /**
@@ -39,5 +40,71 @@ object RsPsiImplUtil {
 
         return null
     }
+
+    /**
+     * @return null if default scope should be used
+     */
+    fun getDeclarationUseScope(element: RsVisible): SearchScope? =
+        getDeclarationUseScope(element, RsVisibility.Public)
+
+    private fun getDeclarationUseScope(
+        element: RsVisible,
+        restrictedVis: RsVisibility
+    ): SearchScope? {
+        when (element) {
+            is RsEnumVariant -> return getDeclarationUseScope(element.parentEnum, restrictedVis)
+            is RsFieldDecl -> return getDeclarationUseScope(
+                element.contextStrict<RsFieldsOwner>() as RsVisible,
+                element.visibility
+            )
+        }
+
+        val owner = PsiTreeUtil.getContextOfType(
+            element,
+            true,
+            RsItemElement::class.java,
+            RsMod::class.java
+        ) as? RsElement ?: return null
+
+        return when (owner) {
+            // Trait members inherit visibility from the trait
+            is RsTraitItem -> getDeclarationUseScope(owner)
+
+            is RsImplItem -> {
+                // Members of `impl Trait for ...` inherit visibility from the implemented trait
+                val traitRef = owner.traitRef
+                if (traitRef != null) return getDeclarationUseScope(traitRef.resolveToTrait ?: return null)
+
+                // Inherent impl members
+                getTopLevelDeclarationUseScope(element, owner.containingMod, restrictedVis)
+            }
+
+            is RsMod -> getTopLevelDeclarationUseScope(element, owner, restrictedVis)
+            is RsForeignModItem -> getTopLevelDeclarationUseScope(element, owner.containingMod, restrictedVis)
+
+            // In this case `owner` is function or code block, i.e. it's local scope
+            else -> LocalSearchScope(owner)
+        }
+    }
+
+    private fun getTopLevelDeclarationUseScope(
+        element: RsVisible,
+        containingMod: RsMod,
+        restrictedVis: RsVisibility
+    ): SearchScope? {
+        val restrictedMod = when (val visibility = restrictedVis.intersect(element.visibility)) {
+            RsVisibility.Public -> return null
+            RsVisibility.Private -> containingMod
+            is RsVisibility.Restricted -> visibility.inMod
+        }
+
+        if (!restrictedMod.hasChildModules()) return LocalSearchScope(containingMod)
+
+        // TODO restrict scope to [restrictedMod]. We can't use `DirectoryScope` b/c file from any
+        //   directory can be included via `#[path]` attribute.
+        return null
+    }
 }
 
+private fun RsMod.hasChildModules(): Boolean =
+    expandedItemsExceptImpls.any { it is RsModDeclItem || it is RsModItem && it.hasChildModules() }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
+import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.RsExpandedElement
@@ -53,4 +54,6 @@ abstract class RsConstantImplMixin : RsStubbedNamedElementImpl<RsConstantStub>, 
     override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
+
+    override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumItem.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
+import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.RsExpandedElement
@@ -34,6 +35,8 @@ abstract class RsEnumItemImplMixin : RsStubbedNamedElementImpl<RsEnumItemStub>, 
     override val declaredType: Ty get() = RsPsiTypeImplUtil.declaredType(this)
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
+
+    override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }
 
 val RsEnumItem.isStdOptionOrResult: Boolean get() {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumVariant.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumVariant.kt
@@ -6,10 +6,12 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.psi.RsEnumItem
 import org.rust.lang.core.psi.RsEnumVariant
+import org.rust.lang.core.psi.RsPsiImplUtil
 import org.rust.lang.core.stubs.RsEnumVariantStub
 import javax.swing.Icon
 
@@ -27,5 +29,7 @@ abstract class RsEnumVariantImplMixin : RsStubbedNamedElementImpl<RsEnumVariantS
         val variantName = name ?: return null
         return parentEnum.crateRelativePath?.let { "$it::$variantName" }
     }
+
+    override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt
@@ -7,10 +7,12 @@ package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
+import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.RsExternCrateItem
+import org.rust.lang.core.psi.RsPsiImplUtil
 import org.rust.lang.core.resolve.ref.RsExternCrateReferenceImpl
 import org.rust.lang.core.resolve.ref.RsReference
 import org.rust.lang.core.stubs.RsExternCrateItemStub
@@ -38,4 +40,6 @@ abstract class RsExternCrateItemImplMixin : RsStubbedNamedElementImpl<RsExternCr
     override fun getIcon(flags: Int) = RsIcons.CRATE
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
+
+    override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.psi.ext
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.psi.PsiElement
+import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.icons.RsIcons
@@ -144,4 +145,6 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
         if (shouldInc) modificationTracker.incModificationCount()
         return shouldInc
     }
+
+    override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroBinding.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroBinding.kt
@@ -7,11 +7,19 @@ package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
+import com.intellij.psi.search.LocalSearchScope
+import com.intellij.psi.search.SearchScope
+import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.RsMacroBinding
 
 abstract class RsMacroBindingImplMixin(node: ASTNode) : RsNamedElementImpl(node), RsMacroBinding {
 
     override fun getNameIdentifier(): PsiElement? = metaVarIdentifier
+
+    override fun getUseScope(): SearchScope {
+        val owner = contextStrict<RsMacro>() ?: error("Macro binding outside of a macro")
+        return LocalSearchScope(owner)
+    }
 }
 
 val RsMacroBinding.fragmentSpecifier: String?

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt
@@ -9,6 +9,7 @@ package org.rust.lang.core.psi.ext
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.RsExpandedElement
@@ -60,6 +61,8 @@ abstract class RsModDeclItemImplMixin : RsStubbedNamedElementImpl<RsModDeclItemS
     override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
+
+    override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }
 
 val RsModDeclItem.hasMacroUse: Boolean get() =

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsModItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsModItem.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
+import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.RsExpandedElement
@@ -46,6 +47,8 @@ abstract class RsModItemImplMixin : RsStubbedNamedElementImpl<RsModItemStub>,
         get() = stubChildrenOfType()
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
+
+    override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }
 
 val RsModItem.hasMacroUse: Boolean get() =

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedFieldDecl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedFieldDecl.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.psi.RsNamedFieldDecl
@@ -23,4 +24,6 @@ abstract class RsNamedFieldDeclImplMixin : RsStubbedNamedElementImpl<RsNamedFiel
 
     // temporary solution.
     override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
+
+    override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructItem.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
+import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.RsExpandedElement
@@ -48,4 +49,6 @@ abstract class RsStructItemImplMixin : RsStubbedNamedElementImpl<RsStructItemStu
     override val declaredType: Ty get() = RsPsiTypeImplUtil.declaredType(this)
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
+
+    override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -9,6 +9,7 @@ import com.intellij.lang.ASTNode
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.Condition
 import com.intellij.psi.PsiElement
+import com.intellij.psi.search.SearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.util.Query
@@ -146,6 +147,8 @@ abstract class RsTraitItemImplMixin : RsStubbedNamedElementImpl<RsTraitItemStub>
     override val declaredType: Ty get() = RsPsiTypeImplUtil.declaredType(this)
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
+
+    override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }
 
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTupleFieldDecl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTupleFieldDecl.kt
@@ -6,7 +6,9 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
+import org.rust.lang.core.psi.RsPsiImplUtil
 import org.rust.lang.core.psi.RsTupleFieldDecl
 import org.rust.lang.core.stubs.RsPlaceholderStub
 
@@ -19,4 +21,6 @@ abstract class RsTupleFieldDeclImplMixin : RsStubbedElementImpl<RsPlaceholderStu
     constructor(stub: RsPlaceholderStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
     override fun getName(): String? = position?.toString()
+
+    override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
+import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.RsExpandedElement
@@ -36,4 +37,6 @@ abstract class RsTypeAliasImplMixin : RsStubbedNamedElementImpl<RsTypeAliasStub>
     override val declaredType: Ty get() = RsPsiTypeImplUtil.declaredType(this)
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
+
+    override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeParameter.kt
@@ -6,9 +6,11 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.lang.core.psi.RsBaseType
 import org.rust.lang.core.psi.RsPolybound
+import org.rust.lang.core.psi.RsPsiImplUtil
 import org.rust.lang.core.psi.RsTypeParameter
 import org.rust.lang.core.stubs.RsTypeParameterStub
 import org.rust.lang.core.types.RsPsiTypeImplUtil
@@ -50,4 +52,6 @@ abstract class RsTypeParameterImplMixin : RsStubbedNamedElementImpl<RsTypeParame
     constructor(stub: RsTypeParameterStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
     override val declaredType: Ty get() = RsPsiTypeImplUtil.declaredType(this)
+
+    override fun getUseScope(): SearchScope = RsPsiImplUtil.getParameterUseScope(this) ?: super.getUseScope()
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
@@ -68,6 +68,18 @@ sealed class RsVisibility {
     data class Restricted(val inMod: RsMod) : RsVisibility()
 }
 
+fun RsVisibility.intersect(other: RsVisibility): RsVisibility = when (this) {
+    RsVisibility.Private -> this
+    RsVisibility.Public -> other
+    is RsVisibility.Restricted -> when (other) {
+        RsVisibility.Private -> other
+        RsVisibility.Public -> this
+        is RsVisibility.Restricted -> {
+            RsVisibility.Restricted(if (inMod.superMods.contains(other.inMod)) inMod else other.inMod)
+        }
+    }
+}
+
 val RsVis.visibility: RsVisibility
     get() = when (stubKind) {
         RsVisStubKind.PUB -> RsVisibility.Public

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RustLifetimeParameterElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RustLifetimeParameterElement.kt
@@ -7,9 +7,11 @@ package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
+import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.lang.core.psi.RsLifetimeParameter
 import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsPsiImplUtil
 import org.rust.lang.core.stubs.RsLifetimeParameterStub
 
 abstract class RsLifetimeParameterImplMixin: RsStubbedNamedElementImpl<RsLifetimeParameterStub>, RsLifetimeParameter {
@@ -22,4 +24,6 @@ abstract class RsLifetimeParameterImplMixin: RsStubbedNamedElementImpl<RsLifetim
         nameIdentifier.replace(RsPsiFactory(project).createQuoteIdentifier(name))
         return this
     }
+
+    override fun getUseScope(): SearchScope = RsPsiImplUtil.getParameterUseScope(this) ?: super.getUseScope()
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsAssocTypeBindingReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsAssocTypeBindingReferenceImpl.kt
@@ -7,7 +7,9 @@ package org.rust.lang.core.resolve.ref
 
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsAssocTypeBinding
+import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.owner
 import org.rust.lang.core.resolve.collectResolveVariants
 import org.rust.lang.core.resolve.processAssocTypeVariants
 
@@ -19,4 +21,7 @@ class RsAssocTypeBindingReferenceImpl(
 
     override fun resolveInner(): List<RsElement> =
         collectResolveVariants(element.referenceName) { processAssocTypeVariants(element, it) }
+
+    override fun isReferenceTo(element: PsiElement): Boolean =
+        element is RsTypeAlias && element.owner.isImplOrTrait && super.isReferenceTo(element)
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsExternCrateReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsExternCrateReferenceImpl.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.resolve.ref
 
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsExternCrateItem
+import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.resolve.collectResolveVariants
 import org.rust.lang.core.resolve.processExternCrateResolveVariants
@@ -20,4 +21,7 @@ class RsExternCrateReferenceImpl(
 
     override fun resolveInner(): List<RsElement> =
         collectResolveVariants(element.referenceName) { processExternCrateResolveVariants(element, false, it) }
+
+    override fun isReferenceTo(element: PsiElement): Boolean =
+        element is RsFile && super.isReferenceTo(element)
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLabelReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLabelReferenceImpl.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.resolve.ref
 
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsLabel
+import org.rust.lang.core.psi.RsLabelDecl
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.resolve.collectResolveVariants
 import org.rust.lang.core.resolve.processLabelResolveVariants
@@ -22,4 +23,7 @@ class RsLabelReferenceImpl(
 
     override fun resolveInner(): List<RsElement> =
         collectResolveVariants(element.referenceName) { processLabelResolveVariants(element, it) }
+
+    override fun isReferenceTo(element: PsiElement): Boolean =
+        element is RsLabelDecl && super.isReferenceTo(element)
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLifetimeReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLifetimeReferenceImpl.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.resolve.ref
 
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsLifetime
+import org.rust.lang.core.psi.RsLifetimeParameter
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.resolve.collectResolveVariants
 import org.rust.lang.core.resolve.processLifetimeResolveVariants
@@ -22,4 +23,7 @@ class RsLifetimeReferenceImpl(
 
     override fun resolveInner(): List<RsElement> =
         collectResolveVariants(element.referenceName) { processLifetimeResolveVariants(element, it) }
+
+    override fun isReferenceTo(element: PsiElement): Boolean =
+        element is RsLifetimeParameter && super.isReferenceTo(element)
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroReferenceImpl.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.resolve.ref
 
 import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RsMacroBinding
 import org.rust.lang.core.psi.RsMacroReference
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.resolve.collectResolveVariants
@@ -20,4 +21,7 @@ class RsMacroReferenceImpl(pattern: RsMacroReference) : RsReferenceCached<RsMacr
 
     override fun resolveInner(): List<RsElement>
         = collectResolveVariants(element.referenceName) { processMacroReferenceVariants(element, it) }
+
+    override fun isReferenceTo(element: PsiElement): Boolean =
+        element is RsMacroBinding && super.isReferenceTo(element)
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMetaItemReferenceContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMetaItemReferenceContributor.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.*
 import com.intellij.util.ProcessingContext
 import org.rust.lang.core.RsPsiPattern
 import org.rust.lang.core.psi.RsMetaItem
+import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.name
 import org.rust.lang.core.resolve.collectResolveVariants
@@ -45,6 +46,9 @@ private class RsDeriveTraitReferenceImpl(
         val traitName = element.name ?: return emptyList()
         return collectResolveVariants(traitName) { processDeriveTraitResolveVariants(element, traitName, it) }
     }
+
+    override fun isReferenceTo(element: PsiElement): Boolean =
+        element is RsTraitItem && super.isReferenceTo(element)
 
     override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> =
         cachedMultiResolve().toTypedArray()

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
@@ -10,6 +10,9 @@ import org.rust.lang.core.psi.RsFieldLookup
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsMethodCall
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsFieldDecl
+import org.rust.lang.core.psi.ext.isAssocFn
+import org.rust.lang.core.psi.ext.owner
 import org.rust.lang.core.resolve.*
 import org.rust.lang.core.types.inference
 import org.rust.lang.core.types.ty.Ty
@@ -24,6 +27,9 @@ class RsMethodCallReferenceImpl(
 
     override fun multiResolve(): List<RsElement> =
         element.inference?.getResolvedMethod(element)?.map { it.element } ?: emptyList()
+
+    override fun isReferenceTo(element: PsiElement): Boolean =
+        element is RsFunction && element.owner.isImplOrTrait && !element.isAssocFn && super.isReferenceTo(element)
 }
 
 class RsFieldLookupReferenceImpl(
@@ -41,6 +47,9 @@ class RsFieldLookupReferenceImpl(
         if (ident != null) doRename(ident, newName)
         return element
     }
+
+    override fun isReferenceTo(element: PsiElement): Boolean =
+        element is RsFieldDecl && super.isReferenceTo(element)
 }
 
 fun resolveMethodCallReferenceWithReceiverType(

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsModReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsModReferenceImpl.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.resolve.ref
 
 import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.resolve.collectResolveVariants
@@ -20,4 +21,7 @@ class RsModReferenceImpl(
 
     override fun resolveInner(): List<RsElement> =
         collectResolveVariants(element.referenceName) { processModDeclResolveVariants(element, it) }
+
+    override fun isReferenceTo(element: PsiElement): Boolean =
+        element is RsFile && super.isReferenceTo(element)
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPatBindingReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPatBindingReferenceImpl.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.resolve.ref
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsPatBinding
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.isConstantLike
 import org.rust.lang.core.resolve.collectResolveVariants
 import org.rust.lang.core.resolve.processPatBindingResolveVariants
 
@@ -23,6 +24,7 @@ class RsPatBindingReferenceImpl(
         collectResolveVariants(element.referenceName) { processPatBindingResolveVariants(element, false, it) }
 
     override fun isReferenceTo(element: PsiElement): Boolean {
+        if (element !is RsElement || !element.isConstantLike) return false
         val target = resolve()
         return element.manager.areElementsEquivalent(target, element)
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -30,6 +30,7 @@ class RsPathReferenceImpl(
     override val RsPath.referenceAnchor: PsiElement get() = referenceNameElement
 
     override fun isReferenceTo(element: PsiElement): Boolean {
+        if (element is RsFieldDecl) return false
         val target = resolve()
         return element.manager.areElementsEquivalent(target, element)
     }

--- a/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
@@ -13,8 +13,8 @@ import org.rust.lang.core.psi.ext.descendantsOfType
 class RenameTest : RsTestBase() {
     fun `test function`() = doTest("spam", """
         mod a {
-            mod b {
-                fn /*caret*/foo() {}
+            pub mod b {
+                pub fn /*caret*/foo() {}
 
                 fn bar() {
                     foo()
@@ -35,8 +35,8 @@ class RenameTest : RsTestBase() {
         }
     """, """
         mod a {
-            mod b {
-                fn spam() {}
+            pub mod b {
+                pub fn spam() {}
 
                 fn bar() {
                     spam()


### PR DESCRIPTION
1. First, by tuning `Rs*ReferenceImpl.isReferenceTo` we say: "this reference is definitely can't be resolve to this element" without resolving the reference. This optimizes find usages of any elements because now we should resolve less references.
2. Optimize "find usages" of type/lifetime parameters by using local scopes. I'd say it was a bug that local scope wasn't used before because of obvious local nature of such parameters.
3. Take into account item visibility. This significantly speeds up "find usages" of private items (**UPD**: only inside modules without child modules for now) and items declared in local scope (i.e. in function bodies, etc)

I don't know how to write tests for it, and I tested performance rather than correctness, so it should be reviewed intently.