### PR TITLE
COMP: prefer Display before Debug in PrintlnPostfixTemplate

### DIFF
--- a/src/main/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplate.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplate.kt
@@ -37,8 +37,8 @@ class PrintlnPostfixTemplate(provider: RsPostfixTemplateProvider, private val ma
                 val kind = (expr as? RsLitExpr)?.kind
                 return when {
                     kind is RsLiteralKind.String && !kind.isByte -> None
-                    expr.isDebug -> Debug
-                    else -> Display
+                    expr.isDisplay -> Display
+                    else -> Debug
                 }
             }
         }

--- a/src/test/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplateTest.kt
@@ -58,7 +58,7 @@ class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate
     """, """
        fn main() {
            let s = "Arbitrary string";
-           println!("{:?}", s);/*caret*/
+           println!("{}", s);/*caret*/
        }
     """)
 
@@ -82,7 +82,7 @@ class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate
     """, """
        fn main() {
            let s = r#"Arbitrary string"#;
-           println!("{:?}", s);/*caret*/
+           println!("{}", s);/*caret*/
        }
     """)
 
@@ -350,7 +350,7 @@ class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate
         use std::fmt::Display;
 
         fn test<T>(variable: T) where T: Debug + Display {
-            println!("{:?}", variable);/*caret*/
+            println!("{}", variable);/*caret*/
         }
     """)
 }


### PR DESCRIPTION
Swaps `Display` with `Debug` in `PrintlnPostfixTemplate` as discussed in
https://github.com/intellij-rust/intellij-rust/pull/5149