### PR TITLE
PERF&GRAM: lazy parseable & reparseable code block

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -454,7 +454,7 @@ Function ::= OuterAttr*
              FnParameters
              RetType?
              WhereClause?
-             (';' | InnerAttrsAndBlock)
+             (';' | ShallowBlock | never SimpleBlock)
 {
   pin = 'identifier'
   implements = [ "org.rust.lang.core.psi.ext.RsQualifiedNamedElement"
@@ -1450,6 +1450,8 @@ InnerAttrsAndBlock ::= '{' InnerAttr* BlockElement* '}' {
   pin = 1
   elementType = Block
 }
+
+private ShallowBlock ::= <<parseCodeBlockLazy>>
 
 private BlockElement ::= !'}' (Macro | BlockElementMacroCall | ExprStmtOrLastExpr | Stmt | Item) {
   pin = 1

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/partial/fn.txt
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/partial/fn.txt
@@ -17,7 +17,7 @@ FILE
               PsiElement(identifier)('i32')
       PsiWhiteSpace(' ')
       PsiElement())(')')
-    PsiErrorElement:'->', ';', where or '{' expected, got 'fn'
+    PsiErrorElement:'->', ';' or where expected, got 'fn'
       <empty list>
   PsiWhiteSpace('\n\n')
   RsFunctionImpl(FUNCTION)

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/partial/impl_body.txt
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/partial/impl_body.txt
@@ -23,7 +23,7 @@ FILE
         RsValueParameterListImpl(VALUE_PARAMETER_LIST)
           PsiElement(()('(')
           PsiElement())(')')
-        PsiErrorElement:'->', ';', where or '{' expected, got 'bar'
+        PsiErrorElement:'->', ';' or where expected, got 'bar'
           <empty list>
       PsiWhiteSpace('\n    ')
       PsiElement(identifier)('bar')
@@ -70,7 +70,7 @@ FILE
         RsValueParameterListImpl(VALUE_PARAMETER_LIST)
           PsiElement(()('(')
           PsiElement())(')')
-        PsiErrorElement:'->', ';', where or '{' expected, got 'fn'
+        PsiErrorElement:'->', ';' or where expected, got 'fn'
           <empty list>
       PsiWhiteSpace('\n    ')
       RsFunctionImpl(FUNCTION)


### PR DESCRIPTION
This fulfills the second bullet-point of #4355. Now we do not re-parse the entire document when typing in a function body. Instead, we re-parse the only function in which the user is typing. I.e. parsing is now incremental. This can slightly speedup completion in large documents.

Merge after the end of 2019.2 support