### PR TITLE
Fix "find usages" action with `include!()` macros and `pub(crate)` items in crate root

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -67,7 +67,7 @@ fun PsiElement.findMacroCallExpandedFrom(): RsMacroCall? {
 }
 
 fun PsiElement.findMacroCallExpandedFromNonRecursive(): RsMacroCall? {
-    return ancestors
+    return stubAncestors
         .filterIsInstance<RsExpandedElement>()
         .mapNotNull { it.expandedFrom }
         .firstOrNull()

--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -76,6 +76,12 @@ fun PsiElement.findMacroCallExpandedFromNonRecursive(): RsMacroCall? {
 val PsiElement.isExpandedFromMacro: Boolean
     get() = findMacroCallExpandedFromNonRecursive() != null
 
+val PsiElement.isExpandedFromIncludeMacro: Boolean
+    get() {
+        val parent = stubParent
+        return parent is RsFile && RsIncludeMacroIndex.getIncludingMod(parent) != null
+    }
+
 private data class MacroCallAndOffset(val call: RsMacroCall, val absoluteOffset: Int)
 
 /**

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
@@ -101,7 +101,7 @@ object RsPsiImplUtil {
             is RsVisibility.Restricted -> visibility.inMod
         }
 
-        if (!restrictedMod.hasChildFiles()) return localOrMacroSearchScope(containingMod)
+        if (!restrictedMod.hasChildFiles()) return localOrMacroSearchScope(restrictedMod)
 
         // TODO restrict scope to [restrictedMod]. We can't use `DirectoryScope` b/c file from any
         //   directory can be included via `#[path]` attribute or `include!()` macro.

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiImplUtil.kt
@@ -10,6 +10,7 @@ import com.intellij.psi.search.LocalSearchScope
 import com.intellij.psi.search.SearchScope
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.lang.core.macros.findMacroCallExpandedFrom
+import org.rust.lang.core.macros.isExpandedFromIncludeMacro
 import org.rust.lang.core.psi.ext.*
 
 /**
@@ -100,10 +101,10 @@ object RsPsiImplUtil {
             is RsVisibility.Restricted -> visibility.inMod
         }
 
-        if (!restrictedMod.hasChildModules()) return localOrMacroSearchScope(containingMod)
+        if (!restrictedMod.hasChildFiles()) return localOrMacroSearchScope(containingMod)
 
         // TODO restrict scope to [restrictedMod]. We can't use `DirectoryScope` b/c file from any
-        //   directory can be included via `#[path]` attribute.
+        //   directory can be included via `#[path]` attribute or `include!()` macro.
         return null
     }
 
@@ -117,5 +118,8 @@ object RsPsiImplUtil {
         LocalSearchScope(scope.findMacroCallExpandedFrom() ?: scope)
 }
 
-private fun RsMod.hasChildModules(): Boolean =
-    expandedItemsExceptImplsAndUses.any { it is RsModDeclItem || it is RsModItem && it.hasChildModules() }
+// TODO support local modules, e.g. `fn foo() { #[path = "baz.rs"] mod bar; }`
+private fun RsMod.hasChildFiles(): Boolean =
+    expandedItemsExceptImplsAndUses.any {
+        it is RsModDeclItem || it is RsModItem && it.hasChildFiles() || it.isExpandedFromIncludeMacro
+    }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -29,6 +29,11 @@ val PsiElement.ancestors: Sequence<PsiElement>
         if (it is PsiFile) null else it.parent
     }
 
+val PsiElement.stubAncestors: Sequence<PsiElement>
+    get() = generateSequence(this) {
+        if (it is PsiFile) null else it.stubParent
+    }
+
 val PsiElement.contexts: Sequence<PsiElement>
     get() = generateSequence(this) {
         if (it is PsiFile) null else it.context

--- a/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt
+++ b/src/test/kotlin/org/rust/ide/search/RsFindUsagesTest.kt
@@ -240,6 +240,16 @@ class RsFindUsagesTest : RsTestBase() {
         """)
     }
 
+    // https://github.com/intellij-rust/intellij-rust/issues/5265
+    fun `test issue 5265`() = doTestByText("""
+        mod foo {
+            pub(crate) enum Foo { Bar { x: i32 } }
+        }                       //^
+        fn main() {
+            let _ = foo::Foo::Bar { x: 123 }; // - init struct
+        }
+    """)
+
     private fun doTestByText(@Language("Rust") code: String) {
         InlineFile(code)
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -177,9 +177,9 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test impl in non-inline mod with cfg`() = stubOnlyResolve("""
     //- bar.rs
-        impl super::S { fn foo(&self) {} }
+        impl super::S { pub fn foo(&self) {} }
     //- baz.rs
-        impl super::S { fn foo(&self) {} }
+        impl super::S { pub fn foo(&self) {} }
     //- lib.rs
         struct S;
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
@@ -336,7 +336,7 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
     fun `test expand macro inside stubbed file`() = stubOnlyResolve("""
     //- bar.rs
         pub struct S;
-        impl S { fn bar(&self) {} }
+        impl S { pub fn bar(&self) {} }
         foo!();
     //- main.rs
         macro_rules! foo {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
@@ -16,6 +16,7 @@ import org.intellij.lang.annotations.Language
 import org.rust.FileTree
 import org.rust.RsTestBase
 import org.rust.fileTreeFromText
+import org.rust.lang.core.macros.isExpandedFromMacro
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ref.RsReference
 
@@ -138,5 +139,16 @@ fun PsiElement.checkedResolve(offset: Int): PsiElement {
         "Incorrect `isReferenceTo` implementation in `${reference.javaClass.name}`"
     }
 
+    checkSearchScope(this, resolved)
+
     return resolved
+}
+
+private fun checkSearchScope(referenceElement: PsiElement, resolvedTo: PsiElement) {
+    if (resolvedTo.isExpandedFromMacro) return
+    val virtualFile = referenceElement.containingFile.virtualFile ?: return
+    check(resolvedTo.useScope.contains(virtualFile)) {
+        "Incorrect `getUseScope` implementation in `${resolvedTo.javaClass.name}`;" +
+            "also this can means that `pub` visibility is missed somewhere in the test"
+    }
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -31,7 +31,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         }
 
     //- inner/child.rs
-        fn foo() {}
+        pub fn foo() {}
     """)
 
     fun `test mod decl`() = stubOnlyResolve("""
@@ -57,7 +57,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         fn main() {}
 
     //- bar.rs
-        struct Bar {}
+        pub struct Bar {}
     """)
 
     fun `test mod decl path`() = stubOnlyResolve("""
@@ -138,7 +138,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         pub mod foobar;
 
     //- foo.rs
-        fn quux() {}
+        pub fn quux() {}
     """)
 
     fun `test mod relative 2`() = stubOnlyResolve("""
@@ -286,7 +286,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
                            //^ foo/baz.rs
         }
     //- foo/baz.rs
-        fn foo() {}
+        pub fn foo() {}
     """, NameResolutionTestmarks.modDeclExplicitPathInInlineModule)
 
     fun `test path inside inline module in mod rs`() = stubOnlyResolve("""
@@ -303,7 +303,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
                            //^ foo/bar/qwe.rs
         }
     //- foo/bar/qwe.rs
-        fn baz() {}
+        pub fn baz() {}
     """, NameResolutionTestmarks.modDeclExplicitPathInInlineModule)
 
     fun `test path inside inline module in non crate root`() = stubOnlyResolve("""
@@ -418,7 +418,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
     //- foo.rs
         struct S(Bar);
         struct Bar;
-        impl Bar { fn bar(self) {} }
+        impl Bar { pub fn bar(self) {} }
     """)
 
     fun `test method call`() = stubOnlyResolve("""
@@ -457,7 +457,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         enum S { X }
 
         impl S {
-            fn foo(&self) { }
+            pub fn foo(&self) { }
         }
     """)
 
@@ -597,7 +597,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         pub trait T {
             fn foo(&self);
         }
-        
+
         impl T for [i32; 1] {
             fn foo(&self) {}
         }
@@ -618,7 +618,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         pub trait T {
             fn foo(&self);
         }
-        
+
         impl T for [i32; 1] {
             fn foo(&self) {}
         }
@@ -639,7 +639,7 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         pub trait T {
             fn foo(&self);
         }
-        
+
         impl <const N: usize> T for [i32; N] {
             fn foo(&self) {}
         }
@@ -658,11 +658,11 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
 
     //- bar.rs
         pub struct S<const N: usize>;
-        
+
         pub trait T {
             fn foo(&self);
         }
-        
+
         impl T for S<{ 0 }> {
             fn foo(&self) {}
         }
@@ -681,11 +681,11 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
 
     //- bar.rs
         pub struct S<const N: usize>;
-        
+
         pub trait T {
             fn foo(&self);
         }
-        
+
         impl T for S<{ 0 }> {
             fn foo(&self) {}
         }
@@ -704,11 +704,11 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
 
     //- bar.rs
         pub struct S<const N: usize>;
-        
+
         pub trait T {
             fn foo(&self);
         }
-        
+
         impl <const N: usize> T for S<{ N }> {
             fn foo(&self) {}
         }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareResolveTest.kt
@@ -97,7 +97,7 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
                                                 //^ aux.rs
 
     //- aux.rs
-        trait T {
+        pub trait T {
             fn virtual_function(&self) {}
         }
     """)
@@ -144,7 +144,7 @@ class RsTypeAwareResolveTest : RsResolveTestBase() {
         }
 
     //- aux.rs
-        struct S { x: f32 }
+        pub struct S { pub x: f32 }
     """)
 
     fun `test tuple field expr`() = checkByCode("""


### PR DESCRIPTION
1. Now we take into account usages in files included to the project by `include!()` macro:
```
//- lib.rs
    include!("foo.rs");
    fn bar() {}
      //^ find usages for this function
//- foo.rs
    pub fn foo() {
        bar(); // this usage will be found
    }
```
2. Fixes #5265
3. T: better tests for search scopes. Now all name resolution tests also check search scopes of resolved items