### PR TITLE
Disable `#[cfg(test)]` in stdlib

### DIFF
--- a/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
@@ -85,6 +85,7 @@ class CfgEvaluator(val options: CfgOptions, val features: Map<String, FeatureSta
 
     private fun evaluateName(name: String): ThreeValuedLogic = when {
         name in SUPPORTED_NAME_OPTIONS -> ThreeValuedLogic.fromBoolean(options.isNameEnabled(name))
+        name == "test" && origin == PackageOrigin.STDLIB -> False
         name == CfgOptions.TEST && isUnitTestMode -> ThreeValuedLogic.fromBoolean(options.isNameEnabled(name))
         else -> Unknown
     }


### PR DESCRIPTION
Fixes #3845