### PR TITLE
COMP: fix crash during macro completion

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -214,11 +214,13 @@ open class RsDefaultInsertHandler : InsertHandler<LookupElement> {
 
             is RsMacro -> {
                 if (curUseItem == null) {
-                    val parens = when (element.name) {
-                        "vec" -> "[]"
-                        else -> "()"
+                    if (!context.nextCharIs('!')) {
+                        val parens = when (element.name) {
+                            "vec" -> "[]"
+                            else -> "()"
+                        }
+                        context.document.insertString(context.selectionEndOffset, "!$parens")
                     }
-                    context.document.insertString(context.selectionEndOffset, "!$parens")
                     EditorModificationUtil.moveCaretRelatively(context.editor, 2)
                 } else {
                     appendSemicolon(context, curUseItem)

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -63,7 +63,7 @@ object RsCommonCompletionProvider : CompletionProvider<CompletionParameters>() {
                 is RsPatBinding -> processPatBindingResolveVariants(element, true, it)
                 is RsStructLiteralField -> processStructLiteralFieldResolveVariants(element, true, it)
 
-                is RsPath -> {
+                is RsPath -> if (element.parent !is RsMacroCall) {
                     val lookup = ImplLookup.relativeTo(element)
                     processPathResolveVariants(
                         lookup,
@@ -80,6 +80,8 @@ object RsCommonCompletionProvider : CompletionProvider<CompletionParameters>() {
                             )
                         )
                     )
+                } else {
+                    processMacroCallPathResolveVariants(element, true, it)
                 }
             }
         }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -478,10 +478,22 @@ class RsCompletionTest : RsCompletionTestBase() {
         }
     """)
 
-    fun `test complete macro`() = doSingleCompletion("""
+    fun `test complete macro 1`() = doSingleCompletion("""
         macro_rules! foo_bar { () => () }
         fn main() {
             fo/*caret*/
+        }
+    """, """
+        macro_rules! foo_bar { () => () }
+        fn main() {
+            foo_bar!(/*caret*/)
+        }
+    """)
+
+    fun `test complete macro 2`() = doSingleCompletion("""
+        macro_rules! foo_bar { () => () }
+        fn main() {
+            fo/*caret*/!()
         }
     """, """
         macro_rules! foo_bar { () => () }


### PR DESCRIPTION
The bug was introduced in #3749 - I forgot about completion =/

Also, do not insert extra parens when completing `fo/*caret*/!()` to foo!(/*caret*/)

bors r+