### PR TITLE
MACRO: disable name resolution for include with env("OUT_DIR") by default

### DIFF
--- a/src/192/main/kotlin/org/rust/openapiext/compatUtils.kt
+++ b/src/192/main/kotlin/org/rust/openapiext/compatUtils.kt
@@ -8,3 +8,4 @@ package org.rust.openapiext
 import com.intellij.openapi.application.Experiments
 
 fun isFeatureEnabled(featureId: String): Boolean = Experiments.isFeatureEnabled(featureId)
+fun setFeatureEnabled(featureId: String, enabled: Boolean) = Experiments.setFeatureEnabled(featureId, enabled)

--- a/src/193/main/kotlin/org/rust/openapiext/compatUtils.kt
+++ b/src/193/main/kotlin/org/rust/openapiext/compatUtils.kt
@@ -8,3 +8,4 @@ package org.rust.openapiext
 import com.intellij.openapi.application.Experiments
 
 fun isFeatureEnabled(featureId: String): Boolean = Experiments.getInstance().isFeatureEnabled(featureId)
+fun setFeatureEnabled(featureId: String, enabled: Boolean) = Experiments.getInstance().setFeatureEnabled(featureId, enabled)

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -34,6 +34,7 @@ import org.rust.cargo.toolchain.Rustup.Companion.checkNeedInstallClippy
 import org.rust.cargo.toolchain.impl.CargoBuildPlan
 import org.rust.cargo.toolchain.impl.CargoMetadata
 import org.rust.ide.actions.InstallBinaryCrateAction
+import org.rust.ide.experiments.RsExperiments
 import org.rust.ide.notifications.showBalloon
 import org.rust.openapiext.*
 import org.rust.stdext.buildList
@@ -129,8 +130,9 @@ class Cargo(private val cargoExecutable: Path) {
         projectDirectory: Path,
         listener: ProcessListener?
     ): CargoBuildPlan? {
+        if (!isFeatureEnabled(RsExperiments.FETCH_OUT_DIR)) return null
         val additionalArgs = mutableListOf("-Z", "unstable-options", "--all-targets", "--build-plan")
-        // Hack to make cargo think that current channel is nightly because we need unstable `--build-plan` option here
+        // Hack to make cargo think that unstable options are available because we need unstable `--build-plan` option here
         val envs = EnvironmentVariablesData.create(mapOf(
             RUSTC_BOOTSTRAP to "1"
         ), true)

--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -8,4 +8,5 @@ package org.rust.ide.experiments
 object RsExperiments {
     const val BUILD_TOOL_WINDOW = "org.rust.cargo.build.tool.window"
     const val CFG_ATTRIBUTES_SUPPORT = "org.rust.lang.cfg.attributes"
+    const val FETCH_OUT_DIR = "org.rust.cargo.fetch.out.dir"
 }

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -304,3 +304,13 @@ val DataContext.elementUnderCaretInEditor: PsiElement?
 
         return psiFile.findElementAt(editor.caretModel.offset)
     }
+
+fun runWithEnabledFeature(featureId: String, action: () -> Unit) {
+    val currentValue = isFeatureEnabled(featureId)
+    setFeatureEnabled(featureId, true)
+    try {
+        action()
+    } finally {
+        setFeatureEnabled(featureId, currentValue)
+    }
+}

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -6,5 +6,8 @@
         <experimentalFeature id="org.rust.lang.cfg.attributes" percentOfUsers="100">
             <description>Enable Rust cfg attributes support</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.cargo.fetch.out.dir" percentOfUsers="0">
+            <description>Fetch `OUT_DIR` environment variable value. It's needed to make proper name resolution for code included via `include` macro</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -6,5 +6,8 @@
         <experimentalFeature id="org.rust.lang.cfg.attributes" percentOfUsers="100">
             <description>Enable Rust cfg attributes support</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.cargo.fetch.out.dir" percentOfUsers="0">
+            <description>Fetch `OUT_DIR` environment variable value. It's needed to make proper name resolution for code included via `include` macro</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/RsIncludeMacroResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/RsIncludeMacroResolveTest.kt
@@ -6,12 +6,14 @@
 package org.rustSlowTests.cargo.runconfig
 
 import org.rust.MinRustcVersion
+import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.core.psi.RsPath
+import org.rust.openapiext.runWithEnabledFeature
 
 @MinRustcVersion("1.32.0")
 class RsIncludeMacroResolveTest : RunConfigurationTestBase() {
 
-    fun `test include in workspace project`() {
+    fun `test include in workspace project`() = withEnabledFetchOutDirFeature {
         val testProject = buildProject {
             toml("Cargo.toml", """
                 [package]
@@ -55,7 +57,7 @@ class RsIncludeMacroResolveTest : RunConfigurationTestBase() {
         }
     }
 
-    fun `test include in dependency`() {
+    fun `test include in dependency`() = withEnabledFetchOutDirFeature {
         val testProject = buildProject {
             toml("Cargo.toml", """
                 [package]
@@ -80,4 +82,7 @@ class RsIncludeMacroResolveTest : RunConfigurationTestBase() {
             testProject.findElementInFile<RsPath>("src/lib.rs").reference.resolve() != null
         }
     }
+
+    private fun withEnabledFetchOutDirFeature(action: () -> Unit) =
+        runWithEnabledFeature(RsExperiments.FETCH_OUT_DIR, action)
 }


### PR DESCRIPTION
Recently supported name resolution for included files uses `cargo build --build-plan` to fetch value of `OUT_DIR` environment variable (see #4542).
Found out that `cargo build --build-plan` force next `build` command to recompile whole project (including dependencies).
See https://github.com/rust-lang/cargo/issues/5579#issuecomment-546760770.
At this moment it is part of refresh, i.e. it is invoked on each `Cargo.toml` change, project reopening, etc. So this command is invoked quite frequently.
It can be rather unexpected for large project to make full compilation after each project reopening

So we decided to disable it by default until it will be fixed from cargo side or we'll find better way to get `OUT_DIR` value
