### PR TITLE
Add "import filtering rule" for "find usages"

### DIFF
--- a/src/main/kotlin/org/rust/ide/search/RsImportFilteringRule.kt
+++ b/src/main/kotlin/org/rust/ide/search/RsImportFilteringRule.kt
@@ -1,0 +1,22 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.search
+
+import com.intellij.usages.Usage
+import com.intellij.usages.UsageTarget
+import com.intellij.usages.rules.ImportFilteringRule
+import com.intellij.usages.rules.PsiElementUsage
+import org.rust.lang.core.psi.RsUseSpeck
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.ancestorStrict
+
+class RsImportFilteringRule : ImportFilteringRule() {
+    override fun isVisible(usage: Usage, targets: Array<out UsageTarget>): Boolean {
+        val psi = (usage as? PsiElementUsage)?.element as? RsElement ?: return true
+        val useSpeck = psi.ancestorStrict<RsUseSpeck>()
+        return !(useSpeck != null && useSpeck.alias == null)
+    }
+}

--- a/src/main/resources/META-INF/core.xml
+++ b/src/main/resources/META-INF/core.xml
@@ -99,6 +99,7 @@
         <findUsagesHandlerFactory implementation="org.rust.ide.search.RsFindUsagesHandlerFactory"/>
         <usageTypeProvider implementation="org.rust.ide.search.RsUsageTypeProvider"/>
         <readWriteAccessDetector implementation="org.rust.ide.search.RsReadWriteAccessDetector" id="rust"/>
+        <importFilteringRule implementation="org.rust.ide.search.RsImportFilteringRule"/>
         <fileStructureGroupRuleProvider implementation="org.rust.ide.search.RsFunctionGroupingRuleProvider"
                                         id="rs-function"/>
         <fileStructureGroupRuleProvider implementation="org.rust.ide.search.RsTraitOrImplGroupingRuleProvider"


### PR DESCRIPTION
Used to filter out usages from `use` items
