### PR TITLE
Make "Navigate Class/Symbol" works with items expanded from macros

### DIFF
--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsNavigationContributorBase.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsNavigationContributorBase.kt
@@ -8,7 +8,10 @@ package org.rust.ide.navigation.goto
 import com.intellij.navigation.ChooseByNameContributorEx
 import com.intellij.navigation.GotoClassContributor
 import com.intellij.navigation.NavigationItem
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.psi.search.EverythingGlobalScope
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
@@ -16,8 +19,11 @@ import com.intellij.util.ArrayUtilRt
 import com.intellij.util.Processor
 import com.intellij.util.indexing.FindSymbolParameters
 import com.intellij.util.indexing.IdFilter
+import org.rust.ide.search.RsWithMacrosScope
+import org.rust.lang.core.macros.findMacroCallExpandedFrom
 import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.RsQualifiedNamedElement
+import org.rust.lang.core.psi.ext.contextualFile
 import org.rust.lang.core.psi.ext.qualifiedName
 import java.util.*
 
@@ -28,19 +34,34 @@ abstract class RsNavigationContributorBase<T> protected constructor(
     GotoClassContributor where T : NavigationItem, T : RsNamedElement {
 
     override fun processNames(processor: Processor<String>, scope: GlobalSearchScope, filter: IdFilter?) {
-        StubIndex.getInstance().processAllKeys(indexKey, processor, scope, filter)
+        checkFilter(filter)
+        StubIndex.getInstance().processAllKeys(
+            indexKey,
+            processor,
+            scope.withMacrosScope(),
+            null // see `checkFilter`
+        )
     }
 
     override fun processElementsWithName(name: String, processor: Processor<NavigationItem>, parameters: FindSymbolParameters) {
+        checkFilter(parameters.idFilter)
+        val originScope = parameters.searchScope
         StubIndex.getInstance().processElements(
             indexKey,
             name,
             parameters.project,
-            parameters.searchScope,
-            parameters.idFilter,
-            clazz,
-            processor
-        )
+            originScope.withMacrosScope(),
+            null, // see `checkFilter`
+            clazz
+        ) { element ->
+            // Filter out elements expanded from macros that are not in the scope
+            val macroVFile = element.findMacroCallExpandedFrom()?.contextualFile?.originalFile?.virtualFile
+            if (macroVFile == null || macroVFile in originScope) {
+                processor.process(element)
+            } else {
+                true
+            }
+        }
     }
 
     // BACKCOMPAT 2019.1
@@ -61,4 +82,23 @@ abstract class RsNavigationContributorBase<T> protected constructor(
     override fun getQualifiedName(item: NavigationItem?): String? = (item as? RsQualifiedNamedElement)?.qualifiedName
 
     override fun getQualifiedNameSeparator(): String = "::"
+}
+
+private fun GlobalSearchScope.withMacrosScope(): GlobalSearchScope {
+    val project = project
+    return if (project != null && this !is EverythingGlobalScope) RsWithMacrosScope(project, this) else this
+}
+
+private val LOG = Logger.getInstance(RsNavigationContributorBase::class.java)
+
+/**
+ * [IdFilter] exists only for optimization purposes and can safely be null. If it is not null, we should
+ * refine it in the same way as a scope in [withMacrosScope]. But looks like in 2019.2 it's always null,
+ * so I can't even test the solution. I decided to always use `null` as a filter and enable this check
+ * (in the internal mode only) to catch the situation when it will become non null.
+ */
+private fun checkFilter(filter: IdFilter?) {
+    if (ApplicationManager.getApplication().isInternal && filter != null) {
+        LOG.error("IdFilter is supposed to be null", Throwable())
+    }
 }


### PR DESCRIPTION
![Screenshot from 2019-08-21 13-54-28](https://user-images.githubusercontent.com/3221931/63426571-d9dfe180-c41b-11e9-86b7-9b6fc192eee8.png)

Note that looks like I already enabled search for items expanded from macros in the case of "All places" scope in #4275. But this PR enables it correctly for all scopes (e.g. project/library files)