### PR TITLE
TY: fix closure type inference with "impl Trait" parameters

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -1162,6 +1162,10 @@ class RsTypeInferenceWalker(
             }
             is TyTraitObject -> lookup.asTyFunction(expected.trait)
             is TyFunction -> expected
+            is TyAnon -> {
+                val trait = expected.traits.find { it.element in listOf(items.Fn, items.FnMut, items.FnOnce) }
+                trait?.let { lookup.asTyFunction(it) }
+            }
             else -> null
         }
     }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsClosuresResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsClosuresResolveTest.kt
@@ -255,6 +255,17 @@ class RsClosuresResolveTest : RsResolveTestBase() {
         }   //^
     """)
 
+    fun `test infer generic parameter from lambda return type by impl trait`() = checkByCode("""
+        struct X;
+        impl X { fn foo(&self) {} }
+                   //X
+        fn apply<T1, T2>(t: T1, f: impl Fn(T1) -> T2) -> T2 { f(t) }
+        fn main() {
+            let a = apply(X, |x| x);
+            a.foo()
+        }   //^
+    """)
+
     fun `test infer generic parameter from lambda return type 1`() = checkByCode("""
         struct X;
         impl X { fn foo(&self) {} }


### PR DESCRIPTION
Works with:
```rust
fn foo(impl Trait Fn(i32)) {}
fn bar() {
    foo(|x| { x })
}
```