### PR TITLE
REPL: Fix imports

### DIFF
--- a/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
@@ -8,44 +8,101 @@ package org.rust.ide.console
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
+import com.intellij.util.containers.ContainerUtil
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.descendantOfTypeStrict
+import org.rust.lang.core.psi.ext.block
+import org.rust.lang.core.psi.ext.childOfType
+import org.rust.lang.core.resolve.TYPES
+import org.rust.lang.core.resolve.findPrelude
+import org.rust.lang.core.resolve.processNestedScopesUpwards
 import org.rust.openapiext.toPsiFile
 
-class RsConsoleCodeFragmentContext {
+class RsConsoleCodeFragmentContext(codeFragment: RsReplCodeFragment?) {
 
-    private val topLevelElements: MutableMap<String, String> = mutableMapOf()
-    private val allCommandsText: StringBuilder = StringBuilder()
+    // concurrent set is needed because accessed both in `addItemsNamesFromPrelude` and `addToContext`
+    private val itemsNames: MutableSet<String> = ContainerUtil.newConcurrentSet()
+    @Volatile
+    private var hasAddedNamesFromPrelude = false
 
-    fun addToContext(lastCommandContext: RsConsoleOneCommandContext) {
-        topLevelElements.putAll(lastCommandContext.topLevelElements)
-        allCommandsText.append(lastCommandContext.statementsText)
-    }
+    private val commands: MutableList<String> = mutableListOf()
 
-    fun updateContext(project: Project, codeFragment: RsReplCodeFragment) {
-        val allCommandsText = getAllCommandsText()
-
-        DumbService.getInstance(project).smartInvokeLater {
-            runWriteAction {
-                codeFragment.context = createContext(project, codeFragment.crateRoot as RsFile?, allCommandsText)
+    init {
+        if (codeFragment != null) {
+            DumbService.getInstance(codeFragment.project).runWhenSmart {
+                addItemsNamesFromPrelude(codeFragment)
             }
         }
     }
 
+    // see org.rust.ide.console.RsConsoleCompletionTest.`test redefine struct from prelude`
+    private fun addItemsNamesFromPrelude(codeFragment: RsReplCodeFragment) {
+        val prelude = findPrelude(codeFragment) ?: return
+
+        val preludeItemsNames = mutableListOf<String>()
+        processNestedScopesUpwards(prelude, TYPES) {
+            preludeItemsNames += it.name
+            false
+        }
+        itemsNames += preludeItemsNames
+        hasAddedNamesFromPrelude = true
+    }
+
+    fun addToContext(lastCommandContext: RsConsoleOneCommandContext) {
+        if (commands.isEmpty()
+            || lastCommandContext.itemsNames.any(itemsNames::contains)
+            || lastCommandContext.containsUseDirective
+            || !hasAddedNamesFromPrelude
+        ) {
+            commands.add(lastCommandContext.command)
+        } else {
+            commands[commands.size - 1] = commands.last() + "\n" + lastCommandContext.command
+        }
+        itemsNames += lastCommandContext.itemsNames
+    }
+
+    fun updateContextAsync(project: Project, codeFragment: RsReplCodeFragment) {
+        DumbService.getInstance(project).smartInvokeLater {
+            runWriteAction {
+                updateContext(project, codeFragment)
+            }
+        }
+    }
+
+    fun updateContext(project: Project, codeFragment: RsReplCodeFragment) {
+        codeFragment.context = createContext(project, codeFragment.crateRoot as RsFile?, commands)
+    }
+
     fun getAllCommandsText(): String {
-        val topLevelElementsText = topLevelElements.values.joinToString("\n")
-        return topLevelElementsText + "\n" + allCommandsText
+        return commands.joinToString("\n")
     }
 
     companion object {
-        fun createContext(project: Project, originalCrateRoot: RsFile?, allCommandsText: String = ""): RsBlock {
-            val rsFile = RsPsiFactory(project).createFile("fn main() { $allCommandsText }")
+        fun createContext(project: Project, originalCrateRoot: RsFile?, commands: List<String> = listOf("")): RsBlock {
+            // command may contain functions/structs with same names as in previous commands
+            // therefore we should put such commands in separate scope
+            // we do this like so:
+            // ```
+            // command1;
+            // {
+            //     command2;
+            //     {
+            //         command3;
+            //     }
+            // }
+            // And `RsBlock` surrounding `command3` will become context of codeFragment
+            // ```
+            val functionBody = commands.joinToString("\n{\n") + "\n}".repeat(commands.size - 1)
+            val rsFile = RsPsiFactory(project).createFile("fn main() { $functionBody }")
 
             val crateRoot = originalCrateRoot ?: findAnyCrateRoot(project)
             crateRoot?.let { rsFile.originalFile = crateRoot }
 
-            return rsFile.descendantOfTypeStrict()!!
+            val functionBlock = rsFile.childOfType<RsFunction>()!!.block!!
+            val blocks = generateSequence(functionBlock) {
+                (it.expr as? RsBlockExpr)?.block
+            }
+            return blocks.drop(commands.size - 1).first()
         }
 
         private fun findAnyCrateRoot(project: Project): RsFile? {
@@ -57,15 +114,13 @@ class RsConsoleCodeFragmentContext {
 }
 
 class RsConsoleOneCommandContext(codeFragment: RsReplCodeFragment) {
-    val topLevelElements: MutableMap<String, String> = mutableMapOf()
-    val statementsText: String
+    val command: String
+    val itemsNames: Set<String> = codeFragment.namedElementsUnique.keys
+    val containsUseDirective: Boolean
 
     init {
-        for (namedElement in codeFragment.namedElements) {
-            val name = namedElement.name ?: continue
-            topLevelElements[name] = namedElement.text
-        }
-
-        statementsText = codeFragment.stmts.joinToString("\n") { it.text } + "\n"
+        val elements = codeFragment.expandedStmtsAndTailExpr.first
+        command = elements.joinToString("\n") { it.text }
+        containsUseDirective = elements.any { it is RsUseItem }
     }
 }

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleView.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleView.kt
@@ -30,7 +30,7 @@ class RsConsoleView(project: Project) : LanguageConsoleImpl(project, VIRTUAL_FIL
 
     private val initialized: ActionCallback = ActionCallback()
     val codeFragment: RsReplCodeFragment? = virtualFile.toPsiFile(project) as? RsReplCodeFragment
-    private val codeFragmentContext: RsConsoleCodeFragmentContext = RsConsoleCodeFragmentContext()
+    private val codeFragmentContext: RsConsoleCodeFragmentContext = RsConsoleCodeFragmentContext(codeFragment)
     private var variablesView: RsConsoleVariablesView? = null
     private val options: RsConsoleOptions = RsConsoleOptions.getInstance(project)
 
@@ -77,7 +77,7 @@ class RsConsoleView(project: Project) : LanguageConsoleImpl(project, VIRTUAL_FIL
     fun addToContext(lastCommandContext: RsConsoleOneCommandContext) {
         if (codeFragment != null) {
             codeFragmentContext.addToContext(lastCommandContext)
-            codeFragmentContext.updateContext(project, codeFragment)
+            codeFragmentContext.updateContextAsync(project, codeFragment)
             variablesView?.rebuild()
         }
     }

--- a/src/main/kotlin/org/rust/ide/structure/RsStructureViewModel.kt
+++ b/src/main/kotlin/org/rust/ide/structure/RsStructureViewModel.kt
@@ -61,7 +61,7 @@ private class RsStructureViewElement(
                 is RsStructItem -> psi.blockFields?.namedFieldDeclList.orEmpty()
                 is RsEnumVariant -> psi.blockFields?.namedFieldDeclList.orEmpty()
                 is RsFunction -> psi.block?.let { extractItems(it) }.orEmpty()
-                is RsReplCodeFragment -> psi.namedElements + psi.getVariablesDeclarations()
+                is RsReplCodeFragment -> psi.namedElementsUnique.values + psi.getVariablesDeclarations()
                 else -> emptyList()
             }
         }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
@@ -16,6 +16,7 @@ import com.intellij.psi.tree.IElementType
 import com.intellij.testFramework.LightVirtualFile
 import org.rust.lang.RsFileType
 import org.rust.lang.RsLanguage
+import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.parser.RustParserUtil.PathParsingMode
 import org.rust.lang.core.parser.RustParserUtil.PathParsingMode.*
 import org.rust.lang.core.psi.ext.*
@@ -158,8 +159,22 @@ class RsPathCodeFragment(
 class RsReplCodeFragment(fileViewProvider: FileViewProvider, override var context: RsElement)
     : RsCodeFragment(fileViewProvider, RsCodeFragmentElementType.REPL, context, false),
       RsInferenceContextOwner, RsItemsOwner {
-    val stmts: List<RsStmt> get() = childrenOfType()
-    val tailExpr: RsExpr?
-        get() = children.findLast { it is RsExpr || it !is PsiWhiteSpace }?.let { it as? RsExpr }
-    val namedElements: List<RsNamedElement> get() = childrenOfType()
+
+    val expandedStmtsAndTailExpr: Pair<List<RsExpandedElement>, RsExpr?>
+        get() {
+            val expandedElements = childrenOfType<RsExpandedElement>()
+            val tailExpr = expandedElements.lastOrNull()?.let { it as? RsExpr }
+            val stmts = when (tailExpr) {
+                null -> expandedElements
+                else -> expandedElements.subList(0, expandedElements.size - 1)
+            }
+            return stmts to tailExpr
+        }
+
+    // if multiple elements have same name, then we keep only last among them
+    val namedElementsUnique: Map<String, RsNamedElement>
+        get() = expandedStmtsAndTailExpr.first
+            .filterIsInstance<RsNamedElement>()
+            .filter { it.name != null }
+            .associateBy { it.name!! }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -1344,7 +1344,7 @@ private fun processLexicalDeclarations(
                 val letDecls = mutableListOf<RsLetDecl>()
                 val stmts = when (scope) {
                     is RsBlock -> scope.expandedStmtsAndTailExpr.first
-                    is RsReplCodeFragment -> scope.stmts
+                    is RsReplCodeFragment -> scope.expandedStmtsAndTailExpr.first
                     else -> emptyList()  // unreachable
                 }
                 for (stmt in stmts) {
@@ -1484,7 +1484,7 @@ inline fun processWithShadowing(
     }
 }
 
-private fun findPrelude(element: RsElement): RsFile? {
+fun findPrelude(element: RsElement): RsFile? {
     val crateRoot = element.crateRoot as? RsFile ?: return null
     val cargoPackage = crateRoot.containingCargoPackage
     val isStdlib = cargoPackage?.origin == PackageOrigin.STDLIB && !element.isDoctestInjection

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -116,10 +116,13 @@ class RsTypeInferenceWalker(
     }
 
     fun inferReplCodeFragment(element: RsReplCodeFragment) {
-        for (stmt in element.stmts) {
-            processStatement(stmt)
+        val (expandedStmts, tailExpr) = element.expandedStmtsAndTailExpr
+        for (stmt in expandedStmts) {
+            if (stmt is RsStmt) {
+                processStatement(stmt)
+            }
         }
-        element.tailExpr?.inferType()
+        tailExpr?.inferType()
     }
 
     // returns true if expr is always diverging

--- a/src/test/kotlin/org/rust/ide/console/RsConsoleCompletionTest.kt
+++ b/src/test/kotlin/org/rust/ide/console/RsConsoleCompletionTest.kt
@@ -11,7 +11,7 @@ class RsConsoleCompletionTest : RsConsoleCompletionTestBase() {
 
     """, """
         /*caret*/
-    """, listOf(
+    """, variants = listOf(
         "let",
         "fn",
         "struct",
@@ -24,7 +24,7 @@ class RsConsoleCompletionTest : RsConsoleCompletionTestBase() {
         let var2 = var1 + 1;
     """, """
         let x = var/*caret*/
-    """, listOf(
+    """, variants = listOf(
         "var1",
         "var2"
     ))
@@ -41,7 +41,7 @@ class RsConsoleCompletionTest : RsConsoleCompletionTestBase() {
         let var1 = Some(1);
     """, """
         let x = var1./*caret*/
-    """, listOf(
+    """, variants = listOf(
         "unwrap",
         "map",
         "and_then"
@@ -79,7 +79,7 @@ class RsConsoleCompletionTest : RsConsoleCompletionTestBase() {
         let s = "foo";
     """, """
         s./*caret*/
-    """, listOf(
+    """, variants = listOf(
         "len",
         "chars"
     ))
@@ -88,7 +88,7 @@ class RsConsoleCompletionTest : RsConsoleCompletionTestBase() {
         let v = Vec::<i32>::new();
     """, """
         v.i/*caret*/
-    """, listOf(
+    """, variants = listOf(
         "insert",
         "is_empty",
         "index"
@@ -117,7 +117,7 @@ class RsConsoleCompletionTest : RsConsoleCompletionTestBase() {
             }
         }
         nop();
-    """, listOf(
+    """, variants = listOf(
         "var1",
         "var2"
     ))

--- a/src/test/kotlin/org/rust/ide/console/RsConsoleCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/console/RsConsoleCompletionTestBase.kt
@@ -26,20 +26,21 @@ abstract class RsConsoleCompletionTestBase : RsTestBase() {
         super.tearDown()
     }
 
-    protected fun checkContainsCompletion(previousLines: String, lastLine: String, variants: List<String>) {
-        val previousLinesTrimmed = previousLines.trimIndent()
-        val lastLineTrimmed = lastLine.trimIndent()
+    protected fun checkContainsCompletion(vararg commands: String, variants: List<String>) {
+        val previousCommands = commands.slice(0 until commands.size - 1)
+        val lastCommand = commands.last()
 
-        completionFixture.checkContainsCompletion(Before(previousLinesTrimmed, lastLineTrimmed), variants)
-        if (previousLines.isBlank()) return
+        completionFixture.checkContainsCompletion(Before(previousCommands, lastCommand), variants)
 
-        val lastLines = previousLinesTrimmed + lastLineTrimmed
-        completionFixture.checkContainsCompletion(Before("", lastLines), variants)
-        completionFixture.checkContainsCompletion(Before("", "if true { $lastLines }"), variants)
-        completionFixture.checkContainsCompletion(Before("", "fn main() { $lastLines }"), variants)
+        if (previousCommands.size == 1) {
+            val allCommands = previousCommands[0] + lastCommand
+            completionFixture.checkContainsCompletion(Before(listOf(""), allCommands), variants)
+            completionFixture.checkContainsCompletion(Before(listOf(""), "if true { $allCommands }"), variants)
+            completionFixture.checkContainsCompletion(Before(listOf(""), "fn main() { $allCommands }"), variants)
+        }
     }
 
-    protected fun checkSingleCompletion(previousLines: String, lastLineBefore: String, lastLineAfter: String) {
-        completionFixture.doSingleCompletion(Before(previousLines, lastLineBefore), lastLineAfter)
+    protected fun checkSingleCompletion(previousCommands: String, lastCommandBefore: String, lastCommandAfter: String) {
+        completionFixture.doSingleCompletion(Before(listOf(previousCommands), lastCommandBefore), lastCommandAfter)
     }
 }

--- a/src/test/kotlin/org/rust/ide/console/RsConsoleCompletionTestFixture.kt
+++ b/src/test/kotlin/org/rust/ide/console/RsConsoleCompletionTestFixture.kt
@@ -16,18 +16,19 @@ import org.rust.lang.core.psi.RsReplCodeFragment
 class RsConsoleCompletionTestFixture(fixture: CodeInsightTestFixture) : RsCompletionTestFixtureBase<Before>(fixture) {
 
     override fun prepare(code: Before) {
-        val (previousLines, lastLine) = code
+        val (previousCommands, lastCommand) = code
+        val previousCommandsTrimmed = previousCommands.map { it.trimIndent() }
 
         // create main.rs file, which will be used as crate root
         InlineFile(myFixture, "", "main.rs")
 
-        InlineFile(myFixture, lastLine.trimIndent(), RsConsoleView.VIRTUAL_FILE_NAME).withCaret()
+        InlineFile(myFixture, lastCommand.trimIndent(), RsConsoleView.VIRTUAL_FILE_NAME).withCaret()
 
         val codeFragment = myFixture.file as RsReplCodeFragment
         val crateRoot = codeFragment.crateRoot as RsFile?
-        codeFragment.context = RsConsoleCodeFragmentContext.createContext(myFixture.project, crateRoot, previousLines.trimIndent())
+        codeFragment.context = RsConsoleCodeFragmentContext.createContext(myFixture.project, crateRoot, previousCommandsTrimmed)
         assertNotNull(codeFragment.crateRoot)
     }
 
-    data class Before(val previousLines: String, val lastLine: String)
+    data class Before(val previousCommands: List<String>, val lastCommand: String)
 }

--- a/src/test/kotlin/org/rust/ide/console/RsConsoleCompletionTestFixture.kt
+++ b/src/test/kotlin/org/rust/ide/console/RsConsoleCompletionTestFixture.kt
@@ -5,29 +5,47 @@
 
 package org.rust.ide.console
 
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiManager
+import com.intellij.psi.SingleRootFileViewProvider
+import com.intellij.testFramework.LightVirtualFile
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import org.junit.Assert.assertNotNull
 import org.rust.InlineFile
 import org.rust.ide.console.RsConsoleCompletionTestFixture.Before
+import org.rust.lang.RsLanguage
 import org.rust.lang.core.completion.RsCompletionTestFixtureBase
-import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.parser.RustParserDefinition
 import org.rust.lang.core.psi.RsReplCodeFragment
 
 class RsConsoleCompletionTestFixture(fixture: CodeInsightTestFixture) : RsCompletionTestFixtureBase<Before>(fixture) {
 
     override fun prepare(code: Before) {
         val (previousCommands, lastCommand) = code
-        val previousCommandsTrimmed = previousCommands.map { it.trimIndent() }
 
         // create main.rs file, which will be used as crate root
         InlineFile(myFixture, "", "main.rs")
 
         InlineFile(myFixture, lastCommand.trimIndent(), RsConsoleView.VIRTUAL_FILE_NAME).withCaret()
-
         val codeFragment = myFixture.file as RsReplCodeFragment
-        val crateRoot = codeFragment.crateRoot as RsFile?
-        codeFragment.context = RsConsoleCodeFragmentContext.createContext(myFixture.project, crateRoot, previousCommandsTrimmed)
+        codeFragment.setContext(myFixture.project, previousCommands.map { it.trimIndent() })
         assertNotNull(codeFragment.crateRoot)
+    }
+
+    private fun RsReplCodeFragment.setContext(project: Project, previousCommands: List<String>) {
+        val codeFragmentContext = RsConsoleCodeFragmentContext(this)
+        for (command in previousCommands) {
+            val codeFragment = createReplCodeFragment(project, command)
+            val oneCommandContext = RsConsoleOneCommandContext(codeFragment)
+            codeFragmentContext.addToContext(oneCommandContext)
+        }
+        codeFragmentContext.updateContext(project, this)
+    }
+
+    private fun createReplCodeFragment(project: Project, text: String): RsReplCodeFragment {
+        val virtualFile = LightVirtualFile(RsConsoleView.VIRTUAL_FILE_NAME, RsLanguage, text)
+        val viewProvider = SingleRootFileViewProvider(PsiManager.getInstance(project), virtualFile, false)
+        return RustParserDefinition().createFile(viewProvider) as RsReplCodeFragment
     }
 
     data class Before(val previousCommands: List<String>, val lastCommand: String)


### PR DESCRIPTION
Fix #5214

Previously only `RsNamedElement` and `RsStmt` were added to context, so imports were ignored