### PR TITLE
PERF&MACRO: do not reset structure mod tracker on macro call change

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -13,6 +13,8 @@ import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.ModificationTracker
+import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.vfs.VirtualFileWithId
@@ -54,8 +56,10 @@ class ExpandedMacroStorage(val project: Project) {
     private val sourceFiles: TIntObjectHashMap<SourceFile> = TIntObjectHashMap()
     private val expandedFileToInfo: TIntObjectHashMap<ExpandedMacroInfoImpl> = TIntObjectHashMap()
     private val stepped: Array<MutableList<SourceFile>?> = arrayOfNulls(DEFAULT_RECURSION_LIMIT)
+    private val _modificationTracker: SimpleModificationTracker = SimpleModificationTracker()
 
     val isEmpty: Boolean get() = sourceFiles.isEmpty
+    val modificationTracker: ModificationTracker get() = _modificationTracker
 
     private fun deserialize(sfs: List<SourceFile>) {
         for (sf in sfs) {
@@ -67,6 +71,7 @@ class ExpandedMacroStorage(val project: Project) {
 
     fun clear() {
         checkWriteAccessAllowed()
+        _modificationTracker.incModificationCount()
         sourceFiles.clear()
         expandedFileToInfo.clear()
         stepped.fill(null)
@@ -126,6 +131,7 @@ class ExpandedMacroStorage(val project: Project) {
         ranges: RangeMap?
     ): ExpandedMacroInfoImpl {
         checkWriteAccessAllowed()
+        _modificationTracker.incModificationCount()
         @Suppress("NAME_SHADOWING")
         val oldInfo = oldInfo as ExpandedMacroInfoImpl
 
@@ -159,6 +165,7 @@ class ExpandedMacroStorage(val project: Project) {
 
     fun removeInvalidInfo(oldInfo: ExpandedMacroInfo, clean: Boolean) {
         checkWriteAccessAllowed()
+        _modificationTracker.incModificationCount()
         @Suppress("NAME_SHADOWING")
         val oldInfo = oldInfo as ExpandedMacroInfoImpl
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -167,8 +167,7 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
             element,
             false,
             RsItemElement::class.java,
-            RsMacro::class.java,
-            RsMacroArgument::class.java
+            RsMacro::class.java
         ) == null
         if (shouldInc) modificationTracker.incModificationCount()
         return shouldInc

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -36,7 +36,8 @@ abstract class RsMacroCallImplMixin : RsStubbedElementImpl<RsMacroCallStub>,
 
     override fun incModificationCount(element: PsiElement): Boolean {
         modificationTracker.incModificationCount()
-        return false // force rustStructureModificationTracker to be incremented
+        val isStructureModification = ancestors.any { it is RsMacroCall && it.macroName == "include" }
+        return !isStructureModification // Note: RsMacroCall is a special case for RsPsiManagerImpl
     }
 }
 
@@ -132,10 +133,7 @@ val RsMacroCall.expansion: MacroExpansion?
             // will be different if completion invoked inside the macro body.
             it.macroBody == this.macroBody
         } ?: this
-        CachedValueProvider.Result.create(
-            project.macroExpansionManager.getExpansionFor(originalOrSelf),
-            rustStructureOrAnyPsiModificationTracker
-        )
+        project.macroExpansionManager.getExpansionFor(originalOrSelf)
     }
 
 val RsMacroCall.expansionFlatten: List<RsExpandedElement>

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsResolveCache.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsResolveCache.kt
@@ -74,7 +74,8 @@ class RsResolveCache(messageBus: MessageBus) {
             override fun beforePsiChanged(isPhysical: Boolean) {}
         })
         connection.subscribe(RUST_PSI_CHANGE_TOPIC, object : RustPsiChangeListener {
-            override fun rustPsiChanged(element: PsiElement) = onRustPsiChanged(element)
+            override fun rustPsiChanged(file: PsiFile, element: PsiElement, isStructureModification: Boolean) =
+                onRustPsiChanged(element)
         })
     }
 


### PR DESCRIPTION
Speeds up things like a completion in macros
