### PR TITLE
RES: fix re-exported crate via use item on 2018 edition

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -95,9 +95,14 @@ fun processItemDeclarations(
         if (!(isPublic || withPrivateImports)) continue
 
         if (isEdition2018 && isAtom) {
-            // Use items like `use foo;` or `use foo::{self}` are meaningless on 2018 edition.
-            // We should ignore it or it breaks resolve of such `foo` in other places.
+            // Use items like `use foo;` or `use foo::{self}` are meaningful on 2018 edition
+            // only if `foo` is a crate, and it is `pub use` item. Otherwise,
+            // we should ignore it or it breaks resolve of such `foo` in other places.
             ItemResolutionTestmarks.extraAtomUse.hit()
+            if (!withPrivateImports) {
+                val crate = findDependencyCrateByName(path, name)
+                if (crate != null && processor(name, crate)) return true
+            }
             continue
         }
         if (processMultiResolveWithNs(name, ns, path.reference, processor)) return true

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -292,7 +292,7 @@ fun processExternCrateResolveVariants(
     return false
 }
 
-private fun findDependencyCrateByName(context: RsElement, name: String): RsFile? {
+fun findDependencyCrateByName(context: RsElement, name: String): RsFile? {
     val refinedName = when {
         name.startsWith(MACRO_CRATE_IDENTIFIER_PREFIX) && context.isExpandedFromMacro -> {
             NameResolutionTestmarks.dollarCrateMagicIdentifier.hit()

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -951,4 +951,17 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
             s2.foo();
         }      //^ foo.rs
     """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test re-exported crate via use item without "extern crate" 2018 edition`() = stubOnlyResolve("""
+    //- trans-lib/lib.rs
+        pub struct Foo;
+    //- dep-lib/lib.rs
+        pub use trans_lib;
+    //- lib.rs
+        use dep_lib_target::trans_lib::Foo;
+        
+        type T = Foo;
+               //^ trans-lib/lib.rs
+    """)
 }


### PR DESCRIPTION
Fixes this corner case:

```rust
    //- trans-lib/lib.rs
        pub struct Foo;
    //- dep-lib/lib.rs
        pub use trans_lib;
    //- lib.rs
        use dep_lib_target::trans_lib::Foo;
        
        type T = Foo;
               //^ trans-lib/lib.rs
```