### PR TITLE
MACRO: properly do "Invalidate caches & Restart"

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachesInvalidator.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachesInvalidator.kt
@@ -6,14 +6,13 @@
 package org.rust.lang.core.macros
 
 import com.intellij.ide.caches.CachesInvalidator
-import com.intellij.util.io.delete
 
 class RsMacroExpansionCachesInvalidator : CachesInvalidator() {
     override fun invalidateCaches() {
         try {
-            getBaseMacroDir().delete()
-        } catch (ignored: Exception) {
-
+            MacroExpansionManager.invalidateCaches()
+        } catch (e: Exception) {
+            MACRO_LOG.warn(e)
         }
     }
 


### PR DESCRIPTION
Previously the "cache" (macro expansion data) directories were deleted immediately when "Invalidate caches & Restart" is performed.

Now we postpone it until the next IDE launch. This is how index/VFS invalidation works. It helps to keep things consistent until the restart.

Fixes #4497