### PR TITLE
ACT:Display impl block info in Go to Imlementations dialog

### DIFF
--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsGotoTargetRendererProvider.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsGotoTargetRendererProvider.kt
@@ -10,12 +10,28 @@ import com.intellij.codeInsight.navigation.GotoTargetRendererProvider
 import com.intellij.ide.util.PsiElementListCellRenderer
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsImplItem
+import org.rust.lang.core.psi.ext.RsAbstractable
+import org.rust.lang.core.psi.ext.RsAbstractableOwner
+import org.rust.lang.core.psi.ext.owner
 
 class RsGotoTargetRendererProvider : GotoTargetRendererProvider {
     override fun getRenderer(element: PsiElement, gotoData: GotoTargetHandler.GotoData): PsiElementListCellRenderer<*>? {
+        val targetsInImpl = gotoData.targets.all { (it as? RsAbstractable)?.owner is RsAbstractableOwner.Impl }
+        if (!gotoData.hasDifferentNames() && targetsInImpl) {
+            return GoToImplRenderer()
+        }
         if (element is RsImplItem) return ImplRenderer()
         return null
     }
+
+    private class GoToImplRenderer : PsiElementListCellRenderer<RsAbstractable>() {
+        override fun getContainerText(element: RsAbstractable, name: String?): String? = element.presentation?.locationString
+        override fun getElementText(element: RsAbstractable): String? =
+            (element.owner as RsAbstractableOwner.Impl).impl.presentation?.presentableText
+
+        override fun getIconFlags(): Int = 0
+    }
+
 
     private class ImplRenderer : PsiElementListCellRenderer<RsImplItem>() {
         override fun getContainerText(element: RsImplItem, name: String?): String? = element.presentation?.locationString


### PR DESCRIPTION
Better when implementations are in the same file. Also corresponds to IDE behavior for other languages.
![image](https://user-images.githubusercontent.com/8453142/69437862-1b529680-0d55-11ea-9a98-c1cb6f6ecec5.png)

Not sure if there is a way to add a test for it, though.