### PR TITLE
Place the caret near a type when navigating to an impl

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/AddImplIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddImplIntention.kt
@@ -12,6 +12,7 @@ import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.RsStructOrEnumItemElement
 import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psi.ext.startOffset
 
 class AddImplIntention : RsElementBaseIntentionAction<AddImplIntention.Context>() {
     override fun getText() = "Add impl block"
@@ -30,6 +31,6 @@ class AddImplIntention : RsElementBaseIntentionAction<AddImplIntention.Context>(
 
         impl = ctx.type.parent.addAfter(impl, ctx.type) as RsImplItem
 
-        editor.caretModel.moveToOffset(impl.textOffset + impl.textLength - 1)
+        editor.caretModel.moveToOffset(impl.impl.startOffset + impl.textLength - 1)
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -38,6 +38,8 @@ abstract class RsImplItemImplMixin : RsStubbedElementImpl<RsImplItemStub>, RsImp
 
     override fun getPresentation(): ItemPresentation = getPresentation(this)
 
+    override fun getTextOffset(): Int = typeReference?.textOffset ?: impl.textOffset
+
     override val implementedTrait: BoundElement<RsTraitItem>? get() {
         val (trait, subst) = traitRef?.resolveToBoundTrait() ?: return null
         return BoundElement(trait, subst)

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoDeclarationTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoDeclarationTest.kt
@@ -136,6 +136,20 @@ class RsGotoDeclarationTest : RsTestBase() {
         }
     """)
 
+    fun `test Self type in impl`() = doTest("""
+        struct S;
+        /// docs
+        impl S {
+            fn foo() -> Self/*caret*/ { unimplemented!() }
+        }
+    """, """
+        struct S;
+        /// docs
+        impl /*caret*/S {
+            fn foo() -> Self { unimplemented!() }
+        }
+    """)
+
     private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) =
         checkEditorAction(before, after, IdeActions.ACTION_GOTO_DECLARATION)
 }

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoImplementationsTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoImplementationsTest.kt
@@ -14,6 +14,7 @@ class RsGotoImplementationsTest : RsTestBase() {
         trait T/*caret*/{
             fn test(&self);
         }
+        /// docs
         impl T for (){
             fn test(&self) {}
         }
@@ -21,7 +22,8 @@ class RsGotoImplementationsTest : RsTestBase() {
         trait T{
             fn test(&self);
         }
-        /*caret*/impl T for (){
+        /// docs
+        impl T for /*caret*/(){
             fn test(&self) {}
         }
     """)


### PR DESCRIPTION
I.e. place the caret near T in `impl T {}` when navigating to this impl (e.g. from `Self`)

```rust
impl /*caret_after*/Foo { // <- navigates here
    fn foo() -> /*caret_before*/Self {} // Ctrl + B
}
```

Note that this also works for "Go To Implementation" navigation from a trait:

```rust
trait T/*caret_before*/ { // Ctrl + Alt + B
    fn test(&self);
}
impl T for /*caret_after*/() { // <- navigates here
    fn test(&self) {}
}
```