### PR TITLE
TY: skip impls with `rustc_reservation_impl` attribute while type inference

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -24,6 +24,9 @@ import org.rust.lang.core.types.ty.Ty
 val RsImplItem.default: PsiElement?
     get() = node.findChildByType(DEFAULT)?.psi
 
+val RsImplItem.isReservationImpl: Boolean
+    get() = queryAttributes.hasAttribute("rustc_reservation_impl")
+
 abstract class RsImplItemImplMixin : RsStubbedElementImpl<RsImplItemStub>, RsImplItem {
 
     constructor(node: ASTNode) : super(node)

--- a/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
@@ -11,6 +11,7 @@ import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTraitRef
 import org.rust.lang.core.psi.ext.RsAbstractable
 import org.rust.lang.core.psi.ext.expandedMembers
+import org.rust.lang.core.psi.ext.isReservationImpl
 import org.rust.lang.core.psi.ext.resolveToBoundTrait
 import org.rust.lang.core.psi.isValidProjectMember
 import org.rust.lang.core.resolve.ref.ResolveCacheDependency
@@ -31,7 +32,7 @@ class RsCachedImplItem(
     val impl: RsImplItem
 ) {
     private val traitRef: RsTraitRef? = impl.traitRef
-    val isValid: Boolean = impl.isValidProjectMember
+    val isValid: Boolean = impl.isValidProjectMember && !impl.isReservationImpl
     val isInherent: Boolean get() = traitRef == null
 
     val implementedTrait: BoundElement<RsTraitItem>? by lazy(PUBLICATION) { traitRef?.resolveToBoundTrait() }


### PR DESCRIPTION
Some time ago `rustc_reservation_impl` attribute was introduced to reserve some implementation (https://github.com/rust-lang/rust/issues/64631).
Such implementations mostly don't take part in code analysis.
Most notable (and maybe only one) impl with such attribute is `impl<T> From<!> for T`. This impl breaks type inference in some cases.
These changes just make type inference ignore such `impl` items
