### PR TITLE
PERF: name resolution micro-optimization

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -561,9 +561,8 @@ class ExpandedMacroInfo(
 
     private fun getExpansionPsi(): RsFile? {
         val expansionFile = expansionFile?.takeIf { it.isValid } ?: return null
-        check(expansionFile.fileType == RsFileType)
-        val psi = PsiManager.getInstance(sourceFile.project).findFile(expansionFile) as? RsFile ?: return null
-        return psi.takeIf { it.isValid }
+        testAssert { expansionFile.fileType == RsFileType }
+        return PsiManager.getInstance(sourceFile.project).findFile(expansionFile) as? RsFile
     }
 
     fun makePipeline(): Pipeline.Stage1ResolveAndExpand {

--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -137,7 +137,7 @@ fun processItemDeclarations(
     }
 
     if (ipm.withExternCrates && Namespace.Types in ns && scope is RsMod) {
-        if (scope.isEdition2018 && !scope.isCrateRoot) {
+        if (isEdition2018 && !scope.isCrateRoot) {
             val crateRoot = scope.crateRoot
             if (crateRoot != null) {
                 val result = processWithShadowing(directlyDeclaredNames, processor) { shadowingProcessor ->


### PR DESCRIPTION
- replace some asserts with `testAssert`s (in hot places)
- avoid unnecessary PSI tree traverse
- remove one useless `PSI.isValid` (looks like it can't be invalid in this place)
