### PR TITLE
MACRO: Fix full re-expand when showing macro expansion

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/macroExpansion/MacroExpansionViewUtils.kt
+++ b/src/main/kotlin/org/rust/ide/actions/macroExpansion/MacroExpansionViewUtils.kt
@@ -25,6 +25,7 @@ import org.rust.lang.core.macros.getExpansionFromExpandedFile
 import org.rust.lang.core.macros.parseExpandedTextWithContext
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsPsiManager
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.computeWithCancelableProgress
 import java.awt.BorderLayout
@@ -118,7 +119,9 @@ private fun reformatMacroExpansion(
         // Without `eventSystemEnabled` file reformatting is too slow
         ?: RsPsiFactory(expansion.file.project, eventSystemEnabled = true).createFile(expansion.file.text)
 
-    DocumentUtil.writeInRunUndoTransparentAction { formatPsiFile(file) }
+    RsPsiManager.withIgnoredPsiEvents(file) {
+        DocumentUtil.writeInRunUndoTransparentAction { formatPsiFile(file) }
+    }
 
     return getExpansionFromExpandedFile(macroToExpand.expansionContext, file)
         ?: error("Can't recover macro expansion after reformat")

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -448,6 +448,7 @@ private class MacroExpansionServiceImplInner(
         override fun handleEvent(event: RsPsiTreeChangeEvent) {
             if (!isExpansionModeNew) return
             val file = event.file as? RsFile ?: return
+            if (RsPsiManager.isIgnorePsiEvents(file)) return
             val virtualFile = file.virtualFile ?: return
             if (virtualFile !is VirtualFileWithId) return
 


### PR DESCRIPTION
Previously, when you open a popup with macro expansion (via alt+enter or a context menu action) it made full re-validation of expanded macros (which usually takes a few seconds)