### PR TITLE
RUN: enable --show-output when executing tests

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -28,6 +28,7 @@ daschl
 dem1tris
 devurandom
 Dimonchik0036
+emmericp
 Falkenfighter
 fan-tom
 farodin91

--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestEventsConverter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestEventsConverter.kt
@@ -155,6 +155,7 @@ class CargoTestEventsConverter(
             }
             "ok" -> {
                 val duration = getTestDuration(testMessage.name)
+                if (!testMessage.stdout.isNullOrEmpty()) messages.add(createTestStdOutMessage(testMessage.name, testMessage.stdout))
                 messages.add(createTestFinishedMessage(testMessage.name, duration))
                 recordSuiteChildFinished(testMessage.name)
                 processFinishedSuites(messages)

--- a/src/main/kotlin/org/rust/cargo/toolchain/RustChannel.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustChannel.kt
@@ -9,11 +9,12 @@ enum class RustChannel(val index: Int, val channel: String?) {
     DEFAULT(0, null),
     STABLE(1, "stable"),
     BETA(2, "beta"),
-    NIGHTLY(3, "nightly");
+    NIGHTLY(3, "nightly"),
+    DEV(4, "dev");
 
     override fun toString(): String = channel ?: "[default]"
 
     companion object {
-        fun fromIndex(index: Int) = RustChannel.values().find { it.index == index } ?: RustChannel.DEFAULT
+        fun fromIndex(index: Int) = values().find { it.index == index } ?: DEFAULT
     }
 }

--- a/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
@@ -14,6 +14,8 @@ import org.rust.openapiext.*
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
 
 data class RustToolchain(val location: Path) {
 
@@ -114,7 +116,7 @@ data class RustcVersion(
     val host: String,
     val channel: RustChannel,
     val commitHash: String? = null,
-    val commitDate: String? = null
+    val commitDate: LocalDate? = null
 )
 
 private fun scrapeRustcVersion(rustc: Path): RustcVersion? {
@@ -144,15 +146,19 @@ private fun scrapeRustcVersion(rustc: Path): RustcVersion? {
     val hostText = find(hostRe)?.groups?.get(1)?.value ?: return null
     val versionText = releaseMatch.groups[1]?.value ?: return null
     val commitHash = find(commitHashRe)?.groups?.get(1)?.value
-    val commitDate = find(commitDateRe)?.groups?.get(1)?.value
+    val commitDate = try {
+        LocalDate.parse(find(commitDateRe)?.groups?.get(1)?.value)
+    } catch (e: DateTimeParseException) {
+        null
+    }
 
     val semVer = SemVer.parseFromText(versionText) ?: return null
-
     val releaseSuffix = releaseMatch.groups[2]?.value.orEmpty()
     val channel = when {
         releaseSuffix.isEmpty() -> RustChannel.STABLE
         releaseSuffix.startsWith("-beta") -> RustChannel.BETA
         releaseSuffix.startsWith("-nightly") -> RustChannel.NIGHTLY
+        releaseSuffix.startsWith("-dev") -> RustChannel.DEV
         else -> RustChannel.DEFAULT
     }
     return RustcVersion(semVer, hostText, channel, commitHash, commitDate)

--- a/src/test/kotlin/org/rust/cargo/runconfig/CargoTestRunStateTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/CargoTestRunStateTest.kt
@@ -6,13 +6,17 @@
 package org.rust.cargo.runconfig
 
 import com.intellij.util.execution.ParametersListUtil
-import org.junit.Assert.assertEquals
+import com.intellij.util.text.SemVer
+import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.rust.cargo.toolchain.CargoCommandLine
+import org.rust.cargo.toolchain.RustChannel
+import org.rust.cargo.toolchain.RustcVersion
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.time.LocalDate
 
 @RunWith(Parameterized::class)
 class CargoTestRunStatePatchArgsTest(
@@ -22,9 +26,29 @@ class CargoTestRunStatePatchArgsTest(
     private val wd: Path = Paths.get("/my-crate")
 
     @Test
-    fun test() = assertEquals(
+    fun `test without show output`() = assertEquals(
         ParametersListUtil.parse(expected),
-        CargoTestRunState.patchArgs(CargoCommandLine("run", wd, ParametersListUtil.parse(input)))
+        CargoTestRunState.patchArgs(
+            CargoCommandLine("run", wd, ParametersListUtil.parse(input)),
+            RustcVersion(
+                SemVer.parseFromText("1.38.0")!!,
+                "x86_64-unknown-linux-gnu",
+                RustChannel.STABLE
+            )
+        )
+    )
+
+    @Test
+    fun `test with show output`() = assertEquals(
+        ParametersListUtil.parse(expected) + "--show-output",
+        CargoTestRunState.patchArgs(
+            CargoCommandLine("run", wd, ParametersListUtil.parse(input)),
+            RustcVersion(
+                SemVer.parseFromText("1.39.0")!!,
+                "x86_64-unknown-linux-gnu",
+                RustChannel.STABLE
+            )
+        )
     )
 
     companion object {
@@ -41,6 +65,64 @@ class CargoTestRunStatePatchArgsTest(
             arrayOf("-- --format json", "--no-fail-fast -- --format json -Z unstable-options"),
             arrayOf("-- --format pretty", "--no-fail-fast -- --format json -Z unstable-options"),
             arrayOf("-- --format=pretty", "--no-fail-fast -- --format=json -Z unstable-options")
+        )
+    }
+}
+
+class CargoTestRunStatePatchArgsShowOutputEnableTest {
+
+    private fun patchArgs(version: String, channel: RustChannel, date: LocalDate) = CargoTestRunState.patchArgs(
+        CargoCommandLine("run", Paths.get("/my-crate"), ParametersListUtil.parse("")),
+        RustcVersion(
+            SemVer.parseFromText(version)!!,
+            "x86_64-unknown-linux-gnu",
+            channel,
+            null,
+            date
+        )
+    )
+
+    // --show-output should be enabled on rustc 1.39 nightly and dev builds with a build date >= 2019-08-28
+    // and on all stable and beta versions >= 1.39
+    @Test
+    fun `old versions should never use --show-output`() {
+        assertFalse(
+            patchArgs("1.38.0", RustChannel.STABLE, LocalDate.of(2019, 12, 31))
+                .contains("--show-output")
+        )
+        assertFalse(
+            patchArgs("1.38.0", RustChannel.NIGHTLY, LocalDate.of(2019, 12, 31))
+                .contains("--show-output")
+        )
+        assertFalse(
+            patchArgs("1.38.0", RustChannel.BETA, LocalDate.of(2019, 12, 31))
+                .contains("--show-output")
+        )
+        assertFalse(
+            patchArgs("1.39.0", RustChannel.NIGHTLY, LocalDate.of(2019, 8, 27))
+                .contains("--show-output")
+        )
+    }
+
+    @Test
+    fun `new versions should use --show-output`() {
+        // beta and stable always has the option, ignoring build date
+        assertTrue(
+            patchArgs("1.39.0", RustChannel.STABLE, LocalDate.of(2019, 7, 28))
+                .contains("--show-output")
+        )
+        assertTrue(
+            patchArgs("1.39.0", RustChannel.BETA, LocalDate.of(2019, 7, 28))
+                .contains("--show-output")
+        )
+        // nightly and dev only if it's new enough
+        assertTrue(
+            patchArgs("1.39.0", RustChannel.NIGHTLY, LocalDate.of(2019, 8, 28))
+                .contains("--show-output")
+        )
+        assertTrue(
+            patchArgs("1.39.0", RustChannel.DEV, LocalDate.of(2019, 8, 28))
+                .contains("--show-output")
         )
     }
 }


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/3994

This requires this patch for rust (hopefully in 1.38?): https://github.com/rust-lang/rust/pull/62600

This is work in progress because it doesn't work yet, I'm looking for some help here:
The problem is you can't run `rustVersion()` in the UI thread and I'd really like to have this behavior as default if the compiler is new enough.
What's the best way to achieve this? Fallback would be to make this an option for the run configuration, but that would be a little bit annoying since virtually everyone would want to enable this?


Edit: changed the code to hardcode 1.38 as Rust version passed to `patchArgs` because I'm using this branch ;) Looking for a good way to get the Rust version here.

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
