### PR TITLE
TY: fix find free impls for type parameter

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -224,6 +224,10 @@ class ImplLookup(
                     .mapTo(implsAndTraits) { TraitImplSource.ExplicitImpl(it) }
             }
             is TyUnknown -> Unit
+            is TyTypeParameter -> {
+                RsImplIndex.findFreeImpls(project)
+                    .mapTo(implsAndTraits) { TraitImplSource.ExplicitImpl(it) }
+            }
             else -> {
                 implsAndTraits += findDerivedTraits(ty).map { TraitImplSource.Derived(it) }
                 implsAndTraits += findSimpleImpls(ty).map { TraitImplSource.ExplicitImpl(it) }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -530,7 +530,15 @@ private fun processTypeQualifiedPathResolveVariants(
             return if (isAppropriateTrait) processor(e) else false
         }
     } else {
-        processor
+        fun(e: AssocItemScopeEntry): Boolean {
+            return if (e.element is RsTypeAlias && baseTy is TyTypeParameter &&
+                e.source is TraitImplSource.ExplicitImpl) {
+                NameResolutionTestmarks.skipAssocTypeFromImpl.hit()
+                false
+            } else {
+                processor(e)
+            }
+        }
     }
     val selfSubst = if (baseTy !is TyTraitObject) {
         mapOf(TyTypeParameter.self() to baseTy).toTypeSubst()
@@ -1362,6 +1370,7 @@ object NameResolutionTestmarks {
     val modDeclExplicitPathInInlineModule = Testmark("modDeclExplicitPathInInlineModule")
     val modDeclExplicitPathInNonInlineModule = Testmark("modDeclExplicitPathInNonInlineModule")
     val selfRelatedTypeSpecialCase = Testmark("selfRelatedTypeSpecialCase")
+    val skipAssocTypeFromImpl = Testmark("skipAssocTypeFromImpl")
 }
 
 private data class ImplicitStdlibCrate(val name: String, val crateRoot: RsFile)

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -1004,4 +1004,33 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
             0.my_add(0).my_add(0);
         }             //^ unresolved
     """)
+
+    fun `test method in "impl for generic type" at type parameter with bound`() = checkByCode("""
+        trait Bound {}
+        trait Tr {
+            fn foo(&self) {}
+        }    //X
+        impl<A: Bound> Tr for A {}
+        fn foo<B: Bound>(b: B) {
+            b.foo();
+        }   //^
+    """)
+
+    fun `test "impl for generic type" is NOT used for associated type resolve`() = checkByCode("""
+        trait Bound {}
+        trait Tr { type Item; }
+        impl<A: Bound> Tr for A { type Item = (); }
+        fn foo<B: Bound>(b: B) {
+            let a: B::Item;
+        }           //^ unresolved
+    """, NameResolutionTestmarks.skipAssocTypeFromImpl)
+
+    fun `test "impl for generic type" is USED for associated type resolve UFCS`() = checkByCode("""
+        trait Bound {}
+        trait Tr { type Item; }
+        impl<A: Bound> Tr for A { type Item = (); }
+        fn foo<B: Bound>(b: B) {     //X
+            let a: <B as Tr>::Item;
+        }                   //^
+    """)
 }


### PR DESCRIPTION
Fixes #3925

Works for:
```rust
trait Bound {}

trait Tr {
    fn foo(&self) {}
}    //X

impl<A: Bound> Tr for A {}

fn foo<B: Bound>(b: B) {
    b.foo();
}   //^
```