### PR TITLE
ANN: fix false-positive E0428 with macro 2.0

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
@@ -43,7 +43,7 @@ val RsNamedElement.namespaces: Set<Namespace> get() = when (this) {
 
     is RsLifetimeParameter -> LIFETIMES
 
-    is RsMacro -> MACROS
+    is RsMacro, is RsMacro2 -> MACROS
 
     else -> TYPES_N_VALUES
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -834,8 +834,8 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         struct <error descr="A type named `Arc` has already been defined in this module [E0428]">Arc</error>{}
         fn <error descr="A value named `test1` has already been defined in this module [E0428]">test1</error>(){}
         fn <error descr="A value named `test2` has already been defined in this module [E0428]">test2</error>(){}
-        
-        
+
+
         mod bar{
             pub struct A{}
             pub mod test3{}
@@ -844,11 +844,11 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         mod baz{
             pub struct test3{}
             pub const test2:u8 = 0;
-        }    
+        }
     """)
 
     fun `test no duplicates with import E0252`() = checkErrors("""
-        use bar::{test1};   
+        use bar::{test1};
         use baz::test2;
         use bar::test3;
         use bar::unresolved;
@@ -858,7 +858,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         struct Arc{}
         fn test1(){}
         fn test2(){}
-        
+
         mod bar{
             pub struct Arc{}
             pub mod test1{}
@@ -867,7 +867,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         mod baz{
             pub struct test2{}
             pub const test3:u8 = 0;
-        }        
+        }
     """)
 
     fun `test unnecessary pub E0449`() = checkErrors("""

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -755,6 +755,10 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
             mod <error>foo</error>;
             fn foo() {}
+
+            // Macros have thair own namespace
+            type NO_M_DUP = u16;
+            macro NO_M_DUP(){}
         }
     """)
 


### PR DESCRIPTION
(Occurs in stdlib with standard traits and "derive" macros, e.g. Clone)

bors r+