### PR TITLE
QDOC: improve generation of external documentation links

### DIFF
--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -165,11 +165,18 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
         // private items don't have external documentation
         if (this is RsVisible) {
             if (this is RsAbstractable) {
-                val owner = owner
-                // items in
-                if ((!owner.isImplOrTrait || owner.isInherentImpl) && !isPublic) return false
+                when (val owner = owner) {
+                    is RsAbstractableOwner.Trait -> return owner.trait.hasExternalDocumentation
+                    is RsAbstractableOwner.Impl -> {
+                        return if (owner.isInherent)  {
+                            visibility == RsVisibility.Public
+                        } else {
+                            owner.impl.traitRef?.resolveToTrait()?.hasExternalDocumentation == true
+                        }
+                    }
+                }
             } else {
-                if (!isPublic) return false
+                if (visibility != RsVisibility.Public) return false
             }
         }
 

--- a/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlStdTest.kt
@@ -64,7 +64,6 @@ class RsExternalDocUrlStdTest : RsDocumentationProviderTest() {
         }
     """, "https://doc.rust-lang.org/alloc/vec/struct.Vec.html#method.new")
 
-    // FIXME: it should generate `https://doc.rust-lang.org/std/primitive.pointer.html#method.is_null`
     fun `test primitive method`() = doUrlTestByText("""
         fn foo(ptr: *const i32) {
             let x = ptr.is_null();

--- a/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
@@ -26,6 +26,12 @@ class RsExternalDocUrlTest : RsDocumentationProviderTest() {
         }
     """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/struct.Foo.html#associatedconstant.BAR")
 
+    fun `test item with restricted visibility`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        pub(crate) enum Foo { V1, V2 }
+                      //^
+    """, null)
+
     fun `test private item`() = doUrlTestByFileTree("""
         //- dep-lib/lib.rs
         struct Foo;
@@ -39,6 +45,34 @@ class RsExternalDocUrlTest : RsDocumentationProviderTest() {
                        //^
         }
     """, null)
+
+    fun `test method in private trait`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        trait Foo {
+            fn foo(&self);
+              //^
+        }
+    """, null)
+
+    fun `test private method`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        pub struct Foo;
+        impl Foo {
+            fn foo(&self) {}
+              //^
+        }
+    """, null)
+
+    fun `test public method in private module`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        pub struct Foo;
+        mod bar {
+            impl crate::Foo {
+                pub fn foo(&self) {}
+                      //^
+            }
+        }
+    """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/struct.Foo.html#method.foo")
 
     fun `test doc hidden`() = doUrlTestByFileTree("""
         //- dep-lib/lib.rs


### PR DESCRIPTION
Now, if public method is located in private module, the plugin still generates external documentation link for it
Original issue was found for [`is_null` method](https://doc.rust-lang.org/std/primitive.pointer.html#method.is_null) for pointer type in stdlib of rust 1.43.0