### PR TITLE
PERF: filter traits by name before resolve in trait selection

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -495,7 +495,12 @@ class ImplLookup(
 
     private fun Sequence<RsImplItem>.assembleImplCandidates(ref: TraitRef): Sequence<SelectionCandidate> =
         mapNotNull { impl ->
-            val formalTraitRef = impl.implementedTrait ?: return@mapNotNull null
+            val traitRef = impl.traitRef ?: return@mapNotNull null
+
+            // Optimization: traits can't be aliased, so we can weed out irrelevant traits without resolve
+            if (traitRef.path.referenceName != ref.trait.element.name) return@mapNotNull null
+
+            val formalTraitRef = traitRef.resolveToBoundTrait() ?: return@mapNotNull null
             if (formalTraitRef.element != ref.trait.element) return@mapNotNull null
             val formalSelfTy = impl.typeReference?.type ?: return@mapNotNull null
             val (_, implTraitRef) =


### PR DESCRIPTION
Traits can't be aliased for now, so we can weed out irrelevant
traits by name, without resolving them.

I measured about 5% speedup of highlighting