### PR TITLE
COMP&MACRO: advanced completion inside macro call bodies

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
@@ -20,6 +20,7 @@ class RsCompletionContributor : CompletionContributor() {
         extend(CompletionType.BASIC, AttributeCompletionProvider.elementPattern, AttributeCompletionProvider)
         extend(CompletionType.BASIC, RsMacroCompletionProvider.elementPattern, RsMacroCompletionProvider)
         extend(CompletionType.BASIC, RsPartialMacroArgumentCompletionProvider.elementPattern, RsPartialMacroArgumentCompletionProvider)
+        extend(CompletionType.BASIC, RsFullMacroArgumentCompletionProvider.elementPattern, RsFullMacroArgumentCompletionProvider)
     }
 
     override fun invokeAutoPopup(position: PsiElement, typeChar: Char): Boolean =

--- a/src/main/kotlin/org/rust/lang/core/completion/RsFullMacroArgumentCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsFullMacroArgumentCompletionProvider.kt
@@ -1,0 +1,48 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.patterns.ElementPattern
+import com.intellij.patterns.PlatformPatterns.psiElement
+import com.intellij.psi.PsiElement
+import com.intellij.util.ProcessingContext
+import org.rust.lang.RsLanguage
+import org.rust.lang.core.macros.findExpansionElements
+import org.rust.lang.core.psi.RsElementTypes.MACRO_ARGUMENT
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.ext.startOffset
+import org.rust.openapiext.Testmark
+
+/**
+ * Provides completion inside a macro argument (e.g. `foo!(/*caret*/)`) if the macro IS expanded
+ * successfully, i.e. [RsMacroCall.expansion] != null. If macro is not expanded successfully,
+ * [RsPartialMacroArgumentCompletionProvider] is used.
+ */
+object RsFullMacroArgumentCompletionProvider : CompletionProvider<CompletionParameters>() {
+    override fun addCompletions(
+        parameters: CompletionParameters,
+        context: ProcessingContext,
+        result: CompletionResultSet
+    ) {
+        val position = parameters.position
+        val dstElement = position.findExpansionElements()?.firstOrNull() ?: return
+        val dstOffset = dstElement.startOffset + (parameters.offset - position.startOffset)
+        Testmarks.touched.hit()
+        rerunCompletion(parameters.withPosition(dstElement, dstOffset), result)
+    }
+
+    val elementPattern: ElementPattern<PsiElement>
+        get() = psiElement()
+            .withLanguage(RsLanguage)
+            .inside(psiElement(MACRO_ARGUMENT))
+
+    object Testmarks {
+        val touched = Testmark("RsFullMacroArgumentCompletionProvider.touched")
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/completion/Utils.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/Utils.kt
@@ -5,15 +5,29 @@
 
 package org.rust.lang.core.completion
 
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.CompletionService
 import com.intellij.codeInsight.completion.CompletionUtil
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.ext.ancestors
 
-fun <T: PsiElement> T.safeGetOriginalOrSelf(): T {
+fun <T: PsiElement> T.getOriginalOrSelf(): T = CompletionUtil.getOriginalOrSelf(this)
+
+fun <T: PsiElement> T.safeGetOriginalElement(): T? {
     return CompletionUtil.getOriginalElement(this)
         ?.takeIf { areAncestorTypesEquals(it, this) }
-        ?: this
+}
+
+fun <T: PsiElement> T.safeGetOriginalOrSelf(): T {
+    return safeGetOriginalElement() ?: this
 }
 
 private fun areAncestorTypesEquals(psi1: PsiElement, psi2: PsiElement): Boolean =
     psi1.ancestors.zip(psi2.ancestors).all { (a, b) -> a.javaClass == b.javaClass }
+
+fun rerunCompletion(parameters: CompletionParameters, result: CompletionResultSet) {
+    CompletionService.getCompletionService().getVariantsFromContributors(parameters, null) {
+        result.addElement(it.lookupElement)
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -20,6 +20,7 @@ import org.rust.ide.injected.isDoctestInjection
 import org.rust.lang.RsConstants
 import org.rust.lang.RsFileType
 import org.rust.lang.RsLanguage
+import org.rust.lang.core.completion.getOriginalOrSelf
 import org.rust.lang.core.macros.macroExpansionManager
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ref.RsReference
@@ -53,7 +54,7 @@ class RsFile(
     fileViewProvider: FileViewProvider
 ) : RsFileBase(fileViewProvider), RsMod {
 
-    override val containingMod: RsMod get() = this
+    override val containingMod: RsMod get() = getOriginalOrSelf()
 
     override val crateRoot: RsMod?
         get() = superMods.lastOrNull()?.takeIf { it.isCrateRoot }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -21,6 +21,7 @@ import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.injected.isDoctestInjection
+import org.rust.lang.core.completion.getOriginalOrSelf
 import org.rust.lang.core.psi.RsConstant
 import org.rust.lang.core.psi.RsEnumVariant
 import org.rust.lang.core.psi.RsFile
@@ -112,7 +113,7 @@ fun RsElement.findDependencyCrateRoot(dependencyName: String): RsFile? {
 
 abstract class RsElementImpl(node: ASTNode) : ASTWrapperPsiElement(node), RsElement {
     override val containingMod: RsMod
-        get() = contextStrict()
+        get() = contextStrict<RsMod>()?.getOriginalOrSelf()
             ?: error("Element outside of module: $text")
 
     final override val crateRoot: RsMod?
@@ -126,7 +127,7 @@ abstract class RsStubbedElementImpl<StubT : StubElement<*>> : StubBasedPsiElemen
     constructor(stub: StubT, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
     override val containingMod: RsMod
-        get() = contextStrict()
+        get() = contextStrict<RsMod>()?.getOriginalOrSelf()
             ?: error("Element outside of module: $text")
 
     final override val crateRoot: RsMod?

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -95,8 +95,13 @@ fun RsMacroCall.resolveToMacro(): RsMacro? =
 val RsMacroCall.expansion: MacroExpansion?
     get() = CachedValuesManager.getCachedValue(this) {
         val project = project
+        val originalOrSelf = CompletionUtil.getOriginalElement(this)?.takeIf {
+            // Use the original element only if macro bodies are equal. They
+            // will be different if completion invoked inside the macro body.
+            it.macroBody == this.macroBody
+        } ?: this
         CachedValueProvider.Result.create(
-            project.macroExpansionManager.getExpansionFor(CompletionUtil.getOriginalOrSelf(this)),
+            project.macroExpansionManager.getExpansionFor(originalOrSelf),
             rustStructureOrAnyPsiModificationTracker
         )
     }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
@@ -32,7 +32,7 @@ fun RsVisibilityOwner.iconWithVisibility(flags: Int, icon: Icon): Icon =
 fun RsVisible.isVisibleFrom(mod: RsMod): Boolean {
     val elementMod = when (val visibility = visibility) {
         RsVisibility.Public -> return true
-        RsVisibility.Private -> (if (this is RsMod) this.`super` else this.contextStrict()) ?: return true
+        RsVisibility.Private -> (if (this is RsMod) this.`super` else containingMod) ?: return true
         is RsVisibility.Restricted -> visibility.inMod
     }
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsMacroCallBodyCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsMacroCallBodyCompletionTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+class RsMacroCallBodyCompletionTest : RsCompletionTestBase() {
+    fun `test simple`() = doSingleCompletion("""
+        macro_rules! foo {
+            ($($ i:item)*) => { $($ i)* };
+        }
+        struct FooBar;
+        foo! {
+            fn bar() {
+                F/*caret*/
+            }
+        }
+    """, """
+        macro_rules! foo {
+            ($($ i:item)*) => { $($ i)* };
+        }
+        struct FooBar;
+        foo! {
+            fn bar() {
+                FooBar/*caret*/
+            }
+        }
+    """)
+
+    fun `test complete struct from the same macro`() = doSingleCompletion("""
+        macro_rules! foo {
+            ($($ i:item)*) => { $($ i)* };
+        }
+        foo! {
+            struct FooBar;
+            fn bar() {
+                F/*caret*/
+            }
+        }
+    """, """
+        macro_rules! foo {
+            ($($ i:item)*) => { $($ i)* };
+        }
+        foo! {
+            struct FooBar;
+            fn bar() {
+                FooBar/*caret*/
+            }
+        }
+    """)
+
+    fun `test nested macro`() = doSingleCompletion("""
+        macro_rules! foo {
+            ($ i:item $($ rest:tt)*) => { $ i foo!($($ rest)*); };
+            () => {}
+        }
+        foo! {
+            struct FooBar;
+            fn bar() {
+                F/*caret*/
+            }
+        }
+    """, """
+        macro_rules! foo {
+            ($ i:item $($ rest:tt)*) => { $ i foo!($($ rest)*); };
+            () => {}
+        }
+        foo! {
+            struct FooBar;
+            fn bar() {
+                FooBar/*caret*/
+            }
+        }
+    """)
+
+    // TODO extra `()`
+    fun `test method`() = doSingleCompletion("""
+        macro_rules! foo {
+            ($ e:expr, $ i:ident) => { fn foo() { $ e.$ i(); } };
+        }
+        struct Foo;
+        impl Foo { fn bar(&self) {} }
+        foo!(Foo, b/*caret*/);
+    """, """
+        macro_rules! foo {
+            ($ e:expr, $ i:ident) => { fn foo() { $ e.$ i(); } };
+        }
+        struct Foo;
+        impl Foo { fn bar(&self) {} }
+        foo!(Foo, bar()/*caret*/);
+    """)
+}

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionTest.kt
@@ -12,7 +12,8 @@ import org.rust.WithStdlibRustProjectDescriptor
 class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
     fun `test expr 1`() = doTest("""
         macro_rules! my_macro {
-            ($ e:expr) => (1);
+            ($ e:expr, foo) => (1);
+            ($ e:expr, bar) => (1);
         }
 
         fn main() {
@@ -23,7 +24,7 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
 
     fun `test expr 2`() = doTest("""
         macro_rules! my_macro {
-            ($ e:expr) => (1);
+            ($ e:expr, foo) => (1);
             (foo $ t:ty) => (1);
         }
 
@@ -35,7 +36,8 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
 
     fun `test expr complex`() = doTest("""
         macro_rules! my_macro {
-            ($ e:expr) => (1);
+            ($ e:expr, foo) => (1);
+            ($ e:expr, bar) => (1);
         }
 
         struct S { ii: i32 }
@@ -49,7 +51,7 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
 
     fun `test expr repeated`() = doTest("""
         macro_rules! my_macro {
-            ($ ($ e:expr),+) => (1);
+            ($ ($ e:expr),+ =>) => (1);
         }
 
         fn main() {
@@ -61,7 +63,7 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
     fun `test type 1`() = doTest("""
         macro_rules! my_macro {
             (bar $ e:expr) => (1);
-            ($ t:ty) => (1);
+            ($ t:ty, foo) => (1);
         }
 
         fn main() {
@@ -72,8 +74,8 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
 
     fun `test expr and ty`() = doTest("""
         macro_rules! my_macro {
-            ($ i:ident $ e:expr) => (1);
-            ($ i:ident $ t:ty) => (1);
+            ($ i:ident $ e:expr, foo) => (1);
+            ($ i:ident $ t:ty, bar) => (1);
         }
 
         fn main() {
@@ -85,13 +87,14 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test no completion from index`() = doTest("""
         macro_rules! my_macro {
-            ($ e:expr) => (1);
+            ($ e:expr, foo) => (1);
+            ($ e:expr, bar) => (1);
         }
 
         fn main() {
             my_macro!(Hash/*caret*/);
         }
-    """, setOf())
+    """, setOf(), setOf("HashMap"))
 
     fun `test different fragment offsets`() = doTest("""
         macro_rules! my_macro {
@@ -106,11 +109,15 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
     """, setOf("iii", "i32"))
 
     private fun doTest(@Language("Rust") code: String, contains: Set<String>, notContains: Set<String> = emptySet()) {
-        for (variant in contains) {
-            checkContainsCompletion(variant, code)
-        }
-        for (variant in notContains) {
-            checkNotContainsCompletion(variant, code)
+        RsPartialMacroArgumentCompletionProvider.Testmarks.touched.checkHit {
+            RsFullMacroArgumentCompletionProvider.Testmarks.touched.checkNotHit {
+                for (variant in contains) {
+                    checkContainsCompletion(variant, code)
+                }
+                for (variant in notContains) {
+                    checkNotContainsCompletion(variant, code)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
If a macro is successfully expanded we follow element under the caret to the macro expansion and invoke completion there. It allows performing completion taking into account the context of expansion. If a macro isn't expanded (e.g. there is a very incomplete code) completion from #4001 will be used.

![image](https://user-images.githubusercontent.com/3221931/59975553-d10c9400-95c1-11e9-92d0-ca32894ad217.png)
