### PR TITLE
ANN&REF: add annotations to leafs when highlighting leafs

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -9,49 +9,102 @@ import com.intellij.ide.annotator.AnnotatorBase
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.util.Key
-import com.intellij.openapi.util.TextRange
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.impl.cache.impl.IndexPatternUtil
 import com.intellij.psi.impl.search.PsiTodoSearchHelperImpl
+import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.search.PsiTodoSearchHelper
 import org.rust.ide.colors.RsColor
 import org.rust.ide.highlight.RsHighlighter
 import org.rust.ide.todo.isTodoPattern
 import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyPrimitive
 import org.rust.openapiext.getOrPut
 
-// Highlighting logic here should be kept in sync with tags in RustColorSettingsPage
 class RsHighlightingAnnotator : AnnotatorBase() {
 
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
-        val (partToHighlight, color) = when {
-            element is RsPatBinding && !element.isReferenceToConstant -> highlightNotReference(element, holder)
-            element is RsMacroCall -> highlightNotReference(element, holder)
-            element is RsModDeclItem -> highlightNotReference(element, holder)
-            element is RsReferenceElement -> highlightReference(element, holder)
-            else -> highlightNotReference(element, holder)
+        val color = when (element) {
+            is LeafPsiElement -> highlightLeaf(element, holder)
+            is RsAttr -> RsColor.ATTRIBUTE
+            else -> null
         } ?: return
 
         if (!element.isEnabledByCfg) return
 
         val severity = if (isUnitTestMode) color.testSeverity else HighlightSeverity.INFORMATION
-        holder.createAnnotation(severity, partToHighlight, null).textAttributes = color.textAttributesKey
+        holder.createAnnotation(severity, element.textRange, null).textAttributes = color.textAttributesKey
     }
 
-    private fun highlightReference(element: RsReferenceElement, holder: AnnotationHolder): Pair<TextRange, RsColor>? {
+    private fun highlightLeaf(element: PsiElement, holder: AnnotationHolder): RsColor? {
+        val parent = element.parent as? RsElement ?: return null
+
+        if (parent is RsMetaVarIdentifier) {
+            val metavarParent = parent.parent as? RsElement ?: return null
+            return highlightIdentifier(parent, metavarParent, holder)
+        }
+
+        if (parent is RsLitExpr) {
+            return when (parent.parent) {
+                is RsMetaItem, is RsMetaItemArgs -> RsHighlighter.map(element.elementType)
+                else -> null
+            }
+        }
+
+        return when (element.elementType) {
+            IDENTIFIER, QUOTE_IDENTIFIER, SELF -> highlightIdentifier(element, parent, holder)
+            // Although we remap tokens from identifier to keyword, this happens in the
+            // parser's pass, so we can't use HighlightingLexer to color these
+            in RS_CONTEXTUAL_KEYWORDS -> RsColor.KEYWORD
+            Q -> if (parent is RsTryExpr) {
+                RsColor.Q_OPERATOR
+            } else {
+                null
+            }
+            EXCL -> if (parent is RsMacro || parent is RsMacroCall && shouldHighlightMacroCall(parent, holder)) {
+                RsColor.MACRO
+            } else {
+                null
+            }
+            else -> null
+        }
+    }
+
+    private fun highlightIdentifier(element: PsiElement, parent: RsElement, holder: AnnotationHolder): RsColor? {
+        return when {
+            parent is RsReferenceElement && parent !is RsModDeclItem &&
+                (parent !is RsPatBinding || parent.isReferenceToConstant) &&
+                parent.referenceNameElement == element -> {
+                highlightReference(parent, holder)
+            }
+            // Highlight `macro_rules`
+            parent is RsMacro -> if (element == parent.identifier) {
+                RsColor.MACRO
+            } else {
+                null
+            }
+            parent is RsNameIdentifierOwner && parent.nameIdentifier == element -> {
+                colorFor(parent)
+            }
+            else -> null
+        }
+    }
+
+    private fun highlightReference(element: RsReferenceElement, holder: AnnotationHolder): RsColor? {
         // These should be highlighted as keywords by the lexer
         if (element is RsPath && element.kind != PathKind.IDENTIFIER) return null
         if (element is RsExternCrateItem && element.self != null) return null
 
-        val isPrimitiveType = element is RsPath && TyPrimitive.fromPath(element) != null
         val parent = element.parent
+        val isPrimitiveType = element is RsPath && TyPrimitive.fromPath(element) != null &&
+            (parent is RsBaseType || parent is RsPath && element.reference.multiResolve().isEmpty())
 
-        val color = when {
+        return when {
             isPrimitiveType -> RsColor.PRIMITIVE_TYPE
             parent is RsMacroCall -> if (shouldHighlightMacroCall(parent, holder)) RsColor.MACRO else null
             element is RsMethodCall -> RsColor.METHOD_CALL
@@ -68,13 +121,13 @@ class RsHighlightingAnnotator : AnnotatorBase() {
                     colorFor(ref)
                 }
             }
+            element is RsPath && parent is RsTraitRef -> RsColor.TRAIT
             else -> {
                 val ref = element.reference.resolve() ?: return null
                 // Highlight the element dependent on what it's referencing.
                 colorFor(ref)
             }
         }
-        return color?.let { element.referenceNameElement.textRange to it }
     }
 
     private fun RsPath.isCall(): Boolean {
@@ -83,37 +136,6 @@ class RsHighlightingAnnotator : AnnotatorBase() {
             expr = expr.parent
         }
         return expr is RsCallExpr
-    }
-
-    private fun highlightNotReference(element: PsiElement, holder: AnnotationHolder): Pair<TextRange, RsColor>? {
-        if (element is RsLitExpr) {
-            if (element.parent is RsMetaItem) {
-                val literal = element.firstChild
-                val color = RsHighlighter.map(literal.elementType)
-                    ?: return null // FIXME: `error` here perhaps?
-                return literal.textRange to color
-            }
-            return null
-        }
-
-        // Although we remap tokens from identifier to keyword, this happens in the
-        // parser's pass, so we can't use HighlightingLexer to color these
-        if (element.elementType in RS_CONTEXTUAL_KEYWORDS) {
-            return element.textRange to RsColor.KEYWORD
-        }
-
-        if (element is RsMacroCall) {
-            if (!shouldHighlightMacroCall(element, holder)) return null
-        }
-
-        if (element is RsElement) {
-            val color = colorFor(element)
-            val part = partToHighlight(element)
-            if (color != null && part != null) {
-                return part to color
-            }
-        }
-        return null
     }
 
     private fun shouldHighlightMacroCall(element: RsMacroCall, holder: AnnotationHolder): Boolean {
@@ -139,13 +161,7 @@ class RsHighlightingAnnotator : AnnotatorBase() {
 // on elements in other files when highlighting references.
 private fun colorFor(element: RsElement): RsColor? = when (element) {
     is RsMacro -> RsColor.MACRO
-
-    is RsAttr -> RsColor.ATTRIBUTE
-    is RsMacroCall -> RsColor.MACRO
     is RsSelfParameter -> RsColor.SELF_PARAMETER
-    is RsTryExpr -> RsColor.Q_OPERATOR
-    is RsTraitRef -> RsColor.TRAIT
-
     is RsEnumItem -> RsColor.ENUM
     is RsEnumVariant -> RsColor.ENUM_VARIANT
     is RsExternCrateItem -> RsColor.CRATE
@@ -169,45 +185,6 @@ private fun colorFor(element: RsElement): RsColor? = when (element) {
     is RsTypeAlias -> RsColor.TYPE_ALIAS
     is RsTypeParameter -> RsColor.TYPE_PARAMETER
     is RsConstParameter -> RsColor.CONST_PARAMETER
-    is RsMacroReference -> RsColor.FUNCTION
-    is RsMacroBinding -> RsColor.FUNCTION
+    is RsMacroBinding -> RsColor.FUNCTION // TODO FUNCTION?
     else -> null
-}
-
-private fun partToHighlight(element: RsElement): TextRange? {
-    if (element is RsMacro) {
-        val range = element.identifier?.textRange ?: return null
-        val excl = element.excl
-        return range.union(excl.textRange)
-    }
-
-    if (element is RsMacroCall) {
-        return element.excl.textRange
-    }
-
-    val name = when (element) {
-        is RsAttr -> element
-        is RsSelfParameter -> element.self
-        is RsTryExpr -> element.q
-        is RsTraitRef -> element.path.identifier
-
-        is RsEnumItem -> element.identifier
-        is RsEnumVariant -> element.identifier
-        is RsExternCrateItem -> element.identifier
-        is RsConstant -> element.identifier
-        is RsNamedFieldDecl -> element.identifier
-        is RsFunction -> element.identifier
-        is RsMethodCall -> element.referenceNameElement
-        is RsModDeclItem -> element.identifier
-        is RsModItem -> element.identifier
-        is RsPatBinding -> element.identifier
-        is RsStructItem -> element.identifier
-        is RsTraitItem -> element.identifier
-        is RsTypeAlias -> element.identifier
-        is RsTypeParameter -> element.identifier
-        is RsConstParameter -> element.identifier
-        is RsMacroBinding -> element.metaVarIdentifier
-        else -> null
-    }
-    return name?.textRange
 }


### PR DESCRIPTION
Now, when we want e.g. to highlight a function name:
```rust
fn foo() {}
// ~~~ highlight this
```
we do it when Annotator.annotate is called with leaf (identifier) element argument, not the function element.

This is more proper usage of annotators API. Particularly, it fixes highlights blinking (most viewable on a dark theme).

Also:
1. fixed incorrectly highlighted "primitive" in this case:
  ```rust
  let mut i32 = 1;
  i32 = 2;
  ```
2. fixed literal highlighting in attributes: `#[foo("bar")]`
