### PR TITLE
REF: use processors instead of sequences in impl lookup

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -44,6 +44,8 @@ enum class ScopeEvent : ScopeEntry {
     override val element: RsElement? get() = null
 }
 
+typealias RsProcessor<T> = (T) -> Boolean
+
 /**
  * Return `true` to stop further processing,
  * return `false` to continue search


### PR DESCRIPTION
It simplifies profiling and stacktrace analysis