### PR TITLE
GRD: don't add channel suffix if channel is `stable`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,7 +172,7 @@ val Project.dependencyCachePath get(): String {
     return cachePath.absolutePath
 }
 
-val channelSuffix = if (channel.isBlank()) "" else "-$channel"
+val channelSuffix = if (channel.isBlank() || channel == "stable") "" else "-$channel"
 val versionSuffix = "-$platformVersion$channelSuffix"
 val patchVersion = prop("patchVersion").toInt()
 


### PR DESCRIPTION
bors r+