### PR TITLE
MACRO: prevent stackoverflow while name resolution for include macro

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsIncludeMacroIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsIncludeMacroIndex.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.stubs.index
 
+import com.intellij.openapi.util.Computable
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.IndexSink
 import com.intellij.psi.stubs.StringStubIndexExtension
@@ -17,6 +18,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsMacroCallStub
+import org.rust.openapiext.recursionGuard
 
 class RsIncludeMacroIndex : StringStubIndexExtension<RsMacroCall>() {
     override fun getVersion(): Int = RsFileStub.Type.stubVersion
@@ -45,20 +47,22 @@ class RsIncludeMacroIndex : StringStubIndexExtension<RsMacroCall>() {
         }
 
         private fun getIncludingModInternal(file: RsFile): RsMod? {
-            val key = file.name
-            val project = file.project
+            return recursionGuard(file, Computable {
+                val key = file.name
+                val project = file.project
 
-            var parentMod: RsMod? = null
-            StubIndex.getInstance().processElements(KEY, key, project, GlobalSearchScope.allScope(project), RsMacroCall::class.java) { macroCall ->
-                val includingFile = macroCall.findIncludingFile()
-                if (includingFile == file) {
-                    parentMod = macroCall.containingMod
-                    false
-                } else {
-                    true
+                var parentMod: RsMod? = null
+                StubIndex.getInstance().processElements(KEY, key, project, GlobalSearchScope.allScope(project), RsMacroCall::class.java) { macroCall ->
+                    val includingFile = macroCall.findIncludingFile()
+                    if (includingFile == file) {
+                        parentMod = macroCall.containingMod
+                        false
+                    } else {
+                        true
+                    }
                 }
-            }
-            return parentMod
+                parentMod
+            })
         }
 
         private fun key(call: RsMacroCall): String? {

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/RsIncludeMacroResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/RsIncludeMacroResolveTest.kt
@@ -57,6 +57,130 @@ class RsIncludeMacroResolveTest : RunConfigurationTestBase() {
         }
     }
 
+    // https://github.com/intellij-rust/intellij-rust/issues/4579
+    fun `test do not overflow stack 1`() = withEnabledFetchOutDirFeature {
+        val testProject = buildProject {
+            toml("Cargo.toml", """
+                [package]
+                name = "intellij-rust-test"
+                version = "0.1.0"
+                authors = []
+            """)
+            rust("build.rs", """
+                use std::env;
+                use std::fs::File;
+                use std::io::Write;
+                use std::path::Path;
+
+                fn main() {
+                    let out_dir = env::var("OUT_DIR").unwrap();
+                    let dest_path = Path::new(&out_dir).join("main.rs");
+                    let mut f = File::create(&dest_path).unwrap();
+
+                    f.write_all(b"
+                        pub fn message() -> &'static str {
+                            \"Hello, World!\"
+                        }",
+                    ).unwrap();
+                }
+            """)
+            dir("src") {
+                rust("main.rs", """
+                    include!(concat!(env!("OUT_DIR"), "/main.rs"));
+
+                    fn main() {
+                        println!("{}", message());
+                                        //^
+                    }
+                """)
+            }
+        }
+        buildProject()
+
+        runWithInvocationEventsDispatching("Failed to resolve the reference") {
+            testProject.findElementInFile<RsPath>("src/main.rs").reference.resolve() != null
+        }
+    }
+
+    // https://github.com/intellij-rust/intellij-rust/issues/4579
+    fun `test do not overflow stack 2`() = withEnabledFetchOutDirFeature {
+        val testProject = buildProject {
+            toml("Cargo.toml", """
+                [workspace]
+                members = [
+                    "intellij-rust-test-1",
+                    "intellij-rust-test-2"
+                ]
+            """)
+            dir("intellij-rust-test-1") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "intellij-rust-test-1"
+                    version = "0.1.0"
+                    authors = []
+
+                """)
+                rust("build.rs", """
+                    use std::env;
+                    use std::fs::File;
+                    use std::io::Write;
+                    use std::path::Path;
+
+                    fn main() {
+                        let out_dir = env::var("OUT_DIR").unwrap();
+                        let dest_path = Path::new(&out_dir).join("lib.rs");
+                        let mut f = File::create(&dest_path).unwrap();
+
+                        f.write_all(b"
+                            pub fn message() -> &'static str {
+                                \"Hello, World!\"
+                            }",
+                        ).unwrap();
+                    }
+                """)
+                dir("src") {
+                    rust("lib.rs", """
+                        include!(concat!(env!("OUT_DIR"), "/lib.rs"));
+
+                        fn main() {
+                            println!("{}", message());
+                                            //^
+                        }
+                    """)
+                }
+            }
+            dir("intellij-rust-test-2") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "intellij-rust-test-2"
+                    version = "0.1.0"
+                    authors = []
+                """)
+                rust("build.rs", """
+                    use std::env;
+                    use std::fs::File;
+                    use std::path::Path;
+
+                    fn main() {
+                        let out_dir = env::var("OUT_DIR").unwrap();
+                        let dest_path = Path::new(&out_dir).join("lib.rs");
+                        let mut f = File::create(&dest_path).unwrap();
+                    }
+                """)
+                dir("src") {
+                    rust("lib.rs", """
+                        include!(concat!(env!("OUT_DIR"), "/lib.rs"));
+                    """)
+                }
+            }
+        }
+        buildProject()
+
+        runWithInvocationEventsDispatching("Failed to resolve the reference") {
+            testProject.findElementInFile<RsPath>("intellij-rust-test-1/src/lib.rs").reference.resolve() != null
+        }
+    }
+
     fun `test include in dependency`() = withEnabledFetchOutDirFeature {
         val testProject = buildProject {
             toml("Cargo.toml", """


### PR DESCRIPTION
The main reason of SO Error was the following construction:
```rust
//- some_name.rs
include!(concat!(env!("OUT_DIR"), "/some_name.rs"))
```

In this case, we start to process `some_name.rs` while processing `include!` macro call and fall into an endless loop. Of course, it's just the simplest example
Fixes #4579