### PR TITLE
COMP: Add completion in partial macro call arguments

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -87,7 +87,7 @@
     elementType(".+BinExpr") = BinaryExpr
     elementType(".+BinOp") = BinaryOp
 
-    elementTypeFactory("ExprCodeFragment") = "org.rust.lang.core.psi.RsCodeFragmentElementTypeKt.factory"
+    elementTypeFactory("(Expr|Stmt|TypeRef)CodeFragment") = "org.rust.lang.core.psi.RsCodeFragmentElementTypeKt.factory"
 
     extends("Pat(Wild|Ref|Tup|Slice|Macro|Struct|TupleStruct|Ident|Range|Box|Const)") = Pat
 
@@ -1444,6 +1444,10 @@ private never ::= !()
 private meta comma_separated_list ::= <<param>> ( ',' <<param>> )* ','?
 private meta list_element ::= <<param>> !'+' (',' | &'>') { pin = 2 }
 
-// This parsing rule is used directly from the code
+// These parsing rules are used directly from the code
 //noinspection BnfUnusedRule
 ExprCodeFragment ::= Expr?
+//noinspection BnfUnusedRule
+StmtCodeFragment ::= Stmt?
+//noinspection BnfUnusedRule
+TypeRefCodeFragment ::= TypeReference?

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -52,6 +52,17 @@ object RsCommonCompletionProvider : CompletionProvider<CompletionParameters>() {
 
         val isSimplePath = simplePathPattern.accepts(parameters.position)
         val expectedTy = getExpectedTypeForEnclosingPathOrDotExpr(element)
+        processElement(element, isSimplePath, expectedTy, processedPathNames, parameters, result)
+    }
+
+    fun processElement(
+        element: RsReferenceElement,
+        isSimplePath: Boolean,
+        expectedTy: Ty?,
+        processedPathNames: HashSet<String>,
+        parameters: CompletionParameters,
+        result: CompletionResultSet
+    ) {
         collectCompletionVariants(result, isSimplePath, expectedTy) {
             when (element) {
                 is RsAssocTypeBinding -> processAssocTypeVariants(element, it)
@@ -184,7 +195,7 @@ object RsCommonCompletionProvider : CompletionProvider<CompletionParameters>() {
     val elementPattern: ElementPattern<PsiElement>
         get() = PlatformPatterns.psiElement().withParent(psiElement<RsReferenceElement>())
 
-    private val simplePathPattern: ElementPattern<PsiElement>
+    val simplePathPattern: ElementPattern<PsiElement>
         get() {
             val simplePath = psiElement<RsPath>()
                 .with(object : PatternCondition<RsPath>("SimplePath") {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
@@ -19,6 +19,7 @@ class RsCompletionContributor : CompletionContributor() {
         extend(CompletionType.BASIC, RsDeriveCompletionProvider.elementPattern, RsDeriveCompletionProvider)
         extend(CompletionType.BASIC, AttributeCompletionProvider.elementPattern, AttributeCompletionProvider)
         extend(CompletionType.BASIC, RsMacroCompletionProvider.elementPattern, RsMacroCompletionProvider)
+        extend(CompletionType.BASIC, RsPartialMacroArgumentCompletionProvider.elementPattern, RsPartialMacroArgumentCompletionProvider)
     }
 
     override fun invokeAutoPopup(position: PsiElement, typeChar: Char): Boolean =

--- a/src/main/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionProvider.kt
@@ -1,0 +1,69 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.patterns.ElementPattern
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.PsiElement
+import com.intellij.util.ProcessingContext
+import org.rust.lang.RsLanguage
+import org.rust.lang.core.macros.FragmentKind
+import org.rust.lang.core.macros.FragmentKind.*
+import org.rust.lang.core.macros.MacroGraphWalker
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psiElement
+
+object RsPartialMacroArgumentCompletionProvider : CompletionProvider<CompletionParameters>() {
+    override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+        fun addCompletions(fragment: RsCodeFragment, offset: Int) {
+            val reference = fragment.findReferenceAt(offset) ?: return
+            val referenceElement = reference.element as? RsReferenceElement ?: return
+            val isSimplePath = RsCommonCompletionProvider.simplePathPattern.accepts(referenceElement.firstChild)
+
+            RsCommonCompletionProvider.processElement(referenceElement, isSimplePath, null, hashSetOf(), parameters, result)
+
+            if (RsPrimitiveTypeCompletionProvider.elementPattern.accepts(referenceElement.firstChild)) {
+                RsPrimitiveTypeCompletionProvider.addCompletionVariants(parameters, context, result)
+            }
+        }
+
+        val project = parameters.originalFile.project
+        val position = parameters.position
+        val macroCall = position.ancestorStrict<RsMacroArgument>()?.ancestorStrict<RsMacroCall>() ?: return
+        val bodyTextRange = macroCall.bodyTextRange ?: return
+        val macroCallBody = macroCall.macroBody ?: return
+        val macro = macroCall.resolveToMacro() ?: return
+        val graph = macro.graph ?: return
+        val offsetInArgument = parameters.offset - bodyTextRange.startOffset
+
+        val walker = MacroGraphWalker(project, graph, macroCallBody, offsetInArgument)
+        val fragmentDescriptors = walker.run().takeIf { it.isNotEmpty() } ?: return
+        val usedKinds = mutableSetOf<FragmentKind>()
+
+        for ((fragmentText, caretOffsetInFragment, kind) in fragmentDescriptors) {
+            if (kind in usedKinds) continue
+
+            val codeFragment = when (kind) {
+                Expr, Path -> RsExpressionCodeFragment(project, fragmentText, macroCall)
+                Stmt -> RsStatementCodeFragment(project, fragmentText, macroCall)
+                Ty -> RsTypeReferenceCodeFragment(project, fragmentText, macroCall)
+                else -> null
+            } ?: continue
+
+            addCompletions(codeFragment, caretOffsetInFragment)
+            usedKinds.add(kind)
+        }
+    }
+
+    val elementPattern: ElementPattern<PsiElement>
+        get() = PlatformPatterns.psiElement()
+            .withLanguage(RsLanguage)
+            .inside(psiElement<RsMacroArgument>())
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/FragmentKind.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/FragmentKind.kt
@@ -1,0 +1,126 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.lang.PsiBuilder
+import com.intellij.lang.parser.GeneratedParserUtilBase
+import com.intellij.psi.tree.TokenSet
+import org.rust.lang.core.parser.RustParser
+import org.rust.lang.core.psi.RS_KEYWORDS
+import org.rust.lang.core.psi.RsElementTypes
+import org.rust.lang.core.psi.tokenSetOf
+
+enum class FragmentKind {
+    Ident,
+    Path,
+    Expr,
+    Ty,
+    Pat,
+    Stmt,
+    Block,
+    Item,
+    Meta,
+    Tt,
+    Vis,
+    Literal,
+    Lifetime;
+
+    fun parse(builder: PsiBuilder): Boolean {
+        return if (this == Ident) {
+            parseIdentifier(builder)
+        } else {
+            // we use similar logic as in org.rust.lang.core.parser.RustParser#parseLight
+            val root = RsElementTypes.FUNCTION
+            val adaptBuilder = GeneratedParserUtilBase.adapt_builder_(
+                root,
+                builder,
+                RustParser(),
+                RustParser.EXTENDS_SETS_
+            )
+            val marker = GeneratedParserUtilBase
+                .enter_section_(adaptBuilder, 0, GeneratedParserUtilBase._COLLAPSE_, null)
+
+            val parsed = when (this) {
+                Path -> RustParser.PathGenericArgsWithColons(adaptBuilder, 0)
+                Expr -> RustParser.Expr(adaptBuilder, 0, -1)
+                Ty -> RustParser.TypeReference(adaptBuilder, 0)
+                Pat -> RustParser.Pat(adaptBuilder, 0)
+                Stmt -> parseStatement(adaptBuilder)
+                Block -> RustParser.SimpleBlock(adaptBuilder, 0)
+                Item -> parseItem(adaptBuilder)
+                Meta -> RustParser.MetaItemWithoutTT(adaptBuilder, 0)
+                Vis -> parseVis(adaptBuilder)
+                Tt -> RustParser.TT(adaptBuilder, 0)
+                Lifetime -> RustParser.Lifetime(adaptBuilder, 0)
+                Literal -> RustParser.LitExpr(adaptBuilder, 0)
+                Ident -> false // impossible
+            }
+            GeneratedParserUtilBase.exit_section_(adaptBuilder, 0, marker, root, parsed, true) { _, _ -> false }
+            parsed
+        }
+    }
+
+    private fun parseIdentifier(b: PsiBuilder): Boolean {
+        return if (b.tokenType in IDENTIFIER_TOKENS) {
+            b.advanceLexer()
+            true
+        } else {
+            false
+        }
+    }
+
+    private fun parseStatement(b: PsiBuilder): Boolean =
+        RustParser.LetDecl(b, 0) || RustParser.Expr(b, 0, -1)
+
+    private fun parseItem(b: PsiBuilder): Boolean =
+        parseItemFns.any { it(b, 0) }
+
+    private fun parseVis(b: PsiBuilder): Boolean {
+        RustParser.Vis(b, 0)
+        return true // Vis can be empty
+    }
+
+    companion object {
+        fun fromString(s: String): FragmentKind? = when (s) {
+            "ident" -> Ident
+            "path" -> Path
+            "expr" -> Expr
+            "ty" -> Ty
+            "pat" -> Pat
+            "stmt" -> Stmt
+            "block" -> Block
+            "item" -> Item
+            "meta" -> Meta
+            "vis" -> Vis
+            "tt" -> Tt
+            "lifetime" -> Lifetime
+            "literal" -> Literal
+            else -> null
+        }
+
+        /**
+         * Some tokens that treated as keywords by our lexer,
+         * but rustc's macro parser treats them as identifiers
+         */
+        private val IDENTIFIER_TOKENS = TokenSet.orSet(tokenSetOf(RsElementTypes.IDENTIFIER), RS_KEYWORDS)
+
+        private val parseItemFns = listOf(
+            RustParser::Constant,
+            RustParser::TypeAlias,
+            RustParser::Function,
+            RustParser::TraitItem,
+            RustParser::ImplItem,
+            RustParser::ModItem,
+            RustParser::ModDeclItem,
+            RustParser::ForeignModItem,
+            RustParser::StructItem,
+            RustParser::EnumItem,
+            RustParser::UseItem,
+            RustParser::ExternCrateItem,
+            RustParser::MacroCall
+        )
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -7,17 +7,14 @@ package org.rust.lang.core.macros
 
 import com.intellij.lang.PsiBuilder
 import com.intellij.lang.PsiBuilderUtil
-import com.intellij.lang.parser.GeneratedParserUtilBase
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
-import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.util.SmartList
-import org.rust.lang.core.parser.RustParser
 import org.rust.lang.core.parser.RustParserUtil.collapsedTokenType
 import org.rust.lang.core.parser.createRustPsiBuilder
 import org.rust.lang.core.psi.*
@@ -30,7 +27,7 @@ import org.rust.stdext.mapNotNullToSet
 import java.util.*
 import java.util.Collections.singletonMap
 
-private data class MacroSubstitution(
+data class MacroSubstitution(
     /**
      * Maps meta variable names with the actual values, e.g. for this macro
      * ```rust
@@ -75,7 +72,7 @@ private data class MacroSubstitution(
     val groups: List<MacroGroup>
 )
 
-private data class MacroGroup(
+data class MacroGroup(
     val definition: RsMacroBindingGroup,
     val substs: List<MacroSubstitution>
 )
@@ -91,9 +88,9 @@ private data class WithParent(
         subst.variables[name] ?: parent?.getVar(name)
 }
 
-private data class MetaVarValue(
+data class MetaVarValue(
     val value: String,
-    val type: String,
+    val kind: FragmentKind?,
     val offsetInCallBody: Int
 )
 
@@ -106,7 +103,7 @@ class MacroExpander(val project: Project) {
             subst,
             WithParent(
                 MacroSubstitution(
-                    singletonMap("crate", MetaVarValue(expandDollarCrateVar(call, def), "", -1)),
+                    singletonMap("crate", MetaVarValue(expandDollarCrateVar(call, def), null, -1)),
                     emptyList()
                 ),
                 null
@@ -158,7 +155,7 @@ class MacroExpander(val project: Project) {
                     if (!substituteMacro(sb, ranges, child, subst)) return false
                 is RsMacroReference -> {
                     val value = subst.getVar(child.referenceName) ?: return false
-                    val parensNeeded = value.type == "expr"
+                    val parensNeeded = value.kind == FragmentKind.Expr
                     if (parensNeeded) {
                         sb.append("(")
                         sb.append(value.value)
@@ -256,7 +253,7 @@ private fun expandDollarCrateVar(call: RsMacroCall, def: RsMacro): String {
 /** Prefix for synthetic identifier produced from `$crate` metavar. See [expandDollarCrateVar] */
 const val MACRO_CRATE_IDENTIFIER_PREFIX: String = "IntellijRustDollarCrate_"
 
-private class MacroPattern private constructor(
+class MacroPattern private constructor(
     val pattern: Sequence<PsiElement>
 ) {
     fun match(macroCallBody: PsiBuilder): MacroSubstitution? {
@@ -281,16 +278,17 @@ private class MacroPattern private constructor(
             when (psi) {
                 is RsMacroBinding -> {
                     val name = psi.metaVarIdentifier.text ?: return null
-                    val type = psi.fragmentSpecifier ?: return null
+                    val fragmentSpecifier = psi.fragmentSpecifier ?: return null
+                    val kind = FragmentKind.fromString(fragmentSpecifier) ?: return null
 
                     val lastOffset = macroCallBody.currentOffset
-                    val parsed = parse(macroCallBody, type)
-                    if (!parsed || (lastOffset == macroCallBody.currentOffset && type != "vis")) {
+                    val parsed = kind.parse(macroCallBody)
+                    if (!parsed || (lastOffset == macroCallBody.currentOffset && kind != FragmentKind.Vis)) {
                         MacroExpansionMarks.failMatchPatternByBindingType.hit()
                         return null
                     }
                     val text = macroCallBody.originalText.substring(lastOffset, macroCallBody.currentOffset)
-                    map[name] = MetaVarValue(text, type, lastOffset)
+                    map[name] = MetaVarValue(text, kind, lastOffset)
                 }
                 is RsMacroBindingGroup -> {
                     groups += MacroGroup(psi, matchGroup(psi, macroCallBody) ?: return null)
@@ -306,40 +304,6 @@ private class MacroPattern private constructor(
         return MacroSubstitution(map, groups)
     }
 
-    private fun parse(builder: PsiBuilder, type: String): Boolean {
-        return if (type == "ident") {
-            parseIdentifier(builder)
-        } else {
-            // we use similar logic as in org.rust.lang.core.parser.RustParser#parseLight
-            val root = RsElementTypes.FUNCTION
-            val adaptBuilder = GeneratedParserUtilBase.adapt_builder_(
-                root,
-                builder,
-                RustParser(),
-                RustParser.EXTENDS_SETS_
-            )
-            val marker = GeneratedParserUtilBase
-                .enter_section_(adaptBuilder, 0, GeneratedParserUtilBase._COLLAPSE_, null)
-
-            val parsed = when (type) {
-                "path" -> RustParser.PathGenericArgsWithColons(adaptBuilder, 0)
-                "expr" -> RustParser.Expr(adaptBuilder, 0, -1)
-                "ty" -> RustParser.TypeReference(adaptBuilder, 0)
-                "pat" -> RustParser.Pat(adaptBuilder, 0)
-                "stmt" -> parseStatement(adaptBuilder)
-                "block" -> RustParser.SimpleBlock(adaptBuilder, 0)
-                "item" -> parseItem(adaptBuilder)
-                "meta" -> RustParser.MetaItemWithoutTT(adaptBuilder, 0)
-                "vis" -> parseVis(adaptBuilder)
-                "tt" -> RustParser.TT(adaptBuilder, 0)
-                "lifetime" -> RustParser.Lifetime(adaptBuilder, 0)
-                "literal" -> RustParser.LitExpr(adaptBuilder, 0)
-                else -> false
-            }
-            GeneratedParserUtilBase.exit_section_(adaptBuilder, 0, marker, root, parsed, true) { _, _ -> false }
-            parsed
-        }
-    }
 
     private fun matchGroup(group: RsMacroBindingGroup, macroCallBody: PsiBuilder): List<MacroSubstitution>? {
         val groups = mutableListOf<MacroSubstitution>()
@@ -400,26 +364,6 @@ private class MacroPattern private constructor(
         return groups
     }
 
-    private fun parseIdentifier(b: PsiBuilder): Boolean {
-        return if (b.tokenType in IDENTIFIER_TOKENS) {
-            b.advanceLexer()
-            true
-        } else {
-            false
-        }
-    }
-
-    private fun parseStatement(b: PsiBuilder): Boolean =
-        RustParser.LetDecl(b, 0) || RustParser.Expr(b, 0, -1)
-
-    private fun parseItem(b: PsiBuilder): Boolean =
-        parseItemFns.any { it(b, 0) }
-
-    private fun parseVis(b: PsiBuilder): Boolean {
-        RustParser.Vis(b, 0)
-        return true // Vis can be empty
-    }
-
     companion object {
         fun valueOf(psi: RsMacroPatternContents): MacroPattern =
             MacroPattern(psi.childrenSkipWhitespaceAndComments().flatten())
@@ -435,35 +379,13 @@ private class MacroPattern private constructor(
         private fun PsiElement.childrenSkipWhitespaceAndComments(): Sequence<PsiElement> =
             generateSequence(firstChild) { it.nextSibling }
                 .filter { it !is PsiWhiteSpace && it !is PsiComment }
-
-        private val parseItemFns = listOf(
-            RustParser::Constant,
-            RustParser::TypeAlias,
-            RustParser::Function,
-            RustParser::TraitItem,
-            RustParser::ImplItem,
-            RustParser::ModItem,
-            RustParser::ModDeclItem,
-            RustParser::ForeignModItem,
-            RustParser::StructItem,
-            RustParser::EnumItem,
-            RustParser::UseItem,
-            RustParser::ExternCrateItem,
-            RustParser::MacroCall
-        )
-
-        /**
-         * Some tokens that treated as keywords by our lexer,
-         * but rustc's macro parser treats them as identifiers
-         */
-        private val IDENTIFIER_TOKENS = TokenSet.orSet(tokenSetOf(RsElementTypes.IDENTIFIER), RS_KEYWORDS)
     }
 }
 
 private val RsMacroCase.pattern: MacroPattern
     get() = MacroPattern.valueOf(macroPattern.macroPatternContents)
 
-private fun PsiBuilder.isSameToken(psi: PsiElement): Boolean {
+fun PsiBuilder.isSameToken(psi: PsiElement): Boolean {
     val (elementType, size) = collapsedTokenType(this) ?: (tokenType to 1)
     val result = psi.elementType == elementType && (elementType != IDENTIFIER || psi.text == tokenText)
     if (result) {

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroGraph.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroGraph.kt
@@ -1,0 +1,129 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.macros.MGNodeData.*
+import org.rust.lang.core.psi.RsMacro
+import org.rust.lang.utils.Node
+import org.rust.lang.utils.PresentableGraph
+import org.rust.lang.utils.PresentableNodeData
+import java.util.*
+
+sealed class MGNodeData : PresentableNodeData {
+    class Literal(val value: PsiElement) : MGNodeData() {
+        override val text: String get() = value.text
+    }
+
+    class Fragment(val kind: FragmentKind) : MGNodeData() {
+        override val text: String get() = kind.toString()
+    }
+
+    object Start : MGNodeData() {
+        override val text: String get() = "START"
+    }
+
+    object End : MGNodeData() {
+        override val text: String get() = "END"
+    }
+
+    object BranchStart : MGNodeData() {
+        override val text: String get() = "[S]"
+    }
+
+    object BranchEnd : MGNodeData() {
+        override val text: String get() = "[E]"
+    }
+}
+
+typealias MacroGraph = PresentableGraph<MGNodeData, Unit>
+typealias MacroGraphNode = Node<MGNodeData, Unit>
+
+class MacroGraphBuilder(private val macro: RsMacro) {
+    private val graph = MacroGraph()
+    private val preds: Deque<MacroGraphNode> = ArrayDeque<MacroGraphNode>()
+    private val pred: MacroGraphNode get() = preds.peek()
+    private var result: MacroGraphNode? = null
+
+    fun build(): MacroGraph? {
+        val matcher = Matcher.buildFor(macro) ?: return null
+        val start = addNode(Start)
+        val exit = process(matcher, start)
+        addNode(End, exit)
+        return graph
+    }
+
+    private fun process(matcher: Matcher, pred: MacroGraphNode): MacroGraphNode {
+        result = null
+        val oldPredsSize = preds.size
+        preds.push(pred)
+        processMatcher(matcher)
+        preds.pop()
+        assert(preds.size == oldPredsSize)
+
+        return checkNotNull(result) { "Processing ended inconclusively" }
+    }
+
+    private fun addNode(nodeData: MGNodeData, vararg preds: MacroGraphNode): MacroGraphNode {
+        val newNode = graph.addNode(nodeData)
+        preds.forEach { addEdge(it, newNode) }
+        return newNode
+    }
+
+    private fun addEdge(source: MacroGraphNode, target: MacroGraphNode) {
+        graph.addEdge(source, target, Unit)
+    }
+
+    private inline fun finishWith(callable: () -> MacroGraphNode) {
+        result = callable()
+    }
+
+    private fun finishWith(value: MacroGraphNode) {
+        result = value
+    }
+
+    private fun processMatcher(matcher: Matcher) {
+        return when (matcher) {
+            is Matcher.Fragment -> finishWith { addNode(Fragment(matcher.kind), pred) }
+
+            is Matcher.Literal -> finishWith { addNode(Literal(matcher.value), pred) }
+
+            is Matcher.Sequence -> {
+                val subMatchersExit = matcher.matchers.fold(pred) { acc, subMatcher -> process(subMatcher, acc) }
+                finishWith(subMatchersExit)
+            }
+
+            is Matcher.Choice -> {
+                val branchStart = addNode(BranchStart, pred)
+                val variantsExits = matcher.matchers.map { process(it, branchStart) }.toTypedArray()
+                val branchEnd = addNode(BranchEnd, *variantsExits)
+                finishWith(branchEnd)
+            }
+
+            is Matcher.Optional -> {
+                val branchStart = addNode(BranchStart, pred)
+                val optMatcherExit = process(matcher.matcher, branchStart)
+                val branchEnd = addNode(BranchEnd, optMatcherExit)
+                addEdge(branchStart, branchEnd)
+                finishWith(branchEnd)
+            }
+
+            is Matcher.Repeat -> {
+                val branchEnd = addNode(BranchEnd, pred)
+                val subMatchersExit = matcher.matchers.fold(branchEnd) { acc, subMatcher -> process(subMatcher, acc) }
+                val branchStart = addNode(BranchStart, subMatchersExit)
+                val separator = matcher.separator
+                if (separator != null) {
+                    val separatorNode = addNode(Literal(separator), branchStart)
+                    addEdge(separatorNode, branchEnd)
+                } else {
+                    addEdge(branchStart, branchEnd)
+                }
+                finishWith(branchStart)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroGraphWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroGraphWalker.kt
@@ -1,0 +1,125 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.lang.PsiBuilder
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import org.rust.lang.core.macros.MGNodeData.*
+import org.rust.lang.core.parser.createRustPsiBuilder
+import java.util.*
+import kotlin.math.min
+
+/**
+ * Walks the [graph] along with macro [callBody] and determines possible [FragmentKind]s for the given [caretOffset]
+ */
+class MacroGraphWalker(
+    project: Project,
+    private val graph: MacroGraph,
+    private val callBody: String,
+    private val caretOffset: Int
+) {
+    private enum class Status { Active, Dead, Finished }
+
+    data class FragmentDescriptor(
+        val fragmentText: String,
+        val caretOffsetInFragment: Int,
+        val kind: FragmentKind
+    )
+
+    data class State(
+        val position: MacroGraphNode,
+        val marker: PsiBuilder.Marker?,
+        val descriptor: FragmentDescriptor?
+    )
+
+    private fun rollbackToState(state: State) {
+        position = state.position
+        state.marker?.rollbackTo()
+        descriptor = state.descriptor
+    }
+
+    private val builder = project.createRustPsiBuilder(callBody).also { it.eof() } // skip whitespace
+    private val processStack: Deque<State> = ArrayDeque()
+    private var position: MacroGraphNode = graph.getNode(0)
+    private var status: Status = Status.Active
+
+    private var descriptor: FragmentDescriptor? = null
+    private val result: MutableList<FragmentDescriptor> = mutableListOf()
+
+    fun run(): List<FragmentDescriptor> {
+        processStack.push(State(position, builder.mark(), descriptor))
+
+        while (processStack.isNotEmpty()) {
+            status = Status.Active
+            val state = processStack.pop()
+            rollbackToState(state)
+
+            processMatcher()
+
+            when (status) {
+                Status.Active -> {
+                    val nextNodes = graph.outgoingEdges(position).map { it.target }.toList()
+
+                    if (nextNodes.size == 1) {
+                        // `nodeState` will be processed in the next iteration, so we don't have to rollback lexer
+                        val nodeState = State(nextNodes.single(), null, descriptor)
+                        processStack.push(nodeState)
+                    } else {
+                        for (node in nextNodes) {
+                            val nodeState = State(node, builder.mark(), descriptor)
+                            processStack.push(nodeState)
+                        }
+                    }
+                }
+                Status.Dead -> {
+                    descriptor = null
+                }
+                Status.Finished -> {
+                    descriptor?.let { result.add(it) }
+                }
+            }
+        }
+
+        return result
+    }
+
+    private fun processMatcher() {
+        when (val matcher = position.data) {
+            is Literal -> {
+                if (!builder.isSameToken(matcher.value)) {
+                    status = Status.Dead
+                }
+            }
+            is Fragment -> {
+                val fragmentStart = builder.currentOffset
+                if (matcher.kind.parse(builder)) {
+                    if (descriptor == null) {
+                        val textRange = TextRange(fragmentStart, builder.currentOffset + 1)
+                        if (textRange.contains(caretOffset) || builder.eof()) {
+                            val fragmentEnd = min(builder.currentOffset, callBody.length)
+                            val fragmentText = callBody.substring(fragmentStart, fragmentEnd)
+                            val caretOffsetInFragment = caretOffset - fragmentStart
+                            descriptor = FragmentDescriptor(fragmentText, caretOffsetInFragment, matcher.kind)
+                        }
+                    }
+                } else {
+                    status = Status.Dead
+                }
+            }
+            End -> {
+                status = if (builder.eof()) {
+                    Status.Finished
+                } else {
+                    Status.Dead
+                }
+            }
+        }
+        if (status == Status.Active && builder.eof()) {
+            status = Status.Finished
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/Matcher.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/Matcher.kt
@@ -1,0 +1,91 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.rust.lang.core.psi.RsMacro
+import org.rust.lang.core.psi.RsMacroBinding
+import org.rust.lang.core.psi.RsMacroBindingGroup
+import org.rust.lang.core.psi.ext.fragmentSpecifier
+
+sealed class Matcher {
+    data class Literal(val value: PsiElement) : Matcher()
+
+    data class Fragment(val kind: FragmentKind) : Matcher()
+
+    data class Optional(val matcher: Matcher) : Matcher()
+
+    data class Choice(val matchers: MutableList<Matcher>) : Matcher()
+
+    data class Sequence(val matchers: MutableList<Matcher>) : Matcher()
+
+    data class Repeat(val matchers: MutableList<Matcher>, val separator: PsiElement?) : Matcher()
+
+    class InvalidPatternException : Exception()
+
+    companion object {
+        fun buildFor(macro: RsMacro): Matcher? {
+            val body = macro.macroBody ?: return null
+
+            val matchers = mutableListOf<Matcher>()
+
+            for (case in body.macroCaseList) {
+                val subMatchers = mutableListOf<Matcher>()
+                val contents = case.macroPattern.macroPatternContents
+                val macroPattern = MacroPattern.valueOf(contents)
+
+                for (psi in macroPattern.pattern) {
+                    try {
+                        addNewMatcher(psi, subMatchers)
+                    } catch (e: InvalidPatternException) {
+                        return null
+                    }
+                }
+                if (subMatchers.isEmpty()) {
+                    continue
+                } else if (subMatchers.size == 1) {
+                    matchers.add(subMatchers.single())
+                } else {
+                    matchers.add(Sequence(subMatchers))
+                }
+            }
+
+            return Choice(matchers)
+        }
+
+        private fun addNewMatcher(psi: PsiElement, matchers: MutableList<Matcher>) {
+            when (psi) {
+                is LeafPsiElement -> {
+                    matchers.add(Literal(psi))
+                }
+                is RsMacroBinding -> {
+                    val specifier = psi.fragmentSpecifier ?: throw InvalidPatternException()
+                    val kind = FragmentKind.fromString(specifier) ?: throw InvalidPatternException()
+                    val matcher = Fragment(kind)
+                    matchers.add(matcher)
+                }
+                is RsMacroBindingGroup -> {
+                    val subMatchers = mutableListOf<Matcher>()
+                    val contents = psi.macroPatternContents ?: throw InvalidPatternException()
+                    val macroPattern = MacroPattern.valueOf(contents)
+                    for (subPsi in macroPattern.pattern) {
+                        addNewMatcher(subPsi, subMatchers)
+                    }
+                    val separator = psi.macroBindingGroupSeparator?.firstChild
+                    val matcher = when {
+                        psi.mul != null -> Optional(Repeat(subMatchers, separator))
+                        psi.plus != null -> Repeat(subMatchers, separator) // at least once
+                        psi.q != null -> Optional(Sequence(subMatchers)) // at most once
+                        else -> throw InvalidPatternException()
+                    }
+                    matchers.add(matcher)
+                }
+                else -> throw InvalidPatternException()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
@@ -20,6 +20,7 @@ import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.RsInferenceContextOwner
 import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.RsNamedElement
 
 abstract class RsCodeFragment(
     fileViewProvider: FileViewProvider,
@@ -98,4 +99,15 @@ class RsExpressionCodeFragment : RsCodeFragment, RsInferenceContextOwner {
         : super(project, text, RsElementTypes.EXPR_CODE_FRAGMENT, context)
 
     val expr: RsExpr? get() = PsiTreeUtil.getChildOfType(this, RsExpr::class.java)
+}
+
+class RsStatementCodeFragment(project: Project, text: CharSequence, context: RsElement)
+    : RsCodeFragment(project, text, RsElementTypes.STMT_CODE_FRAGMENT, context) {
+    val stmt: RsStmt? get() = PsiTreeUtil.getChildOfType(this, RsStmt::class.java)
+}
+
+class RsTypeReferenceCodeFragment(project: Project, text: CharSequence, context: RsElement)
+    : RsCodeFragment(project, text, RsElementTypes.TYPE_REF_CODE_FRAGMENT, context),
+      RsNamedElement {
+    val typeReference: RsTypeReference? get() = PsiTreeUtil.getChildOfType(this, RsTypeReference::class.java)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentElementType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentElementType.kt
@@ -14,6 +14,8 @@ import org.rust.lang.core.parser.RustParser
 
 fun factory(name: String): IElementType = when (name) {
     "EXPR_CODE_FRAGMENT" -> RsExprCodeFragmentElementType
+    "STMT_CODE_FRAGMENT" -> RsStmtCodeFragmentElementType
+    "TYPE_REF_CODE_FRAGMENT" -> RsTypeRefCodeFragmentElementType
     else -> error("Unknown element $name")
 }
 
@@ -27,3 +29,5 @@ abstract class RsCodeFragmentElementTypeBase(debugName: String) : ICodeFragmentE
 }
 
 object RsExprCodeFragmentElementType : RsCodeFragmentElementTypeBase("RS_EXPR_CODE_FRAGMENT")
+object RsStmtCodeFragmentElementType : RsCodeFragmentElementTypeBase("RS_STMT_CODE_FRAGMENT")
+object RsTypeRefCodeFragmentElementType : RsCodeFragmentElementTypeBase("RS_TYPE_REF_CODE_FRAGMENT")

--- a/src/main/kotlin/org/rust/lang/utils/Graph.kt
+++ b/src/main/kotlin/org/rust/lang/utils/Graph.kt
@@ -8,7 +8,7 @@ package org.rust.lang.utils
 import org.rust.stdext.nextOrNull
 import java.util.*
 
-class Graph<N, E>(
+open class Graph<N, E>(
     private val nodes: MutableList<Node<N, E>> = mutableListOf(),
     private val edges: MutableList<Edge<N, E>> = mutableListOf()
 ) {
@@ -113,6 +113,37 @@ class Graph<N, E>(
 
         return result
     }
+}
+
+interface PresentableNodeData {
+    val text: String
+}
+
+class PresentableGraph<N : PresentableNodeData, E> : Graph<N, E>() {
+    /**
+     * Creates graph description written in the DOT language.
+     * Usage: copy the output into `cfg.dot` file and run `dot -Tpng cfg.dot -o cfg.png`
+     */
+    fun createDotDescription(): String =
+        buildString {
+            append("digraph {\n")
+
+            forEachEdge { edge ->
+                val source = edge.source
+                val target = edge.target
+                val sourceNode = source.data
+                val targetNode = target.data
+                val escapedSourceText = sourceNode.text.replace("\"", "\\\"")
+                val escapedTargetText = targetNode.text.replace("\"", "\\\"")
+
+                append("    \"${source.index}: $escapedSourceText\" -> \"${target.index}: $escapedTargetText\";\n")
+            }
+
+            append("}\n")
+        }
+
+    fun depthFirstTraversalTrace(startNode: Node<N, E> = getNode(0)): String =
+        depthFirstTraversal(startNode).joinToString("\n") { it.data.text }
 }
 
 class Node<N, E>(

--- a/src/test/kotlin/org/rust/lang/core/cfg/RsControlFlowGraphTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/cfg/RsControlFlowGraphTest.kt
@@ -583,7 +583,7 @@ class RsControlFlowGraphTest : RsTestBase() {
         val block = myFixture.file.descendantsOfType<RsBlock>().firstOrNull() ?: return
         val cfg = ControlFlowGraph.buildFor(block)
         val expected = expectedIndented.trimIndent()
-        val actual = cfg.depthFirstTraversalTrace()
+        val actual = cfg.graph.depthFirstTraversalTrace(cfg.entry)
         check(actual == expected) { throw ComparisonFailure("Comparision failed", expected, actual) }
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
@@ -76,8 +76,20 @@ abstract class RsCompletionTestBase : RsTestBase() {
         checkNotNull(variants) {
             "Expected completions that contain $text, but no completions found"
         }
-        variants.filter { it.lookupString == text }.forEach { return }
-        error("Expected completions that contain $text, but got ${variants.toList()}")
+        if (variants.all { it.lookupString != text }) {
+            error("Expected completions that contain $text, but got ${variants.toList()}")
+        }
+    }
+
+    protected fun checkNotContainsCompletion(text: String, @Language("Rust") code: String) {
+        InlineFile(code).withCaret()
+        val variants = myFixture.completeBasic()
+        checkNotNull(variants) {
+            "Expected completions that contain $text, but no completions found"
+        }
+        if (variants.any { it.lookupString == text }) {
+            error("Expected completions that don't contain $text, but got ${variants.toList()}")
+        }
     }
 
     protected fun checkNoCompletion(@Language("Rust") code: String) {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import org.intellij.lang.annotations.Language
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+
+class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
+    fun `test expr 1`() = doTest("""
+        macro_rules! my_macro {
+            ($ e:expr) => (1);
+        }
+
+        fn main() {
+            let iii = 1;
+            my_macro!(i/*caret*/);
+        }
+    """, setOf("iii"))
+
+    fun `test expr 2`() = doTest("""
+        macro_rules! my_macro {
+            ($ e:expr) => (1);
+            (foo $ t:ty) => (1);
+        }
+
+        fn main() {
+            let iii = 1;
+            my_macro!(i/*caret*/);
+        }
+    """, setOf("iii"), setOf("i32"))
+
+    fun `test expr complex`() = doTest("""
+        macro_rules! my_macro {
+            ($ e:expr) => (1);
+        }
+
+        struct S { ii: i32 }
+
+        fn main() {
+            let iii = 1;
+            let s = S { ii: 42 };
+            my_macro!(foo.bar(a * s./*caret*/) + baz);
+        }
+    """, setOf("ii"), setOf("iii", "i32"))
+
+    fun `test expr repeated`() = doTest("""
+        macro_rules! my_macro {
+            ($ ($ e:expr),+) => (1);
+        }
+
+        fn main() {
+            let iii = 1;
+            my_macro!(a, b, i/*caret*/, d);
+        }
+    """, setOf("iii"))
+
+    fun `test type 1`() = doTest("""
+        macro_rules! my_macro {
+            (bar $ e:expr) => (1);
+            ($ t:ty) => (1);
+        }
+
+        fn main() {
+            let iii = 1;
+            my_macro!(i/*caret*/);
+        }
+    """, setOf("i32"), setOf("iii"))
+
+    fun `test expr and ty`() = doTest("""
+        macro_rules! my_macro {
+            ($ i:ident $ e:expr) => (1);
+            ($ i:ident $ t:ty) => (1);
+        }
+
+        fn main() {
+            let iii = 1;
+            my_macro!(foo i/*caret*/);
+        }
+    """, setOf("iii", "i32"))
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test no completion from index`() = doTest("""
+        macro_rules! my_macro {
+            ($ e:expr) => (1);
+        }
+
+        fn main() {
+            my_macro!(Hash/*caret*/);
+        }
+    """, setOf())
+
+    fun `test different fragment offsets`() = doTest("""
+        macro_rules! my_macro {
+            (foo * $ e:ty, b) => (1);
+            ($ e:expr, a) => (1);
+        }
+        
+        fn main() {
+            let iii = 1;
+            my_macro!(foo * i/*caret*/);
+        }
+    """, setOf("iii", "i32"))
+
+    private fun doTest(@Language("Rust") code: String, contains: Set<String>, notContains: Set<String> = emptySet()) {
+        for (variant in contains) {
+            checkContainsCompletion(variant, code)
+        }
+        for (variant in notContains) {
+            checkNotContainsCompletion(variant, code)
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroGraphBuilderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroGraphBuilderTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import junit.framework.ComparisonFailure
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+import org.rust.lang.core.psi.RsMacro
+import org.rust.lang.core.psi.ext.descendantsOfType
+import org.rust.lang.core.psi.ext.graph
+
+class RsMacroGraphBuilderTest : RsTestBase() {
+    private fun check(@Language("Rust") code: String, expectedIndented: String) {
+        InlineFile(code)
+        val macro = myFixture.file.descendantsOfType<RsMacro>().single()
+        val graph = macro.graph!!
+        // println(graph.createDotDescription())
+        val expected = expectedIndented.trimIndent()
+        val actual = graph.depthFirstTraversalTrace()
+        check(actual == expected) { throw ComparisonFailure("Comparision failed", expected, actual) }
+    }
+
+    fun `test one rule simple`() = check("""
+        macro_rules! my_macro {
+            ($ e:expr) => (1);
+        }
+    """, """
+        START
+        [S]
+        Expr
+        [E]
+        END
+    """)
+
+    fun `test one rule ?`() = check("""
+        macro_rules! my_macro {
+            ($ ($ id:ident $ e:expr)? ) => (1);
+        }
+    """, """
+        START
+        [S]
+        [S]
+        Ident
+        Expr
+        [E]
+        [E]
+        END
+    """)
+
+    fun `test one rule repetition *`() = check("""
+        macro_rules! my_macro {
+            ($ ($ id:ident),* ) => (1);
+        }
+    """, """
+        START
+        [S]
+        [S]
+        [E]
+        Ident
+        [S]
+        ,
+        [E]
+        [E]
+        END
+    """)
+
+    fun `test one rule repetition +`() = check("""
+        macro_rules! my_macro {
+            ($ ($ id:ident),+ ) => (1);
+        }
+    """, """
+        START
+        [S]
+        [E]
+        Ident
+        [S]
+        ,
+        [E]
+        END
+    """)
+
+    fun `test one rule parens`() = check("""
+        macro_rules! my_macro {
+            ($ i:ident($ t:ty)) => (1);
+        }
+    """, """
+        START
+        [S]
+        Ident
+        (
+        Ty
+        )
+        [E]
+        END
+    """)
+
+    fun `test many rules simple`() = check("""
+        macro_rules! my_macro {
+            ($ e:expr) => (1);
+            ($ e:ident) => (2);
+            ($ x:ty) => (3);
+            ($ x:literal) => (4);
+        }
+    """, """
+        START
+        [S]
+        Expr
+        [E]
+        END
+        Ident
+        Ty
+        Literal
+    """)
+
+    fun `test many rules complex`() = check("""
+        macro_rules! my_macro {
+            ($ e:expr) => (1);
+            ($ ($ id:ident)+ ) => (2);
+            ($ x:expr, $ y:ident) => (2);
+            ($ x:literal, ABC $ y:expr) => (4);
+        }
+    """, """
+        START
+        [S]
+        Expr
+        [E]
+        END
+        [E]
+        Ident
+        [S]
+        Expr
+        ,
+        Ident
+        Literal
+        ,
+        ABC
+        Expr
+    """)
+}

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroGraphWalkerTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroGraphWalkerTest.kt
@@ -1,0 +1,203 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import junit.framework.ComparisonFailure
+import org.intellij.lang.annotations.Language
+import org.rust.ProjectDescriptor
+import org.rust.RsTestBase
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.ext.*
+import java.util.*
+
+class RsMacroGraphWalkerTest : RsTestBase() {
+    private fun check(@Language("Rust") code: String, expected: HashSet<FragmentKind>) {
+        InlineFile(code)
+        val macroCall = myFixture.file.descendantsOfType<RsMacroCall>().single()
+        val macro = macroCall.resolveToMacro()!!
+        val graph = macro.graph!!
+
+        val position = myFixture.file.findElementAt(myFixture.caretOffset - 1)!!
+        val bodyTextRange = macroCall.bodyTextRange!!
+        val offset = position.endOffset - bodyTextRange.startOffset
+
+        val walker = MacroGraphWalker(myFixture.project, graph, macroCall.macroBody!!, offset)
+        val actual = walker.run().map { it.kind }.toSet()
+        check(actual == expected) { throw ComparisonFailure("Comparision failed", expected.toString(), actual.toString()) }
+    }
+
+    fun `test simple`() = check("""
+        macro_rules! my_macro {
+            ($ e:expr) => (1);
+            ($ i:ident) => (1);
+        }
+
+        fn main() {
+            my_macro!(x/*caret*/);
+        }
+    """, hashSetOf(FragmentKind.Expr, FragmentKind.Ident))
+
+    fun `test complex expr`() = check("""
+        macro_rules! my_macro {
+            ($ e:expr) => (1);
+        }
+
+        fn main() {
+            my_macro!(x * (y.a/*caret*/ - y.b) * z);
+        }
+    """, hashSetOf(FragmentKind.Expr))
+
+    fun `test ident repetition *`() = check("""
+        macro_rules! my_macro {
+            ($ ($ id:ident)* $ t:ty) => (1);
+        }
+
+        fn main() {
+            my_macro!(x y z/*caret*/);
+        }
+    """, hashSetOf(FragmentKind.Ident, FragmentKind.Ty))
+
+    fun `test ident repetition +`() = check("""
+        macro_rules! my_macro {
+            ($ ($ id:ident),+ ) => (1);
+        }
+
+        fn main() {
+            my_macro!(x, y/*caret*/);
+        }
+    """, hashSetOf(FragmentKind.Ident))
+
+    fun `test ident repetition ?`() = check("""
+        macro_rules! my_macro {
+            ($ ($ id:ident)? $ t:ty) => (1);
+        }
+
+        fn main() {
+            my_macro!(x y/*caret*/);
+        }
+    """, hashSetOf(FragmentKind.Ty))
+
+    fun `test parens`() = check("""
+        macro_rules! my_macro {
+            ($ i:ident($ t:ty)) => (1);
+        }
+        fn main() {
+            my_macro!(foo(i/*caret*/));
+        }
+    """, hashSetOf(FragmentKind.Ty))
+
+    fun `test many rules 1`() = check("""
+        macro_rules! my_macro {
+            ($ e:expr) => (1);
+            ($ ($ id:ident)+ ) => (2);
+            ($ x:expr, $ y:ident) => (2);
+            ($ x:literal, $ y:expr) => (4);
+        }
+
+        fn main() {
+            my_macro!(5, 5+7, i/*caret*/);
+        }
+    """, hashSetOf())
+
+    fun `test nom method 1`() = check("""
+        macro_rules! method {
+            ($ name:ident<$ a:ty>( $ i:ty ) -> $ o:ty, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty,$ i:ty,$ o:ty,$ e:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty,$ i:ty,$ o:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty,$ o:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty>( $ i:ty ) -> $ o:ty, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty,$ i:ty,$ o:ty,$ e:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty,$ i:ty,$ o:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty,$ o:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty>( $ i:ty ) -> $ o:ty, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty,$ i:ty,$ o:ty,$ e:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty,$ i:ty,$ o:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty,$ o:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty>( $ i:ty ) -> $ o:ty, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty,$ i:ty,$ o:ty,$ e:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty,$ i:ty,$ o:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty,$ o:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+        }
+
+        fn main() {
+            method!(pub foo<MyType, u8, i/*caret*/);
+        }
+    """, hashSetOf(FragmentKind.Ty))
+
+    fun `test nom method 2`() = check("""
+        macro_rules! method {
+            ($ name:ident<$ a:ty>( $ i:ty ) -> $ o:ty, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty,$ i:ty,$ o:ty,$ e:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty,$ i:ty,$ o:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty,$ o:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty>( $ i:ty ) -> $ o:ty, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty,$ i:ty,$ o:ty,$ e:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty,$ i:ty,$ o:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty,$ o:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty>, $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty>( $ i:ty ) -> $ o:ty, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty,$ i:ty,$ o:ty,$ e:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty,$ i:ty,$ o:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty,$ o:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            ($ name:ident<$ a:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty>( $ i:ty ) -> $ o:ty, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty,$ i:ty,$ o:ty,$ e:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty,$ i:ty,$ o:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty,$ o:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+            (pub $ name:ident<$ a:ty>, mut $ self_:ident, $ submac:ident!( $ ($ args:tt)* )) => (1);
+        }
+
+        fn main() {
+            method!(foo<i/*caret*/>, bar, baz!(a));
+        }
+    """, hashSetOf(FragmentKind.Ty))
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test thread_local 1`() = check("""
+        fn main() {
+            thread_local! {
+               pub static FOO: RefCell<i/*caret*/> = RefCell::new(1);
+            }
+        }
+    """, hashSetOf(FragmentKind.Ty))
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test thread_local 2`() = check("""
+        fn main() {
+            thread_local! {
+               pub static FOO: RefCell<i32> = RefCell::new(i/*caret*/);
+            }
+        }
+    """, hashSetOf(FragmentKind.Expr))
+
+    fun `test cond reduce`() = check("""
+        macro_rules! cond_reduce {
+            ($ i:expr, $ cond:expr, $ submac:ident!( $($ args:tt)* )) => (1);
+            ($ i:expr, $ cond:expr) => (1);
+            ($ i:expr, $ cond:expr, $ f:expr) => (1);
+        }
+
+        fn main() {
+            cond_reduce!(foo, foo.bar(i/*caret*/), foobar!(a b c));
+        }
+    """, hashSetOf(FragmentKind.Expr))
+
+    fun `test collapsed tokens`() = check("""
+        macro_rules! my_macro {
+            (&& $ i:ident) => (1);
+        }
+
+        fn main() {
+            my_macro!(&& foo/*caret*/);
+        }
+    """, hashSetOf(FragmentKind.Ident))
+}


### PR DESCRIPTION
This PR adds new completion provider for incomplete macro calls. The provider suggests variants based on possible kinds (`expr`, `ty` and so on) of the fragment under the cursor. If there are several possible kinds, all suitable completions are suggested.

![macrocall_comp](https://user-images.githubusercontent.com/4854600/59201649-90fde800-8ba3-11e9-8088-e90d013882cc.gif)
