### PR TITLE
REPL: Add variables view

### DIFF
--- a/src/main/kotlin/org/rust/ide/console/RsConsoleActions.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleActions.kt
@@ -101,3 +101,13 @@ class PrintAction(private val consoleView: RsConsoleView) : DumbAwareAction() {
         }
     }
 }
+
+class ShowVariablesAction(private val consoleView: RsConsoleView)
+    : ToggleAction("Show Variables", "Shows active console variables", AllIcons.Debugger.Watch), DumbAware {
+
+    override fun isSelected(e: AnActionEvent): Boolean = consoleView.isShowVariables
+
+    override fun setSelected(e: AnActionEvent, state: Boolean) {
+        consoleView.updateVariables(state)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
@@ -33,7 +33,7 @@ class RsConsoleCodeFragmentContext {
         }
     }
 
-    private fun getAllCommandsText(): String {
+    fun getAllCommandsText(): String {
         val topLevelElementsText = topLevelElements.values.joinToString("\n")
         return topLevelElementsText + "\n" + allCommandsText
     }

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleOptions.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleOptions.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.console
+
+import com.intellij.openapi.components.*
+import com.intellij.openapi.project.Project
+
+@State(name = "RsConsoleOptions", storages = [Storage(StoragePathMacros.WORKSPACE_FILE)])
+class RsConsoleOptions : PersistentStateComponent<RsConsoleOptions> {
+
+    var showVariables: Boolean = true
+
+    override fun getState(): RsConsoleOptions = this
+
+    override fun loadState(state: RsConsoleOptions) {
+        showVariables = state.showVariables
+    }
+
+    companion object {
+        fun getInstance(project: Project): RsConsoleOptions =
+            ServiceManager.getService(project, RsConsoleOptions::class.java)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleRunner.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleRunner.kt
@@ -102,7 +102,8 @@ class RsConsoleRunner(project: Project) :
             SoftWrapAction(consoleView),
             ScrollToTheEndToolbarAction(consoleView.editor),
             PrintAction(consoleView),
-            ConsoleHistoryController.getController(consoleView)!!.browseHistory
+            ConsoleHistoryController.getController(consoleView)!!.browseHistory,
+            ShowVariablesAction(consoleView)
         )
         outputActionGroup.addAll(outputActions)
 
@@ -192,6 +193,7 @@ class RsConsoleRunner(project: Project) :
 
     private fun connect() {
         invokeLater {
+            consoleView.initVariablesWindow()
             consoleView.executeActionHandler = consoleExecuteActionHandler
 
             consoleExecuteActionHandler.isEnabled = true

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleVariablesView.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleVariablesView.kt
@@ -1,0 +1,67 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.console
+
+import com.intellij.ide.util.treeView.smartTree.SmartTreeStructure
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.SimpleToolWindowPanel
+import com.intellij.psi.PsiFileFactory
+import com.intellij.ui.ScrollPaneFactory
+import com.intellij.ui.tree.AsyncTreeModel
+import com.intellij.ui.tree.StructureTreeModel
+import com.intellij.ui.treeStructure.Tree
+import org.rust.ide.structure.RsStructureViewModel
+import org.rust.lang.RsLanguage
+import org.rust.lang.core.psi.RsReplCodeFragment
+import org.rust.openapiext.document
+
+class RsConsoleVariablesView(project: Project, private val codeFragmentContext: RsConsoleCodeFragmentContext) :
+    SimpleToolWindowPanel(true, true), Disposable {
+
+    private val variablesFile: RsReplCodeFragment
+    private val treeStructure: SmartTreeStructure
+    private val structureTreeModel: StructureTreeModel<SmartTreeStructure>
+
+    init {
+        val allCommands = codeFragmentContext.getAllCommandsText()
+        variablesFile = PsiFileFactory.getInstance(project)
+            .createFileFromText(RsConsoleView.VIRTUAL_FILE_NAME, RsLanguage, allCommands) as RsReplCodeFragment
+        val structureViewModel = RsStructureViewModel(null, variablesFile)
+        treeStructure = SmartTreeStructure(project, structureViewModel)
+
+        structureTreeModel = StructureTreeModel(treeStructure, this)
+        val asyncTreeModel = AsyncTreeModel(structureTreeModel, this)
+
+        val tree = Tree(asyncTreeModel)
+        tree.isRootVisible = false
+        tree.emptyText.text = EMPTY_TEXT
+
+        setContent(ScrollPaneFactory.createScrollPane(tree))
+    }
+
+    fun rebuild() {
+        runInEdt {
+            runWriteAction {
+                val allCommands = codeFragmentContext.getAllCommandsText()
+                variablesFile.virtualFile.document?.setText(allCommands)
+            }
+
+            structureTreeModel.invoker.invokeLater {
+                treeStructure.rebuildTree()
+                structureTreeModel.invalidate()
+            }
+        }
+    }
+
+    override fun dispose() {}
+
+    companion object {
+        private const val EMPTY_TEXT: String = "No variables yet"
+    }
+}

--- a/src/main/kotlin/org/rust/ide/presentation/Utils.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/Utils.kt
@@ -12,6 +12,7 @@ import org.rust.ide.icons.addVisibilityIcon
 import org.rust.lang.core.macros.isExpandedFromMacro
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.inference
 
 fun getPresentation(psi: RsElement): ItemPresentation {
     val location = run {
@@ -43,6 +44,9 @@ fun getPresentationForStructure(psi: RsElement): ItemPresentation {
             }
             is RsNamedFieldDecl -> {
                 psi.typeReference?.let { append(": ${it.getStubOnlyText()}") }
+            }
+            is RsPatBinding -> {
+                psi.inference?.let { append(": ${it.getBindingType(psi)}") }
             }
             is RsEnumVariant -> {
                 val fields = psi.tupleFields

--- a/src/main/kotlin/org/rust/ide/structure/RsPsiStructureViewFactory.kt
+++ b/src/main/kotlin/org/rust/ide/structure/RsPsiStructureViewFactory.kt
@@ -11,11 +11,11 @@ import com.intellij.ide.structureView.TreeBasedStructureViewBuilder
 import com.intellij.lang.PsiStructureViewFactory
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiFile
-import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.RsFileBase
 
 class RsPsiStructureViewFactory : PsiStructureViewFactory {
     override fun getStructureViewBuilder(psiFile: PsiFile): StructureViewBuilder? {
-        val rustFile = psiFile as RsFile
+        val rustFile = psiFile as RsFileBase
         return object : TreeBasedStructureViewBuilder() {
             override fun createStructureViewModel(editor: Editor?): StructureViewModel {
                 return RsStructureViewModel(editor, rustFile)

--- a/src/main/kotlin/org/rust/ide/structure/RsStructureViewModel.kt
+++ b/src/main/kotlin/org/rust/ide/structure/RsStructureViewModel.kt
@@ -18,7 +18,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.stdext.buildList
 
-class RsStructureViewModel(editor: Editor?, file: RsFile)
+class RsStructureViewModel(editor: Editor?, file: RsFileBase)
     : StructureViewModelBase(file, editor, RsStructureViewElement(file)),
       StructureViewModel.ElementInfoProvider {
 
@@ -61,6 +61,7 @@ private class RsStructureViewElement(
                 is RsStructItem -> psi.blockFields?.namedFieldDeclList.orEmpty()
                 is RsEnumVariant -> psi.blockFields?.namedFieldDeclList.orEmpty()
                 is RsFunction -> psi.block?.let { extractItems(it) }.orEmpty()
+                is RsReplCodeFragment -> psi.namedElements + psi.getVariablesDeclarations()
                 else -> emptyList()
             }
         }
@@ -95,4 +96,16 @@ private class RsStructureViewElement(
                 }
             }
         }
+}
+
+private fun RsReplCodeFragment.getVariablesDeclarations(): Collection<RsPatBinding> {
+    val variables = mutableMapOf<String, RsPatBinding>()
+    for (letDecl in childrenOfType<RsLetDecl>()) {
+        val pat = letDecl.pat ?: continue
+        for (patBinding in pat.descendantsOfType<RsPatBinding>()) {
+            val name = patBinding.name ?: continue
+            variables[name] = patBinding
+        }
+    }
+    return variables.values
 }

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -57,7 +57,11 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> {
                 TreeUtil.ensureParsed(file.node) // profiler hint
-                return RsFileStub(file as RsFile)
+                return when (file) {
+                    // for tests related to rust console
+                    is RsReplCodeFragment -> RsFileStub(null, RsFile.Attributes.NONE)
+                    else -> RsFileStub(file as RsFile)
+                }
             }
 
             override fun skipChildProcessingWhenBuildingStubs(parent: ASTNode, child: ASTNode): Boolean {

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -881,6 +881,8 @@
 
         <!-- REPL Console -->
 
+        <projectService serviceImplementation="org.rust.ide.console.RsConsoleOptions"/>
+
         <consoleHistoryModelProvider implementation="org.rust.ide.console.RsConsoleHistoryModelProvider"/>
         <scratch.rootType implementation="org.rust.ide.console.RsConsoleRootType"/>
 


### PR DESCRIPTION
Add variables view to REPL console. It shows available variables, functions and structs (and their types)
<img width="837" alt="Screen Shot 2020-03-16 at 11 56 37" src="https://user-images.githubusercontent.com/2539310/76739479-4e45ed80-677d-11ea-80e0-7140f98f3330.png">
