### PR TITLE
Consider expanded macros in control flow and borrow checker

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/cfg/CFGBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/cfg/CFGBuilder.kt
@@ -179,11 +179,15 @@ class CFGBuilder(
     }
 
     override fun visitBlock(block: RsBlock) {
-        val stmtsExit = block.stmtList.fold(pred) { pred, stmt -> process(stmt, pred) }
-        val blockExpr = block.expr ?: return finishWithAstNode(block, stmtsExit)
-        val exprExit = process(blockExpr, stmtsExit)
+        val (expandedStmts, tailExpr) = block.expandedStmtsAndTailExpr
+        val stmtsExit = expandedStmts.fold(pred) { pred, stmt -> process(stmt, pred) }
 
-        finishWithAstNode(block, exprExit)
+        if (tailExpr != null) {
+            val exprExit = process(tailExpr, stmtsExit)
+            finishWithAstNode(block, exprExit)
+        } else {
+            finishWithAstNode(block, stmtsExit)
+        }
     }
 
     override fun visitLetDecl(letDecl: RsLetDecl) {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsBlock.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsBlock.kt
@@ -6,19 +6,33 @@
 package org.rust.lang.core.psi.ext
 
 import org.rust.lang.core.macros.RsExpandedElement
+import org.rust.lang.core.macros.expandedFromSequence
 import org.rust.lang.core.psi.*
 
 /**
  * Can contain [RsStmt]s and [RsExpr]s (which are equivalent to RsExprStmt(RsExpr))
  */
-val RsBlock.expandedStmts: List<RsExpandedElement>
+val RsBlock.expandedStmtsAndTailExpr: Pair<List<RsExpandedElement>, RsExpr?>
     get() {
         val stmts = mutableListOf<RsExpandedElement>()
         processExpandedStmtsInternal { stmt ->
             stmts.add(stmt)
             false
         }
-        return stmts
+        val tailExpr = stmts.lastOrNull()
+            ?.let { it as? RsExpr }
+            ?.takeIf { e ->
+                // If tail expr is expanded from a macro, we should check that this macro doesn't have
+                // semicolon (`foo!();`), otherwice it's not a tail expr but a regular statement
+                e.expandedFromSequence.all {
+                    val bracesKind = it.bracesKind ?: return@all false
+                    !bracesKind.needsSemicolon || it.semicolon == null
+                }
+            }
+        return when (tailExpr) {
+            null -> stmts
+            else -> stmts.subList(0, stmts.size - 1)
+        } to tailExpr
     }
 
 private val RsBlock.stmtsAndMacros: Sequence<RsElement>

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -1286,7 +1286,7 @@ private fun processLexicalDeclarations(
                 }
 
                 val letDecls = mutableListOf<RsLetDecl>()
-                for (stmt in scope.expandedStmts) {
+                for (stmt in scope.expandedStmtsAndTailExpr.first) {
                     if (cameFrom == stmt) break
                     if (stmt is RsLetDecl) {
                         letDecls.add(stmt)

--- a/src/main/kotlin/org/rust/lang/core/types/borrowck/ExprUseWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/borrowck/ExprUseWalker.kt
@@ -243,6 +243,8 @@ class ExprUseWalker(private val delegate: Delegate, private val mc: MemoryCatego
             is RsRetExpr -> expr.expr?.let { consumeExpr(it) }
 
             is RsCastExpr -> consumeExpr(expr.expr)
+
+            is RsParenExpr -> consumeExpr(expr.expr)
         }
     }
 

--- a/src/main/kotlin/org/rust/lang/core/types/borrowck/ExprUseWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/borrowck/ExprUseWalker.kt
@@ -283,8 +283,17 @@ class ExprUseWalker(private val delegate: Delegate, private val mc: MemoryCatego
     }
 
     private fun walkBlock(block: RsBlock) {
-        block.stmtList.forEach { walkStmt(it) }
-        block.expr?.let { consumeExpr(it) }
+        val (expandedStmts, tailExpr) = block.expandedStmtsAndTailExpr
+        for (element in expandedStmts) {
+            when (element) {
+                is RsStmt -> walkStmt(element)
+                is RsExpr -> walkExpr(element)
+            }
+        }
+
+        if (tailExpr != null) {
+            consumeExpr(tailExpr)
+        }
     }
 
     private fun walkStructExpr(fields: List<RsStructLiteralField>, withExpr: RsExpr?) {

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
@@ -586,4 +586,16 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
             <error descr="Use of moved value">s</error>;
         }
     """, checkWarn = false)
+
+    fun `test move in expanded macro call`() = checkByText("""
+        macro_rules! my_macro_move {
+            ($ e:expr) => ($ e;);
+        }
+        struct S;
+        fn main() {
+            let s = S;
+            my_macro_move!(s);
+            <error descr="Use of moved value">s</error>;
+        }
+    """, checkWarn = false)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
@@ -577,4 +577,13 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
             <error descr="Use of moved value">s</error>;
         }
     """, checkWarn = false)
+
+    fun `test move in paren expr`() = checkByText("""
+        struct S;
+        fn main() {
+            let s = S;
+            (s);
+            <error descr="Use of moved value">s</error>;
+        }
+    """, checkWarn = false)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerUninitializedTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerUninitializedTest.kt
@@ -228,4 +228,15 @@ class RsBorrowCheckerUninitializedTest : RsInspectionsTestBase(RsBorrowCheckerIn
             value
         }
     """, checkWarn = false)
+
+    fun `test no E0381 init in macro call`() = checkByText("""
+        macro_rules! my_macro_init {
+            ($ i:ident) => ($ i = 42);
+        }
+        fn main() {
+            let value: i32;
+            my_macro_init!(value);
+            value;
+        }
+    """, checkWarn = false)
 }

--- a/src/test/kotlin/org/rust/lang/core/cfg/RsControlFlowGraphTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/cfg/RsControlFlowGraphTest.kt
@@ -808,6 +808,23 @@ class RsControlFlowGraphTest : RsTestBase() {
         Exit
     """)
 
+    fun `test arbitrary macro call`() = testCFG("""
+        macro_rules! my_macro {
+            ($ e1:expr, $ e2:expr) => ($ e1 + $ e2);
+        }
+
+        fn main() {
+            my_macro!(x, y);
+        }
+    """, """
+        Entry
+        x
+        y
+        x + y
+        BLOCK
+        Exit
+    """)
+
     private fun testCFG(@Language("Rust") code: String, expectedIndented: String) {
         InlineFile(code)
         val function = myFixture.file.descendantsOfType<RsFunction>().firstOrNull() ?: return


### PR DESCRIPTION
This allows borrow checker to find move errors caused by macro calls, and also to correctly process variable initialization generated by macro calls.

Merge after #4687.

- [x]  Run RsRealProjectAnalysisTest before merge