### PR TITLE
REPL: Remove experimental feature

### DIFF
--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -8,6 +8,5 @@ package org.rust.ide.experiments
 object RsExperiments {
     const val BUILD_TOOL_WINDOW = "org.rust.cargo.build.tool.window"
     const val FETCH_OUT_DIR = "org.rust.cargo.fetch.out.dir"
-    const val REPL_TOOL_WINDOW = "org.rust.ide.repl.tool.window"
     const val EVALUATE_BUILD_SCRIPTS = "org.rust.cargo.evaluate.build.scripts"
 }

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -6,9 +6,6 @@
         <experimentalFeature id="org.rust.cargo.fetch.out.dir" percentOfUsers="0">
             <description>Fetch `OUT_DIR` environment variable value. It's needed to make proper name resolution for code included via `include` macro</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.ide.repl.tool.window" percentOfUsers="0">
-            <description>Enable integration with Evcxr REPL (restart required)</description>
-        </experimentalFeature>
         <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="0">
             <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
         </experimentalFeature>

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -6,9 +6,6 @@
         <experimentalFeature id="org.rust.cargo.fetch.out.dir" percentOfUsers="0">
             <description>Fetch `OUT_DIR` environment variable value. It's needed to make proper name resolution for code included via `include` macro</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.ide.repl.tool.window" percentOfUsers="0">
-            <description>Enable integration with Evcxr REPL (restart required)</description>
-        </experimentalFeature>
         <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="0">
             <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
         </experimentalFeature>


### PR DESCRIPTION
`REPL_TOOL_WINDOW` experimental feature is not used now (REPL was activated by default in #4879)