### PR TITLE
ACT: fix IllegalStateException in `Attach` action

### DIFF
--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -109,7 +109,7 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
     private fun createAttachCargoProjectPanel(debugId: String, file: VirtualFile, message: String): RsEditorNotificationPanel =
         RsEditorNotificationPanel(debugId).apply {
             setText(message)
-            createActionLabel("Attach", "Rust.AttachCargoProject")
+            createActionLabel("Attach", "Cargo.AttachCargoProject")
             createActionLabel("Do not show again") {
                 disableNotification(file)
                 updateAllNotifications()


### PR DESCRIPTION
After some refactoring action id was changed in plugin.xml but wasn't changed in `MissingToolchainNotificationProvider`. That leads to IllegalStateException because the corresponding action cannot be found by old id

Fixes #4503