### PR TITLE
INSP: fix autoimport on 2018 edition

### DIFF
--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -1534,6 +1534,23 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
     """)
 
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test import item from root module (edition 2018)`() = checkAutoImportFixByText("""
+        struct Foo;
+
+        mod bar {
+            type T = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
+        }
+    """, """
+        struct Foo;
+
+        mod bar {
+            use crate::Foo;
+
+            type T = Foo;
+        }
+    """)
+
     fun `test import inside nested module`() = checkAutoImportFixByText("""
         mod b {
             pub struct S;


### PR DESCRIPTION
Fixes #3948

Looks like we just forgot to adjust autoimport to work with unified paths #3768.
I don't sure how autoimport should work with unified paths. For now, I just add `crate::` prefix to any local path (i.e. use anchored path fashion)