### PR TITLE
T: improve `MinRustcVersion` annotation

### DIFF
--- a/src/test/kotlin/org/rust/MinRustcVersion.kt
+++ b/src/test/kotlin/org/rust/MinRustcVersion.kt
@@ -3,12 +3,15 @@
  * found in the LICENSE file.
  */
 
-package org.rust.cargo
+package org.rust
+
+import com.intellij.util.text.SemVer
 
 /**
  * Specify minimum rustc version to launch test.
- * Handled by [RsWithToolchainTestBase]
  */
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class MinRustcVersion(val version: String)
+
+val MinRustcVersion.semver: SemVer get() = SemVer.parseFromText(version) ?: error("Invalid version value: $version")

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -103,10 +103,9 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
     }
 
     override fun runTest() {
-        val projectDescriptor = projectDescriptor
-        val reason = (projectDescriptor as? RustProjectDescriptorBase)?.skipTestReason
+        val reason = skipTestReason
         if (reason != null) {
-            System.err.println("SKIP $name: $reason")
+            System.err.println("SKIP \"$name\": $reason")
             return
         }
 
@@ -121,6 +120,21 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
             super.runTest()
         }
     }
+
+    protected open val skipTestReason: String?
+        get() {
+            val projectDescriptor = projectDescriptor as? RustProjectDescriptorBase
+            var reason = projectDescriptor?.skipTestReason
+            if (reason == null) {
+                val minRustVersion = findAnnotationInstance<MinRustcVersion>() ?: return null
+                val requiredVersion = minRustVersion.semver
+                val rustcVersion = projectDescriptor?.rustcInfo?.version ?: return null
+                if (rustcVersion.semver < requiredVersion) {
+                    reason = "$requiredVersion Rust version required, ${rustcVersion.semver} found"
+                }
+            }
+            return reason
+        }
 
     private fun runTestEdition2015() {
         project.cargoProjects.setEdition(CargoWorkspace.Edition.EDITION_2015)

--- a/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
@@ -8,14 +8,10 @@ package org.rust.cargo
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.builders.ModuleFixtureBuilder
 import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase
-import com.intellij.util.text.SemVer
-import org.rust.FileTree
-import org.rust.FileTreeBuilder
-import org.rust.TestProject
+import org.rust.*
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.toolchain.RustToolchain
-import org.rust.fileTree
 
 /**
  * This class allows executing real Cargo during the tests.
@@ -47,10 +43,7 @@ abstract class RsWithToolchainTestBase : CodeInsightFixtureTestCase<ModuleFixtur
         }
         val minRustVersion = findAnnotationInstance<MinRustcVersion>()
         if (minRustVersion != null) {
-            val requiredVersion = SemVer.parseFromText(minRustVersion.version)
-            if (requiredVersion == null) {
-                fail("Invalid version value: ${minRustVersion.version}")
-            }
+            val requiredVersion = minRustVersion.semver
             val rustcVersion = toolchain.queryVersions().rustc
             if (rustcVersion == null) {
                 System.err.println("SKIP \"$name\": failed to query Rust version")

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ApplySuggestionFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ApplySuggestionFixTest.kt
@@ -6,7 +6,7 @@
 package org.rust.ide.annotator.fixes
 
 import org.intellij.lang.annotations.Language
-import org.rust.cargo.MinRustcVersion
+import org.rust.MinRustcVersion
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.toolchain.ExternalLinter

--- a/src/test/kotlin/org/rustSlowTests/CargoProjectResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/CargoProjectResolveTest.kt
@@ -6,7 +6,7 @@
 package org.rustSlowTests
 
 import com.intellij.openapi.util.SystemInfo
-import org.rust.cargo.MinRustcVersion
+import org.rust.MinRustcVersion
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.resolve.NameResolutionTestmarks

--- a/src/test/kotlin/org/rustSlowTests/RsExternalLinterPassTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsExternalLinterPassTest.kt
@@ -7,7 +7,7 @@ package org.rustSlowTests
 
 import com.intellij.lang.annotation.HighlightSeverity
 import org.intellij.lang.annotations.Language
-import org.rust.cargo.MinRustcVersion
+import org.rust.MinRustcVersion
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.rustSettings


### PR DESCRIPTION
Now it can be used in inheritors of `RsTestBase`. Previously, it was supported only by `RsWithToolchainTestBase`