### PR TITLE
REF: don't rename non rust directories

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/RsDirectoryRenameProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsDirectoryRenameProcessor.kt
@@ -7,12 +7,14 @@ package org.rust.ide.refactoring
 
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.openapiext.Testmark
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiDirectoryContainer
 import com.intellij.psi.PsiElement
 import com.intellij.refactoring.RefactoringSettings
 import com.intellij.refactoring.rename.RenameDialog
 import com.intellij.refactoring.rename.RenamePsiFileProcessor
+import org.rust.cargo.project.model.cargoProjects
 import org.rust.lang.RsConstants
 
 class RsDirectoryRenameProcessor : RenamePsiFileProcessor() {
@@ -22,10 +24,15 @@ class RsDirectoryRenameProcessor : RenamePsiFileProcessor() {
     }
 
     override fun canProcessElement(element: PsiElement): Boolean {
-        return element is PsiDirectory || element is PsiDirectoryContainer
+        if (!(element is PsiDirectory || element is PsiDirectoryContainer)) return false
+        // Do nothing for directories outside of cargo project.
+        // Otherwise, it may affect rename provided by other languages like renaming of Java packages.
+        // See https://youtrack.jetbrains.com/issue/IDEA-238958
+        return element.project.cargoProjects.findProjectForFile(element.toDir().virtualFile) != null
     }
 
     override fun prepareRenaming(element: PsiElement, newName: String, allRenames: MutableMap<PsiElement, String>) {
+        Testmarks.rustDirRenameHandler.hit()
         super.prepareRenaming(element, newName, allRenames)
         if (!RefactoringSettings.getInstance().RENAME_SEARCH_FOR_REFERENCES_FOR_DIRECTORY) return
 
@@ -39,4 +46,8 @@ class RsDirectoryRenameProcessor : RenamePsiFileProcessor() {
 
     private fun PsiElement.toDir(): PsiDirectory = (this as? PsiDirectoryContainer)?.directories?.first()
         ?: (this as PsiDirectory)
+
+    object Testmarks {
+        val rustDirRenameHandler = Testmark("rustDirRename")
+    }
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RenameTest.kt
@@ -6,9 +6,12 @@
 package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
+import org.rust.EmptyDescriptor
+import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
 import org.rust.lang.core.psi.RsModDeclItem
 import org.rust.lang.core.psi.ext.descendantsOfType
+import org.rust.openapiext.toPsiDirectory
 
 class RenameTest : RsTestBase() {
     fun `test function`() = doTest("spam", """
@@ -263,6 +266,13 @@ class RenameTest : RsTestBase() {
         myFixture.renameElement(file, "bar")
     }
 
+    @ProjectDescriptor(EmptyDescriptor::class)
+    fun `test do not invoke rename refactoring for directory outside of cargo project`() {
+        val dir = myFixture.tempDirFixture.findOrCreateDir("dir").toPsiDirectory(project)!!
+        RsDirectoryRenameProcessor.Testmarks.rustDirRenameHandler.checkNotHit {
+            myFixture.renameElement(dir, "dir2")
+        }
+    }
 
     fun `test rename file to keyword`() = checkByDirectory("""
     //- main.rs


### PR DESCRIPTION
Otherwise, it may affect rename provided by other languages like renaming of Java packages.

Fixes https://youtrack.jetbrains.com/issue/IDEA-238958