### PR TITLE
Pretty-printers for GDB: Disable EnumProvider in case of invalid discriminant

### DIFF
--- a/prettyPrinters/gdb_lookup.py
+++ b/prettyPrinters/gdb_lookup.py
@@ -18,6 +18,17 @@ def classify_rust_type(type):
     return RustType.OTHER
 
 
+def check_enum_discriminant(valobj):
+    content = valobj[valobj.type.fields()[0]]
+    fields = content.type.fields()
+    if len(fields) > 1:
+        discriminant = int(content[fields[0]]) + 1
+        if discriminant > len(fields):
+            # invalid discriminant
+            return False
+    return True
+
+
 def lookup(valobj):
     rust_type = classify_rust_type(valobj.type)
 
@@ -26,7 +37,8 @@ def lookup(valobj):
     if rust_type == RustType.TUPLE:
         return TupleProvider(valobj)
     if rust_type == RustType.ENUM:
-        return EnumProvider(valobj)
+        if check_enum_discriminant(valobj):
+            return EnumProvider(valobj)
 
     if rust_type == RustType.STD_STRING:
         return StdStringProvider(valobj)


### PR DESCRIPTION
Hotfix of #4155. Just disables the `EnumProvider` in case of the invalid discriminant.

@Kobzol I haven't found the proper way to print such enums yet, so I would be really grateful if you would investigate this problem too!