### PR TITLE
RES: Initial support of cfg attributes

### DIFF
--- a/src/main/kotlin/org/rust/cargo/CfgOptions.kt
+++ b/src/main/kotlin/org/rust/cargo/CfgOptions.kt
@@ -1,0 +1,54 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo
+
+import com.intellij.util.SmartList
+import org.jetbrains.annotations.TestOnly
+
+class CfgOptions(
+    val keyValueOptions: Map<String, List<String>>,
+    val nameOptions: Set<String>
+) {
+    companion object {
+        fun parse(rawCfgOptions: List<String>): CfgOptions {
+            val knownKeyValueOptions = hashMapOf<String, SmartList<String>>()
+            val knownNameOptions = hashSetOf<String>()
+
+            for (option in rawCfgOptions) {
+                val parts = option.split('=', limit = 2)
+                val key = parts.getOrNull(0)
+                val value = parts.getOrNull(1)?.trim('"')
+
+                if (key != null && value != null) {
+                    knownKeyValueOptions.getOrPut(key, { SmartList() }).add(value)
+                } else if (key != null) {
+                    knownNameOptions.add(key)
+                }
+            }
+
+            return CfgOptions(knownKeyValueOptions, knownNameOptions)
+        }
+
+        @TestOnly
+        val DEFAULT: CfgOptions = CfgOptions(
+            keyValueOptions = hashMapOf(
+                "target_has_atomic" to listOf("8", "16", "32", "64", "ptr", "cas"),
+                "target_arch" to listOf("x86_64"),
+                "target_endian" to listOf("little"),
+                "target_env" to listOf("gnu"),
+                "target_family" to listOf("unix"),
+                "target_os" to listOf("linux"),
+                "target_pointer_width" to listOf("64"),
+                "feature" to listOf("use_std")
+            ),
+
+            nameOptions = hashSetOf("debug_assertions", "unix")
+        )
+
+        @TestOnly
+        val EMPTY: CfgOptions = CfgOptions(emptyMap(), emptySet())
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -18,6 +18,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.messages.Topic
 import org.jetbrains.annotations.TestOnly
 import org.rust.cargo.CargoConstants
+import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.toolchain.RustToolchain
@@ -54,6 +55,9 @@ interface CargoProjectsService {
 
     @TestOnly
     fun setEdition(edition: CargoWorkspace.Edition)
+
+    @TestOnly
+    fun setCfgOptions(cfgOptions: CfgOptions)
 
     @TestOnly
     fun discoverAndRefreshSync(): List<CargoProject> {

--- a/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
@@ -46,6 +46,16 @@ data class RustToolchain(val location: Path) {
         return fs.refreshAndFindFileByPath(FileUtil.join(sysroot, "lib/rustlib/src/rust/src"))
     }
 
+    fun getCfgOptions(projectDirectory: Path): List<String>? {
+        val timeoutMs = 10000
+        val output = GeneralCommandLine(pathToExecutable(RUSTC))
+            .withCharset(Charsets.UTF_8)
+            .withWorkDirectory(projectDirectory)
+            .withParameters("--print", "cfg")
+            .execute(timeoutMs)
+        return if (output?.isSuccess == true) output.stdoutLines else null
+    }
+
     fun rawCargo(): Cargo = Cargo(pathToExecutable(CARGO))
 
     fun cargoOrWrapper(cargoProjectDirectory: Path?): Cargo {

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -695,6 +695,7 @@ class RsErrorAnnotator : RsAnnotatorBase(), HighlightRangeExtension {
 
     private fun checkExternCrate(holder: AnnotationHolder, el: RsExternCrateItem) {
         if (el.reference.multiResolve().isEmpty() && el.containingCargoPackage?.origin == PackageOrigin.WORKSPACE) {
+            if (!el.isEnabledByCfg) return
             RsDiagnostic.CrateNotFoundError(el, el.referenceName).addToHolder(holder)
         }
         if (el.self != null) {
@@ -853,6 +854,7 @@ private fun AnnotationSession.duplicatesByNamespace(owner: PsiElement, recursive
         owner.namedChildren(recursively, stopAt = RsFnPointerType::class.java)
             .filter { it !is RsExternCrateItem } // extern crates can have aliases.
             .filter { it.name != null }
+            .filter { it !is RsDocAndAttributeOwner || it.isEnabledByCfg }
             .flatMap { it.namespaced }
             .groupBy { it.first }       // Group by namespace
             .map { entry ->
@@ -861,10 +863,7 @@ private fun AnnotationSession.duplicatesByNamespace(owner: PsiElement, recursive
                     .map { it.second }
                     .groupBy { it.name }
                     .map { it.value }
-                    .filter {
-                        it.size > 1 &&
-                            it.any { !(it is RsDocAndAttributeOwner && it.queryAttributes.hasCfgAttr()) }
-                    }
+                    .filter { it.size > 1 }
                     .flatten()
                     .toSet()
             }
@@ -906,9 +905,8 @@ private val RsNamedElement.namespaced: Sequence<Pair<Namespace, RsNamedElement>>
 private fun RsCallExpr.expectedParamsCount(): Pair<Int, Boolean>? {
     val path = (expr as? RsPathExpr)?.path ?: return null
     val el = path.reference.resolve()
-    if (el is RsDocAndAttributeOwner && el.queryAttributes.hasCfgAttr()) return null
     return when (el) {
-        is RsFieldsOwner -> el.tupleFields?.tupleFieldDeclList?.size?.let { Pair(it, false) }
+        is RsFieldsOwner -> Pair(el.fields.size, false)
         is RsFunction -> {
             val owner = el.owner
             if (owner.isTraitImpl) return null
@@ -922,7 +920,6 @@ private fun RsCallExpr.expectedParamsCount(): Pair<Int, Boolean>? {
 
 private fun RsMethodCall.expectedParamsCount(): Pair<Int, Boolean>? {
     val fn = reference.resolve() as? RsFunction ?: return null
-    if (fn.queryAttributes.hasCfgAttr()) return null
     return fn.valueParameterList?.valueParameterList?.size?.let { Pair(it, fn.isVariadic) }
         .takeIf { fn.owner.isInherentImpl }
 }

--- a/src/main/kotlin/org/rust/ide/annotator/RsExpressionAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExpressionAnnotator.kt
@@ -9,8 +9,8 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.psi.PsiElement
 import com.intellij.util.SmartList
-import org.rust.ide.annotator.fixes.CreateStructFieldFromConstructorFix
 import org.rust.ide.annotator.fixes.AddStructFieldsFix
+import org.rust.ide.annotator.fixes.CreateStructFieldFromConstructorFix
 import org.rust.ide.intentions.RemoveParenthesesFromExprIntention
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -110,5 +110,5 @@ private fun <T : RsReferenceElement> Collection<T>.findDuplicateReferences(): Co
 
 fun calculateMissingFields(expr: RsStructLiteralBody, decl: RsFieldsOwner): List<RsFieldDecl> {
     val declaredFields = expr.structLiteralFieldList.map { it.referenceName }.toSet()
-    return decl.fields.filter { it.name !in declaredFields && !it.queryAttributes.hasCfgAttr() }
+    return decl.fields.filter { it.name !in declaredFields }
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/generateConstructor/GenerateConstructorHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generateConstructor/GenerateConstructorHandler.kt
@@ -17,6 +17,8 @@ import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorOrSelf
 import org.rust.lang.core.psi.ext.isTupleStruct
+import org.rust.lang.core.psi.ext.namedFields
+import org.rust.lang.core.psi.ext.positionalFields
 import org.rust.openapiext.checkWriteAccessAllowed
 
 class GenerateConstructorAction : CodeInsightAction() {
@@ -93,9 +95,9 @@ data class ConstructorArgument(
     companion object {
         fun fromStruct(structItem: RsStructItem): List<ConstructorArgument> {
             return if (structItem.isTupleStruct) {
-                fromTupleList(structItem.tupleFields?.tupleFieldDeclList.orEmpty())
+                fromTupleList(structItem.positionalFields)
             } else {
-                fromFieldList(structItem.blockFields?.namedFieldDeclList.orEmpty())
+                fromFieldList(structItem.namedFields)
             }
         }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt
@@ -20,11 +20,13 @@ interface RsFieldsOwner : RsElement, RsNameIdentifierOwner, RsQualifiedNamedElem
 val RsFieldsOwner.fields: List<RsFieldDecl>
     get() = namedFields + positionalFields
 
+/** Returns those named fields that are not disabled by cfg attributes */
 val RsFieldsOwner.namedFields: List<RsNamedFieldDecl>
-    get() = blockFields?.namedFieldDeclList.orEmpty()
+    get() = blockFields?.namedFieldDeclList?.filter { it.isEnabledByCfg }.orEmpty()
 
+/** Returns those positional (tuple) fields that are not disabled by cfg attributes */
 val RsFieldsOwner.positionalFields: List<RsTupleFieldDecl>
-    get() = tupleFields?.tupleFieldDeclList.orEmpty()
+    get() = tupleFields?.tupleFieldDeclList?.filter { it.isEnabledByCfg }.orEmpty()
 
 /**
  * If some field of a struct/enum is private (not visible from [mod]),
@@ -43,7 +45,8 @@ val RsFieldsOwner.positionalFields: List<RsTupleFieldDecl>
 fun RsFieldsOwner.canBeInstantiatedIn(mod: RsMod): Boolean =
     fields.all { it.isVisibleFrom(mod) }
 
-val RsFieldsOwner.fieldTypes: List<Ty> get() = fields.mapNotNull { it.typeReference?.type }
+val RsFieldsOwner.fieldTypes: List<Ty>
+    get() = fields.filter { it.isEnabledByCfg }.mapNotNull { it.typeReference?.type }
 
 /**
  * True for:

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
@@ -114,10 +114,14 @@ private fun RsItemsOwner.processExpandedItemsInternal(processor: (RsItemElement)
     return itemsAndMacros.any { it.processItem(processor) }
 }
 
-private fun RsElement.processItem(processor: (RsItemElement) -> Boolean) = when (this) {
-    is RsMacroCall -> processExpansionRecursively { it is RsItemElement && processor(it) }
-    is RsItemElement -> processor(this)
-    else -> false
+private fun RsElement.processItem(processor: (RsItemElement) -> Boolean): Boolean {
+    if (this is RsDocAndAttributeOwner && !this.isEnabledByCfg) return false
+
+    return when (this) {
+        is RsMacroCall -> processExpansionRecursively { it is RsItemElement && processor(it) }
+        is RsItemElement -> processor(this)
+        else -> false
+    }
 }
 
 private val RsPath.isAtom: Boolean

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTupleFieldDecl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTupleFieldDecl.kt
@@ -13,7 +13,7 @@ import org.rust.lang.core.psi.RsTupleFieldDecl
 import org.rust.lang.core.stubs.RsPlaceholderStub
 
 val RsTupleFieldDecl.position: Int?
-    get() = parentStruct?.tupleFields?.tupleFieldDeclList?.withIndex()?.firstOrNull { it.value === this }?.index
+    get() = parentStruct?.positionalFields?.withIndex()?.firstOrNull { it.value === this }?.index
 
 
 abstract class RsTupleFieldDeclImplMixin : RsStubbedElementImpl<RsPlaceholderStub>, RsTupleFieldDecl {

--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -221,6 +221,7 @@ private fun processMultiResolveWithNs(name: String, ns: Set<Namespace>, ref: RsR
 
     // XXX: there are two `cfg`ed `boxed` modules in liballoc, so
     // we apply "first in the namespace wins" heuristic.
+    // TODO fix after enabling #[cfg(...)] evaluation
 
     if (ns.size == 1) {
         // Optimized version for single namespace.

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
@@ -1,0 +1,92 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.utils.evaluation
+
+import org.rust.cargo.CfgOptions
+import org.rust.lang.core.psi.RsMetaItem
+import org.rust.lang.core.psi.ext.name
+import org.rust.lang.core.psi.ext.value
+import org.rust.openapiext.Testmark
+
+// See https://doc.rust-lang.org/reference/conditional-compilation.html for more information
+
+class CfgEvaluator(val options: CfgOptions) {
+    fun evaluate(cfgAttributes: Sequence<RsMetaItem>): Boolean {
+        val cfgPredicate = CfgPredicate.fromCfgAttributes(cfgAttributes)
+        val result = evaluatePredicate(cfgPredicate)
+
+        when (result) {
+            true -> CfgTestmarks.evaluatesTrue.hit()
+            false -> CfgTestmarks.evaluatesFalse.hit()
+        }
+        return result
+    }
+
+    private fun evaluatePredicate(predicate: CfgPredicate): Boolean = when (predicate) {
+        is CfgPredicate.All -> predicate.list.all(::evaluatePredicate)
+        is CfgPredicate.Any -> predicate.list.any(::evaluatePredicate)
+        is CfgPredicate.Not -> !evaluatePredicate(predicate.single)
+        is CfgPredicate.NameOption -> predicate.name in options.nameOptions
+        is CfgPredicate.NameValueOption -> options.keyValueOptions[predicate.name]?.contains(predicate.value) ?: false
+        is CfgPredicate.Error -> true
+    }
+}
+
+/** Configuration predicate */
+private sealed class CfgPredicate {
+    data class NameOption(val name: String) : CfgPredicate()
+    data class NameValueOption(val name: String, val value: String) : CfgPredicate()
+    class All(val list: List<CfgPredicate>) : CfgPredicate()
+    class Any(val list: List<CfgPredicate>) : CfgPredicate()
+    class Not(val single: CfgPredicate) : CfgPredicate()
+    object Error : CfgPredicate()
+
+    companion object {
+        fun fromCfgAttributes(cfgAttributes: Sequence<RsMetaItem>): CfgPredicate {
+            val cfgPredicates = cfgAttributes
+                .mapNotNull { it.metaItemArgs?.metaItemList?.firstOrNull() } // `unix` in `#[cfg(unix)]`
+                .map(Companion::fromMetaItem)
+
+            return when (val predicate = cfgPredicates.singleOrNull()) {
+                is CfgPredicate -> predicate
+                null -> All(cfgPredicates.toList())
+            }
+        }
+
+        private fun fromMetaItem(metaItem: RsMetaItem): CfgPredicate {
+            val args = metaItem.metaItemArgs
+            val name = metaItem.name
+            val value = metaItem.value
+
+            return when {
+                // e.g. `#[cfg(any(foo, bar))]`
+                args != null -> {
+                    val predicates = args.metaItemList.mapNotNull { fromMetaItem(it) }
+                    when (name) {
+                        "all" -> All(predicates)
+                        "any" -> Any(predicates)
+                        "not" -> Not(predicates.singleOrNull()
+                            ?: Error)
+                        else -> Error
+                    }
+                }
+
+                // e.g. `#[cfg(target_os = "macos")]`
+                name != null && value != null -> NameValueOption(name, value)
+
+                // e.g. `#[cfg(unix)]`
+                name != null -> NameOption(name)
+
+                else -> Error
+            }
+        }
+    }
+}
+
+object CfgTestmarks {
+    val evaluatesTrue = Testmark("evaluatesTrue")
+    val evaluatesFalse = Testmark("evaluatesFalse")
+}

--- a/src/main/resources/META-INF/core.xml
+++ b/src/main/resources/META-INF/core.xml
@@ -752,6 +752,8 @@
 
         <registryKey key="cargo.build.tool.window.enabled" defaultValue="true"
                      description="Enable Cargo tasks to use Build Tool Window"/>
+        <registryKey key="rust.cfg.attributes.enabled" defaultValue="false"
+                     description="Enable Rust cfg attributes support"/>
 
         <!-- Icon Provider -->
 

--- a/src/test/kotlin/org/rust/MockAdditionalCfgOptions.kt
+++ b/src/test/kotlin/org/rust/MockAdditionalCfgOptions.kt
@@ -1,0 +1,18 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust
+
+import java.lang.annotation.Inherited
+
+/**
+ * Allows to extend default cfg options ([org.rust.cargo.CfgOptions.DEFAULT]) for a specific test
+ *
+ * @see RsTestBase.setupMockCfgOptions
+ */
+@Inherited
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MockAdditionalCfgOptions(vararg val options: String)

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -27,6 +27,7 @@ import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCa
 import com.intellij.util.text.SemVer
 import junit.framework.AssertionFailedError
 import org.intellij.lang.annotations.Language
+import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.RustcInfo
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
@@ -64,6 +65,7 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
 
         setupMockRustcVersion()
         setupMockEdition()
+        setupMockCfgOptions()
         findAnnotationInstance<ExpandMacros>()?.let {
             val disposable = project.macroExpansionManager.setUnitTestExpansionModeAndDirectory(it.mode, it.cache)
             Disposer.register(testRootDisposable, disposable)
@@ -89,6 +91,17 @@ abstract class RsTestBase : LightPlatformCodeInsightFixtureTestCase(), RsTestCas
     private fun setupMockEdition() {
         val edition = findAnnotationInstance<MockEdition>()?.edition ?: CargoWorkspace.Edition.EDITION_2015
         project.cargoProjects.setEdition(edition)
+    }
+
+    private fun setupMockCfgOptions() {
+        val additionalOptions = findAnnotationInstance<MockAdditionalCfgOptions>()?.options
+            ?.takeIf { it.isNotEmpty() } ?: return
+
+        val allOptions = CfgOptions(
+            CfgOptions.DEFAULT.keyValueOptions,
+            CfgOptions.DEFAULT.nameOptions + additionalOptions
+        )
+        project.cargoProjects.setCfgOptions(allOptions)
     }
 
     private fun parse(version: String): Pair<SemVer, RustChannel> {

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.testFramework.LightProjectDescriptor
 import com.intellij.testFramework.VfsTestUtil
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.RustcInfo
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
@@ -56,7 +57,7 @@ open class RustProjectDescriptorBase : LightProjectDescriptor() {
 
     open fun testCargoProject(module: Module, contentRoot: String): CargoWorkspace {
         val packages = listOf(testCargoPackage(contentRoot))
-        return CargoWorkspace.deserialize(Paths.get("/my-crate/Cargo.toml"), CargoWorkspaceData(packages, emptyMap()))
+        return CargoWorkspace.deserialize(Paths.get("/my-crate/Cargo.toml"), CargoWorkspaceData(packages, emptyMap()), CfgOptions.DEFAULT)
     }
 
     protected fun testCargoPackage(contentRoot: String, name: String = "test-package") = CargoWorkspaceData.Package(
@@ -97,7 +98,7 @@ open class WithRustup(private val delegate: RustProjectDescriptorBase) : RustPro
 
     override fun testCargoProject(module: Module, contentRoot: String): CargoWorkspace {
         val stdlib = StandardLibrary.fromFile(stdlib!!)!!
-        return delegate.testCargoProject(module, contentRoot).withStdlib(stdlib, rustcInfo)
+        return delegate.testCargoProject(module, contentRoot).withStdlib(stdlib, CfgOptions.DEFAULT, rustcInfo)
     }
 
     override fun setUp(fixture: CodeInsightTestFixture) {
@@ -121,7 +122,7 @@ open class WithCustomStdlibRustProjectDescriptor(
     }
 
     override fun testCargoProject(module: Module, contentRoot: String): CargoWorkspace =
-        delegate.testCargoProject(module, contentRoot).withStdlib(stdlib!!)
+        delegate.testCargoProject(module, contentRoot).withStdlib(stdlib!!, CfgOptions.DEFAULT)
 
     override fun setUp(fixture: CodeInsightTestFixture) {
         delegate.setUp(fixture)
@@ -194,6 +195,6 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
             packages[3].id to setOf(
                 Dependency(packages[7].id)
             )
-        )))
+        )), CfgOptions.DEFAULT)
     }
 }

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestBase.kt
@@ -22,6 +22,7 @@ import org.intellij.lang.annotations.Language
 import org.jdom.Element
 import org.rust.RsTestBase
 import org.rust.cargo.CargoConstants
+import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.*
@@ -223,7 +224,8 @@ abstract class RunConfigurationProducerTestBase : RsTestBase() {
                         )
                     ),
                     dependencies = emptyMap()
-                )
+                ),
+                CfgOptions.DEFAULT
             )
 
             project.cargoProjects.createTestProject(myFixture.findFileInTempDir("."), projectDescription)

--- a/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
@@ -7,6 +7,7 @@ package org.rust.cargo.util
 
 import com.intellij.codeInsight.completion.PlainPrefixMatcher
 import org.rust.RsTestBase
+import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.*
@@ -132,6 +133,6 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
             )),
             pkg("quux", false, listOf(target("quux", TargetKind.Lib(LibKind.LIB))))
         )
-        CargoWorkspace.deserialize(Paths.get("/my-crate/Cargo.toml"), CargoWorkspaceData(pkgs, dependencies = emptyMap()))
+        CargoWorkspace.deserialize(Paths.get("/my-crate/Cargo.toml"), CargoWorkspaceData(pkgs, dependencies = emptyMap()), CfgOptions.DEFAULT)
     }
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -326,7 +326,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class.java) {
         }
         fn main() {
             let foo = Foo;
-            foo.bar(10);  // Ignore both calls
+            foo.bar<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(10)</error>;
             foo.bar();
         }
     """)
@@ -783,13 +783,17 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class.java) {
         }
     """)
 
+    @MockAdditionalCfgOptions("foo")
     fun `test respects cfg attribute E0428`() = checkErrors("""
         mod opt {
-            #[cfg(not(windows))] mod foo {}
-            #[cfg(windows)]     mod foo {}
+            #[cfg(not(bar))] mod foo {}
+            #[cfg(bar)]      mod foo {}
 
-            #[cfg(windows)] fn <error descr="A value named `hello_world` has already been defined in this module [E0428]">hello_world</error>() {}
+            #[cfg(foo)] fn <error descr="A value named `hello_world` has already been defined in this module [E0428]">hello_world</error>() {}
             fn <error descr="A value named `hello_world` has already been defined in this module [E0428]">hello_world</error>() {}
+
+            #[cfg(bar)] fn hello_rust() {}
+            fn hello_rust() {}
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -114,7 +114,6 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test complex fn`() = doTest("""
         /// Docs
-        #[cfg(test)]
         /// More Docs
         pub const unsafe extern "C" fn foo<T: Into<String>, F>(t: T, f: F) where F: Ord {}
                                       //^

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.docs
 
 import org.intellij.lang.annotations.Language
+import org.rust.MockAdditionalCfgOptions
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 
@@ -43,9 +44,10 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    @MockAdditionalCfgOptions("foo")
     fun `test big signature`() = doTest("""
         /// Docs
-        #[cfg(test)]
+        #[cfg(foo)]
         /// More Docs
         pub const unsafe extern "C" fn foo<T>(x: T) -> u32 where T: Clone { 92 }
 
@@ -137,8 +139,6 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
         use std::fmt::{Debug, Display};
 
         /// Docs
-        #[cfg(test)]
-        /// More Docs
         pub const unsafe extern "C" fn foo<T, U, V>(x: T) -> u32 where T: Clone,
                                                                        U: Debug,
                                                                        V: Display
@@ -158,8 +158,6 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
         use std::fmt::{Debug, Display};
 
         /// Docs
-        #[cfg(test)]
-        /// More Docs
         pub const unsafe extern "C" fn foo<T, U, V>(
          x: T,
          y: u32,

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoBenchRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoBenchRunLineMarkerContributorTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.lineMarkers
 
+import org.rust.MockAdditionalCfgOptions
 import org.rust.fileTree
 
 /**
@@ -43,6 +44,7 @@ class CargoBenchRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         }
     """)
 
+    @MockAdditionalCfgOptions("test")
     fun `test function in a nested tests module`() = doTestByText("""
         #[cfg(test)]
         mod tests { // - Bench lib::tests

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
@@ -9,6 +9,7 @@ import com.intellij.execution.TestStateStorage
 import com.intellij.execution.testframework.sm.runner.states.TestStateInfo
 import com.intellij.psi.PsiFileFactory
 import org.intellij.lang.annotations.Language
+import org.rust.MockAdditionalCfgOptions
 import org.rust.cargo.icons.CargoIcons
 import org.rust.cargo.runconfig.test.CargoTestLocator
 import org.rust.fileTree
@@ -56,6 +57,7 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         }
     """)
 
+    @MockAdditionalCfgOptions("test")
     fun `test function in a nested tests module`() = doTestByText("""
         #[cfg(test)]
         mod tests { // - Test lib::tests

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve
+
+import org.rust.ExpandMacros
+import org.rust.MockAdditionalCfgOptions
+import org.rust.lang.core.psi.RsTupleFieldDecl
+
+class RsCfgAttrResolveTest : RsResolveTestBase() {
+    @MockAdditionalCfgOptions("foo")
+    fun `test fn with cfg`() = checkByCode("""
+        #[cfg(foo)]
+        fn foo() {}
+         //X
+        #[cfg(not(foo))]
+        fn foo() {}
+
+        fn main() {
+            foo();
+          //^
+        }
+    """)
+
+    @MockAdditionalCfgOptions("foo")
+    fun `test struct field with cfg`() = checkByCode("""
+        struct S {
+            #[cfg(not(foo))] x: u32,
+            #[cfg(foo)]      x: i32,
+                           //X
+        }
+
+        fn t(f: S) {
+            f.x;
+            //^
+        }
+    """)
+
+    @MockAdditionalCfgOptions("foo")
+    fun `test tuple struct field with cfg`() = checkByCodeGeneric<RsTupleFieldDecl>("""
+        struct S(#[cfg(not(foo))] u32,
+                 #[cfg(foo)]      i32);
+                                //X
+        fn t(f: S) {
+            f.0;
+            //^
+        }
+    """)
+
+    @MockAdditionalCfgOptions("foo")
+    fun `test tuple enum variant with cfg`() = checkByCode("""
+        enum E {
+            #[cfg(not(foo))] Variant(u32),
+            #[cfg(foo)]      Variant(u32),
+                           //X
+        }
+
+        fn t() {
+            E::Variant(0);
+             //^
+        }
+    """)
+
+    @MockAdditionalCfgOptions("foo")
+    fun `test inline mod with cfg`() = checkByCode("""
+        #[cfg(foo)]
+        mod my {
+            pub fn bar() {}
+                 //X
+        }
+        
+        #[cfg(not(foo))]
+        mod my {
+            pub fn bar() {}
+        }
+        
+        fn t() {
+            my::bar();
+              //^
+        }
+     """)
+
+    @MockAdditionalCfgOptions("foo")
+    fun `test use item with cfg`() = checkByCode(""" 
+        mod my {
+            pub fn bar() {}
+                 //X
+            pub fn baz() {}
+        }
+        
+        #[cfg(foo)]
+        use my::bar as quux;
+        
+        #[cfg(not(foo))]
+        use my::baz as quux;
+
+        fn t() {
+            quux();
+          //^
+        }
+     """)
+
+    @ExpandMacros
+    @MockAdditionalCfgOptions("foo")
+    fun `test macro expansion with cfg`() = checkByCode(""" 
+        struct S { x: i32 }
+                 //X
+                 
+        macro_rules! my_macro {
+            ($ t:ty) => { fn foobar() -> $ t {} };
+        }
+
+        #[cfg(foo)]
+        my_macro!(S);
+      
+      
+        #[cfg(not(foo))]
+        my_macro!(i32);
+
+        fn t() {
+            foobar().x;
+                   //^
+        }
+     """)
+
+    @MockAdditionalCfgOptions("foo")
+    fun `test extern crate with cfg`() = stubOnlyResolve(""" 
+        //- main.rs
+        #[cfg(foo)]
+        extern crate test_package;
+
+        fn main() {
+            test_package::hello();
+        }               //^ lib.rs
+
+        //- lib.rs
+        pub fn hello() {}
+             //X
+     """)
+}

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
@@ -16,7 +16,6 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
     fun `test expand item`() = checkByCode("""
         macro_rules! if_std {
             ($ i:item) => (
-                #[cfg(feature = "use_std")]
                 $ i
             )
         }
@@ -38,7 +37,6 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
     fun `test expand items star`() = checkByCode("""
         macro_rules! if_std {
             ($ ($ i:item)*) => ($ (
-                #[cfg(feature = "use_std")]
                 $ i
             )*)
         }
@@ -55,12 +53,12 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
         fn main() {
             foo().bar()
         }       //^
+
     """)
 
     fun `test expand items star with reexport`() = checkByCode("""
         macro_rules! if_std {
             ($ ($ i:item)*) => ($ (
-                #[cfg(feature = "use_std")]
                 $ i
             )*)
         }
@@ -82,7 +80,6 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
     fun `test expand items star with reexport from expansion`() = checkByCode("""
         macro_rules! if_std {
             ($ ($ i:item)*) => ($ (
-                #[cfg(feature = "use_std")]
                 $ i
             )*)
         }
@@ -105,7 +102,6 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
     fun `test expand items star with nested macro calls`() = checkByCode("""
         macro_rules! if_std {
             ($ ($ i:item)*) => ($ (
-                #[cfg(feature = "use_std")]
                 $ i
             )*)
         }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
@@ -52,7 +52,7 @@ abstract class RsResolveTestBase : RsTestBase() {
         val target = findElementInEditor(targetPsiClass, "X")
 
         check(resolved == target) {
-            "$refElement `${refElement.text}` should resolve to $target, was $resolved instead"
+            "$refElement `${refElement.text}` should resolve to $target (${target.text}), was $resolved (${resolved.text}) instead"
         }
     }
 


### PR DESCRIPTION
This PR is based on #2166 (but does not include #2840 and #3031) and adds [cfg attributes](https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute) support to our name resolution. 

Part of #1191

@kumbayo thank you so much for your contribution! We are really sorry that we didn't merge your original PRs at a reasonable time. We've decided to merge the initial part of cfg support (related only to name resolution, without any UI changes) via this PR. So reviewing other cfg-related changes will become more convenient after this PR is merged.

Co-authored-by: Peter Oberndorfer <kumbayo84@arcor.de>
