### PR TITLE
REF: omit unchanged default type parameters of parameters in ExtractFunction

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
@@ -54,7 +54,7 @@ class Parameter private constructor(
 
     private val mutText: String = if (isMutableValue) "mut " else ""
     private val referenceText: String = reference.text
-    private val typeText: String = type?.renderInsertionSafe().orEmpty()
+    private val typeText: String = type?.renderInsertionSafe(skipUnchangedDefaultTypeArguments = true).orEmpty()
 
     val originalParameterText: String
         get() = if (type != null) "$mutText$originalName: $referenceText$typeText" else originalName

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -1110,6 +1110,50 @@ class RsExtractFunctionTest : RsTestBase() {
         false,
         "foo")
 
+    fun `test extract a function with unset default type parameter`() = doTest("""
+        struct S<R, T=u32>(r: R, t: T);
+
+        fn main() {
+            let s: S<u32> = S(1u32, 2u32);
+            <selection>println!(s)</selection>;
+        }
+    """, """
+        struct S<R, T=u32>(r: R, t: T);
+
+        fn main() {
+            let s: S<u32> = S(1u32, 2u32);
+            foo(s);
+        }
+
+        fn foo(s: S<u32>) {
+            println!(s)
+        }
+    """,
+        false,
+        "foo")
+
+    fun `test extract a function with set default type parameter`() = doTest("""
+        struct S<R, T=u32>(r: R, t: T);
+
+        fn main() {
+            let s: S<u32, bool> = S(1u32, true);
+            <selection>println!(s)</selection>;
+        }
+    """, """
+        struct S<R, T=u32>(r: R, t: T);
+
+        fn main() {
+            let s: S<u32, bool> = S(1u32, true);
+            foo(s);
+        }
+
+        fn foo(s: S<u32, bool>) {
+            println!(s)
+        }
+    """,
+        false,
+        "foo")
+
     private fun doTest(@Language("Rust") code: String,
                        @Language("Rust") excepted: String,
                        pub: Boolean,

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -1111,14 +1111,14 @@ class RsExtractFunctionTest : RsTestBase() {
         "foo")
 
     fun `test extract a function with unset default type parameter`() = doTest("""
-        struct S<R, T=u32>(r: R, t: T);
+        struct S<R, T=u32>(R, T);
 
         fn main() {
             let s: S<u32> = S(1u32, 2u32);
             <selection>println!(s)</selection>;
         }
     """, """
-        struct S<R, T=u32>(r: R, t: T);
+        struct S<R, T=u32>(R, T);
 
         fn main() {
             let s: S<u32> = S(1u32, 2u32);
@@ -1133,14 +1133,14 @@ class RsExtractFunctionTest : RsTestBase() {
         "foo")
 
     fun `test extract a function with set default type parameter`() = doTest("""
-        struct S<R, T=u32>(r: R, t: T);
+        struct S<R, T=u32>(R, T);
 
         fn main() {
             let s: S<u32, bool> = S(1u32, true);
             <selection>println!(s)</selection>;
         }
     """, """
-        struct S<R, T=u32>(r: R, t: T);
+        struct S<R, T=u32>(R, T);
 
         fn main() {
             let s: S<u32, bool> = S(1u32, true);


### PR DESCRIPTION
This PR modifies the `ExtractFunction` refactoring to omit needless type arguments which are the same as the default for its given type parameter.

~I had to create yet another type renderer to not mess with other places where types are rendered. I wonder if it would be possible to replace things like `Ty.insertionSafeTextWithAliasesAndLifetimes` with simply creating a type renderer in each individual place where it's needed? The callers could then specify exactly the properties for type rendering that they need. The `TypeRenderer` seems very cheap to create, but if it would be a perf. problem then some dynamic caching mechanism could be used.~

I think that skipping the default unchanged type arguments is pretty useful and could be used as a default for type rendering. But maybe there are some places where it could cause problems (I can try to switch it to be used as a default and we can see what the CI says about it). 

Fixes second part of https://github.com/intellij-rust/intellij-rust/issues/4444