### PR TITLE
PERF: make macro call body reparseable

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
@@ -337,6 +337,9 @@ object RustParserUtil : GeneratedParserUtilBase() {
         put(RustParser::EnvMacroArgument, true, "env")
     }
 
+    fun isSpecialMacro(name: String): Boolean =
+        name in SPECIAL_MACRO_PARSERS
+
     @JvmStatic
     fun parseMacroCall(b: PsiBuilder, level: Int, mode: MacroCallParsingMode): Boolean {
         if (!RustParser.AttrsAndVis(b, level + 1)) return false

--- a/src/main/kotlin/org/rust/lang/core/psi/LazyElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/LazyElements.kt
@@ -10,11 +10,11 @@ import com.intellij.lang.Language
 import com.intellij.openapi.project.Project
 import com.intellij.psi.impl.source.tree.LazyParseableElement
 import com.intellij.psi.tree.IElementType
-import com.intellij.psi.tree.ILazyParseableElementType
 import com.intellij.psi.tree.IReparseableElementType
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.lexer.RsLexer
 import org.rust.lang.core.parser.RustParserUtil
+import org.rust.lang.core.psi.ext.macroName
 
 fun factory(name: String): IElementType = when (name) {
     "MACRO_ARGUMENT" -> RsMacroArgumentElementType
@@ -22,17 +22,26 @@ fun factory(name: String): IElementType = when (name) {
     else -> error("Unknown element $name")
 }
 
-private object RsMacroArgumentElementType : ILazyParseableElementType("MACRO_ARGUMENT", RsLanguage)
+private object RsMacroArgumentElementType : RsReparseableElementTypeBase("MACRO_ARGUMENT") {
+    override fun isParsable(parent: ASTNode?, buffer: CharSequence, fileLanguage: Language, project: Project): Boolean {
+        val parentMacro = parent?.psi as? RsMacroCall ?: return false
+
+        // Special macros are not reparseable because a change in the content of a macro argument
+        // can change a type of the argument (e.g. to VEC_MACRO_ARGUMENT)
+        if (RustParserUtil.isSpecialMacro(parentMacro.macroName)) return false
+
+        return RustParserUtil.hasProperTokenTreeBraceBalance(buffer, RsLexer())
+    }
+}
+
 private object RsMacroBodyElementType : RsTTBodyLazyElementTypeBase("MACRO_BODY")
 
 private abstract class RsTTBodyLazyElementTypeBase(debugName: String) : RsReparseableElementTypeBase(debugName) {
-    override fun isParsable(seq: CharSequence, fileLanguage: Language, project: Project): Boolean =
-        RustParserUtil.hasProperTokenTreeBraceBalance(seq, RsLexer())
+    override fun isParsable(buffer: CharSequence, fileLanguage: Language, project: Project): Boolean =
+        RustParserUtil.hasProperTokenTreeBraceBalance(buffer, RsLexer())
 }
 
 private abstract class RsReparseableElementTypeBase(debugName: String) : IReparseableElementType(debugName, RsLanguage) {
-    abstract override fun isParsable(seq: CharSequence, fileLanguage: Language, project: Project): Boolean
-
     /**
      * Must be non-null to make re-parsing work.
      * See [com.intellij.psi.impl.BlockSupportImpl.tryReparseNode]


### PR DESCRIPTION
Finish the work started in #4357 (using infrastructure from #4491). Most likely this doesn't affect users anyhow but can speed up completion in macro calls in large files