### PR TITLE
LI: disable doctest injection for not doctestable libs

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructure.kt
+++ b/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructure.kt
@@ -86,12 +86,12 @@ class CargoProjectStructure(private var cargoProjects: List<CargoProject> = empt
         }
 
         private val CargoWorkspace.Target.icon: Icon? get() = when (kind) {
-            LIB -> CargoIcons.LIB_TARGET
-            BIN -> CargoIcons.BIN_TARGET
-            TEST -> CargoIcons.TEST_TARGET
-            BENCH -> CargoIcons.BENCH_TARGET
-            EXAMPLE -> CargoIcons.EXAMPLE_TARGET
-            UNKNOWN -> null
+            is Lib -> CargoIcons.LIB_TARGET
+            Bin -> CargoIcons.BIN_TARGET
+            Test -> CargoIcons.TEST_TARGET
+            Bench -> CargoIcons.BENCH_TARGET
+            ExampleBin, is ExampleLib -> CargoIcons.EXAMPLE_TARGET
+            Unknown -> null
         }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructureTree.kt
+++ b/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectStructureTree.kt
@@ -64,8 +64,8 @@ class CargoProjectTreeRenderer : ColoredTreeCellRenderer() {
             is CargoProjectStructure.Node.Target -> {
                 append(node.name)
                 val targetKind = node.target.kind
-                if (targetKind != CargoWorkspace.TargetKind.UNKNOWN) {
-                    toolTipText = "${StringUtil.capitalize(targetKind.name.toLowerCase())} target `${node.name}`"
+                if (targetKind != CargoWorkspace.TargetKind.Unknown) {
+                    toolTipText = "${StringUtil.capitalize(targetKind.name)} target `${node.name}`"
                 }
             }
             else -> append(node.name)

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
@@ -34,7 +34,6 @@ data class CargoWorkspaceData(
         val crateRootUrl: String,
         val name: String,
         val kind: CargoWorkspace.TargetKind,
-        val crateTypes: List<CargoWorkspace.CrateType>,
         val edition: CargoWorkspace.Edition
     )
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsAsyncRunner.kt
@@ -28,7 +28,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
-import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.toolchain.Cargo
 import org.rust.cargo.toolchain.CargoCommandLine
@@ -202,13 +201,13 @@ abstract class RsAsyncRunner(private val executorId: String, private val errorMe
                                 }
                                 .filter { (target, profile) ->
                                     val isSuitableTarget = when (target.cleanKind) {
-                                        CargoWorkspace.TargetKind.BIN -> true
-                                        CargoWorkspace.TargetKind.EXAMPLE -> {
+                                        CargoMetadata.TargetKind.BIN -> true
+                                        CargoMetadata.TargetKind.EXAMPLE -> {
                                             // TODO: support cases when crate types list contains not only binary
-                                            target.cleanCrateTypes.singleOrNull() == CargoWorkspace.CrateType.BIN
+                                            target.cleanCrateTypes.singleOrNull() == CargoMetadata.CrateType.BIN
                                         }
-                                        CargoWorkspace.TargetKind.TEST -> true
-                                        CargoWorkspace.TargetKind.LIB -> profile.test
+                                        CargoMetadata.TargetKind.TEST -> true
+                                        CargoMetadata.TargetKind.LIB -> profile.test
                                         else -> false
                                     }
                                     isSuitableTarget && (!testsOnly || profile.test)

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoExecutableRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoExecutableRunConfigurationProducer.kt
@@ -68,7 +68,7 @@ class CargoExecutableRunConfigurationProducer : CargoRunConfigurationProducer() 
 
         private fun findBinaryTarget(ws: CargoWorkspace, file: VirtualFile): ExecutableTarget? {
             val target = ws.findTargetByCrateRoot(file) ?: return null
-            if (!target.isBin && !target.isExample) return null
+            if (!target.isBin && !target.isExampleBin) return null
             return ExecutableTarget(target)
         }
     }

--- a/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
@@ -61,12 +61,13 @@ data class CargoCommandLine(
 
             val targetArgs = targets.distinctBy { it.name }.flatMap { target ->
                 when (target.kind) {
-                    CargoWorkspace.TargetKind.BIN -> listOf("--bin", target.name)
-                    CargoWorkspace.TargetKind.TEST -> listOf("--test", target.name)
-                    CargoWorkspace.TargetKind.EXAMPLE -> listOf("--example", target.name)
-                    CargoWorkspace.TargetKind.BENCH -> listOf("--bench", target.name)
-                    CargoWorkspace.TargetKind.LIB -> listOf("--lib")
-                    CargoWorkspace.TargetKind.UNKNOWN -> emptyList()
+                    CargoWorkspace.TargetKind.Bin -> listOf("--bin", target.name)
+                    CargoWorkspace.TargetKind.Test -> listOf("--test", target.name)
+                    CargoWorkspace.TargetKind.ExampleBin, is CargoWorkspace.TargetKind.ExampleLib ->
+                        listOf("--example", target.name)
+                    CargoWorkspace.TargetKind.Bench -> listOf("--bench", target.name)
+                    is CargoWorkspace.TargetKind.Lib -> listOf("--lib")
+                    CargoWorkspace.TargetKind.Unknown -> emptyList()
                 }
             }
 
@@ -121,12 +122,12 @@ data class CargoCommandLine(
 
 fun CargoWorkspace.Target.launchCommand(): String? {
     return when (kind) {
-        CargoWorkspace.TargetKind.BIN -> "run"
-        CargoWorkspace.TargetKind.LIB -> "build"
-        CargoWorkspace.TargetKind.TEST -> "test"
-        CargoWorkspace.TargetKind.BENCH -> "bench"
-        CargoWorkspace.TargetKind.EXAMPLE ->
-            if (crateTypes.singleOrNull() == CargoWorkspace.CrateType.BIN) "run" else "build"
+        CargoWorkspace.TargetKind.Bin -> "run"
+        is CargoWorkspace.TargetKind.Lib -> "build"
+        CargoWorkspace.TargetKind.Test -> "test"
+        CargoWorkspace.TargetKind.Bench -> "bench"
+        CargoWorkspace.TargetKind.ExampleBin -> "run"
+        is CargoWorkspace.TargetKind.ExampleLib -> "build"
         else -> null
     }
 }

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -10,12 +10,15 @@ import com.google.gson.JsonObject
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.PathUtil
-import org.rust.cargo.project.workspace.CargoWorkspace.*
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
+import org.rust.cargo.project.workspace.CargoWorkspace.LibKind
 import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.cargo.project.workspace.PackageId
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.openapiext.findFileByMaybeRelativePath
 import org.rust.stdext.mapToSet
+import java.util.*
 
 /**
  * Classes mirroring JSON output of `cargo metadata`.
@@ -159,6 +162,20 @@ object CargoMetadata {
             }
     }
 
+    enum class TargetKind {
+        LIB, BIN, TEST, EXAMPLE, BENCH, UNKNOWN
+    }
+
+    /**
+     * Represents possible variants of generated artifact binary
+     * corresponded to `--crate-type` compiler attribute
+     *
+     * See [linkage](https://doc.rust-lang.org/reference/linkage.html)
+     */
+    enum class CrateType {
+        BIN, LIB, DYLIB, STATICLIB, CDYLIB, RLIB, PROC_MACRO, UNKNOWN
+    }
+
     /**
      * A rooted graph of dependencies, represented as adjacency list
      */
@@ -255,8 +272,43 @@ object CargoMetadata {
     private fun Target.clean(root: VirtualFile): CargoWorkspaceData.Target? {
         val mainFile = root.findFileByMaybeRelativePath(src_path)?.canonicalFile
         return mainFile?.let {
-            CargoWorkspaceData.Target(it.url, name, cleanKind, cleanCrateTypes, edition.cleanEdition())
+            CargoWorkspaceData.Target(
+                it.url,
+                name,
+                makeTargetKind(cleanKind, cleanCrateTypes),
+                edition.cleanEdition()
+            )
         }
+    }
+
+    private fun makeTargetKind(target: TargetKind, crateTypes: List<CrateType>): CargoWorkspace.TargetKind {
+        return when (target) {
+            TargetKind.LIB -> CargoWorkspace.TargetKind.Lib(crateTypes.toLibKinds())
+            TargetKind.BIN -> CargoWorkspace.TargetKind.Bin
+            TargetKind.TEST -> CargoWorkspace.TargetKind.Test
+            TargetKind.EXAMPLE -> if (crateTypes.contains(CrateType.BIN)) {
+                CargoWorkspace.TargetKind.ExampleBin
+            } else {
+                CargoWorkspace.TargetKind.ExampleLib(crateTypes.toLibKinds())
+            }
+            TargetKind.BENCH -> CargoWorkspace.TargetKind.Bench
+            TargetKind.UNKNOWN -> CargoWorkspace.TargetKind.Unknown
+        }
+    }
+
+    private fun List<CrateType>.toLibKinds(): EnumSet<LibKind> {
+        return EnumSet.copyOf(map {
+            when (it) {
+                CrateType.LIB -> LibKind.LIB
+                CargoMetadata.CrateType.DYLIB -> LibKind.DYLIB
+                CargoMetadata.CrateType.STATICLIB -> LibKind.STATICLIB
+                CargoMetadata.CrateType.CDYLIB -> LibKind.CDYLIB
+                CargoMetadata.CrateType.RLIB -> LibKind.RLIB
+                CargoMetadata.CrateType.PROC_MACRO -> LibKind.PROC_MACRO
+                CargoMetadata.CrateType.BIN -> LibKind.UNKNOWN
+                CargoMetadata.CrateType.UNKNOWN -> LibKind.UNKNOWN
+            }
+        })
     }
 
     private fun String?.cleanEdition(): Edition = when (this) {

--- a/src/main/kotlin/org/rust/cargo/util/CargoCommandCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/util/CargoCommandCompletionProvider.kt
@@ -153,11 +153,11 @@ private class OptBuilder(
             .map { it.lookupElement }
     }
 
-    fun targetBin() = opt("bin", targetCompleter(CargoWorkspace.TargetKind.BIN))
+    fun targetBin() = opt("bin", targetCompleter(CargoWorkspace.TargetKind.Bin))
 
-    fun targetExample() = opt("example", targetCompleter(CargoWorkspace.TargetKind.EXAMPLE))
-    fun targetTest() = opt("test", targetCompleter(CargoWorkspace.TargetKind.TEST))
-    fun targetBench() = opt("bench", targetCompleter(CargoWorkspace.TargetKind.BENCH))
+    fun targetExample() = opt("example", targetCompleter(CargoWorkspace.TargetKind.ExampleBin))
+    fun targetTest() = opt("test", targetCompleter(CargoWorkspace.TargetKind.Test))
+    fun targetBench() = opt("bench", targetCompleter(CargoWorkspace.TargetKind.Bench))
 
     fun targetAll() {
         flag("lib")

--- a/src/main/kotlin/org/rust/ide/annotator/RsDoctestAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsDoctestAnnotator.kt
@@ -13,6 +13,7 @@ import com.intellij.psi.impl.source.tree.injected.InjectionBackgroundSuppressor
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.ide.injected.RsDoctestLanguageInjector
 import org.rust.ide.injected.findDoctestInjectableRanges
+import org.rust.ide.injected.isDoctestable
 import org.rust.lang.core.psi.RsDocCommentImpl
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.ancestorStrict
@@ -30,7 +31,7 @@ class RsDoctestAnnotator : RsAnnotatorBase() {
         if (element !is RsDocCommentImpl) return
         if (!element.project.rustSettings.doctestInjectionEnabled) return
         // only library targets can have doctests
-        if (element.ancestorStrict<RsElement>()?.containingCargoTarget?.isLib != true) return
+        if (element.ancestorStrict<RsElement>()?.containingCargoTarget?.isDoctestable != true) return
 
         val startOffset = element.startOffset
         findDoctestInjectableRanges(element).flatten().forEach {

--- a/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
+++ b/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
@@ -15,6 +15,9 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.tree.IElementType
 import com.intellij.util.text.CharArrayUtil
 import org.rust.cargo.project.settings.rustSettings
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.CargoWorkspace.LibKind
+import org.rust.cargo.project.workspace.CargoWorkspace.TargetKind
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.lang.RsLanguage
@@ -60,7 +63,7 @@ class RsDoctestLanguageInjector : MultiHostInjector {
 
         val rsElement = context.ancestorStrict<RsElement>() ?: return
         val cargoTarget = rsElement.containingCargoTarget ?: return
-        if (!cargoTarget.isLib) return // only library targets can have doctests
+        if (!cargoTarget.isDoctestable) return // only library targets can have doctests
         val crateName = cargoTarget.normName
         val text = context.text
 
@@ -165,6 +168,16 @@ private fun findDoctestInjectableRanges(text: String, elementType: IElementType)
         ranges
     }
 }
+
+// See https://github.com/rust-lang/cargo/blob/5a0c31d81/src/cargo/core/manifest.rs#L775
+val CargoWorkspace.Target.isDoctestable: Boolean
+    get() {
+        val kind = kind
+        return kind is TargetKind.Lib &&
+            (LibKind.LIB in kind.kinds ||
+                LibKind.RLIB in kind.kinds ||
+                LibKind.PROC_MACRO in kind.kinds)
+    }
 
 private fun String.indicesOf(s: String): Sequence<Int> =
     generateSequence(indexOf(s)) { indexOf(s, it + s.length) }.takeWhile { it != -1 }

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -65,8 +65,8 @@ open class RustProjectDescriptorBase : LightProjectDescriptor() {
         name = name,
         version = "0.0.1",
         targets = listOf(
-            Target("$contentRoot/main.rs", name, TargetKind.BIN, listOf(CrateType.BIN), edition = Edition.EDITION_2015),
-            Target("$contentRoot/lib.rs", name, TargetKind.LIB, listOf(CrateType.LIB), edition = Edition.EDITION_2015)
+            Target("$contentRoot/main.rs", name, TargetKind.Bin, edition = Edition.EDITION_2015),
+            Target("$contentRoot/lib.rs", name, TargetKind.Lib(LibKind.LIB), edition = Edition.EDITION_2015)
         ),
         source = null,
         origin = PackageOrigin.WORKSPACE,
@@ -136,7 +136,7 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
         targetName: String = name,
         version: String = "0.0.1",
         origin: PackageOrigin = PackageOrigin.DEPENDENCY,
-        crateType: CrateType = CrateType.BIN
+        libKind: LibKind = LibKind.LIB
     ): Package {
         return Package(
             id = "$name $version",
@@ -147,7 +147,7 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
                 // don't use `FileUtil.join` here because it uses `File.separator`
                 // which is system dependent although all other code uses `/` as separator
                 Target(source?.let { "$contentRoot/$it" } ?: "", targetName,
-                    TargetKind.LIB, listOf(crateType), Edition.EDITION_2015)
+                    TargetKind.Lib(libKind), Edition.EDITION_2015)
             ),
             source = source,
             origin = origin,
@@ -171,7 +171,7 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
                 origin = PackageOrigin.TRANSITIVE_DEPENDENCY),
             externalPackage("$contentRoot/dep-lib-new", "lib.rs", "dep-lib", "dep-lib-target",
                 version = "0.0.2", origin = PackageOrigin.TRANSITIVE_DEPENDENCY),
-            externalPackage("$contentRoot/dep-proc-macro", "lib.rs", "dep-proc-macro", crateType = CrateType.PROC_MACRO)
+            externalPackage("$contentRoot/dep-proc-macro", "lib.rs", "dep-proc-macro", libKind = LibKind.PROC_MACRO)
         )
 
         return CargoWorkspace.deserialize(Paths.get("/my-crate/Cargo.toml"), CargoWorkspaceData(packages, mapOf(

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestBase.kt
@@ -138,7 +138,6 @@ abstract class RunConfigurationProducerTestBase : RsTestBase() {
             val name: String,
             val file: File,
             val kind: CargoWorkspace.TargetKind,
-            val crateTypes: List<CargoWorkspace.CrateType>,
             val edition: CargoWorkspace.Edition
         )
 
@@ -151,27 +150,27 @@ abstract class RunConfigurationProducerTestBase : RsTestBase() {
         private val hello = """pub fn hello() -> String { return "Hello, World!".to_string(); }"""
 
         fun bin(name: String, path: String, @Language("Rust") code: String = helloWorld): TestProjectBuilder {
-            addTarget(name, TargetKind.BIN, CrateType.BIN, Edition.EDITION_2015, path, code)
+            addTarget(name, TargetKind.Bin, Edition.EDITION_2015, path, code)
             return this
         }
 
         fun example(name: String, path: String, @Language("Rust") code: String = helloWorld): TestProjectBuilder {
-            addTarget(name, TargetKind.EXAMPLE, CrateType.BIN, Edition.EDITION_2015, path, code)
+            addTarget(name, TargetKind.ExampleBin, Edition.EDITION_2015, path, code)
             return this
         }
 
         fun test(name: String, path: String, @Language("Rust") code: String = simpleTest): TestProjectBuilder {
-            addTarget(name, TargetKind.TEST, CrateType.BIN, Edition.EDITION_2015, path, code)
+            addTarget(name, TargetKind.Test, Edition.EDITION_2015, path, code)
             return this
         }
 
         fun bench(name: String, path: String, @Language("Rust") code: String = simpleBench): TestProjectBuilder {
-            addTarget(name, TargetKind.BENCH, CrateType.BIN, Edition.EDITION_2015, path, code)
+            addTarget(name, TargetKind.Bench, Edition.EDITION_2015, path, code)
             return this
         }
 
         fun lib(name: String, path: String, @Language("Rust") code: String = hello): TestProjectBuilder {
-            addTarget(name, TargetKind.LIB, CrateType.LIB, Edition.EDITION_2015, path, code)
+            addTarget(name, TargetKind.Lib(LibKind.LIB), Edition.EDITION_2015, path, code)
             return this
         }
 
@@ -214,7 +213,6 @@ abstract class RunConfigurationProducerTestBase : RsTestBase() {
                                     myFixture.tempDirFixture.getFile(it.file.path)!!.url,
                                     it.name,
                                     it.kind,
-                                    it.crateTypes,
                                     it.edition
                                 )
                             },
@@ -233,13 +231,12 @@ abstract class RunConfigurationProducerTestBase : RsTestBase() {
         private fun addTarget(
             name: String,
             kind: CargoWorkspace.TargetKind,
-            crateType: CargoWorkspace.CrateType,
             edition: CargoWorkspace.Edition,
             path: String,
             code: String
         ) {
             val file = addFile(path, code)
-            targets.add(Target(name, file, kind, listOf(crateType), edition))
+            targets.add(Target(name, file, kind, edition))
         }
 
         private fun addFile(path: String, code: String): File {

--- a/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
@@ -99,13 +99,11 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
         fun target(
             name: String,
             kind: TargetKind,
-            crateType: CrateType,
             edition: Edition = Edition.EDITION_2015
         ): CargoWorkspaceData.Target = CargoWorkspaceData.Target(
             crateRootUrl = "/tmp/lib/rs",
             name = name,
             kind = kind,
-            crateTypes = listOf(crateType),
             edition = edition
         )
 
@@ -127,11 +125,11 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
 
         val pkgs = listOf(
             pkg("foo", true, listOf(
-                target("foo", TargetKind.LIB, CrateType.LIB),
-                target("bar", TargetKind.BIN, CrateType.BIN),
-                target("baz", TargetKind.BIN, CrateType.BIN)
+                target("foo", TargetKind.Lib(LibKind.LIB)),
+                target("bar", TargetKind.Bin),
+                target("baz", TargetKind.Bin)
             )),
-            pkg("quux", false, listOf(target("quux", TargetKind.LIB, CrateType.LIB)))
+            pkg("quux", false, listOf(target("quux", TargetKind.Lib(LibKind.LIB))))
         )
         CargoWorkspace.deserialize(Paths.get("/my-crate/Cargo.toml"), CargoWorkspaceData(pkgs, dependencies = emptyMap()))
     }


### PR DESCRIPTION
1. CLEAN: change TargetKind to follow [cargo internal structure](https://github.com/rust-lang/cargo/blob/5a0c31d81/src/cargo/core/manifest.rs#L157)
2. LI: disable doctest injection for not doctestable libs (fixes false-positives inside rust-lang/rust)