### PR TITLE
ACT: improve `Attach Cargo Project` action

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/AttachCargoProjectAction.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/AttachCargoProjectAction.kt
@@ -5,7 +5,9 @@
 
 package org.rust.cargo.project.model
 
+import com.google.common.annotations.VisibleForTesting
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DataKey
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.fileChooser.FileChooserFactory
@@ -14,22 +16,30 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapiext.isUnitTestMode
 import org.rust.cargo.project.model.CargoProjectChooserDescriptor.withFileFilter
 import org.rust.cargo.project.toolwindow.CargoToolWindow
 import org.rust.cargo.toolchain.RustToolchain.Companion.CARGO_TOML
+import org.rust.ide.notifications.RsEditorNotificationPanel
 import org.rust.openapiext.pathAsPath
 import org.rust.openapiext.saveAllDocuments
 import java.nio.file.Path
 
+/**
+ * Adds cargo project to [CargoProjectsService]
+ *
+ * It can be invoked from Project View, [CargoToolWindow] and [RsEditorNotificationPanel]
+ */
 class AttachCargoProjectAction : CargoProjectActionBase() {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         saveAllDocuments()
 
         val file = when (e.place) {
-            CargoToolWindow.CARGO_TOOLBAR_PLACE -> {
-                val chooser = FileChooserFactory.getInstance().createFileChooser(CargoProjectChooserDescriptor, project, null)
-                chooser.choose(project).singleOrNull()
+            CargoToolWindow.CARGO_TOOLBAR_PLACE -> chooseFile(project, e)
+            RsEditorNotificationPanel.NOTIFICATION_PANEL_PLACE -> {
+                val file = e.getData(PlatformDataKeys.VIRTUAL_FILE)
+                if (file?.isCargoToml == true) file else chooseFile(project, e)
             }
             else -> e.getData(PlatformDataKeys.VIRTUAL_FILE)
         } ?: return
@@ -45,6 +55,15 @@ class AttachCargoProjectAction : CargoProjectActionBase() {
         }
     }
 
+    private fun chooseFile(project: Project, event: AnActionEvent): VirtualFile? {
+        return if (isUnitTestMode) {
+            event.getData(MOCK_CHOSEN_FILE_KEY)
+        } else {
+            val chooser = FileChooserFactory.getInstance().createFileChooser(CargoProjectChooserDescriptor, project, null)
+            return chooser.choose(project).singleOrNull()
+        }
+    }
+
     override fun update(e: AnActionEvent) {
         val project = e.project ?: return
         e.presentation.isEnabledAndVisible = isActionEnabled(e, project)
@@ -52,7 +71,7 @@ class AttachCargoProjectAction : CargoProjectActionBase() {
 
     private fun isActionEnabled(e: AnActionEvent, project: Project): Boolean {
         return when (e.place) {
-            CargoToolWindow.CARGO_TOOLBAR_PLACE -> true
+            CargoToolWindow.CARGO_TOOLBAR_PLACE, RsEditorNotificationPanel.NOTIFICATION_PANEL_PLACE -> true
             else -> {
                 // We need to use `ProjectFileIndex` to check if `Cargo.toml` is in project content
                 // so disable the action in dumb mode
@@ -60,26 +79,36 @@ class AttachCargoProjectAction : CargoProjectActionBase() {
                 val file = e.getData(PlatformDataKeys.VIRTUAL_FILE)
                 val cargoToml = file?.findCargoToml() ?: return false
 
-                if (!ProjectFileIndex.getInstance(project).isInContent(cargoToml)) return false
-
-                val path = cargoToml.pathAsPath
-
-                // Project module already contains Cargo project with `cargoToml` as manifest file
-                if (project.cargoProjects.allProjects.any { it.manifest == path }) return false
-                // Project module already contains a package with `cargoToml` as manifest file
-                if (project.cargoProjects.allProjects.any { it.containsWorkspaceManifest(path) }) return false
-                true
+                canBeAttached(project, cargoToml)
             }
         }
     }
 
-    private fun CargoProject.containsWorkspaceManifest(path: Path): Boolean {
-        val rootDir = path.parent
-        return workspace?.packages.orEmpty().any { it.rootDirectory == rootDir }
-    }
-
     private fun VirtualFile.findCargoToml(): VirtualFile? {
         return if (isDirectory) findChild(CARGO_TOML) else takeIf { it.isCargoToml }
+    }
+
+    companion object {
+        @VisibleForTesting
+        val MOCK_CHOSEN_FILE_KEY: DataKey<VirtualFile> = DataKey.create("MOCK_CHOSEN_FILE_KEY")
+
+        fun canBeAttached(project: Project, cargoToml: VirtualFile): Boolean {
+            require(cargoToml.isCargoToml)
+            if (!ProjectFileIndex.getInstance(project).isInContent(cargoToml)) return false
+
+            val path = cargoToml.pathAsPath
+
+            // Project module already contains Cargo project with `cargoToml` as manifest file
+            if (project.cargoProjects.allProjects.any { it.manifest == path }) return false
+            // Project module already contains a package with `cargoToml` as manifest file
+            if (project.cargoProjects.allProjects.any { it.containsWorkspaceManifest(path) }) return false
+            return true
+        }
+
+        private fun CargoProject.containsWorkspaceManifest(path: Path): Boolean {
+            val rootDir = path.parent
+            return workspace?.packages.orEmpty().any { it.rootDirectory == rootDir }
+        }
     }
 }
 
@@ -96,4 +125,4 @@ object CargoProjectChooserDescriptor : FileChooserDescriptor(true, true, false, 
     }
 }
 
-private val VirtualFile.isCargoToml: Boolean get() = name == CARGO_TOML
+val VirtualFile.isCargoToml: Boolean get() = name == CARGO_TOML

--- a/src/main/kotlin/org/rust/cargo/project/model/AttachCargoProjectAction.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/AttachCargoProjectAction.kt
@@ -6,27 +6,36 @@
 package org.rust.cargo.project.model
 
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.fileChooser.FileChooserFactory
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.project.model.CargoProjectChooserDescriptor.withFileFilter
-import org.rust.cargo.toolchain.RustToolchain
+import org.rust.cargo.project.toolwindow.CargoToolWindow
+import org.rust.cargo.toolchain.RustToolchain.Companion.CARGO_TOML
 import org.rust.openapiext.pathAsPath
 import org.rust.openapiext.saveAllDocuments
-
+import java.nio.file.Path
 
 class AttachCargoProjectAction : CargoProjectActionBase() {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         saveAllDocuments()
-        val chooser = FileChooserFactory.getInstance().createFileChooser(CargoProjectChooserDescriptor, project, null)
-        val file = chooser.choose(project).singleOrNull() ?: return
-        val cargoToml = if (file.isDirectory) {
-            file.findChild(RustToolchain.CARGO_TOML) ?: return
-        } else {
-            file
-        }
+
+        val file = when (e.place) {
+            CargoToolWindow.CARGO_TOOLBAR_PLACE -> {
+                val chooser = FileChooserFactory.getInstance().createFileChooser(CargoProjectChooserDescriptor, project, null)
+                chooser.choose(project).singleOrNull()
+            }
+            else -> e.getData(PlatformDataKeys.VIRTUAL_FILE)
+        } ?: return
+
+        val cargoToml = file.findCargoToml() ?: return
+
         if (!project.cargoProjects.attachCargoProject(cargoToml.pathAsPath)) {
             Messages.showErrorDialog(
                 project,
@@ -35,17 +44,56 @@ class AttachCargoProjectAction : CargoProjectActionBase() {
             )
         }
     }
+
+    override fun update(e: AnActionEvent) {
+        val project = e.project ?: return
+        e.presentation.isEnabledAndVisible = isActionEnabled(e, project)
+    }
+
+    private fun isActionEnabled(e: AnActionEvent, project: Project): Boolean {
+        return when (e.place) {
+            CargoToolWindow.CARGO_TOOLBAR_PLACE -> true
+            else -> {
+                // We need to use `ProjectFileIndex` to check if `Cargo.toml` is in project content
+                // so disable the action in dumb mode
+                if (DumbService.isDumb(project)) return false
+                val file = e.getData(PlatformDataKeys.VIRTUAL_FILE)
+                val cargoToml = file?.findCargoToml() ?: return false
+
+                if (!ProjectFileIndex.getInstance(project).isInContent(cargoToml)) return false
+
+                val path = cargoToml.pathAsPath
+
+                // Project module already contains Cargo project with `cargoToml` as manifest file
+                if (project.cargoProjects.allProjects.any { it.manifest == path }) return false
+                // Project module already contains a package with `cargoToml` as manifest file
+                if (project.cargoProjects.allProjects.any { it.containsWorkspaceManifest(path) }) return false
+                true
+            }
+        }
+    }
+
+    private fun CargoProject.containsWorkspaceManifest(path: Path): Boolean {
+        val rootDir = path.parent
+        return workspace?.packages.orEmpty().any { it.rootDirectory == rootDir }
+    }
+
+    private fun VirtualFile.findCargoToml(): VirtualFile? {
+        return if (isDirectory) findChild(CARGO_TOML) else takeIf { it.isCargoToml }
+    }
 }
 
 object CargoProjectChooserDescriptor : FileChooserDescriptor(true, true, false, false, false, false) {
 
     init {
         // The filter is not used for directories
-        withFileFilter { it.name == RustToolchain.CARGO_TOML }
+        withFileFilter { it.isCargoToml }
         withTitle("Select Cargo.toml")
     }
 
     override fun isFileSelectable(file: VirtualFile): Boolean {
-        return super.isFileSelectable(file) && (!file.isDirectory || file.findChild(RustToolchain.CARGO_TOML) != null)
+        return super.isFileSelectable(file) && (!file.isDirectory || file.findChild(CARGO_TOML) != null)
     }
 }
+
+private val VirtualFile.isCargoToml: Boolean get() = name == CARGO_TOML

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/TestCargoProjectsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/TestCargoProjectsServiceImpl.kt
@@ -64,9 +64,7 @@ class TestCargoProjectsServiceImpl(project: Project) : CargoProjectsServiceImpl(
 
     @TestOnly
     fun discoverAndRefreshSync(): List<CargoProject> {
-        val projects = discoverAndRefresh().get(1, TimeUnit.MINUTES)
+        return discoverAndRefresh().get(1, TimeUnit.MINUTES)
             ?: error("Timeout when refreshing a test Cargo project")
-        if (projects.isEmpty()) error("Failed to update a test Cargo project")
-        return projects
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoToolWindow.kt
+++ b/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoToolWindow.kt
@@ -58,7 +58,7 @@ class CargoToolWindow(
 ) {
     val toolbar: ActionToolbar = run {
         val actionManager = ActionManager.getInstance()
-        actionManager.createActionToolbar("Cargo Toolbar", actionManager.getAction("Rust.Cargo") as DefaultActionGroup, true)
+        actionManager.createActionToolbar(CARGO_TOOLBAR_PLACE, actionManager.getAction("Rust.Cargo") as DefaultActionGroup, true)
     }
 
     val note = JEditorPane("text/html", html("")).apply {
@@ -108,5 +108,7 @@ class CargoToolWindow(
     companion object {
         @JvmStatic
         val SELECTED_CARGO_PROJECT: DataKey<CargoProject> = DataKey.create<CargoProject>("SELECTED_CARGO_PROJECT")
+
+        const val CARGO_TOOLBAR_PLACE: String = "Cargo Toolbar"
     }
 }

--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -69,15 +69,8 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
         }
 
         val cargoProjects = project.cargoProjects
-        if (!cargoProjects.hasAtLeastOneValidProject) {
-            return createNoCargoProjectsPanel(file)
-        }
 
-        val cargoProject = cargoProjects.findProjectForFile(file) ?:
-            //TODO: more precise check here
-            return createNoCargoProjectForFilePanel(file)
-
-        val workspace = cargoProject.workspace ?: return null
+        val workspace = cargoProjects.findProjectForFile(file)?.workspace ?: return null
         if (!workspace.hasStandardLibrary) {
             // If rustup is not null, the WorkspaceService will use it
             // to add stdlib automatically. This happens asynchronously,
@@ -94,22 +87,6 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
             createActionLabel("Setup toolchain") {
                 project.rustSettings.configureToolchain()
             }
-            createActionLabel("Do not show again") {
-                disableNotification(file)
-                updateAllNotifications()
-            }
-        }
-
-    private fun createNoCargoProjectsPanel(file: VirtualFile): RsEditorNotificationPanel =
-        createAttachCargoProjectPanel(NO_CARGO_PROJECTS, file, "No Cargo projects found")
-
-    private fun createNoCargoProjectForFilePanel(file: VirtualFile): RsEditorNotificationPanel =
-        createAttachCargoProjectPanel(FILE_NOT_IN_CARGO_PROJECT, file, "File does not belong to any known Cargo project")
-
-    private fun createAttachCargoProjectPanel(debugId: String, file: VirtualFile, message: String): RsEditorNotificationPanel =
-        RsEditorNotificationPanel(debugId).apply {
-            setText(message)
-            createActionLabel("Attach", "Cargo.AttachCargoProject")
             createActionLabel("Do not show again") {
                 disableNotification(file)
                 updateAllNotifications()
@@ -142,8 +119,6 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
     companion object {
         private const val NOTIFICATION_STATUS_KEY = "org.rust.hideToolchainNotifications"
         const val NO_RUST_TOOLCHAIN = "NoRustToolchain"
-        const val NO_CARGO_PROJECTS = "NoCargoProjects"
-        const val FILE_NOT_IN_CARGO_PROJECT = "FileNotInCargoProject"
         const val NO_ATTACHED_STDLIB = "NoAttachedStdlib"
 
         private val PROVIDER_KEY: Key<EditorNotificationPanel> = Key.create("Setup Rust toolchain")

--- a/src/main/kotlin/org/rust/ide/notifications/NoCargoProjectNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/NoCargoProjectNotificationProvider.kt
@@ -1,0 +1,84 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.notifications
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapiext.isUnitTestMode
+import com.intellij.ui.EditorNotificationPanel
+import org.rust.cargo.project.model.*
+import org.rust.lang.core.psi.isRustFile
+
+class NoCargoProjectNotificationProvider(project: Project) : RsNotificationProvider(project) {
+
+    init {
+        project.messageBus.connect().apply {
+            subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsService.CargoProjectsListener {
+                override fun cargoProjectsUpdated(projects: Collection<CargoProject>) {
+                    updateAllNotifications()
+                }
+            })
+        }
+    }
+
+    override val VirtualFile.disablingKey: String
+        get() = NOTIFICATION_STATUS_KEY + path
+
+    override fun createNotificationPanel(
+        file: VirtualFile,
+        editor: FileEditor,
+        project: Project
+    ): RsEditorNotificationPanel? {
+        if (isUnitTestMode && !ApplicationManager.getApplication().isDispatchThread) return null
+        if (!(file.isRustFile || file.isCargoToml) || isNotificationDisabled(file)) return null
+
+        val cargoProjects = project.cargoProjects
+        if (!cargoProjects.hasAtLeastOneValidProject) {
+            return createNoCargoProjectsPanel(file)
+        }
+
+        if (file.isCargoToml) {
+            if (AttachCargoProjectAction.canBeAttached(project, file)) {
+                return createNoCargoProjectForFilePanel(file)
+            }
+        } else if (cargoProjects.findProjectForFile(file) == null) {
+            //TODO: more precise check here
+            return createNoCargoProjectForFilePanel(file)
+        }
+
+        return null
+    }
+
+    private fun createNoCargoProjectsPanel(file: VirtualFile): RsEditorNotificationPanel =
+        createAttachCargoProjectPanel(NO_CARGO_PROJECTS, file, "No Cargo projects found")
+
+    private fun createNoCargoProjectForFilePanel(file: VirtualFile): RsEditorNotificationPanel =
+        createAttachCargoProjectPanel(FILE_NOT_IN_CARGO_PROJECT, file, "File does not belong to any known Cargo project")
+
+    private fun createAttachCargoProjectPanel(debugId: String, file: VirtualFile, message: String): RsEditorNotificationPanel =
+        RsEditorNotificationPanel(debugId).apply {
+            setText(message)
+            createActionLabel("Attach", "Cargo.AttachCargoProject")
+            createActionLabel("Do not show again") {
+                disableNotification(file)
+                updateAllNotifications()
+            }
+        }
+
+    override fun getKey(): Key<EditorNotificationPanel> = PROVIDER_KEY
+
+    companion object {
+        private const val NOTIFICATION_STATUS_KEY = "org.rust.hideNoCargoProjectNotifications"
+
+        const val NO_CARGO_PROJECTS = "NoCargoProjects"
+        const val FILE_NOT_IN_CARGO_PROJECT = "FileNotInCargoProject"
+
+        private val PROVIDER_KEY: Key<EditorNotificationPanel> = Key.create("No Cargo project")
+    }
+}

--- a/src/main/kotlin/org/rust/ide/notifications/RsNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/RsNotificationProvider.kt
@@ -36,4 +36,10 @@ abstract class RsNotificationProvider(
         PropertiesComponent.getInstance(project).getBoolean(file.disablingKey)
 }
 
-class RsEditorNotificationPanel(val debugId: String) : EditorNotificationPanel()
+class RsEditorNotificationPanel(val debugId: String) : EditorNotificationPanel() {
+    override fun getActionPlace(): String = NOTIFICATION_PANEL_PLACE
+
+    companion object {
+        const val NOTIFICATION_PANEL_PLACE = "RsEditorNotificationPanel"
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -825,6 +825,7 @@
 
         <editorNotificationProvider implementation="org.rust.ide.notifications.MissingToolchainNotificationProvider"/>
         <editorNotificationProvider implementation="org.rust.ide.notifications.DetachedFileNotificationProvider"/>
+        <editorNotificationProvider implementation="org.rust.ide.notifications.NoCargoProjectNotificationProvider"/>
 
         <!-- Editor Tab Title Providers -->
 

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1065,6 +1065,11 @@
             <reference id="Cargo.ShowSettings"/>
         </group>
 
+        <group id="Rust.ProjectView">
+            <reference id="Cargo.AttachCargoProject"/>
+            <add-to-group group-id="ProjectViewPopupMenu"/>
+        </group>
+
         <!-- Internal -->
 
         <action id="RsGenerateDictionaries" class="org.rust.ide.spelling.RsSpellCheckerGenerateDictionariesAction"

--- a/src/test/kotlin/org/rust/cargo/project/model/AttachCargoProjectActionTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/AttachCargoProjectActionTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.model
+
+import com.intellij.openapi.actionSystem.PlatformDataKeys
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.MapDataContext
+import com.intellij.testFramework.TestActionEvent
+import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl
+import com.intellij.util.ui.UIUtil
+import org.rust.FileTreeBuilder
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.fileTree
+import org.rust.openapiext.pathAsPath
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class AttachCargoProjectActionTest : RsWithToolchainTestBase() {
+
+    private val tempDirFixture = TempDirTestFixtureImpl()
+
+    private val cargoProjectSupplier: FileTreeBuilder.() -> Unit = {
+        toml("Cargo.toml", """
+            [package]
+            name = "hello"
+            version = "0.1.0"
+            authors = []
+        """)
+
+        dir("src") {
+            rust("main.rs", """
+                fn main() {
+                    println!("Hello, world!");
+                }
+            """)
+        }
+    }
+
+    override fun setUp() {
+        super.setUp()
+        tempDirFixture.setUp()
+    }
+
+    override fun tearDown() {
+        tempDirFixture.tearDown()
+        super.tearDown()
+    }
+
+    fun `test attach cargo project via root directory`() {
+        val testProject = buildProject {
+            dir("dir", cargoProjectSupplier)
+        }
+
+        val rootDir = testProject.root.findChild("dir")!!
+        testAction(rootDir, true)
+        val cargoProject = project.cargoProjects.allProjects.find { it.rootDir == rootDir }
+        assertNotNull("Failed to attach project in `$rootDir`", cargoProject)
+    }
+
+    fun `test attach cargo project via cargo toml`() {
+        val testProject = buildProject {
+            dir("dir", cargoProjectSupplier)
+        }
+
+        val cargoToml = testProject.root.findFileByRelativePath("dir/Cargo.toml")!!
+        testAction(cargoToml, true)
+        val cargoProject = project.cargoProjects.allProjects.find { it.manifest == cargoToml.pathAsPath }
+        assertNotNull("Failed to attach project via `$cargoToml` file", cargoProject)
+    }
+
+    fun `test no action for cargo toml of existing cargo project`() {
+        val testProject = buildProject(cargoProjectSupplier)
+        val cargoToml = testProject.root.findFileByRelativePath("Cargo.toml")!!
+        testAction(cargoToml, false)
+    }
+
+    fun `test no action for cargo toml of existing package in cargo project`() {
+        val testProject = buildProject {
+            toml("Cargo.toml", """
+                [workspace]
+                members = [ "foo" ]
+            """)
+
+            dir("foo", cargoProjectSupplier)
+        }
+
+        val cargoToml = testProject.root.findFileByRelativePath("foo/Cargo.toml")!!
+        testAction(cargoToml, false)
+    }
+
+    fun `test no action for cargo toml outside of project`() {
+        val libraryProject = fileTree(cargoProjectSupplier).create(project, tempDirFixture.getFile("")!!)
+        val cargoToml = libraryProject.root.findFileByRelativePath("Cargo.toml")!!
+        testAction(cargoToml, false)
+    }
+
+    private fun testAction(file: VirtualFile, shouldBeEnabled: Boolean) {
+        val context = MapDataContext().apply {
+            put(PlatformDataKeys.PROJECT, project)
+            put(PlatformDataKeys.VIRTUAL_FILE, file)
+        }
+        val testEvent = TestActionEvent(context)
+        val action = AttachCargoProjectAction()
+        action.beforeActionPerformedUpdate(testEvent)
+        assertEquals(shouldBeEnabled, testEvent.presentation.isEnabledAndVisible)
+        if (shouldBeEnabled) {
+            val latch = CountDownLatch(1)
+            project.messageBus.connect().subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsService.CargoProjectsListener {
+                override fun cargoProjectsUpdated(projects: Collection<CargoProject>) {
+                    latch.countDown()
+                }
+            })
+
+            action.actionPerformed(testEvent)
+
+            for (i in 1..20) {
+                UIUtil.dispatchAllInvocationEvents()
+                if (latch.await(50, TimeUnit.MILLISECONDS)) break
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/cargo/project/model/AttachCargoProjectActionTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/AttachCargoProjectActionTest.kt
@@ -5,15 +5,18 @@
 
 package org.rust.cargo.project.model
 
+import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.MapDataContext
-import com.intellij.testFramework.TestActionEvent
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl
 import com.intellij.util.ui.UIUtil
 import org.rust.FileTreeBuilder
 import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.cargo.project.toolwindow.CargoToolWindow
 import org.rust.fileTree
+import org.rust.ide.notifications.RsEditorNotificationPanel
 import org.rust.openapiext.pathAsPath
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -55,7 +58,7 @@ class AttachCargoProjectActionTest : RsWithToolchainTestBase() {
         }
 
         val rootDir = testProject.root.findChild("dir")!!
-        testAction(rootDir, true)
+        testAction(ActionPlaces.PROJECT_VIEW_POPUP, true, contextFile = rootDir)
         val cargoProject = project.cargoProjects.allProjects.find { it.rootDir == rootDir }
         assertNotNull("Failed to attach project in `$rootDir`", cargoProject)
     }
@@ -66,7 +69,7 @@ class AttachCargoProjectActionTest : RsWithToolchainTestBase() {
         }
 
         val cargoToml = testProject.root.findFileByRelativePath("dir/Cargo.toml")!!
-        testAction(cargoToml, true)
+        testAction(ActionPlaces.PROJECT_VIEW_POPUP, true, contextFile = cargoToml)
         val cargoProject = project.cargoProjects.allProjects.find { it.manifest == cargoToml.pathAsPath }
         assertNotNull("Failed to attach project via `$cargoToml` file", cargoProject)
     }
@@ -74,7 +77,7 @@ class AttachCargoProjectActionTest : RsWithToolchainTestBase() {
     fun `test no action for cargo toml of existing cargo project`() {
         val testProject = buildProject(cargoProjectSupplier)
         val cargoToml = testProject.root.findFileByRelativePath("Cargo.toml")!!
-        testAction(cargoToml, false)
+        testAction(ActionPlaces.PROJECT_VIEW_POPUP, false, contextFile = cargoToml)
     }
 
     fun `test no action for cargo toml of existing package in cargo project`() {
@@ -88,21 +91,56 @@ class AttachCargoProjectActionTest : RsWithToolchainTestBase() {
         }
 
         val cargoToml = testProject.root.findFileByRelativePath("foo/Cargo.toml")!!
-        testAction(cargoToml, false)
+        testAction(ActionPlaces.PROJECT_VIEW_POPUP, false, contextFile = cargoToml)
     }
 
     fun `test no action for cargo toml outside of project`() {
         val libraryProject = fileTree(cargoProjectSupplier).create(project, tempDirFixture.getFile("")!!)
         val cargoToml = libraryProject.root.findFileByRelativePath("Cargo.toml")!!
-        testAction(cargoToml, false)
+        testAction(ActionPlaces.PROJECT_VIEW_POPUP, false, contextFile = cargoToml)
     }
 
-    private fun testAction(file: VirtualFile, shouldBeEnabled: Boolean) {
+    fun `test action is always available from cargo tool window`() {
+        val testProject = buildProject {
+            dir("dir", cargoProjectSupplier)
+        }
+
+        val cargoToml = testProject.root.findFileByRelativePath("dir/Cargo.toml")!!
+        testAction(CargoToolWindow.CARGO_TOOLBAR_PLACE, true, contextFile = null, mockChosenFile = cargoToml)
+        val cargoProject = project.cargoProjects.allProjects.find { it.manifest == cargoToml.pathAsPath }
+        assertNotNull("Failed to attach project via `$cargoToml` file", cargoProject)
+    }
+
+    fun `test action is available from editor notification 1`() {
+        val testProject = buildProject {
+            dir("dir", cargoProjectSupplier)
+        }
+
+        val srcFile = testProject.root.findFileByRelativePath("dir/src/main.rs")!!
+        val cargoToml = testProject.root.findFileByRelativePath("dir/Cargo.toml")!!
+        testAction(RsEditorNotificationPanel.NOTIFICATION_PANEL_PLACE, true, contextFile = srcFile, mockChosenFile = cargoToml)
+        val cargoProject = project.cargoProjects.allProjects.find { it.manifest == cargoToml.pathAsPath }
+        assertNotNull("Failed to attach project via `$srcFile` file", cargoProject)
+    }
+
+    fun `test action is available from editor notification 2`() {
+        val testProject = buildProject {
+            dir("dir", cargoProjectSupplier)
+        }
+
+        val cargoToml = testProject.root.findFileByRelativePath("dir/Cargo.toml")!!
+        testAction(RsEditorNotificationPanel.NOTIFICATION_PANEL_PLACE, true, contextFile = cargoToml)
+        val cargoProject = project.cargoProjects.allProjects.find { it.manifest == cargoToml.pathAsPath }
+        assertNotNull("Failed to attach project via `$cargoToml` file", cargoProject)
+    }
+
+    private fun testAction(place: String, shouldBeEnabled: Boolean, contextFile: VirtualFile? = null, mockChosenFile: VirtualFile? = null) {
         val context = MapDataContext().apply {
             put(PlatformDataKeys.PROJECT, project)
-            put(PlatformDataKeys.VIRTUAL_FILE, file)
+            put(PlatformDataKeys.VIRTUAL_FILE, contextFile)
+            put(AttachCargoProjectAction.MOCK_CHOSEN_FILE_KEY, mockChosenFile)
         }
-        val testEvent = TestActionEvent(context)
+        val testEvent = TestActionEvent(context, place)
         val action = AttachCargoProjectAction()
         action.beforeActionPerformedUpdate(testEvent)
         assertEquals(shouldBeEnabled, testEvent.presentation.isEnabledAndVisible)
@@ -121,5 +159,12 @@ class AttachCargoProjectActionTest : RsWithToolchainTestBase() {
                 if (latch.await(50, TimeUnit.MILLISECONDS)) break
             }
         }
+    }
+
+    private class TestActionEvent(
+        dataContext: DataContext,
+        private val testPlace: String
+    ) : com.intellij.testFramework.TestActionEvent(dataContext) {
+        override fun getPlace(): String = testPlace
     }
 }


### PR DESCRIPTION
* provide `Attach Cargo Project` action for files (`Cargo.toml` and its parent dir) in project view
* provide editor notification that `Cargo.toml` doesn't belong to any cargo project with `Attach` action. The action creates new cargo project in project model without manual choice of directory

Related to #4813