### PR TITLE
INT: replace usages of struct literals and tuple constructors in ExtractEnumVariantIntention

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -135,6 +135,9 @@ class RsPsiFactory(
     fun createStructLiteral(name: String): RsStructLiteral =
         createExpressionOfType("$name { }")
 
+    fun createStructLiteral(name: String, fields: String): RsStructLiteral =
+        createExpressionOfType("$name $fields")
+
     fun createStructLiteralField(name: String, value: String): RsStructLiteralField {
         return createExpressionOfType<RsStructLiteral>("S { $name: $value }")
             .structLiteralBody
@@ -444,6 +447,9 @@ class RsPsiFactory(
 
     fun createFunctionCall(functionName: String, arguments: Iterable<RsExpr>): RsCallExpr =
         createExpressionOfType("$functionName(${arguments.joinToString { it.text }})")
+
+    fun createFunctionCall(functionName: String, arguments: String): RsCallExpr =
+        createExpressionOfType("$functionName(${arguments})")
 
     fun createAssocFunctionCall(typeText: String, methodNameText: String, arguments: Iterable<RsExpr>): RsCallExpr {
         val isCorrectTypePath = tryCreatePath(typeText) != null

--- a/src/test/kotlin/org/rust/ide/intentions/ExtractEnumVariantIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ExtractEnumVariantIntentionTest.kt
@@ -280,7 +280,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
         }
     """)
 
-    fun `test replace usage tuple`() = doAvailableTest("""
+    fun `test replace usage tuple in pattern`() = doAvailableTest("""
         enum A {
             /*caret*/V1(u32, bool, i32)
         }
@@ -316,7 +316,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
         }
     """)
 
-    fun `test replace usage struct`() = doAvailableTest("""
+    fun `test replace usage struct in pattern`() = doAvailableTest("""
         enum A {
             /*caret*/V1 { x: u32, y: bool, z: i32 }
         }
@@ -349,6 +349,56 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
             if let Option::Some(A::V1(V1 { ref mut x, ref y, z })) = b {
 
             }
+        }
+    """)
+
+    fun `test replace usage struct`() = doAvailableTest("""
+        enum E {
+            /*caret*/V1 { x: i32, y: u32, z: u32 },
+            V2
+        }
+
+        fn foo() {
+            let z = 5;
+            let v = E::V1 { x: 42, y: 50, z };
+            let v = E::V1 { x: 42, y: 50 /* comment */, z: 3 };
+        }
+    """, """
+        struct /*caret*/V1 { x: i32, y: u32, z: u32 }
+
+        enum E {
+            V1(V1),
+            V2
+        }
+
+        fn foo() {
+            let z = 5;
+            let v = E::V1(V1 { x: 42, y: 50, z });
+            let v = E::V1(V1 { x: 42, y: 50 /* comment */, z: 3 });
+        }
+    """)
+
+    fun `test replace usage tuple`() = doAvailableTest("""
+        enum E {
+            /*caret*/V1(i32, u32),
+            V2
+        }
+
+        fn foo() {
+            let v = E::V1(1, 2);
+            let v = E::V1(1, /*comment*/ 2);
+        }
+    """, """
+        struct /*caret*/V1(i32, u32);
+
+        enum E {
+            V1(V1),
+            V2
+        }
+
+        fn foo() {
+            let v = E::V1(V1(1, 2));
+            let v = E::V1(V1(1, /*comment*/ 2));
         }
     """)
 }


### PR DESCRIPTION
To preserve original comments and other things, I reuse the text of the original struct/tuple literals.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5136