### PR TITLE
REPL: Fix for windows (update evcxr)

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -396,7 +396,7 @@ class Cargo(private val cargoExecutable: Path) {
 
         fun checkNeedInstallEvcxr(project: Project): Boolean {
             val crateName = "evcxr_repl"
-            val minVersion = SemVer("v0.4.7", 0, 4, 7)
+            val minVersion = SemVer("v0.5.1", 0, 5, 1)
             return checkNeedInstallBinaryCrate(
                 project,
                 crateName,

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleCommunication.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleCommunication.kt
@@ -62,8 +62,7 @@ class RsConsoleCommunication(private val consoleView: RsConsoleView) {
          *      subject to the prior agreement of the sender and the recipient of the data."
          * so they are ideal for our purpose
          */
-        // BACKCOMPAT: Evcxr 0.4.6. Remove \u0001 and \u0002
-        val SUCCESS_EXECUTION_MARKER: Regex = Regex("[\u0091\u0001]")
-        val FAILED_EXECUTION_MARKER: Regex = Regex("[\u0092\u0002]")
+        const val SUCCESS_EXECUTION_MARKER: String = "\u0091"
+        const val FAILED_EXECUTION_MARKER: String = "\u0092"
     }
 }

--- a/src/test/kotlin/org/rustSlowTests/console/RsEvcxrTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/console/RsEvcxrTest.kt
@@ -68,7 +68,7 @@ class RsEvcxrTest : RsWithToolchainTestBase() {
             RsConsoleCommunication.FAILED_EXECUTION_MARKER
         }
         val markerReceived = scanner.nextChar().toString()
-        check(markerReceived.matches(markerExpected))
+        assertEquals(markerExpected, markerReceived)
 
         expectInput(scanner, promptColored)
     }


### PR DESCRIPTION
Update Evcxr to 0.5.1 (with https://github.com/google/evcxr/pull/111 merged)

This is second part of #5066

Fixes #5058, fixes #5046, fixes #4883