### PR TITLE
COMP: add completion of angle brackets for generic types

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -322,8 +322,7 @@ private fun addAngleBrackets(element: RsGenericDeclaration, document: Document, 
     val path = context.getElementOfType<RsPath>()
     if (path == null || path.parent !is RsTypeReference) return
 
-    if (!context.alreadyHasAngleBrackets)
-    {
+    if (!context.alreadyHasAngleBrackets) {
         document.insertString(context.selectionEndOffset, "<>")
     }
     EditorModificationUtil.moveCaretRelatively(context.editor, 1)

--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -11,6 +11,7 @@ import com.intellij.codeInsight.completion.InsertionContext
 import com.intellij.codeInsight.completion.PrioritizedLookupElement
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.EditorModificationUtil
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
@@ -223,6 +224,11 @@ open class RsDefaultInsertHandler : InsertHandler<LookupElement> {
         if (element is RsNameIdentifierOwner && !RsNamesValidator.isIdentifier(scopeName) && scopeName !in CAN_NOT_BE_ESCAPED) {
             document.insertString(startOffset, RS_RAW_PREFIX)
         }
+
+        if (element is RsGenericDeclaration) {
+            addAngleBrackets(element, document, context)
+        }
+
         when (element) {
 
             is RsMod -> {
@@ -308,6 +314,19 @@ private fun appendSemicolon(context: InsertionContext, curUseItem: RsUseItem?) {
     }
 }
 
+private fun addAngleBrackets(element: RsGenericDeclaration, document: Document, context: InsertionContext) {
+    if (element.typeParameters.isEmpty()) return
+
+    // do not complete angle brackets if not in type place
+    if (context.getElementOfType<RsPathExpr>() != null) return
+
+    if (!context.alreadyHasAngleBrackets)
+    {
+        document.insertString(context.selectionEndOffset, "<>")
+    }
+    EditorModificationUtil.moveCaretRelatively(context.editor, 1)
+}
+
 inline fun <reified T : PsiElement> InsertionContext.getElementOfType(strict: Boolean = false): T? =
     PsiTreeUtil.findElementOfClassAtOffset(file, tailOffset - 1, T::class.java, strict)
 
@@ -316,6 +335,9 @@ private val InsertionContext.isInUseGroup: Boolean
 
 val InsertionContext.alreadyHasCallParens: Boolean
     get() = nextCharIs('(')
+
+private val InsertionContext.alreadyHasAngleBrackets: Boolean
+    get() = nextCharIs('<')
 
 private val InsertionContext.alreadyHasStructBraces: Boolean
     get() = nextCharIs('{')

--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -315,10 +315,12 @@ private fun appendSemicolon(context: InsertionContext, curUseItem: RsUseItem?) {
 }
 
 private fun addAngleBrackets(element: RsGenericDeclaration, document: Document, context: InsertionContext) {
-    if (element.typeParameters.isEmpty()) return
+    // complete only types that have at least one type parameter without a default
+    if (element.typeParameters.all { it.typeReference != null }) return
 
-    // do not complete angle brackets if not in type place
-    if (context.getElementOfType<RsPathExpr>() != null) return
+    // complete angle brackets only in a type context
+    val path = context.getElementOfType<RsPath>()
+    if (path == null || path.parent !is RsTypeReference) return
 
     if (!context.alreadyHasAngleBrackets)
     {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -877,4 +877,28 @@ class RsCompletionTest : RsCompletionTestBase() {
             Foo.foo()/*caret*/
         }
     """)
+
+    fun `test complete type parameters on tuple struct`() = doSingleCompletion("""
+        struct Frobnicate<T>(T);
+        fn main() { let x: Frob/*caret*/ }
+    """, """
+        struct Frobnicate<T>(T);
+        fn main() { let x: Frobnicate</*caret*/> }
+    """)
+
+    fun `test move cursor if angle brackets already exist`() = doSingleCompletion("""
+        struct Frobnicate<T>(T);
+        fn main() { let x: Frob/*caret*/<> }
+    """, """
+        struct Frobnicate<T>(T);
+        fn main() { let x: Frobnicate</*caret*/> }
+    """)
+
+    fun `test don't complete type arguments in expression context`() = doSingleCompletion("""
+        struct Frobnicate<T>(T);
+        fn main() { let x = Frob/*caret*/ }
+    """, """
+        struct Frobnicate<T>(T);
+        fn main() { let x = Frobnicate/*caret*/ }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -878,27 +878,97 @@ class RsCompletionTest : RsCompletionTestBase() {
         }
     """)
 
-    fun `test complete type parameters on tuple struct`() = doSingleCompletion("""
+    fun `test complete type parameters in let binding`() = doSingleCompletion("""
         struct Frobnicate<T>(T);
-        fn main() { let x: Frob/*caret*/ }
+        fn main() {
+            let x: Frob/*caret*/
+        }
     """, """
         struct Frobnicate<T>(T);
-        fn main() { let x: Frobnicate</*caret*/> }
+        fn main() {
+            let x: Frobnicate</*caret*/>
+        }
+    """)
+
+    fun `test complete type parameters in parameter`() = doSingleCompletion("""
+        struct Frobnicate<T>(T);
+        fn foo(a: Frob/*caret*/) {}
+    """, """
+        struct Frobnicate<T>(T);
+        fn foo(a: Frobnicate</*caret*/>) {}
+    """)
+
+    fun `test complete type parameters in generic function call`() = doSingleCompletion("""
+        struct Frobnicate<T>(T);
+        fn gen<T>(t: T) {}
+        fn foo() {
+            gen::<Frob/*caret*/
+        }
+    """, """
+        struct Frobnicate<T>(T);
+        fn gen<T>(t: T) {}
+        fn foo() {
+            gen::<Frobnicate</*caret*/>
+        }
     """)
 
     fun `test move cursor if angle brackets already exist`() = doSingleCompletion("""
         struct Frobnicate<T>(T);
-        fn main() { let x: Frob/*caret*/<> }
+        fn main() {
+            let x: Frob/*caret*/<>
+        }
     """, """
         struct Frobnicate<T>(T);
-        fn main() { let x: Frobnicate</*caret*/> }
+        fn main() {
+            let x: Frobnicate</*caret*/>
+        }
     """)
 
-    fun `test don't complete type arguments in expression context`() = doSingleCompletion("""
+    fun `test don't complete type arguments in expression context 1`() = doSingleCompletion("""
         struct Frobnicate<T>(T);
-        fn main() { let x = Frob/*caret*/ }
+        fn main() {
+            let x = Frob/*caret*/
+        }
     """, """
         struct Frobnicate<T>(T);
-        fn main() { let x = Frobnicate/*caret*/ }
+        fn main() {
+            let x = Frobnicate/*caret*/
+        }
+    """)
+
+    fun `test don't complete type arguments in expression context 2`() = doSingleCompletion("""
+        struct Frobnicate<T>(T);
+        fn main() {
+            if (Frob/*caret*/
+        }
+    """, """
+        struct Frobnicate<T>(T);
+        fn main() {
+            if (Frobnicate/*caret*/
+        }
+    """)
+
+    fun `test don't complete type arguments in use item`() = doSingleCompletion("""
+        mod a {
+            pub struct Frobnicate<T>(T);
+        }
+        use a::Frob/*caret*/
+    """, """
+        mod a {
+            pub struct Frobnicate<T>(T);
+        }
+        use a::Frobnicate;/*caret*/
+    """)
+
+    fun `test don't complete type arguments if all type parameters have a default`() = doSingleCompletion("""
+        struct Frobnicate<T=u32,R=i32>(T, R);
+        fn main() {
+            let x: Frob/*caret*/
+        }
+    """, """
+        struct Frobnicate<T=u32,R=i32>(T, R);
+        fn main() {
+            let x: Frobnicate/*caret*/
+        }
     """)
 }


### PR DESCRIPTION
This PR adds completion for angle brackets for generic types, i.e.

```rust
let x: Ve/*caret*/
vvv
let x: Vec</*caret*/>
```

Fixes: https://github.com/intellij-rust/intellij-rust/issues/4508