### PR TITLE
INSP: add RsRedundantElseInspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsRedundantElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsRedundantElseInspection.kt
@@ -1,0 +1,59 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.rust.ide.inspections.fixes.SubstituteTextFix
+import org.rust.lang.core.psi.RsCondition
+import org.rust.lang.core.psi.RsElseBranch
+import org.rust.lang.core.psi.RsIfExpr
+import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.ext.endOffsetInParent
+import org.rust.lang.core.psi.ext.isIrrefutable
+import org.rust.lang.core.psi.ext.leftSiblings
+import org.rust.lang.core.psi.ext.rangeWithPrevSpace
+
+/**
+ * Detects redundant `else` statements preceded by an irrefutable pattern.
+ * Quick fix: Remove `else`
+ */
+class RsRedundantElseInspection : RsLocalInspectionTool() {
+    override fun getDisplayName() = "Redundant else"
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+        object : RsVisitor() {
+            override fun visitElseBranch(expr: RsElseBranch) {
+                if (!expr.isRedundant()) return
+
+                val elseExpr = expr.`else`
+                holder.registerProblem(
+                    expr,
+                    TextRange(elseExpr.startOffsetInParent, elseExpr.endOffsetInParent),
+                    "Redundant `else`",
+                    SubstituteTextFix.delete(
+                        "Remove `else`",
+                        expr.containingFile,
+                        expr.rangeWithPrevSpace
+                    )
+                )
+            }
+        }
+
+    private fun RsElseBranch.isRedundant(): Boolean {
+        val set = mutableSetOf<RsCondition>()
+        var candidate: PsiElement = this
+
+        while (candidate is RsElseBranch || candidate is RsIfExpr) {
+            candidate.leftSiblings.filterIsInstance<RsCondition>().forEach { set.add(it) }
+            candidate = candidate.parent
+        }
+
+        return set.any {
+            it.orPats?.patList?.all { pat -> pat?.isIrrefutable ?: false } ?: false
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/RsRedundantElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsRedundantElseInspection.kt
@@ -5,17 +5,17 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import org.rust.ide.inspections.fixes.SubstituteTextFix
 import org.rust.lang.core.psi.RsCondition
 import org.rust.lang.core.psi.RsElseBranch
 import org.rust.lang.core.psi.RsIfExpr
 import org.rust.lang.core.psi.RsVisitor
-import org.rust.lang.core.psi.ext.endOffsetInParent
 import org.rust.lang.core.psi.ext.isIrrefutable
 import org.rust.lang.core.psi.ext.leftSiblings
 import org.rust.lang.core.psi.ext.rangeWithPrevSpace
+import org.rust.lang.core.types.consts.asBool
+import org.rust.lang.utils.evaluation.evaluate
 
 /**
  * Detects redundant `else` statements preceded by an irrefutable pattern.
@@ -27,12 +27,12 @@ class RsRedundantElseInspection : RsLocalInspectionTool() {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitElseBranch(expr: RsElseBranch) {
-                if (!expr.isRedundant()) return
+                if (!expr.isRedundant) return
 
                 val elseExpr = expr.`else`
                 holder.registerProblem(
                     expr,
-                    TextRange(elseExpr.startOffsetInParent, elseExpr.endOffsetInParent),
+                    elseExpr.textRangeInParent,
                     "Redundant `else`",
                     SubstituteTextFix.delete(
                         "Remove `else`",
@@ -43,17 +43,23 @@ class RsRedundantElseInspection : RsLocalInspectionTool() {
             }
         }
 
-    private fun RsElseBranch.isRedundant(): Boolean {
-        val set = mutableSetOf<RsCondition>()
-        var candidate: PsiElement = this
+    companion object {
+        private val RsElseBranch.isRedundant: Boolean
+            get() {
+                val set = mutableSetOf<RsCondition>()
+                var candidate: PsiElement = this
 
-        while (candidate is RsElseBranch || candidate is RsIfExpr) {
-            candidate.leftSiblings.filterIsInstance<RsCondition>().forEach { set.add(it) }
-            candidate = candidate.parent
-        }
+                while (candidate is RsElseBranch || candidate is RsIfExpr) {
+                    candidate.leftSiblings.filterIsInstance<RsCondition>().forEach { set.add(it) }
+                    candidate = candidate.parent
+                }
 
-        return set.any {
-            it.orPats?.patList?.all { pat -> pat?.isIrrefutable ?: false } ?: false
-        }
+                return set.any { it.isRedundant }
+            }
+        private val RsCondition.isRedundant: Boolean
+            get() {
+                val patList = orPats?.patList
+                return patList?.all { pat -> pat?.isIrrefutable ?: false } ?: (this.expr.evaluate().asBool() ?: false)
+            }
     }
 }

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -323,6 +323,11 @@
                          implementationClass="org.rust.ide.inspections.RsMissingElseInspection"/>
 
         <localInspection language="Rust" groupName="Rust"
+                         displayName="Missing else"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RsRedundantElseInspection"/>
+
+        <localInspection language="Rust" groupName="Rust"
                          displayName="Dropping reference"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RsDropRefInspection"/>

--- a/src/main/resources/inspectionDescriptions/RsRedundantElse.html
+++ b/src/main/resources/inspectionDescriptions/RsRedundantElse.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Detects <code>`else`</code>-statements preceded by irrefutable patterns.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/RsRedundantElseInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsRedundantElseInspectionTest.kt
@@ -10,7 +10,7 @@ package org.rust.ide.inspections
  */
 class RsRedundantElseInspectionTest : RsInspectionsTestBase(RsRedundantElseInspection::class) {
 
-    fun `test simple`() = checkFixByText("Remove `else`", """
+    fun `test variable binding`() = checkFixByText("Remove `else`", """
         fn main() {
             let a = 5;
             if let x = a {
@@ -135,6 +135,15 @@ class RsRedundantElseInspectionTest : RsInspectionsTestBase(RsRedundantElseInspe
                 if a > 5 {
                 } else if a <= 5 {
                 }
+            }
+        }
+    """)
+
+    fun `test boolean constant`() = checkByText("""
+        fn main() {
+            if true {
+            } <warning descr="Redundant `else`">else</warning> {
+                let a = 5;
             }
         }
     """)

--- a/src/test/kotlin/org/rust/ide/inspections/RsRedundantElseInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsRedundantElseInspectionTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+/**
+ * Tests for Redundant Else inspection.
+ */
+class RsRedundantElseInspectionTest : RsInspectionsTestBase(RsRedundantElseInspection::class) {
+
+    fun `test simple`() = checkFixByText("Remove `else`", """
+        fn main() {
+            let a = 5;
+            if let x = a {
+            } <warning descr="Redundant `else`"><caret>else</warning> {
+            }
+        }
+    """, """
+        fn main() {
+            let a = 5;
+            if let x = a {
+            }
+        }
+    """)
+
+    fun `test empty single variant enum`() = checkFixByText("Remove `else`", """
+        enum E { V1 }
+
+        fn main() {
+            let a = E::V1;
+            if let E::V1 = a {
+            } <warning descr="Redundant `else`"><caret>else</warning> {
+            }
+        }
+    """, """
+        enum E { V1 }
+
+        fn main() {
+            let a = E::V1;
+            if let E::V1 = a {
+            }
+        }
+    """)
+
+    fun `test single field enum variant`() = checkFixByText("Remove `else`", """
+        enum E { V1(u32) }
+
+        fn main() {
+            let a = E::V1(5);
+            if let E::V1(x) = a {
+            } <warning descr="Redundant `else`"><caret>else</warning> {
+            }
+        }
+    """, """
+        enum E { V1(u32) }
+
+        fn main() {
+            let a = E::V1(5);
+            if let E::V1(x) = a {
+            }
+        }
+    """)
+
+    fun `test else if`() = checkFixByText("Remove `else`", """
+        fn main() {
+            let a = 5;
+            if let x = a {
+            } <warning descr="Redundant `else`"><caret>else</warning> if true {
+            }
+        }
+    """, """
+        fn main() {
+            let a = 5;
+            if let x = a {
+            }
+        }
+    """)
+
+    fun `test first condition irrefutable`() = checkFixByText("Remove `else`", """
+        enum E { V1(u32), V2 }
+
+        fn main() {
+            let a = 5;
+            let b = E::V1(5);
+            if let x = a {
+            } <warning descr="Redundant `else`">else</warning> if let E::V1(x) = b {
+            } <warning descr="Redundant `else`"><caret>else</warning> {
+            }
+        }
+    """, """
+        enum E { V1(u32), V2 }
+
+        fn main() {
+            let a = 5;
+            let b = E::V1(5);
+            if let x = a {
+            } else if let E::V1(x) = b {
+            }
+        }
+    """)
+
+    fun `test intermediate condition irrefutable`() = checkFixByText("Remove `else`", """
+        enum E { V1(u32), V2 }
+
+        fn main() {
+            let a = 5;
+            let b = E::V1(5);
+            if a > 5 {
+            } else if let x = a {
+            } <warning descr="Redundant `else`"><caret>else</warning> {
+            }
+        }
+    """, """
+        enum E { V1(u32), V2 }
+
+        fn main() {
+            let a = 5;
+            let b = E::V1(5);
+            if a > 5 {
+            } else if let x = a {
+            }
+        }
+    """)
+
+    fun `test nested condition`() = checkByText("""
+        enum E { V1(u32), V2 }
+
+        fn main() {
+            let a = 5;
+            let b = E::V1(5);
+            if let x = a {
+            } <warning descr="Redundant `else`">else</warning> {
+                if a > 5 {
+                } else if a <= 5 {
+                }
+            }
+        }
+    """)
+}


### PR DESCRIPTION
Adds inspection to find redundant else branches, as discussed in https://github.com/intellij-rust/intellij-rust/pull/4972.

Right now it doesn't work for these irrefutable patterns:
```rust
enum E { V1 }
fn main() {
    let a = E::V1;
    if let E::V1 = a {
    } else { // <- this else should be redundant
    }
}
```
because `let E::V1 = a` is `RsPatConst` and `RsPat.isIrrefutable` returns `false` for it. Should I change this?

Should the inspection's warning range cover only `else` or the whole block after the `else`?

It would be also nice if it recognized irrefutable conditions like `if true` or `if 5 == 5`, but we need some basic constant propagation for this to work (is there something like this in the plugin already)?