### PR TITLE
GRD: update 2019.2 EAPs

### DIFF
--- a/gradle-192.properties
+++ b/gradle-192.properties
@@ -1,6 +1,6 @@
-ideaVersion=IU-192.5438-EAP-CANDIDATE-SNAPSHOT
-clionVersion=CL-192.5438-EAP-CANDIDATE-SNAPSHOT
+ideaVersion=IU-192.5587-EAP-CANDIDATE-SNAPSHOT
+clionVersion=CL-192.5587-EAP-CANDIDATE-SNAPSHOT
 
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
 sinceBuild=192.5281
-untilBuild=192.*
+untilBuild=193.*


### PR DESCRIPTION
Also, increase untilBuild to `193.*` to make plugin compatible with 2019.3 nightly builds