### PR TITLE
MACRO: process modules declared inside macro call better

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -18,7 +18,7 @@ import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.ide.injected.isDoctestInjection
-import org.rust.ide.search.RsWithMacrosScope
+import org.rust.ide.search.RsWithMacrosProjectScope
 import org.rust.lang.core.parser.RustParserUtil.PathParsingMode
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -218,7 +218,7 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
             val superMods = LinkedHashSet(scope.containingMod.superMods)
             val attributes = scope.stdlibAttributes
 
-            val searchScope = RsWithMacrosScope(project, GlobalSearchScope.allScope(project))
+            val searchScope = RsWithMacrosProjectScope(project)
             return traitsToImport
                 .asSequence()
                 .map { QualifiedNamedItem.ExplicitItem(it) }
@@ -666,7 +666,7 @@ data class ImportContext private constructor(
             project = project,
             mod = path.containingMod,
             superMods = LinkedHashSet(path.containingMod.superMods),
-            scope = RsWithMacrosScope(project, GlobalSearchScope.allScope(project)),
+            scope = RsWithMacrosProjectScope(project),
             pathParsingMode = path.pathParsingMode,
             attributes = path.stdlibAttributes,
             namespaceFilter = path.namespaceFilter(isCompletion)
@@ -676,7 +676,7 @@ data class ImportContext private constructor(
             project = project,
             mod = element.containingMod,
             superMods = LinkedHashSet(element.containingMod.superMods),
-            scope = RsWithMacrosScope(project, GlobalSearchScope.allScope(project)),
+            scope = RsWithMacrosProjectScope(project),
             pathParsingMode = PathParsingMode.TYPE,
             attributes = element.stdlibAttributes,
             namespaceFilter = { true }

--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -66,7 +66,7 @@ class ExpandedMacroStorage(val project: Project) {
     private fun deserialize(sfs: List<SourceFile>) {
         for (sf in sfs) {
             sourceFiles.put(sf.fileId, sf)
-            getOrPutStagedList(sf).add(sf)
+            getOrPutStagedList(sf.depthNotSync).add(sf)
             sf.forEachInfoNotSync { if (it.fileId > 0) expandedFileToInfo.put(it.fileId, it) }
         }
     }
@@ -320,6 +320,9 @@ class SourceFile(
     private val fileUrl: String get() = file.url
     val fileId: Int get() = file.fileId
     val project: Project get() = storage.project
+
+    // Used only for deserialization
+    val depthNotSync: Int get() = _depth
 
     var depth: Int
         get() {

--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -219,7 +219,7 @@ class ExpandedMacroStorage(val project: Project) {
 
     companion object {
         private val LOG = Logger.getInstance(ExpandedMacroStorage::class.java)
-        private const val STORAGE_VERSION = 8
+        private const val STORAGE_VERSION = 9
         const val RANGE_MAP_ATTRIBUTE_VERSION = 2
 
         fun load(project: Project, dataFile: Path): ExpandedMacroStorage? {

--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -49,6 +49,8 @@ import java.nio.file.Path
 import java.util.concurrent.locks.ReentrantLock
 import java.util.zip.DeflaterOutputStream
 import java.util.zip.InflaterInputStream
+import kotlin.collections.ArrayList
+import kotlin.collections.HashMap
 import kotlin.concurrent.withLock
 
 class ExpandedMacroStorage(val project: Project) {
@@ -83,10 +85,14 @@ class ExpandedMacroStorage(val project: Project) {
     }
 
     private fun getOrPutStagedList(sf: SourceFile): MutableList<SourceFile> {
-        var list = stepped[sf.depth]
+        return getOrPutStagedList(sf.depth)
+    }
+
+    private fun getOrPutStagedList(step: Int): MutableList<SourceFile> {
+        var list = stepped[step]
         if (list == null) {
             list = mutableListOf()
-            stepped[sf.depth] = list
+            stepped[step] = list
         }
         return list
     }
@@ -111,15 +117,20 @@ class ExpandedMacroStorage(val project: Project) {
         return stepped.asSequence().withIndex().map { (i, step) ->
             // Release memory. [map] contains prefetched calls only for the first step, so clear it on the second step
             if (i == 1) map.clear()
+            step?.map { sf -> Extractable(sf, workspaceOnly, map[sf]) }.orEmpty()
+        }
+    }
 
-            step?.map { sf ->
-                object : Extractable {
-                    override fun extract(): List<Pipeline.Stage1ResolveAndExpand> {
-                        val calls = if (sf.depth == 0) map[sf] else null
-                        return sf.extract(workspaceOnly, calls)
-                    }
-                }
-            } ?: emptyList()
+    fun moveSourceFilesToStep(files: Collection<SourceFile>, step: Int) {
+        checkWriteAccessAllowed()
+        val groupedByStep = files.groupBy { it.depth }
+
+        for ((currentStep, group) in groupedByStep) {
+            stepped[currentStep]?.removeAll(group.toHashSet())
+            group.forEach {
+                it.depth = step
+            }
+            getOrPutStagedList(step).addAll(group)
         }
     }
 
@@ -300,7 +311,7 @@ class ExpandedMacroStorage(val project: Project) {
 class SourceFile(
     val storage: ExpandedMacroStorage,
     val file: VirtualFile,
-    val depth: Int,
+    private var _depth: Int,
     private var _modificationStamp: Long = FRESH_FLAG,
     private val _infos: MutableList<ExpandedMacroInfoImpl> = mutableListOf()
 ) {
@@ -309,6 +320,16 @@ class SourceFile(
     private val fileUrl: String get() = file.url
     val fileId: Int get() = file.fileId
     val project: Project get() = storage.project
+
+    var depth: Int
+        get() {
+            assertSync()
+            return _depth
+        }
+        set(value) {
+            assertSync()
+            _depth = value
+        }
 
     private var modificationStamp: Long
         get() {
@@ -467,7 +488,7 @@ class SourceFile(
         infos.remove(info) // No synchronization needed in the write action
     }
 
-    fun extract(workspaceOnly: Boolean, calls: List<RsMacroCall>?): List<Pipeline.Stage1ResolveAndExpand> {
+    fun extract(workspaceOnly: Boolean, calls: List<RsMacroCall>?): List<Pipeline.Stage1ResolveAndExpand>? {
         if (workspaceOnly && !isBelongToWorkspace) {
             // very hot path; the condition should be as fast as possible
             return emptyList()
@@ -476,13 +497,13 @@ class SourceFile(
         return extract(calls)
     }
 
-    private fun extract(calls: List<RsMacroCall>?): List<Pipeline.Stage1ResolveAndExpand> {
+    private fun extract(calls: List<RsMacroCall>?): List<Pipeline.Stage1ResolveAndExpand>? {
         checkReadAccessAllowed() // Needed to access PSI
         checkIsSmartMode(project)
 
+        val isExpansionFile = project.macroExpansionManager.isExpansionFile(file)
         val isIndexedFile = file.isValid && (
-            FileBasedIndexScanRunnableCollector.getInstance(project).shouldCollect(file) ||
-                project.macroExpansionManager.isExpansionFile(file))
+            FileBasedIndexScanRunnableCollector.getInstance(project).shouldCollect(file) || isExpansionFile)
 
         val stages1 = if (!isIndexedFile) {
             // The file is now outside of the project, so we should not access it.
@@ -492,6 +513,12 @@ class SourceFile(
                 info.makeInvalidationPipeline()
             }
         } else {
+            // If project file doesn't have crate root
+            // we shouldn't try to expand its macro calls
+            if (!isExpansionFile) {
+                val psiFile = loadPsi()
+                if (psiFile != null && psiFile.crateRoot == null) return null
+            }
             matchRefs(MakePipeline(), calls)
         }
         return stages1.takeIf { it.isNotEmpty() } ?: listOf(RemoveSourceFileIfEmptyPipeline(this))

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -93,7 +93,7 @@ inline fun <T> MacroExpansionManager.withExpansionState(
     }
 }
 
-val MACRO_LOG = Logger.getInstance("rust.macros")
+val MACRO_LOG = Logger.getInstance("org.rust.macros")
 private const val RUST_EXPANDED_MACROS = "rust_expanded_macros"
 
 fun getBaseMacroExpansionDir(): Path =
@@ -536,7 +536,7 @@ private class MacroExpansionServiceImplInner(
         get() = expansionMode is MacroExpansionMode.New
 
     private fun processUnprocessedMacros() {
-        MACRO_LOG.trace("processUnprocessedMacros")
+        MACRO_LOG.info("processUnprocessedMacros")
         if (!isExpansionModeNew) return
         class ProcessUnprocessedMacrosTask : MacroExpansionTaskBase(
             project,
@@ -556,7 +556,7 @@ private class MacroExpansionServiceImplInner(
 
                 val calls = runReadActionInSmartMode(project) {
                     val calls = RsMacroCallIndex.getMacroCalls(project, scope)
-                    MACRO_LOG.debug("Macros to expand: ${calls.size}")
+                    MACRO_LOG.info("Macros to expand: ${calls.size}")
                     calls.groupBy { it.containingFile.virtualFile }
 
                 }
@@ -571,7 +571,7 @@ private class MacroExpansionServiceImplInner(
     }
 
     private fun processChangedMacros(workspaceOnly: Boolean) {
-        MACRO_LOG.trace("processChangedMacros")
+        MACRO_LOG.info("processChangedMacros")
         if (!isExpansionModeNew) return
 
         // Fixes inplace rename when the renamed element is referenced from a macro call body

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -21,6 +21,7 @@ import com.intellij.openapi.roots.ContentIterator
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.ModificationTracker
+import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.openapi.vfs.*
 import com.intellij.openapiext.Testmark
 import com.intellij.openapiext.isHeadlessEnvironment
@@ -66,22 +67,30 @@ interface MacroExpansionManager {
     fun isExpansionFile(file: VirtualFile): Boolean
     fun reexpand()
 
-    var isResolvingMacro: Boolean
     val macroExpansionMode: MacroExpansionMode
+
+    var expansionState: ExpansionState?
 
     @TestOnly
     fun setUnitTestExpansionModeAndDirectory(mode: MacroExpansionScope, cacheDirectory: String = ""): Disposable
+
+    data class ExpansionState(
+        val expandedSearchScope: GlobalSearchScope,
+        val stepModificationTracker: ModificationTracker
+    )
 }
 
-inline fun MacroExpansionManager.withResolvingMacro(action: () -> Boolean): Boolean {
-    val old = isResolvingMacro
-    isResolvingMacro = true
-    try {
-        if (action()) return true
+inline fun <T> MacroExpansionManager.withExpansionState(
+    newState: MacroExpansionManager.ExpansionState,
+    action: () -> T
+): T {
+    val oldState = expansionState
+    expansionState = newState
+    return try {
+        action()
     } finally {
-        isResolvingMacro = old
+        expansionState = oldState
     }
-    return false
 }
 
 val MACRO_LOG = Logger.getInstance("rust.macros")
@@ -173,14 +182,14 @@ class MacroExpansionManagerImpl(
         inner?.reexpand()
     }
 
-    override var isResolvingMacro: Boolean
-        get() = inner?.isResolvingMacro != false
-        set(value) {
-            inner?.isResolvingMacro = value
-        }
-
     override val macroExpansionMode: MacroExpansionMode
         get() = inner?.expansionMode ?: MacroExpansionMode.OLD
+
+    override var expansionState: MacroExpansionManager.ExpansionState?
+        get() = inner?.expansionState
+        set(value) {
+            inner?.expansionState = value
+        }
 
     override fun setUnitTestExpansionModeAndDirectory(mode: MacroExpansionScope, cacheDirectory: String): Disposable {
         check(isUnitTestMode)
@@ -235,17 +244,6 @@ private class MacroExpansionServiceImplInner(
     val dirs: Dirs,
     private val storage: ExpandedMacroStorage
 ) {
-    companion object {
-        fun build(project: Project, dirs: Dirs): MacroExpansionServiceImplInner {
-            val dataFile = dirs.dataFile
-            val storage = ExpandedMacroStorage.load(project, dataFile) ?: run {
-                MACRO_LOG.debug("Using fresh ExpandedMacroStorage")
-                ExpandedMacroStorage(project)
-            }
-            return MacroExpansionServiceImplInner(project, dirs, storage)
-        }
-    }
-
     private val taskQueue = MacroExpansionTaskQueue(project)
 
     /**
@@ -260,13 +258,15 @@ private class MacroExpansionServiceImplInner(
      */
     private val pool = Executors.newWorkStealingPool()
 
+    private val stepModificationTracker: SimpleModificationTracker = SimpleModificationTracker()
+
     private val dataFile: Path
         get() = dirs.dataFile
 
     @TestOnly
     var macroExpansionMode: MacroExpansionScope = MacroExpansionScope.NONE
 
-    var isResolvingMacro: Boolean by ThreadLocalDelegate { false }
+    var expansionState: MacroExpansionManager.ExpansionState? by ThreadLocalDelegate { null }
 
     fun isExpansionFile(file: VirtualFile): Boolean =
         VfsUtil.isAncestor(dirs.expansionsDirVi, file, true)
@@ -435,6 +435,17 @@ private class MacroExpansionServiceImplInner(
         connect.subscribe(RUST_PSI_CHANGE_TOPIC, treeChangeListener)
     }
 
+    companion object {
+        fun build(project: Project, dirs: Dirs): MacroExpansionServiceImplInner {
+            val dataFile = dirs.dataFile
+            val storage = ExpandedMacroStorage.load(project, dataFile) ?: run {
+                MACRO_LOG.debug("Using fresh ExpandedMacroStorage")
+                ExpandedMacroStorage(project)
+            }
+            return MacroExpansionServiceImplInner(project, dirs, storage)
+        }
+    }
+
     private enum class ChangedMacrosScope { NONE, WORKSPACE, ALL }
 
     private operator fun ChangedMacrosScope.plus(other: ChangedMacrosScope): ChangedMacrosScope =
@@ -531,7 +542,8 @@ private class MacroExpansionServiceImplInner(
             project,
             storage,
             pool,
-            dirs.expansionsDirVi.pathAsPath
+            dirs.expansionsDirVi,
+            stepModificationTracker
         ) {
             override fun getMacrosToExpand(): Sequence<List<Extractable>> {
                 val mode = expansionMode
@@ -569,7 +581,8 @@ private class MacroExpansionServiceImplInner(
             project,
             storage,
             pool,
-            dirs.expansionsDirVi.pathAsPath
+            dirs.expansionsDirVi,
+            stepModificationTracker
         ) {
             override fun getMacrosToExpand(): Sequence<List<Extractable>> {
                 return runReadAction { storage.makeValidationTask(workspaceOnly) }
@@ -601,7 +614,7 @@ private class MacroExpansionServiceImplInner(
 
     fun getExpansionFor(call: RsMacroCall): CachedValueProvider.Result<MacroExpansion?> {
         checkReadAccessAllowed()
-        if (isResolvingMacro) return CachedValueProvider.Result.create(null, ModificationTracker.EVER_CHANGED)
+        if (expansionState != null) return CachedValueProvider.Result.create(null, ModificationTracker.EVER_CHANGED)
 
         if (expansionMode == MacroExpansionMode.OLD) {
             return expandMacroOld(call)

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
@@ -27,7 +27,7 @@ interface MacroExpansionVfsBatch {
 
     fun resolve(file: VirtualFile): Path
 
-    fun createFileWithContent(content: String): Path
+    fun createFileWithContent(content: String, stepNumber: Int): Path
     fun deleteFile(file: Path)
     fun writeFile(file: Path, content: String)
 
@@ -42,13 +42,14 @@ class LocalFsMacroExpansionVfsBatch(
     override fun resolve(file: VirtualFile): MacroExpansionVfsBatch.Path =
         PathImpl.VFile(file)
 
-    override fun createFileWithContent(content: String): MacroExpansionVfsBatch.Path =
-        PathImpl.NioPath(createFileInternal(content))
+    override fun createFileWithContent(content: String, stepNumber: Int): MacroExpansionVfsBatch.Path =
+        PathImpl.NioPath(createFileInternal(content, stepNumber))
 
-    private fun createFileInternal(content: String): Path {
-        val name = RandomStringUtils.random(16, "0123456789abcdifghijklmnopqrstuvwxyz")
+    private fun createFileInternal(content: String, stepNumber: Int): Path {
+        val name = RandomStringUtils.random(16, "0123456789abcdefghijklmnopqrstuvwxyz")
         return batch.run {
             realFsExpansionContentRoot
+                .getOrCreateDirectory(stepNumber.toString())
                 .getOrCreateDirectory(name[0].toString())
                 .getOrCreateDirectory(name[1].toString())
                 .createFile(name.substring(2) + ".rs", content)

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -757,9 +757,7 @@ fun processMacrosExportedByCrateName(context: RsElement, crateName: String, proc
 }
 
 fun processMacroCallVariantsInScope(context: PsiElement, processor: RsResolveProcessor): Boolean {
-    val result = context.project.macroExpansionManager.withResolvingMacro {
-        MacroResolver.processMacrosInLexicalOrderUpward(context, processor)
-    }
+    val result = MacroResolver.processMacrosInLexicalOrderUpward(context, processor)
     if (result) return true
 
     val prelude = context.contextOrSelf<RsElement>()?.findDependencyCrateRoot(STD) ?: return false
@@ -970,7 +968,7 @@ private fun exportedMacrosAsScopeEntries(scope: RsFile): List<ScopeEntry> {
         LOG.warn("`${scope.virtualFile}` should be crate root")
         return emptyList()
     }
-    val cacheKey = if (scope.project.macroExpansionManager.isResolvingMacro) EXPORTED_MACROS_KEY else EXPORTED_KEY
+    val cacheKey = if (scope.project.macroExpansionManager.expansionState != null) EXPORTED_MACROS_KEY else EXPORTED_KEY
     return CachedValuesManager.getCachedValue(scope, cacheKey) {
         val macros = exportedMacrosInternal(scope)
         CachedValueProvider.Result.create(macros, scope.rustStructureOrAnyPsiModificationTracker)

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsMacroIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsMacroIndex.kt
@@ -42,7 +42,7 @@ class RsMacroIndex : StringStubIndexExtension<RsMacro>() {
         }
 
         fun allExportedMacros(project: Project): Map<RsMod, List<RsMacro>> {
-            val cacheKey = if (project.macroExpansionManager.isResolvingMacro) EXPORTED_MACROS_KEY else EXPORTED_KEY
+            val cacheKey = if (project.macroExpansionManager.expansionState != null) EXPORTED_MACROS_KEY else EXPORTED_KEY
             return CachedValuesManager.getManager(project).getCachedValue(project, cacheKey, {
                 val result = HashMap<RsMod, MutableList<RsMacro>>()
                 val keys = StubIndex.getInstance().getAllKeys(KEY, project)

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsModulesIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsModulesIndex.kt
@@ -32,11 +32,8 @@ class RsModulesIndex : StringStubIndexExtension<RsModDeclItem>() {
 
             var result: RsModDeclItem? = null
 
-            val scope = if (project.macroExpansionManager.isResolvingMacro) {
-                GlobalSearchScope.allScope(project)
-            } else {
-                RsWithMacrosProjectScope(project)
-            }
+            val scope = project.macroExpansionManager.expansionState?.expandedSearchScope
+                ?: RsWithMacrosProjectScope(project)
             StubIndex.getInstance().processElements(
                 KEY, key, project, scope, RsModDeclItem::class.java
             ) { modDecl ->

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
@@ -519,4 +519,26 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
             foo().bar();
         }       //^
     """)
+
+    fun `test resolve module under macro chain`() = stubOnlyResolve("""
+    //- main.rs
+        macro_rules! if_std {
+            ($ i:item) => (
+                $ i
+            )
+        }
+        if_std! { pub mod foo; }
+        fn main() {
+            let a = foo::bar::baz::Baz;
+                                  //^ foo/bar/baz.rs
+        }
+    //- foo/mod.rs
+        if_std! { pub mod bar; }
+    //- foo/bar/mod.rs
+        if_std! { pub mod baz; }
+    //- foo/bar/baz.rs
+        if_std! {
+            pub struct Baz;
+        }
+    """)
 }


### PR DESCRIPTION
The previous version of macro expansion engine processed all project files on the first step.
It led to a situation when a module was added to the module structure via macro call and at the same time, it had own macro calls.
It such cases we failed to expand module's macro calls because name resolution for macro calls didn't work properly.

These changes introduce pending files - project files that are not belong to the module tree.
Such files are postponed to expand their macro calls until they belong to module tree.
It should solve "File is not included into module tree" issue for some popular crates like `async-std` and `tokio`

Fixes the following issues when new macro expansion engine is enabled: 
* #4627
* #4679
* #4706
* #4714
* #4929