### PR TITLE
UI: introduce detached notification provider

### DIFF
--- a/src/main/kotlin/org/rust/ide/notifications/DetachedFileNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/DetachedFileNotificationProvider.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.notifications
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
@@ -36,8 +37,12 @@ class DetachedFileNotificationProvider(project: Project) : RsNotificationProvide
 
     override fun getKey(): Key<EditorNotificationPanel> = PROVIDER_KEY
 
-    override fun createNotificationPanel(file: VirtualFile, editor: FileEditor, project: Project): EditorNotificationPanel? {
-        if (isUnitTestMode) return null
+    override fun createNotificationPanel(
+        file: VirtualFile,
+        editor: FileEditor,
+        project: Project
+    ): RsEditorNotificationPanel? {
+        if (isUnitTestMode && !ApplicationManager.getApplication().isDispatchThread) return null
         if (file.isNotRustFile || isNotificationDisabled(file)) return null
 
         val cargoProjects = project.cargoProjects
@@ -51,8 +56,8 @@ class DetachedFileNotificationProvider(project: Project) : RsNotificationProvide
         return null
     }
 
-    private fun createFileNotIncludedInModulesPanel(file: VirtualFile): EditorNotificationPanel =
-        EditorNotificationPanel().apply {
+    private fun createFileNotIncludedInModulesPanel(file: VirtualFile): RsEditorNotificationPanel =
+        RsEditorNotificationPanel(DETACHED_FILE).apply {
             setText("File is not included in module tree, analysis is not available")
             createActionLabel("Do not show again") {
                 disableNotification(file)
@@ -62,6 +67,8 @@ class DetachedFileNotificationProvider(project: Project) : RsNotificationProvide
 
     companion object {
         private const val NOTIFICATION_STATUS_KEY = "org.rust.hideDetachedFileNotifications"
+
+        const val DETACHED_FILE = "DetachedFile"
 
         private val PROVIDER_KEY: Key<EditorNotificationPanel> = Key.create("Detached Rust file")
     }

--- a/src/main/kotlin/org/rust/ide/notifications/DetachedFileNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/DetachedFileNotificationProvider.kt
@@ -1,0 +1,68 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.notifications
+
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.ui.EditorNotificationPanel
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.lang.core.psi.RUST_STRUCTURE_CHANGE_TOPIC
+import org.rust.lang.core.psi.RustStructureChangeListener
+import org.rust.lang.core.psi.isNotRustFile
+import org.rust.lang.core.psi.rustFile
+import org.rust.openapiext.isUnitTestMode
+import org.rust.openapiext.toPsiFile
+
+class DetachedFileNotificationProvider(project: Project) : RsNotificationProvider(project) {
+
+    override val VirtualFile.disablingKey: String get() = NOTIFICATION_STATUS_KEY + path
+
+    init {
+        project.messageBus.connect().apply {
+            subscribe(RUST_STRUCTURE_CHANGE_TOPIC, object : RustStructureChangeListener {
+                override fun rustStructureChanged(file: PsiFile?, changedElement: PsiElement?) {
+                    updateAllNotifications()
+                }
+            })
+        }
+    }
+
+    override fun getKey(): Key<EditorNotificationPanel> = PROVIDER_KEY
+
+    override fun createNotificationPanel(file: VirtualFile, editor: FileEditor, project: Project): EditorNotificationPanel? {
+        if (isUnitTestMode) return null
+        if (file.isNotRustFile || isNotificationDisabled(file)) return null
+
+        val cargoProjects = project.cargoProjects
+        // Handled by [MissingToolchainNotificationProvider]
+        if (cargoProjects.findProjectForFile(file) == null) return null
+
+        val psiFile = file.toPsiFile(project)?.rustFile ?: return null
+        if (psiFile.crateRoot == null) {
+            return createFileNotIncludedInModulesPanel(file)
+        }
+        return null
+    }
+
+    private fun createFileNotIncludedInModulesPanel(file: VirtualFile): EditorNotificationPanel =
+        EditorNotificationPanel().apply {
+            setText("File is not included in module tree, analysis is not available")
+            createActionLabel("Do not show again") {
+                disableNotification(file)
+                updateAllNotifications()
+            }
+        }
+
+    companion object {
+        private const val NOTIFICATION_STATUS_KEY = "org.rust.hideDetachedFileNotifications"
+
+        private val PROVIDER_KEY: Key<EditorNotificationPanel> = Key.create("Detached Rust file")
+    }
+}

--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -52,7 +52,11 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
 
     override fun getKey(): Key<EditorNotificationPanel> = PROVIDER_KEY
 
-    override fun createNotificationPanel(file: VirtualFile, editor: FileEditor, project: Project): EditorNotificationPanel? {
+    override fun createNotificationPanel(
+        file: VirtualFile,
+        editor: FileEditor,
+        project: Project
+    ): RsEditorNotificationPanel? {
         if (file.isNotRustFile || isNotificationDisabled(file)) return null
         if (guessAndSetupRustProject(project)) return null
 
@@ -81,9 +85,8 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
         return null
     }
 
-
-    private fun createBadToolchainPanel(file: VirtualFile): EditorNotificationPanel =
-        EditorNotificationPanel().apply {
+    private fun createBadToolchainPanel(file: VirtualFile): RsEditorNotificationPanel =
+        RsEditorNotificationPanel(NO_RUST_TOOLCHAIN).apply {
             setText("No Rust toolchain configured")
             createActionLabel("Setup toolchain") {
                 project.rustSettings.configureToolchain()
@@ -94,14 +97,14 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
             }
         }
 
-    private fun createNoCargoProjectsPanel(file: VirtualFile): EditorNotificationPanel =
-        createAttachCargoProjectPanel(file, "No Cargo projects found")
+    private fun createNoCargoProjectsPanel(file: VirtualFile): RsEditorNotificationPanel =
+        createAttachCargoProjectPanel(NO_CARGO_PROJECTS, file, "No Cargo projects found")
 
-    private fun createNoCargoProjectForFilePanel(file: VirtualFile): EditorNotificationPanel =
-        createAttachCargoProjectPanel(file, "File does not belong to any known Cargo project")
+    private fun createNoCargoProjectForFilePanel(file: VirtualFile): RsEditorNotificationPanel =
+        createAttachCargoProjectPanel(FILE_NOT_IN_CARGO_PROJECT, file, "File does not belong to any known Cargo project")
 
-    private fun createAttachCargoProjectPanel(file: VirtualFile, message: String): EditorNotificationPanel =
-        EditorNotificationPanel().apply {
+    private fun createAttachCargoProjectPanel(debugId: String, file: VirtualFile, message: String): RsEditorNotificationPanel =
+        RsEditorNotificationPanel(debugId).apply {
             setText(message)
             createActionLabel("Attach", "Rust.AttachCargoProject")
             createActionLabel("Do not show again") {
@@ -110,8 +113,8 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
             }
         }
 
-    private fun createLibraryAttachingPanel(file: VirtualFile): EditorNotificationPanel =
-        EditorNotificationPanel().apply {
+    private fun createLibraryAttachingPanel(file: VirtualFile): RsEditorNotificationPanel =
+        RsEditorNotificationPanel(NO_ATTACHED_STDLIB).apply {
             setText("Can not attach stdlib sources automatically without rustup.")
             createActionLabel("Attach manually") {
                 val descriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
@@ -135,6 +138,10 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
 
     companion object {
         private const val NOTIFICATION_STATUS_KEY = "org.rust.hideToolchainNotifications"
+        const val NO_RUST_TOOLCHAIN = "NoRustToolchain"
+        const val NO_CARGO_PROJECTS = "NoCargoProjects"
+        const val FILE_NOT_IN_CARGO_PROJECT = "FileNotInCargoProject"
+        const val NO_ATTACHED_STDLIB = "NoAttachedStdlib"
 
         private val PROVIDER_KEY: Key<EditorNotificationPanel> = Key.create("Setup Rust toolchain")
     }

--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -12,8 +12,6 @@ import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import com.intellij.ui.EditorNotificationPanel
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.CargoProjectsService
@@ -23,11 +21,7 @@ import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.StandardLibrary
-import org.rust.lang.core.psi.RUST_STRUCTURE_CHANGE_TOPIC
-import org.rust.lang.core.psi.RustStructureChangeListener
-import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.isNotRustFile
-import org.rust.openapiext.toPsiFile
 
 /**
  * Warn user if rust toolchain or standard library is not properly configured.
@@ -50,11 +44,6 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
 
             subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsService.CargoProjectsListener {
                 override fun cargoProjectsUpdated(projects: Collection<CargoProject>) {
-                    updateAllNotifications()
-                }
-            })
-            subscribe(RUST_STRUCTURE_CHANGE_TOPIC, object : RustStructureChangeListener {
-                override fun rustStructureChanged(file: PsiFile?, changedElement: PsiElement?) {
                     updateAllNotifications()
                 }
             })
@@ -81,11 +70,6 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
             //TODO: more precise check here
             return createNoCargoProjectForFilePanel(file)
 
-        val psiFile = file.toPsiFile(project) as RsElement
-        if (psiFile.crateRoot == null) {
-            return createFileNotIncludedInModulesPanel()
-        }
-
         val workspace = cargoProject.workspace ?: return null
         if (!workspace.hasStandardLibrary) {
             // If rustup is not null, the WorkspaceService will use it
@@ -97,10 +81,6 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
         return null
     }
 
-    private fun createFileNotIncludedInModulesPanel(): EditorNotificationPanel =
-        EditorNotificationPanel().apply {
-            setText("File is not included in module tree, analysis is not available")
-        }
 
     private fun createBadToolchainPanel(file: VirtualFile): EditorNotificationPanel =
         EditorNotificationPanel().apply {

--- a/src/main/kotlin/org/rust/ide/notifications/RsNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/RsNotificationProvider.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.notifications
 
 import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.EditorNotificationPanel
@@ -16,6 +17,12 @@ abstract class RsNotificationProvider(
 ) : EditorNotifications.Provider<EditorNotificationPanel>() {
 
     protected abstract val VirtualFile.disablingKey: String
+
+    abstract override fun createNotificationPanel(
+        file: VirtualFile,
+        editor: FileEditor,
+        project: Project
+    ): RsEditorNotificationPanel?
 
     protected fun updateAllNotifications() {
         EditorNotifications.getInstance(project).updateAllNotifications()
@@ -28,3 +35,5 @@ abstract class RsNotificationProvider(
     protected fun isNotificationDisabled(file: VirtualFile): Boolean =
         PropertiesComponent.getInstance(project).getBoolean(file.disablingKey)
 }
+
+class RsEditorNotificationPanel(val debugId: String) : EditorNotificationPanel()

--- a/src/main/kotlin/org/rust/ide/notifications/RsNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/RsNotificationProvider.kt
@@ -1,0 +1,30 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.notifications
+
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.EditorNotificationPanel
+import com.intellij.ui.EditorNotifications
+
+abstract class RsNotificationProvider(
+    protected val project: Project
+) : EditorNotifications.Provider<EditorNotificationPanel>() {
+
+    protected abstract val VirtualFile.disablingKey: String
+
+    protected fun updateAllNotifications() {
+        EditorNotifications.getInstance(project).updateAllNotifications()
+    }
+
+    protected fun disableNotification(file: VirtualFile) {
+        PropertiesComponent.getInstance(project).setValue(file.disablingKey, true)
+    }
+
+    protected fun isNotificationDisabled(file: VirtualFile): Boolean =
+        PropertiesComponent.getInstance(project).getBoolean(file.disablingKey)
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -766,6 +766,7 @@
         <!-- Notification Providers -->
 
         <editorNotificationProvider implementation="org.rust.ide.notifications.MissingToolchainNotificationProvider"/>
+        <editorNotificationProvider implementation="org.rust.ide.notifications.DetachedFileNotificationProvider"/>
 
         <!-- Editor Tab Title Providers -->
 

--- a/src/test/kotlin/org/rust/ide/notifications/DetachedFileNotificationProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/notifications/DetachedFileNotificationProviderTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.notifications
+
+import org.rust.fileTree
+
+class DetachedFileNotificationProviderTest : RsNotificationProviderTestBase() {
+
+    override val notificationProvider: RsNotificationProvider get() = DetachedFileNotificationProvider(project)
+
+    override fun setUp() {
+        super.setUp()
+        fileTree {
+            rust("main.rs", """
+                include!("bar.rs");
+                mod foo;
+                fn main() {}
+            """)
+            rust("foo.rs", "")
+            rust("bar.rs", "")
+            rust("baz.rs", "")
+        }.create()
+    }
+
+    fun `test no notification for attached root file`() = doTest("main.rs")
+    fun `test no notification for attached module file`() = doTest("foo.rs")
+    fun `test notification for included file`() = doTest("bar.rs")
+    fun `test notification for detached file`() = doTest("baz.rs", DetachedFileNotificationProvider.DETACHED_FILE)
+}

--- a/src/test/kotlin/org/rust/ide/notifications/RsNotificationProviderTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/notifications/RsNotificationProviderTestBase.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.notifications
+
+import com.intellij.openapi.fileEditor.FileEditorManager
+import org.rust.RsTestBase
+
+abstract class RsNotificationProviderTestBase : RsTestBase() {
+
+    protected abstract val notificationProvider: RsNotificationProvider
+
+    protected fun doTest(filePath: String, expectedId: String? = null) {
+        val file = myFixture.findFileInTempDir(filePath)!!
+        val editor = FileEditorManager.getInstance(project).openFile(file, true)[0]
+        val actualId = notificationProvider.createNotificationPanel(file, editor, project)?.debugId
+        val message = when {
+            actualId == null && expectedId != null -> "`$expectedId` notification not shown"
+            actualId != null && expectedId == null -> "Unexpected `$actualId` notification"
+            else -> ""
+        }
+        assertEquals(message, expectedId, actualId)
+    }
+}


### PR DESCRIPTION
Extract "File is not included in module tree, ..." notification introduced in #3826 to separate notification provider and allow to disable such notifications (https://github.com/intellij-rust/intellij-rust/issues/771#issuecomment-496451670)
