### PR TITLE
CARGO: set 2018 edition for std crates with latest rust versions

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -291,7 +291,7 @@ data class CargoProjectImpl(
     override val workspace: CargoWorkspace? by lazy(LazyThreadSafetyMode.PUBLICATION) {
         val rawWorkspace = rawWorkspace ?: return@lazy null
         val stdlib = stdlib ?: return@lazy rawWorkspace
-        rawWorkspace.withStdlib(stdlib)
+        rawWorkspace.withStdlib(stdlib, rustcInfo)
     }
 
     override val presentableName: String

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -97,7 +97,7 @@ open class WithRustup(private val delegate: RustProjectDescriptorBase) : RustPro
 
     override fun testCargoProject(module: Module, contentRoot: String): CargoWorkspace {
         val stdlib = StandardLibrary.fromFile(stdlib!!)!!
-        return delegate.testCargoProject(module, contentRoot).withStdlib(stdlib)
+        return delegate.testCargoProject(module, contentRoot).withStdlib(stdlib, rustcInfo)
     }
 
     override fun setUp(fixture: CodeInsightTestFixture) {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -33,14 +33,12 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         fn main() {}
     """)
 
-    // TODO handle 2018 edition in std itself
-    fun `test BTreeMap`() = expect<IllegalStateException> {
-    stubOnlyResolve("""
+    // BACKCOMPAT: Rust 1.28.0
+    fun `test BTreeMap`() = stubOnlyResolve("""
     //- main.rs
         use std::collections::BTreeMap;
-                                //^ lib.rs
+                                //^ ...liballoc/btree/map.rs|...liballoc/collections/btree/map.rs
     """)
-    }
 
     fun `test resolve core`() = stubOnlyResolve("""
     //- main.rs


### PR DESCRIPTION
Fixes #3835
Fixes #3491