### PR TITLE
INT: fix ConvertToNamedFields handling of function calls

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/convertStruct/RsConvertToNamedFieldsProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/convertStruct/RsConvertToNamedFieldsProcessor.kt
@@ -9,13 +9,15 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiReference
 import com.intellij.psi.search.searches.ReferencesSearch
-import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.refactoring.BaseRefactoringProcessor
 import com.intellij.usageView.BaseUsageViewDescriptor
 import com.intellij.usageView.UsageInfo
 import com.intellij.usageView.UsageViewDescriptor
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.RsFieldsOwner
+import org.rust.lang.core.psi.ext.RsReferenceElement
+import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.rust.lang.core.psi.ext.descendantOfTypeStrict
 
 class RsConvertToNamedFieldsProcessor(
     project: Project,
@@ -107,6 +109,11 @@ class RsConvertToNamedFieldsProcessor(
                     val callExpr = usageParent
                         .ancestorOrSelf<RsCallExpr>(RsValueArgumentList::class.java)
                         ?: continue@loop
+
+                    // we only want to convert constructors
+                    if ((callExpr.expr as? RsPathExpr)?.path != element) {
+                        continue@loop
+                    }
                     val values = callExpr.valueArgumentList.exprList
                     val text = "let a = ${callExpr.expr.text}" +
                         values.zip(newNames)
@@ -146,5 +153,4 @@ class RsConvertToNamedFieldsProcessor(
     override fun getRefactoringId(): String? {
         return "refactoring.convertToNamedFields"
     }
-
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/ConvertToTupleRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/ConvertToTupleRefactoringTest.kt
@@ -45,7 +45,7 @@ class ConvertToTupleRefactoringTest : RsTestBase() {
         }
     """)
 
-    fun `test convert stuct literal`() = doAvailableTest("""
+    fun `test convert struct literal`() = doAvailableTest("""
         struct Test{/*caret*/
             pub a:usize,
             b:i32
@@ -115,11 +115,36 @@ class ConvertToTupleRefactoringTest : RsTestBase() {
         }
     """)
 
-    protected fun doAvailableTest(@Language("Rust") before: String, @Language("Rust") after: String) {
+    fun `test convert function call`() = doAvailableTest("""
+        struct S {
+            /*caret*/a: u32
+        }
+        impl S {
+            fn new(v: u32) -> S {
+                S { a: v }
+            }
+        }
+
+        fn main() {
+            let s = S::new(0);
+        }
+    """, """
+        struct S(u32);
+
+        impl S {
+            fn new(v: u32) -> S {
+                S(v)
+            }
+        }
+
+        fn main() {
+            let s = S::new(0);
+        }
+    """)
+
+    private fun doAvailableTest(@Language("Rust") before: String, @Language("Rust") after: String) {
         InlineFile(before.trimIndent()).withCaret()
         myFixture.testAction(RsConvertToTupleAction())
         myFixture.checkResult(replaceCaretMarker(after.trimIndent()))
     }
-
-
 }


### PR DESCRIPTION
This PR changes ConvertToNamedFields so that it doesn't try to convert all function calls to a named struct literal.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5017