### PR TITLE
Provide missing versions for indexers

### DIFF
--- a/duplicates/src/main/kotlin/org/rust/ide/clones/RsDuplicateScope.kt
+++ b/duplicates/src/main/kotlin/org/rust/ide/clones/RsDuplicateScope.kt
@@ -21,6 +21,7 @@ import com.jetbrains.clones.core.NodeHash
 import com.jetbrains.clones.core.longHash
 import com.jetbrains.clones.core.nodeListHash
 import com.jetbrains.clones.languagescope.common.DuplicateScopeBase
+import org.rust.lang.core.parser.RustParserDefinition
 import org.rust.lang.core.psi.RS_COMMENTS
 import org.rust.lang.core.psi.RS_LITERALS
 import org.rust.lang.core.psi.RsElementTypes.*
@@ -34,6 +35,8 @@ class RsDuplicateScope : DuplicateScopeBase() {
      * Used as a DuplicateScope id in settings serialization
      */
     override val languageName: String = "Rust"
+
+    override fun getIndexVersion(): Int = RustParserDefinition.PARSER_VERSION + VERSION
 
     /**
      * @return true if [file] should be analyzed
@@ -150,6 +153,9 @@ class RsDuplicateScope : DuplicateScopeBase() {
     }
 
     companion object {
+
+        private val VERSION: Int = 1
+
         private val NOISE = TokenSet.orSet(RS_COMMENTS, tokenSetOf(
             TokenType.WHITE_SPACE,
             // Ignore trailing commas

--- a/src/main/kotlin/org/rust/ide/search/RsWordScanner.kt
+++ b/src/main/kotlin/org/rust/ide/search/RsWordScanner.kt
@@ -8,6 +8,7 @@ package org.rust.ide.search
 import com.intellij.lang.cacheBuilder.DefaultWordsScanner
 import com.intellij.psi.tree.TokenSet
 import org.rust.lang.core.lexer.RsLexer
+import org.rust.lang.core.parser.RustParserDefinition
 import org.rust.lang.core.psi.RS_COMMENTS
 import org.rust.lang.core.psi.RsElementTypes.*
 
@@ -16,4 +17,6 @@ class RsWordScanner : DefaultWordsScanner(
     TokenSet.create(IDENTIFIER),
     RS_COMMENTS,
     TokenSet.create(STRING_LITERAL)
-)
+) {
+    override fun getVersion(): Int = RustParserDefinition.LEXER_VERSION
+}

--- a/src/main/kotlin/org/rust/ide/todo/RsTodoIndexer.kt
+++ b/src/main/kotlin/org/rust/ide/todo/RsTodoIndexer.kt
@@ -12,13 +12,18 @@ import com.intellij.psi.impl.cache.impl.todo.LexerBasedTodoIndexer
 import com.intellij.psi.search.UsageSearchContext
 import com.intellij.psi.tree.IElementType
 import org.rust.lang.core.lexer.RsLexer
+import org.rust.lang.core.parser.RustParserDefinition
 import org.rust.lang.core.psi.RS_COMMENTS
 import org.rust.lang.core.psi.RsElementTypes.EXCL
 import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 
 class RsTodoIndexer : LexerBasedTodoIndexer() {
-    override fun getVersion(): Int = 2
+    override fun getVersion(): Int = RustParserDefinition.LEXER_VERSION + VERSION
     override fun createLexer(consumer: OccurrenceConsumer): Lexer = RsFilterLexer(consumer)
+
+    companion object {
+        private const val VERSION = 2
+    }
 }
 
 private class RsFilterLexer(consumer: OccurrenceConsumer) : BaseFilterLexer(RsLexer(), consumer) {

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
@@ -85,5 +85,15 @@ class RustParserDefinition : ParserDefinition {
         @JvmField val OUTER_BLOCK_DOC_COMMENT = RsTokenType("<OUTER_BLOCK_DOC_COMMENT>")
         @JvmField val INNER_EOL_DOC_COMMENT = RsTokenType("<INNER_EOL_DOC_COMMENT>")
         @JvmField val OUTER_EOL_DOC_COMMENT = RsTokenType("<OUTER_EOL_DOC_COMMENT>")
+
+        /**
+         * Should be increased after any change of lexer rules
+         */
+        const val LEXER_VERSION: Int = 2
+
+        /**
+         * Should be increased after any change of parser rules
+         */
+        const val PARSER_VERSION: Int = LEXER_VERSION + 1
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -25,6 +25,7 @@ import com.intellij.util.io.DataInputOutputUtil.writeNullable
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.lexer.RsLexer
 import org.rust.lang.core.parser.RustParser
+import org.rust.lang.core.parser.RustParserDefinition
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.psi.ext.*
@@ -48,8 +49,10 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
     override fun getType() = Type
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
+        private const val STUB_VERSION = 193
+
         // Bump this number if Stub structure changes
-        override fun getStubVersion(): Int = 193
+        override fun getStubVersion(): Int = RustParserDefinition.PARSER_VERSION + STUB_VERSION
 
         override fun getBuilder(): StubBuilder = object : DefaultStubBuilder() {
             override fun createStubForFile(file: PsiFile): StubElement<*> {


### PR DESCRIPTION
It should update the corresponding indices after lexer or parser changes.
Also, introduce separate lexer, parser and stub versions