### PR TITLE
INT: AddConstructor intention

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/generateConstructor/GenerateConstructorHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generateConstructor/GenerateConstructorHandler.kt
@@ -18,6 +18,9 @@ import org.rust.lang.core.psi.ext.ancestorOrSelf
 import org.rust.lang.core.psi.ext.isTupleStruct
 import org.rust.lang.core.psi.ext.namedFields
 import org.rust.lang.core.psi.ext.positionalFields
+import org.rust.lang.core.types.Substitution
+import org.rust.lang.core.types.emptySubstitution
+import org.rust.lang.core.types.type
 import org.rust.openapiext.checkWriteAccessAllowed
 import org.rust.openapiext.checkWriteAccessNotAllowed
 
@@ -31,52 +34,90 @@ class GenerateConstructorAction : CodeInsightAction() {
         generateConstructorHandler.isValidFor(editor, file)
 }
 
+private data class Context(val struct: RsStructItem, val implBlock: RsImplItem? = null)
+
 class GenerateConstructorHandler : LanguageCodeInsightActionHandler {
-    override fun isValidFor(editor: Editor, file: PsiFile): Boolean = getStructItem(editor, file) != null
+    override fun isValidFor(editor: Editor, file: PsiFile): Boolean = getContext(editor, file) != null
 
     override fun startInWriteAction() = false
-    private fun getStructItem(editor: Editor, file: PsiFile): RsStructItem? =
-        file.findElementAt(editor.caretModel.offset)?.ancestorOrSelf()
+    private fun getContext(editor: Editor, file: PsiFile): Context? {
+        val element = file.findElementAt(editor.caretModel.offset) ?: return null
+        val struct = element.ancestorOrSelf<RsStructItem>()
+        return if (struct != null) {
+            Context(struct)
+        } else {
+            val impl = element.ancestorOrSelf<RsImplItem>() ?: return null
 
-    override fun invoke(project: Project, editor: Editor, file: PsiFile) {
-        val structItem = getStructItem(editor, file) ?: return
-        generateConstructorBody(structItem, editor)
-    }
+            // Filter out blocks already containing a constructor.
+            // This is just a best effort filter that doesn't consider all impl blocks of the struct.
+            if (!impl.isSuitableForConstructor) return null
 
-    private fun generateConstructorBody(structItem: RsStructItem, editor: Editor) {
-        checkWriteAccessNotAllowed()
-        val chosenFields = showConstructorArgumentsChooser(structItem.project, structItem) ?: return
-        runWriteAction {
-            insertNewConstructor(structItem, chosenFields, editor)
+            val structRef = impl.typeReference?.baseType?.path?.reference?.resolve() as? RsStructItem ?: return null
+            Context(structRef, impl)
         }
     }
 
-    private fun insertNewConstructor(structItem: RsStructItem, selectedFields: List<ConstructorArgument>, editor: Editor) {
+    override fun invoke(project: Project, editor: Editor, file: PsiFile) {
+        val context = getContext(editor, file) ?: return
+        generateConstructorBody(context, editor)
+    }
+
+    private fun generateConstructorBody(context: Context, editor: Editor) {
+        checkWriteAccessNotAllowed()
+        val substitution = context.implBlock?.typeReference?.type?.typeParameterValues ?: emptySubstitution
+        val chosenFields = showConstructorArgumentsChooser(context.struct.project, context.struct, substitution)
+            ?: return
+        runWriteAction {
+            insertNewConstructor(context.struct, context.implBlock, chosenFields, substitution, editor)
+        }
+    }
+
+    private fun insertNewConstructor(
+        structItem: RsStructItem,
+        implBlock: RsImplItem?,
+        selectedFields: List<ConstructorArgument>,
+        substitution: Substitution,
+        editor: Editor
+    ) {
         checkWriteAccessAllowed()
         val project = editor.project ?: return
         val structName = structItem.name ?: return
         val psiFactory = RsPsiFactory(project)
-        val impl = psiFactory.createInherentImplItem(structName, structItem.typeParameterList, structItem.whereClause)
-        val anchor = impl.lastChild.lastChild
-        val constructor = getFunction(structItem, selectedFields, psiFactory)
-        impl.lastChild.addBefore(constructor, anchor)
-        val insertedImpl = structItem.parent.addAfter(impl, structItem) as RsImplItem
-        editor.caretModel.moveToOffset(insertedImpl.textOffset + insertedImpl.textLength - 1)
-    }
-
-    private fun getFunction(structItem: RsStructItem, selectedFields: List<ConstructorArgument>, psiFactory: RsPsiFactory): RsFunction {
-        val arguments = selectedFields.joinToString(prefix = "(", postfix = ")", separator = ",") {
-            "${it.argumentIdentifier}: ${it.typeReference}"
+        val impl = if (implBlock == null) {
+            val impl = psiFactory.createInherentImplItem(structName, structItem.typeParameterList, structItem.whereClause)
+            structItem.parent.addAfter(impl, structItem) as RsImplItem
+        } else {
+            implBlock
         }
 
-        val body = generateBody(structItem, selectedFields)
+        val anchor = impl.lastChild.lastChild
+        val constructor = createConstructor(structItem, selectedFields, psiFactory, substitution)
+        impl.lastChild.addBefore(constructor, anchor)
+        editor.caretModel.moveToOffset(impl.textOffset + impl.textLength - 1)
+    }
+
+    private fun createConstructor(
+        structItem: RsStructItem,
+        selectedFields: List<ConstructorArgument>,
+        psiFactory: RsPsiFactory,
+        substitution: Substitution
+    ): RsFunction {
+        val arguments = selectedFields.joinToString(prefix = "(", postfix = ")", separator = ",") {
+            "${it.argumentIdentifier}: ${it.typeReferenceText}"
+        }
+
+        val body = generateBody(structItem, selectedFields, substitution)
         return psiFactory.createTraitMethodMember("pub fn new$arguments->Self{\n$body}\n")
     }
 
-    private fun generateBody(structItem: RsStructItem, selectedFields: List<ConstructorArgument>): String {
+    private fun generateBody(
+        structItem: RsStructItem,
+        selectedFields: List<ConstructorArgument>,
+        substitution: Substitution
+    ): String {
         val prefix = if (structItem.isTupleStruct) "(" else "{"
         val postfix = if (structItem.isTupleStruct) ")" else "}"
-        val arguments = ConstructorArgument.fromStruct(structItem).joinToString(prefix = prefix, postfix = postfix, separator = ",") {
+        val arguments = ConstructorArgument.fromStruct(structItem, substitution).joinToString(prefix = prefix, postfix = postfix, separator = ",") {
             if (it !in selectedFields) it.fieldIdentifier else it.argumentIdentifier
         }
         return structItem.nameIdentifier?.text + arguments
@@ -86,37 +127,38 @@ class GenerateConstructorHandler : LanguageCodeInsightActionHandler {
 data class ConstructorArgument(
     val argumentIdentifier: String,
     val fieldIdentifier: String,
-    val typeReference: String,
-    val type: RsTypeReference?
+    val typeReferenceText: String
 ) {
 
-    val dialogRepresentation: String get() = "$argumentIdentifier: ${type?.text ?: "()"}"
+    val dialogRepresentation: String get() = "$argumentIdentifier: $typeReferenceText"
 
     companion object {
-        fun fromStruct(structItem: RsStructItem): List<ConstructorArgument> {
+        fun fromStruct(structItem: RsStructItem, substitution: Substitution): List<ConstructorArgument> {
             return if (structItem.isTupleStruct) {
-                fromTupleList(structItem.positionalFields)
+                fromTupleList(structItem.positionalFields, substitution)
             } else {
-                fromFieldList(structItem.namedFields)
+                fromFieldList(structItem.namedFields, substitution)
             }
         }
 
-        private fun fromTupleList(tupleFieldList: List<RsTupleFieldDecl>): List<ConstructorArgument> {
+        private fun fromTupleList(tupleFieldList: List<RsTupleFieldDecl>, substitution: Substitution): List<ConstructorArgument> {
             return tupleFieldList.mapIndexed { index, tupleField ->
-                val typeName = tupleField.typeReference.text ?: "()"
-                ConstructorArgument("field$index", "()", typeName, tupleField.typeReference)
+                val typeName = tupleField.typeReference.substAndGetText(substitution) ?: "()"
+                ConstructorArgument("field$index", "()", typeName)
             }
         }
 
-        private fun fromFieldList(fieldDeclList: List<RsNamedFieldDecl>): List<ConstructorArgument> {
+        private fun fromFieldList(fieldDeclList: List<RsNamedFieldDecl>, substitution: Substitution): List<ConstructorArgument> {
             return fieldDeclList.map {
                 ConstructorArgument(
                     it.identifier.text ?: "()",
                     it.identifier.text + ":()",
-                    it.typeReference?.text ?: "()",
-                    it.typeReference
+                    it.typeReference?.substAndGetText(substitution) ?: "()"
                 )
             }
         }
     }
 }
+
+private val RsImplItem.isSuitableForConstructor: Boolean
+    get() = this.traitRef == null && this.members?.functionList?.find { it.name == "new" } == null

--- a/src/main/kotlin/org/rust/ide/refactoring/generateConstructor/ui.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generateConstructor/ui.kt
@@ -14,12 +14,14 @@ import com.intellij.openapiext.isUnitTestMode
 import org.jetbrains.annotations.TestOnly
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.psi.RsStructItem
+import org.rust.lang.core.types.Substitution
 
 private var MOCK: StructMemberChooserUi? = null
 
 fun showConstructorArgumentsChooser(
     project: Project,
-    structItem: RsStructItem
+    structItem: RsStructItem,
+    substitution: Substitution
 ): List<ConstructorArgument>? {
     val chooser = if (isUnitTestMode) {
         MOCK ?: error("You should set mock ui via `withMockStructMemberChooserUi`")
@@ -27,7 +29,7 @@ fun showConstructorArgumentsChooser(
         DialogStructMemberChooserUi
     }
     val base = MemberChooserObjectBase(structItem.name, structItem.getIcon(0))
-    val arguments = ConstructorArgument.fromStruct(structItem).map { RsStructMemberChooserObject(base, it) }
+    val arguments = ConstructorArgument.fromStruct(structItem, substitution).map { RsStructMemberChooserObject(base, it) }
     return chooser.selectMembers(project, arguments)?.map { it.member }
 }
 


### PR DESCRIPTION
This PR adds support for generating a constructor (a `new` associated function) for structs. The intention is not complete yet, it doesn't create lifetime/type parameters on the impl block (amongst other things).

I wanted to ask if this is the right direction to go and whether you want to add this intention at all.
Some questions to resolve:
- Offer this intention only on the Struct definition or also in an existing struct impl block?
- Detect if there is already a `new` associated function or a `Default` impl present and do not offer this intention in such a case?
- Detect if there is already an impl block present in the same file to avoid creating a new one?
    - Is there an intention to merge impl blocks?
    - The AddImplIntention does no such check.
- Should this be a simple intention or should it be integrated into the `Alt+Insert` generate dialog? Possibly by extending RsTraitImplementationInspection?
    - It would probably make more sense to be in the dialog, as is common in other languages (Generate constructor/getter/setter etc.)

Fixes: #4937