### PR TITLE
MACRO: rework macro-to-expansion linkage

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiTreeChangeListener.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiTreeChangeListener.kt
@@ -103,7 +103,7 @@ sealed class RsPsiTreeChangeEvent {
         val parent: PsiElement,
         /**
          * "generic change" event means that "something changed inside an element" and
-         * sends after all events for concrete PSI changes in the element.
+         * sends before/after all events for concrete PSI changes in the element.
          */
         val isGenericChange: Boolean
     ) : RsPsiTreeChangeEvent() {


### PR DESCRIPTION
The problem: there is `RsMacroCall` and `ExpandedMacroInfo`.
We want reliably link them to each other.

Previous solution:
- `ExpandedMacroInfo` holds stub index (aka `ID`) of a macro call
  and a `SoftReference` to the macro call
- there is `rebind` function that fills in such soft references
- we use such soft references in most cases
- if we detect that references was lost (GCed), we do `rebind` again
- *sometimes* we dump stub indices (aka `ID`s) from macro calls
  (accessed trough sort references)

Issues with that solution:
- it's not clear when to call `rebind`. `SoftReference`s can
  be GCed at any time. We should detect it and call `rebind`
  in this case. It's difficult to make it reliable.
- it's not clear when we should dump stub indices (IDs).
  We should do it before PSI unloads (soft references GC).
  We did it while saving a document, but PSI may already be unloaded
  at that moment.

In short, the solution was unreliable: we lost macro
expansions sometimes.

New solution:
- `ExpandedMacroInfo` holds stub index (aka `ID`) of a macro call
  and a *strong* reference to the macro call (that is `null`
  most of the time)
- we use *stub indices* most of the time
- before PSI modification we store *strong* references and then,
  after the end of PSI modification, we switching back to stub
  references and releasing strong refs.

It solves both mentioned problems:
- no soft references no problems
- no soft references no problems