### PR TITLE
Macro type provider and extend selection

### DIFF
--- a/src/main/kotlin/org/rust/ide/hints/RsExpressionTypeProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/RsExpressionTypeProvider.kt
@@ -6,12 +6,18 @@
 package org.rust.ide.hints
 
 import com.intellij.lang.ExpressionTypeProvider
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.FakePsiElement
+import org.rust.lang.core.macros.findExpansionElementOrSelf
+import org.rust.lang.core.macros.findMacroCallExpandedFromNonRecursive
+import org.rust.lang.core.macros.mapRangeFromExpansionToCallBodyStrict
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsPat
 import org.rust.lang.core.psi.RsPatField
 import org.rust.lang.core.psi.ext.RsItemElement
-import org.rust.lang.core.psi.ext.ancestors
+import org.rust.lang.core.psi.ext.contexts
+import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.type
 import org.rust.openapiext.escaped
 
@@ -20,18 +26,45 @@ class RsExpressionTypeProvider : ExpressionTypeProvider<PsiElement>() {
     override fun getErrorHint(): String = "Select an expression!"
 
     override fun getExpressionsAt(pivot: PsiElement): List<PsiElement> =
-        pivot.ancestors
+        pivot.findExpansionElementOrSelf()
+            .contexts
             .takeWhile { it !is RsItemElement }
             .filter { it is RsExpr || it is RsPat || it is RsPatField }
+            .mapNotNull { it.wrapExpandedElements() }
             .toList()
 
     override fun getInformationHint(element: PsiElement): String {
-        val type = when (element) {
-            is RsExpr -> element.type
-            is RsPat -> element.type
-            is RsPatField -> element.type
-            else -> error("Unexpected element type: $element")
-        }
+        val type = getType(element)
         return type.toString().escaped
     }
+
+    private fun getType(element: PsiElement): Ty = when (element) {
+        is MyFakePsiElement -> getType(element.elementInMacroExpansion)
+        is RsExpr -> element.type
+        is RsPat -> element.type
+        is RsPatField -> element.type
+        else -> error("Unexpected element type: $element")
+    }
+}
+
+/** A hack around [ExpressionTypeProvider] to make it work inside macro calls (by following macro expansions) */
+private fun PsiElement.wrapExpandedElements(): PsiElement? {
+    val macroCall = findMacroCallExpandedFromNonRecursive()
+    return if (macroCall != null) {
+        val rangeInExpansion = textRange
+        val rangeInMacroCall = macroCall.mapRangeFromExpansionToCallBodyStrict(rangeInExpansion)
+            ?: return null
+        MyFakePsiElement(this, rangeInMacroCall)
+    } else {
+        this
+    }
+}
+
+private class MyFakePsiElement(
+    val elementInMacroExpansion: PsiElement,
+    val textRangeInMacroCall: TextRange
+) : FakePsiElement() {
+    override fun getParent(): PsiElement = elementInMacroExpansion.parent
+    override fun getTextRange(): TextRange? = textRangeInMacroCall
+    override fun getText(): String? = elementInMacroExpansion.text
 }

--- a/src/main/kotlin/org/rust/ide/wordSelection/RsMacroCallSelectionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/wordSelection/RsMacroCallSelectionHandler.kt
@@ -1,0 +1,45 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.wordSelection
+
+import com.intellij.codeInsight.editorActions.ExtendWordSelectionHandlerBase
+import com.intellij.codeInsight.editorActions.SelectWordUtil
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.macros.findExpansionElements
+import org.rust.lang.core.macros.findMacroCallExpandedFromNonRecursive
+import org.rust.lang.core.macros.mapRangeFromExpansionToCallBodyStrict
+import org.rust.lang.core.psi.RsMacroArgument
+import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psi.ext.expansion
+import org.rust.lang.core.psi.ext.startOffset
+
+class RsMacroCallSelectionHandler : ExtendWordSelectionHandlerBase() {
+    override fun canSelect(e: PsiElement): Boolean = e.ancestorStrict<RsMacroArgument>() != null
+
+    override fun select(e: PsiElement, editorText: CharSequence, cursorOffset: Int, editor: Editor): List<TextRange>? {
+        val elementInExpansion = e.findExpansionElements()?.firstOrNull() ?: return null
+        val offsetInExpansion = elementInExpansion.startOffset + (cursorOffset - e.startOffset)
+        val macroCall = elementInExpansion.findMacroCallExpandedFromNonRecursive() ?: return null // impossible?
+        val expansion = macroCall.expansion ?: return null // impossible?
+        val expansionText = expansion.file.text
+        val factory = EditorFactory.getInstance()
+        val expansionEditor = factory.createEditor(factory.createDocument(expansionText))
+
+        val ranges = mutableListOf<TextRange>()
+        try {
+            SelectWordUtil.processRanges(elementInExpansion, expansionText, offsetInExpansion, expansionEditor) {
+                ranges.add(it)
+                false // Continue processing (do not believe `Processor`'s docs)
+            }
+        } finally {
+            factory.releaseEditor(expansionEditor)
+        }
+        return ranges.mapNotNull { macroCall.mapRangeFromExpansionToCallBodyStrict(it) }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/RangeMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RangeMap.kt
@@ -39,7 +39,7 @@ data class RangeMap private constructor(private val ranges: List<MappedTextRange
         return ranges.mapNotNull { it.dstIntersection(toMap) }
     }
 
-    private fun mapMappedTextRangeFromExpansionToCallBody(toMap: MappedTextRange): List<MappedTextRange> {
+    fun mapMappedTextRangeFromExpansionToCallBody(toMap: MappedTextRange): List<MappedTextRange> {
         return mapTextRangeFromExpansionToCallBody(TextRange(toMap.srcOffset, toMap.srcEndOffset)).map { mapped ->
             MappedTextRange(
                 mapped.srcOffset,
@@ -101,6 +101,10 @@ data class MappedTextRange(
 
 val MappedTextRange.srcEndOffset: Int get() = srcOffset + length
 val MappedTextRange.dstEndOffset: Int get() = dstOffset + length
+
+val MappedTextRange.srcRange: TextRange get() = TextRange(srcOffset, srcOffset + length)
+
+fun MappedTextRange.srcShiftLeft(delta: Int) = copy(srcOffset = srcOffset - delta)
 
 private fun MappedTextRange.dstIntersection(range: TextRange): MappedTextRange? {
     val newDstStart = Math.max(dstOffset, range.startOffset)

--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.macros
 
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsMacroArgument
@@ -197,6 +198,9 @@ fun PsiElement.findExpansionElements(): List<PsiElement>? {
     }
 }
 
+fun PsiElement.findExpansionElementOrSelf(): PsiElement =
+    findExpansionElements()?.singleOrNull() ?: this
+
 private fun PsiElement.findExpansionElementsNonRecursive(): List<PsiElement>? {
     val call = ancestorStrict<RsMacroArgument>()?.ancestorStrict<RsMacroCall>() ?: return null
     val expansion = call.expansion ?: return null
@@ -220,7 +224,9 @@ private fun mapOffsetFromCallBodyToExpansion(
 }
 
 private fun Int.toBodyRelativeOffset(call: RsMacroCall): Int? {
-    val macroOffset = call.bodyTextRange?.startOffset ?: return null
+    val bodyTextRange = call.bodyTextRange ?: return null
+    if (this !in bodyTextRange) return null
+    val macroOffset = bodyTextRange.startOffset
     val elementOffset = this - macroOffset
     check(elementOffset >= 0)
     return elementOffset
@@ -231,6 +237,48 @@ private fun Int.fromBodyRelativeOffset(call: RsMacroCall): Int? {
     val elementOffset = this + macroRange.startOffset
     check(elementOffset <= macroRange.endOffset)
     return elementOffset
+}
+
+private fun MappedTextRange.fromBodyRelativeRange(call: RsMacroCall): MappedTextRange? {
+    val newSrcOffset = srcOffset.fromBodyRelativeOffset(call) ?: return null
+    return MappedTextRange(newSrcOffset, dstOffset, length)
+}
+
+fun RsMacroCall.mapRangeFromExpansionToCallBodyStrict(range: TextRange): TextRange? {
+    return mapRangeFromExpansionToCallBody(range).singleOrNull()?.takeIf { it.length == range.length }
+}
+
+private fun RsMacroCall.mapRangeFromExpansionToCallBody(range: TextRange): List<TextRange> {
+    val expansion = expansion ?: return emptyList()
+    return mapRangeFromExpansionToCallBody(expansion, this, range)
+}
+
+private fun mapRangeFromExpansionToCallBody(
+    expansion: MacroExpansion,
+    call: RsMacroCall,
+    range: TextRange
+): List<TextRange> {
+    return mapRangeFromExpansionToCallBody(
+        expansion,
+        call,
+        MappedTextRange(range.startOffset, range.startOffset, range.length)
+    ).map { it.srcRange }
+}
+
+private fun mapRangeFromExpansionToCallBody(
+    expansion: MacroExpansion,
+    call: RsMacroCall,
+    range: MappedTextRange
+): List<MappedTextRange> {
+    val fileOffset = call.expansionContext.expansionFileStartOffset
+    if (range.srcOffset - fileOffset < 0) return emptyList()
+    val mappedRanges = expansion.ranges.mapMappedTextRangeFromExpansionToCallBody(range.srcShiftLeft(fileOffset))
+        .mapNotNull { it.fromBodyRelativeRange(call) }
+    val parentCall = call.findMacroCallExpandedFromNonRecursive() ?: return mappedRanges
+    return mappedRanges.flatMap {
+        val parentExpansion = parentCall.expansion ?: return emptyList() // impossible?
+        mapRangeFromExpansionToCallBody(parentExpansion, parentCall, it)
+    }
 }
 
 /**

--- a/src/main/resources/META-INF/core.xml
+++ b/src/main/resources/META-INF/core.xml
@@ -38,6 +38,7 @@
         <extendWordSelectionHandler implementation="org.rust.ide.wordSelection.RsGroupSelectionHandler"/>
         <extendWordSelectionHandler implementation="org.rust.ide.wordSelection.RsFieldLikeSelectionHandler"/>
         <extendWordSelectionHandler implementation="org.rust.ide.wordSelection.RsListSelectionHandler"/>
+        <extendWordSelectionHandler implementation="org.rust.ide.wordSelection.RsMacroCallSelectionHandler"/>
 
         <!-- Syntax Highlighter -->
 

--- a/src/test/kotlin/org/rust/ide/wordSelection/RsSelectionHandlerTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/wordSelection/RsSelectionHandlerTestBase.kt
@@ -11,6 +11,24 @@ import org.rust.RsTestBase
 
 abstract class RsSelectionHandlerTestBase : RsTestBase() {
     fun doTest(before: String, vararg after: String) {
+        doTestWithoutMacro(before, after)
+        doTestWithMacro(before, after)
+    }
+
+    private fun doTestWithoutMacro(before: String, after: Array<out String>) =
+        doTestInner(before, after.toList())
+
+    private fun doTestWithMacro(before: String, after: Array<out String>) {
+        val wrap = fun(s: String) = """
+           macro_rules! foo { ($ i:item) => { $ i } } 
+           foo! {
+           $s
+           }
+        """.trimIndent()
+        doTestInner(wrap(before), after.map { wrap(it) })
+    }
+
+    private fun doTestInner(before: String, after: List<out String>) {
         myFixture.configureByText("main.rs", before)
         val action = SelectWordHandler(null)
         val dataContext = DataManager.getInstance().getDataContext(myFixture.editor.component)


### PR DESCRIPTION
Now `Extend Selection` and `Type Info` actions should work properly for code inside macro calls

Extend selection:
![Peek 2019-09-30 18-03](https://user-images.githubusercontent.com/3221931/65891161-c295fb80-e3ac-11e9-83f3-01d43c74341e.gif)

Type provider:
![Peek 2019-09-30 18-03_1](https://user-images.githubusercontent.com/3221931/65891188-d04b8100-e3ac-11e9-8399-0137aa6a87e3.gif)

(note that this works only with the new macro expansion engine enabled)