### PR TITLE
ANN: fix false-positive E0026 on a struct pattern with a raw identifier

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatField.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPatField.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsPat
 import org.rust.lang.core.psi.RsPatBinding
 import org.rust.lang.core.psi.RsPatField
+import org.rust.lang.core.psi.unescapedText
 
 val RsPatField.kind: RsPatFieldKind
     get() = patBinding?.let { RsPatFieldKind.Shorthand(it, box != null) }
@@ -32,6 +33,6 @@ sealed class RsPatFieldKind {
 
 val RsPatFieldKind.fieldName: String
     get() = when (this) {
-        is RsPatFieldKind.Full -> ident.text
-        is RsPatFieldKind.Shorthand -> binding.identifier.text
+        is RsPatFieldKind.Full -> ident.unescapedText
+        is RsPatFieldKind.Shorthand -> binding.name!! // can't be null
     }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -2903,4 +2903,11 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class.java) {
             let Foo { a, } = foo;
         }
     """)
+
+    fun `test no E0026 on raw identifier field`() = checkErrors("""
+        struct Foo { r#field: u64 }
+        fn bar(f: Foo) {
+            let Foo { r#field: _ } = f;
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #4341