### PR TITLE
Fix possible crash in type inference

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -717,7 +717,7 @@ class ImplLookup(
 
             val inputArgVar = TyInfer.TyVar()
             val ok = fnTraits.asSequence()
-                .mapNotNull { selectProjection(it to output, ty, inputArgVar).ok() }
+                .mapNotNull { ctx.commitIfNotNull { selectProjection(it to output, ty, inputArgVar).ok() } }
                 .firstOrNull() ?: return@run null
             TyWithObligations(
                 TyFunction((ctx.shallowResolve(inputArgVar) as? TyTuple)?.types.orEmpty(), ok.value),

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -151,6 +151,13 @@ class RsInferenceContext(
         }
     }
 
+    inline fun <T: Any> commitIfNotNull(action: () -> T?): T? {
+        val snapshot = startSnapshot()
+        val result = action()
+        if (result == null) snapshot.rollback() else snapshot.commit()
+        return result
+    }
+
     fun infer(element: RsInferenceContextOwner): RsInferenceResult {
         if (element is RsFunction) {
             val fctx = RsTypeInferenceWalker(this, element.returnType)


### PR DESCRIPTION
Fixes [this](https://github.com/intellij-rust/intellij-rust/blob/96bc6a1321233acf8c0a857a12b7686ffc078581/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt#L385) assertion failure. In production env it could lead to crashes in other places