### PR TITLE
INT: handle raw identifiers in AddStructFieldsFix

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsDefaultValueBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsDefaultValueBuilder.kt
@@ -155,8 +155,15 @@ class RsDefaultValueBuilder(
         return addedFields
     }
 
+    private fun getName(fieldDecl: RsFieldDecl): String? {
+        return when (fieldDecl) {
+            is RsNamedFieldDecl -> fieldDecl.identifier.text
+            else -> fieldDecl.name
+        }
+    }
+
     private fun findLocalBinding(fieldDecl: RsFieldDecl, bindings: Map<String, RsPatBinding>): RsStructLiteralField? {
-        val name = fieldDecl.name ?: return null
+        val name = getName(fieldDecl) ?: return null
         val type = fieldDecl.typeReference?.type ?: return null
 
         val binding = bindings[name] ?: return null
@@ -233,7 +240,7 @@ class RsDefaultValueBuilder(
     }
 
     private fun specializedCreateStructLiteralField(fieldDecl: RsFieldDecl, bindings: Map<String, RsPatBinding>): RsStructLiteralField? {
-        val fieldName = fieldDecl.name ?: return null
+        val fieldName = getName(fieldDecl) ?: return null
         val fieldType = fieldDecl.typeReference?.type ?: return null
         val fieldLiteral = buildFor(fieldType, bindings)
         return psiFactory.createStructLiteralField(fieldName, fieldLiteral)
@@ -243,7 +250,7 @@ class RsDefaultValueBuilder(
         fun getVisibleBindings(place: RsElement): Map<String, RsPatBinding> {
             val bindings = HashMap<String, RsPatBinding>()
             processLocalVariables(place) { variable ->
-                variable.name?.let {
+                variable.identifier.text?.let {
                     bindings[it] = variable
                 }
             }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt
@@ -659,8 +659,7 @@ class AddStructFieldsFixTest : RsAnnotatorTestBase(RsExpressionAnnotator::class)
         }
     """)
 
-    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    fun `test keyword field`() = checkBothQuickFix("""
+    fun `test raw identifier field`() = checkBothQuickFix("""
         struct S { r#type: i32 }
 
         fn main() {
@@ -674,8 +673,7 @@ class AddStructFieldsFixTest : RsAnnotatorTestBase(RsExpressionAnnotator::class)
         }
     """)
 
-    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    fun `test keyword field local variable`() = checkBothQuickFix("""
+    fun `test raw identifier field local variable`() = checkBothQuickFix("""
         struct S { r#type: i32 }
 
         fn main() {
@@ -688,6 +686,24 @@ class AddStructFieldsFixTest : RsAnnotatorTestBase(RsExpressionAnnotator::class)
         fn main() {
             let r#type: i32 = 0;
             S { r#type };
+        }
+    """)
+
+    fun `test raw identifier field unnecessary escape`() = checkBothQuickFix("""
+        struct S { r#foo: i32, bar: i32 }
+
+        fn main() {
+            let foo: i32 = 0;
+            let r#bar: i32 = 0;
+            <error>S</error> { /*caret*/ };
+        }
+    """, """
+        struct S { r#foo: i32, bar: i32 }
+
+        fn main() {
+            let foo: i32 = 0;
+            let r#bar: i32 = 0;
+            S { foo, bar };
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsFixTest.kt
@@ -659,6 +659,38 @@ class AddStructFieldsFixTest : RsAnnotatorTestBase(RsExpressionAnnotator::class)
         }
     """)
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test keyword field`() = checkBothQuickFix("""
+        struct S { r#type: i32 }
+
+        fn main() {
+            <error>S</error> { /*caret*/ };
+        }
+    """, """
+        struct S { r#type: i32 }
+
+        fn main() {
+            S { r#type: 0/*caret*/ };
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test keyword field local variable`() = checkBothQuickFix("""
+        struct S { r#type: i32 }
+
+        fn main() {
+            let r#type: i32 = 0;
+            <error>S</error> { /*caret*/ };
+        }
+    """, """
+        struct S { r#type: i32 }
+
+        fn main() {
+            let r#type: i32 = 0;
+            S { r#type };
+        }
+    """)
+
     private fun checkBothQuickFix(@Language("Rust") before: String, @Language("Rust") after: String) {
         checkFixByText("Add missing fields", before, after)
         checkFixByText("Recursively add missing fields", before, after)


### PR DESCRIPTION
This PR fixes AddStructFieldsFix so that it doesn't fail for structs containing raw identifiers (for example `r#type`). Previously, the fix failed, because it tried to construct code like `{ type: 0 }`, which is not valid and thus the fix would just silently ignore that field.

The `name` attribute/function of both local variables (`RsPatBinding`) and struct fields (`RsFieldDecl`) with a raw identifier returns just the inner name after `r#`. I wasn't sure what's the correct way of getting the whole identifier, so I just used `item.identifier.text`. Please let me know if there's a better way.

Fixes #4861