### PR TITLE
GRD: disable OmitStackTraceInFastThrow in tests & set 2 Gb heap for tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,6 +142,7 @@ allprojects {
         }
 
         tasks.withType<Test>().configureEach {
+            jvmArgs = listOf("-Xmx2g", "-XX:-OmitStackTraceInFastThrow")
             // We need to prevent the platform-specific shared JNA library to loading from the system library paths,
             // because otherwise it can lead to compatibility issues.
             // Also note that IDEA does the same thing at startup, and not only for tests.


### PR DESCRIPTION
Sometimes we don't see stacktraces for failed tests on CI. I think it should be fixed by `-XX:-OmitStackTraceInFastThrow` JVM property applied for tests. Also, I found that gradle allocate 512mb for test JVM which is too low and so can slow down test execution, so I bumped it to 2gb