### PR TITLE
INSP: improve unresolved reference inspection

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -30,6 +30,7 @@ devurandom
 dima74
 Dimonchik0036
 emmericp
+Exidex
 Falkenfighter
 fan-tom
 farodin91

--- a/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
@@ -71,9 +71,9 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
             }
         }
 
-    private fun <T> RsProblemsHolder.registerProblem(
+    private fun RsProblemsHolder.registerProblem(
         element: RsReferenceElement,
-        context: AutoImportFix.Context<T>?
+        context: AutoImportFix.Context?
     ) {
         val candidates = context?.candidates
         if (candidates.isNullOrEmpty() && ignoreWithoutQuickFix) return

--- a/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
@@ -8,20 +8,17 @@ package org.rust.ide.inspections
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ui.MultipleCheckboxOptionsPanel
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElementVisitor
 import org.rust.ide.inspections.import.AutoImportFix
 import org.rust.ide.inspections.import.AutoImportHintFix
-import org.rust.ide.inspections.import.ImportCandidate
 import org.rust.ide.settings.RsCodeInsightSettings
 import org.rust.lang.core.psi.RsMetaItem
 import org.rust.lang.core.psi.RsMethodCall
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.RsVisitor
-import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsReferenceElement
 import org.rust.lang.core.psi.ext.ancestorStrict
-import org.rust.lang.core.psi.ext.endOffsetInParent
-import org.rust.lang.core.psi.ext.getPrevNonCommentSibling
+import org.rust.lang.core.psi.ext.isUnresolved
 import org.rust.lang.core.psi.ext.qualifier
 import javax.swing.JComponent
 
@@ -33,70 +30,72 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
         object : RsVisitor() {
+
             override fun visitPath(path: RsPath) {
+                if (path.reference == null) return
+
                 // Don't show unresolved reference error in attributes for now
                 if (path.ancestorStrict<RsMetaItem>() != null) return
-                // here we check if this path is resolved
-                // if it is we return
-                // if not than check whether qualifier of this path is resolved
-                // if it is we register problem
-                // if not then we assume that unresolved parent paths of this path
-                // were or will be handled
-                // because all paths will eventually be processed by visitor
-                val (problemPath, candidates) = AutoImportFix.findApplicableContext(holder.project, path)
-                    ?: return
 
-                if (candidates.isEmpty() && ignoreWithoutQuickFix) return
+                val isPathUnresolved = path.isUnresolved
+                val qualifier = path.qualifier
 
-                path.qualifier
-                    ?.let { AutoImportFix.findApplicableContext(holder.project, it) }
-                    ?.let { return }
+                val context = when {
+                    qualifier == null && isPathUnresolved -> AutoImportFix.findApplicableContext(holder.project, path)
+                    qualifier != null && isPathUnresolved -> {
+                        // There is not sense to highlight path as unresolved
+                        // if qualifier cannot be resolved as well
+                        if (qualifier.isUnresolved) return
+                        null
+                    }
+                    // Despite the fact that path is (multi)resolved by our resolve engine, it can be unresolved from
+                    // the view of the rust compiler. Specifically we resolve associated items even if corresponding
+                    // trait is not in the scope, so here we suggest importing such traits
+                    (qualifier != null || path.typeQual != null) && !isPathUnresolved ->
+                        AutoImportFix.findApplicableContextForAssocItemPath(holder.project, path)
+                    else -> null
+                }
 
-                val referenceName = problemPath.identifier?.text
-                val range = TextRange(
-                    // Don't highlight parent identifiers
-                    problemPath.identifier?.startOffsetInParent ?: 0,
-                    // Don't highlight generic parameters
-                    problemPath.typeArgumentList?.getPrevNonCommentSibling()?.endOffsetInParent
-                        ?: problemPath.textLength
-                )
-
-                holder.registerProblem(problemPath, candidates, referenceName, range)
+                if (isPathUnresolved || context != null) {
+                    holder.registerProblem(path, context)
+                }
             }
 
             override fun visitMethodCall(methodCall: RsMethodCall) {
-                val (_, candidates) = AutoImportFix.findApplicableContext(holder.project, methodCall)
-                    ?: return
+                val isMethodResolved = methodCall.reference.multiResolve().isNotEmpty()
+                val context = AutoImportFix.findApplicableContext(holder.project, methodCall)
 
-                if (candidates.isEmpty() && ignoreWithoutQuickFix) return
-
-                val range = TextRange(
-                    0,
-                    methodCall.identifier.textLength
-                )
-
-                holder.registerProblem(methodCall, candidates, methodCall.identifier.text, range)
+                if (!isMethodResolved || context != null) {
+                    holder.registerProblem(methodCall, context)
+                }
             }
         }
 
-    private fun RsProblemsHolder.registerProblem(
-        element: RsElement,
-        candidates: List<ImportCandidate>,
-        referenceName: String?,
-        range: TextRange
+    private fun <T> RsProblemsHolder.registerProblem(
+        element: RsReferenceElement,
+        context: AutoImportFix.Context<T>?
     ) {
+        val candidates = context?.candidates
+        if (candidates.isNullOrEmpty() && ignoreWithoutQuickFix) return
+
+        val referenceName = element.referenceName
         val description = if (referenceName == null) "Unresolved reference" else "Unresolved reference: `$referenceName`"
         var fix: LocalQuickFix? = null
-        if (candidates.isNotEmpty()) {
+        if (candidates != null && candidates.isNotEmpty()) {
             fix = if (RsCodeInsightSettings.getInstance().showImportPopup) {
-                AutoImportHintFix(element, candidates[0].info.usePath, candidates.size > 1)
+                AutoImportHintFix(element, context.type, candidates[0].info.usePath, candidates.size > 1)
             } else {
-                AutoImportFix(element)
+                AutoImportFix(element, context.type)
             }
         }
 
-        registerProblem(element, description, ProblemHighlightType.LIKE_UNKNOWN_SYMBOL,
-            range, *listOfNotNull(fix).toTypedArray())
+        val highlightedElement = element.referenceNameElement ?: element
+        registerProblem(
+            highlightedElement,
+            description,
+            ProblemHighlightType.LIKE_UNKNOWN_SYMBOL,
+            *listOfNotNull(fix).toTypedArray()
+        )
     }
 
     override fun createOptionsPanel(): JComponent = MultipleCheckboxOptionsPanel(this).apply {

--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -18,6 +18,7 @@ import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.ide.injected.isDoctestInjection
+import org.rust.ide.inspections.import.AutoImportFix.Type.*
 import org.rust.ide.search.RsWithMacrosProjectScope
 import org.rust.lang.core.parser.RustParserUtil.PathParsingMode
 import org.rust.lang.core.psi.*
@@ -39,7 +40,7 @@ import org.rust.lang.core.types.type
 import org.rust.openapiext.checkWriteAccessAllowed
 import org.rust.openapiext.runWriteCommandAction
 
-class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), HighPriorityAction {
+class AutoImportFix(element: RsElement, private val type: Type) : LocalQuickFixOnPsiElement(element), HighPriorityAction {
 
     private var isConsumed: Boolean = false
 
@@ -54,11 +55,11 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
 
     fun invoke(project: Project) {
         val element = startElement as? RsElement ?: return
-        val (_, candidates) = when (element) {
-            is RsPath -> findApplicableContext(project, element) ?: return
-            is RsMethodCall -> findApplicableContext(project, element) ?: return
-            else -> return
-        }
+        val candidates = when (type) {
+            GENERAL_PATH -> findApplicableContext(project, element as RsPath)?.candidates
+            ASSOC_ITEM_PATH -> findApplicableContextForAssocItemPath(project, element as RsPath)?.candidates
+            METHOD -> findApplicableContext(project, element as RsMethodCall)?.candidates
+        } ?: return
 
         if (candidates.size == 1) {
             project.runWriteCommandAction {
@@ -90,52 +91,47 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
         const val NAME = "Import"
 
         fun findApplicableContext(project: Project, path: RsPath): Context<RsPath>? {
-            val reference = path.reference ?: return null
-            val isPathResolved = TyPrimitive.fromPath(path) != null || reference.multiResolve().isNotEmpty()
+            if (path.reference == null) return null
 
-            if (isPathResolved) {
-                // Despite the fact that path is (multi)resolved by our resolve engine, it can be unresolved from
-                // the view of the rust compiler. Specifically we resolve associated items even if corresponding
-                // trait is not in the scope, so here we suggest importing such traits
-
-                return findApplicableContextForAssocItemPath(path, project)
-            }
+            val basePath = path.basePath()
+            if (!basePath.isUnresolved) return null
 
             if (path.ancestorStrict<RsUseSpeck>() != null) {
                 // Don't try to import path in use item
                 Testmarks.pathInUseItem.hit()
-                return Context(path, emptyList())
+                return null
             }
 
-            val isNameInScope = path.hasInScope(path.referenceName, TYPES_N_VALUES)
+            val isNameInScope = path.hasInScope(basePath.referenceName, TYPES_N_VALUES)
             if (isNameInScope) {
                 // Don't import names that are already in scope but cannot be resolved
                 // because namespace of psi element prevents correct name resolution.
                 // It's possible for incorrect or incomplete code like "let map = HashMap"
                 Testmarks.nameInScope.hit()
-                return Context(path, emptyList())
+                return null
             }
 
+            val superPath = path.superPath()
             val candidates = getImportCandidates(
                 ImportContext.from(project, path, false),
-                path.referenceName,
-                path.text
+                basePath.referenceName,
+                superPath.text
             ) {
-                true
+                superPath != basePath || !(it.item is RsMod || it.item is RsModDeclItem || it.item.parent is RsMembers)
             }.toList()
 
-            return Context(path, candidates)
+            return Context(basePath, GENERAL_PATH, candidates)
         }
 
         fun findApplicableContext(project: Project, methodCall: RsMethodCall): Context<Unit>? {
             val results = methodCall.inference?.getResolvedMethod(methodCall) ?: emptyList()
-            if (results.isEmpty()) return Context(Unit, emptyList())
+            if (results.isEmpty()) return Context(Unit, METHOD, emptyList())
             val candidates = getImportCandidates(project, methodCall, results)?.toList() ?: return null
-            return Context(Unit, candidates)
+            return Context(Unit, METHOD, candidates)
         }
 
         /** Import traits for type-related UFCS method calls and assoc items */
-        private fun findApplicableContextForAssocItemPath(path: RsPath, project: Project): Context<RsPath>? {
+        fun findApplicableContextForAssocItemPath(project: Project, path: RsPath): Context<RsPath>? {
             val parent = path.parent as? RsPathExpr ?: return null
             val resolved = path.inference?.getResolvedPath(parent) ?: return null
             val sources = resolved.map {
@@ -143,7 +139,7 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
                 it.source
             }
             val candidates = getTraitImportCandidates(project, path, sources)?.toList() ?: return null
-            return Context(path, candidates)
+            return Context(path, ASSOC_ITEM_PATH, candidates)
         }
 
         /**
@@ -414,8 +410,15 @@ class AutoImportFix(element: RsElement) : LocalQuickFixOnPsiElement(element), Hi
 
     data class Context<T>(
         val data: T,
+        val type: Type,
         val candidates: List<ImportCandidate>
     )
+
+    enum class Type {
+        GENERAL_PATH,
+        ASSOC_ITEM_PATH,
+        METHOD
+    }
 
     object Testmarks {
         val autoInjectedStdCrate = Testmark("autoInjectedStdCrate")
@@ -470,6 +473,12 @@ sealed class ImportInfo {
 }
 
 data class ImportCandidate(val qualifiedNamedItem: QualifiedNamedItem, val info: ImportInfo)
+
+/** For `Foo::bar` in `Foo::bar::baz::quux` returns `Foo::bar::baz::quux` */
+private tailrec fun RsPath.superPath(): RsPath {
+    val parent = context
+    return if (parent is RsPath) parent.superPath() else this
+}
 
 private fun RsPath.namespaceFilter(isCompletion: Boolean): (RsQualifiedNamedElement) -> Boolean = when (context) {
     is RsTypeElement -> { e ->

--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportHintFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportHintFix.kt
@@ -19,11 +19,12 @@ import org.rust.lang.core.psi.ext.endOffset
 
 class AutoImportHintFix(
     element: RsElement,
+    type: AutoImportFix.Type,
     private val hint: String,
     private val multiple: Boolean
 ) : LocalQuickFixOnPsiElement(element), HintAction, HighPriorityAction {
 
-    private val delegate: AutoImportFix = AutoImportFix(element)
+    private val delegate: AutoImportFix = AutoImportFix(element, type)
 
     override fun getFamilyName(): String = delegate.familyName
     override fun getText(): String = delegate.name

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
@@ -15,6 +15,7 @@ import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.resolve.*
 import org.rust.lang.core.resolve.ref.*
 import org.rust.lang.core.stubs.RsPathStub
+import org.rust.lang.core.types.ty.TyPrimitive
 
 private val RS_PATH_KINDS = tokenSetOf(IDENTIFIER, SELF, SUPER, CSELF, CRATE)
 
@@ -79,6 +80,12 @@ fun RsPath.allowedNamespaces(isCompletion: Boolean = false): Set<Namespace> = wh
     is RsPathCodeFragment -> parent.ns
     else -> TYPES_N_VALUES
 }
+
+val RsPath.isUnresolved: Boolean
+    get() {
+        val reference = reference ?: return false
+        return TyPrimitive.fromPath(this) == null && reference.multiResolve().isEmpty()
+    }
 
 val RsPath.lifetimeArguments: List<RsLifetime> get() = typeArgumentList?.lifetimeList.orEmpty()
 

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -132,6 +132,34 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         impl Foo { fn foo() -> Self {} }
     """, false)
 
+    fun `test unresolved reference for module`() = checkByText("""
+        use <error descr="Unresolved reference: `foo`">foo</error>::bar::Foo;
+    """, false)
+
+    fun `test unresolved reference for nested module`() = checkByText("""
+        mod foo { }
+        use foo::<error descr="Unresolved reference: `bar`">bar</error>::Foo;
+    """, false)
+
+    fun `test unresolved reference for struct in nested module 1`() = checkByText("""
+        mod foo {
+            pub mod bar { }
+        }
+        use foo::bar::<error descr="Unresolved reference: `Foo`">Foo</error>;
+    """, false)
+
+    fun `test unresolved reference for struct in nested module 2`() = checkByText("""
+        mod foo { }
+        use foo::<error descr="Unresolved reference: `bar`">bar</error>::{qux, boo};
+    """, false)
+
+    fun `test unresolved reference for function in nested module`() = checkByText("""
+        mod foo { }
+        fn main() {
+            foo::<error descr="Unresolved reference: `bar`">bar</error>::Qux::foobar();
+        }
+    """, false)
+
     private fun checkByText(@Language("Rust") text: String, ignoreWithoutQuickFix: Boolean) {
         val inspection = inspection as RsUnresolvedReferenceInspection
         val defaultValue = inspection.ignoreWithoutQuickFix

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixStdTest.kt
@@ -13,11 +13,11 @@ import org.rust.cargo.project.workspace.CargoWorkspace
 @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
 class AutoImportFixStdTest : AutoImportFixTestBase() {
     fun `test import item from std crate`() = checkAutoImportFixByText("""
-        fn foo<T: <error descr="Unresolved reference: `io`">io::Read/*caret*/</error>>(t: T) {}
+        fn foo<T: <error descr="Unresolved reference: `io`">io/*caret*/</error>::Read>(t: T) {}
     """, """
         use std::io;
 
-        fn foo<T: io::Read/*caret*/>(t: T) {}
+        fn foo<T: io/*caret*/::Read>(t: T) {}
     """, AutoImportFix.Testmarks.autoInjectedStdCrate)
 
     fun `test import item from not std crate`() = checkAutoImportFixByFileTree("""
@@ -96,7 +96,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
 
     fun `test import reexported item from stdlib`() = checkAutoImportFixByText("""
         fn main() {
-            let mutex = <error descr="Unresolved reference: `Mutex`">Mutex/*caret*/::new</error>(Vec::new());
+            let mutex = <error descr="Unresolved reference: `Mutex`">Mutex/*caret*/</error>::new(Vec::new());
         }
     """, """
         use std::sync::Mutex;
@@ -157,7 +157,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         #![no_std]
 
         fn main() {
-            let x = <error descr="Unresolved reference: `Rc`">Rc::new/*caret*/</error>(123);
+            let x = <error descr="Unresolved reference: `Rc`">Rc/*caret*/</error>::new(123);
         }
     """, """
         #![no_std]
@@ -167,7 +167,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         use alloc::rc::Rc;
 
         fn main() {
-            let x = Rc::new/*caret*/(123);
+            let x = Rc/*caret*/::new(123);
         }
     """)
 
@@ -458,13 +458,13 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
 
     fun `test import HashMap`() = checkAutoImportFixByText("""
         fn main() {
-            let a = <error descr="Unresolved reference: `HashMap`">HashMap::new</error>/*caret*/();
+            let a = <error descr="Unresolved reference: `HashMap`">HashMap</error>/*caret*/::new();
         }
     """, """
         use std::collections::HashMap;
 
         fn main() {
-            let a = HashMap::new/*caret*/();
+            let a = HashMap/*caret*/::new();
         }
     """)
 
@@ -472,7 +472,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         #[derive(Debug)]
         pub struct S;
         fn main() {
-            <error descr="Unresolved reference: `fmt`">S::fmt/*caret*/</error>(&S, panic!(""));
+            S::<error descr="Unresolved reference: `fmt`">fmt/*caret*/</error>(&S, panic!(""));
         }
     """, """
         use std::fmt::Debug;
@@ -611,7 +611,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            <error descr="Unresolved reference: `Foo`">Foo::fmt/*caret*/</error>();
+            <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>::fmt();
         }
     """, """
         use foo::Foo;
@@ -622,7 +622,7 @@ class AutoImportFixStdTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            Foo::fmt/*caret*/();
+            Foo/*caret*/::fmt();
         }
     """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -39,7 +39,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            <error descr="Unresolved reference: `Foo`">Foo::A/*caret*/</error>;
+            <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>::A;
         }
     """, """
         use foo::Foo;
@@ -49,7 +49,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            Foo::A/*caret*/;
+            Foo/*caret*/::A;
         }
     """)
 
@@ -118,7 +118,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            <error descr="Unresolved reference: `Foo`">Foo::foo/*caret*/</error>();
+            <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>::foo();
         }
     """, """
         use foo::Foo;
@@ -131,7 +131,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            Foo::foo/*caret*/();
+            Foo/*caret*/::foo();
         }
     """)
 
@@ -180,7 +180,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            let f = <error descr="Unresolved reference: `Foo`">Foo::/*caret*/<i32>::bar</error>();
+            let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>::<i32>::bar();
         }
     """, """
         use foo::Foo;
@@ -193,7 +193,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            let f = Foo::/*caret*/<i32>::bar();
+            let f = Foo/*caret*/::<i32>::bar();
         }
     """)
 
@@ -226,7 +226,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            let <error descr="Unresolved reference: `Foo`">Foo::/*caret*/<i32>::bar</error>(x) = ();
+            let <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>::<i32>::bar(x) = ();
         }
     """, """
         use foo::Foo;
@@ -239,7 +239,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            let Foo::/*caret*/<i32>::bar(x) = ();
+            let Foo/*caret*/::<i32>::bar(x) = ();
         }
     """)
 
@@ -251,7 +251,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            let f = <error descr="Unresolved reference: `bar`">bar/*caret*/::foo_bar</error>();
+            let f = <error descr="Unresolved reference: `bar`">bar/*caret*/</error>::foo_bar();
         }
     """, """
         use foo::bar;
@@ -462,7 +462,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             pub mod bar;
         }
         fn main() {
-            <error descr="Unresolved reference: `bar`">bar::foo_bar/*caret*/</error>();
+            <error descr="Unresolved reference: `bar`">bar/*caret*/</error>::foo_bar();
         }
     """, """
         //- main.rs
@@ -472,7 +472,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             pub mod bar;
         }
         fn main() {
-            bar::foo_bar/*caret*/();
+            bar/*caret*/::foo_bar();
         }
     """)
 
@@ -520,7 +520,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            <error descr="Unresolved reference: `bar`">bar::foo_bar/*caret*/</error>();
+            <error descr="Unresolved reference: `bar`">bar/*caret*/</error>::foo_bar();
         }
     """, """
         use foo2::bar;
@@ -536,7 +536,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            bar::foo_bar/*caret*/();
+            bar/*caret*/::foo_bar();
         }
     """)
 
@@ -559,7 +559,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             }
         }
         fn main() {
-            <error descr="Unresolved reference: `bar`">bar::foo_bar/*caret*/</error>();
+            <error descr="Unresolved reference: `bar`">bar/*caret*/</error>::foo_bar();
         }
     """)
 
@@ -570,7 +570,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             }
         }
         fn main() {
-            <error descr="Unresolved reference: `Bar`">Bar::bar/*caret*/</error>();
+            <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>::bar();
         }
     """)
 
@@ -581,7 +581,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             }
         }
         fn main() {
-            <error descr="Unresolved reference: `Bar`">Bar::bar/*caret*/</error>();
+            <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>::bar();
         }
     """, """
         use foo::Bar;
@@ -603,7 +603,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             }
         }
         fn main() {
-            <error descr="Unresolved reference: `Bar`">Bar::bar/*caret*/</error>();
+            <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>::bar();
         }
     """, """
         use foo::Bar;
@@ -614,7 +614,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             }
         }
         fn main() {
-            Bar::bar();
+            Bar/*caret*/::bar();
         }
     """)
 
@@ -625,7 +625,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             }
         }
         fn main() {
-            <error descr="Unresolved reference: `Bar`">Bar::BAR/*caret*/</error>();
+            <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>::BAR();
         }
     """)
 
@@ -636,7 +636,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             }
         }
         fn main() {
-            <error descr="Unresolved reference: `Bar`">Bar::C/*caret*/</error>;
+            <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>::C;
         }
     """, """
         use foo::Bar;
@@ -647,7 +647,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             }
         }
         fn main() {
-            Bar::C/*caret*/;
+            Bar/*caret*/::C;
         }
     """)
 
@@ -658,7 +658,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
             }
         }
         fn main() {
-            let _: <error descr="Unresolved reference: `Bar`">Bar::Item/*caret*/</error>;
+            let _: <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>::Item;
         }
     """)
 
@@ -839,15 +839,11 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """)
 
     fun `test do not import path in use item`() = checkAutoImportFixIsUnavailable("""
-        mod foo {
-            pub struct Foo;
-        }
-
         mod bar {
             pub struct Bar;
         }
 
-        use foo::{Foo, <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>};
+        use <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>;
     """, AutoImportFix.Testmarks.pathInUseItem)
 
     fun `test multiple import`() = checkAutoImportFixByTextWithMultipleChoice("""
@@ -1366,7 +1362,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            let x = <error descr="Unresolved reference: `foo`">i32::foo/*caret*/</error>(123);
+            let x = i32::<error descr="Unresolved reference: `foo`">foo/*caret*/</error>(123);
         }
     """, """
         use foo::Foo;
@@ -1399,7 +1395,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
         struct S;
         fn main() {
-            let x = <error descr="Unresolved reference: `foo`">S::foo/*caret*/</error>(123);
+            let x = S::<error descr="Unresolved reference: `foo`">foo/*caret*/</error>(123);
         }
     """, """
         use foo::Foo;
@@ -1432,7 +1428,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            let x = <error descr="Unresolved reference: `foo`"><i32>::foo/*caret*/</error>(123);
+            let x = <i32>::<error descr="Unresolved reference: `foo`">foo/*caret*/</error>(123);
         }
     """, """
         use foo::Foo;
@@ -1464,7 +1460,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            let x = <error descr="Unresolved reference: `C`">i32::C/*caret*/</error>(123);
+            let x = i32::<error descr="Unresolved reference: `C`">C/*caret*/</error>(123);
         }
     """, """
         use foo::Foo;
@@ -1494,7 +1490,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            let x = <error descr="Unresolved reference: `foo`">i32::foo/*caret*/</error>(123);
+            let x = i32::<error descr="Unresolved reference: `foo`">foo/*caret*/</error>(123);
         }
     """, """
         use foo::Foo;
@@ -1523,7 +1519,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            let x = <error descr="Unresolved reference: `S`">S::foo/*caret*/</error>();
+            let x = <error descr="Unresolved reference: `S`">S/*caret*/</error>::foo();
         }
     """, """
         use foo::S;
@@ -1538,7 +1534,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
 
         fn main() {
-            let x = S::foo/*caret*/();
+            let x = S/*caret*/::foo();
         }
     """)
 
@@ -2275,7 +2271,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
         struct S<T>(T);
         fn foo<T>(a: S<T>) where S<T>: foo::Foo {
-            <error descr="Unresolved reference: `foo`"><S<T>>::foo/*caret*/</error>(&a);
+            <S<T>>::<error descr="Unresolved reference: `foo`">foo/*caret*/</error>(&a);
         }
     """, """
         use foo::Foo;
@@ -2285,7 +2281,7 @@ class AutoImportFixTest : AutoImportFixTestBase() {
         }
         struct S<T>(T);
         fn foo<T>(a: S<T>) where S<T>: foo::Foo {
-            <S<T>>::foo(&a);
+            <S<T>>::foo/*caret*/(&a);
         }
     """)
 


### PR DESCRIPTION
Now it highlights only unresolved identifier instead of whole path.
Also, it can highlight unresolved items in the middle of path

Based on #4839

#### Before PR (`ignoreWithoutQuickFix` set to`true`) - default 
![Screenshot from 2020-01-15 20-23-26](https://user-images.githubusercontent.com/16986685/72468957-9927a100-37de-11ea-86fd-1dcdd29e6bba.png)

#### Before PR (`ignoreWithoutQuickFix` set to `false`)
![Screenshot from 2020-01-15 20-23-54](https://user-images.githubusercontent.com/16986685/72468951-962cb080-37de-11ea-9f5f-30fd60103c00.png)

#### After PR (`ignoreWithoutQuickFix` set to`true`) 
![Screenshot from 2020-01-22 23-21-52](https://user-images.githubusercontent.com/16986685/72939897-1c606e00-3d6e-11ea-8601-d422875e9614.png)

#### After PR  (`ignoreWithoutQuickFix` set to `false`)
![Screenshot from 2020-01-15 20-26-01](https://user-images.githubusercontent.com/16986685/72468938-8a40ee80-37de-11ea-9ff0-6c646083efe1.png)

<details> <summary>code</summary>

```rust
mod foo {
    pub mod bar {
        pub struct Foo;
        impl Foo {
            pub fn foobar() {}
        }
        pub mod faz {
            pub struct Baz;
            pub mod qux {}
        }
    }
}

use no_foo::bar::{baz, faz};
use foo::no_bar::{baz, faz};
use foo::bar::{baz, faz::Baz};
use foo::bar::{faz::faz::Qux};
use foo::bar::{faz::qux::Qux};

fn main() {
    bar::Foo::foobar();
    foo::no_bar::Foo::foobar();
    foo::bar::NoFoo::foobar();
    foo::bar::Foo::no_foobar();
}
```
</details>
Closes #4839