### PR TITLE
FMT: disable "comment at first line" code style settings by default

### DIFF
--- a/src/main/kotlin/org/rust/ide/formatter/settings/RsLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/settings/RsLanguageCodeStyleSettingsProvider.kt
@@ -112,16 +112,19 @@ class RsLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider() 
 
     override fun getIndentOptionsEditor(): IndentOptionsEditor? = SmartIndentOptionsEditor()
 
-    override fun getDefaultCommonSettings(): CommonCodeStyleSettings =
-        CommonCodeStyleSettings(language).apply {
-            RIGHT_MARGIN = 100
-            ALIGN_MULTILINE_PARAMETERS_IN_CALLS = true
-            initIndentOptions().apply {
-                // FIXME(mkaput): It's a hack
-                // Nobody else does this and still somehow achieve similar effect
-                CONTINUATION_INDENT_SIZE = INDENT_SIZE
-            }
-        }
+    override fun customizeDefaults(commonSettings: CommonCodeStyleSettings, indentOptions: CommonCodeStyleSettings.IndentOptions) {
+        commonSettings.RIGHT_MARGIN = 100
+        commonSettings.ALIGN_MULTILINE_PARAMETERS_IN_CALLS = true
+
+        // Make default behavior consistent with rustfmt
+        commonSettings.LINE_COMMENT_AT_FIRST_COLUMN = false
+        commonSettings.LINE_COMMENT_ADD_SPACE = true
+        commonSettings.BLOCK_COMMENT_AT_FIRST_COLUMN = false
+
+        // FIXME(mkaput): It's a hack
+        // Nobody else does this and still somehow achieve similar effect
+        indentOptions.CONTINUATION_INDENT_SIZE = indentOptions.INDENT_SIZE
+    }
 }
 
 private fun sample(@org.intellij.lang.annotations.Language("Rust") code: String) = code.trim()

--- a/src/main/kotlin/org/rust/ide/formatter/settings/RsLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/settings/RsLanguageCodeStyleSettingsProvider.kt
@@ -10,6 +10,7 @@ import com.intellij.application.options.SmartIndentOptionsEditor
 import com.intellij.lang.Language
 import com.intellij.openapi.application.ApplicationBundle
 import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable
+import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable.*
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings
 import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
 import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider.SettingsType.*
@@ -32,49 +33,49 @@ class RsLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider() 
         when (settingsType) {
             BLANK_LINES_SETTINGS -> {
                 consumer.showStandardOptions(
-                    "KEEP_LINE_BREAKS",
-                    "KEEP_BLANK_LINES_IN_DECLARATIONS",
-                    "KEEP_BLANK_LINES_IN_CODE")
+                    BlankLinesOption.KEEP_BLANK_LINES_IN_DECLARATIONS.name,
+                    BlankLinesOption.KEEP_BLANK_LINES_IN_CODE.name)
 
                 consumer.showCustomOption(RsCodeStyleSettings::class.java,
                     "MIN_NUMBER_OF_BLANKS_BETWEEN_ITEMS",
                     "Between declarations:",
-                    CodeStyleSettingsCustomizable.BLANK_LINES)
+                    BLANK_LINES)
             }
 
             SPACING_SETTINGS -> {
                 consumer.showCustomOption(RsCodeStyleSettings::class.java,
                     "SPACE_AROUND_ASSOC_TYPE_BINDING",
                     "Around associated type bindings",
-                    CodeStyleSettingsCustomizable.SPACES_IN_TYPE_PARAMETERS)
+                    SPACES_IN_TYPE_PARAMETERS)
             }
 
             WRAPPING_AND_BRACES_SETTINGS -> {
                 consumer.showStandardOptions(
-                    "RIGHT_MARGIN",
-                    "ALIGN_MULTILINE_CHAINED_METHODS",
-                    "ALIGN_MULTILINE_PARAMETERS",
-                    "ALIGN_MULTILINE_PARAMETERS_IN_CALLS")
+                    WrappingOrBraceOption.KEEP_LINE_BREAKS.name,
+                    WrappingOrBraceOption.RIGHT_MARGIN.name,
+                    WrappingOrBraceOption.ALIGN_MULTILINE_CHAINED_METHODS.name,
+                    WrappingOrBraceOption.ALIGN_MULTILINE_PARAMETERS.name,
+                    WrappingOrBraceOption.ALIGN_MULTILINE_PARAMETERS_IN_CALLS.name)
 
                 consumer.showCustomOption(RsCodeStyleSettings::class.java,
                     "ALLOW_ONE_LINE_MATCH",
                     "Match expressions in one line",
-                    CodeStyleSettingsCustomizable.WRAPPING_KEEP)
+                    WRAPPING_KEEP)
 
                 consumer.showCustomOption(RsCodeStyleSettings::class.java,
                     "PRESERVE_PUNCTUATION",
                     "Punctuation",
-                    CodeStyleSettingsCustomizable.WRAPPING_KEEP)
+                    WRAPPING_KEEP)
 
                 consumer.showCustomOption(RsCodeStyleSettings::class.java,
                     "ALIGN_RET_TYPE",
                     "Align return type to function parameters",
-                    CodeStyleSettingsCustomizable.WRAPPING_METHOD_PARAMETERS)
+                    WRAPPING_METHOD_PARAMETERS)
 
                 consumer.showCustomOption(RsCodeStyleSettings::class.java,
                     "ALIGN_WHERE_CLAUSE",
                     "Align where clause to function parameters",
-                    CodeStyleSettingsCustomizable.WRAPPING_METHOD_PARAMETERS)
+                    WRAPPING_METHOD_PARAMETERS)
 
                 consumer.showCustomOption(RsCodeStyleSettings::class.java,
                     "ALIGN_TYPE_PARAMS",
@@ -103,9 +104,9 @@ class RsLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider() 
 
             COMMENTER_SETTINGS -> {
                 consumer.showStandardOptions(
-                    CodeStyleSettingsCustomizable.CommenterOption.LINE_COMMENT_AT_FIRST_COLUMN.name,
-                    CodeStyleSettingsCustomizable.CommenterOption.LINE_COMMENT_ADD_SPACE.name,
-                    CodeStyleSettingsCustomizable.CommenterOption.BLOCK_COMMENT_AT_FIRST_COLUMN.name)
+                    CommenterOption.LINE_COMMENT_AT_FIRST_COLUMN.name,
+                    CommenterOption.LINE_COMMENT_ADD_SPACE.name,
+                    CommenterOption.BLOCK_COMMENT_AT_FIRST_COLUMN.name)
             }
         }
     }

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.util.io.StreamUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileFilter
+import com.intellij.openapiext.Testmark
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.PsiManagerEx
 import com.intellij.psi.util.PsiTreeUtil
@@ -208,6 +209,23 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
         InlineFile(before)
         action()
         myFixture.checkResult(replaceCaretMarker(after))
+    }
+
+    protected fun checkEditorAction(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String,
+        actionId: String,
+        trimIndent: Boolean = true,
+        testmark: Testmark? = null
+    ) {
+        fun String.trimIndentIfNeeded(): String = if (trimIndent) trimIndent() else this
+
+        val action = {
+            checkByText(before.trimIndentIfNeeded(), after.trimIndentIfNeeded()) {
+                myFixture.performEditorAction(actionId)
+            }
+        }
+        testmark?.checkHit { action() } ?: action()
     }
 
     protected fun openFileInEditor(path: String) {

--- a/src/test/kotlin/org/rust/ide/actions/RsJoinLinesHandlerTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/actions/RsJoinLinesHandlerTestBase.kt
@@ -11,9 +11,7 @@ import org.rust.RsTestBase
 
 abstract class RsJoinLinesHandlerTestBase : RsTestBase() {
     protected fun doTestRaw(before: String, after: String) {
-        checkByText(before, after) {
-            myFixture.performEditorAction(IdeActions.ACTION_EDITOR_JOIN_LINES)
-        }
+        checkEditorAction(before, after, IdeActions.ACTION_EDITOR_JOIN_LINES, false)
     }
 
     protected fun doTest(

--- a/src/test/kotlin/org/rust/ide/actions/RsMoveLeftRightHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/RsMoveLeftRightHandlerTest.kt
@@ -193,12 +193,8 @@ class RsMoveLeftRightHandlerTest : RsTestBase() {
     }
 
     private fun doMoveLeftTest(@Language("Rust") before: String, @Language("Rust") after: String) =
-        checkByText(before, after) {
-            myFixture.performEditorAction(IdeActions.MOVE_ELEMENT_LEFT)
-        }
+        checkEditorAction(before, after, IdeActions.MOVE_ELEMENT_LEFT)
 
     private fun doMoveRightTest(@Language("Rust") before: String, @Language("Rust") after: String) =
-        checkByText(before, after) {
-            myFixture.performEditorAction(IdeActions.MOVE_ELEMENT_RIGHT)
-        }
+        checkEditorAction(before, after, IdeActions.MOVE_ELEMENT_RIGHT)
 }

--- a/src/test/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMoverTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMoverTestBase.kt
@@ -38,11 +38,6 @@ abstract class RsStatementUpDownMoverTestBase : RsTestBase() {
         actionId: String,
         testmark: Testmark? = null
     ) {
-        val action = {
-            checkByText(before.trimIndent() + "\n", after.trimIndent() + "\n") {
-                myFixture.performEditorAction(actionId)
-            }
-        }
-        testmark?.checkHit(action) ?: action()
+        checkEditorAction(before.trimIndent() + "\n", after.trimIndent() + "\n", actionId, false, testmark)
     }
 }

--- a/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
+++ b/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
@@ -6,29 +6,126 @@
 package org.rust.ide.commenter
 
 import com.intellij.openapi.actionSystem.IdeActions
+import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 
 class RsCommenterTest : RsTestBase() {
 
-    override val dataPath = "org/rust/ide/commenter/fixtures"
+    fun `test single line`() = checkEditorAction("""
+        fn <caret>double(x: i32) -> i32 {
+            x * 2
+        }
+    """, """
+        //fn double(x: i32) -> i32 {
+            x<caret> * 2
+        }
+    """, IdeActions.ACTION_COMMENT_LINE)
 
-    private fun doTest(actionId: String) {
-        myFixture.configureByFile(fileName)
-        myFixture.performEditorAction(actionId)
-        myFixture.checkResultByFile(fileName.replace(".rs", "_after.rs"), true)
+    fun `test multi line`() = checkEditorAction("""
+        fn doub<selection>le(x: i32) -> i32 {
+            x</selection> * 2
+        }
+    """, """
+        //fn doub<selection>le(x: i32) -> i32 {
+        //    x</selection> * 2
+        }
+    """, IdeActions.ACTION_COMMENT_LINE)
+
+    fun `test single line block`() = checkEditorAction("""
+        fn d<caret>ouble(x: i32) -> i32 {
+            x * 2
+        }
+    """, """
+        fn d/*<caret>*/ouble(x: i32) -> i32 {
+            x * 2
+        }
+    """, IdeActions.ACTION_COMMENT_BLOCK)
+
+    fun `test multi line block`() = checkEditorAction("""
+        fn doub<selection>le(x: i32) -> i32 {
+            x</selection> * 2
+        }
+    """, """
+        fn doub<selection>/*le(x: i32) -> i32 {
+            x*/</selection> * 2
+        }
+    """, IdeActions.ACTION_COMMENT_BLOCK)
+
+    fun `test single line uncomment`() = checkEditorAction("""
+        //fn d<caret>ouble(x: i32) -> i32 {
+        //    x * 2
+        }
+    """, """
+        fn double(x: i32) -> i32 {
+        //  <caret>  x * 2
+        }
+    """, IdeActions.ACTION_COMMENT_LINE)
+
+    fun `test multi line uncomment`() = checkEditorAction("""
+        //fn doub<selection>le(x: i32) -> i32 {
+        //    x</selection> * 2
+        }
+    """, """
+        fn doub<selection>le(x: i32) -> i32 {
+            x</selection> * 2
+        }
+    """, IdeActions.ACTION_COMMENT_LINE)
+
+    fun `test single line block uncomment`() = checkEditorAction("""
+        fn d/*<caret>*/ouble(x: i32) -> i32 {
+            x * 2
+        }
+    """, """
+        fn d<caret>ouble(x: i32) -> i32 {
+            x * 2
+        }
+    """, IdeActions.ACTION_COMMENT_BLOCK)
+
+    fun `test multi line block uncomment`() = checkEditorAction("""
+        fn doub<selection>/*le(x: i32) -> i32 {
+            x*/</selection> * 2
+        }
+    """, """
+        fn doub<selection>le(x: i32) -> i32 {
+            x</selection> * 2
+        }
+    """, IdeActions.ACTION_COMMENT_BLOCK)
+
+    fun `test single line uncomment with space`() = checkEditorAction("""
+        // fn d<caret>ouble(x: i32) -> i32 {
+        //     x * 2
+        }
+    """, """
+         fn double(x: i32) -> i32 {
+        //   <caret>  x * 2
+        }
+    """, IdeActions.ACTION_COMMENT_LINE)
+
+    fun `test nested block comments`() = checkEditorAction("""
+        fn double<selection>(x: i32/* foobar */) -> i32</selection> {
+            x * 2
+        }
+    """, """
+        fn double<selection>/*(x: i32*//* foobar *//*) -> i32*/</selection> {
+            x * 2
+        }
+    """, IdeActions.ACTION_COMMENT_BLOCK) // FIXME
+
+    fun `test indented single line comment`() = checkEditorAction("""
+        fn double(x: i32) -> i32 {
+            x<caret> * 2
+        }
+    """, """
+        fn double(x: i32) -> i32 {
+        //    x * 2
+        }<caret>
+    """, IdeActions.ACTION_COMMENT_LINE)
+
+    private fun checkEditorAction(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String,
+        actionId: String
+    ) {
+        checkByText(before.trimIndent(), after.trimIndent()) { myFixture.performEditorAction(actionId) }
     }
-
-    fun `test single line`() = doTest(IdeActions.ACTION_COMMENT_LINE)
-    fun `test multi line`() = doTest(IdeActions.ACTION_COMMENT_LINE)
-    fun `test single line block`() = doTest(IdeActions.ACTION_COMMENT_BLOCK)
-    fun `test multi line block`() = doTest(IdeActions.ACTION_COMMENT_BLOCK)
-
-    fun `test single line uncomment`() = doTest(IdeActions.ACTION_COMMENT_LINE)
-    fun `test multi line uncomment`() = doTest(IdeActions.ACTION_COMMENT_LINE)
-    fun `test single line block uncomment`() = doTest(IdeActions.ACTION_COMMENT_BLOCK)
-    fun `test multi line block uncomment`() = doTest(IdeActions.ACTION_COMMENT_BLOCK)
-
-    fun `test single line uncomment with space`() = doTest(IdeActions.ACTION_COMMENT_LINE)
-    fun `test nested block comments`() = doTest(IdeActions.ACTION_COMMENT_BLOCK) // FIXME
-    fun `test indented single line comment`() = doTest(IdeActions.ACTION_COMMENT_LINE)
 }

--- a/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
+++ b/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.commenter
 
 import com.intellij.openapi.actionSystem.IdeActions
-import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 
 class RsCommenterTest : RsTestBase() {
@@ -120,12 +119,4 @@ class RsCommenterTest : RsTestBase() {
         //    x * 2
         }<caret>
     """, IdeActions.ACTION_COMMENT_LINE)
-
-    private fun checkEditorAction(
-        @Language("Rust") before: String,
-        @Language("Rust") after: String,
-        actionId: String
-    ) {
-        checkByText(before.trimIndent(), after.trimIndent()) { myFixture.performEditorAction(actionId) }
-    }
 }

--- a/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
+++ b/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
@@ -15,8 +15,8 @@ class RsCommenterTest : RsTestBase() {
             x * 2
         }
     """, """
-        //fn double(x: i32) -> i32 {
-            x<caret> * 2
+        // fn double(x: i32) -> i32 {
+            x <caret>* 2
         }
     """, IdeActions.ACTION_COMMENT_LINE)
 
@@ -25,8 +25,8 @@ class RsCommenterTest : RsTestBase() {
             x</selection> * 2
         }
     """, """
-        //fn doub<selection>le(x: i32) -> i32 {
-        //    x</selection> * 2
+        // fn doub<selection>le(x: i32) -> i32 {
+        //     x</selection> * 2
         }
     """, IdeActions.ACTION_COMMENT_LINE)
 
@@ -50,6 +50,26 @@ class RsCommenterTest : RsTestBase() {
         }
     """, IdeActions.ACTION_COMMENT_BLOCK)
 
+    fun `test multi line block proper indent`() = checkEditorAction("""
+        fn fib(x: i32) -> i32 {
+        <selection>    match x {
+                0 => 1,
+                1 => 1,
+                _ => fib(x - 2) + fib(x - 1)
+            }
+        </selection>}
+    """, """
+        fn fib(x: i32) -> i32 {
+            /*
+            match x {
+                0 => 1,
+                1 => 1,
+                _ => fib(x - 2) + fib(x - 1)
+            }
+            */
+        }
+    """, IdeActions.ACTION_COMMENT_BLOCK)
+
     fun `test single line uncomment`() = checkEditorAction("""
         //fn d<caret>ouble(x: i32) -> i32 {
         //    x * 2
@@ -62,7 +82,7 @@ class RsCommenterTest : RsTestBase() {
 
     fun `test multi line uncomment`() = checkEditorAction("""
         //fn doub<selection>le(x: i32) -> i32 {
-        //    x</selection> * 2
+        //     x</selection> * 2
         }
     """, """
         fn doub<selection>le(x: i32) -> i32 {
@@ -95,8 +115,8 @@ class RsCommenterTest : RsTestBase() {
         //     x * 2
         }
     """, """
-         fn double(x: i32) -> i32 {
-        //   <caret>  x * 2
+        fn double(x: i32) -> i32 {
+        //  <caret>   x * 2
         }
     """, IdeActions.ACTION_COMMENT_LINE)
 
@@ -116,7 +136,7 @@ class RsCommenterTest : RsTestBase() {
         }
     """, """
         fn double(x: i32) -> i32 {
-        //    x * 2
+            // x * 2
         }<caret>
     """, IdeActions.ACTION_COMMENT_LINE)
 }

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoDeclarationTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoDeclarationTest.kt
@@ -136,7 +136,6 @@ class RsGotoDeclarationTest : RsTestBase() {
         }
     """)
 
-    private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) = checkByText(before, after) {
-        myFixture.performEditorAction(IdeActions.ACTION_GOTO_DECLARATION)
-    }
+    private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) =
+        checkEditorAction(before, after, IdeActions.ACTION_GOTO_DECLARATION)
 }

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoImplementationsTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoImplementationsTest.kt
@@ -57,7 +57,6 @@ class RsGotoImplementationsTest : RsTestBase() {
     """)
 
 
-    private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) = checkByText(before, after) {
-        myFixture.performEditorAction(IdeActions.ACTION_GOTO_IMPLEMENTATION)
-    }
+    private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) =
+        checkEditorAction(before, after, IdeActions.ACTION_GOTO_IMPLEMENTATION)
 }

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoTypeDeclarationTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoTypeDeclarationTest.kt
@@ -333,7 +333,6 @@ class RsGotoTypeDeclarationTest : RsTestBase() {
         }
     """)
 
-    private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) = checkByText(before, after) {
-        myFixture.performEditorAction(ACTION_GOTO_TYPE_DECLARATION)
-    }
+    private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) =
+        checkEditorAction(before, after, ACTION_GOTO_TYPE_DECLARATION)
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/GenerateConstructorTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/GenerateConstructorTest.kt
@@ -161,9 +161,7 @@ class GenerateConstructorTest : RsTestBase() {
                 return all.filter { it.text in selected }
             }
         }) {
-            checkByText(code.trimIndent(), expected.trimIndent()) {
-                myFixture.performEditorAction("Rust.GenerateConstructor")
-            }
+            checkEditorAction(code, expected, "Rust.GenerateConstructor")
         }
     }
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -13,9 +13,7 @@ import org.rust.ide.refactoring.extractFunction.ExtractFunctionUi
 import org.rust.ide.refactoring.extractFunction.RsExtractFunctionConfig
 import org.rust.ide.refactoring.extractFunction.withMockExtractFunctionUi
 
-
 class RsExtractFunctionTest : RsTestBase() {
-    override val dataPath = "org/rust/lang/refactoring/fixtures/extract_function/"
 
     fun `test extract a function without parameters and a return value`() = doTest("""
             fn main() {
@@ -1005,9 +1003,7 @@ class RsExtractFunctionTest : RsTestBase() {
                 callback()
             }
         }) {
-            checkByText(code, excepted) {
-                myFixture.performEditorAction("ExtractMethod")
-            }
+            checkEditorAction(code, excepted, "ExtractMethod", trimIndent = false)
         }
     }
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
@@ -387,9 +387,6 @@ class RsImportOptimizerTest: RsTestBase() {
         mod ccc {}
     """)
 
-    private fun doTest(@Language("Rust") code: String, @Language("Rust") excepted: String) {
-        checkByText(code.trimIndent(), excepted.trimIndent()) {
-            myFixture.performEditorAction("OptimizeImports")
-        }
-    }
+    private fun doTest(@Language("Rust") code: String, @Language("Rust") excepted: String) =
+        checkEditorAction(code, excepted, "OptimizeImports")
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceParameterTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceParameterTest.kt
@@ -4,7 +4,6 @@
  */
 package org.rust.ide.refactoring
 
-import junit.framework.TestCase
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.lang.core.psi.RsExpr
@@ -269,20 +268,11 @@ class RsIntroduceParameterTest : RsTestBase() {
         @Language("Rust") after: String,
         replaceAll: Boolean = false
     ) {
-        checkByText(before, after) {
-            doIntroduce(expressions, exprTarget, methodTarget, replaceAll)
-        }
-    }
-
-    private fun doIntroduce(expressions: List<String>,
-                            exprTarget: Int,
-                            methodTarget: Int,
-                            replaceAll: Boolean) {
         var shownTargetChooser = false
         withMockTargetExpressionChooser(object : ExtractExpressionUi {
             override fun chooseTarget(exprs: List<RsExpr>): RsExpr {
                 shownTargetChooser = true
-                TestCase.assertEquals(exprs.map { it.text }, expressions)
+                assertEquals(exprs.map { it.text }, expressions)
                 return exprs[exprTarget]
             }
 
@@ -293,9 +283,10 @@ class RsIntroduceParameterTest : RsTestBase() {
                 return methods[methodTarget]
             }
         }) {
-            myFixture.performEditorAction("IntroduceParameter")
-            if (expressions.isNotEmpty() && !shownTargetChooser) {
-                error("Didn't shown chooser")
+
+            checkEditorAction(before, after, "IntroduceParameter")
+            check(expressions.isEmpty() || shownTargetChooser) {
+                "Chooser isn't shown"
             }
         }
     }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.refactoring
 
 import com.intellij.openapiext.Testmark
-import junit.framework.TestCase
 import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
@@ -275,49 +274,28 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
         }
     """)
 
-
-    private fun doTest(
-        @Language("Rust") before: String,
-        expressions: List<String>,
-        target: Int,
-        @Language("Rust") after: String,
-        replaceAll: Boolean = false
-    ) {
-        checkByText(before, after) {
-            doIntroduce(expressions, target, replaceAll)
-        }
-    }
-
     private fun doTest(
         @Language("Rust") before: String,
         expressions: List<String>,
         target: Int,
         @Language("Rust") after: String,
         replaceAll: Boolean = false,
-        mark: Testmark
+        mark: Testmark? = null
     ) {
-        checkByText(before, after) {
-            mark.checkHit {
-                doIntroduce(expressions, target, replaceAll)
-            }
-        }
-    }
-
-    private fun doIntroduce(expressions: List<String>, target: Int, replaceAll: Boolean) {
         var shownTargetChooser = false
         withMockTargetExpressionChooser(object : ExtractExpressionUi {
             override fun chooseTarget(exprs: List<RsExpr>): RsExpr {
                 shownTargetChooser = true
-                TestCase.assertEquals(exprs.map { it.text }, expressions)
+                assertEquals(exprs.map { it.text }, expressions)
                 return exprs[target]
             }
 
             override fun chooseOccurrences(expr: RsExpr, occurrences: List<RsExpr>): List<RsExpr> =
                 if (replaceAll) occurrences else listOf(expr)
         }) {
-            myFixture.performEditorAction("IntroduceVariable")
-            if (expressions.isNotEmpty() && !shownTargetChooser) {
-                error("Didn't shown chooser")
+            checkEditorAction(before, after, "IntroduceVariable", testmark = mark)
+            check(expressions.isEmpty() || shownTargetChooser) {
+                "Chooser isn't shown"
             }
         }
     }

--- a/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt
@@ -150,9 +150,7 @@ class RsLiveTemplatesTest : RsTestBase() {
     """)
 
     private fun expandSnippet(@Language("Rust") before: String, @Language("Rust") after: String) =
-        checkByText(before.trimIndent(), after.trimIndent()) {
-            myFixture.performEditorAction(IdeActions.ACTION_EXPAND_LIVE_TEMPLATE_BY_TAB)
-        }
+        checkEditorAction(before, after, IdeActions.ACTION_EXPAND_LIVE_TEMPLATE_BY_TAB)
 
     private fun noSnippet(@Language("Rust") code: String) = expandSnippet(code, code)
 }

--- a/src/test/kotlin/org/rust/ide/typing/assist/RsSmartEnterProcessorTest.kt
+++ b/src/test/kotlin/org/rust/ide/typing/assist/RsSmartEnterProcessorTest.kt
@@ -79,7 +79,7 @@ class RsSmartEnterProcessorTest : RsTestBase() {
             x: i32,
             y: i32,
         }
-        
+
         fn main() {
             let origin = Point { x: 0, y: 0 }/*caret*/
         }
@@ -88,7 +88,7 @@ class RsSmartEnterProcessorTest : RsTestBase() {
             x: i32,
             y: i32,
         }
-        
+
         fn main() {
             let origin = Point { x: 0, y: 0 };
             /*caret*/
@@ -99,7 +99,7 @@ class RsSmartEnterProcessorTest : RsTestBase() {
         fn f() -> i32 {
             return 42;
         }
-        
+
         fn main() {
             let x = f(/*caret*/
         }
@@ -107,7 +107,7 @@ class RsSmartEnterProcessorTest : RsTestBase() {
         fn f() -> i32 {
             return 42;
         }
-        
+
         fn main() {
             let x = f();
             /*caret*/
@@ -205,7 +205,6 @@ class RsSmartEnterProcessorTest : RsTestBase() {
         }
     """)
 
-    private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) = checkByText(before, after) {
-        myFixture.performEditorAction(IdeActions.ACTION_EDITOR_COMPLETE_STATEMENT)
-    }
+    private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) =
+        checkEditorAction(before, after, IdeActions.ACTION_EDITOR_COMPLETE_STATEMENT)
 }

--- a/src/test/resources/org/rust/ide/commenter/fixtures/indented_single_line_comment.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/indented_single_line_comment.rs
@@ -1,3 +1,0 @@
-fn double(x: i32) -> i32 {
-    x<caret> * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/indented_single_line_comment_after.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/indented_single_line_comment_after.rs
@@ -1,3 +1,0 @@
-fn double(x: i32) -> i32 {
-//    x * 2
-}<caret>

--- a/src/test/resources/org/rust/ide/commenter/fixtures/multi_line.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/multi_line.rs
@@ -1,3 +1,0 @@
-fn doub<selection>le(x: i32) -> i32 {
-    x</selection> * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/multi_line_after.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/multi_line_after.rs
@@ -1,3 +1,0 @@
-//fn doub<selection>le(x: i32) -> i32 {
-//    x</selection> * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/multi_line_block.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/multi_line_block.rs
@@ -1,3 +1,0 @@
-fn doub<selection>le(x: i32) -> i32 {
-    x</selection> * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/multi_line_block_after.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/multi_line_block_after.rs
@@ -1,3 +1,0 @@
-fn doub<selection>/*le(x: i32) -> i32 {
-    x*/</selection> * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/multi_line_block_uncomment.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/multi_line_block_uncomment.rs
@@ -1,3 +1,0 @@
-fn doub<selection>/*le(x: i32) -> i32 {
-    x*/</selection> * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/multi_line_block_uncomment_after.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/multi_line_block_uncomment_after.rs
@@ -1,3 +1,0 @@
-fn doub<selection>le(x: i32) -> i32 {
-    x</selection> * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/multi_line_uncomment.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/multi_line_uncomment.rs
@@ -1,3 +1,0 @@
-//fn doub<selection>le(x: i32) -> i32 {
-//    x</selection> * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/multi_line_uncomment_after.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/multi_line_uncomment_after.rs
@@ -1,3 +1,0 @@
-fn doub<selection>le(x: i32) -> i32 {
-    x</selection> * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/nested_block_comments.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/nested_block_comments.rs
@@ -1,3 +1,0 @@
-fn double<selection>(x: i32/* foobar */) -> i32</selection> {
-    x * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/nested_block_comments_after.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/nested_block_comments_after.rs
@@ -1,3 +1,0 @@
-fn double<selection>/*(x: i32*//* foobar *//*) -> i32*/</selection> {
-    x * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/single_line.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/single_line.rs
@@ -1,3 +1,0 @@
-fn d<caret>ouble(x: i32) -> i32 {
-    x * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/single_line_after.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/single_line_after.rs
@@ -1,3 +1,0 @@
-//fn double(x: i32) -> i32 {
-    x <caret>* 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/single_line_block.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/single_line_block.rs
@@ -1,3 +1,0 @@
-fn d<caret>ouble(x: i32) -> i32 {
-    x * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/single_line_block_after.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/single_line_block_after.rs
@@ -1,3 +1,0 @@
-fn d/*<caret>*/ouble(x: i32) -> i32 {
-    x * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/single_line_block_uncomment.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/single_line_block_uncomment.rs
@@ -1,3 +1,0 @@
-fn d/*<caret>*/ouble(x: i32) -> i32 {
-    x * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/single_line_block_uncomment_after.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/single_line_block_uncomment_after.rs
@@ -1,3 +1,0 @@
-fn d<caret>ouble(x: i32) -> i32 {
-    x * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/single_line_uncomment.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/single_line_uncomment.rs
@@ -1,3 +1,0 @@
-//fn d<caret>ouble(x: i32) -> i32 {
-//    x * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/single_line_uncomment_after.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/single_line_uncomment_after.rs
@@ -1,3 +1,0 @@
-fn double(x: i32) -> i32 {
-//  <caret>  x * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/single_line_uncomment_with_space.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/single_line_uncomment_with_space.rs
@@ -1,3 +1,0 @@
-// fn d<caret>ouble(x: i32) -> i32 {
-//     x * 2
-}

--- a/src/test/resources/org/rust/ide/commenter/fixtures/single_line_uncomment_with_space_after.rs
+++ b/src/test/resources/org/rust/ide/commenter/fixtures/single_line_uncomment_with_space_after.rs
@@ -1,3 +1,0 @@
- fn double(x: i32) -> i32 {
-//   <caret>  x * 2
-}


### PR DESCRIPTION
It should provide behavior similar with `rustfmt`

Fixes #1770