### PR TITLE
ANN: highlight never type exit points

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/cfg/ControlFlowGraph.kt
+++ b/src/main/kotlin/org/rust/lang/core/cfg/ControlFlowGraph.kt
@@ -171,7 +171,17 @@ private class ExitPointVisitor(
             && macroCall.exprMacroArgument != null
             && inTry == 0) sink(ExitPoint.TryExpr(macroExpr))
 
-        if (macroExpr.type == TyNever) sink(ExitPoint.DivergingExpr(macroExpr))
+        macroExpr.markNeverTypeAsExit(sink)
+    }
+
+    override fun visitCallExpr(callExpr: RsCallExpr) {
+        super.visitCallExpr(callExpr)
+        callExpr.markNeverTypeAsExit(sink)
+    }
+
+    override fun visitDotExpr(dotExpr: RsDotExpr) {
+        super.visitDotExpr(dotExpr)
+        dotExpr.markNeverTypeAsExit(sink)
     }
 
     override fun visitBreakExpr(breakExpr: RsBreakExpr) {
@@ -238,4 +248,8 @@ private class ExitPointVisitor(
             }
             return false
         }
+}
+
+private fun RsExpr.markNeverTypeAsExit(sink: (ExitPoint) -> Unit) {
+    if (this.type == TyNever) sink(ExitPoint.DivergingExpr(this))
 }

--- a/src/main/kotlin/org/rust/lang/core/cfg/ControlFlowGraph.kt
+++ b/src/main/kotlin/org/rust/lang/core/cfg/ControlFlowGraph.kt
@@ -164,6 +164,8 @@ private class ExitPointVisitor(
     }
 
     override fun visitMacroExpr(macroExpr: RsMacroExpr) {
+        super.visitMacroExpr(macroExpr)
+
         val macroCall = macroExpr.macroCall
         if (macroCall.macroName == "try"
             && macroCall.exprMacroArgument != null

--- a/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
+++ b/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
@@ -94,6 +94,18 @@ class RsHighlightExitPointsHandlerFactoryTest : RsTestBase() {
         }
     """, "return 1", "test()")
 
+    fun `test highlight last macro call as return`() = doTest("""
+        macro_rules! test {
+            () => { () }
+        }
+        fn main() {
+            if true {
+                /*caret*/return;
+            }
+            test!()
+        }
+    """, "return", "test!()")
+
     fun `test highlight should not highlight inner function`() = doTest("""
         fn main() {
             fn bar() {

--- a/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
+++ b/src/test/kotlin/org/rust/ide/highlight/RsHighlightExitPointsHandlerFactoryTest.kt
@@ -42,6 +42,35 @@ class RsHighlightExitPointsHandlerFactoryTest : RsTestBase() {
         }
     """, "panic!(\"test\")", "unimplemented!()", "return 0")
 
+    fun `test highlight diverging expressions as return`() = doTest("""
+        fn diverge() -> ! { unimplemented!() }
+
+        fn main() {
+            if true {
+                diverge();
+            }
+            /*caret*/return 0;
+        }
+    """, "diverge()", "return 0")
+
+    fun `test highlight diverging expressions as return 2`() = doTest("""
+        struct S;
+
+        impl S {
+           fn diverge(&self) -> ! { panic!() }
+        }
+
+        fn main() {
+           let s = S;
+
+           if true {
+              /*caret*/return;
+           }
+
+           s.diverge();
+        }
+    """, "return", "s.diverge()")
+
     fun `test highlight ? operator as return`() = doTest("""
         fn main() {
             if true {


### PR DESCRIPTION
Added support for highlighting never types as function exit points.
Also fixes highlighting of macro expressions in tail position.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/1712