### PR TITLE
RES: enable all cfg features by default

### DIFF
--- a/src/main/kotlin/org/rust/cargo/CfgOptions.kt
+++ b/src/main/kotlin/org/rust/cargo/CfgOptions.kt
@@ -12,6 +12,13 @@ class CfgOptions(
     val keyValueOptions: Map<String, List<String>>,
     val nameOptions: Set<String>
 ) {
+    fun isNameEnabled(name: String): Boolean =
+        name in nameOptions
+
+    // TODO remove special case for "feature"
+    fun isNameValueEnabled(name: String, value: String): Boolean =
+        name == "feature" || keyValueOptions[name]?.contains(value) ?: false
+
     companion object {
         fun parse(rawCfgOptions: List<String>): CfgOptions {
             val knownKeyValueOptions = hashMapOf<String, SmartList<String>>()

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
@@ -29,8 +29,8 @@ class CfgEvaluator(val options: CfgOptions) {
         is CfgPredicate.All -> predicate.list.all(::evaluatePredicate)
         is CfgPredicate.Any -> predicate.list.any(::evaluatePredicate)
         is CfgPredicate.Not -> !evaluatePredicate(predicate.single)
-        is CfgPredicate.NameOption -> predicate.name in options.nameOptions
-        is CfgPredicate.NameValueOption -> options.keyValueOptions[predicate.name]?.contains(predicate.value) ?: false
+        is CfgPredicate.NameOption -> options.isNameEnabled(predicate.name)
+        is CfgPredicate.NameValueOption -> options.isNameValueEnabled(predicate.name, predicate.value)
         is CfgPredicate.Error -> true
     }
 }


### PR DESCRIPTION
See #4232
Since cargo features should be additive, we can just enable them all for now. At least it should work better than disabling them all.