### PR TITLE
INSP: fix false-positive unresolved reference `Self`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -51,8 +51,8 @@ class RsPathReferenceImpl(
         return advancedMultiResolve().toTypedArray()
     }
 
-    override fun multiResolve(): List<RsNamedElement> =
-        advancedMultiResolve().mapNotNull { it.element as? RsNamedElement }
+    override fun multiResolve(): List<RsElement> =
+        advancedMultiResolve().map { it.element }
 
     private fun advancedMultiResolve(): List<BoundElement<RsElement>> =
         (element.parent as? RsPathExpr)?.let { it.inference?.getResolvedPath(it)?.map { BoundElement(it.element) } }

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -127,6 +127,11 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         }
     """)
 
+    fun `test no unresolved reference for 'Self' type`() = checkByText("""
+        struct Foo;
+        impl Foo { fn foo() -> Self {} }
+    """, false)
+
     private fun checkByText(@Language("Rust") text: String, ignoreWithoutQuickFix: Boolean) {
         val inspection = inspection as RsUnresolvedReferenceInspection
         val defaultValue = inspection.ignoreWithoutQuickFix


### PR DESCRIPTION
when "ignoreWithoutQuickFix" is disabled.
(every `Self` was red if "ignoreWithoutQuickFix" is disabled)
