### PR TITLE
Fix rustc/cargo messages being split incorrectly.

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildAdapter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildAdapter.kt
@@ -110,6 +110,12 @@ class CargoBuildAdapter(
         // otherwise the line contains only part of the message.
         if (concat.contains("{\"reason\"") && !concat.endsWith("}\n")) return
 
+        // Bit of a weird hack, but it's entirely possible that the error message contains explanations.
+        // Those explanations can contain "}\n", and even more bizarre, it's entirely possible that
+        // we get the text event that splits the message exactly on that boundary.
+        val count = concat.count { it == '\"' }
+        if ((count and 1) != 0) return
+
         val text = concat.replace(BUILD_PROGRESS_FULL_RE) { it.value.trimEnd(' ', '\r', '\n') + "\n" }
         textBuffer.clear()
 


### PR DESCRIPTION
For some reason, if/when all of the planets align, it's entirely possible that the text event we get lands directly in the middle of an explanation, which tripped the code to drain the text buffer, and process the event.

IntelliJ Console View:
![IntelliJ Console View](https://user-images.githubusercontent.com/4224088/73025477-f7343400-3e2f-11ea-86f1-7de5e6d5aa67.png)

I printed out the event's text as we received it.
IntelliJ Log (The second line " - }"):
![IntelliJ Log](https://user-images.githubusercontent.com/4224088/73025501-01563280-3e30-11ea-8e8c-29d4132a3ec1.png)

The fix is a bit weird, but I couldn't really think of another way.
I count all of the quotation marks, and if it's even, assume we have a complete message.

I could only think of one more fix which didn't require changes to cargo, which is to manually construct a JSONParser, and hook it up to the incoming events, and only when the parser spits out a complete Object, drain that part of the buffer, and continue.

It would require much more work, but I'm happy to implement that too.