### PR TITLE
INT: add support for type aliases in ImplementMembersFix

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -38,6 +38,9 @@ val Ty.insertionSafeTextWithAliases: String
 val Ty.insertionSafeTextWithLifetimes: String
     get() = TypeRenderer.INSERTION_SAFE_WITH_LIFETIMES.render(this)
 
+val Ty.insertionSafeTextWithAliasesAndLifetimes: String
+    get() = TypeRenderer.INSERTION_SAFE_WITH_ALIASES_AND_LIFETIMES.render(this)
+
 val Ty.textWithAliasNames: String
     @TestOnly get() = TypeRenderer.WITH_ALIASES.render(this)
 
@@ -217,6 +220,7 @@ private data class TypeRenderer(
         )
         val INSERTION_SAFE_WITH_ALIASES = INSERTION_SAFE.copy(useAliasNames = true)
         val INSERTION_SAFE_WITH_LIFETIMES: TypeRenderer = INSERTION_SAFE.copy(includeLifetimeArguments = true)
+        val INSERTION_SAFE_WITH_ALIASES_AND_LIFETIMES = INSERTION_SAFE.copy(useAliasNames = true, includeLifetimeArguments = true)
         val WITH_ALIASES: TypeRenderer = TypeRenderer(useAliasNames = true)
     }
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
@@ -118,7 +118,7 @@ private fun insertNewTraitMembers(
         }
     }
 
-    importTypeReferencesFromElements(existingMembers, selected, trait.subst)
+    importTypeReferencesFromElements(existingMembers, selected, trait.subst, true)
 
     if (needToSelect != null && editor != null) {
         selectElement(needToSelect, editor)

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiParserFacade
 import com.intellij.util.LocalTimeCounter
 import org.rust.ide.inspections.checkMatch.Pattern
+import org.rust.ide.presentation.insertionSafeTextWithAliasesAndLifetimes
 import org.rust.ide.presentation.insertionSafeTextWithLifetimes
 import org.rust.lang.RsFileType
 import org.rust.lang.core.macros.MacroExpansionContext
@@ -499,7 +500,7 @@ private fun RsFunction.getSignatureText(subst: Substitution): String? {
 private fun String.iff(cond: Boolean) = if (cond) this + " " else " "
 
 fun RsTypeReference.substAndGetText(subst: Substitution): String =
-    type.substitute(subst).insertionSafeTextWithLifetimes
+    type.substitute(subst).insertionSafeTextWithAliasesAndLifetimes
 
 private fun RsSelfParameter.substAndGetText(subst: Substitution): String =
     if (isExplicitType) {


### PR DESCRIPTION
This PR changes `RsTypeReference.substAndGetText` to support both lifetimes and aliases. It fixes alias generation in ImplementMembersFix, let's see what CI says about the rest of tests :)

Fixes: https://github.com/intellij-rust/intellij-rust/issues/3082