### PR TITLE
Fix IndexNotReadyException when typing in the dumb mode

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.psi
 import com.intellij.ProjectTopics
 import com.intellij.injected.editor.VirtualFileWindow
 import com.intellij.openapi.components.ProjectComponent
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootEvent
 import com.intellij.openapi.roots.ModuleRootListener
@@ -120,7 +121,7 @@ class RsPsiManagerImpl(val project: Project) : ProjectComponent, RsPsiManager {
         // about it because it is a rare case and implementing it differently
         // is much more difficult.
 
-        val owner = psi.findModificationTrackerOwner(!isChildrenChange)
+        val owner = if (DumbService.isDumb(project)) null else psi.findModificationTrackerOwner(!isChildrenChange)
         if (owner == null || !owner.incModificationCount(psi)) {
             incRustStructureModificationCount(file, psi)
         }


### PR DESCRIPTION
Fixes #4036

The bug was introduced in #3935 - not it's forbidden to access `PsiElement.context` in the dumb mode