### PR TITLE
INT: Add "Change return type" fix

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
@@ -1,0 +1,96 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.ide.inspections.import.RsImportHelper.importTypeReferencesFromTy
+import org.rust.ide.presentation.insertionSafeTextWithAliasesAndLifetimes
+import org.rust.ide.presentation.textWithAliasNames
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsLambdaExpr
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsRetExpr
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyUnit
+
+
+class ChangeReturnTypeFix(element: RsElement, private val actualTy: Ty) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+    override fun getFamilyName(): String = "Change return type"
+    override fun getText(): String {
+        val (item, name) = when (val callable = findCallableOwner(startElement)) {
+            is RsFunction -> {
+                val item = if (callable.owner.isImplOrTrait) " of method" else " of function"
+                val name = callable.name?.let { " '$it'" } ?: ""
+                item to name
+            }
+            is RsLambdaExpr -> " of closure" to ""
+            else -> "" to ""
+        }
+        return "Change return type$item$name to '${actualTy.textWithAliasNames}'"
+    }
+
+    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
+        val owner = findCallableOwner(startElement) ?: return
+
+        val oldRetType = when (owner) {
+            is RsFunction -> owner.retType
+            is RsLambdaExpr -> owner.retType
+            else -> return
+        }
+
+        if (actualTy is TyUnit) {
+            oldRetType?.delete()
+            return
+        }
+
+        val psiFactory = RsPsiFactory(project)
+        val retType = psiFactory.createRetType(actualTy.insertionSafeTextWithAliasesAndLifetimes)
+
+        if (oldRetType != null) {
+            oldRetType.replace(retType)
+        } else {
+            val parameters = when (owner) {
+                is RsFunction -> owner.valueParameterList
+                is RsLambdaExpr -> owner.valueParameterList
+                else -> return
+            }
+            owner.addAfter(retType, parameters)
+        }
+
+        importTypeReferencesFromTy(owner, actualTy, useAliases = true)
+    }
+
+    companion object {
+        private fun findCallableOwner(element: PsiElement): RsElement? =
+            PsiTreeUtil.getContextOfType(element, true, RsFunction::class.java, RsLambdaExpr::class.java)
+
+        fun createIfCompatible(element: RsElement, actualTy: Ty): ChangeReturnTypeFix? {
+            if (element.containingCargoPackage?.origin != PackageOrigin.WORKSPACE) return null
+
+            val owner = findCallableOwner(element)
+            val isOverriddenFn = owner is RsFunction && owner.superItem != null
+            if (isOverriddenFn) return null // TODO: Support overridden items
+
+            val retExpr = when (owner) {
+                is RsFunction -> owner.block?.expr
+                is RsLambdaExpr -> owner.expr
+                else -> return null
+            }
+
+            val isRetExpr = element.parent is RsRetExpr || retExpr === element
+            if (!isRetExpr) return null
+
+            return ChangeReturnTypeFix(element, actualTy)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -352,11 +352,13 @@ class RsPsiFactory(
         createFromText<RsFunction>("unsafe fn foo(){}")?.unsafe
             ?: error("Failed to create unsafe element")
 
-    fun createFunction(
-        text: String
-    ): RsFunction =
+    fun createFunction(text: String): RsFunction =
         createFromText(text)
-            ?: error("Failed to create function element: text")
+            ?: error("Failed to create function element: $text")
+
+    fun createRetType(ty: String): RsRetType =
+        createFromText("fn foo() -> $ty {}")
+            ?: error("Failed to create function return type: $ty")
 
     fun createImpl(name: String, functions: List<RsFunction>): RsImplItem =
         createFromText("impl $name {\n${functions.joinToString(separator = "\n", transform = { it.text })}\n}")

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -19,6 +19,7 @@ import org.rust.lang.core.types.consts.Const
 import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.consts.CtInferVar
 import org.rust.lang.core.types.consts.CtUnknown
+import org.rust.lang.core.types.regions.ReStatic
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.utils.RsDiagnostic
 import org.rust.lang.utils.evaluation.ConstExpr
@@ -295,9 +296,9 @@ class RsTypeInferenceWalker(
                 if (stubKind.isByte) {
                     val size = stubKind.value?.length?.toLong()
                     val const = size?.let { ConstExpr.Value.Integer(it, TyInteger.USize).toConst() } ?: CtUnknown
-                    TyReference(TyArray(TyInteger.U8, const), Mutability.IMMUTABLE)
+                    TyReference(TyArray(TyInteger.U8, const), Mutability.IMMUTABLE, ReStatic)
                 } else {
-                    TyReference(TyStr, Mutability.IMMUTABLE)
+                    TyReference(TyStr, Mutability.IMMUTABLE, ReStatic)
                 }
             }
             is RsStubLiteralKind.Integer -> {

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -129,6 +129,12 @@ sealed class RsDiagnostic(
                                 add(ConvertToMutStrFix(element))
                             }
                         }
+
+                        val retFix = ChangeReturnTypeFix.createIfCompatible(element, actualTy)
+                        if (retFix != null) {
+                            add(retFix)
+                        }
+
                         val derefsRefsToExpected = derefRefPathFromActualToExpected(lookup, element)
                         if (derefsRefsToExpected != null) {
                             add(ConvertToTyWithDerefsRefsFix(element, expectedTy, derefsRefsToExpected))

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ChangeReturnTypeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ChangeReturnTypeFixTest.kt
@@ -1,0 +1,164 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.typecheck
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.RsTypeCheckInspection
+
+class ChangeReturnTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::class) {
+
+    fun `test str vs () in function`() = checkFixByText("Change return type of function 'foo' to '&str'", """
+        fn foo() {
+            <error>"Hello World!"<caret></error>
+        }
+    """, """
+        fn foo() -> &'static str {
+            "Hello World!"
+        }
+    """)
+
+    fun `test return str vs () in function`() = checkFixByText("Change return type of function 'foo' to '&str'", """
+        fn foo() {
+            return <error>"Hello World!"<caret></error>;
+        }
+    """, """
+        fn foo() -> &'static str {
+            return "Hello World!";
+        }
+    """)
+
+    fun `test str vs i32 in function`() = checkFixByText("Change return type of function 'foo' to '&str'", """
+        fn foo() -> i32 {
+            <error>"Hello World!"<caret></error>
+        }
+    """, """
+        fn foo() -> &'static str {
+            "Hello World!"
+        }
+    """)
+
+    fun `test return str vs i32 in function`() = checkFixByText("Change return type of function 'foo' to '&str'", """
+        fn foo() -> i32 {
+            return <error>"Hello World!"<caret></error>;
+        }
+    """, """
+        fn foo() -> &'static str {
+            return "Hello World!";
+        }
+    """)
+
+    fun `test str vs i32 in closure`() = checkFixByText("Change return type of closure to '&str'", """
+        fn foo() {
+            let _ = || -> i32 <error>"Hello World!"<caret></error>;
+        }
+    """, """
+        fn foo() {
+            let _ = || -> &'static str "Hello World!";
+        }
+    """)
+
+    fun `test return str vs i32 in closure`() = checkFixByText("Change return type of closure to '&str'", """
+        fn foo() {
+            let _ = || -> i32 { return <error>"Hello World!"<caret></error>; };
+        }
+    """, """
+        fn foo() {
+            let _ = || -> &'static str { return "Hello World!"; };
+        }
+    """)
+
+    fun `test str vs i32 in method`() = checkFixByText("Change return type of method 'foo' to '&str'", """
+        struct S;
+        impl S {
+            fn foo(&self) -> i32 {
+                <error>"Hello World!"<caret></error>
+            }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self) -> &'static str {
+                "Hello World!"
+            }
+        }
+    """)
+
+    fun `test don't show () return type`() = checkFixByText("Change return type of function 'foo' to '()'", """
+        fn foo() -> i32 {
+            <error>()<caret></error>
+        }
+    """, """
+        fn foo() {
+            ()
+        }
+    """)
+
+    fun `test alias`() = checkFixByText("Change return type of function 'foo' to 'A'", """
+        struct S;
+        type A = S;
+        fn foo(a: A) {
+            <error>a<caret></error>
+        }
+    """, """
+        struct S;
+        type A = S;
+        fn foo(a: A) -> A {
+            a
+        }
+    """)
+
+    fun `test import unresolved type (add)`() = checkFixByText("Change return type of function 'foo' to '(S, A)'", """
+        use a::bar;
+
+        mod a {
+            pub struct S;
+            pub type A = S;
+            pub fn bar() -> (S, A) { (S, A) }
+        }
+        
+        fn foo() {
+            <error>bar()<caret></error>
+        }
+    """, """
+        use a::{bar, A, S};
+
+        mod a {
+            pub struct S;
+            pub type A = S;
+            pub fn bar() -> (S, A) { (S, A) }
+        }
+        
+        fn foo() -> (S, A) {
+            bar()
+        }
+    """)
+
+    fun `test import unresolved type (replace)`() = checkFixByText("Change return type of function 'foo' to '(S, A)'", """
+        use a::bar;
+
+        mod a {
+            pub struct S;
+            pub type A = S;
+            pub fn bar() -> (S, A) { (S, A) }
+        }
+        
+        fn foo() -> i32 {
+            <error>bar()<caret></error>
+        }
+    """, """
+        use a::{bar, A, S};
+
+        mod a {
+            pub struct S;
+            pub type A = S;
+            pub fn bar() -> (S, A) { (S, A) }
+        }
+        
+        fn foo() -> (S, A) {
+            bar()
+        }
+    """)
+}


### PR DESCRIPTION
Relates to https://github.com/intellij-rust/intellij-rust/issues/5027.

Applicable to functions, non-inherited methods, and closures.