### PR TITLE
Fix crash in type inference on `Self()` expr

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -318,7 +318,7 @@ class RsTypeInferenceWalker(
         ctx.writePath(expr, filteredVariants.mapNotNull { it.element })
 
         val first = filteredVariants.singleOrNull() ?: return TyUnknown
-        return instantiatePath(first.element as RsNamedElement, first, expr)
+        return instantiatePath(first.element ?: return TyUnknown, first, expr)
     }
 
     /** This works for `String::from` where multiple impls of `From` trait found for `String` */
@@ -360,7 +360,7 @@ class RsTypeInferenceWalker(
     }
 
     private fun instantiatePath(
-        element: RsNamedElement,
+        element: RsElement,
         scopeEntry: ScopeEntry,
         pathExpr: RsPathExpr
     ): Ty {

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -939,6 +939,17 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    // TODO
+    fun `test Self tuple struct init`() = testExpr("""
+        struct S();
+        impl S {
+            fn new() {
+                let a = Self();
+                a;
+            } //^ <unknown>
+        }
+    """)
+
     fun `test Self as struct field type`() = testExpr("""
         pub struct S<'a> {
             field: &'a Self


### PR DESCRIPTION
Fixes #3975
The bug is introduced in #3905

The PR fixes the crash only. I'll fix type inference for this case later.

bors r+