### PR TITLE
DOC: add method impl/trait name to its FQN

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
@@ -55,7 +55,8 @@ abstract class RsConstantImplMixin : RsStubbedNamedElementImpl<RsConstantStub>, 
 
     override val isAbstract: Boolean get() = expr == null
 
-    override val crateRelativePath: String? get() = fullCrateRelativePath
+    override val crateRelativePath: String?
+        get() = fullCrateRelativePath
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsConstant.kt
@@ -27,11 +27,12 @@ val RsConstant.isMut: Boolean get() = greenStub?.isMut ?: (mut != null)
 
 val RsConstant.isConst: Boolean get() = greenStub?.isConst ?: (const != null)
 
-val RsConstant.kind: RsConstantKind get() = when {
-    isMut -> RsConstantKind.MUT_STATIC
-    isConst -> RsConstantKind.CONST
-    else -> RsConstantKind.STATIC
-}
+val RsConstant.kind: RsConstantKind
+    get() = when {
+        isMut -> RsConstantKind.MUT_STATIC
+        isConst -> RsConstantKind.CONST
+        else -> RsConstantKind.STATIC
+    }
 
 val RsConstant.default: PsiElement?
     get() = node.findChildByType(DEFAULT)?.psi
@@ -54,7 +55,7 @@ abstract class RsConstantImplMixin : RsStubbedNamedElementImpl<RsConstantStub>, 
 
     override val isAbstract: Boolean get() = expr == null
 
-    override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
+    override val crateRelativePath: String? get() = fullCrateRelativePath
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -171,7 +171,8 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
 
     override val isUnsafe: Boolean get() = this.greenStub?.isUnsafe ?: (unsafe != null)
 
-    override val crateRelativePath: String? = fullCrateRelativePath
+    override val crateRelativePath: String?
+        get() = fullCrateRelativePath
 
     final override val innerAttrList: List<RsInnerAttr>
         get() = stubOnlyBlock?.innerAttrList.orEmpty()

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -171,7 +171,7 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
 
     override val isUnsafe: Boolean get() = this.greenStub?.isUnsafe ?: (unsafe != null)
 
-    override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
+    override val crateRelativePath: String? = fullCrateRelativePath
 
     final override val innerAttrList: List<RsInnerAttr>
         get() = stubOnlyBlock?.innerAttrList.orEmpty()

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedFieldDecl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedFieldDecl.kt
@@ -22,8 +22,11 @@ abstract class RsNamedFieldDeclImplMixin : RsStubbedNamedElementImpl<RsNamedFiel
     override fun getIcon(flags: Int): Icon =
         iconWithVisibility(flags, RsIcons.FIELD)
 
-    // temporary solution.
-    override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
+    override val crateRelativePath: String?
+        get() {
+            val parent = parentStruct ?: return RsPsiImplUtil.crateRelativePath(this)
+            return RsPsiImplUtil.crateRelativePath(parent)?.plus("::$name")
+        }
 
     override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
@@ -32,7 +32,7 @@ abstract class RsTypeAliasImplMixin : RsStubbedNamedElementImpl<RsTypeAliasStub>
 
     override val isAbstract: Boolean get() = typeReference == null
 
-    override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
+    override val crateRelativePath: String? get() = fullCrateRelativePath
 
     override val declaredType: Ty get() = RsPsiTypeImplUtil.declaredType(this)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
@@ -32,7 +32,8 @@ abstract class RsTypeAliasImplMixin : RsStubbedNamedElementImpl<RsTypeAliasStub>
 
     override val isAbstract: Boolean get() = typeReference == null
 
-    override val crateRelativePath: String? get() = fullCrateRelativePath
+    override val crateRelativePath: String?
+        get() = fullCrateRelativePath
 
     override val declaredType: Ty get() = RsPsiTypeImplUtil.declaredType(this)
 

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -151,7 +151,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                   //^
         }
     """, """
-        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Foo">Foo</a>
+        <div class='definition'><pre>test_package::Foo<br>impl <a href="psi_element://Foo">Foo</a>
         pub fn <b>foo</b>(&amp;self)</pre></div>
     """)
 
@@ -163,7 +163,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                   //^
         }
     """, """
-        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Foo">Foo</a>
+        <div class='definition'><pre>test_package::Foo<br>impl <a href="psi_element://Foo">Foo</a>
         pub fn <b>foo</b>(&amp;self) -&gt; Self</pre></div>
     """)
 
@@ -175,7 +175,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                   //^
         }
     """, """
-        <div class='definition'><pre>test_package<br>impl&lt;T&gt; <a href="psi_element://Foo">Foo</a>&lt;T&gt;
+        <div class='definition'><pre>test_package::Foo<br>impl&lt;T&gt; <a href="psi_element://Foo">Foo</a>&lt;T&gt;
         pub fn <b>foo</b>(&amp;self)</pre></div>
     """)
 
@@ -188,7 +188,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                   //^
         }
     """, """
-        <div class='definition'><pre>test_package<br>impl&lt;T, F&gt; <a href="psi_element://Foo">Foo</a>&lt;T, F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        <div class='definition'><pre>test_package::Foo<br>impl&lt;T, F&gt; <a href="psi_element://Foo">Foo</a>&lt;T, F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
         pub fn <b>foo</b>(&amp;self)</pre></div>
     """)
 
@@ -401,7 +401,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
+        <div class='definition'><pre>test_package::Foo<br>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
         type <b>AssocType</b> = <a href="psi_element://Option">Option</a>&lt;i32&gt;</pre></div>
     """)
 
@@ -416,7 +416,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        <div class='definition'><pre>test_package<br>impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;
+        <div class='definition'><pre>test_package::Foo<br>impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;
         type <b>AssocType</b> = <a href="psi_element://Option">Option</a>&lt;T&gt;</pre></div>
     """)
 
@@ -431,7 +431,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        <div class='definition'><pre>test_package<br>impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        <div class='definition'><pre>test_package::Foo<br>impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
         type <b>AssocType</b> = <a href="psi_element://Option">Option</a>&lt;T&gt;</pre></div>
     """)
 
@@ -518,7 +518,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
+        <div class='definition'><pre>test_package::Foo<br>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
         const <b>AWESOME</b>: u8 = 42</pre></div>
     """)
 
@@ -569,7 +569,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
+        <div class='definition'><pre>test_package::Foo<br>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
         fn <b>foo</b>()</pre></div>
     """)
 
@@ -583,7 +583,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        <div class='definition'><pre>test_package<br>impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;
+        <div class='definition'><pre>test_package::Foo<br>impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;
         fn <b>foo</b>()</pre></div>
     """)
 
@@ -598,7 +598,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        <div class='definition'><pre>test_package<br>impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        <div class='definition'><pre>test_package::Foo<br>impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
         fn <b>foo</b>()</pre></div>
     """)
 
@@ -888,7 +888,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Foo2">Foo2</a> for <a href="psi_element://S">S</a>
+        <div class='definition'><pre>test_package::S<br>impl <a href="psi_element://Foo2">Foo2</a> for <a href="psi_element://S">S</a>
         type <b>Bar</b> = &lt;Self as <a href="psi_element://Foo1">Foo1</a>&gt;::<a href="psi_element://&lt;Self as Foo1&gt;::Bar">Bar</a></pre></div>
     """)
 
@@ -982,7 +982,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
             fn bar(&self) {}
         }
     """, """
-        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Foo">Foo</a>
+        <div class='definition'><pre>test_package::Foo<br>impl <a href="psi_element://Foo">Foo</a>
         fn <b>foo</b>(&amp;self)</pre></div>
         <div class='content'><p><a href="psi_element://test_package/struct.Foo.html#method.bar"><code>Foo::bar</code></a></p></div>
     """)
@@ -1000,7 +1000,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Foo">Foo</a> for <a href="psi_element://Bar">Bar</a>
+        <div class='definition'><pre>test_package::Bar<br>impl <a href="psi_element://Foo">Foo</a> for <a href="psi_element://Bar">Bar</a>
         fn <b>foo</b>()</pre></div>
         <div class='content'><p>Impl doc</p></div>
     """)
@@ -1017,7 +1017,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
                //^
         }
     """, """
-        <div class='definition'><pre>test_package<br>impl <a href="psi_element://Foo">Foo</a> for <a href="psi_element://Bar">Bar</a>
+        <div class='definition'><pre>test_package::Bar<br>impl <a href="psi_element://Foo">Foo</a> for <a href="psi_element://Bar">Bar</a>
         type <b>Baz</b> = ()</pre></div>
         <div class='content'><p>Trait doc</p></div>
     """)

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
@@ -71,7 +71,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
             //^
         }
     """, """
-        test_package<br>impl <a href="psi_element://S">S</a>
+        test_package::S<br>impl <a href="psi_element://S">S</a>
         pub fn <b>consume</b>(self) -&gt; i32
     """)
 
@@ -83,7 +83,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
                   //^
         }
     """, """
-        test_package<br>impl&lt;T&gt; <a href="psi_element://Foo">Foo</a>&lt;T&gt;
+        test_package::Foo<br>impl&lt;T&gt; <a href="psi_element://Foo">Foo</a>&lt;T&gt;
         pub fn <b>foo</b>(&amp;self)
     """)
 
@@ -96,7 +96,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
                   //^
         }
     """, """
-        test_package<br>impl&lt;T, F&gt; <a href="psi_element://Foo">Foo</a>&lt;T, F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        test_package::Foo<br>impl&lt;T, F&gt; <a href="psi_element://Foo">Foo</a>&lt;T, F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
         pub fn <b>foo</b>(&amp;self)
     """)
 
@@ -192,7 +192,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        test_package<br>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
+        test_package::Foo<br>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
         fn <b>foo</b>()
     """)
 
@@ -206,7 +206,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        test_package<br>impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;
+        test_package::Foo<br>impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;
         fn <b>foo</b>()
     """)
 
@@ -221,7 +221,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
               //^
         }
     """, """
-        test_package<br>impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        test_package::Foo<br>impl&lt;T, F&gt; <a href="psi_element://Trait">Trait</a>&lt;T&gt; for <a href="psi_element://Foo">Foo</a>&lt;F&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Ord">Ord</a>,<br>&nbsp;&nbsp;&nbsp;&nbsp;F: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
         fn <b>foo</b>()
     """)
 
@@ -446,7 +446,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        test_package<br>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
+        test_package::Foo<br>impl <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>
         type <b>AssocType</b> = <a href="psi_element://Option">Option</a>&lt;i32&gt;
     """)
 
@@ -461,7 +461,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        test_package<br>impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;
+        test_package::Foo<br>impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;
         type <b>AssocType</b> = <a href="psi_element://Option">Option</a>&lt;T&gt;
     """)
 
@@ -476,7 +476,7 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
                 //^
         }
     """, """
-        test_package<br>impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
+        test_package::Foo<br>impl&lt;T&gt; <a href="psi_element://Trait">Trait</a> for <a href="psi_element://Foo">Foo</a>&lt;T&gt;<br>where<br>&nbsp;&nbsp;&nbsp;&nbsp;T: <a href="psi_element://Into">Into</a>&lt;<a href="psi_element://String">String</a>&gt;,
         type <b>AssocType</b> = <a href="psi_element://Option">Option</a>&lt;T&gt;
     """)
 


### PR DESCRIPTION
This PR adds the name of a struct/enum/trait to the FQN of methods, constants and type aliases.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/1083