### PR TITLE
RES: Use three-valued logic in cfg evaluation

### DIFF
--- a/src/main/kotlin/org/rust/cargo/CfgOptions.kt
+++ b/src/main/kotlin/org/rust/cargo/CfgOptions.kt
@@ -57,5 +57,8 @@ class CfgOptions(
 
         @TestOnly
         val EMPTY: CfgOptions = CfgOptions(emptyMap(), emptySet())
+
+        @TestOnly
+        const val TEST: String = "intellij_rust"
     }
 }

--- a/src/main/kotlin/org/rust/ide/utils/CfgUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/CfgUtils.kt
@@ -8,10 +8,11 @@ package org.rust.ide.utils
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.ext.RsDocAndAttributeOwner
 import org.rust.lang.core.psi.ext.ancestors
+import org.rust.lang.core.psi.ext.isCfgUnknown
 import org.rust.lang.core.psi.ext.isEnabledByCfg
 
-/**
- * Element is conditionally enabled iff it is not conditionally disabled by any of parent [RsDocAndAttributeOwner]
- */
 val PsiElement.isEnabledByCfg: Boolean
     get() = ancestors.filterIsInstance<RsDocAndAttributeOwner>().all { it.isEnabledByCfg }
+
+val PsiElement.isCfgUnknown: Boolean
+    get() = ancestors.filterIsInstance<RsDocAndAttributeOwner>().any { it.isCfgUnknown }

--- a/src/test/kotlin/org/rust/MockAdditionalCfgOptions.kt
+++ b/src/test/kotlin/org/rust/MockAdditionalCfgOptions.kt
@@ -8,7 +8,11 @@ package org.rust
 import java.lang.annotation.Inherited
 
 /**
- * Allows to extend default cfg options ([org.rust.cargo.CfgOptions.DEFAULT]) for a specific test
+ * Allows extending default cfg options ([org.rust.cargo.CfgOptions.DEFAULT]) for a specific test.
+ *
+ * NB: Only a few cfg options are allowed to be evaluated.
+ * You can either use the special test-only [org.rust.cargo.CfgOptions.TEST] option here
+ * or one of the supported options from [org.rust.lang.utils.evaluation.CfgEvaluator.SUPPORTED_NAME_OPTIONS].
  *
  * @see RsTestBase.setupMockCfgOptions
  */

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -783,13 +783,13 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class.java) {
         }
     """)
 
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test respects cfg attribute E0428`() = checkErrors("""
         mod opt {
             #[cfg(not(bar))] mod foo {}
             #[cfg(bar)]      mod foo {}
 
-            #[cfg(foo)] fn <error descr="A value named `hello_world` has already been defined in this module [E0428]">hello_world</error>() {}
+            #[cfg(intellij_rust)] fn <error descr="A value named `hello_world` has already been defined in this module [E0428]">hello_world</error>() {}
             fn <error descr="A value named `hello_world` has already been defined in this module [E0428]">hello_world</error>() {}
 
             #[cfg(bar)] fn hello_rust() {}

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
@@ -44,10 +44,10 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test big signature`() = doTest("""
         /// Docs
-        #[cfg(foo)]
+        #[cfg(intellij_rust)]
         /// More Docs
         pub const unsafe extern "C" fn foo<T>(x: T) -> u32 where T: Clone { 92 }
 

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoBenchRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoBenchRunLineMarkerContributorTest.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.lineMarkers
 
-import org.rust.MockAdditionalCfgOptions
 import org.rust.fileTree
 
 /**
@@ -44,7 +43,6 @@ class CargoBenchRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         }
     """)
 
-    @MockAdditionalCfgOptions("test")
     fun `test function in a nested tests module`() = doTestByText("""
         #[cfg(test)]
         mod tests { // - Bench lib::tests

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
@@ -9,7 +9,6 @@ import com.intellij.execution.TestStateStorage
 import com.intellij.execution.testframework.sm.runner.states.TestStateInfo
 import com.intellij.psi.PsiFileFactory
 import org.intellij.lang.annotations.Language
-import org.rust.MockAdditionalCfgOptions
 import org.rust.cargo.icons.CargoIcons
 import org.rust.cargo.runconfig.test.CargoTestLocator
 import org.rust.fileTree
@@ -57,7 +56,6 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         }
     """)
 
-    @MockAdditionalCfgOptions("test")
     fun `test function in a nested tests module`() = doTestByText("""
         #[cfg(test)]
         mod tests { // - Test lib::tests

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -12,12 +12,12 @@ import org.rust.lang.core.psi.RsTupleFieldDecl
 class RsCfgAttrResolveTest : RsResolveTestBase() {
     override val followMacroExpansions: Boolean get() = true
 
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test fn with cfg`() = checkByCode("""
-        #[cfg(foo)]
+        #[cfg(intellij_rust)]
         fn foo() {}
          //X
-        #[cfg(not(foo))]
+        #[cfg(not(intellij_rust))]
         fn foo() {}
 
         fn main() {
@@ -26,12 +26,12 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test struct field with cfg`() = checkByCode("""
         struct S {
-            #[cfg(not(foo))] x: u32,
-            #[cfg(foo)]      x: i32,
-                           //X
+            #[cfg(not(intellij_rust))] x: u32,
+            #[cfg(intellij_rust)]      x: i32,
+                                     //X
         }
 
         fn t(f: S) {
@@ -40,23 +40,23 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test tuple struct field with cfg`() = checkByCodeGeneric<RsTupleFieldDecl>("""
-        struct S(#[cfg(not(foo))] u32,
-                 #[cfg(foo)]      i32);
-                                //X
+        struct S(#[cfg(not(intellij_rust))] u32,
+                 #[cfg(intellij_rust)]      i32);
+                                          //X
         fn t(f: S) {
             f.0;
             //^
         }
     """)
 
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test tuple enum variant with cfg`() = checkByCode("""
         enum E {
-            #[cfg(not(foo))] Variant(u32),
-            #[cfg(foo)]      Variant(u32),
-                           //X
+            #[cfg(not(intellij_rust))] Variant(u32),
+            #[cfg(intellij_rust)]      Variant(u32),
+                                     //X
         }
 
         fn t() {
@@ -65,15 +65,15 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test inline mod with cfg`() = checkByCode("""
-        #[cfg(foo)]
+        #[cfg(intellij_rust)]
         mod my {
             pub fn bar() {}
                  //X
         }
         
-        #[cfg(not(foo))]
+        #[cfg(not(intellij_rust))]
         mod my {
             pub fn bar() {}
         }
@@ -84,7 +84,7 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }
      """)
 
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test use item with cfg`() = checkByCode(""" 
         mod my {
             pub fn bar() {}
@@ -92,10 +92,10 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
             pub fn baz() {}
         }
         
-        #[cfg(foo)]
+        #[cfg(intellij_rust)]
         use my::bar as quux;
         
-        #[cfg(not(foo))]
+        #[cfg(not(intellij_rust))]
         use my::baz as quux;
 
         fn t() {
@@ -105,7 +105,7 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
      """)
 
     @ExpandMacros
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test macro expansion with cfg`() = checkByCode(""" 
         struct S { x: i32 }
                  //X
@@ -114,11 +114,11 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
             ($ t:ty) => { fn foobar() -> $ t {} };
         }
 
-        #[cfg(foo)]
+        #[cfg(intellij_rust)]
         my_macro!(S);
       
       
-        #[cfg(not(foo))]
+        #[cfg(not(intellij_rust))]
         my_macro!(i32);
 
         fn t() {
@@ -127,10 +127,10 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }
      """)
 
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test extern crate with cfg`() = stubOnlyResolve(""" 
     //- main.rs
-        #[cfg(foo)]
+        #[cfg(intellij_rust)]
         extern crate test_package;
 
         fn main() {
@@ -142,28 +142,28 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
              //X
      """)
 
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test impl`() = checkByCode(""" 
         struct S;
-        #[cfg(foo)]
+        #[cfg(intellij_rust)]
         impl S { fn foo(&self) {} }
                    //X
-        #[cfg(not(foo))]
+        #[cfg(not(intellij_rust))]
         impl S { fn foo(&self) {} }
         fn main() {
             S.foo()
         }   //^
      """)
 
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test impl in inline mod with cfg`() = checkByCode(""" 
         struct S;
-        #[cfg(foo)]
+        #[cfg(intellij_rust)]
         mod foo {
             impl super::S { fn foo(&self) {} }
                              //X
         }
-        #[cfg(not(foo))]
+        #[cfg(not(intellij_rust))]
         mod foo {
             impl super::S { fn foo(&self) {} }
         }
@@ -172,7 +172,7 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }   //^
      """)
 
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test impl in non-inline mod with cfg`() = stubOnlyResolve(""" 
     //- bar.rs
         impl super::S { fn foo(&self) {} }
@@ -181,11 +181,11 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
     //- lib.rs
         struct S;
         
-        #[cfg(foo)]
+        #[cfg(intellij_rust)]
         #[path = "bar.rs"]
         mod foo;
         
-        #[cfg(not(foo))]
+        #[cfg(not(intellij_rust))]
         #[path = "baz.rs"]
         mod foo;
         
@@ -194,15 +194,15 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }   //^ bar.rs
      """)
 
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test impl in function body with cfg`() = checkByCode(""" 
         struct S;
-        #[cfg(foo)]
+        #[cfg(intellij_rust)]
         fn foo() {
             impl S { fn foo(&self) {} }
                       //X
         }
-        #[cfg(not(foo))]
+        #[cfg(not(intellij_rust))]
         fn foo() {
             impl S { fn foo(&self) {} }
         }
@@ -212,18 +212,18 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
      """)
 
     @ExpandMacros
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test impl expanded from macro with cfg`() = checkByCode(""" 
         macro_rules! same {
             ($ i:item) => { $ i };
         }
         struct S;
-        #[cfg(foo)]
+        #[cfg(intellij_rust)]
         same! {
             impl S { fn foo(&self) {} }
                       //X
         }
-        #[cfg(not(foo))]
+        #[cfg(not(intellij_rust))]
         same! {
             impl S { fn foo(&self) {} }
         }
@@ -233,20 +233,20 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
      """)
 
     @ExpandMacros
-    @MockAdditionalCfgOptions("foo")
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test cfg inside macros`() = checkByCode(""" 
         macro_rules! as_is { ($($ i:item)*) => { $($ i)* } }
         as_is! {
-            #[cfg(bar)]
+            #[cfg(not(intellij_rust))]
             mod spam { pub fn eggs() {} }
-            #[cfg(bar)]
+            #[cfg(not(intellij_rust))]
             pub use spam::*;
-        
-            #[cfg(foo)]
+
+            #[cfg(intellij_rust)]
             mod spam {
                 pub fn eggs() {}
             }        //X
-            #[cfg(foo)]
+            #[cfg(intellij_rust)]
             pub use spam::*;
         }
         fn main() {


### PR DESCRIPTION
Related to #1191. Some cfg options cannot be evaluated to `True` or `False` in IDE (e.g. `test` option), so now they are evaluated to `Unknown` according to [three-valued logic](https://en.wikipedia.org/wiki/Three-valued_logic).