### PR TITLE
HINT: add hints for chained method calls

### DIFF
--- a/src/193/test/kotlin/org/rust/ide/hints/RsInlayTypeHintsTestPlatformBase.kt
+++ b/src/193/test/kotlin/org/rust/ide/hints/RsInlayTypeHintsTestPlatformBase.kt
@@ -5,10 +5,11 @@
 
 package org.rust.ide.hints
 
+import org.rust.RsTestBase
 import com.intellij.codeInsight.hints.presentation.PresentationRenderer
 
-class RsInlayTypeHintsProviderTest : RsInlayTypeHintsProviderTestBase() {
-    override fun checkInlays() {
+abstract class RsInlayTypeHintsTestPlatformBase: RsTestBase() {
+    protected fun checkInlays() {
         myFixture.testInlays(
             { (it.renderer as PresentationRenderer).presentation.toString() },
             { it.renderer is PresentationRenderer }

--- a/src/201/test/kotlin/org/rust/ide/hints/RsInlayTypeHintsTestPlatformBase.kt
+++ b/src/201/test/kotlin/org/rust/ide/hints/RsInlayTypeHintsTestPlatformBase.kt
@@ -5,12 +5,12 @@
 
 package org.rust.ide.hints
 
+import org.rust.RsTestBase
 import com.intellij.codeInsight.hints.LinearOrderInlayRenderer
 
-// BACKOMPAT: 2019.3. Merge it with RsInlayTypeHintsProviderTestBase
-class RsInlayTypeHintsProviderTest : RsInlayTypeHintsProviderTestBase() {
-
-    override fun checkInlays() {
+// BACKCOMPAT: 2019.3.
+abstract class RsInlayTypeHintsTestPlatformBase : RsTestBase() {
+    protected fun checkInlays() {
         myFixture.testInlays(
             { (it.renderer as LinearOrderInlayRenderer<*>).toString() },
             { it.renderer is LinearOrderInlayRenderer<*> }

--- a/src/main/kotlin/org/rust/ide/hints/RsChainMethodTypeHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/RsChainMethodTypeHintsProvider.kt
@@ -1,0 +1,138 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+@file:Suppress("UnstableApiUsage")
+
+package org.rust.ide.hints
+
+import com.intellij.codeInsight.hints.*
+import com.intellij.codeInsight.hints.presentation.InlayPresentation
+import com.intellij.codeInsight.hints.presentation.InsetPresentation
+import com.intellij.codeInsight.hints.presentation.MenuOnClickPresentation
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.ui.components.CheckBox
+import com.intellij.ui.layout.panel
+import com.intellij.util.ui.JBUI
+import org.rust.ide.utils.isEnabledByCfg
+import org.rust.lang.RsLanguage
+import org.rust.lang.core.psi.RsDotExpr
+import org.rust.lang.core.psi.RsMethodCall
+import org.rust.lang.core.psi.ext.childOfType
+import org.rust.lang.core.psi.ext.endOffset
+import org.rust.lang.core.psi.ext.parentDotExpr
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyUnknown
+import org.rust.lang.core.types.type
+import javax.swing.JPanel
+
+class RsChainMethodTypeHintsProvider : InlayHintsProvider<RsChainMethodTypeHintsProvider.Settings> {
+    override val key: SettingsKey<Settings> get() = KEY
+
+    override val name: String get() = "Chain method hints"
+
+    override val previewText: String? = null
+
+    override fun createConfigurable(settings: Settings): ImmediateConfigurable = object : ImmediateConfigurable {
+        private val consecutiveField = CheckBox("Show same consecutive types")
+
+        override fun createComponent(listener: ChangeListener): JPanel {
+            consecutiveField.isSelected = settings.showSameConsecutiveTypes
+            consecutiveField.addItemListener { handleChange(listener) }
+
+            val panel = panel {
+                row { consecutiveField(pushX) }
+            }
+            panel.border = JBUI.Borders.empty(5)
+            return panel
+        }
+
+        private fun handleChange(listener: ChangeListener) {
+            settings.showSameConsecutiveTypes = consecutiveField.isSelected
+            listener.settingsChanged()
+        }
+    }
+
+    override fun createSettings(): Settings = Settings()
+
+    override fun getCollectorFor(file: PsiFile, editor: Editor, settings: Settings, sink: InlayHintsSink): InlayHintsCollector? =
+        object : FactoryInlayHintsCollector(editor) {
+
+            val typeHintsFactory = RsTypeHintsPresentationFactory(factory, true)
+
+            override fun collect(element: PsiElement, editor: Editor, sink: InlayHintsSink): Boolean {
+                if (DumbService.isDumb(element.project)) return true
+                if (element !is RsMethodCall) return true
+                if (!element.isLastInChain) return true
+                if (!element.isEnabledByCfg) return true
+
+                val chain = collectChain(element)
+                var lastType: Ty? = null
+                for (call in chain.dropLast(1)) {
+                    if (call.type != TyUnknown && call.isLastOnLine) {
+                        if (settings.showSameConsecutiveTypes || call.type != lastType) {
+                            presentTypeForMethodCall(call)
+                        }
+                        lastType = call.type
+                    }
+                }
+
+                return true
+            }
+
+            private fun presentTypeForMethodCall(call: RsMethodCall) {
+                val project = call.project
+                val type = call.type
+                val presentation = typeHintsFactory.typeHint(type)
+                val finalPresentation = presentation.withDisableAction(project)
+                sink.addInlineElement(call.endOffset, true, finalPresentation)
+            }
+        }
+
+    private fun InlayPresentation.withDisableAction(project: Project): InsetPresentation = InsetPresentation(
+        MenuOnClickPresentation(this, project) {
+            listOf(InlayProviderDisablingAction(name, RsLanguage, project, key))
+        }, left = 1
+    )
+
+    data class Settings(var showSameConsecutiveTypes: Boolean = true)
+
+    companion object {
+        val KEY: SettingsKey<Settings> = SettingsKey("chain-method.hints")
+    }
+}
+
+private val RsMethodCall.isLastInChain: Boolean
+    get() = parentDotExpr.parent !is RsDotExpr && parentDotExpr.expr.childOfType<RsMethodCall>() != null
+
+private val RsMethodCall.isLastOnLine: Boolean
+    get() = this.parentDotExpr.isLastOnLine
+
+private val PsiElement.isLastOnLine: Boolean
+    get() {
+        return when (val sibling = this.nextSibling) {
+            is PsiWhiteSpace -> sibling.textContains('\n') || sibling.isLastOnLine
+            is PsiComment -> sibling.isLastOnLine
+            else -> false
+        }
+    }
+
+private val RsMethodCall.type: Ty
+    get() = parentDotExpr.type
+
+
+private fun collectChain(call: RsMethodCall): List<RsMethodCall> {
+    val chain = mutableListOf<RsMethodCall>()
+    var current = call
+    while (true) {
+        chain.add(current)
+        current = current.parentDotExpr.expr.childOfType() ?: break
+    }
+    return chain.reversed()
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -145,6 +145,7 @@
         <codeInsight.parameterNameHints language="Rust"
                                         implementationClass="org.rust.ide.hints.RsInlayParameterHintsProvider"/>
         <codeInsight.inlayProvider language="Rust" implementationClass="org.rust.ide.hints.RsInlayTypeHintsProvider"/>
+        <codeInsight.inlayProvider language="Rust" implementationClass="org.rust.ide.hints.RsChainMethodTypeHintsProvider"/>
 
         <declarationRangeHandler key="org.rust.lang.core.psi.RsStructItem"
                                  implementationClass="org.rust.ide.hints.RsStructItemDeclarationRangeHandler"/>

--- a/src/test/kotlin/org/rust/ide/hints/RsChainMethodTypeHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RsChainMethodTypeHintsProviderTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints
+
+import com.intellij.codeInsight.hints.InlayHintsSettings
+import org.intellij.lang.annotations.Language
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.RsLanguage
+
+class RsChainMethodTypeHintsProviderTest : RsInlayTypeHintsTestBase() {
+    private val types = """
+        struct A;
+        struct B;
+
+        impl A {
+            fn clone(&self) -> A { A }
+            fn change(&self) -> B { B }
+        }
+
+        impl B {
+            fn clone(&self) -> B { B }
+            fn change(&self) -> A { A }
+        }
+    """
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test result and option`() = doTest("""
+        fn main() {
+            let foo: Result<Option<i32>, &str> = Ok(Some(10i32));
+            foo
+              .map_err(|_| 0_u32)/*hint text="[:  [Result [< [[Option [< i32 >]] ,  u32] >]]]"*/
+              .unwrap()/*hint text="[:  [Option [< i32 >]]]"*/
+              .and_then(|_| Some("foo"))/*hint text="[:  [Option [< [& str] >]]]"*/
+              .unwrap();
+        }
+    """)
+
+    fun `test show only last type on a line`() = doTest("""
+        $types
+
+        fn main() {
+            let foo = A;
+            foo
+              .clone()/*hint text="[:  A]"*/
+              .clone().change()/*hint text="[:  B]"*/
+              .clone();
+        }
+    """)
+
+    fun `test show only last type on a line with comment`() = doTest("""
+        $types
+
+        fn main() {
+            let foo = A;
+            foo
+              .change()/**/.change()/*hint text="[:  A]"*/
+              .change() .change()/*hint text="[:  A]"*//**/
+              .change().change()/*hint text="[:  A]"*/ /**/
+              .change().change()/*hint text="[:  A]"*///
+              .clone();
+        }
+    """, showSameConsecutiveTypes = true)
+
+    fun `test respect last type on a previous line`() = doTest("""
+        $types
+
+        fn main() {
+            let foo = A;
+            foo
+              .clone()/*hint text="[:  A]"*/
+              .change().change()
+              .change()/*hint text="[:  B]"*/
+              .change();
+        }
+    """, showSameConsecutiveTypes = false)
+
+    fun `test ignore repeated types`() = doTest("""
+        $types
+
+        fn main() {
+            let foo = A;
+            foo
+              .clone()/*hint text="[:  A]"*/
+              .clone()
+              .change()/*hint text="[:  B]"*/
+              .clone()
+              .change();
+        }
+    """, showSameConsecutiveTypes = false)
+
+    fun `test do not show hints for a single method call`() = doTest("""
+        struct S;
+        impl S {
+            fn foo(): u32 { 0 }
+        }
+
+        fn main() {
+            let s = S;
+            s.foo();
+        }
+    """)
+
+    fun `test do not show hints for unknown type`() = doTest("""
+        fn main() {
+            let s = S;
+            s.bar()
+             .foo();
+        }
+    """)
+
+    @Suppress("UnstableApiUsage")
+    private fun doTest(@Language("Rust") code: String, showSameConsecutiveTypes: Boolean = true) {
+        val service = InlayHintsSettings.instance()
+        val key = RsChainMethodTypeHintsProvider.KEY
+        val settings = RsChainMethodTypeHintsProvider.Settings(showSameConsecutiveTypes = showSameConsecutiveTypes)
+        val originalSettings = service.findSettings(key, RsLanguage) { settings }
+        try {
+            service.storeSettings(key, RsLanguage, settings)
+            checkByText(code)
+        } finally {
+            service.storeSettings(key, RsLanguage, originalSettings)
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/ide/hints/RsInlayTypeHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RsInlayTypeHintsProviderTest.kt
@@ -6,14 +6,12 @@
 package org.rust.ide.hints
 
 import com.intellij.openapi.vfs.VirtualFileFilter
-import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
-import org.rust.RsTestBase
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.fileTreeFromText
 import org.rust.lang.core.psi.RsMethodCall
 
-abstract class RsInlayTypeHintsProviderTestBase : RsTestBase() {
+class RsInlayTypeHintsProviderTest : RsInlayTypeHintsTestBase() {
     fun `test simple`() = checkByText("""
         fn main() {
             let s/*hint text="[:  i32]"*/ = 42;
@@ -172,9 +170,9 @@ abstract class RsInlayTypeHintsProviderTestBase : RsTestBase() {
         fn main() {
             let s: S<(), ()> = unimplemented!();
             let foo/*hint text="[:  [S [< [[[fn( … )] [ →  … ]] ,  [S [< … >]]] >]]]"*/ = s
-                .wrap(|x: i32| x)
-                .wrap(|x: i32| x)
-                .wrap(|x: i32| x)
+                .wrap(|x: i32| x)/*hint text="[:  [S [< [[[fn( … )] [ →  … ]] ,  [S [< … >]]] >]]]"*/
+                .wrap(|x: i32| x)/*hint text="[:  [S [< [[[fn( … )] [ →  … ]] ,  [S [< … >]]] >]]]"*/
+                .wrap(|x: i32| x)/*hint text="[:  [S [< [[[fn( … )] [ →  … ]] ,  [S [< … >]]] >]]]"*/
                 .wrap(|x: i32| x);
         }
     """)
@@ -385,16 +383,4 @@ abstract class RsInlayTypeHintsProviderTestBase : RsTestBase() {
             let y/*hint text="[:  [V [< [u8 ,  f32] >]]]"*/ = x;
         }
     """)
-
-    private fun checkByText(@Language("Rust") code: String) {
-        InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))
-        checkInlays()
-    }
-
-    // BACKCOMPAT: 2019.3. Inline it
-    protected abstract fun checkInlays()
-
-    companion object {
-        private val HINT_COMMENT_PATTERN = Regex("""/\*(hint.*?)\*/""")
-    }
 }

--- a/src/test/kotlin/org/rust/ide/hints/RsInlayTypeHintsTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RsInlayTypeHintsTestBase.kt
@@ -1,0 +1,19 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hints
+
+import org.intellij.lang.annotations.Language
+
+abstract class RsInlayTypeHintsTestBase : RsInlayTypeHintsTestPlatformBase() {
+    protected fun checkByText(@Language("Rust") code: String) {
+        InlineFile(code.replace(HINT_COMMENT_PATTERN, "<$1/>"))
+        checkInlays()
+    }
+
+    companion object {
+        private val HINT_COMMENT_PATTERN = Regex("""/\*(hint.*?)\*/""")
+    }
+}


### PR DESCRIPTION
This PR adds support for chained method hints.

![image](https://user-images.githubusercontent.com/4539057/80112702-b0b2ba80-8581-11ea-9942-d266e1be3cc8.png)

Questions:
1) ~I copied the new (201) inlay tests from `RsInlayTypeHintsProviderTestBase`, should I also add support for 193?~ Turns out that CI won't pass without it, so I added it. Also I'm not sure that I understand the syntax for writing hint tests :-)
2) The preview text in settings does not seem to be affected by the hints. Maybe it misses the std types, can they be added somehow or do I have to prepare a standalone preview without std?
3) Should I add some settings?
4) I'm a bit confused about the difference between `RsPlainHint` and the various `InlayHintsProvider`s. Should I add support for this hint to `RsPlainHint`?

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5190