### PR TITLE
PERF: cache crate root of RsFiles

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -57,7 +57,12 @@ class RsFile(
     override val containingMod: RsMod get() = getOriginalOrSelf()
 
     override val crateRoot: RsMod?
-        get() = superMods.lastOrNull()?.takeIf { it.isCrateRoot }
+        get() = CachedValuesManager.getCachedValue(this) {
+            CachedValueProvider.Result(doCrateRoot(), rustStructureOrAnyPsiModificationTracker)
+        }
+
+    private fun doCrateRoot(): RsMod? =
+        superMods.lastOrNull()?.takeIf { it.isCrateRoot }
 
     override fun setName(name: String): PsiElement {
         val nameWithExtension = if ('.' !in name) "$name.rs" else name


### PR DESCRIPTION
I found this place in the recent performance investigation. This speeds up type inference performance up to 15% (!!!)