### PR TITLE
REF: handle async functions in ExtractFunction refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
@@ -139,7 +139,7 @@ class RsExtractFunctionConfig private constructor(
             append("async ")
         }
         append("fn $name$typeParametersText(${if (isOriginal) originalParametersText else parametersText})")
-        if (returnValue != null) {
+        if (returnValue != null && returnValue.type !is TyUnit) {
             append(" -> ${returnValue.type.insertionSafeText}")
         }
         append(whereClausesText)

--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
@@ -110,6 +110,9 @@ class RsExtractFunctionHandler : RefactoringActionHandler {
             }
             "${if (type != null) "$type::" else ""}${config.name}(${config.argumentsText})"
         }
+        if (config.isAsync) {
+            stmt += ".await"
+        }
         val element = if (config.returnValue == null || config.returnValue.exprText != null) {
             stmt += ";"
             psiFactory.createStatement(stmt)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldLookup.kt
@@ -17,3 +17,5 @@ abstract class RsFieldLookupImplMixin(node: ASTNode) : RsElementImpl(node), RsFi
     override fun getReference(): RsReference = RsFieldLookupReferenceImpl(this)
 }
 
+val RsFieldLookup.isAsync: Boolean
+    get() = this.text == "await"

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -609,7 +609,7 @@ class RsExtractFunctionTest : RsTestBase() {
                 bar(a, b, c, d)
             }
 
-            fn bar<A, B, C, D>(a: A, b: B, c: Option<C>, d: Option<D>) -> () {
+            fn bar<A, B, C, D>(a: A, b: B, c: Option<C>, d: Option<D>) {
                 a;
                 b;
                 c;
@@ -671,7 +671,7 @@ class RsExtractFunctionTest : RsTestBase() {
                 bar(t, u)
             }
 
-            fn bar<T, U>(t: T, u: U) -> () where T: Trait1 + Trait2, U: Trait3 {
+            fn bar<T, U>(t: T, u: U) where T: Trait1 + Trait2, U: Trait3 {
                 t;
                 u;
                 println!("test")
@@ -1008,7 +1008,7 @@ class RsExtractFunctionTest : RsTestBase() {
             bar().await
         }
 
-        async fn bar() -> () {
+        async fn bar() {
             async { () }.await
         }
     """, false, "bar"

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -6,9 +6,11 @@
 package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
+import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.refactoring.extractFunction.ExtractFunctionUi
 import org.rust.ide.refactoring.extractFunction.RsExtractFunctionConfig
 import org.rust.ide.refactoring.extractFunction.withMockExtractFunctionUi
@@ -989,6 +991,100 @@ class RsExtractFunctionTest : RsTestBase() {
         }
     """, false, "bar", listOf("a")
     )
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test extract async function with await`() = doTest("""
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+
+        async fn foo() {
+            <selection>async { () }.await</selection>
+        }
+    """, """
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+
+        async fn foo() {
+            bar().await
+        }
+
+        async fn bar() -> () {
+            async { () }.await
+        }
+    """, false, "bar"
+    )
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test extract async function with nested await`() = doTest("""
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+
+        struct S;
+        struct W(S);
+        impl S {
+            async fn foo(&self) -> (u32, u32) { (0, 0) }
+        }
+
+        async fn foo() -> u32 {
+            let w = W(S);
+            <selection>w.0.foo().await.0</selection>
+        }
+    """, """
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+
+        struct S;
+        struct W(S);
+        impl S {
+            async fn foo(&self) -> (u32, u32) { (0, 0) }
+        }
+
+        async fn foo() -> u32 {
+            let w = W(S);
+            bar(w).await
+        }
+
+        async fn bar(w: W) -> u32 {
+            w.0.foo().await.0
+        }
+    """, false, "bar"
+    )
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test extract sync function with await inside block`() = doTest("""
+        async fn foo() {
+            <selection>async { async { () }.await };</selection>
+        }
+    """, """
+        async fn foo() {
+            bar();
+        }
+
+        fn bar() {
+            async { async { () }.await };
+        }
+    """,
+        false,
+        "bar")
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test extract sync function with await inside closure`() = doTest("""
+        #![feature(async_closure)]
+        async fn foo() {
+            let x = <selection>async || foo().await</selection>;
+        }
+    """, """
+        #![feature(async_closure)]
+        async fn foo() {
+            let x = bar();
+        }
+
+        fn bar() -> fn() -> _ {
+            async || foo().await
+        }
+    """,
+        false,
+        "bar")
 
     private fun doTest(@Language("Rust") code: String,
                        @Language("Rust") excepted: String,


### PR DESCRIPTION
This PR adds support for `async` function in `RsExtractFunction` refactoring.

Currently I try to find if the extracted elements from the function contain a (top-level) `.await`, and if yes, the extracted function will be `async` too and it's call will be `.await`ed in the original function. However I'm not sure how to correctly recognize if a block is async (I want to stop the `await` search at async blocks, nested awaits inside them are not intereseting). The same should happen for async closures.

We can also simplify this and if the original function is `async`, the extracted function could always be async.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/4432