### PR TITLE
FMT: better visibility formatting

### DIFF
--- a/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt
@@ -82,6 +82,7 @@ fun createSpacingBuilder(commonSettings: CommonCodeStyleSettings, rustSettings: 
     val sb2 = sb1
         //== items
         .before(VIS_RESTRICTION).spaces(0) // pub(crate)
+        .after(VIS).spaces(1)
         .between(VALUE_PARAMETER_LIST, RET_TYPE).spacing(1, 1, 0, true, 0)
         .before(WHERE_CLAUSE).spacing(1, 1, 0, true, 0)
         .beforeInside(LBRACE, FLAT_BRACE_BLOCKS).spaces(1)

--- a/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt
@@ -51,13 +51,21 @@ class RsFormatterTest : RsFormatterTestBase() {
 
         pub ( super ) struct S2;
 
-        pub ( in foo :: bar ) struct S3;
+        pub ( in foo :: bar )struct S3;
+
+        struct S4(pub(i32, i32));
+
+        struct Foo<'a>(pub(crate)     &'a i32);
     """, """
         pub(crate) struct S1;
 
         pub(super) struct S2;
 
         pub(in foo::bar) struct S3;
+
+        struct S4(pub (i32, i32));
+
+        struct Foo<'a>(pub(crate) &'a i32);
     """)
 
     fun `test align incomplete chain`() = doTextTest("""


### PR DESCRIPTION
Provide proper spacing between `pub`/`pub(path)` and next token