### PR TITLE
GRD: use token instead of username/password while plugin publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,8 +88,7 @@ allprojects {
     }
 
     tasks.withType<PublishTask> {
-        username(prop("publishUsername"))
-        password(prop("publishPassword"))
+        token(prop("publishToken"))
         channels(channel)
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,7 @@ baseIDE=idea
 patchVersion=102
 buildNumber=SNAPSHOT
 
-publishUsername=user
-publishPassword=password
+publishToken=token
 publishChannel=
 
 showTestStatus=false


### PR DESCRIPTION
See https://www.jetbrains.org/intellij/sdk/docs/plugin_repository/api/plugin_upload.html