### PR TITLE
PERF: fix index access during PSI event processing

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -24,11 +24,11 @@ interface RsExpandedElement : RsElement {
     override fun getContext(): PsiElement?
 
     companion object {
-        fun getContextImpl(psi: RsExpandedElement): PsiElement? {
+        fun getContextImpl(psi: RsExpandedElement, isIndexAccessForbidden: Boolean = false): PsiElement? {
             psi.expandedFrom?.let { return it.context }
             psi.getUserData(RS_EXPANSION_CONTEXT)?.let { return it }
             val parent = psi.stubParent
-            if (parent is RsFile) {
+            if (parent is RsFile && !isIndexAccessForbidden) {
                 RsIncludeMacroIndex.getIncludingMod(parent)?.let { return it }
             }
             return parent

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -42,11 +42,11 @@ val PsiElement.ancestorPairs: Sequence<Pair<PsiElement, PsiElement>>
         }
     }
 
-val PsiElement.stubParent: PsiElement
+val PsiElement.stubParent: PsiElement?
     get() {
         if (this is StubBasedPsiElement<*>) {
             val stub = this.greenStub
-            if (stub != null) return stub.parentStub.psi
+            if (stub != null) return stub.parentStub?.psi
         }
         return parent
     }


### PR DESCRIPTION
... that forces to rebuild stubs synchronously (in the EDT!) and affects editor responsiveness