### PR TITLE
PSI: introduce `escapedName` property

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsDefaultValueBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsDefaultValueBuilder.kt
@@ -160,7 +160,7 @@ class RsDefaultValueBuilder(
         val type = fieldDecl.typeReference?.type ?: return null
 
         val binding = bindings[name] ?: return null
-        val escapedName = escapeFieldName(fieldDecl) ?: return null
+        val escapedName = fieldDecl.escapedName ?: return null
         return when {
             type == binding.type -> {
                 val field = psiFactory.createStructLiteralField(escapedName, psiFactory.createExpression(escapedName))
@@ -233,18 +233,8 @@ class RsDefaultValueBuilder(
         return null
     }
 
-    private fun escapeFieldName(fieldDecl: RsFieldDecl): String? {
-        val name = fieldDecl.name ?: return null
-
-        // Tuple structs field names are integers and we don't want to escape them
-        return if (name.all { it.isDigit() }) {
-            name
-        }
-        else fieldDecl.name?.escapeIdentifierIfNeeded()
-    }
-
     private fun specializedCreateStructLiteralField(fieldDecl: RsFieldDecl, bindings: Map<String, RsPatBinding>): RsStructLiteralField? {
-        val fieldName = escapeFieldName(fieldDecl) ?: return null
+        val fieldName = fieldDecl.escapedName ?: return null
         val fieldType = fieldDecl.typeReference?.type ?: return null
         val fieldLiteral = buildFor(fieldType, bindings)
         return psiFactory.createStructLiteralField(fieldName, fieldLiteral)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldDecl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldDecl.kt
@@ -9,6 +9,8 @@ import org.rust.lang.core.psi.RsTypeReference
 
 val RsFieldDecl.parentStruct: RsFieldsOwner? get() = stubAncestorStrict()
 
+val RsFieldDecl.escapedName: String? get() = (this as? RsNamedElement)?.escapedName ?: name
+
 interface RsFieldDecl : RsOuterAttributeOwner, RsVisibilityOwner {
     val typeReference: RsTypeReference?
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedElement.kt
@@ -16,12 +16,15 @@ import com.intellij.psi.stubs.StubElement
 import org.rust.ide.presentation.getPresentation
 import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.escapeIdentifierIfNeeded
 import org.rust.lang.core.psi.unescapedText
 import org.rust.lang.core.stubs.RsNamedStub
 
 interface RsNamedElement : RsElement, PsiNamedElement, NavigatablePsiElement
 
 interface RsNameIdentifierOwner : RsNamedElement, PsiNameIdentifierOwner
+
+val RsNamedElement.escapedName: String? get() = name?.escapeIdentifierIfNeeded()
 
 abstract class RsNamedElementImpl(node: ASTNode) : RsElementImpl(node),
                                                    RsNameIdentifierOwner {


### PR DESCRIPTION
It should simplify raw identifiers handling in code that creates new psi from text
