### PR TITLE
Adds a conditionClass to the Cargo tool window

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -87,6 +87,7 @@ pavel-v-chernykh
 pcholakov
 pocket7878
 rrevenantt
+samdfonseca
 sanmai-NL
 sgift
 sgrif

--- a/src/main/resources/META-INF/core.xml
+++ b/src/main/resources/META-INF/core.xml
@@ -798,6 +798,7 @@
         <toolWindow id="Cargo"
                     anchor="right"
                     factoryClass="org.rust.cargo.project.toolwindow.CargoToolWindowFactory"
+                    conditionClass="org.rust.cargo.project.toolwindow.CargoToolWindowCondition"
                     icon="/icons/tool-window.svg"/>
 
         <additionalLibraryRootsProvider


### PR DESCRIPTION
- Only displays tool window if a Cargo.toml file is found in any of the
content roots

I've found myself repeatedly removing the Cargo tool window from the sidebar, since I mostly work on non-Rust projects in IntelliJ. This change makes displaying the tool window conditional on finding a `Cargo.toml` file in any of the content roots.

My only real concern relates to `CargoToolWindowFactory` implementing `DumbAware` and how inspecting the content roots behaves during indexing, however I tested it and it appears to work as expected.

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
