### PR TITLE
INSP: Don't check mutability of expr with unknown type

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt
@@ -11,7 +11,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psi.ext.isAssignBinaryExpr
 import org.rust.lang.core.types.declaration
-import org.rust.lang.core.types.isMutable
+import org.rust.lang.core.types.isImmutable
 import org.rust.lang.utils.RsDiagnostic
 import org.rust.lang.utils.addToHolder
 
@@ -20,8 +20,9 @@ class RsReassignImmutableInspection : RsLocalInspectionTool() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitBinaryExpr(expr: RsBinaryExpr) {
-                val left = expr.left
-                if (expr.isAssignBinaryExpr && left is RsPathExpr && !left.isMutable) {
+                val left = expr.left.takeIf { it.isImmutable } ?: return
+
+                if (expr.isAssignBinaryExpr && left is RsPathExpr) {
                     // TODO: perform some kind of data-flow analysis
                     val letExpr = left.declaration?.ancestorStrict<RsLetDecl>()
                     if (letExpr == null) registerProblem(holder, expr, left)

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -19,7 +19,6 @@ import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.borrowck.BorrowCheckContext
 import org.rust.lang.core.types.borrowck.BorrowCheckResult
 import org.rust.lang.core.types.infer.*
-import org.rust.lang.core.types.ty.Mutability
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyTypeParameter
 import org.rust.lang.core.types.ty.TyUnknown
@@ -115,7 +114,10 @@ val RsExpr.cmt: Cmt?
     }
 
 val RsExpr.isMutable: Boolean
-    get() = cmt?.isMutable ?: Mutability.DEFAULT_MUTABILITY.isMut
+    get() = type !is TyUnknown && cmt?.isMutable == true
+
+val RsExpr.isImmutable: Boolean
+    get() = type !is TyUnknown && cmt?.isMutable == false
 
 private val BORROW_CHECKER_KEY: Key<CachedValue<BorrowCheckResult>> = Key.create("BORROW_CHECKER_KEY")
 

--- a/src/test/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspectionTest.kt
@@ -5,6 +5,9 @@
 
 package org.rust.ide.inspections
 
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+
 class RsAssignToImmutableInspectionTest : RsInspectionsTestBase(RsAssignToImmutableInspection()) {
 
     fun `test E0594 assign to immutable borrowed content`() = checkByText("""
@@ -56,6 +59,7 @@ class RsAssignToImmutableInspectionTest : RsInspectionsTestBase(RsAssignToImmuta
         }
     """)
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test E0594 assign to field of immutable binding while iterating`() = checkByText("""
         struct Foo { a: i32 }
         fn main() {
@@ -66,6 +70,7 @@ class RsAssignToImmutableInspectionTest : RsInspectionsTestBase(RsAssignToImmuta
         }
     """)
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test E0594 assign to indexed content of immutable binding`() = checkByText("""
         fn main() {
             let a: [i32; 3] = [0; 3];
@@ -87,6 +92,12 @@ class RsAssignToImmutableInspectionTest : RsInspectionsTestBase(RsAssignToImmuta
         fn main() {
             let xs = &mut unknownType;
             xs[0] = 1;
+        }
+    """)
+
+    fun `test assign to field of expr of unknown type`() = checkByText("""
+        fn foo(x: &mut Unknown) {
+            x.a = 1;
         }
     """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerInspectionTest.kt
@@ -278,4 +278,11 @@ class RsBorrowCheckerInspectionTest : RsInspectionsTestBase(RsBorrowCheckerInspe
             let c = &mut b[0];
         }
     """, checkWarn = false)
+
+    /** Issue [3914](https://github.com/intellij-rust/intellij-rust/issues/3914) */
+    fun `test closure borrow parameter of unknown type as mutable`() = checkByText("""
+        fn main() {
+            |x| &mut x;
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/fixes/AddMutableFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/fixes/AddMutableFixTest.kt
@@ -6,6 +6,8 @@
 package org.rust.ide.inspections.fixes
 
 
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsAssignToImmutableInspection
 import org.rust.ide.inspections.RsBorrowCheckerInspection
 import org.rust.ide.inspections.RsMultipleInspectionsTestBase
@@ -196,6 +198,7 @@ class AddMutableFixTest : RsMultipleInspectionsTestBase(
         }
     """)
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test fix E0594 assign to array element`() = checkFixByText("Make `arr` mutable", """
         fn main() {
             let arr = [0; 3];
@@ -208,6 +211,7 @@ class AddMutableFixTest : RsMultipleInspectionsTestBase(
         }
     """)
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test fix E0594 assign to borrowed array element`() = checkFixIsUnavailable("Make `arr2` mutable", """
         fn main() {
             let arr = [0; 3];


### PR DESCRIPTION
Fixes #3914 
Fixes #3782