### PR TITLE
Provide a User Agent to crates.io

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -82,6 +82,7 @@ pocket7878
 rrevenantt
 sanmai-NL
 sgift
+sgrif
 Shiroy
 shssoichiro
 sirgl

--- a/toml/src/main/kotlin/org/rust/toml/CratesIoApi.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CratesIoApi.kt
@@ -61,6 +61,7 @@ private fun <T> requestCratesIo(context: PsiElement, path: String, cls: Class<T>
     return try {
         runWithCheckCanceled {
             val response = HttpRequests.request("https://crates.io/api/v1/$path")
+                .userAgent("IntelliJ Rust Plugin (https://github.com/intellij-rust/intellij-rust)")
                 .readString(ProgressManager.getInstance().progressIndicator)
             Gson().fromJson(response, cls)
         }


### PR DESCRIPTION
As per [crates.io's crawler policy](https://crates.io/policies#crawlers), all bots must provide a user agent identifying themselves. While sending "Java/1.8.0_202-release" is technically following the policy, it makes it difficult for us to identify the impact this plugin's traffic has on our service, or contact you if we have potential improvements that could be made or changes we need you to make.

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
