### PR TITLE
INT: add "Put struct literal fields on separate lines/one line" intention

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/ChopListIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ChopListIntention.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.codeStyle.CodeStyleManager
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.elementType
 import org.rust.lang.core.psi.ext.startOffset
 
 abstract class ChopListIntentionBase<TList : RsElement, TElement : RsElement>(
@@ -21,8 +22,8 @@ abstract class ChopListIntentionBase<TList : RsElement, TElement : RsElement>(
 ) : ListIntentionBase<TList, TElement>(listClass, elementClass, intentionText) {
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): TList? {
         val list = element.listContext ?: return null
-        val elements = list.elements
-        if (elements.size < 2 || elements.dropLast(1).all { hasLineBreakAfter(it) }) return null
+        val elements = getElements(list)
+        if (elements.size < 2 || elements.dropLast(1).all { hasLineBreakAfter(list, it) }) return null
         return list
     }
 
@@ -30,11 +31,12 @@ abstract class ChopListIntentionBase<TList : RsElement, TElement : RsElement>(
         val document = editor.document
         val startOffset = ctx.startOffset
 
-        val elements = ctx.elements
-        val lastElementOrTrailingComma = elements.last().let { commaAfter(it) ?: it }
-        if (!hasLineBreakAfter(lastElementOrTrailingComma)) {
-            lastElementOrTrailingComma.textRange?.endOffset?.also { document.insertString(it, "\n") }
+        val elements = getElements(ctx)
+        val last = elements.last()
+        if (!hasLineBreakAfter(ctx, last)) {
+            getEndElement(ctx, last).textRange?.endOffset?.also { document.insertString(it, "\n") }
         }
+
         elements.asReversed().forEach {
             if (!hasLineBreakBefore(it)) {
                 document.insertString(it.startOffset, "\n")
@@ -68,6 +70,25 @@ class ChopFieldListIntention : ChopListIntentionBase<RsBlockFields, RsNamedField
     RsNamedFieldDecl::class.java,
     "Put fields on separate lines"
 )
+
+/**
+ * This intention has a special case for the dotdot (..) element.
+ */
+class ChopLiteralFieldListIntention : ChopListIntentionBase<RsStructLiteralBody, RsStructLiteralField>(
+    RsStructLiteralBody::class.java,
+    RsStructLiteralField::class.java,
+    "Put fields on separate lines"
+) {
+    override fun getElements(context: RsStructLiteralBody): List<PsiElement> = super.getElements(context) + listOfNotNull(context.dotdot)
+    override fun getEndElement(ctx: RsStructLiteralBody, element: PsiElement): PsiElement {
+        return if (element.elementType == RsElementTypes.DOTDOT) {
+            ctx.expr?.let {
+                getEndElement(ctx, it)
+            } ?: element
+        }
+        else super.getEndElement(ctx, element)
+    }
+}
 
 class ChopVariantListIntention : ChopListIntentionBase<RsEnumBody, RsEnumVariant>(
     RsEnumBody::class.java,

--- a/src/main/kotlin/org/rust/ide/intentions/ListIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ListIntention.kt
@@ -27,10 +27,11 @@ abstract class ListIntentionBase<TList : RsElement, TElement : RsElement>(
     protected val PsiElement.listContext: TList?
         get() = PsiTreeUtil.getParentOfType(this, listClass, true)
 
-    protected val TList.elements: List<TElement>
-        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, elementClass)
+    protected open fun getElements(context: TList): List<PsiElement> = PsiTreeUtil.getChildrenOfTypeAsList(context, elementClass)
 
-    protected fun hasLineBreakAfter(element: PsiElement): Boolean = nextBreak(element) != null
+    protected open fun getEndElement(ctx: TList, element: PsiElement): PsiElement = commaAfter(element) ?: element
+
+    protected fun hasLineBreakAfter(ctx: TList, element: PsiElement): Boolean = nextBreak(getEndElement(ctx, element)) != null
 
     protected fun nextBreak(element: PsiElement): PsiWhiteSpace? = element.rightSiblings.lineBreak()
 
@@ -38,7 +39,7 @@ abstract class ListIntentionBase<TList : RsElement, TElement : RsElement>(
 
     protected fun prevBreak(element: PsiElement): PsiWhiteSpace? = element.leftSiblings.lineBreak()
 
-    protected fun commaAfter(element: PsiElement): PsiElement? =
+    private fun commaAfter(element: PsiElement): PsiElement? =
         element.getNextNonCommentSibling()?.takeIf { it.elementType == COMMA }
 
     private fun Sequence<PsiElement>.lineBreak(): PsiWhiteSpace? =

--- a/src/main/resources/META-INF/core.xml
+++ b/src/main/resources/META-INF/core.xml
@@ -696,6 +696,14 @@
             <category>Rust</category>
         </intentionAction>
         <intentionAction>
+            <className>org.rust.ide.intentions.ChopLiteralFieldListIntention</className>
+            <category>Rust</category>
+        </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.JoinLiteralFieldListIntention</className>
+            <category>Rust</category>
+        </intentionAction>
+        <intentionAction>
             <className>org.rust.ide.intentions.ChopVariantListIntention</className>
             <category>Rust</category>
         </intentionAction>

--- a/src/main/resources/intentionDescriptions/ChopLiteralFieldListIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/ChopLiteralFieldListIntention/after.rs.template
@@ -1,0 +1,4 @@
+let s = struct S {
+    <spot>x: 0,
+    y: 1</spot>
+}

--- a/src/main/resources/intentionDescriptions/ChopLiteralFieldListIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/ChopLiteralFieldListIntention/before.rs.template
@@ -1,0 +1,1 @@
+let s = struct S { <spot>x: 0, y: 1</spot> }

--- a/src/main/resources/intentionDescriptions/ChopLiteralFieldListIntention/description.html
+++ b/src/main/resources/intentionDescriptions/ChopLiteralFieldListIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention formats fields of a struct literal placing each field on a separate line.
+</body>
+</html>

--- a/src/main/resources/intentionDescriptions/JoinLiteralFieldListIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/JoinLiteralFieldListIntention/after.rs.template
@@ -1,0 +1,1 @@
+let s = struct S { <spot>x: 0, y: 1</spot> }

--- a/src/main/resources/intentionDescriptions/JoinLiteralFieldListIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/JoinLiteralFieldListIntention/before.rs.template
@@ -1,0 +1,4 @@
+let s = struct S {
+    <spot>x: 0,
+    y: 1</spot>
+}

--- a/src/main/resources/intentionDescriptions/JoinLiteralFieldListIntention/description.html
+++ b/src/main/resources/intentionDescriptions/JoinLiteralFieldListIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention formats fields of a struct literal placing all fields on a single line.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/ChopLiteralFieldListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ChopLiteralFieldListIntentionTest.kt
@@ -1,0 +1,185 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+class ChopLiteralFieldListIntentionTest : RsIntentionTestBase(ChopLiteralFieldListIntention()) {
+    fun `test one parameter`() = doUnavailableTest("""
+        struct S { x: i32 }
+        fn foo {
+            S { /*caret*/x: 0 };
+        }
+    """)
+
+    fun `test two parameters`() = doAvailableTest("""
+        struct S { x: i32, y: i32 }
+        fn foo() {
+            S { /*caret*/x: 0, y: 0 };
+        }
+    """, """
+        struct S { x: i32, y: i32 }
+        fn foo() {
+            S {
+                x: 0,
+                y: 0
+            };
+        }
+    """)
+
+    fun `test has all line breaks`() = doUnavailableTest("""
+        struct S { x: i32, y: i32, z: i32 }
+        fn foo() {
+            S {
+                /*caret*/x: 0,
+                y: 0,
+                z: 0
+            };
+        }
+    """)
+
+    fun `test has some line breaks`() = doAvailableTest("""
+        struct S { x: i32, y: i32, z: i32 }
+        fn foo() {
+            S { x: 0, /*caret*/y: 0,
+                z: 0
+            };
+        }
+    """, """
+        struct S { x: i32, y: i32, z: i32 }
+        fn foo() {
+            S {
+                x: 0,
+                y: 0,
+                z: 0
+            };
+        }
+    """)
+
+    fun `test has some line breaks 2`() = doAvailableTest("""
+        struct S { x: i32, y: i32, z: i32 }
+        fn foo() {
+            S {
+                x: 0, y: 0, z: 0/*caret*/
+            };
+        }
+    """, """
+        struct S { x: i32, y: i32, z: i32 }
+        fn foo() {
+            S {
+                x: 0,
+                y: 0,
+                z: 0
+            };
+        }
+    """)
+
+    fun `test has comment`() = doUnavailableTest("""
+        struct S {  x: i32, y: i32, z: i32 }
+        fn foo() {
+            S { 
+                /*caret*/x: 0, /* comment */ 
+                y: 0,
+                z: 0
+            };
+        }
+    """)
+
+    fun `test has comment 2`() = doAvailableTest("""
+        struct S {  x: i32, y: i32, z: i32 }
+        fn foo() {
+            S { 
+                /*caret*/x: 0, /*
+                    comment
+                */y: 0,
+                z: 0
+            };
+        }
+    """, """
+        struct S {  x: i32, y: i32, z: i32 }
+        fn foo() {
+            S {
+                x: 0, /*
+                    comment
+                */
+                y: 0,
+                z: 0
+            };
+        }
+    """)
+
+    fun `test has single line comment`() = doAvailableTest("""
+        struct S {  x: i32, y: i32, z: i32 }
+        fn foo() {
+            S {
+                /*caret*/x: 0, // comment x
+                y: 0, z: 0 // comment z
+            };
+        }
+   """, """
+        struct S {  x: i32, y: i32, z: i32 }
+        fn foo() {
+            S {
+                x: 0, // comment x
+                y: 0,
+                z: 0 // comment z
+            };
+        }
+    """)
+
+    fun `test init shorthand`() = doAvailableTest("""
+        struct S {  x: i32, y: i32, z: i32 }
+        fn foo() {
+            let x = 1;
+            let y = 2;
+            S {
+                /*caret*/x, z: 3, y
+            };
+        }
+   """, """
+        struct S {  x: i32, y: i32, z: i32 }
+        fn foo() {
+            let x = 1;
+            let y = 2;
+            S {
+                x,
+                z: 3,
+                y
+            };
+        }
+    """)
+
+    fun `test dotdot`() = doAvailableTest("""
+        struct S {  x: i32, y: i32, z: i32 }
+        fn foo() {
+            let s = S { x: 0, y: 0, z: 0 };
+            S { /*caret*/x: 1, ..s };
+        }
+   """, """
+        struct S {  x: i32, y: i32, z: i32 }
+        fn foo() {
+            let s = S { x: 0, y: 0, z: 0 };
+            S {
+                x: 1,
+                ..s
+            };
+        }
+    """)
+
+    fun `test enum`() = doAvailableTest("""
+        enum E { A { x: i32, y: i32, z: i32 } }
+        fn foo() {
+            let e = E::A { /*caret*/ x: 0, y: 0, z: 0 };
+        }
+   """, """
+        enum E { A { x: i32, y: i32, z: i32 } }
+        fn foo() {
+            let e = E::A {
+                x: 0,
+                y: 0,
+                z: 0
+            };
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/intentions/JoinLiteralFieldListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/JoinLiteralFieldListIntentionTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+class JoinLiteralFieldListIntentionTest : RsIntentionTestBase(JoinLiteralFieldListIntention()) {
+    fun `test one parameter`() = doAvailableTest("""
+        struct S { x: i32 }
+        fn foo() {
+            S {
+                /*caret*/x: 0
+            };
+        }
+    """, """
+        struct S { x: i32 }
+        fn foo() {
+            S { x: 0 };
+        }""")
+
+    fun `test two parameters`() = doAvailableTest("""
+        struct S { x: i32, y: i32 }
+        fn foo() {
+            S {
+                /*caret*/x: 0,
+                y: 0
+            };
+        }
+    """, """
+        struct S { x: i32, y: i32 }
+        fn foo() {
+            S { x: 0, y: 0 };
+        }
+    """)
+
+    fun `test no line breaks`() = doUnavailableTest("""
+        struct S { x: i32, y: i32, z: i32 }
+        fn foo() {
+            S { /*caret*/x: 0, y: 0, z: 0 };
+        }
+    """)
+
+    fun `test has some line breaks`() = doAvailableTest("""
+        struct S { x: i32, y: i32, z: i32 }
+        fn foo() {
+            S { x: 0, /*caret*/y: 0, 
+                z: 0 };
+        }
+    """, """
+        struct S { x: i32, y: i32, z: i32 }
+        fn foo() {
+            S { x: 0, y: 0, z: 0 };
+        }
+    """)
+
+    fun `test has some line breaks 2`() = doAvailableTest("""
+        struct S { x: i32, y: i32, z: i32 }
+        fn foo() {
+            S { 
+                x: 0, y: 0, z: 0/*caret*/ 
+            };
+        }
+    """, """
+        struct S { x: i32, y: i32, z: i32 }
+        fn foo() {
+            S { x: 0, y: 0, z: 0 };
+        }
+    """)
+
+    fun `test has comment`() = doUnavailableTest("""
+        struct S { x: i32, y: i32, z: i32 }
+        fn foo() {
+            S { /*caret*/x: 0, /* comment */ y: 0, z: 0 };
+        }
+    """)
+
+    fun `test has comment 2`() = doAvailableTest("""
+        struct S { x: i32, y: i32, z: i32 }
+        fn foo() {
+            S { /*caret*/x: 0, /*
+                comment
+                */ y: 0,
+                z: 0
+            };
+        }
+    """, """
+        struct S { x: i32, y: i32, z: i32 }
+        fn foo() {
+            S { x: 0, /*
+                comment
+                */ y: 0, z: 0 };
+        }
+    """)
+
+    fun `test init shorthand`() = doAvailableTest("""
+        struct S {  x: i32, y: i32, z: i32 }
+        fn foo() {
+            let x = 1;
+            let y = 2;
+            S {
+                /*caret*/x,
+                z: 3,
+                y
+            };
+        }
+   """, """
+        struct S {  x: i32, y: i32, z: i32 }
+        fn foo() {
+            let x = 1;
+            let y = 2;
+            S { x, z: 3, y };
+        }
+    """)
+
+    fun `test dotdot`() = doAvailableTest("""
+        struct S {  x: i32, y: i32, z: i32 }
+        fn foo() {
+            let s = S { x: 0, y: 1, z: 2 };
+            S {
+                /*caret*/x: 0,
+                ..s
+            };
+        }
+    """, """
+        struct S {  x: i32, y: i32, z: i32 }
+        fn foo() {
+            let s = S { x: 0, y: 1, z: 2 };
+            S { x: 0, ..s };
+        }
+    """)
+
+    fun `test enum`() = doAvailableTest("""
+        enum E { A { x: i32, y: i32, z: i32 } }
+        fn foo() {
+            let e = E::A {
+                /*caret*/ x: 0,
+                y: 0,
+                z: 0
+            };
+        }
+   """, """
+        enum E { A { x: i32, y: i32, z: i32 } }
+        fn foo() {
+            let e = E::A { x: 0, y: 0, z: 0 };
+        }
+    """)
+}


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/4322
I basically copy-pasted the tests from the struct fields and changed them to work with struct literal fields.

Note:
Test with a single line comment produces this formatting on a struct:
```rust
struct S {
    x: i32,
    // comment x
    y: i32,
    z: i32 // comment z
}
```
and this formatting with a literal:
```rust
struct S {  x: i32, y: i32, z: i32 }
fn foo() {
    S {
        x: 0, // comment x
        y: 0,
        z: 0 // comment z
    };
}
```
Not sure if that's important. Should I investigate?
Also, should I add the same thing for Enum literals?