### PR TITLE
RES: Don't use ImplLookup for trait-relative paths

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -252,6 +252,7 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
 
                     is TraitImplSource.TraitBound -> return null
                     is TraitImplSource.Object -> return null
+                    is TraitImplSource.Trait -> return null
                 }
 
                 trait

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -407,10 +407,9 @@ class ImplLookup(
                 // Check that trait is resolved if it's not an inherent impl; checking it after types because
                 // we assume that unresolved trait is a rare case
                 (cachedImpl.isInherent || cachedImpl.implementedTrait != null) &&
-                // ignore blanket implementations for trait objects for now because
-                // both trait objects and trait bounds are represented here as TyTraitObject
-                // but they should be treated differently in terms of applicable impls
-                (selfTy !is TyTraitObject || type !is TyTypeParameter)
+                // Ignore `Sized` blanket implementations for trait objects.
+                // TODO remove it after support of completion results filtering by `Sized` trait
+                (selfTy !is TyTraitObject || type !is TyTypeParameter || !type.isSized)
             isAppropriateImpl && processor(cachedImpl)
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -137,6 +137,12 @@ sealed class TraitImplSource {
      */
     data class Collapsed(override val value: RsTraitItem) : TraitImplSource()
 
+    /**
+     * A trait is directly referenced in UFCS path `TraitName::foo`, an impl should be selected
+     * during type inference
+     */
+    data class Trait(override val value: RsTraitItem) : TraitImplSource()
+
     /** A trait impl hardcoded in Intellij-Rust. Mostly it's something defined with a macro in stdlib */
     data class Hardcoded(override val value: RsTraitItem) : TraitImplSource()
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -1175,6 +1175,7 @@ private fun processAssociatedItems(
 
     for (traitOrImpl in lookup.findImplsAndTraits(type)) {
         val isInherentImpl = traitOrImpl is TraitImplSource.ExplicitImpl && traitOrImpl.isInherent
+            || traitOrImpl is TraitImplSource.Object
 
         for (member in traitOrImpl.implAndTraitExpandedMembers) {
             if (!nsFilter(member)) continue

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.types.infer
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Computable
 import com.intellij.openapiext.Testmark
+import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import org.jetbrains.annotations.TestOnly
@@ -763,6 +764,10 @@ class RsInferenceContext(
                 registerMethodRefinement(methodCall, traitRef)
             }
             typeParameters
+        }
+        is TraitImplSource.Trait -> {
+            if (isUnitTestMode) error("unreachable")
+            emptySubstitution
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -424,7 +424,7 @@ class RsTypeInferenceWalker(
                         val traitRef = TraitRef(selfTy, boundTrait)
                         fulfill.registerPredicateObligation(Obligation(Predicate.Trait(traitRef)))
                         when (scopeEntry.source) {
-                            is TraitImplSource.Object, is TraitImplSource.Collapsed -> {
+                            is TraitImplSource.Trait, is TraitImplSource.Collapsed -> {
                                 ctx.registerPathRefinement(pathExpr, traitRef)
                             }
                         }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsTypeAwareCompletionTest.kt
@@ -215,4 +215,15 @@ class RsTypeAwareCompletionTest : RsCompletionTestBase() {
         struct S;
         fn main() { let a: <S as Tr>::Item/*caret*/; }
     """)
+
+    fun `test impl for 'Sized' type parameter is not completed for trait object`() = checkNotContainsCompletion("bar", """
+        trait Foo { fn foo(&self); fn foo2(&self); }
+        trait Bar { fn bar(&self); }
+        impl<T> Bar for T {
+            fn bar(&self) {}
+        }
+        fn foo(a: &dyn Foo) {
+            (*a)./*caret*/
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
@@ -57,6 +57,14 @@ class RsMultiResolveTest : RsResolveTestBase() {
         }   //^
     """)
 
+    fun `test trait object inherent impl`() = doTest("""
+        trait Foo { fn foo(&self){} }
+        impl dyn Foo { fn foo(&self){} }
+        fn foo(a: &dyn Foo){
+            a.foo()
+        }   //^
+    """)
+
     private fun doTest(@Language("Rust") code: String) {
         InlineFile(code)
         val ref = findElementInEditor<RsReferenceElement>().reference

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -218,6 +218,17 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
         }
     """)
 
+    fun `test UFCS assoc function call on self trait from bound for Self`() = checkByCode("""
+        trait Foo {
+            fn foo() {}
+        }    //X
+        trait Bar {
+            fn bar() where Self: Foo {
+                Self::foo();
+            }        //^
+        }
+    """)
+
     fun `test Result unwrap`() = checkByCode("""
         enum Result<T, E> { Ok(T), Err(E)}
 
@@ -1053,7 +1064,7 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
                              //X
         impl Foo<Y> for S { fn foo(_: Y) {} }
         impl Unknown<Z> for S { fn foo(_: Z) {} }
-        
+
         fn main() {
             S::foo(X);
         }    //^

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -1069,4 +1069,25 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
             S::foo(X);
         }    //^
     """)
+
+    fun `test generic trait object inherent impl`() = checkByCode("""
+        trait Foo<T>{}
+        impl<T> dyn Foo<T>{
+            fn foo(&self){}
+        }    //X
+        fn foo(a: &dyn Foo<i32>){
+            a.foo()
+        }   //^
+    """)
+
+    fun `test impl for type parameter resolved for trait object`() = checkByCode("""
+        trait Foo {}
+        trait Bar { fn bar(&self); }
+        impl<T: ?Sized> Bar for T {
+            fn bar(&self) {}
+        }    //X
+        fn foo(a: &dyn Foo) {
+            (*a).bar()
+        }      //^
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -728,17 +728,14 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }
     """)
 
-    fun `test generic trait object inherent impl`() = checkByCode("""
-        trait Test<T>{}
-        impl<T> dyn Test<T>{
-            fn test(&self){}
-              //X
-        }
-        fn main(){
-            let a:&dyn Test<i32> = unimplemented!();
-            a.test()
-             //^
-        }
+    fun `test trait object method wins over non-inherent trait impl`() = checkByCode("""
+        trait Foo { fn bar(&self) {} }
+                     //X
+        trait Bar { fn bar(&self); }
+        impl Bar for dyn Foo { fn bar(&self) {} }
+        fn foo(a: &(dyn Foo + 'static)) {
+            (*a).bar()
+        }      //^
     """)
 
     fun `test filter methods from dangling (not attached to some crate) rust files`() = stubOnlyResolve("""

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1711,4 +1711,16 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             s;
         } //^ S<u8, <unknown>>
     """)
+
+    fun `test UFCS explicit trait type parameter`() = testExpr("""
+        struct S;
+        trait Foo<T> { fn foo(_: Self) -> T; }
+        impl Foo<i32> for S { fn foo(_: Self) -> i32 { unimplemented!() } }
+        impl Foo<u32> for S { fn foo(_: Self) -> u32 { unimplemented!() } }
+        fn main() {
+            let a = Foo::<i32>::foo(S);
+            let b = Foo::<u32>::foo(S);
+            (a, b);
+        } //^ (i32, u32)
+    """)
 }


### PR DESCRIPTION
1. Better resolve for `Self`-related paths in traits:
```rust
trait Foo {
    fn foo() {}
}    //X
trait Bar {
    fn bar() where Self: Foo {
        Self::foo();
    }        //^
}
```
2. Better type inference for trait-relative paths with type parameters (e.g. `Foo::<Bar>::baz()` where `Foo` is a trait)
3. Take into account blanket `impl<T> for T` impls when looking for trait object methods. Continuation of #4913

The PR is a result of [the discussion](https://github.com/intellij-rust/intellij-rust/pull/4913#discussion_r376583843).