### PR TITLE
INT: add ExtractEnumVariantIntention

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/ExtractEnumVariantIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ExtractEnumVariantIntention.kt
@@ -1,0 +1,352 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.searches.ReferencesSearch
+import org.rust.ide.refactoring.RsInPlaceVariableIntroducer
+import org.rust.lang.core.ARBITRARY_ENUM_DISCRIMINANT
+import org.rust.lang.core.FeatureAvailability
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.consts.Const
+import org.rust.lang.core.types.consts.CtConstParameter
+import org.rust.lang.core.types.infer.TypeVisitor
+import org.rust.lang.core.types.infer.hasCtConstParameters
+import org.rust.lang.core.types.infer.hasTyTypeParameters
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyTypeParameter
+import org.rust.lang.core.types.type
+
+class ExtractEnumVariantIntention : RsElementBaseIntentionAction<ExtractEnumVariantIntention.Context>() {
+    override fun getText(): String = "Extract enum variant"
+    override fun getFamilyName(): String = text
+
+    class Context(val variant: RsEnumVariant)
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val variant = element.ancestorStrict<RsEnumVariant>() ?: return null
+        if (variant.isFieldless) {
+            return null
+        }
+        if (variant.variantDiscriminant != null &&
+            ARBITRARY_ENUM_DISCRIMINANT.availability(variant.containingMod) != FeatureAvailability.AVAILABLE) {
+            return null
+        }
+        return Context(variant)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val element = createElement(ctx.variant)
+        val factory = RsPsiFactory(project)
+
+        val enum = ctx.variant.parentEnum
+        val parameters = filterTypeParameters(element.typeReferences, enum.typeParameterList)
+        val typeParametersText = parameters.format()
+        val whereClause = buildWhereClause(enum.whereClause, parameters)
+        val name = ctx.variant.name ?: return
+
+        val struct = element.createStruct(name, typeParametersText, whereClause)
+        val inserted = enum.parent.addBefore(struct, enum) as RsStructItem
+        val visibility = element.visibility
+
+        for (usage in ReferencesSearch.search(ctx.variant)) {
+            element.replaceUsage(usage.element, name)
+        }
+
+        val newVariant = factory.createTupleFields(listOf(RsPsiFactory.TupleField(visibility, inserted.declaredType)))
+        val replaced = element.toBeReplaced.replace(newVariant)
+
+        offerStructRename(project, editor, inserted, replaced)
+    }
+
+    companion object {
+        private data class Parameters(
+            val lifetimes: List<RsLifetimeParameter>,
+            val typeParameters: List<RsTypeParameter>,
+            val constParameters: List<RsConstParameter>
+        ) {
+            fun format(): String {
+                val all = lifetimes + typeParameters + constParameters
+                return if (all.isNotEmpty()) {
+                    all.joinToString(", ", prefix = "<", postfix = ">") { it.text }
+                } else {
+                    ""
+                }
+            }
+        }
+
+        private fun filterTypeParameters(references: List<RsTypeReference>, parameters: RsTypeParameterList?): Parameters {
+            if (parameters == null) {
+                return Parameters(listOf(), listOf(), listOf())
+            }
+
+            val typeParameters = gatherTypeParameters(references, parameters.typeParameterList)
+            val lifetimes = gatherLifetimes(references, parameters.lifetimeParameterList, typeParameters)
+            val constParameters = parameters.constParameterList.filter { param -> references.any { matchesConstParameter(it, param) } }
+
+            return Parameters(lifetimes, typeParameters, constParameters)
+        }
+
+        private fun matchesConstParameter(ref: RsTypeReference, parameter: RsConstParameter): Boolean =
+            ref.type.visitWith(HasConstParameterVisitor(parameter))
+
+        private fun offerStructRename(
+            project: Project,
+            editor: Editor,
+            inserted: RsStructItem,
+            replaced: PsiElement
+        ) {
+            val range = inserted.identifier?.textRange ?: return
+            editor.caretModel.moveToOffset(range.startOffset)
+
+            PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
+            RsInPlaceVariableIntroducer(inserted, editor, project, "choose struct name", arrayOf(replaced))
+                .performInplaceRefactoring(null)
+        }
+
+        private fun createElement(variant: RsEnumVariant): VariantElement {
+            val tupleFields = variant.tupleFields
+            val blockFields = variant.blockFields
+
+            return when {
+                tupleFields != null -> TupleVariant(tupleFields)
+                blockFields != null -> StructVariant(blockFields)
+                else -> error("unreachable")
+            }
+        }
+
+        private fun buildWhereClause(whereClause: RsWhereClause?, parameters: Parameters): String {
+            val where = whereClause ?: return ""
+            if (where.wherePredList.isEmpty()) return ""
+
+            val parameterMap = parameters.typeParameters.filter { it.name != null }.associateBy { it.name!! }
+            val lifetimeMap = parameters.lifetimes.filter { it.name != null }.associateBy { it.name!! }
+            val predicates = where.wherePredList.mapNotNull { predicate ->
+                val typeRef = predicate.typeReference
+                if (typeRef != null && hasTypeParameter(typeRef, parameterMap)) {
+                    return@mapNotNull predicate.text
+                }
+                val lifetime = predicate.lifetime
+                if (lifetime != null) {
+                    return@mapNotNull createLifetimePredicate(
+                        predicate,
+                        lifetime,
+                        predicate.lifetimeParamBounds,
+                        lifetimeMap
+                    )
+                }
+                return@mapNotNull null
+            }
+
+            return if (predicates.isEmpty()) "" else predicates.joinToString(separator = ",", prefix = " where ")
+        }
+
+        /**
+         * Create a predicate if the lifetime is in the map and at least one of its bounds is in the map.
+         * Bounds that are not in the map are removed.
+         */
+        private fun createLifetimePredicate(
+            predicate: RsWherePred,
+            lifetime: RsLifetime,
+            lifetimeParamBounds: RsLifetimeParamBounds?,
+            lifetimeMap: Map<String, RsLifetimeParameter>
+        ): String? {
+            if (lifetimeMap.containsKey(lifetime.name)) {
+                if (lifetimeParamBounds == null) return predicate.text
+
+                val bounds = lifetimeParamBounds.lifetimeList.filter { lifetimeMap.containsKey(it.name) }
+                return if (bounds.isEmpty()) {
+                    return null
+                } else {
+                    "${lifetime.text}: ${bounds.joinToString(" + ") { it.text }}"
+                }
+            }
+            return null
+        }
+
+        private fun hasTypeParameter(ref: RsTypeReference, map: Map<String, RsTypeParameter>): Boolean =
+            HasTypeParameterVisitor(map, ref).visitTy(ref.type)
+    }
+}
+
+private sealed class VariantElement(val toBeReplaced: PsiElement) {
+    abstract val visibility: RsVis?
+    abstract val typeReferences: List<RsTypeReference>
+    abstract fun createStruct(
+        name: String,
+        typeParameters: String,
+        whereClause: String
+    ): RsStructItem
+
+    abstract fun replaceUsage(element: PsiElement, name: String)
+
+    protected val factory: RsPsiFactory get() = RsPsiFactory(toBeReplaced.project)
+}
+
+private class TupleVariant(val fields: RsTupleFields) : VariantElement(fields) {
+    override val visibility: RsVis? = extractVisibility(fields.tupleFieldDeclList.mapNotNull { it.vis }.toSet())
+    override val typeReferences: List<RsTypeReference> = fields.tupleFieldDeclList.map { it.typeReference }
+    override fun createStruct(
+        name: String,
+        typeParameters: String,
+        whereClause: String
+    ): RsStructItem {
+        return factory.createStruct("struct $name$typeParameters${fields.text}$whereClause;")
+    }
+
+    override fun replaceUsage(element: PsiElement, name: String) {
+        val parent = element.ancestorStrict<RsPatTupleStruct>() ?: return
+        val binding = factory.createPatTupleStruct(name, parent.patList)
+
+        for (pat in parent.patList) {
+            val comma = pat.nextSibling
+            pat.delete()
+            if (comma.text == ",") {
+                comma.delete()
+            }
+        }
+        parent.addAfter(binding, parent.lparen)
+    }
+}
+
+private class StructVariant(val fields: RsBlockFields) : VariantElement(fields) {
+    override val visibility: RsVis? = extractVisibility(fields.namedFieldDeclList.mapNotNull { it.vis }.toSet())
+    override val typeReferences: List<RsTypeReference> = fields.namedFieldDeclList.mapNotNull { it.typeReference }
+    override fun createStruct(
+        name: String,
+        typeParameters: String,
+        whereClause: String
+    ): RsStructItem {
+        return factory.createStruct("struct $name$typeParameters$whereClause${fields.text}")
+    }
+
+    override fun replaceUsage(element: PsiElement, name: String) {
+        val parent = element.ancestorStrict<RsPatStruct>() ?: return
+        val path = parent.path
+        val binding = factory.createPatStruct(name, parent.patFieldList, parent.patRest)
+        val newPat = factory.createPatTupleStruct(path.text, listOf(binding))
+        parent.replace(newPat)
+    }
+}
+
+private fun extractVisibility(visibilities: Set<RsVis>): RsVis? {
+    return visibilities.maxBy {
+        when (val visibility = it.visibility) {
+            is RsVisibility.Public -> 4
+            is RsVisibility.Restricted -> if (visibility.inMod == it.crateRoot) {
+                3
+            } else {
+                2
+            }
+            is RsVisibility.Private -> 1
+        }
+    }
+}
+
+private data class CollectTypeParametersVisitor(val parameters: Map<String, RsTypeParameter>,
+                                                val collected: MutableSet<RsTypeParameter>) : RsRecursiveVisitor() {
+    override fun visitTypeReference(ref: RsTypeReference) {
+        super.visitTypeReference(ref)
+
+        when (val type = ref.type) {
+            is TyTypeParameter -> {
+                val name = type.name
+                parameters[name]?.let { parameter ->
+                    collected.add(parameter)
+                    parameter.bounds.forEach { bound ->
+                        bound.accept(this)
+                    }
+                }
+            }
+        }
+    }
+}
+
+fun gatherTypeParameters(
+    references: List<RsTypeReference>,
+    parameters: List<RsTypeParameter>
+): List<RsTypeParameter> {
+    val parameterMap = parameters.filter { it.name != null }.associateBy { it.name!! }
+    val collected = mutableSetOf<RsTypeParameter>()
+    for (ref in references) {
+        ref.accept(CollectTypeParametersVisitor(parameterMap, collected))
+    }
+    return collected.sortedBy { parameters.indexOf(it) }
+}
+
+private data class CollectLifetimesVisitor(val parameters: Map<String, RsTypeParameter>,
+                                           val lifetimeMap: Map<String, RsLifetimeParameter>,
+                                           val collected: MutableSet<RsLifetimeParameter>) : RsRecursiveVisitor() {
+    override fun visitTypeReference(ref: RsTypeReference) {
+        super.visitTypeReference(ref)
+
+        when (val type = ref.type) {
+            is TyTypeParameter -> {
+                val name = type.name
+                parameters[name]?.let { parameter ->
+                    parameter.bounds.forEach { bound ->
+                        bound.accept(this)
+                    }
+                }
+            }
+        }
+    }
+
+    override fun visitLifetime(lifetime: RsLifetime) {
+        super.visitLifetime(lifetime)
+
+        lifetimeMap[lifetime.name]?.let { parameter ->
+            if (!collected.contains(parameter)) {
+                collected.add(parameter)
+                parameter.accept(this)
+            }
+        }
+    }
+}
+
+fun gatherLifetimes(
+    references: List<RsTypeReference>,
+    lifetimes: List<RsLifetimeParameter>,
+    parameters: List<RsTypeParameter>
+): List<RsLifetimeParameter> {
+    val parameterMap = parameters.filter { it.name != null }.associateBy { it.name!! }
+    val lifetimeMap = lifetimes.filter { it.name != null }.associateBy { it.name!! }
+    val collected = mutableSetOf<RsLifetimeParameter>()
+
+    for (ref in references) {
+        ref.accept(CollectLifetimesVisitor(parameterMap, lifetimeMap, collected))
+    }
+
+    return collected.sortedBy { lifetimes.indexOf(it) }
+}
+
+
+private data class HasConstParameterVisitor(val parameter: RsConstParameter) : TypeVisitor {
+    override fun visitTy(ty: Ty): Boolean =
+        if (ty.hasCtConstParameters) ty.superVisitWith(this) else false
+
+    override fun visitConst(const: Const): Boolean =
+        when {
+            const is CtConstParameter -> const.parameter == parameter
+            const.hasCtConstParameters -> const.superVisitWith(this)
+            else -> false
+        }
+}
+
+private data class HasTypeParameterVisitor(val parameters: Map<String, RsTypeParameter>,
+                                           val ref: RsTypeReference) : TypeVisitor {
+    override fun visitTy(ty: Ty): Boolean {
+        return when {
+            ty is TyTypeParameter -> parameters.containsKey(ty.name)
+            ty.hasTyTypeParameters -> ty.superVisitWith(this)
+            else -> false
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -159,6 +159,17 @@ class RsPsiFactory(
             .blockFields!!
     }
 
+    data class TupleField(val visibility: RsVis?, val type: Ty)
+
+    fun createTupleFields(fields: List<TupleField>): RsTupleFields {
+        fun addSpace(t: String?) = if (t != null) { "$t " } else { "" }
+
+        val fieldsText = fields.joinToString(separator = ", ") {
+            "${addSpace(it.visibility?.text)}${it.type.insertionSafeTextWithLifetimes}"
+        }
+        return createFromText("struct S($fieldsText)") ?: error("Failed to create struct")
+    }
+
     fun createEnum(text: String): RsEnumItem =
         createFromText(text)
             ?: error("Failed to create enum from text: `$text`")
@@ -391,6 +402,14 @@ class RsPsiFactory(
             }
         """) ?: error("Failed to create pat field")
 
+    fun createPatStruct(name: String, pats: List<RsPatField>, patRest: RsPatRest?): RsPatStruct {
+        val pad = if (pats.isEmpty()) "" else " "
+        val items = pats.map { it.text } + listOfNotNull(patRest?.text)
+        val body = items
+            .joinToString(separator = ", ", prefix = " {$pad", postfix = "$pad}")
+        return createFromText("fn f($name$body: $name) {}") ?: error("Failed to create pat struct")
+    }
+
     fun createPatStruct(struct: RsStructItem, name: String? = null): RsPatStruct {
         val structName = name ?: struct.name ?: error("Failed to create pat struct")
         val pad = if (struct.namedFields.isEmpty()) "" else " "
@@ -404,6 +423,11 @@ class RsPsiFactory(
         val body = struct.positionalFields
             .joinToString(separator = ", ", prefix = "(", postfix = ")") { "_${it.name}" }
         return createFromText("fn f($structName$body: $structName) {}") ?: error("Failed to create pat tuple struct")
+    }
+
+    fun createPatTupleStruct(name: String, pats: List<RsPat>): RsPatTupleStruct {
+        val patsText = pats.joinToString(", ", prefix = "(", postfix = ")") { it.text }
+        return createFromText("fn f($name${patsText}: $name) {}") ?: error("Failed to create pat tuple struct")
     }
 
     fun createPatTuple(fieldNum: Int): RsPatTup {
@@ -449,6 +473,9 @@ class RsPsiFactory(
     fun createVisRestriction(pathText: String): RsVisRestriction =
         createFromText<RsFunction>("pub(in $pathText) fn foo() {}")?.vis?.visRestriction
             ?: error("Failed to create vis restriction element")
+
+    fun createVis(text: String): RsVis =
+        createFromText("$text fn foo() {}") ?: error("Failed to create vis")
 
     private inline fun <reified E : RsExpr> createExpressionOfType(text: String): E =
         createExpression(text) as? E

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -757,6 +757,10 @@
             <className>org.rust.ide.intentions.AddStructFieldsLiteralRecursiveIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.ExtractEnumVariantIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 

--- a/src/main/resources/intentionDescriptions/ExtractEnumVariantIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/ExtractEnumVariantIntention/after.rs.template
@@ -1,0 +1,5 @@
+struct Variant1 { name: String, id: usize }
+
+enum A {
+     Variant1(Variant1)
+}

--- a/src/main/resources/intentionDescriptions/ExtractEnumVariantIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/ExtractEnumVariantIntention/before.rs.template
@@ -1,0 +1,3 @@
+enum A {
+    Variant1 { name: String, id: usize, }
+}

--- a/src/main/resources/intentionDescriptions/ExtractEnumVariantIntention/description.html
+++ b/src/main/resources/intentionDescriptions/ExtractEnumVariantIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention extracts a single enum variant into a standalone struct.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/ExtractEnumVariantIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ExtractEnumVariantIntentionTest.kt
@@ -1,0 +1,354 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIntention()) {
+    fun `test not available on empty variant`() = doUnavailableTest("""
+        enum A {
+            /*caret*/V1
+        }
+    """)
+
+    fun `test not available on variant with discriminant`() = doUnavailableTest("""
+        enum A {
+            /*caret*/V1 = 1
+        }
+    """)
+
+    fun `test tuple variant`() = doAvailableTest("""
+        enum A {
+            /*caret*/V1(i32, bool, String),
+            V2
+        }
+    """, """
+        struct /*caret*/V1(i32, bool, String);
+
+        enum A {
+            V1(V1),
+            V2
+        }
+    """)
+
+    fun `test struct variant`() = doAvailableTest("""
+        enum A {
+            /*caret*/V1 { a: i32, b: bool, c: String },
+            V2
+        }
+    """, """
+        struct /*caret*/V1 { a: i32, b: bool, c: String }
+
+        enum A {
+            V1(V1),
+            V2
+        }
+    """)
+
+    fun `test extract pub visibility`() = doAvailableTest("""
+        enum A {
+            /*caret*/V1 { pub a: i32, pub(crate) b: bool, c: String },
+            V2
+        }
+    """, """
+        struct /*caret*/V1 { pub a: i32, pub(crate) b: bool, c: String }
+
+        enum A {
+            V1(pub V1),
+            V2
+        }
+    """)
+
+    fun `test extract crate visibility`() = doAvailableTest("""
+        enum A {
+            /*caret*/V1 { a: i32, pub(crate) b: bool, c: String },
+            V2
+        }
+    """, """
+        struct /*caret*/V1 { a: i32, pub(crate) b: bool, c: String }
+
+        enum A {
+            V1(pub(crate) V1),
+            V2
+        }
+    """)
+
+    fun `test generic type`() = doAvailableTest("""
+        enum A<T> {
+            /*caret*/V1(T),
+            V2
+        }
+    """, """
+        struct /*caret*/V1<T>(T);
+
+        enum A<T> {
+            V1(V1<T>),
+            V2
+        }
+    """)
+
+    fun `test type bound`() = doAvailableTest("""
+        trait Trait {}
+        enum A<T: Trait> {
+            /*caret*/V1(T),
+            V2
+        }
+    """, """
+        trait Trait {}
+
+        struct /*caret*/V1<T: Trait>(T);
+
+        enum A<T: Trait> {
+            V1(V1<T>),
+            V2
+        }
+    """)
+
+    fun `test where clause tuple`() = doAvailableTest("""
+        trait Trait {}
+        enum A<T> where T: Trait {
+            /*caret*/V1(T),
+            V2
+        }
+    """, """
+        trait Trait {}
+
+        struct /*caret*/V1<T>(T) where T: Trait;
+
+        enum A<T> where T: Trait {
+            V1(V1<T>),
+            V2
+        }
+    """)
+
+    fun `test where clause struct`() = doAvailableTest("""
+        trait Trait {}
+        enum A<T> where T: Trait {
+            /*caret*/V1 { a: T },
+            V2
+        }
+    """, """
+        trait Trait {}
+
+        struct /*caret*/V1<T> where T: Trait { a: T }
+
+        enum A<T> where T: Trait {
+            V1(V1<T>),
+            V2
+        }
+    """)
+
+    fun `test select only used parameters in where clause`() = doAvailableTest("""
+        trait Trait {}
+        trait Trait2<S> {
+            type Item;
+            fn foo() -> S;
+        }
+
+        enum A<'a, 'b, 'c, T, S, R, U> where T: Trait + Trait2<S, Item=U>, R: Trait, 'a: 'b + 'c, 'b: 'c {
+            /*caret*/V1 { a: &'a T, b: &'b T },
+            V2((&'b R, &'c T, S))
+        }
+    """, """
+        trait Trait {}
+        trait Trait2<S> {
+            type Item;
+            fn foo() -> S;
+        }
+
+        struct /*caret*/V1<'a, 'b, T, S, U> where T: Trait + Trait2<S, Item=U>, 'a: 'b { a: &'a T, b: &'b T }
+
+        enum A<'a, 'b, 'c, T, S, R, U> where T: Trait + Trait2<S, Item=U>, R: Trait, 'a: 'b + 'c, 'b: 'c {
+            V1(V1<'a, 'b, T, S, U>),
+            V2((&'b R, &'c T, S))
+        }
+    """)
+
+    fun `test lifetime bounds`() = doAvailableTest("""
+        enum A<'a: 'b, 'b: 'a> {
+            /*caret*/V1 { a: &'a u32, b: &'b u32 }
+        }
+    """, """
+        struct /*caret*/V1<'a: 'b, 'b: 'a> { a: &'a u32, b: &'b u32 }
+
+        enum A<'a: 'b, 'b: 'a> {
+            V1(V1<'a, 'b>)
+        }
+    """)
+
+    fun `test type parameter bounded by lifetime`() = doAvailableTest("""
+        trait Sync {}
+
+        enum S<'a, T: 'a> where &'a T: Sync {
+            /*caret*/V1(T),
+            V2
+        }
+    """, """
+        trait Sync {}
+
+        struct /*caret*/V1<'a, T: 'a>(T) where &'a T: Sync;
+
+        enum S<'a, T: 'a> where &'a T: Sync {
+            V1(V1<'a, T>),
+            V2
+        }
+    """)
+
+    fun `test transitive lifetime bound`() = doAvailableTest("""
+        trait Sync {}
+
+        enum S<'a: 'b, 'b, T: 'a> where &'b T: Sync {
+            /*caret*/V1(&'a T),
+            V2(&'b u32)
+        }
+    """, """
+        trait Sync {}
+
+        struct /*caret*/V1<'a: 'b, 'b, T: 'a>(&'a T) where &'b T: Sync;
+
+        enum S<'a: 'b, 'b, T: 'a> where &'b T: Sync {
+            V1(V1<'a, 'b, T>),
+            V2(&'b u32)
+        }
+    """)
+
+    fun `test const generics`() = doAvailableTest("""
+        trait Trait {}
+        enum A<const T: usize> {
+            /*caret*/V1 { a: [u32; T] },
+            V2
+        }
+    """, """
+        trait Trait {}
+
+        struct /*caret*/V1<const T: usize> { a: [u32; T] }
+
+        enum A<const T: usize> {
+            V1(V1<{ T }>),
+            V2
+        }
+    """)
+
+    fun `test lifetime`() = doAvailableTest("""
+        enum A<'a> {
+            /*caret*/V1(&'a u32),
+            V2
+        }
+    """, """
+        struct /*caret*/V1<'a>(&'a u32);
+
+        enum A<'a> {
+            V1(V1<'a>),
+            V2
+        }
+    """)
+
+    fun `test skip unused generic type`() = doAvailableTest("""
+        struct S<X> { a: X }
+
+        enum A<'a, T1, T2, T3, T4> {
+            /*caret*/V1(T1, &'a T2, S<S<T4>>),
+            V2(T3)
+        }
+    """, """
+        struct S<X> { a: X }
+
+        struct /*caret*/V1<'a, T1, T2, T4>(T1, &'a T2, S<S<T4>>);
+
+        enum A<'a, T1, T2, T3, T4> {
+            V1(V1<'a, T1, T2, T4>),
+            V2(T3)
+        }
+    """)
+
+    fun `test skip unused lifetime`() = doAvailableTest("""
+        struct S<X> { a: X }
+
+        enum A<'a, 'b> {
+            /*caret*/V1(S<S<&'a u32>>),
+            V2('b u32)
+        }
+    """, """
+        struct S<X> { a: X }
+
+        struct /*caret*/V1<'a>(S<S<&'a u32>>);
+
+        enum A<'a, 'b> {
+            V1(V1<'a>),
+            V2('b u32)
+        }
+    """)
+
+    fun `test replace usage tuple`() = doAvailableTest("""
+        enum A {
+            /*caret*/V1(u32, bool, i32)
+        }
+
+        enum Option<T> { Some(T), None }
+
+        fn foo(mut a: A, mut b: Option<A>) {
+            match a {
+                A::V1(ref mut x, ref y, ..) => {},
+            }
+
+            if let Option::Some(A::V1(ref mut x, ref y, z)) = b {
+
+            }
+        }
+    """, """
+        struct /*caret*/V1(u32, bool, i32);
+
+        enum A {
+            V1(V1)
+        }
+
+        enum Option<T> { Some(T), None }
+
+        fn foo(mut a: A, mut b: Option<A>) {
+            match a {
+                A::V1(V1(ref mut x, ref y, ..)) => {},
+            }
+
+            if let Option::Some(A::V1(V1(ref mut x, ref y, z))) = b {
+
+            }
+        }
+    """)
+
+    fun `test replace usage struct`() = doAvailableTest("""
+        enum A {
+            /*caret*/V1 { x: u32, y: bool, z: i32 }
+        }
+
+        enum Option<T> { Some(T), None }
+
+        fn foo(mut a: A, mut b: Option<A>) {
+            match a {
+                A::V1 { ref mut x, y: ref u, .. } => {}
+            }
+
+            if let Option::Some(A::V1 { ref mut x, ref y, z }) = b {
+
+            }
+        }
+    """, """
+        struct /*caret*/V1 { x: u32, y: bool, z: i32 }
+
+        enum A {
+            V1(V1)
+        }
+
+        enum Option<T> { Some(T), None }
+
+        fn foo(mut a: A, mut b: Option<A>) {
+            match a {
+                A::V1(V1 { ref mut x, y: ref u, .. }) => {}
+            }
+
+            if let Option::Some(A::V1(V1 { ref mut x, ref y, z })) = b {
+
+            }
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds intention for extracting an enum variant into a standalone struct and replaces usages of the old variant.

How should it handle visibility?
For example:

```rust
enum S {
    V1(pub u32, pub(crate) u32, u32)
}
```

```rust
struct V1(pub u32, pub(crate) u32, u32);

enum S {
    V1(??? V1)
}
```
Right now I select the "broadest" visibility level (`pub` > `crate` > `mod` > `private`).

TODO:
- [x] Filter only used type parameters
- [x] Replace usages

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5024