### PR TITLE
TY&RES: fix UFCS-like assoc types resolve (`Iterator.take()`)

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -224,10 +224,6 @@ class ImplLookup(
                     .mapTo(implsAndTraits) { TraitImplSource.ExplicitImpl(it) }
             }
             is TyUnknown -> Unit
-            is TyTypeParameter -> {
-                RsImplIndex.findFreeImpls(project)
-                    .mapTo(implsAndTraits) { TraitImplSource.ExplicitImpl(it) }
-            }
             else -> {
                 implsAndTraits += findDerivedTraits(ty).map { TraitImplSource.Derived(it) }
                 implsAndTraits += findSimpleImpls(ty).map { TraitImplSource.ExplicitImpl(it) }

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
@@ -32,11 +32,12 @@ class RsImplIndex : AbstractStubIndex<TyFingerprint, RsImplItem>() {
          * @see TyFingerprint
          */
         fun findPotentialImpls(project: Project, target: Ty): Sequence<RsImplItem> {
-            val fingerprint = TyFingerprint.create(target)
-                ?: return emptySequence()
-
             project.macroExpansionManager.ensureUpToDate()
-            val impls = getElements(KEY, fingerprint, project, RsWithMacrosProjectScope(project))
+            val impls = run {
+                val fingerprint = TyFingerprint.create(target)
+                    ?: return@run emptyList<RsImplItem>()
+                getElements(KEY, fingerprint, project, RsWithMacrosProjectScope(project))
+            }
             val freeImpls = getElements(KEY, TyFingerprint.TYPE_PARAMETER_FINGERPRINT, project, RsWithMacrosProjectScope(project))
             // filter dangling (not attached to some crate) rust files, e.g. tests, generated source
             return (impls.asSequence() + freeImpls.asSequence()).filter { it.crateRoot != null }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -1025,12 +1025,21 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }           //^ unresolved
     """, NameResolutionTestmarks.skipAssocTypeFromImpl)
 
-    fun `test "impl for generic type" is USED for associated type resolve UFCS`() = checkByCode("""
+    fun `test "impl for generic type" is USED for associated type resolve UFCS 1`() = checkByCode("""
         trait Bound {}
         trait Tr { type Item; }
         impl<A: Bound> Tr for A { type Item = (); }
         fn foo<B: Bound>(b: B) {     //X
             let a: <B as Tr>::Item;
         }                   //^
+    """)
+
+    fun `test "impl for generic type" is USED for associated type resolve UFCS 2`() = checkByCode("""
+        trait Bound { type Item; }
+        impl<A: Bound> Bound for &A { type Item = (); }
+                                          //X
+        fn foo<B: Bound>(b: B) {
+            let a: <&B as Bound>::Item;
+        }                       //^
     """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -476,6 +476,18 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test iter take`() = stubOnlyTypeInfer("""
+    //- main.rs
+        fn main() {
+            let mut names = vec![0i32, 1]
+                .iter()
+                .take(3)
+                .next();
+            names;
+          //^ Option<&i32>
+        }
+    """)
+
     fun `test iterator collect`() = stubOnlyTypeInfer("""
     //- main.rs
         use std::vec::Vec;


### PR DESCRIPTION
#3932 was implemented wrongly,  so it introduces some bugs. Trying to fix it.

It looks like a rare case but at least it affects some Iterator implementations, e.g. `Iterator.take()`