### PR TITLE
Fix incorrect module search scope

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferencesSearchExtensionImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsReferencesSearchExtensionImpl.kt
@@ -23,7 +23,7 @@ class RsReferencesSearchExtensionImpl : QueryExecutorBase<RsReference, Reference
                 val elementIndex = elementOwnerStruct.tupleFields!!.tupleFieldDeclList.indexOf(element)
                 queryParameters.optimizer.searchWord(
                     elementIndex.toString(),
-                    elementOwnerStruct.useScope,
+                    queryParameters.effectiveSearchScope,
                     UsageSearchContext.IN_CODE,
                     false,
                     element
@@ -32,7 +32,7 @@ class RsReferencesSearchExtensionImpl : QueryExecutorBase<RsReference, Reference
             element is RsFile && element.getOwnedDirectory() != null ->
                 queryParameters.optimizer.searchWord(
                     element.getOwnedDirectory()!!.name,
-                    element.useScope,
+                    queryParameters.effectiveSearchScope,
                     true,
                     element)
         }


### PR DESCRIPTION
The bug was introduced in #4012. Fixes such artifacts:
![image](https://user-images.githubusercontent.com/3221931/69008344-64bc7380-095a-11ea-89a5-71ef86183c9e.png)
