### PR TITLE
INT: improve "specify type explicitly" intention

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntention.kt
@@ -14,6 +14,7 @@ import org.rust.lang.core.psi.RsLetDecl
 import org.rust.lang.core.psi.RsPatIdent
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psi.ext.startOffset
 import org.rust.lang.core.types.infer.containsTyOfClass
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyAnon
@@ -30,6 +31,8 @@ class SpecifyTypeExplicitlyIntention : RsElementBaseIntentionAction<SpecifyTypeE
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
         val letDecl = element.ancestorStrict<RsLetDecl>() ?: return null
         if (letDecl.typeReference != null) return null
+        val initializer = letDecl.expr
+        if (initializer != null && element.startOffset >= initializer.startOffset - 1) return null
         val ident = letDecl.pat as? RsPatIdent ?: return null
         val type = ident.patBinding.type
         if (type.containsTyOfClass(listOf(TyUnknown::class.java, TyInfer::class.java, TyAnon::class.java))) {

--- a/src/main/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntention.kt
@@ -11,7 +11,6 @@ import com.intellij.psi.PsiElement
 import org.rust.ide.inspections.import.RsImportHelper.importTypeReferencesFromTy
 import org.rust.ide.presentation.insertionSafeTextWithAliases
 import org.rust.lang.core.psi.RsLetDecl
-import org.rust.lang.core.psi.RsPatIdent
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psi.ext.startOffset
@@ -33,8 +32,8 @@ class SpecifyTypeExplicitlyIntention : RsElementBaseIntentionAction<SpecifyTypeE
         if (letDecl.typeReference != null) return null
         val initializer = letDecl.expr
         if (initializer != null && element.startOffset >= initializer.startOffset - 1) return null
-        val ident = letDecl.pat as? RsPatIdent ?: return null
-        val type = ident.patBinding.type
+        val pat = letDecl.pat ?: return null
+        val type = pat.type
         if (type.containsTyOfClass(listOf(TyUnknown::class.java, TyInfer::class.java, TyAnon::class.java))) {
             return null
         }

--- a/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
@@ -35,6 +35,14 @@ class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplic
         }
     """)
 
+    fun `test unavailable in expr 1`() = doUnavailableTest(
+        """ fn main() { let var = /*caret*/1; } """
+    )
+
+    fun `test unavailable in expr 2`() = doUnavailableTest(
+        """ fn main() { let var = 1/*caret*/; } """
+    )
+
     fun `test not inferred type`() = doUnavailableTest(
         """ fn main() { let var/*caret*/ = a; } """
     )

--- a/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
@@ -18,6 +18,10 @@ class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplic
         """struct A<T>(T);fn main() { let var/*caret*/ = A(42); } """,
         """struct A<T>(T);fn main() { let var: A<i32> = A(42); } """
     )
+    fun `test complex pattern`() = doAvailableTest(
+        """ fn main() { let (a, b)/*caret*/ = (1, 2); } """,
+        """ fn main() { let (a, b): (i32, i32) = (1, 2); } """
+    )
 
     fun `test aliased type`() = doAvailableTest("""
         struct Foo<T>;


### PR DESCRIPTION
1. Make it unavailable in initializer (just like int Kotlin): `let a = /*caret*/b;` Useful in constructions like `let = if foo { /*caret*/ } else {};`
2. Make it work with complex patterns like `let (a, b) = ...`