### PR TITLE
Fix move analysis of struct literals with base expr

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/borrowck/ExprUseWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/borrowck/ExprUseWalker.kt
@@ -22,10 +22,12 @@ import org.rust.lang.core.types.infer.Categorization.Local
 import org.rust.lang.core.types.infer.Cmt
 import org.rust.lang.core.types.infer.MemoryCategorizationContext
 import org.rust.lang.core.types.infer.MutabilityCategory
+import org.rust.lang.core.types.infer.substituteOrUnknown
 import org.rust.lang.core.types.regions.ReScope
 import org.rust.lang.core.types.regions.Scope
 import org.rust.lang.core.types.ty.TyAdt
 import org.rust.lang.core.types.ty.TyFunction
+import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.ty.isMovesByDefault
 import org.rust.lang.core.types.type
 
@@ -421,23 +423,26 @@ class ExprUseWalker(private val delegate: Delegate, private val mc: MemoryCatego
             }
         }
 
-        if (withExpr == null) return
-
-        val withCmt = mc.processExpr(withExpr)
-        val withType = withCmt.ty
-        if (withType is TyAdt) {
-            val structFields = (withType.item as? RsStructItem)?.namedFields.orEmpty()
-            for (field in structFields) {
-                val isMentioned = fields.any { it.identifier?.text == field.identifier.text }
-                if (!isMentioned) {
-                    val interior = Interior.Field(withCmt, field.name)
-                    val fieldCmt = Cmt(withExpr, interior, withCmt.mutabilityCategory.inherit(), withType)
-                    delegateConsume(withExpr, fieldCmt)
+        // With base expr, e.g. `S { x, ..s }`
+        if (withExpr != null) {
+            val withCmt = mc.processExpr(withExpr)
+            val withType = withCmt.ty
+            if (withType is TyAdt) {
+                val withFields = (withType.item as? RsStructItem)?.namedFields.orEmpty()
+                for (withField in withFields) {
+                    val isMentioned = fields.any { it.referenceName == withField.name }
+                    // Consume only needed (not mentioned before) fields of `withExpr`
+                    if (!isMentioned) {
+                        val rawWithFieldType = withField.typeReference?.type ?: TyUnknown
+                        val withFieldType = rawWithFieldType.substituteOrUnknown(withType.typeParameterValues)
+                        val interior = Interior.Field(withCmt, withField.name)
+                        val fieldCmt = Cmt(withExpr, interior, withCmt.mutabilityCategory.inherit(), withFieldType)
+                        delegateConsume(withExpr, fieldCmt)
+                    }
                 }
             }
+            walkExpr(withExpr)
         }
-
-        walkExpr(withExpr)
     }
 
     private fun armMoveMode(discriminantCmt: Cmt, arm: RsMatchArm): TrackMatchMode {


### PR DESCRIPTION
Fixes #5013
Fixes #5151

- [x] Run `RsRealProjectAnalysisTest` before merge
