### PR TITLE
ANN: highlight exit point better if last statement is loop

### DIFF
--- a/src/main/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactory.kt
+++ b/src/main/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactory.kt
@@ -14,8 +14,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.Consumer
 import org.rust.lang.core.cfg.ExitPoint
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.RsElementTypes.Q
-import org.rust.lang.core.psi.RsElementTypes.RETURN
+import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.psi.ext.*
 
 class RsHighlightExitPointsHandlerFactory : HighlightUsagesHandlerFactoryBase() {
@@ -24,7 +23,7 @@ class RsHighlightExitPointsHandlerFactory : HighlightUsagesHandlerFactoryBase() 
 
         val createHandler: (PsiElement) -> RsHighlightExitPointsHandler? = { element ->
             val elementType = element.elementType
-            if (elementType == RETURN || (elementType == Q && element.parent is RsTryExpr)) {
+            if (elementType == RETURN || (elementType == Q && element.parent is RsTryExpr) || elementType == BREAK) {
                 RsHighlightExitPointsHandler(editor, file, element)
             } else null
         }
@@ -42,12 +41,13 @@ private class RsHighlightExitPointsHandler(editor: Editor, file: PsiFile, var ta
     }
 
     override fun computeUsages(targets: MutableList<PsiElement>?) {
+        val usages = mutableListOf<PsiElement>()
         val sink: (ExitPoint) -> Unit = { exitPoint ->
             when (exitPoint) {
-                is ExitPoint.Return -> addOccurrence(exitPoint.e)
-                is ExitPoint.TryExpr -> if (exitPoint.e is RsTryExpr) addOccurrence(exitPoint.e.q) else addOccurrence(exitPoint.e)
-                is ExitPoint.DivergingExpr -> addOccurrence(exitPoint.e)
-                is ExitPoint.TailExpr -> addOccurrence(exitPoint.e)
+                is ExitPoint.Return -> usages.add(exitPoint.e)
+                is ExitPoint.TryExpr -> if (exitPoint.e is RsTryExpr) usages.add(exitPoint.e.q) else usages.add(exitPoint.e)
+                is ExitPoint.DivergingExpr -> usages.add(exitPoint.e)
+                is ExitPoint.TailExpr -> usages.add(exitPoint.e)
                 is ExitPoint.TailStatement -> Unit
             }
         }
@@ -65,6 +65,11 @@ private class RsHighlightExitPointsHandler(editor: Editor, file: PsiFile, var ta
                 ExitPoint.process(ancestor.expr, sink)
                 break
             }
+        }
+
+        // highlight only if target inside exit point
+        if (usages.any { target.ancestors.contains(it) }) {
+            usages.forEach(this::addOccurrence)
         }
     }
 }

--- a/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
+++ b/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
@@ -272,6 +272,37 @@ class RsHighlightExitPointsHandlerFactoryTest : RsTestBase() {
         }
     """)
 
+    fun `test loop as return on exit break`() = doTest("""
+        fn main() -> i32 {
+            let a = loop { break 0; };
+            return 1;
+            'outer: loop {
+                break/*caret*/ 2;
+                return 3;
+                loop {
+                    break 5;
+                    break 'outer 4;
+                }
+                6
+            }
+        }
+    """, "return 1", "break 2", "return 3", "break 'outer 4")
+
+    fun `test loop as return on not exit break`() = doTest("""
+        fn main() -> i32 {
+            return 1;
+            'outer: loop {
+                break 2;
+                return 3;
+                loop {
+                    break/*caret*/ 5;
+                    break 'outer 4;
+                }
+                6
+            }
+        }
+    """)
+
     private fun doTest(@Language("Rust") check: String, vararg usages: String) {
         InlineFile(check)
         HighlightUsagesHandler.invoke(myFixture.project, myFixture.editor, myFixture.file)

--- a/src/test/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspectionTest.kt
@@ -40,6 +40,13 @@ class RsExtraSemicolonInspectionTest : RsInspectionsTestBase(RsExtraSemicolonIns
         }
     """)
 
+    fun `test not applicable in loop`() = checkByText("""
+        fn test() {}
+        fn a() -> i32 {
+            loop { test(); }
+        }
+    """)
+
     fun `test fix`() = checkFixByText("Remove semicolon", """
         fn foo() -> i32 {
             let x = 92;


### PR DESCRIPTION
If last statement is loop, highlighting whole loop does not provide any additional information. This PR improves it.