### PR TITLE
Fix false-positive DropRefInspection at unresolved function with no_std

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsDropRefInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDropRefInspection.kt
@@ -30,7 +30,7 @@ class RsDropRefInspection : RsLocalInspectionTool() {
     fun inspectExpr(expr: RsCallExpr, holder: ProblemsHolder) {
         val pathExpr = expr.expr as? RsPathExpr ?: return
 
-        val fn = pathExpr.path.reference.resolve()
+        val fn = pathExpr.path.reference.resolve() ?: return
         if (fn != expr.knownItems.drop) return
 
         val args = expr.valueArgumentList.exprList


### PR DESCRIPTION
This false-positive unlikely to occur in the real world, but
it's relevant for our unit tests. So this is mostly internal fix

bors r+