### PR TITLE
MACRO: Add expansion of compiler built-in macros

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -303,7 +303,7 @@ object ExpansionPipeline {
             if (info.isUpToDate(call, def)) {
                 return EmptyPipeline // old expansion is up-to-date
             }
-            val expansion = expander.expandMacroAsText(def, call)?.toString()
+            val expansion = expander.expandMacroAsText(def, call)
             if (expansion == null) {
                 MACRO_LOG.debug("Failed to expand macro: `${call.path.referenceName}!(${call.macroBody})`")
                 return if (oldExpansionFile == null) EmptyPipeline else nextStageFail(callHash, defHash)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -49,6 +49,7 @@ val RsMacroCall.macroBody: String?
         if (stub != null) return stub.macroBody
         return macroArgument?.compactTT?.text
             ?: formatMacroArgument?.braceListBodyText()?.toString()
+            ?: includeMacroArgument?.braceListBodyText()?.toString()
             ?: logMacroArgument?.braceListBodyText()?.toString()
             ?: assertMacroArgument?.braceListBodyText()?.toString()
             ?: exprMacroArgument?.braceListBodyText()?.toString()
@@ -66,13 +67,14 @@ fun RsMacroCall.resolveToMacro(): RsMacro? =
     path.reference.resolve() as? RsMacro
 
 val RsMacroCall.expansion: MacroExpansion?
-    get() = CachedValuesManager.getCachedValue(this) {
-        val project = project
-        CachedValueProvider.Result.create(
-            project.macroExpansionManager.getExpansionFor(CompletionUtil.getOriginalOrSelf(this)),
-            rustStructureOrAnyPsiModificationTracker
-        )
-    }
+//    get() = CachedValuesManager.getCachedValue(this) {
+//        val project = project
+//        CachedValueProvider.Result.create(
+//            project.macroExpansionManager.getExpansionFor(CompletionUtil.getOriginalOrSelf(this)),
+//            rustStructureOrAnyPsiModificationTracker
+//        )
+//    }
+    get() = project.macroExpansionManager.getExpansionFor(CompletionUtil.getOriginalOrSelf(this))
 
 fun RsMacroCall.expandAllMacrosRecursively(): String =
     expandAllMacrosRecursively(0)


### PR DESCRIPTION
Adds support for expanding `env!`, `option_env!`, `concat!`, `include!` macros:
![image](https://user-images.githubusercontent.com/7559560/58748009-6ca35c80-847b-11e9-9689-113b94abb3f0.png)
Currently some of the caching of macro expansions is commented out.
Eventually should fix https://github.com/intellij-rust/intellij-rust/issues/1908.
The current problem is getting the value of the `OUT_DIR` environment variable, as `cargo metadata` does not report it. It can only have a meaningful value once the project is built at least once, and can change after subsequent builds. Any thoughts of what is possible to do here?