### PR TITLE
INT: don't generate useless match arm for irrefutable patterns in IfLetToMatchIntention

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/IfLetToMatchIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/IfLetToMatchIntention.kt
@@ -53,6 +53,7 @@ class IfLetToMatchIntention : RsElementBaseIntentionAction<IfLetToMatchIntention
         val (ifStmt, target, matchArms, elseBody) = ctx
         val item = (target.type as? TyAdt)?.item as? RsEnumItem
         val optionOrResultPats = matchArms.flatMap { it.orPats.patList }.filter(RsPat::isPossibleOptionOrResultVariant)
+        val isIrrefutable = matchArms.all { it.orPats.patList.all { pat -> pat?.isIrrefutable ?: false } }
         val generatedCode = buildString {
             append("match ")
             append(target.text)
@@ -63,7 +64,7 @@ class IfLetToMatchIntention : RsElementBaseIntentionAction<IfLetToMatchIntention
                 append(" => ")
                 append(it.body.text)
             }
-            if (elseBody != null || item == null || !allOptionOrResultVariantsCovered(item, optionOrResultPats)) {
+            if (elseBody != null || (!isIrrefutable && (item == null || !allOptionOrResultVariantsCovered(item, optionOrResultPats)))) {
                 append('\n')
                 append(missingBranch(item, optionOrResultPats))
                 append(" => ")

--- a/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt
@@ -636,4 +636,50 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention()) {
             }
         }
     """)
+
+    fun `test irrefutable pattern`() = doAvailableTest("""
+        struct Id(u32);
+        struct S { a: Id, b: u32 }
+        fn foo(s: S) {
+            if let S { a: Id(ref name), .. } = s/*caret*/ {
+                let _x = name;
+            }
+        }
+    """, """
+        struct Id(u32);
+        struct S { a: Id, b: u32 }
+        fn foo(s: S) {
+            match s {
+                S { a: Id(ref name), .. } => {
+                    let _x = name;
+                }
+            }
+        }
+    """)
+
+    fun `test irrefutable pattern with else`() = doAvailableTest("""
+        struct Id(u32);
+        struct S { a: Id, b: u32 }
+        fn foo(s: S) {
+            if let S { a: Id(ref name), .. } = s/*caret*/ {
+                let _x = name;
+            }
+            else {
+                let _y = 0;
+            }
+        }
+    """, """
+        struct Id(u32);
+        struct S { a: Id, b: u32 }
+        fn foo(s: S) {
+            match s {
+                S { a: Id(ref name), .. } => {
+                    let _x = name;
+                }
+                _ => {
+                    let _y = 0;
+                }
+            }
+        }
+    """)
 }


### PR DESCRIPTION
This PR modifies `IfLetToMatchIntention` to avoid generating useless `_ => { ... }` arms if the match arm is already irrefutable. Before the generated code would right away contain a warning that the arms after the irrefutable arm can be removed.

It also removes the code from a potential else branch if the pattern is irrefutable, since the else was basically dead code.