### PR TITLE
Rename RsMacroCallBodyCompletionTest according to provider

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/completion/RsFullMacroArgumentCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsFullMacroArgumentCompletionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.lang.core.completion
 
-class RsMacroCallBodyCompletionTest : RsCompletionTestBase() {
+class RsFullMacroArgumentCompletionTest : RsCompletionTestBase() {
     fun `test simple`() = doSingleCompletion("""
         macro_rules! foo {
             ($($ i:item)*) => { $($ i)* };


### PR DESCRIPTION
Rename `RsMacroCallBodyCompletionTest` to `RsFullMacroArgumentCompletionTest` (like `RsPartialMacroArgumentCompletionTest`)