### PR TITLE
COMP: guess proper type of braces while macro call completion

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -274,14 +274,21 @@ open class RsDefaultInsertHandler : InsertHandler<LookupElement> {
 
             is RsMacro -> {
                 if (curUseItem == null) {
+                    var caretShift = 2
                     if (!context.nextCharIs('!')) {
-                        val parens = when (element.name) {
-                            "vec" -> "[]"
-                            else -> "()"
+                        val braces = element.preferredBraces
+                        val text = buildString {
+                            append("!")
+                            if (braces == MacroBraces.BRACES) {
+                                append(" ")
+                                caretShift = 3
+                            }
+                            append(braces.openText)
+                            append(braces.closeText)
                         }
-                        document.insertString(context.selectionEndOffset, "!$parens")
+                        document.insertString(context.selectionEndOffset, text)
                     }
-                    EditorModificationUtil.moveCaretRelatively(context.editor, 2)
+                    EditorModificationUtil.moveCaretRelatively(context.editor, caretShift)
                 } else {
                     appendSemicolon(context, curUseItem)
                 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
@@ -16,12 +16,11 @@ import com.intellij.psi.util.CachedValuesManager
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.MacroGraph
 import org.rust.lang.core.macros.MacroGraphBuilder
-import org.rust.lang.core.psi.RsElementTypes
-import org.rust.lang.core.psi.RsMacro
-import org.rust.lang.core.psi.RsMacroBody
-import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.stubs.RsMacroStub
+import org.rust.lang.doc.documentation
 import org.rust.stdext.HashCode
+import java.util.*
 import javax.swing.Icon
 
 abstract class RsMacroImplMixin : RsStubbedNamedElementImpl<RsMacroStub>,
@@ -72,6 +71,29 @@ val RsMacro.macroBodyStubbed: RsMacroBody?
             )
         }
     }
+
+val RsMacro.preferredBraces: MacroBraces
+    get() = stub?.preferredBraces ?: guessPreferredBraces()
+
+
+private val MACRO_CALL_PATTERN: Regex = """(^|[^\p{Alnum}_])(r#)?(?<name>\w+)\s*!\s*(?<brace>[({\[])""".toRegex()
+
+/**
+ * Analyses documentation of macro definition to determine what kind of brackets usually used
+ */
+private fun RsMacro.guessPreferredBraces(): MacroBraces {
+    val documentation = documentation()
+    if (documentation.isNullOrEmpty()) return MacroBraces.PARENS
+
+    val map: MutableMap<MacroBraces, Int> = EnumMap(MacroBraces::class.java)
+    for (result in MACRO_CALL_PATTERN.findAll(documentation)) {
+        if (result.groups["name"]?.value != name) continue
+        val braces = MacroBraces.values().find { it.openText == result.groups["brace"]?.value } ?: continue
+        map.merge(braces, 1, Int::plus)
+    }
+
+    return map.maxBy { it.value }?.key ?: MacroBraces.PARENS
+}
 
 private val MACRO_BODY_HASH_KEY: Key<CachedValue<HashCode>> = Key.create("MACRO_BODY_HASH_KEY")
 

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -35,7 +35,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 188
+        override fun getStubVersion(): Int = 189
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> = RsFileStub(file as RsFile)
@@ -1026,7 +1026,8 @@ class RsLifetimeParameterStub(
 class RsMacroStub(
     parent: StubElement<*>?, elementType: IStubElementType<*, *>,
     override val name: String?,
-    val macroBody: String?
+    val macroBody: String?,
+    val preferredBraces: MacroBraces
 ) : StubBase<RsMacro>(parent, elementType),
     RsNamedStub {
 
@@ -1036,20 +1037,22 @@ class RsMacroStub(
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
             RsMacroStub(parentStub, this,
                 dataStream.readNameAsString(),
-                dataStream.readUTFFastAsNullable()
+                dataStream.readUTFFastAsNullable(),
+                dataStream.readEnum()
             )
 
         override fun serialize(stub: RsMacroStub, dataStream: StubOutputStream) =
             with(dataStream) {
                 writeName(stub.name)
                 writeUTFFastAsNullable(stub.macroBody)
+                writeEnum(stub.preferredBraces)
             }
 
         override fun createPsi(stub: RsMacroStub): RsMacro =
             RsMacroImpl(stub, this)
 
         override fun createStub(psi: RsMacro, parentStub: StubElement<*>?) =
-            RsMacroStub(parentStub, this, psi.name, psi.macroBody?.text)
+            RsMacroStub(parentStub, this, psi.name, psi.macroBody?.text, psi.preferredBraces)
 
         override fun indexStub(stub: RsMacroStub, sink: IndexSink) = sink.indexMacro(stub)
     }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsMacroBracketCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsMacroBracketCompletionTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+class RsMacroBracketCompletionTest : RsCompletionTestBase() {
+
+    fun `test default bracket`() = doSingleCompletion("""
+        macro_rules! foo {
+            () => {};
+        }
+        fn main() {
+            foo/*caret*/
+        }
+    """, """
+        macro_rules! foo {
+            () => {};
+        }
+        fn main() {
+            foo!(/*caret*/)
+        }
+    """)
+
+    fun `test bracket from documentation`() = doSingleCompletion("""
+        /// `foo![]`
+        ///
+        /// ```
+        /// foo![];
+        /// bar_foo!();
+        /// foo();
+        /// ```
+        ///
+        /// `foo!()`
+        ///
+        macro_rules! foo {
+            () => {};
+        }
+        fn main() {
+            foo/*caret*/
+        }
+    """, """
+        /// `foo![]`
+        ///
+        /// ```
+        /// foo![];
+        /// bar_foo!();
+        /// foo();
+        /// ```
+        ///
+        /// `foo!()`
+        ///
+        macro_rules! foo {
+            () => {};
+        }
+        fn main() {
+            foo![/*caret*/]
+        }
+    """)
+
+    fun `test insert space for before braces`() = doSingleCompletion("""
+        /// `foo! {}`
+        macro_rules! foo {
+            () => {};
+        }
+        fn main() {
+            foo/*caret*/
+        }
+    """, """
+        /// `foo! {}`
+        macro_rules! foo {
+            () => {};
+        }
+        fn main() {
+            foo! {/*caret*/}
+        }
+    """)
+
+    fun `test raw macro calls`() = doSingleCompletion("""
+        /// `r#foo![]`
+        ///
+        /// ```
+        /// foo!();
+        /// foo![];
+        /// ```
+        ///
+        macro_rules! foo {
+            () => {};
+        }
+        fn main() {
+            foo/*caret*/
+        }
+    """, """
+        /// `r#foo![]`
+        ///
+        /// ```
+        /// foo!();
+        /// foo![];
+        /// ```
+        ///
+        macro_rules! foo {
+            () => {};
+        }
+        fn main() {
+            foo![/*caret*/]
+        }
+    """)
+
+    fun `test do not mess with other macro calls`() = doSingleCompletion("""
+        /// ```
+        /// foo![];
+        /// assert!(true);
+        /// assert!(true);
+        /// ```
+        ///
+        macro_rules! foo {
+            () => {};
+        }
+        fn main() {
+            foo/*caret*/
+        }
+    """, """
+        /// ```
+        /// foo![];
+        /// assert!(true);
+        /// assert!(true);
+        /// ```
+        ///
+        macro_rules! foo {
+            () => {};
+        }
+        fn main() {
+            foo![/*caret*/]
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
@@ -54,6 +54,12 @@ class RsStdlibCompletionTest : RsCompletionTestBase() {
         fn main() { vec![/*caret*/] }
     """)
 
+    fun `test macro with braces`() = doFirstCompletion("""
+       thread_lo/*caret*/
+    """, """
+       thread_local! {/*caret*/}
+    """)
+
     fun `test macro in use item`() = doSingleCompletion("""
        #![feature(use_extern_macros)]
 


### PR DESCRIPTION
Analyze documentation of macro definition and extract the most commonly used type of braces from it.
For example, it allows the plugin to insert `{}` while `thread_local` completion instead of `()`

It was originally implemented in https://github.com/rust-analyzer/rust-analyzer/pull/2039