### PR TITLE
Ignore underscore names during duplicates detection

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1318,7 +1318,10 @@ private fun AnnotationSession.duplicatesByNamespace(
         (owner.namedChildren(recursively, stopAt = RsFnPointerType::class.java)
             + importedNames)
             .filter { it !is RsExternCrateItem } // extern crates can have aliases.
-            .filter { it.nameOrImportedName() != null }
+            .filter {
+                val name = it.nameOrImportedName()
+                name != null && name != "_"
+            }
             .filter { it.isEnabledByCfg && !it.isCfgUnknown }
             .flatMap { it.namespaced() }
             .groupBy { it.first }       // Group by namespace

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -4068,4 +4068,15 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         impl ForeignTrait for Box<dyn LocalTrait> {}
         impl <error descr="Only traits defined in the current crate can be implemented for arbitrary types [E0117]">ForeignTrait</error> for Box<dyn ForeignTrait0> {}
     """)
+
+    fun `test no E0252 multiple underscore aliases`() = checkErrors("""
+        mod foo {
+            pub trait T1 {}
+        }
+        mod bar {
+            pub trait T2 {}
+        }
+        use foo::T1 as _;
+        use bar::T2 as _;
+    """)
 }


### PR DESCRIPTION
This fixes false-positive duplicate annotation when there are multiple underscore imports, e.g.
```Rust
use std::fmt::Debug as _;
use std::hash::Hash as _; // False-positive: A second item with name '_' imported 
```

Note, there was a similar problem with `RsConstant`  after implementing underscore constants parsing: https://github.com/intellij-rust/intellij-rust/pull/4724. But that problem was solved in a quite different way – by introducing `nameLikeElement` to distinguish the actual name from the underscores.

However, in this case, looks like it's enough to just ignore the underscore names during duplicates detection in order to keep untouched all the existing logic in the name resolution and auto import. Thanks to @dima74 for finding this out!

Fixes #5067
