### PR TITLE
RES: Fix random unresolved refs; drop per-mod name cache

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -8,9 +8,6 @@ package org.rust.lang.core.resolve
 import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.Key
 import com.intellij.psi.util.CachedValue
-import com.intellij.psi.util.CachedValueProvider
-import com.intellij.psi.util.CachedValuesManager
-import com.intellij.util.SmartList
 import org.rust.cargo.util.AutoInjectedCrates.CORE
 import org.rust.cargo.util.AutoInjectedCrates.STD
 import org.rust.lang.core.psi.*
@@ -224,7 +221,6 @@ private fun processMultiResolveWithNs(name: String, ns: Set<Namespace>, ref: RsR
 
     if (ns.size == 1) {
         // Optimized version for single namespace.
-        // Also this provides ability to cache ScopeEntries and so necessary for [processItemDeclarationsWithCache]
         return processor.lazy(name) {
             ref.multiResolve().find { it is RsNamedElement && ns.intersects(it.namespaces) }
         }
@@ -251,37 +247,6 @@ private fun processMultiResolveWithNs(name: String, ns: Set<Namespace>, ref: RsR
         if (processor(name, element)) return true
     }
     return false
-}
-
-/**
- * A cached version of [processItemDeclarations]. Exists only for optimization purposes and can be safely
- * replaced with [processItemDeclarations]. The cached version is used only when [ns] consists of the
- * single element that is [Namespace.Types]. This is due to the following reasons:
- * 1. Types namespace is an absolute record holder in name resolution invocations and time
- * 2. We can cache only single namespace due to [processMultiResolveWithNs] implementation
- */
-fun processItemDeclarationsWithCache(
-    scope: RsMod,
-    ns: Set<Namespace>,
-    processor: RsResolveProcessor,
-    ipm: ItemProcessingMode = ItemProcessingMode.WITH_PRIVATE_IMPORTS
-): Boolean {
-    return if (ns == TYPES) {
-        val cached = CachedValuesManager.getCachedValue(scope, ipm.cacheKey) {
-            val scopeEntryList = SmartList<ScopeEntry>()
-            processItemDeclarations(scope, TYPES, {
-                scopeEntryList.add(it)
-                false
-            }, ipm)
-            CachedValueProvider.Result.create(scopeEntryList, scope.rustStructureOrAnyPsiModificationTracker)
-        }
-        for (e in cached) {
-            if (processor(e)) return true
-        }
-        false
-    } else {
-        processItemDeclarations(scope, ns, processor, ipm)
-    }
 }
 
 enum class ItemProcessingMode(val withExternCrates: Boolean) {

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -1216,7 +1216,7 @@ private fun processLexicalDeclarations(
 
     when (scope) {
         is RsMod -> {
-            if (processItemDeclarationsWithCache(scope, ns, processor, ipm = ipm)) return true
+            if (processItemDeclarations(scope, ns, processor, ipm = ipm)) return true
         }
 
         is RsTypeAlias -> {
@@ -1358,7 +1358,7 @@ fun processNestedScopesUpwards(
         // XXX: fix prelude items resolve on the nightly. Revert it to `v -> v.name !in prevScope`
         //   after cfg attrs support or when `#[cfg(bootstrap)]` will be removed from the prelude
         val preludeProcessor: (ScopeEntry) -> Boolean = { v -> prevScope.add(v.name) && processor(v) }
-        return processItemDeclarationsWithCache(prelude, ns, preludeProcessor, ItemProcessingMode.WITHOUT_PRIVATE_IMPORTS)
+        return processItemDeclarations(prelude, ns, preludeProcessor, ItemProcessingMode.WITHOUT_PRIVATE_IMPORTS)
     }
 
     return false

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -929,4 +929,26 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         fn foo(foo: dep_lib_target::trans_lib::Foo) {}
                                               //^ trans-lib/lib.rs
     """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test complex circular dependent star imports`() = stubOnlyResolve("""
+    //- foo.rs
+        pub struct S1;
+        pub struct S2;
+        impl S2 { pub fn foo(&self) {} }
+    //- lib.rs
+        pub mod foo;
+        pub mod prelude {
+            pub use crate::foo::{S1, S2};
+            pub use crate::bar::*; // `bar` may exists or may not
+        }
+        
+        pub use self::prelude::*;
+    //- main.rs
+        use test_package::{S1, S2};
+
+        fn create(_: S1, s2: S2) {
+            s2.foo();
+        }      //^ foo.rs
+    """)
 }


### PR DESCRIPTION
I ran into a very weird bug when some name is resolved but then randomly unresolved after some typing. After a long investigation (it was hard to even reduce it to some test) I found that that bug is caused by the cache introduced in #3744. The cache is wrong in general b/c with the current name resolution engine names visible in scope are caller-dependent because of infinite recursions possible with star imports (prevented by a recursion guard). 

Good news is that performance is about 5%. When the cache was introduced it was about 15%. I think this difference is caused by our recent optimizations, so this cache is no longer needed anyway.

(Btw #4262 brings 5% optimization, so if we put them together into one release, we will not have regression :)