### PR TITLE
PERF&MACRO: use refresh-based VFS batch

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -450,10 +450,10 @@ private class MacroExpansionServiceImplInner(
                     })
                 }
                 if (toDelete.isNotEmpty()) {
-                    val batch = EventBasedVfsBatch()
-                    toDelete.forEach { batch.deleteFile(it.path) }
+                    val batch = VfsBatch()
+                    toDelete.forEach { batch.deleteFile(it) }
                     WriteAction.runAndWait<Throwable> {
-                        batch.applyToVfs()
+                        batch.applyToVfs(async = false)
                     }
                 }
             }

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -7,7 +7,6 @@ package org.rust.lang.core.macros
 
 import com.intellij.openapi.application.AccessToken
 import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.openapi.progress.ProcessCanceledException
@@ -35,7 +34,6 @@ import org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl
 import org.rust.lang.core.resolve.ref.RsResolveCache
 import org.rust.openapiext.*
 import org.rust.stdext.HashCode
-import org.rust.stdext.executeSequentially
 import org.rust.stdext.nextOrNull
 import org.rust.stdext.supplyAsync
 import java.util.concurrent.*
@@ -206,7 +204,7 @@ abstract class MacroExpansionTaskBase(
                         }
                     }
                 }
-                doneStages.addAndGet(if (result is EmptyPipeline) Pipeline.STAGES else 1)
+                doneStages.addAndGet(if (result is EmptyPipeline) Pipeline.STAGES else 2)
 
                 // Enter heavy process mode only if at least one macros is not up-to-date
                 if (result !is EmptyPipeline) {
@@ -224,23 +222,24 @@ abstract class MacroExpansionTaskBase(
                 // We can cancel task if the project is disposed b/c after project reopen storage consistency will be
                 // re-checked
 
-                // Note that if project is disposed, this task will not be executed or may be executed partially
-                executeSequentially(transactionExecutor, stages2.chunked(VFS_BATCH_SIZE)) { stages2c ->
-                    runWriteAction {
-                        val batch = vfsBatchFactory()
-                        val stages3 = stages2c.map { stage2 ->
-                            val result = stage2.writeExpansionToFs(batch, currentStep.get())
-                            result
-                        }
-                        batch.applyToVfs()
-                        for (stage3 in stages3) {
-                            stage3.save(storage)
-                        }
-                        doneStages.addAndGet(stages3.size * 2)
+                val batch = vfsBatchFactory()
+                val stages3 = stages2.map { stage2 ->
+                    val result = stage2.writeExpansionToFs(batch, currentStep.get())
+                    doneStages.incrementAndGet()
+                    result
+                }
+                totalExpanded.addAndGet(stages3.size)
+
+                val future = CompletableFuture<Unit>()
+                batch.applyToVfs(true, Runnable {
+                    // we're in write action
+                    for (stage3 in stages3) {
+                        stage3.save(storage)
                     }
-                    totalExpanded.addAndGet(stages2c.size)
-                    Unit
-                }.thenApply { Unit }
+                    future.complete(Unit)
+                })
+
+                future
             } else {
                 CompletableFuture.completedFuture(Unit)
             }
@@ -345,7 +344,7 @@ object InvalidationPipeline {
         override fun writeExpansionToFs(batch: MacroExpansionVfsBatch, stepNumber: Int): Pipeline.Stage3SaveToStorage {
             val expansionFile = info.expansionFile
             if (expansionFile != null && expansionFile.isValid) {
-                batch.deleteFile(batch.resolve(expansionFile))
+                batch.deleteFile(expansionFile)
             }
             return Stage3(info)
         }
@@ -440,9 +439,7 @@ object ExpansionPipeline {
             val oldExpansionFile = info.expansionFile
             val file = if (oldExpansionFile != null) {
                 check(oldExpansionFile.isValid) { "VirtualFile is not valid ${oldExpansionFile.url}" }
-                val file = batch.resolve(oldExpansionFile)
-                batch.writeFile(file, expansionText)
-                file
+                batch.writeFile(oldExpansionFile, expansionText)
             } else {
                 batch.createFileWithContent(expansionText, stepNumber)
             }
@@ -471,7 +468,7 @@ object ExpansionPipeline {
         override fun writeExpansionToFs(batch: MacroExpansionVfsBatch, stepNumber: Int): Pipeline.Stage3SaveToStorage {
             val oldExpansionFile = info.expansionFile
             if (oldExpansionFile != null && oldExpansionFile.isValid) {
-                batch.deleteFile(batch.resolve(oldExpansionFile))
+                batch.deleteFile(oldExpansionFile)
             }
             return Stage3(info, callHash, defHash, null, null)
         }

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionVfsBatch.kt
@@ -5,15 +5,11 @@
 
 package org.rust.lang.core.macros
 
-import com.intellij.openapi.util.io.FileSystemUtil
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.VirtualFileManager
-import com.intellij.openapi.vfs.ex.VirtualFileManagerEx
-import com.intellij.openapi.vfs.newvfs.events.*
-import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
-import org.rust.openapiext.checkWriteAccessAllowed
+import com.intellij.openapi.vfs.newvfs.RefreshQueue
 import org.rust.stdext.randomLowercaseAlphabetic
-import java.util.*
 
 interface MacroExpansionVfsBatch {
     interface Path {
@@ -23,15 +19,15 @@ interface MacroExpansionVfsBatch {
     fun resolve(file: VirtualFile): Path
 
     fun createFileWithContent(content: String, stepNumber: Int): Path
-    fun deleteFile(file: Path)
-    fun writeFile(file: Path, content: String)
+    fun deleteFile(file: VirtualFile)
+    fun writeFile(file: VirtualFile, content: String): Path
 
-    fun applyToVfs()
+    fun applyToVfs(async: Boolean, callback: Runnable?)
 }
 
 class MacroExpansionVfsBatchImpl(rootDirName: String) : MacroExpansionVfsBatch {
     private val contentRoot = "/$MACRO_EXPANSION_VFS_ROOT/$rootDirName"
-    private val batch: VfsBatch = EventBasedVfsBatch()
+    private val batch: VfsBatch = VfsBatch()
 
     override fun resolve(file: VirtualFile): MacroExpansionVfsBatch.Path =
         PathImpl.VFile(file)
@@ -41,154 +37,75 @@ class MacroExpansionVfsBatchImpl(rootDirName: String) : MacroExpansionVfsBatch {
 
     private fun createFileInternal(content: String, stepNumber: Int): String {
         val name = randomLowercaseAlphabetic(16)
-        return batch.run {
-            contentRoot
-                .getOrCreateDirectory(stepNumber.toString())
-                .getOrCreateDirectory(name[0].toString())
-                .getOrCreateDirectory(name[1].toString())
-                .createFile(name.substring(2) + ".rs", content)
-        }
+        val parentPath = "$contentRoot/${stepNumber}/${name[0]}/${name[1]}"
+        return batch.createFile(parentPath, name.substring(2) + ".rs", content)
     }
 
-    override fun deleteFile(file: MacroExpansionVfsBatch.Path) {
-        batch.deleteFile((file as PathImpl).toPath())
+    override fun deleteFile(file: VirtualFile) {
+        batch.deleteFile(file)
     }
 
-    override fun writeFile(file: MacroExpansionVfsBatch.Path, content: String) {
-        batch.writeFile((file as PathImpl).toPath(), content)
+    override fun writeFile(file: VirtualFile, content: String): MacroExpansionVfsBatch.Path {
+        batch.writeFile(file, content)
+        return resolve(file)
     }
 
-    override fun applyToVfs() {
-        batch.applyToVfs()
+    override fun applyToVfs(async: Boolean, callback: Runnable?) {
+        batch.applyToVfs(async, callback)
     }
 
     private sealed class PathImpl : MacroExpansionVfsBatch.Path {
-        abstract fun toPath(): String
 
-        class VFile(val file: VirtualFile): PathImpl() {
+        class VFile(val file: VirtualFile) : PathImpl() {
             override fun toVirtualFile(): VirtualFile? = file
-
-            override fun toPath(): String = file.path
         }
-        class StringPath(val path: String): PathImpl() {
+
+        class StringPath(val path: String) : PathImpl() {
             override fun toVirtualFile(): VirtualFile? =
                 MacroExpansionFileSystem.getInstance().findFileByPath(path)
-
-            override fun toPath(): String = path
         }
     }
 }
 
-abstract class VfsBatch {
-    protected val dirEvents: MutableList<DirCreateEvent> = LinkedList()
-    protected val fileEvents: MutableList<Event> = mutableListOf()
+class VfsBatch {
+    private val pathsToMarkDirty: MutableSet<String> = mutableSetOf()
 
-    fun String.createFile(name: String, content: String): String =
-        createFile(this, name, content)
-
-    @JvmName("createFile_")
-    private fun createFile(parent: String, name: String, content: String): String {
+    fun createFile(parent: String, name: String, content: String): String {
         val child = "$parent/$name"
-        MacroExpansionFileSystem.getInstance().createFileWithContent(child, content)
-        fileEvents.add(Event.Create(parent, name))
+        MacroExpansionFileSystem.getInstance().createFileWithContent(child, content, mkdirs = true)
+        pathsToMarkDirty += parent
         return child
     }
 
-    private fun createDirectory(parent: String, name: String): String {
-        val child = "$parent/$name"
-        MacroExpansionFileSystem.getInstance().createDirectory(child)
-        dirEvents.add(DirCreateEvent(parent, name))
-        return child
+    fun writeFile(file: VirtualFile, content: String) {
+        MacroExpansionFileSystem.getInstance().setFileContent(file.path, content)
+        markDirty(file)
     }
 
-    fun String.getOrCreateDirectory(name: String): String =
-        getOrCreateDirectory(this, name)
+    fun deleteFile(file: VirtualFile) {
+        MacroExpansionFileSystem.getInstance().deleteFile(file.path)
+        markDirty(file)
+    }
 
-    @JvmName("getOrCreateDirectory_")
-    private fun getOrCreateDirectory(parent: String, name: String): String {
-        val child = "$parent/$name"
-        if (MacroExpansionFileSystem.getInstance().exists(child)) {
-            return child
+    fun applyToVfs(async: Boolean, callback: Runnable? = null) {
+        val root = MacroExpansionFileSystem.getInstance().findFileByPath("/") ?: return
+
+        for (path in pathsToMarkDirty) {
+            markDirty(findNearestExistingFile(root, path))
         }
-        return createDirectory(parent, name)
+
+        RefreshQueue.getInstance().refresh(async, true, callback, root)
     }
 
-    fun writeFile(file: String, content: String) {
-        MacroExpansionFileSystem.getInstance().setFileContent(file, content)
-
-        fileEvents.add(Event.Write(file))
-    }
-
-    fun deleteFile(file: String) {
-        MacroExpansionFileSystem.getInstance().deleteFile(file)
-
-        fileEvents.add(Event.Delete(file))
-    }
-
-    abstract fun applyToVfs()
-
-    protected class DirCreateEvent(val parent: String, val name: String)
-
-    protected sealed class Event {
-        class Create(val parent: String, val name: String): Event()
-        class Write(val file: String): Event()
-        class Delete(val file: String): Event()
-    }
-
-}
-
-class EventBasedVfsBatch : VfsBatch() {
-    override fun applyToVfs() {
-        checkWriteAccessAllowed()
-        if (dirEvents.isEmpty() && fileEvents.isEmpty()) return
-
-        val manager = VirtualFileManager.getInstance() as VirtualFileManagerEx
-        manager.fireBeforeRefreshStart(/*asynchronous = */ false)
-        try {
-            val events = mutableListOf<VFileEvent>()
-            while (dirEvents.isNotEmpty()) {
-                val iter = dirEvents.iterator()
-                while (iter.hasNext()) {
-                    val event = iter.next().toVFileEvent()
-                    if (event != null) {
-                        iter.remove()
-                        events.add(event)
-                    }
-                }
-                check(events.isNotEmpty())
-                PersistentFS.getInstance().processEvents(events)
-                events.clear()
-            }
-
-            if (fileEvents.isNotEmpty()) {
-                PersistentFS.getInstance().processEvents(fileEvents.mapNotNull { it.toVFileEvent() })
-                fileEvents.clear()
-            }
-        } finally {
-            manager.fireAfterRefreshFinish(/*asynchronous = */ false)
+    private fun findNearestExistingFile(root: VirtualFile, path: String): VirtualFile {
+        var file = root
+        for (segment in StringUtil.split(path, "/")) {
+            file = file.findChild(segment) ?: break
         }
+        return file
     }
 
-    private fun DirCreateEvent.toVFileEvent(): VFileEvent? {
-        val vParent = MacroExpansionFileSystem.getInstance().findFileByPath(parent) ?: return null
-        @Suppress("UnstableApiUsage")
-        return VFileCreateEvent(null, vParent, name, true, null, null, true, ChildInfo.EMPTY_ARRAY)
-    }
-
-    private fun Event.toVFileEvent(): VFileEvent? = when (this) {
-        is Event.Create -> {
-            val vParent = MacroExpansionFileSystem.getInstance().findFileByPath(parent)!!
-            val attributes = FileSystemUtil.getAttributes("$parent/$name")
-            VFileCreateEvent(null, vParent, name, false, attributes, null, true, null)
-        }
-        is Event.Write -> {
-            val vFile = MacroExpansionFileSystem.getInstance().findFileByPath(file)!!
-            VFileContentChangeEvent(null, vFile, vFile.modificationStamp, -1, true)
-        }
-        is Event.Delete -> {
-            val vFile = MacroExpansionFileSystem.getInstance().findFileByPath(file)
-            // skip if file is already deleted (not sure how this can happen)
-            if (vFile == null) null else VFileDeleteEvent(null, vFile, true)
-        }
+    private fun markDirty(file: VirtualFile) {
+        VfsUtil.markDirty(false, false, file)
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystemTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystemTest.kt
@@ -9,46 +9,52 @@ import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileSystem
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import org.rust.openapiext.fullyRefreshDirectory
+import org.rust.checkMacroExpansionFileSystemAfterTest
 
 class MacroExpansionFileSystemTest : BasePlatformTestCase() {
     fun `test simple`() {
-        val vfs = MacroExpansionFileSystem.getInstance().apply {
-            createDirectory("/foo")
-            createFileWithContent("/foo/bar.txt", "bar content")
-            createFileWithContent("/foo/baz.txt", "baz content")
-            refresh(false)
+        batch {
+            createFile("/foo", "bar.txt", "bar content")
+            createFile("/foo", "baz.txt", "baz content")
         }
+        val vfs = MacroExpansionFileSystem.getInstance()
+        val foo = vfs.findNonNullFileByPath("/foo")
         val bar = vfs.findNonNullFileByPath("/foo/bar.txt")
         val baz = vfs.findNonNullFileByPath("/foo/baz.txt")
-        val parent = bar.parent
         assertEquals("bar content", VfsUtil.loadText(bar))
         assertEquals("baz content", VfsUtil.loadText(baz))
         assertEquals("bar.txt", bar.name)
-        assertEquals("foo", parent.name)
-        assertEquals(2, parent.children.size)
-        assertContainsElements(parent.children.toList(), bar, baz)
-        assertEquals(vfs.findNonNullFileByPath("/foo"), parent)
-        assertEquals(vfs.findNonNullFileByPath("/foo/"), parent)
-        assertEquals(vfs.findNonNullFileByPath("/"), parent.parent)
+        assertEquals(foo, bar.parent)
+        assertEquals(2, foo.children.size)
+        assertContainsElements(foo.children.toList(), bar, baz)
+        assertEquals(vfs.findNonNullFileByPath("/foo"), foo)
+        assertEquals(vfs.findNonNullFileByPath("/foo/"), foo)
+        assertEquals(vfs.findNonNullFileByPath("/"), foo.parent)
 
-        vfs.setFileContent("/foo/bar.txt", "new bar content")
-        vfs.refresh(false)
+        batch { writeFile(bar, "new bar content") }
         assertEquals("new bar content", VfsUtil.loadText(bar))
         assertEquals("baz content", VfsUtil.loadText(baz))
 
-        vfs.deleteFile("/foo/bar.txt")
-        fullyRefreshDirectory(vfs.root)
+        batch { deleteFile(bar) }
         assertNull(vfs.findFileByPath("/foo/bar.txt"))
+        assertNotNull(vfs.findFileByPath("/foo/baz.txt"))
 
-        vfs.deleteFile("/foo")
-        fullyRefreshDirectory(vfs.root)
+        batch { deleteFile(foo) }
         assertNull(vfs.findFileByPath("/foo/baz.txt"))
         assertNull(vfs.findFileByPath("/foo"))
+    }
+
+    override fun tearDown() {
+        super.tearDown()
+        checkMacroExpansionFileSystemAfterTest()
     }
 }
 
 private fun VirtualFileSystem.findNonNullFileByPath(path: String): VirtualFile =
     findFileByPath(path) ?: error("File not found: $path")
 
-private val VirtualFileSystem.root: VirtualFile get() = findNonNullFileByPath("/")
+private fun batch(action: VfsBatch.() -> Unit) {
+    val batch = VfsBatch()
+    batch.action()
+    batch.applyToVfs(async = false)
+}


### PR DESCRIPTION
Previously, we didn't use the platform's refresh because of too large UI freezes. Since 2019.3 a part of the refresh process was extracted from EDT and now freezes duration seems acceptable. This speeds up macro expansion a bit