### PR TITLE
Recognize irrefutable constant patterns

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPat.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPat.kt
@@ -26,7 +26,9 @@ val RsPat.isIrrefutable: Boolean
             pat.path.isIrrefutable && pat.patList.all { it.isIrrefutable }
         is RsPatIdent ->
             pat.patBinding.isIrrefutable
-        is RsPatConst, is RsPatRange ->
+        is RsPatConst ->
+            (pat.expr as? RsPathExpr)?.path?.isIrrefutable ?: false
+        is RsPatRange ->
             false
         else ->
             true

--- a/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt
@@ -682,4 +682,40 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention()) {
             }
         }
     """)
+
+    fun `test irrefutable single variant enum`() = doAvailableTest("""
+        enum V { V1 }
+        fn foo(v: V) {
+            if let V::V1 = v/*caret*/ {
+                println!("hello");
+            }
+        }
+    """, """
+        enum V { V1 }
+        fn foo(v: V) {
+            match v {
+                V::V1 => {
+                    println!("hello");
+                }
+            }
+        }
+    """)
+
+    fun `test irrefutable struct`() = doAvailableTest("""
+        struct S;
+        fn foo(s: S) {
+            if let S = s/*caret*/ {
+                println!("hello");
+            }
+        }
+    """, """
+        struct S;
+        fn foo(s: S) {
+            match s {
+                S => {
+                    println!("hello");
+                }
+            }
+        }
+    """)
 }


### PR DESCRIPTION
Adds support for `RsPat.isIrrefutable` for `RsPatConst`.