### PR TITLE
Update Grammar-Kit to 2019.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ plugins {
     idea
     kotlin("jvm") version "1.3.41"
     id("org.jetbrains.intellij") version "0.4.9"
-    id("org.jetbrains.grammarkit") version "2018.2.2"
+    id("org.jetbrains.grammarkit") version "2019.2"
     id("de.undercouch.download") version "3.4.3"
     id("net.saliman.properties") version "1.4.6"
 }

--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -87,7 +87,7 @@
     elementType(".+BinExpr") = BinaryExpr
     elementType(".+BinOp") = BinaryOp
 
-    elementTypeFactory("(Expr|Stmt|TypeRef)CodeFragment") = "org.rust.lang.core.psi.RsCodeFragmentElementTypeKt.factory"
+    extraRoot(".*CodeFragment")=true
 
     extends("Pat(Wild|Ref|Tup|Slice|Macro|Struct|TupleStruct|Ident|Range|Box|Const)") = Pat
 
@@ -109,7 +109,9 @@
 
 
 File ::= [ SHEBANG_LINE ] InnerAttr* Items
-
+ExprCodeFragment ::= Expr?
+StmtCodeFragment ::= Stmt?
+TypeRefCodeFragment ::= TypeReference?
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Attributes
@@ -1470,11 +1472,3 @@ private never ::= !()
 // Trailing commas are allowed
 private meta comma_separated_list ::= <<param>> ( ',' <<param>> )* ','?
 private meta list_element ::= <<param>> !'+' (',' | &'>') { pin = 2 }
-
-// These parsing rules are used directly from the code
-//noinspection BnfUnusedRule
-ExprCodeFragment ::= Expr?
-//noinspection BnfUnusedRule
-StmtCodeFragment ::= Stmt?
-//noinspection BnfUnusedRule
-TypeRefCodeFragment ::= TypeReference?

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
@@ -93,21 +93,21 @@ abstract class RsCodeFragment(
 
 class RsExpressionCodeFragment : RsCodeFragment, RsInferenceContextOwner {
     constructor(fileViewProvider: FileViewProvider, context: RsElement)
-        : super(fileViewProvider, RsElementTypes.EXPR_CODE_FRAGMENT, context)
+        : super(fileViewProvider, RsCodeFragmentElementType.EXPR, context)
 
     constructor(project: Project, text: CharSequence, context: RsElement)
-        : super(project, text, RsElementTypes.EXPR_CODE_FRAGMENT, context)
+        : super(project, text, RsCodeFragmentElementType.EXPR, context)
 
     val expr: RsExpr? get() = PsiTreeUtil.getChildOfType(this, RsExpr::class.java)
 }
 
 class RsStatementCodeFragment(project: Project, text: CharSequence, context: RsElement)
-    : RsCodeFragment(project, text, RsElementTypes.STMT_CODE_FRAGMENT, context) {
+    : RsCodeFragment(project, text, RsCodeFragmentElementType.STMT, context) {
     val stmt: RsStmt? get() = PsiTreeUtil.getChildOfType(this, RsStmt::class.java)
 }
 
 class RsTypeReferenceCodeFragment(project: Project, text: CharSequence, context: RsElement)
-    : RsCodeFragment(project, text, RsElementTypes.TYPE_REF_CODE_FRAGMENT, context),
+    : RsCodeFragment(project, text, RsCodeFragmentElementType.TYPE_REF, context),
       RsNamedElement {
     val typeReference: RsTypeReference? get() = PsiTreeUtil.getChildOfType(this, RsTypeReference::class.java)
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentElementType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentElementType.kt
@@ -8,26 +8,24 @@ package org.rust.lang.core.psi
 import com.intellij.lang.ASTNode
 import com.intellij.lang.PsiBuilderFactory
 import com.intellij.psi.impl.source.tree.ICodeFragmentElementType
+import com.intellij.psi.impl.source.tree.TreeElement
 import com.intellij.psi.tree.IElementType
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.parser.RustParser
 
-fun factory(name: String): IElementType = when (name) {
-    "EXPR_CODE_FRAGMENT" -> RsExprCodeFragmentElementType
-    "STMT_CODE_FRAGMENT" -> RsStmtCodeFragmentElementType
-    "TYPE_REF_CODE_FRAGMENT" -> RsTypeRefCodeFragmentElementType
-    else -> error("Unknown element $name")
-}
+class RsCodeFragmentElementType(private val elementType: IElementType, debugName: String) : ICodeFragmentElementType(debugName, RsLanguage) {
 
-abstract class RsCodeFragmentElementTypeBase(debugName: String) : ICodeFragmentElementType(debugName, RsLanguage) {
     override fun parseContents(chameleon: ASTNode): ASTNode? {
-        val project = chameleon.psi.project
+        if (chameleon !is TreeElement) return null
+        val project = chameleon.manager.project
         val builder = PsiBuilderFactory.getInstance().createBuilder(project, chameleon)
-        val root = RustParser().parse(this, builder)
+        val root = RustParser().parse(elementType, builder)
         return root.firstChildNode
     }
-}
 
-object RsExprCodeFragmentElementType : RsCodeFragmentElementTypeBase("RS_EXPR_CODE_FRAGMENT")
-object RsStmtCodeFragmentElementType : RsCodeFragmentElementTypeBase("RS_STMT_CODE_FRAGMENT")
-object RsTypeRefCodeFragmentElementType : RsCodeFragmentElementTypeBase("RS_TYPE_REF_CODE_FRAGMENT")
+    companion object {
+        val EXPR = RsCodeFragmentElementType(RsElementTypes.EXPR_CODE_FRAGMENT, "RS_EXPR_CODE_FRAGMENT")
+        val STMT = RsCodeFragmentElementType(RsElementTypes.STMT_CODE_FRAGMENT, "RS_STMT_CODE_FRAGMENT")
+        val TYPE_REF = RsCodeFragmentElementType(RsElementTypes.TYPE_REF_CODE_FRAGMENT, "RS_TYPE_REF_CODE_FRAGMENT")
+    }
+}


### PR DESCRIPTION
Now we don't have any rules with `IFileElementType` except `File` so everything (including `*CodeFragment`s) should parse successfully