### PR TITLE
GRD: fix #3963 by bumping grammar-kit to 2019.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
     idea
     kotlin("jvm") version "1.3.30"
     id("org.jetbrains.intellij") version "0.4.8"
-    id("org.jetbrains.grammarkit") version "2018.2.2"
+    id("org.jetbrains.grammarkit") version "2019.2"
     id("de.undercouch.download") version "3.4.3"
     id("net.saliman.properties") version "1.4.6"
 }


### PR DESCRIPTION
As title. This addresses some comments in #3760 