### PR TITLE
Assert we do not access indices during document committing

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
@@ -18,6 +18,7 @@ import org.rust.lang.core.resolve.RsProcessor
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsImplItemStub
 import org.rust.lang.core.types.TyFingerprint
+import org.rust.openapiext.checkCommitIsNotInProgress
 import org.rust.openapiext.getElements
 
 class RsImplIndex : AbstractStubIndex<TyFingerprint, RsImplItem>() {
@@ -40,6 +41,7 @@ class RsImplIndex : AbstractStubIndex<TyFingerprint, RsImplItem>() {
             tyf: TyFingerprint,
             processor: RsProcessor<RsCachedImplItem>
         ): Boolean {
+            checkCommitIsNotInProgress(project)
             val impls = getElements(KEY, tyf, project, RsWithMacrosProjectScope(project))
 
             // Note that `getElements` is intentionally used with intermediate collection instead of

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsLangItemIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsLangItemIndex.kt
@@ -18,6 +18,7 @@ import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.containingCargoPackage
 import org.rust.lang.core.psi.ext.queryAttributes
 import org.rust.lang.core.stubs.RsFileStub
+import org.rust.openapiext.checkCommitIsNotInProgress
 import org.rust.openapiext.getElements
 
 class RsLangItemIndex : AbstractStubIndex<String, RsItemElement>() {
@@ -31,6 +32,7 @@ class RsLangItemIndex : AbstractStubIndex<String, RsItemElement>() {
             langAttribute: String,
             crateName: String = AutoInjectedCrates.CORE
         ): RsNamedElement? {
+            checkCommitIsNotInProgress(project)
             val elements = getElements(KEY, langAttribute, project, GlobalSearchScope.allScope(project))
             return if (elements.size < 2) {
                 elements.firstOrNull() as? RsNamedElement

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsMacroCallIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsMacroCallIndex.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.stubs.StringStubIndexExtension
 import com.intellij.psi.stubs.StubIndexKey
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.stubs.RsFileStub
+import org.rust.openapiext.checkCommitIsNotInProgress
 import org.rust.openapiext.getElements
 
 class RsMacroCallIndex : StringStubIndexExtension<RsMacroCall>() {
@@ -33,7 +34,9 @@ class RsMacroCallIndex : StringStubIndexExtension<RsMacroCall>() {
         fun getMacroCalls(
             project: Project,
             scope: GlobalSearchScope = GlobalSearchScope.allScope(project)
-        ): Collection<RsMacroCall> =
-            getElements(KEY, SINGLE_KEY, project, scope)
+        ): Collection<RsMacroCall> {
+            checkCommitIsNotInProgress(project)
+            return getElements(KEY, SINGLE_KEY, project, scope)
+        }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsMacroIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsMacroIndex.kt
@@ -24,6 +24,7 @@ import org.rust.lang.core.psi.isValidProjectMember
 import org.rust.lang.core.psi.rustStructureModificationTracker
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsMacroStub
+import org.rust.openapiext.checkCommitIsNotInProgress
 import org.rust.openapiext.getElements
 
 class RsMacroIndex : StringStubIndexExtension<RsMacro>() {
@@ -45,6 +46,7 @@ class RsMacroIndex : StringStubIndexExtension<RsMacro>() {
         }
 
         fun allExportedMacros(project: Project): Map<RsMod, List<RsMacro>> {
+            checkCommitIsNotInProgress(project)
             val cacheKey = if (project.macroExpansionManager.expansionState != null) EXPORTED_MACROS_KEY else EXPORTED_KEY
             return CachedValuesManager.getManager(project).getCachedValue(project, cacheKey, {
                 val result = HashMap<RsMod, MutableList<RsMacro>>()

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsExternCrateReexportIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsExternCrateReexportIndex.kt
@@ -18,6 +18,7 @@ import org.rust.lang.core.psi.ext.containingCargoTarget
 import org.rust.lang.core.psi.rustStructureOrAnyPsiModificationTracker
 import org.rust.lang.core.stubs.RsExternCrateItemStub
 import org.rust.lang.core.stubs.RsFileStub
+import org.rust.openapiext.checkCommitIsNotInProgress
 import org.rust.openapiext.getElements
 
 class RsExternCrateReexportIndex : StringStubIndexExtension<RsExternCrateItem>() {
@@ -36,6 +37,7 @@ class RsExternCrateReexportIndex : StringStubIndexExtension<RsExternCrateItem>()
         }
 
         fun findReexports(project: Project, crateRoot: RsMod): List<RsExternCrateItem> {
+            checkCommitIsNotInProgress(project)
             return CachedValuesManager.getCachedValue(crateRoot) {
                 val targetName = crateRoot.containingCargoTarget?.normName
                 val reexports = if (targetName != null) {

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsFeatureIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsFeatureIndex.kt
@@ -14,6 +14,7 @@ import org.rust.lang.core.psi.RsInnerAttr
 import org.rust.lang.core.psi.ext.name
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsInnerAttrStub
+import org.rust.openapiext.checkCommitIsNotInProgress
 import org.rust.openapiext.getElements
 
 class RsFeatureIndex : StringStubIndexExtension<RsInnerAttr>() {
@@ -37,6 +38,7 @@ class RsFeatureIndex : StringStubIndexExtension<RsInnerAttr>() {
         }
 
         fun getFeatureAttributes(project: Project, featureName: String): Collection<RsInnerAttr> {
+            checkCommitIsNotInProgress(project)
             return getElements(KEY, featureName, project, GlobalSearchScope.allScope(project))
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsIncludeMacroIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsIncludeMacroIndex.kt
@@ -8,7 +8,10 @@ package org.rust.lang.core.stubs.index
 import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.ModificationTracker
-import com.intellij.psi.stubs.*
+import com.intellij.psi.stubs.AbstractStubIndex
+import com.intellij.psi.stubs.IndexSink
+import com.intellij.psi.stubs.StubIndex
+import com.intellij.psi.stubs.StubIndexKey
 import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
@@ -17,9 +20,13 @@ import com.intellij.util.io.KeyDescriptor
 import org.rust.ide.search.RsWithMacrosProjectScope
 import org.rust.lang.core.macros.macroExpansionManagerIfCreated
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.findIncludingFile
+import org.rust.lang.core.psi.ext.macroName
+import org.rust.lang.core.psi.ext.stringValue
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsMacroCallStub
+import org.rust.openapiext.checkCommitIsNotInProgress
 import org.rust.openapiext.recursionGuard
 import java.io.DataInput
 import java.io.DataOutput
@@ -71,6 +78,7 @@ class RsIncludeMacroIndex : AbstractStubIndex<IncludeMacroKey, RsMacroCall>() {
         private fun makeIndexLookup(key: IncludeMacroKey, file: RsFile): RsMod? {
             return recursionGuard(file, Computable {
                 val project = file.project
+                checkCommitIsNotInProgress(project)
 
                 var parentMod: RsMod? = null
                 val scope = project.macroExpansionManagerIfCreated?.expansionState?.expandedSearchScope

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsModulesIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsModulesIndex.kt
@@ -21,6 +21,7 @@ import org.rust.lang.core.psi.ext.pathAttribute
 import org.rust.lang.core.psi.isValidProjectMember
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsModDeclItemStub
+import org.rust.openapiext.checkCommitIsNotInProgress
 
 class RsModulesIndex : StringStubIndexExtension<RsModDeclItem>() {
     override fun getVersion(): Int = RsFileStub.Type.stubVersion
@@ -30,6 +31,7 @@ class RsModulesIndex : StringStubIndexExtension<RsModDeclItem>() {
         fun getDeclarationsFor(mod: RsFile): List<RsModDeclItem> {
             val key = key(mod) ?: return emptyList()
             val project = mod.project
+            checkCommitIsNotInProgress(project)
 
             val result = SmartList<RsModDeclItem>()
 

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsNamedElementIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsNamedElementIndex.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.stubs.StringStubIndexExtension
 import com.intellij.psi.stubs.StubIndexKey
 import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.stubs.RsFileStub
+import org.rust.openapiext.checkCommitIsNotInProgress
 import org.rust.openapiext.getElements
 
 class RsNamedElementIndex : StringStubIndexExtension<RsNamedElement>() {
@@ -26,6 +27,7 @@ class RsNamedElementIndex : StringStubIndexExtension<RsNamedElement>() {
             target: String,
             scope: GlobalSearchScope = GlobalSearchScope.allScope(project)
         ): Collection<RsNamedElement> {
+            checkCommitIsNotInProgress(project)
             return getElements(KEY, target, project, scope)
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsReexportIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsReexportIndex.kt
@@ -17,6 +17,7 @@ import org.rust.lang.core.psi.ext.nameInScope
 import org.rust.lang.core.psi.ext.pathOrQualifier
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsUseSpeckStub
+import org.rust.openapiext.checkCommitIsNotInProgress
 import org.rust.openapiext.getElements
 
 class RsReexportIndex : StringStubIndexExtension<RsUseSpeck>() {
@@ -44,6 +45,7 @@ class RsReexportIndex : StringStubIndexExtension<RsUseSpeck>() {
             target: String,
             scope: GlobalSearchScope = GlobalSearchScope.allScope(project)
         ): Collection<RsUseSpeck> {
+            checkCommitIsNotInProgress(project)
             return getElements(KEY, target, project, scope)
         }
     }

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -39,6 +39,7 @@ import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.vfs.VirtualFileWithId
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.*
+import com.intellij.psi.impl.PsiDocumentManagerBase
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
@@ -99,6 +100,15 @@ fun checkIsBackgroundThread() {
 
 fun checkIsSmartMode(project: Project) {
     if (DumbService.getInstance(project).isDumb) throw IndexNotReadyException.create()
+}
+
+fun checkCommitIsNotInProgress(project: Project) {
+    val app = ApplicationManager.getApplication()
+    if ((app.isUnitTestMode || app.isInternal) && app.isDispatchThread) {
+        if ((PsiDocumentManager.getInstance(project) as PsiDocumentManagerBase).isCommitInProgress) {
+            error("Accessing indices during PSI event processing can lead to typing performance issues")
+        }
+    }
 }
 
 fun fullyRefreshDirectory(directory: VirtualFile) {


### PR DESCRIPTION
Accessing indices during document committing (PSI event processing) forces to rebuild stubs synchronously (in the EDT!) and affects editor responsiveness, so let's assert that nobody does that.

Previous index access was fixed in #4487