### PR TITLE
CARGO: Support configuring workspace features in `Cargo.toml`

### DIFF
--- a/.idea/dictionaries/intellij_rust.xml
+++ b/.idea/dictionaries/intellij_rust.xml
@@ -15,6 +15,7 @@
       <w>decl</w>
       <w>demangle</w>
       <w>dep</w>
+      <w>deps</w>
       <w>dereferenced</w>
       <w>destructure</w>
       <w>env</w>

--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -17,8 +17,11 @@ import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.messages.Topic
 import org.rust.cargo.CargoConstants
+import org.rust.cargo.project.model.impl.UserDisabledFeatures
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.FeatureState
+import org.rust.cargo.project.workspace.PackageFeature
 import org.rust.cargo.toolchain.RsToolchain
 import org.rust.cargo.toolchain.impl.RustcVersion
 import org.rust.cargo.toolchain.isRustupAvailable
@@ -50,6 +53,8 @@ interface CargoProjectsService {
     fun refreshAllProjects(): CompletableFuture<out List<CargoProject>>
     fun discoverAndRefresh(): CompletableFuture<out List<CargoProject>>
     fun suggestManifests(): Sequence<VirtualFile>
+
+    fun modifyFeatures(cargoProject: CargoProject, features: Set<PackageFeature>, newState: FeatureState)
 
     companion object {
         val CARGO_PROJECTS_TOPIC: Topic<CargoProjectsListener> = Topic(
@@ -93,9 +98,12 @@ interface CargoProject : UserDataHolderEx {
     val stdlibStatus: UpdateStatus
     val rustcInfoStatus: UpdateStatus
 
-    val mergedStatus: UpdateStatus get() = workspaceStatus
-        .merge(stdlibStatus)
-        .merge(rustcInfoStatus)
+    val mergedStatus: UpdateStatus
+        get() = workspaceStatus
+            .merge(stdlibStatus)
+            .merge(rustcInfoStatus)
+
+    val userDisabledFeatures: UserDisabledFeatures
 
     sealed class UpdateStatus(private val priority: Int) {
         object UpToDate : UpdateStatus(0)

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/TestCargoProjectsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/TestCargoProjectsServiceImpl.kt
@@ -25,7 +25,7 @@ class TestCargoProjectsServiceImpl(project: Project) : CargoProjectsServiceImpl(
     @TestOnly
     fun createTestProject(rootDir: VirtualFile, ws: CargoWorkspace, rustcInfo: RustcInfo? = null) {
         val manifest = rootDir.pathAsPath.resolve("Cargo.toml")
-        val testProject = CargoProjectImpl(manifest, this, ws, null, rustcInfo,
+        val testProject = CargoProjectImpl(manifest, this, UserDisabledFeatures.EMPTY, ws, null, rustcInfo,
             workspaceStatus = CargoProject.UpdateStatus.UpToDate,
             rustcInfoStatus = if (rustcInfo != null) CargoProject.UpdateStatus.UpToDate else CargoProject.UpdateStatus.NeedsUpdate)
         testProject.setRootDir(rootDir)

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/UserDisabledFeatures.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/UserDisabledFeatures.kt
@@ -1,0 +1,71 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.model.impl
+
+import org.rust.cargo.project.workspace.*
+import org.rust.stdext.exhaustive
+
+abstract class UserDisabledFeatures {
+    abstract val pkgRootToDisabledFeatures: Map<PackageRoot, Set<FeatureName>>
+
+    fun getDisabledFeatures(packages: Iterable<CargoWorkspace.Package>): List<PackageFeature> {
+        return packages.flatMap { pkg ->
+            pkgRootToDisabledFeatures[pkg.rootDirectory]
+                ?.mapNotNull { name -> PackageFeature(pkg, name).takeIf { it in pkg.features } }
+                ?: emptyList()
+        }
+    }
+
+    fun isEmpty(): Boolean {
+        return pkgRootToDisabledFeatures.isEmpty() || pkgRootToDisabledFeatures.values.all { it.isEmpty() }
+    }
+
+    fun toMutable(): MutableUserDisabledFeatures = MutableUserDisabledFeatures(
+        pkgRootToDisabledFeatures
+            .mapValues { (_, v) -> v.toMutableSet() }
+            .toMutableMap()
+    )
+
+    fun retain(packages: Iterable<CargoWorkspace.Package>): UserDisabledFeatures {
+        val newMap = EMPTY.toMutable()
+        for (disabledFeature in getDisabledFeatures(packages)) {
+            newMap.setFeatureState(disabledFeature, FeatureState.Disabled)
+        }
+        return newMap
+    }
+
+    companion object {
+        val EMPTY: UserDisabledFeatures = ImmutableUserDisabledFeatures(emptyMap())
+
+        fun of(pkgRootToDisabledFeatures: Map<PackageRoot, Set<FeatureName>>): UserDisabledFeatures =
+            ImmutableUserDisabledFeatures(pkgRootToDisabledFeatures)
+    }
+}
+
+private class ImmutableUserDisabledFeatures(
+    override val pkgRootToDisabledFeatures: Map<PackageRoot, Set<FeatureName>>
+) : UserDisabledFeatures()
+
+class MutableUserDisabledFeatures(
+    override val pkgRootToDisabledFeatures: MutableMap<PackageRoot, MutableSet<FeatureName>>
+) : UserDisabledFeatures() {
+
+    fun setFeatureState(
+        feature: PackageFeature,
+        state: FeatureState
+    ) {
+        val packageRoot = feature.pkg.rootDirectory
+        when (state) {
+            FeatureState.Enabled -> {
+                pkgRootToDisabledFeatures[packageRoot]?.remove(feature.name)
+            }
+            FeatureState.Disabled -> {
+                pkgRootToDisabledFeatures.getOrPut(packageRoot) { hashSetOf() }
+                    .add(feature.name)
+            }
+        }.exhaustive
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/UserDisabledFeaturesHolder.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/UserDisabledFeaturesHolder.kt
@@ -1,0 +1,74 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.model.impl
+
+import com.intellij.openapi.components.*
+import com.intellij.openapi.project.Project
+import com.intellij.util.io.systemIndependentPath
+import org.jdom.Element
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.stdext.mapNotNullToSet
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * A service needed to store [UserDisabledFeatures] separately from [CargoProjectsServiceImpl].
+ * Needed to make it possible to store them in different XML files ([Storage]s)
+ */
+@State(name = "CargoProjectFeatures", storages = [
+    Storage(StoragePathMacros.WORKSPACE_FILE, roamingType = RoamingType.DISABLED)
+])
+@Service
+class UserDisabledFeaturesHolder(private val project: Project) : PersistentStateComponent<Element> {
+    private var loadedUserDisabledFeatures: Map<Path, UserDisabledFeatures> = emptyMap()
+
+    fun takeLoadedUserDisabledFeatures(): Map<Path, UserDisabledFeatures> {
+        val result = loadedUserDisabledFeatures
+        loadedUserDisabledFeatures = emptyMap()
+        return result
+    }
+
+    override fun getState(): Element {
+        val state = Element("state")
+        for (cargoProject in project.cargoProjects.allProjects) {
+            val pkgToFeatures = cargoProject.userDisabledFeatures
+            if (!pkgToFeatures.isEmpty()) {
+                val cargoProjectElement = Element("cargoProject")
+                cargoProjectElement.setAttribute("file", cargoProject.manifest.systemIndependentPath)
+                for ((pkg, features) in pkgToFeatures.pkgRootToDisabledFeatures) {
+                    if (features.isNotEmpty()) {
+                        val packageElement = Element("package")
+                        packageElement.setAttribute("file", pkg.systemIndependentPath)
+                        for (feature in features) {
+                            val featureElement = Element("feature")
+                            featureElement.setAttribute("name", feature)
+                            packageElement.addContent(featureElement)
+                        }
+                        cargoProjectElement.addContent(packageElement)
+                    }
+                }
+                state.addContent(cargoProjectElement)
+            }
+        }
+        return state
+    }
+
+    override fun loadState(state: Element) {
+        val cargoProjects = state.getChildren("cargoProject")
+
+        loadedUserDisabledFeatures = cargoProjects.associate { cargoProject ->
+            val projectFile = cargoProject.getAttributeValue("file").orEmpty()
+            val features = UserDisabledFeatures.of(cargoProject.getChildren("package").associate { pkg ->
+                val packageFile = pkg.getAttributeValue("file").orEmpty()
+                val features = pkg.getChildren("feature").mapNotNullToSet {
+                    it.getAttributeValue("name")
+                }
+                Paths.get(packageFile) to features
+            })
+            Paths.get(projectFile) to features
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/project/workspace/FeatureGraph.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/FeatureGraph.kt
@@ -1,0 +1,119 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.workspace
+
+import org.rust.lang.utils.Node
+import org.rust.lang.utils.PresentableGraph
+
+private typealias FeaturesGraphInner = PresentableGraph<PackageFeature, Unit>
+private typealias FeatureNode = Node<PackageFeature, Unit>
+
+class FeatureGraph private constructor(
+    private val graph: FeaturesGraphInner,
+    private val featureToNode: Map<PackageFeature, FeatureNode>
+) {
+    /** Applies the specified function [f] to a freshly created [FeaturesView] and returns its state */
+    fun apply(defaultState: FeatureState, f: FeaturesView.() -> Unit): Map<PackageFeature, FeatureState> =
+        FeaturesView(defaultState).apply(f).state
+
+    /** Mutable view of a [FeatureGraph] */
+    inner class FeaturesView(defaultState: FeatureState) {
+        val state: MutableMap<PackageFeature, FeatureState> = hashMapOf()
+
+        init {
+            for (feature in featureToNode.keys) {
+                state[feature] = defaultState
+            }
+        }
+
+        fun enableAll(features: Iterable<PackageFeature>) {
+            for (feature in features) {
+                enable(feature)
+            }
+        }
+
+        fun disableAll(features: Iterable<PackageFeature>) {
+            for (feature in features) {
+                disable(feature)
+            }
+        }
+
+        fun enable(feature: PackageFeature) {
+            val node = featureToNode[feature] ?: return
+            enableFeatureTransitively(node)
+        }
+
+        fun disable(feature: PackageFeature) {
+            val node = featureToNode[feature] ?: return
+            disableFeatureTransitively(node)
+        }
+
+        private fun enableFeatureTransitively(node: FeatureNode) {
+            if (state[node.data] == FeatureState.Enabled) return
+
+            state[node.data] = FeatureState.Enabled
+
+            for (edge in graph.incomingEdges(node)) {
+                val dependency = edge.source
+                enableFeatureTransitively(dependency)
+            }
+        }
+
+        private fun disableFeatureTransitively(node: FeatureNode) {
+            if (state[node.data] == FeatureState.Disabled) return
+
+            state[node.data] = FeatureState.Disabled
+
+            for (edge in graph.outgoingEdges(node)) {
+                val dependant = edge.target
+                disableFeatureTransitively(dependant)
+            }
+        }
+
+    }
+
+    companion object {
+        fun buildFor(features: Map<PackageFeature, List<PackageFeature>>): FeatureGraph {
+            val graph = FeaturesGraphInner()
+            val featureToNode = hashMapOf<PackageFeature, FeatureNode>()
+
+            fun addFeatureIfNeeded(feature: PackageFeature) {
+                if (feature in featureToNode) return
+                val newNode = graph.addNode(feature)
+                featureToNode[feature] = newNode
+            }
+
+            // Add nodes
+            for (feature in features.keys) {
+                addFeatureIfNeeded(feature)
+            }
+
+            // Add edges
+            for ((feature, dependencies) in features) {
+                for (dependency in dependencies) {
+                    addFeatureIfNeeded(feature)
+                    addFeatureIfNeeded(dependency)
+                    val sourceNode = featureToNode[dependency]!!
+                    val targetNode = featureToNode[feature]!!
+                    graph.addEdge(sourceNode, targetNode, Unit)
+                }
+            }
+
+            return FeatureGraph(graph, featureToNode)
+        }
+
+        val Empty: FeatureGraph
+            get() = FeatureGraph(FeaturesGraphInner(), emptyMap())
+    }
+}
+
+fun Map<PackageFeature, FeatureState>.associateByPackageRoot(): Map<PackageRoot, Map<FeatureName, FeatureState>> {
+    val map: MutableMap<PackageRoot, MutableMap<String, FeatureState>> = hashMapOf()
+    for ((feature, state) in this) {
+        map.getOrPut(feature.pkg.rootDirectory) { hashMapOf() }[feature.name] = state
+    }
+    return map
+}

--- a/src/main/kotlin/org/rust/cargo/project/workspace/PackageFeature.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/PackageFeature.kt
@@ -1,0 +1,32 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.workspace
+
+import org.rust.lang.utils.PresentableNodeData
+
+/** A [cargo feature](https://doc.rust-lang.org/cargo/reference/features.html) with [name] in some package [pkg] */
+data class PackageFeature(val pkg: CargoWorkspace.Package, val name: FeatureName) : PresentableNodeData {
+    override val text: String
+        get() = "${pkg.name}/$name"
+
+    override fun toString(): String = text
+}
+
+enum class FeatureState {
+    Enabled,
+    Disabled;
+
+    val isEnabled: Boolean
+        get() = when (this) {
+            Enabled -> true
+            Disabled -> false
+        }
+
+    operator fun not(): FeatureState = when (this) {
+        Enabled -> Disabled
+        Disabled -> Enabled
+    }
+}

--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -10,5 +10,6 @@ object RsExperiments {
     const val TEST_TOOL_WINDOW = "org.rust.cargo.test.tool.window"
     const val FETCH_OUT_DIR = "org.rust.cargo.fetch.out.dir"
     const val EVALUATE_BUILD_SCRIPTS = "org.rust.cargo.evaluate.build.scripts"
+    const val CARGO_FEATURES_SETTINGS_GUTTER = "org.rust.cargo.features.settings.gutter"
     const val MACROS_NEW_ENGINE = "org.rust.macros.new.engine"
 }

--- a/src/main/kotlin/org/rust/ide/icons/RsIcons.kt
+++ b/src/main/kotlin/org/rust/ide/icons/RsIcons.kt
@@ -7,7 +7,11 @@ package org.rust.ide.icons
 
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.util.IconLoader
+import com.intellij.ui.ColorUtil
 import com.intellij.ui.LayeredIcon
+import com.intellij.util.IconUtil
+import java.awt.Color
+import java.awt.image.RGBImageFilter
 import javax.swing.Icon
 
 /**
@@ -33,6 +37,11 @@ object RsIcons {
     val STATIC_MARK = AllIcons.Nodes.StaticMark
     val TEST_MARK = AllIcons.Nodes.JunitTestMark
     val DOCS_MARK = IconLoader.getIcon("/icons/docsrs.svg")
+    val FEATURE_CHECKED_MARK = AllIcons.Diff.GutterCheckBoxSelected
+    val FEATURE_UNCHECKED_MARK = AllIcons.Diff.GutterCheckBox
+    val FEATURE_CHECKED_MARK_GRAYED = FEATURE_CHECKED_MARK.grayed()
+    val FEATURE_UNCHECKED_MARK_GRAYED = FEATURE_UNCHECKED_MARK.grayed()
+    val FEATURES_SETTINGS = AllIcons.General.Settings
 
     // Source code elements
 
@@ -100,3 +109,13 @@ fun Icon.multiple(): Icon {
     compoundIcon.setIcon(this, 1, 0, 0)
     return compoundIcon
 }
+
+fun Icon.grayed(): Icon =
+    IconUtil.filterIcon(this, {
+        object : RGBImageFilter() {
+            override fun filterRGB(x: Int, y: Int, rgb: Int): Int {
+                val color = Color(rgb, true)
+                return ColorUtil.toAlpha(color, (color.alpha / 2.2).toInt()).rgb
+            }
+        }
+    }, null)

--- a/src/main/kotlin/org/rust/ide/inspections/RsMissingFeaturesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsMissingFeaturesInspection.kt
@@ -1,0 +1,92 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.psi.PsiFile
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.FeatureState
+import org.rust.cargo.project.workspace.PackageFeature
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.ide.inspections.fixes.EnableCargoFeaturesFix
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.ext.containingCargoTarget
+import org.rust.lang.core.psi.ext.findCargoProject
+
+class RsMissingFeaturesInspection : RsLocalInspectionTool() {
+    override fun checkFile(file: PsiFile, manager: InspectionManager, isOnTheFly: Boolean): Array<ProblemDescriptor?>? {
+        if (file !is RsFile) return null
+
+        val cargoProject = file.findCargoProject() ?: return null
+        val target = file.containingCargoTarget ?: return null
+        if (target.pkg.origin != PackageOrigin.WORKSPACE) return null
+        val missingFeatures = collectMissingFeatureForTarget(target)
+
+        return createProblemDescriptors(missingFeatures, manager, file, isOnTheFly, cargoProject)
+    }
+
+    private fun collectMissingFeatureForTarget(target: CargoWorkspace.Target): Set<PackageFeature> {
+        val missingFeatures = mutableSetOf<PackageFeature>()
+
+        collectMissingFeaturesForPackage(target.pkg, missingFeatures)
+
+        val libTarget = target.pkg.libTarget
+
+        if (libTarget != null && target != libTarget) {
+            for (requiredFeature in target.requiredFeatures) {
+                if (target.pkg.featureState[requiredFeature] == FeatureState.Disabled) {
+                    missingFeatures += PackageFeature(target.pkg, requiredFeature)
+                }
+            }
+        }
+        return missingFeatures
+    }
+
+    companion object {
+        private fun collectMissingFeaturesForPackage(pkg: CargoWorkspace.Package, missingFeatures: MutableSet<PackageFeature>) {
+            for (dep in pkg.dependencies) {
+                if (dep.pkg.origin == PackageOrigin.WORKSPACE) {
+                    for (requiredFeature in dep.requiredFeatures) {
+                        if (dep.pkg.featureState[requiredFeature] == FeatureState.Disabled) {
+                            missingFeatures += PackageFeature(dep.pkg, requiredFeature)
+                        }
+                    }
+                }
+            }
+        }
+
+        fun collectMissingFeaturesForPackage(pkg: CargoWorkspace.Package): Set<PackageFeature> {
+            val missingFeatures = mutableSetOf<PackageFeature>()
+            collectMissingFeaturesForPackage(pkg, missingFeatures)
+            return missingFeatures
+        }
+
+        fun createProblemDescriptors(
+            missingFeatures: Set<PackageFeature>,
+            manager: InspectionManager,
+            file: PsiFile,
+            isOnTheFly: Boolean,
+            cargoProject: CargoProject
+        ): Array<ProblemDescriptor?> {
+            return if (missingFeatures.isEmpty()) {
+                ProblemDescriptor.EMPTY_ARRAY
+            } else {
+                arrayOf(
+                    manager.createProblemDescriptor(
+                        file,
+                        "Missing features: ${missingFeatures.joinToString()}",
+                        isOnTheFly,
+                        arrayOf(EnableCargoFeaturesFix(cargoProject, missingFeatures)),
+                        ProblemHighlightType.WARNING
+                    )
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/EnableCargoFeaturesFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/EnableCargoFeaturesFix.kt
@@ -1,0 +1,25 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.workspace.FeatureState
+import org.rust.cargo.project.workspace.PackageFeature
+
+class EnableCargoFeaturesFix(
+    private val cargoProject: CargoProject,
+    private val features: Set<PackageFeature>
+) : LocalQuickFix {
+    override fun getFamilyName(): String = "Enable features"
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        project.cargoProjects.modifyFeatures(cargoProject, features, FeatureState.Enabled)
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.FeatureState
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.core.psi.RsFile
 import java.util.*
@@ -33,7 +34,7 @@ interface Crate {
     val origin: PackageOrigin
 
     val cfgOptions: CfgOptions
-    val features: Collection<CargoWorkspace.Feature>
+    val features: Map<String, FeatureState>
 
     /** A map of compile-time environment variables, needed for `env!("FOO")` macros expansion */
     val env: Map<String, String>

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/CargoBasedCrate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/CargoBasedCrate.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.FeatureState
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.CratePersistentId
@@ -25,7 +26,7 @@ class CargoBasedCrate(
     override val flatDependencies: LinkedHashSet<Crate>
 ) : Crate {
     override val reverseDependencies = mutableListOf<CargoBasedCrate>()
-    override var features: Collection<CargoWorkspace.Feature> = cargoTarget.pkg.features
+    override var features: Map<String, FeatureState> = cargoTarget.pkg.featureState
 
     // These properties are fields (not just delegates to `cargoTarget`) because [Crate] must be immutable
     override val rootModFile: VirtualFile? = cargoTarget.crateRoot

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/DoctestCrate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/DoctestCrate.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.FeatureState
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.CratePersistentId
@@ -32,7 +33,7 @@ class DoctestCrate(
     override val kind: CargoWorkspace.TargetKind get() = CargoWorkspace.TargetKind.Test
 
     override val cfgOptions: CfgOptions get() = CfgOptions.EMPTY
-    override val features: Collection<CargoWorkspace.Feature> get() = emptyList()
+    override val features: Map<String, FeatureState> get() = emptyMap()
     override val env: Map<String, String> get() = emptyMap()
     override val outDir: VirtualFile? get() = null
 

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
@@ -24,6 +24,8 @@ import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.testFramework.LightVirtualFile
 import com.intellij.util.messages.MessageBusConnection
 import com.intellij.util.messages.Topic
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.model.CargoProjectsService
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.lang.RsFileType
 import org.rust.lang.core.macros.MacroExpansionMode
@@ -108,6 +110,11 @@ class RsPsiManagerImpl(val project: Project) : RsPsiManager, Disposable {
         PsiManager.getInstance(project).addPsiTreeChangeListener(CacheInvalidator(), this)
         project.messageBus.connect().subscribe(ProjectTopics.PROJECT_ROOTS, object : ModuleRootListener {
             override fun rootsChanged(event: ModuleRootEvent) {
+                incRustStructureModificationCount()
+            }
+        })
+        project.messageBus.connect().subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsService.CargoProjectsListener {
+            override fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>) {
                 incRustStructureModificationCount()
             }
         })

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -225,8 +225,8 @@ private fun RsDocAndAttributeOwner.evaluateCfg(): ThreeValuedLogic {
     // this will return the library as containing package.
     // When the application now requests certain features, which are not enabled by default in the library
     // we will evaluate features wrongly here
-    val crate = containingCrate ?: return ThreeValuedLogic.True
-    val features = crate.features.associate { it.name to it.state }
+    val crate = containingCrate ?: return ThreeValuedLogic.True // TODO: maybe unknown?
+    val features = crate.features
     return CfgEvaluator(crate.cargoWorkspace.cfgOptions, crate.cfgOptions, features, crate.origin).evaluate(cfgAttributes)
 }
 

--- a/src/main/kotlin/org/rust/lang/utils/Graph.kt
+++ b/src/main/kotlin/org/rust/lang/utils/Graph.kt
@@ -124,6 +124,7 @@ class PresentableGraph<N : PresentableNodeData, E> : Graph<N, E>() {
      * Creates graph description written in the DOT language.
      * Usage: copy the output into `cfg.dot` file and run `dot -Tpng cfg.dot -o cfg.png`
      */
+    @Suppress("unused")
     fun createDotDescription(): String =
         buildString {
             append("digraph {\n")

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
@@ -8,7 +8,7 @@ package org.rust.lang.utils.evaluation
 import com.intellij.openapiext.Testmark
 import com.intellij.openapiext.isUnitTestMode
 import org.rust.cargo.CfgOptions
-import org.rust.cargo.project.workspace.CargoWorkspace.FeatureState
+import org.rust.cargo.project.workspace.FeatureState
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.core.psi.RsMetaItem
 import org.rust.lang.core.psi.ext.name
@@ -108,8 +108,8 @@ class CfgEvaluator(
     }
 
     private fun evaluateFeature(name: String): ThreeValuedLogic {
-        if (origin == PackageOrigin.WORKSPACE || origin == PackageOrigin.STDLIB) {
-            // Currently evaluates only dependency features
+        if (origin == PackageOrigin.STDLIB) {
+            // We don't have info about std features
             return Unknown
         }
 

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -559,6 +559,11 @@
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RsDetachedFileInspection"/>
 
+        <localInspection language="Rust" groupName="Rust"
+                         displayName="Missing features"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.RsMissingFeaturesInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1007,6 +1007,11 @@
 
         <console.folding implementation="org.rust.ide.console.RsConsoleFolding"/>
 
+        <!--  Experimental features -->
+        <experimentalFeature id="org.rust.cargo.features.settings.gutter" percentOfUsers="0">
+            <description>Show settings gutter icon near [features] section in `Cargo.toml` where you can enable or disable all features</description>
+        </experimentalFeature>
+
     </extensions>
 
     <extensionPoints>

--- a/src/main/resources/inspectionDescriptions/RsMissingFeatures.html
+++ b/src/main/resources/inspectionDescriptions/RsMissingFeatures.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Detects Cargo packages with missing cargo features in some of their dependency packages
+</body>
+</html>

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -71,7 +71,7 @@ open class RustProjectDescriptorBase : LightProjectDescriptor() {
     open fun testCargoProject(module: Module, contentRoot: String): CargoWorkspace {
         val packages = listOf(testCargoPackage(contentRoot))
         return CargoWorkspace.deserialize(Paths.get("${Urls.newFromIdea(contentRoot).path}/workspace/Cargo.toml"),
-            CargoWorkspaceData(packages, emptyMap()), CfgOptions.DEFAULT)
+            CargoWorkspaceData(packages, emptyMap(), emptyMap()), CfgOptions.DEFAULT)
     }
 
     protected fun testCargoPackage(contentRoot: String, name: String = "test-package") = Package(
@@ -80,18 +80,19 @@ open class RustProjectDescriptorBase : LightProjectDescriptor() {
         name = name,
         version = "0.0.1",
         targets = listOf(
-            Target("$contentRoot/main.rs", name, TargetKind.Bin, edition = Edition.EDITION_2015, doctest = true),
-            Target("$contentRoot/lib.rs", name, TargetKind.Lib(LibKind.LIB), edition = Edition.EDITION_2015, doctest = true),
-            Target("$contentRoot/bin/a.rs", name, TargetKind.Bin, edition = Edition.EDITION_2015, doctest = true),
-            Target("$contentRoot/bench/a.rs", name, TargetKind.Bench, edition = Edition.EDITION_2015, doctest = true),
-            Target("$contentRoot/example/a.rs", name, TargetKind.ExampleBin, edition = Edition.EDITION_2015, doctest = true),
-            Target("$contentRoot/example-lib/a.rs", name, TargetKind.ExampleLib(EnumSet.of(LibKind.LIB)), edition = Edition.EDITION_2015, doctest = true),
-            Target("$contentRoot/build.rs", "build_script_build", TargetKind.CustomBuild, edition = Edition.EDITION_2015, doctest = false)
+            Target("$contentRoot/main.rs", name, TargetKind.Bin, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
+            Target("$contentRoot/lib.rs", name, TargetKind.Lib(LibKind.LIB), edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
+            Target("$contentRoot/bin/a.rs", name, TargetKind.Bin, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
+            Target("$contentRoot/bench/a.rs", name, TargetKind.Bench, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
+            Target("$contentRoot/example/a.rs", name, TargetKind.ExampleBin, edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
+            Target("$contentRoot/example-lib/a.rs", name, TargetKind.ExampleLib(EnumSet.of(LibKind.LIB)), edition = Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList()),
+            Target("$contentRoot/build.rs", "build_script_build", TargetKind.CustomBuild, edition = Edition.EDITION_2015, doctest = false, requiredFeatures = emptyList())
         ),
         source = null,
         origin = PackageOrigin.WORKSPACE,
         edition = Edition.EDITION_2015,
-        features = emptyList(),
+        features = emptyMap(),
+        enabledFeatures = emptySet(),
         cfgOptions = CfgOptions.EMPTY,
         env = emptyMap(),
         outDirUrl = null
@@ -181,12 +182,13 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
                 // don't use `FileUtil.join` here because it uses `File.separator`
                 // which is system dependent although all other code uses `/` as separator
                 Target(source?.let { "$contentRoot/$it" } ?: "", targetName,
-                    TargetKind.Lib(libKind), Edition.EDITION_2015, doctest = true)
+                    TargetKind.Lib(libKind), Edition.EDITION_2015, doctest = true, requiredFeatures = emptyList())
             ),
             source = source,
             origin = origin,
             edition = Edition.EDITION_2015,
-            features = emptyList(),
+            features = emptyMap(),
+            enabledFeatures = emptySet(),
             cfgOptions = CfgOptions.EMPTY,
             env = emptyMap(),
             outDirUrl = null
@@ -232,6 +234,6 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
             packages[3].id to setOf(
                 Dependency(packages[7].id)
             )
-        )), CfgOptions.DEFAULT)
+        ), emptyMap()), CfgOptions.DEFAULT)
     }
 }

--- a/src/test/kotlin/org/rust/cargo/project/model/impl/CargoFeaturesModificationTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/impl/CargoFeaturesModificationTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.model.impl
+
+import org.intellij.lang.annotations.Language
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.workspace.FeatureState
+import org.rust.cargo.project.workspace.PackageFeature
+import org.rust.cargo.project.workspace.PackageOrigin
+
+/**
+ * Mostly tests [org.rust.cargo.project.model.impl.CargoProjectsServiceImpl.modifyFeatures] and
+ * [org.rust.cargo.project.workspace.WorkspaceImpl.inferFeatureState]
+ */
+class CargoFeaturesModificationTest : RsWithToolchainTestBase() {
+    fun `test independent features`() = doTest("""
+        foo = [] # [x]
+        bar = [] # [x]
+    """, disable("foo", """
+        foo = [] # [ ]
+        bar = [] # [x]
+    """), disable("bar", """
+        foo = [] # [ ]
+        bar = [] # [ ]
+    """), enable("foo", """
+        foo = [] # [x]
+        bar = [] # [ ]
+    """), enable("bar", """
+        foo = [] # [x]
+        bar = [] # [x]
+    """))
+
+    fun `test 2 dependent features`() = doTest("""
+        foo = ["dep"] # [x]
+        dep = []      # [x]
+    """, disable("dep", """
+        foo = ["dep"] # [ ]
+        dep = []      # [ ]
+    """), enable("foo", """
+        foo = ["dep"] # [x]
+        dep = []      # [x]
+    """), disable("foo", """
+        foo = ["dep"] # [ ]
+        dep = []      # [x]
+    """), disable("dep", """
+        foo = ["dep"] # [ ]
+        dep = []      # [ ]
+    """), enable("dep", """
+        foo = ["dep"] # [ ]
+        dep = []      # [x]
+    """))
+
+    fun `test 3 dependent features`() = doTest("""
+        foo = ["dep"] # [x]
+        bar = ["dep"] # [x]
+        dep = []      # [x]
+    """, disable("dep", """
+        foo = ["dep"] # [ ]
+        bar = ["dep"] # [ ]
+        dep = []      # [ ]
+    """), enable("foo", """
+        foo = ["dep"] # [x]
+        bar = ["dep"] # [ ]
+        dep = []      # [x]
+    """), enable("bar", """
+        foo = ["dep"] # [x]
+        bar = ["dep"] # [x]
+        dep = []      # [x]
+    """), disable("foo", """
+        foo = ["dep"] # [ ]
+        bar = ["dep"] # [x]
+        dep = []      # [x]
+    """), disable("bar", """
+        foo = ["dep"] # [ ]
+        bar = ["dep"] # [ ]
+        dep = []      # [x]
+    """), disable("dep", """
+        foo = ["dep"] # [ ]
+        bar = ["dep"] # [ ]
+        dep = []      # [ ]
+    """), enable("dep", """
+        foo = ["dep"] # [ ]
+        bar = ["dep"] # [ ]
+        dep = []      # [x]
+    """))
+
+    private fun doTest(@Language("TOML") toml: String, vararg checkingSteps: CheckingStep) {
+        buildProject {
+            toml("Cargo.toml", """
+                [package]
+                name = "intellij-rust-test"
+                version = "0.1.0"
+                authors = []
+
+                [features]
+                $toml
+            """)
+            dir("src") {
+                rust("lib.rs", "")
+            }
+        }
+
+        val tomlTrimmed = toml.trimIndent()
+        val baseFeatures = tomlTrimmed.lines().map {
+            val line = it.removeAfter("#")
+            val feature = it.removeAfter("=").trim()
+            feature to line
+        }
+
+        var cargoProject = project.cargoProjects.allProjects.singleOrNull() ?: error("Cargo project is not created")
+        val workspace = cargoProject.workspace ?: error("Cargo workspace is not created")
+        var pkg = workspace.packages.single { it.origin == PackageOrigin.WORKSPACE }
+
+        assertEquals(tomlTrimmed, baseFeatures.withState(pkg.featureState))
+
+        for ((i, action) in checkingSteps.withIndex()) {
+            project.cargoProjects.modifyFeatures(cargoProject, setOf(PackageFeature(pkg, action.feature)), action.action)
+
+            cargoProject = project.cargoProjects.allProjects.singleOrNull() ?: error("Cargo project is not created")
+            pkg = cargoProject.workspace!!.packages.find { it.rootDirectory == pkg.rootDirectory }!!
+
+            assertEquals("${i + 1}th iteration, just ${action.action.toString().toLowerCase()} `${action.feature}` ",
+                action.result.trimIndent(),
+                baseFeatures.withState(pkg.featureState)
+            )
+        }
+    }
+
+    private fun enable(
+        @Language("TOML", suffix = "=1") feature: String,
+        @Language("TOML") result: String
+    ): CheckingStep = CheckingStep(feature, FeatureState.Enabled, result)
+
+    private fun disable(
+        @Language("TOML", suffix = "=1") feature: String,
+        @Language("TOML") result: String
+    ): CheckingStep = CheckingStep(feature, FeatureState.Disabled, result)
+
+    private data class CheckingStep(val feature: String, val action: FeatureState, val result: String)
+}
+
+private fun List<Pair<String, String>>.withState(featureState: Map<String, FeatureState>): String {
+    return joinToString(separator = "\n") {
+        val state = featureState[it.first] ?: error("Feature `${it.first}` not found")
+        val sign = if (state.isEnabled) "x" else " "
+        it.second + "# [$sign]"
+    }
+}
+
+private fun String.removeAfter(s: String): String {
+    val index = indexOf(s).takeIf { it != -1 } ?: return this
+    return substring(0, index)
+}

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestBase.kt
@@ -11,8 +11,6 @@ import com.intellij.execution.actions.RunConfigurationProducer
 import com.intellij.execution.impl.RunnerAndConfigurationSettingsImpl
 import com.intellij.ide.DataManager
 import com.intellij.openapi.actionSystem.LangDataKeys.PSI_ELEMENT_ARRAY
-import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
@@ -198,19 +196,22 @@ abstract class RunConfigurationProducerTestBase : RsTestBase() {
                                     it.name,
                                     it.kind,
                                     it.edition,
-                                    doctest = true
+                                    doctest = true,
+                                    requiredFeatures = emptyList()
                                 )
                             },
                             source = null,
                             origin = PackageOrigin.WORKSPACE,
                             edition = Edition.EDITION_2015,
-                            features = emptyList(),
+                            features = emptyMap(),
+                            enabledFeatures = emptySet(),
                             cfgOptions = CfgOptions.EMPTY,
                             env = emptyMap(),
                             outDirUrl = null
                         )
                     ),
-                    dependencies = emptyMap()
+                    dependencies = emptyMap(),
+                    rawDependencies = emptyMap()
                 ),
                 CfgOptions.DEFAULT
             )

--- a/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
@@ -152,7 +152,8 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
             name = name,
             kind = kind,
             edition = edition,
-            doctest = true
+            doctest = true,
+            requiredFeatures = emptyList()
         )
 
         fun pkg(
@@ -169,7 +170,8 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
             source = null,
             origin = if (isWorkspaceMember) PackageOrigin.WORKSPACE else PackageOrigin.DEPENDENCY,
             edition = edition,
-            features = emptyList(),
+            features = emptyMap(),
+            enabledFeatures = emptySet(),
             cfgOptions = CfgOptions.EMPTY,
             env = emptyMap(),
             outDirUrl = null
@@ -183,6 +185,14 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
             )),
             pkg("quux", false, listOf(target("quux", TargetKind.Lib(LibKind.LIB))))
         )
-        CargoWorkspace.deserialize(Paths.get("/my-crate/Cargo.toml"), CargoWorkspaceData(pkgs, dependencies = emptyMap()), CfgOptions.DEFAULT)
+        CargoWorkspace.deserialize(
+            Paths.get("/my-crate/Cargo.toml"),
+            CargoWorkspaceData(
+                pkgs,
+                dependencies = emptyMap(),
+                rawDependencies = emptyMap()
+            ),
+            CfgOptions.DEFAULT
+        )
     }
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsMissingFeaturesInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsMissingFeaturesInspectionTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import com.intellij.testFramework.InspectionTestUtil
+import org.rust.FileTree
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.workspace.FeatureState
+import org.rust.cargo.project.workspace.PackageFeature
+import org.rust.fileTree
+
+class RsMissingFeaturesInspectionTest : RsWithToolchainTestBase() {
+    fun `test missing dependency feature`() = doTest(
+        fileTree {
+            toml("Cargo.toml", """
+                [workspace]
+                members = ["foo", "bar"]
+            """)
+
+            dir("foo") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "foo"
+                    version = "0.1.0"
+                    authors = []
+
+                    [dependencies]
+                    bar = { path = "../bar", features = ["feature_bar"] }
+                """)
+                dir("src") {
+                    file("main.rs", """
+                        <warning descr="Missing features: bar/feature_bar">
+                        fn main() {}
+                        </warning>
+                    """)
+                }
+            }
+
+            dir("bar") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "bar"
+                    version = "0.1.0"
+                    authors = []
+
+                    [features]
+                    feature_bar = [] # disabled
+                """)
+                dir("src") {
+                    file("lib.rs", "")
+                }
+            }
+        },
+        pkgWithFeature = "bar",
+        featureName = "feature_bar",
+        fileToCheck = "foo/src/main.rs"
+    )
+
+    fun `test missing required target feature`() = doTest(
+        fileTree {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+
+                [[bin]]
+                name = "main"
+                path = "src/main.rs"
+                required-features = ["feature_hello"]
+
+                [features]
+                feature_hello = []
+
+                [dependencies]
+            """)
+            dir("src") {
+                file("main.rs", """
+                    <warning descr="Missing features: hello/feature_hello">
+                    fn main() {}
+                    </warning>
+                """)
+                file("lib.rs", "")
+            }
+        },
+        pkgWithFeature = "hello",
+        featureName = "feature_hello",
+        fileToCheck = "src/main.rs"
+    )
+
+    private fun doTest(tree: FileTree, pkgWithFeature: String, featureName: String, fileToCheck: String) {
+        tree.create()
+
+        val cargoProject = project.cargoProjects.allProjects.singleOrNull() ?: error("Cargo project is not created")
+        val workspace = cargoProject.workspace ?: error("Workspace is not created")
+        val pkg = workspace.packages.find { it.name == pkgWithFeature } ?: error("Package $pkgWithFeature not found")
+
+        project.cargoProjects.modifyFeatures(cargoProject, setOf(PackageFeature(pkg, featureName)), FeatureState.Disabled)
+
+        val enabledInspections = InspectionTestUtil.instantiateTool(RsMissingFeaturesInspection::class.java)
+        myFixture.enableInspections(enabledInspections)
+
+        myFixture.openFileInEditor(cargoProjectDirectory.findFileByRelativePath(fileToCheck)!!)
+        myFixture.checkHighlighting(
+            /* checkWarnings = */ true,
+            /* checkInfos = */ false,
+            /* checkWeakWarnings = */ false
+        )
+    }
+}

--- a/toml/src/main/kotlin/org/rust/toml/CargoFeatureLineMarkerProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoFeatureLineMarkerProvider.kt
@@ -1,0 +1,220 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml
+
+import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProvider
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.editor.markup.GutterIconRenderer.Alignment
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.ui.popup.JBPopup
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.ui.awt.RelativePoint
+import org.rust.cargo.CargoConstants
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.model.CargoProjectsService
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.FeatureState
+import org.rust.cargo.project.workspace.PackageFeature
+import org.rust.cargo.project.workspace.PackageOrigin.WORKSPACE
+import org.rust.ide.experiments.RsExperiments
+import org.rust.ide.icons.RsIcons
+import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psi.ext.elementType
+import org.rust.lang.core.psi.ext.findCargoPackage
+import org.rust.lang.core.psi.ext.findCargoProject
+import org.rust.openapiext.isFeatureEnabled
+import org.rust.openapiext.saveAllDocuments
+import org.toml.lang.psi.*
+import java.awt.event.MouseEvent
+
+class CargoFeatureLineMarkerProvider : LineMarkerProvider {
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? = null
+
+    override fun collectSlowLineMarkers(
+        elements: List<PsiElement>,
+        result: MutableCollection<in LineMarkerInfo<*>>
+    ) {
+        if (!tomlPluginIsAbiCompatible()) return
+
+        val firstElement = elements.firstOrNull() ?: return
+        val file = firstElement.containingFile as? TomlFile ?: return
+        if (!file.name.equals(CargoConstants.MANIFEST_FILE, ignoreCase = true)) return
+        val cargoPackage = file.findCargoPackage() ?: return
+        val features = cargoPackage.featureState
+
+        loop@ for (element in elements) {
+            val parent = element.parent
+            if (parent is TomlKey) {
+                val key = parent
+                val isFeatureKey = key.isFeatureKey
+                if (!isFeatureKey && !key.isDependencyName) continue@loop
+                val featureName = key.text
+                if ("." in featureName) continue@loop
+                if (!isFeatureKey && featureName !in features) continue@loop
+                result += genFeatureLineMarkerInfo(
+                    key,
+                    featureName,
+                    features[featureName],
+                    cargoPackage
+                )
+            }
+            if (isFeatureEnabled(RsExperiments.CARGO_FEATURES_SETTINGS_GUTTER)
+                && element.elementType == TomlElementTypes.L_BRACKET && cargoPackage.origin == WORKSPACE) {
+                val header = parent as? TomlTableHeader ?: continue@loop
+                if (!header.isFeatureListHeader) continue@loop
+                result += genSettingsLineMarkerInfo(header)
+            }
+        }
+    }
+
+    private val PsiElement.isDependencyName
+        get() = CargoTomlPsiPattern.onDependencyKey.accepts(this) ||
+            CargoTomlPsiPattern.onSpecificDependencyHeaderKey.accepts(this)
+
+    private val TomlKey.isFeatureKey: Boolean
+        get() {
+            val keyValue = parent as? TomlKeyValue ?: return false
+            val table = keyValue.parent as? TomlTable ?: return false
+            return table.header.isFeatureListHeader
+        }
+
+    private fun genFeatureLineMarkerInfo(
+        element: TomlKey,
+        name: String,
+        featureState: FeatureState?,
+        cargoPackage: CargoWorkspace.Package
+    ): LineMarkerInfo<PsiElement> {
+        val anchor = element.firstChild
+
+        return when (cargoPackage.origin) {
+            WORKSPACE -> {
+                val icon = when (featureState) {
+                    FeatureState.Enabled -> RsIcons.FEATURE_CHECKED_MARK
+                    FeatureState.Disabled, null -> RsIcons.FEATURE_UNCHECKED_MARK
+                }
+                LineMarkerInfo(
+                    anchor,
+                    anchor.textRange,
+                    icon,
+                    { "Toggle feature `$name`" },
+                    ToggleFeatureAction,
+                    Alignment.RIGHT
+                )
+            }
+
+            else -> {
+                val icon = when (featureState) {
+                    FeatureState.Enabled -> RsIcons.FEATURE_CHECKED_MARK_GRAYED
+                    FeatureState.Disabled, null -> RsIcons.FEATURE_UNCHECKED_MARK_GRAYED
+                }
+                LineMarkerInfo(
+                    anchor,
+                    anchor.textRange,
+                    icon,
+                    { "Feature `$name` is $featureState" },
+                    null,
+                    Alignment.RIGHT
+                )
+            }
+        }
+    }
+
+    private fun genSettingsLineMarkerInfo(header: TomlTableHeader): LineMarkerInfo<PsiElement> {
+        val anchor = header.firstChild
+
+        return LineMarkerInfo(
+            anchor,
+            anchor.textRange,
+            RsIcons.FEATURES_SETTINGS,
+            { "Configure features" },
+            OpenSettingsAction,
+            Alignment.RIGHT
+        )
+    }
+}
+
+private object ToggleFeatureAction : GutterIconNavigationHandler<PsiElement> {
+    override fun navigate(e: MouseEvent, element: PsiElement) {
+        val context = getContext(element) ?: return
+        val featureName = element.ancestorStrict<TomlKey>()?.text ?: return
+        val oldState = context.cargoPackage.featureState.getOrDefault(featureName, FeatureState.Disabled)
+        val newState = !oldState
+        val tomlDoc = PsiDocumentManager.getInstance(context.cargoProject.project).getDocument(element.containingFile)
+        val isDocUnsaved = tomlDoc != null && FileDocumentManager.getInstance().isDocumentUnsaved(tomlDoc)
+
+        if (isDocUnsaved) {
+            runWriteAction { saveAllDocuments() }
+            context.cargoProjectsService.refreshAllProjects()
+        }
+
+        context.cargoProjectsService.modifyFeatures(
+            context.cargoProject,
+            setOf(PackageFeature(context.cargoPackage, featureName)),
+            newState
+        )
+    }
+}
+
+private object OpenSettingsAction : GutterIconNavigationHandler<PsiElement> {
+    override fun navigate(e: MouseEvent, element: PsiElement) {
+        val context = getContext(element) ?: return
+        createActionGroupPopup(context).show(RelativePoint(e))
+    }
+
+    private fun createActionGroupPopup(context: Context): JBPopup {
+        val actions = listOf(
+            FeaturesSettingsCheckboxAction(context, FeatureState.Enabled),
+            FeaturesSettingsCheckboxAction(context, FeatureState.Disabled)
+        )
+        val group = DefaultActionGroup(actions)
+        val dataContext = SimpleDataContext.getProjectContext(context.cargoProject.project)
+        return JBPopupFactory.getInstance()
+            .createActionGroupPopup(null, group, dataContext, JBPopupFactory.ActionSelectionAid.SPEEDSEARCH, true)
+    }
+
+    private class FeaturesSettingsCheckboxAction(
+        private val context: Context,
+        private val newState: FeatureState
+    ) : AnAction() {
+
+        init {
+            val text = when (newState) {
+                FeatureState.Enabled -> "Enable all features"
+                FeatureState.Disabled -> "Disable all features"
+            }
+            templatePresentation.description = text
+            templatePresentation.text = text
+        }
+
+        override fun actionPerformed(e: AnActionEvent) {
+            context.cargoProjectsService.modifyFeatures(context.cargoProject, context.cargoPackage.features, newState)
+        }
+    }
+}
+
+private data class Context(
+    val cargoProjectsService: CargoProjectsService,
+    val cargoProject: CargoProject,
+    val cargoPackage: CargoWorkspace.Package
+)
+
+private fun getContext(element: PsiElement): Context? {
+    val file = element.containingFile as? TomlFile ?: return null
+    if (!file.name.equals(CargoConstants.MANIFEST_FILE, ignoreCase = true)) return null
+
+    val cargoProject = file.findCargoProject() ?: return null
+    val cargoPackage = file.findCargoPackage() ?: return null
+    return Context(file.project.cargoProjects, cargoProject, cargoPackage)
+}

--- a/toml/src/main/kotlin/org/rust/toml/Util.kt
+++ b/toml/src/main/kotlin/org/rust/toml/Util.kt
@@ -48,8 +48,17 @@ val TomlKey.isDependencyKey: Boolean
         return text == "dependencies" || text == "dev-dependencies" || text == "build-dependencies"
     }
 
+val TomlKey.isFeaturesKey: Boolean
+    get() {
+        val text = text
+        return text == "features"
+    }
+
 val TomlTableHeader.isDependencyListHeader: Boolean
     get() = names.lastOrNull()?.isDependencyKey == true
+
+val TomlTableHeader.isFeatureListHeader: Boolean
+    get() = names.lastOrNull()?.isFeaturesKey == true
 
 /** Inserts `=` between key and value if missed and wraps inserted string with quotes if needed */
 class StringValueInsertionHandler(private val keyValue: TomlKeyValue) : InsertHandler<LookupElement> {

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CargoTomlMissingFeaturesInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CargoTomlMissingFeaturesInspection.kt
@@ -1,0 +1,28 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.psi.PsiFile
+import org.rust.cargo.CargoConstants
+import org.rust.ide.inspections.RsMissingFeaturesInspection
+import org.rust.lang.core.psi.ext.findCargoPackage
+import org.rust.lang.core.psi.ext.findCargoProject
+import org.rust.openapiext.pathAsPath
+
+class CargoTomlMissingFeaturesInspection : LocalInspectionTool() {
+    override fun checkFile(file: PsiFile, manager: InspectionManager, isOnTheFly: Boolean): Array<ProblemDescriptor?>? {
+        if (file.name != CargoConstants.MANIFEST_FILE) return null
+
+        val cargoProject = file.findCargoProject() ?: return null
+        val pkg = file.findCargoPackage()?.takeIf { it.rootDirectory == file.virtualFile?.parent?.pathAsPath } ?: return null
+        val missingFeatures = RsMissingFeaturesInspection.collectMissingFeaturesForPackage(pkg)
+
+        return RsMissingFeaturesInspection.createProblemDescriptors(missingFeatures, manager, file, isOnTheFly, cargoProject)
+    }
+}

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -6,6 +6,8 @@
                                 implementationClass="org.rust.toml.completion.CargoTomlCompletionContributor"/>
         <codeInsight.lineMarkerProvider language="TOML"
                                         implementationClass="org.rust.toml.CargoCrateDocLineMarkerProvider"/>
+        <codeInsight.lineMarkerProvider language="TOML"
+                                        implementationClass="org.rust.toml.CargoFeatureLineMarkerProvider"/>
         <codeInsight.gotoSuper language="TOML" implementationClass="org.rust.toml.CargoTomlGotoSuperHandler"/>
     </extensions>
 </idea-plugin>

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -9,5 +9,10 @@
         <codeInsight.lineMarkerProvider language="TOML"
                                         implementationClass="org.rust.toml.CargoFeatureLineMarkerProvider"/>
         <codeInsight.gotoSuper language="TOML" implementationClass="org.rust.toml.CargoTomlGotoSuperHandler"/>
+
+        <localInspection language="TOML" groupName="Rust"
+                         displayName="Missing features"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.toml.inspections.CargoTomlMissingFeaturesInspection"/>
     </extensions>
 </idea-plugin>

--- a/toml/src/main/resources/inspectionDescriptions/CargoTomlMissingFeatures.html
+++ b/toml/src/main/resources/inspectionDescriptions/CargoTomlMissingFeatures.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Detects Cargo packages with missing cargo features in some of their dependency packages
+</body>
+</html>

--- a/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
@@ -5,42 +5,11 @@
 
 package org.rust.toml
 
-import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.project.Project
-import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
-import org.rust.RsTestBase
 import org.rust.WithStdlibAndDependencyRustProjectDescriptor
 
 @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
-class CargoCrateDocLineMarkerProviderTest : RsTestBase() {
-    protected fun doTestByText(@Language("toml") source: String) {
-        myFixture.configureByText("cargo.toml", source)
-        myFixture.doHighlighting()
-        val expected = markersFrom(source)
-        val actual = markersFrom(myFixture.editor, myFixture.project)
-        assertEquals(expected.joinToString(COMPARE_SEPARATOR), actual.joinToString(COMPARE_SEPARATOR))
-    }
-
-    private fun markersFrom(text: String) =
-        text.split('\n')
-            .withIndex()
-            .filter { it.value.contains(MARKER) }
-            .map { Pair(it.index, it.value.substring(it.value.indexOf(MARKER) + MARKER.length).trim()) }
-
-    private fun markersFrom(editor: Editor, project: Project) =
-        DaemonCodeAnalyzerImpl.getLineMarkers(editor.document, project)
-            .map {
-                Pair(editor.document.getLineNumber(it.element?.textRange?.startOffset as Int), it.lineMarkerTooltip)
-            }
-            .sortedBy { it.first }
-
-    private companion object {
-        val MARKER = "# - "
-        val COMPARE_SEPARATOR = " | "
-    }
-
+class CargoCrateDocLineMarkerProviderTest : CargoTomlLineMarkerProviderTestBase() {
     fun `test standard version`() = doTestByText("""
         [dependencies]
         base64 = "0.8.0"  # - Open documentation for `base64@^0.8.0`

--- a/toml/src/test/kotlin/org/rust/toml/CargoFeatureLineMarkerProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoFeatureLineMarkerProviderTest.kt
@@ -1,0 +1,19 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml
+
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibAndDependencyRustProjectDescriptor
+
+@ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
+class CargoFeatureLineMarkerProviderTest : CargoTomlLineMarkerProviderTestBase() {
+    fun `test simple features`() = doTestByText("""
+        [features]
+        foo = []   # - Toggle feature `foo`
+        bar = []   # - Toggle feature `bar`
+        foobar = ["foo", "bar"]  # - Toggle feature `foobar`
+    """)
+}

--- a/toml/src/test/kotlin/org/rust/toml/CargoTomlLineMarkerProviderTestBase.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoTomlLineMarkerProviderTestBase.kt
@@ -1,0 +1,43 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml
+
+import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+
+abstract class CargoTomlLineMarkerProviderTestBase : RsTestBase() {
+    protected fun doTestByText(@Language("Toml") source: String) {
+        myFixture.configureByText("Cargo.toml", source)
+        myFixture.doHighlighting()
+        val expected = markersFrom(source)
+        val actual = markersFrom(myFixture.editor, myFixture.project)
+        assertEquals(expected.joinToString(COMPARE_SEPARATOR), actual.joinToString(COMPARE_SEPARATOR))
+    }
+
+    private fun markersFrom(text: String): List<Pair<Int, String>> =
+        text.lines()
+            .withIndex()
+            .filter { it.value.contains(MARKER) }
+            .map { (index, line) ->
+                index to line.substringAfter(MARKER).trim()
+            }
+
+    private fun markersFrom(editor: Editor, project: Project): List<Pair<Int, String>> =
+        DaemonCodeAnalyzerImpl.getLineMarkers(editor.document, project)
+            .map {
+                val startOffset = it.element!!.textRange.startOffset
+                editor.document.getLineNumber(startOffset) to it.lineMarkerTooltip!!
+            }
+            .sortedBy { it.first }
+
+    private companion object {
+        const val MARKER = "# - "
+        const val COMPARE_SEPARATOR = " | "
+    }
+}

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlMissingFeaturesInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlMissingFeaturesInspectionTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.testFramework.InspectionTestUtil
+import org.rust.FileTree
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.workspace.FeatureState
+import org.rust.cargo.project.workspace.PackageFeature
+import org.rust.fileTree
+
+class CargoTomlMissingFeaturesInspectionTest : RsWithToolchainTestBase() {
+    fun `test missing dependency feature`() = doTest(
+        fileTree {
+            toml("Cargo.toml", """
+                [workspace]
+                members = ["foo", "bar"]
+            """)
+
+            dir("foo") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "foo"
+                    version = "0.1.0"
+                    authors = []
+
+                    [dependencies]
+                    bar = { path = "../bar", features = ["feature_bar"] }
+                """)
+                dir("src") {
+                    file("main.rs", """
+                        fn main() {}
+                    """)
+                }
+            }
+
+            dir("bar") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "bar"
+                    version = "0.1.0"
+                    authors = []
+
+                    [features]
+                    feature_bar = [] # disabled
+                """)
+                dir("src") {
+                    file("lib.rs", "")
+                }
+            }
+        },
+        pkgWithFeature = "bar",
+        featureName = "feature_bar",
+        "foo/Cargo.toml"
+    )
+
+    private fun doTest(tree: FileTree, pkgWithFeature: String, featureName: String, vararg filesToCheck: String) {
+        tree.create()
+
+        val cargoProject = project.cargoProjects.allProjects.singleOrNull() ?: error("Cargo project is not created")
+        val workspace = cargoProject.workspace ?: error("Workspace is not created")
+        val pkg = workspace.packages.find { it.name == pkgWithFeature } ?: error("Package $pkgWithFeature not found")
+
+        project.cargoProjects.modifyFeatures(cargoProject, setOf(PackageFeature(pkg, featureName)), FeatureState.Disabled)
+
+        val enabledInspection = InspectionTestUtil.instantiateTool(CargoTomlMissingFeaturesInspection::class.java)
+        myFixture.enableInspections(enabledInspection)
+
+        for (fileToCheck in filesToCheck) {
+            myFixture.openFileInEditor(cargoProjectDirectory.findFileByRelativePath(fileToCheck)!!)
+            val infos = myFixture.doHighlighting(HighlightSeverity.WARNING)
+            val info = infos.singleOrNull() ?: error("Not a single annotation in `$fileToCheck`: $infos")
+            assertEquals("in `$fileToCheck`", enabledInspection.id, info.inspectionToolId)
+        }
+    }
+}


### PR DESCRIPTION
Related to #4693.

This PR is logically based on the original @kumbayo's PRs (thank you very much for your work!) but provides a different UI/UX for viewing and enabling/disabling features.
Closes #2166
Closes #2840
Closes #3031
Closes #2821
Closes #4075
Closes #6215

Now user can enable or disable any specific workspace feature in the `Cargo.toml` file, and our name resolution and other code insight will take them into account.

![features](https://user-images.githubusercontent.com/4854600/78377554-6a001f00-75d8-11ea-8b7b-39377dcebe2b.gif)

Also supports features in workspaces with multiple packages and relations between them:

![features2](https://user-images.githubusercontent.com/4854600/78772805-fd4fa080-799a-11ea-8d3f-d825c610ba7c.gif)
