### PR TITLE
Make parameter info handler asynchronous

### DIFF
--- a/src/main/kotlin/org/rust/ide/hints/RsAsyncParameterInfoHandler.kt
+++ b/src/main/kotlin/org/rust/ide/hints/RsAsyncParameterInfoHandler.kt
@@ -1,0 +1,71 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints
+
+import com.intellij.lang.parameterInfo.CreateParameterInfoContext
+import com.intellij.lang.parameterInfo.ParameterInfoHandler
+import com.intellij.lang.parameterInfo.UpdateParameterInfoContext
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.ReadAction
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.util.concurrency.AppExecutorUtil
+import org.rust.lang.core.psi.ext.startOffset
+import org.rust.openapiext.isUnitTestMode
+import java.util.concurrent.Callable
+import java.util.concurrent.Executor
+
+/**
+ * This is a hack to make [ParameterInfoHandler] asynchronous. Usual [ParameterInfoHandler] is called from the EDT
+ * and so complex computations inside it (e.g. name resolution) can freeze the UI.
+ */
+abstract class RsAsyncParameterInfoHandler<ParameterOwner : PsiElement, ParameterType : Any>
+    : ParameterInfoHandler<ParameterOwner, ParameterType> {
+
+    abstract fun findTargetElement(file: PsiFile, offset: Int): ParameterOwner?
+
+    /**
+     * Ran in background thread
+     */
+    abstract fun calculateParameterInfo(element: ParameterOwner): Array<ParameterType>?
+
+    final override fun findElementForParameterInfo(context: CreateParameterInfoContext): ParameterOwner? {
+        val element = findTargetElement(context.file, context.offset) ?: return null
+
+        return if (isUnitTestMode) {
+            context.itemsToShow = calculateParameterInfo(element) ?: return null
+            element
+        } else {
+            ReadAction.nonBlocking(Callable {
+                calculateParameterInfo(element)
+            }).finishOnUiThread(ModalityState.defaultModalityState()) { paramInfo ->
+                if (paramInfo != null) {
+                    context.itemsToShow = paramInfo
+                    showParameterInfo(element, context)
+                }
+            }.expireWhen { !element.isValid }.submit(executor)
+
+            null
+        }
+    }
+
+    final override fun findElementForUpdatingParameterInfo(context: UpdateParameterInfoContext): ParameterOwner? {
+        return findTargetElement(context.file, context.offset)
+    }
+
+    /**
+     * This method is not called by the platform b/c we always return null from [findElementForParameterInfo].
+     * We call it manually from [findElementForParameterInfo] and from unit tests.
+     */
+    override fun showParameterInfo(element: ParameterOwner, context: CreateParameterInfoContext) {
+        context.showHint(element, element.startOffset, this)
+    }
+
+    private companion object {
+        private val executor: Executor =
+            AppExecutorUtil.createBoundedApplicationPoolExecutor("Rust async parameter info handler", 1)
+    }
+}

--- a/src/test/kotlin/org/rust/ide/hints/RsParameterInfoHandlerTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RsParameterInfoHandlerTestBase.kt
@@ -1,0 +1,50 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints
+
+import com.intellij.lang.parameterInfo.ParameterInfoHandler
+import com.intellij.psi.PsiElement
+import com.intellij.testFramework.utils.parameterInfo.MockCreateParameterInfoContext
+import com.intellij.testFramework.utils.parameterInfo.MockParameterInfoUIContext
+import com.intellij.testFramework.utils.parameterInfo.MockUpdateParameterInfoContext
+import org.rust.RsTestBase
+
+abstract class RsParameterInfoHandlerTestBase<A : PsiElement, B>(
+    private val handler: ParameterInfoHandler<A, B>
+) : RsTestBase() {
+    protected fun checkByText(code: String, hint: String, index: Int) =
+        checkByText(code, hint to index)
+
+    protected fun checkByText(code: String, vararg hintWithIndex: Pair<String, Int>) {
+        myFixture.configureByText("main.rs", replaceCaretMarker(code))
+        val createContext = MockCreateParameterInfoContext(myFixture.editor, myFixture.file)
+
+        // Check hint
+        val elt = handler.findElementForParameterInfo(createContext)
+        if (hintWithIndex.isNotEmpty() && hintWithIndex[0].first.isNotEmpty()) {
+            elt ?: error("Hint not found")
+            handler.showParameterInfo(elt, createContext)
+            val items = createContext.itemsToShow ?: error("Parameters are not shown")
+            if (items.isEmpty()) error("Parameters are empty")
+            assertEquals(hintWithIndex.size, items.size)
+            hintWithIndex.forEachIndexed { i, (hint, index) ->
+                val context = MockParameterInfoUIContext(elt)
+                @Suppress("UNCHECKED_CAST")
+                handler.updateUI(items[i] as B, context)
+                assertEquals(hint, context.text)
+
+                // Check parameter index
+                val updateContext = MockUpdateParameterInfoContext(myFixture.editor, myFixture.file)
+                updateContext.parameterOwner = elt
+                val element = handler.findElementForUpdatingParameterInfo(updateContext) ?: error("Parameter not found")
+                handler.updateParameterInfo(element, updateContext)
+                assertEquals(index, updateContext.currentParameter)
+            }
+        } else if (elt != null) {
+            error("Unexpected hint found")
+        }
+    }
+}


### PR DESCRIPTION
Another hack to make "parameter info handler"s asynchronous. Also, gets rid of "Preparing parameter info..." popup

F'ixes #3900