### PR TITLE
Add support for replacing comments via intentions.

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/ReplaceBlockCommentWithLineCommentIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ReplaceBlockCommentWithLineCommentIntention.kt
@@ -1,0 +1,61 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
+import org.rust.lang.core.parser.RustParserDefinition.Companion.BLOCK_COMMENT
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.ext.*
+
+class ReplaceBlockCommentWithLineCommentIntention : RsElementBaseIntentionAction<ReplaceBlockCommentWithLineCommentIntention.Context>() {
+
+    override fun getText(): String = familyName
+    override fun getFamilyName(): String = "Replace with end of line comment"
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val comment = element.ancestorOrSelf<PsiComment>() ?: return null
+        if (BLOCK_COMMENT != comment.tokenType) {
+            return null
+        }
+        return Context(comment)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val selected = ctx.comment
+        val factory = RsPsiFactory(project)
+
+        val indent = if (selected.prevSibling is PsiWhiteSpace) {
+            val space = selected.prevSibling.text.reversed().takeWhile {  it == ' ' || it == '\t' }
+            factory.createWhitespace("\n$space")
+        } else {
+            factory.createNewline()
+        }
+
+        val comments = selected.text
+            .substring(2, selected.text.length - 2)
+            .trim()
+            .split("\n")
+            .reversed()
+
+        val lastIndex = comments.size - 1
+        val parent = selected.parent
+        comments.forEachIndexed { index, comment ->
+            val commentText = comment.trim()
+            parent.addAfter(factory.createLineComment(commentText), selected)
+            if (index != lastIndex) parent.addAfter(indent, selected)
+        }
+
+        selected.delete()
+    }
+
+    data class Context(
+        val comment: PsiComment
+    )
+}

--- a/src/main/kotlin/org/rust/ide/intentions/ReplaceBlockCommentWithLineCommentIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ReplaceBlockCommentWithLineCommentIntention.kt
@@ -12,50 +12,52 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
 import org.rust.lang.core.parser.RustParserDefinition.Companion.BLOCK_COMMENT
 import org.rust.lang.core.psi.RsPsiFactory
-import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.ancestorOrSelf
 
-class ReplaceBlockCommentWithLineCommentIntention : RsElementBaseIntentionAction<ReplaceBlockCommentWithLineCommentIntention.Context>() {
+class ReplaceBlockCommentWithLineCommentIntention : RsElementBaseIntentionAction<PsiComment>() {
 
     override fun getText(): String = familyName
     override fun getFamilyName(): String = "Replace with end of line comment"
 
-    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): PsiComment? {
         val comment = element.ancestorOrSelf<PsiComment>() ?: return null
         if (BLOCK_COMMENT != comment.tokenType) {
             return null
         }
-        return Context(comment)
+        return comment
     }
 
-    override fun invoke(project: Project, editor: Editor, ctx: Context) {
-        val selected = ctx.comment
+    override fun invoke(project: Project, editor: Editor, ctx: PsiComment) {
         val factory = RsPsiFactory(project)
 
-        val indent = if (selected.prevSibling is PsiWhiteSpace) {
-            val space = selected.prevSibling.text.reversed().takeWhile {  it == ' ' || it == '\t' }
+        val indent = if (ctx.prevSibling is PsiWhiteSpace) {
+            val space = ctx.prevSibling
+                .text
+                .reversed()
+                .takeWhile { it == ' ' || it == '\t' }
+
             factory.createWhitespace("\n$space")
         } else {
             factory.createNewline()
         }
 
-        val comments = selected.text
-            .substring(2, selected.text.length - 2)
+        val comments = ctx.text
+            .substring(2, ctx.text.length - 2)
             .trim()
             .split("\n")
             .reversed()
 
         val lastIndex = comments.size - 1
-        val parent = selected.parent
+        val parent = ctx.parent
         comments.forEachIndexed { index, comment ->
             val commentText = comment.trim()
-            parent.addAfter(factory.createLineComment(commentText), selected)
-            if (index != lastIndex) parent.addAfter(indent, selected)
+            parent.addAfter(factory.createLineComment(commentText), ctx)
+
+            if (index != lastIndex) {
+                parent.addAfter(indent, ctx)
+            }
         }
 
-        selected.delete()
+        ctx.delete()
     }
-
-    data class Context(
-        val comment: PsiComment
-    )
 }

--- a/src/main/kotlin/org/rust/ide/intentions/ReplaceLineCommentWithBlockCommentIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ReplaceLineCommentWithBlockCommentIntention.kt
@@ -15,72 +15,58 @@ import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.ancestorOrSelf
 import org.rust.lang.core.psi.ext.getNextNonWhitespaceSibling
 import org.rust.lang.core.psi.ext.getPrevNonWhitespaceSibling
-import java.lang.StringBuilder
 
-class ReplaceLineCommentWithBlockCommentIntention : RsElementBaseIntentionAction<ReplaceLineCommentWithBlockCommentIntention.Context>() {
+class ReplaceLineCommentWithBlockCommentIntention : RsElementBaseIntentionAction<PsiComment>() {
 
     override fun getText(): String = familyName
     override fun getFamilyName(): String = "Replace with block comment"
 
-    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): PsiComment? {
         val comment = element.ancestorOrSelf<PsiComment>() ?: return null
         if (!comment.isEndOfLineComment()) {
             return null
         }
 
-        var firstComment = comment
-        while (true) {
-            val previous = firstComment.getPrevNonWhitespaceSibling() ?: break
-            if (!previous.isEndOfLineComment()) {
-                break
-            }
-            firstComment = previous as PsiComment
-        }
-
-        return Context(firstComment)
+        return generateSequence(comment) { it.prevComment() }.last()
     }
 
-    override fun invoke(project: Project, editor: Editor, ctx: Context) {
-        val firstComment = ctx.firstComment
-
-        val indent = (firstComment.prevSibling as? PsiWhiteSpace)
+    override fun invoke(project: Project, editor: Editor, ctx: PsiComment) {
+        val indent = (ctx.prevSibling as? PsiWhiteSpace)
             ?.text
             ?.reversed()
             ?.takeWhile { it == ' ' || it == '\t' } ?: ""
 
-        val comments = mutableListOf(firstComment)
-        var nextComment = firstComment
-        while (true) {
-            nextComment = nextComment.nextComment() ?: break
-            comments.add(nextComment)
-        }
+        val comments = generateSequence(ctx) { it.nextComment() }.toList()
 
-        val blockComment = if (comments.size == 1)
+        val blockComment = if (comments.size == 1) {
             " ${comments.first().commentText()} "
-        else
+        } else {
             comments.joinToString(separator = "\n", prefix = "\n", postfix = "\n$indent") {
                 "$indent${it.commentText()}"
             }
+        }
 
         comments.drop(1).forEach {
             (it.prevSibling as? PsiWhiteSpace)?.delete()
             it.delete()
         }
-        firstComment.replace(RsPsiFactory(project).createBlockComment(blockComment))
+
+        val newComment = RsPsiFactory(project).createBlockComment(blockComment)
+        ctx.replace(newComment)
     }
 
-    private fun PsiElement.isEndOfLineComment() = node.elementType == EOL_COMMENT
+    private fun PsiElement.isEndOfLineComment(): Boolean = node.elementType == EOL_COMMENT
 
-    private fun PsiComment.commentText() = text.substring(2)
+    private fun PsiComment.commentText(): String = text.substring(2)
         .replace("/*", "/ *")
         .replace("*/", "* /")
         .trim()
 
+    private fun PsiComment.prevComment(): PsiComment? {
+        return (getPrevNonWhitespaceSibling() as? PsiComment)?.takeIf { it.isEndOfLineComment() }
+    }
+
     private fun PsiComment.nextComment(): PsiComment? {
         return (getNextNonWhitespaceSibling() as? PsiComment)?.takeIf { it.isEndOfLineComment() }
     }
-
-    data class Context(
-        val firstComment: PsiComment
-    )
 }

--- a/src/main/kotlin/org/rust/ide/intentions/ReplaceLineCommentWithBlockCommentIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ReplaceLineCommentWithBlockCommentIntention.kt
@@ -1,0 +1,86 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
+import org.rust.lang.core.parser.RustParserDefinition.Companion.EOL_COMMENT
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.rust.lang.core.psi.ext.getNextNonWhitespaceSibling
+import org.rust.lang.core.psi.ext.getPrevNonWhitespaceSibling
+import java.lang.StringBuilder
+
+class ReplaceLineCommentWithBlockCommentIntention : RsElementBaseIntentionAction<ReplaceLineCommentWithBlockCommentIntention.Context>() {
+
+    override fun getText(): String = familyName
+    override fun getFamilyName(): String = "Replace with block comment"
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val comment = element.ancestorOrSelf<PsiComment>() ?: return null
+        if (!comment.isEndOfLineComment()) {
+            return null
+        }
+
+        var firstComment = comment
+        while (true) {
+            val previous = firstComment.getPrevNonWhitespaceSibling() ?: break
+            if (!previous.isEndOfLineComment()) {
+                break
+            }
+            firstComment = previous as PsiComment
+        }
+
+        return Context(firstComment)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val firstComment = ctx.firstComment
+
+        val indent = (firstComment.prevSibling as? PsiWhiteSpace)
+            ?.text
+            ?.reversed()
+            ?.takeWhile { it == ' ' || it == '\t' } ?: ""
+
+        val comments = mutableListOf(firstComment)
+        var nextComment = firstComment
+        while (true) {
+            nextComment = nextComment.nextComment() ?: break
+            comments.add(nextComment)
+        }
+
+        val blockComment = if (comments.size == 1)
+            " ${comments.first().commentText()} "
+        else
+            comments.joinToString(separator = "\n", prefix = "\n", postfix = "\n$indent") {
+                "$indent${it.commentText()}"
+            }
+
+        comments.drop(1).forEach {
+            (it.prevSibling as? PsiWhiteSpace)?.delete()
+            it.delete()
+        }
+        firstComment.replace(RsPsiFactory(project).createBlockComment(blockComment))
+    }
+
+    private fun PsiElement.isEndOfLineComment() = node.elementType == EOL_COMMENT
+
+    private fun PsiComment.commentText() = text.substring(2)
+        .replace("/*", "/ *")
+        .replace("*/", "* /")
+        .trim()
+
+    private fun PsiComment.nextComment(): PsiComment? {
+        return (getNextNonWhitespaceSibling() as? PsiComment)?.takeIf { it.isEndOfLineComment() }
+    }
+
+    data class Context(
+        val firstComment: PsiComment
+    )
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.psi
 
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiParserFacade
@@ -13,6 +14,7 @@ import com.intellij.util.LocalTimeCounter
 import org.rust.ide.inspections.checkMatch.Pattern
 import org.rust.ide.presentation.insertionSafeTextWithLifetimes
 import org.rust.lang.RsFileType
+import org.rust.lang.RsLanguage
 import org.rust.lang.core.macros.MacroExpansionContext
 import org.rust.lang.core.macros.prepareExpandedTextForParsing
 import org.rust.lang.core.parser.RustParserUtil.PathParsingMode
@@ -343,6 +345,20 @@ class RsPsiFactory(
     fun createPubCrateRestricted(): RsVis =
         createFromText("pub(crate) fn f() {}")
             ?: error("Failed to create `pub(crate)` element")
+
+    fun createComment(text: String): PsiComment {
+        val file = createFile(text)
+        val comments = file.children.filterIsInstance<PsiComment>()
+        val comment = comments.single()
+        assert(comment.text == text)
+        return comment
+    }
+
+    fun createBlockComment(text: String): PsiComment =
+        PsiParserFacade.SERVICE.getInstance(project).createBlockCommentFromText(RsLanguage, text)
+
+    fun createLineComment(text: String): PsiComment =
+        PsiParserFacade.SERVICE.getInstance(project).createLineCommentFromText(RsFileType, text)
 
     fun createComma(): PsiElement =
         createFromText<RsValueParameter>("fn f(_ : (), )")!!.nextSibling

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -210,10 +210,22 @@ val PsiElement.contextualFile: PsiFile
     get() = contextOrSelf() ?: error("Element outside of file: $text")
 
 /**
+ * Finds first sibling that is not whitespace before given element.
+ */
+fun PsiElement?.getPrevNonWhitespaceSibling(): PsiElement? =
+    PsiTreeUtil.skipSiblingsBackward(this, PsiWhiteSpace::class.java)
+
+/**
  * Finds first sibling that is neither comment, nor whitespace before given element.
  */
 fun PsiElement?.getPrevNonCommentSibling(): PsiElement? =
     PsiTreeUtil.skipSiblingsBackward(this, PsiWhiteSpace::class.java, PsiComment::class.java)
+
+/**
+ * Finds first sibling that is not whitespace after given element.
+ */
+fun PsiElement?.getNextNonWhitespaceSibling(): PsiElement? =
+    PsiTreeUtil.skipSiblingsForward(this, PsiWhiteSpace::class.java)
 
 /**
  * Finds first sibling that is neither comment, nor whitespace after given element.

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -570,6 +570,14 @@
             <category>Rust</category>
         </intentionAction>
         <intentionAction>
+            <className>org.rust.ide.intentions.ReplaceLineCommentWithBlockCommentIntention</className>
+            <category>Rust</category>
+        </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.ReplaceBlockCommentWithLineCommentIntention</className>
+            <category>Rust</category>
+        </intentionAction>
+        <intentionAction>
             <className>org.rust.ide.intentions.AddCurlyBracesIntention</className>
             <category>Rust</category>
         </intentionAction>

--- a/src/main/resources/intentionDescriptions/ReplaceBlockCommentWithLineCommentIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/ReplaceBlockCommentWithLineCommentIntention/after.rs.template
@@ -1,0 +1,1 @@
+<spot>// Hello, world!</spot>

--- a/src/main/resources/intentionDescriptions/ReplaceBlockCommentWithLineCommentIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/ReplaceBlockCommentWithLineCommentIntention/before.rs.template
@@ -1,0 +1,1 @@
+<spot>/* Hello, world! */</spot>

--- a/src/main/resources/intentionDescriptions/ReplaceBlockCommentWithLineCommentIntention/description.html
+++ b/src/main/resources/intentionDescriptions/ReplaceBlockCommentWithLineCommentIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Replaces a block comment with an end of line comment.
+</body>
+</html>

--- a/src/main/resources/intentionDescriptions/ReplaceLineCommentWithBlockCommentIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/ReplaceLineCommentWithBlockCommentIntention/after.rs.template
@@ -1,0 +1,1 @@
+<spot>/* Hello, world! */</spot>

--- a/src/main/resources/intentionDescriptions/ReplaceLineCommentWithBlockCommentIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/ReplaceLineCommentWithBlockCommentIntention/before.rs.template
@@ -1,0 +1,1 @@
+<spot>// Hello, world!</spot>

--- a/src/main/resources/intentionDescriptions/ReplaceLineCommentWithBlockCommentIntention/description.html
+++ b/src/main/resources/intentionDescriptions/ReplaceLineCommentWithBlockCommentIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Replaces an end of line comment with a block comment.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/ReplaceBlockCommentWithLineCommentIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ReplaceBlockCommentWithLineCommentIntentionTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+class ReplaceBlockCommentWithLineCommentIntentionTest : RsIntentionTestBase(ReplaceBlockCommentWithLineCommentIntention()) {
+
+    fun `test convert single block comment to line`() = doAvailableTest("""
+        /* /*caret*/Hello, World! */
+    """, """
+        /*caret*///Hello, World!
+    """)
+
+    fun `test convert multiline block comment to line`() = doAvailableTestRaw("""
+        /*
+        First
+        /*caret*/Second
+        Third
+        */
+    """.trimIndent(), """
+        /*caret*///First
+        //Second
+        //Third
+    """.trimIndent())
+}

--- a/src/test/kotlin/org/rust/ide/intentions/ReplaceLineCommentWithBlockCommentIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ReplaceLineCommentWithBlockCommentIntentionTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+class ReplaceLineCommentWithBlockCommentIntentionTest : RsIntentionTestBase(ReplaceLineCommentWithBlockCommentIntention()) {
+
+    fun `test convert single line comment to block`() = doAvailableTest("""
+        // /*caret*/Hello, World!
+    """, """
+        /* /*caret*/Hello, World! */
+    """)
+
+    fun `test convert multiline comment to block`() = doAvailableTestRaw("""
+        // First
+		// /*caret*/Second
+		// Third
+    """.trimIndent(), """
+        /*
+        First
+        Second
+        Third
+        *//*caret*/
+    """.trimIndent() + '\n')
+}

--- a/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
@@ -15,9 +15,13 @@ import org.rust.fileTreeFromText
 abstract class RsIntentionTestBase(val intention: IntentionAction) : RsTestBase() {
 
     protected fun doAvailableTest(@Language("Rust") before: String, @Language("Rust") after: String) {
-        InlineFile(before.trimIndent()).withCaret()
+        doAvailableTestRaw(before.trimIndent(), after.trimIndent())
+    }
+
+    protected fun doAvailableTestRaw(@Language("Rust") before: String, @Language("Rust") after: String) {
+        InlineFile(before).withCaret()
         launchAction()
-        myFixture.checkResult(replaceCaretMarker(after.trimIndent()))
+        myFixture.checkResult(replaceCaretMarker(after))
     }
 
     protected fun doAvailableTestWithFileTree(@Language("Rust") fileStructureBefore: String, @Language("Rust") openedFileAfter: String) {


### PR DESCRIPTION
Closes #4719.

Add a "Replace block comment with an end of line comment" intention.
Add a "Replace end of line comment with a block comment intention" intention.
Add couple of comment methods to the `RsPsiFactory` so we can easily create comment nodes.