### PR TITLE
REF: Introduce field refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/RsRefactoringSupportProvider.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsRefactoringSupportProvider.kt
@@ -9,6 +9,7 @@ import com.intellij.lang.refactoring.RefactoringSupportProvider
 import com.intellij.psi.PsiElement
 import com.intellij.refactoring.RefactoringActionHandler
 import org.rust.ide.refactoring.extractFunction.RsExtractFunctionHandler
+import org.rust.ide.refactoring.introduceField.RsIntroduceFieldHandler
 import org.rust.ide.refactoring.introduceParameter.RsIntroduceParameterHandler
 import org.rust.ide.refactoring.introduceVariable.RsIntroduceVariableHandler
 import org.rust.lang.core.macros.isExpandedFromMacro
@@ -28,4 +29,6 @@ class RsRefactoringSupportProvider : RefactoringSupportProvider() {
     override fun getExtractMethodHandler(): RefactoringActionHandler = RsExtractFunctionHandler()
 
     override fun getIntroduceParameterHandler(): RefactoringActionHandler = RsIntroduceParameterHandler()
+
+    override fun getIntroduceFieldHandler(): RefactoringActionHandler? = RsIntroduceFieldHandler()
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceField/RsIntroduceFieldHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceField/RsIntroduceFieldHandler.kt
@@ -1,0 +1,121 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.introduceField
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.AbstractFileViewProvider.findElementAt
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.refactoring.RefactoringActionHandler
+import com.intellij.refactoring.RefactoringBundle
+import com.intellij.refactoring.util.CommonRefactoringUtil
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.rust.lang.core.psi.ext.rightSiblings
+import org.rust.openapiext.runWriteCommandAction
+
+class RsIntroduceFieldHandler: RefactoringActionHandler {
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?, dataContext: DataContext?) {
+        if (file !is RsFile) return
+        if (editor == null) return
+
+        val offset = editor.caretModel.offset
+        val struct = findElementAt(file, offset)?.ancestorOrSelf<RsStructItem>()
+        if (struct == null || (struct.tupleFields == null && struct.blockFields == null)) {
+            val message = RefactoringBundle.message("refactoring.introduce.selection.error")
+            val title = RefactoringBundle.message("introduce.field.title")
+            val helpId = "refactoring.introduceField"
+            CommonRefactoringUtil.showErrorHint(project, editor, message, title, helpId)
+        }
+        else {
+            showIntroduceFieldChooser(struct) { fields ->
+                fields?.let {
+                    introduceFields(struct, it)
+                }
+            }
+        }
+    }
+
+    override fun invoke(project: Project, elements: Array<out PsiElement>, dataContext: DataContext?) {
+        //this doesn't get called form the editor.
+    }
+}
+
+private fun introduceFields(struct: RsStructItem, info: ParameterInfo) {
+    if (info.fields.isEmpty()) return
+
+    val project = struct.project
+    val factory = RsPsiFactory(project)
+
+    val block = struct.blockFields
+    val tuples = struct.tupleFields
+    when {
+        block != null -> introduceBlockFields(factory, info, block)
+        tuples != null -> introduceTupleFields(factory, info, tuples)
+    }
+}
+
+private fun introduceBlockFields(factory: RsPsiFactory, info: ParameterInfo, fields: RsBlockFields) {
+    val newFields = factory.createBlockFields(info.fields.map {
+        RsPsiFactory.BlockField(it.pub, it.name, it.type)
+    })
+    val blockFields = fields.namedFieldDeclList
+    var anchor = blockFields.lastOrNull() ?: fields.lbrace
+
+    val addNewline = if (blockFields.isEmpty()) {
+        true
+    }
+    else blockFields.firstOrNull()?.typeReference?.rightSiblings?.lineBreak() != null
+    var addComma = blockFields.isNotEmpty()
+
+    fields.project.runWriteCommandAction {
+        for (field in newFields.namedFieldDeclList) {
+            if (addComma) {
+                val comma = factory.createComma()
+                anchor = fields.addAfter(comma, anchor)
+            }
+            else addComma = true
+            anchor = fields.addAfter(field, anchor)
+            if (addNewline) {
+                val newline = factory.createNewline()
+                anchor = fields.addAfter(newline, anchor)
+            }
+        }
+    }
+}
+private fun introduceTupleFields(factory: RsPsiFactory, info: ParameterInfo, fields: RsTupleFields) {
+    val newFields = factory.createTupleFields(info.fields.map {
+        RsPsiFactory.BlockField(it.pub, it.name, it.type)
+    })
+    var anchor: PsiElement = fields.tupleFieldDeclList.lastOrNull() ?: fields.lparen
+    var addComma = fields.tupleFieldDeclList.isNotEmpty()
+
+    fields.project.runWriteCommandAction {
+        for (field in newFields.tupleFieldDeclList) {
+            if (addComma) {
+                val comma = factory.createComma()
+                anchor = fields.addAfter(comma, anchor)
+            }
+            else addComma = true
+
+            anchor = fields.addAfter(field, anchor)
+        }
+    }
+}
+
+// TODO: support tuple fields
+// TODO: import types
+// TODO: add lifetimes/type parameters to struct
+// TODO: change call sites, add default value to new fields
+
+private fun Sequence<PsiElement>.lineBreak(): PsiWhiteSpace? =
+    dropWhile { it !is PsiWhiteSpace && it !is PsiComment }
+        .takeWhile { it is PsiWhiteSpace || it is PsiComment }
+        .firstOrNull { it is PsiWhiteSpace && it.textContains('\n') } as? PsiWhiteSpace

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceField/ui.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceField/ui.kt
@@ -1,0 +1,126 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+package org.rust.ide.refactoring.introduceField
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapiext.isUnitTestMode
+import com.intellij.refactoring.ui.NameSuggestionsField
+import com.intellij.ui.components.dialog
+import com.intellij.ui.layout.panel
+import org.jetbrains.annotations.TestOnly
+import org.rust.lang.RsFileType
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsStructItem
+import org.rust.lang.core.types.ty.Ty
+
+fun showIntroduceFieldChooser(struct: RsStructItem,
+                              callback: (fields: ParameterInfo?) -> Unit) {
+    val impl = if (isUnitTestMode) {
+        MOCK!!
+    } else {
+        DialogIntroduceVariableUi(struct.project)
+    }
+    callback(impl.introduceField(struct))
+}
+
+private class DialogIntroduceVariableUi(
+    private val project: Project
+) : IntroduceFieldUi {
+    override fun introduceField(struct: RsStructItem): ParameterInfo? {
+        val panel = panel {
+            row("Name:") { NameSuggestionsField(emptyArray(), project, RsFileType) }
+        }
+
+        // empty -> allow names
+        // non-empty -> decide based on tuple/block
+        val dialog = dialog(
+            "Introduce field",
+            panel,
+            resizable = true,
+//            focusedComponent = functionNameField.focusableComponent,
+            okActionEnabled = false,
+            project = project,
+            parent = null,
+            errorText = null,
+            modality = DialogWrapper.IdeModalityType.IDE
+        ) {
+//            updateConfig(config, functionNameField, visibilityBox)
+//            callback()
+            emptyList()
+        }
+
+        /*
+        val functionNameField = NameSuggestionsField(emptyArray(), project, RsFileType)
+        functionNameField.minimumSize = JBUI.size(300, 30)
+
+        val visibilityBox = ComboBox<String>()
+        with(visibilityBox) {
+            addItem("Public")
+            addItem("Private")
+        }
+        visibilityBox.selectedItem = "Private"
+        val signatureComponent = RsSignatureComponent(config.signature, project)
+        signatureComponent.minimumSize = JBUI.size(300, 30)
+
+        visibilityBox.addActionListener {
+            updateConfig(config, functionNameField, visibilityBox)
+            signatureComponent.setSignature(config.signature)
+        }
+
+        val parameterPanel = ExtractFunctionParameterTablePanel(project, ::isValidRustVariableIdentifier, config) {
+            signatureComponent.setSignature(config.signature)
+        }
+
+        val panel = panel {
+            row("Name:") { functionNameField(CCFlags.grow) }
+            row("Visibility:") { visibilityBox() }
+            row("Parameters:") { parameterPanel() }
+            row("Signature:") { signatureComponent(CCFlags.grow) }
+        }
+
+        val extractDialog = dialog(
+            "Extract Function",
+            panel,
+            resizable = true,
+            focusedComponent = functionNameField.focusableComponent,
+            okActionEnabled = false,
+            project = project,
+            parent = null,
+            errorText = null,
+            modality = DialogWrapper.IdeModalityType.IDE
+        ) {
+            updateConfig(config, functionNameField, visibilityBox)
+            callback()
+            emptyList()
+        }
+
+        functionNameField.addDataChangedListener {
+            updateConfig(config, functionNameField, visibilityBox)
+            signatureComponent.setSignature(config.signature)
+            extractDialog.isOKActionEnabled = isValidRustVariableIdentifier(config.name)
+        }
+        extractDialog.show()*/
+        dialog.show()
+        return null
+    }
+}
+
+data class ParameterInfo(val fields: List<RsPsiFactory.BlockField>)
+
+interface IntroduceFieldUi {
+    fun introduceField(struct: RsStructItem): ParameterInfo?
+}
+
+var MOCK: IntroduceFieldUi? = null
+@TestOnly
+fun withMockIntroduceFieldChooser(mock: IntroduceFieldUi, f: () -> Unit) {
+    MOCK = mock
+    try {
+        f()
+    } finally {
+        MOCK = null
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -162,6 +162,14 @@ class RsPsiFactory(
             .blockFields!!
     }
 
+    fun createTupleFields(fields: List<BlockField>): RsTupleFields {
+        val fieldsText = fields.joinToString(separator = ", ") {
+            "${"pub".iff(it.pub)}${it.type.insertionSafeTextWithLifetimes}"
+        }
+        return createStruct("struct S($fieldsText)")
+            .tupleFields!!
+    }
+
     fun createEnum(text: String): RsEnumItem =
         createFromText(text)
             ?: error("Failed to create enum from text: `$text`")

--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceFieldTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceFieldTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring
+
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+import org.rust.ide.refactoring.introduceField.IntroduceFieldUi
+import org.rust.ide.refactoring.introduceField.ParameterInfo
+import org.rust.ide.refactoring.introduceField.withMockIntroduceFieldChooser
+import org.rust.lang.core.psi.RsPsiFactory.BlockField
+import org.rust.lang.core.psi.RsStructItem
+import org.rust.lang.core.types.ty.TyInteger
+
+class RsIntroduceFieldTest : RsTestBase() {
+    fun `test empty block`() = doTest("""
+        struct S {}
+    """, listOf(BlockField(false, "a", TyInteger.I32)), """
+        struct S {
+            a: i32
+        }
+    """)
+
+    fun `test block with existing fields`() = doTest("""
+        struct S {
+            a: u32,
+            b: u32
+        }
+    """, listOf(BlockField(false, "c", TyInteger.I32)), """
+        struct S {
+            a: u32,
+            b: u32,
+            c: i32
+        }
+    """)
+
+    fun `test respect block on one line`() = doTest("""
+        struct S { a: u32, b: u32 };
+    """, listOf(BlockField(false, "c", TyInteger.I32)), """
+        struct S { a: u32, b: u32, c: i32 };
+    """)
+
+    fun `test empty tuple`() = doTest("""
+        struct S();
+    """, listOf(BlockField(false, "", TyInteger.I32)), """
+        struct S(i32);
+    """)
+
+    fun `test tuple with existing fields`() = doTest("""
+        struct S(u32, u32);
+    """, listOf(BlockField(false, "", TyInteger.I32)), """
+        struct S(u32, u32, i32);
+    """)
+
+    private fun doTest(
+        @Language("Rust") before: String,
+        fields: List<BlockField>,
+        @Language("Rust") after: String
+    ) {
+        withMockIntroduceFieldChooser(object: IntroduceFieldUi {
+            override fun introduceField(struct: RsStructItem): ParameterInfo? {
+                return ParameterInfo(fields)
+            }
+        }) {
+            checkEditorAction(before, after, "IntroduceField")
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for the IntroduceField refactoring.
The current version is just an initial prototype. First I want to get an idea how exactly should the refactoring work.

Questions:
- If the struct is empty like this: ```struct S;```, should we not offer the refactoring or offer it while letting the user choose whether he wants a block/tuple struct or offer it and choose some default (block/tuple)? Right now I decided not to offer it. It's simple for the user to add two characters (`{}` or `()`), while the possibility to choose would complicate the implementation quite a bit.
- Should the refactoring try to respect whether existing block fields are on separate lines or on a single line? Currently I use a simple heuristic (no fields => use newlines, last field has a newline => use newlines, otherwise no newlines).
- The UI will have to let the user choose the type of the fields. I haven't found a similar dialog in the plugin (the closest is Extract function, but there the type is read-only). Should we just let the user type the type (no pun intended) as a string and then try to parse it as `Ty/TypeReference` and infer it? It would probably be annoying to introduce new lifetimes/types like this, but that's maybe too much for this refactoring.
- Should the usage sites of the struct be changed to add the new fields with a default value?

TODO:
- [ ] import types from the added fields
- [ ] add lifetimes/type parameters to struct from the added fields?
- [ ] change usage sites of the struct
- [ ] create UI dialog