### PR TITLE
Disable live templates in macro definitions

### DIFF
--- a/src/main/kotlin/org/rust/ide/template/RsContextType.kt
+++ b/src/main/kotlin/org/rust/ide/template/RsContextType.kt
@@ -95,6 +95,7 @@ sealed class RsContextType(
     companion object {
         private fun owner(element: PsiElement): PsiElement? = PsiTreeUtil.findFirstParent(element) {
             it is RsBlock || it is RsItemElement || it is RsAttr || it is PsiFile
+                || it is RsMacro || it is RsMacroCall
         }
     }
 }

--- a/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt
@@ -85,6 +85,30 @@ class RsLiveTemplatesTest : RsTestBase() {
         }
     """)
 
+    fun `test macro definition 1`() = noSnippet("""
+        macro_rules! foo {
+            (impl/*caret*/) => {};
+        }
+    """)
+
+    fun `test macro definition 2`() = noSnippet("""
+        macro_rules! foo {
+            () => { impl/*caret*/ };
+        }
+    """)
+
+    fun `test macro2 definition`() = noSnippet("""
+        macro foo() {
+            impl/*caret*/
+        }
+    """)
+
+    fun `test macro call`() = noSnippet("""
+        foo! {
+            impl/*caret*/
+        }
+    """)
+
     val indent = "    "
     fun `test module level context available in file`() = expandSnippet("""
         tfn/*caret*/


### PR DESCRIPTION
Disable live templates in macro calls and definitions (they shouldn't and anyway previously they worked very weird)
Completion in macro calls will start to work with #4060