### PR TITLE
ACT: make "extend selection" action work with string literals

### DIFF
--- a/src/main/kotlin/org/rust/ide/wordSelection/RsStringLiteralSelectioner.kt
+++ b/src/main/kotlin/org/rust/ide/wordSelection/RsStringLiteralSelectioner.kt
@@ -1,0 +1,39 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.wordSelection
+
+import com.intellij.codeInsight.editorActions.ExtendWordSelectionHandlerBase
+import com.intellij.codeInsight.editorActions.SelectWordUtil
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.lexer.RsEscapesLexer
+import org.rust.lang.core.psi.RS_ALL_STRING_LITERALS
+import org.rust.lang.core.psi.RsLiteralKind
+import org.rust.lang.core.psi.ext.elementType
+import org.rust.lang.core.psi.ext.startOffset
+
+/** Inspired by Java's LiteralSelectioner */
+class RsStringLiteralSelectioner : ExtendWordSelectionHandlerBase() {
+    override fun canSelect(e: PsiElement): Boolean =
+        e.elementType in RS_ALL_STRING_LITERALS
+
+    override fun select(e: PsiElement, editorText: CharSequence, cursorOffset: Int, editor: Editor): List<TextRange>? {
+        val valueRange = (RsLiteralKind.fromAstNode(e.node) as? RsLiteralKind.String)?.offsets?.value?.shiftRight(e.startOffset)
+            ?: return null
+        val result: MutableList<TextRange> = super.select(e, editorText, cursorOffset, editor)!!
+
+        if (e.elementType in RsEscapesLexer.ESCAPABLE_LITERALS_TOKEN_SET) {
+            SelectWordUtil.addWordHonoringEscapeSequences(editorText, valueRange, cursorOffset,
+                RsEscapesLexer.of(e.elementType),
+                result)
+        }
+
+        result += valueRange
+
+        return result
+    }
+}

--- a/src/main/resources/META-INF/core.xml
+++ b/src/main/resources/META-INF/core.xml
@@ -40,6 +40,7 @@
 
         <!-- Selection Handler -->
 
+        <extendWordSelectionHandler implementation="org.rust.ide.wordSelection.RsStringLiteralSelectioner"/>
         <extendWordSelectionHandler implementation="org.rust.ide.wordSelection.RsBlockSelectionHandler"/>
         <extendWordSelectionHandler implementation="org.rust.ide.wordSelection.RsGroupSelectionHandler"/>
         <extendWordSelectionHandler implementation="org.rust.ide.wordSelection.RsFieldLikeSelectionHandler"/>

--- a/src/test/kotlin/org/rust/ide/wordSelection/RsSelectionHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/wordSelection/RsSelectionHandlerTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.wordSelection
+
+class RsSelectionHandlerTest : RsSelectionHandlerTestBase() {
+    fun `test string literal`() = doTest("""
+        const C: &str = "foo <caret>bar baz";
+    """, """
+        const C: &str = "foo <selection><caret>bar</selection> baz";
+    """, """
+        const C: &str = "<selection>foo <caret>bar baz</selection>";
+    """, """
+        const C: &str = <selection>"foo <caret>bar baz"</selection>;
+    """)
+
+    fun `test string literal escape code`() = doTest("""
+        const C: &str = "foo <caret>\u{00} baz";
+    """, """
+        const C: &str = "foo <selection><caret>\u{00}</selection> baz";
+    """)
+
+    fun `test raw string literal`() = doTest("""
+        const C: &str = r#"foo <caret>bar baz"#;
+    """, """
+        const C: &str = r#"foo <selection><caret>bar</selection> baz"#;
+    """, """
+        const C: &str = r#"<selection>foo <caret>bar baz</selection>"#;
+    """, """
+        const C: &str = <selection>r#"foo <caret>bar baz"#</selection>;
+    """)
+
+    fun `test byte string literal`() = doTest("""
+        const C: &[u8] = b"foo <caret>bar baz";
+    """, """
+        const C: &[u8] = b"foo <selection><caret>bar</selection> baz";
+    """, """
+        const C: &[u8] = b"<selection>foo <caret>bar baz</selection>";
+    """, """
+        const C: &[u8] = <selection>b"foo <caret>bar baz"</selection>;
+    """)
+}


### PR DESCRIPTION
I.e. select content of string literals (inside "")

(extend selection is ctrl+W or cmd+↑)