### PR TITLE
DBG: Use RsCodeFragment for gdb/lldb console injection

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/RsBackendConsoleInjectionHelper.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/RsBackendConsoleInjectionHelper.kt
@@ -1,0 +1,60 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiLanguageInjectionHost
+import com.intellij.xdebugger.XDebugSession
+import com.intellij.xdebugger.XDebugSessionListener
+import com.jetbrains.cidr.execution.debugger.BackendConsoleInjectionHelper
+import com.jetbrains.cidr.execution.debugger.CidrDebugProcess
+import com.jetbrains.cidr.execution.debugger.backend.lang.GDBExpressionPlaceholder
+import org.rust.lang.RsDebugInjectionListener
+import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.rust.openapiext.virtualFile
+
+class RsBackendConsoleInjectionHelper : BackendConsoleInjectionHelper {
+    override fun subscribeToInjection(session: XDebugSession) {
+        val connection = session.project.messageBus.connect()
+
+        val listener = object : RsDebugInjectionListener, XDebugSessionListener {
+            @Volatile
+            private var document: Document? = null
+
+            override fun evalDebugContext(host: PsiLanguageInjectionHost, context: RsDebugInjectionListener.DebugContext) {
+                val document = host.originalDocument ?: return
+                val process = document.getUserData(CidrDebugProcess.DEBUG_PROCESS_KEY) ?: return
+                context.element = process.debuggerContext?.ancestorOrSelf()
+            }
+
+            override fun didInject(host: PsiLanguageInjectionHost) {
+                if (host is GDBExpressionPlaceholder) {
+                    this.document = host.originalDocument
+                }
+            }
+
+            override fun stackFrameChanged() {
+                val file = document?.virtualFile ?: return
+                ApplicationManager.getApplication().invokeLater({
+                    PsiDocumentManager.getInstance(session.project).reparseFiles(setOf(file), true)
+                }, ModalityState.NON_MODAL)
+            }
+
+            override fun sessionStopped() {
+                connection.disconnect()
+            }
+        }
+
+        connection.subscribe(RsDebugInjectionListener.INJECTION_TOPIC, listener)
+        session.addSessionListener(listener)
+    }
+
+    private val PsiLanguageInjectionHost.originalDocument: Document?
+        get() = containingFile.originalFile.viewProvider.document
+}

--- a/debugger/src/main/resources/META-INF/debugger-only.xml
+++ b/debugger/src/main/resources/META-INF/debugger-only.xml
@@ -3,6 +3,7 @@
         <languageSupport language="Rust" implementationClass="org.rust.debugger.lang.RsDebuggerLanguageSupport"/>
         <editorsExtension implementation="org.rust.debugger.lang.RsDebuggerEditorsExtension"/>
         <lineBreakpointFileTypesProvider implementation="org.rust.debugger.RsLineBreakpointFileTypesProvider"/>
+        <backendConsoleInjectionHelper implementation="org.rust.debugger.RsBackendConsoleInjectionHelper"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/src/main/kotlin/org/rust/lang/RsDebugInjectionListener.kt
+++ b/src/main/kotlin/org/rust/lang/RsDebugInjectionListener.kt
@@ -1,0 +1,23 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang
+
+import com.intellij.psi.PsiLanguageInjectionHost
+import com.intellij.util.messages.Topic
+import org.rust.lang.core.psi.ext.RsElement
+
+interface RsDebugInjectionListener {
+    data class DebugContext(var element: RsElement? = null)
+
+    fun evalDebugContext(host: PsiLanguageInjectionHost, context: DebugContext)
+
+    fun didInject(host: PsiLanguageInjectionHost)
+
+    companion object {
+        @JvmField
+        val INJECTION_TOPIC = Topic.create("Rust Language Injected", RsDebugInjectionListener::class.java)
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
@@ -22,18 +22,24 @@ import org.rust.lang.core.psi.ext.RsInferenceContextOwner
 import org.rust.lang.core.psi.ext.RsMod
 
 abstract class RsCodeFragment(
-    project: Project,
-    text: CharSequence,
-    private val context: RsElement,
-    contentElementType: IElementType
-) : RsFileBase(
-    PsiManagerEx.getInstanceEx(project).fileManager.createFileViewProvider(
-        LightVirtualFile(
-            "fragment.rs",
-            RsLanguage,
-            text
-        ), true)
-), PsiCodeFragment {
+    fileViewProvider: FileViewProvider,
+    contentElementType: IElementType,
+    private val context: RsElement
+) : RsFileBase(fileViewProvider), PsiCodeFragment {
+
+    constructor(
+        project: Project,
+        text: CharSequence,
+        contentElementType: IElementType,
+        context: RsElement
+    ) : this(
+        PsiManagerEx.getInstanceEx(project).fileManager.createFileViewProvider(
+            LightVirtualFile("fragment.rs", RsLanguage, text), true
+        ),
+        contentElementType,
+        context
+    )
+
     override val containingMod: RsMod
         get() = context.containingMod
 
@@ -84,8 +90,12 @@ abstract class RsCodeFragment(
     }
 }
 
-class RsExpressionCodeFragment(project: Project, text: CharSequence, context: RsElement)
-    : RsCodeFragment(project, text, context, RsElementTypes.EXPR_CODE_FRAGMENT),
-      RsInferenceContextOwner {
+class RsExpressionCodeFragment : RsCodeFragment, RsInferenceContextOwner {
+    constructor(fileViewProvider: FileViewProvider, context: RsElement)
+        : super(fileViewProvider, RsElementTypes.EXPR_CODE_FRAGMENT, context)
+
+    constructor(project: Project, text: CharSequence, context: RsElement)
+        : super(project, text, RsElementTypes.EXPR_CODE_FRAGMENT, context)
+
     val expr: RsExpr? get() = PsiTreeUtil.getChildOfType(this, RsExpr::class.java)
 }


### PR DESCRIPTION
Fixes #3713

![dbg_console_comp](https://user-images.githubusercontent.com/4854600/58892522-0d518080-86f7-11e9-82ee-e0175167ee52.gif)
