### PR TITLE
CLEAN: refactor `resolveTo(Bound)Trait` into function

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -153,7 +153,7 @@ class RsErrorAnnotator : RsAnnotatorBase(), HighlightRangeExtension {
             // core::ops::drop::Drop::drop(x)
             is RsAbstractableOwner.Trait -> owner.trait
             // Foo::drop(x), x.drop()
-            is RsAbstractableOwner.Impl -> owner.impl.traitRef?.resolveToTrait
+            is RsAbstractableOwner.Impl -> owner.impl.traitRef?.resolveToTrait()
             else -> null
         } ?: return
 
@@ -328,7 +328,7 @@ class RsErrorAnnotator : RsAnnotatorBase(), HighlightRangeExtension {
 
     private fun checkImpl(holder: AnnotationHolder, impl: RsImplItem) {
         val traitRef = impl.traitRef ?: return
-        val trait = traitRef.resolveToTrait ?: return
+        val trait = traitRef.resolveToTrait() ?: return
         checkImplDropForNonAdtError(holder, impl, traitRef, trait)
         checkImplBothCopyAndDrop(holder, impl, trait)
         val traitName = trait.name ?: return

--- a/src/main/kotlin/org/rust/ide/hints/RsGenericParameterInfoHandler.kt
+++ b/src/main/kotlin/org/rust/ide/hints/RsGenericParameterInfoHandler.kt
@@ -101,7 +101,7 @@ private fun firstLine(params: List<RsTypeParameter>): HintLine {
         val qSizedBound = if (!param.isSized) listOf("?Sized") else emptyList()
         val declaredBounds = param.bounds
             // `?Sized`, if needed, in separate val, `Sized` shouldn't be shown
-            .filter { it.bound.traitRef?.resolveToBoundTrait?.element?.isSizedTrait == false }
+            .filter { it.bound.traitRef?.resolveToBoundTrait()?.element?.isSizedTrait == false }
             .mapNotNull { it.bound.traitRef?.path?.text }
         val allBounds = qSizedBound + declaredBounds
         param.name + (allBounds.nullize()?.joinToString(prefix = ": ", separator = " + ") ?: "")

--- a/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
@@ -11,14 +11,15 @@ import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.tree.IElementType
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsImplItem
+import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.Testmark
 
 class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
         override fun visitImplItem(impl: RsImplItem) {
-            val trait = impl.traitRef?.resolveToTrait ?: return
+            val trait = impl.traitRef?.resolveToTrait() ?: return
             val typeRef = impl.typeReference ?: return
             if (sortedImplItems(impl.items(), trait.items()) == null) return
             val textRange = TextRange(
@@ -51,7 +52,7 @@ class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
 
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
             val impl = descriptor.psiElement as? RsImplItem ?: return
-            val trait = impl.traitRef?.resolveToTrait ?: return
+            val trait = impl.traitRef?.resolveToTrait() ?: return
             val implItems = impl.items()
             val traitItems = trait.items()
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsTraitImplementationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsTraitImplementationInspection.kt
@@ -22,7 +22,7 @@ class RsTraitImplementationInspection : RsLocalInspectionTool() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = object : RsVisitor() {
         override fun visitImplItem(impl: RsImplItem) {
             val traitRef = impl.traitRef ?: return
-            val trait = traitRef.resolveToTrait ?: return
+            val trait = traitRef.resolveToTrait() ?: return
             val traitName = trait.name ?: return
 
             val implInfo = TraitImplementationInfo.create(trait, impl) ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -197,7 +197,7 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
                     is TraitImplSource.ExplicitImpl -> {
                         val impl = source.value
                         if (impl.traitRef == null) return null
-                        impl.traitRef?.resolveToTrait ?: return@mapNotNull null
+                        impl.traitRef?.resolveToTrait() ?: return@mapNotNull null
                     }
                     is TraitImplSource.Derived -> source.value
                     is TraitImplSource.Collapsed -> source.value

--- a/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
@@ -38,7 +38,7 @@ fun generateTraitMembers(impl: RsImplItem, editor: Editor?) {
 private fun findMembersToImplement(impl: RsImplItem): Pair<TraitImplementationInfo, BoundElement<RsTraitItem>>? {
     checkReadAccessAllowed()
 
-    val trait = impl.traitRef?.resolveToBoundTrait ?: return null
+    val trait = impl.traitRef?.resolveToBoundTrait() ?: return null
     val implInfo = TraitImplementationInfo.create(trait.element, impl) ?: return null
     if (implInfo.declared.isEmpty()) return null
     return implInfo to trait

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
@@ -73,7 +73,7 @@ object RsPsiImplUtil {
             is RsImplItem -> {
                 // Members of `impl Trait for ...` inherit visibility from the implemented trait
                 val traitRef = owner.traitRef
-                if (traitRef != null) return getDeclarationUseScope(traitRef.resolveToTrait ?: return null)
+                if (traitRef != null) return getDeclarationUseScope(traitRef.resolveToTrait() ?: return null)
 
                 // Inherent impl members
                 getTopLevelDeclarationUseScope(element, owner.containingMod, restrictedVis)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
@@ -42,7 +42,7 @@ val RsAbstractable.owner: RsAbstractableOwner
 val RsAbstractable.superItem: RsAbstractable?
     get() {
         val rustImplItem = ancestorStrict<RsImplItem>() ?: return null
-        val superTrait = rustImplItem.traitRef?.resolveToTrait ?: return null
+        val superTrait = rustImplItem.traitRef?.resolveToTrait() ?: return null
         return superTrait.findCorrespondingElement(this)
     }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -36,7 +36,7 @@ abstract class RsImplItemImplMixin : RsStubbedElementImpl<RsImplItemStub>, RsImp
     override fun getPresentation(): ItemPresentation = getPresentation(this)
 
     override val implementedTrait: BoundElement<RsTraitItem>? get() {
-        val (trait, subst) = traitRef?.resolveToBoundTrait ?: return null
+        val (trait, subst) = traitRef?.resolveToBoundTrait() ?: return null
         return BoundElement(trait, subst)
     }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -87,7 +87,7 @@ private val RsTraitItem.superTraits: Sequence<BoundElement<RsTraitItem>> get() {
     val bounds = typeParamBounds?.polyboundList.orEmpty().asSequence() + whereBounds
     return bounds
         .filter { !it.hasQ } // ignore `?Sized`
-        .mapNotNull { it.bound.traitRef?.resolveToBoundTrait }
+        .mapNotNull { it.bound.traitRef?.resolveToBoundTrait() }
 }
 
 val RsTraitItem.isSized: Boolean get() {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitRef.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitRef.kt
@@ -9,9 +9,9 @@ import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTraitRef
 import org.rust.lang.core.types.BoundElement
 
-val RsTraitRef.resolveToTrait: RsTraitItem?
-    get() = path.reference.resolve() as? RsTraitItem
+fun RsTraitRef.resolveToTrait(): RsTraitItem? =
+    path.reference.resolve() as? RsTraitItem
 
-val RsTraitRef.resolveToBoundTrait: BoundElement<RsTraitItem>?
-    get() = path.reference.advancedResolve()?.downcast<RsTraitItem>()
+fun RsTraitRef.resolveToBoundTrait(): BoundElement<RsTraitItem>? =
+    path.reference.advancedResolve()?.downcast()
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
@@ -45,7 +45,7 @@ fun RsVisible.isVisibleFrom(mod: RsMod): Boolean {
     val parent = members.context ?: return true
     return when {
         // Associated items in a pub Trait are public by default
-        parent is RsImplItem && parent.traitRef != null -> parent.traitRef?.resolveToTrait?.isPublic ?: true
+        parent is RsImplItem && parent.traitRef != null -> parent.traitRef?.resolveToTrait()?.isPublic ?: true
         parent is RsTraitItem && parent.isPublic -> true
         else -> false
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -427,7 +427,7 @@ private fun processExplicitTypeQualifiedPathResolveVariants(
     typeQual: RsTypeQual,
     processor: RsResolveProcessor
 ): Boolean {
-    val trait = typeQual.traitRef?.resolveToBoundTrait
+    val trait = typeQual.traitRef?.resolveToBoundTrait()
         // TODO this is a hack to fix completion test `test associated type in explicit UFCS form`.
         // Looks like we should use getOriginalOrSelf during resolve
         ?.let { BoundElement(CompletionUtil.getOriginalOrSelf(it.element), it.subst) }
@@ -1128,7 +1128,7 @@ private fun processLexicalDeclarations(
             if (scope is RsImplItem) {
                 scope.traitRef?.let { traitRef ->
                     // really should be unnamed, but "_" is not a valid name in rust, so I think it's ok
-                    if (processor.lazy("_") { traitRef.resolveToTrait }) return true
+                    if (processor.lazy("_") { traitRef.resolveToTrait() }) return true
                 }
             }
         }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -86,7 +86,7 @@ fun inferTypeReferenceType(ref: RsTypeReference, defaultTraitObjectRegion: Regio
         }
 
         is RsTraitType -> {
-            val traitBounds = type.polyboundList.mapNotNull { it.bound.traitRef?.resolveToBoundTrait }
+            val traitBounds = type.polyboundList.mapNotNull { it.bound.traitRef?.resolveToBoundTrait() }
             val lifetimeBounds = type.polyboundList.mapNotNull { it.bound.lifetime }
             if (type.isImpl) {
                 TyAnon(type, traitBounds)

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -961,7 +961,7 @@ class RsFnInferenceContext(
 
         val traits = elements.mapNotNull {
             when (val owner = it.owner) {
-                is RsAbstractableOwner.Impl -> owner.impl.traitRef?.resolveToTrait
+                is RsAbstractableOwner.Impl -> owner.impl.traitRef?.resolveToTrait()
                 is RsAbstractableOwner.Trait -> owner.trait
                 else -> null
             }
@@ -1199,7 +1199,7 @@ class RsFnInferenceContext(
                 val typeParameters = instantiateBounds(impl)
                 impl.typeReference?.type?.substitute(typeParameters)?.let { ctx.combineTypes(callee.selfTy, it) }
                 if (callee.element.owner is RsAbstractableOwner.Trait) {
-                    impl.traitRef?.resolveToBoundTrait?.substitute(typeParameters)?.subst ?: emptySubstitution
+                    impl.traitRef?.resolveToBoundTrait()?.substitute(typeParameters)?.subst ?: emptySubstitution
                 } else {
                     typeParameters
                 }
@@ -1271,7 +1271,7 @@ class RsFnInferenceContext(
             val traitToCallee = hashMapOf<RsTraitItem, MutableList<MethodResolveVariant>>()
             val filtered = mutableListOf<MethodResolveVariant>()
             for (callee in list) {
-                val trait = callee.source.impl?.traitRef?.resolveToTrait
+                val trait = callee.source.impl?.traitRef?.resolveToTrait()
                 if (trait != null) {
                     traitToCallee.getOrPut(trait) { mutableListOf() }.add(callee)
                 } else {
@@ -1989,7 +1989,7 @@ private fun RsGenericDeclaration.doGetBounds(): List<TraitRef> {
 
 private fun List<RsPolybound>?.toTraitRefs(selfTy: Ty): Sequence<TraitRef> = orEmpty().asSequence()
     .filter { !it.hasQ } // ignore `?Sized`
-    .mapNotNull { it.bound.traitRef?.resolveToBoundTrait }
+    .mapNotNull { it.bound.traitRef?.resolveToBoundTrait() }
     .map { TraitRef(selfTy, it) }
 
 private fun Sequence<Ty>.infiniteWithTyUnknown(): Sequence<Ty> =

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
@@ -84,7 +84,7 @@ class TyTypeParameter private constructor(
 
 private fun traitBounds(parameter: RsTypeParameter): List<BoundElement<RsTraitItem>> =
     parameter.bounds.mapNotNull {
-        val trait = it.bound.traitRef?.resolveToBoundTrait ?: return@mapNotNull null
+        val trait = it.bound.traitRef?.resolveToBoundTrait() ?: return@mapNotNull null
         // if `T: ?Sized` then T doesn't have `Sized` bound
         if (!trait.element.isSizedTrait || parameter.isSized) trait else null
     }

--- a/src/test/kotlin/org/rust/lang/core/ext/RsPsiStructureTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/ext/RsPsiStructureTest.kt
@@ -65,7 +65,7 @@ class RsPsiStructureTest : RsTestBase() {
             fn spam() {}
         }
     """) { impl ->
-        val trait = impl.traitRef!!.resolveToTrait!!
+        val trait = impl.traitRef!!.resolveToTrait()!!
         val implInfo = TraitImplementationInfo.create(trait, impl)!!
         check(implInfo.declared.map { it.name } == listOf(
             "optional_fn", "required_fn", "another_required_fn", "RequiredType", "same_name", "same_name"


### PR DESCRIPTION
"resolve" is a verb and so I think function style is better