### PR TITLE
Fix. Ignore entire mod subtree if disabled `#[cfg]`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -97,7 +97,8 @@ class RsFile(
         val declaration = declaration
         if (declaration != null) {
             val (file, isEnabledByCfg) = declaration.contextualFileAndIsEnabledByCfgOnThisWay()
-            return (file as? RsFile)?.cachedData?.copy(isDeeplyEnabledByCfg = isEnabledByCfg) ?: EMPTY_CACHED_DATA
+            val parentCachedData = (file as? RsFile)?.cachedData ?: return EMPTY_CACHED_DATA
+            return parentCachedData.copy(isDeeplyEnabledByCfg = parentCachedData.isDeeplyEnabledByCfg && isEnabledByCfg)
         }
 
         val possibleCrateRoot = this

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -197,6 +197,34 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
      """)
 
     @MockAdditionalCfgOptions("intellij_rust")
+    fun `test impl in non-inline mod with cfg 2`() = stubOnlyResolve("""
+    //- bar1.rs
+        impl super::super::S { pub fn foo(&self) {} }
+    //- baz1.rs
+        impl super::super::S { pub fn foo(&self) {} }
+    //- bar.rs
+        #[path = "bar1.rs"]
+        mod bar1;
+    //- baz.rs
+        #[path = "baz1.rs"]
+        mod baz1;
+    //- lib.rs
+        struct S;
+
+        #[cfg(intellij_rust)]
+        #[path = "bar.rs"]
+        mod foo;
+
+        #[cfg(not(intellij_rust))]
+        #[path = "baz.rs"]
+        mod foo;
+
+        fn main() {
+            S.foo()
+        }   //^ bar1.rs
+     """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
     fun `test impl in function body with cfg`() = checkByCode("""
         struct S;
         #[cfg(intellij_rust)]


### PR DESCRIPTION
This mostly affects `impl`s collecting.
#4335 was implemented a bit buggy, so `impl`s wasn't filtered from nested modules if a parent module is disabled by `#[cfg]` (see test).