### PR TITLE
Drop processItemDeclarationsWithCache

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -11,9 +11,6 @@ import com.intellij.openapi.util.RecursionManager
 import com.intellij.openapiext.Testmark
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.CachedValue
-import com.intellij.psi.util.CachedValueProvider
-import com.intellij.psi.util.CachedValuesManager
-import com.intellij.util.SmartList
 import org.rust.cargo.util.AutoInjectedCrates.CORE
 import org.rust.cargo.util.AutoInjectedCrates.STD
 import org.rust.lang.core.psi.*
@@ -230,8 +227,7 @@ private fun processMultiResolveWithNs(name: String, ns: Set<Namespace>, ref: RsR
     // TODO fix after enabling #[cfg(...)] evaluation
 
     if (ns.size == 1) {
-        // Optimized version for single namespace.
-        // Also this provides ability to cache ScopeEntries and so necessary for [processItemDeclarationsWithCache]
+        // An optimized version for single namespace.
         return processor.lazy(name) {
             ref.multiResolve().find { it is RsNamedElement && ns.intersects(it.namespaces) }
         }
@@ -258,37 +254,6 @@ private fun processMultiResolveWithNs(name: String, ns: Set<Namespace>, ref: RsR
         if (processor(name, element)) return true
     }
     return false
-}
-
-/**
- * A cached version of [processItemDeclarations]. Exists only for optimization purposes and can be safely
- * replaced with [processItemDeclarations]. The cached version is used only when [ns] consists of the
- * single element that is [Namespace.Types]. This is due to the following reasons:
- * 1. Types namespace is an absolute record holder in name resolution invocations and time
- * 2. We can cache only single namespace due to [processMultiResolveWithNs] implementation
- */
-fun processItemDeclarationsWithCache(
-    scope: RsMod,
-    ns: Set<Namespace>,
-    processor: RsResolveProcessor,
-    ipm: ItemProcessingMode = ItemProcessingMode.WITH_PRIVATE_IMPORTS
-): Boolean {
-    return if (ns == TYPES) {
-        val cached = CachedValuesManager.getCachedValue(scope, ipm.cacheKey) {
-            val scopeEntryList = SmartList<ScopeEntry>()
-            processItemDeclarations(scope, TYPES, {
-                scopeEntryList.add(it)
-                false
-            }, ipm)
-            CachedValueProvider.Result.create(scopeEntryList, scope.rustStructureOrAnyPsiModificationTracker)
-        }
-        for (e in cached) {
-            if (processor(e)) return true
-        }
-        false
-    } else {
-        processItemDeclarations(scope, ns, processor, ipm)
-    }
 }
 
 enum class ItemProcessingMode(val withExternCrates: Boolean) {

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -1226,7 +1226,7 @@ private fun processLexicalDeclarations(
 
     when (scope) {
         is RsMod -> {
-            if (processItemDeclarationsWithCache(scope, ns, processor, ipm = ipm)) return true
+            if (processItemDeclarations(scope, ns, processor, ipm = ipm)) return true
         }
 
         is RsTypeAlias -> {
@@ -1372,7 +1372,7 @@ fun processNestedScopesUpwards(
         // XXX: fix prelude items resolve on the nightly. Revert it to `v -> v.name !in prevScope`
         //   after cfg attrs support or when `#[cfg(bootstrap)]` will be removed from the prelude
         val preludeProcessor: (ScopeEntry) -> Boolean = { v -> prevScope.add(v.name) && processor(v) }
-        return processItemDeclarationsWithCache(prelude, ns, preludeProcessor, ItemProcessingMode.WITHOUT_PRIVATE_IMPORTS)
+        return processItemDeclarations(prelude, ns, preludeProcessor, ItemProcessingMode.WITHOUT_PRIVATE_IMPORTS)
     }
 
     return false


### PR DESCRIPTION
This cache was introduced before the latest optimization series and now is not actual.

I measured the impact of its removal and it is zero or even positive (some benchmarks works faster without the cache, lol)

But the main reason for its removal is (rare) `Non-idempotent computation` assert triggering. Unfortunately I didnt found the real reason of this