### PR TITLE
MACRO&RES: resolve attribute and custom derive proc macros to their defenitions

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
@@ -21,6 +21,67 @@ import org.rust.lang.core.psi.ext.*
 object RsPsiPattern {
     private val STATEMENT_BOUNDARIES = TokenSet.create(SEMICOLON, LBRACE, RBRACE)
 
+    /**
+     * Source of attributes: [https://doc.rust-lang.org/1.30.0/reference/attributes.html]
+     */
+    private val STD_ATTRIBUTES: Set<String> = setOf(
+        "crate_name",
+        "crate_type",
+        "no_builtins",
+        "no_main",
+        "no_start",
+        "no_std",
+        "recursion_limit",
+        "windows_subsystem",
+
+        "no_implicit_prelude",
+        "path",
+
+        "link_args",
+        "link",
+        "linked_from",
+
+        "link_name",
+        "linkage",
+
+        "macro_use",
+        "macro_use",
+        "macro_reexport",
+        "macro_export",
+        "no_link",
+
+        "proc_macro",
+        "proc_macro_derive",
+        "proc_macro_attribute",
+
+        "export_name",
+        "global_allocator",
+        "link_section",
+        "no_mangle",
+
+        "deprecated",
+
+        "doc",
+
+        "test",
+        "should_panic",
+
+        "cfg",
+        "cfg_attr",
+
+        "allow",
+        "deny",
+        "forbid",
+        "warn",
+
+        "must_use",
+
+        "cold",
+        "inline",
+
+        "derive"
+    )
+
     val onStatementBeginning: PsiElementPattern.Capture<PsiElement> = psiElement().with(OnStatementBeginning())
 
     fun onStatementBeginning(vararg startWords: String): PsiElementPattern.Capture<PsiElement> =
@@ -93,6 +154,14 @@ object RsPsiPattern {
                 .withSuperParent<RsStructOrEnumItemElement>(2)
                 .with("deriveCondition") { e -> e is RsMetaItem && e.name == "derive" }
         )
+
+    /**
+     * Supposed to capture outer attributes names, like `attribute` in `#[attribute(par1, par2)]`.
+     */
+    val nonStdOuterAttributeMetaItem: PsiElementPattern.Capture<RsMetaItem> =
+        psiElement<RsMetaItem>()
+            .withSuperParent(2, RsOuterAttributeOwner::class.java)
+            .with("nonStdAttributeCondition") { e -> e.name !in STD_ATTRIBUTES }
 
     val includeMacroLiteral: PsiElementPattern.Capture<RsLitExpr> = psiElement<RsLitExpr>()
         .withParent(psiElement<RsIncludeMacroArgument>())

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -98,6 +98,11 @@ class QueryAttributes(
         return attrs.any()
     }
 
+    fun hasAnyOfOuterAttributes(vararg attributes: String): Boolean {
+        val outerAttrList = (psi as? RsOuterAttributeOwner)?.outerAttrList ?: return false
+        return outerAttrList.any { it.metaItem.name in attributes }
+    }
+
     // `#[attributeName]`
     fun hasAtomAttribute(attributeName: String): Boolean {
         val attrs = attrsByName(attributeName)
@@ -108,6 +113,13 @@ class QueryAttributes(
     fun hasAttributeWithArg(attributeName: String, arg: String): Boolean {
         val attrs = attrsByName(attributeName)
         return attrs.any { it.metaItemArgs?.metaItemList?.any { it.name == arg } ?: false }
+    }
+
+    // `#[attributeName(arg)]`
+    fun getFirstArgOfSingularAttribute(attributeName: String): String? {
+        return attrsByName(attributeName).singleOrNull()
+            ?.metaItemArgs?.metaItemList?.firstOrNull()
+            ?.name
     }
 
     // `#[attributeName(key = "value")]`

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -103,6 +103,22 @@ val RsFunction.isActuallyUnsafe: Boolean
         }
     }
 
+val RsFunction.isBangProcMacroDef: Boolean
+    get() = queryAttributes.hasAtomAttribute("proc_macro")
+
+val RsFunction.isAttributeProcMacroDef: Boolean
+    get() = queryAttributes.hasAtomAttribute("proc_macro_attribute")
+
+val RsFunction.isCustomDeriveProcMacroDef: Boolean
+    get() = queryAttributes.hasAttribute("proc_macro_derive")
+
+val RsFunction.isProcMacroDef: Boolean
+    get() = queryAttributes.hasAnyOfOuterAttributes(
+        "proc_macro",
+        "proc_macro_attribute",
+        "proc_macro_derive"
+    )
+
 abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, RsFunction, RsModificationTrackerOwner {
 
     constructor(node: ASTNode) : super(node)

--- a/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.resolve
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.RsNamedElement
+import org.rust.lang.core.psi.ext.isProcMacroDef
 import java.util.*
 
 enum class Namespace(val itemName: String) {
@@ -33,8 +34,8 @@ val RsNamedElement.namespaces: Set<Namespace> get() = when (this) {
     is RsTypeAlias -> TYPES
 
     is RsPatBinding,
-    is RsConstant,
-    is RsFunction -> VALUES
+    is RsConstant -> VALUES
+    is RsFunction -> if (this.isProcMacroDef) MACROS else VALUES
 
     is RsEnumVariant -> if (blockFields == null) VALUES else TYPES
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -130,7 +130,7 @@ fun collectCompletionVariants(
     }
 }
 
-private data class SimpleScopeEntry(
+data class SimpleScopeEntry(
     override val name: String,
     override val element: RsElement,
     override val subst: Substitution = emptySubstitution
@@ -160,8 +160,8 @@ private class LazyScopeEntry(
 }
 
 
-operator fun RsResolveProcessor.invoke(name: String, e: RsElement, subst: Substitution = emptySubstitution): Boolean =
-    this(SimpleScopeEntry(name, e, subst))
+operator fun RsResolveProcessor.invoke(name: String, e: RsElement): Boolean =
+    this(SimpleScopeEntry(name, e))
 
 fun RsResolveProcessor.lazy(name: String, e: () -> RsElement?): Boolean =
     this(LazyScopeEntry(name, lazy(LazyThreadSafetyMode.PUBLICATION, e)))
@@ -176,14 +176,12 @@ operator fun RsResolveProcessor.invoke(e: BoundElement<RsNamedElement>): Boolean
     return this(SimpleScopeEntry(name, e.element, e.subst))
 }
 
-fun processAll(elements: Collection<RsNamedElement>, processor: RsResolveProcessor): Boolean =
-    processAll(elements.asSequence(), processor)
+fun processAll(elements: List<RsNamedElement>, processor: RsResolveProcessor): Boolean {
+    return elements.any { processor(it) }
+}
 
-fun processAll(elements: Sequence<RsNamedElement>, processor: RsResolveProcessor): Boolean {
-    for (e in elements) {
-        if (processor(e)) return true
-    }
-    return false
+fun processAllScopeEntries(elements: List<ScopeEntry>, processor: RsResolveProcessor): Boolean {
+    return elements.any { processor(it) }
 }
 
 fun processAllWithSubst(

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMetaItemReferenceContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMetaItemReferenceContributor.kt
@@ -8,22 +8,72 @@ package org.rust.lang.core.resolve.ref
 import com.intellij.psi.*
 import com.intellij.util.ProcessingContext
 import org.rust.lang.core.RsPsiPattern
+import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsMetaItem
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.name
 import org.rust.lang.core.resolve.collectResolveVariants
+import org.rust.lang.core.resolve.processAttributeProcMacroResolveVariants
 import org.rust.lang.core.resolve.processDeriveTraitResolveVariants
 
 class RsMetaItemReferenceContributor : PsiReferenceContributor() {
+
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
-        registrar.registerReferenceProvider(RsPsiPattern.derivedTraitMetaItem, RsDeriveTraitReferenceProvider())
+        registrar.registerReferenceProvider(
+            RsPsiPattern.derivedTraitMetaItem,
+            RsDeriveTraitReferenceProvider(),
+            PsiReferenceRegistrar.DEFAULT_PRIORITY
+        )
+        // FIXME: We assume that attribute proc macros are used only as top level attributes
+        // (so we ignore the fact that attribute proc macro can be nested inside `cfg_attr`)
+        registrar.registerReferenceProvider(
+            RsPsiPattern.nonStdOuterAttributeMetaItem,
+            RsAttributeProcMacroReferenceProvider(),
+            PsiReferenceRegistrar.LOWER_PRIORITY
+        )
+    }
+}
+
+class RsAttributeProcMacroReferenceProvider : PsiReferenceProvider() {
+    override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> {
+        val metaItem = element as? RsMetaItem ?: return PsiReference.EMPTY_ARRAY
+        return arrayOf(RsAttributeProcMacroReferenceImpl(metaItem))
+    }
+}
+
+class RsAttributeProcMacroReferenceImpl(element: RsMetaItem) : RsReferenceBase<RsMetaItem>(element) {
+    override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> =
+        cachedMultiResolve().toTypedArray()
+
+    override val RsMetaItem.referenceAnchor: PsiElement? get() = element.identifier
+
+    override fun isReferenceTo(element: PsiElement): Boolean =
+        element is RsFunction && super.isReferenceTo(element)
+
+    override fun multiResolve(): List<RsElement> =
+        cachedMultiResolve().mapNotNull { it.element as? RsElement }
+
+    private fun cachedMultiResolve(): List<PsiElementResolveResult> {
+        return RsResolveCache.getInstance(element.project)
+            .resolveWithCaching(element, ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE, Resolver).orEmpty()
+    }
+
+    private object Resolver : (RsMetaItem) -> List<PsiElementResolveResult> {
+        override fun invoke(ref: RsMetaItem): List<PsiElementResolveResult> {
+            return resolve(ref).map { PsiElementResolveResult(it) }
+        }
+
+        private fun resolve(element: RsMetaItem): List<RsElement> {
+            val attributeMacroName = element.name ?: return emptyList()
+            return collectResolveVariants(attributeMacroName) { processAttributeProcMacroResolveVariants(element, it) }
+        }
     }
 }
 
 private class RsDeriveTraitReferenceProvider : PsiReferenceProvider() {
     override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> {
-        val metaItem = element as? RsMetaItem ?: return emptyArray()
+        val metaItem = element as? RsMetaItem ?: return PsiReference.EMPTY_ARRAY
         return arrayOf(RsDeriveTraitReferenceImpl(metaItem))
     }
 }
@@ -48,7 +98,7 @@ private class RsDeriveTraitReferenceImpl(
     }
 
     override fun isReferenceTo(element: PsiElement): Boolean =
-        element is RsTraitItem && super.isReferenceTo(element)
+        (element is RsTraitItem || element is RsFunction) && super.isReferenceTo(element)
 
     override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> =
         cachedMultiResolve().toTypedArray()

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -556,16 +556,34 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
+    // FIXME
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
-    fun `test resolve bang proc definition in macro crate itself`() = stubOnlyResolve("""
-    //- dep-proc-macro/lib.rs
-        #[proc_macro]
-        pub fn example_proc_macro_1(item: TokenStream) -> TokenStream { item }
+    fun `test resolve bang proc definition in macro crate itself`() = expect<IllegalStateException> {
+        stubOnlyResolve("""
+        //- dep-proc-macro/lib.rs
+            #[proc_macro]
+            pub fn example_proc_macro_1(item: TokenStream) -> TokenStream { item }
+    
+            #[proc_macro]
+            pub fn example_proc_macro_2(item: TokenStream) -> TokenStream { example_proc_macro_1(item) }
+                                                                            //^ dep-proc-macro/lib.rs
+        """)
+    }
 
-        #[proc_macro]
-        pub fn example_proc_macro_2(item: TokenStream) -> TokenStream { example_proc_macro_1(item) }
-                                                                        //^ dep-proc-macro/lib.rs
-    """)
+    // FIXME
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve bang proc definition in macro in macro crate itself from mod`() = expect<IllegalStateException> {
+        stubOnlyResolve("""
+        //- dep-proc-macro/lib.rs
+            #[proc_macro]
+            pub fn example_proc_macro_1(item: TokenStream) -> TokenStream { item }
+        
+            mod foo {
+                use super::example_proc_macro_1;
+                pub fn proc_macro_user(item: TokenStream) -> TokenStream { example_proc_macro_1(item) }
+            }                                                                //^ dep-proc-macro/lib.rs
+        """)
+    }
 
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test resolve use item inside proc macro crate`() = stubOnlyResolve("""
@@ -589,17 +607,16 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
     """)
 
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
-    fun `test proc macro crate cannot export anything but proc macros`() = expect<IllegalStateException> {
-        stubOnlyResolve("""
-        //- dep-proc-macro/lib.rs
-            #[proc_macro]
-            pub fn example_proc_macro(item: TokenStream) -> TokenStream { item }
-            pub fn unseen_function() {}
-        //- lib.rs
-            use dep_proc_macro::unseen_function;
-                                    //^ dep-proc-macro/lib.rs
-        """)
-    }
+    fun `test proc macro crate cannot export anything but proc macros`() = stubOnlyResolve("""
+    //- dep-proc-macro/lib.rs
+        #[proc_macro]
+        pub fn example_proc_macro(item: TokenStream) -> TokenStream { item }
+        pub fn unseen_function() {}
+    //- lib.rs
+        use dep_proc_macro::unseen_function;
+                                //^ unresolved
+    """)
+
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test resolve bang proc macro from macro call`() = stubOnlyResolve("""
     //- dep-proc-macro/lib.rs
@@ -609,6 +626,177 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         use dep_proc_macro::example_proc_macro;
         example_proc_macro!();
         //^ dep-proc-macro/lib.rs
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve attr proc macro in use item`() = stubOnlyResolve("""
+    //- dep-proc-macro/lib.rs
+        #[proc_macro_attribute]
+        pub fn example_proc_macro(attr: TokenStream, item: TokenStream) -> TokenStream { item }
+    //- lib.rs
+        use dep_proc_macro::example_proc_macro;
+                          //^ dep-proc-macro/lib.rs
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve attr proc macro from macro call`() = stubOnlyResolve("""
+    //- dep-proc-macro/lib.rs
+        #[proc_macro_attribute]
+        pub fn example_proc_macro(attr: TokenStream, item: TokenStream) -> TokenStream { item }
+    //- lib.rs
+        use dep_proc_macro::example_proc_macro;
+
+        #[example_proc_macro]
+              //^ dep-proc-macro/lib.rs
+        struct S;
+    """)
+
+    // FIXME
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve attr proc macro from macro call with full path`() = expect<IllegalStateException> {
+        stubOnlyResolve("""
+        //- dep-proc-macro/lib.rs
+            #[proc_macro_attribute]
+            pub fn example_proc_macro(attr: TokenStream, item: TokenStream) -> TokenStream { item }
+        //- lib.rs
+            #[dep_proc_macro::example_proc_macro]
+                                //^ dep-proc-macro/lib.rs
+            struct S;
+    """)
+    }
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve custom derive proc macro in use item`() = stubOnlyResolve("""
+    //- dep-proc-macro/lib.rs
+        #[proc_macro_derive(ProcMacroName)]
+        pub fn example_proc_macro(item: TokenStream) -> TokenStream { item }
+    //- lib.rs
+        use dep_proc_macro::ProcMacroName;
+                          //^ dep-proc-macro/lib.rs
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve custom derive proc macro from derive attribute`() = stubOnlyResolve("""
+    //- dep-proc-macro/lib.rs
+        #[proc_macro_derive(ProcMacroName)]
+        pub fn example_proc_macro(item: TokenStream) -> TokenStream { item }
+    //- lib.rs
+        use dep_proc_macro::ProcMacroName;
+        #[derive(ProcMacroName)]
+                  //^ dep-proc-macro/lib.rs
+        struct S;
+    """)
+
+    // FIXME
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve custom derive proc macro from derive attribute with full path`() = expect<IllegalStateException>{
+        stubOnlyResolve("""
+        //- dep-proc-macro/lib.rs
+            #[proc_macro_derive(ProcMacroName)]
+            pub fn example_proc_macro(item: TokenStream) -> TokenStream { item }
+        //- lib.rs
+            #[derive(dep_proc_macro::ProcMacroName)]
+                      //^ dep-proc-macro/lib.rs
+            struct S;
+        """)
+    }
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve bang proc macro reexported from lib to main from use item`() = stubOnlyResolve("""
+    //- lib.rs
+        extern crate dep_proc_macro;
+        pub use dep_proc_macro::example_proc_macro;
+
+    //- dep-proc-macro/lib.rs
+        #[proc_macro]
+        pub fn example_proc_macro(item: TokenStream) -> TokenStream { item }
+
+    //- main.rs
+        use test_package::example_proc_macro;
+                            //^ dep-proc-macro/lib.rs
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve bang proc macro reexported from lib to main from macro call`() = stubOnlyResolve("""
+    //- lib.rs
+        extern crate dep_proc_macro;
+        pub use dep_proc_macro::example_proc_macro;
+
+    //- dep-proc-macro/lib.rs
+        #[proc_macro]
+        pub fn example_proc_macro(item: TokenStream) -> TokenStream { item }
+
+    //- main.rs
+        use test_package::example_proc_macro;
+        
+        example_proc_macro!();
+                    //^ dep-proc-macro/lib.rs
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve custom derive proc macro reexported from lib to main from use item`() = stubOnlyResolve("""
+    //- lib.rs
+        extern crate dep_proc_macro;
+        pub use dep_proc_macro::ProcMacroName;
+
+    //- dep-proc-macro/lib.rs
+        #[proc_macro_derive(ProcMacroName)]
+        pub fn example_proc_macro(item: TokenStream) -> TokenStream { item }
+
+    //- main.rs
+        use test_package::ProcMacroName;
+                         //^ dep-proc-macro/lib.rs 
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve custom derive proc macro reexported from lib to main from macro call`() = stubOnlyResolve("""
+    //- lib.rs
+        extern crate dep_proc_macro;
+        pub use dep_proc_macro::ProcMacroName;
+
+    //- dep-proc-macro/lib.rs
+        #[proc_macro_derive(ProcMacroName)]
+        pub fn example_proc_macro(item: TokenStream) -> TokenStream { item }
+
+    //- main.rs
+        use test_package::ProcMacroName;
+        
+        #[derive(ProcMacroName)]
+                 //^ dep-proc-macro/lib.rs
+        struct S;
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve attribute proc macro reexported from lib to main from use item`() = stubOnlyResolve("""
+    //- lib.rs
+        extern crate dep_proc_macro;
+        pub use dep_proc_macro::example_proc_macro;
+
+    //- dep-proc-macro/lib.rs
+        #[proc_macro_attribute]
+        pub fn example_proc_macro(item: TokenStream) -> TokenStream { item }
+
+    //- main.rs
+        use test_package::example_proc_macro;
+                             //^ dep-proc-macro/lib.rs 
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve attribute proc macro reexported from lib to main from macro call`() = stubOnlyResolve("""
+    //- lib.rs
+        extern crate dep_proc_macro;
+        pub use dep_proc_macro::example_proc_macro;
+
+    //- dep-proc-macro/lib.rs
+        #[proc_macro_attribute]
+        pub fn example_proc_macro(item: TokenStream) -> TokenStream { item }
+
+    //- main.rs
+        use test_package::example_proc_macro;
+        
+        #[example_proc_macro]
+                 //^ dep-proc-macro/lib.rs
+        struct S;
     """)
 
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)


### PR DESCRIPTION
This PR is based on @vlad20012 [draft](https://github.com/intellij-rust/intellij-rust/files/3156357/RES__resolve_derive_macros.patch.zip) for this functionality, and on #3690 

NB: there are problems with resolving proc macro definitions inside proc-macro crates themselves; there are two ignored tests in `RsPackageLibraryResolveTest.kt` that should pass when this will be resolved
