### PR TITLE
Show type alias names in type hints for TyAdt

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/type/RsShortTypeRenderingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsShortTypeRenderingTest.kt
@@ -62,6 +62,14 @@ class RsShortTypeRenderingTest : RsTestBase() {
         } //^ S<?>
     """)
 
+    fun `test aliased type`() = testShortTypeExpr("""
+        struct S<A, B>(A, B);
+        type Foo<T> = S<T, u8>;
+        fn foo(s: Foo<i32>) {
+            s;
+        } //^ Foo<i32>
+    """)
+
     private fun testShortTypeExpr(@Language("Rust") code: String) {
         InlineFile(code)
         val (expr, expectedType) = findElementAndDataInEditor<RsExpr>()


### PR DESCRIPTION
![Screenshot from 2019-08-12 13-07-54](https://user-images.githubusercontent.com/3221931/62863792-8500e480-bd12-11e9-8a66-d36fb07ee564.png)

This works for ADTs only (struct/enum types). 
Note that I intentionally included `aliasedBy` field in equals/hashCode of TyAdt b/c otherwise there can be caching issues and incorrect types can be shown. However this can bring some bugs with intentions/etc where incorrect type comparison used. If you run into such issue, consider using unification instead of `==`.