### PR TITLE
TY: normalize trait bounds

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -510,7 +510,7 @@ class RsInferenceContext(
         return ty.foldTyInferWith(this::shallowResolve)
     }
 
-    private fun <T : TypeFoldable<T>> fullyResolve(ty: T): T {
+    fun <T : TypeFoldable<T>> fullyResolve(ty: T): T {
         fun go(ty: Ty): Ty {
             if (ty !is TyInfer) return ty
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -1090,4 +1090,13 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
             (*a).bar()
         }      //^
     """)
+
+    fun `test trait bounds normalization`() = checkByCode("""
+        trait Foo { fn foo(&self) {} }
+                     //X
+        trait Bar { type Item; }
+        fn foo<A: Bar<Item=B>, B>(b: B) where A::Item: Foo {
+            b.foo()
+        }   //^
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1723,4 +1723,15 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             (a, b);
         } //^ (i32, u32)
     """)
+
+    fun `test trait bounds normalization`() = testExpr("""
+        struct X;
+        trait Foo<T> {  }
+        fn foo<A: Foo<B>, B>(_: A) -> B { unimplemented!() }
+        trait Bar { type Item; }
+        fn bar<A: Bar<Item=B>, B>(b: B) where A::Item: Foo<X> {
+            let a = foo(b);
+            a;
+        } //^ X
+    """)
 }


### PR DESCRIPTION
Works for such case:
```rust
trait Foo {
    fn foo(&self) {}
}     //X
trait Bar {
    type Item;
}
fn foo<A, B>(b: B) 
    where A: Bar<Item=B>, 
          A::Item: Foo // `A::Item` is equivalent to `B`
{
    b.foo()
}   //^
```