### PR TITLE
Fix control flow of some elements

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/cfg/CFGBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/cfg/CFGBuilder.kt
@@ -454,8 +454,14 @@ class CFGBuilder(
     override fun visitTupleExpr(tupleExpr: RsTupleExpr) =
         finishWith { straightLine(tupleExpr, pred, tupleExpr.exprList) }
 
-    override fun visitStructLiteral(structLiteral: RsStructLiteral) =
-        finishWith { straightLine(structLiteral, pred, structLiteral.structLiteralBody.structLiteralFieldList.map { it.expr }) }
+    override fun visitStructLiteral(structLiteral: RsStructLiteral) {
+        val subExprs = structLiteral.structLiteralBody.structLiteralFieldList.map { it.expr ?: it }
+        val subExprsExit = subExprs.fold(pred) { acc, subExpr -> process(subExpr, acc) }
+        finishWithAstNode(structLiteral, subExprsExit)
+    }
+
+    override fun visitStructLiteralField(structLiteralField: RsStructLiteralField) =
+        finishWithAstNode(structLiteralField, pred)
 
     override fun visitCastExpr(castExpr: RsCastExpr) =
         finishWith { straightLine(castExpr, pred, listOf(castExpr.expr)) }

--- a/src/main/kotlin/org/rust/lang/core/cfg/CFGBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/cfg/CFGBuilder.kt
@@ -530,5 +530,10 @@ class CFGBuilder(
         finishWith(exprExit)
     }
 
+    override fun visitLambdaExpr(lambdaExpr: RsLambdaExpr) {
+        val exprExit = process(lambdaExpr.expr, pred)
+        finishWithAstNode(lambdaExpr, exprExit)
+    }
+
     override fun visitElement(element: RsElement) = finishWith(pred)
 }

--- a/src/main/kotlin/org/rust/lang/core/types/borrowck/ExprUseWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/borrowck/ExprUseWalker.kt
@@ -234,6 +234,8 @@ class ExprUseWalker(private val delegate: Delegate, private val mc: MemoryCatego
                 consumeExpr(right)
             }
 
+            is RsLambdaExpr -> expr.expr?.let { walkExpr(it) }
+
             is RsBlockExpr -> walkBlock(expr.block)
 
             is RsBreakExpr -> expr.expr?.let { consumeExpr(it) }

--- a/src/main/kotlin/org/rust/lang/core/types/borrowck/ExprUseWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/borrowck/ExprUseWalker.kt
@@ -188,6 +188,7 @@ class ExprUseWalker(private val delegate: Delegate, private val mc: MemoryCatego
             is RsIfExpr -> {
                 expr.condition?.let { walkCondition(it) }
                 expr.block?.let { walkBlock(it) }
+                expr.elseBranch?.ifExpr?.let { walkExpr(it) }
                 expr.elseBranch?.block?.let { walkBlock(it) }
             }
 

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
@@ -145,6 +145,19 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
         }
     """, checkWarn = false)
 
+    fun `test move else if`() = checkByText("""
+        struct S;
+        
+        fn main() {
+            let x = S;
+            if a {
+            } else if b {
+                x;
+            }
+            <error descr="Use of moved value">x</error>;
+        }
+    """, checkWarn = false)
+
     fun `test move in while let or patterns`() = checkByText("""
         struct S;
         enum E { A(S), B(S), C }

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
@@ -568,4 +568,13 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
             }
         }
     """, checkWarn = false)
+
+    fun `test move in lambda expr`() = checkByText("""
+        struct S;
+        fn main() {
+            let s = S;
+            let f = || { s };
+            <error descr="Use of moved value">s</error>;
+        }
+    """, checkWarn = false)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
@@ -145,6 +145,16 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
         }
     """, checkWarn = false)
 
+    fun `test move in shorthand struct literal`() = checkByText("""
+        struct S;
+        struct T { s: S }
+        fn main() {
+            let s = S;
+            s;
+            let t = T { <error descr="Use of moved value">s</error> };
+        }
+    """, checkWarn = false)
+
     fun `test move else if`() = checkByText("""
         struct S;
         

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
@@ -158,6 +158,25 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
         }
     """, checkWarn = false)
 
+    fun `test move for loop`() = checkByText("""
+        struct S { data: i32 }
+        struct T;
+
+        fn f(s: S) {}
+
+        fn main() {
+            let x = S { data: 42 };
+            for mut i in 0..5 {
+                if x.data == 10 { f(<error descr="Use of moved value">x</error>); } else {}
+                i += 1;
+            }
+            <error descr="Use of moved value">x<caret></error>;
+
+            let ts = vec![T, T, T];
+            for t in ts { t; }
+        }
+    """, checkWarn = false)
+
     fun `test move in while let or patterns`() = checkByText("""
         struct S;
         enum E { A(S), B(S), C }
@@ -526,6 +545,17 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
         fn main() {
             let v: Vec<i32> = vec![1, 2, 3];
             if let [a, b, c] = v[..] {}
+        }
+    """, checkWarn = false)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test no move error for loop`() = checkByText("""
+        struct S;
+        fn main() {
+            let xs: Vec<S> = vec![S, S, S];
+            for x in xs {
+                let y = x;
+            }
         }
     """, checkWarn = false)
 }

--- a/src/test/kotlin/org/rust/lang/core/cfg/RsControlFlowGraphTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/cfg/RsControlFlowGraphTest.kt
@@ -99,7 +99,7 @@ class RsControlFlowGraphTest : RsTestBase() {
 
     fun `test if else`() = testCFG("""
         fn foo() {
-            if true { 1 } else { 2 };
+            if true { 1 } else if false { 2 } else { 3 };
         }
     """, """
         Entry
@@ -110,7 +110,11 @@ class RsControlFlowGraphTest : RsTestBase() {
         IF;
         BLOCK
         Exit
+        false
         2
+        BLOCK
+        IF
+        3
         BLOCK
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/cfg/RsControlFlowGraphTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/cfg/RsControlFlowGraphTest.kt
@@ -789,6 +789,25 @@ class RsControlFlowGraphTest : RsTestBase() {
         Exit
     """)
 
+    fun `test lambda expr`() = testCFG("""
+        fn foo() {
+            let f = |x: i32| { x + 1 };
+        }
+    """, """
+        Entry
+        x
+        1
+        x + 1
+        BLOCK
+        BLOCK
+        |x: i32| { x + 1 }
+        f
+        f
+        let f = |x: i32| { x + 1 };
+        BLOCK
+        Exit
+    """)
+
     private fun testCFG(@Language("Rust") code: String, expectedIndented: String) {
         InlineFile(code)
         val function = myFixture.file.descendantsOfType<RsFunction>().firstOrNull() ?: return

--- a/src/test/kotlin/org/rust/lang/core/cfg/RsControlFlowGraphTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/cfg/RsControlFlowGraphTest.kt
@@ -774,6 +774,21 @@ class RsControlFlowGraphTest : RsTestBase() {
         some_macro!()
     """)
 
+    fun `test shorthand struct literal`() = testCFG("""
+        struct S { x: i32 }
+        
+        fn foo(x: i32) {
+            S { x };
+        }
+    """, """
+        Entry
+        x
+        S { x }
+        S { x };
+        BLOCK
+        Exit
+    """)
+
     private fun testCFG(@Language("Rust") code: String, expectedIndented: String) {
         InlineFile(code)
         val function = myFixture.file.descendantsOfType<RsFunction>().firstOrNull() ?: return

--- a/src/test/kotlin/org/rust/lang/core/cfg/RsControlFlowGraphTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/cfg/RsControlFlowGraphTest.kt
@@ -436,24 +436,28 @@ class RsControlFlowGraphTest : RsTestBase() {
         }
     """, """
         Entry
-        Dummy
         x
         42
         x.foo(42)
+        Dummy
         FOR
         FOR;
         y
         y;
         BLOCK
         Exit
-        Dummy
+        i
+        i
         0
         x
         x.bar
         x.bar.foo
         0..x.bar.foo
+        Dummy
         FOR
         BLOCK
+        j
+        j
         x
         i
         x += i
@@ -476,20 +480,24 @@ class RsControlFlowGraphTest : RsTestBase() {
         }
     """, """
         Entry
-        Dummy
         xs
+        Dummy
         FOR
         FOR;
         y
         y;
         BLOCK
         Exit
+        x
+        x
         op1
         op1;
-        Dummy
         ys
+        Dummy
         FOR
         BLOCK
+        y
+        y
         op2
         op2;
         cond


### PR DESCRIPTION
This allows borrow checker to find move errors in some new cases. Also, these fixes will be necessary for liveness analysis.

Merge after #4686.

- [x] Run `RsRealProjectAnalysisTest` before merge