### PR TITLE
CARGO&RES: Initial support of cargo features

### DIFF
--- a/src/main/kotlin/org/rust/cargo/CfgOptions.kt
+++ b/src/main/kotlin/org/rust/cargo/CfgOptions.kt
@@ -15,9 +15,8 @@ class CfgOptions(
     fun isNameEnabled(name: String): Boolean =
         name in nameOptions
 
-    // TODO remove special case for "feature"
     fun isNameValueEnabled(name: String, value: String): Boolean =
-        name == "feature" || keyValueOptions[name]?.contains(value) ?: false
+        keyValueOptions[name]?.contains(value) ?: false
 
     companion object {
         fun parse(rawCfgOptions: List<String>): CfgOptions {

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -74,6 +74,8 @@ interface CargoWorkspace {
 
         val cfgOptions: CfgOptions
 
+        val features: Collection<Feature>
+
         val workspace: CargoWorkspace
 
         val edition: Edition
@@ -137,6 +139,16 @@ interface CargoWorkspace {
         EDITION_2015, EDITION_2018
     }
 
+    class Feature(
+        val name: String,
+        val state: FeatureState
+    )
+
+    enum class FeatureState {
+        Enabled,
+        Disabled
+    }
+
     companion object {
         fun deserialize(manifestPath: Path, data: CargoWorkspaceData, cfgOptions: CfgOptions): CargoWorkspace =
             WorkspaceImpl.deserialize(manifestPath, data, cfgOptions)
@@ -161,7 +173,8 @@ private class WorkspaceImpl(
             pkg.source,
             pkg.origin,
             pkg.edition,
-            cfgOptions
+            cfgOptions,
+            pkg.features
         )
     }
 
@@ -294,7 +307,8 @@ private class PackageImpl(
     override val source: String?,
     override var origin: PackageOrigin,
     override val edition: CargoWorkspace.Edition,
-    override val cfgOptions: CfgOptions
+    override val cfgOptions: CfgOptions,
+    override val features: Collection<CargoWorkspace.Feature>
 ) : CargoWorkspace.Package {
     override val targets = targetsData.map {
         TargetImpl(
@@ -360,7 +374,8 @@ private fun PackageImpl.asPackageData(edition: CargoWorkspace.Edition? = null): 
         },
         source = source,
         origin = origin,
-        edition = edition ?: this.edition
+        edition = edition ?: this.edition,
+        features = features
     )
 
 private fun StandardLibrary.StdCrate.asPackageData(rustcInfo: RustcInfo?): CargoWorkspaceData.Package {
@@ -392,7 +407,8 @@ private fun StandardLibrary.StdCrate.asPackageData(rustcInfo: RustcInfo?): Cargo
         )),
         source = null,
         origin = PackageOrigin.STDLIB,
-        edition = edition
+        edition = edition,
+        features = emptyList()
     )
 }
 

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
@@ -27,7 +27,8 @@ data class CargoWorkspaceData(
         val targets: Collection<Target>,
         val source: String?,
         val origin: PackageOrigin,
-        val edition: CargoWorkspace.Edition
+        val edition: CargoWorkspace.Edition,
+        val features: Collection<CargoWorkspace.Feature>
     )
 
     data class Target(

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -7,6 +7,7 @@ package org.rust.cargo.toolchain.impl
 
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.PathUtil
@@ -19,6 +20,8 @@ import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.openapiext.findFileByMaybeRelativePath
 import org.rust.stdext.mapToSet
 import java.util.*
+
+private val LOG = Logger.getInstance(CargoMetadata::class.java)
 
 /**
  * Classes mirroring JSON output of `cargo metadata`.
@@ -95,7 +98,13 @@ object CargoMetadata {
          * Can be "2015", "2018" or null. Null value can be got from old version of cargo
          * so it is the same as "2015"
          */
-        val edition: String?
+        val edition: String?,
+
+        /**
+         * Features available in this package.
+         * The entry named "default" defines which features are enabled by default.
+         */
+        val features: Map<String, List<String>>
     )
 
 
@@ -198,9 +207,13 @@ object CargoMetadata {
          * List of dependency info
          *
          * Contains additional info compared with [dependencies] like custom package name.
-         * Can be null for old cargo version
          */
-        val deps: List<Dep>?
+        val deps: List<Dep>?,
+
+        /**
+         * Enabled features (including optional dependencies)
+         */
+        val features: List<String>?
     )
 
     data class Dep(
@@ -240,12 +253,32 @@ object CargoMetadata {
     fun clean(project: Project, buildPlan: CargoBuildPlan?): CargoWorkspaceData {
         val fs = LocalFileSystem.getInstance()
         val members = project.workspace_members
-            ?: error("No `members` key in the `cargo metadata` output.\n" +
-            "Your version of Cargo is no longer supported, please upgrade Cargo.")
-
+            ?: error(
+                "No `workspace_members` key in the `cargo metadata` output.\n" +
+                    "Your version of Cargo is no longer supported, please upgrade Cargo."
+            )
         val variables = TargetVariables.from(buildPlan)
+        val packageIdToNode = project.resolve.nodes.associateBy { it.id }
+
         return CargoWorkspaceData(
-            project.packages.mapNotNull { it.clean(fs, it.id in members, variables) },
+            project.packages.mapNotNull { pkg ->
+                // resolve contains all enabled features for each package
+                val resolveNode = packageIdToNode[pkg.id]
+                if (resolveNode == null) {
+                    LOG.error("Could not find package with `id` '${pkg.id}' in `resolve` section of the `cargo metadata` output.")
+                }
+
+                val enabledFeatures = resolveNode?.features?.toSet().orEmpty()
+                val features = pkg.features.keys.map { feature ->
+                    val state = when {
+                        enabledFeatures.contains(feature) -> CargoWorkspace.FeatureState.Enabled
+                        else -> CargoWorkspace.FeatureState.Disabled
+                    }
+                    CargoWorkspace.Feature(feature, state)
+                }
+
+                pkg.clean(fs, pkg.id in members, variables, features)
+            },
             project.resolve.nodes.associate { (id, dependencies, deps) ->
                 val dependencySet = if (deps != null) {
                     deps.mapToSet { (pkgId, name) -> CargoWorkspaceData.Dependency(pkgId, name) }
@@ -261,11 +294,13 @@ object CargoMetadata {
     private fun Package.clean(
         fs: LocalFileSystem,
         isWorkspaceMember: Boolean,
-        variables: TargetVariables
+        variables: TargetVariables,
+        features: List<CargoWorkspace.Feature>
     ): CargoWorkspaceData.Package? {
         val root = checkNotNull(fs.refreshAndFindFileByPath(PathUtil.getParentPath(manifest_path))?.canonicalFile) {
             "`cargo metadata` reported a package which does not exist at `$manifest_path`"
         }
+
         return CargoWorkspaceData.Package(
             id,
             root.url,
@@ -274,7 +309,8 @@ object CargoMetadata {
             targets.mapNotNull { it.clean(this, root, variables) },
             source,
             origin = if (isWorkspaceMember) PackageOrigin.WORKSPACE else PackageOrigin.TRANSITIVE_DEPENDENCY,
-            edition = edition.cleanEdition()
+            edition = edition.cleanEdition(),
+            features = features
         )
     }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -203,7 +203,7 @@ private fun RsDocAndAttributeOwner.evaluateCfg(): ThreeValuedLogic {
     // this will return the library as containing package.
     // When the application now requests certain features, which are not enabled by default in the library
     // we will evaluate features wrongly here
-    val options = containingCargoPackage?.cfgOptions ?: return ThreeValuedLogic.True
-
-    return CfgEvaluator(options).evaluate(cfgAttributes)
+    val pkg = containingCargoPackage ?: return ThreeValuedLogic.True
+    val features = pkg.features.associate { it.name to it.state }
+    return CfgEvaluator(pkg.cfgOptions, features, pkg.origin).evaluate(cfgAttributes)
 }

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -74,7 +74,8 @@ open class RustProjectDescriptorBase : LightProjectDescriptor() {
         ),
         source = null,
         origin = PackageOrigin.WORKSPACE,
-        edition = Edition.EDITION_2015
+        edition = Edition.EDITION_2015,
+        features = emptyList()
     )
 }
 
@@ -156,7 +157,8 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
             ),
             source = source,
             origin = origin,
-            edition = Edition.EDITION_2015
+            edition = Edition.EDITION_2015,
+            features = emptyList()
         )
     }
 

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestBase.kt
@@ -221,7 +221,8 @@ abstract class RunConfigurationProducerTestBase : RsTestBase() {
                             },
                             source = null,
                             origin = PackageOrigin.WORKSPACE,
-                            edition = Edition.EDITION_2015
+                            edition = Edition.EDITION_2015,
+                            features = emptyList()
                         )
                     ),
                     dependencies = emptyMap()

--- a/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
@@ -123,7 +123,8 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
             targets = targets,
             source = null,
             origin = if (isWorkspaceMember) PackageOrigin.WORKSPACE else PackageOrigin.DEPENDENCY,
-            edition = edition
+            edition = edition,
+            features = emptyList()
         )
 
         val pkgs = listOf(


### PR DESCRIPTION
Name resolution now takes into account which Cargo features are enabled when resolving items from dependency.

Note that only dependencies' features evaluation is supported so far. Workspace features will be supported later.

Fixes #4329. Part of #1191