### PR TITLE
INT: support type aliases in DestructureIntention

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -32,6 +32,9 @@ val Ty.insertionSafeText: String
 val Ty.insertionSafeTextWithAliases: String
     get() = TypeRenderer.INSERTION_SAFE_WITH_ALIASES.render(this)
 
+val Ty.insertionSafeTextWithAliasesWithoutTypes: String
+    get() = TypeRenderer.INSERTION_SAFE_WITH_ALIASES_WITHOUT_TYPES.render(this)
+
 val Ty.insertionSafeTextWithLifetimes: String
     get() = TypeRenderer.INSERTION_SAFE_WITH_LIFETIMES.render(this)
 
@@ -233,6 +236,7 @@ private data class TypeRenderer(
             float = "_"
         )
         val INSERTION_SAFE_WITH_ALIASES = INSERTION_SAFE.copy(useAliasNames = true)
+        val INSERTION_SAFE_WITH_ALIASES_WITHOUT_TYPES: TypeRenderer = TypeRenderer(useAliasNames = true, includeTypeArguments = false)
         val INSERTION_SAFE_WITH_LIFETIMES: TypeRenderer = INSERTION_SAFE.copy(includeLifetimeArguments = true)
         val INSERTION_SAFE_WITH_ALIASES_AND_LIFETIMES = INSERTION_SAFE.copy(useAliasNames = true, includeLifetimeArguments = true)
         val WITH_ALIASES: TypeRenderer = TypeRenderer(useAliasNames = true)

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -409,16 +409,16 @@ class RsPsiFactory(
             }
         """) ?: error("Failed to create pat field")
 
-    fun createPatStruct(struct: RsStructItem): RsPatStruct {
-        val structName = struct.name ?: error("Failed to create pat struct")
+    fun createPatStruct(struct: RsStructItem, name: String? = null): RsPatStruct {
+        val structName = name ?: struct.name ?: error("Failed to create pat struct")
         val pad = if (struct.namedFields.isEmpty()) "" else " "
         val body = struct.namedFields
             .joinToString(separator = ", ", prefix = " {$pad", postfix = "$pad}") { it.name ?: "_" }
         return createFromText("fn f($structName$body: $structName) {}") ?: error("Failed to create pat struct")
     }
 
-    fun createPatTupleStruct(struct: RsStructItem): RsPatTupleStruct {
-        val structName = struct.name ?: error("Failed to create pat tuple struct")
+    fun createPatTupleStruct(struct: RsStructItem, name: String? = null): RsPatTupleStruct {
+        val structName = name ?: struct.name ?: error("Failed to create pat tuple struct")
         val body = struct.positionalFields
             .joinToString(separator = ", ", prefix = "(", postfix = ")") { "_${it.name}" }
         return createFromText("fn f($structName$body: $structName) {}") ?: error("Failed to create pat tuple struct")

--- a/src/test/kotlin/org/rust/ide/intentions/DestructureIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/DestructureIntentionTest.kt
@@ -134,7 +134,6 @@ class DestructureIntentionTest : RsIntentionTestBase(DestructureIntention()) {
         }
     """)
 
-    // TODO: Support type aliases
     fun `test import unresolved type alias`() = doAvailableTest("""
         use a::foo;
 
@@ -148,7 +147,7 @@ class DestructureIntentionTest : RsIntentionTestBase(DestructureIntention()) {
             let /*caret*/x = foo();
         }
     """, """
-        use a::{foo, S};
+        use a::{foo, R};
 
         mod a {
             pub struct S;
@@ -157,7 +156,7 @@ class DestructureIntentionTest : RsIntentionTestBase(DestructureIntention()) {
         }
 
         fn main() {
-            let S {} = foo();
+            let R {} = foo();
         }
     """)
 }


### PR DESCRIPTION
This PR adds support for aliased types in DestructureIntention. The struct creation is a bit hacky, is there a better way?

I need to pass the type in the context because `ty.item.declaredType != ty` (the declared type has no alias).

For the destructured struct name, I need the base (possibly aliased) name of the struct. I tried to use `type.insertionSafeTextWithAliases`, but for a type with generics and/or lifetimes, it returns for example `S<i32, &str>`, which is not a valid name for a struct pat. Basically I want to get an alias of a type, but only the base name, without generics and lifetimes. I created a new monstrosity (`insertionSafeTextWithAliasesWithoutTypes`).