### PR TITLE
TYPE: improve extend selection for Rust and Toml string literals

### DIFF
--- a/intellij-toml/src/main/kotlin/org/toml/ide/wordSelection/TomlStringLiteralSelectionHandler.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/wordSelection/TomlStringLiteralSelectionHandler.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.wordSelection
+
+import com.intellij.codeInsight.editorActions.ExtendWordSelectionHandlerBase
+import com.intellij.codeInsight.editorActions.SelectWordUtil
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.toml.lang.lexer.TomlEscapeLexer
+import org.toml.lang.psi.TOML_STRING_LITERALS
+import org.toml.lang.psi.ext.TomlLiteralKind
+import org.toml.lang.psi.ext.elementType
+
+class TomlStringLiteralSelectionHandler : ExtendWordSelectionHandlerBase() {
+    override fun canSelect(e: PsiElement): Boolean =
+        e.elementType in TOML_STRING_LITERALS
+
+    override fun select(e: PsiElement, editorText: CharSequence, cursorOffset: Int, editor: Editor): List<TextRange>? {
+        val kind = TomlLiteralKind.fromAstNode(e.node) as? TomlLiteralKind.String ?: return null
+        val valueRange = kind.offsets.value?.shiftRight(kind.node.startOffset) ?: return null
+        val result = super.select(e, editorText, cursorOffset, editor) ?: mutableListOf()
+
+        val elementType = e.elementType
+        if (elementType in TomlEscapeLexer.ESCAPABLE_LITERALS_TOKEN_SET) {
+            SelectWordUtil.addWordHonoringEscapeSequences(
+                editorText,
+                valueRange,
+                cursorOffset,
+                TomlEscapeLexer.of(elementType),
+                result
+            )
+        }
+
+        result += valueRange
+        return result
+    }
+}

--- a/intellij-toml/src/main/kotlin/org/toml/lang/psi/ext/PsiElement.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/psi/ext/PsiElement.kt
@@ -1,0 +1,12 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.lang.psi.ext
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.util.PsiUtilCore
+
+val PsiElement.elementType: IElementType get() = PsiUtilCore.getElementType(this)

--- a/intellij-toml/src/main/kotlin/org/toml/lang/psi/ext/TomlLiteral.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/psi/ext/TomlLiteral.kt
@@ -16,13 +16,7 @@ import org.toml.lang.psi.TomlLiteral
 val TomlLiteral.kind: TomlLiteralKind?
     get() {
         val child = node.findChildByType(TOML_LITERALS) ?: return null
-        return when (child.elementType) {
-            BOOLEAN -> TomlLiteralKind.Boolean(child)
-            NUMBER -> TomlLiteralKind.Number(child)
-            DATE_TIME -> TomlLiteralKind.DateTime(child)
-            in TOML_STRING_LITERALS -> TomlLiteralKind.String(child)
-            else -> error("Unknown literal: $child (`$text`)")
-        }
+        return TomlLiteralKind.fromAstNode(child) ?: error("Unknown literal: $child (`$text`)")
     }
 
 sealed class TomlLiteralKind(val node: ASTNode) {
@@ -36,6 +30,18 @@ sealed class TomlLiteralKind(val node: ASTNode) {
             }
 
         val offsets: LiteralOffsets by lazy { offsetsForTomlText(node) }
+    }
+
+    companion object {
+        fun fromAstNode(node: ASTNode): TomlLiteralKind? {
+            return when (node.elementType) {
+                BOOLEAN -> Boolean(node)
+                NUMBER -> Number(node)
+                DATE_TIME -> DateTime(node)
+                in TOML_STRING_LITERALS -> String(node)
+                else -> null
+            }
+        }
     }
 }
 

--- a/intellij-toml/src/main/resources/META-INF/plugin.xml
+++ b/intellij-toml/src/main/resources/META-INF/plugin.xml
@@ -36,5 +36,6 @@
         <todoIndexer filetype="TOML" implementationClass="org.toml.ide.todo.TomlTodoIndexer"/>
         <annotator language="TOML" implementationClass="org.toml.ide.annotator.TomlAnnotator"/>
         <annotator language="TOML" implementationClass="org.toml.ide.annotator.TomlHighlightingAnnotator"/>
+        <extendWordSelectionHandler implementation="org.toml.ide.wordSelection.TomlStringLiteralSelectionHandler"/>
     </extensions>
 </idea-plugin>

--- a/intellij-toml/src/test/kotlin/org/toml/ide/wordSelection/TomlSelectionHandlerTestBase.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/ide/wordSelection/TomlSelectionHandlerTestBase.kt
@@ -1,0 +1,24 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.wordSelection
+
+import com.intellij.codeInsight.editorActions.SelectWordHandler
+import com.intellij.ide.DataManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.intellij.lang.annotations.Language
+
+abstract class TomlSelectionHandlerTestBase : BasePlatformTestCase() {
+
+    protected fun doTest(@Language("TOML") before: String, @Language("TOML") vararg after: String) {
+        myFixture.configureByText("example.toml", before)
+        val action = SelectWordHandler(null)
+        val dataContext = DataManager.getInstance().getDataContext(myFixture.editor.component)
+        for (text in after) {
+            action.execute(myFixture.editor, null, dataContext)
+            myFixture.checkResult(text, false)
+        }
+    }
+}

--- a/intellij-toml/src/test/kotlin/org/toml/ide/wordSelection/TomlStringLiteralSelectionHandlerTest.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/ide/wordSelection/TomlStringLiteralSelectionHandlerTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.wordSelection
+
+class TomlStringLiteralSelectionHandlerTest : TomlSelectionHandlerTestBase() {
+
+    fun `test select whole string literal value`() = doTest("""
+        serde = "1<caret>.0.104"
+    """, """
+        serde = "<selection>1</selection>.0.104"
+    """, """
+        serde = "<selection>1.0.104</selection>"
+    """, """
+        serde = <selection>"1.0.104"</selection>
+    """)
+
+    fun `test select string literal escape symbols`() = doTest("""
+        key = "foo <caret>\u002D bar"
+    """, """
+        key = "foo <selection><caret>\u002D</selection> bar"
+    """)
+}

--- a/src/main/kotlin/org/rust/ide/wordSelection/RsBlockSelectionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/wordSelection/RsBlockSelectionHandler.kt
@@ -35,6 +35,6 @@ class RsBlockSelectionHandler : ExtendWordSelectionHandlerBase() {
         if (startOffset >= endOffset) return null
 
         val range = TextRange.create(startOffset, endOffset)
-        return ExtendWordSelectionHandlerBase.expandToWholeLine(editorText, range)
+        return expandToWholeLine(editorText, range)
     }
 }

--- a/src/main/kotlin/org/rust/ide/wordSelection/RsFieldLikeSelectionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/wordSelection/RsFieldLikeSelectionHandler.kt
@@ -30,7 +30,7 @@ class RsFieldLikeSelectionHandler : ExtendWordSelectionHandlerBase() {
             ?.takeIf { it.elementType == RsElementTypes.COMMA }
             ?.let { end = it.endOffset }
 
-        return ExtendWordSelectionHandlerBase.expandToWholeLine(editorText, TextRange.create(start, end))
+        return expandToWholeLine(editorText, TextRange.create(start, end))
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/ide/wordSelection/RsGroupSelectionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/wordSelection/RsGroupSelectionHandler.kt
@@ -64,7 +64,7 @@ class RsGroupSelectionHandler : ExtendWordSelectionHandlerBase() {
 
         while (endElement is PsiWhiteSpace) endElement = endElement.prevSibling
 
-        result.addAll(ExtendWordSelectionHandlerBase.expandToWholeLine(
+        result.addAll(expandToWholeLine(
             editorText, TextRange(startElement.startOffset, endElement.endOffset)))
 
         return result

--- a/src/main/kotlin/org/rust/ide/wordSelection/RsStringLiteralSelectionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/wordSelection/RsStringLiteralSelectionHandler.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.wordSelection
+
+import com.intellij.codeInsight.editorActions.ExtendWordSelectionHandlerBase
+import com.intellij.codeInsight.editorActions.SelectWordUtil
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.lexer.RsEscapesLexer
+import org.rust.lang.core.psi.RS_ALL_STRING_LITERALS
+import org.rust.lang.core.psi.RsLiteralKind
+import org.rust.lang.core.psi.ext.elementType
+
+class RsStringLiteralSelectionHandler : ExtendWordSelectionHandlerBase() {
+    override fun canSelect(e: PsiElement): Boolean =
+        e.elementType in RS_ALL_STRING_LITERALS
+
+    override fun select(e: PsiElement, editorText: CharSequence, cursorOffset: Int, editor: Editor): List<TextRange>? {
+        val kind = RsLiteralKind.fromAstNode(e.node) as? RsLiteralKind.String ?: return null
+        val valueRange = kind.offsets.value?.shiftRight(kind.node.startOffset) ?: return null
+        val result = super.select(e, editorText, cursorOffset, editor) ?: mutableListOf()
+
+        val elementType = e.elementType
+        if (elementType in RsEscapesLexer.ESCAPABLE_LITERALS_TOKEN_SET) {
+            SelectWordUtil.addWordHonoringEscapeSequences(
+                editorText,
+                valueRange,
+                cursorOffset,
+                RsEscapesLexer.of(elementType),
+                result
+            )
+        }
+
+        result += valueRange
+        return result
+    }
+}

--- a/src/main/resources/META-INF/core.xml
+++ b/src/main/resources/META-INF/core.xml
@@ -40,6 +40,7 @@
 
         <!-- Selection Handler -->
 
+        <extendWordSelectionHandler implementation="org.rust.ide.wordSelection.RsStringLiteralSelectionHandler"/>
         <extendWordSelectionHandler implementation="org.rust.ide.wordSelection.RsBlockSelectionHandler"/>
         <extendWordSelectionHandler implementation="org.rust.ide.wordSelection.RsGroupSelectionHandler"/>
         <extendWordSelectionHandler implementation="org.rust.ide.wordSelection.RsFieldLikeSelectionHandler"/>

--- a/src/test/kotlin/org/rust/ide/wordSelection/RsSelectionHandlerTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/wordSelection/RsSelectionHandlerTestBase.kt
@@ -7,10 +7,11 @@ package org.rust.ide.wordSelection
 
 import com.intellij.codeInsight.editorActions.SelectWordHandler
 import com.intellij.ide.DataManager
+import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 
 abstract class RsSelectionHandlerTestBase : RsTestBase() {
-    fun doTest(before: String, vararg after: String) {
+    fun doTest(@Language("Rust") before: String, @Language("Rust") vararg after: String) {
         doTestWithoutMacro(before, after)
         doTestWithMacro(before, after)
     }

--- a/src/test/kotlin/org/rust/ide/wordSelection/RsStringLiteralSelectionHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/wordSelection/RsStringLiteralSelectionHandlerTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.wordSelection
+
+class RsStringLiteralSelectionHandlerTest : RsSelectionHandlerTestBase() {
+
+    fun `test select whole string literal value`() = doTest("""
+        const C: &str = "st<caret>ring literal";
+    """, """
+        const C: &str = "<selection>string</selection> literal";
+    """, """
+        const C: &str = "<selection>string literal</selection>";
+    """, """
+        const C: &str = <selection>"string literal"</selection>;
+    """)
+
+    fun `test select string literal escape symbols`() = doTest("""
+        const C: &str = "foo <caret>\u{2D} baz";
+    """, """
+        const C: &str = "foo <selection><caret>\u{2D}</selection> baz";
+    """)
+
+    fun `test select whole raw string literal value`() = doTest("""
+        const C: &str = r#"raw <caret>string literal"#;
+    """, """
+        const C: &str = r#"raw <selection><caret>string</selection> literal"#;
+    """, """
+        const C: &str = r#"<selection>raw <caret>string literal</selection>"#;
+    """, """
+        const C: &str = <selection>r#"raw <caret>string literal"#</selection>;
+    """)
+
+    fun `test select whole byte string literal value`() = doTest("""
+        const C: &[u8] = b"byte st<caret>ring literal";
+    """, """
+        const C: &[u8] = b"byte <selection>string</selection> literal";
+    """, """
+        const C: &[u8] = b"<selection>byte string literal</selection>";
+    """, """
+        const C: &[u8] = <selection>b"byte string literal"</selection>;
+    """)
+}


### PR DESCRIPTION
Improve `Extend Selection` action for Rust and Toml literals:
* select whole string literal without quotes
* select escapes symbols

| Before | After |
|-|-|
| ![2019-12-28 22 13 23](https://user-images.githubusercontent.com/2539310/71548454-56349380-29bf-11ea-8036-246692f11d5b.gif) | ![2019-12-28 22 12 04](https://user-images.githubusercontent.com/2539310/71548456-56cd2a00-29bf-11ea-9e59-105ada892c19.gif) |
| ![2019-12-28 22 12 29](https://user-images.githubusercontent.com/2539310/71548455-56cd2a00-29bf-11ea-896d-bfadbf86bf63.gif) | ![2019-12-28 22 09 46](https://user-images.githubusercontent.com/2539310/71548457-56cd2a00-29bf-11ea-989e-b8379d90cb4d.gif) |