### PR TITLE
REF: Move single file (add handler)

### DIFF
--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -9,4 +9,5 @@ object RsExperiments {
     const val BUILD_TOOL_WINDOW = "org.rust.cargo.build.tool.window"
     const val FETCH_OUT_DIR = "org.rust.cargo.fetch.out.dir"
     const val EVALUATE_BUILD_SCRIPTS = "org.rust.cargo.evaluate.build.scripts"
+    const val MOVE_REFACTORING = "org.rust.ide.refactoring.move"
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesDialog.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesDialog.kt
@@ -1,0 +1,163 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.move
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.ui.showOkCancelDialog
+import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiElement
+import com.intellij.refactoring.RefactoringBundle
+import com.intellij.refactoring.RefactoringSettings
+import com.intellij.refactoring.copy.CopyFilesOrDirectoriesHandler
+import com.intellij.refactoring.move.MoveCallback
+import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesDialog
+import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesProcessor
+import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesUtil
+import com.intellij.refactoring.util.CommonRefactoringUtil
+import com.intellij.util.IncorrectOperationException
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.lang.RsConstants
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.cargoWorkspace
+import org.rust.lang.core.psi.ext.getChildModule
+import org.rust.openapiext.pathAsPath
+import org.rust.openapiext.toPsiFile
+
+class RsMoveFilesOrDirectoriesDialog(
+    private val project2: Project,  // BACKCOMPAT: 2019.3 rename to project
+    private val elementsToMove: Array<PsiElement>,
+    initialTargetDirectory: PsiDirectory?,
+    private val moveCallback: MoveCallback?
+) : MoveFilesOrDirectoriesDialog(project2, elementsToMove, initialTargetDirectory) {
+
+    override fun performMove(targetDirectory: PsiDirectory) {
+        if (!CommonRefactoringUtil.checkReadOnlyStatus(project2, targetDirectory)) return
+        if (!CommonRefactoringUtil.checkReadOnlyStatus(project2, elementsToMove.toList(), true)) return
+
+        try {
+            for (element in elementsToMove) {
+                if (element is RsFile) {
+                    CopyFilesOrDirectoriesHandler.checkFileExist(targetDirectory, null, element, element.name, "Move")
+                }
+                MoveFilesOrDirectoriesUtil.checkMove(element, targetDirectory)
+            }
+
+            val doneCallback = Runnable { close(DialogWrapper.CANCEL_EXIT_CODE) }
+            val searchForReferences = RefactoringSettings.getInstance().MOVE_SEARCH_FOR_REFERENCES_FOR_FILE
+
+            doPerformMove(targetDirectory, searchForReferences, doneCallback)
+        } catch (e: IncorrectOperationException) {
+            CommonRefactoringUtil.showErrorMessage(RefactoringBundle.message("error.title"), e.message, "refactoring.moveFile", project2)
+        }
+    }
+
+    // also used by tests
+    fun doPerformMove(targetDirectory: PsiDirectory, searchForReferences: Boolean, doneCallback: Runnable) {
+        fun runDefaultProcessor() {
+            MoveFilesOrDirectoriesProcessor(
+                project2,
+                elementsToMove,
+                targetDirectory,
+                /* searchForReferences = */ false,
+                /* searchInComments = */ true,
+                /* searchInNonJavaFiles = */ true,
+                moveCallback,
+                doneCallback
+            ).run()
+        }
+
+        if (!searchForReferences) {
+            runDefaultProcessor()
+            return
+        }
+
+        val movedFile = elementsToMove.singleOrNull() as? RsFile
+            ?: error("Currently move is supported only for single file")
+        val crateRoot = movedFile.crateRoot
+            ?: error("movedFile.crateRoot is checked for null in RsMoveFilesOrDirectoriesHandler::canMove")
+        val newParentMod = targetDirectory.getOwningMod(crateRoot)
+        when {
+            newParentMod == null -> {
+                if (askShouldMoveIfNoNewParentMod()) {
+                    runDefaultProcessor()
+                }
+            }
+            newParentMod.crateRoot != movedFile.crateRoot -> {
+                // TODO: support move file to different crate
+                runDefaultProcessor()
+            }
+            else -> {
+                // here our processor will run
+                runDefaultProcessor()
+            }
+        }
+    }
+
+    private fun askShouldMoveIfNoNewParentMod(): Boolean {
+        val result = showOkCancelDialog(
+            "Move",
+            "File will not be included in module tree after move. Continue?",
+            Messages.OK_BUTTON,
+            project = project2
+        )
+        return result == Messages.OK
+    }
+}
+
+private fun PsiDirectory.getOwningMod(crateRoot: RsMod): RsMod? {
+    // TODO: if crateRoot is binary crate (main.rs) and directory is root (src/)
+    //  Should we return binary crate or library crate (lib.rs)?
+    if (crateRoot.getOwnedDirectory() == this) return crateRoot
+
+    val mod = getOwningModAtDefaultLocation()
+        ?: getOwningModWalkingFromCrateRoot(crateRoot)
+        ?: crateRoot.cargoWorkspace?.let { getOwningModWalkingFromAllCrateRoots(it) }
+        ?: return null
+
+    return if (mod.getOwnedDirectory() == this) {
+        mod
+    } else {
+        // e.g. because of #[path] attributes on mod declarations
+        null
+    }
+}
+
+private fun PsiDirectory.getOwningModAtDefaultLocation(): RsMod? {
+    val file1 = findFile(RsConstants.MOD_RS_FILE) as? RsMod
+    val file2 = parentDirectory?.findFile("$name.rs") as? RsMod
+    return file1.takeIf { file2 == null }
+        ?: file2.takeIf { file1 == null }
+}
+
+private fun PsiDirectory.getOwningModWalkingFromCrateRoot(crateRoot: RsMod): RsMod? {
+    val crateRootDirectory = crateRoot.getOwnedDirectory() ?: return null
+    val crateRootPath = crateRootDirectory.virtualFile.pathAsPath
+    val path = virtualFile.pathAsPath
+    if (!path.startsWith(crateRootPath)) return null
+
+    var mod = crateRoot
+    for (segmentPath in crateRootPath.relativize(path)) {
+        val segment = segmentPath.toString()
+        mod = mod.getChildModule(segment) ?: return null
+    }
+    return mod
+}
+
+private fun PsiDirectory.getOwningModWalkingFromAllCrateRoots(cargoWorkspace: CargoWorkspace): RsMod? {
+    val cargoPackages = cargoWorkspace.packages.filter { it.origin == PackageOrigin.WORKSPACE }
+    for (cargoPackage in cargoPackages) {
+        for (cargoTarget in cargoPackage.targets) {
+            val crateRoot = cargoTarget.crateRoot?.toPsiFile(project) as? RsMod ?: continue
+            val owningMod = getOwningModWalkingFromCrateRoot(crateRoot)
+            if (owningMod != null) return owningMod
+        }
+    }
+    return null
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesHandler.kt
@@ -1,0 +1,98 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.move
+
+import com.intellij.lang.Language
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiReference
+import com.intellij.refactoring.move.MoveCallback
+import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesHandler
+import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesUtil
+import com.intellij.refactoring.util.CommonRefactoringUtil
+import org.rust.ide.experiments.RsExperiments
+import org.rust.lang.RsLanguage
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.ext.hasChildModules
+import org.rust.lang.core.psi.ext.isEdition2018
+import org.rust.openapiext.isFeatureEnabled
+
+class RsMoveFilesOrDirectoriesHandler : MoveFilesOrDirectoriesHandler() {
+
+    override fun supportsLanguage(language: Language): Boolean = language.`is`(RsLanguage)
+
+    override fun adjustTargetForMove(dataContext: DataContext?, targetContainer: PsiElement?): PsiElement? =
+        (targetContainer as? PsiFile)?.containingDirectory ?: targetContainer
+
+    override fun canMove(
+        elements: Array<out PsiElement>,
+        targetContainer: PsiElement?,
+        reference: PsiReference?
+    ): Boolean {
+        if (!isFeatureEnabled(RsExperiments.MOVE_REFACTORING)) return false
+        if (!elements.all { it.canBeMoved() }) return false
+
+        // TODO: support move multiply files
+        if (elements.size > 1) return false
+
+        val adjustedTargetContainer = adjustTargetForMove(null, targetContainer)
+        return super.canMove(elements, adjustedTargetContainer, reference)
+    }
+
+    override fun doMove(
+        project: Project,
+        elements: Array<out PsiElement>,
+        targetContainer: PsiElement?,
+        moveCallback: MoveCallback?
+    ) {
+        if (!CommonRefactoringUtil.checkReadOnlyStatusRecursively(project, elements.toList(), true)) return
+
+        val adjustedTargetContainer = adjustTargetForMove(null, targetContainer)
+        val adjustedElements = adjustForMove(project, elements, adjustedTargetContainer) ?: return
+
+        val targetDirectory = MoveFilesOrDirectoriesUtil.resolveToDirectory(project, adjustedTargetContainer)
+        // adjustedTargetContainer will be null if refactoring is performed by action (F6),
+        // otherwise (when refactoring is performed using cut & paste in file tree) it should be some PsiDirectory
+        // resolveToDirectory will return adjustedTargetContainer unchanged if it is PsiDirectory
+        // so this return could happen only in rare cases when adjustedTargetContainer is PsiDirectoryContainer
+        if (adjustedTargetContainer != null && targetDirectory == null) return
+        val initialTargetDirectory = MoveFilesOrDirectoriesUtil.getInitialTargetDirectory(targetDirectory, elements)
+
+        RsMoveFilesOrDirectoriesDialog(project, adjustedElements, initialTargetDirectory, moveCallback).show()
+    }
+
+    override fun tryToMove(
+        element: PsiElement,
+        project: Project,
+        dataContext: DataContext?,
+        reference: PsiReference?,
+        editor: Editor?
+    ): Boolean {
+        if (!canMove(arrayOf(element), null, reference)) return false
+
+        return super.tryToMove(element, project, dataContext, reference, editor)
+    }
+}
+
+private fun PsiElement.canBeMoved(): Boolean {
+    if (this !is RsFile) return false
+
+    // TODO: support move files with its child modules
+    if (ownsDirectory) return false
+    if (hasChildModules()) return false
+
+    // TODO: support path attribute on mod declaration
+    if (pathAttribute != null) return false
+
+    return modName != null
+        && crateRoot != null
+        && crateRelativePath != null
+        && !isCrateRoot
+        && isEdition2018  // TODO: support 2015 edition
+}

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -9,5 +9,8 @@
         <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="0">
             <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.ide.refactoring.move" percentOfUsers="0">
+            <description>Move refactoring</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -9,5 +9,8 @@
         <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="0">
             <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.ide.refactoring.move" percentOfUsers="0">
+            <description>Move refactoring</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -905,6 +905,15 @@
         <registryKey key="org.rust.lang.cfg.attributes" defaultValue="true" restartRequired="false"
                      description="Enable Rust cfg attributes support"/>
 
+        <!-- Move refactoring -->
+
+        <!--
+            `before kotlin.moveFilesOrDirectories` is needed because otherwise
+            incorrect handler can be used: https://youtrack.jetbrains.com/issue/IDEA-237769
+        -->
+        <refactoring.moveHandler implementation="org.rust.ide.refactoring.move.RsMoveFilesOrDirectoriesHandler"
+                                 order="first, before moveJavaFileOrDir, before kotlin.moveFilesOrDirectories"/>
+
     </extensions>
 
     <extensionPoints>


### PR DESCRIPTION
Add handler for move refactoring (#5181). Handler checks if file can be moved, and find module which should become new parent module of moved file

Currently handler will always run default move processor (which just moves file). Handler code is split into separate PR in order to improve review process (main PR is somewhat too big)

Handler is disabled by default and can be enabled using `org.rust.ide.refactoring.move` experimental feature (in registry)