### PR TITLE
COMP: not add parentheses when completing a function passed as a param

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -244,9 +244,18 @@ open class RsDefaultInsertHandler : InsertHandler<LookupElement> {
                 if (curUseItem != null) {
                     appendSemicolon(context, curUseItem)
                 } else {
-                    val isMethodCall = context.getElementOfType<RsMethodOrField>() != null
+                    val methodOrField = context.getElementOfType<RsMethodOrField>()
+                    val isMethodCall = methodOrField != null
                     if (!context.alreadyHasCallParens) {
-                        document.insertString(context.selectionEndOffset, "()")
+                        val rsMethodCall = context.getElementOfType<RsMethodCall>()
+                        if (rsMethodCall == null) {
+                            document.insertString(context.selectionEndOffset, "()")
+                        } else {
+                            val exprList = rsMethodCall.valueArgumentList.exprList
+                            if (exprList.any { (it as? RsLambdaExpr)?.textRange?.contains(context.selectionEndOffset) == true }) {
+                                document.insertString(context.selectionEndOffset, "()")
+                            }
+                        }
                     }
                     val caretShift = if (element.valueParameters.isEmpty() && (isMethodCall || !element.hasSelfParameters)) 2 else 1
                     EditorModificationUtil.moveCaretRelatively(context.editor, caretShift)

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -877,4 +877,50 @@ class RsCompletionTest : RsCompletionTestBase() {
             Foo.foo()/*caret*/
         }
     """)
+
+    fun `test function pointer completion`() = doSingleCompletion("""
+        fn multiply_by_two(input: i32) -> i32 {
+            input * 2
+        }
+        fn main() {
+            Some(5).map(multi/*caret*/)
+        }
+    """, """
+        fn multiply_by_two(input: i32) -> i32 {
+            input * 2
+        }
+        fn main() {
+            Some(5).map(multiply_by_two)/*caret*/
+        }
+    """)
+
+    fun `test function completion`() = doSingleCompletion("""
+        fn multiply_by_two(input: i32) -> i32 { input * 2 }
+        fn main() {
+            Some(5).map(|i| {
+                multi/*caret*/
+            });
+        }
+    """, """
+        fn multiply_by_two(input: i32) -> i32 { input * 2 }
+        fn main() {
+            Some(5).map(|i| {
+                multiply_by_two(/*caret*/)
+            });
+        }
+    """)
+
+    fun `test function completion in function composition`() = doSingleCompletion("""
+        fn foo() -> i32 {0}
+        fn bar(i: i32) {}
+        fn main() {
+            bar(fo/*caret*/);
+        }
+    """, """
+        fn foo() -> i32 {0}
+        fn bar(i: i32) {}
+        fn main() {
+            bar(foo()/*caret*/);
+        }
+    """)
 }


### PR DESCRIPTION
Fix #4450 

I'm new to the code base and not sure if this is the best approach.
If there is a better way to fix this, please let me know. Thanks!