### PR TITLE
MACRO: fix matching `$($ e:expr,)+` group

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -278,7 +278,7 @@ class MacroExpander(val project: Project) {
     }
 
     companion object {
-        const val EXPANDER_VERSION = 1
+        const val EXPANDER_VERSION = 2
     }
 }
 
@@ -428,9 +428,10 @@ class MacroPattern private constructor(
                 break
             }
 
+            mark?.drop()
+            mark = macroCallBody.mark()
+
             if (separator != null) {
-                mark?.drop()
-                mark = macroCallBody.mark()
                 if (!macroCallBody.isSameToken(separator)) {
                     MacroExpansionMarks.failMatchGroupBySeparator.hit()
                     break

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -644,6 +644,19 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
          fn foo() {}
     """)
 
+    fun `test distinguish between ',)+' and '),*' groups`() = doTest("""
+        macro_rules! foo {
+            ($($ e:expr,)+) => { fn foo() { $( $ e; )+ } };
+            ($($ e:expr),*) => { fn bar() { $( $ e; )* } };
+        }
+        foo!{ 1, 2, }
+        foo!{ 1, 2 }
+    """, """
+        fn foo() { 1; 2; }
+    """, """
+        fn bar() { 1; 2; }
+    """)
+
     fun `test impl members context`() = checkSingleMacro("""
         macro_rules! foo {
             () => {


### PR DESCRIPTION
bors r+