### PR TITLE
Cleanup `ApplicationManager` usages

### DIFF
--- a/clion/src/main/kotlin/org/rust/clion/valgrind/RsValgrindConfigurationExtension.kt
+++ b/clion/src/main/kotlin/org/rust/clion/valgrind/RsValgrindConfigurationExtension.kt
@@ -24,6 +24,8 @@ import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapiext.isInternal
+import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.search.GlobalSearchScopes
 import com.intellij.util.ArrayUtil
 import com.intellij.util.ui.StatusText
@@ -174,8 +176,7 @@ class RsValgrindConfigurationExtension : CargoCommandConfigurationExtension() {
     }
 
     private fun deleteFile(file: File) {
-        val application = ApplicationManager.getApplication()
-        if (!application.isUnitTestMode && !application.isInternal) {
+        if (!isUnitTestMode && !isInternal) {
             FileUtil.delete(file)
         }
     }

--- a/common/src/main/kotlin/com/intellij/openapiext/utils.kt
+++ b/common/src/main/kotlin/com/intellij/openapiext/utils.kt
@@ -10,3 +10,4 @@ import com.intellij.openapi.application.ApplicationManager
 val isUnitTestMode: Boolean get() = ApplicationManager.getApplication().isUnitTestMode
 val isHeadlessEnvironment: Boolean get() = ApplicationManager.getApplication().isHeadlessEnvironment
 val isDispatchThread: Boolean get() = ApplicationManager.getApplication().isDispatchThread
+val isInternal: Boolean get() = ApplicationManager.getApplication().isInternal

--- a/common/src/main/kotlin/com/intellij/openapiext/utils.kt
+++ b/common/src/main/kotlin/com/intellij/openapiext/utils.kt
@@ -9,3 +9,4 @@ import com.intellij.openapi.application.ApplicationManager
 
 val isUnitTestMode: Boolean get() = ApplicationManager.getApplication().isUnitTestMode
 val isHeadlessEnvironment: Boolean get() = ApplicationManager.getApplication().isHeadlessEnvironment
+val isDispatchThread: Boolean get() = ApplicationManager.getApplication().isDispatchThread

--- a/coverage/src/main/kotlin/org/rust/coverage/RsCoverageRunner.kt
+++ b/coverage/src/main/kotlin/org/rust/coverage/RsCoverageRunner.kt
@@ -8,9 +8,9 @@ package org.rust.coverage
 import com.intellij.coverage.CoverageEngine
 import com.intellij.coverage.CoverageRunner
 import com.intellij.coverage.CoverageSuite
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapiext.isDispatchThread
 import com.intellij.rt.coverage.data.LineData
 import com.intellij.rt.coverage.data.ProjectData
 import org.rust.coverage.LcovCoverageReport.Serialization.readLcov
@@ -30,7 +30,7 @@ class RsCoverageRunner : CoverageRunner() {
     override fun loadCoverageData(sessionDataFile: File, baseCoverageSuite: CoverageSuite?): ProjectData? {
         if (baseCoverageSuite !is RsCoverageSuite) return null
         return try {
-            if (ApplicationManager.getApplication().isDispatchThread) {
+            if (isDispatchThread) {
                 baseCoverageSuite.project.computeWithCancelableProgress("Loading Coverage Data...") {
                     readProjectData(sessionDataFile, baseCoverageSuite)
                 }

--- a/debugger/src/main/kotlin/org/rust/debugger/RsBackendConsoleInjectionHelper.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/RsBackendConsoleInjectionHelper.kt
@@ -5,8 +5,8 @@
 
 package org.rust.debugger
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.editor.Document
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiLanguageInjectionHost
@@ -41,9 +41,9 @@ class RsBackendConsoleInjectionHelper : BackendConsoleInjectionHelper {
 
             override fun stackFrameChanged() {
                 val file = document?.virtualFile ?: return
-                ApplicationManager.getApplication().invokeLater({
+                invokeLater(ModalityState.NON_MODAL) {
                     PsiDocumentManager.getInstance(session.project).reparseFiles(setOf(file), true)
-                }, ModalityState.NON_MODAL)
+                }
             }
 
             override fun sessionStopped() {

--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -7,7 +7,7 @@ package org.rust.cargo.project.model
 
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
@@ -133,7 +133,7 @@ fun guessAndSetupRustProject(project: Project, explicitRequest: Boolean = false)
 
 private fun discoverToolchain(project: Project) {
     val toolchain = RustToolchain.suggest() ?: return
-    ApplicationManager.getApplication().invokeLater {
+    invokeLater {
         if (project.isDisposed) return@invokeLater
 
         val oldToolchain = project.rustSettings.toolchain

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -9,7 +9,7 @@ import com.intellij.execution.ExecutionException
 import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.invokeAndWaitIfNeeded
 import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.components.PersistentStateComponent
@@ -215,7 +215,7 @@ open class CargoProjectsServiceImpl(
     ): CompletableFuture<List<CargoProjectImpl>> =
         projects.updateAsync(f)
             .thenApply { projects ->
-                ApplicationManager.getApplication().invokeAndWait {
+                invokeAndWaitIfNeeded {
                     runWriteAction {
                         directoryIndex.resetIndex()
                         ProjectRootManagerEx.getInstanceEx(project)
@@ -419,7 +419,7 @@ private fun doRefresh(project: Project, projects: List<CargoProjectImpl>): Compl
 }
 
 private fun setupProjectRoots(project: Project, cargoProjects: List<CargoProject>) {
-    ApplicationManager.getApplication().invokeAndWait {
+    invokeAndWaitIfNeeded {
         runWriteAction {
             if (project.isDisposed) return@runWriteAction
             ProjectRootManagerEx.getInstanceEx(project).mergeRootsChangesDuring {

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -10,6 +10,7 @@ import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
@@ -247,7 +248,7 @@ open class CargoProjectsServiceImpl(
         // instead of `modifyProjects` for this reason
         projects.updateSync { _ -> loaded }
             .whenComplete { _, _ ->
-                ApplicationManager.getApplication().invokeLater { refreshAllProjects() }
+                invokeLater { refreshAllProjects() }
             }
     }
 

--- a/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoToolWindow.kt
+++ b/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoToolWindow.kt
@@ -8,8 +8,8 @@ package org.rust.cargo.project.toolwindow
 import com.intellij.ide.DefaultTreeExpander
 import com.intellij.ide.TreeExpander
 import com.intellij.openapi.actionSystem.*
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.SimpleToolWindowPanel
@@ -91,14 +91,14 @@ class CargoToolWindow(
         with(project.messageBus.connect()) {
             subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsService.CargoProjectsListener {
                 override fun cargoProjectsUpdated(projects: Collection<CargoProject>) {
-                    ApplicationManager.getApplication().invokeLater {
+                    invokeLater {
                         projectStructure.updateCargoProjects(projects.sortedBy { it.manifest })
                     }
                 }
             })
         }
 
-        ApplicationManager.getApplication().invokeLater {
+        invokeLater {
             projectStructure.updateCargoProjects(project.cargoProjects.allProjects.sortedBy { it.manifest })
         }
     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoTestCommandRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoTestCommandRunner.kt
@@ -16,7 +16,7 @@ import com.intellij.execution.runners.AsyncProgramRunner
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.showRunContent
 import com.intellij.execution.ui.RunContentDescriptor
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.invokeLater
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.getBuildConfiguration
@@ -67,7 +67,7 @@ class CargoTestCommandRunner : AsyncProgramRunner<RunnerSettings>() {
             } else {
                 buildProcessHandler.addProcessListener(object : ProcessAdapter() {
                     override fun processTerminated(event: ProcessEvent) {
-                        ApplicationManager.getApplication().invokeLater {
+                        invokeLater {
                             exitCode.setResult(buildProcessHandler.exitCode)
                         }
                     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
@@ -11,7 +11,7 @@ import com.intellij.execution.filters.Filter
 import com.intellij.execution.ui.RunContentManager
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DataContext
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.invokeAndWaitIfNeeded
 import com.intellij.openapi.project.Project
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
@@ -61,7 +61,7 @@ fun Project.buildProject() {
     }
 
     // Initialize run content manager
-    ApplicationManager.getApplication().invokeAndWait {
+    invokeAndWaitIfNeeded {
         RunContentManager.getInstance(this)
     }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
@@ -19,6 +19,7 @@ import com.intellij.execution.runners.ProgramRunner
 import com.intellij.notification.NotificationGroup
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.TransactionGuard
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.openapi.progress.ProcessCanceledException
@@ -262,7 +263,7 @@ object CargoBuildManager {
         if (messageType === MessageType.ERROR) {
             MessageView.SERVICE.getInstance(project) // register ToolWindowId.MESSAGES_WINDOW
             val manager = ToolWindowManager.getInstance(project)
-            ApplicationManager.getApplication().invokeLater {
+            invokeLater {
                 manager.notifyByBalloon(ToolWindowId.MESSAGES_WINDOW, messageType, notificationContent)
             }
         }

--- a/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
@@ -21,7 +21,7 @@ import com.intellij.execution.runners.AsyncProgramRunner
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.showRunContent
 import com.intellij.execution.ui.RunContentDescriptor
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
@@ -143,7 +143,7 @@ abstract class RsAsyncRunner(
 
         processForUser.addProcessListener(CapturingProcessAdapter(processForUserOutput))
 
-        ApplicationManager.getApplication().invokeLater {
+        invokeLater {
             if (!checkToolchainConfigured(project)) {
                 promise.setResult(null)
                 return@invokeLater

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -16,11 +16,11 @@ import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.process.ProcessOutput
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapiext.Testmark
+import com.intellij.openapiext.isDispatchThread
 import com.intellij.util.execution.ParametersListUtil
 import com.intellij.util.net.HttpConfigurable
 import com.intellij.util.text.SemVer
@@ -417,7 +417,7 @@ class Cargo(private val cargoExecutable: Path) {
                 return !installed
             }
 
-            val needInstall = if (ApplicationManager.getApplication().isDispatchThread) {
+            val needInstall = if (isDispatchThread) {
                 project.computeWithCancelableProgress("Checking if $crateName is installed...", ::isNotInstalled)
             } else {
                 isNotInstalled()

--- a/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterPass.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterPass.kt
@@ -11,8 +11,8 @@ import com.intellij.codeHighlighting.TextEditorHighlightingPassRegistrar
 import com.intellij.codeInsight.daemon.impl.*
 import com.intellij.lang.annotation.AnnotationSession
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
@@ -114,7 +114,7 @@ class RsExternalLinterPass(
 
     private fun doFinish(highlights: List<HighlightInfo>) {
         val document = document ?: return
-        ApplicationManager.getApplication().invokeLater({
+        invokeLater(ModalityState.stateForComponent(editor.component)) {
             if (Disposer.isDisposed(disposable)) return@invokeLater
             UpdateHighlightersUtil.setHighlightersToEditor(
                 myProject,
@@ -126,7 +126,7 @@ class RsExternalLinterPass(
                 id
             )
             DaemonCodeAnalyzerEx.getInstanceEx(myProject).fileStatusMap.markFileUpToDate(document, id)
-        }, ModalityState.stateForComponent(editor.component))
+        }
     }
 
     private val highlights: List<HighlightInfo>

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
@@ -5,10 +5,9 @@
 
 package org.rust.ide.console
 
-import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.project.Project
-import com.intellij.ui.GuiUtils
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.descendantOfTypeStrict
@@ -27,11 +26,11 @@ class RsConsoleCodeFragmentContext {
     fun updateContext(project: Project, codeFragment: RsReplCodeFragment) {
         val allCommandsText = getAllCommandsText()
 
-        GuiUtils.invokeLaterIfNeeded({
-            ApplicationManager.getApplication().runWriteAction {
+        runInEdt {
+            runWriteAction {
                 codeFragment.context = createContext(project, codeFragment.crateRoot as RsFile?, allCommandsText)
             }
-        }, ModalityState.defaultModalityState())
+        }
     }
 
     private fun getAllCommandsText(): String {

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleRunner.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleRunner.kt
@@ -17,9 +17,9 @@ import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.TransactionGuard
 import com.intellij.openapi.application.invokeLater
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.actions.ScrollToTheEndToolbarAction
 import com.intellij.openapi.progress.ProgressIndicator
@@ -27,7 +27,6 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
-import com.intellij.ui.GuiUtils
 import com.intellij.ui.JBColor
 import com.intellij.util.ui.JBEmptyBorder
 import com.intellij.util.ui.MessageCategory
@@ -222,9 +221,9 @@ class RsConsoleRunner(project: Project) :
                     processHandler.waitFor()
                 }
 
-                GuiUtils.invokeLaterIfNeeded({
+                runInEdt {
                     RsConsoleRunner(project).run(true)
-                }, ModalityState.defaultModalityState())
+                }
             }
         }.queue()
     }

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleRunner.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleRunner.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.TransactionGuard
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.actions.ScrollToTheEndToolbarAction
 import com.intellij.openapi.progress.ProgressIndicator
@@ -195,7 +196,7 @@ class RsConsoleRunner(project: Project) :
     }
 
     private fun connect() {
-        ApplicationManager.getApplication().invokeLater {
+        invokeLater {
             consoleView.executeActionHandler = consoleExecuteActionHandler
 
             consoleExecuteActionHandler.isEnabled = true

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleRunner.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleRunner.kt
@@ -16,10 +16,7 @@ import com.intellij.ide.errorTreeView.NewErrorTreeViewPanel
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.DefaultActionGroup
-import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.TransactionGuard
-import com.intellij.openapi.application.invokeLater
-import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.application.*
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.actions.ScrollToTheEndToolbarAction
 import com.intellij.openapi.progress.ProgressIndicator
@@ -30,7 +27,6 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.ui.JBColor
 import com.intellij.util.ui.JBEmptyBorder
 import com.intellij.util.ui.MessageCategory
-import com.intellij.util.ui.UIUtil
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.runconfig.command.workingDirectory
@@ -155,7 +151,7 @@ class RsConsoleRunner(project: Project) :
                         }
                     } catch (e: Exception) {
                         LOG.warn("Error running console", e)
-                        UIUtil.invokeAndWaitIfNeeded(Runnable { showErrorsInConsole(e) })
+                        invokeAndWaitIfNeeded { showErrorsInConsole(e) }
                     }
                 }
             })
@@ -163,9 +159,9 @@ class RsConsoleRunner(project: Project) :
     }
 
     override fun initAndRun() {
-        UIUtil.invokeAndWaitIfNeeded(Runnable {
+        invokeAndWaitIfNeeded {
             super.initAndRun()
-        })
+        }
     }
 
     override fun createProcessHandler(process: Process): OSProcessHandler =

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RenameFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RenameFix.kt
@@ -6,7 +6,7 @@
 package org.rust.ide.inspections.fixes
 
 import com.intellij.codeInspection.LocalQuickFixOnPsiElement
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -28,7 +28,7 @@ class RenameFix(
     override fun getFamilyName() = "Rename element"
 
     override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) =
-        ApplicationManager.getApplication().invokeLater {
+        invokeLater {
             RefactoringFactory.getInstance(project).createRename(startElement, newName).run()
         }
 }

--- a/src/main/kotlin/org/rust/ide/intentions/addFmtStringArgument/AddFmtStringArgumentIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/addFmtStringArgument/AddFmtStringArgumentIntention.kt
@@ -6,15 +6,18 @@
 package org.rust.ide.intentions.addFmtStringArgument
 
 import com.google.common.annotations.VisibleForTesting
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
 import org.rust.ide.intentions.RsElementBaseIntentionAction
 import org.rust.lang.core.macros.expansionContext
 import org.rust.lang.core.macros.isExprOrStmtContext
-import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.STRING_LITERAL
+import org.rust.lang.core.psi.RsExpressionCodeFragment
+import org.rust.lang.core.psi.RsLitExpr
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.runWriteCommandAction
 
@@ -55,7 +58,7 @@ class AddFmtStringArgumentIntention : RsElementBaseIntentionAction<AddFmtStringA
 
         val codeFragment = RsExpressionCodeFragment(project, CODE_FRAGMENT_TEXT, macroCallExpr)
 
-        if (ApplicationManager.getApplication().isUnitTestMode) {
+        if (isUnitTestMode) {
             addFmtStringArgument(project, editor, ctx, codeFragment, caretOffsetInLiteral, placeholderNumber)
         } else {
             RsAddFmtStringArgumentPopup.show(editor, project, codeFragment) {

--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsNavigationContributorBase.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsNavigationContributorBase.kt
@@ -6,9 +6,9 @@
 package org.rust.ide.navigation.goto
 
 import com.intellij.navigation.NavigationItem
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapiext.isInternal
 import com.intellij.psi.search.EverythingGlobalScope
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
@@ -95,7 +95,7 @@ private val LOG = Logger.getInstance(RsNavigationContributorBase::class.java)
  * (in the internal mode only) to catch the situation when it will become non null.
  */
 private fun checkFilter(filter: IdFilter?) {
-    if (ApplicationManager.getApplication().isInternal && filter != null) {
+    if (isInternal && filter != null) {
         LOG.error("IdFilter is supposed to be null", Throwable())
     }
 }

--- a/src/main/kotlin/org/rust/ide/notifications/DetachedFileNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/DetachedFileNotificationProvider.kt
@@ -5,11 +5,11 @@
 
 package org.rust.ide.notifications
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapiext.isDispatchThread
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -42,7 +42,7 @@ class DetachedFileNotificationProvider(project: Project) : RsNotificationProvide
         editor: FileEditor,
         project: Project
     ): RsEditorNotificationPanel? {
-        if (isUnitTestMode && !ApplicationManager.getApplication().isDispatchThread) return null
+        if (isUnitTestMode && !isDispatchThread) return null
         if (file.isNotRustFile || isNotificationDisabled(file)) return null
 
         val cargoProjects = project.cargoProjects

--- a/src/main/kotlin/org/rust/ide/notifications/NoCargoProjectNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/NoCargoProjectNotificationProvider.kt
@@ -5,11 +5,11 @@
 
 package org.rust.ide.notifications
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapiext.isDispatchThread
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.ui.EditorNotificationPanel
 import org.rust.cargo.project.model.*
@@ -35,7 +35,7 @@ class NoCargoProjectNotificationProvider(project: Project) : RsNotificationProvi
         editor: FileEditor,
         project: Project
     ): RsEditorNotificationPanel? {
-        if (isUnitTestMode && !ApplicationManager.getApplication().isDispatchThread) return null
+        if (isUnitTestMode && !isDispatchThread) return null
         if (!(file.isRustFile || file.isCargoToml) || isNotificationDisabled(file)) return null
 
         val cargoProjects = project.cargoProjects

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -24,6 +24,7 @@ import com.intellij.openapi.util.ModificationTracker
 import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.openapi.vfs.*
 import com.intellij.openapiext.Testmark
+import com.intellij.openapiext.isDispatchThread
 import com.intellij.openapiext.isHeadlessEnvironment
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
@@ -836,7 +837,7 @@ private class MacroExpansionTaskQueue(val project: Project) {
 
     fun ensureUpToDate() {
         check(isUnitTestMode)
-        if (ApplicationManager.getApplication().isDispatchThread && !processor.isEmpty) {
+        if (isDispatchThread && !processor.isEmpty) {
             checkWriteAccessNotAllowed()
             if (isProcessingUpdates) return
             isProcessingUpdates = true

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.macros
 
 import com.intellij.openapi.application.AccessToken
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
@@ -20,6 +19,7 @@ import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ex.ProgressIndicatorEx
+import com.intellij.openapiext.isDispatchThread
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.containers.ContainerUtil
@@ -248,7 +248,7 @@ abstract class MacroExpansionTaskBase(
             // This callback will be executed regardless of success or exceptional result
             if (success != null) {
                 // Success
-                if (ApplicationManager.getApplication().isDispatchThread) {
+                if (isDispatchThread) {
                     pool.execute(::runNextStep)
                 } else {
                     runNextStep()

--- a/src/main/kotlin/org/rust/openapiext/DelayedBackgroundableProcessIndicator.kt
+++ b/src/main/kotlin/org/rust/openapiext/DelayedBackgroundableProcessIndicator.kt
@@ -5,7 +5,7 @@
 
 package org.rust.openapiext
 
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.progress.PerformInBackgroundOption
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.progress.TaskInfo
@@ -33,11 +33,11 @@ class DelayedBackgroundableProcessIndicator(task: Task.Backgroundable, delay: In
 
     init {
         val timer = TimerUtil.createNamedTimer("DelayedBackgroundableProcessIndicator timer", delay) {
-            ApplicationManager.getApplication().invokeLater({
+            invokeLater(modalityState) {
                 if (isRunning && !isFinishCalled) {
                     background()
                 }
-            }, modalityState)
+            }
         }
         timer.isRepeats = false
         timer.start()

--- a/src/main/kotlin/org/rust/openapiext/ui.kt
+++ b/src/main/kotlin/org/rust/openapiext/ui.kt
@@ -6,8 +6,8 @@
 package org.rust.openapiext
 
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.TextComponentAccessor
@@ -34,11 +34,11 @@ class UiDebouncer(
         alarm.cancelAllRequests()
         alarm.addRequest({
             val r = onPooledThread()
-            ApplicationManager.getApplication().invokeLater({
+            invokeLater(ModalityState.any()) {
                 if (!Disposer.isDisposed(parentDisposable)) {
                     onUiThread(r)
                 }
-            }, ModalityState.any())
+            }
         }, delayMillis)
     }
 }


### PR DESCRIPTION
Get rid of various old-fashioned `ApplicationManager` usages:
* Replace `ApplicationManager.getApplication().invokeLater` with `invokeLater`
* Replace `ApplicationManager.getApplication().invokeAndWait` with `invokeAndWaitIfNeeded`
* Introduce `isDispatchThread` and use instead of `ApplicationManager.getApplication().isDispatchThread` 
* Introduce `isInternal` and use instead of `ApplicationManager.getApplication().isInternal`

Get rid of potentially incorrect `GuiUtils` and `UIUtil` usages:
* Replace `GuiUtils.invokeLaterIfNeeded` with `runInEdt`
* Replace `UIUtil.invokeAndWaitIfNeeded` with `invokeAndWaitIfNeeded`