### PR TITLE
Get rid of some project/application components

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingPassFactoryRegistrar.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingPassFactoryRegistrar.kt
@@ -1,0 +1,16 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+import com.intellij.codeHighlighting.TextEditorHighlightingPassFactoryRegistrar
+import com.intellij.codeHighlighting.TextEditorHighlightingPassRegistrar
+import com.intellij.openapi.project.Project
+
+class RsHighlightingPassFactoryRegistrar : TextEditorHighlightingPassFactoryRegistrar {
+    override fun registerHighlightingPassFactory(registrar: TextEditorHighlightingPassRegistrar, project: Project) {
+        RsExternalLinterPassFactory(project, registrar)
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -178,6 +178,8 @@
         <annotator language="Rust" implementationClass="org.rust.ide.annotator.RsCfgDisabledCodeAnnotator"/>
         <highlightRangeExtension implementation="org.rust.ide.annotator.RsErrorAnnotator"/>
 
+        <highlightingPassFactory implementation="org.rust.ide.annotator.RsHighlightingPassFactoryRegistrar"/>
+
         <!-- Line Marker Providers -->
 
         <codeInsight.lineMarkerProvider language="Rust"
@@ -922,9 +924,6 @@
         <component>
             <interface-class>org.rust.lang.core.psi.RsPsiManager</interface-class>
             <implementation-class>org.rust.lang.core.psi.RsPsiManagerImpl</implementation-class>
-        </component>
-        <component>
-            <implementation-class>org.rust.ide.annotator.RsExternalLinterPassFactory</implementation-class>
         </component>
         <component>
             <interface-class>org.rust.lang.core.macros.MacroExpansionManager</interface-class>

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -894,6 +894,10 @@
         <consoleHistoryModelProvider implementation="org.rust.ide.console.RsConsoleHistoryModelProvider"/>
         <scratch.rootType implementation="org.rust.ide.console.RsConsoleRootType"/>
 
+        <!-- Listeners -->
+
+        <fileDocumentManagerListener implementation="org.rust.cargo.RustfmtWatcher$RustfmtListener"/>
+
         <!-- Registry keys -->
 
         <registryKey key="org.rust.lang.type.alias.threshold" defaultValue="10" restartRequired="false"
@@ -911,9 +915,6 @@
     <application-components>
         <component>
             <implementation-class>org.rust.ide.update.UpdateComponent</implementation-class>
-        </component>
-        <component>
-            <implementation-class>org.rust.cargo.RustfmtWatcher</implementation-class>
         </component>
         <component>
             <implementation-class>org.rust.ide.todo.RsTodoApplicationComponent</implementation-class>

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -878,8 +878,6 @@
         <multiHostInjector implementation="org.rust.ide.injected.RsDoctestLanguageInjector"/>
 
 
-        <projectService serviceImplementation="org.rust.lang.core.resolve.ref.RsResolveCache"/>
-
         <!-- Macro expansion service -->
 
         <indexedRootsProvider implementation="org.rust.lang.core.macros.RsIndexableSetContributor"/>


### PR DESCRIPTION
To become a dynamic plugin someday, we should get rid of all project/application components. 

I refactored RustfmtWatcher and RsExternalLinterPassFactory. 

Remained UpdateComponent, RsTodoApplicationComponent, RsPsiManager, MacroExpansionManager

Part of #4832. Fixes https://github.com/intellij-rust/intellij-rust/issues/5230.