### PR TITLE
T: add checks for `isReferenceTo` implementation to resolve tests

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
@@ -131,7 +131,7 @@ fun PsiElement.findReference(offset: Int): PsiReference? = findReferenceAt(offse
 
 fun PsiElement.checkedResolve(offset: Int): PsiElement {
     val reference = findReference(offset) ?: error("element doesn't have reference")
-    return reference.resolve() ?: run {
+    val resolved = reference.resolve() ?: run {
         val multiResolve = (reference as? RsReference)?.multiResolve().orEmpty()
         check(multiResolve.size != 1)
         if (multiResolve.isEmpty()) {
@@ -140,4 +140,10 @@ fun PsiElement.checkedResolve(offset: Int): PsiElement {
             error("Failed to resolve $text, multiple variants:\n${multiResolve.joinToString()}")
         }
     }
+
+    check(reference.isReferenceTo(resolved)) {
+        "Incorrect `isReferenceTo` implementation in `${reference.javaClass.name}`"
+    }
+
+    return resolved
 }


### PR DESCRIPTION
Method `RsReference.isReferenceTo` is mostly untested, but with #3831 it becomes heavily overrode.
This PR adds additional `isReferenceTo` check to all resolve tests. I.e. if some reference "r" is resolved to element "e", `r.isReferenceTo(e)` must be true