### PR TITLE
TYPE: improve heuristic for quote handler

### DIFF
--- a/src/main/kotlin/org/rust/ide/typing/RsQuoteHandler.kt
+++ b/src/main/kotlin/org/rust/ide/typing/RsQuoteHandler.kt
@@ -57,8 +57,8 @@ class RsQuoteHandler : SimpleTokenSetQuoteHandler(
         if (super.isNonClosedLiteral(iterator, chars)) return true
         // Rust allows multiline literals, so an unclosed quote will
         // match with an opening quote of the next literal.
-        // Let's employ heuristics to find out if it is the case!
-        // Specifically, check if the next token can't appear
+        // Let's employ heuristics to find out if it is not the case!
+        // Specifically, check if the next token can appear
         // in valid Rust code.
         val nextChar = chars.getOrElse(iterator.end) { '"' }
         if (nextChar == '"') return true
@@ -68,9 +68,9 @@ class RsQuoteHandler : SimpleTokenSetQuoteHandler(
             iterator.advance()
         }
         when (iterator.tokenType) {
-            IDENTIFIER, INTEGER_LITERAL, FLOAT_LITERAL -> return true
+            COMMA, DOT, RBRACE, RBRACK, RPAREN, SEMICOLON -> return false
         }
-        return false
+        return true
     }
 
     /**

--- a/src/test/kotlin/org/rust/ide/typing/RsQuoteHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/RsQuoteHandlerTest.kt
@@ -110,4 +110,5 @@ class RsQuoteHandlerTest : RsTypingTestBase() {
     fun `test test next string is empty`() = checkUnclosedHeuristic("")
     fun `test test next string starts with space and word`() = checkUnclosedHeuristic("\nhello world\n")
     fun `test test next string starts with number`() = checkUnclosedHeuristic("92")
+    fun `test test next string starts with brace`() = checkUnclosedHeuristic("{")
 }


### PR DESCRIPTION
Current heuristic works very bad when code contains a lot of format strings, which often results to reanalysis of whole file and disabled code insight for dozens of seconds on big files. I could just have added `{` to the list of invalid tokens, but I think it is much easier to create full list of tokens that are valid after string. 

But it is still not very reliable solution, and since consequences of the unmatched quote can be quite annoying maybe it would be better to have more reliable implementation?
I can suggest couple of options:
- check couple of the next string literals for valid subsequent token, which should drastically decrease possibility of false positive result while still being quite fast.
- calculate number of quotes until the end of file. Although, I am not sure if it will be fast enough for smooth typing experience.



<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
