### PR TITLE
RES: fix pattern namespaces

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
@@ -64,7 +64,7 @@ val RsPath.qualifier: RsPath?
     }
 
 fun RsPath.allowedNamespaces(isCompletion: Boolean = false): Set<Namespace> = when (val parent = parent) {
-    is RsPath, is RsTypeElement, is RsTraitRef, is RsStructLiteral -> TYPES
+    is RsPath, is RsTypeElement, is RsTraitRef, is RsStructLiteral, is RsPatStruct -> TYPES
     is RsUseSpeck -> when {
         // use foo::bar::{self, baz};
         //     ~~~~~~~~
@@ -76,6 +76,7 @@ fun RsPath.allowedNamespaces(isCompletion: Boolean = false): Set<Namespace> = wh
         else -> TYPES_N_VALUES_N_MACROS
     }
     is RsPathExpr -> if (isCompletion) TYPES_N_VALUES else VALUES
+    is RsPatTupleStruct -> VALUES
     is RsPathCodeFragment -> parent.ns
     else -> TYPES_N_VALUES
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -1613,7 +1613,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         enum E2 { A, V { x: i32 } }
         fn foo(a: S, b: ST, c: E1, d: E2, e: Unknown) {
             if let <error descr="irrefutable let pattern is experimental [E0658]">S { x }</error> = a {}
-            if let <error descr="irrefutable let pattern is experimental [E0658]">S(x)</error> = b {}
+            if let <error descr="irrefutable let pattern is experimental [E0658]">ST(x)</error> = b {}
             if let <error descr="irrefutable let pattern is experimental [E0658]">E1::V { x }</error> = c {}
             if let E2::V { x } = d {}
             if let Unknown { x } = e {}
@@ -2968,16 +2968,16 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
                 #[unstable(feature = "bbb", reason = "foo")] pub field: i32
             }
         }
-        
+
         use a::<error descr="`aaa` is unstable [E0658]">S</error>;
-        
+
         #[unstable(feature = "ddd")]
         impl <error descr="`aaa` is unstable [E0658]">S</error> {
             #[unstable(feature = "ccc", reason = "bar \
                 baz")]
             fn foo(self) -> Self {}
         }
-        
+
         fn main() {
             let x = <error descr="`aaa` is unstable [E0658]">S</error> { field: 0 };
             x.<error descr="`bbb` is unstable: foo [E0658]">field</error>;
@@ -2991,23 +2991,23 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         #![feature(bbb)]
         #![feature(ccc)]
         #![feature(ddd)]
-        
+
         mod a {
             #[unstable(feature = "aaa")]
             pub struct S {
                 #[unstable(feature = "bbb", reason = "foo")] pub field: i32
             }
         }
-        
+
         use a::S;
-        
+
         #[unstable(feature = "ddd")]
         impl S {
             #[unstable(feature = "ccc", reason = "bar \
                 baz")]
             fn foo(self) -> Self {}
         }
-        
+
         fn main() {
             let x = S { field: 0 };
             x.field;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsNamespaceResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsNamespaceResolveTest.kt
@@ -213,8 +213,28 @@ class RsNamespaceResolveTest : RsResolveTestBase() {
         }                  //^
     """)
 
+    fun `test tuple struct pattern namespace`() = checkByCode("""
+        struct Foo {}
+        enum Bar {
+            Foo(i32)
+        } //X
+        use self::Bar::*;
+        fn main() {
+            let Foo(_) = Foo(1);
+        }     //^
+    """)
+
+    fun `test struct pattern namespace`() = checkByCode("""
+        struct Foo { f: i32 }
+             //X
+        fn Foo() {}
+        fn main() {
+            let Foo { f } = Foo { f: 1 };
+        }     //^
+    """)
+
     fun `test const generic type namespace (type alias)`() = checkByCode("""
-        type A<const N: usize> = 
+        type A<const N: usize> =
                    //X
             [N; N];
               //^


### PR DESCRIPTION
E.g. int this case `Foo` was incorrectly multi-resolved:
```rust
struct Foo { f: i32 }
     //X
fn Foo() {}
fn main() {
    let Foo { f } = Foo { f: 1 };
}     //^
```

bors r+