### PR TITLE
GRD: try jcenter instead of maven central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ val httpClient: OkHttpClient by lazy { OkHttpClient() }
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath("com.squareup.okhttp3:okhttp:4.4.0")
@@ -80,6 +81,7 @@ allprojects {
 
     repositories {
         mavenCentral()
+        jcenter()
         maven("https://dl.bintray.com/jetbrains/markdown")
     }
 


### PR DESCRIPTION
Maven Central servers are sometimes unavailable from Travis CI (see [issue](https://issues.sonatype.org/browse/MVNCENTRAL-4985)). I think it's reasonable to add [jcenter](https://bintray.com/bintray/jcenter) mirror as a fallback.

(at first, let's try to use jcenter *instead* of maven central to check that it ever works)