### PR TITLE
T: correctly instantiate inspection instance in tests

### DIFF
--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddAsTyFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddAsTyFixTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.annotator.fixes
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsTypeCheckInspection
 
-class AddAsTyFixTest : RsInspectionsTestBase(RsTypeCheckInspection()) {
+class AddAsTyFixTest : RsInspectionsTestBase(RsTypeCheckInspection::class) {
     fun `test numeric value cast`() = checkFixByText("Add safe cast to u8", """
         fn main () {
             let _: u8 = <error>42u16/*caret*/</error>;

--- a/src/test/kotlin/org/rust/ide/inspections/RsApproxConstantInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsApproxConstantInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections;
 /**
  * Tests for the Approximate Constant inspection
  */
-class RsApproxConstantInspectionTest : RsInspectionsTestBase(RsApproxConstantInspection()) {
+class RsApproxConstantInspectionTest : RsInspectionsTestBase(RsApproxConstantInspection::class) {
 
     fun testConstants() = checkByText("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsAssertEqualInspectionTest.kt
@@ -9,7 +9,7 @@ import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspection()) {
+class RsAssertEqualInspectionTest : RsInspectionsTestBase(RsAssertEqualInspection::class) {
     fun `test simple assert_eq fix`() = checkFixByText("Convert to assert_eq!", """
         fn main() {
             let x = 10;

--- a/src/test/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 
-class RsAssignToImmutableInspectionTest : RsInspectionsTestBase(RsAssignToImmutableInspection()) {
+class RsAssignToImmutableInspectionTest : RsInspectionsTestBase(RsAssignToImmutableInspection::class) {
 
     fun `test E0594 assign to immutable borrowed content`() = checkByText("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/RsCStringPointerInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsCStringPointerInspectionTest.kt
@@ -12,7 +12,7 @@ import org.rust.WithStdlibRustProjectDescriptor
  * Tests for the CString Pointer inspection
  */
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-class RsCStringPointerInspectionTest : RsInspectionsTestBase(RsCStringPointerInspection()) {
+class RsCStringPointerInspectionTest : RsInspectionsTestBase(RsCStringPointerInspection::class) {
 
     fun testInspection() = checkByText("""
         use std::ffi::{CString};

--- a/src/test/kotlin/org/rust/ide/inspections/RsDanglingElseInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDanglingElseInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections
 /**
  * Tests for Dangling Else inspection.
  */
-class RsDanglingElseInspectionTest : RsInspectionsTestBase(RsDanglingElseInspection()) {
+class RsDanglingElseInspectionTest : RsInspectionsTestBase(RsDanglingElseInspection::class) {
 
     fun testSimple() = checkByText("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/RsDeprecationInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDeprecationInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections
 /**
  * Tests for Deprecated Attribute inspection.
  */
-class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspection()) {
+class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspection::class) {
 
     fun `test deprecated function without params`() = checkByText("""
         #[deprecated()]

--- a/src/test/kotlin/org/rust/ide/inspections/RsDoubleNegInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDoubleNegInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections
 /**
  * Tests for Double Negation inspection.
  */
-class RsDoubleNegInspectionTest : RsInspectionsTestBase(RsDoubleNegInspection()) {
+class RsDoubleNegInspectionTest : RsInspectionsTestBase(RsDoubleNegInspection::class) {
 
     fun testSimple() = checkByText("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/RsDropRefInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDropRefInspectionTest.kt
@@ -12,7 +12,7 @@ import org.rust.WithStdlibRustProjectDescriptor
  * Tests for Drop Reference inspection.
  */
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-class RsDropRefInspectionTest : RsInspectionsTestBase(RsDropRefInspection()) {
+class RsDropRefInspectionTest : RsInspectionsTestBase(RsDropRefInspection::class) {
 
     fun testDropRefSimple() = checkByText("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/RsExperimentalChecksInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsExperimentalChecksInspectionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.inspections
 
-class RsExperimentalChecksInspectionTest : RsInspectionsTestBase(RsExperimentalChecksInspection()) {
+class RsExperimentalChecksInspectionTest : RsInspectionsTestBase(RsExperimentalChecksInspection::class) {
     fun `test E0614 type cannot be dereferenced`() = checkByText("""
         fn main() {
             let _ = <error>*0</error>;

--- a/src/test/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspectionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.inspections
 
-class RsExtraSemicolonInspectionTest : RsInspectionsTestBase(RsExtraSemicolonInspection()) {
+class RsExtraSemicolonInspectionTest : RsInspectionsTestBase(RsExtraSemicolonInspection::class) {
 
     fun `test not applicable without return type`() = checkByText("""
         fn foo() { 92; }

--- a/src/test/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspectionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.inspections
 
-class RsFieldInitShorthandInspectionTest : RsInspectionsTestBase(RsFieldInitShorthandInspection()) {
+class RsFieldInitShorthandInspectionTest : RsInspectionsTestBase(RsFieldInitShorthandInspection::class) {
 
     fun `test not applicable`() = checkFixIsUnavailable("Use initialization shorthand", """
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/RsInspectionSuppressorTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsInspectionSuppressorTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections
 /**
  * Tests for inspections suppression
  */
-class RsInspectionSuppressorTest : RsInspectionsTestBase(RsSelfConventionInspection()) {
+class RsInspectionSuppressorTest : RsInspectionsTestBase(RsSelfConventionInspection::class) {
 
     fun testWithoutSuppression() = checkByText("""
         struct S;

--- a/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt
@@ -5,18 +5,30 @@
 
 package org.rust.ide.inspections
 
+import com.intellij.codeInspection.InspectionProfileEntry
+import com.intellij.testFramework.InspectionTestUtil
 import org.rust.TestProject
 import org.rust.ide.annotator.RsAnnotationTestBase
+import kotlin.reflect.KClass
 
 abstract class RsInspectionsTestBase(
-    val inspection: RsLocalInspectionTool
+    private val inspectionClass: KClass<out InspectionProfileEntry>
 ) : RsAnnotationTestBase() {
 
+    protected lateinit var inspection: InspectionProfileEntry
+
+    override fun setUp() {
+        super.setUp()
+        inspection = InspectionTestUtil.instantiateTools(listOf(inspectionClass.java))[0]
+    }
+
     fun testInspectionHasDocumentation() {
-        val description = "inspectionDescriptions/${inspection.javaClass.simpleName?.dropLast("Inspection".length)}.html"
-        val text = getResourceAsString(description)
-            ?: error("No inspection description for ${inspection.javaClass} ($description)")
-        checkHtmlStyle(text)
+        if (inspection is RsLocalInspectionTool) {
+            val description = "inspectionDescriptions/${inspection.javaClass.simpleName?.dropLast("Inspection".length)}.html"
+            val text = getResourceAsString(description)
+                ?: error("No inspection description for ${inspection.javaClass} ($description)")
+            checkHtmlStyle(text)
+        }
     }
 
     private fun enableInspection() = myFixture.enableInspections(inspection)

--- a/src/test/kotlin/org/rust/ide/inspections/RsLintLevelTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsLintLevelTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections
 /**
  * Tests for lint level detection.
  */
-class RsLintLevelStructTest : RsInspectionsTestBase(RsStructNamingInspection()) {
+class RsLintLevelStructTest : RsInspectionsTestBase(RsStructNamingInspection::class) {
 
     fun testDirrectAllow() = checkByText("""
         #[allow(non_camel_case_types)]
@@ -101,7 +101,7 @@ class RsLintLevelStructTest : RsInspectionsTestBase(RsStructNamingInspection()) 
     """)
 }
 
-class RsLintLevelFieldTest : RsInspectionsTestBase(RsFieldNamingInspection()) {
+class RsLintLevelFieldTest : RsInspectionsTestBase(RsFieldNamingInspection::class) {
 
     fun testParentAllow() = checkByText("""
         #[allow(non_snake_case)]

--- a/src/test/kotlin/org/rust/ide/inspections/RsMatchCheckInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsMatchCheckInspectionTest.kt
@@ -7,7 +7,7 @@ package org.rust.ide.inspections
 
 import org.rust.ide.inspections.checkMatch.RsMatchCheckInspection
 
-class RsMatchCheckInspectionTest : RsInspectionsTestBase(RsMatchCheckInspection()) {
+class RsMatchCheckInspectionTest : RsInspectionsTestBase(RsMatchCheckInspection::class) {
 
     fun `test simple boolean useless`() = checkByText("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/RsMissingElseInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsMissingElseInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections
 /**
  * Tests for Missing Else inspection.
  */
-class RsMissingElseInspectionTest : RsInspectionsTestBase(RsMissingElseInspection()) {
+class RsMissingElseInspectionTest : RsInspectionsTestBase(RsMissingElseInspection::class) {
 
     fun testSimple() = checkByText("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/RsMultipleInspectionsTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsMultipleInspectionsTestBase.kt
@@ -5,14 +5,24 @@
 
 package org.rust.ide.inspections
 
+import com.intellij.codeInspection.InspectionProfileEntry
+import com.intellij.testFramework.InspectionTestUtil
 import org.rust.TestProject
 import org.rust.ide.annotator.RsAnnotationTestBase
+import kotlin.reflect.KClass
 
 abstract class RsMultipleInspectionsTestBase(
-    vararg val inspections: RsLocalInspectionTool
+    private vararg val inspectionClasses: KClass<out InspectionProfileEntry>
 ) : RsAnnotationTestBase() {
 
-    private fun enableInspections() = myFixture.enableInspections(*inspections)
+    protected lateinit var inspections: List<InspectionProfileEntry>
+
+    override fun setUp() {
+        super.setUp()
+        inspections = InspectionTestUtil.instantiateTools(inspectionClasses.map { it.java })
+    }
+
+    private fun enableInspections() = myFixture.enableInspections(*inspections.toTypedArray())
 
     override fun configureByText(text: String) {
         super.configureByText(text)

--- a/src/test/kotlin/org/rust/ide/inspections/RsNeedlessLifetimesInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsNeedlessLifetimesInspectionTest.kt
@@ -9,7 +9,7 @@ import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 
-class RsNeedlessLifetimesInspectionTest : RsInspectionsTestBase(RsNeedlessLifetimesInspection()) {
+class RsNeedlessLifetimesInspectionTest : RsInspectionsTestBase(RsNeedlessLifetimesInspection::class) {
 
     fun `test no output lifetimes 1`() = doTest("""
         <weak_warning>fn <caret>foo<'a>(s: &'a str)</weak_warning> { unimplemented!() }

--- a/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsReassignImmutableInspectionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.inspections
 
-class RsReassignImmutableInspectionTest : RsInspectionsTestBase(RsReassignImmutableInspection()) {
+class RsReassignImmutableInspectionTest : RsInspectionsTestBase(RsReassignImmutableInspection::class) {
 
     fun `test E0384 reassign immutable binding`() = checkByText("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/RsSelfConventionInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSelfConventionInspectionTest.kt
@@ -11,7 +11,7 @@ import org.rust.WithStdlibRustProjectDescriptor
 /**
  * Tests for Self Convention inspection
  */
-class RsSelfConventionInspectionTest : RsInspectionsTestBase(RsSelfConventionInspection()) {
+class RsSelfConventionInspectionTest : RsInspectionsTestBase(RsSelfConventionInspection::class) {
 
     fun testFrom() = checkByText("""
         struct Foo;

--- a/src/test/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspectionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.inspections
 
-class RsSimplifyBooleanExpressionInspectionTest : RsInspectionsTestBase(RsSimplifyBooleanExpressionInspection()) {
+class RsSimplifyBooleanExpressionInspectionTest : RsInspectionsTestBase(RsSimplifyBooleanExpressionInspection::class) {
     fun `test subexpression`() = checkByText("""
             fn main() {
                 let _ = <warning><warning>true && foo</warning> && bar</warning>;

--- a/src/test/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspectionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.inspections
 
-class RsSimplifyPrintInspectionTest : RsInspectionsTestBase(RsSimplifyPrintInspection()) {
+class RsSimplifyPrintInspectionTest : RsInspectionsTestBase(RsSimplifyPrintInspection::class) {
 
     fun testFix() = checkFixByText("Remove unnecessary argument", """
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.inspections
 
-class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTraitMembersInspection()) {
+class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTraitMembersInspection::class) {
 
     fun `test same order`() = checkFixIsUnavailable("Apply same member order", """
         struct Struct {

--- a/src/test/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections
 /**
  * Tests for Suspicious Assignment inspection.
  */
-class RsSuspiciousAssignmentInspectionTest : RsInspectionsTestBase(RsSuspiciousAssignmentInspection()) {
+class RsSuspiciousAssignmentInspectionTest : RsInspectionsTestBase(RsSuspiciousAssignmentInspection::class) {
 
     fun testMinus() = checkByText("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/RsTraitImplementationInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsTraitImplementationInspectionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.inspections
 
-class RsTraitImplementationInspectionTest : RsInspectionsTestBase(RsTraitImplementationInspection()) {
+class RsTraitImplementationInspectionTest : RsInspectionsTestBase(RsTraitImplementationInspection::class) {
 
     fun `test self in trait not in impl E0186`() = checkErrors("""
         trait T {

--- a/src/test/kotlin/org/rust/ide/inspections/RsTryMacroInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsTryMacroInspectionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.inspections
 
-class RsTryMacroInspectionTest : RsInspectionsTestBase(RsTryMacroInspection()) {
+class RsTryMacroInspectionTest : RsInspectionsTestBase(RsTryMacroInspection::class) {
 
     fun testFix() = checkFixByText("Change try! to ?", """
         fn foo() -> Result<(), ()> {

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections
 import org.intellij.lang.annotations.Language
 import org.rust.ide.inspections.import.AutoImportFix
 
-class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection()) {
+class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection::class) {
 
     fun `test unresolved reference with quick fix`() = checkByText("""
         mod foo {
@@ -128,7 +128,8 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
     """)
 
     private fun checkByText(@Language("Rust") text: String, ignoreWithoutQuickFix: Boolean) {
-        val defaultValue = (inspection as RsUnresolvedReferenceInspection).ignoreWithoutQuickFix
+        val inspection = inspection as RsUnresolvedReferenceInspection
+        val defaultValue = inspection.ignoreWithoutQuickFix
         try {
             inspection.ignoreWithoutQuickFix = ignoreWithoutQuickFix
             checkByText(text)

--- a/src/test/kotlin/org/rust/ide/inspections/RsVariableMutableInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsVariableMutableInspectionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.inspections
 
-class RsVariableMutableInspectionTest : RsInspectionsTestBase(RsVariableMutableInspection()) {
+class RsVariableMutableInspectionTest : RsInspectionsTestBase(RsVariableMutableInspection::class) {
 
     fun `test should annotate unused variable`() = checkByText("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/inspections/RsWhileTrueLoopInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsWhileTrueLoopInspectionTest.kt
@@ -7,7 +7,7 @@ package org.rust.ide.inspections
 
 import org.intellij.lang.annotations.Language
 
-class RsWhileTrueLoopInspectionTest : RsInspectionsTestBase(RsWhileTrueLoopInspection()) {
+class RsWhileTrueLoopInspectionTest : RsInspectionsTestBase(RsWhileTrueLoopInspection::class) {
     fun `test simple`() = checkFix("""
         fn main() {
             <weak_warning descr="Denote infinite loops with `loop { ... }`">while/*caret*/ true</weak_warning> {

--- a/src/test/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.inspections
 
-class RsWrongLifetimeParametersNumberInspectionTest : RsInspectionsTestBase(RsWrongLifetimeParametersNumberInspection()) {
+class RsWrongLifetimeParametersNumberInspectionTest : RsInspectionsTestBase(RsWrongLifetimeParametersNumberInspection::class) {
 
     fun `test E0106 missing lifetime in struct field`() = checkByText("""
         struct Foo<'a> {

--- a/src/test/kotlin/org/rust/ide/inspections/RsWrongTypeParametersNumberInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsWrongTypeParametersNumberInspectionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.inspections
 
-class RsWrongTypeParametersNumberInspectionTest : RsInspectionsTestBase(RsWrongTypeParametersNumberInspection()) {
+class RsWrongTypeParametersNumberInspectionTest : RsInspectionsTestBase(RsWrongTypeParametersNumberInspection::class) {
 
     fun `test E0243 number of type parameters is less than expected`() = checkByText("""
         struct Foo1<T> { t: T }

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerFixesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerFixesTest.kt
@@ -10,7 +10,7 @@ import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsBorrowCheckerInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 
-class RsBorrowCheckerFixesTest : RsInspectionsTestBase(RsBorrowCheckerInspection()) {
+class RsBorrowCheckerFixesTest : RsInspectionsTestBase(RsBorrowCheckerInspection::class) {
 
     fun `test derive copy on struct`() = checkFixByText("Derive Copy trait", """
         struct S;

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerInspectionTest.kt
@@ -10,7 +10,7 @@ import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsBorrowCheckerInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 
-class RsBorrowCheckerInspectionTest : RsInspectionsTestBase(RsBorrowCheckerInspection()) {
+class RsBorrowCheckerInspectionTest : RsInspectionsTestBase(RsBorrowCheckerInspection::class) {
 
     fun `test mutable used at ref mutable method call (self)`() = checkByText("""
         struct S;

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
@@ -10,7 +10,7 @@ import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsBorrowCheckerInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 
-class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection()) {
+class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection::class) {
 
     fun `test move by call`() = checkByText("""
         struct S { data: i32 }

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerUninitializedTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerUninitializedTest.kt
@@ -10,7 +10,7 @@ import org.rust.WithStdlibAndDependencyRustProjectDescriptor
 import org.rust.ide.inspections.RsBorrowCheckerInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 
-class RsBorrowCheckerUninitializedTest : RsInspectionsTestBase(RsBorrowCheckerInspection()) {
+class RsBorrowCheckerUninitializedTest : RsInspectionsTestBase(RsBorrowCheckerInspection::class) {
     fun `test E0381 error no init`() = checkFixByText("Initialize with a default value", """
         fn main() {
             let x: i32;

--- a/src/test/kotlin/org/rust/ide/inspections/fixes/AddMutableFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/fixes/AddMutableFixTest.kt
@@ -14,9 +14,9 @@ import org.rust.ide.inspections.RsMultipleInspectionsTestBase
 import org.rust.ide.inspections.RsReassignImmutableInspection
 
 class AddMutableFixTest : RsMultipleInspectionsTestBase(
-    RsBorrowCheckerInspection(),
-    RsAssignToImmutableInspection(),
-    RsReassignImmutableInspection()
+    RsBorrowCheckerInspection::class,
+    RsAssignToImmutableInspection::class,
+    RsReassignImmutableInspection::class
 ) {
     fun `test fix E0596 method call`() = checkFixByText("Make `self` mutable", """
         struct A {}

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt
@@ -10,7 +10,7 @@ import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsUnresolvedReferenceInspection
 import org.rust.openapiext.Testmark
 
-abstract class AutoImportFixTestBase : RsInspectionsTestBase(RsUnresolvedReferenceInspection()) {
+abstract class AutoImportFixTestBase : RsInspectionsTestBase(RsUnresolvedReferenceInspection::class) {
 
     protected fun checkAutoImportFixIsUnavailable(@Language("Rust") text: String, testmark: Testmark? = null) =
         doTest { checkFixIsUnavailable(AutoImportFix.NAME, text, testmark = testmark) }
@@ -56,7 +56,8 @@ abstract class AutoImportFixTestBase : RsInspectionsTestBase(RsUnresolvedReferen
     }
 
     private inline fun doTest(action: () -> Unit) {
-        val defaultValue = (inspection as RsUnresolvedReferenceInspection).ignoreWithoutQuickFix
+        val inspection = inspection as RsUnresolvedReferenceInspection
+        val defaultValue = inspection.ignoreWithoutQuickFix
         try {
             inspection.ignoreWithoutQuickFix = false
             action()

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsArgumentNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsArgumentNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsArgumentNamingInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 
-class RsArgumentNamingInspectionTest: RsInspectionsTestBase(RsArgumentNamingInspection()) {
+class RsArgumentNamingInspectionTest: RsInspectionsTestBase(RsArgumentNamingInspection::class) {
     fun `test function arguments`() = checkByText("""
         fn fn_par(
             par_ok: u32,

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsAssocTypeNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsAssocTypeNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsAssocTypeNamingInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 
-class RsAssocTypeNamingInspectionTest : RsInspectionsTestBase(RsAssocTypeNamingInspection()) {
+class RsAssocTypeNamingInspectionTest : RsInspectionsTestBase(RsAssocTypeNamingInspection::class) {
     fun `test associated types`() = checkByText("""
         trait Foo {
             type AssocTypeOk;

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsConstNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsConstNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsConstNamingInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 
-class RsConstNamingInspectionTest : RsInspectionsTestBase(RsConstNamingInspection()) {
+class RsConstNamingInspectionTest : RsInspectionsTestBase(RsConstNamingInspection::class) {
     fun `test constants`() = checkByText("""
         const CONST_OK: u32 = 12;
         const <warning descr="Constant `const_foo` should have an upper case name such as `CONST_FOO`">const_foo</warning>: u32 = 12;

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsEnumNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsEnumNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsEnumNamingInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 
-class RsEnumNamingInspectionTest : RsInspectionsTestBase(RsEnumNamingInspection()) {
+class RsEnumNamingInspectionTest : RsInspectionsTestBase(RsEnumNamingInspection::class) {
     fun `test enums`() = checkByText("""
         enum EnumOk {}
         enum <warning descr="Type `enum_foo` should have a camel case name such as `EnumFoo`">enum_foo</warning> {}

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsEnumVariantNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsEnumVariantNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsEnumVariantNamingInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 
-class RsEnumVariantNamingInspectionTest : RsInspectionsTestBase(RsEnumVariantNamingInspection()) {
+class RsEnumVariantNamingInspectionTest : RsInspectionsTestBase(RsEnumVariantNamingInspection::class) {
     fun `test enum variants`() = checkByText("""
         enum EnumVars {
             VariantOk,

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsFieldNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsFieldNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsFieldNamingInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 
-class RsFieldNamingInspectionTest : RsInspectionsTestBase(RsFieldNamingInspection()) {
+class RsFieldNamingInspectionTest : RsInspectionsTestBase(RsFieldNamingInspection::class) {
     fun `test enum variant fields`() = checkByText("""
         enum EnumVarFields {
             Variant {

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsFunctionNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsFunctionNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsFunctionNamingInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
 
-class RsFunctionNamingInspectionTest : RsInspectionsTestBase(RsFunctionNamingInspection()) {
+class RsFunctionNamingInspectionTest : RsInspectionsTestBase(RsFunctionNamingInspection::class) {
     fun `test functions`() = checkByText("""
         fn fn_ok() {}
         fn <warning descr="Function `FN_BAR` should have a snake case name such as `fn_bar`">FN_BAR</warning>() {}

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsLifetimeNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsLifetimeNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsLifetimeNamingInspection
 
-class RsLifetimeNamingInspectionTest : RsInspectionsTestBase(RsLifetimeNamingInspection()) {
+class RsLifetimeNamingInspectionTest : RsInspectionsTestBase(RsLifetimeNamingInspection::class) {
     fun `test lifetimes`() = checkByText("""
         fn lifetimes<
             'lifetime_ok,

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsMacroNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsMacroNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsMacroNamingInspection
 
-class RsMacroNamingInspectionTest : RsInspectionsTestBase(RsMacroNamingInspection()) {
+class RsMacroNamingInspectionTest : RsInspectionsTestBase(RsMacroNamingInspection::class) {
     fun `test macros`() = checkByText("""
         macro_rules! macro_ok { () => {}; }
         macro_rules! <warning descr="Macro `MacroFoo` should have a snake case name such as `macro_foo`">MacroFoo</warning> { () => {}; }

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsMethodNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsMethodNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsMethodNamingInspection
 
-class RsMethodNamingInspectionTest : RsInspectionsTestBase(RsMethodNamingInspection()) {
+class RsMethodNamingInspectionTest : RsInspectionsTestBase(RsMethodNamingInspection::class) {
     fun `test methods`() = checkByText("""
         struct Foo {}
         impl Foo {

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsModuleNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsModuleNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsModuleNamingInspection
 
-class RsModuleNamingInspectionTest : RsInspectionsTestBase(RsModuleNamingInspection()) {
+class RsModuleNamingInspectionTest : RsInspectionsTestBase(RsModuleNamingInspection::class) {
     fun `test modules`() = checkByText("""
         mod module_ok {}
         mod <warning descr="Module `moduleA` should have a snake case name such as `module_a`">moduleA</warning> {}

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsStaticConstNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsStaticConstNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsStaticConstNamingInspection
 
-class RsStaticConstNamingInspectionTest : RsInspectionsTestBase(RsStaticConstNamingInspection()) {
+class RsStaticConstNamingInspectionTest : RsInspectionsTestBase(RsStaticConstNamingInspection::class) {
     fun `test statics`() = checkByText("""
         static STATIC_OK: u32 = 12;
         static <warning descr="Static constant `static_foo` should have an upper case name such as `STATIC_FOO`">static_foo</warning>: u32 = 12;

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsStructNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsStructNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsStructNamingInspection
 
-class RsStructNamingInspectionTest : RsInspectionsTestBase(RsStructNamingInspection()) {
+class RsStructNamingInspectionTest : RsInspectionsTestBase(RsStructNamingInspection::class) {
     fun `test structs`() = checkByText("""
         struct StructOk {}
         struct <warning descr="Type `struct_foo` should have a camel case name such as `StructFoo`">struct_foo</warning> {}

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsTraitNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsTraitNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsTraitNamingInspection
 
-class RsTraitNamingInspectionTest : RsInspectionsTestBase(RsTraitNamingInspection()) {
+class RsTraitNamingInspectionTest : RsInspectionsTestBase(RsTraitNamingInspection::class) {
     fun `test traits`() = checkByText("""
         trait TraitOk {}
         trait <warning descr="Trait `trait_foo` should have a camel case name such as `TraitFoo`">trait_foo</warning> {}

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsTypeAliasNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsTypeAliasNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsTypeAliasNamingInspection
 
-class RsTypeAliasNamingInspectionTest : RsInspectionsTestBase(RsTypeAliasNamingInspection()) {
+class RsTypeAliasNamingInspectionTest : RsInspectionsTestBase(RsTypeAliasNamingInspection::class) {
     fun `test type aliases`() = checkByText("""
         type TypeOk = u32;
         type <warning descr="Type `type_foo` should have a camel case name such as `TypeFoo`">type_foo</warning> = u32;

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsTypeParameterNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsTypeParameterNamingInspectionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.naming
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsTypeParameterNamingInspection
 
-class RsTypeParameterNamingInspectionTest : RsInspectionsTestBase(RsTypeParameterNamingInspection()) {
+class RsTypeParameterNamingInspectionTest : RsInspectionsTestBase(RsTypeParameterNamingInspection::class) {
     fun `test type parameters`() = checkByText("""
         fn type_params<
             SomeType: Clone,

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsVariableNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsVariableNamingInspectionTest.kt
@@ -10,7 +10,7 @@ import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsVariableNamingInspection
 
-class RsVariableNamingInspectionTest : RsInspectionsTestBase(RsVariableNamingInspection()) {
+class RsVariableNamingInspectionTest : RsInspectionsTestBase(RsVariableNamingInspection::class) {
     fun `test variables`() = checkByText("""
         fn loc_var() {
             let var_ok = 12;

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToOwnedTyFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToOwnedTyFixTest.kt
@@ -11,7 +11,7 @@ import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsTypeCheckInspection
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-class ConvertToOwnedTyFixTest : RsInspectionsTestBase(RsTypeCheckInspection()) {
+class ConvertToOwnedTyFixTest : RsInspectionsTestBase(RsTypeCheckInspection::class) {
     fun `test B is Owned type of A`() = checkFixByText("Convert to B using `ToOwned` trait","""
         use std::borrow::Borrow;
 

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToStrFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToStrFixTest.kt
@@ -11,7 +11,7 @@ import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsTypeCheckInspection
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-class ConvertToStrFixTest : RsInspectionsTestBase(RsTypeCheckInspection()) {
+class ConvertToStrFixTest : RsInspectionsTestBase(RsTypeCheckInspection::class) {
     fun `test String to &str`() = checkFixByText("Convert to &str using `as_str` method", """
             fn main () {
                 let _: &str = <error>String::from("Hello World!")<caret></error>;

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToStringFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToStringFixTest.kt
@@ -11,7 +11,7 @@ import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsTypeCheckInspection
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-class ConvertToStringFixTest : RsInspectionsTestBase(RsTypeCheckInspection()) {
+class ConvertToStringFixTest : RsInspectionsTestBase(RsTypeCheckInspection::class) {
     fun `test str to_string`() = checkFixByText("Convert to String using `ToString` trait", """
             fn main () {
                 let _: String = <error>"Hello World!"<caret></error>;

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyUsingFromStrFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyUsingFromStrFixTest.kt
@@ -12,7 +12,7 @@ import org.rust.ide.inspections.RsTypeCheckInspection
 
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-class ConvertToTyUsingFromStrFixTest : RsInspectionsTestBase(RsTypeCheckInspection()) {
+class ConvertToTyUsingFromStrFixTest : RsInspectionsTestBase(RsTypeCheckInspection::class) {
     fun `test A from &str when impl FromStr for A is available`() = simpleTestWithStr("\"HelloWorld!\"")
     fun `test A from &String when impl FromStr for A is available`() = simpleTestWithStr("&String::from(\"HelloWorld!\")", "(&String::from(\"HelloWorld!\"))")
     fun `test A from &mut Str when impl FromStr for A is available`() = simpleTestWithStr("String::from(\"HelloWorld!\").as_mut_str()")

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyUsingFromTraitFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyUsingFromTraitFixTest.kt
@@ -11,7 +11,7 @@ import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsTypeCheckInspection
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-class ConvertToTyUsingFromTraitFixTest : RsInspectionsTestBase(RsTypeCheckInspection()) {
+class ConvertToTyUsingFromTraitFixTest : RsInspectionsTestBase(RsTypeCheckInspection::class) {
     fun `test B from A when impl From A for B is available`() = checkFixByText("Convert to B using `From` trait", """
         struct A{}
         struct B{}

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyUsingTraitFixTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyUsingTraitFixTestBase.kt
@@ -13,7 +13,7 @@ import org.rust.ide.inspections.RsTypeCheckInspection
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 abstract class ConvertToTyUsingTraitFixTestBase(
     isExpectedMut: Boolean, private val trait: String, private val method: String, protected val imports: String = ""
-) : RsInspectionsTestBase(RsTypeCheckInspection()) {
+) : RsInspectionsTestBase(RsTypeCheckInspection::class) {
     private val ref = if (isExpectedMut) "&mut " else "&"
     private val fixName = "Convert to ${ref}A using `$trait` trait"
 

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyUsingTryFromTraitFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyUsingTryFromTraitFixTest.kt
@@ -12,7 +12,7 @@ import org.rust.ide.inspections.RsTypeCheckInspection
 
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-class ConvertToTyUsingTryFromTraitFixTest : RsInspectionsTestBase(RsTypeCheckInspection()) {
+class ConvertToTyUsingTryFromTraitFixTest : RsInspectionsTestBase(RsTypeCheckInspection::class) {
     fun `test B from A when impl TryFrom A for B is available`() = checkFixByText("Convert to Bb using `TryFrom` trait", """
         #![feature(try_from)]
         use std::convert::TryFrom;

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyWithDerefsRefsFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyWithDerefsRefsFixTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.inspections.typecheck
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsTypeCheckInspection
 
-class ConvertToTyWithDerefsRefsFixTest : RsInspectionsTestBase(RsTypeCheckInspection()) {
+class ConvertToTyWithDerefsRefsFixTest : RsInspectionsTestBase(RsTypeCheckInspection::class) {
 
     fun `test &T to T `() = checkFixByText("Convert to i32 using dereferences and/or references", """
         fn main () {

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
@@ -12,7 +12,7 @@ import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsTypeCheckInspection
 import org.rust.lang.core.macros.MacroExpansionScope
 
-class RsTypeCheckInspectionTest : RsInspectionsTestBase(RsTypeCheckInspection()) {
+class RsTypeCheckInspectionTest : RsInspectionsTestBase(RsTypeCheckInspection::class) {
     fun `test type mismatch E0308 primitive`() = checkByText("""
         fn main () {
             let _: u8 = <error>1u16</error>;


### PR DESCRIPTION
Now, `RsInspectionsTestBase` takes inspection class instead of inspection instance. Turned out that inspection should have additional initialization sometimes. `com.intellij.testFramework.InspectionTestUtil#instantiateTools` does it