### PR TITLE
Don't annotate 2018 edition keywords inside cfg-disabled code

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotator.kt
@@ -8,6 +8,7 @@ package org.rust.ide.annotator
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.psi.PsiElement
 import org.rust.ide.colors.RsColor
+import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 import org.rust.lang.core.psi.ext.*
@@ -15,6 +16,7 @@ import org.rust.lang.core.psi.ext.*
 class RsEdition2018KeywordsAnnotator : RsAnnotatorBase() {
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         if (!isEdition2018Keyword(element)) return
+        if (!element.isEnabledByCfg) return
 
         val isEdition2018 = element.isEdition2018
         val isIdentifier = element.elementType == IDENTIFIER

--- a/src/test/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotatorTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+import org.rust.MockAdditionalCfgOptions
+import org.rust.MockEdition
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ide.colors.RsColor
+
+class RsCfgDisabledCodeAnnotatorTest : RsAnnotatorTestBase(RsCfgDisabledCodeAnnotator::class.java) {
+    override fun setUp() {
+        super.setUp()
+        registerSeverities(listOf(RsColor.CFG_DISABLED_CODE.testSeverity))
+    }
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test enabled function`() = checkHighlighting("""
+        #[cfg(intellij_rust)]
+        fn foo() {
+            let x = 1;
+        }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test disabled function`() = checkHighlighting("""
+        <CFG_DISABLED_CODE descr="Conditionally disabled code">#[cfg(not(intellij_rust))]
+        fn foo() {
+            let x = 1;
+        }
+        </CFG_DISABLED_CODE>
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test disabled function multiple attrs`() = checkHighlighting("""
+        <CFG_DISABLED_CODE descr="Conditionally disabled code">#[allow(unused_variables)]
+        #[cfg(not(intellij_rust))]
+        #[allow(non_camel_case_types)]
+        fn foo() {
+            let x = 1;
+        }
+        </CFG_DISABLED_CODE>
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test disabled async function 2018 edition`() = checkHighlighting("""
+        <CFG_DISABLED_CODE descr="Conditionally disabled code">#[cfg(not(intellij_rust))]
+        async fn foo() {
+            let x = 1;
+        }
+        </CFG_DISABLED_CODE>
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test disabled try expr 2018 edition`() = checkHighlighting("""
+        fn foo() {
+        <CFG_DISABLED_CODE descr="Conditionally disabled code">#[cfg(not(intellij_rust))]try {
+                let x = 1;
+            }
+        </CFG_DISABLED_CODE>    
+        }
+    """)
+}


### PR DESCRIPTION
Fixes #4571

<img width="218" alt="Screenshot 2019-10-28 at 17 15 35" src="https://user-images.githubusercontent.com/4854600/67685676-96b76700-f9a6-11e9-99cb-0f5da2be3296.png">
