### PR TITLE
Update run configuration for our unit tests

### DIFF
--- a/.idea/runConfigurations/Test.xml
+++ b/.idea/runConfigurations/Test.xml
@@ -1,23 +1,15 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test" type="JUnit" factoryName="JUnit">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
-    <module name="intellij-rust_test" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-    <option name="ALTERNATIVE_JRE_PATH" />
+    <module name="intellij-rust.test" />
     <option name="PACKAGE_NAME" value="org.rust" />
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="package" />
     <option name="VM_PARAMETERS" value="-ea -Didea.system.path=$PROJECT_DIR$/build/idea-sandbox/system-test -Didea.config.path=$PROJECT_DIR$/build/idea-sandbox/config-test" />
     <option name="PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
-    <option name="ENV_VARIABLES" />
-    <option name="PASS_PARENT_ENVS" value="true" />
-    <option name="TEST_SEARCH_SCOPE">
-      <value defaultName="singleModule" />
-    </option>
-    <envs />
-    <patterns />
-    <method />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Test_Performance.xml
+++ b/.idea/runConfigurations/Test_Performance.xml
@@ -1,23 +1,15 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test Performance" type="JUnit" factoryName="JUnit">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
-    <module name="intellij-rust_test" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-    <option name="ALTERNATIVE_JRE_PATH" />
+    <module name="intellij-rust.test" />
     <option name="PACKAGE_NAME" value="org.rustPerformanceTests" />
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="package" />
     <option name="VM_PARAMETERS" value="-ea -Didea.system.path=$PROJECT_DIR$/build/idea-sandbox/system-test -Didea.config.path=$PROJECT_DIR$/build/idea-sandbox/config-test" />
     <option name="PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
-    <option name="ENV_VARIABLES" />
-    <option name="PASS_PARENT_ENVS" value="true" />
-    <option name="TEST_SEARCH_SCOPE">
-      <value defaultName="singleModule" />
-    </option>
-    <envs />
-    <patterns />
-    <method />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Test_Slow.xml
+++ b/.idea/runConfigurations/Test_Slow.xml
@@ -1,23 +1,15 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test Slow" type="JUnit" factoryName="JUnit">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
-    <module name="intellij-rust_test" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-    <option name="ALTERNATIVE_JRE_PATH" />
+    <module name="intellij-rust.test" />
     <option name="PACKAGE_NAME" value="org.rustSlowTests" />
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="package" />
     <option name="VM_PARAMETERS" value="-ea -Didea.system.path=$PROJECT_DIR$/build/idea-sandbox/system-test -Didea.config.path=$PROJECT_DIR$/build/idea-sandbox/config-test" />
     <option name="PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
-    <option name="ENV_VARIABLES" />
-    <option name="PASS_PARENT_ENVS" value="true" />
-    <option name="TEST_SEARCH_SCOPE">
-      <value defaultName="singleModule" />
-    </option>
-    <envs />
-    <patterns />
-    <method />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>


### PR DESCRIPTION
For some reason, our test run configurations don't work with IDEA 2019.2. It requires to select "intellij-rust.test" module.