### PR TITLE
CARGO: fetch real stdlib metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jdk: oraclejdk8
 
 env:
   global:
-    - OLD_RUST_VERSION=1.28.0
+    - OLD_RUST_VERSION=1.30.0
     - CURRENT_RUST_VERSION=1.34.0
     - NIGHLY_RUST_VERSION=nightly-2019-04-23
     - RUST_SRC_WITH_SYMLINK=$HOME/.rust-src
@@ -36,7 +36,7 @@ before_script:
   - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $RUST_VERSION -y
   - export PATH=$HOME/.cargo/bin:$PATH
   - rustup component add rust-src
-  - if [ $RUST_VERSION != $OLD_RUST_VERSION ]; then rustup component add clippy-preview; fi # BACKCOMPAT: Rust 1.28.0
+  - rustup component add clippy-preview
   - rustup component add rustfmt-preview
   - ln -s $(rustc --print sysroot)/lib/rustlib/src/rust/src $RUST_SRC_WITH_SYMLINK
   - ./check-license.sh

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -326,7 +326,7 @@ data class CargoProjectImpl(
     private fun refreshStdlib(): CompletableFuture<CargoProjectImpl> {
         if (doesProjectLooksLikeRustc()) {
             // rust-lang/rust contains stdlib inside the project
-            val std = StandardLibrary.fromPath(manifest.parent.toString())
+            val std = StandardLibrary.fromPath(project, manifest.parent.toString())
             if (std != null) {
                 return CompletableFuture.completedFuture(withStdlib(TaskResult.Ok(std)))
             }
@@ -335,7 +335,7 @@ data class CargoProjectImpl(
         val rustup = toolchain?.rustup(projectDirectory)
         if (rustup == null) {
             val explicitPath = project.rustSettings.explicitPathToStdlib
-            val lib = explicitPath?.let { StandardLibrary.fromPath(it) }
+            val lib = explicitPath?.let { StandardLibrary.fromPath(project, it) }
             val result = when {
                 explicitPath == null -> TaskResult.Err<StandardLibrary>("no explicit stdlib or rustup found")
                 lib == null -> TaskResult.Err("invalid standard library: $explicitPath")
@@ -470,7 +470,7 @@ private fun fetchStdlib(
         val download = rustup.downloadStdlib()
         when (download) {
             is DownloadResult.Ok -> {
-                val lib = StandardLibrary.fromFile(download.value)
+                val lib = StandardLibrary.fromFile(project, download.value)
                 if (lib == null) {
                     err("" +
                         "corrupted standard library: ${download.value.presentableUrl}"

--- a/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
@@ -5,31 +5,38 @@
 
 package org.rust.cargo.project.workspace
 
+import com.intellij.execution.ExecutionException
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.cargo.util.StdLibType
+import org.rust.openapiext.pathAsPath
 
 class StandardLibrary private constructor(
     val crates: List<StdCrate>
 ) {
 
     data class StdCrate(
-        val name: String,
+        val pkg: CargoWorkspaceData.Package,
         val type: StdLibType,
-        val crateRootUrl: String,
-        val packageRootUrl: String,
-        val dependencies: Collection<String>
+        val dependencies: Set<CargoWorkspaceData.Dependency>
     ) {
-        val id: PackageId get() = "(stdlib) $name"
+        val id: PackageId get() = pkg.id
     }
 
     companion object {
-        fun fromPath(path: String): StandardLibrary? =
-            LocalFileSystem.getInstance().findFileByPath(path)?.let { fromFile(it) }
 
-        fun fromFile(sources: VirtualFile): StandardLibrary? {
+        private val LOG: Logger = Logger.getInstance(StandardLibrary::class.java)
+
+        fun fromPath(project: Project, path: String): StandardLibrary? =
+            LocalFileSystem.getInstance().findFileByPath(path)?.let { fromFile(project, it) }
+
+        fun fromFile(project: Project, sources: VirtualFile): StandardLibrary? {
             if (!sources.isDirectory) return null
+            val cargo = project.toolchain?.rawCargo() ?: return null
             val srcDir = if (sources.name == "src") {
                 sources
             } else {
@@ -37,12 +44,20 @@ class StandardLibrary private constructor(
             }
 
             val stdlib = AutoInjectedCrates.stdlibCrates.mapNotNull { libInfo ->
-                val packageSrcDir = srcDir.findFileByRelativePath(libInfo.srcDir)?.canonicalFile
-                val libFile = packageSrcDir?.findChild("lib.rs")
-                if (packageSrcDir != null && libFile != null)
-                    StdCrate(libInfo.name, libInfo.type, libFile.url, packageSrcDir.url, libInfo.dependencies)
-                else
-                    null
+                val rootDir = srcDir.findFileByRelativePath(libInfo.srcDir)?.canonicalFile ?: return@mapNotNull null
+                val workspace = try {
+                    cargo.projectWorkspaceData(project, rootDir.pathAsPath)
+                } catch (e: ExecutionException) {
+                    LOG.warn("Failed to get workspace data of ${libInfo.name}", e)
+                    return@mapNotNull null
+                }
+
+                val pkg = workspace.packages.firstOrNull { it.origin == PackageOrigin.WORKSPACE } ?: return@mapNotNull null
+                StdCrate(
+                    pkg = pkg.copy(origin = PackageOrigin.STDLIB),
+                    type = libInfo.type,
+                    dependencies = workspace.dependencies[pkg.id].orEmpty()
+                )
             }
             if (stdlib.isEmpty()) return null
             return StandardLibrary(stdlib)

--- a/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
@@ -27,11 +27,10 @@ enum class StdLibType {
     DEPENDENCY
 }
 
-data class StdLibInfo (
+data class StdLibInfo(
     val name: String,
     val type: StdLibType,
-    val srcDir: String = "lib" + name,
-    val dependencies: List<String> = emptyList()
+    val srcDir: String = "lib$name"
 )
 
 object AutoInjectedCrates {
@@ -39,35 +38,24 @@ object AutoInjectedCrates {
     const val CORE: String = "core"
     val stdlibCrates = listOf(
         // Roots
-        StdLibInfo(STD, StdLibType.ROOT, dependencies = listOf("alloc_jemalloc", "alloc_system", "panic_abort", "rand",
-            "compiler_builtins", "unwind", "rustc_asan", "rustc_lsan", "rustc_msan", "rustc_tsan",
-            "build_helper")),
+        StdLibInfo(STD, StdLibType.ROOT),
         StdLibInfo(CORE, StdLibType.ROOT),
         StdLibInfo("alloc", StdLibType.ROOT),
-        StdLibInfo("collections", StdLibType.ROOT),
-        StdLibInfo("libc", StdLibType.ROOT, srcDir = "liblibc/src"),
-        StdLibInfo("panic_unwind", type = StdLibType.ROOT),
-        StdLibInfo("proc_macro", type = StdLibType.ROOT),
-        StdLibInfo("rustc_unicode", type = StdLibType.ROOT),
-        StdLibInfo("std_unicode", type = StdLibType.ROOT),
-        StdLibInfo("test", dependencies = listOf("getopts", "term"), type = StdLibType.ROOT),
+        StdLibInfo("proc_macro", StdLibType.ROOT),
+        StdLibInfo("test", StdLibType.ROOT),
         // Feature gated
-        StdLibInfo("alloc_jemalloc", StdLibType.FEATURE_GATED),
-        StdLibInfo("alloc_system", StdLibType.FEATURE_GATED),
-        StdLibInfo("compiler_builtins", StdLibType.FEATURE_GATED),
-        StdLibInfo("getopts", StdLibType.FEATURE_GATED),
         StdLibInfo("panic_unwind", StdLibType.FEATURE_GATED),
         StdLibInfo("panic_abort", StdLibType.FEATURE_GATED),
-        StdLibInfo("rand", StdLibType.FEATURE_GATED),
-        StdLibInfo("term", StdLibType.FEATURE_GATED),
         StdLibInfo("unwind", StdLibType.FEATURE_GATED),
+        StdLibInfo("syntax", StdLibType.FEATURE_GATED),
+        StdLibInfo("rustc", StdLibType.FEATURE_GATED),
+        StdLibInfo("rustc_plugin", StdLibType.FEATURE_GATED),
         // Dependencies
         StdLibInfo("build_helper", StdLibType.DEPENDENCY, srcDir = "build_helper"),
         StdLibInfo("rustc_asan", StdLibType.DEPENDENCY),
         StdLibInfo("rustc_lsan", StdLibType.DEPENDENCY),
         StdLibInfo("rustc_msan", StdLibType.DEPENDENCY),
-        StdLibInfo("rustc_tsan", StdLibType.DEPENDENCY),
-        StdLibInfo("syntax", StdLibType.DEPENDENCY)
+        StdLibInfo("rustc_tsan", StdLibType.DEPENDENCY)
     )
 }
 

--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -139,7 +139,7 @@ class MissingToolchainNotificationProvider(
             createActionLabel("Attach manually") {
                 val descriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
                 val stdlib = FileChooser.chooseFile(descriptor, this, project, null) ?: return@createActionLabel
-                if (StandardLibrary.fromFile(stdlib) != null) {
+                if (StandardLibrary.fromFile(project, stdlib) != null) {
                     project.rustSettings.modify { it.explicitPathToStdlib = stdlib.path }
                 } else {
                     project.showBalloon(

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -16,6 +16,7 @@ import org.rust.stdext.BothEditions
 @BothEditions
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsStdlibResolveTest : RsResolveTestBase() {
+
     fun `test resolve fs`() = stubOnlyResolve("""
     //- main.rs
         use std::fs::File;
@@ -24,23 +25,19 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         fn main() {}
     """)
 
-    // BACKCOMPAT: Rust 1.25.0
     fun `test resolve collections`() = stubOnlyResolve("""
     //- main.rs
         use std::collections::Bound;
-                             //^ ...lib.rs|...libcore/ops/range.rs
+                             //^ ...libcore/ops/range.rs
 
         fn main() {}
     """)
 
-    // TODO handle 2018 edition in std itself
-    fun `test BTreeMap`() = expect<IllegalStateException> {
-    stubOnlyResolve("""
+    fun `test BTreeMap`() = stubOnlyResolve("""
     //- main.rs
         use std::collections::BTreeMap;
-                                //^ lib.rs
+                                //^ ...liballoc/collections/btree/map.rs
     """)
-    }
 
     fun `test resolve core`() = stubOnlyResolve("""
     //- main.rs
@@ -127,36 +124,31 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                                 //^ unresolved
     """)
 
-    // BACKCOMPAT: Rust 1.26.0
     fun `test string slice resolve`() = stubOnlyResolve("""
-
     //- main.rs
         fn main() { "test".lines(); }
-                            //^ ...str.rs|...str/mod.rs
+                            //^ ...str/mod.rs
     """)
 
-    // BACKCOMPAT: Rust 1.26.0
     fun `test slice resolve`() = stubOnlyResolve("""
     //- main.rs
         fn main() {
             let x : [i32];
             x.iter()
-             //^ ...slice.rs|...slice/mod.rs
+             //^ ...slice/mod.rs
         }
     """)
 
-    // BACKCOMPAT: Rust 1.25.0
     fun `test inherent impl char 1`() = stubOnlyResolve("""
     //- main.rs
         fn main() { 'Z'.is_lowercase(); }
-                      //^ .../char.rs|...libcore/char/methods.rs
+                      //^ ...libcore/char/methods.rs
     """)
 
-    // BACKCOMPAT: Rust 1.25.0
     fun `test inherent impl char 2`() = stubOnlyResolve("""
     //- main.rs
         fn main() { char::is_lowercase('Z'); }
-                        //^ .../char.rs|...libcore/char/methods.rs
+                        //^ ...libcore/char/methods.rs
     """)
 
     fun `test inherent impl str 1`() = stubOnlyResolve("""
@@ -302,12 +294,11 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }
     """)
 
-    // BACKCOMPAT: Rust 1.26.0
     fun `test vec slice`() = stubOnlyResolve("""
     //- main.rs
         fn foo(xs: Vec<i32>) {
             xs[0..3].len();
-                     //^ ...slice.rs|...slice/mod.rs
+                     //^ ...slice/mod.rs
         }
     """)
 
@@ -336,13 +327,12 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }
     """)
 
-    // BACKCOMPAT: Rust 1.24.1
     fun `test Instant minus Duration`() = stubOnlyResolve("""
     //- main.rs
         use std::time::{Duration, Instant};
         fn main() {
             (Instant::now() - Duration::from_secs(3)).elapsed();
-                                                      //^ ...time.rs|...time/mod.rs
+                                                      //^ ...time.rs
         }
     """)
 
@@ -355,13 +345,12 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }
     """)
 
-    // BACKCOMPAT: Rust 1.24.1
     fun `test resolve arithmetic operator`() = stubOnlyResolve("""
     //- main.rs
         use std::time::{Duration, Instant};
         fn main() {
             let x = Instant::now() - Duration::from_secs(3);
-                                 //^ ...time.rs|...time/mod.rs
+                                 //^ ...time.rs
         }
     """)
 
@@ -493,8 +482,6 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }
     """, TypeInferenceMarks.questionOperator)
 
-
-
     fun `test try! macro with aliased Result`() = checkByCode("""
         mod io {
             pub struct IoError;
@@ -577,9 +564,9 @@ class RsStdlibResolveTest : RsResolveTestBase() {
     fun `test non-absolute std-qualified path in non-root module`() = stubOnlyResolve("""
     //- main.rs
         mod foo {
-            fn main() {
-                std::mem::size_of::<i32>();
-            }           //^ .../libcore/mem.rs
+            fn bar() {
+                std::mem::needs_drop::<i32>();
+            }                   //^ .../libcore/mem.rs
         }
     """)
 
@@ -587,12 +574,12 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         mod foo {
             mod std {
                 pub mod mem {
-                    pub fn size_of<T>() {}
-                }         //X
+                    pub fn needs_drop<T>() {}
+                }            //X
             }
             fn main() {
-                std::mem::size_of::<i32>();
-            }           //^
+                std::mem::needs_drop::<i32>();
+            }                //^
         }
     """)
 


### PR DESCRIPTION
It allows us to get actual info (like edition) about stdlib crates.
It's important because name resolution rules depend on edition

Fixes #3835