### PR TITLE
REF: allow the user to select mutability of parameters in ExtractFunction

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/ui.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/ui.kt
@@ -71,7 +71,7 @@ private class DialogExtractFunctionUi(
             signatureComponent.setSignature(config.signature)
         }
 
-        val parameterPanel = ExtractFunctionParameterTablePanel(project, ::isValidRustVariableIdentifier, config) {
+        val parameterPanel = ExtractFunctionParameterTablePanel(::isValidRustVariableIdentifier, config) {
             signatureComponent.setSignature(config.signature)
         }
 

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -1086,7 +1086,7 @@ class RsExtractFunctionTest : RsTestBase() {
         false,
         "bar")
 
-    fun `test extract a function with empty lines`() = doTest("""
+    fun `test extract with empty lines`() = doTest("""
         fn main() {
             <selection>println!("a");
 
@@ -1154,16 +1154,78 @@ class RsExtractFunctionTest : RsTestBase() {
         false,
         "foo")
 
+    fun `test extract set value to mutable`() = doTest("""
+        fn main() {
+            let a = 1u32;
+            <selection>println!(a);</selection>
+        }
+    """, """
+        fn main() {
+            let a = 1u32;
+            foo(a);
+        }
+
+        fn foo(mut a: u32) {
+            println!(a);
+        }
+    """,
+        false,
+        "foo", mutabilityOverride = mapOf("a" to true))
+
+    fun `test extract a function set reference to immutable`() = doTest("""
+        fn main() {
+            let mut a = 1u32;
+            <selection>a = 5;</selection>
+        }
+    """, """
+        fn main() {
+            let mut a = 1u32;
+            foo(&a);
+        }
+
+        fn foo(a: &u32) {
+            a = 5;
+        }
+    """,
+        false,
+        "foo", mutabilityOverride = mapOf("a" to false))
+
+    fun `test extract a function set reference to mutable`() = doTest("""
+        fn test(x: &u32) {}
+
+        fn main() {
+            let a = 1u32;
+            <selection>test(&a);</selection>
+        }
+    """, """
+        fn test(x: &u32) {}
+
+        fn main() {
+            let a = 1u32;
+            foo(&mut a);
+        }
+
+        fn foo(a: &mut u32) {
+            test(&a);
+        }
+    """,
+        false,
+        "foo", mutabilityOverride = mapOf("a" to true))
+
     private fun doTest(@Language("Rust") code: String,
                        @Language("Rust") excepted: String,
                        pub: Boolean,
                        name: String,
-                       noSelected: List<String> = emptyList()) {
+                       noSelected: List<String> = emptyList(),
+                       mutabilityOverride: Map<String, Boolean> = emptyMap()) {
         withMockExtractFunctionUi(object : ExtractFunctionUi {
             override fun extract(config: RsExtractFunctionConfig, callback: () -> Unit) {
                 config.name = name
                 config.visibilityLevelPublic = pub
                 noSelected.forEach { n -> config.parameters.filter { n == it.name }[0].isSelected = false }
+                mutabilityOverride.forEach { (key, mutable) ->
+                    config.parameters.filter { key == it.name }[0].isMutable = mutable
+                }
                 callback()
             }
         }) {


### PR DESCRIPTION
This PR adds mutability selection to the UI of `ExtractFunction`. I separated mutability from references, which should make it easier to add another option to choose "by value" or "by ref" parameters in the future.

There is a slightly weird interaction with `requiresMut` (formerly called `isMutableValue`), for example here:
```rust
fn test(mut v: Vec<i32>) {}
fn test2(v: &mut Vec<i32>) {}

fn foo() {
    let mut vec = vec![1, 2, 3];
    let mut vec2 = vec![1, 2, 3];

    /*caret*/bar(vec, &mut vec2);
}

fn bar(mut vec: Vec<i32>, mut vec2: &mut Vec<i32>) {
    test(vec);
    test2(&mut vec2);
}
```

If I turn off the mutability of `vec2`, it switches from `mut vec2: &mut Vec<i32>` to `vec2: &Vec<i32>`. A better solution would be to not require `mut` there and just pass `vec2` to `test2` directly: `test2(vec2)`. But that would require further changes in how the function is generated, as the extracted code would have to be modified.

Umbrella issue: https://github.com/intellij-rust/intellij-rust/issues/2186