### PR TITLE
Revert "Use default formatting settings from kotlin official style guide"

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,10 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <JetCodeStyleSettings>
-      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
-    </JetCodeStyleSettings>
     <codeStyleSettings language="kotlin">
-      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
       <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,3 @@ showTestStatus=false
 enableBuildSearchableOptions=false
 
 org.gradle.jvmargs=-Xmx2g
-
-kotlin.code.style=official


### PR DESCRIPTION
This reverts commit da1f8e78 (PR https://github.com/intellij-rust/intellij-rust/pull/4598).

The Kotlin official style guide should be applied to the project more carefully later because now it brokes our test formatting.