### PR TITLE
PERF: don't parse function bodies during indexing

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -454,7 +454,7 @@ Function ::= OuterAttr*
              FnParameters
              RetType?
              WhereClause?
-             (';' | ShallowBlock | never SimpleBlock)
+             (';' | ShallowBlock)
 {
   pin = 'identifier'
   implements = [ "org.rust.lang.core.psi.ext.RsQualifiedNamedElement"

--- a/src/main/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactory.kt
+++ b/src/main/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactory.kt
@@ -16,10 +16,7 @@ import org.rust.lang.core.cfg.ExitPoint
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.Q
 import org.rust.lang.core.psi.RsElementTypes.RETURN
-import org.rust.lang.core.psi.ext.ancestors
-import org.rust.lang.core.psi.ext.elementType
-import org.rust.lang.core.psi.ext.isAsync
-import org.rust.lang.core.psi.ext.isTry
+import org.rust.lang.core.psi.ext.*
 
 class RsHighlightExitPointsHandlerFactory : HighlightUsagesHandlerFactoryBase() {
     override fun createHighlightUsagesHandler(editor: Editor, file: PsiFile, target: PsiElement): HighlightUsagesHandlerBase<*>? {

--- a/src/main/kotlin/org/rust/ide/hints/RsDeclarationRangeHandler.kt
+++ b/src/main/kotlin/org/rust/ide/hints/RsDeclarationRangeHandler.kt
@@ -8,10 +8,7 @@ package org.rust.ide.hints
 import com.intellij.codeInsight.hint.DeclarationRangeHandler
 import com.intellij.openapi.util.TextRange
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.endOffset
-import org.rust.lang.core.psi.ext.getPrevNonCommentSibling
-import org.rust.lang.core.psi.ext.startOffset
-import org.rust.lang.core.psi.ext.union
+import org.rust.lang.core.psi.ext.*
 
 class RsStructItemDeclarationRangeHandler : DeclarationRangeHandler<RsStructItem> {
     override fun getDeclarationRange(container: RsStructItem): TextRange {

--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
@@ -19,6 +19,7 @@ import com.intellij.usageView.UsageInfo
 import org.rust.ide.refactoring.RsRenameProcessor
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsAbstractableOwner
+import org.rust.lang.core.psi.ext.block
 import org.rust.lang.core.psi.ext.owner
 import org.rust.lang.core.psi.ext.valueParameters
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -80,10 +80,10 @@ val RsDocAndAttributeOwner.queryAttributes: QueryAttributes
  * **Do not instantiate directly**, use [RsDocAndAttributeOwner.queryAttributes] instead.
  */
 class QueryAttributes(
-    private val psi: RsDocAndAttributeOwner
+    private val psi: RsDocAndAttributeOwner,
+    private val attributes: Sequence<RsAttr> = (psi as? RsInnerAttributeOwner)?.innerAttrList.orEmpty().asSequence() +
+        (psi as? RsOuterAttributeOwner)?.outerAttrList.orEmpty().asSequence()
 ) {
-    private val attributes: Sequence<RsAttr> = Sequence { (psi as? RsInnerAttributeOwner)?.innerAttrList.orEmpty().iterator() } +
-        Sequence { (psi as? RsOuterAttributeOwner)?.outerAttrList.orEmpty().iterator() }
 
     // #[doc(hidden)]
     val isDocHidden: Boolean get() = hasAttributeWithArg("doc", "hidden")

--- a/src/test/kotlin/org/rust/lang/core/cfg/RsControlFlowGraphTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/cfg/RsControlFlowGraphTest.kt
@@ -9,6 +9,7 @@ import junit.framework.ComparisonFailure
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.ext.block
 import org.rust.lang.core.psi.ext.descendantsOfType
 import org.rust.lang.core.types.regions.getRegionScopeTree
 
@@ -815,7 +816,7 @@ class RsControlFlowGraphTest : RsTestBase() {
 
     fun `test shorthand struct literal`() = testCFG("""
         struct S { x: i32 }
-        
+
         fn foo(x: i32) {
             S { x };
         }
@@ -831,7 +832,7 @@ class RsControlFlowGraphTest : RsTestBase() {
 
     fun `test struct literal dot dot syntax`() = testCFG("""
         struct S { x: i32, y: i32 }
-        
+
         fn main() {
             S { x, ..s };
         }

--- a/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt
@@ -19,7 +19,6 @@ class RsStubTest : RsTestBase() {
         RsFileStub
           FUNCTION:RsFunctionStub
             VALUE_PARAMETER_LIST:RsPlaceholderStub
-            BLOCK:RsPlaceholderStub
     """)
 
     fun `test expression is not stubbed inside statement`() = doTest("""
@@ -28,7 +27,6 @@ class RsStubTest : RsTestBase() {
         RsFileStub
           FUNCTION:RsFunctionStub
             VALUE_PARAMETER_LIST:RsPlaceholderStub
-            BLOCK:RsPlaceholderStub
     """)
 
     fun `test literal is not stubbed inside function tail expr`() = doTest("""
@@ -41,7 +39,6 @@ class RsStubTest : RsTestBase() {
               TYPE_REFERENCE:RsPlaceholderStub
                 BASE_TYPE:RsBaseTypeStub
                   PATH:RsPathStub
-            BLOCK:RsPlaceholderStub
     """)
 
     fun `test expression is not stubbed inside function tail expr`() = doTest("""
@@ -54,7 +51,6 @@ class RsStubTest : RsTestBase() {
               TYPE_REFERENCE:RsPlaceholderStub
                 BASE_TYPE:RsBaseTypeStub
                   PATH:RsPathStub
-            BLOCK:RsPlaceholderStub
     """)
 
     fun `test lifetime is stubbed inside function signature`() = doTest("""
@@ -76,7 +72,6 @@ class RsStubTest : RsTestBase() {
               TYPE_REFERENCE:RsPlaceholderStub
                 BASE_TYPE:RsBaseTypeStub
                   PATH:RsPathStub
-            BLOCK:RsPlaceholderStub
     """)
 
     fun `test literal is not stubbed inside closure tail expr`() = doTest("""
@@ -87,7 +82,6 @@ class RsStubTest : RsTestBase() {
         RsFileStub
           FUNCTION:RsFunctionStub
             VALUE_PARAMETER_LIST:RsPlaceholderStub
-            BLOCK:RsPlaceholderStub
     """)
 
     fun `test expression is not stubbed inside closure tail expr`() = doTest("""
@@ -98,7 +92,6 @@ class RsStubTest : RsTestBase() {
         RsFileStub
           FUNCTION:RsFunctionStub
             VALUE_PARAMETER_LIST:RsPlaceholderStub
-            BLOCK:RsPlaceholderStub
     """)
 
     fun `test literal is stubbed inside const body`() = doTest("""
@@ -153,6 +146,44 @@ class RsStubTest : RsTestBase() {
                   LIT_EXPR:RsLitExprStub
                   BINARY_OP:RsBinaryOpStub
                   LIT_EXPR:RsLitExprStub
+    """)
+
+    fun `test function block is stubbed if contains item`() = doTest("""
+        fn foo() {
+            struct S;
+        }
+    """, """
+        RsFileStub
+          FUNCTION:RsFunctionStub
+            VALUE_PARAMETER_LIST:RsPlaceholderStub
+            BLOCK:RsPlaceholderStub
+              STRUCT_ITEM:RsStructItemStub
+    """)
+
+    fun `test function block is stubbed if contains union`() = doTest("""
+        fn foo() {
+            union Foo {}
+        }
+    """, """
+        RsFileStub
+          FUNCTION:RsFunctionStub
+            VALUE_PARAMETER_LIST:RsPlaceholderStub
+            BLOCK:RsPlaceholderStub
+              STRUCT_ITEM:RsStructItemStub
+                BLOCK_FIELDS:RsPlaceholderStub
+    """)
+
+    fun `test function block is stubbed if contains inner attrs`() = doTest("""
+        fn foo() {
+            #![foo]
+        }
+    """, """
+        RsFileStub
+          FUNCTION:RsFunctionStub
+            VALUE_PARAMETER_LIST:RsPlaceholderStub
+            BLOCK:RsPlaceholderStub
+              INNER_ATTR:RsInnerAttrStub
+                META_ITEM:RsMetaItemStub
     """)
 
     fun `test nested block is stubbed if contains items`() = doTest("""
@@ -218,7 +249,7 @@ class RsStubTest : RsTestBase() {
             mod bar {
                 include!("a.rs");
             }
-        }     
+        }
     """, """
         RsFileStub
           FUNCTION:RsFunctionStub
@@ -232,7 +263,7 @@ class RsStubTest : RsTestBase() {
     """)
 
     fun `test expressions are stubs inside file`() = doTest("""
-        include!("foo.rs");    
+        include!("foo.rs");
     """, """
         RsFileStub
           MACRO_CALL:RsMacroCallStub

--- a/src/test/kotlin/org/rustPerformanceTests/RsHighlightingPerformanceTest.kt
+++ b/src/test/kotlin/org/rustPerformanceTests/RsHighlightingPerformanceTest.kt
@@ -12,6 +12,7 @@ import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.macros.macroExpansionManager
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.ext.RsReferenceElement
+import org.rust.lang.core.psi.ext.block
 import org.rust.lang.core.psi.ext.descendantsOfType
 import org.rust.stdext.Timings
 import org.rust.stdext.repeatBenchmark

--- a/src/test/kotlin/org/rustSlowTests/RsLazyCodeBlockIsNotExpandedDuringStubBuildingTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsLazyCodeBlockIsNotExpandedDuringStubBuildingTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rustSlowTests
+
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileVisitor
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.StubBasedPsiElement
+import com.intellij.psi.SyntaxTraverser
+import com.intellij.psi.impl.DebugUtil
+import com.intellij.psi.impl.source.tree.LazyParseableElement
+import com.intellij.psi.impl.source.tree.TreeUtil
+import com.intellij.util.LocalTimeCounter
+import junit.framework.TestCase
+import org.rust.RsTestBase
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.RsFileType
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.descendantsOfType
+import org.rust.lang.core.stubs.RsFileStub
+import org.rustPerformanceTests.fullyRefreshDirectoryInUnitTests
+
+class RsLazyCodeBlockIsNotExpandedDuringStubBuildingTest : RsTestBase() {
+    override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
+
+    fun `test stdlib source`() {
+        val sources = rustSrcDir()
+        checkRustFiles(
+            sources,
+            ignored = setOf("tests", "test", "doc", "etc", "grammar")
+        )
+    }
+
+    private fun checkRustFiles(directory: VirtualFile, ignored: Collection<String>) {
+        val files = collectRustFiles(directory, ignored)
+            .mapNotNull { it.toInMemoryPsiFile() as? RsFile }
+
+        var numBlocks = 0
+        var numParsedBlocks = 0
+
+        for (psi in files) {
+            parseFile(psi)
+            val blocks = SyntaxTraverser.psiTraverser(psi).expand { it !is RsBlock }.filterIsInstance<RsBlock>()
+
+            blocks.forEach {
+                check(it.parent !is RsFunction || !it.isParsed) {
+                    "Expected NOT parsed block: `${it.text}`"
+                }
+            }
+
+            val stubBuilder = RsFileStub.Type.builder
+            val stub1 = stubBuilder.buildStubTree(psi)
+
+            for (block in blocks) {
+                if (block.parent !is RsFunction) continue
+                numBlocks++
+                val skipChildProcessing = stubBuilder.skipChildProcessingWhenBuildingStubs(block.node.treeParent, block.node)
+                val blockIsParsed = block.isParsed
+
+                check(skipChildProcessing == !blockIsParsed) {
+                    "Sanity check failed; skipChildProcessing = $skipChildProcessing, blockIsParsed = $blockIsParsed"
+                }
+                parseBlock(block)
+
+                val blockIsStubbed = block.elementType.shouldCreateStub(block.node)
+
+                val stubbedElements = block.descendantsOfType<StubBasedPsiElement<*>>()
+                    .filter { it.elementType.shouldCreateStub(it.node) }
+                val containsStubbedElements = stubbedElements.isNotEmpty()
+
+                // Macros can contain any tokens, so our heuristic can give false-positives; allow them
+                val parsingAllowed = containsStubbedElements ||
+                    block.descendantsOfType<RsMacroCall>().isNotEmpty() ||
+                    block.descendantsOfType<RsMacro>().isNotEmpty() ||
+                    block.descendantsOfType<RsMacro2>().isNotEmpty()
+
+                if (blockIsParsed) {
+                    numParsedBlocks++
+                    check(parsingAllowed) { "Expected NOT parsed block after stub tree building: `${block.text}`" }
+                    if (containsStubbedElements) {
+                        check(blockIsStubbed) {
+                            "Expected `block.elementType.shouldCreateStub` returning `true` " +
+                                "(b/c the block contains stubbed elements), got `false` for block: `${block.text}`"
+                        }
+                    }
+                } else {
+                    check(!containsStubbedElements) {
+                        "Expected PARSED block after stub tree building: `${block.text}`\n" +
+                            "Because it contains elements that should be stubbed: " +
+                            stubbedElements.joinToString { "`${it.text}`" }
+                    }
+                    check(!blockIsStubbed) {
+                        "Expected `block.elementType.shouldCreateStub` returning `false` " +
+                            "(b/c the block is not parsed), got `true` for block: `${block.text}`"
+                    }
+                }
+            }
+
+            // Check stubs are the same after full reparse
+            val stub2 = stubBuilder.buildStubTree(psi)
+            TestCase.assertEquals(DebugUtil.stubTreeToString(stub1), DebugUtil.stubTreeToString(stub2))
+        }
+
+        println("Blocks: $numBlocks, parsed: $numParsedBlocks (${(numParsedBlocks * 1000 / numBlocks)/10.0}%)")
+    }
+
+    private fun parseFile(psi: RsFile) { // profiler hint
+        TreeUtil.ensureParsed(psi.node)
+    }
+
+    private fun parseBlock(psi: RsBlock) { // profiler hint
+        TreeUtil.ensureParsed(psi.node)
+    }
+
+    private fun collectRustFiles(directory: VirtualFile, ignored: Collection<String>): List<VirtualFile> {
+        val files = mutableListOf<VirtualFile>()
+        fullyRefreshDirectoryInUnitTests(directory)
+        VfsUtilCore.visitChildrenRecursively(directory, object : VirtualFileVisitor<Void>() {
+            override fun visitFileEx(file: VirtualFile): Result {
+                if (file.isDirectory && file.name in ignored) return SKIP_CHILDREN
+                if (file.fileType != RsFileType) return CONTINUE
+
+                files += file
+
+                return CONTINUE
+            }
+        })
+        return files
+    }
+
+    private fun VirtualFile.toInMemoryPsiFile(): PsiFile {
+        return PsiFileFactory.getInstance(project).createFileFromText(
+            name,
+            fileType,
+            String(contentsToByteArray()),
+            LocalTimeCounter.currentTime(),
+            true,
+            false
+        )
+    }
+
+    private val RsBlock.isParsed get() = (node as LazyParseableElement).isParsed
+
+    private fun rustSrcDir(): VirtualFile = projectDescriptor.stdlib!!
+}


### PR DESCRIPTION
Now during indexation, we only parse function bodies that can contain local items (that should be indexed). I measured that for most projects now only about 3% function bodies should be parsed, i.e. other 97% should not. This speeds up indexation by about 20%.
Closes #4355