### PR TITLE
INT: Fix `Make public fix` for mod decl

### DIFF
--- a/src/test/kotlin/org/rust/ide/annotator/fixes/MakePublicFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/MakePublicFixTest.kt
@@ -513,4 +513,26 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class.java) {
             pub fn bar() {}
         }
     """, stubOnly = false)
+
+    fun `test make mod decl public`() = checkFixByFileTree("Make `bar` public", """
+    //- main.rs
+        mod foo {
+            mod bar;
+        }
+        fn main() {
+            <error>foo::bar/*caret*/</error>::baz();
+        }
+    //- foo/bar.rs
+        pub fn baz() {}
+    """, """
+    //- main.rs
+        mod foo {
+            pub(crate) mod bar;
+        }
+        fn main() {
+            foo::bar/*caret*/::baz();
+        }
+    //- foo/bar.rs
+        pub fn baz() {}
+    """, stubOnly = false)
 }


### PR DESCRIPTION
Fixes
```
java.lang.ClassCastException: class org.rust.lang.core.psi.RsFile cannot be cast to class org.rust.lang.core.psi.ext.RsNameIdentifierOwner (org.rust.lang.core.psi.RsFile and org.rust.lang.core.psi.ext.RsNameIdentifierOwner are in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @a482658)
	at org.rust.ide.annotator.fixes.MakePublicFix.invoke(MakePublicFix.kt:39)
	at com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement.invoke(LocalQuickFixAndIntentionActionOnPsiElement.java:42)
	at com.intellij.codeInsight.intention.impl.IntentionActionWithTextCaching$MyIntentionAction.invoke(IntentionActionWithTextCaching.java:179)
	at com.intellij.codeInsight.intention.impl.ShowIntentionActionsHandler.lambda$invokeIntention$4(ShowIntentionActionsHandler.java:214)
	at com.intellij.openapi.application.WriteAction.run(WriteAction.java:92)
	at com.intellij.codeInsight.intention.impl.ShowIntentionActionsHandler.invokeIntention(ShowIntentionActionsHandler.java:216)
	at com.intellij.codeInsight.intention.impl.ShowIntentionActionsHandler.lambda$null$2(ShowIntentionActionsHandler.java:191)
	at com.intellij.openapi.application.TransactionGuardImpl.runSyncTransaction(TransactionGuardImpl.java:82)
	at com.intellij.openapi.application.TransactionGuardImpl.submitTransactionAndWait(TransactionGuardImpl.java:148)
	at com.intellij.codeInsight.intention.impl.ShowIntentionActionsHandler.lambda$chooseActionAndInvoke$3(ShowIntentionActionsHandler.java:190)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:220)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:178)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:168)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:154)
	at com.intellij.codeInsight.intention.impl.ShowIntentionActionsHandler.chooseActionAndInvoke(ShowIntentionActionsHandler.java:189)
	at com.intellij.codeInsight.intention.impl.IntentionListStep.lambda$applyAction$0(IntentionListStep.java:107)
	at com.intellij.openapi.application.TransactionGuardImpl.performUserActivity(TransactionGuardImpl.java:192)
	at com.intellij.ui.popup.AbstractPopup.lambda$dispose$13(AbstractPopup.java:1430)
	at com.intellij.util.ui.UIUtil.invokeLaterIfNeeded(UIUtil.java:2423)
	at com.intellij.ide.IdeEventQueue.ifFocusEventsInTheQueue(IdeEventQueue.java:166)
	at com.intellij.ide.IdeEventQueue.executeWhenAllFocusEventsLeftTheQueue(IdeEventQueue.java:118)
	at com.intellij.openapi.wm.impl.FocusManagerImpl.doWhenFocusSettlesDown(FocusManagerImpl.java:161)
	at com.intellij.openapi.wm.impl.IdeFocusManagerImpl.doWhenFocusSettlesDown(IdeFocusManagerImpl.java:58)
	at com.intellij.ui.popup.AbstractPopup.dispose(AbstractPopup.java:1426)
	at com.intellij.ui.popup.WizardPopup.dispose(WizardPopup.java:162)
	at com.intellij.ui.popup.list.ListPopupImpl.dispose(ListPopupImpl.java:318)
	at com.intellij.openapi.util.Disposer$1.execute(Disposer.java:47)
	at com.intellij.openapi.util.Disposer$1.execute(Disposer.java:43)
	at com.intellij.openapi.util.objectTree.ObjectNode$1.execute(ObjectNode.java:135)
	at com.intellij.openapi.util.objectTree.ObjectNode$1.execute(ObjectNode.java:104)
	at com.intellij.openapi.util.objectTree.ObjectTree.executeActionWithRecursiveGuard(ObjectTree.java:194)
	at com.intellij.openapi.util.objectTree.ObjectNode.execute(ObjectNode.java:104)
	at com.intellij.openapi.util.objectTree.ObjectTree.executeAll(ObjectTree.java:142)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:136)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:132)
	at com.intellij.ui.popup.WizardPopup.disposeAllParents(WizardPopup.java:263)
	at com.intellij.ui.popup.list.ListPopupImpl.handleNextStep(ListPopupImpl.java:453)
	at com.intellij.ui.popup.list.ListPopupImpl._handleSelect(ListPopupImpl.java:407)
	at com.intellij.ui.popup.list.ListPopupImpl.handleSelect(ListPopupImpl.java:353)
	at com.intellij.ui.popup.list.ListPopupImpl$MyMouseListener.mouseReleased(ListPopupImpl.java:512)
	at java.desktop/java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:298)
	at java.desktop/java.awt.Component.processMouseEvent(Component.java:6651)
	at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3342)
	at com.intellij.ui.popup.list.ListPopupImpl$MyList.processMouseEvent(ListPopupImpl.java:566)
	at java.desktop/java.awt.Component.processEvent(Component.java:6416)
	at java.desktop/java.awt.Container.processEvent(Container.java:2263)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5026)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2321)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4858)
	at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4918)
	at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4547)
	at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4488)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2307)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2772)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4858)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:778)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:727)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:95)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:751)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:749)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:748)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:782)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:727)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:396)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:704)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:395)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```
