### PR TITLE
FMT: add newline between items inside function

### DIFF
--- a/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt
@@ -196,6 +196,12 @@ fun Block.computeSpacing(child1: Block?, child2: Block, ctx: RsFmtContext): Spac
 
                 keepLineBreaks = ctx.commonSettings.KEEP_LINE_BREAKS,
                 keepBlankLines = ctx.commonSettings.KEEP_BLANK_LINES_IN_DECLARATIONS)
+
+        // Format blank lines between items (e.g. inside function)
+            ncPsi1 is RsItemElement
+                && (ncPsi2 is RsItemElement || ncPsi2.isStmtOrExpr)
+                && node2.firstChildNode !is PsiComment
+            -> return lineBreak(1)
         }
     }
     return ctx.spacingBuilder.getSpacing(this, child1, child2)

--- a/src/test/kotlin/org/rust/ide/formatter/RsFormatterLineBreaksTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsFormatterLineBreaksTest.kt
@@ -157,6 +157,35 @@ class RsFormatterLineBreaksTest : RsFormatterTestBase() {
         }
     """)
 
+    fun `test line breaks between items in function`() = doTextTest("""
+        fn test1() {
+            use mod1; use mod2; const C: i32 = 1; let foo = 1;
+        }
+
+        fn test2() {
+            // comments should be kept on same line
+            use mod1;  // m1
+            use mod2;  // m2
+            const C1: i32 = 1;  // c1
+            const C2: i32 = 1;  // c2
+        }
+    """, """
+        fn test1() {
+            use mod1;
+            use mod2;
+            const C: i32 = 1;
+            let foo = 1;
+        }
+
+        fn test2() {
+            // comments should be kept on same line
+            use mod1;  // m1
+            use mod2;  // m2
+            const C1: i32 = 1;  // c1
+            const C2: i32 = 1;  // c2
+        }
+    """)
+
     fun `test blocks`() = doTextTest("""
         fn main() {
             let foo = { foo(123, 456,


### PR DESCRIPTION
So this code
```rust
fn main() {
    use mod1; use mod2; let foo = 1;
}
```

will be reformatted into
```rust
fn main() {
    use mod1;
    use mod2;
    let foo = 1;
}
```