### PR TITLE
TY: Don't throw exception on unbounded inclusive range

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -1039,8 +1039,7 @@ class RsTypeInferenceWalker(
             dot3 != null && el.size == 2 -> {
                 "RangeInclusive" to getMoreCompleteType(el[0].inferType(), el[1].inferType())
             }
-
-            else -> error("Unrecognized range expression")
+            else -> return TyUnknown
         }
 
         return items.findRangeTy(rangeName, indexType)


### PR DESCRIPTION
Fixes
```
java.lang.IllegalStateException: Unrecognized range expression
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferRangeType(TypeInferenceWalker.kt:1043)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:161)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:100)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType$default(TypeInferenceWalker.kt:95)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferIfExprType(TypeInferenceWalker.kt:876)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:152)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:100)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType$default(TypeInferenceWalker.kt:95)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferForExprType(TypeInferenceWalker.kt:825)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:155)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType$default(TypeInferenceWalker.kt:130)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.processStatement(TypeInferenceWalker.kt:126)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:98)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferTypeCoercableTo(TypeInferenceWalker.kt:93)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferFnBody(TypeInferenceWalker.kt:81)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferLambdaBody(TypeInferenceWalker.kt:87)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferLambdaExprType(TypeInferenceWalker.kt:1187)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:164)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferTypeCoercableTo(TypeInferenceWalker.kt:177)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferArgumentTypes(TypeInferenceWalker.kt:745)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferMethodCallExprType(TypeInferenceWalker.kt:567)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferDotExprType(TypeInferenceWalker.kt:781)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:149)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType$default(TypeInferenceWalker.kt:130)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.processStatement(TypeInferenceWalker.kt:126)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:98)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferTypeCoercableTo(TypeInferenceWalker.kt:93)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferFnBody(TypeInferenceWalker.kt:81)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferLambdaBody(TypeInferenceWalker.kt:87)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferLambdaExprType(TypeInferenceWalker.kt:1187)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:164)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferTypeCoercableTo(TypeInferenceWalker.kt:177)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferArgumentTypes(TypeInferenceWalker.kt:745)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferMethodCallExprType(TypeInferenceWalker.kt:567)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferDotExprType(TypeInferenceWalker.kt:781)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:149)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferTypeCoercableTo(TypeInferenceWalker.kt:177)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferArgumentTypes(TypeInferenceWalker.kt:745)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferMethodCallExprType(TypeInferenceWalker.kt:567)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferDotExprType(TypeInferenceWalker.kt:781)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:149)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType$default(TypeInferenceWalker.kt:130)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.processStatement(TypeInferenceWalker.kt:126)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:98)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferTypeCoercableTo(TypeInferenceWalker.kt:93)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferFnBody(TypeInferenceWalker.kt:81)
	at org.rust.lang.core.types.infer.RsInferenceContext.infer(TypeInference.kt:165)
	at org.rust.lang.core.types.infer.TypeInferenceKt$inferTypesIn$1.compute(TypeInference.kt:30)
	at org.rust.lang.core.types.infer.TypeInferenceKt$inferTypesIn$1.compute(TypeInference.kt)
	at com.intellij.openapi.util.RecursionManager$1.doPreventingRecursion(RecursionManager.java:113)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:71)
	at org.rust.openapiext.UtilsKt.recursionGuard(utils.kt:62)
	at org.rust.openapiext.UtilsKt.recursionGuard$default(utils.kt:61)
	at org.rust.lang.core.types.infer.TypeInferenceKt.inferTypesIn(TypeInference.kt:30)
	at org.rust.lang.core.types.ExtensionsKt$inference$1.compute(Extensions.kt:65)
	at com.intellij.psi.util.CachedValuesManager.lambda$getCachedValue$0(CachedValuesManager.java:148)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:54)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$1(CachedValueBase.java:240)
	at com.intellij.openapi.util.RecursionManager$1.doPreventingRecursion(RecursionManager.java:113)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:71)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:241)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:43)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValueFromExHolder(CachedValuesManagerImpl.java:72)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:45)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:147)
	at org.rust.lang.core.types.ExtensionsKt.getInference(Extensions.kt:64)
	at org.rust.lang.core.types.ExtensionsKt.getInference(Extensions.kt:134)
	at org.rust.lang.core.types.ExtensionsKt.getType(Extensions.kt:83)
	at org.rust.ide.intentions.UnwrapToMatchIntention.findApplicableContext(UnwrapToMatchIntention.kt:26)
	at org.rust.ide.intentions.UnwrapToMatchIntention.findApplicableContext(UnwrapToMatchIntention.kt:20)
	at org.rust.ide.intentions.RsElementBaseIntentionAction.isAvailable(RsElementBaseIntentionAction.kt:54)
	at com.intellij.codeInsight.intention.BaseElementAtCaretIntentionAction.isAvailable(BaseElementAtCaretIntentionAction.java:40)
	at com.intellij.codeInsight.intention.impl.ShowIntentionActionsHandler.availableFor(ShowIntentionActionsHandler.java:135)
	at com.intellij.codeInsight.daemon.impl.ShowIntentionsPass.lambda$getActionsToShow$1(ShowIntentionsPass.java:299)
	at com.intellij.codeInsight.intention.impl.ShowIntentionActionsHandler.chooseBetweenHostAndInjected(ShowIntentionActionsHandler.java:160)
	at com.intellij.codeInsight.daemon.impl.ShowIntentionsPass.getActionsToShow(ShowIntentionsPass.java:297)
	at com.intellij.codeInsight.daemon.impl.ShowIntentionsPass.doCollectInformation(ShowIntentionsPass.java:220)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:55)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$null$1(PassExecutorService.java:429)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1105)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:422)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:591)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:537)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:59)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:421)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:397)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:164)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:204)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:395)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:161)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
```