### PR TITLE
TY: provide `Copy` and `Clone` impls for array types

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -273,9 +273,14 @@ class ImplLookup(
     }
 
     // TODO rename to BuiltinImpls
+    /**
+     * Keep in sync with [getHardcodedImplPredicates]
+     *
+     * @see <a href="https://doc.rust-lang.org/std/clone/trait.Clone.html#additional-implementors">Clone additional implementors</a>
+     * @see <a href="https://doc.rust-lang.org/std/marker/trait.Copy.html#additional-implementors">Copy additional implementors</a>
+     */
     private fun getHardcodedImpls(ty: Ty): Collection<BoundElement<RsTraitItem>> {
-        if (ty is TyTuple) {
-            // Keep in sync with `getHardcodedImplPredicates`
+        if (ty is TyTuple || ty is TyArray) {
             return listOfNotNull(items.Clone, items.Copy).map { BoundElement(it) }
         }
 
@@ -370,12 +375,18 @@ class ImplLookup(
         return impls
     }
 
+    /**
+     * Keep in sync with [getHardcodedImpls]
+     *
+     * @see <a href="https://doc.rust-lang.org/std/clone/trait.Clone.html#additional-implementors">Clone additional implementors</a>
+     * @see <a href="https://doc.rust-lang.org/std/marker/trait.Copy.html#additional-implementors">Copy additional implementors</a>
+     */
     private fun getHardcodedImplPredicates(ty: Ty, trait: BoundElement<RsTraitItem>): List<Predicate> {
-        if (ty is TyTuple) {
-            // Keep in sync with `getHardcodedImplPredicated`
-            return ty.types.map { Predicate.Trait(TraitRef(it, trait)) }
+        return when (ty) {
+            is TyTuple -> ty.types.map { Predicate.Trait(TraitRef(it, trait)) }
+            is TyArray -> listOf(Predicate.Trait(TraitRef(ty.base, trait)))
+            else -> emptyList()
         }
-        return emptyList()
     }
 
     private fun findExplicitImpls(selfTy: Ty, processor: RsProcessor<RsCachedImplItem>): Boolean {

--- a/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
@@ -163,6 +163,17 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
                //^ !Copy
     """)
 
+    fun `test array of 'Copy' type is 'Copy'`() = doTest("""
+        type T = [i32; 4];
+               //^ Copy
+    """)
+
+    fun `test array of non 'Copy' type is not 'Copy'`() = doTest("""
+        struct X;
+        type T = [X; 4];
+               //^ !Copy
+    """)
+
     private fun checkPrimitiveTypes(traitName: String) {
         val allIntegers = TyInteger.VALUES.toTypedArray()
         val allFloats = TyFloat.VALUES.toTypedArray()


### PR DESCRIPTION
Now the plugin can infer type of `[0; 4].clone()` expression

Fixes type inference part of #4814
Fixes #4819