### PR TITLE
REF: introduce RsPathCodeFragment, use it in RsCodeFragmentFactory

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -112,6 +112,8 @@ File ::= [ SHEBANG_LINE ] InnerAttr* Items
 ExprCodeFragment ::= Expr?
 StmtCodeFragment ::= Stmt?
 TypeRefCodeFragment ::= TypeReference?
+PathWithColonsCodeFragment ::= PathGenericArgsWithColons?
+PathWithoutColonsCodeFragment ::= PathGenericArgsWithoutColons?
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Attributes
@@ -172,8 +174,7 @@ MetaItemArgs ::= '(' ( [ <<comma_separated_list (LitExpr | MetaItemWithoutTT )>>
 private PathIdent ::= !("union" identifier) identifier | self | super | 'Self' | crate
 
 fake Path ::= (Path '::' | '::' | TypeQual)? PathIdent PathTypeArguments? {
-  implements = [ "org.rust.lang.core.psi.ext.RsPathReferenceElement"
-                 "org.rust.lang.core.macros.RsExpandedElement" ]
+  implements = [ "org.rust.lang.core.psi.ext.RsPathReferenceElement" ]
   mixin = "org.rust.lang.core.psi.ext.RsPathImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsPathStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"

--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -18,6 +18,7 @@ import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.ide.injected.isDoctestInjection
 import org.rust.ide.search.RsWithMacrosScope
+import org.rust.lang.core.parser.RustParserUtil.PathParsingMode
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.TYPES_N_VALUES
@@ -321,8 +322,14 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
             } else {
                 info.externCrateName
             }
-            val path = RsCodeFragmentFactory(context.project)
-                .createPathInTmpMod(importingPathName, context.mod, context.ns, info.usePath, externCrateName) ?: return false
+            val path = RsCodeFragmentFactory(context.project).createPathInTmpMod(
+                importingPathName,
+                context.mod,
+                context.pathParsingMode,
+                TYPES_N_VALUES,
+                info.usePath,
+                externCrateName
+            ) ?: return false
             val element = path.reference.deepResolve() as? RsQualifiedNamedElement ?: return false
             if (!context.namespaceFilter(element)) return false
             return !(element.parent is RsMembers && element.ancestorStrict<RsTraitItem>() != null)
@@ -638,7 +645,7 @@ data class ImportContext private constructor(
     val mod: RsMod,
     val superMods: LinkedHashSet<RsMod>,
     val scope: GlobalSearchScope,
-    val ns: RsPsiFactory.PathNamespace,
+    val pathParsingMode: PathParsingMode,
     val attributes: RsFile.Attributes,
     val namespaceFilter: (RsQualifiedNamedElement) -> Boolean
 ) {
@@ -648,19 +655,19 @@ data class ImportContext private constructor(
             mod = path.containingMod,
             superMods = LinkedHashSet(path.containingMod.superMods),
             scope = RsWithMacrosScope(project, GlobalSearchScope.allScope(project)),
-            ns = path.pathNamespace,
+            pathParsingMode = path.pathParsingMode,
             attributes = path.stdlibAttributes,
             namespaceFilter = path.namespaceFilter(isCompletion)
         )
     }
 }
 
-private val RsPath.pathNamespace: RsPsiFactory.PathNamespace get() = when (context) {
+private val RsPath.pathParsingMode: PathParsingMode get() = when (parent) {
     is RsPathExpr,
     is RsStructLiteral,
     is RsPatStruct,
-    is RsPatTupleStruct -> RsPsiFactory.PathNamespace.VALUES
-    else -> RsPsiFactory.PathNamespace.TYPES
+    is RsPatTupleStruct -> PathParsingMode.COLONS
+    else -> PathParsingMode.NO_COLONS
 }
 private val RsElement.stdlibAttributes: RsFile.Attributes
     get() = (crateRoot?.containingFile as? RsFile)?.attributes ?: RsFile.Attributes.NONE

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
@@ -27,7 +27,14 @@ import org.rust.stdext.makeBitMask
 
 @Suppress("UNUSED_PARAMETER")
 object RustParserUtil : GeneratedParserUtilBase() {
-    enum class PathParsingMode { COLONS, NO_COLONS, NO_TYPES }
+    enum class PathParsingMode {
+        /** `Foo::<i32>` */
+        COLONS,
+        /** `Foo<i32>` */
+        NO_COLONS,
+        /** `Foo` */
+        NO_TYPES
+    }
     enum class BinaryMode { ON, OFF }
 
     private val FLAGS: Key<Int> = Key("RustParserUtil.FLAGS")

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentElementType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentElementType.kt
@@ -27,5 +27,7 @@ class RsCodeFragmentElementType(private val elementType: IElementType, debugName
         val EXPR = RsCodeFragmentElementType(RsElementTypes.EXPR_CODE_FRAGMENT, "RS_EXPR_CODE_FRAGMENT")
         val STMT = RsCodeFragmentElementType(RsElementTypes.STMT_CODE_FRAGMENT, "RS_STMT_CODE_FRAGMENT")
         val TYPE_REF = RsCodeFragmentElementType(RsElementTypes.TYPE_REF_CODE_FRAGMENT, "RS_TYPE_REF_CODE_FRAGMENT")
+        val PATH_WITHOUT_COLONS = RsCodeFragmentElementType(RsElementTypes.PATH_WITHOUT_COLONS_CODE_FRAGMENT, "PATH_WITHOUT_COLONS")
+        val PATH_WITH_COLONS = RsCodeFragmentElementType(RsElementTypes.PATH_WITH_COLONS_CODE_FRAGMENT, "PATH_WITH_COLONS")
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -10,7 +10,6 @@ import com.intellij.extapi.psi.StubBasedPsiElementBase
 import com.intellij.injected.editor.VirtualFileWindow
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -39,8 +38,6 @@ interface RsElement : PsiElement {
     val crateRoot: RsMod?
 }
 
-val CARGO_WORKSPACE = Key.create<CargoWorkspace>("CARGO_WORKSPACE")
-
 val RsElement.cargoProject: CargoProject?
     get() = contextualFile.originalFile.findCargoProject()
 
@@ -48,7 +45,6 @@ val RsElement.cargoWorkspace: CargoWorkspace?
     get() {
         val psiFile = contextualFile.originalFile
         psiFile.virtualFile?.getInjectedFromIfDoctestInjection(project)?.cargoWorkspace?.let { return it }
-        psiFile.getUserData(CARGO_WORKSPACE)?.let { return it }
         return psiFile.findCargoProject()?.workspace
     }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
@@ -9,7 +9,6 @@ import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
-import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.resolve.*
@@ -64,7 +63,7 @@ val RsPath.qualifier: RsPath?
         return (ctx as? RsUseSpeck)?.qualifier
     }
 
-fun RsPath.allowedNamespaces(isCompletion: Boolean = false): Set<Namespace> = when (val parent = context) {
+fun RsPath.allowedNamespaces(isCompletion: Boolean = false): Set<Namespace> = when (val parent = parent) {
     is RsPath, is RsTypeElement, is RsTraitRef, is RsStructLiteral -> TYPES
     is RsUseSpeck -> when {
         // use foo::bar::{self, baz};
@@ -77,6 +76,7 @@ fun RsPath.allowedNamespaces(isCompletion: Boolean = false): Set<Namespace> = wh
         else -> TYPES_N_VALUES_N_MACROS
     }
     is RsPathExpr -> if (isCompletion) TYPES_N_VALUES else VALUES
+    is RsPathCodeFragment -> parent.ns
     else -> TYPES_N_VALUES
 }
 
@@ -95,8 +95,6 @@ abstract class RsPathImplMixin : RsStubbedElementImpl<RsPathStub>,
         }
 
     override val referenceName: String get() = greenStub?.referenceName ?: super.referenceName
-
-    override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 
     override val containingMod: RsMod
         get() {


### PR DESCRIPTION
Simplifies path handling. Also, now it's possible to pass namespaces
to `RsCodeFragmentFactory.createPath`