### PR TITLE
RES&TY: support enum type aliases

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -578,15 +578,13 @@ class RsResolveTest : RsResolveTestBase() {
         }
     """)
 
-    // Enum variants behind an alias are not resolved
-    // https://github.com/rust-lang/rust/issues/26264
-    // https://github.com/rust-lang/rfcs/issues/2218
     fun `test enum variant with alias`() = checkByCode("""
         enum E { A }
+               //X
         type T1 = E;
         fn main() {
             let _ = T1::A;
-        }             //^ unresolved
+        }             //^
     """)
 
     fun `test local fn`() = checkByCode("""

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -510,6 +510,31 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ S<u8>
     """)
 
+    fun `test enum with alias 1`() = testExpr("""
+        enum Foo<T, U> {
+            A(T),
+            B(U)
+        }
+        type Baz = Foo<i32, u8>;
+        fn main() {
+            let a = Baz::A(123);
+            a;
+        } //^ Foo<i32, u8>
+    """)
+
+    fun `test enum with alias 2`() = testExpr("""
+        enum Foo<T, U> {
+            A(T),
+            B(U)
+        }
+        type Bar<T> = Foo<T, u8>;
+        type Baz = Bar<i32>;
+        fn main() {
+            let a = Baz::A(123);
+            a;
+        } //^ Foo<i32, u8>
+    """)
+
     fun `test generic struct arg`() = testExpr("""
         struct Foo<F>(F);
         fn foo<T>(xs: Foo<T>) -> T { unimplemented!() }


### PR DESCRIPTION
See the corresponding [RFC](https://github.com/rust-lang/rfcs/blob/master/text/2338-type-alias-enum-variants.md)

Fixes #4923