### PR TITLE
ANN: Fix false positive E0451 when constructing enum

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt
@@ -29,7 +29,7 @@ val RsFieldsOwner.positionalFields: List<RsTupleFieldDecl>
     get() = tupleFields?.tupleFieldDeclList?.filter { it.isEnabledByCfg }.orEmpty()
 
 /**
- * If some field of a struct/enum is private (not visible from [mod]),
+ * If some field of a struct is private (not visible from [mod]),
  * it isn't possible to instantiate it at [mod] anyhow.
  * ```
  * mod foo {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
@@ -44,6 +44,9 @@ fun RsVisible.isVisibleFrom(mod: RsMod): Boolean {
     if (mod.superMods.contains(elementMod)) return true
     if (mod is RsFile && mod.originalFile == elementMod) return true
 
+    // Enum variants in a pub enum are public by default
+    if (this is RsNamedFieldDecl && parent.parent is RsEnumVariant) return true
+
     val members = this.context as? RsMembers ?: return false
     val parent = members.context ?: return true
     return when {

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -1088,6 +1088,18 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
+    fun `test construct pub enum (fields in pub enum are public by default)`() = checkErrors("""
+        mod some_module {
+            pub enum Foo {
+                Foo1 { x: u32 },
+            }
+        }
+        fn main() {
+            let foo = some_module::Foo::Foo1 { x: 1 };
+            let some_module::Foo::Foo1 { x } = foo;
+        }
+    """)
+
     fun `test attempted to access a private field on a struct E0616`() = checkErrors("""
         mod some_module {
             pub struct Foo {


### PR DESCRIPTION
Fix false positive "Field is private" error for such code (introduced in #5120):

```rust
mod some_module {
    pub enum Foo {
        Foo1 { field: i32 },
    }
}

fn main() {
    let foo = some_module::Foo::Foo1 { field: 1 };
}
```