### PR TITLE
ACT: create new issue action

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,7 +6,7 @@ Feel free to remove all the irrelevant text to request a new feature.
 
 ## Environment
 
-* **Intellij-Rust plugin version:**
+* **IntelliJ Rust plugin version:**
 * **Rust toolchain version:**
 * **IDE name and version:**
 * **Operating system:**

--- a/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
@@ -100,7 +100,8 @@ data class RustcVersion(
     val semver: SemVer,
     val host: String,
     val channel: RustChannel,
-    val commitHash: String?
+    val commitHash: String? = null,
+    val commitDate: String? = null
 )
 
 private fun scrapeRustcVersion(rustc: Path): RustcVersion? {
@@ -123,12 +124,14 @@ private fun scrapeRustcVersion(rustc: Path): RustcVersion? {
     val releaseRe = """release: (\d+\.\d+\.\d+)(.*)""".toRegex()
     val hostRe = "host: (.*)".toRegex()
     val commitHashRe = "commit-hash: ([A-Fa-f0-9]{40})".toRegex()
+    val commitDateRe = """commit-date: (\d{4}-\d{2}-\d{2})""".toRegex()
     val find = { re: Regex -> lines.mapNotNull { re.matchEntire(it) }.firstOrNull() }
 
     val releaseMatch = find(releaseRe) ?: return null
     val hostText = find(hostRe)?.groups?.get(1)?.value ?: return null
     val versionText = releaseMatch.groups[1]?.value ?: return null
     val commitHash = find(commitHashRe)?.groups?.get(1)?.value
+    val commitDate = find(commitDateRe)?.groups?.get(1)?.value
 
     val semVer = SemVer.parseFromText(versionText) ?: return null
 
@@ -139,7 +142,7 @@ private fun scrapeRustcVersion(rustc: Path): RustcVersion? {
         releaseSuffix.startsWith("-nightly") -> RustChannel.NIGHTLY
         else -> RustChannel.DEFAULT
     }
-    return RustcVersion(semVer, hostText, channel, commitHash)
+    return RustcVersion(semVer, hostText, channel, commitHash, commitDate)
 }
 
 private object Suggestions {

--- a/src/main/kotlin/org/rust/ide/actions/diagnostic/CreateNewGithubIssue.kt
+++ b/src/main/kotlin/org/rust/ide/actions/diagnostic/CreateNewGithubIssue.kt
@@ -1,0 +1,107 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.actions.diagnostic
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.PlatformDataKeys
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.util.io.URLUtil
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.runconfig.hasCargoProject
+import org.rust.cargo.toolchain.RustChannel
+import org.rust.cargo.toolchain.RustcVersion
+import org.rust.ide.icons.RsIcons
+import org.rust.lang.core.psi.isRustFile
+import org.rust.openapiext.plugin
+
+class CreateNewGithubIssue : DumbAwareAction(
+    "Create New Issue",
+    "Creates new issue in https://github.com/intellij-rust/intellij-rust repo",
+    RsIcons.RUST
+) {
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = e.project?.hasCargoProject == true
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+
+        val pluginVersion = plugin().version
+        val toolchainVersion = project.cargoProjects.allProjects
+            .asSequence()
+            .mapNotNull { it.rustcInfo?.version }
+            .firstOrNull()
+            ?.displayText
+        val ideVersion = ApplicationInfo.getInstance().build.toString()
+        val os = SystemInfo.getOsNameAndVersion()
+        val codeSnippet = e.getData(PlatformDataKeys.EDITOR)?.codeExample ?: ""
+
+        val body = ISSUE_TEMPLATE.format(pluginVersion, toolchainVersion, ideVersion, os, codeSnippet)
+        val link = "https://github.com/intellij-rust/intellij-rust/issues/new?body=${URLUtil.encodeURIComponent(body)}"
+        BrowserUtil.browse(link)
+    }
+
+    companion object {
+        private val ISSUE_TEMPLATE = """
+            <!--
+            Hello and thank you for the issue!
+            If you would like to report a bug, we have added some points below that you can fill out.
+            Feel free to remove all the irrelevant text to request a new feature.
+            -->
+            
+            ## Environment
+            
+            * **IntelliJ Rust plugin version:** %s
+            * **Rust toolchain version:** %s
+            * **IDE name and version:** %s
+            * **Operating system:** %s
+            
+            ## Problem description
+            
+            
+            ## Steps to reproduce
+            %s
+            
+            <!--
+            Please include as much of your codebase as needed to reproduce the error.
+            If the relevant files are large, please provide a link to a public repository or a [Gist](https://gist.github.com/).
+            -->            
+        """.trimIndent()
+
+        private val RustcVersion.displayText: String
+            get() = buildString {
+                append(semver)
+                if (channel != RustChannel.DEFAULT && channel != RustChannel.STABLE) {
+                    append("-")
+                    append(channel.channel)
+                }
+                if (commitHash != null) {
+                    append(" (")
+                    append(commitHash.take(9))
+                    if (commitDate != null) {
+                        append(" ")
+                        append(commitDate)
+                    }
+                    append(")")
+                }
+                append(" ")
+                append(host)
+            }
+
+        private val Editor.codeExample: String
+            get() {
+                if (FileDocumentManager.getInstance().getFile(document)?.isRustFile != true) return ""
+                val selectedCode = selectionModel.selectedText ?: return ""
+                return "```rust\n$selectedCode```"
+            }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -981,6 +981,9 @@
                 class="org.rust.lang.core.macros.ReexpandMacrosAction"
                 text="Re-expand all Rust macros">
         </action>
+
+        <action id="Rust.CreateNewGithubIssue"
+                class="org.rust.ide.actions.diagnostic.CreateNewGithubIssue"/>
     </actions>
 
 </idea-plugin>

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -76,7 +76,7 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
     private fun setupMockRustcVersion() {
         val annotation = findAnnotationInstance<MockRustcVersion>() ?: return
         val (semVer, channel) = parse(annotation.rustcVersion)
-        val rustcInfo = RustcInfo("", RustcVersion(semVer, "", channel, null))
+        val rustcInfo = RustcInfo("", RustcVersion(semVer, "", channel))
         project.cargoProjects.setRustcInfo(rustcInfo)
     }
 


### PR DESCRIPTION
Now it's possible to open Github "new issue" page just from IDE.
It automatically fills info about the environment like IDE, IntelliJ Rust and Rust toolchain versions.
Also, if you have selected code in `.rs` file, it substitutes it into `Steps to reproduce` section