### PR TITLE
REPL: Remove border between current command and previous commands

### DIFF
--- a/src/main/kotlin/org/rust/ide/console/RsConsoleRunner.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleRunner.kt
@@ -211,6 +211,7 @@ class RsConsoleRunner(project: Project) :
 
     private fun connect() {
         invokeLater {
+            consoleView.removeBorders()
             consoleView.initVariablesWindow()
             consoleView.executeActionHandler = consoleExecuteActionHandler
 

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleView.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleView.kt
@@ -82,6 +82,11 @@ class RsConsoleView(project: Project) : LanguageConsoleImpl(project, VIRTUAL_FIL
         }
     }
 
+    fun removeBorders() {
+        historyViewer.setBorder(null)
+        consoleEditor.setBorder(null)
+    }
+
     val isShowVariables: Boolean
         get() = options.showVariables
 


### PR DESCRIPTION
On 2020.1 platform there are strange borders in REPL console:

![image](https://user-images.githubusercontent.com/6505554/78919248-15aee080-7aab-11ea-9a4f-e986cd3005a8.png)
