### PR TITLE
CPP-18528: provide help id for cargo command configuration type in IDEA and CLion

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfigurationType.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfigurationType.kt
@@ -10,6 +10,7 @@ import com.intellij.execution.configurations.ConfigurationTypeBase
 import com.intellij.execution.configurations.ConfigurationTypeUtil
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.openapi.project.Project
+import com.intellij.util.PlatformUtils
 import org.rust.ide.icons.RsIcons
 
 class CargoCommandConfigurationType : ConfigurationTypeBase(
@@ -28,6 +29,10 @@ class CargoCommandConfigurationType : ConfigurationTypeBase(
     }
 
     val factory: ConfigurationFactory get() = configurationFactories.single()
+
+    override fun getHelpTopic(): String? =
+        // Only IDEA and CLion have special page about IntelliJ Rust in their help
+        if (PlatformUtils.isIntelliJ() || PlatformUtils.isCLion()) "rundebugconfigs.cargocommand" else null
 
     companion object {
         fun getInstance(): CargoCommandConfigurationType =


### PR DESCRIPTION
It allows opening special help page about Cargo Command run configuration