### PR TITLE
PERF&STUB: store `cfg` existence flags to stubs

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -677,7 +677,7 @@ upper ForeignModItem ::= ExternAbi ForeignModBody {
   implements = [ "org.rust.lang.core.psi.ext.RsItemElement"
                  "org.rust.lang.core.psi.ext.RsInnerAttributeOwner" ]
   mixin = "org.rust.lang.core.psi.ext.RsForeignModItemImplMixin"
-  stubClass = "org.rust.lang.core.stubs.RsPlaceholderStub"
+  stubClass = "org.rust.lang.core.stubs.RsForeignModStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 // Extracted due to a bug in uppers. BACKCOMPAT 2019.3

--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -7,7 +7,6 @@ package org.rust.ide.experiments
 
 object RsExperiments {
     const val BUILD_TOOL_WINDOW = "org.rust.cargo.build.tool.window"
-    const val CFG_ATTRIBUTES_SUPPORT = "org.rust.lang.cfg.attributes"
     const val FETCH_OUT_DIR = "org.rust.cargo.fetch.out.dir"
     const val REPL_TOOL_WINDOW = "org.rust.ide.repl.tool.window"
     const val EVALUATE_BUILD_SCRIPTS = "org.rust.cargo.evaluate.build.scripts"

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -208,9 +208,6 @@ val RsDocAndAttributeOwner.isCfgUnknown: Boolean
     get() = evaluateCfg() == ThreeValuedLogic.Unknown
 
 private fun RsDocAndAttributeOwner.evaluateCfg(): ThreeValuedLogic {
-    // TODO: get rid of this registry key when cfg support is done
-    if (!isUnitTestMode && !isFeatureEnabled(RsExperiments.CFG_ATTRIBUTES_SUPPORT)) return ThreeValuedLogic.True
-
     // TODO: add cfg to RsFile's stub and remove this line
     if (this is RsFile) return ThreeValuedLogic.True
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -5,14 +5,13 @@
 
 package org.rust.lang.core.psi.ext
 
-import com.intellij.openapiext.isUnitTestMode
+import com.intellij.extapi.psi.StubBasedPsiElementBase
 import com.intellij.psi.NavigatablePsiElement
 import com.intellij.psi.PsiElement
-import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.core.psi.*
+import org.rust.lang.core.stubs.RsAttributeOwnerStub
 import org.rust.lang.utils.evaluation.CfgEvaluator
 import org.rust.lang.utils.evaluation.ThreeValuedLogic
-import org.rust.openapiext.isFeatureEnabled
 
 interface RsDocAndAttributeOwner : RsElement, NavigatablePsiElement
 
@@ -70,11 +69,23 @@ data class Attribute(val name: String, val argText: String? = null) {
     val text: String get() = if (argText == null) name else "$name($argText)"
 }
 
+inline val RsDocAndAttributeOwner.attributeStub: RsAttributeOwnerStub?
+    get() = (this as? StubBasedPsiElementBase<*>)?.greenStub as? RsAttributeOwnerStub
+
 /**
  * Returns [QueryAttributes] for given PSI element.
  */
 val RsDocAndAttributeOwner.queryAttributes: QueryAttributes
-    get() = QueryAttributes(this)
+    get() {
+        val stub = attributeStub
+        return if (stub?.hasAttrs == false) {
+            QueryAttributes.EMPTY
+        } else {
+            val attributes: Sequence<RsAttr> = (this as? RsInnerAttributeOwner)?.innerAttrList.orEmpty().asSequence() +
+                (this as? RsOuterAttributeOwner)?.outerAttrList.orEmpty().asSequence()
+            QueryAttributes(attributes)
+        }
+    }
 
 /**
  * Allows for easy querying [RsDocAndAttributeOwner] for specific attributes.
@@ -82,24 +93,14 @@ val RsDocAndAttributeOwner.queryAttributes: QueryAttributes
  * **Do not instantiate directly**, use [RsDocAndAttributeOwner.queryAttributes] instead.
  */
 class QueryAttributes(
-    private val psi: RsDocAndAttributeOwner,
-    private val attributes: Sequence<RsAttr> = (psi as? RsInnerAttributeOwner)?.innerAttrList.orEmpty().asSequence() +
-        (psi as? RsOuterAttributeOwner)?.outerAttrList.orEmpty().asSequence()
+    private val attributes: Sequence<RsAttr>
 ) {
-
     // #[doc(hidden)]
     val isDocHidden: Boolean get() = hasAttributeWithArg("doc", "hidden")
 
     // #[cfg(test)], #[cfg(target_has_atomic = "ptr")], #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    fun hasCfgAttr(): Boolean {
-        if (psi is RsFunction) {
-            val stub = psi.greenStub
-            if (stub != null) return stub.isCfg
-        }
-        // TODO: We probably want this optimization also for other items that we query regularly
-
-        return hasAttribute("cfg")
-    }
+    fun hasCfgAttr(): Boolean =
+        hasAttribute("cfg")
 
     // `#[attributeName]`, `#[attributeName(arg)]`, `#[attributeName = "Xxx"]`
     fun hasAttribute(attributeName: String): Boolean {
@@ -112,10 +113,8 @@ class QueryAttributes(
         return attrs.any()
     }
 
-    fun hasAnyOfOuterAttributes(vararg attributes: String): Boolean {
-        val outerAttrList = (psi as? RsOuterAttributeOwner)?.outerAttrList ?: return false
-        return outerAttrList.any { it.metaItem.name in attributes }
-    }
+    fun hasAnyOfAttributes(vararg names: String): Boolean =
+        attributes.any { it.metaItem.name in names }
 
     // `#[attributeName]`
     fun hasAtomAttribute(attributeName: String): Boolean {
@@ -194,6 +193,10 @@ class QueryAttributes(
 
     override fun toString(): String =
         "QueryAttributes(${attributes.joinToString { it.text }})"
+
+    companion object {
+        val EMPTY: QueryAttributes = QueryAttributes(emptySequence())
+    }
 }
 
 /**
@@ -211,8 +214,9 @@ private fun RsDocAndAttributeOwner.evaluateCfg(): ThreeValuedLogic {
     // TODO: add cfg to RsFile's stub and remove this line
     if (this is RsFile) return ThreeValuedLogic.True
 
-    if (!queryAttributes.hasCfgAttr()) return ThreeValuedLogic.True
-    val cfgAttributes = queryAttributes.cfgAttributes.takeIf { it.any() } ?: return ThreeValuedLogic.True
+    if (attributeStub?.hasCfg == false) return ThreeValuedLogic.True
+
+    val cfgAttributes = queryAttributes.cfgAttributes
 
     // TODO: When we open both cargo projects for an application and a library,
     // this will return the library as containing package.

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt
@@ -20,7 +20,7 @@ import org.rust.lang.core.stubs.RsExternCrateItemStub
 val RsExternCrateItem.nameWithAlias: String get() = alias?.name ?: referenceName
 
 val RsExternCrateItem.hasMacroUse: Boolean get() =
-    queryAttributes.hasAttribute("macro_use")
+    greenStub?.hasMacroUse ?: queryAttributes.hasAttribute("macro_use")
 
 abstract class RsExternCrateItemImplMixin : RsStubbedNamedElementImpl<RsExternCrateItemStub>,
                                             RsExternCrateItem {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt
@@ -11,14 +11,14 @@ import com.intellij.psi.stubs.IStubElementType
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.RsForeignModItem
 import org.rust.lang.core.psi.RsInnerAttr
-import org.rust.lang.core.stubs.RsPlaceholderStub
+import org.rust.lang.core.stubs.RsForeignModStub
 
-abstract class RsForeignModItemImplMixin : RsStubbedElementImpl<RsPlaceholderStub>,
+abstract class RsForeignModItemImplMixin : RsStubbedElementImpl<RsForeignModStub>,
                                            RsForeignModItem {
 
     constructor(node: ASTNode) : super(node)
 
-    constructor(stub: RsPlaceholderStub, elementType: IStubElementType<*, *>) : super(stub, elementType)
+    constructor(stub: RsForeignModStub, elementType: IStubElementType<*, *>) : super(stub, elementType)
 
     override val innerAttrList: List<RsInnerAttr>
         get() = stubChildrenOfType()

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -135,7 +135,10 @@ val RsFunction.isCustomDeriveProcMacroDef: Boolean
     get() = queryAttributes.hasAttribute("proc_macro_derive")
 
 val RsFunction.isProcMacroDef: Boolean
-    get() = queryAttributes.hasAnyOfOuterAttributes(
+    get() = greenStub?.isProcMacroDef ?: (queryAttributes.isProcMacroDef)
+
+val QueryAttributes.isProcMacroDef
+    get() = hasAnyOfAttributes(
         "proc_macro",
         "proc_macro_attribute",
         "proc_macro_derive"

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt
@@ -28,7 +28,7 @@ fun RsModDeclItem.getOrCreateModuleFile(): PsiFile? {
 }
 
 val RsModDeclItem.isLocal: Boolean
-    get() = greenStub?.isLocal ?: (ancestorStrict<RsBlock>() != null)
+    get() = ancestorStrict<RsBlock>() != null
 
 
 //TODO: use explicit path if present.
@@ -42,6 +42,9 @@ private val RsModDeclItem.implicitPaths: List<String> get() {
 }
 
 val RsModDeclItem.pathAttribute: String? get() = queryAttributes.lookupStringValueForKey("path")
+
+val RsModDeclItem.hasMacroUse: Boolean get() =
+    greenStub?.hasMacroUse ?: queryAttributes.hasAttribute("macro_use")
 
 abstract class RsModDeclItemImplMixin : RsStubbedNamedElementImpl<RsModDeclItemStub>,
                                         RsModDeclItem {
@@ -64,6 +67,3 @@ abstract class RsModDeclItemImplMixin : RsStubbedNamedElementImpl<RsModDeclItemS
 
     override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }
-
-val RsModDeclItem.hasMacroUse: Boolean get() =
-    stub?.hasMacroUse ?: queryAttributes.hasAttribute("macro_use")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsModItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsModItem.kt
@@ -17,6 +17,9 @@ import org.rust.lang.core.psi.RsPsiImplUtil
 import org.rust.lang.core.stubs.RsModItemStub
 import javax.swing.Icon
 
+val RsModItem.hasMacroUse: Boolean get() =
+    greenStub?.hasMacroUse ?: queryAttributes.hasAttribute("macro_use")
+
 abstract class RsModItemImplMixin : RsStubbedNamedElementImpl<RsModItemStub>,
                                     RsModItem {
 
@@ -46,6 +49,3 @@ abstract class RsModItemImplMixin : RsStubbedNamedElementImpl<RsModItemStub>,
 
     override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }
-
-val RsModItem.hasMacroUse: Boolean get() =
-    queryAttributes.hasAttribute("macro_use")

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubInterfaces.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubInterfaces.kt
@@ -5,6 +5,57 @@
 
 package org.rust.lang.core.stubs
 
+import com.intellij.util.BitUtil
+import org.rust.lang.core.psi.ext.QueryAttributes
+import org.rust.lang.core.psi.ext.RsDocAndAttributeOwner
+import org.rust.lang.core.psi.ext.name
+import org.rust.lang.core.psi.ext.queryAttributes
+import org.rust.stdext.makeBitMask
+
 interface RsNamedStub {
     val name: String?
+}
+
+/**
+ * These properties are stored in stubs for performance reasons: it's much cheaper to check
+ * a flag in a stub then traverse a PSI
+ */
+interface RsAttributeOwnerStub {
+    val hasAttrs: Boolean
+
+    // #[cfg()]
+    val hasCfg: Boolean
+
+    // #[macro_use]
+    val hasMacroUse: Boolean
+
+    companion object {
+        val ATTRS_MASK: Int = makeBitMask(0)
+        val CFG_MASK: Int = makeBitMask(1)
+        val HAS_MACRO_USE_MASK: Int = makeBitMask(2)
+        const val USED_BITS: Int = 3
+
+        fun extractFlags(element: RsDocAndAttributeOwner): Int =
+            extractFlags(element.queryAttributes)
+
+        fun extractFlags(attrs: QueryAttributes): Int {
+            var hasAttrs = false
+            var hasCfg = false
+            var hasMacroUse = false
+            for (meta in attrs.metaItems) {
+                hasAttrs = true
+                when (meta.name) {
+                    "cfg" -> hasCfg = true
+                    "macro_use" -> hasMacroUse = true
+                    // TODO cfg_attr
+                }
+                if (hasCfg && hasMacroUse) break
+            }
+            var flags = 0
+            flags = BitUtil.set(flags, ATTRS_MASK, hasAttrs)
+            flags = BitUtil.set(flags, CFG_MASK, hasCfg)
+            flags = BitUtil.set(flags, HAS_MACRO_USE_MASK, hasMacroUse)
+            return flags
+        }
+    }
 }

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -3,9 +3,6 @@
         <experimentalFeature id="org.rust.cargo.build.tool.window" percentOfUsers="100">
             <description>Enable Cargo tasks to use Build Tool Window</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.lang.cfg.attributes" percentOfUsers="100">
-            <description>Enable Rust cfg attributes support</description>
-        </experimentalFeature>
         <experimentalFeature id="org.rust.cargo.fetch.out.dir" percentOfUsers="0">
             <description>Fetch `OUT_DIR` environment variable value. It's needed to make proper name resolution for code included via `include` macro</description>
         </experimentalFeature>

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -3,9 +3,6 @@
         <experimentalFeature id="org.rust.cargo.build.tool.window" percentOfUsers="0">
             <description>Enable Cargo tasks to use Build Tool Window</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.lang.cfg.attributes" percentOfUsers="100">
-            <description>Enable Rust cfg attributes support</description>
-        </experimentalFeature>
         <experimentalFeature id="org.rust.cargo.fetch.out.dir" percentOfUsers="0">
             <description>Fetch `OUT_DIR` environment variable value. It's needed to make proper name resolution for code included via `include` macro</description>
         </experimentalFeature>


### PR DESCRIPTION
This speeds up `cfg` attributes processing, which in turn speeds up name resolution & type inference
Required for #4936 to avoid performance regression