### PR TITLE
Fix compilation warnings on 2019.1

### DIFF
--- a/clion/src/main/kotlin/org/rust/clion/valgrind/RsValgrindConfigurationExtension.kt
+++ b/clion/src/main/kotlin/org/rust/clion/valgrind/RsValgrindConfigurationExtension.kt
@@ -9,7 +9,6 @@ import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.RunnerSettings
-import com.intellij.execution.configurations.SearchScopeProvider
 import com.intellij.execution.filters.TextConsoleBuilderImpl
 import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
@@ -25,6 +24,7 @@ import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.search.GlobalSearchScopes
 import com.intellij.util.ArrayUtil
 import com.intellij.util.ui.StatusText
 import com.jetbrains.cidr.cpp.CPPBundle
@@ -92,11 +92,19 @@ class RsValgrindConfigurationExtension : CargoCommandConfigurationExtension() {
 
         val project = configuration.project
         val treeDataModel = MemoryProfileTreeDataModel("Valgrind", project)
-        val outputPanel = MemoryProfileOutputPanel(treeDataModel, ValgrindUtil.EDIT_SETTINGS_ACTION_ID, ValgrindUtil.TREE_POPUP_ID, project)
+        val outputPanel = MemoryProfileOutputPanel(
+            treeDataModel,
+            ValgrindUtil.EDIT_SETTINGS_ACTION_ID,
+            ValgrindUtil.TREE_POPUP_ID,
+            project
+        )
         putUserData(DATA_MODEL_KEY, treeDataModel, configuration, context)
         putUserData(OUTPUT_PANEL_KEY, outputPanel, configuration, context)
         val console = state.consoleBuilder.console
-        state.consoleBuilder = object : TextConsoleBuilderImpl(project, SearchScopeProvider.createSearchScope(environment.project, environment.runProfile)) {
+        state.consoleBuilder = object : TextConsoleBuilderImpl(
+            project,
+            GlobalSearchScopes.executionScope(environment.project, environment.runProfile)
+        ) {
             override fun getConsole(): ConsoleView {
                 val icon = ValgrindExecutor.getExecutorInstance().icon
                 return MemoryProfileConsoleViewWrapper(ValgrindUtil.PROFILER_NAME, console, outputPanel, project, icon)

--- a/src/main/kotlin/org/rust/cargo/project/CargoProjectOpenProcessor.kt
+++ b/src/main/kotlin/org/rust/cargo/project/CargoProjectOpenProcessor.kt
@@ -20,7 +20,7 @@ class CargoProjectOpenProcessor : ProjectOpenProcessor() {
     override fun getIcon(): Icon? = CargoIcons.ICON
     override fun getName(): String = "Cargo"
 
-    override fun canOpenProject(file: VirtualFile): Boolean = FileUtil.namesEqual(file?.name, CargoConstants.MANIFEST_FILE)
+    override fun canOpenProject(file: VirtualFile): Boolean = FileUtil.namesEqual(file.name, CargoConstants.MANIFEST_FILE)
 
     override fun doOpenProject(virtualFile: VirtualFile, projectToClose: Project?, forceNewFrame: Boolean): Project? {
         val basedir = if (virtualFile.isDirectory) virtualFile else virtualFile.parent

--- a/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
@@ -107,7 +107,7 @@ class RustProjectSettingsPanel(
                 pathToStdlibField.isEditable = !hasRustup
                 pathToStdlibField.button.isEnabled = !hasRustup
                 if (stdlibLocation != null) {
-                    pathToStdlibField.text = stdlibLocation ?: ""
+                    pathToStdlibField.text = stdlibLocation
                 }
 
                 if (rustcVersion == null) {

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
@@ -5,8 +5,8 @@
 
 package org.rust.cargo.runconfig
 
-import com.intellij.execution.configurations.SearchScopeProvider
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.psi.search.GlobalSearchScopes
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.runconfig.console.CargoConsoleBuilder
 
@@ -16,7 +16,7 @@ class CargoRunState(
     config: CargoCommandConfiguration.CleanConfiguration.Ok
 ) : CargoRunStateBase(environment, runConfiguration, config) {
     init {
-        val scope = SearchScopeProvider.createSearchScope(environment.project, environment.runProfile)
+        val scope = GlobalSearchScopes.executionScope(environment.project, environment.runProfile)
         consoleBuilder = CargoConsoleBuilder(environment.project, scope)
         createFilters().forEach { consoleBuilder.addFilter(it) }
     }

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -118,12 +118,9 @@ private fun colorFor(element: RsElement): RsColor? = when (element) {
 
 private fun partToHighlight(element: RsElement): TextRange? {
     if (element is RsMacro) {
-        var range = element.identifier?.textRange ?: return null
+        val range = element.identifier?.textRange ?: return null
         val excl = element.excl
-        if (excl != null) {
-            range = range.union(excl.textRange)
-        }
-        return range
+        return range.union(excl.textRange)
     }
 
     if (element is RsMacroCall) {

--- a/src/main/kotlin/org/rust/ide/folding/RsCodeFoldingOptionsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/folding/RsCodeFoldingOptionsProvider.kt
@@ -14,6 +14,8 @@ class RsCodeFoldingOptionsProvider :
 
     init {
         val settings = instance
+        // BACKCOMPAT: 2019.1
+        @Suppress("SENSELESS_COMPARISON")
         if (settings != null) {
             val getter: () -> Boolean = { settings.collapsibleOneLineMethods }
             val setter: (Boolean) -> Unit = { v -> settings.collapsibleOneLineMethods = v }

--- a/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
@@ -137,7 +137,7 @@ class RsExternalLinterInspection : GlobalSimpleInspectionTool() {
         private fun convertToProblemDescriptors(annotations: List<Annotation>, file: PsiFile): List<ProblemDescriptor> {
             if (annotations.isEmpty()) return emptyList()
 
-            val problems = ContainerUtil.newArrayListWithCapacity<ProblemDescriptor>(annotations.size)
+            val problems = ArrayList<ProblemDescriptor>(annotations.size)
             val quickFixMappingCache = ContainerUtil.newIdentityHashMap<IntentionAction, LocalQuickFix>()
             for (annotation in annotations) {
                 if (annotation.severity === HighlightSeverity.INFORMATION ||

--- a/src/main/kotlin/org/rust/lang/core/cfg/CFGBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/cfg/CFGBuilder.kt
@@ -93,7 +93,7 @@ class CFGBuilder(val graph: Graph<CFGNodeData, CFGEdgeData>, val entry: CFGNode,
     }
 
     private fun processSubPats(pat: RsPat, subPats: List<RsPat>): CFGNode {
-        val patsExit = subPats.fold(pred) { acc, pat -> process(pat, acc) }
+        val patsExit = subPats.fold(pred) { acc, subPat -> process(subPat, acc) }
         return addAstNode(pat, patsExit)
     }
 


### PR DESCRIPTION
The `ListCellRendererWrapper` deprecation warning is still there :(
The alternative (`SimpleListCellRenderer`) is introduced in 2019.2.