### PR TITLE
Enable `dynamic plugin verification` inspection for project

### DIFF
--- a/.idea/inspectionProfiles/intellij_rust.xml
+++ b/.idea/inspectionProfiles/intellij_rust.xml
@@ -1,0 +1,8 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="intellij-rust" />
+    <inspection_tool class="PluginXmlDynamicPlugin" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="highlightNonDynamicEPUsages" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" value="intellij-rust" />
+    <version value="1.0" />
+  </settings>
+</component>


### PR DESCRIPTION
It should help us to make plugin dynamic and avoid using of non dynamic API

Related to #4832