### PR TITLE
QDOC: provide link to external documentation for non stdlib items

### DIFF
--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -177,16 +177,18 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
             externalPackage("$contentRoot/dep-proc-macro", "lib.rs", "dep-proc-macro", libKind = LibKind.PROC_MACRO),
             externalPackage("$contentRoot/dep-lib-2", "lib.rs", "dep-lib-2", "dep-lib-target-2"),
             externalPackage("$contentRoot/trans-lib-2", "lib.rs", "trans-lib-2",
-                origin = PackageOrigin.TRANSITIVE_DEPENDENCY)
+                origin = PackageOrigin.TRANSITIVE_DEPENDENCY),
+            externalPackage("$contentRoot/no-source-lib", "lib.rs", "no-source-lib").copy(source = null)
         )
 
         return CargoWorkspace.deserialize(Paths.get("/my-crate/Cargo.toml"), CargoWorkspaceData(packages, mapOf(
-            // Our package depends on dep_lib 0.0.1, nosrc_lib, dep-proc-macro and dep_lib-2
+            // Our package depends on dep_lib 0.0.1, nosrc_lib, dep-proc-macro, dep_lib-2 and no-source-lib
             packages[0].id to setOf(
                 Dependency(packages[1].id),
                 Dependency(packages[2].id),
                 Dependency(packages[5].id),
-                Dependency(packages[6].id)
+                Dependency(packages[6].id),
+                Dependency(packages[8].id)
             ),
             // dep_lib 0.0.1 depends on trans-lib and dep_lib 0.0.2
             packages[1].id to setOf(

--- a/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
@@ -14,7 +14,7 @@ class RsExternalDocUrlTest : RsDocumentationProviderTest() {
         //- dep-lib/lib.rs
         pub struct Foo;
                   //^
-    """, "test://doc-host.org/dep_lib_target/struct.Foo.html")
+    """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/struct.Foo.html")
 
     fun `test associated const`() = doUrlTestByFileTree("""
         //- dep-lib/lib.rs
@@ -24,7 +24,7 @@ class RsExternalDocUrlTest : RsDocumentationProviderTest() {
             pub const BAR: i32 = 123;
                      //^
         }
-    """, "test://doc-host.org/dep_lib_target/struct.Foo.html#associatedconstant.BAR")
+    """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/struct.Foo.html#associatedconstant.BAR")
 
     fun `test private item`() = doUrlTestByFileTree("""
         //- dep-lib/lib.rs
@@ -54,7 +54,7 @@ class RsExternalDocUrlTest : RsDocumentationProviderTest() {
                     //^
             () => { unimplemented!() };
         }
-    """, "test://doc-host.org/dep_lib_target/macro.foo.html")
+    """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/macro.foo.html")
 
     fun `test not exported macro`() = doUrlTestByFileTree("""
         //- dep-lib/lib.rs
@@ -63,4 +63,16 @@ class RsExternalDocUrlTest : RsDocumentationProviderTest() {
             () => { unimplemented!() };
         }
     """, null, RsDocumentationProvider.Testmarks.notExportedMacro)
+
+    fun `test not external url for workspace package`() = doUrlTestByFileTree("""
+        //- lib.rs
+        pub enum Foo { FOO, BAR }
+                //^
+    """, null, RsDocumentationProvider.Testmarks.nonDependency)
+
+    fun `test not external url for dependency package without source`() = doUrlTestByFileTree("""
+        //- no-source-lib/lib.rs
+        pub enum Foo { FOO, BAR }
+                //^
+    """, null, RsDocumentationProvider.Testmarks.pkgWithoutSource)
 }


### PR DESCRIPTION
Previously, we didn't provide link to external documentation for non-stdlib items because we can't check that the corresponding link exists. But due to https://docs.rs/ automatically builds documentation of crates from crates.io and we already provide links for extern crate items by `RsCrateDocLineMarkerProvider`, I think it's ok always provide such link for all items from non-local dependencies

Closes #4112