### PR TITLE
TY: Fix inference of full RsPatField and RsPatWild

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -77,7 +77,7 @@ val RsPat.type: Ty
     get() = inference?.getPatType(this) ?: TyUnknown
 
 val RsPatField.type: Ty
-    get() = patBinding?.let { inference?.getBindingType(it) } ?: TyUnknown
+    get() = inference?.getPatFieldType(this) ?: TyUnknown
 
 val RsExpr.type: Ty
     get() = inference?.getExprType(this) ?: TyUnknown

--- a/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
@@ -16,7 +16,7 @@ import org.rust.lang.core.types.type
 
 fun RsPat.extractBindings(fcx: RsTypeInferenceWalker, type: Ty, defBm: RsBindingModeKind = BindByValue(IMMUTABLE)) {
     when (this) {
-        is RsPatWild -> {}
+        is RsPatWild -> fcx.writePatTy(this, type)
         is RsPatConst -> {
             val expr = expr
             val expected = when {
@@ -90,7 +90,10 @@ fun RsPat.extractBindings(fcx: RsTypeInferenceWalker, type: Ty, defBm: RsBinding
                     ?: TyUnknown
 
                 when (kind) {
-                    is RsPatFieldKind.Full -> kind.pat.extractBindings(fcx, fieldType, mut)
+                    is RsPatFieldKind.Full -> {
+                        kind.pat.extractBindings(fcx, fieldType, mut)
+                        fcx.writePatFieldTy(patField, fieldType)
+                    }
                     is RsPatFieldKind.Shorthand -> {
                         val bindingType = if (fieldType is TyAdt && kind.isBox) {
                             fieldType.typeArguments.singleOrNull() ?: return


### PR DESCRIPTION
Fixes the following cases:

<img width="294" alt="Screenshot 2019-07-18 at 14 03 39" src="https://user-images.githubusercontent.com/4854600/61452675-05773400-a965-11e9-8d2f-a6498d160a05.png">
<img width="318" alt="Screenshot 2019-07-18 at 14 04 37" src="https://user-images.githubusercontent.com/4854600/61452677-05773400-a965-11e9-9ccc-ced9a4324053.png">
<img width="313" alt="Screenshot 2019-07-18 at 14 04 47" src="https://user-images.githubusercontent.com/4854600/61452679-060fca80-a965-11e9-8e48-46c1c5c1b527.png">
