### PR TITLE
TY: fix random type inference fails caused by STUB usage instead of AST

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsBlock.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsBlock.kt
@@ -6,10 +6,7 @@
 package org.rust.lang.core.psi.ext
 
 import org.rust.lang.core.macros.RsExpandedElement
-import org.rust.lang.core.psi.RsBlock
-import org.rust.lang.core.psi.RsExpr
-import org.rust.lang.core.psi.RsMacroCall
-import org.rust.lang.core.psi.RsStmt
+import org.rust.lang.core.psi.*
 
 /**
  * Can contain [RsStmt]s and [RsExpr]s (which are equivalent to RsExprStmt(RsExpr))
@@ -26,8 +23,9 @@ val RsBlock.expandedStmts: List<RsExpandedElement>
 
 private val RsBlock.stmtsAndMacros: Sequence<RsElement>
     get() {
+        val parentItem = contextStrict<RsItemElement>()
         val stub = greenStub
-        return if (stub != null) {
+        return if (stub != null && parentItem is RsConstant && parentItem.isConst) {
             stub.childrenStubs.asSequence().map { it.psi }
         } else {
             childrenWithLeaves


### PR DESCRIPTION
The bug was introduced in #4094 (because we used a stubbed statement list) and led to the fact that sometimes all types in some file was not inferred until you type some text there