### PR TITLE
Use performance optimizations provided by FileTypeDetector API not to slow down IDEs using TOML plugin

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -105,6 +105,7 @@ Turbo87
 tuxxi
 ujpv
 Undin
+valich
 vasily-kirichenko
 vitvakatu
 vlad20012

--- a/intellij-toml/src/192/main/kotlin/org/toml/lang/TomlFileTypeDetector.kt
+++ b/intellij-toml/src/192/main/kotlin/org/toml/lang/TomlFileTypeDetector.kt
@@ -1,0 +1,9 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.lang
+
+class TomlFileTypeDetector : TomlFileTypeDetectorBase() {
+}

--- a/intellij-toml/src/193/main/kotlin/org/toml/lang/TomlFileTypeDetector.kt
+++ b/intellij-toml/src/193/main/kotlin/org/toml/lang/TomlFileTypeDetector.kt
@@ -5,10 +5,11 @@
 
 package org.toml.lang
 
+import com.intellij.openapi.fileTypes.FileType
 import org.toml.lang.psi.TomlFileType
 
 class TomlFileTypeDetector : TomlFileTypeDetectorBase() {
-    override fun getDetectedFileTypes() = listOf(TomlFileType)
+    override fun getDetectedFileTypes(): Collection<FileType> = listOf(TomlFileType)
 
-    override fun getDesiredContentPrefixLength() = 0
+    override fun getDesiredContentPrefixLength(): Int = 0
 }

--- a/intellij-toml/src/193/main/kotlin/org/toml/lang/TomlFileTypeDetector.kt
+++ b/intellij-toml/src/193/main/kotlin/org/toml/lang/TomlFileTypeDetector.kt
@@ -1,0 +1,14 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.lang
+
+import org.toml.lang.psi.TomlFileType
+
+class TomlFileTypeDetector : TomlFileTypeDetectorBase() {
+    override fun getDetectedFileTypes() = listOf(TomlFileType)
+
+    override fun getDesiredContentPrefixLength() = 0
+}

--- a/intellij-toml/src/main/kotlin/org/toml/lang/TomlFileTypeDetector.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/TomlFileTypeDetector.kt
@@ -12,8 +12,12 @@ import com.intellij.openapi.vfs.VirtualFile
 import org.toml.lang.psi.TomlFileType
 
 class TomlFileTypeDetector : FileTypeRegistry.FileTypeDetector {
-    override fun getVersion(): Int = 1
+    override fun getVersion() = 1
 
     override fun detect(file: VirtualFile, firstBytes: ByteSequence, firstCharsIfText: CharSequence?): FileType? =
         if (file.name == "config" && file.parent?.name == ".cargo") TomlFileType else null
+
+    override fun getDetectedFileTypes() = listOf(TomlFileType)
+
+    override fun getDesiredContentPrefixLength() = 0
 }

--- a/intellij-toml/src/main/kotlin/org/toml/lang/TomlFileTypeDetectorBase.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/TomlFileTypeDetectorBase.kt
@@ -12,7 +12,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import org.toml.lang.psi.TomlFileType
 
 abstract class TomlFileTypeDetectorBase : FileTypeRegistry.FileTypeDetector {
-    override fun getVersion() = 1
+    override fun getVersion(): Int = 1
 
     override fun detect(file: VirtualFile, firstBytes: ByteSequence, firstCharsIfText: CharSequence?): FileType? =
         if (file.name == "config" && file.parent?.name == ".cargo") TomlFileType else null

--- a/intellij-toml/src/main/kotlin/org/toml/lang/TomlFileTypeDetectorBase.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/TomlFileTypeDetectorBase.kt
@@ -11,13 +11,9 @@ import com.intellij.openapi.util.io.ByteSequence
 import com.intellij.openapi.vfs.VirtualFile
 import org.toml.lang.psi.TomlFileType
 
-class TomlFileTypeDetector : FileTypeRegistry.FileTypeDetector {
+abstract class TomlFileTypeDetectorBase : FileTypeRegistry.FileTypeDetector {
     override fun getVersion() = 1
 
     override fun detect(file: VirtualFile, firstBytes: ByteSequence, firstCharsIfText: CharSequence?): FileType? =
         if (file.name == "config" && file.parent?.name == ".cargo") TomlFileType else null
-
-    override fun getDetectedFileTypes() = listOf(TomlFileType)
-
-    override fun getDesiredContentPrefixLength() = 0
 }


### PR DESCRIPTION
I suspect TOML plugin to be responsible for numerous IDE freezes due to our poor file type matching API. Namely, all FileTypeDetectors which do not implement `getDetectedFileTypes` take part in all `isFileOfType` checks by eating loading file content, which is loaded lazily.

This PR fixes the behaviour.