### PR TITLE
FIX: search for parent expression recursively in SurroundWithUnsafeFix

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/SurroundWithUnsafeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/SurroundWithUnsafeFix.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.util.parentOfType
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsExprStmt
 import org.rust.lang.core.psi.RsPsiFactory
@@ -19,15 +20,8 @@ class SurroundWithUnsafeFix(expr: RsExpr) : LocalQuickFixAndIntentionActionOnPsi
     override fun getText() = "Surround with unsafe block"
 
     override fun invoke(project: Project, file: PsiFile, editor: Editor?, expr: PsiElement, endElement: PsiElement) {
-        when (expr.parent) {
-            is RsExprStmt -> {
-                val unsafe = RsPsiFactory(project).createUnsafeBlockExpr(expr.parent.text)
-                expr.parent.replace(unsafe)
-            }
-            else -> {
-                val unsafe = RsPsiFactory(project).createUnsafeBlockExpr(expr.text)
-                expr.replace(unsafe)
-            }
-        }
+        val target = expr.parentOfType<RsExprStmt>() ?: expr
+        val unsafe = RsPsiFactory(project).createUnsafeBlockExpr(target.text)
+        target.replace(unsafe)
     }
 }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeTest.kt
@@ -146,4 +146,30 @@ class AddUnsafeTest : RsAnnotatorTestBase(RsUnsafeExpressionAnnotator::class) {
             unsafe { foo(); }
         }
     """)
+
+    fun `test left-hand side assignment`() = checkFixByText("Surround with unsafe block", """
+        fn test() {
+            let buffer = 0xb00000 as *mut u8;
+            <error>*buffer/*caret*/</error> = 5;
+        }
+    """, """
+        fn test() {
+            let buffer = 0xb00000 as *mut u8;
+            unsafe { *buffer = 5; }
+        }
+    """)
+
+    fun `test nested left-hand side assignment`() = checkFixByText("Surround with unsafe block", """
+        extern "C" { fn foo() -> *mut u8; }
+
+        fn test() {
+            <error>*<error>foo()/*caret*/</error></error> = 5;
+        }
+    """, """
+        extern "C" { fn foo() -> *mut u8; }
+
+        fn test() {
+            unsafe { *foo() = 5; }
+        }
+    """)
 }


### PR DESCRIPTION
I modified SurroundWithUnsafeFix to find parent expression statements recursively, before it only looked one level up.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5285