### PR TITLE
 TY: add predicates for derived traits & provide builtin `Clone`&`Copy` impls for tuples

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -686,8 +686,17 @@ class RsInferenceContext(
         return map
     }
 
+    /** Checks that [selfTy] satisfies all trait bounds of the [source] */
+    fun canEvaluateBounds(source: TraitImplSource, selfTy: Ty): Boolean {
+        return when (source) {
+            is TraitImplSource.ExplicitImpl -> canEvaluateBounds(source.value, selfTy)
+            is TraitImplSource.Derived -> lookup.canSelect(TraitRef(selfTy, BoundElement(source.value)))
+            else -> return true
+        }
+    }
+
     /** Checks that [selfTy] satisfies all trait bounds of the [impl] */
-    fun canEvaluateBounds(impl: RsImplItem, selfTy: Ty): Boolean {
+    private fun canEvaluateBounds(impl: RsImplItem, selfTy: Ty): Boolean {
         val ff = FulfillmentContext(this, lookup)
         val subst = impl.generics.associateWith { typeVarForParam(it) }.toTypeSubst()
         return probe {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -690,7 +690,10 @@ class RsInferenceContext(
     fun canEvaluateBounds(source: TraitImplSource, selfTy: Ty): Boolean {
         return when (source) {
             is TraitImplSource.ExplicitImpl -> canEvaluateBounds(source.value, selfTy)
-            is TraitImplSource.Derived -> lookup.canSelect(TraitRef(selfTy, BoundElement(source.value)))
+            is TraitImplSource.Derived, is TraitImplSource.Hardcoded -> {
+                if (source.value.typeParameters.isNotEmpty()) return true
+                lookup.canSelect(TraitRef(selfTy, BoundElement(source.value as RsTraitItem)))
+            }
             else -> return true
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -7,7 +7,6 @@ package org.rust.lang.core.types.infer
 
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.psi.PsiElement
-import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.containers.isNullOrEmpty
 import org.rust.lang.core.macros.MacroExpansion
 import org.rust.lang.core.psi.*
@@ -629,8 +628,7 @@ class RsTypeInferenceWalker(
         }.singleOrFilter { callee ->
             // 2. Filter methods by trait bounds (try to select all obligations for each impl)
             TypeInferenceMarks.methodPickCheckBounds.hit()
-            val impl = callee.source.impl ?: return@singleOrFilter true
-            ctx.canEvaluateBounds(impl, callee.selfTy)
+            ctx.canEvaluateBounds(callee.source, callee.selfTy)
         }
     }
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
@@ -202,4 +202,24 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
             MyStruct/*caret*/
         }
     """)
+
+    fun `test derived method is not completed if the derived trait is not implemented to type argument`() = checkNoCompletion("""
+        #[lang = "clone"]  pub trait Clone { fn clone(&self) -> Self; }
+        struct X; // Not `Clone`
+        #[derive(Clone)]
+        struct S<T>(T);
+        fn main() {
+            S(X).cl/*caret*/;
+        }
+    """)
+
+    fun `test derived method is not completed UFCS if the derived trait is not implemented to type argument`() = checkNoCompletion("""
+        #[lang = "clone"]  pub trait Clone { fn clone(&self) -> Self; }
+        struct X; // Not `Clone`
+        #[derive(Clone)]
+        struct S<T>(T);
+        fn main() {
+            <S<X>>::cl/*caret*/;
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
@@ -152,6 +152,17 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
                //^ !Copy
     """)
 
+    fun `test tuple of 'Copy' types is 'Copy'`() = doTest("""
+        type T = (i32, i32);
+               //^ Copy
+    """)
+
+    fun `test tuple of not 'Copy' types is not 'Copy'`() = doTest("""
+        struct X;
+        type T = (i32, X);
+               //^ !Copy
+    """)
+
     private fun checkPrimitiveTypes(traitName: String) {
         val allIntegers = TyInteger.VALUES.toTypedArray()
         val allFloats = TyFloat.VALUES.toTypedArray()

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -770,4 +770,16 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
             c;
         } //^ String
     """)
+
+    fun `test 'Clone' is not derived for generic type`() = stubOnlyTypeInfer("""
+    //- main.rs
+        struct X; // Not `Clone`
+        #[derive(Clone)]
+        struct S<T>(T);
+        fn main() {
+            let a = &S(X);
+            let b = a.clone(); // `S<X>` is not `Clone`, so resolved to std `impl for &T`
+            b;
+        } //^ &S<X>
+    """)
 }


### PR DESCRIPTION
Fixes #4740, fixes #3288

Also fixes some other wrong type inference cases, false-positives in typechecker and false-negatives in borrow-checker