### PR TITLE
RES: fix incorrect recursion guard usages

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -178,7 +178,7 @@ fun processItemDeclarations(
             // BACKCOMPAT 2019.1
             val rootQualifier = generateSequence(basePath) { it.qualifier }.drop(1).lastOrNull()
             if (rootQualifier != null) {
-                guard.doPreventingRecursion(rootQualifier, false) { basePath.reference.resolve() }
+                guard.doPreventingRecursion(rootQualifier, memoize = false) { basePath.reference.resolve() }
             } else {
                 basePath.reference.resolve()
             }
@@ -191,7 +191,7 @@ fun processItemDeclarations(
                 { it.name !in directlyDeclaredNames && originalProcessor(it) },
                 withPrivateImports = basePath != null && isSuperChain(basePath)
             )
-        })
+        }, memoize = false)
         if (found == true) return true
     }
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -28,7 +28,7 @@ fun inferTypesIn(element: RsInferenceContextOwner): RsInferenceResult {
     val items = element.knownItems
     val paramEnv = if (element is RsGenericDeclaration) ParamEnv.buildFor(element) else ParamEnv.EMPTY
     val lookup = ImplLookup(element.project, element.cargoProject, items, paramEnv)
-    return recursionGuard(element, Computable { lookup.ctx.infer(element) })
+    return recursionGuard(element, Computable { lookup.ctx.infer(element) }, memoize = false)
         ?: error("Can not run nested type inference")
 }
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -929,4 +929,26 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         fn foo(foo: dep_lib_target::trans_lib::Foo) {}
                                               //^ trans-lib/lib.rs
     """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test complex circular dependent star imports`() = stubOnlyResolve("""
+    //- foo.rs
+        pub struct S1;
+        pub struct S2;
+        impl S2 { pub fn foo(&self) {} }
+    //- lib.rs
+        pub mod foo;
+        pub mod prelude {
+            pub use crate::foo::{S1, S2};
+            pub use crate::bar::*; // `bar` may exists or may not
+        }
+        
+        pub use self::prelude::*;
+    //- main.rs
+        use test_package::{S1, S2};
+
+        fn create(_: S1, s2: S2) {
+            s2.foo();
+        }      //^ foo.rs
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
@@ -623,8 +623,7 @@ class RsUseResolveTest : RsResolveTestBase() {
         }  //^
     """)
 
-    fun `test cyclic dependent imports`() = expect<IllegalStateException> {
-        checkByCode("""
+    fun `test cyclic dependent imports`() = checkByCode("""
         mod a {
             pub use b::*;
 
@@ -640,7 +639,6 @@ class RsUseResolveTest : RsResolveTestBase() {
             pub use self::c::*;
         }
     """)
-    }
 
     fun `test underscore import doesn't bring a name into scope`() = checkByCode("""
         pub mod foo {


### PR DESCRIPTION
... causing randomly unresolved references

I measured about 2% performance regression. I think it's pretty well.