### PR TITLE
PERF: use `strict = false` in `RsResolveCache`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsModificationTrackerOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsModificationTrackerOwner.kt
@@ -32,7 +32,7 @@ interface RsModificationTrackerOwner : RsElement {
     fun incModificationCount(element: PsiElement): Boolean
 }
 
-fun PsiElement.findModificationTrackerOwner(strict: Boolean = true): RsModificationTrackerOwner? {
+fun PsiElement.findModificationTrackerOwner(strict: Boolean): RsModificationTrackerOwner? {
     return PsiTreeUtil.getContextOfType(
         this,
         strict,

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsResolveCache.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsResolveCache.kt
@@ -122,7 +122,7 @@ class RsResolveCache(messageBus: MessageBus) {
     private fun getCacheFor(element: PsiElement, dep: ResolveCacheDependency): ConcurrentMap<PsiElement, Any?> {
         return when (dep) {
             ResolveCacheDependency.LOCAL, ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE -> {
-                val owner = element.findModificationTrackerOwner()
+                val owner = element.findModificationTrackerOwner(strict = false)
                 return if (owner != null) {
                     if (dep == ResolveCacheDependency.LOCAL) {
                         CachedValuesManager.getCachedValue(owner, LOCAL_CACHE_KEY) {


### PR DESCRIPTION
Previous (default) `strict = true` value really isn't needed, and just slows down performance in the case of `RsModDecl` reference cache