### PR TITLE
ANN: check existence and type of parameters in format macros

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
@@ -13,124 +13,149 @@ import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
 import org.intellij.lang.annotations.Language
 import org.rust.ide.colors.RsColor
-import org.rust.lang.core.psi.RsLitExpr
-import org.rust.lang.core.psi.RsLiteralKind
-import org.rust.lang.core.psi.RsMacroCall
+import org.rust.ide.presentation.render
+import org.rust.lang.core.macros.MacroExpansionMode
+import org.rust.lang.core.macros.macroExpansionManager
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.descendantOfTypeStrict
 import org.rust.lang.core.psi.ext.macroName
 import org.rust.lang.core.psi.ext.startOffset
-import org.rust.lang.core.psi.kind
+import org.rust.lang.core.psi.ext.withSubst
+import org.rust.lang.core.resolve.KnownItems
+import org.rust.lang.core.resolve.knownItems
+import org.rust.lang.core.types.TraitRef
+import org.rust.lang.core.types.implLookup
+import org.rust.lang.core.types.ty.TyInteger
+import org.rust.lang.core.types.ty.stripReferences
+import org.rust.lang.core.types.type
 import org.rust.lang.utils.parseRustStringCharacters
 
 class RsFormatMacroAnnotator : AnnotatorBase() {
-
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         val formatMacro = element as? RsMacroCall ?: return
 
-        val formatStr = formatMacro
-            .formatMacroArgument
-            ?.formatMacroArgList
-            ?.getOrNull(macroToFormatPos(formatMacro.macroName))
+        val macroPos = macroToFormatPos(formatMacro.macroName) ?: return
+        val macroArgs = formatMacro.formatMacroArgument?.formatMacroArgList ?: return
+        val formatStr = macroArgs
+            .getOrNull(macroPos)
             ?.descendantOfTypeStrict<RsLitExpr>()
             ?: return
 
-        val literalKind = (formatStr.kind as? RsLiteralKind.String) ?: return
-        val rawTextRange = literalKind.offsets.value ?: return
-        val (unescapedText, sourceMap, _) = parseRustStringCharacters(rawTextRange.substring(literalKind.node.text))
+        val parseCtx = parseParameters(formatStr) ?: return
 
-        val arguments = formatParser.findAll(unescapedText)
-        var currentOffset = 0
-
-        fun IntRange.toSourceRange(additionalOffset: Int = currentOffset): TextRange =
-            TextRange(sourceMap[first + additionalOffset], sourceMap[last + additionalOffset] + 1)
-                .shiftRight(formatStr.startOffset + rawTextRange.startOffset)
-
-        fun AnnotationHolder.highlightArgument(range: IntRange?, color: RsColor = RsColor.IDENTIFIER) {
-            if (range != null && !range.isEmpty()) {
-                // BACKCOMPAT: 2019.3
-                @Suppress("DEPRECATION")
-                createAnnotation(
-                    HighlightSeverity.INFORMATION,
-                    range.toSourceRange(),
-                    null
-                ).textAttributes = color.textAttributesKey
-            }
-        }
-
-        val key = RsColor.FORMAT_SPECIFIER
-        val highlightSeverity = if (isUnitTestMode) key.testSeverity else HighlightSeverity.INFORMATION
-        for (arg in arguments) {
-            currentOffset = 0
-            val textRange = arg.range.toSourceRange()
+        val errors = checkSyntaxErrors(parseCtx)
+        for (error in errors) {
             // BACKCOMPAT: 2019.3
             @Suppress("DEPRECATION")
-            holder.createAnnotation(highlightSeverity, textRange, null)
-                .textAttributes = key.textAttributesKey
+            holder.createErrorAnnotation(error.range, error.error)
+        }
 
-            if (arg.groups[3] != null) {
-                // BACKCOMPAT: 2019.3
-                @Suppress("DEPRECATION")
-                holder.createErrorAnnotation(
-                    arg.range.toSourceRange(),
-                    "Invalid format string: unmatched '}'"
-                )
-            }
-            if (arg.groups[1] != null) {
+        highlightParametersOutside(parseCtx, holder)
 
-                val inside = arg.groups[2] ?: error(" should not be null because can match empty string")
-                currentOffset = inside.range.first
-                val matchResult = formatArgParser.find(inside.value)
-                    ?: error(" should be not null because can match empty string")
+        // skip advanced checks and highlighting if there are syntax errors
+        if (errors.isNotEmpty()) {
+            return
+        }
 
-                if (!arg.groups[1]!!.value.endsWith("}")) {
-                    val possibleEnd = matchResult.value.length - 1
-                    // BACKCOMPAT: 2019.3
-                    @Suppress("DEPRECATION")
-                    holder.createErrorAnnotation(
-                        (possibleEnd..possibleEnd).toSourceRange(),
-                        "Invalid format string: } expected.\nIf you intended to print `{` symbol, you can escape it using `{{`"
-                    )
-                    continue
-                }
+        highlightParametersInside(parseCtx, holder)
 
-                val validParsedEnd = matchResult.range.last + 1
-                if (validParsedEnd != inside.value.length) {
-                    // BACKCOMPAT: 2019.3
-                    @Suppress("DEPRECATION")
-                    holder.createErrorAnnotation(
-                        (validParsedEnd until inside.value.length).toSourceRange(),
-                        "Invalid format string"
-                    )
-                } else {
-                    holder.highlightArgument(matchResult.groups["id"]?.range)
-                    holder.highlightArgument(matchResult.groups["width"]?.range)
-                    holder.highlightArgument(matchResult.groups["precision"]?.range)
-                    holder.highlightArgument(matchResult.groups["type"]?.range, RsColor.FUNCTION)
-                    //TODO: argument type/count/other checks
-                }
+        if (!isUnitTestMode && element.project.macroExpansionManager.macroExpansionMode !is MacroExpansionMode.New) return
+
+        val parameters = buildParameters(parseCtx)
+        val arguments = macroArgs
+            .drop(macroPos + 1)
+            .toList()
+        val ctx = FormatContext(parameters, arguments, formatMacro)
+
+        val annotations = checkParameters(ctx).toMutableList()
+        annotations += checkArguments(ctx)
+
+        for (annotation in annotations) {
+            // BACKCOMPAT: 2019.3
+            @Suppress("DEPRECATION")
+            holder.createErrorAnnotation(annotation.range, annotation.error)
+        }
+    }
+}
+
+private data class ParameterMatchInfo(val range: TextRange, val text: String)
+
+private sealed class ParameterLookup {
+    data class Named(val name: String) : ParameterLookup()
+    data class Positional(val position: Int) : ParameterLookup()
+}
+
+private sealed class FormatParameter(val matchInfo: ParameterMatchInfo, val lookup: ParameterLookup) {
+    override fun toString(): String {
+        return this.matchInfo.text
+    }
+
+    val range: TextRange = matchInfo.range
+
+    // normal parameter which will be formatted
+    class Value(matchInfo: ParameterMatchInfo, lookup: ParameterLookup, val type: String, val typeRange: TextRange)
+        : FormatParameter(matchInfo, lookup) {
+        fun requiredTrait(knownItems: KnownItems): RsTraitItem? {
+            return when (this.type) {
+                "" -> knownItems.Display
+                "?", "x?", "X?" -> knownItems.Debug
+                "o" -> knownItems.Octal
+                "x" -> knownItems.LowerHex
+                "X" -> knownItems.UpperHex
+                "p" -> knownItems.Pointer
+                "b" -> knownItems.Binary
+                "e" -> knownItems.LowerExp
+                "E" -> knownItems.UpperExp
+                else -> return null
             }
         }
     }
 
-    private fun macroToFormatPos(macro: String): Int = when (macro) {
-        "println" -> 0
-        "print" -> 0
-        "eprintln" -> 0
-        "eprint" -> 0
-        "format" -> 0
-        "format_args" -> 0
-        "format_args_nl" -> 0
-        "write" -> 1
-        "writeln" -> 1
-        else -> -1
-    }
+    // width or precision formatting specifier
+    class Specifier(matchInfo: ParameterMatchInfo, lookup: ParameterLookup, val specifier: String)
+        : FormatParameter(matchInfo, lookup)
+}
 
-    companion object {
-        private val formatParser = Regex("""\{\{|}}|(\{([^}]*)}?)|(})""")
+private data class FormatContext(
+    val parameters: List<FormatParameter>,
+    val arguments: List<RsFormatMacroArg>,
+    val macro: RsMacroCall
+) {
+    val namedParameters = parameters.mapNotNull {
+        val lookup = it.lookup as? ParameterLookup.Named ?: return@mapNotNull null
+        Pair(it, lookup)
+    }.toSet()
+    val positionalParameters = parameters.mapNotNull {
+        val lookup = it.lookup as? ParameterLookup.Positional ?: return@mapNotNull null
+        Pair(it, lookup)
+    }.toSet()
 
-        @Language("Regexp")
-        private const val argument = """([a-zA-Z_][\w+]*|\d+)"""
-        private val formatArgParser = Regex("""(?x) # enable comments
+    val namedArguments: Map<String, RsFormatMacroArg> = arguments.filter { it.name() != null }.map { it.name()!! to it }.toMap()
+
+    val knownItems: KnownItems = macro.knownItems
+}
+
+private data class ParsedParameter(
+    val completeMatch: MatchResult,
+    val innerContentMatch: MatchResult? = null
+) {
+    val innerContent = completeMatch.groups[2]
+    val range: IntRange = completeMatch.range
+}
+
+private data class ParseContext(val sourceMap: IntArray, val offset: Int, val parameters: List<ParsedParameter>) {
+    fun toSourceRange(range: IntRange, additionalOffset: Int = 0): TextRange =
+        TextRange(sourceMap[range.first + additionalOffset], sourceMap[range.last + additionalOffset] + 1)
+            .shiftRight(offset)
+}
+
+private data class ErrorAnnotation(val range: TextRange, val error: String)
+
+private val formatParser = Regex("""\{\{|}}|(\{([^}]*)}?)|(})""")
+
+@Language("Regexp")
+private const val argument = """([a-zA-Z_][\w+]*|\d+)"""
+private val formatParameterParser = Regex("""(?x) # enable comments
 ^(?<id>$argument)?
 (:
     (.?[\^<>])?[+\-]?\#?
@@ -140,5 +165,306 @@ class RsFormatMacroAnnotator : AnnotatorBase() {
     (?<type>\w?\??)?
 )?\s*""")
 
+private fun parseParameters(formatStr: RsLitExpr): ParseContext? {
+    val literalKind = (formatStr.kind as? RsLiteralKind.String) ?: return null
+    val rawTextRange = literalKind.offsets.value ?: return null
+    val (unescapedText, sourceMap, _) = parseRustStringCharacters(rawTextRange.substring(literalKind.node.text))
+
+    val arguments = formatParser.findAll(unescapedText)
+    val parsed = arguments.map { arg ->
+        if (arg.groups[1] != null) {
+            val innerContent = arg.groups[2] ?: error(" should not be null because can match empty string")
+            val innerContentMatch = formatParameterParser.find(innerContent.value)
+                ?: error(" should be not null because can match empty string")
+
+            ParsedParameter(arg, innerContentMatch)
+        } else {
+            ParsedParameter(arg)
+        }
+    }.toList()
+
+    return ParseContext(sourceMap, formatStr.startOffset + rawTextRange.startOffset, parsed)
+}
+
+private fun checkSyntaxErrors(ctx: ParseContext): List<ErrorAnnotation> {
+    val errors = mutableListOf<ErrorAnnotation>()
+
+    for (parameter in ctx.parameters) {
+        val completeMatch = parameter.completeMatch
+        val range = ctx.toSourceRange(parameter.range)
+
+        if (completeMatch.groups[3] != null) {
+            errors.add(ErrorAnnotation(range, "Invalid format string: unmatched '}'"))
+        }
+
+        if (parameter.innerContent != null && parameter.innerContentMatch != null) {
+            val innerContent = parameter.innerContent
+            val content = completeMatch.groups[1]
+            if (content != null && !content.value.endsWith("}")) {
+                val possibleEnd = parameter.innerContentMatch.value.length - 1
+                errors.add(ErrorAnnotation(
+                    ctx.toSourceRange(possibleEnd..possibleEnd, innerContent.range.first),
+                    "Invalid format string: } expected.\nIf you intended to print `{` symbol, you can escape it using `{{`"
+                ))
+                continue
+            }
+
+            val validParsedEnd = parameter.innerContentMatch.range.last + 1
+            if (validParsedEnd != innerContent.value.length) {
+                errors.add(ErrorAnnotation(
+                    ctx.toSourceRange(validParsedEnd until innerContent.value.length, innerContent.range.first),
+                    "Invalid format string"
+                ))
+            }
+        }
+    }
+    return errors
+}
+
+private fun highlightParametersOutside(ctx: ParseContext, holder: AnnotationHolder) {
+    val key = RsColor.FORMAT_SPECIFIER
+    val highlightSeverity = if (isUnitTestMode) key.testSeverity else HighlightSeverity.INFORMATION
+
+    for (parameter in ctx.parameters) {
+        // BACKCOMPAT: 2019.3
+        @Suppress("DEPRECATION")
+        holder.createAnnotation(highlightSeverity, ctx.toSourceRange(parameter.range), null)
+            .textAttributes = key.textAttributesKey
     }
 }
+
+private fun highlightParametersInside(ctx: ParseContext, holder: AnnotationHolder) {
+    fun highlight(range: IntRange?, offset: Int, color: RsColor = RsColor.IDENTIFIER) {
+        if (range != null && !range.isEmpty()) {
+            // BACKCOMPAT: 2019.3
+            @Suppress("DEPRECATION")
+            holder.createAnnotation(
+                HighlightSeverity.INFORMATION,
+                ctx.toSourceRange(range, offset),
+                null
+            ).textAttributes = color.textAttributesKey
+        }
+    }
+
+    for (parameter in ctx.parameters) {
+        val match = parameter.innerContentMatch
+        match?.let {
+            val offset = parameter.innerContent?.range?.first ?: return@let
+
+            highlight(it.groups["id"]?.range, offset)
+            highlight(it.groups["width"]?.range, offset)
+            highlight(it.groups["precision"]?.range, offset)
+            highlight(it.groups["type"]?.range, offset, RsColor.FUNCTION)
+        }
+    }
+}
+
+private fun buildLookup(value: String): ParameterLookup {
+    val identifier = value.toIntOrNull()
+    return if (identifier == null) {
+        ParameterLookup.Named(value)
+    } else {
+        ParameterLookup.Positional(identifier)
+    }
+}
+
+private fun buildParameters(ctx: ParseContext): List<FormatParameter> {
+    val ignored = setOf("{{", "}}")
+    var implicitPositionCounter = 0
+
+    return ctx.parameters.flatMap { param ->
+        val parameters = mutableListOf<FormatParameter>()
+
+        val innerRange = param.innerContent?.range ?: return@flatMap parameters
+        val match = param.innerContentMatch ?: return@flatMap parameters
+
+        val id = match.groups["id"]
+        val type = match.groups["type"]
+        val precision = match.groups["precision"]
+        val isPrecisionAsterisk = precision != null && precision.value == "*"
+        var isPrecisionValueFirst = false
+
+        if (match.value in ignored) return@flatMap parameters
+
+        val typeStr = type?.value ?: ""
+        val typeRange = type?.range ?: IntRange(0, 0)
+
+        val mainParameter = if (id != null) {
+            val matchInfo = ParameterMatchInfo(ctx.toSourceRange(id.range, innerRange.first), param.completeMatch.value)
+            isPrecisionValueFirst = true
+            FormatParameter.Value(matchInfo, buildLookup(id.value), typeStr, ctx.toSourceRange(typeRange, innerRange.first))
+        } else {
+            val matchInfo = ParameterMatchInfo(ctx.toSourceRange(param.range), param.completeMatch.value)
+
+            if (isPrecisionAsterisk) {
+                FormatParameter.Specifier(matchInfo, ParameterLookup.Positional(implicitPositionCounter++), "precision")
+            } else {
+                FormatParameter.Value(matchInfo, ParameterLookup.Positional(implicitPositionCounter++), typeStr, ctx.toSourceRange(typeRange, innerRange.first))
+            }
+        }
+
+        parameters.add(mainParameter)
+
+        val specifiers = listOf("width", "precision")
+        for (specifier in specifiers) {
+            val group = match.groups[specifier] ?: continue
+            val text = group.value
+            if (!text.endsWith("$")) continue
+            parameters.add(FormatParameter.Specifier(
+                ParameterMatchInfo(ctx.toSourceRange(group.range, innerRange.first), text),
+                buildLookup(text.trimEnd('$')),
+                specifier
+            ))
+        }
+
+        if (isPrecisionAsterisk) {
+            if (isPrecisionValueFirst) {
+                parameters.add(FormatParameter.Specifier(
+                    ParameterMatchInfo(ctx.toSourceRange(precision!!.range, innerRange.first), precision.value),
+                    ParameterLookup.Positional(implicitPositionCounter++),
+                    "precision"
+                ))
+            } else {
+                val matchInfo = ParameterMatchInfo(ctx.toSourceRange(param.range), param.completeMatch.value)
+                parameters.add(FormatParameter.Value(
+                    matchInfo, ParameterLookup.Positional(implicitPositionCounter++),
+                    typeStr, ctx.toSourceRange(typeRange, innerRange.first))
+                )
+            }
+        }
+
+        parameters
+    }
+}
+
+private fun checkParameter(parameter: FormatParameter, ctx: FormatContext): List<ErrorAnnotation> {
+    val errors = mutableListOf<ErrorAnnotation>()
+
+    when (val lookup = parameter.lookup) {
+        is ParameterLookup.Named -> {
+            if (lookup.name !in ctx.namedArguments) {
+                errors.add(ErrorAnnotation(parameter.range, "There is no argument named `${lookup.name}`"))
+            }
+        }
+        is ParameterLookup.Positional -> {
+            if (lookup.position >= ctx.arguments.size) {
+                val count = when (ctx.arguments.size) {
+                    0 -> "no arguments were given"
+                    1 -> "there is 1 argument"
+                    else -> "there are ${ctx.arguments.size} arguments"
+                }
+                errors.add(ErrorAnnotation(parameter.range, "Invalid reference to positional argument ${lookup.position} ($count)"))
+            }
+        }
+    }
+
+    if (errors.isEmpty() && parameter is FormatParameter.Value) {
+        if (parameter.requiredTrait(ctx.knownItems) == null) {
+            errors.add(ErrorAnnotation(parameter.typeRange, "Unknown format trait `${parameter.type}`"))
+        }
+    }
+
+    return errors
+}
+
+private fun checkParameters(ctx: FormatContext): List<ErrorAnnotation> {
+    val errors = mutableListOf<ErrorAnnotation>()
+    for (parameter in ctx.parameters) {
+        for (error in checkParameter(parameter, ctx)) {
+            errors.add(error)
+        }
+    }
+    return errors
+}
+
+private fun findParameters(argument: RsFormatMacroArg, position: Int, ctx: FormatContext): List<FormatParameter> {
+    val name = argument.name()
+    val positional = ctx.positionalParameters.filter { it.second.position == position }.map { it.first }.toList()
+    return if (name == null) {
+        positional
+    } else {
+        positional + ctx.namedParameters.filter { it.second.name == name }.map { it.first }.toList()
+    }
+}
+
+private fun checkParameterTraitMatch(argument: RsFormatMacroArg, parameter: FormatParameter.Value): ErrorAnnotation? {
+    val requiredTrait = parameter.requiredTrait(argument.knownItems) ?: return null
+
+    val expr = argument.expr
+    if (!expr.implLookup.canSelectWithDeref(TraitRef(expr.type, requiredTrait.withSubst()))) {
+        return ErrorAnnotation(argument.textRange, "`${expr.type.render(useAliasNames = true)}` doesn't implement `${requiredTrait.name}` (required by ${parameter.matchInfo.text})")
+    }
+    return null
+}
+
+// i32 is allowed because of integers without a specific type
+private val ALLOWED_SPECIFIERS_TYPES = setOf(TyInteger.USize, TyInteger.I32)
+
+private fun checkSpecifierType(argument: RsFormatMacroArg, parameter: FormatParameter.Specifier): ErrorAnnotation? {
+    val expr = argument.expr
+    val type = expr.type.stripReferences()
+    if (type !in ALLOWED_SPECIFIERS_TYPES) {
+        return ErrorAnnotation(argument.textRange, "${parameter.specifier.capitalize()} specifier must be of type `usize`")
+    }
+    return null
+}
+
+private fun checkArgument(argument: RsFormatMacroArg, ctx: FormatContext): List<ErrorAnnotation> {
+    val errors = mutableListOf<ErrorAnnotation>()
+    val name = argument.name()
+    val position = ctx.arguments.indexOf(argument)
+    val hasPositionalParameter = ctx.positionalParameters.find { it.second.position == position } != null
+
+    if (name == null) {
+        val firstNamed = ctx.arguments.indexOfFirst { it.identifier != null }
+        if (firstNamed != -1 && firstNamed < position) {
+            errors.add(ErrorAnnotation(argument.textRange, "Positional arguments cannot follow named arguments"))
+        } else if (!hasPositionalParameter) {
+            errors.add(ErrorAnnotation(argument.textRange, "Argument never used"))
+        }
+    } else if (name !in ctx.namedParameters.map { it.second.name } && !hasPositionalParameter) {
+        errors.add(ErrorAnnotation(argument.textRange, "Named argument never used"))
+    }
+
+    if (errors.isEmpty()) {
+        val parameters = findParameters(argument, position, ctx)
+        check(parameters.isNotEmpty()) // should be caught by the checks above
+        for (parameter in parameters) {
+            val error = when (parameter) {
+                is FormatParameter.Value -> checkParameterTraitMatch(argument, parameter)
+                is FormatParameter.Specifier -> checkSpecifierType(argument, parameter)
+            }
+            error?.let {
+                errors.add(it)
+            }
+        }
+    }
+
+    return errors
+}
+
+private fun checkArguments(ctx: FormatContext): List<ErrorAnnotation> {
+    val errors = mutableListOf<ErrorAnnotation>()
+    for (arg in ctx.arguments) {
+        for (error in checkArgument(arg, ctx)) {
+            errors.add(error)
+        }
+    }
+    return errors
+}
+
+// TODO: handle log, tracing
+private fun macroToFormatPos(macro: String): Int? = when (macro) {
+    "println" -> 0
+    "print" -> 0
+    "eprintln" -> 0
+    "eprint" -> 0
+    "format" -> 0
+    "format_args" -> 0
+    "format_args_nl" -> 0
+    "write" -> 1
+    "writeln" -> 1
+    else -> null
+}
+
+private fun RsFormatMacroArg.name(): String? = this.identifier?.text

--- a/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
@@ -97,6 +97,13 @@ class KnownItems(
     val Try: RsTraitItem? get() = findItem("core::ops::try::Try")
     val Generator: RsTraitItem? get() = findItem("core::ops::generator::Generator")
     val Future: RsTraitItem? get() = findItem("core::future::future::Future")
+    val Octal: RsTraitItem? get() = findItem("core::fmt::Octal")
+    val LowerHex: RsTraitItem? get() = findItem("core::fmt::LowerHex")
+    val UpperHex: RsTraitItem? get() = findItem("core::fmt::UpperHex")
+    val Pointer: RsTraitItem? get() = findItem("core::fmt::Pointer")
+    val Binary: RsTraitItem? get() = findItem("core::fmt::Binary")
+    val LowerExp: RsTraitItem? get() = findItem("core::fmt::LowerExp")
+    val UpperExp: RsTraitItem? get() = findItem("core::fmt::UpperExp")
 
     // Lang items
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -5,15 +5,78 @@
 
 package org.rust.ide.annotator
 
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.colors.RsColor
 
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::class) {
     override fun setUp() {
         super.setUp()
         super.annotationFixture.registerSeverities(RsColor.values().map(RsColor::testSeverity))
     }
 
-    fun `test invalid 1`() = checkHighlighting("""
+    private val implDisplayI32 = """
+        use std::fmt;
+        impl fmt::Display for i32 {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { unimplemented!() }
+        }
+    """
+
+    fun `test missing argument`() = checkErrors("""
+        $implDisplayI32
+
+        fn main() {
+            println!("<error descr="Invalid reference to positional argument 0 (no arguments were given)">{}</error>");
+            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<error descr="Invalid reference to positional argument 1 (there is 1 argument)">1</error>}</FORMAT_SPECIFIER>", 1);
+            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{1}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<error descr="Invalid reference to positional argument 3 (there are 2 arguments)">3</error>}</FORMAT_SPECIFIER>", 1, 1);
+            println!("Hello <FORMAT_SPECIFIER>{:<error descr="Invalid reference to positional argument 1 (there is 1 argument)">1${'$'}</error>}</FORMAT_SPECIFIER>", 1);
+            println!("<FORMAT_SPECIFIER>{<error descr="There is no argument named `foo`">foo</error>}</FORMAT_SPECIFIER>");
+            println!("Hello <FORMAT_SPECIFIER>{:<error descr="There is no argument named `foo`">foo$</error>}</FORMAT_SPECIFIER>", 1);
+        }
+    """)
+
+    fun `test missing parameter`() = checkErrors("""
+        $implDisplayI32
+
+        fn main() {
+            println!("", <error descr="Argument never used">1.2</error>);
+            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER>", 1, <error descr="Argument never used">1.2</error>);
+            println!("", <error descr="Named argument never used">foo=1.2</error>);
+        }
+    """)
+
+    fun `test invalid parameter type`() = checkErrors("""
+        fn main() {
+            println!("<FORMAT_SPECIFIER>{:<error descr="Unknown format trait `u`">u</error>}</FORMAT_SPECIFIER>", 1);
+        }
+    """)
+
+    fun `test argument matches parameter`() = checkErrors("""
+        $implDisplayI32
+
+        struct Debug;
+        impl std::fmt::Debug for Debug {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result { unimplemented!() }
+        }
+
+        fn main() {
+            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", 1);
+            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", 1);
+            println!("<FORMAT_SPECIFIER>{foo}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", foo=1);
+            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", 1, 1);
+            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", foo=1);
+
+            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER>", foo=1);
+            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{1:?}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER>", 1, Debug);
+
+            println!("<FORMAT_SPECIFIER>{foo}</FORMAT_SPECIFIER>", foo=1);
+            println!("<FORMAT_SPECIFIER>{bar:?}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{foo}</FORMAT_SPECIFIER>", foo=1, bar=Debug);
+            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{foo}</FORMAT_SPECIFIER>", foo=1);
+        }
+    """)
+
+    fun `test invalid syntax 1`() = checkErrors("""
         fn main() {
             println!("<error descr="Invalid format string: } expected.
 If you intended to print `{` symbol, you can escape it using `{{`">{</error>");
@@ -30,10 +93,10 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>");
             //~^ ERROR invalid format string: expected `'}'` but string was terminated
             let _ = format!("<error descr="Invalid format string: unmatched '}'">}</error>");
             //~^ ERROR invalid format string: unmatched `}` found
-            let _ = format!("{<error descr="Invalid format string">\</error>\}");
+            let _ = format!("<FORMAT_SPECIFIER>{<error descr="Invalid format string">\</error>\}</FORMAT_SPECIFIER>");
             //~^ ERROR invalid format string: expected `'}'`, found `'\\'`
-            let _ = format!("\n\n\n{\n\n<error descr="Invalid format string: } expected.
-If you intended to print `{` symbol, you can escape it using `{{`">\</error>n");
+            let _ = format!("\n\n\n<FORMAT_SPECIFIER>{\n\n<error descr="Invalid format string: } expected.
+If you intended to print `{` symbol, you can escape it using `{{`">\</error></FORMAT_SPECIFIER>n");
             //~^ ERROR invalid format string
             let _ = format!(r###"
             <error descr="Invalid format string: } expected.
@@ -45,7 +108,9 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
             //~^^^ ERROR invalid format string: unmatched `}` found
         }     """)
 
-    fun `test invalid 2`() = checkHighlighting("""
+    fun `test invalid syntax 2`() = checkErrors("""
+        $implDisplayI32
+
         fn main() {
             format!("<FORMAT_SPECIFIER>{
            <error descr="Invalid format string: } expected.
@@ -108,8 +173,6 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
             <error descr="Invalid format string">asdf</error>}</FORMAT_SPECIFIER>
             ", asdf=1);
             //~^^ ERROR invalid format string
-            println!("\t<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>");
-            //~^ ERROR 1 positional argument in format string
 
             // note: `\x7B` is `{`
             println!("<FORMAT_SPECIFIER>\x7B}</FORMAT_SPECIFIER>\u{8} <error descr="Invalid format string: } expected.
@@ -126,40 +189,204 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         }
     """)
 
-    fun `test invalid inside`() = checkHighlighting("""
-        fn main(){
-            println!("{3<error descr="Invalid format string">a</error>}");
-            println!("{:<error descr="Invalid format string">|</error>}");
-            println!("{:>><error descr="Invalid format string">></error>}");
-            println!("{<error descr="Invalid format string">!:?</error>}");
-            println!("{:?<error descr="Invalid format string">?</error>}");
+    fun `test invalid inner syntax`() = checkErrors("""
+        fn main() {
+            println!("<FORMAT_SPECIFIER>{3<error descr="Invalid format string">a</error>}</FORMAT_SPECIFIER>");
+            println!("<FORMAT_SPECIFIER>{:<error descr="Invalid format string">|</error>}</FORMAT_SPECIFIER>");
+            println!("<FORMAT_SPECIFIER>{:>><error descr="Invalid format string">></error>}</FORMAT_SPECIFIER>");
+            println!("<FORMAT_SPECIFIER>{<error descr="Invalid format string">!:?</error>}</FORMAT_SPECIFIER>");
+            println!("<FORMAT_SPECIFIER>{:?<error descr="Invalid format string">?</error>}</FORMAT_SPECIFIER>");
         }
     """)
 
-    fun `test valid`() = checkByText("""
+    fun `test valid syntax`() = checkErrors("""
+        use std::fmt;
+
+        struct S;
+        impl fmt::Display for S {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
+        }
+        impl fmt::Debug for S {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
+        }
+        impl fmt::LowerExp for S {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
+        }
+        impl fmt::LowerHex for S {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
+        }
+
         fn main(){
             println!("<FORMAT_SPECIFIER>{{</FORMAT_SPECIFIER><FORMAT_SPECIFIER>}}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{3}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{3:}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{:?}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{x:}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{3:a}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{3:a?}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{3:0<}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{3:0$}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{3:00$}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{3:*<abc}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{3:10s}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{3:10$.10s}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{3:a$.b${'$'}s}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{number:*>+#0width$.10x?}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{:-}</FORMAT_SPECIFIER> <FORMAT_SPECIFIER>{:#}</FORMAT_SPECIFIER> <FORMAT_SPECIFIER>{:+#}</FORMAT_SPECIFIER>");
+            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{0:}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:?}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:#?}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:e}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{x:}</FORMAT_SPECIFIER>", x=S);
+            println!("<FORMAT_SPECIFIER>{0:x}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{0:x?}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{0:0<}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{1:0$}</FORMAT_SPECIFIER>", 1, S);
+            println!("<FORMAT_SPECIFIER>{1:00$}</FORMAT_SPECIFIER>", 1, S);
+            println!("<FORMAT_SPECIFIER>{0:10x}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{0:1$.10x}</FORMAT_SPECIFIER>", S, 1);
+            println!("<FORMAT_SPECIFIER>{0:a$.b${'$'}x}</FORMAT_SPECIFIER>", S, a=2, b=3);
+            println!("<FORMAT_SPECIFIER>{number:*>+#0width$.10x?}</FORMAT_SPECIFIER>", number=S, width=1);
+            println!("<FORMAT_SPECIFIER>{:-}</FORMAT_SPECIFIER> <FORMAT_SPECIFIER>{:#}</FORMAT_SPECIFIER> <FORMAT_SPECIFIER>{:+#}</FORMAT_SPECIFIER>", S, S, S);
             println!("");
-            println!("<FORMAT_SPECIFIER>\x7B}</FORMAT_SPECIFIER>");
+            println!("<FORMAT_SPECIFIER>\x7B}</FORMAT_SPECIFIER>", S);
             let mut w = Vec::new();
-            write!(&mut w,"<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>",1)
-            format_args!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>",1)
+            write!(&mut w, "<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
+            format_args!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
         }
-    """, checkInfo = true, ignoreExtraHighlighting = true)
+    """)
 
+    fun `test format trait is not implemented`() = checkErrors("""
+        struct S;
+
+        fn main() {
+            let s = S;
+            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Display` (required by {})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:?}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:?})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:x?}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:x?})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:X?}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:X?})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:#?}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:#?})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:o}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Octal` (required by {:o})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:x}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `LowerHex` (required by {:x})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:X}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `UpperHex` (required by {:X})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:p}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Pointer` (required by {:p})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:b}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Binary` (required by {:b})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:e}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `LowerExp` (required by {:e})">s</error>);
+            println!("<FORMAT_SPECIFIER>{0:E}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `UpperExp` (required by {0:E})">s</error>);
+        }
+    """)
+
+    fun `test format trait is implemented`() = checkErrors("""
+        use std::fmt;
+
+        struct S;
+        impl fmt::Display for S {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
+        }
+        impl fmt::Debug for S {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
+        }
+        impl fmt::Octal for S {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
+        }
+        impl fmt::LowerHex for S {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
+        }
+        impl fmt::UpperHex for S {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
+        }
+        impl fmt::Pointer for S {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
+        }
+        impl fmt::Binary for S {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
+        }
+        impl fmt::LowerExp for S {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
+        }
+        impl fmt::UpperExp for S {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
+        }
+
+        fn main() {
+            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:?}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:x?}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:X?}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:#?}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:o}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:x}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:X}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:p}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:b}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:e}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:E}</FORMAT_SPECIFIER>", S);
+        }
+    """)
+
+    fun `test format trait is implemented behind deref`() = checkErrors("""
+        use std::fmt;
+        use std::ops::Deref;
+
+        struct S;
+        impl fmt::Display for S {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { unimplemented!() }
+        }
+
+        struct W { s: S }
+
+        impl Deref for W {
+            type Target = S;
+            fn deref(&self) -> &Self::Target { &self.s }
+        }
+
+        fn main() {
+            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", *W { s: S });
+        }
+    """)
+
+    fun `test format trait is implemented behind reference`() = checkErrors("""
+        $implDisplayI32
+
+        fn main() {
+            let s = S;
+            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", &1);
+        }
+    """)
+
+    fun `test match format parameters`() = checkErrors("""
+        $implDisplayI32
+
+        fn main() {
+            let a = 5;
+            println!("Hello <FORMAT_SPECIFIER>{:1${'$'}}</FORMAT_SPECIFIER>!", 1, a);
+
+            println!("Hello <FORMAT_SPECIFIER>{:1${'$'}}</FORMAT_SPECIFIER>!", 1, 5);
+            println!("Hello <FORMAT_SPECIFIER>{1:0${'$'}}</FORMAT_SPECIFIER>!", 5, 1);
+            println!("Hello <FORMAT_SPECIFIER>{1:0${'$'}.2${'$'}}</FORMAT_SPECIFIER>!", 1, 1, 4);
+            println!("Hello <FORMAT_SPECIFIER>{:width${'$'}}</FORMAT_SPECIFIER>!", 1, width = 5);
+        }
+    """)
+
+    fun `test check format parameters type`() = checkErrors("""
+        $implDisplayI32
+
+        fn main() {
+            println!("Hello <FORMAT_SPECIFIER>{:1${'$'}}</FORMAT_SPECIFIER>!", 1, <error descr="Width specifier must be of type `usize`">"asd"</error>);
+            println!("Hello <FORMAT_SPECIFIER>{:.1${'$'}}</FORMAT_SPECIFIER>!", 1, <error descr="Precision specifier must be of type `usize`">2.0</error>);
+            println!("Hello <FORMAT_SPECIFIER>{:1${'$'}.1${'$'}}</FORMAT_SPECIFIER>!", 1, <error descr="Width specifier must be of type `usize`"><error descr="Precision specifier must be of type `usize`">2.0</error></error>);
+        }
+    """)
+
+    fun `test check precision asterisk`() = checkErrors("""
+        $implDisplayI32
+
+        fn main() {
+            println!("<FORMAT_SPECIFIER>{:.*}</FORMAT_SPECIFIER>", 1, 2);
+            println!("<FORMAT_SPECIFIER>{0:.*}</FORMAT_SPECIFIER>", 1);
+            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{name:.*}</FORMAT_SPECIFIER>", 1, 3, name=2);
+            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{2:.*}</FORMAT_SPECIFIER>", 1, 5, 2);
+            println!("<FORMAT_SPECIFIER>{:a${'$'}.*}</FORMAT_SPECIFIER>!", 5, 1, a=3);
+        }
+    """)
+
+    fun `test check precision asterisk wrong parameter`() = checkErrors("""
+        use std::fmt;
+
+        struct S;
+        impl fmt::Display for S {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { unimplemented!() }
+        }
+
+        fn main() {
+            println!("<FORMAT_SPECIFIER>{:.*}</FORMAT_SPECIFIER>!", <error descr="Precision specifier must be of type `usize`">"asd"</error>, S);
+            println!("<FORMAT_SPECIFIER>{0:.*}</FORMAT_SPECIFIER>!", <error descr="Precision specifier must be of type `usize`">S</error>);
+        }
+    """)
 }


### PR DESCRIPTION
This PR builds on top of https://github.com/intellij-rust/intellij-rust/pull/3869 and adds additional checks which look for missing or invalid parameters in format macros. After this check exists we can possibly add quick fixes to add missing parameters.

Questions:
- I need to check if a `Ty` implements a given trait. I tried to use `isTraitImplemented` from `ImplLookup`, but I had to make it public and it also doesn't seem to work in tests, I'm probably doing something wrong.
- Should this check be performed every time? Now I only do the check if there are not large errors in the format (for example missing `}`). If there is such a fundamental error, it will probably produce a lot of (false positive) parameter errors, so the parameter check should probably be skipped.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/4089
Umbrella issue: https://github.com/intellij-rust/intellij-rust/issues/2256