### PR TITLE
INT: Fix and enable "Extract enum variant" intention

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFix.kt
@@ -53,7 +53,7 @@ class CreateStructFieldFromConstructorFix(
     }
 
     private fun RsPsiFactory.createBlockFields(pub: Boolean, name: String, type: Ty): RsBlockFields {
-        return createBlockFields(listOf(RsPsiFactory.BlockField(pub, name, type)))
+        return createBlockFields(listOf(RsPsiFactory.BlockField(name, type, pub)))
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/ide/inspections/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/RsImportHelper.kt
@@ -38,7 +38,7 @@ object RsImportHelper {
         importElements(context, toImport)
     }
 
-    private fun importElements(context: RsElement, elements: Set<RsQualifiedNamedElement>) {
+    fun importElements(context: RsElement, elements: Set<RsQualifiedNamedElement>) {
         if (!RsCodeInsightSettings.getInstance().importOutOfScopeItems) return
         val importContext = ImportContext.from(context.project, context)
         for (element in elements) {

--- a/src/main/kotlin/org/rust/ide/refactoring/RsInPlaceVariableIntroducer.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsInPlaceVariableIntroducer.kt
@@ -7,6 +7,8 @@ package org.rust.ide.refactoring
 
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Pair
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
 import com.intellij.refactoring.introduce.inplace.InplaceVariableIntroducer
@@ -16,5 +18,13 @@ class RsInPlaceVariableIntroducer(
     editor: Editor,
     project: Project,
     title: String,
-    occurrences: Array<PsiElement> = emptyArray()
-) : InplaceVariableIntroducer<PsiElement>(elementToRename, editor, project, title, occurrences, null)
+    private val additionalElementsToRename: List<PsiElement> = emptyList()
+) : InplaceVariableIntroducer<PsiElement>(elementToRename, editor, project, title, emptyArray(), null) {
+    override fun collectAdditionalElementsToRename(stringUsages: MutableList<Pair<PsiElement, TextRange>>) {
+        for (element in additionalElementsToRename) {
+            if (element.isValid) {
+                stringUsages.add(Pair(element, TextRange(0, element.textLength)))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -152,25 +152,22 @@ class RsPsiFactory(
         return structLiteralField
     }
 
-    data class BlockField(val pub: Boolean, val name: String, val type: Ty)
+    data class BlockField(val name: String, val type: Ty, val addPub: Boolean)
+
+    data class TupleField(val type: Ty, val addPub: Boolean)
 
     fun createBlockFields(fields: List<BlockField>): RsBlockFields {
         val fieldsText = fields.joinToString(separator = ",\n") {
-            "${"pub".iff(it.pub)}${it.name}: ${it.type.insertionSafeTextWithLifetimes}"
+            "${"pub".iff(it.addPub)}${it.name}: ${it.type.insertionSafeTextWithLifetimes}"
         }
-        return createStruct("struct S { $fieldsText }")
-            .blockFields!!
+        return createFromText("struct S { $fieldsText }")  ?: error("Failed to create block fields")
     }
 
-    data class TupleField(val visibility: RsVis?, val type: Ty)
-
     fun createTupleFields(fields: List<TupleField>): RsTupleFields {
-        fun addSpace(t: String?) = if (t != null) { "$t " } else { "" }
-
         val fieldsText = fields.joinToString(separator = ", ") {
-            "${addSpace(it.visibility?.text)}${it.type.insertionSafeTextWithLifetimes}"
+            "${"pub".iff(it.addPub)}${it.type.insertionSafeTextWithLifetimes}"
         }
-        return createFromText("struct S($fieldsText)") ?: error("Failed to create struct")
+        return createFromText("struct S($fieldsText)") ?: error("Failed to create tuple fields")
     }
 
     fun createEnum(text: String): RsEnumItem =

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -762,10 +762,10 @@
             <className>org.rust.ide.intentions.AddStructFieldsLiteralRecursiveIntention</className>
             <category>Rust</category>
         </intentionAction>
-<!--        <intentionAction>-->
-<!--            <className>org.rust.ide.intentions.ExtractEnumVariantIntention</className>-->
-<!--            <category>Rust</category>-->
-<!--        </intentionAction>-->
+        <intentionAction>
+            <className>org.rust.ide.intentions.ExtractEnumVariantIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 

--- a/src/test/kotlin/org/rust/ide/intentions/ExtractEnumVariantIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ExtractEnumVariantIntentionTest.kt
@@ -7,8 +7,6 @@ package org.rust.ide.intentions
 
 class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIntention()) {
 
-    override fun shouldRunTest(): Boolean = System.getenv("CI") == null
-
     fun `test not available on empty variant`() = doUnavailableTest("""
         enum A {
             /*caret*/V1
@@ -27,7 +25,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
             V2
         }
     """, """
-        struct /*caret*/V1(i32, bool, String);
+        struct /*caret*/V1(pub i32, pub bool, pub String);
 
         enum A {
             V1(V1),
@@ -41,38 +39,10 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
             V2
         }
     """, """
-        struct /*caret*/V1 { a: i32, b: bool, c: String }
+        struct /*caret*/V1 { pub a: i32, pub b: bool, pub c: String }
 
         enum A {
             V1(V1),
-            V2
-        }
-    """)
-
-    fun `test extract pub visibility`() = doAvailableTest("""
-        enum A {
-            /*caret*/V1 { pub a: i32, pub(crate) b: bool, c: String },
-            V2
-        }
-    """, """
-        struct /*caret*/V1 { pub a: i32, pub(crate) b: bool, c: String }
-
-        enum A {
-            V1(pub V1),
-            V2
-        }
-    """)
-
-    fun `test extract crate visibility`() = doAvailableTest("""
-        enum A {
-            /*caret*/V1 { a: i32, pub(crate) b: bool, c: String },
-            V2
-        }
-    """, """
-        struct /*caret*/V1 { a: i32, pub(crate) b: bool, c: String }
-
-        enum A {
-            V1(pub(crate) V1),
             V2
         }
     """)
@@ -83,7 +53,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
             V2
         }
     """, """
-        struct /*caret*/V1<T>(T);
+        struct /*caret*/V1<T>(pub T);
 
         enum A<T> {
             V1(V1<T>),
@@ -100,7 +70,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
     """, """
         trait Trait {}
 
-        struct /*caret*/V1<T: Trait>(T);
+        struct /*caret*/V1<T: Trait>(pub T);
 
         enum A<T: Trait> {
             V1(V1<T>),
@@ -117,7 +87,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
     """, """
         trait Trait {}
 
-        struct /*caret*/V1<T>(T) where T: Trait;
+        struct /*caret*/V1<T>(pub T) where T: Trait;
 
         enum A<T> where T: Trait {
             V1(V1<T>),
@@ -134,7 +104,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
     """, """
         trait Trait {}
 
-        struct /*caret*/V1<T> where T: Trait { a: T }
+        struct /*caret*/V1<T> where T: Trait { pub a: T }
 
         enum A<T> where T: Trait {
             V1(V1<T>),
@@ -160,7 +130,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
             fn foo() -> S;
         }
 
-        struct /*caret*/V1<'a, 'b, T, S, U> where T: Trait + Trait2<S, Item=U>, 'a: 'b { a: &'a T, b: &'b T }
+        struct /*caret*/V1<'a, 'b, T, S, U> where T: Trait + Trait2<S, Item=U>, 'a: 'b { pub a: &'a T, pub b: &'b T }
 
         enum A<'a, 'b, 'c, T, S, R, U> where T: Trait + Trait2<S, Item=U>, R: Trait, 'a: 'b + 'c, 'b: 'c {
             V1(V1<'a, 'b, T, S, U>),
@@ -173,7 +143,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
             /*caret*/V1 { a: &'a u32, b: &'b u32 }
         }
     """, """
-        struct /*caret*/V1<'a: 'b, 'b: 'a> { a: &'a u32, b: &'b u32 }
+        struct /*caret*/V1<'a: 'b, 'b: 'a> { pub a: &'a u32, pub b: &'b u32 }
 
         enum A<'a: 'b, 'b: 'a> {
             V1(V1<'a, 'b>)
@@ -190,7 +160,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
     """, """
         trait Sync {}
 
-        struct /*caret*/V1<'a, T: 'a>(T) where &'a T: Sync;
+        struct /*caret*/V1<'a, T: 'a>(pub T) where &'a T: Sync;
 
         enum S<'a, T: 'a> where &'a T: Sync {
             V1(V1<'a, T>),
@@ -208,7 +178,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
     """, """
         trait Sync {}
 
-        struct /*caret*/V1<'a: 'b, 'b, T: 'a>(&'a T) where &'b T: Sync;
+        struct /*caret*/V1<'a: 'b, 'b, T: 'a>(pub &'a T) where &'b T: Sync;
 
         enum S<'a: 'b, 'b, T: 'a> where &'b T: Sync {
             V1(V1<'a, 'b, T>),
@@ -225,7 +195,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
     """, """
         trait Trait {}
 
-        struct /*caret*/V1<const T: usize> { a: [u32; T] }
+        struct /*caret*/V1<const T: usize> { pub a: [u32; T] }
 
         enum A<const T: usize> {
             V1(V1<{ T }>),
@@ -239,7 +209,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
             V2
         }
     """, """
-        struct /*caret*/V1<'a>(&'a u32);
+        struct /*caret*/V1<'a>(pub &'a u32);
 
         enum A<'a> {
             V1(V1<'a>),
@@ -257,7 +227,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
     """, """
         struct S<X> { a: X }
 
-        struct /*caret*/V1<'a, T1, T2, T4>(T1, &'a T2, S<S<T4>>);
+        struct /*caret*/V1<'a, T1, T2, T4>(pub T1, pub &'a T2, pub S<S<T4>>);
 
         enum A<'a, T1, T2, T3, T4> {
             V1(V1<'a, T1, T2, T4>),
@@ -275,7 +245,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
     """, """
         struct S<X> { a: X }
 
-        struct /*caret*/V1<'a>(S<S<&'a u32>>);
+        struct /*caret*/V1<'a>(pub S<S<&'a u32>>);
 
         enum A<'a, 'b> {
             V1(V1<'a>),
@@ -300,7 +270,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
             }
         }
     """, """
-        struct /*caret*/V1(u32, bool, i32);
+        struct /*caret*/V1(pub u32, pub bool, pub i32);
 
         enum A {
             V1(V1)
@@ -336,7 +306,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
             }
         }
     """, """
-        struct /*caret*/V1 { x: u32, y: bool, z: i32 }
+        struct /*caret*/V1 { pub x: u32, pub y: bool, pub z: i32 }
 
         enum A {
             V1(V1)
@@ -367,7 +337,7 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
             let v = E::V1 { x: 42, y: 50 /* comment */, z: 3 };
         }
     """, """
-        struct /*caret*/V1 { x: i32, y: u32, z: u32 }
+        struct /*caret*/V1 { pub x: i32, pub y: u32, pub z: u32 }
 
         enum E {
             V1(V1),
@@ -383,16 +353,16 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
 
     fun `test replace usage tuple`() = doAvailableTest("""
         enum E {
-            /*caret*/V1(i32, u32),
+            /*caret*/V1(i32, String),
             V2
         }
 
         fn foo() {
-            let v = E::V1(1, 2);
-            let v = E::V1(1, /*comment*/ 2);
+            let v = E::V1(1, String::new());
+            let v = E::V1(1, /*comment*/ String::new());
         }
     """, """
-        struct /*caret*/V1(i32, u32);
+        struct /*caret*/V1(pub i32, pub String);
 
         enum E {
             V1(V1),
@@ -400,8 +370,115 @@ class ExtractEnumVariantIntentionTest : RsIntentionTestBase(ExtractEnumVariantIn
         }
 
         fn foo() {
-            let v = E::V1(V1(1, 2));
-            let v = E::V1(V1(1, /*comment*/ 2));
+            let v = E::V1(V1(1, String::new()));
+            let v = E::V1(V1(1, /*comment*/ String::new()));
+        }
+    """)
+
+    fun `test generated struct has same visibility`() = doAvailableTest("""
+        pub enum A {
+            /*caret*/V1 { a: i32, b: bool, c: String },
+            V2
+        }
+    """, """
+        pub struct /*caret*/V1 { pub a: i32, pub b: bool, pub c: String }
+
+        pub enum A {
+            V1(V1),
+            V2
+        }
+    """)
+
+    fun `test add pub to all struct's fields with default vis`() = doAvailableTest("""
+        enum A {
+            /*caret*/V1 { /* comment */a: i32, /* comment */b: i32, pub c: i32, pub(crate) d: i32 },
+            V2
+        }
+    """, """
+        struct /*caret*/V1 { /* comment */pub a: i32, /* comment */pub b: i32, pub c: i32, pub(crate) d: i32 }
+
+        enum A {
+            V1(V1),
+            V2
+        }
+    """)
+
+    fun `test add pub to all tuple's fields with default vis`() = doAvailableTest("""
+        enum A {
+            /*caret*/V1(/* comment */i32, /* comment */i32, pub i32, pub(crate) i32),
+            V2
+        }
+    """, """
+        struct /*caret*/V1(/* comment */pub i32, /* comment */pub i32, pub i32, pub(crate) i32);
+
+        enum A {
+            V1(V1),
+            V2
+        }
+    """)
+
+    fun `test import generated struct if needed`() = doAvailableTest("""
+        use a::E;
+
+        mod a {
+            pub enum E {
+                /*caret*/V1 { x: i32, y: i32 },
+                V2
+            }
+        }
+        
+        fn main() {
+            let _ = E::V1 { x: 0, y: 1 };
+        }
+    """, """
+        use a::{E, V1};
+
+        mod a {
+            pub struct /*caret*/V1 { pub x: i32, pub y: i32 }
+
+            pub enum E {
+                V1(V1),
+                V2
+            }
+        }
+        
+        fn main() {
+            let _ = E::V1(V1 { x: 0, y: 1 });
+        }
+    """)
+
+    // TODO: fix
+    fun `test don't import generated struct if its name already in scope`() = doAvailableTest("""
+        use a::E;
+        
+        struct V1;
+
+        mod a {
+            pub enum E {
+                /*caret*/V1 { x: i32, y: i32 },
+                V2
+            }
+        }
+        
+        fn main() {
+            let _ = E::V1 { x: 0, y: 1 };
+        }
+    """, """
+        use a::E;
+        
+        struct V1;
+
+        mod a {
+            pub struct /*caret*/V1 { pub x: i32, pub y: i32 }
+
+            pub enum E {
+                V1(V1),
+                V2
+            }
+        }
+        
+        fn main() {
+            let _ = E::V1(V1 { x: 0, y: 1 });
         }
     """)
 }


### PR DESCRIPTION
Bunch of fixes:
* Enable the intention.
* Get rid of `extractVisibility` and related staff since visibility qualifiers for enum variant's fields are not permitted ([E0449](https://doc.rust-lang.org/error-index.html#E0449)).
* Now generated struct has the same visibility qualifier as parent enum has.
* Since enum's fields have public visibility by default, add `pub` qualifier to all fields in generated struct if the corresponding field in the enum variant has no visibility qualifier.
* After replacing usages of the original enum variant, import the generated struct if needed.
* Fix struct renaming if an element with the same name already exists in the scope.

There is one more problem. `RsInPlaceVariableIntroducer` doesn't work if the element to rename has non-local use scope.

Closes #5024