### PR TITLE
Track changed properties in settings change event

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -45,6 +45,8 @@ import org.rust.cargo.project.model.CargoProjectsService
 import org.rust.cargo.project.model.RustcInfo
 import org.rust.cargo.project.model.setup
 import org.rust.cargo.project.settings.RustProjectSettingsService
+import org.rust.cargo.project.settings.RustProjectSettingsService.RustSettingsChangedEvent
+import org.rust.cargo.project.settings.RustProjectSettingsService.RustSettingsListener
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.toolwindow.CargoToolWindow.Companion.initializeToolWindowIfNeeded
@@ -81,9 +83,11 @@ open class CargoProjectsServiceImpl(
                 refreshAllProjects()
             }))
 
-            subscribe(RustProjectSettingsService.TOOLCHAIN_TOPIC, object : RustProjectSettingsService.ToolchainListener {
-                override fun toolchainChanged() {
-                    refreshAllProjects()
+            subscribe(RustProjectSettingsService.RUST_SETTINGS_TOPIC, object : RustSettingsListener {
+                override fun rustSettingsChanged(e: RustSettingsChangedEvent) {
+                    if (e.affectsCargoMetadata) {
+                        refreshAllProjects()
+                    }
                 }
             })
 

--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -20,6 +20,8 @@ import org.rust.cargo.project.model.CargoProjectsService
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.model.guessAndSetupRustProject
 import org.rust.cargo.project.settings.RustProjectSettingsService
+import org.rust.cargo.project.settings.RustProjectSettingsService.RustSettingsChangedEvent
+import org.rust.cargo.project.settings.RustProjectSettingsService.RustSettingsListener
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.StandardLibrary
@@ -37,9 +39,9 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
 
     init {
         project.messageBus.connect().apply {
-            subscribe(RustProjectSettingsService.TOOLCHAIN_TOPIC,
-                object : RustProjectSettingsService.ToolchainListener {
-                    override fun toolchainChanged() {
+            subscribe(RustProjectSettingsService.RUST_SETTINGS_TOPIC,
+                object : RustSettingsListener {
+                    override fun rustSettingsChanged(e: RustSettingsChangedEvent) {
                         updateAllNotifications()
                     }
                 })


### PR DESCRIPTION
Now we have `RustSettingsChangedEvent` and can check what properties are changed by a user. For example, now we refresh a cargo project only if the Rust toolchain is changed in settings.

![image](https://user-images.githubusercontent.com/3221931/76606493-64f10800-6523-11ea-910e-25e344f2775e.png)
