### PR TITLE
RUN & INSP: Fix error span in rustc messages if the error comes from macro expansion

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/RustcMessage.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustcMessage.kt
@@ -52,8 +52,9 @@ data class RustcMessage(
 ) {
     val mainSpan: RustcSpan?
         get() {
-            val validSpans = spans.filter { it.isValid() && !it.file_name.startsWith("<") }
-            return validSpans.firstOrNull { it.is_primary } ?: validSpans.maxBy { it.byte_start }
+            val validSpan = spans.filter { it.isValid() }.firstOrNull { it.is_primary } ?: return null
+            return generateSequence(validSpan) { it.expansion?.span }.last()
+                .takeIf { it.isValid() && !it.file_name.startsWith("<") }
         }
 }
 

--- a/src/test/kotlin/org/rustSlowTests/RsExternalLinterPassTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsExternalLinterPassTest.kt
@@ -38,8 +38,8 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
         fn main() {
             let mut x = 42;
             let r = &mut x;
-            dbg!(x);
-            dbg!(<error descr="${RsExternalLinterUtils.TEST_MESSAGE}">r</error>);
+            <error descr="${RsExternalLinterUtils.TEST_MESSAGE}">dbg!(x);</error>
+            dbg!(r);
         }
     """)
 


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/4636.