### PR TITLE
QDOC: render `async` keyword for async functions in quick doc

### DIFF
--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -283,6 +283,9 @@ private val RsItemElement.declarationModifiers: List<String> get() {
     }
     when (this) {
         is RsFunction -> {
+            if (isAsync) {
+                modifiers += "async"
+            }
             if (isConst) {
                 modifiers += "const"
             }

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -93,6 +93,14 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         extern "C" fn <b>foo</b>()</pre></div>
     """)
 
+    fun `test async fn`() = doTest("""
+        async fn foo() {}
+                //^
+    """, """
+        <div class='definition'><pre>test_package
+        async fn <b>foo</b>()</pre></div>
+    """)
+
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test generic fn`() = doTest("""
         fn foo<T: Into<String>>(t: T) {}


### PR DESCRIPTION
Fixes #4552