### PR TITLE
INSP & ANN: Disable analysis on cfg-disabled code

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsAnnotationHolder.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsAnnotationHolder.kt
@@ -1,0 +1,22 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+import com.intellij.lang.annotation.Annotation
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.AnnotationSession
+import com.intellij.psi.PsiElement
+import org.rust.ide.utils.isEnabledByCfg
+
+class RsAnnotationHolder(val holder: AnnotationHolder) {
+    fun createErrorAnnotation(element: PsiElement, message: String?): Annotation? =
+        if (element.isEnabledByCfg) holder.createErrorAnnotation(element, message) else null
+
+    fun createWeakWarningAnnotation(element: PsiElement, message: String?): Annotation? =
+        if (element.isEnabledByCfg) holder.createWeakWarningAnnotation(element, message) else null
+
+    val currentAnnotationSession: AnnotationSession = holder.currentAnnotationSession
+}

--- a/src/main/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotator.kt
@@ -1,0 +1,30 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.rust.ide.colors.RsColor
+import org.rust.lang.core.psi.ext.RsDocAndAttributeOwner
+import org.rust.lang.core.psi.ext.isEnabledByCfg
+import org.rust.lang.core.psi.ext.rangeWithSurroundingLineBreaks
+import org.rust.openapiext.isUnitTestMode
+
+class RsCfgDisabledCodeAnnotator : RsAnnotatorBase() {
+    override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
+        if (element is RsDocAndAttributeOwner && !element.isEnabledByCfg) {
+            holder.createCfgDisabledAnnotation(element.rangeWithSurroundingLineBreaks)
+        }
+    }
+
+    private fun AnnotationHolder.createCfgDisabledAnnotation(textRange: TextRange) {
+        val color = RsColor.CFG_DISABLED_CODE
+        val severity = if (isUnitTestMode) color.testSeverity else HighlightSeverity.INFORMATION
+        createAnnotation(severity, textRange, "Conditionally disabled code").textAttributes = color.textAttributesKey
+    }
+}

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import org.rust.ide.colors.RsColor
 import org.rust.ide.highlight.RsHighlighter
+import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyPrimitive
@@ -27,6 +28,8 @@ class RsHighlightingAnnotator : RsAnnotatorBase() {
             element is RsReferenceElement -> highlightReference(element)
             else -> highlightNotReference(element)
         } ?: return
+
+        if (!element.isEnabledByCfg) return
 
         val severity = if (isUnitTestMode) color.testSeverity else HighlightSeverity.INFORMATION
         holder.createAnnotation(severity, partToHighlight, null).textAttributes = color.textAttributesKey

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotator.kt
@@ -9,6 +9,7 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.psi.PsiElement
 import org.rust.ide.colors.RsColor
+import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.psi.RsPatBinding
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.RsSelfParameter
@@ -43,6 +44,7 @@ class RsHighlightingMutableAnnotator : RsAnnotatorBase() {
     }
 
     private fun distinctAnnotation(element: PsiElement, ref: RsElement, holder: AnnotationHolder) {
+        if (!element.isEnabledByCfg) return
         val color = annotationFor(ref) ?: return
         if (ref.isMut) {
             @Suppress("NAME_SHADOWING")

--- a/src/main/kotlin/org/rust/ide/colors/RsColors.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RsColors.kt
@@ -71,7 +71,8 @@ enum class RsColor(humanName: String, val default: TextAttributesKey? = null) {
     PARENTHESES("Braces and Operators//Parentheses", Default.PARENTHESES),
 
     ATTRIBUTE("Attribute", Default.METADATA),
-    UNSAFE_CODE("Unsafe code")
+    UNSAFE_CODE("Unsafe code"),
+    CFG_DISABLED_CODE("Conditionally disabled code"),
     ;
 
     val textAttributesKey = TextAttributesKey.createTextAttributesKey("org.rust.$name", default)

--- a/src/main/kotlin/org/rust/ide/hints/RsInlayTypeHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/RsInlayTypeHintsProvider.kt
@@ -18,6 +18,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.ui.components.CheckBox
 import com.intellij.ui.layout.panel
 import com.intellij.util.ui.JBUI
+import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -90,6 +91,7 @@ class RsInlayTypeHintsProvider : InlayHintsProvider<RsInlayTypeHintsProvider.Set
             override fun collect(element: PsiElement, editor: Editor, sink: InlayHintsSink): Boolean {
                 if (file.project.service<DumbService>().isDumb) return true
                 if (element !is RsElement) return true
+                if (!element.isEnabledByCfg) return true
 
                 if (settings.showForVariables) {
                     presentVariable(element)

--- a/src/main/kotlin/org/rust/ide/hints/RsPlainParameterHint.kt
+++ b/src/main/kotlin/org/rust/ide/hints/RsPlainParameterHint.kt
@@ -9,6 +9,7 @@ import com.intellij.codeInsight.hints.InlayInfo
 import com.intellij.codeInsight.hints.Option
 import com.intellij.psi.PsiElement
 import org.rust.ide.utils.CallInfo
+import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.psi.RsCallExpr
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsMethodCall
@@ -41,6 +42,7 @@ enum class RsPlainParameterHint(desc: String, enabled: Boolean) : RsPlainHint {
                 is RsMethodCall -> (CallInfo.resolve(elem) to elem.valueArgumentList)
                 else -> return emptyList()
             }
+            if (!elem.isEnabledByCfg) return emptyList()
             if (callInfo == null) return emptyList()
 
             val hints = buildList<String> {

--- a/src/main/kotlin/org/rust/ide/inspections/RsApproxConstantInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsApproxConstantInspection.kt
@@ -5,15 +5,14 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
-import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsLitExpr
 import org.rust.lang.core.psi.RsLiteralKind
 import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.kind
 
 class RsApproxConstantInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
         override fun visitLitExpr(o: RsLitExpr) {
             val literal = o.kind
             if (literal is RsLiteralKind.Float) {
@@ -52,6 +51,6 @@ data class PredefinedConstant(val name: String, val value: Double, val minDigits
     fun matches(value: Double) = Math.abs(value - this.value) < accuracy
 }
 
-private fun ProblemsHolder.registerProblem(element: PsiElement, type: String, constant: PredefinedConstant) {
+private fun RsProblemsHolder.registerProblem(element: RsElement, type: String, constant: PredefinedConstant) {
     registerProblem(element, "Approximate value of `std::$type::consts::${constant.name}` found. Consider using it directly.")
 }

--- a/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
@@ -7,7 +7,6 @@ package org.rust.ide.inspections
 
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
 import org.rust.lang.core.macros.expansionContext
 import org.rust.lang.core.psi.*
@@ -20,7 +19,7 @@ import org.rust.lang.core.types.type
 import org.rust.openapiext.Testmark
 
 class RsAssertEqualInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
 
         override fun visitMacroCall(o: RsMacroCall) {
             if (o.macroName != "assert") return

--- a/src/main/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import org.rust.ide.annotator.fixes.AddMutableFix
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.containerExpr
@@ -21,14 +20,14 @@ import org.rust.lang.utils.addToHolder
 
 class RsAssignToImmutableInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitBinaryExpr(expr: RsBinaryExpr) {
                 if (expr.isAssignBinaryExpr) checkAssignment(expr, holder)
             }
         }
 
-    private fun checkAssignment(expr: RsBinaryExpr, holder: ProblemsHolder) {
+    private fun checkAssignment(expr: RsBinaryExpr, holder: RsProblemsHolder) {
         val left = unwrapParenExprs(expr.left).takeIf { it.isImmutable } ?: return
 
         when (left) {
@@ -38,14 +37,14 @@ class RsAssignToImmutableInspection : RsLocalInspectionTool() {
         }
     }
 
-    private fun registerDereferenceProblem(left: RsUnaryExpr, holder: ProblemsHolder, expr: RsBinaryExpr) {
+    private fun registerDereferenceProblem(left: RsUnaryExpr, holder: RsProblemsHolder, expr: RsBinaryExpr) {
         when (left.expr?.type) {
             is TyReference -> registerProblem(holder, "immutable borrowed content", expr)
             is TyPointer -> registerProblem(holder, "immutable dereference of raw pointer", expr)
         }
     }
 
-    private fun registerProblem(holder: ProblemsHolder, message: String, expr: RsExpr, assigneeExpr: RsExpr? = null) {
+    private fun registerProblem(holder: RsProblemsHolder, message: String, expr: RsExpr, assigneeExpr: RsExpr? = null) {
         val fix = assigneeExpr?.let { AddMutableFix.createIfCompatible(it) }
         RsDiagnostic.CannotAssignToImmutable(expr, message, fix).addToHolder(holder)
     }

--- a/src/main/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import org.rust.ide.annotator.fixes.AddMutableFix
 import org.rust.ide.inspections.fixes.DeriveCopyFix
 import org.rust.ide.inspections.fixes.InitializeWithDefaultValueFix
@@ -18,7 +17,7 @@ import org.rust.lang.core.types.type
 
 class RsBorrowCheckerInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitMethodCall(o: RsMethodCall) {
                 val fn = o.reference.resolve() as? RsFunction ?: return
@@ -52,21 +51,21 @@ class RsBorrowCheckerInspection : RsLocalInspectionTool() {
             }
         }
 
-    private fun registerProblem(holder: ProblemsHolder, expr: RsExpr, nameExpr: RsExpr) {
+    private fun registerProblem(holder: RsProblemsHolder, expr: RsExpr, nameExpr: RsExpr) {
         val fix = AddMutableFix.createIfCompatible(nameExpr)
         holder.registerProblem(expr, "Cannot borrow immutable local variable `${nameExpr.text}` as mutable", fix)
     }
 
-    private fun registerUseOfMovedValueProblem(holder: ProblemsHolder, use: RsElement) {
+    private fun registerUseOfMovedValueProblem(holder: RsProblemsHolder, use: RsElement) {
         val fix = DeriveCopyFix.createIfCompatible(use)
         holder.registerProblem(use, "Use of moved value", fix)
     }
 
-    private fun registerMoveProblem(holder: ProblemsHolder, element: RsElement) {
+    private fun registerMoveProblem(holder: RsProblemsHolder, element: RsElement) {
         holder.registerProblem(element, "Cannot move")
     }
 
-    private fun registerUseOfUninitializedVariableProblem(holder: ProblemsHolder, use: RsElement) {
+    private fun registerUseOfUninitializedVariableProblem(holder: RsProblemsHolder, use: RsElement) {
         val fix = InitializeWithDefaultValueFix.createIfCompatible(use)
         holder.registerProblem(use, "Use of possibly uninitialized variable", fix)
     }

--- a/src/main/kotlin/org/rust/ide/inspections/RsCStringPointerInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsCStringPointerInspection.kt
@@ -5,14 +5,13 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.parentDotExpr
 
 class RsCStringPointerInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Unsafe CString pointer"
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitMethodCall(asPtrCall: RsMethodCall) {
                 if (asPtrCall.referenceName != "as_ptr") return

--- a/src/main/kotlin/org/rust/ide/inspections/RsDanglingElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDanglingElseInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
@@ -27,7 +26,7 @@ import org.rust.lang.core.psi.ext.startOffset
 class RsDanglingElseInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Dangling else"
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitElseBranch(expr: RsElseBranch) {
                 val elseEl = expr.`else`

--- a/src/main/kotlin/org/rust/ide/inspections/RsDeprecationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDeprecationInspection.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.inspections
 
 import com.intellij.codeInspection.ProblemHighlightType.LIKE_DEPRECATED
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import org.rust.lang.core.psi.RsFile
@@ -20,7 +19,7 @@ class RsDeprecationInspection : RsLintInspection() {
 
     override val lint: RsLint = RsLint.Deprecated
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = object : RsVisitor() {
         override fun visitElement(ref: RsElement) {
             // item is non-inline module declaration or not reference element
             if (ref is RsModDeclItem || ref !is RsWeakReferenceElement) return
@@ -38,7 +37,7 @@ class RsDeprecationInspection : RsLintInspection() {
         }
     }
 
-    private fun checkAndRegisterAsDeprecated(identifier: PsiElement, original: PsiElement, holder: ProblemsHolder) {
+    private fun checkAndRegisterAsDeprecated(identifier: PsiElement, original: PsiElement, holder: RsProblemsHolder) {
         if (original is RsOuterAttributeOwner) {
             val attr = original.queryAttributes.deprecatedAttribute ?: return
             holder.registerProblem(identifier, attr.extractDeprecatedMessage(identifier.text), LIKE_DEPRECATED)

--- a/src/main/kotlin/org/rust/ide/inspections/RsDiagnosticBasedInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDiagnosticBasedInspection.kt
@@ -5,21 +5,20 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsInferenceContextOwner
 import org.rust.lang.core.types.inference
 import org.rust.lang.utils.addToHolder
 
 abstract class RsDiagnosticBasedInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
         override fun visitFunction(o: RsFunction) = collectDiagnostics(holder, o)
         override fun visitConstant(o: RsConstant) = collectDiagnostics(holder, o)
         override fun visitArrayType(o: RsArrayType) = collectDiagnostics(holder, o)
         override fun visitVariantDiscriminant(o: RsVariantDiscriminant) = collectDiagnostics(holder, o)
     }
 
-    private fun collectDiagnostics(holder: ProblemsHolder, element: RsInferenceContextOwner) {
+    private fun collectDiagnostics(holder: RsProblemsHolder, element: RsInferenceContextOwner) {
         for (it in element.inference.diagnostics) {
             if (it.inspectionClass == javaClass) it.addToHolder(holder)
         }

--- a/src/main/kotlin/org/rust/ide/inspections/RsDoubleNegInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDoubleNegInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsUnaryExpr
 import org.rust.lang.core.psi.RsVisitor
@@ -19,7 +18,7 @@ import org.rust.lang.core.psi.RsVisitor
 class RsDoubleNegInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Double negation"
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitUnaryExpr(expr: RsUnaryExpr) {
                 if (expr.isNegation && expr.expr.isNegation) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsDropRefInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDropRefInspection.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.inspections
 
 import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemsHolder
 import org.rust.ide.inspections.fixes.RemoveRefFix
 import org.rust.lang.core.psi.RsCallExpr
 import org.rust.lang.core.psi.RsPathExpr
@@ -22,12 +21,12 @@ import org.rust.lang.core.types.type
 class RsDropRefInspection : RsLocalInspectionTool() {
     override fun getDisplayName(): String = "Drop reference"
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitCallExpr(expr: RsCallExpr) = inspectExpr(expr, holder)
         }
 
-    fun inspectExpr(expr: RsCallExpr, holder: ProblemsHolder) {
+    fun inspectExpr(expr: RsCallExpr, holder: RsProblemsHolder) {
         val pathExpr = expr.expr as? RsPathExpr ?: return
 
         val fn = pathExpr.path.reference.resolve() ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
@@ -37,7 +37,6 @@ import org.rust.ide.annotator.createAnnotationsForFile
 import org.rust.ide.annotator.createDisposableOnAnyPsiChange
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.ext.ancestorOrSelf
-import org.rust.lang.core.psi.ext.cargoProject
 import org.rust.lang.core.psi.ext.containingCargoPackage
 import org.rust.stdext.buildList
 import java.util.*

--- a/src/main/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspection.kt
@@ -7,7 +7,6 @@ package org.rust.ide.inspections
 
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElementVisitor
 import org.rust.lang.core.cfg.ExitPoint
@@ -27,14 +26,14 @@ import org.rust.lang.core.types.type
 class RsExtraSemicolonInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Extra semicolon"
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
         object : RsVisitor() {
             override fun visitFunction(o: RsFunction) = inspect(holder, o)
         }
 }
 
 
-private fun inspect(holder: ProblemsHolder, fn: RsFunction) {
+private fun inspect(holder: RsProblemsHolder, fn: RsFunction) {
     val retType = fn.retType?.typeReference ?: return
     if (retType.type == TyUnit) return
     ExitPoint.process(fn) { exitPoint ->

--- a/src/main/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspection.kt
@@ -8,7 +8,6 @@ package org.rust.ide.inspections
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
 import org.rust.lang.core.psi.RsPathExpr
 import org.rust.lang.core.psi.RsStructLiteralField
@@ -16,7 +15,7 @@ import org.rust.lang.core.psi.RsVisitor
 
 
 class RsFieldInitShorthandInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
         override fun visitStructLiteralField(o: RsStructLiteralField) {
             val init = o.expr ?: return
             if (!(init is RsPathExpr && init.text == o.identifier?.text)) return
@@ -36,8 +35,7 @@ class RsFieldInitShorthandInspection : RsLocalInspectionTool() {
     }
 
     companion object {
-        fun applyShorthandInit(field: RsStructLiteralField)
-        {
+        fun applyShorthandInit(field: RsStructLiteralField) {
             field.expr?.delete()
             field.colon?.delete()
         }

--- a/src/main/kotlin/org/rust/ide/inspections/RsImplicitTraitObjectInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsImplicitTraitObjectInspection.kt
@@ -7,7 +7,6 @@ package org.rust.ide.inspections
 
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElementVisitor
 import org.rust.lang.core.psi.RsPsiFactory
@@ -19,7 +18,7 @@ import org.rust.lang.core.psi.ext.isEdition2018
 import org.rust.lang.core.resolve.ref.deepResolve
 
 class RsImplicitTraitObjectInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
         object : RsVisitor() {
             override fun visitTypeReference(typeReference: RsTypeReference) {
                 if (!typeReference.isEdition2018) return

--- a/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt
@@ -5,6 +5,65 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.*
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiFile
+import org.rust.ide.utils.isEnabledByCfg
 
-abstract class RsLocalInspectionTool : LocalInspectionTool()
+abstract class RsLocalInspectionTool : LocalInspectionTool() {
+    final override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+        buildVisitor(RsProblemsHolder(holder), isOnTheFly) ?: super.buildVisitor(holder, isOnTheFly)
+
+    open fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor? = null
+}
+
+class RsProblemsHolder(private val holder: ProblemsHolder) {
+    val manager: InspectionManager get() = holder.manager
+    val file: PsiFile get() = holder.file
+    val project: Project get() = holder.project
+    val isOnTheFly: Boolean get() = holder.isOnTheFly
+
+    fun registerProblem(element: PsiElement, descriptionTemplate: String, vararg fixes: LocalQuickFix?) {
+        if (element.isEnabledByCfg) {
+            holder.registerProblem(element, descriptionTemplate, *fixes)
+        }
+    }
+
+    fun registerProblem(
+        element: PsiElement,
+        descriptionTemplate: String,
+        highlightType: ProblemHighlightType,
+        vararg fixes: LocalQuickFix
+    ) {
+        if (element.isEnabledByCfg) {
+            holder.registerProblem(element, descriptionTemplate, highlightType, *fixes)
+        }
+    }
+
+    fun registerProblem(problemDescriptor: ProblemDescriptor) {
+        if (problemDescriptor.psiElement.isEnabledByCfg) {
+            holder.registerProblem(problemDescriptor)
+        }
+    }
+
+    fun registerProblem(element: PsiElement, rangeInElement: TextRange, message: String, vararg fixes: LocalQuickFix?) {
+        if (element.isEnabledByCfg) {
+            holder.registerProblem(element, rangeInElement, message, *fixes)
+        }
+    }
+
+    fun registerProblem(
+        element: PsiElement,
+        message: String,
+        highlightType: ProblemHighlightType,
+        rangeInElement: TextRange,
+        vararg fixes: LocalQuickFix?
+    ) {
+        if (element.isEnabledByCfg) {
+            holder.registerProblem(element, message, highlightType, rangeInElement, *fixes)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/RsMissingElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsMissingElseInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
@@ -25,7 +24,7 @@ import org.rust.lang.core.psi.ext.startOffset
 class RsMissingElseInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Missing else"
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitExprStmt(expr: RsExprStmt) {
                 val firstIf = expr.extractIf() ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/RsNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsNamingInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.util.PsiTreeUtil
@@ -27,7 +26,7 @@ abstract class RsNamingInspection(
 ) : RsLintInspection() {
     override fun getDisplayName() = "$elementTitle naming convention"
 
-    fun inspect(id: PsiElement?, holder: ProblemsHolder, fix: Boolean = true) {
+    fun inspect(id: PsiElement?, holder: RsProblemsHolder, fix: Boolean = true) {
         if (id == null) return
         val name = id.unescapedText
         val (isOk, suggestedName) = checkName(name)
@@ -151,7 +150,7 @@ fun String.toSnakeCase(upper: Boolean): String {
 //
 
 class RsArgumentNamingInspection : RsSnakeCaseNamingInspection("Argument") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitPatBinding(el: RsPatBinding) {
                 if (el.parent?.parent is RsValueParameter) {
@@ -162,7 +161,7 @@ class RsArgumentNamingInspection : RsSnakeCaseNamingInspection("Argument") {
 }
 
 class RsConstNamingInspection : RsUpperCaseNamingInspection("Constant") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitConstant(el: RsConstant) {
                 if (el.kind == RsConstantKind.CONST) {
@@ -173,7 +172,7 @@ class RsConstNamingInspection : RsUpperCaseNamingInspection("Constant") {
 }
 
 class RsStaticConstNamingInspection : RsUpperCaseNamingInspection("Static constant") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitConstant(el: RsConstant) {
                 if (el.kind != RsConstantKind.CONST) {
@@ -184,21 +183,21 @@ class RsStaticConstNamingInspection : RsUpperCaseNamingInspection("Static consta
 }
 
 class RsEnumNamingInspection : RsCamelCaseNamingInspection("Type", "Enum") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitEnumItem(el: RsEnumItem) = inspect(el.identifier, holder)
         }
 }
 
 class RsEnumVariantNamingInspection : RsCamelCaseNamingInspection("Enum variant") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitEnumVariant(el: RsEnumVariant) = inspect(el.identifier, holder)
         }
 }
 
 class RsFunctionNamingInspection : RsSnakeCaseNamingInspection("Function") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitFunction(el: RsFunction) {
                 if (el.owner is RsAbstractableOwner.Free) {
@@ -209,7 +208,7 @@ class RsFunctionNamingInspection : RsSnakeCaseNamingInspection("Function") {
 }
 
 class RsMethodNamingInspection : RsSnakeCaseNamingInspection("Method") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitFunction(el: RsFunction) = when (el.owner) {
                 is RsAbstractableOwner.Trait, is RsAbstractableOwner.Impl -> inspect(el.identifier, holder)
@@ -219,21 +218,21 @@ class RsMethodNamingInspection : RsSnakeCaseNamingInspection("Method") {
 }
 
 class RsLifetimeNamingInspection : RsSnakeCaseNamingInspection("Lifetime") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitLifetimeParameter(el: RsLifetimeParameter) = inspect(el.quoteIdentifier, holder)
         }
 }
 
 class RsMacroNamingInspection : RsSnakeCaseNamingInspection("Macro") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitMacro(el: RsMacro) = inspect(el.nameIdentifier, holder)
         }
 }
 
 class RsModuleNamingInspection : RsSnakeCaseNamingInspection("Module") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitModDeclItem(el: RsModDeclItem) = inspect(el.identifier, holder)
             override fun visitModItem(el: RsModItem) = inspect(el.identifier, holder)
@@ -241,28 +240,28 @@ class RsModuleNamingInspection : RsSnakeCaseNamingInspection("Module") {
 }
 
 class RsStructNamingInspection : RsCamelCaseNamingInspection("Type", "Struct") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitStructItem(el: RsStructItem) = inspect(el.identifier, holder)
         }
 }
 
 class RsFieldNamingInspection : RsSnakeCaseNamingInspection("Field") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitNamedFieldDecl(el: RsNamedFieldDecl) = inspect(el.identifier, holder)
         }
 }
 
 class RsTraitNamingInspection : RsCamelCaseNamingInspection("Trait") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitTraitItem(el: RsTraitItem) = inspect(el.identifier, holder)
         }
 }
 
 class RsTypeAliasNamingInspection : RsCamelCaseNamingInspection("Type", "Type alias") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitTypeAlias(el: RsTypeAlias) {
                 if (el.owner is RsAbstractableOwner.Free) {
@@ -273,7 +272,7 @@ class RsTypeAliasNamingInspection : RsCamelCaseNamingInspection("Type", "Type al
 }
 
 class RsAssocTypeNamingInspection : RsCamelCaseNamingInspection("Type", "Associated type") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitTypeAlias(el: RsTypeAlias) {
                 if (el.owner is RsAbstractableOwner.Trait) {
@@ -285,14 +284,14 @@ class RsAssocTypeNamingInspection : RsCamelCaseNamingInspection("Type", "Associa
 
 
 class RsTypeParameterNamingInspection : RsCamelCaseNamingInspection("Type parameter") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitTypeParameter(el: RsTypeParameter) = inspect(el.identifier, holder)
         }
 }
 
 class RsVariableNamingInspection : RsSnakeCaseNamingInspection("Variable") {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitPatBinding(el: RsPatBinding) {
                 val pattern = PsiTreeUtil.getTopmostParentOfType(el, RsPat::class.java) ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/RsNeedlessLifetimesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsNeedlessLifetimesInspection.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.inspections
 
 import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.util.TextRange
 import org.rust.ide.inspections.ReferenceLifetime.*
 import org.rust.ide.inspections.fixes.ElideLifetimesFix
@@ -24,7 +23,7 @@ import org.rust.stdext.chain
  * Corresponds to needless_lifetimes lint from Rust Clippy.
  */
 class RsNeedlessLifetimesInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
         override fun visitFunction(fn: RsFunction) {
             if (couldUseElision(fn)) registerProblem(holder, fn)
         }
@@ -231,7 +230,7 @@ private fun checkLifetimesUsedInBody(body: RsBlock?): Boolean {
     return checker.lifetimesUsedInBody
 }
 
-private fun registerProblem(holder: ProblemsHolder, fn: RsFunction) {
+private fun registerProblem(holder: RsProblemsHolder, fn: RsFunction) {
     holder.registerProblem(
         fn,
         "Explicit lifetimes given in parameter types where they could be elided",

--- a/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import org.rust.ide.annotator.fixes.AddMutableFix
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorStrict
@@ -17,7 +16,7 @@ import org.rust.lang.utils.addToHolder
 
 class RsReassignImmutableInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitBinaryExpr(expr: RsBinaryExpr) {
                 val left = expr.left.takeIf { it.isImmutable } ?: return
@@ -35,7 +34,7 @@ class RsReassignImmutableInspection : RsLocalInspectionTool() {
             }
         }
 
-    private fun registerProblem(holder: ProblemsHolder, expr: RsExpr, nameExpr: RsExpr) {
+    private fun registerProblem(holder: RsProblemsHolder, expr: RsExpr, nameExpr: RsExpr) {
         val fix = AddMutableFix.createIfCompatible(nameExpr)
         RsDiagnostic.CannotReassignToImmutable(expr, fix).addToHolder(holder)
     }

--- a/src/main/kotlin/org/rust/ide/inspections/RsSelfConventionInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSelfConventionInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsVisitor
@@ -17,7 +16,7 @@ import org.rust.stdext.typeAscription
 
 class RsSelfConventionInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitFunction(m: RsFunction) {
                 val traitOrImpl = when (val owner = m.owner) {
@@ -70,7 +69,7 @@ private val RsFunction.selfSignature: SelfSignature
 
 data class SelfConvention(val prefix: String, val selfSignatures: Collection<SelfSignature>)
 
-private fun ProblemsHolder.registerProblem(element: PsiElement, convention: SelfConvention) {
+private fun RsProblemsHolder.registerProblem(element: PsiElement, convention: SelfConvention) {
     val selfTypes = convention.selfSignatures.joinToString(" or ") { it.description }
 
     val description = "methods called `${convention.prefix}*` usually take $selfTypes; " +

--- a/src/main/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import org.rust.ide.inspections.fixes.SimplifyBooleanExpressionFix
 import org.rust.ide.utils.BooleanExprSimplifier
 import org.rust.ide.utils.isPure
@@ -18,7 +17,7 @@ import org.rust.lang.core.psi.RsVisitor
 class RsSimplifyBooleanExpressionInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Simplify boolean expression"
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
 
         override fun visitExpr(expr: RsExpr) {
             if (expr.isPure() == true && BooleanExprSimplifier.canBeSimplified(expr)) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspection.kt
@@ -7,7 +7,6 @@ package org.rust.ide.inspections
 
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsFormatMacroArgument
@@ -21,7 +20,7 @@ import org.rust.lang.core.psi.ext.macroName
 class RsSimplifyPrintInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "println!(\"\") usage"
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
 
         override fun visitMacroCall(o: RsMacroCall) {
             val macroName = o.macroName

--- a/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
@@ -7,7 +7,6 @@ package org.rust.ide.inspections
 
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.tree.IElementType
@@ -17,7 +16,7 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.Testmark
 
 class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
         override fun visitImplItem(impl: RsImplItem) {
             val trait = impl.traitRef?.resolveToTrait() ?: return
             val typeRef = impl.typeReference ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
@@ -27,7 +26,7 @@ import org.rust.lang.core.psi.ext.startOffset
 class RsSuspiciousAssignmentInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Suspicious assignment"
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
         object : RsVisitor() {
             override fun visitBinaryExpr(expr: RsBinaryExpr) {
                 if (expr.operator.text != "=") return

--- a/src/main/kotlin/org/rust/ide/inspections/RsTraitImplementationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsTraitImplementationInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElementVisitor
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsImplItem
@@ -19,7 +18,7 @@ import org.rust.lang.utils.addToHolder
 
 class RsTraitImplementationInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = object : RsVisitor() {
         override fun visitImplItem(impl: RsImplItem) {
             val traitRef = impl.traitRef ?: return
             val trait = traitRef.resolveToTrait() ?: return
@@ -47,7 +46,7 @@ class RsTraitImplementationInspection : RsLocalInspectionTool() {
     }
 
     private fun checkTraitFnImplParams(
-        holder: ProblemsHolder,
+        holder: RsProblemsHolder,
         fn: RsFunction,
         superFn: RsFunction,
         traitName: String

--- a/src/main/kotlin/org/rust/ide/inspections/RsTryMacroInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsTryMacroInspection.kt
@@ -7,10 +7,12 @@ package org.rust.ide.inspections
 
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
 import org.rust.lang.core.macros.isExprOrStmtContext
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsTryExpr
+import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.macroName
 import org.rust.lang.core.psi.ext.replaceWithExpr
 
@@ -20,7 +22,7 @@ import org.rust.lang.core.psi.ext.replaceWithExpr
 class RsTryMacroInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "try! macro usage"
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
         override fun visitMacroCall(o: RsMacroCall) {
             val isApplicable = o.isExprOrStmtContext && o.macroName == "try" && o.exprMacroArgument?.expr != null
             if (!isApplicable) return

--- a/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
@@ -7,7 +7,6 @@ package org.rust.ide.inspections
 
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.codeInspection.ui.MultipleCheckboxOptionsPanel
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElementVisitor
@@ -29,7 +28,7 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
 
     override fun getDisplayName() = "Unresolved reference"
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
         object : RsVisitor() {
             override fun visitPath(path: RsPath) {
                 if (path.parent is RsPath) return
@@ -57,7 +56,7 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
             }
         }
 
-    private fun ProblemsHolder.registerProblem(
+    private fun RsProblemsHolder.registerProblem(
         element: RsElement,
         candidates: List<ImportCandidate>,
         referenceName: String?,

--- a/src/main/kotlin/org/rust/ide/inspections/RsVariableMutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsVariableMutableInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.search.LocalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
@@ -18,14 +17,14 @@ import org.rust.lang.core.psi.ext.selfParameter
 
 class RsVariableMutableInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "No mutable required"
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitPatBinding(o: RsPatBinding) {
                 if (!o.mutability.isMut) return
                 val block = o.ancestorStrict<RsBlock>() ?: o.ancestorStrict<RsFunction>() ?: return
                 if (ReferencesSearch.search(o, LocalSearchScope(block))
-                    .asSequence()
-                    .any { checkOccurrenceNeedMutable(it.element.parent) }) return
+                        .asSequence()
+                        .any { checkOccurrenceNeedMutable(it.element.parent) }) return
                 if (block.descendantsOfType<RsMacroCall>().any { checkExprPosition(o, it) }) return
                 holder.registerProblem(
                     o,

--- a/src/main/kotlin/org/rust/ide/inspections/RsWhileTrueLoopInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWhileTrueLoopInspection.kt
@@ -7,7 +7,6 @@ package org.rust.ide.inspections
 
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import org.rust.ide.utils.skipParenExprDown
@@ -20,7 +19,7 @@ import org.rust.lang.core.psi.ext.endOffsetInParent
 class RsWhileTrueLoopInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "While true loop"
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
         override fun visitWhileExpr(o: RsWhileExpr) {
             val condition = o.condition ?: return
             val expr = condition.skipParenExprDown() as? RsLitExpr ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import org.rust.lang.core.psi.RsBaseType
 import org.rust.lang.core.psi.RsRefLikeType
 import org.rust.lang.core.psi.RsVisitor
@@ -16,7 +15,7 @@ import org.rust.lang.utils.addToHolder
 
 class RsWrongLifetimeParametersNumberInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitBaseType(type: RsBaseType) {
                 // Don't apply generic declaration checks to Fn-traits and `Self`

--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongTypeParametersNumberInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongTypeParametersNumberInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.codeInspection.ProblemsHolder
 import org.rust.ide.inspections.fixes.RemoveTypeParameter
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
@@ -16,7 +15,7 @@ import org.rust.lang.core.psi.ext.RsGenericDeclaration
  */
 class RsWrongTypeParametersNumberInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitBaseType(type: RsBaseType) {
                 // Don't apply generic declaration checks to Fn-traits and `Self`
@@ -29,10 +28,10 @@ class RsWrongTypeParametersNumberInspection : RsLocalInspectionTool() {
             override fun visitMethodCall(o: RsMethodCall) = checkMethod(holder, o)
         }
 
-    private fun checkMethod(holder: ProblemsHolder, o: RsElement) {
+    private fun checkMethod(holder: RsProblemsHolder, o: RsElement) {
         val (actualArguments, declaration) = when (o) {
             is RsMethodCall ->
-                o.typeArgumentList  to o.reference.resolve()
+                o.typeArgumentList to o.reference.resolve()
 
             is RsCallExpr ->
                 (o.expr as? RsPathExpr)?.path?.typeArgumentList to (o.expr as? RsPathExpr)?.path?.reference?.resolve()

--- a/src/main/kotlin/org/rust/ide/inspections/checkMatch/RsMatchCheckInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/checkMatch/RsMatchCheckInspection.kt
@@ -6,10 +6,10 @@
 package org.rust.ide.inspections.checkMatch
 
 import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.rust.ide.inspections.RsLocalInspectionTool
+import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.ide.inspections.checkMatch.Constructor.Companion.allConstructors
 import org.rust.ide.inspections.checkMatch.Usefulness.*
 import org.rust.ide.inspections.fixes.SubstituteTextFix
@@ -29,7 +29,7 @@ import org.rust.lang.utils.addToHolder
 class RsMatchCheckInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Match Check"
 
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
         override fun visitMatchExpr(matchExpr: RsMatchExpr) {
             val exprType = matchExpr.expr?.type ?: return
             if (exprType.containsTyOfClass(TyUnknown::class.java)) return
@@ -44,7 +44,7 @@ class RsMatchCheckInspection : RsLocalInspectionTool() {
 }
 
 
-private fun checkUselessArm(match: RsMatchExpr, holder: ProblemsHolder) {
+private fun checkUselessArm(match: RsMatchExpr, holder: RsProblemsHolder) {
     val matrix = match.arms
         .calculateMatrix()
         .takeIf { it.type !is TyUnknown }
@@ -83,7 +83,7 @@ private fun checkUselessArm(match: RsMatchExpr, holder: ProblemsHolder) {
     }
 }
 
-private fun checkExhaustive(match: RsMatchExpr, holder: ProblemsHolder) {
+private fun checkExhaustive(match: RsMatchExpr, holder: RsProblemsHolder) {
     val matrix = match.arms
         .filter { it.matchArmGuard == null }
         .calculateMatrix()

--- a/src/main/kotlin/org/rust/ide/utils/CfgUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/CfgUtils.kt
@@ -1,0 +1,17 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.utils
+
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.ext.RsDocAndAttributeOwner
+import org.rust.lang.core.psi.ext.ancestors
+import org.rust.lang.core.psi.ext.isEnabledByCfg
+
+/**
+ * Element is conditionally enabled iff it is not conditionally disabled by any of parent [RsDocAndAttributeOwner]
+ */
+val PsiElement.isEnabledByCfg: Boolean
+    get() = ancestors.filterIsInstance<RsDocAndAttributeOwner>().all { it.isEnabledByCfg }

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.util.text.StringUtil.pluralize
 import com.intellij.psi.PsiElement
 import com.intellij.xml.util.XmlStringUtil.escapeString
+import org.rust.ide.annotator.RsAnnotationHolder
 import org.rust.ide.annotator.RsErrorAnnotator
 import org.rust.ide.annotator.fixes.*
 import org.rust.ide.inspections.RsExperimentalChecksInspection
@@ -24,6 +25,7 @@ import org.rust.ide.inspections.checkMatch.Pattern
 import org.rust.ide.inspections.fixes.AddRemainingArmsFix
 import org.rust.ide.inspections.fixes.AddWildcardArmFix
 import org.rust.ide.refactoring.implementMembers.ImplementMembersFix
+import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ImplLookup
@@ -1192,6 +1194,12 @@ class PreparedAnnotation(
     val description: String = "",
     val fixes: List<LocalQuickFix> = emptyList()
 )
+
+fun RsDiagnostic.addToHolder(holder: RsAnnotationHolder) {
+    if (element.isEnabledByCfg) {
+        addToHolder(holder.holder)
+    }
+}
 
 fun RsDiagnostic.addToHolder(holder: AnnotationHolder) {
     val prepared = prepare()

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -9,7 +9,6 @@ import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.util.TextRange
@@ -19,6 +18,7 @@ import com.intellij.xml.util.XmlStringUtil.escapeString
 import org.rust.ide.annotator.RsErrorAnnotator
 import org.rust.ide.annotator.fixes.*
 import org.rust.ide.inspections.RsExperimentalChecksInspection
+import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.ide.inspections.RsTypeCheckInspection
 import org.rust.ide.inspections.checkMatch.Pattern
 import org.rust.ide.inspections.fixes.AddRemainingArmsFix
@@ -1233,7 +1233,7 @@ fun RsDiagnostic.addToHolder(holder: AnnotationHolder) {
     }
 }
 
-fun RsDiagnostic.addToHolder(holder: ProblemsHolder) {
+fun RsDiagnostic.addToHolder(holder: RsProblemsHolder) {
     val prepared = prepare()
     val descriptor = holder.manager.createProblemDescriptor(
         element,

--- a/src/main/resources/META-INF/core.xml
+++ b/src/main/resources/META-INF/core.xml
@@ -160,6 +160,7 @@
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsExpressionAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsErrorAnnotator"/>
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsUnsafeExpressionAnnotator"/>
+        <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsCfgDisabledCodeAnnotator"/>
         <highlightRangeExtension implementation="org.rust.ide.annotator.RsErrorAnnotator"/>
 
         <!-- Line Marker Providers -->

--- a/src/main/resources/org/rust/ide/colors/RustDarcula.xml
+++ b/src/main/resources/org/rust/ide/colors/RustDarcula.xml
@@ -40,12 +40,17 @@
     </option>
     <option name="org.rust.FUNCTION_CALL">
         <value>
-            <option name="FOREGROUND" value="FFC66D" />
+            <option name="FOREGROUND" value="FFC66D"/>
         </value>
     </option>
     <option name="org.rust.METHOD_CALL">
         <value>
-            <option name="FOREGROUND" value="FFC66D" />
+            <option name="FOREGROUND" value="FFC66D"/>
+        </value>
+    </option>
+    <option name="org.rust.CFG_DISABLED_CODE">
+        <value>
+            <option name="FOREGROUND" value="686A4E"/>
         </value>
     </option>
 </list>

--- a/src/main/resources/org/rust/ide/colors/RustDefault.xml
+++ b/src/main/resources/org/rust/ide/colors/RustDefault.xml
@@ -35,12 +35,17 @@
     </option>
     <option name="org.rust.DIMMED_TEXT">
         <value>
-            <option name="FOREGROUND" value="CBCBCB" />
+            <option name="FOREGROUND" value="CBCBCB"/>
         </value>
     </option>
     <option name="org.rust.UNSAFE_CODE">
         <value>
-            <option name="BACKGROUND" value="FFE8C6" />
+            <option name="BACKGROUND" value="FFE8C6"/>
+        </value>
+    </option>
+    <option name="org.rust.CFG_DISABLED_CODE">
+        <value>
+            <option name="FOREGROUND" value="526544"/>
         </value>
     </option>
 </list>

--- a/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspectionTest.kt
@@ -214,7 +214,7 @@ class RsSortImplTraitMembersInspectionTest : RsInspectionsTestBase(RsSortImplTra
         }
 
         // Some comment
-        #[cfg(some_attr = "value")]
+        #[allow(something)]
         <weak_warning descr="Different impl member order from the trait">/*caret*/impl Foo for ()</weak_warning> {
             fn bar() {
             }

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -327,7 +327,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             pub struct Foo;
         }
 
-        #[cfg(test)]
         mod tests {
             fn foo() {
                 let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
@@ -338,7 +337,6 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             pub struct Foo;
         }
 
-        #[cfg(test)]
         mod tests {
             use foo::Foo;
 


### PR DESCRIPTION
* Disable inspections on cfg-disabled code via `RsProblemsHolder` proxy
* Disable annotations on cfg-disabled code via `RsAnnotationHolder` proxy
* Disable parameter and type hints on cfg-disabled code
* Gray cfg-disabled code via `RsCfgDisabledCodeAnnotator`