### PR TITLE
Fix too recursive `RsFile.cachedData`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
@@ -81,12 +81,3 @@ val RsMod.superMods: List<RsMod> get() {
         .takeWhile { visited.add(it) }
         .toList()
 }
-
-// For malformed programs, chain of `super`s may be infinite
-// because of cycles, and we need to detect this situation.
-val RsMod.isCycledMod: Boolean
-    get() {
-        val visited = HashSet<RsMod>()
-        return generateSequence(this) { it.`super` }
-            .any { !visited.add(it) }
-    }


### PR DESCRIPTION
Looks like in #4334 (not released yet) or maybe even in #4190 I made `RsFile.cachedData` "too recursive" (maybe infinite sometimes, don't sure), i.e. access to `RsFile.cachedData` of one file forces computing of `RsFile.cachedData` of a lot of other files, that can impact performance significantly.
Example of a thread dump: [threadDump-20190905-031534.txt](https://github.com/intellij-rust/intellij-rust/files/3584276/threadDump-20190905-031534.txt)
