### PR TITLE
PERF: introduce `RsCachedImplItem`

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -238,9 +238,8 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
             val traits = sources.mapNotNull { source ->
                 val trait = when (source) {
                     is TraitImplSource.ExplicitImpl -> {
-                        val impl = source.value
-                        val traitRef = impl.traitRef ?: return null
-                        traitRef.resolveToTrait() ?: return@mapNotNull null
+                        if (source.isInherent) return null
+                        source.implementedTrait?.element ?: return@mapNotNull null
                     }
                     is TraitImplSource.Derived -> source.value
                     is TraitImplSource.Collapsed -> source.value

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -528,7 +528,7 @@ private fun processTypeQualifiedPathResolveVariants(
         fun(e: AssocItemScopeEntry): Boolean {
             if (e.element !is RsTypeAlias) return processor(e)
 
-            val implementedTrait = e.source.value.implementedTrait
+            val implementedTrait = e.source.implementedTrait
                 ?.foldTyTypeParameterWith { TyInfer.TyVar(it) }
                 ?: return processor(e)
 
@@ -1129,12 +1129,12 @@ private fun processAssociatedItems(
          * which are not implemented.
          */
         fun processMembersWithDefaults(accessor: (RsMembers) -> List<RsAbstractable>): Boolean {
-            val directlyImplemented = traitOrImpl.value.members?.let { accessor(it) }.orEmpty()
+            val directlyImplemented = traitOrImpl.members?.let { accessor(it) }.orEmpty()
             if (directlyImplemented.any { inherentProcessor(it) }) return true
 
             if (traitOrImpl is TraitImplSource.ExplicitImpl) {
                 val direct = directlyImplemented.map { it.name }.toSet()
-                val membersFromTrait = traitOrImpl.value.implementedTrait?.element?.members ?: return false
+                val membersFromTrait = traitOrImpl.implementedTrait?.element?.members ?: return false
                 for (member in accessor(membersFromTrait)) {
                     if (member.name !in direct && inherentProcessor(member)) return true
                 }
@@ -1152,7 +1152,7 @@ private fun processAssociatedItems(
         return false
     }
 
-    val (inherent, traits) = lookup.findImplsAndTraits(type).partition { it is TraitImplSource.ExplicitImpl && it.value.traitRef == null }
+    val (inherent, traits) = lookup.findImplsAndTraits(type).partition { it is TraitImplSource.ExplicitImpl && it.isInherent }
     if (inherent.any { processTraitOrImpl(it, true) }) return true
     if (traits.any { processTraitOrImpl(it, false) }) return true
     return false

--- a/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
@@ -1,0 +1,51 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve
+
+import com.intellij.openapi.project.Project
+import org.rust.lang.core.psi.RsImplItem
+import org.rust.lang.core.psi.RsMembers
+import org.rust.lang.core.psi.RsTraitItem
+import org.rust.lang.core.psi.RsTraitRef
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.resolveToBoundTrait
+import org.rust.lang.core.resolve.ref.ResolveCacheDependency
+import org.rust.lang.core.resolve.ref.RsResolveCache
+import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.types.infer.generics
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyTypeParameter
+import org.rust.lang.core.types.type
+import kotlin.LazyThreadSafetyMode.PUBLICATION
+
+/**
+ * Used for optimization purposes, to reduce access to cache and PSI tree in some very hot places,
+ * [ImplLookup.assembleCandidates] and [processAssociatedItems] in particular
+ */
+class RsCachedImplItem(
+    val impl: RsImplItem,
+    val crateRoot: RsMod? = impl.crateRoot,
+    val traitRef: RsTraitRef? = impl.traitRef,
+    val membres: RsMembers? = impl.members
+) {
+    val implementedTrait: BoundElement<RsTraitItem>? by lazy(PUBLICATION) { traitRef?.resolveToBoundTrait() }
+    val typeAndGenerics: Pair<Ty, List<TyTypeParameter>>? by lazy(PUBLICATION) {
+        impl.typeReference?.type?.let { it to impl.generics }
+    }
+
+    companion object {
+        fun forImpl(project: Project, impl: RsImplItem): RsCachedImplItem {
+            return RsResolveCache.getInstance(project)
+                .resolveWithCaching(impl, ResolveCacheDependency.RUST_STRUCTURE, Resolver)!!
+        }
+
+        private object Resolver : (RsImplItem) -> RsCachedImplItem {
+            override fun invoke(impl: RsImplItem): RsCachedImplItem {
+                return RsCachedImplItem(impl)
+            }
+        }
+    }
+}


### PR DESCRIPTION
I found this place during the recent performance investigation. This speeds up type inference up to 30% (!!!) (the baseline is before #4179)