### PR TITLE
PERF&MACRO: cancellable extraction step (better editor responsiveness)

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -143,7 +143,7 @@ abstract class MacroExpansionTaskBase(
             realTaskIndicator.text2 = "Expanding macros"
 
             val stages1 = extractableList.parallelStream().unordered().flatMap { extractable ->
-                executeUnderProgress(subTaskIndicator) {
+                executeUnderProgressWithWriteActionPriorityWithRetries(subTaskIndicator) {
                     // We need smart mode because rebind can be performed
                     runReadActionInSmartMode(project) {
                         val result = extractable.extract()


### PR DESCRIPTION
Relates to the new macro expansion engine #3628. `extract()` is basically fast, but may access indices. When accessing indices, an index may rebuild stubs for unsaved files, which is slow. Slow read actions should be wrapped with a cancellable section