### PR TITLE
LI: fix doctest prelude in libcore

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -1284,7 +1284,7 @@ private inline fun processWithShadowing(
 private fun findPrelude(element: RsElement): RsFile? {
     val crateRoot = element.crateRoot as? RsFile ?: return null
     val cargoPackage = crateRoot.containingCargoPackage
-    val isStdlib = cargoPackage?.origin == PackageOrigin.STDLIB
+    val isStdlib = cargoPackage?.origin == PackageOrigin.STDLIB && !element.isDoctestInjection
     val packageName = cargoPackage?.normName
 
     // `std` and `core` crates explicitly add their prelude


### PR DESCRIPTION
Fixes resolve of prelude items (e.g. `Some`&`None`) in doctests located in the `core` (stdlib part).

bors r+