### PR TITLE
TY: fix empty array type inference

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -1213,7 +1213,7 @@ class RsTypeInferenceWalker(
             elementType to size
         } else {
             val elementTypes = expr.arrayElements?.map { it.inferType(expectedElemTy) }
-            if (elementTypes.isNullOrEmpty()) return TySlice(TyUnknown)
+            if (elementTypes.isNullOrEmpty()) return TyArray(TyInfer.TyVar(), 0)
 
             // '!!' is safe here because we've just checked that elementTypes isn't null
             val elementType = getMoreCompleteType(elementTypes!!)

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -834,6 +834,13 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test array expression type6`() = testExpr("""
+        fn main() {
+            let x: [i32; 0] = [];
+                            //^ [i32; 0]
+        }
+    """)
+
     fun `test usize constant as array size`() = testExpr("""
         const COUNT: usize = 2;
         fn main() {


### PR DESCRIPTION
Works for `[]`