### PR TITLE
ACT: Go to Cargo.toml when invoking "Go to super" in a crate root

### DIFF
--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.testFramework.LightProjectDescriptor
 import com.intellij.testFramework.VfsTestUtil
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import com.intellij.util.Urls
 import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.RustcInfo
 import org.rust.cargo.project.model.cargoProjects
@@ -57,7 +58,8 @@ open class RustProjectDescriptorBase : LightProjectDescriptor() {
 
     open fun testCargoProject(module: Module, contentRoot: String): CargoWorkspace {
         val packages = listOf(testCargoPackage(contentRoot))
-        return CargoWorkspace.deserialize(Paths.get("/my-crate/Cargo.toml"), CargoWorkspaceData(packages, emptyMap()), CfgOptions.DEFAULT)
+        return CargoWorkspace.deserialize(Paths.get("${Urls.newFromIdea(contentRoot).path}/workspace/Cargo.toml"),
+            CargoWorkspaceData(packages, emptyMap()), CfgOptions.DEFAULT)
     }
 
     protected fun testCargoPackage(contentRoot: String, name: String = "test-package") = CargoWorkspaceData.Package(

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandlerTest.kt
@@ -139,6 +139,8 @@ class RsGotoSuperHandlerTest : RsTestBase() {
             mod bar;
     """)
 
+    // Navigation from a crate root to Cargo.toml is tested in `CargoTomlGotoSuperHandlerTest`
+
     private fun checkNavigationInFiles(@Language("Rust") fileTreeText: String, expected: String) {
         fileTreeFromText(fileTreeText).createAndOpenFileWithCaretMarker()
         val target = gotoSuperTarget(myFixture.file)

--- a/toml/src/main/kotlin/org/rust/toml/CargoTomlGotoSuperHandler.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoTomlGotoSuperHandler.kt
@@ -1,0 +1,36 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml
+
+import com.intellij.lang.LanguageCodeInsightActionHandler
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.NavigatablePsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.ext.findCargoPackage
+import org.rust.openapiext.toPsiFile
+import org.toml.lang.psi.TomlFileType
+
+/**
+ * Provides navigation from a package Cargo.toml to the workspace Cargo.toml, in addition to
+ * [org.rust.ide.navigation.goto.RsGotoSuperHandler]
+ */
+class CargoTomlGotoSuperHandler : LanguageCodeInsightActionHandler {
+    override fun isValidFor(editor: Editor?, file: PsiFile?) =
+        tomlPluginIsAbiCompatible() && file?.fileType == TomlFileType
+
+    override fun invoke(project: Project, editor: Editor, file: PsiFile) {
+        gotoSuperTarget(project, file)?.navigate(true)
+    }
+}
+
+private fun gotoSuperTarget(project: Project, file: PsiFile): NavigatablePsiElement? =
+    if (file.name.equals("cargo.toml", ignoreCase = true)) {
+        val manifestPath = file.findCargoPackage()?.workspace?.manifestPath
+        file.virtualFile?.fileSystem?.findFileByPath(manifestPath.toString())?.toPsiFile(project)
+    } else {
+        null
+    }

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -6,5 +6,6 @@
                                 implementationClass="org.rust.toml.CargoTomlCompletionContributor"/>
         <codeInsight.lineMarkerProvider language="TOML"
                                         implementationClass="org.rust.toml.CargoCrateDocLineMarkerProvider"/>
+        <codeInsight.gotoSuper language="TOML" implementationClass="org.rust.toml.CargoTomlGotoSuperHandler"/>
     </extensions>
 </idea-plugin>

--- a/toml/src/test/kotlin/org/rust/toml/CargoTomlGotoSuperHandlerTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoTomlGotoSuperHandlerTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml
+
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.FileEditorManager
+import org.rust.RsTestBase
+import org.rust.fileTreeFromText
+
+class CargoTomlGotoSuperHandlerTest : RsTestBase() {
+
+    // Test for `RsGotoSuperHandler`
+    fun `test go from a crate root to cargo toml`() = checkNavigationInFiles("""
+    //- main.rs
+        /*caret*/fn main() {}
+
+    //- Cargo.toml
+        [package]
+        name = "example"
+    """, "Cargo.toml")
+
+    // Test for CargoTomlGotoSuperHandler
+    fun `test go from package cargo toml to workspace cargo toml`() = checkNavigationInFiles("""
+    //- Cargo.toml
+        /*caret*/[package]
+        name = "example"
+    //- workspace/Cargo.toml
+        [workspace]
+    """, "workspace/Cargo.toml")
+
+    private fun checkNavigationInFiles(fileTreeText: String, expectedFilePath: String) {
+        fileTreeFromText(fileTreeText).createAndOpenFileWithCaretMarker()
+        myFixture.performEditorAction("GotoSuperMethod")
+        val file = FileDocumentManager.getInstance().getFile(
+            FileEditorManager.getInstance(project).selectedTextEditor!!.document)!!
+        check(file.path.endsWith(expectedFilePath)) { "Expected `$expectedFilePath`, actual `${file.path}`" }
+    }
+}


### PR DESCRIPTION
Fixes #2781