### PR TITLE
INT: use text with aliases in Type Info intention

### DIFF
--- a/src/main/kotlin/org/rust/ide/hints/RsExpressionTypeProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/RsExpressionTypeProvider.kt
@@ -9,6 +9,7 @@ import com.intellij.lang.ExpressionTypeProvider
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.FakePsiElement
+import org.rust.ide.presentation.textWithAliasNames
 import org.rust.lang.core.macros.findExpansionElementOrSelf
 import org.rust.lang.core.macros.findMacroCallExpandedFromNonRecursive
 import org.rust.lang.core.macros.mapRangeFromExpansionToCallBodyStrict
@@ -35,7 +36,7 @@ class RsExpressionTypeProvider : ExpressionTypeProvider<PsiElement>() {
 
     override fun getInformationHint(element: PsiElement): String {
         val type = getType(element)
-        return type.toString().escaped
+        return type.textWithAliasNames.escaped
     }
 
     private fun getType(element: PsiElement): Ty = when (element) {

--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -39,7 +39,7 @@ val Ty.insertionSafeTextWithLifetimes: String
     get() = TypeRenderer.INSERTION_SAFE_WITH_LIFETIMES.render(this)
 
 val Ty.textWithAliasNames: String
-    @TestOnly get() = TypeRenderer.WITH_ALIASES.render(this)
+    get() = TypeRenderer.WITH_ALIASES.render(this)
 
 fun tyToString(ty: Ty): String = TypeRenderer.DEFAULT.render(ty)
 

--- a/src/test/kotlin/org/rust/ide/hints/RsExpressionTypeProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RsExpressionTypeProviderTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints
+
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+import org.rust.openapiext.escaped
+
+
+class RsExpressionTypeProviderTest : RsTestBase() {
+    fun `test simple type`() = doTest("""
+        fn foo() {
+            let /*caret*/x = 5u32;
+        }
+    """, "u32")
+
+    fun `test generic type`() = doTest("""
+        struct S<T> { t: T }
+
+        fn foo<T>(c: S<T>) {
+            let /*caret*/b = c;
+        }
+    """, "S<T>")
+
+    fun `test complex generic type`() = doTest("""
+        struct S<T, U, V=u32> { t: T, u: U, v: V }
+
+        fn foo<T, U>(c: S<T, U>) {
+            let /*caret*/b = c;
+        }
+    """, "S<T, U, u32>")
+
+    fun `test ref type`() = doTest("""
+        fn foo(c: &mut u32) {
+            let /*caret*/b = c;
+        }
+    """, "&mut u32")
+
+    fun `test associated type`() = doTest("""
+        trait Trait {
+            type Item = ();
+        }
+
+        fn foo(c: Trait<Item=u32>) {
+            let /*caret*/b = c;
+        }
+    """, "Trait<Item=u32>")
+
+    fun `test associated generic type`() = doTest("""
+        trait Trait {
+            type Item = ();
+        }
+
+        fn foo<T>(c: Trait<Item=T>) {
+            let /*caret*/b = c;
+        }
+    """, "Trait<Item=T>")
+
+    fun `test aliased type`() = doTest("""
+        struct S<T> { t: T }
+
+        type BoxedS<T> = S<T>;
+
+        fn foo<T>(c: &BoxedS<T>) {
+            let /*caret*/b = c;
+        }
+    """, "&BoxedS<T>")
+
+    private fun doTest(@Language("Rust") code: String, type: String) {
+        InlineFile(code).withCaret()
+
+        val element = myFixture.elementAtCaret
+
+        val provider = RsExpressionTypeProvider()
+        val expressions = provider.getExpressionsAt(element)
+        assertEquals(type.escaped, expressions.joinToString(", ") { provider.getInformationHint(it) })
+    }
+}


### PR DESCRIPTION
I replaced `toString()` with `insertionSafeTextWithAliases` to show aliases in the `Type Info` hint. I didn't find any tests for this, so I'm not sure if this is enough. @Undin thoughts?

Fixes https://github.com/intellij-rust/intellij-rust/issues/4366