### PR TITLE
INSP: fix false-positive "unresolved reference" if multiple method defs

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -336,7 +336,8 @@ class RsTypeInferenceWalker(
         if (traits.size == elements.size && traits.toSet().size == 1) {
             val fnName = elements.first().name
             val trait = traits.first()
-            return trait.members?.functionList?.find { it.name == fnName } ?: return null
+            val functionList = trait.members?.functionList ?: return null
+            return functionList.singleOrNull { it.name == fnName }
         }
 
         return null

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -115,6 +115,18 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         }
     """, testmark = AutoImportFix.Testmarks.nameInScope)
 
+    fun `test do not highlight unresolved method of trait bound if multiple defs (invalid code)`() = checkByText("""
+        mod foo {
+            pub trait Trait {
+                fn foo(&self) {}
+                fn foo(&self) {}
+            }
+        }
+        fn bar<T: foo::Trait>(t: T) {
+            t.foo(a); // no error here
+        }
+    """)
+
     private fun checkByText(@Language("Rust") text: String, ignoreWithoutQuickFix: Boolean) {
         val defaultValue = (inspection as RsUnresolvedReferenceInspection).ignoreWithoutQuickFix
         try {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
@@ -45,6 +45,18 @@ class RsMultiResolveTest : RsResolveTestBase() {
         }
     """)
 
+    fun `test other mod trait bound method`() = doTest("""
+        mod foo {
+            pub trait Trait {
+                fn foo(&self) {}
+                fn foo(&self) {}
+            }
+        }
+        fn bar<T: foo::Trait>(t: T) {
+            t.foo(a);
+        }   //^
+    """)
+
     private fun doTest(@Language("Rust") code: String) {
         InlineFile(code)
         val ref = findElementInEditor<RsReferenceElement>().reference


### PR DESCRIPTION
(in the real worlds it's relevant for `cfg`ed trait methods)