### PR TITLE
PERF: less recursive `RsExpandedElement.getContextImpl`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -26,7 +26,7 @@ interface RsExpandedElement : RsElement {
 
     companion object {
         fun getContextImpl(psi: RsExpandedElement, isIndexAccessForbidden: Boolean = false): PsiElement? {
-            psi.expandedFrom?.let { return it.context }
+            psi.project.macroExpansionManager.getContextOfMacroCallExpandedFrom(psi)?.let { return it }
             psi.getUserData(RS_EXPANSION_CONTEXT)?.let { return it }
             val parent = psi.stubParent
             if (parent is RsFile && !isIndexAccessForbidden) {


### PR DESCRIPTION
Now `RsExpandedElement.getContextImpl` looks more flat in the profiler. 
(this simplifies profiling rather than improves performance)