### PR TITLE
TY&RES: support associated type bounds in traits

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -251,6 +251,7 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
                     is TraitImplSource.Hardcoded -> source.value
 
                     is TraitImplSource.TraitBound -> return null
+                    is TraitImplSource.ProjectionBound -> return null
                     is TraitImplSource.Object -> return null
                     is TraitImplSource.Trait -> return null
                 }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -804,7 +804,12 @@ private fun RsGenericDeclaration.doGetBounds(): List<TraitRef> {
         val selfTy = TyTypeParameter.named(it)
         it.typeParamBounds?.polyboundList.toTraitRefs(selfTy)
     }
-    return (bounds + whereBounds).toList()
+    val assocTypeBounds = if (this is RsTraitItem) {
+        expandedMembers.types.asSequence().flatMap { it.typeParamBounds?.polyboundList.toTraitRefs(it.declaredType) }
+    } else {
+        emptySequence()
+    }
+    return (bounds + whereBounds + assocTypeBounds).toList()
 }
 
 private fun List<RsPolybound>?.toTraitRefs(selfTy: Ty): Sequence<TraitRef> = orEmpty().asSequence()

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -1099,4 +1099,13 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
             b.foo()
         }   //^
     """)
+
+    fun `test assoc type bound method`() = checkByCode("""
+        trait Foo { fn foo(&self) {} }
+                     //X
+        trait Bar where Self::Item: Foo { type Item; }
+        fn bar<A: Bar>(_: A, b: A::Item) {
+            b.foo();
+        }   //^
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1767,4 +1767,15 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             (a, b);
         } //^ (X, X)
     """)
+
+    fun `test assoc type bound selection 4`() = testExpr("""
+        struct X;
+        trait Foo<T> {}
+        fn foo<A: Foo<B>, B>(_: A) -> B { unimplemented!() }
+        trait Bar { type Item: Foo<X>; }
+        fn bar<T: Bar>(_: T, b: T::Item) {
+            let a = foo(b);
+            a;
+        } //^ X
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1734,4 +1734,37 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ X
     """)
+
+    fun `test assoc type bound selection 1`() = testExpr("""
+        struct X;
+        trait Foo<T> {}
+        fn foo<A: Foo<B>, B>(_: A) -> B { unimplemented!() }
+        trait Bar where Self::Item: Foo<X> { type Item; }
+        fn bar<T: Bar>(_: T, b: T::Item) {
+            let a = foo(b);
+            a;
+        } //^ X
+    """)
+
+    fun `test assoc type bound selection 2`() = testExpr("""
+        struct X;
+        trait Foo<T> {}
+        fn foo<A: Foo<B>, B>(_: A) -> B { unimplemented!() }
+        trait Bar<T> where Self::Item: Foo<T> { type Item; }
+        fn bar<T: Bar<X>>(_: T, b: T::Item) {
+            let a = foo(b);
+            a;
+        } //^ X
+    """)
+
+    fun `test assoc type bound selection 3`() = testExpr("""
+        struct X;
+        trait Foo<T> { fn foo(&self) -> T; }
+        trait Bar<T> where Self::Item: Foo<T> { type Item; }
+        fn bar<T: Bar<X>>(_: T, b: T::Item) {
+            let a = b.foo();
+            let b = Foo::foo(&b);
+            (a, b);
+        } //^ (X, X)
+    """)
 }


### PR DESCRIPTION
```rust
trait Foo { fn foo(&self) {} }
              //X
trait Bar where { type Item: Foo; }
fn bar<A: Bar>(_: A, b: A::Item) {
    b.foo();
}   //^
```