### PR TITLE
Add support of `Grazie` plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,7 @@ The current Rust plugin modules:
 * `:copyright` - integration with [copyright](https://github.com/JetBrains/intellij-community/tree/master/plugins/copyright) plugin
 * `:duplicates` - support `Duplicated code fragment` inspection
 * `:coverage` - integration with [coverage](https://github.com/JetBrains/intellij-community/tree/master/plugins/coverage-common) plugin
+* `:grazie` - integration with [grazie](https://plugins.jetbrains.com/plugin/12175-grazie) plugin 
 
 If you want to implement integration with another plugin/IDE, you should create a new gradle module for that.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,10 +29,11 @@ val baseVersion = when (baseIDE) {
     else -> error("Unexpected IDE name: `$baseIDE`")
 }
 
-val psiViewerPluginVersion = prop("psiViewerPluginVersion")
-
 val isAtLeast192 = platformVersion.toInt() >= 192
 val isAtLeast193 = platformVersion.toInt() >= 193
+
+val graziePlugin = "tanvd.grazi:${prop("graziePluginVersion")}"
+val psiViewerPlugin = "PsiViewer:${prop("psiViewerPluginVersion")}"
 
 plugins {
     idea
@@ -170,7 +171,8 @@ project(":plugin") {
         val plugins = mutableListOf(
             project(":intellij-toml"),
             "IntelliLang",
-            "PsiViewer:$psiViewerPluginVersion"
+            graziePlugin,
+            psiViewerPlugin
         )
         if (baseIDE == "idea") {
             plugins += "copyright"
@@ -192,6 +194,7 @@ project(":plugin") {
         compile(project(":coverage"))
         compile(project(":intelliLang"))
         compile(project(":duplicates"))
+        compile(project(":grazie"))
     }
 
     tasks {
@@ -409,6 +412,18 @@ project(":coverage") {
         if (baseIDE == "idea") {
             setPlugins("coverage")
         }
+    }
+    dependencies {
+        compile(project(":"))
+        compile(project(":common"))
+        testCompile(project(":", "testOutput"))
+        testCompile(project(":common", "testOutput"))
+    }
+}
+
+project(":grazie") {
+    intellij {
+        setPlugins(graziePlugin)
     }
     dependencies {
         compile(project(":"))

--- a/gradle-192.properties
+++ b/gradle-192.properties
@@ -1,6 +1,7 @@
 ideaVersion=IU-2019.2.3
 clionVersion=CL-2019.2.3
 
+graziePluginVersion=2019.2-6.1.dev@dev
 psiViewerPluginVersion=192-SNAPSHOT
 
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description

--- a/gradle-193.properties
+++ b/gradle-193.properties
@@ -1,6 +1,7 @@
 ideaVersion=IU-193.5233-EAP-CANDIDATE-SNAPSHOT
 clionVersion=CL-193.5233-EAP-CANDIDATE-SNAPSHOT
 
+graziePluginVersion=2019.3-6.1.dev@dev
 psiViewerPluginVersion=193-SNAPSHOT
 
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description

--- a/grazie/src/main/kotlin/org/rust/grazie/RsGrammarCheckingStrategy.kt
+++ b/grazie/src/main/kotlin/org/rust/grazie/RsGrammarCheckingStrategy.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.grazie
+
+import com.intellij.grazie.grammar.strategy.GrammarCheckingStrategy
+import com.intellij.grazie.grammar.strategy.StrategyUtils
+import com.intellij.grazie.grammar.strategy.impl.RuleGroup
+import com.intellij.grazie.utils.LinkedSet
+import com.intellij.psi.PsiElement
+import org.rust.ide.injected.findDoctestInjectableRanges
+import org.rust.lang.core.psi.RsDocCommentImpl
+import org.rust.lang.core.psi.RsLitExpr
+import org.rust.lang.core.psi.ext.stubKind
+import org.rust.lang.core.stubs.RsStubLiteralKind
+
+class RsGrammarCheckingStrategy : GrammarCheckingStrategy {
+    override fun isMyContextRoot(element: PsiElement): Boolean =
+        element is RsDocCommentImpl || element is RsLitExpr && element.stubKind is RsStubLiteralKind.String
+
+    override fun isTypoAccepted(root: PsiElement, typoRange: IntRange, ruleRange: IntRange): Boolean {
+        if (root !is RsDocCommentImpl) return true
+
+        return findDoctestInjectableRanges(root)
+            .flatten()
+            .none { it.intersects(typoRange.first, typoRange.last) }
+    }
+
+    override fun getIgnoredRuleGroup(root: PsiElement, child: PsiElement): RuleGroup? = RuleGroup.LITERALS
+
+    override fun getStealthyRanges(root: PsiElement, text: CharSequence): LinkedSet<IntRange> =
+        StrategyUtils.indentIndexes(text, setOf(' ', '/', '!'))
+}

--- a/grazie/src/main/resources/META-INF/grazie-only.xml
+++ b/grazie/src/main/resources/META-INF/grazie-only.xml
@@ -1,0 +1,5 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij.grazie">
+        <grammar.strategy language="Rust" implementationClass="org.rust.grazie.RsGrammarCheckingStrategy"/>
+    </extensions>
+</idea-plugin>

--- a/grazie/src/test/kotlin/org/rust/grazie/RsGrammarCheckingTest.kt
+++ b/grazie/src/test/kotlin/org/rust/grazie/RsGrammarCheckingTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.grazie
+
+import com.intellij.grazie.GrazieConfig
+import com.intellij.grazie.ide.GrazieInspection
+import com.intellij.grazie.jlanguage.LangDetector
+import org.rust.ide.annotator.RsAnnotationTestFixture
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class RsGrammarCheckingTest : RsInspectionsTestBase(GrazieInspection::class) {
+
+    override fun setUp() {
+        super.setUp()
+        LangDetector.init(GrazieConfig.get(), project)
+    }
+
+    override fun createAnnotationFixture(): RsAnnotationTestFixture =
+        RsAnnotationTestFixture(myFixture, inspectionClasses = listOf(inspectionClass), baseFileName = "lib.rs")
+
+    fun `test check literals`() = checkByText("""
+        fn foo() {
+            let literal = "<TYPO>There is two apples</TYPO>";
+            let raw_literal = r"<TYPO>There is two apples</TYPO>";
+            let binary_literal = b"<TYPO>There is two apples</TYPO>";
+        }
+    """)
+
+    fun `test check doc comments`() = checkByText("""
+        ///
+        /// ```
+        /// let literal = "<TYPO>There is two apples</TYPO>";
+        /// for i in 1..10 {}
+        /// ```
+        pub fn foo() {}
+    """)
+}

--- a/grazie/src/test/resources/META-INF/plugin.xml
+++ b/grazie/src/test/resources/META-INF/plugin.xml
@@ -1,0 +1,5 @@
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+    <id>org.rust.grazie</id>
+    <xi:include href="/META-INF/core.xml" xpointer="xpointer(/idea-plugin/*)"/>
+    <depends optional="true" config-file="grazie-only.xml">tanvd.grazi</depends>
+</idea-plugin>

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -29,6 +29,7 @@
     <depends optional="true" config-file="copyright-only.xml">com.intellij.copyright</depends>
     <depends optional="true" config-file="duplicates-only.xml">com.intellij.modules.duplicatesDetector</depends>
     <depends optional="true" config-file="coverage-only.xml">com.intellij.modules.coverage</depends>
+    <depends optional="true" config-file="grazie-only.xml">tanvd.grazi</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- although Rust module type is only created by IDEA, we need it in other IDEs as well

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,5 +11,6 @@ include(
     "coverage",
     "intelliLang",
     "duplicates",
+    "grazie",
     "intellij-toml"
 )

--- a/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestFixture.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestFixture.kt
@@ -21,10 +21,9 @@ import kotlin.reflect.KClass
 class RsAnnotationTestFixture(
     codeInsightFixture: CodeInsightTestFixture,
     annotatorClasses: List<KClass<out AnnotatorBase>> = emptyList(),
-    inspectionClasses: List<KClass<out InspectionProfileEntry>> = emptyList()
-) : AnnotationTestFixtureBase(codeInsightFixture, annotatorClasses, inspectionClasses) {
-
+    inspectionClasses: List<KClass<out InspectionProfileEntry>> = emptyList(),
     override val baseFileName: String = "main.rs"
+) : AnnotationTestFixtureBase(codeInsightFixture, annotatorClasses, inspectionClasses) {
 
     fun checkByFileTree(
         @Language("Rust") text: String,

--- a/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt
@@ -12,7 +12,7 @@ import org.rust.ide.annotator.RsAnnotationTestFixture
 import kotlin.reflect.KClass
 
 abstract class RsInspectionsTestBase(
-    private val inspectionClass: KClass<out InspectionProfileEntry>
+    protected val inspectionClass: KClass<out InspectionProfileEntry>
 ) : RsAnnotationTestBase() {
 
     override fun createAnnotationFixture(): RsAnnotationTestFixture =


### PR DESCRIPTION
Note, at this moment we use [`grazie`](https://plugins.jetbrains.com/plugin/12175-grazie/) plugin from `dev` channel because it's the first version where `grazie` doesn't depend on intellij rust (otherwise, there is cyclic dependency between these plugin and an IDE doesn't load both ones).
Stable version will be published soon