### PR TITLE
FMT: Fix indenting of braces when on their own line

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -98,6 +98,7 @@ slavam2605
 snpefk
 sohich
 SomeoneToIgnore
+srjek
 stigger
 Stzx
 t-kameyama

--- a/src/main/kotlin/org/rust/ide/formatter/impl/indent.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/impl/indent.kt
@@ -12,6 +12,9 @@ import org.rust.ide.formatter.blocks.RsFmtBlock
 import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsIfExpr
+import org.rust.lang.core.psi.RsMatchExpr
+import org.rust.lang.core.psi.RsStructLiteral
+import org.rust.lang.core.psi.ext.RsLooplikeExpr
 
 fun RsFmtBlock.computeIndent(child: ASTNode, childCtx: RsFmtContext): Indent? {
     val parentType = node.elementType
@@ -53,6 +56,15 @@ fun RsFmtBlock.computeIndent(child: ASTNode, childCtx: RsFmtContext): Indent? {
 
     // Indent if-expressions
         parentPsi is RsIfExpr -> Indent.getNoneIndent()
+
+    // Indent loop-expressions
+        parentPsi is RsLooplikeExpr -> Indent.getNoneIndent()
+
+    // Indent match-expressions
+        parentPsi is RsMatchExpr -> Indent.getNoneIndent()
+
+    // Indent struct literals
+        parentPsi is RsStructLiteral -> Indent.getNoneIndent()
 
     // Indent other expressions (chain calls, binary expressions, ...)
         parentPsi is RsExpr -> Indent.getContinuationWithoutFirstIndent()

--- a/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt
@@ -722,6 +722,58 @@ class RsFormatterTest : RsFormatterTestBase() {
         fn foo<T, C>(value: T) where T: Trait<Output=C> {}
     """)
 
+    // https://github.com/intellij-rust/intellij-rust/issues/907
+    fun `test issue 907`() = checkNotChanged("""
+        struct TestStruct
+        {
+            a: i32,
+            b: i32,
+        }
+
+        impl TestStruct
+        {
+            fn new() -> Self
+            {
+                Self
+                {
+                    a: 0,
+                    b: 0,
+                }
+            }
+        }
+
+        enum TestEnum
+        {
+            A,
+            B,
+        }
+
+        fn main()
+        {
+            for _ in 0..42
+            {
+                let i = 3;
+            }
+            while 1 != 1
+            {
+                let i = 5;
+            }
+            loop
+            {
+                let i = 10;
+            }
+            if 6 == 6
+            {
+                let x = 7;
+            }
+            match 8
+            {
+                9 => Some(()),
+                _ => None,
+            }
+        }
+    """)
+
     private fun common() = getSettings(RsLanguage)
     private fun custom() = settings.rust
 }


### PR DESCRIPTION
Fixes #907

Note that this *only* fixes indentation. The plugin as is doesn't seem to enforce any particular bracket style (at least on any code posted in the issue), it was just messing up the indentation. I assume enforcement of brackets would be covered by #4576, so therefore #907 can be considered as fixed