### PR TITLE
INSP: Ignore `Self` identifier in RsDeprecationInspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsDeprecationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDeprecationInspection.kt
@@ -8,6 +8,7 @@ package org.rust.ide.inspections
 import com.intellij.codeInspection.ProblemHighlightType.LIKE_DEPRECATED
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
+import org.rust.lang.core.psi.RsElementTypes.CSELF
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsMetaItem
 import org.rust.lang.core.psi.RsModDeclItem
@@ -26,6 +27,9 @@ class RsDeprecationInspection : RsLintInspection() {
 
             val original = ref.reference?.resolve() ?: return
             val identifier = ref.referenceNameElement ?: return
+
+            // ignore `Self` identifier
+            if (identifier.elementType == CSELF) return
 
             val targetElement = when (original) {
                 is RsFile -> original.declaration

--- a/src/test/kotlin/org/rust/ide/inspections/RsDeprecationInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDeprecationInspectionTest.kt
@@ -352,4 +352,10 @@ class RsDeprecationInspectionTest : RsInspectionsTestBase(RsDeprecationInspectio
         }
     """)
 
+    fun `test no warning on Self inside deprecated trait`() = checkByText("""
+        #[deprecated()]
+        trait T {
+            fn new() -> Self;
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #4557