### PR TITLE
 INT: don't suggest "Put parameters/arguments/fields/variants on separate lines/one line" if comments are present

### DIFF
--- a/src/test/kotlin/org/rust/ide/intentions/JoinArgumentListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/JoinArgumentListIntentionTest.kt
@@ -93,4 +93,14 @@ class JoinArgumentListIntentionTest : RsIntentionTestBase(JoinArgumentListIntent
                 */ 2, 3);
         }
     """)
+
+    fun `test has end-of-line comments`() = doUnavailableTest("""
+        fn foo(p1: i32, p2: i32) {}
+        fn main() {
+            foo(
+                /*caret*/1, // comment
+                2
+            );
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/JoinFieldListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/JoinFieldListIntentionTest.kt
@@ -26,15 +26,15 @@ class JoinFieldListIntentionTest : RsIntentionTestBase(JoinFieldListIntention())
     """)
 
     fun `test has some line breaks`() = doAvailableTest("""
-        struct S { x: i32, /*caret*/y: i32, 
+        struct S { x: i32, /*caret*/y: i32,
                    z: i32 }
     """, """
         struct S { x: i32, y: i32, z: i32 }
     """)
 
     fun `test has some line breaks 2`() = doAvailableTest("""
-        struct S { 
-            x: i32, y: i32, z: i32/*caret*/ 
+        struct S {
+            x: i32, y: i32, z: i32/*caret*/
         }
     """, """
         struct S { x: i32, y: i32, z: i32 }
@@ -54,5 +54,12 @@ class JoinFieldListIntentionTest : RsIntentionTestBase(JoinFieldListIntention())
         struct S { x: i32, /*
                    comment
                    */ y: i32, z: i32 }
+    """)
+
+    fun `test has end-of-line comments`() = doUnavailableTest("""
+        struct S {
+            /*caret*/x: i32, // comment
+            y: i32
+        }
     """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/JoinLiteralFieldListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/JoinLiteralFieldListIntentionTest.kt
@@ -44,7 +44,7 @@ class JoinLiteralFieldListIntentionTest : RsIntentionTestBase(JoinLiteralFieldLi
     fun `test has some line breaks`() = doAvailableTest("""
         struct S { x: i32, y: i32, z: i32 }
         fn foo() {
-            S { x: 0, /*caret*/y: 0, 
+            S { x: 0, /*caret*/y: 0,
                 z: 0 };
         }
     """, """
@@ -57,8 +57,8 @@ class JoinLiteralFieldListIntentionTest : RsIntentionTestBase(JoinLiteralFieldLi
     fun `test has some line breaks 2`() = doAvailableTest("""
         struct S { x: i32, y: i32, z: i32 }
         fn foo() {
-            S { 
-                x: 0, y: 0, z: 0/*caret*/ 
+            S {
+                x: 0, y: 0, z: 0/*caret*/
             };
         }
     """, """
@@ -143,6 +143,16 @@ class JoinLiteralFieldListIntentionTest : RsIntentionTestBase(JoinLiteralFieldLi
         enum E { A { x: i32, y: i32, z: i32 } }
         fn foo() {
             let e = E::A { x: 0, y: 0, z: 0 };
+        }
+    """)
+
+    fun `test has end-of-line comments`() = doUnavailableTest("""
+        struct S { x: i32, y: i32 }
+        fn foo() {
+            S {
+                /*caret*/x: 0, // comment
+                y: 0
+            };
         }
     """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/JoinParameterListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/JoinParameterListIntentionTest.kt
@@ -55,4 +55,11 @@ class JoinParameterListIntentionTest : RsIntentionTestBase(JoinParameterListInte
                comment
                */ p2: i32, p3: i32) {}
     """)
+
+    fun `test has end-of-line comments`() = doUnavailableTest("""
+        fn foo(
+            /*caret*/p1: i32, // comment
+            p2: i32
+        ) {}
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/JoinVariantListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/JoinVariantListIntentionTest.kt
@@ -26,15 +26,15 @@ class JoinVariantListIntentionTest : RsIntentionTestBase(JoinVariantListIntentio
     """)
 
     fun `test has some line breaks`() = doAvailableTest("""
-        enum E { A, /*caret*/B, 
+        enum E { A, /*caret*/B,
                    C }
     """, """
         enum E { A, B, C }
     """)
 
     fun `test has some line breaks 2`() = doAvailableTest("""
-        enum E { 
-            A, B, C/*caret*/ 
+        enum E {
+            A, B, C/*caret*/
         }
     """, """
         enum E { A, B, C }
@@ -54,5 +54,12 @@ class JoinVariantListIntentionTest : RsIntentionTestBase(JoinVariantListIntentio
         enum E { A, /*
                    comment
                    */ B, C }
+    """)
+
+    fun `test has end-of-line comments`() = doUnavailableTest("""
+        enum E {
+            /*caret*/A(i32, i32), // comment
+            B
+        }
     """)
 }


### PR DESCRIPTION
Fixes #4708 