### PR TITLE
PSI: Rename code fragments consistently

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -87,7 +87,7 @@
     elementType(".+BinExpr") = BinaryExpr
     elementType(".+BinOp") = BinaryOp
 
-    extraRoot(".*CodeFragment")=true
+    extraRoot(".*CodeFragmentElement")=true
 
     extends("Pat(Wild|Ref|Tup|Slice|Macro|Struct|TupleStruct|Ident|Range|Box|Const|Rest)") = Pat
 
@@ -109,12 +109,12 @@
 
 
 File ::= [ SHEBANG_LINE ] InnerAttr* Items
-ExprCodeFragment ::= Expr?
-StmtCodeFragment ::= Stmt?
-TypeRefCodeFragment ::= TypeReference?
-ValuePathCodeFragment ::= ValuePathGenericArgs?
-TypePathCodeFragment ::= TypePathGenericArgs?
-ReplCodeFragment ::= (Item | Stmt)* Expr?
+ExpressionCodeFragmentElement ::= Expr?
+StatementCodeFragmentElement ::= Stmt?
+TypeReferenceCodeFragmentElement ::= TypeReference?
+ValuePathCodeFragmentElement ::= ValuePathGenericArgs?
+TypePathCodeFragmentElement ::= TypePathGenericArgs?
+ReplCodeFragmentElement ::= (Item | Stmt)* Expr?
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Attributes

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
@@ -122,14 +122,6 @@ class RsStatementCodeFragment(project: Project, text: CharSequence, context: RsE
     val stmt: RsStmt? get() = childOfType()
 }
 
-class RsReplCodeFragment(fileViewProvider: FileViewProvider, override var context: RsElement)
-    : RsCodeFragment(fileViewProvider, RsCodeFragmentElementType.REPL, context, false),
-      RsInferenceContextOwner, RsItemsOwner {
-    val stmts: List<RsStmt> get() = childrenOfType()
-    val tailExpr: RsExpr? get() = children.lastOrNull()?.let { it as? RsExpr }
-    val namedElements: List<RsNamedElement> get() = childrenOfType()
-}
-
 class RsTypeReferenceCodeFragment(project: Project, text: CharSequence, context: RsElement)
     : RsCodeFragment(project, text, RsCodeFragmentElementType.TYPE_REF, context),
       RsNamedElement {
@@ -156,9 +148,17 @@ class RsPathCodeFragment(
     companion object {
         @JvmStatic
         private fun PathParsingMode.elementType() = when (this) {
-            TYPE -> RsCodeFragmentElementType.TYPE_PATH_CODE_FRAGMENT
-            VALUE -> RsCodeFragmentElementType.VALUE_PATH_CODE_FRAGMENT
+            TYPE -> RsCodeFragmentElementType.TYPE_PATH
+            VALUE -> RsCodeFragmentElementType.VALUE_PATH
             NO_TYPE_ARGS -> error("$NO_TYPE_ARGS mode is not supported; use $TYPE")
         }
     }
+}
+
+class RsReplCodeFragment(fileViewProvider: FileViewProvider, override var context: RsElement)
+    : RsCodeFragment(fileViewProvider, RsCodeFragmentElementType.REPL, context, false),
+      RsInferenceContextOwner, RsItemsOwner {
+    val stmts: List<RsStmt> get() = childrenOfType()
+    val tailExpr: RsExpr? get() = children.lastOrNull()?.let { it as? RsExpr }
+    val namedElements: List<RsNamedElement> get() = childrenOfType()
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentElementType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentElementType.kt
@@ -24,11 +24,11 @@ class RsCodeFragmentElementType(private val elementType: IElementType, debugName
     }
 
     companion object {
-        val EXPR = RsCodeFragmentElementType(RsElementTypes.EXPR_CODE_FRAGMENT, "RS_EXPR_CODE_FRAGMENT")
-        val STMT = RsCodeFragmentElementType(RsElementTypes.STMT_CODE_FRAGMENT, "RS_STMT_CODE_FRAGMENT")
-        val REPL = RsCodeFragmentElementType(RsElementTypes.REPL_CODE_FRAGMENT, "RS_REPL_CODE_FRAGMENT")
-        val TYPE_REF = RsCodeFragmentElementType(RsElementTypes.TYPE_REF_CODE_FRAGMENT, "RS_TYPE_REF_CODE_FRAGMENT")
-        val TYPE_PATH_CODE_FRAGMENT = RsCodeFragmentElementType(RsElementTypes.TYPE_PATH_CODE_FRAGMENT, "RS_TYPE_PATH_CODE_FRAGMENT")
-        val VALUE_PATH_CODE_FRAGMENT = RsCodeFragmentElementType(RsElementTypes.VALUE_PATH_CODE_FRAGMENT, "RS_VALUE_PATH_CODE_FRAGMENT")
+        val EXPR = RsCodeFragmentElementType(RsElementTypes.EXPRESSION_CODE_FRAGMENT_ELEMENT, "RS_EXPR_CODE_FRAGMENT")
+        val STMT = RsCodeFragmentElementType(RsElementTypes.STATEMENT_CODE_FRAGMENT_ELEMENT, "RS_STMT_CODE_FRAGMENT")
+        val TYPE_REF = RsCodeFragmentElementType(RsElementTypes.TYPE_REFERENCE_CODE_FRAGMENT_ELEMENT, "RS_TYPE_REF_CODE_FRAGMENT")
+        val TYPE_PATH = RsCodeFragmentElementType(RsElementTypes.TYPE_PATH_CODE_FRAGMENT_ELEMENT, "RS_TYPE_PATH_CODE_FRAGMENT")
+        val VALUE_PATH = RsCodeFragmentElementType(RsElementTypes.VALUE_PATH_CODE_FRAGMENT_ELEMENT, "RS_VALUE_PATH_CODE_FRAGMENT")
+        val REPL = RsCodeFragmentElementType(RsElementTypes.REPL_CODE_FRAGMENT_ELEMENT, "RS_REPL_CODE_FRAGMENT")
     }
 }


### PR DESCRIPTION
There were two classes named `RsReplCodeFragment`, and that's why plugin build fails sometimes. So now the generated classes will be `*CodeFragmentElement.java`.
