### PR TITLE
COMP: add block comment suffix after enter

### DIFF
--- a/src/main/kotlin/org/rust/ide/commenter/RsCommenter.kt
+++ b/src/main/kotlin/org/rust/ide/commenter/RsCommenter.kt
@@ -5,9 +5,23 @@
 
 package org.rust.ide.commenter
 
+import com.intellij.lang.CodeDocumentationAwareCommenter
 import com.intellij.lang.Commenter
+import com.intellij.psi.PsiComment
+import com.intellij.psi.tree.IElementType
+import org.rust.lang.core.parser.RustParserDefinition.Companion.BLOCK_COMMENT
 
-class RsCommenter : Commenter {
+class RsCommenter : Commenter, CodeDocumentationAwareCommenter {
+    // act like there are no doc or line comments, these are handled separately
+    override fun isDocumentationComment(element: PsiComment?) = false
+    override fun getDocumentationCommentTokenType(): IElementType? = null
+    override fun getDocumentationCommentLinePrefix(): String? = null
+    override fun getDocumentationCommentPrefix(): String? = null
+    override fun getDocumentationCommentSuffix(): String? = null
+
+    override fun getLineCommentTokenType(): IElementType? = null
+    override fun getBlockCommentTokenType(): IElementType = BLOCK_COMMENT
+
     override fun getLineCommentPrefix(): String = "//"
 
     override fun getBlockCommentPrefix(): String = "/*"

--- a/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
+++ b/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
@@ -139,4 +139,12 @@ class RsCommenterTest : RsTestBase() {
             // x * 2
         }<caret>
     """, IdeActions.ACTION_COMMENT_LINE)
+
+    fun `test complete block comment`() = checkEditorAction("""
+        /*<caret>
+    """, """
+        /*
+        <caret>
+         */
+    """, IdeActions.ACTION_EDITOR_ENTER)
 }


### PR DESCRIPTION
I used `CodeDocumentationAwareCommenter` to add support for completing block comments. Because line comments are handled separately and doc comments are pretty complex in Rust and can't be handled by `CodeDocumentationAwareCommenter` alone, I act as there are only block comments in Rust for the sake of completion provided by `CodeDocumentationAwareCommenter`.

Let's see what CI says about this change.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5171