### PR TITLE
Fix #3544 crash in type inference

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -28,6 +28,7 @@ import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.resolve.namespaces
 import org.rust.lang.core.resolve.ref.deepResolve
 import org.rust.lang.core.types.TraitRef
+import org.rust.lang.core.types.implLookup
 import org.rust.lang.core.types.asTy
 import org.rust.lang.core.types.inference
 import org.rust.lang.core.types.ty.*

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFix.kt
@@ -13,9 +13,8 @@ import com.intellij.psi.PsiFile
 import org.rust.ide.presentation.tyToStringWithoutTypeArgs
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.withSubst
-import org.rust.lang.core.resolve.ImplLookup
-import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.TraitRef
+import org.rust.lang.core.types.implLookupAndKnownItems
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyAdt
 import org.rust.lang.core.types.type
@@ -85,8 +84,7 @@ abstract class ConvertToTyUsingTryTraitAndUnpackFix(
     }
 
     private fun isFnRetTyResultAndMatchErrTy(element: RsExpr, fnRetTy: Ty): Boolean {
-        val items = element.knownItems
-        val lookup = ImplLookup(element.project, items)
+        val (lookup, items) = element.implLookupAndKnownItems
         return fnRetTy is TyAdt && fnRetTy.item == items.Result
             && lookup.select(TraitRef(fnRetTy.typeArguments.get(1), (items.From
             ?: return false).withSubst(errTy))).ok() != null

--- a/src/main/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplate.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplate.kt
@@ -13,6 +13,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.TraitRef
+import org.rust.lang.core.types.implLookup
 import org.rust.lang.core.types.ty.TyReference
 import org.rust.lang.core.types.ty.TyStr
 import org.rust.lang.core.types.ty.TyUnit

--- a/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
@@ -13,8 +13,7 @@ import org.rust.lang.core.psi.RsBinaryExpr
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.ext.EqualityOp
 import org.rust.lang.core.psi.ext.operatorType
-import org.rust.lang.core.resolve.ImplLookup
-import org.rust.lang.core.resolve.knownItems
+import org.rust.lang.core.types.implLookup
 import org.rust.lang.core.types.ty.TyPointer
 import org.rust.lang.core.types.ty.TyReference
 import org.rust.lang.core.types.type
@@ -124,7 +123,7 @@ class DbgPostfixTemplate(provider: RsPostfixTemplateProvider) :
 }
 
 private val RsExpr.isIntoIterator: Boolean
-    get() = ImplLookup(project, knownItems).isIntoIterator(type)
+    get() = implLookup.isIntoIterator(type)
 
 private val RsExpr.implementsDeref: Boolean
-    get() = ImplLookup(project, knownItems).isDeref(this.type)
+    get() = implLookup.isDeref(this.type)

--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -20,7 +20,7 @@ import org.rust.ide.refactoring.RsNamesValidator
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ImplLookup
-import org.rust.lang.core.resolve.knownItems
+import org.rust.lang.core.types.implLookup
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyNever
@@ -68,7 +68,7 @@ fun createLookupElement(
         priority += LOCAL_PRIORITY_OFFSET
     }
 
-    if (isCompatibleTypes(ImplLookup(element.project, element.knownItems), element.asTy, expectedTy)) {
+    if (isCompatibleTypes(element.implLookup, element.asTy, expectedTy)) {
         priority += EXPECTED_TYPE_PRIORITY_OFFSET
     }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/RsDefaultValueBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsDefaultValueBuilder.kt
@@ -9,6 +9,7 @@ import org.rust.ide.inspections.RsFieldInitShorthandInspection
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.KnownItems
 import org.rust.lang.core.resolve.processLocalVariables
+import org.rust.lang.core.types.implLookup
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -26,7 +26,6 @@ import org.rust.lang.core.psi.RsConstant
 import org.rust.lang.core.psi.RsEnumVariant
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.rustFile
-import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.VALUES
 import org.rust.lang.core.resolve.processNestedScopesUpwards
 import org.rust.openapiext.toPsiFile
@@ -135,9 +134,6 @@ abstract class RsStubbedElementImpl<StubT : StubElement<*>> : StubBasedPsiElemen
 
     override fun toString(): String = "${javaClass.simpleName}($elementType)"
 }
-
-val RsElement.implLookup: ImplLookup
-    get() = ImplLookup.relativeTo(this)
 
 fun RsElement.findInScope(name: String): PsiElement? {
     var resolved: PsiElement? = null

--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -15,6 +15,7 @@ import com.intellij.psi.util.PsiModificationTracker
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.resolve.KnownItems
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.borrowck.BorrowCheckContext
 import org.rust.lang.core.types.borrowck.BorrowCheckResult
@@ -105,10 +106,15 @@ val RsTraitOrImpl.selfType: Ty
         else -> error("Unreachable")
     }
 
+val RsElement.implLookup: ImplLookup
+    get() = ImplLookup.relativeTo(this)
+
+val RsElement.implLookupAndKnownItems: Pair<ImplLookup, KnownItems>
+    get() = implLookup to knownItems
+
 val RsExpr.cmt: Cmt?
     get() {
-        val items = this.knownItems
-        val lookup = ImplLookup(this.project, items)
+        val (lookup, items) = implLookupAndKnownItems
         val inference = this.inference ?: return null
         return MemoryCategorizationContext(lookup, inference).processExpr(this)
     }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -26,7 +26,7 @@ import org.rust.stdext.zipValues
 fun inferTypesIn(element: RsInferenceContextOwner): RsInferenceResult {
     val items = element.knownItems
     val paramEnv = if (element is RsGenericDeclaration) ParamEnv.buildFor(element) else ParamEnv.EMPTY
-    val lookup = ImplLookup(element.project, items, paramEnv)
+    val lookup = ImplLookup(element.project, element.cargoProject, items, paramEnv)
     return recursionGuard(element, Computable { lookup.ctx.infer(element) })
         ?: error("Can not run nested type inference")
 }

--- a/src/main/kotlin/org/rust/lang/utils/CargoProjectCache.kt
+++ b/src/main/kotlin/org/rust/lang/utils/CargoProjectCache.kt
@@ -1,0 +1,58 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.utils
+
+import com.intellij.openapi.util.Key
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.util.containers.ContainerUtil
+import org.rust.cargo.project.model.CargoProject
+import org.rust.lang.core.psi.rustStructureModificationTracker
+import org.rust.stdext.Cache
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+
+/**
+ * Similar to [org.rust.openapiext.ProjectCache], but based on [CargoProject]
+ */
+class CargoProjectCache<in T: Any, R: Any>(
+    cacheName: String,
+    private val dependencyGetter: (CargoProject) -> Any = { it.project.rustStructureModificationTracker }
+) {
+    init {
+        if (!registered.add(cacheName)) {
+            error("""
+                CargoProjectCache `$cacheName` is already registered.
+                Make sure ProjectCache is static, that is, put it inside companion object.
+            """.trimIndent())
+        }
+    }
+
+    private val cacheKey: Key<CachedValue<ConcurrentMap<T, R>>> = Key.create(cacheName)
+
+    fun getOrPut(project: CargoProject, key: T, defaultValue: () -> R): R {
+        val cache = getCacheInternal(project)
+        return cache.getOrPut(key) { defaultValue() }
+    }
+
+    fun getCache(project: CargoProject): Cache<T, R> =
+        Cache.fromConcurrentMap(getCacheInternal(project))
+
+    private fun getCacheInternal(project: CargoProject): ConcurrentMap<T, R> {
+        return CachedValuesManager.getManager(project.project)
+            .getCachedValue(project, cacheKey, {
+                CachedValueProvider.Result.create(
+                    ConcurrentHashMap(),
+                    dependencyGetter(project)
+                )
+            }, false)
+    }
+
+    companion object {
+        private val registered = ContainerUtil.newConcurrentSet<String>()
+    }
+}

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -27,15 +27,11 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.resolve.KnownItems
-import org.rust.lang.core.resolve.knownItems
-import org.rust.lang.core.types.BoundElement
-import org.rust.lang.core.types.TraitRef
-import org.rust.lang.core.types.asTy
+import org.rust.lang.core.types.*
 import org.rust.lang.core.types.infer.TypeFoldable
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.infer.hasTyInfer
-import org.rust.lang.core.types.isMutable
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.utils.RsErrorCode.*
 import org.rust.lang.utils.Severity.*
@@ -75,8 +71,7 @@ sealed class RsDiagnostic(
                     if (expectedTy is TyNumeric && isActualTyNumeric()) {
                         add(AddAsTyFix(element, expectedTy))
                     } else  if (element is RsElement) {
-                        val items = element.knownItems
-                        val lookup = ImplLookup(element.project, items)
+                        val (lookup, items) = element.implLookupAndKnownItems
                         if (isFromActualImplForExpected(items, lookup)) {
                             add(ConvertToTyUsingFromTraitFix(element, expectedTy))
                         } else { // only check TryFrom if From is not available

--- a/src/main/kotlin/org/rust/stdext/Cache.kt
+++ b/src/main/kotlin/org/rust/stdext/Cache.kt
@@ -1,0 +1,38 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.stdext
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+
+/**
+ * A very simple interface for caching
+ */
+interface Cache<in K: Any, V: Any> {
+    fun getOrPut(key: K, defaultValue: () -> V): V
+
+    companion object {
+        fun <K: Any, V: Any> new(): Cache<K, V> =
+            fromMutableMap(mutableMapOf())
+
+        fun <K: Any, V: Any> newConcurrent(): Cache<K, V> =
+            fromConcurrentMap(ConcurrentHashMap())
+
+        private fun <K: Any, V: Any> fromMutableMap(map: MutableMap<K, V>): Cache<K, V> {
+            return object : Cache<K, V> {
+                override fun getOrPut(key: K, defaultValue: () -> V): V =
+                    map.getOrPut(key, defaultValue)
+            }
+        }
+
+        fun <K: Any, V: Any> fromConcurrentMap(map: ConcurrentMap<K, V>): Cache<K, V> {
+            return object : Cache<K, V> {
+                override fun getOrPut(key: K, defaultValue: () -> V): V =
+                    map.getOrPut(key, defaultValue)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3544

Currently, we use global `ProjectCache` to cache trait selection results. This leads to bugs when there are multiple cargo projects inside one IDEA project or when we open a file without a cargo project (e.g. virtual file in git diff window).

This PR introduces `CargoProjectCache` (in addition to `ProjectCache`).