### PR TITLE
RUN: Add setting to emulate the terminal on Unix

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsAsyncRunner.kt
@@ -118,7 +118,8 @@ abstract class RsAsyncRunner(private val executorId: String, private val errorMe
                     workingDirectory,
                     backtraceMode,
                     environmentVariables,
-                    executableArguments
+                    executableArguments,
+                    emulateTerminal
                 )
             }
         }

--- a/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
@@ -28,7 +28,8 @@ fun CargoCommandLine.mergeWithDefault(default: CargoCommandConfiguration): Cargo
         channel = default.channel,
         environmentVariables = default.env,
         allFeatures = default.allFeatures,
-        nocapture = default.nocapture
+        nocapture = default.nocapture,
+        emulateTerminal = default.emulateTerminal
     )
 
 fun RunManager.createCargoCommandRunConfiguration(cargoCommandLine: CargoCommandLine, name: String? = null): RunnerAndConfigurationSettings {

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -45,6 +45,7 @@ class CargoCommandConfiguration(
     var command: String = "run"
     var allFeatures: Boolean = false
     var nocapture: Boolean = false
+    var emulateTerminal: Boolean = false
     var backtrace: BacktraceMode = BacktraceMode.SHORT
     var workingDirectory: Path? = project.cargoProjects.allProjects.firstOrNull()?.workingDirectory
     var env: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
@@ -55,6 +56,7 @@ class CargoCommandConfiguration(
         element.writeString("command", command)
         element.writeBool("allFeatures", allFeatures)
         element.writeBool("nocapture", nocapture)
+        element.writeBool("emulateTerminal", emulateTerminal)
         element.writeEnum("backtrace", backtrace)
         element.writePath("workingDirectory", workingDirectory)
         env.writeExternal(element)
@@ -70,6 +72,7 @@ class CargoCommandConfiguration(
         element.readString("command")?.let { command = it }
         element.readBool("allFeatures")?.let { allFeatures = it }
         element.readBool("nocapture")?.let { nocapture = it }
+        element.readBool("emulateTerminal")?.let { emulateTerminal = it }
         element.readEnum<BacktraceMode>("backtrace")?.let { backtrace = it }
         element.readPath("workingDirectory")?.let { workingDirectory = it }
         env = EnvironmentVariablesData.readExternal(element)
@@ -80,6 +83,7 @@ class CargoCommandConfiguration(
         command = ParametersListUtil.join(cmd.command, *cmd.additionalArguments.toTypedArray())
         allFeatures = cmd.allFeatures
         nocapture = cmd.nocapture
+        emulateTerminal = cmd.emulateTerminal
         backtrace = cmd.backtraceMode
         workingDirectory = cmd.workingDirectory
         env = cmd.environmentVariables
@@ -140,7 +144,8 @@ class CargoCommandConfiguration(
                 channel,
                 env,
                 allFeatures,
-                nocapture
+                nocapture,
+                emulateTerminal
             )
         }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.LabeledComponent
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.ui.ListCellRendererWrapper
 import com.intellij.ui.components.CheckBox
@@ -96,12 +97,14 @@ class CargoCommandConfigurationEditor(private val project: Project) : SettingsEd
     private val environmentVariables = EnvironmentVariablesComponent()
     private val allFeatures = CheckBox("Use all features in tests", false)
     private val nocapture = CheckBox("Show stdout/stderr in tests (and disable test tool window)", false)
+    private val emulateTerminal = CheckBox("Emulate terminal in output console", false)
 
     override fun resetEditorFrom(configuration: CargoCommandConfiguration) {
         channel.selectedIndex = configuration.channel.index
         command.text = configuration.command
         allFeatures.isSelected = configuration.allFeatures
         nocapture.isSelected = configuration.nocapture
+        emulateTerminal.isSelected = configuration.emulateTerminal
         backtraceMode.selectedIndex = configuration.backtrace.index
         workingDirectory.component.text = configuration.workingDirectory?.toString() ?: ""
         environmentVariables.envData = configuration.env
@@ -122,6 +125,7 @@ class CargoCommandConfigurationEditor(private val project: Project) : SettingsEd
         configuration.command = command.text
         configuration.allFeatures = allFeatures.isSelected
         configuration.nocapture = nocapture.isSelected
+        configuration.emulateTerminal = emulateTerminal.isSelected && !SystemInfo.isWindows
         configuration.backtrace = BacktraceMode.fromIndex(backtraceMode.selectedIndex)
         configuration.workingDirectory = currentWorkingDirectory
         configuration.env = environmentVariables.envData
@@ -143,6 +147,10 @@ class CargoCommandConfigurationEditor(private val project: Project) : SettingsEd
 
         row { allFeatures() }
         row { nocapture() }
+
+        if (!SystemInfo.isWindows) {
+            row { emulateTerminal() }
+        }
 
         row(environmentVariables.label) { environmentVariables.apply { makeWide() }() }
         row(workingDirectory.label) {

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -10,6 +10,7 @@ import com.google.gson.JsonSyntaxException
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.PtyCommandLine
 import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.process.ProcessOutput
 import com.intellij.notification.NotificationType
@@ -193,6 +194,7 @@ class Cargo(private val cargoExecutable: Path) {
                 backtraceMode,
                 environmentVariables,
                 parameters,
+                emulateTerminal,
                 http
             )
         }
@@ -245,6 +247,7 @@ class Cargo(private val cargoExecutable: Path) {
             backtraceMode: BacktraceMode,
             environmentVariables: EnvironmentVariablesData,
             parameters: List<String>,
+            emulateTerminal: Boolean,
             http: HttpConfigurable = HttpConfigurable.getInstance()
         ): GeneralCommandLine {
             val cmdLine = GeneralCommandLine(executablePath)
@@ -263,7 +266,11 @@ class Cargo(private val cargoExecutable: Path) {
                 BacktraceMode.NO -> Unit
             }
             environmentVariables.configureCommandLine(cmdLine, true)
-            return cmdLine
+            return if (emulateTerminal) {
+                PtyCommandLine(cmdLine).withConsoleMode(false)
+            } else {
+                cmdLine
+            }
         }
 
         fun checkNeedInstallCargoExpand(project: Project): Boolean {

--- a/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CargoCommandLine.kt
@@ -28,7 +28,8 @@ data class CargoCommandLine(
     val channel: RustChannel = RustChannel.DEFAULT,
     val environmentVariables: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT,
     val allFeatures: Boolean = false,
-    val nocapture: Boolean = false
+    val nocapture: Boolean = false,
+    val emulateTerminal: Boolean = false
 ) {
     /**
      * Adds [arg] to [additionalArguments] as an positional argument, in other words, inserts [arg] right after

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/BenchRunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/BenchRunConfigurationProducerTest.kt
@@ -203,6 +203,7 @@ class BenchRunConfigurationProducerTest : RunConfigurationProducerTestBase() {
             channel = RustChannel.NIGHTLY
             allFeatures = true
             nocapture = true
+            emulateTerminal = true
             backtrace = BacktraceMode.FULL
             env = EnvironmentVariablesData.create(mapOf("FOO" to "BAR"), true)
         }

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/ExecutableRunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/ExecutableRunConfigurationProducerTest.kt
@@ -55,6 +55,7 @@ class ExecutableRunConfigurationProducerTest : RunConfigurationProducerTestBase(
             channel = RustChannel.NIGHTLY
             allFeatures = true
             nocapture = true
+            emulateTerminal = true
             backtrace = BacktraceMode.FULL
             env = EnvironmentVariablesData.create(mapOf("FOO" to "BAR"), true)
         }

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/TestRunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/TestRunConfigurationProducerTest.kt
@@ -221,6 +221,7 @@ class TestRunConfigurationProducerTest : RunConfigurationProducerTestBase() {
             channel = RustChannel.NIGHTLY
             allFeatures = true
             nocapture = true
+            emulateTerminal = true
             backtrace = BacktraceMode.FULL
             env = EnvironmentVariablesData.create(mapOf("FOO" to "BAR"), true)
         }

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench configuration uses default environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench configuration uses default environment.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --lib bench_foo -- --exact" />
     <option name="allFeatures" value="true" />
     <option name="nocapture" value="true" />
+    <option name="emulateTerminal" value="true" />
     <option name="backtrace" value="FULL" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench fn is more specific than main or test mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench fn is more specific than main or test mod.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --bin foo bench_foo -- --exact" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer adds bin name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer adds bin name.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --bin foo bench_foo -- --exact" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer ignores selected files that contain no benches.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer ignores selected files that contain no benches.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --bench foo &quot;&quot;" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer uses complete function path.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer uses complete function path.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --lib foo_mod::bench_foo -- --exact" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for annotated functions.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for annotated functions.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --lib bench_foo -- --exact" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for benches source root.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for benches source root.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --bench foo &quot;&quot;" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for directories inside benches source root.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for directories inside benches source root.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --bench foo --bench baz &quot;&quot;" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for files.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --bench foo &quot;&quot;" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for module declarations.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for module declarations.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --lib tests" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for modules.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for modules.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --lib foo" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for multiple files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for multiple files.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --bench foo --bench baz &quot;&quot;" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for nested modules 1.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for nested modules 1.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --lib foo::bar" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for nested modules 2.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for nested modules 2.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --lib foo" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for root module.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ bench producer works for root module.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --lib &quot;&quot;" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable configuration uses default environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable configuration uses default environment.xml
@@ -4,6 +4,7 @@
     <option name="command" value="run --package test-package --bin hello" />
     <option name="allFeatures" value="true" />
     <option name="nocapture" value="true" />
+    <option name="emulateTerminal" value="true" />
     <option name="backtrace" value="FULL" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable producer works for bin.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable producer works for bin.xml
@@ -4,6 +4,7 @@
     <option name="command" value="run --package test-package --bin hello" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable producer works for example.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ executable producer works for example.xml
@@ -4,6 +4,7 @@
     <option name="command" value="run --package test-package --example hello" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ hyphen in name works.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ hyphen in name works.xml
@@ -4,6 +4,7 @@
     <option name="command" value="run --package test-package --example hello-world" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than bench fn.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than bench fn.xml
@@ -4,6 +4,7 @@
     <option name="command" value="run --package test-package --bin foo" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than bench mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than bench mod.xml
@@ -4,6 +4,7 @@
     <option name="command" value="run --package test-package --bin foo" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than test fn.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than test fn.xml
@@ -4,6 +4,7 @@
     <option name="command" value="run --package test-package --bin foo" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than test mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main fn is more specific than test mod.xml
@@ -4,6 +4,7 @@
     <option name="command" value="run --package test-package --bin foo" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main mod is more specific than test mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ main mod is more specific than test mod.xml
@@ -4,6 +4,7 @@
     <option name="command" value="run --package test-package --bin foo" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ meaningful bench configuration name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ meaningful bench configuration name.xml
@@ -4,6 +4,7 @@
     <option name="command" value="bench --package test-package --lib bar::tests" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ meaningful test configuration name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ meaningful test configuration name.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --lib bar::tests" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ take into account path attribute.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ take into account path attribute.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --lib test::foo -- --exact" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test configuration uses default environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test configuration uses default environment.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --lib test_foo -- --exact" />
     <option name="allFeatures" value="true" />
     <option name="nocapture" value="true" />
+    <option name="emulateTerminal" value="true" />
     <option name="backtrace" value="FULL" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs>

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test fn is more specific than main mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test fn is more specific than main mod.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --bin foo test_foo -- --exact" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test mod decl is more specific than main mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test mod decl is more specific than main mod.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --bin foo tests" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test mod is more specific than bench mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test mod is more specific than bench mod.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --lib &quot;&quot;" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer adds bin name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer adds bin name.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --bin foo test_foo -- --exact" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer ignores selected files that contain no tests.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer ignores selected files that contain no tests.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --test foo &quot;&quot;" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer uses complete function path.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer uses complete function path.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --lib foo_mod::test_foo -- --exact" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for annotated functions.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for annotated functions.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --lib test_foo -- --exact" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for directories inside tests source root.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for directories inside tests source root.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --test foo --test baz &quot;&quot;" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for files.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --test foo &quot;&quot;" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for module declarations.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for module declarations.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --lib tests" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for modules.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for modules.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --lib foo" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for multiple files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for multiple files.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --test foo --test baz &quot;&quot;" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for nested modules 1.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for nested modules 1.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --lib foo::bar" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for nested modules 2.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for nested modules 2.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --lib foo" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for project root.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for project root.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///test" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for root module.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for root module.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --lib &quot;&quot;" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for tests source root.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ test producer works for tests source root.xml
@@ -4,6 +4,7 @@
     <option name="command" value="test --package test-package --test foo &quot;&quot;" />
     <option name="allFeatures" value="false" />
     <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
     <option name="backtrace" value="SHORT" />
     <option name="workingDirectory" value="file:///my-crate" />
     <envs />


### PR DESCRIPTION
Closes https://github.com/intellij-rust/intellij-rust/issues/4061.

This option is disabled by default, but you can enable it for all new configurations in the Cargo Command template settings (`Run > Edit Configurations... > Templates > Cargo Command`):

![image](https://user-images.githubusercontent.com/6079006/60612088-903a2980-9dd0-11e9-8ddd-bc96c4c377a9.png)

Tested with `color-backtrace 0.2.1`:

* Default color scheme:
![image](https://user-images.githubusercontent.com/6079006/60612605-adbbc300-9dd1-11e9-834c-3d092b7daf75.png)

* Darcula color scheme:
![image](https://user-images.githubusercontent.com/6079006/60612562-91b82180-9dd1-11e9-91fd-c1099595bb71.png)
