### PR TITLE
PERF: create `ImplLookup` lazy when resolving paths

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -365,7 +365,7 @@ class RsTypeInferenceWalker(
         scopeEntry: ScopeEntry,
         pathExpr: RsPathExpr
     ): Ty {
-        val subst = instantiatePathGenerics(pathExpr.path, BoundElement(element, scopeEntry.subst), lookup).subst
+        val subst = instantiatePathGenerics(pathExpr.path, BoundElement(element, scopeEntry.subst)).subst
         val type = when (element) {
             is RsPatBinding -> ctx.getBindingType(element)
             is RsTypeDeclarationElement -> element.declaredType


### PR DESCRIPTION
This speeds up highlighting up to 5% (the baseline is the latest 103 release)