### PR TITLE
MACRO: check macro expansion depth during type inference

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -814,4 +814,5 @@ object TypeInferenceMarks {
     val methodPickDerefOrder = Testmark("methodPickDerefOrder")
     val methodPickCollapseTraits = Testmark("methodPickCollapseTraits")
     val traitSelectionSpecialization = Testmark("traitSelectionSpecialization")
+    val macroExprDepthLimitReached = Testmark("reachMacroExprDepthLimit")
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsMacroTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsMacroTypeInferenceTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.lang.core.type
 
+import org.rust.lang.core.types.infer.TypeInferenceMarks
+
 class RsMacroTypeInferenceTest : RsTypificationTestBase() {
     override val followMacroExpansions: Boolean get() = true
 
@@ -124,4 +126,12 @@ class RsMacroTypeInferenceTest : RsTypificationTestBase() {
             b;
         } //^ <unknown>
     """)
+
+    fun `test infinite recursion`() = testExpr("""
+        macro_rules! foo { () => { foo!(); }; }
+        fn main() {
+            let a = foo!();
+            a;
+        } //^ <unknown>
+    """, TypeInferenceMarks.macroExprDepthLimitReached)
 }


### PR DESCRIPTION
Prevents infinite recursive macros.
(More generic fix for #4375)