### PR TITLE
Enable cfg attributes support on nightly

### DIFF
--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -3,7 +3,7 @@
         <experimentalFeature id="org.rust.cargo.build.tool.window" percentOfUsers="100">
             <description>Enable Cargo tasks to use Build Tool Window</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.lang.cfg.attributes" percentOfUsers="0">
+        <experimentalFeature id="org.rust.lang.cfg.attributes" percentOfUsers="100">
             <description>Enable Rust cfg attributes support</description>
         </experimentalFeature>
     </extensions>


### PR DESCRIPTION
Relates to #1191

This PR enables [cfg attributes support](https://github.com/intellij-rust/intellij-rust/pull/4232) in nightly versions of IntelliJ Rust. This affects type inference, navigation, code completion, and other features. Also, conditionally disabled code is [greyed out](https://github.com/intellij-rust/intellij-rust/pull/4342).

Only a few cfg options can be evaluated to `true` or `false`:
* debug_assertions
* unix
* windows
* target_arch
* target_env
* target_family
* target_feature
* target_os
* target_pointer_width
* target_vendor

Other cfg options are considered as `unknown` and don’t affect name resolution. Note that `test` cfg option is considered as `unknown` too:
* `cfg(test)` cannot be `false`, because then all the tests in your code are grey
* `cfg(test)` cannot be `true`, because then `cfg(not(test))` is `false` and name resolution is broken

Cfg options specified via [features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section) have not been supported so far.