### PR TITLE
LI: fix doctests with existing "main" function

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -5,24 +5,20 @@
 
 package org.rust.lang.core.macros
 
-import com.intellij.lang.LanguageParserDefinitions
 import com.intellij.lang.PsiBuilder
-import com.intellij.lang.PsiBuilderFactory
 import com.intellij.lang.PsiBuilderUtil
 import com.intellij.lang.parser.GeneratedParserUtilBase
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiWhiteSpace
-import com.intellij.psi.impl.source.DummyHolderFactory
 import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
-import org.rust.lang.RsLanguage
 import org.rust.lang.core.parser.RustParser
 import org.rust.lang.core.parser.RustParserUtil.collapsedTokenType
+import org.rust.lang.core.parser.createRustPsiBuilder
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 import org.rust.lang.core.psi.ext.*
@@ -117,7 +113,7 @@ class MacroExpander(val project: Project) {
         def: RsMacro,
         call: RsMacroCall
     ): Pair<RsMacroCase, MacroSubstitution>? {
-        val macroCallBody = createPsiBuilder(call, call.macroBody ?: return null)
+        val macroCallBody = project.createRustPsiBuilder(call.macroBody ?: return null)
         var start = macroCallBody.mark()
         val macroCaseList = def.macroBodyStubbed?.macroCaseList ?: return null
 
@@ -132,14 +128,6 @@ class MacroExpander(val project: Project) {
         }
 
         return null
-    }
-
-    private fun createPsiBuilder(context: PsiElement, text: String): PsiBuilder {
-        val holder = DummyHolderFactory.createHolder(PsiManager.getInstance(project), context).treeElement
-        val parserDefinition = LanguageParserDefinitions.INSTANCE.forLanguage(RsLanguage)
-            ?: error("No parser definition for language $RsLanguage")
-        val lexer = parserDefinition.createLexer(project)
-        return PsiBuilderFactory.getInstance().createBuilder(project, holder, lexer, RsLanguage, text)
     }
 
     private fun substituteMacro(root: PsiElement, subst: WithParent): CharSequence? =

--- a/src/main/kotlin/org/rust/lang/core/parser/util.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/util.kt
@@ -1,0 +1,28 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.parser
+
+import com.intellij.lang.LanguageParserDefinitions
+import com.intellij.lang.PsiBuilder
+import com.intellij.lang.PsiBuilderFactory
+import com.intellij.openapi.project.Project
+import org.rust.lang.RsLanguage
+
+fun Project.createRustPsiBuilder(text: String): PsiBuilder {
+    val parserDefinition = LanguageParserDefinitions.INSTANCE.forLanguage(RsLanguage)
+        ?: error("No parser definition for language $RsLanguage")
+    val lexer = parserDefinition.createLexer(this)
+    return PsiBuilderFactory.getInstance().createBuilder(parserDefinition, lexer, text)
+}
+
+inline fun <T> PsiBuilder.probe(action: () -> T): T {
+    val mark = mark()
+    try {
+        return action()
+    } finally {
+        mark.rollbackTo()
+    }
+}

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
@@ -31,10 +31,8 @@ class RsDoctestInjectionResolveTest : RsResolveTestBase() {
         pub fn foo() {}
     """)
 
-    // TODO handle existing main https://github.com/rust-lang/rust/blob/5182cc1ca/src/librustdoc/test.rs#L438
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
-    fun `test outer crate dependency`() = expect<IllegalStateException> {
-    stubOnlyResolve("""
+    fun `test outer crate dependency`() = stubOnlyResolve("""
     //- lib.rs
         /// ```
         /// extern crate dep_lib_target;
@@ -47,5 +45,35 @@ class RsDoctestInjectionResolveTest : RsResolveTestBase() {
     //- dep-lib/lib.rs
         pub fn bar() {}
     """)
-    }
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test macro`() = stubOnlyResolve("""
+    //- lib.rs
+        /// ```
+        /// #[macro_use]
+        /// extern crate test_package;
+        /// fn main() {
+        ///     foo!();
+        ///   //^ lib.rs
+        /// }
+        /// ```
+        #[macro_export]
+        macro_rules! foo {
+            () => {};
+        }
+    """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test extra extern crate`() = stubOnlyResolve("""
+    //- lib.rs
+        /// ```
+        /// extern crate test_package;
+        /// fn main() {
+        ///     use test_package::foo;
+        ///     foo();
+        ///   //^ lib.rs
+        /// }
+        /// ```
+        pub fn foo() {}
+    """)
 }


### PR DESCRIPTION
This is reasonable for 2015 edition doctests that contain `extern crate` declarations. Previously, such doctests worked due to accident combination of bugs (sic!) but this bug balance was (intentionally) broken in #3768