### PR TITLE
MACRO&RES: initial version of include macro support

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1325,7 +1325,11 @@ LogMacroArgument ::=
 
 private IncludeMacro ::= &(("include" | "include_str" | "include_bytes") '!') PathWithoutTypes '!' IncludeMacroArgument
 
-IncludeMacroArgument ::= <<any_braces (AnyExpr ','?)>>
+IncludeMacroArgument ::= <<any_braces (AnyExpr ','?)>> {
+  extends = "org.rust.lang.core.psi.ext.RsStubbedElementImpl<?>"
+  stubClass = "org.rust.lang.core.stubs.RsPlaceholderStub"
+  elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
+}
 
 private meta any_braces ::=
   '(' <<param>> ')'

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -144,10 +144,17 @@ class MacroExpansionManagerImpl(
     override fun getExpansionFor(call: RsMacroCall): MacroExpansion? {
         val impl = inner
         return when {
+            call.macroName == "include" -> expandIncludeMacroCall(call)
             impl != null -> impl.getExpansionFor(call)
             isUnitTestMode -> expandMacroOld(call)
             else -> null
         }
+    }
+
+    private fun expandIncludeMacroCall(call: RsMacroCall): MacroExpansion? {
+        val includingFile = call.findIncludingFile() ?: return null
+        val items = includingFile.stubChildrenOfType<RsExpandedElement>()
+        return MacroExpansion.Items(includingFile, items)
     }
 
     override fun getExpandedFrom(element: RsExpandedElement): RsMacroCall? {

--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -7,10 +7,12 @@ package org.rust.lang.core.macros
 
 import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.ancestors
 import org.rust.lang.core.psi.ext.stubParent
+import org.rust.lang.core.stubs.index.RsIncludeMacroIndex
 
 /**
  *  [RsExpandedElement]s are those elements which exist in temporary,
@@ -25,7 +27,11 @@ interface RsExpandedElement : RsElement {
         fun getContextImpl(psi: RsExpandedElement): PsiElement? {
             psi.expandedFrom?.let { return it.context }
             psi.getUserData(RS_EXPANSION_CONTEXT)?.let { return it }
-            return psi.stubParent
+            val parent = psi.stubParent
+            if (parent is RsFile) {
+                RsIncludeMacroIndex.getIncludingMod(parent)?.let { return it }
+            }
+            return parent
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -15,12 +15,10 @@ import com.intellij.psi.util.CachedValuesManager
 import org.rust.lang.core.macros.MacroExpansion
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.macros.macroExpansionManager
-import org.rust.lang.core.psi.RsLitExpr
-import org.rust.lang.core.psi.RsMacro
-import org.rust.lang.core.psi.RsMacroCall
-import org.rust.lang.core.psi.rustStructureOrAnyPsiModificationTracker
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.resolve.DEFAULT_RECURSION_LIMIT
 import org.rust.lang.core.stubs.RsMacroCallStub
+import org.rust.openapiext.toPsiFile
 import org.rust.stdext.HashCode
 
 
@@ -63,6 +61,13 @@ val RsMacroCall.includingFilePath: String?
         val expr = includeMacroArgument?.expr as? RsLitExpr ?: return null
         return expr.stringValue ?: return null
     }
+
+fun RsMacroCall.findIncludingFile(): RsFile? {
+    val path = includingFilePath ?: return null
+    // TODO: it doesn't work if `include!()` macro call comes from other macro
+    val file = containingFile?.originalFile?.virtualFile ?: return null
+    return file.parent?.findFileByRelativePath(path)?.toPsiFile(project)?.rustFile
+}
 
 val RsMacroCall.bodyHash: HashCode?
     get() = CachedValuesManager.getCachedValue(this) {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -15,6 +15,7 @@ import com.intellij.psi.util.CachedValuesManager
 import org.rust.lang.core.macros.MacroExpansion
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.macros.macroExpansionManager
+import org.rust.lang.core.psi.RsLitExpr
 import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.rustStructureOrAnyPsiModificationTracker
@@ -53,6 +54,14 @@ val RsMacroCall.macroBody: String?
             ?: assertMacroArgument?.braceListBodyText()?.toString()
             ?: exprMacroArgument?.braceListBodyText()?.toString()
             ?: vecMacroArgument?.braceListBodyText()?.toString()
+    }
+
+val RsMacroCall.includingFilePath: String?
+    get() {
+        if (macroName != "include") return null
+        // TODO: support more cases
+        val expr = includeMacroArgument?.expr as? RsLitExpr ?: return null
+        return expr.stringValue ?: return null
     }
 
 val RsMacroCall.bodyHash: HashCode?

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -139,6 +139,8 @@ fun factory(name: String): RsStubElementType<*, *> = when (name) {
     "MACRO_2" -> RsMacro2Stub.Type
     "MACRO_CALL" -> RsMacroCallStub.Type
 
+    "INCLUDE_MACRO_ARGUMENT" -> RsPlaceholderStub.Type("INCLUDE_MACRO_ARGUMENT", ::RsIncludeMacroArgumentImpl)
+
     "INNER_ATTR" -> RsInnerAttrStub.Type
     "OUTER_ATTR" -> RsPlaceholderStub.Type("OUTER_ATTR", ::RsOuterAttrImpl)
 

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
@@ -82,6 +82,7 @@ fun IndexSink.indexMacroDef(stub: RsMacro2Stub) {
 
 fun IndexSink.indexMacroCall(stub: RsMacroCallStub) {
     RsMacroCallIndex.index(this)
+    RsIncludeMacroIndex.index(stub, this)
 }
 
 fun IndexSink.indexUseSpeck(stub: RsUseSpeckStub) {

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
@@ -5,9 +5,11 @@
 
 package org.rust.lang.core.stubs
 
+import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IndexSink
 import org.rust.lang.core.psi.ext.RsAbstractableOwner
-import org.rust.lang.core.psi.ext.owner
+import org.rust.lang.core.psi.ext.getOwner
+import org.rust.lang.core.psi.ext.stubParent
 import org.rust.lang.core.resolve.indexes.RsImplIndex
 import org.rust.lang.core.resolve.indexes.RsLangItemIndex
 import org.rust.lang.core.resolve.indexes.RsMacroCallIndex
@@ -62,7 +64,7 @@ fun IndexSink.indexConstant(stub: RsConstantStub) {
 
 fun IndexSink.indexTypeAlias(stub: RsTypeAliasStub) {
     indexNamedStub(stub)
-    if (stub.psi.owner !is RsAbstractableOwner.Impl) {
+    if (stub.psi.getOwner(PsiElement::stubParent) !is RsAbstractableOwner.Impl) {
         indexGotoClass(stub)
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsIncludeMacroIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsIncludeMacroIndex.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.stubs.index
+
+import com.intellij.psi.stubs.IndexSink
+import com.intellij.psi.stubs.StringStubIndexExtension
+import com.intellij.psi.stubs.StubIndexKey
+import com.intellij.util.PathUtil
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.ext.includingFilePath
+import org.rust.lang.core.stubs.RsFileStub
+import org.rust.lang.core.stubs.RsMacroCallStub
+
+class RsIncludeMacroIndex : StringStubIndexExtension<RsMacroCall>() {
+    override fun getVersion(): Int = RsFileStub.Type.stubVersion
+    override fun getKey(): StubIndexKey<String, RsMacroCall> = KEY
+
+    companion object {
+        val KEY : StubIndexKey<String, RsMacroCall> =
+            StubIndexKey.createIndexKey("org.rust.lang.core.stubs.index.RsIncludeMacroIndex")
+
+        fun index(stub: RsMacroCallStub, indexSink: IndexSink) {
+            val key = key(stub.psi) ?: return
+            indexSink.occurrence(KEY, key)
+        }
+
+        private fun key(call: RsMacroCall): String? {
+            val path = call.includingFilePath ?: return null
+            return PathUtil.getFileName(path)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsIncludeMacroIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsIncludeMacroIndex.kt
@@ -5,12 +5,20 @@
 
 package org.rust.lang.core.stubs.index
 
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.IndexSink
 import com.intellij.psi.stubs.StringStubIndexExtension
+import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
 import com.intellij.util.PathUtil
+import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.findIncludingFile
 import org.rust.lang.core.psi.ext.includingFilePath
+import org.rust.lang.core.psi.rustStructureOrAnyPsiModificationTracker
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsMacroCallStub
 
@@ -25,6 +33,36 @@ class RsIncludeMacroIndex : StringStubIndexExtension<RsMacroCall>() {
         fun index(stub: RsMacroCallStub, indexSink: IndexSink) {
             val key = key(stub.psi) ?: return
             indexSink.occurrence(KEY, key)
+        }
+
+        /**
+         * Returns mod item that includes given [file] via `include!()` macro
+         */
+        fun getIncludingMod(file: RsFile): RsMod? {
+            val originalFile = file.originalFile as? RsFile ?: return null
+            return CachedValuesManager.getCachedValue(originalFile) {
+                CachedValueProvider.Result.create(
+                    getIncludingModInternal(originalFile),
+                    originalFile.rustStructureOrAnyPsiModificationTracker
+                )
+            }
+        }
+
+        private fun getIncludingModInternal(file: RsFile): RsMod? {
+            val key = file.name
+            val project = file.project
+
+            var parentMod: RsMod? = null
+            StubIndex.getInstance().processElements(KEY, key, project, GlobalSearchScope.allScope(project), RsMacroCall::class.java) { macroCall ->
+                val includingFile = macroCall.findIncludingFile()
+                if (includingFile == file) {
+                    parentMod = macroCall.containingMod
+                    false
+                } else {
+                    true
+                }
+            }
+            return parentMod
         }
 
         private fun key(call: RsMacroCall): String? {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -750,6 +750,7 @@
         <stubIndex implementation="org.rust.lang.core.stubs.index.RsGotoClassIndex"/>
         <stubIndex implementation="org.rust.lang.core.stubs.index.RsReexportIndex"/>
         <stubIndex implementation="org.rust.lang.core.stubs.index.RsFeatureIndex"/>
+        <stubIndex implementation="org.rust.lang.core.stubs.index.RsIncludeMacroIndex"/>
 
         <stubIndex implementation="org.rust.lang.core.resolve.indexes.RsImplIndex"/>
         <stubIndex implementation="org.rust.lang.core.resolve.indexes.RsLangItemIndex"/>

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve
+
+import org.intellij.lang.annotations.Language
+import org.rust.ExpandMacros
+
+class RsIncludeMacroResolveTest : RsResolveTestBase() {
+
+    fun `test resolve struct to included file`() = checkResolve("""
+    //- main.rs
+        include!("foo.rs");
+        fn main() {
+            println("{:?}", Foo);
+                           //^ foo.rs
+        }
+    //- foo.rs
+        #[derive(Debug)]
+        struct Foo;
+    """)
+
+    fun `test resolve method to included file`() = checkResolve("""
+    //- main.rs
+        include!("foo.rs");
+        fn main() {
+            Foo.foo();
+                //^ foo.rs
+        }
+    //- foo.rs
+        struct Foo;
+        impl Foo {
+            fn foo(&self) {}
+        }
+    """)
+
+    fun `test resolve function from included file`() = checkResolve("""
+    //- lib.rs
+        include!("foo.rs");
+        fn bar() {}
+    //- foo.rs
+        pub fn foo() {
+            bar();
+           //^ lib.rs
+        }
+    """)
+
+    fun `test resolve method from included file`() = checkResolve("""
+    //- lib.rs
+        include!("foo.rs");
+        struct Bar;
+        impl Bar {
+            fn bar(&self) {}
+        }
+    //- foo.rs
+        pub fn foo() {
+            Bar.bar();
+               //^ lib.rs
+        }
+    """)
+
+    fun `test resolve to correct included file`() = checkResolve("""
+    //- main.rs
+        include!("foo/baz.rs");
+
+        fn foo(f: Foo) {}
+                 //^ foo/baz.rs
+    //- lib.rs
+        include!("bar/baz.rs");
+    //- foo/baz.rs
+        struct Foo;
+    //- bar/baz.rs
+        struct Foo;
+    """)
+
+    fun `test include in inline module 1`() = checkResolve("""
+    //- lib.rs
+        mod foo {
+            include!("bar.rs");
+        }
+        fn foo(f: foo::Foo) {}
+                      //^ bar.rs
+    //- foo/bar.rs
+        pub struct Foo;
+    //- bar.rs
+        pub struct Foo;
+    """)
+
+    fun `test include in inline module 2`() = checkResolve("""
+    //- lib.rs
+        mod foo {
+            struct Foo;
+            include!("bar.rs");
+        }
+    //- bar.rs
+        fn bar(x: Foo) {}
+                  //^ lib.rs
+    """)
+
+    fun `test include file in included file 1`() = checkResolve("""
+    //- lib.rs
+        include!("foo.rs");
+        fn foo(x: Foo) {}
+                 //^ bar.rs
+    //- foo.rs
+        include!("bar.rs");
+    //- bar.rs
+        struct Foo;
+    """)
+
+    fun `test include file in included file 2`() = checkResolve("""
+    //- lib.rs
+        include!("foo.rs");
+        struct Foo;
+    //- foo.rs
+        include!("bar.rs");
+    //- bar.rs
+        fn foo(x: Foo) {}
+                //^ lib.rs
+    """)
+
+    @ExpandMacros
+    fun `test include macro in macro 1`() = expect<IllegalStateException> {
+        checkResolve("""
+        //- lib.rs
+            macro_rules! foo {
+                () => { include!("bar.rs") };
+            }
+            struct Foo;
+            foo!();
+        //- bar.rs
+            fn foo(x: Foo) {}
+                     //^ lib.rs
+        """)
+    }
+
+    @ExpandMacros
+    fun `test include macro in macro 2`() = expect<IllegalStateException> {
+        checkResolve("""
+        //- lib.rs
+            macro_rules! foo {
+                () => { include!("bar.rs") };
+            }
+            foo!();
+            fn foo(x: Foo) {}
+                      //^ lib.rs
+        //- bar.rs
+            struct Foo;
+        """)
+    }
+
+    private fun checkResolve(@Language("Rust") code: String) {
+        stubOnlyResolve(code) { element -> element.containingFile.virtualFile }
+    }
+}

--- a/toml/src/test/kotlin/org/rust/toml/CargoTomlKeyResolveTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoTomlKeyResolveTest.kt
@@ -50,6 +50,6 @@ class CargoTomlKeyResolveTest : RsResolveTestBase() {
 
     private fun checkResolve(@Language("TOML") code: String) {
         val fileTree = fileTree { toml("Cargo.toml", code) }
-        stubOnlyResolve<TomlKey>(fileTree)
+        stubOnlyResolve<TomlKey>(fileTree, resolveFileProducer = this::getActualResolveFile)
     }
 }


### PR DESCRIPTION
Add initial support of `include!` macro. It brings all common code insight features (like name resolution, code completion, etc.) in both including and included files. Also, it should fix false positive editor notification for included files.

![2019-06-03 12 47 16](https://user-images.githubusercontent.com/2539310/58792898-bcaa2c80-85fd-11e9-9e4e-1064fe61b146.gif)

Restrictions:
* only string literals are supported as arguments
* `include` macro call should be located only in a module. At this moment, if `include` macro is called in a function, it won't be indexed and as a result, won't be found via the corresponding index. So the current implementation works only with instances of `RsMod`

Fixes #3563
Fixes problems described in #771 and #1078 in certain cases
The initial step of #1908