### PR TITLE
TY&RES: disambiguate trait associated items by scope & trait bounds

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
@@ -56,7 +56,7 @@ fun resolveMethodCallReferenceWithReceiverType(
     receiverType: Ty,
     methodCall: RsMethodCall
 ): List<MethodResolveVariant> {
-    return collectResolveVariants(methodCall.referenceName) {
+    return collectResolveVariantsAsScopeEntries(methodCall.referenceName) {
         processMethodCallExprResolveVariants(lookup, receiverType, it)
     }
 }
@@ -66,7 +66,7 @@ fun resolveFieldLookupReferenceWithReceiverType(
     receiverType: Ty,
     expr: RsFieldLookup
 ): List<FieldResolveVariant> {
-    return collectResolveVariants(expr.referenceName) {
+    return collectResolveVariantsAsScopeEntries(expr.referenceName) {
         processFieldExprResolveVariants(lookup, receiverType, it)
     }
 }
@@ -95,16 +95,5 @@ data class MethodResolveVariant(
      * trait definition, this contains the impl of the actual trait for the receiver type.
      * Otherwise it's just a trait the method defined in
      */
-    val source: TraitImplSource
-) : DotExprResolveVariant
-
-private fun <T : ScopeEntry> collectResolveVariants(referenceName: String, f: ((T) -> Boolean) -> Unit): List<T> {
-    val result = mutableListOf<T>()
-    f { e ->
-        if (e.name == referenceName) {
-            result += e
-        }
-        false
-    }
-    return result
-}
+    override val source: TraitImplSource
+) : DotExprResolveVariant, AssocItemScopeEntryBase<RsFunction>

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -309,8 +309,8 @@ class RsInferenceContext(
         expectedDotExprTypes[psi] = ty
     }
 
-    fun writePath(path: RsPathExpr, resolved: List<BoundElement<RsElement>>) {
-        resolvedPaths[path] = resolved.map { it.element }
+    fun writePath(path: RsPathExpr, resolved: List<RsElement>) {
+        resolvedPaths[path] = resolved
     }
 
     fun writeResolvedMethod(call: RsMethodCall, resolvedTo: List<MethodResolveVariant>) {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -362,4 +362,88 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
                //^
         }
     """, TypeInferenceMarks.methodPickTraitsOutOfScope)
+
+    fun `test filter associated functions by trait visibility`() = checkByCode("""
+        struct S;
+
+        mod foo {
+            pub trait Foo {
+                fn new() {}
+            }    //X
+            impl Foo for super::S {}
+        }
+        mod bar {
+            pub trait Bar {
+                fn new() {}
+            }
+            impl Bar for super::S {}
+        }
+        use foo::Foo;
+
+        fn main () {
+            S::new();
+        }    //^
+    """)
+
+    fun `test filter associated constants by trait visibility`() = checkByCode("""
+        struct S;
+
+        mod foo {
+            pub trait Foo {
+                const C: i32 = 0;
+            }       //X
+            impl Foo for super::S {}
+        }
+        mod bar {
+            pub trait Bar {
+                const C: i32 = 0;
+            }
+            impl Bar for super::S {}
+        }
+        use foo::Foo;
+
+        fn main () {
+            let a = S::C;
+        }            //^
+    """)
+
+    fun `test filter associated functions by trait bounds`() = checkByCode("""
+        struct S;
+        trait Bound1 {}
+        trait Bound2 {}
+        impl Bound1 for S {}
+
+        pub trait Foo {
+            fn new() {}
+        }    //X
+        pub trait Bar {
+            fn new() {}
+        }
+        impl<T: Bound1> Foo for T {}
+        impl<T: Bound2> Bar for T {}
+
+        fn main () {
+            S::new();
+        }    //^
+    """)
+
+    fun `test filter associated constants by trait bounds`() = checkByCode("""
+        struct S;
+        trait Bound1 {}
+        trait Bound2 {}
+        impl Bound1 for S {}
+
+        pub trait Foo {
+            const C: i32 = 0;
+        }       //X
+        pub trait Bar {
+            const C: i32 = 0;
+        }
+        impl<T: Bound1> Foo for T {}
+        impl<T: Bound2> Bar for T {}
+
+        fn main () {
+            let a = S::C;
+        }            //^
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1559,4 +1559,20 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             let _: Box<[&Bar; 1]> = (Box::new([&Foo]));
         }                         //^ Box<[&Bar; 1]>
     """)
+
+    fun `test associated constant with complex type`() = testExpr("""
+        trait Tr<A> { const C: A; }
+        struct S<T>(T);
+        impl<T: Tr<T>> Tr<T> for S<T> {
+            const C: T = T::C;
+        }
+        struct X;
+        impl Tr<X> for X {
+            const C: X = X;
+        }
+        fn main() {
+            let a = S::<X>::C;
+            a;
+        } //^ X
+    """)
 }


### PR DESCRIPTION
Fixes #3689