### PR TITLE
Add support for blacklisting to RsInlayParameterHintsProvider

### DIFF
--- a/src/main/kotlin/org/rust/ide/hints/RsInlayParameterHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/RsInlayParameterHintsProvider.kt
@@ -10,6 +10,15 @@ import com.intellij.codeInsight.hints.InlayInfo
 import com.intellij.codeInsight.hints.InlayParameterHintsProvider
 import com.intellij.codeInsight.hints.Option
 import com.intellij.psi.PsiElement
+import org.rust.lang.RsLanguage
+import org.rust.lang.core.psi.RsCallExpr
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsMethodCall
+import org.rust.lang.core.psi.RsPathExpr
+import org.rust.lang.core.psi.ext.patText
+import org.rust.lang.core.psi.ext.qualifiedName
+import org.rust.lang.core.psi.ext.selfParameter
+import org.rust.lang.core.psi.ext.valueParameters
 
 class RsInlayParameterHintsProvider : InlayParameterHintsProvider {
     override fun getSupportedOptions(): List<Option> =
@@ -17,7 +26,13 @@ class RsInlayParameterHintsProvider : InlayParameterHintsProvider {
 
     override fun getDefaultBlackList(): Set<String> = emptySet()
 
-    override fun getHintInfo(element: PsiElement): HintInfo? = null
+    override fun getHintInfo(element: PsiElement): HintInfo? {
+        return when (element) {
+            is RsCallExpr -> resolve(element)
+            is RsMethodCall -> resolve(element)
+            else -> null
+        }
+    }
 
     override fun getParameterHints(element: PsiElement): List<InlayInfo> {
         val resolved = RsPlainHint.resolve(element) ?: return emptyList()
@@ -26,4 +41,34 @@ class RsInlayParameterHintsProvider : InlayParameterHintsProvider {
     }
 
     override fun getInlayPresentation(inlayText: String): String = inlayText
+
+    override fun getBlacklistExplanationHTML(): String {
+        return """
+            To disable hints for a function use the appropriate pattern:<br />
+            <b>std::*</b> - functions from the standard library<br />
+            <b>std::fs::*(*, *)</b> - functions from the <i>std::fs</i> module with two parameters<br />
+            <b>(*_)</b> - single parameter function where the parameter name ends with <i>_</i><br />
+            <b>(key, value)</b> - functions with parameters <i>key</i> and <i>value</i><br />
+            <b>*.put(key, value)</b> - <i>put</i> functions with <i>key</i> and <i>value</i> parameters
+        """.trimIndent()
+    }
+
+    companion object {
+        private fun resolve(call: RsCallExpr): HintInfo.MethodInfo? {
+            val fn = (call.expr as? RsPathExpr)?.path?.reference?.resolve() as? RsFunction ?: return null
+            return createMethodInfo(fn, fn.valueParameters.map { it.patText ?: "_" })
+        }
+
+        private fun resolve(methodCall: RsMethodCall): HintInfo.MethodInfo? {
+            val fn = methodCall.reference.resolve() as? RsFunction? ?: return null
+            return createMethodInfo(fn, listOfNotNull(fn.selfParameter?.name) + fn.valueParameters.map {
+                it.patText ?: "_"
+            })
+        }
+
+        private fun createMethodInfo(function: RsFunction, parameters: List<String>): HintInfo.MethodInfo? {
+            val path = function.qualifiedName ?: return null
+            return HintInfo.MethodInfo(path, parameters, RsLanguage)
+        }
+    }
 }


### PR DESCRIPTION
Adds support for blacklisting to parameter hints. The explanation HTML was largely adapted from the Java example shown by @ortem, with some adaptations for Rust (`std` module and `_` patterns in parameters).

Questions:
1) The type hint provider has a method which shows an example window in the settings. `InlayParameterHintsProvider` has `getSettingsPreview`, but even if I implement it it doesn't show any preview in the settings. Is this the correct method to implement?
2) Is there a way to test this?
3) Should we provide some special syntax for the local crate? For example we could put `$crate::module` syntax into the blacklist and then use this path for crate-local functions.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5167