### PR TITLE
PERF&MACRO: Introduce MacroExpansionVFS

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -36,6 +36,7 @@ import java.util.concurrent.CompletableFuture
 interface CargoProjectsService {
     val allProjects: Collection<CargoProject>
     val hasAtLeastOneValidProject: Boolean
+    val initialized: Boolean
 
     fun findProjectForFile(file: VirtualFile): CargoProject?
     fun findPackageForFile(file: VirtualFile): CargoWorkspace.Package?

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -159,6 +159,9 @@ open class CargoProjectsServiceImpl(
     override val hasAtLeastOneValidProject: Boolean
         get() = hasAtLeastOneValidProject(allProjects)
 
+    // Guarded by the platform RWLock
+    override var initialized: Boolean = false
+
     override fun findProjectForFile(file: VirtualFile): CargoProject? =
         file.applyWithSymlink { directoryIndex.getInfoForFile(it).takeIf { it !== noProjectMarker } }
 
@@ -218,6 +221,7 @@ open class CargoProjectsServiceImpl(
                             .makeRootsChange(EmptyRunnable.getInstance(), false, true)
                         project.messageBus.syncPublisher(CargoProjectsService.CARGO_PROJECTS_TOPIC)
                             .cargoProjectsUpdated(projects)
+                        initialized = true
                     }
                 }
 

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystem.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystem.kt
@@ -1,0 +1,455 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.openapi.util.io.BufferExposingByteArrayInputStream
+import com.intellij.openapi.util.io.FileAttributes
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.impl.local.LocalFileSystemBase
+import com.intellij.util.ArrayUtil
+import com.intellij.util.IncorrectOperationException
+import com.intellij.util.PathUtilRt
+import org.rust.lang.core.macros.MacroExpansionFileSystem.Companion.readFSItem
+import org.rust.lang.core.macros.MacroExpansionFileSystem.Companion.writeFSItem
+import org.rust.lang.core.macros.MacroExpansionFileSystem.FSItem
+import org.rust.lang.core.macros.MacroExpansionFileSystem.FSItem.FSDir
+import org.rust.lang.core.macros.MacroExpansionFileSystem.FSItem.FSFile
+import java.io.*
+
+/**
+ * An implementation of [com.intellij.openapi.vfs.VirtualFileSystem] used to store macro expansions.
+ *
+ * The problem is that we need to store tens of thousands of small files (with macro expansions).
+ * A real filesystem is slow, and a lot small files consumes too much of diskspace.
+ * [com.intellij.openapi.vfs.ex.temp.TempFileSystem] can't be used because these files should
+ * persist between IDE restarts, and because `TempFileSystem` stores all files in the RAM.
+ *
+ * [MacroExpansionFileSystem] is a "snapshot-only VFS", i.e. it doesn't have any "backend" (like
+ * a real FS in [com.intellij.openapi.vfs.LocalFileSystem] or RAM in
+ * [com.intellij.openapi.vfs.ex.temp.TempFileSystem]) and file contents are stored only in the
+ * snapshot ([com.intellij.openapi.vfs.newvfs.persistent.PersistentFS]).
+ *
+ * ## Under the hood
+ * The platform VFS implementation ([com.intellij.openapi.vfs.newvfs.persistent.PersistentFS])
+ * sometimes (during [refresh]) invokes methods [getTimeStamp] and [getLength] from a backend
+ * filesystem (i.e. [MacroExpansionFileSystem]) to check that files does not change (and reloads
+ * changed files). To satisfy this mechanism, [MacroExpansionFileSystem] maintain file tree
+ * structure with `last modified` and `length` properties, but without file contents (to be honest,
+ * there is a "temporary" file content [FSItem.FSFile.tempContent] that is cleared once loaded
+ * to the snapshot). [MacroExpansionFileSystem] stores such tree in-memory, but since it should
+ * persist between the IDE restarts, there are methods that allow loading/storing parts of the file
+ * tree externally (see [getDirectory], [setDirectory], [readFSItem], [writeFSItem])
+ *
+ * Since VFS is global and exists regardless of open projects, [MacroExpansionFileSystem] should
+ * either store the file tree in memory for all ever existing projects, or load subtrees on-demand
+ * for opened projects. Storing the file tree in memory for all ever existing projects can be too
+ * expensive, so on-demand solution is preferred.
+ *
+ * For macro expansions we use such directory layout:
+ * "/rust_expanded_macros/<random_project_id>/a/b/<random_file_name>.rs", where "<random_project_id>" is a
+ * project root that should be loaded/unloaded on-demand. Loading is trivial - it's just a combination of
+ * [readFSItem] and [setDirectory] methods. More interesting is unloading. There is a problem with it:
+ * [MacroExpansionFileSystem] still should say `last modified` and `length` to the platform for
+ * _all_ files, so we can't just remove a project subtree. But with a knowledge of how [refresh]
+ * works we made a trick.
+ *
+ * Quick explanation of the [refresh] process works. First, a file or directory should be marked as dirty
+ * with [com.intellij.openapi.vfs.newvfs.NewVirtualFile.markDirty]. This method also marks dirty all
+ * ancestor directories of the file, i.e. if we mark a file "/foo/bar/baz.rs" as dirty, "bar", "foo"
+ * and "/" (root) directories will be also marked dirty. Then [refresh] machinery, starting from the root
+ * directory, traverses dirty or modified ([getTimeStamp]) directories.
+ *
+ * So, if we want to trick the refresher, [MacroExpansionFileSystem] should always store in-memory
+ * list of "/rust_expanded_macros/<random_project_id>" directories with their `last modified` values
+ * and answer "yes, this directory still exists and unmodified, do not traverse it!" to the platform.
+ * But subtrees "/rust_expanded_macros/<random_project_id>/..." can be omitted. There is a special
+ * class for such fake, "dummy" directories - [FSItem.FSDir.DummyDir], and a method that replaces
+ * a real directory to dummy - [makeDummy].
+ *
+ * So,
+ * 1. prior to any operations with [MacroExpansionFileSystem], a list of all ever created
+ *   "/rust_expanded_macros/<random_project_id>" directories should be loaded.
+ *   This is done by [org.rust.lang.core.macros.MacroExpansionFileSystemRootsLoader.loadProjectDirs];
+ * 2. when some project "foo" is closed, "/rust_expanded_macros/foo" should be replaced with
+ *   a dummy directory using [makeDummy].
+ */
+class MacroExpansionFileSystem : LocalFileSystemBase() {
+    private val root: FSDir = FSDir(null, "/")
+
+    override fun getProtocol(): String = PROTOCOL
+    override fun extractRootPath(path: String): String = "/"
+    override fun normalize(path: String): String = path
+    override fun getCanonicallyCasedName(file: VirtualFile): String = file.name
+    override fun isCaseSensitive(): Boolean = true
+
+    override fun isValidName(name: String): Boolean =
+        PathUtilRt.isValidFileName(name, PathUtilRt.Platform.UNIX, false, null)
+
+    @Throws(IOException::class)
+    override fun createChildDirectory(requestor: Any?, parent: VirtualFile, dir: String): VirtualFile =
+        throw UnsupportedOperationException()
+
+    @Throws(IOException::class)
+    override fun createChildFile(requestor: Any?, parent: VirtualFile, file: String): VirtualFile =
+        throw UnsupportedOperationException()
+
+    @Throws(IOException::class)
+    override fun copyFile(requestor: Any?, file: VirtualFile, newParent: VirtualFile, copyName: String): VirtualFile =
+        throw UnsupportedOperationException()
+
+    @Throws(IOException::class)
+    override fun deleteFile(requestor: Any?, file: VirtualFile): Unit =
+        throw UnsupportedOperationException()
+
+    @Throws(IOException::class)
+    override fun moveFile(requestor: Any?, file: VirtualFile, newParent: VirtualFile): Unit =
+        throw UnsupportedOperationException()
+
+    @Throws(IOException::class)
+    override fun renameFile(requestor: Any?, file: VirtualFile, newName: String): Unit =
+        throw UnsupportedOperationException()
+
+    private fun convert(file: VirtualFile): FSItem? {
+        val parentFile = file.parent ?: return root
+
+        val parentItem = convert(parentFile)
+        return if (parentItem != null && parentItem is FSDir) {
+            parentItem.findChild(file.name)
+        } else {
+            null
+        }
+    }
+
+    private fun convert(path: String): FSItem? {
+        val segments = StringUtil.split(path, "/")
+
+        var file: FSItem = root
+        for (segment in segments) {
+            file = (file as? FSDir)?.findChild(segment) ?: return null
+        }
+
+        return file
+    }
+
+    override fun exists(fileOrDirectory: VirtualFile): Boolean {
+        return convert(fileOrDirectory) != null
+    }
+
+    override fun list(file: VirtualFile): Array<String> {
+        val fsItem = convert(file) as? FSDir ?: return ArrayUtil.EMPTY_STRING_ARRAY
+        return fsItem.list()
+    }
+
+    override fun isDirectory(file: VirtualFile): Boolean {
+        return convert(file) is FSDir
+    }
+
+    override fun getTimeStamp(file: VirtualFile): Long {
+        val fsItem = convert(file) ?: return DEFAULT_TIMESTAMP
+        return fsItem.timestamp
+    }
+
+    override fun setTimeStamp(file: VirtualFile, timeStamp: Long) {
+        val fsItem = convert(file) ?: return
+        fsItem.timestamp = if (timeStamp > 0) timeStamp else currentTimestamp()
+    }
+
+    override fun isWritable(file: VirtualFile): Boolean = true
+
+    override fun setWritable(file: VirtualFile, writableFlag: Boolean) {}
+
+    @Throws(IOException::class)
+    override fun contentsToByteArray(file: VirtualFile): ByteArray {
+        val fsItem = convert(file) ?: throw FileNotFoundException(file.path + " (No such file or directory)")
+        if (fsItem !is FSFile) throw FileNotFoundException(file.path + " (Is a directory)")
+        return fsItem.fetchAndRemoveContent()
+            ?: throw FileNotFoundException(file.path + " (Content is not provided)")
+    }
+
+    @Throws(IOException::class)
+    override fun getInputStream(file: VirtualFile): InputStream {
+        return BufferExposingByteArrayInputStream(contentsToByteArray(file))
+    }
+
+    @Throws(IOException::class)
+    override fun getOutputStream(file: VirtualFile,
+                                 requestor: Any?,
+                                 modStamp: Long,
+                                 timeStamp: Long): OutputStream {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getLength(file: VirtualFile): Long {
+        val fsItem = convert(file) as? FSFile ?: return DEFAULT_LENGTH
+        return fsItem.length.toLong()
+    }
+
+    override fun getAttributes(file: VirtualFile): FileAttributes? {
+        val item = convert(file) ?: return null
+        val length = ((item as? FSFile)?.length ?: 0).toLong()
+        return FileAttributes(item is FSDir, false, false, false, length, item.timestamp, true)
+    }
+
+    override fun replaceWatchedRoots(watchRequests: Collection<WatchRequest>,
+                                     recursiveRoots: Collection<String>?,
+                                     flatRoots: Collection<String>?): Set<WatchRequest> {
+        throw IncorrectOperationException()
+    }
+
+    sealed class FSItem {
+        abstract val parent: FSDir?
+        abstract var name: String
+        abstract var timestamp: Long
+
+        protected fun bumpTimestamp() {
+            timestamp = Math.min(currentTimestamp(), timestamp + 1)
+        }
+
+        override fun toString(): String = javaClass.simpleName + ": " + name
+
+        open class FSDir(
+            override var parent: FSDir?,
+            override var name: String,
+
+            @get:Synchronized
+            @set:Synchronized
+            override var timestamp: Long = currentTimestamp()
+        ) : FSItem() {
+            protected open val children: MutableList<FSItem> = mutableListOf()
+
+            @Synchronized
+            fun copyChildren(): List<FSItem> = ArrayList(children)
+
+            @Synchronized
+            fun findChild(name: String): FSItem? = children.find { it.name == name }
+
+            @Synchronized
+            fun addChild(item: FSItem, bump: Boolean = false, override: Boolean = false) {
+                require(item.parent == this)
+                require(item.name.isNotEmpty())
+                if (override) {
+                    children.removeIf { it.name == item.name }
+                } else {
+                    check(children.find { it.name == item.name } == null) { "File `${item.name}` already exists" }
+                }
+                children.add(item)
+                if (bump) {
+                    bumpTimestamp()
+                }
+            }
+
+            fun addChildFile(name: String, bump: Boolean = false): FSFile =
+                FSFile(this, name).also { addChild(it, bump) }
+
+            fun addChildDir(name: String, bump: Boolean = false): FSDir =
+                FSDir(this, name).also { addChild(it, bump) }
+
+            @Synchronized
+            fun removeChild(name: String, bump: Boolean = false) {
+                children.removeIf { it.name == name }
+                if (bump) {
+                    bumpTimestamp()
+                }
+            }
+
+            @Synchronized
+            fun list(): Array<String> = children.map { it.name }.toTypedArray()
+
+            @Synchronized
+            fun clear(bump: Boolean = false) {
+                children.clear()
+                if (bump) {
+                    bumpTimestamp()
+                }
+            }
+
+            class DummyDir(
+                parent: FSDir?,
+                name: String,
+                timestamp: Long = currentTimestamp()
+            ) : FSDir(parent, name, timestamp) {
+                override val children: MutableList<FSItem>
+                    get() {
+                        parent?.removeChild(name, bump = false)
+                        return mutableListOf()
+                    }
+            }
+
+            fun dummy(): FSDir = DummyDir(parent, name, timestamp)
+        }
+
+        class FSFile(
+            override val parent: FSDir,
+            override var name: String,
+
+            @get:Synchronized
+            @set:Synchronized
+            override var timestamp: Long = currentTimestamp(),
+
+            @get:Synchronized
+            var length: Int = 0,
+
+            @get:Synchronized
+            var tempContent: ByteArray? = null
+        ) : FSItem() {
+
+            @Synchronized
+            fun setContent(content: ByteArray) {
+                tempContent = content
+                length = content.size
+                bumpTimestamp()
+            }
+
+            @Synchronized
+            @Throws(FileNotFoundException::class)
+            fun fetchAndRemoveContent(): ByteArray? {
+                val tmp = tempContent ?: run {
+                    parent.removeChild(name, bump = true)
+                    return null
+                }
+                tempContent = null
+                return tmp
+            }
+        }
+    }
+
+    private fun splitFilenameAndParent(path: String): Pair<String, String> {
+        val index = path.lastIndexOf('/')
+        check(index >= 0) { "$index" }
+        val pathStart = path.substring(0, index)
+        val filename = path.substring(index + 1)
+        return pathStart to filename
+    }
+
+    fun createFileWithContent(path: String, content: String) {
+        val (parentName, name) = splitFilenameAndParent(path)
+        val parent = convert(parentName) ?: throw FileNotFoundException(parentName)
+        check(parent is FSDir)
+        val item = parent.addChildFile(name)
+        item.setContent(content.toByteArray())
+    }
+
+    fun setFileContent(path: String, content: String) {
+        val item = convert(path) ?: throw FileNotFoundException(path)
+        check(item is FSFile)
+        item.setContent(content.toByteArray())
+    }
+
+    fun createDirectory(path: String) {
+        val (parentName, name) = splitFilenameAndParent(path)
+        val parent = convert(parentName) ?: throw FileNotFoundException(parentName)
+        check(parent is FSDir)
+        parent.addChildDir(name, bump = true)
+    }
+
+    fun createDirectoryIfNotExistsOrDummy(path: String) {
+        val (parentName, name) = splitFilenameAndParent(path)
+        val parent = convert(parentName) ?: throw FileNotFoundException(parentName)
+        check(parent is FSDir)
+        val child = parent.findChild(name)
+        if (child == null || child is FSDir.DummyDir) {
+            if (child is FSDir.DummyDir) {
+                parent.removeChild(name)
+            }
+            parent.addChildDir(name, bump = true)
+        }
+    }
+
+    fun setDirectory(path: String, dir: FSDir, override: Boolean = true) {
+        val (parentName, name) = splitFilenameAndParent(path)
+        val parent = convert(parentName) ?: throw FileNotFoundException(parentName)
+        check(parent is FSDir)
+        dir.parent = parent
+        dir.name = name
+        parent.addChild(dir, bump = true, override = override)
+    }
+
+    fun makeDummy(path: String) {
+        setDirectory(path, getDirectory(path).dummy())
+    }
+
+    fun getDirectory(path: String): FSDir {
+        return convert(path) as? FSDir ?: throw FileNotFoundException(path)
+    }
+
+    fun deleteFile(path: String) {
+        val (parentName, name) = splitFilenameAndParent(path)
+        val parent = convert(parentName) ?: return
+        check(parent is FSDir)
+        parent.removeChild(name, bump = true)
+    }
+
+    fun cleanDirectory(path: String, bump: Boolean = true) {
+        val dir = convert(path) ?: throw FileNotFoundException(path)
+        check(dir is FSDir)
+        dir.clear(bump)
+    }
+
+    fun exists(path: String): Boolean = convert(path) != null
+    fun isFile(path: String): Boolean = convert(path) is FSFile
+
+    companion object {
+        private const val PROTOCOL: String = "rust_macros"
+        fun getInstance(): MacroExpansionFileSystem {
+            return VirtualFileManager.getInstance().getFileSystem(PROTOCOL) as MacroExpansionFileSystem
+        }
+
+        @Throws(IOException::class)
+        fun writeFSItem(data: DataOutput, item: FSItem) {
+            // TODO proper synchronization
+            data.writeBoolean(item is FSDir)
+            data.writeUTF(item.name)
+            data.writeLong(item.timestamp)
+            when (item) {
+                is FSDir -> {
+                    val children = item.copyChildren()
+                    data.writeInt(children.size)
+                    for (child in children) {
+                        writeFSItem(data, child)
+                    }
+                }
+                is FSFile -> {
+                    val length = item.length
+                    data.writeInt(length)
+                    val content = item.tempContent?.takeIf { it.size == length }
+                    data.writeBoolean(content != null)
+                    if (content != null) {
+                        data.write(content)
+                    }
+                }
+            }
+        }
+
+        @Throws(IOException::class)
+        fun readFSItem(data: DataInput, parent: FSDir?): FSItem {
+            val isDir = data.readBoolean()
+            val name = data.readUTF()
+            val timestamp = data.readLong()
+            return if (isDir) {
+                val dir = FSDir(parent, name, timestamp)
+                val count = data.readInt()
+                for (i in 0 until count) {
+                    val child = readFSItem(data, dir)
+                    dir.addChild(child)
+                }
+                dir
+            } else {
+                val length = data.readInt()
+                val hasContent = data.readBoolean()
+                val content = if (hasContent) {
+                    ByteArray(length).also { data.readFully(it) }
+                } else {
+                    null
+                }
+                FSFile(parent!!, name, timestamp, length, content)
+            }
+        }
+
+        private fun currentTimestamp() = System.currentTimeMillis()
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
@@ -6,18 +6,13 @@
 package org.rust.lang.core.macros
 
 import com.intellij.openapi.util.io.FileSystemUtil
-import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapi.vfs.ex.VirtualFileManagerEx
 import com.intellij.openapi.vfs.newvfs.events.*
 import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
-import com.intellij.util.io.*
-import org.apache.commons.lang.RandomStringUtils
 import org.rust.openapiext.checkWriteAccessAllowed
-import org.rust.openapiext.pathAsPath
-import java.nio.file.Files
-import java.nio.file.Path
+import org.rust.stdext.randomLowercaseAlphabetic
 import java.util.*
 
 interface MacroExpansionVfsBatch {
@@ -34,21 +29,20 @@ interface MacroExpansionVfsBatch {
     fun applyToVfs()
 }
 
-class LocalFsMacroExpansionVfsBatch(
-    private val realFsExpansionContentRoot: Path
-) : MacroExpansionVfsBatch {
+class MacroExpansionVfsBatchImpl(rootDirName: String) : MacroExpansionVfsBatch {
+    private val contentRoot = "/$MACRO_EXPANSION_VFS_ROOT/$rootDirName"
     private val batch: VfsBatch = EventBasedVfsBatch()
 
     override fun resolve(file: VirtualFile): MacroExpansionVfsBatch.Path =
         PathImpl.VFile(file)
 
     override fun createFileWithContent(content: String, stepNumber: Int): MacroExpansionVfsBatch.Path =
-        PathImpl.NioPath(createFileInternal(content, stepNumber))
+        PathImpl.StringPath(createFileInternal(content, stepNumber))
 
-    private fun createFileInternal(content: String, stepNumber: Int): Path {
-        val name = RandomStringUtils.random(16, "0123456789abcdefghijklmnopqrstuvwxyz")
+    private fun createFileInternal(content: String, stepNumber: Int): String {
+        val name = randomLowercaseAlphabetic(16)
         return batch.run {
-            realFsExpansionContentRoot
+            contentRoot
                 .getOrCreateDirectory(stepNumber.toString())
                 .getOrCreateDirectory(name[0].toString())
                 .getOrCreateDirectory(name[1].toString())
@@ -69,18 +63,18 @@ class LocalFsMacroExpansionVfsBatch(
     }
 
     private sealed class PathImpl : MacroExpansionVfsBatch.Path {
-        abstract fun toPath(): Path
+        abstract fun toPath(): String
 
         class VFile(val file: VirtualFile): PathImpl() {
             override fun toVirtualFile(): VirtualFile? = file
 
-            override fun toPath(): Path = file.pathAsPath
+            override fun toPath(): String = file.path
         }
-        class NioPath(val path: Path): PathImpl() {
+        class StringPath(val path: String): PathImpl() {
             override fun toVirtualFile(): VirtualFile? =
-                LocalFileSystem.getInstance().findFileByIoFile(path.toFile())
+                MacroExpansionFileSystem.getInstance().findFileByPath(path)
 
-            override fun toPath(): Path = path
+            override fun toPath(): String = path
         }
     }
 }
@@ -89,64 +83,56 @@ abstract class VfsBatch {
     protected val dirEvents: MutableList<DirCreateEvent> = LinkedList()
     protected val fileEvents: MutableList<Event> = mutableListOf()
 
-    fun Path.createFile(name: String, content: String): Path =
+    fun String.createFile(name: String, content: String): String =
         createFile(this, name, content)
 
     @JvmName("createFile_")
-    private fun createFile(parent: Path, name: String, content: String): Path {
-        val child = parent.resolve(name)
-        check(!child.exists())
-        child.createFile()
-        val data = content.toByteArray() // UTF-8
-        Files.write(child, data)
-
+    private fun createFile(parent: String, name: String, content: String): String {
+        val child = "$parent/$name"
+        MacroExpansionFileSystem.getInstance().createFileWithContent(child, content)
         fileEvents.add(Event.Create(parent, name))
         return child
     }
 
-    private fun createDirectory(parent: Path, name: String): Path {
-        val child = parent.resolve(name)
-        check(!child.exists())
-        Files.createDirectory(child)
-
+    private fun createDirectory(parent: String, name: String): String {
+        val child = "$parent/$name"
+        MacroExpansionFileSystem.getInstance().createDirectory(child)
         dirEvents.add(DirCreateEvent(parent, name))
-
         return child
     }
 
-    fun Path.getOrCreateDirectory(name: String): Path =
+    fun String.getOrCreateDirectory(name: String): String =
         getOrCreateDirectory(this, name)
 
     @JvmName("getOrCreateDirectory_")
-    private fun getOrCreateDirectory(parent: Path, name: String): Path {
-        val child = parent.resolve(name)
-        if (child.exists()) {
+    private fun getOrCreateDirectory(parent: String, name: String): String {
+        val child = "$parent/$name"
+        if (MacroExpansionFileSystem.getInstance().exists(child)) {
             return child
         }
         return createDirectory(parent, name)
     }
 
-    fun writeFile(file: Path, content: String) {
-        check(file.isFile())
-        file.write(content) // UTF-8
+    fun writeFile(file: String, content: String) {
+        MacroExpansionFileSystem.getInstance().setFileContent(file, content)
 
         fileEvents.add(Event.Write(file))
     }
 
-    fun deleteFile(file: Path) {
-        file.delete()
+    fun deleteFile(file: String) {
+        MacroExpansionFileSystem.getInstance().deleteFile(file)
 
         fileEvents.add(Event.Delete(file))
     }
 
     abstract fun applyToVfs()
 
-    protected class DirCreateEvent(val parent: Path, val name: String)
+    protected class DirCreateEvent(val parent: String, val name: String)
 
     protected sealed class Event {
-        class Create(val parent: Path, val name: String): Event()
-        class Write(val file: Path): Event()
-        class Delete(val file: Path): Event()
+        class Create(val parent: String, val name: String): Event()
+        class Write(val file: String): Event()
+        class Delete(val file: String): Event()
     }
 
 }
@@ -184,23 +170,23 @@ class EventBasedVfsBatch : VfsBatch() {
     }
 
     private fun DirCreateEvent.toVFileEvent(): VFileEvent? {
-        val vParent = LocalFileSystem.getInstance().findFileByPath(parent.toString()) ?: return null
+        val vParent = MacroExpansionFileSystem.getInstance().findFileByPath(parent) ?: return null
         @Suppress("UnstableApiUsage")
         return VFileCreateEvent(null, vParent, name, true, null, null, true, ChildInfo.EMPTY_ARRAY)
     }
 
     private fun Event.toVFileEvent(): VFileEvent? = when (this) {
         is Event.Create -> {
-            val vParent = LocalFileSystem.getInstance().findFileByPath(parent.toString())!!
-            val attributes = FileSystemUtil.getAttributes(parent.resolve(name).toString())
+            val vParent = MacroExpansionFileSystem.getInstance().findFileByPath(parent)!!
+            val attributes = FileSystemUtil.getAttributes("$parent/$name")
             VFileCreateEvent(null, vParent, name, false, attributes, null, true, null)
         }
         is Event.Write -> {
-            val vFile = LocalFileSystem.getInstance().findFileByPath(file.toString())!!
+            val vFile = MacroExpansionFileSystem.getInstance().findFileByPath(file)!!
             VFileContentChangeEvent(null, vFile, vFile.modificationStamp, -1, true)
         }
         is Event.Delete -> {
-            val vFile = LocalFileSystem.getInstance().findFileByPath(file.toString())
+            val vFile = MacroExpansionFileSystem.getInstance().findFileByPath(file)
             // skip if file is already deleted (not sure how this can happen)
             if (vFile == null) null else VFileDeleteEvent(null, vFile, true)
         }

--- a/src/main/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachesInvalidator.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachesInvalidator.kt
@@ -11,7 +11,7 @@ import com.intellij.util.io.delete
 class RsMacroExpansionCachesInvalidator : CachesInvalidator() {
     override fun invalidateCaches() {
         try {
-            getBaseMacroExpansionDir().delete()
+            getBaseMacroDir().delete()
         } catch (ignored: Exception) {
 
         }

--- a/src/main/kotlin/org/rust/stdext/Utils.kt
+++ b/src/main/kotlin/org/rust/stdext/Utils.kt
@@ -8,6 +8,7 @@ package org.rust.stdext
 
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VirtualFile
+import org.apache.commons.lang.RandomStringUtils
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -24,3 +25,6 @@ inline fun <T> VirtualFile.applyWithSymlink(f: (VirtualFile) -> T?): T? {
 fun String.toPath(): Path = Paths.get(this)
 
 fun String.pluralize(): String = StringUtil.pluralize(this)
+
+fun randomLowercaseAlphabetic(length: Int): String =
+    RandomStringUtils.random(length, "0123456789abcdefghijklmnopqrstuvwxyz")

--- a/src/main/kotlin/org/rust/stdext/path.kt
+++ b/src/main/kotlin/org/rust/stdext/path.kt
@@ -5,12 +5,16 @@
 
 package org.rust.stdext
 
+import java.io.DataInputStream
+import java.io.DataOutputStream
 import java.io.IOException
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
+import java.util.zip.DeflaterOutputStream
+import java.util.zip.InflaterInputStream
 
 fun Path.cleanDirectory() = Files.walkFileTree(this, object : SimpleFileVisitor<Path>() {
     override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
@@ -25,3 +29,9 @@ fun Path.cleanDirectory() = Files.walkFileTree(this, object : SimpleFileVisitor<
         return FileVisitResult.CONTINUE
     }
 })
+
+fun Path.newDeflaterDataOutputStream(): DataOutputStream =
+    DataOutputStream(DeflaterOutputStream(Files.newOutputStream(this)))
+
+fun Path.newInflaterDataInputStream(): DataInputStream =
+    DataInputStream(InflaterInputStream(Files.newInputStream(this)))

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -877,6 +877,7 @@
         <indexedRootsProvider implementation="org.rust.lang.core.macros.RsIndexableSetContributor"/>
         <writingAccessProvider implementation="org.rust.lang.core.macros.RsMacroExpansionWritingAccessProvider"/>
         <cachesInvalidator implementation="org.rust.lang.core.macros.RsMacroExpansionCachesInvalidator"/>
+        <virtualFileSystem key="rust_macros" implementationClass="org.rust.lang.core.macros.MacroExpansionFileSystem"/>
 
         <!-- REPL Console -->
 

--- a/src/test/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystemTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystemTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileSystem
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.rust.openapiext.fullyRefreshDirectory
+
+class MacroExpansionFileSystemTest : BasePlatformTestCase() {
+    fun `test simple`() {
+        val vfs = MacroExpansionFileSystem.getInstance().apply {
+            createDirectory("/foo")
+            createFileWithContent("/foo/bar.txt", "bar content")
+            createFileWithContent("/foo/baz.txt", "baz content")
+            refresh(false)
+        }
+        val bar = vfs.findNonNullFileByPath("/foo/bar.txt")
+        val baz = vfs.findNonNullFileByPath("/foo/baz.txt")
+        val parent = bar.parent
+        assertEquals("bar content", VfsUtil.loadText(bar))
+        assertEquals("baz content", VfsUtil.loadText(baz))
+        assertEquals("bar.txt", bar.name)
+        assertEquals("foo", parent.name)
+        assertEquals(2, parent.children.size)
+        assertContainsElements(parent.children.toList(), bar, baz)
+        assertEquals(vfs.findNonNullFileByPath("/foo"), parent)
+        assertEquals(vfs.findNonNullFileByPath("/foo/"), parent)
+        assertEquals(vfs.findNonNullFileByPath("/"), parent.parent)
+
+        vfs.setFileContent("/foo/bar.txt", "new bar content")
+        vfs.refresh(false)
+        assertEquals("new bar content", VfsUtil.loadText(bar))
+        assertEquals("baz content", VfsUtil.loadText(baz))
+
+        vfs.deleteFile("/foo/bar.txt")
+        fullyRefreshDirectory(vfs.root)
+        assertNull(vfs.findFileByPath("/foo/bar.txt"))
+
+        vfs.deleteFile("/foo")
+        fullyRefreshDirectory(vfs.root)
+        assertNull(vfs.findFileByPath("/foo/baz.txt"))
+        assertNull(vfs.findFileByPath("/foo"))
+    }
+}
+
+private fun VirtualFileSystem.findNonNullFileByPath(path: String): VirtualFile =
+    findFileByPath(path) ?: error("File not found: $path")
+
+private val VirtualFileSystem.root: VirtualFile get() = findNonNullFileByPath("/")


### PR DESCRIPTION
Fixes #3968

Expanded macros now are not stored on a disk as individual physical files. Instead, they are stored in a snapshot only (snapshot is an IntelliJ platform concept that means a copy of a part of filesystem stored in embedded DB in IntelliJ directory) with new `MacroExpansionVFS`.

Now macro expansion should occupy much less disk space. Also, this should speed up macro expansion because of fewer system calls (filesystem interaction).