### PR TITLE
RUN: match test attributes more loosely to support custom attributes

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -105,8 +105,8 @@ class QueryAttributes(
         return attrs.any()
     }
 
-    fun hasMatchingAttribute(regex: Regex): Boolean {
-        val attrs = attrsByRegex(regex)
+    fun hasAttribute(attributeNameRe: Regex): Boolean {
+        val attrs = attrsByText(attributeNameRe)
         return attrs.any()
     }
 
@@ -183,9 +183,12 @@ class QueryAttributes(
     private fun attrsByName(name: String): Sequence<RsMetaItem> = metaItems.filter { it.name == name }
 
     /**
-     * Get a sequence of all attributes matching the given [regex]
+     * Get a sequence of all attributes that match the given [regex]
      */
-    private fun attrsByRegex(regex: Regex): Sequence<RsMetaItem> = metaItems.filter { it.name?.let { name -> regex.containsMatchIn(name) } ?: false }
+    private fun attrsByText(regex: Regex): Sequence<RsMetaItem> = metaItems.filter {
+        val name = it.text ?: return@filter false
+        name.matches(regex)
+    }
 
     override fun toString(): String =
         "QueryAttributes(${attributes.joinToString { it.text }})"

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -105,8 +105,8 @@ class QueryAttributes(
         return attrs.any()
     }
 
-    fun hasAttribute(attributeNameRe: Regex): Boolean {
-        val attrs = attrsByText(attributeNameRe)
+    fun hasAttribute(regex: Regex): Boolean {
+        val attrs = attrsByText(regex)
         return attrs.any()
     }
 
@@ -186,8 +186,8 @@ class QueryAttributes(
      * Get a sequence of all attributes that match the given [regex]
      */
     private fun attrsByText(regex: Regex): Sequence<RsMetaItem> = metaItems.filter {
-        val name = it.text ?: return@filter false
-        name.matches(regex)
+        val text = it.text ?: return@filter false
+        text.matches(regex)
     }
 
     override fun toString(): String =

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -105,6 +105,11 @@ class QueryAttributes(
         return attrs.any()
     }
 
+    fun hasMatchingAttribute(regex: Regex): Boolean {
+        val attrs = attrsByRegex(regex)
+        return attrs.any()
+    }
+
     fun hasAnyOfOuterAttributes(vararg attributes: String): Boolean {
         val outerAttrList = (psi as? RsOuterAttributeOwner)?.outerAttrList ?: return false
         return outerAttrList.any { it.metaItem.name in attributes }
@@ -176,6 +181,11 @@ class QueryAttributes(
      * Get a sequence of all attributes named [name]
      */
     private fun attrsByName(name: String): Sequence<RsMetaItem> = metaItems.filter { it.name == name }
+
+    /**
+     * Get a sequence of all attributes matching the given [regex]
+     */
+    private fun attrsByRegex(regex: Regex): Sequence<RsMetaItem> = metaItems.filter { it.name?.let { name -> regex.containsMatchIn(name) } ?: false }
 
     override fun toString(): String =
         "QueryAttributes(${attributes.joinToString { it.text }})"

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -22,7 +22,7 @@ import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.type
 import javax.swing.Icon
 
-val FUNCTION_TEST_REGEX = Regex(".*test.*")
+private val FUNCTION_TEST_REGEX = Regex("""^[\w:]*test.*""")
 
 val RsFunction.isAssocFn: Boolean get() = !hasSelfParameters && owner.isImplOrTrait
 val RsFunction.isMethod: Boolean get() = hasSelfParameters && owner.isImplOrTrait

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -29,7 +29,7 @@ val RsFunction.isTest: Boolean
     get() {
         val stub = greenStub
         return stub?.isTest
-            ?: (queryAttributes.hasAtomAttribute("test") || queryAttributes.hasAtomAttribute("quickcheck"))
+            ?: (queryAttributes.hasMatchingAttribute(Regex("test")) || queryAttributes.hasAtomAttribute("quickcheck"))
     }
 
 val RsFunction.isBench: Boolean

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -22,6 +22,8 @@ import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.type
 import javax.swing.Icon
 
+val FUNCTION_TEST_REGEX = Regex(".*test.*")
+
 val RsFunction.isAssocFn: Boolean get() = !hasSelfParameters && owner.isImplOrTrait
 val RsFunction.isMethod: Boolean get() = hasSelfParameters && owner.isImplOrTrait
 
@@ -29,7 +31,7 @@ val RsFunction.isTest: Boolean
     get() {
         val stub = greenStub
         return stub?.isTest
-            ?: (queryAttributes.hasMatchingAttribute(Regex("test")) || queryAttributes.hasAtomAttribute("quickcheck"))
+            ?: (queryAttributes.hasAttribute(FUNCTION_TEST_REGEX) || queryAttributes.hasAtomAttribute("quickcheck"))
     }
 
 val RsFunction.isBench: Boolean

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -38,7 +38,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 189
+        override fun getStubVersion(): Int = 190
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
@@ -216,6 +216,21 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         fn has_icon() { assert(true) } // - Test has_icon
     """)
 
+    fun `test custom test attribute with underscore`() = doTestByText("""
+        #[my_tokio::test(threaded_scheduler)]
+        fn has_icon() { assert(true) } // - Test has_icon
+    """)
+
+    fun `test ignore attributes with irrelevant test 1`() = doTestByText("""
+        #[cfg(test)]
+        fn has_icon() { assert(true) }
+    """)
+
+    fun `test ignore attributes with irrelevant test 2`() = doTestByText("""
+        #[cfg(not(test))]
+        fn has_icon() { assert(true) }
+    """)
+
     private inline fun <reified E : RsElement> checkElement(@Language("Rust") code: String, callback: (E) -> Unit) {
         val element = PsiFileFactory.getInstance(project)
             .createFileFromText("main.rs", RsFileType, code)

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
@@ -201,6 +201,11 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         fn has_icon() { assert(true) } // - Test has_icon
     """)
 
+    fun `test custom test attribute`() = doTestByText("""
+        #[tokio::test(threaded_scheduler)]
+        fn has_icon() { assert(true) } // - Test has_icon
+    """)
+
     private inline fun <reified E : RsElement> checkElement(@Language("Rust") code: String, callback: (E) -> Unit) {
         val element = PsiFileFactory.getInstance(project)
             .createFileFromText("main.rs", RsFileType, code)

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
@@ -201,7 +201,17 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
         fn has_icon() { assert(true) } // - Test has_icon
     """)
 
-    fun `test custom test attribute`() = doTestByText("""
+    fun `test simple custom test attribute`() = doTestByText("""
+        #[custom_test]
+        fn has_icon() { assert(true) } // - Test has_icon
+    """)
+
+    fun `test custom test attribute with path`() = doTestByText("""
+        #[tokio::test]
+        fn has_icon() { assert(true) } // - Test has_icon
+    """)
+
+    fun `test custom test attribute with parameters`() = doTestByText("""
         #[tokio::test(threaded_scheduler)]
         fn has_icon() { assert(true) } // - Test has_icon
     """)


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/4746

I tried to loosen up the matching of `#[test]` attributes, as described in https://github.com/intellij-rust/intellij-rust/issues/4746.

To support `tokio`'s `#[tokio::test(threaded_scheduler)]` (https://github.com/tokio-rs/tokio/blob/master/tokio-macros/src/lib.rs#L137), the check now tries to find any occurence of `test` inside the function attribute.