### PR TITLE
REPL: Fix for windows (use new escape characters)

### DIFF
--- a/src/main/kotlin/org/rust/ide/console/RsConsoleCommunication.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleCommunication.kt
@@ -54,7 +54,16 @@ class RsConsoleCommunication(private val consoleView: RsConsoleView) {
     }
 
     companion object {
-        const val SUCCESS_EXECUTION_MARKER: String = "\u0001"
-        const val FAILED_EXECUTION_MARKER: String = "\u0002"
+        /**
+         * \u0091 and \u0092 are C1 control codes (https://en.wikipedia.org/wiki/C0_and_C1_control_codes#C1_control_codes_for_general_use)
+         * with names "Private Use 1" and "Private Use 2"
+         * and meaning
+         *     "Reserved for a function without standardized meaning for private use as required,
+         *      subject to the prior agreement of the sender and the recipient of the data."
+         * so they are ideal for our purpose
+         */
+        // BACKCOMPAT: Evcxr 0.4.6. Remove \u0001 and \u0002
+        val SUCCESS_EXECUTION_MARKER: Regex = Regex("[\u0091\u0001]")
+        val FAILED_EXECUTION_MARKER: Regex = Regex("[\u0092\u0002]")
     }
 }


### PR DESCRIPTION
There are two problems with rust console on windows:

1. Colors not displayed correctly (#5058, #5046, #4883). It is related to `colored` crate (used by Evcxr) and will be fixed by adding `colored::control::set_virtual_terminal(true);` to Evcxr code
2. It is possible to run only one command (#5046, #4883). This is because we use `\u0001` and `\u0002` characters as special markers to determine whether the last command was successful. For some reason under windows these characters changes into some other characters. So we will use new marker characters `\u0091` and `\u0092`