### PR TITLE
INT & ANN: Implement intention and fix for struct fields expansion instead of `..`

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsPatFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsPatFix.kt
@@ -1,0 +1,34 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.ide.utils.expandStructFields
+import org.rust.ide.utils.expandTupleStructFields
+import org.rust.lang.core.psi.RsPatStruct
+import org.rust.lang.core.psi.RsPatTupleStruct
+import org.rust.lang.core.psi.RsPsiFactory
+
+class AddStructFieldsPatFix(
+    element: PsiElement
+) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+    override fun getText() = "Add missing fields"
+
+    override fun getFamilyName() = text
+
+    override fun invoke(project: Project, file: PsiFile, editor: Editor?, pat: PsiElement, endElement: PsiElement) {
+        val factory = RsPsiFactory(project)
+        if (pat is RsPatStruct) {
+            expandStructFields(factory, pat)
+        } else if (pat is RsPatTupleStruct) {
+            expandTupleStructFields(factory, editor, pat)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/intentions/AddStructFieldsPatIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddStructFieldsPatIntention.kt
@@ -1,0 +1,43 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.rust.ide.utils.expandStructFields
+import org.rust.ide.utils.expandTupleStructFields
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.elementType
+
+class AddStructFieldsPatIntention : RsElementBaseIntentionAction<AddStructFieldsPatIntention.Context>() {
+    override fun getText() = "Replace .. with actual fields"
+
+    override fun getFamilyName() = text
+
+    data class Context(
+        val structBody: RsPat
+    )
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        return if (element.elementType == RsElementTypes.DOTDOT
+            && (element.context is RsPatStruct || element.context is RsPatTupleStruct)) {
+            Context(element.context as RsPat)
+        } else {
+            null
+        }
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val factory = RsPsiFactory(project)
+        val structBody = ctx.structBody
+        if (structBody is RsPatStruct) {
+            expandStructFields(factory, structBody)
+        } else if (structBody is RsPatTupleStruct) {
+            expandTupleStructFields(factory, editor, structBody)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/utils/StructFieldsExpander.kt
+++ b/src/main/kotlin/org/rust/ide/utils/StructFieldsExpander.kt
@@ -1,0 +1,101 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.utils
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve.ref.deepResolve
+import org.rust.openapiext.buildAndRunTemplate
+import org.rust.openapiext.createSmartPointer
+
+fun expandStructFields(factory: RsPsiFactory, patStruct: RsPatStruct) {
+    val declaration = patStruct.path.reference.deepResolve() as? RsFieldsOwner ?: return
+    val hasTrailingComma = patStruct.rbrace.getPrevNonCommentSibling()?.elementType == RsElementTypes.COMMA
+    patStruct.dotdot?.delete()
+    val existingFields = patStruct.patFieldList
+    val bodyFieldNames = existingFields.map { it.kind.fieldName }.toSet()
+    val missingFields = declaration.fields
+        .filter { it.name !in bodyFieldNames && !it.queryAttributes.hasCfgAttr() }
+        .map { factory.createPatField(it.name!!) }
+
+    if (existingFields.isEmpty()) {
+        addFieldsToPat(factory, patStruct, missingFields, hasTrailingComma)
+        return
+    }
+
+    val fieldPositions = declaration.fields.withIndex().associate { it.value.name!! to it.index }
+    var insertedFieldsAmount = 0
+    for (missingField in missingFields) {
+        val missingFieldPosition = fieldPositions[missingField.kind.fieldName]!!
+        for (existingField in existingFields) {
+            val existingFieldPosition = fieldPositions[existingField.kind.fieldName] ?: continue
+            if (missingFieldPosition < existingFieldPosition) {
+                patStruct.addBefore(missingField, existingField)
+                patStruct.addAfter(factory.createComma(), existingField.getPrevNonCommentSibling())
+                insertedFieldsAmount++
+                break
+            }
+        }
+    }
+    addFieldsToPat(factory, patStruct, missingFields.drop(insertedFieldsAmount), hasTrailingComma)
+}
+
+fun expandTupleStructFields(factory: RsPsiFactory, editor: Editor?, patTuple: RsPatTupleStruct) {
+    val declaration = patTuple.path.reference.deepResolve() as? RsFieldsOwner ?: return
+    val hasTrailingComma = patTuple.rparen.getPrevNonCommentSibling()?.elementType == RsElementTypes.COMMA
+    val bodyFields = patTuple.childrenOfType<RsPatIdent>()
+    val missingFieldsAmount = declaration.fields.size - bodyFields.size
+    addFieldsToPat(factory, patTuple, createTupleStructMissingFields(factory, missingFieldsAmount), hasTrailingComma)
+    patTuple.dotdot?.delete()
+    editor?.buildAndRunTemplate(patTuple, patTuple.childrenOfType<RsPatBinding>().map { it.createSmartPointer() })
+}
+
+private fun createTupleStructMissingFields(factory: RsPsiFactory, amount: Int): List<RsPatBinding> {
+    val missingFields = ArrayList<RsPatBinding>(amount)
+    for (i in 0 until amount) {
+        missingFields.add(factory.createPatBinding("_$i"))
+    }
+    return missingFields
+}
+
+private fun addFieldsToPat(factory: RsPsiFactory, pat: RsPat, fields: List<PsiElement>, hasTrailingComma: Boolean) {
+    var anchor = determineOrCreateAnchor(factory, pat)
+    for (missingField in fields) {
+        pat.addAfter(missingField, anchor)
+        // Do not insert comma if we are in the middle of pattern
+        // since it will cause double comma in patterns with a trailing comma.
+        if (fields.last() == missingField) {
+            if (anchor.nextSibling?.getNextNonCommentSibling()?.elementType != RsElementTypes.DOTDOT) {
+                pat.addAfter(factory.createComma(), anchor.nextSibling)
+            }
+        } else {
+            pat.addAfter(factory.createComma(), anchor.nextSibling)
+        }
+        anchor = anchor.nextSibling.nextSibling as LeafPsiElement
+    }
+    if (!hasTrailingComma) {
+        anchor.delete()
+    }
+}
+
+private fun determineOrCreateAnchor(factory: RsPsiFactory, pat: RsPat): PsiElement {
+    val dots = pat.childrenOfType<LeafPsiElement>().firstOrNull { it.elementType == RsElementTypes.DOTDOT }
+    if (dots != null) {
+        // Picking dots prev sibling as anchor allows as to fill the pattern starting from dots position
+        // instead of filling pattern starting from the end.
+        return dots.getPrevNonCommentSibling()!! as LeafPsiElement
+    }
+    val lastElementInBody = pat.lastChild.getPrevNonCommentSibling()!!
+    return if (lastElementInBody !is LeafPsiElement) {
+        pat.addAfter(factory.createComma(), lastElementInBody)
+        lastElementInBody.nextSibling
+    } else {
+        lastElementInBody
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -387,6 +387,14 @@ class RsPsiFactory(
             ?.firstChild as RsPatBinding?
             ?: error("Failed to create pat element")
 
+    fun createPatField(name: String): RsPatField =
+        createFromText("""
+            struct Foo { bar: i32 }
+            fn baz(foo: Foo) {
+                let Foo { $name } = foo;
+            }
+        """) ?: error("Failed to create pat field")
+
     fun createPatStruct(struct: RsStructItem): RsPatStruct {
         val structName = struct.name ?: error("Failed to create pat struct")
         val pad = if (struct.namedFields.isEmpty()) "" else " "

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1104,10 +1104,77 @@ sealed class RsDiagnostic(
                 "nested `impl Trait` is not allowed"
             )
     }
+
+    class MissingFieldsInEnumVariantTuplePattern(pat: RsPat, private val declaration: String) : RsDiagnostic(pat) {
+        override fun prepare(): PreparedAnnotation {
+            return PreparedAnnotation(
+                ERROR,
+                E0023,
+                "Enum variant pattern does not correspond to its declaration: `$declaration`",
+                fixes = listOf(AddStructFieldsPatFix(element))
+            )
+        }
+    }
+    class MissingFieldsInEnumVariantPattern(pat: RsPat, private val declaration: String) : RsDiagnostic(pat) {
+        override fun prepare(): PreparedAnnotation {
+            return PreparedAnnotation(
+                ERROR,
+                E0027,
+                "Enum variant pattern does not correspond to its declaration: `$declaration`",
+                fixes = listOf(AddStructFieldsPatFix(element))
+            )
+        }
+    }
+
+    class MissingFieldsInStructPattern(pat: RsPat, private val declaration: String) : RsDiagnostic(pat) {
+        override fun prepare(): PreparedAnnotation {
+            return PreparedAnnotation(
+                ERROR,
+                E0027,
+                "Struct pattern does not correspond to its declaration: `$declaration`",
+                fixes = listOf(AddStructFieldsPatFix(element))
+            )
+        }
+    }
+
+    class MissingFieldsInTupleStructPattern(pat: RsPat, private val declaration: String) : RsDiagnostic(pat) {
+        override fun prepare(): PreparedAnnotation {
+            return PreparedAnnotation(
+                ERROR,
+                E0023,
+                "Tuple struct pattern does not correspond to its declaration: `$declaration`",
+                fixes = listOf(AddStructFieldsPatFix(element))
+            )
+        }
+    }
+
+    class ExtraFieldInStructPattern(private val extraField: RsPatField) : RsDiagnostic(extraField) {
+        override fun prepare(): PreparedAnnotation {
+            return PreparedAnnotation(
+                ERROR,
+                E0026,
+                "Extra field found in the struct pattern: `${extraField.kind.fieldName}`"
+            )
+        }
+    }
+
+    class ExtraFieldInTupleStructPattern(
+        patTupleStruct: RsPatTupleStruct,
+        private val extraFieldsAmount: Int,
+        private val expectedAmount: Int
+    ) : RsDiagnostic(patTupleStruct) {
+        override fun prepare(): PreparedAnnotation {
+            return PreparedAnnotation(
+                ERROR,
+                E0023,
+                "Extra fields found in the tuple struct pattern: Expected $expectedAmount, found $extraFieldsAmount"
+            )
+        }
+    }
 }
 
 enum class RsErrorCode {
-    E0004, E0040, E0046, E0050, E0060, E0061, E0069, E0081, E0084,
+    E0004, E0023, E0026, E0027, E0040, E0046, E0050, E0060, E0061, E0069, E0081, E0084,
     E0106, E0107, E0118, E0120, E0121, E0124, E0132, E0133, E0184, E0185, E0186, E0198, E0199,
     E0200, E0201, E0202, E0261, E0262, E0263, E0267, E0268, E0277,
     E0308, E0322, E0328, E0379, E0384,

--- a/src/main/resources/META-INF/core.xml
+++ b/src/main/resources/META-INF/core.xml
@@ -690,6 +690,10 @@
             <className>org.rust.ide.intentions.ConvertToTupleIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.AddStructFieldsPatIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 

--- a/src/main/resources/intentionDescriptions/AddStructFieldsPatIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/AddStructFieldsPatIntention/after.rs.template
@@ -1,0 +1,4 @@
+struct Bar { baz: i32, quux: i32, eggs:i32 }
+fn foo(bar: Bar) {
+    let Bar { baz, quux, eggs } = bar;
+}

--- a/src/main/resources/intentionDescriptions/AddStructFieldsPatIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/AddStructFieldsPatIntention/before.rs.template
@@ -1,0 +1,4 @@
+struct Bar { baz: i32, quux: i32, eggs:i32 }
+fn foo(bar: Bar) {
+    let Bar { baz, .. } = bar;
+}

--- a/src/main/resources/intentionDescriptions/AddStructFieldsPatIntention/description.html
+++ b/src/main/resources/intentionDescriptions/AddStructFieldsPatIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention expands actual struct fields instead of `..`.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsPatFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsPatFixTest.kt
@@ -1,0 +1,283 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.rust.ide.annotator.RsAnnotatorTestBase
+import org.rust.ide.annotator.RsErrorAnnotator
+
+class AddStructFieldsPatFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class.java) {
+    fun `test one field missing`() = checkFixByText("Add missing fields", """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+        }
+        fn main() {
+            let <error>Foo { a, b }/*caret*/</error> = foo;
+        }
+        """, """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+        }
+        fn main() {
+            let Foo { a, b, c }/*caret*/ = foo;
+        }
+        """
+    )
+
+    fun `test one field missing with trailing comma`() = checkFixByText("Add missing fields", """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+        }
+        fn main() {
+            let <error>Foo { a, b, }/*caret*/</error> = foo;
+        }
+        """, """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+        }
+        fn main() {
+            let Foo { a, b, c, }/*caret*/ = foo;
+        }
+        """
+    )
+
+    fun `test missing fields with extra fields existing`() = checkFixByText("Add missing fields", """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+            d: i32,
+        }
+        fn main() {
+            let <error>Foo { a, <error>bar</error>, d }/*caret*/</error> = foo;
+        }
+        """, """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+            d: i32,
+        }
+        fn main() {
+            let Foo { a, bar, b, c, d }/*caret*/ = foo;
+        }
+        """
+    )
+
+    fun `test filling order between 2 last fields existing`() = checkFixByText("Add missing fields", """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+            d: i32,
+        }
+        fn main() {
+            let <error>Foo { b, d }/*caret*/</error> = foo;
+        }
+        """, """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+            d: i32,
+        }
+        fn main() {
+            let Foo { a, b, c, d }/*caret*/ = foo;
+        }
+        """
+    )
+
+    fun `test filling order between first and last fields existing`() = checkFixByText("Add missing fields", """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+            d: i32,
+        }
+        fn main() {
+            let <error>Foo { a, d }/*caret*/</error> = foo;
+        }
+        """, """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+            d: i32,
+        }
+        fn main() {
+            let Foo { a, b, c, d }/*caret*/ = foo;
+        }
+        """
+    )
+
+    fun `test filling order with the first field existing`() = checkFixByText("Add missing fields", """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+            d: i32,
+        }
+        fn main() {
+            let <error>Foo { a }/*caret*/</error> = foo;
+        }
+        """, """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+            d: i32,
+        }
+        fn main() {
+            let Foo { a, b, c, d }/*caret*/ = foo;
+        }
+        """
+    )
+
+    fun `test filling order with the second field existing`() = checkFixByText("Add missing fields", """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+            d: i32,
+        }
+        fn main() {
+            let <error>Foo { b }/*caret*/</error> = foo;
+        }
+        """, """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+            d: i32,
+        }
+        fn main() {
+            let Foo { a, b, c, d }/*caret*/ = foo;
+        }
+        """
+    )
+
+    fun `test filling order with the third field existing`() = checkFixByText("Add missing fields", """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+            d: i32,
+        }
+        fn main() {
+            let <error>Foo { c }/*caret*/</error> = foo;
+        }
+        """, """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+            d: i32,
+        }
+        fn main() {
+            let Foo { a, b, c, d }/*caret*/ = foo;
+        }
+        """
+    )
+
+    fun `test one field missing in tuple`() = checkFixByText("Add missing fields", """
+        enum Foo {
+            Bar(i32, i32, i32)
+        }
+        fn main() {
+            let x = Foo::Bar(1, 2, 3);
+            match x {
+                <error>Foo::Bar(a, b)/*caret*/</error> => {}
+            }
+        }
+        """, """
+        enum Foo {
+            Bar(i32, i32, i32)
+        }
+        fn main() {
+            let x = Foo::Bar(1, 2, 3);
+            match x {
+                Foo::Bar(a, b, _0/*caret*/) => {}
+            }
+        }
+        """
+    )
+
+    fun `test tuple with no fields`() = checkFixByText("Add missing fields", """
+        enum Foo {
+            Bar(i32, i32, i32)
+        }
+        fn main() {
+            let x = Foo::Bar(1, 2, 3);
+            match x {
+                <error>Foo::Bar()/*caret*/</error> => {}
+            }
+        }
+        """, """
+        enum Foo {
+            Bar(i32, i32, i32)
+        }
+        fn main() {
+            let x = Foo::Bar(1, 2, 3);
+            match x {
+                Foo::Bar(_0/*caret*/, _1, _2) => {}
+            }
+        }
+        """
+    )
+
+    fun `test tuple with one field with comma`() = checkFixByText("Add missing fields", """
+        enum Foo {
+            Bar(i32, i32, i32)
+        }
+        fn main() {
+            let x = Foo::Bar(1, 2, 3);
+            match x {
+                <error>Foo::Bar(a,)/*caret*/</error> => {}
+            }
+        }
+        """, """
+        enum Foo {
+            Bar(i32, i32, i32)
+        }
+        fn main() {
+            let x = Foo::Bar(1, 2, 3);
+            match x {
+                Foo::Bar(a, _0/*caret*/, _1, ) => {}
+            }
+        }
+        """
+    )
+
+    fun `test tuple with one field without comma`() = checkFixByText("Add missing fields", """
+        enum Foo {
+            Bar(i32, i32, i32)
+        }
+        fn main() {
+            let x = Foo::Bar(1, 2, 3);
+            match x {
+                <error>Foo::Bar(a)/*caret*/</error> => {}
+            }
+        }
+        """, """
+        enum Foo {
+            Bar(i32, i32, i32)
+        }
+        fn main() {
+            let x = Foo::Bar(1, 2, 3);
+            match x {
+                Foo::Bar(a, _0/*caret*/, _1) => {}
+            }
+        }
+        """
+    )
+}

--- a/src/test/kotlin/org/rust/ide/intentions/AddStructFieldsPatIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddStructFieldsPatIntentionTest.kt
@@ -1,0 +1,362 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+class AddStructFieldsPatIntentionTest : RsIntentionTestBase(AddStructFieldsPatIntention()) {
+    fun `test simple case match`() = doAvailableTest(
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                match foo {
+                    Foo { a, b, ./*caret*/. } => {}
+                }
+            }
+        """,
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                match foo {
+                    Foo { a, b, c, d /*caret*/} => {}
+                }
+            }
+        """
+    )
+
+    fun `test no fields match`() = doAvailableTest(
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                match foo {
+                    Foo { ./*caret*/. } => {}
+                }
+            }
+        """,
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                match foo {
+                    Foo { a, b, c, d /*caret*/} => {}
+                }
+            }
+        """
+    )
+
+    fun `test simple let expression`() = doAvailableTest(
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                let Foo { a, b, ./*caret*/. } = foo;
+            }
+        """,
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                let Foo { a, b, c, d /*caret*/} = foo;
+            }
+        """
+    )
+
+    fun `test no fields let expression`() = doAvailableTest(
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                let Foo { ./*caret*/. } = foo;
+            }
+        """,
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                let Foo { a, b, c, d /*caret*/} = foo;
+            }
+        """
+    )
+
+    fun `test match one field missing`() = doAvailableTest(
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                match foo {
+                    Foo { a, b, c, ./*caret*/. } => {}
+                }
+            }
+        """,
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                match foo {
+                    Foo { a, b, c, d /*caret*/} => {}
+                }
+            }
+        """
+    )
+
+    fun `test let one field missing`() = doAvailableTest(
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                let Foo { a, b, c, ./*caret*/. } = foo;
+            }
+        """,
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                let Foo { a, b, c, d /*caret*/} = foo;
+            }
+        """
+    )
+
+    fun `test filling order with existing 2 last fields in descending order`() = doAvailableTest(
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                let Foo { d, c, ./*caret*/. } = foo;
+            }
+        """,
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                let Foo { a, b, d, c /*caret*/} = foo;
+            }
+        """
+    )
+
+    fun `test filling order with the second field existing`() = doAvailableTest(
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                let Foo { b, ./*caret*/. } = foo;
+            }
+        """,
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+                d: i32,
+            }
+            fn f(foo: Foo) {
+                let Foo { a, b, c, d /*caret*/} = foo;
+            }
+        """
+    )
+
+    fun `test tuple struct with dots`() = doAvailableTest(
+        """
+            struct Foo(i32, i32, i32);
+            fn f(foo: Foo) {
+                match foo {
+                    Foo (a, b, ./*caret*/.) => {}
+                }
+            }
+        """,
+        """
+            struct Foo(i32, i32, i32);
+            fn f(foo: Foo) {
+                match foo {
+                    Foo (a, b, _0/*caret*/) => {}
+                }
+            }
+        """
+    )
+
+    fun `test struct with no spaces`() = doAvailableTest(
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+            }
+
+            fn f(foo: Foo) {
+                let Foo {a,b,./*caret*/.} = foo;
+            }
+        """,
+        """
+            struct Foo {
+                a: i32,
+                b: i32,
+                c: i32,
+            }
+
+            fn f(foo: Foo) {
+                let Foo {a,b,/*caret*/ c } = foo;
+            }
+        """
+    )
+
+    fun `test tuple struct with no spaces`() = doAvailableTest(
+        """
+            struct Foo(i32, i32, i32);
+            fn f(foo: Foo) {
+                match foo {
+                    Foo (a,b,./*caret*/.) => {}
+                }
+            }
+        """,
+        """
+            struct Foo(i32, i32, i32);
+            fn f(foo: Foo) {
+                match foo {
+                    Foo (a, b, _0/*caret*/) => {}
+                }
+            }
+        """
+    )
+
+    fun `test intention not available in range`() = doUnavailableTest(
+        """
+            fn f() {
+                match 1 {
+                    0./*caret*/.2 => {}
+                    _ => {}
+                }
+            }
+        """
+    )
+
+    fun `test tuple with dots in the middle`() = doAvailableTest(
+        """
+            struct Foo(i32, i32, i32);
+
+            fn f(foo: Foo) {
+                let Foo (a, ./*caret*/., c) = foo;
+            }
+        """,
+        """
+            struct Foo(i32, i32, i32);
+
+            fn f(foo: Foo) {
+                let Foo (a, _0/*caret*/, c) = foo;
+            }
+        """
+    )
+
+    fun `test tuple with dots in the middle and trailing comma`() = doAvailableTest(
+        """
+            struct Foo(i32, i32, i32);
+
+            fn f(foo: Foo) {
+                let Foo (a, ./*caret*/., c,) = foo;
+            }
+        """,
+        """
+            struct Foo(i32, i32, i32);
+
+            fn f(foo: Foo) {
+                let Foo (a, _0/*caret*/, c,) = foo;
+            }
+        """
+    )
+
+    fun `test tuple with dots in the middle and 4 fields`() = doAvailableTest(
+        """
+            struct Foo(i32, i32, i32, i32);
+
+            fn f(foo: Foo) {
+                let Foo (a, ./*caret*/., c) = foo;
+            }
+        """,
+        """
+            struct Foo(i32, i32, i32, i32);
+
+            fn f(foo: Foo) {
+                let Foo (a, _0/*caret*/, _1, c) = foo;
+            }
+        """
+    )
+
+    fun `test tuple with dots in the middle and 5 fields`() = doAvailableTest(
+        """
+            struct Foo(i32, i32, i32, i32, i32);
+
+            fn f(foo: Foo) {
+                let Foo (a, ./*caret*/., c) = foo;
+            }
+        """,
+        """
+            struct Foo(i32, i32, i32, i32, i32);
+
+            fn f(foo: Foo) {
+                let Foo (a, _0/*caret*/, _1, _2, c) = foo;
+            }
+        """
+    )
+}


### PR DESCRIPTION
<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
In this pull request I intend to do the following:
1) Create E0023 and E0027 error classes and implement analysis for them.
2) Create fix for those errors.
3) Create intention for struct fields expansion.
4) Create a module with shared code for using it in the fix and intention.

Once these steps are complete I will squash all the commits and #3928 should be closed after merge.