### PR TITLE
[Simple/Enhancement] Rust file caption

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -10,6 +10,7 @@ alygin
 amakeev
 andruhon
 anton-okolelov
+AregevDev
 ArtsiomCh
 ashleysommer
 AtomicInteger

--- a/src/main/kotlin/org/rust/ide/actions/RsCreateFileAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsCreateFileAction.kt
@@ -39,6 +39,6 @@ class RsCreateFileAction : CreateFileFromTemplateAction(RsCreateFileAction.CAPTI
     }
 
     private companion object {
-        private const val CAPTION = "New Rust File"
+        private const val CAPTION = "Rust File"
     }
 }


### PR DESCRIPTION
Hello,
I have updated the caption in `RsCreateFileAction.kt` to Rust File from New Rust File in order to match the rest of the New menu.
This is a very minor change and I think it will be accepted gradually

Before:
![image](https://user-images.githubusercontent.com/40574704/59563145-bb85f000-903e-11e9-8728-0b67e611695a.png)
After:
![image](https://user-images.githubusercontent.com/40574704/59563152-dbb5af00-903e-11e9-9fa2-d93614d09284.png)

Thank you!