### PR TITLE
RES: fix duplicating definitions for `use` with bang proc macros

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -391,6 +391,13 @@ private fun processQualifiedPathResolveVariants(
             if (processAll(exportedMacros(base), processor)) return true
         }
     }
+
+    // Proc macro crates are not allowed to export anything but procedural macros,
+    // and all possible macro exports are collected above.
+    if (base.containingCargoTarget?.isProcMacro == true) {
+        return false
+    }
+
     if (parent is RsUseSpeck && path.path == null) {
         selfInGroup.hit()
         if (processor("self", base)) return true

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -390,12 +390,14 @@ private fun processQualifiedPathResolveVariants(
             containingMod is RsFile && containingMod.isCrateRoot) {
             if (processAll(exportedMacros(base), processor)) return true
         }
-    }
 
-    // Proc macro crates are not allowed to export anything but procedural macros,
-    // and all possible macro exports are collected above.
-    if (base.containingCargoTarget?.isProcMacro == true) {
-        return false
+        // Proc macro crates are not allowed to export anything but procedural macros,
+        // and all possible macro exports are collected above. However, when resolve
+        // happens inside proc macro crate itself, all items are allowed
+        val resolveBetweenDifferentTargets = base.containingCargoTarget != path.containingCargoTarget
+        if (resolveBetweenDifferentTargets && base.containingCargoTarget?.isProcMacro == true) {
+            return false
+        }
     }
 
     if (parent is RsUseSpeck && path.path == null) {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -557,7 +557,28 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
     """)
 
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
-    fun `test resolve bang proc macro with use item`() = stubOnlyResolve("""
+    fun `test resolve bang proc definition in macro crate itself`() = stubOnlyResolve("""
+    //- dep-proc-macro/lib.rs
+        #[proc_macro]
+        pub fn example_proc_macro_1(item: TokenStream) -> TokenStream { item }
+
+        #[proc_macro]
+        pub fn example_proc_macro_2(item: TokenStream) -> TokenStream { example_proc_macro_1(item) }
+                                                                        //^ dep-proc-macro/lib.rs
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve bang proc macro from use item`() = stubOnlyResolve("""
+    //- dep-proc-macro/lib.rs
+        #[proc_macro]
+        pub fn example_proc_macro(item: TokenStream) -> TokenStream { item }
+    //- lib.rs
+        use dep_proc_macro::example_proc_macro;
+                            //^ dep-proc-macro/lib.rs
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve bang proc macro from macro call`() = stubOnlyResolve("""
     //- dep-proc-macro/lib.rs
         #[proc_macro]
         pub fn example_proc_macro(item: TokenStream) -> TokenStream { item }


### PR DESCRIPTION
Clicking `Ctrl+B` on bang proc macro `use` item resulted in duplicating definitions like this: 

![image](https://user-images.githubusercontent.com/8393617/59463997-f7973600-8e2f-11e9-96a6-f37342b2aed6.png)

This is due to the fact that bang proc macro definitions are counted as macro imports (since #3455), and at the same time the definition itself is a function and seen as a function by resolve 

Proc macro crates cannot import anything other than proc macro definitions, so I've added extra for crate type to prevent dupliaction (but I may be wrong about the way to fix this)
