### PR TITLE
Fix false-positive E0308 with `?` expr in lambda with error conversion

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -999,11 +999,7 @@ class RsTypeInferenceWalker(
         // TODO: make it work with generic `std::ops::Try` trait
         if (base.item != items.Result && base.item != items.Option) return TyUnknown
         TypeInferenceMarks.questionOperator.hit()
-        val okTy = base.typeArguments.getOrElse(0) { TyUnknown }
-        val errTy = base.typeArguments.getOrElse(1) { TyUnknown }
-        val resultTy = tryTy ?: return okTy
-        registerTryProjection(resultTy, "Error", errTy)
-        return okTy
+        return base.typeArguments.getOrElse(0) { TyUnknown }
     }
 
     private fun inferTryMacroArgumentType(expr: RsExpr): Ty {

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
@@ -248,4 +248,19 @@ class RsTypeCheckInspectionTest : RsInspectionsTestBase(RsTypeCheckInspection())
             unify(panic!(), 0);
         }
     """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test ? expression in closure with different error types`() = checkByText("""
+        struct ErrorTo;
+        struct ErrorFrom;
+        impl From<ErrorFrom> for ErrorTo {
+            fn from(_: ErrorFrom) -> Self { ErrorTo }
+        }
+        fn main() {
+            let a: Result<(), ErrorTo> = (|| {
+                Err(ErrorFrom)?;
+                Ok(())
+            })();
+        }
+    """)
 }


### PR DESCRIPTION
The deleted code fragment currently doesn't matter. Try (`?`) checking will be landed later with #2819