### PR TITLE
INT: don't import inner types of type aliases in ImplementMembers intention

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/RsImportHelper.kt
@@ -111,6 +111,9 @@ object RsImportHelper {
                     is TyAdt -> {
                         val alias = ty.aliasedBy?.element.takeIf { useAliases } as? RsQualifiedNamedElement
                         result += alias ?: ty.item
+                        if (alias != null) {
+                            return true
+                        }
                     }
                     is TyAnon -> result += ty.traits.map { it.element }
                     is TyTraitObject -> result += ty.trait.element

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -151,6 +151,40 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
     """)
 
+    fun `test don't import type alias inner type`() = doTest("""
+        use a::T;
+        mod a {
+            pub struct A;
+            pub struct B;
+            pub struct R<T1, T2>(T1, T2);
+            pub type U<P> = R<P, B>;
+            pub trait T<P> {
+                fn f() -> U<P>;
+            }
+        }
+        struct S;
+        impl T for S {/*caret*/}
+    """, listOf(
+        ImplementMemberSelection("f() -> U<P>", true, true)
+    ), """
+        use a::{T, U};
+        mod a {
+            pub struct A;
+            pub struct B;
+            pub struct R<T1, T2>(T1, T2);
+            pub type U<P> = R<P, B>;
+            pub trait T<P> {
+                fn f() -> U<P>;
+            }
+        }
+        struct S;
+        impl T for S {
+            fn f() -> U<P> {
+                <selection>unimplemented!()</selection>
+            }
+        }
+    """)
+
     fun `test support type aliases`() = doTest("""
         pub struct R;
         pub type U = R;


### PR DESCRIPTION
This PR stops `RsImportHelper` from importing types behind a type alias.

```rust
mod a {
    pub struct A;
    pub struct B;
    pub struct R<T1, T2>(T1, T2);
    pub type U = R<A, B>;
    pub trait T {
        fn f() -> U;
    }
}

// use a::{T, A, B, U}; // <- before PR
use a::{T, U}; // <- after PR

struct S;
impl /*caret*/T for S {
    fn f() -> U {  }
}
```

Fixes second half of https://github.com/intellij-rust/intellij-rust/issues/4979