### PR TITLE
Improve "fill match arms" intention

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/FillMatchArmsIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/FillMatchArmsIntention.kt
@@ -11,7 +11,6 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psi.ext.arms
-import org.rust.lang.core.psi.ext.isStdOptionOrResult
 import org.rust.lang.core.psi.ext.variants
 import org.rust.lang.core.types.ty.TyAdt
 import org.rust.lang.core.types.ty.stripReferences
@@ -27,15 +26,13 @@ class FillMatchArmsIntention : RsElementBaseIntentionAction<FillMatchArmsIntenti
         if (matchExpr.arms.isNotEmpty()) return null
         val item = (matchExpr.expr?.type?.stripReferences() as? TyAdt)?.item as? RsEnumItem ?: return null
         // TODO: check enum variants can be used without enum name qualifier
-        val name = if (!item.isStdOptionOrResult) {
-            item.name ?: return null
-        } else null
+        val name = item.name ?: return null
         return Context(matchExpr, name, item.variants)
     }
 
     override fun invoke(project: Project, editor: Editor, ctx: Context) {
         val (expr, name, variants) = ctx
-        var body = RsPsiFactory(project).createMatchBody(name, variants)
+        var body = RsPsiFactory(project).createMatchBody(expr, name, variants)
         val matchBody = expr.matchBody
         if (matchBody != null) {
             val rbrace = matchBody.rbrace
@@ -54,7 +51,7 @@ class FillMatchArmsIntention : RsElementBaseIntentionAction<FillMatchArmsIntenti
 
     data class Context(
         val matchExpr: RsMatchExpr,
-        val enumName: String?,
+        val enumName: String,
         val variants: List<RsEnumVariant>
     )
 }

--- a/src/main/kotlin/org/rust/ide/intentions/FillMatchArmsIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/FillMatchArmsIntention.kt
@@ -14,6 +14,7 @@ import org.rust.lang.core.psi.ext.arms
 import org.rust.lang.core.psi.ext.isStdOptionOrResult
 import org.rust.lang.core.psi.ext.variants
 import org.rust.lang.core.types.ty.TyAdt
+import org.rust.lang.core.types.ty.stripReferences
 import org.rust.lang.core.types.type
 
 class FillMatchArmsIntention : RsElementBaseIntentionAction<FillMatchArmsIntention.Context>() {
@@ -24,7 +25,7 @@ class FillMatchArmsIntention : RsElementBaseIntentionAction<FillMatchArmsIntenti
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
         val matchExpr = element.ancestorStrict<RsMatchExpr>() ?: return null
         if (matchExpr.arms.isNotEmpty()) return null
-        val item = (matchExpr.expr?.type as? TyAdt)?.item as? RsEnumItem ?: return null
+        val item = (matchExpr.expr?.type?.stripReferences() as? TyAdt)?.item as? RsEnumItem ?: return null
         // TODO: check enum variants can be used without enum name qualifier
         val name = if (!item.isStdOptionOrResult) {
             item.name ?: return null

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -278,8 +278,9 @@ class RsPsiFactory(
         createFromText("#![$text]")
             ?: error("Failed to create an inner attribute from text: `$text`")
 
-    fun createMatchBody(enumName: String?, variants: List<RsEnumVariant>): RsMatchBody {
+    fun createMatchBody(context: RsElement, enumName: String, variants: List<RsEnumVariant>): RsMatchBody {
         val matchBodyText = variants.joinToString(",\n", postfix = ",") { variant ->
+            val variantName = variant.name ?: return@joinToString ""
             val tupleFields = variant.tupleFields?.tupleFieldDeclList
             val blockFields = variant.blockFields
             val suffix = when {
@@ -287,8 +288,8 @@ class RsPsiFactory(
                 blockFields != null -> " { .. }"
                 else -> ""
             }
-            val prefix = if (enumName != null) "$enumName::" else ""
-            "$prefix${variant.name}$suffix => {}"
+            val prefix = if (context.findInScope(variantName) != variant) "$enumName::" else ""
+            "$prefix$variantName$suffix => {}"
         }
         return createExpressionOfType<RsMatchExpr>("match x { $matchBodyText }").matchBody
             ?: error("Failed to create match body from text: `$matchBodyText`")

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -154,6 +154,12 @@ fun Ty.builtinDeref(explicit: Boolean = true): Pair<Ty, Mutability>? =
         else -> null
     }
 
+tailrec fun Ty.stripReferences(): Ty =
+    when {
+        this is TyReference -> referenced.stripReferences()
+        else -> this
+    }
+
 /**
  * TODO:
  * There are some problems with `Self` inference (e.g. https://github.com/intellij-rust/intellij-rust/issues/2530)

--- a/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionTest.kt
@@ -200,4 +200,19 @@ class FillMatchArmsIntentionTest : RsIntentionTestBase(FillMatchArmsIntention())
             }
         }
     """)
+
+    fun `test match ergonomics`() = doAvailableTest("""
+        enum E { A, B }
+        fn foo(x: &E) {
+            match x/*caret*/ {}
+        }
+    """, """
+        enum E { A, B }
+        fn foo(x: &E) {
+            match x {
+                E::A => {},
+                E::B => {},
+            }
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionTest.kt
@@ -215,4 +215,27 @@ class FillMatchArmsIntentionTest : RsIntentionTestBase(FillMatchArmsIntention())
             }
         }
     """)
+
+    fun `test one variant is in scope`() = doAvailableTest("""
+        mod foo {
+            enum E { A, B }
+        }
+        use foo::E;
+        use foo::E::A;
+        fn foo(x: &E) {
+            match x/*caret*/ {}
+        }
+    """, """
+        mod foo {
+            enum E { A, B }
+        }
+        use foo::E;
+        use foo::E::A;
+        fn foo(x: &E) {
+            match x {
+                A => {},
+                E::B => {},
+            }
+        }
+    """)
 }


### PR DESCRIPTION
1. Support match ergonomics (`match &Some(1) {}`)
2. Support custom enums with variant names in the scope. Previously only Option/Result was supported this way.
```rust
mod foo {
    enum E { A, B }
}
use foo::E;
use foo::E::A;
fn foo(x: &E) {
    match x/*caret*/ {}
}
```
=>
```rust
match x {
    A => {},
    E::B => {},
}
```