### PR TITLE
 PERF: reduce PSI tree access in very hot item resolution

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoBenchRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoBenchRunConfigurationProducer.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.isBench
-import org.rust.lang.core.psi.ext.processExpandedItemsExceptImpls
+import org.rust.lang.core.psi.ext.processExpandedItemsExceptImplsAndUses
 
 class CargoBenchRunConfigurationProducer : CargoTestRunConfigurationProducerBase() {
     override val commandName: String = "bench"
@@ -23,6 +23,6 @@ class CargoBenchRunConfigurationProducer : CargoTestRunConfigurationProducerBase
 
     companion object {
         private fun hasBenchFunction(mod: RsMod): Boolean =
-            mod.processExpandedItemsExceptImpls { it is RsFunction && it.isBench || it is RsMod && hasBenchFunction(it) }
+            mod.processExpandedItemsExceptImplsAndUses { it is RsFunction && it.isBench || it is RsMod && hasBenchFunction(it) }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestRunConfigurationProducer.kt
@@ -48,7 +48,7 @@ class CargoTestRunConfigurationProducer : CargoTestRunConfigurationProducerBase(
 
     companion object {
         private fun hasTestFunction(mod: RsMod): Boolean =
-            mod.processExpandedItemsExceptImpls { it is RsFunction && it.isTest || it is RsMod && hasTestFunction(it) }
+            mod.processExpandedItemsExceptImplsAndUses { it is RsFunction && it.isTest || it is RsMod && hasTestFunction(it) }
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
@@ -118,4 +118,4 @@ object RsPsiImplUtil {
 }
 
 private fun RsMod.hasChildModules(): Boolean =
-    expandedItemsExceptImpls.any { it is RsModDeclItem || it is RsModItem && it.hasChildModules() }
+    expandedItemsExceptImplsAndUses.any { it is RsModDeclItem || it is RsModItem && it.hasChildModules() }


### PR DESCRIPTION
This speeds up highlighting up to 5% (the baseline is before #4179)

The approach is similar to #4182 - make more things accessible by one cache key and retrieve them together to reduce **PSI** (in the case of this PR) and cache access in very hot code. 