### PR TITLE
RES: support impls for aliased types

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
@@ -18,7 +18,6 @@ import org.rust.lang.core.resolve.RsProcessor
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsImplItemStub
 import org.rust.lang.core.types.TyFingerprint
-import org.rust.lang.core.types.ty.Ty
 import org.rust.openapiext.getElements
 
 class RsImplIndex : AbstractStubIndex<TyFingerprint, RsImplItem>() {
@@ -27,29 +26,24 @@ class RsImplIndex : AbstractStubIndex<TyFingerprint, RsImplItem>() {
     override fun getKeyDescriptor(): KeyDescriptor<TyFingerprint> = TyFingerprint.KeyDescriptor
 
     companion object {
+        /** return impls for generic type `impl<T> Trait for T {}` */
+        fun findFreeImpls(project: Project, processor: RsProcessor<RsCachedImplItem>): Boolean {
+            return findPotentialImpls(project, TyFingerprint.TYPE_PARAMETER_FINGERPRINT, processor)
+        }
+
         /**
          * Note this method may return false positives
          * @see TyFingerprint
          */
-        fun findPotentialImpls(project: Project, target: Ty, processor: RsProcessor<RsCachedImplItem>): Boolean {
-            val fingerprint = TyFingerprint.create(target)
-            if (fingerprint != null && findPotentialImplsInner(project, fingerprint, processor)) return true
-            return findPotentialImplsInner(project, TyFingerprint.TYPE_PARAMETER_FINGERPRINT, processor)
-        }
-
-        /** return impls for generic type `impl<T> Trait for T {}` */
-        fun findFreeImpls(project: Project, processor: RsProcessor<RsCachedImplItem>): Boolean {
-            return findPotentialImplsInner(project, TyFingerprint.TYPE_PARAMETER_FINGERPRINT, processor)
-        }
-
-        private fun findPotentialImplsInner(
+        fun findPotentialImpls(
             project: Project,
             tyf: TyFingerprint,
             processor: RsProcessor<RsCachedImplItem>
         ): Boolean {
             val impls = getElements(KEY, tyf, project, RsWithMacrosProjectScope(project))
-            // I intentionally use `getElements` with intermediate collection instead of `StubIndex.processElements`
-            // to simplify profiling
+
+            // Note that `getElements` is intentionally used with intermediate collection instead of
+            // `StubIndex.processElements` in order to simplify profiling
             return impls.any {
                 val cachedImpl = RsCachedImplItem.forImpl(project, it)
                 cachedImpl.isValid && processor(cachedImpl)

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsTypeAliasIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsTypeAliasIndex.kt
@@ -1,0 +1,84 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve.indexes
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.util.registry.RegistryValue
+import com.intellij.psi.stubs.AbstractStubIndex
+import com.intellij.psi.stubs.IndexSink
+import com.intellij.psi.stubs.StubIndexKey
+import com.intellij.util.io.KeyDescriptor
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.ide.search.RsWithMacrosProjectScope
+import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.psi.ext.RsAbstractableOwner
+import org.rust.lang.core.psi.ext.containingCargoPackage
+import org.rust.lang.core.psi.ext.owner
+import org.rust.lang.core.psi.isValidProjectMember
+import org.rust.lang.core.resolve.RsProcessor
+import org.rust.lang.core.stubs.RsFileStub
+import org.rust.lang.core.stubs.RsTypeAliasStub
+import org.rust.lang.core.types.TyFingerprint
+import org.rust.openapiext.getElements
+
+class RsTypeAliasIndex : AbstractStubIndex<TyFingerprint, RsTypeAlias>() {
+    override fun getVersion(): Int = RsFileStub.Type.stubVersion
+    override fun getKey(): StubIndexKey<TyFingerprint, RsTypeAlias> = KEY
+    override fun getKeyDescriptor(): KeyDescriptor<TyFingerprint> = TyFingerprint.KeyDescriptor
+
+    companion object {
+        fun findPotentialAliases(
+            project: Project,
+            tyf: TyFingerprint,
+            processor: RsProcessor<RsTypeAlias>
+        ): Boolean {
+            // Note that `getElements` is intentionally used with intermediate collection instead of
+            // `StubIndex.processElements` in order to simplify profiling
+            val aliases = getElements(KEY, tyf, project, RsWithMacrosProjectScope(project))
+                .filter { it.owner is RsAbstractableOwner.Free && it.isValidProjectMember }
+
+            // This is basically a hack to make some crates (winapi 0.2) work in a reasonable amount of time.
+            // If the number of aliases exceeds the threshold, we prefer ones from stdlib and a workspace over
+            // aliases from dependencies
+            val threshold = ALIAS_COUNT_THRESHOLD.asInteger()
+            val filteredAliases = if (aliases.size <= threshold) {
+                aliases
+            } else {
+                val stdlibAliases = mutableListOf<RsTypeAlias>()
+                val workspaceAliases = mutableListOf<RsTypeAlias>()
+                for (alias in aliases) {
+                    val packageOrigin = alias.containingCargoPackage?.origin ?: continue
+                    when (packageOrigin) {
+                        PackageOrigin.STDLIB -> stdlibAliases += alias
+                        PackageOrigin.WORKSPACE -> workspaceAliases += alias
+                        else -> Unit
+                    }
+                }
+                when {
+                    stdlibAliases.size + workspaceAliases.size <= threshold -> {
+                        stdlibAliases + workspaceAliases
+                    }
+                    stdlibAliases.size <= threshold -> stdlibAliases
+                    else -> return false
+                }
+            }
+
+            return filteredAliases.any { processor(it) }
+        }
+
+        fun index(stub: RsTypeAliasStub, sink: IndexSink) {
+            val alias = stub.psi
+            val typeRef = alias.typeReference ?: return
+            TyFingerprint.create(typeRef, emptyList())
+                .forEach { sink.occurrence(KEY, it) }
+        }
+
+        private val ALIAS_COUNT_THRESHOLD: RegistryValue = Registry.get("org.rust.lang.type.alias.threshold")
+        private val KEY: StubIndexKey<TyFingerprint, RsTypeAlias> =
+            StubIndexKey.createIndexKey("org.rust.lang.core.stubs.index.RsTypeAliasIndex")
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
@@ -10,10 +10,7 @@ import com.intellij.psi.stubs.IndexSink
 import org.rust.lang.core.psi.ext.RsAbstractableOwner
 import org.rust.lang.core.psi.ext.getOwner
 import org.rust.lang.core.psi.ext.stubParent
-import org.rust.lang.core.resolve.indexes.RsImplIndex
-import org.rust.lang.core.resolve.indexes.RsLangItemIndex
-import org.rust.lang.core.resolve.indexes.RsMacroCallIndex
-import org.rust.lang.core.resolve.indexes.RsMacroIndex
+import org.rust.lang.core.resolve.indexes.*
 import org.rust.lang.core.stubs.index.*
 
 fun IndexSink.indexExternCrate(stub: RsExternCrateItemStub) {
@@ -73,6 +70,7 @@ fun IndexSink.indexTypeAlias(stub: RsTypeAliasStub) {
     indexNamedStub(stub)
     if (stub.psi.getOwner(PsiElement::stubParent) !is RsAbstractableOwner.Impl) {
         indexGotoClass(stub)
+        RsTypeAliasIndex.index(stub, this)
     }
 }
 

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -822,6 +822,7 @@
         <stubIndex implementation="org.rust.lang.core.stubs.index.RsIncludeMacroIndex"/>
 
         <stubIndex implementation="org.rust.lang.core.resolve.indexes.RsImplIndex"/>
+        <stubIndex implementation="org.rust.lang.core.resolve.indexes.RsTypeAliasIndex"/>
         <stubIndex implementation="org.rust.lang.core.resolve.indexes.RsLangItemIndex"/>
         <stubIndex implementation="org.rust.lang.core.resolve.indexes.RsMacroIndex"/>
         <stubIndex implementation="org.rust.lang.core.resolve.indexes.RsMacroCallIndex"/>
@@ -881,6 +882,11 @@
 
         <consoleHistoryModelProvider implementation="org.rust.ide.console.RsConsoleHistoryModelProvider"/>
         <scratch.rootType implementation="org.rust.ide.console.RsConsoleRootType"/>
+
+        <!-- Registry keys -->
+
+        <registryKey key="org.rust.lang.type.alias.threshold" defaultValue="10" restartRequired="false"
+                     description="Maximum number of type aliases to take into account during `impl`s search"/>
 
     </extensions>
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -854,4 +854,14 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
             let a = f64::INFINITY;
         }              //^
     """)
+
+    fun `test impl for alias`() = checkByCode("""
+        struct X;
+        type Y = X;
+        impl Y { fn foo(&self) {} }
+                  //X
+        fn main() {
+            X.foo();
+        }   //^
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -746,6 +746,18 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ i32
     """)
 
+    fun `test infer generic argument from trait bound (aliased impl)`() = testExpr("""
+        struct S<X>(X);
+        type Alias<X> = S<X>;
+        trait Tr<Y> { fn foo(&self) -> Y; }
+        impl<Z> Tr<Z> for Alias<Z> { fn foo(&self) -> Z { unimplemented!() } }
+        fn bar<A, B: Tr<A>>(b: B) -> A { b.foo() }
+        fn main() {
+            let a = bar(S(1));
+            a;
+        } //^ i32
+    """)
+
     fun `test infer complex generic argument from trait bound`() = testExpr("""
         struct S<A>(A);
         trait Tr<B> { fn foo(&self) -> B; }


### PR DESCRIPTION
Fixes #2778

```rust
struct X;
type Y = X;
impl Y { fn foo(&self) {} }
          //X
fn main() {
    X.foo();
}   //^
```