### PR TITLE
TY: fix default type parameters

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -128,9 +128,23 @@ fun <T: RsElement> instantiatePathGenerics(
         }
     }
 
-    val typeParameters = element.typeParameters.map { TyTypeParameter.named(it) }
+    val parent = path.parent
+    // Generic arguments are optional in expression context, e.g.
+    // `let a = Foo::<u8>::bar::<u16>();` can be written as `let a = Foo::bar();`
+    // if it is possible to infer `u8` and `u16` during type inference
+    val areOptionalArgs = parent is RsExpr || parent is RsPath && parent.parent is RsExpr
+    val typeSubst = element.typeParameters.withIndex().associate { (i, param) ->
+        val paramTy = TyTypeParameter.named(param)
+        val value = typeArguments?.getOrNull(i) ?: if (!areOptionalArgs) {
+            // Args aren't optional and aren't present, so use either default argument
+            // from a definition `struct S<T=u8>(T);` or falling back to `TyUnknown`
+            param.typeReference?.type ?: TyUnknown
+        } else {
+            paramTy
+        }
+        paramTy to value
+    }
     val regionParameters = element.lifetimeParameters.map { ReEarlyBound(it) }
-    val typeSubst = typeParameters.zip(typeArguments ?: typeParameters).toMap()
     val regionSubst = regionParameters.zip(regionArguments ?: regionParameters).toMap()
     val newSubst = Substitution(typeSubst, regionSubst)
     return BoundElement(resolved.element, subst + newSubst, assocTypes)

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyAdt.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyAdt.kt
@@ -16,7 +16,6 @@ import org.rust.lang.core.types.mergeFlags
 import org.rust.lang.core.types.regions.ReEarlyBound
 import org.rust.lang.core.types.regions.ReUnknown
 import org.rust.lang.core.types.regions.Region
-import org.rust.lang.core.types.type
 
 /**
  * Represents struct/enum/union.
@@ -58,9 +57,7 @@ data class TyAdt private constructor(
 }
 
 private fun defaultTypeArguments(item: RsStructOrEnumItemElement): List<Ty> =
-    item.typeParameters.map { param ->
-        param.typeReference?.type ?: TyTypeParameter.named(param)
-    }
+    item.typeParameters.map { param -> TyTypeParameter.named(param) }
 
 private fun defaultRegionArguments(item: RsStructOrEnumItemElement): List<Region> =
     item.lifetimeParameters.map { param -> ReEarlyBound(param) }

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -8,9 +8,7 @@ package org.rust.ide.refactoring.implementMembers
 import com.intellij.openapi.actionSystem.ex.ActionManagerEx
 import junit.framework.TestCase
 import org.intellij.lang.annotations.Language
-import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
-import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsTraitImplementationInspection
 
 class ImplementMembersHandlerTest : RsTestBase() {
@@ -269,11 +267,13 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """)
 
     fun `test implement generic trait`() = doTest("""
-        trait T<A, B> {
+        trait T<A, B = i16, C = u32> {
             fn f1(_: A) -> A;
             const C1: A;
             fn f2(_: B) -> B;
             const C2: B;
+            fn f3(_: C) -> C;
+            const C3: C;
         }
         struct S;
         impl T<u8, u16> for S {/*caret*/}
@@ -281,13 +281,17 @@ class ImplementMembersHandlerTest : RsTestBase() {
         ImplementMemberSelection("f1(_: A) -> A", true),
         ImplementMemberSelection("C1: A", true),
         ImplementMemberSelection("f2(_: B) -> B", true),
-        ImplementMemberSelection("C2: B", true)
+        ImplementMemberSelection("C2: B", true),
+        ImplementMemberSelection("f3(_: C) -> C", true),
+        ImplementMemberSelection("C3: C", true)
     ), """
-        trait T<A, B> {
+        trait T<A, B = i16, C = u32> {
             fn f1(_: A) -> A;
             const C1: A;
             fn f2(_: B) -> B;
             const C2: B;
+            fn f3(_: C) -> C;
+            const C3: C;
         }
         struct S;
         impl T<u8, u16> for S {
@@ -302,6 +306,12 @@ class ImplementMembersHandlerTest : RsTestBase() {
             }
 
             const C2: u16 = unimplemented!();
+
+            fn f3(_: u32) -> u32 {
+                unimplemented!()
+            }
+
+            const C3: u32 = unimplemented!();
         }
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -795,9 +795,7 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }                   //^
     """, NameResolutionTestmarks.selfRelatedTypeSpecialCase)
 
-    // TODO support default type parameters
-    fun `test Self-qualified path in trait impl is resolved to assoc type of super trait (generic trait 2)`() = expect<IllegalStateException> {
-        checkByCode("""
+    fun `test Self-qualified path in trait impl is resolved to assoc type of super trait (generic trait 2)`() = checkByCode("""
         struct S;
         trait Trait1<T=u8> { type Item; }
         trait Trait2<T>: Trait1<T> { fn foo() -> i32; }
@@ -811,8 +809,7 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         impl Trait2<i32> for S {
             fn foo() -> Self::Item { unreachable!() }
         }                   //^
-        """, NameResolutionTestmarks.selfRelatedTypeSpecialCase)
-    }
+    """, NameResolutionTestmarks.selfRelatedTypeSpecialCase)
 
     fun `test explicit UFCS-like type-qualified path`() = checkByCode("""
         struct S;

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1621,4 +1621,58 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             foo1.0;
         }      //^ X
     """)
+
+    // Issue https://github.com/intellij-rust/intellij-rust/issues/3999
+    fun `test default type argument is not used in expression context 1`() = testExpr("""
+        struct S<T = X>(T);
+        struct X;
+        fn main() {
+            let a = S(1);
+            a;
+        } //^ S<i32>
+    """)
+
+    fun `test default type argument is not used in expression context 2`() = testExpr("""
+        struct S<T = X>(T);
+        struct X;
+        impl<T> S<T> {
+            fn new(t: T) -> S<T> { S(t) }
+        }
+        fn main() {
+            let a = S::new(1);
+            a;
+        } //^ S<i32>
+    """)
+
+    fun `test default type argument is not used in pat context`() = testExpr("""
+        struct S<T = X>(T);
+        struct X;
+        fn main() {
+            let S(a) = S(1);
+            a;
+        } //^ i32
+    """)
+
+    fun `test default type argument is used in type context 1`() = testExpr("""
+        struct S<T = X>(T);
+        struct X;
+        fn foo(s: S) {
+            s;
+        } //^ S<X>
+    """)
+
+    fun `test default type argument is used in type context 2`() = testExpr("""
+        struct S<T1 = X, T2 = Y>(T1, T2);
+        struct X; struct Y;
+        fn foo(s: S<u8>) {
+            s;
+        } //^ S<u8, Y>
+    """)
+
+    fun `test type argument is unknown if not passed`() = testExpr("""
+        struct S<T1, T2>(T1, T2);
+        fn foo(s: S<u8>) {
+            s;
+        } //^ S<u8, <unknown>>
+    """)
 }


### PR DESCRIPTION
Previously was implemented in #3473, but then was reverted in #3647.

Fixes #3999, fixes #3470