### PR TITLE
MACRO: use common task queue with cargo sync

### DIFF
--- a/src/main/kotlin/org/rust/RsProjectTaskQueueService.kt
+++ b/src/main/kotlin/org/rust/RsProjectTaskQueueService.kt
@@ -1,0 +1,254 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.*
+import com.intellij.openapi.progress.impl.BackgroundableProcessIndicator
+import com.intellij.openapi.progress.impl.ProgressManagerImpl
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Condition
+import com.intellij.openapiext.isHeadlessEnvironment
+import com.intellij.openapiext.isUnitTestMode
+import com.intellij.util.PairConsumer
+import com.intellij.util.concurrency.QueueProcessor
+import org.rust.RsTask.TaskType.*
+import org.rust.openapiext.DelayedBackgroundableProcessIndicator
+import org.rust.openapiext.checkIsDispatchThread
+import org.rust.stdext.exhaustive
+import java.util.function.BiConsumer
+
+/**
+ * A common queue for cargo and macro expansion tasks that should be executed sequentially.
+ * Can run any [Task.Backgroundable], but provides additional features for tasks that implement [RsTask].
+ * The most important feature is that newly submitted tasks can cancel a currently running task or
+ * tasks in the queue (See [RsTask.taskType]).
+ */
+@Service
+class RsProjectTaskQueueService : Disposable {
+    private val queue: RsBackgroundTaskQueue = RsBackgroundTaskQueue()
+
+    /** Submits a task. A task can implement [RsTask] */
+    fun run(task: Task.Backgroundable) = queue.run(task)
+
+    /** Equivalent to running an empty task with [RsTask.taskType] = [taskType] */
+    fun cancelTasks(taskType: RsTask.TaskType) = queue.cancelTasks(taskType)
+
+    /** @return true if no running or pending tasks */
+    val isEmpty: Boolean get() = queue.isEmpty
+
+    override fun dispose() {
+        queue.dispose()
+    }
+}
+
+val Project.taskQueue: RsProjectTaskQueueService get() = service()
+
+interface RsTask {
+    @JvmDefault
+    val taskType: TaskType
+        get() = TaskType.INDEPENDENT
+
+    @JvmDefault
+    val progressBarShowDelay: Int
+        get() = 0
+
+    /** If true, the task will not be run (and progress bar will not be shown) until the smart mode */
+    @JvmDefault
+    val waitForSmartMode: Boolean
+        get() = false
+
+    @JvmDefault
+    val runSyncInUnitTests: Boolean
+        get() = false
+
+    /**
+     * Higher position in the enum means higher priority; Newly submitted tasks with higher or equal
+     * priority cancels other tasks with lower or equal priority if [canBeCanceledByOther] == true.
+     * E.g. [CARGO_SYNC] cancels [MACROS_UNPROCESSED] and subsequent but not [MACROS_CLEAR] or itself.
+     * [MACROS_UNPROCESSED] cancels itself, [MACROS_FULL] and subsequent.
+     */
+    enum class TaskType(val canBeCanceledByOther: Boolean = true) {
+        CARGO_SYNC(canBeCanceledByOther = false),
+        MACROS_CLEAR(canBeCanceledByOther = false),
+        MACROS_UNPROCESSED,
+        MACROS_FULL,
+        MACROS_WORKSPACE,
+
+        /** Can't be canceled, cancels nothing. Should be the last variant of the enum. */
+        INDEPENDENT(canBeCanceledByOther = false);
+
+        fun canCancelOther(other: TaskType): Boolean =
+            other.canBeCanceledByOther && this.ordinal <= other.ordinal
+    }
+}
+
+/** Inspired by [BackgroundTaskQueue] */
+private class RsBackgroundTaskQueue {
+    private val LOG = Logger.getInstance(RsBackgroundTaskQueue::class.java)
+    private val processor = QueueProcessor<ContinuableRunnable>(
+        QueueConsumer(),
+        true,
+        QueueProcessor.ThreadToUse.AWT,
+        Condition<Any> { isDisposed }
+    )
+
+    @Volatile
+    private var isDisposed: Boolean = false
+
+    // Guarded by self object monitor (@Synchronized)
+    private val cancelableTasks: MutableList<BackgroundableTaskData> = mutableListOf()
+
+    val isEmpty: Boolean get() = processor.isEmpty
+
+    @Synchronized
+    fun run(task: Task.Backgroundable) {
+        if (isUnitTestMode && task is RsTask && task.runSyncInUnitTests) {
+            runTaskInCurrentThread(task)
+        } else {
+            LOG.debug("Scheduling task $task")
+            if (task is RsTask) {
+                cancelTasks(task.taskType)
+            }
+            val data = BackgroundableTaskData(task, ::onFinish)
+
+            // Add to cancelable tasks even if the task is not [RsTaskExt] b/c it still can be canceled by [cancelAll]
+            cancelableTasks += data
+
+            processor.add(data)
+        }
+    }
+
+    private fun runTaskInCurrentThread(task: Task.Backgroundable) {
+        check(isUnitTestMode)
+        val pm = ProgressManager.getInstance() as ProgressManagerImpl
+        pm.runProcessWithProgressInCurrentThread(task, EmptyProgressIndicator(), ModalityState.NON_MODAL)
+    }
+
+    @Synchronized
+    fun cancelTasks(taskType: RsTask.TaskType) {
+        cancelableTasks.removeIf { data ->
+            if (data.task is RsTask && taskType.canCancelOther(data.task.taskType)) {
+                data.cancel()
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    @Synchronized
+    private fun onFinish(data: BackgroundableTaskData) {
+        cancelableTasks.remove(data)
+    }
+
+    fun dispose() {
+        isDisposed = true
+        processor.clear()
+        cancelAll()
+    }
+
+    @Synchronized
+    private fun cancelAll() {
+        for (task in cancelableTasks) {
+            task.cancel()
+        }
+        cancelableTasks.clear()
+    }
+
+    private interface ContinuableRunnable {
+        fun run(continuation: Runnable)
+    }
+
+    // BACKCOMPAT: 2019.3. get rid of [PairConsumer] implementation
+    private class QueueConsumer : PairConsumer<ContinuableRunnable, Runnable>, BiConsumer<ContinuableRunnable, Runnable> {
+        override fun consume(s: ContinuableRunnable, t: Runnable) = accept(s, t)
+        override fun accept(t: ContinuableRunnable, u: Runnable) = t.run(u)
+    }
+
+    private class BackgroundableTaskData(
+        val task: Task.Backgroundable,
+        val onFinish: (BackgroundableTaskData) -> Unit
+    ) : ContinuableRunnable {
+
+        // Guarded by self object monitor (@Synchronized)
+        private var state: State = State.Pending
+
+        @Synchronized
+        override fun run(continuation: Runnable) {
+            // BackgroundableProcessIndicator should be created from EDT
+            checkIsDispatchThread()
+
+            when (state) {
+                State.CanceledContinued -> {
+                    // continuation is already invoked, do nothing
+                    return
+                }
+                State.Canceled -> {
+                    continuation.run()
+                    return
+                }
+                is State.Running -> error("Trying to re-run already running task")
+            }
+
+            if (task is RsTask && task.waitForSmartMode && DumbService.isDumb(task.project)) {
+                check(state !is State.WaitForSmartMode)
+                state = State.WaitForSmartMode(continuation)
+                DumbService.getInstance(task.project).runWhenSmart { run(continuation) }
+                return
+            }
+
+            val indicator = when {
+                isHeadlessEnvironment -> EmptyProgressIndicator()
+
+                task is RsTask && task.progressBarShowDelay > 0 ->
+                    DelayedBackgroundableProcessIndicator(task, task.progressBarShowDelay)
+
+                else -> BackgroundableProcessIndicator(task)
+            }
+
+            state = State.Running(indicator)
+
+            val pm = ProgressManager.getInstance() as ProgressManagerImpl
+            pm.runProcessWithProgressAsynchronously(
+                task,
+                indicator,
+                {
+                    onFinish(this)
+                    continuation.run()
+                },
+                ModalityState.NON_MODAL
+            )
+        }
+
+        @Synchronized
+        fun cancel() {
+            when (val state = state) {
+                State.Pending -> this.state = State.Canceled
+                is State.Running -> state.indicator.cancel()
+                is State.WaitForSmartMode -> {
+                    this.state = State.CanceledContinued
+                    state.continuation.run()
+                }
+                State.Canceled -> Unit
+                State.CanceledContinued -> Unit
+            }.exhaustive
+        }
+
+        private sealed class State {
+            object Pending : State()
+            data class WaitForSmartMode(val continuation: Runnable) : State()
+            object Canceled : State()
+            object CanceledContinued : State()
+            data class Running(val indicator: ProgressIndicator) : State()
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -19,7 +19,6 @@ import com.intellij.openapi.components.StoragePathMacros
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleUtilCore
-import com.intellij.openapi.progress.BackgroundTaskQueue
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ContentEntry
 import com.intellij.openapi.roots.ModuleRootManager
@@ -67,6 +66,7 @@ import org.rust.openapiext.*
 import org.rust.stdext.AsyncValue
 import org.rust.stdext.applyWithSymlink
 import org.rust.stdext.joinAll
+import org.rust.taskQueue
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.CompletableFuture
@@ -104,14 +104,6 @@ open class CargoProjectsServiceImpl(
             })
         }
     }
-
-    /**
-     * While in theory Cargo and rustup are concurrency-safe, in practice
-     * it's better to serialize their execution, and this queue does
-     * exactly that. Not that [AsyncValue] [projects] also provides
-     * serialization grantees, so this queue is no strictly necessary.
-     */
-    val taskQueue = BackgroundTaskQueue(project, "Cargo update")
 
     /**
      * The heart of the plugin Project model. Care must be taken to ensure
@@ -375,7 +367,7 @@ data class CargoProjectImpl(
             return CompletableFuture.completedFuture(withStdlib(result))
         }
 
-        return fetchStdlib(project, projectService.taskQueue, rustup).thenApply(this::withStdlib)
+        return fetchStdlib(project, rustup).thenApply(this::withStdlib)
     }
 
     // Checks that the project is https://github.com/rust-lang/rust
@@ -400,7 +392,7 @@ data class CargoProjectImpl(
                 "Can't update Cargo project, no Rust toolchain"
             )))
 
-        return fetchCargoWorkspace(project, projectService.taskQueue, toolchain, workingDirectory)
+        return fetchCargoWorkspace(project, toolchain, workingDirectory)
             .thenApply(this::withWorkspace)
     }
 
@@ -415,7 +407,7 @@ data class CargoProjectImpl(
                 "Can't get rustc info, no Rust toolchain"
             )))
 
-        return fetchRustcInfo(project, projectService.taskQueue, toolchain, workingDirectory)
+        return fetchRustcInfo(project, toolchain, workingDirectory)
             .thenApply(this::withRustcInfo)
     }
 
@@ -522,10 +514,9 @@ private fun VirtualFile.setupContentRoots(packageModule: Module, setup: ContentE
 
 private fun fetchStdlib(
     project: Project,
-    queue: BackgroundTaskQueue,
     rustup: Rustup
 ): CompletableFuture<TaskResult<StandardLibrary>> {
-    return runAsyncTask(project, queue, "Getting Rust stdlib") {
+    return runAsyncTask(project, project.taskQueue::run, "Getting Rust stdlib") {
         progress.isIndeterminate = true
         when (val download = rustup.downloadStdlib()) {
             is DownloadResult.Ok -> {
@@ -547,11 +538,10 @@ private fun fetchStdlib(
 
 private fun fetchCargoWorkspace(
     project: Project,
-    queue: BackgroundTaskQueue,
     toolchain: RustToolchain,
     projectDirectory: Path
 ): CompletableFuture<TaskResult<CargoWorkspace>> {
-    return runAsyncTask(project, queue, "Updating cargo") {
+    return runAsyncTask(project, project.taskQueue::run, "Updating cargo") {
         progress.isIndeterminate = true
         if (!toolchain.looksLikeValidToolchain()) {
             return@runAsyncTask err(
@@ -588,11 +578,10 @@ private fun fetchCargoWorkspace(
 
 private fun fetchRustcInfo(
     project: Project,
-    queue: BackgroundTaskQueue,
     toolchain: RustToolchain,
     projectDirectory: Path
 ): CompletableFuture<TaskResult<RustcInfo>> {
-    return runAsyncTask(project, queue, "Getting toolchain version") {
+    return runAsyncTask(project, project.taskQueue::run, "Getting toolchain version") {
         progress.isIndeterminate = true
         if (!toolchain.looksLikeValidToolchain()) {
             return@runAsyncTask err(

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -23,6 +23,7 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.containers.ContainerUtil
 import com.intellij.util.io.storage.HeavyProcessLatch
+import org.rust.RsTask
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.RsMembers
 import org.rust.lang.core.psi.ext.RsMod
@@ -49,7 +50,8 @@ abstract class MacroExpansionTaskBase(
     private val vfsBatchFactory: () -> MacroExpansionVfsBatch,
     private val createExpandedSearchScope: (Int) -> GlobalSearchScope,
     private val stepModificationTracker: SimpleModificationTracker
-) : Task.Backgroundable(project, "Expanding Rust macros", /* canBeCancelled = */ false) {
+) : Task.Backgroundable(project, "Expanding Rust macros", /* canBeCancelled = */ false),
+    RsTask {
     private val transactionExecutor = TransactionExecutor(project)
     private val expander = MacroExpander(project)
     private val sync = CountDownLatch(1)
@@ -295,9 +297,8 @@ abstract class MacroExpansionTaskBase(
 
     protected abstract fun getMacrosToExpand(): Sequence<List<Extractable>>
 
-    open fun canEat(other: MacroExpansionTaskBase): Boolean = false
-
-    open val isProgressBarDelayed: Boolean get() = true
+    override val waitForSmartMode: Boolean
+        get() = true
 
     companion object {
         /**

--- a/src/main/kotlin/org/rust/stdext/Utils.kt
+++ b/src/main/kotlin/org/rust/stdext/Utils.kt
@@ -18,6 +18,20 @@ import java.nio.file.Paths
 @Suppress("NOTHING_TO_INLINE")
 inline fun <T> typeAscription(t: T): T = t
 
+/**
+ * Just a way to force exhaustiveness analysis for Kotlin's `when` expression.
+ *
+ * Use it like this:
+ * ```
+ * when (foo) {
+ *     is Bar -> {}
+ *     is Baz -> {}
+ * }.exhaustive // ensure `Bar` and `Baz` are the only variants of `foo`
+ * ```
+ */
+val <T> T.exhaustive: T
+    inline get() = this
+
 inline fun <T> VirtualFile.applyWithSymlink(f: (VirtualFile) -> T?): T? {
     return f(this) ?: f(canonicalFile ?: return null)
 }


### PR DESCRIPTION
This makes macro expansion cancellation more fast in the case of cargo refresh (e.g. Cargo.toml editing)

Also:
1. macro expansion is now cancelled immediately if the new engine is disabled in the settings;
2. progress bar of macro expansion task is not shown until the end of the indexing