### PR TITLE
INSP: Improve RsUnresolvedReferenceInspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
@@ -20,6 +20,7 @@ import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.endOffsetInParent
 import org.rust.lang.core.psi.ext.getPrevNonCommentSibling
+import org.rust.lang.core.psi.ext.qualifier
 import javax.swing.JComponent
 
 class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
@@ -31,28 +32,46 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
         object : RsVisitor() {
             override fun visitPath(path: RsPath) {
-                if (path.parent is RsPath) return
-                val (basePath, candidates) = AutoImportFix.findApplicableContext(holder.project, path) ?: return
+                // here we check if this path is resolved
+                // if it is we return
+                // if not than check whether qualifier of this path is resolved
+                // if it is we register problem
+                // if not then we assume that unresolved parent paths of this path
+                // were or will be handled
+                // because all paths will eventually be processed by visitor
+                val (problemPath, candidates) = AutoImportFix.findApplicableContext(holder.project, path)
+                    ?: return
+
                 if (candidates.isEmpty() && ignoreWithoutQuickFix) return
 
-                val referenceName = basePath.identifier?.text
-                // Don't highlight generic parameters
+                path.qualifier
+                    ?.let { AutoImportFix.findApplicableContext(holder.project, it) }
+                    ?.let { return }
+
+                val referenceName = problemPath.identifier?.text
                 val range = TextRange(
-                    0,
-                    path.typeArgumentList?.getPrevNonCommentSibling()?.endOffsetInParent ?: path.textLength
+                    // Don't highlight parent identifiers
+                    problemPath.identifier?.startOffsetInParent ?: 0,
+                    // Don't highlight generic parameters
+                    problemPath.typeArgumentList?.getPrevNonCommentSibling()?.endOffsetInParent
+                        ?: problemPath.textLength
                 )
-                holder.registerProblem(path, candidates, referenceName, range)
+
+                holder.registerProblem(problemPath, candidates, referenceName, range)
             }
 
             override fun visitMethodCall(methodCall: RsMethodCall) {
-                val (_, candidates) = AutoImportFix.findApplicableContext(holder.project, methodCall) ?: return
+                val (_, candidates) = AutoImportFix.findApplicableContext(holder.project, methodCall)
+                    ?: return
 
                 if (candidates.isEmpty() && ignoreWithoutQuickFix) return
 
-                val identifier = methodCall.identifier
-                val referenceName = identifier.text
-                val range = TextRange(0, identifier.textLength)
-                holder.registerProblem(methodCall, candidates, referenceName, range)
+                val range = TextRange(
+                    0,
+                    methodCall.identifier.textLength
+                )
+
+                holder.registerProblem(methodCall, candidates, methodCall.identifier.text, range)
             }
         }
 

--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -90,12 +90,10 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
         const val NAME = "Import"
 
         fun findApplicableContext(project: Project, path: RsPath): Context<RsPath>? {
-            val basePath = path.basePath()
 
-            val isBasePathResolved = TyPrimitive.fromPath(basePath) != null ||
-                basePath.reference.multiResolve().isNotEmpty()
+            val isPathResolved = TyPrimitive.fromPath(path) != null || path.reference.multiResolve().isNotEmpty()
 
-            if (isBasePathResolved) {
+            if (isPathResolved) {
                 // Despite the fact that path is (multi)resolved by our resolve engine, it can be unresolved from
                 // the view of the rust compiler. Specifically we resolve associated items even if corresponding
                 // trait is not in the scope, so here we suggest importing such traits
@@ -106,23 +104,27 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
             if (path.ancestorStrict<RsUseSpeck>() != null) {
                 // Don't try to import path in use item
                 Testmarks.pathInUseItem.hit()
-                return Context(basePath, emptyList())
+                return Context(path, emptyList())
             }
 
-            val isNameInScope = path.hasInScope(basePath.referenceName, TYPES_N_VALUES)
+            val isNameInScope = path.hasInScope(path.referenceName, TYPES_N_VALUES)
             if (isNameInScope) {
                 // Don't import names that are already in scope but cannot be resolved
                 // because namespace of psi element prevents correct name resolution.
                 // It's possible for incorrect or incomplete code like "let map = HashMap"
                 Testmarks.nameInScope.hit()
-                return Context(basePath, emptyList())
+                return Context(path, emptyList())
             }
 
-            val candidates = getImportCandidates(ImportContext.from(project, path, false), basePath.referenceName, path.text) {
-                path != basePath || !(it.item is RsMod || it.item is RsModDeclItem || it.item.parent is RsMembers)
+            val candidates = getImportCandidates(
+                ImportContext.from(project, path, false),
+                path.referenceName,
+                path.text
+            ) {
+                true
             }.toList()
 
-            return Context(basePath, candidates)
+            return Context(path, candidates)
         }
 
         fun findApplicableContext(project: Project, methodCall: RsMethodCall): Context<Unit>? {

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -132,6 +132,34 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         impl Foo { fn foo() -> Self {} }
     """, false)
 
+    fun `test unresolved reference for module`() = checkByText("""
+        use <error descr="Unresolved reference: `foo`">foo</error>::bar::Foo;
+    """, false)
+
+    fun `test unresolved reference for nested module`() = checkByText("""
+        mod foo { }
+        use foo::<error descr="Unresolved reference: `bar`">bar</error>::Foo;
+    """, false)
+
+    fun `test unresolved reference for struct in nested module 1`() = checkByText("""
+        mod foo {
+            pub mod bar { }
+        }
+        use foo::bar::<error descr="Unresolved reference: `Foo`">Foo</error>;
+    """, false)
+
+    fun `test unresolved reference for struct in nested module 2`() = checkByText("""
+        mod foo { }
+        use foo::<error descr="Unresolved reference: `bar`">bar</error>::{qux, boo};
+    """, false)
+
+    fun `test unresolved reference for function in nested module`() = checkByText("""
+        mod foo { }
+        fn main() {
+            foo::<error descr="Unresolved reference: `bar`">bar</error>::Qux::foobar();
+        }
+    """, false)
+
     private fun checkByText(@Language("Rust") text: String, ignoreWithoutQuickFix: Boolean) {
         val inspection = inspection as RsUnresolvedReferenceInspection
         val defaultValue = inspection.ignoreWithoutQuickFix


### PR DESCRIPTION
#### Before PR (`ignoreWithoutQuickFix` set to`true`) - default 
![Screenshot from 2020-01-15 20-23-26](https://user-images.githubusercontent.com/16986685/72468957-9927a100-37de-11ea-86fd-1dcdd29e6bba.png)

#### Before PR (`ignoreWithoutQuickFix` set to `false`)
![Screenshot from 2020-01-15 20-23-54](https://user-images.githubusercontent.com/16986685/72468951-962cb080-37de-11ea-9f5f-30fd60103c00.png)

#### After PR (`ignoreWithoutQuickFix` set to`true`) 
![Screenshot from 2020-01-22 23-21-52](https://user-images.githubusercontent.com/16986685/72939897-1c606e00-3d6e-11ea-8601-d422875e9614.png)

#### After PR  (`ignoreWithoutQuickFix` set to `false`)
![Screenshot from 2020-01-15 20-26-01](https://user-images.githubusercontent.com/16986685/72468938-8a40ee80-37de-11ea-9ff0-6c646083efe1.png)

This PR is tested with experimental macro expansion engine enabled,
~~so this PR would probably make more sense to merge after making new engine the default~~ with `ignoreWithoutQuickFix` it could be merged now

~~I removed `ignoreWithoutQuickFix` checkbox, it is my main issue with current implementation,
as it defeats one of the main purposes of the inspection which is to show references that cannot be resolved, for reasons more than just 'not imported'~~

Left `ignoreWithoutQuickFix` as is until experimental macro expansion engine will be enabled by default

Also previously this inspection could register problem for same PsiElement multiple times, this is fixed in PR

~~Due to `ignoreWithoutQuickFix` being removed several tests that assumed this variable was set
to true do not really make sense now, some were corrected.~~

This PR is WIP because it broke some tests in `AutoImportFixTest` and `AutoImportFixStdTest` and I'd like some feedback on the PR before fixing

There are also some failed tests in `RsBuildActionTest` and `CargoBuildManagerTest` not sure whether this is my fault
