### PR TITLE
Copy enum attributes in RsExtractEnumVariant

### DIFF
--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractEnumVariantTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractEnumVariantTest.kt
@@ -485,6 +485,42 @@ class RsExtractEnumVariantTest : RsTestBase() {
         }
     """)
 
+    fun `test keep supported attributes`() = doAvailableTest("""
+        #[derive(Debug, Clone)]
+        #[repr(C)]
+        pub enum E {
+            /*caret*/V1 { x: i32, y: i32 },
+            V2
+        }
+    """, """
+        #[derive(Debug, Clone)]
+        #[repr(C)]
+        pub struct /*caret*/V1 { pub x: i32, pub y: i32 }
+
+        #[derive(Debug, Clone)]
+        #[repr(C)]
+        pub enum E {
+            V1(V1),
+            V2
+        }
+    """)
+
+    fun `test ignore unsupported attributes`() = doAvailableTest("""
+        #[attr]
+        pub enum E {
+            /*caret*/V1 { x: i32, y: i32 },
+            V2
+        }
+    """, """
+        pub struct /*caret*/V1 { pub x: i32, pub y: i32 }
+
+        #[attr]
+        pub enum E {
+            V1(V1),
+            V2
+        }
+    """)
+
     private fun doAvailableTest(@Language("Rust") before: String, @Language("Rust") after: String) {
         checkEditorAction(before, after, "Rust.RsExtractEnumVariant")
     }


### PR DESCRIPTION
This PR adds support for copying (a supported subset of) attributes from the parent enum to the generated struct in `RsExtractEnumVariant`. I added `derive` and `repr` to the set for now.

@Undin The generated code puts an empty line between the attributes and the struct, like this:
```rust
#[derive(Debug, Clone)]
#[repr(C)]

pub struct V1 { pub x: i32, pub y: i32 }
```

I'm not putting it there, it seems like it's done automatically by the formatter. How can I avoid the empty line?

Blocked by https://github.com/intellij-rust/intellij-rust/pull/5291
Fixes: https://github.com/intellij-rust/intellij-rust/issues/5283