### PR TITLE
CI: use openjdk on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 
 language: java
 
-jdk: oraclejdk8
+jdk: openjdk8
 
 env:
   global:


### PR DESCRIPTION
Looks like default Ubuntu version on Travis is Xenial now. And you can't install oraclejdk8 anymore (https://github.com/travis-ci/travis-ci/issues/10290)

Let's use openjdk

Fixes #4018