### PR TITLE
LI: don't inject doctests in targets with `doctest=false` in Cargo.toml

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -89,6 +89,8 @@ interface CargoWorkspace {
         val pkg: Package
 
         val edition: Edition
+
+        val doctest: Boolean
     }
 
     interface Dependency {
@@ -271,7 +273,8 @@ private class PackageImpl(
             crateRootUrl = it.crateRootUrl,
             name = it.name,
             kind = it.kind,
-            edition = it.edition
+            edition = it.edition,
+            doctest = it.doctest
         )
     }
 
@@ -291,7 +294,8 @@ private class TargetImpl(
     val crateRootUrl: String,
     override val name: String,
     override val kind: CargoWorkspace.TargetKind,
-    override val edition: CargoWorkspace.Edition
+    override val edition: CargoWorkspace.Edition,
+    override val doctest: Boolean
 ) : CargoWorkspace.Target {
 
     override val crateRoot: VirtualFile? by CachedVirtualFile(crateRootUrl)
@@ -317,7 +321,8 @@ private fun PackageImpl.asPackageData(edition: CargoWorkspace.Edition? = null): 
                 crateRootUrl = it.crateRootUrl,
                 name = it.name,
                 kind = it.kind,
-                edition = edition ?: it.edition
+                edition = edition ?: it.edition,
+                doctest = it.doctest
             )
         },
         source = source,
@@ -348,7 +353,8 @@ private fun StandardLibrary.StdCrate.asPackageData(rustcInfo: RustcInfo?): Cargo
             crateRootUrl = crateRootUrl,
             name = name,
             kind = CargoWorkspace.TargetKind.Lib(CargoWorkspace.LibKind.LIB),
-            edition = edition
+            edition = edition,
+            doctest = true
         )),
         source = null,
         origin = PackageOrigin.STDLIB,

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
@@ -34,7 +34,8 @@ data class CargoWorkspaceData(
         val crateRootUrl: String,
         val name: String,
         val kind: CargoWorkspace.TargetKind,
-        val edition: CargoWorkspace.Edition
+        val edition: CargoWorkspace.Edition,
+        val doctest: Boolean
     )
 
     data class Dependency(

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -131,7 +131,9 @@ object CargoMetadata {
          * Can be "2015", "2018" or null. Null value can be got from old version of cargo
          * so it is the same as "2015"
          */
-        val edition: String?
+        val edition: String?,
+
+        val doctest: Boolean?
     ) {
         val cleanKind: TargetKind
             get() = when (kind.singleOrNull()) {
@@ -276,7 +278,8 @@ object CargoMetadata {
                 it.url,
                 name,
                 makeTargetKind(cleanKind, cleanCrateTypes),
-                edition.cleanEdition()
+                edition.cleanEdition(),
+                doctest = doctest ?: true
             )
         }
     }

--- a/src/main/kotlin/org/rust/ide/annotator/RsDoctestAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsDoctestAnnotator.kt
@@ -12,8 +12,8 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.tree.injected.InjectionBackgroundSuppressor
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.ide.injected.RsDoctestLanguageInjector
+import org.rust.ide.injected.areDoctestsEnabled
 import org.rust.ide.injected.findDoctestInjectableRanges
-import org.rust.ide.injected.isDoctestable
 import org.rust.lang.core.psi.RsDocCommentImpl
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.ancestorStrict
@@ -31,7 +31,7 @@ class RsDoctestAnnotator : RsAnnotatorBase() {
         if (element !is RsDocCommentImpl) return
         if (!element.project.rustSettings.doctestInjectionEnabled) return
         // only library targets can have doctests
-        if (element.ancestorStrict<RsElement>()?.containingCargoTarget?.isDoctestable != true) return
+        if (element.ancestorStrict<RsElement>()?.containingCargoTarget?.areDoctestsEnabled != true) return
 
         val startOffset = element.startOffset
         findDoctestInjectableRanges(element).flatten().forEach {

--- a/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
+++ b/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
@@ -68,7 +68,7 @@ class RsDoctestLanguageInjector : MultiHostInjector {
 
         val rsElement = context.ancestorStrict<RsElement>() ?: return
         val cargoTarget = rsElement.containingCargoTarget ?: return
-        if (!cargoTarget.isDoctestable) return // only library targets can have doctests
+        if (!cargoTarget.areDoctestsEnabled) return // only library targets can have doctests
         val crateName = cargoTarget.normName
         val text = context.text
 
@@ -210,8 +210,11 @@ private fun findDoctestInjectableRanges(text: String, elementType: IElementType)
     }
 }
 
+val CargoWorkspace.Target.areDoctestsEnabled: Boolean
+    get() = doctest && isDoctestable
+
 // See https://github.com/rust-lang/cargo/blob/5a0c31d81/src/cargo/core/manifest.rs#L775
-val CargoWorkspace.Target.isDoctestable: Boolean
+private val CargoWorkspace.Target.isDoctestable: Boolean
     get() {
         val kind = kind
         return kind is TargetKind.Lib &&

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -65,8 +65,8 @@ open class RustProjectDescriptorBase : LightProjectDescriptor() {
         name = name,
         version = "0.0.1",
         targets = listOf(
-            Target("$contentRoot/main.rs", name, TargetKind.Bin, edition = Edition.EDITION_2015),
-            Target("$contentRoot/lib.rs", name, TargetKind.Lib(LibKind.LIB), edition = Edition.EDITION_2015)
+            Target("$contentRoot/main.rs", name, TargetKind.Bin, edition = Edition.EDITION_2015, doctest = true),
+            Target("$contentRoot/lib.rs", name, TargetKind.Lib(LibKind.LIB), edition = Edition.EDITION_2015, doctest = true)
         ),
         source = null,
         origin = PackageOrigin.WORKSPACE,
@@ -147,7 +147,7 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
                 // don't use `FileUtil.join` here because it uses `File.separator`
                 // which is system dependent although all other code uses `/` as separator
                 Target(source?.let { "$contentRoot/$it" } ?: "", targetName,
-                    TargetKind.Lib(libKind), Edition.EDITION_2015)
+                    TargetKind.Lib(libKind), Edition.EDITION_2015, doctest = true)
             ),
             source = source,
             origin = origin,

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestBase.kt
@@ -213,7 +213,8 @@ abstract class RunConfigurationProducerTestBase : RsTestBase() {
                                     myFixture.tempDirFixture.getFile(it.file.path)!!.url,
                                     it.name,
                                     it.kind,
-                                    it.edition
+                                    it.edition,
+                                    doctest = true
                                 )
                             },
                             source = null,

--- a/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
@@ -104,7 +104,8 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
             crateRootUrl = "/tmp/lib/rs",
             name = name,
             kind = kind,
-            edition = edition
+            edition = edition,
+            doctest = true
         )
 
         fun pkg(


### PR DESCRIPTION
Fixes #3852