### PR TITLE
Revert #3918 "PERF: filter traits by name before resolve in trait selection"

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -499,12 +499,7 @@ class ImplLookup(
 
     private fun Sequence<RsImplItem>.assembleImplCandidates(ref: TraitRef): Sequence<SelectionCandidate> =
         mapNotNull { impl ->
-            val traitRef = impl.traitRef ?: return@mapNotNull null
-
-            // Optimization: traits can't be aliased, so we can weed out irrelevant traits without resolve
-            if (traitRef.path.referenceName != ref.trait.element.name) return@mapNotNull null
-
-            val formalTraitRef = traitRef.resolveToBoundTrait() ?: return@mapNotNull null
+            val formalTraitRef = impl.implementedTrait ?: return@mapNotNull null
             if (formalTraitRef.element != ref.trait.element) return@mapNotNull null
             val formalSelfTy = impl.typeReference?.type ?: return@mapNotNull null
             val (_, implTraitRef) =

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1575,4 +1575,16 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ X
     """)
+
+    fun `test select trait with use alias`() = testExpr("""
+        #[lang = "deref"]
+        trait Deref { type Target; }
+        mod foo { pub use super::Deref as DerefAlias; }
+        struct A; struct B;
+        impl foo::DerefAlias for A { type Target = B; }
+        fn main() {
+            let b = *A;
+            b;
+        } //^ B
+    """)
 }


### PR DESCRIPTION
Revert #3918. I forget that traits can be aliased with use items :(
bors r+