### PR TITLE
Add external package with the same workspace

### DIFF
--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -166,6 +166,8 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
         val packages = listOf(
             testCargoPackage(contentRoot),
             externalPackage("$contentRoot/dep-lib", "lib.rs", "dep-lib", "dep-lib-target"),
+            externalPackage("$contentRoot/dep-lib-same-workspace", "lib.rs",
+                "dep-lib-same-workspace", "dep-lib-same-workspace-target", origin = PackageOrigin.WORKSPACE),
             externalPackage("", null, "nosrc-lib", "nosrc-lib-target"),
             externalPackage("$contentRoot/trans-lib", "lib.rs", "trans-lib",
                 origin = PackageOrigin.TRANSITIVE_DEPENDENCY),


### PR DESCRIPTION
There is already `dep-lib` for separation code into different crates,but it has PackageOrigin.DEPENDENCY, thus it is treated like external dependency which we cannot modify. However, sometimes it is useful to create tests that rely on different crates, but the same workspace. For example, there can be some fixes that cannot modify external dependencies, but have to modify any code that is located within one workspace, even in different crates.

As a real world example, I suggest you to consider [my another commit](https://github.com/intellij-rust/intellij-rust/pull/3833/commits/a948c816792899f5cba23290ba83c314aad23da8) that has to be tested using this feature: There can be multiple crates within one workspace, so `Make public` fix has to be able to modify each of them, since they are not external dependencies. Unfortunately, I cannot test this behavior because there is no possibility to create test environment with multiple crates within one workspace.
<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
