### PR TITLE
Initial support of multiple module declarations of the same module

### DIFF
--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandler.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandler.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.navigation.goto
 
 import com.google.common.annotations.VisibleForTesting
+import com.intellij.codeInsight.navigation.NavigationUtil
 import com.intellij.lang.LanguageCodeInsightActionHandler
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
@@ -24,35 +25,40 @@ class RsGotoSuperHandler : LanguageCodeInsightActionHandler {
 
     override fun invoke(project: Project, editor: Editor, file: PsiFile) {
         val focusedElement = file.findElementAt(editor.caretModel.offset) ?: file
-            ?: return
-        gotoSuperTarget(focusedElement)?.navigate(true)
+        val targets = gotoSuperTargets(focusedElement)
+        when (targets.size) {
+            0 -> return
+            1 -> targets.single().navigate(true)
+            else -> NavigationUtil.getPsiElementPopup(targets.toTypedArray(), "Choose module declaration")
+                .showInBestPositionFor(editor)
+        }
     }
 }
 
 @VisibleForTesting
-fun gotoSuperTarget(source: PsiElement): NavigatablePsiElement? {
+fun gotoSuperTargets(source: PsiElement): List<NavigatablePsiElement> {
     val item = PsiTreeUtil.getNonStrictParentOfType(
         source,
         RsAbstractable::class.java,
         RsMod::class.java
     )
     if (item is RsAbstractable) return when {
-        item.owner.isTraitImpl -> item.superItem
-        else -> gotoSuperTarget(item.parent)
+        item.owner.isTraitImpl -> listOfNotNull(item.superItem)
+        else -> gotoSuperTargets(item.parent)
     }
 
     if (item is RsMod) {
         return if (item is RsFile) {
             if (item.isCrateRoot) {
-                val manifestPath = item.containingCargoPackage?.rootDirectory?.resolve("Cargo.toml") ?: return null
-                item.virtualFile?.fileSystem?.findFileByPath(manifestPath.toString())?.toPsiFile(item.project)
+                val manifestPath = item.containingCargoPackage?.rootDirectory?.resolve("Cargo.toml") ?: return emptyList()
+                listOfNotNull(item.virtualFile?.fileSystem?.findFileByPath(manifestPath.toString())?.toPsiFile(item.project))
             } else {
-                item.declaration
+                item.declarations
             }
         } else {
-            item.`super`
+            listOfNotNull(item.`super`)
         }
     }
 
-    return null
+    return emptyList()
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -175,11 +175,13 @@ class RsFile(
             return Attributes.NONE
         }
 
-    val declaration: RsModDeclItem? get() {
+    val declaration: RsModDeclItem? get() = declarations.firstOrNull()
+
+    val declarations: List<RsModDeclItem> get() {
         // XXX: without this we'll close over `thisFile`, and it's verboten
         // to store references to PSI inside `CachedValueProvider` other than
         // the key PSI element
-        val originalFile = originalFile as? RsFile ?: return null
+        val originalFile = originalFile as? RsFile ?: return emptyList()
 
         val state = project.macroExpansionManagerIfCreated?.expansionState
         // [RsModulesIndex.getDeclarationFor] behaves differently depending on whether macros are expanding
@@ -190,7 +192,7 @@ class RsFile(
         }
         return CachedValuesManager.getCachedValue(originalFile, key) {
             CachedValueProvider.Result.create(
-                RsModulesIndex.getDeclarationFor(originalFile),
+                RsModulesIndex.getDeclarationsFor(originalFile),
                 originalFile.rustStructureOrAnyPsiModificationTracker,
                 cacheDependency
             )
@@ -226,8 +228,8 @@ val PsiFile.rustFile: RsFile? get() = this as? RsFile
 val VirtualFile.isNotRustFile: Boolean get() = !isRustFile
 val VirtualFile.isRustFile: Boolean get() = fileType == RsFileType
 
-private val MOD_DECL_KEY: Key<CachedValue<RsModDeclItem?>> = Key.create("MOD_DECL_KEY")
-private val MOD_DECL_MACROS_KEY: Key<CachedValue<RsModDeclItem?>> = Key.create("MOD_DECL_MACROS_KEY")
+private val MOD_DECL_KEY: Key<CachedValue<List<RsModDeclItem>>> = Key.create("MOD_DECL_KEY")
+private val MOD_DECL_MACROS_KEY: Key<CachedValue<List<RsModDeclItem>>> = Key.create("MOD_DECL_MACROS_KEY")
 
 private val CACHED_DATA_KEY: Key<CachedValue<CachedData>> = Key.create("CACHED_DATA_KEY")
 private val CACHED_DATA_MACROS_KEY: Key<CachedValue<CachedData>> = Key.create("CACHED_DATA_MACROS_KEY")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
@@ -33,6 +33,10 @@ fun RsVisibilityOwner.iconWithVisibility(flags: Int, icon: Icon): Icon =
         icon.addVisibilityIcon(isPublic)
 
 fun RsVisible.isVisibleFrom(mod: RsMod): Boolean {
+    // XXX: this hack fixes false-positive "E0603 module is private" for modules with multiple
+    // declarations. It produces false-negatives, see
+    if (this is RsFile && declarations.size > 1) return true
+
     val elementMod = when (val visibility = visibility) {
         RsVisibility.Public -> return true
         RsVisibility.Private -> (if (this is RsMod) this.`super` else containingMod) ?: return true

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsModulesIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsModulesIndex.kt
@@ -27,8 +27,8 @@ class RsModulesIndex : StringStubIndexExtension<RsModDeclItem>() {
     override fun getKey(): StubIndexKey<String, RsModDeclItem> = KEY
 
     companion object {
-        fun getDeclarationFor(mod: RsFile): RsModDeclItem? {
-            val key = key(mod) ?: return null
+        fun getDeclarationsFor(mod: RsFile): List<RsModDeclItem> {
+            val key = key(mod) ?: return emptyList()
             val project = mod.project
 
             val result = SmartList<RsModDeclItem>()
@@ -44,7 +44,7 @@ class RsModulesIndex : StringStubIndexExtension<RsModDeclItem>() {
                 true
             }
 
-            return result.firstOrNull { it.isValidProjectMember } ?: result.firstOrNull()
+            return result.filter { it.isValidProjectMember }.takeIf { it.isNotEmpty() } ?: result
         }
 
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -3108,16 +3108,15 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
     """)
 
     fun `test no E0603 for module with multiple declarations`() = checkDontTouchAstInOtherFiles("""
-        //- main.rs
-            mod foo;
-            mod bar;
-            mod baz;
-            use foo::S; // error was here
-        //- foo.rs
-            pub struct S;
-        //- bar.rs
-            #[path = "foo.rs"] mod foo1;
-        """)
+    //- main.rs
+        mod foo;
+        mod bar;
+        use foo::S; // error was here
+    //- foo.rs
+        pub struct S;
+    //- bar.rs
+        #[path = "foo.rs"] mod foo1;
+    """)
 
     fun `test E0603 for module with multiple declarations`() = checkDontTouchAstInOtherFiles("""
     //- main.rs

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -3107,6 +3107,39 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         const _: i32 = 1;
     """)
 
+    fun `test no E0603 for module with multiple declarations`() = checkDontTouchAstInOtherFiles("""
+        //- main.rs
+            mod foo;
+            mod bar;
+            mod baz;
+            use foo::S; // error was here
+        //- foo.rs
+            pub struct S;
+        //- bar.rs
+            #[path = "foo.rs"] mod foo1;
+        """)
+
+    fun `test E0603 for module with multiple declarations`() = checkDontTouchAstInOtherFiles("""
+    //- main.rs
+        use crate::foo::bar::x; // TODO no error here although compiler produces it
+
+        mod foo {
+            mod bar;
+        }
+
+        fn main() {}
+
+    //- lib.rs
+        use crate::foo::bar::x;
+
+        mod foo {
+            pub mod bar;
+        }
+
+    //- foo/bar.rs
+        pub fn x() {}
+    """)
+
     @MockAdditionalCfgOptions("intellij_rust")
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test no E0603 for module with multiple declarations under cfg attributes`() = checkByFileTree("""

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandlerTest.kt
@@ -13,93 +13,53 @@ import org.rust.lang.RsLanguage
 
 class RsGotoSuperHandlerTest : RsTestBase() {
     fun `test module from function`() = checkNavigation("""
-        mod foo {
+        mod /*caret_after*/foo {
             mod bar {
-                fn foo() { /*caret*/ }
-            }
-        }
-    """, """
-        mod /*caret*/foo {
-            mod bar {
-                fn foo() {  }
+                fn foo() { /*caret_before*/ }
             }
         }
     """)
 
     fun `test method declaration from impl`() = checkNavigation("""
         trait T {
-            fn foo(); // <- should go here
+            fn /*caret_after*/foo(); // <- should go here
         }
         impl T for () {
-            fn foo/*caret*/() {}
-        }
-    """, """
-        trait T {
-            fn /*caret*/foo(); // <- should go here
-        }
-        impl T for () {
-            fn foo() {}
+            fn foo/*caret_before*/() {}
         }
     """)
 
     fun `test constant declaration from impl`() = checkNavigation("""
         trait T {
-            const Z: u32; // <- should go here
+            const /*caret_after*/Z: u32; // <- should go here
         }
         impl T for () {
-            const /*caret*/Z: u32 = 1;
-        }
-    """, """
-        trait T {
-            const /*caret*/Z: u32; // <- should go here
-        }
-        impl T for () {
-            const Z: u32 = 1;
+            const /*caret_before*/Z: u32 = 1;
         }
     """)
 
     fun `test type alias declaration from impl`() = checkNavigation("""
         trait T {
-             type Z; // <- should go here
+             type /*caret_after*/Z; // <- should go here
         }
         impl T for () {
-            type /*caret*/Z = ();
-        }
-    """, """
-        trait T {
-             type /*caret*/Z; // <- should go here
-        }
-        impl T for () {
-            type Z = ();
+            type /*caret_before*/Z = ();
         }
     """)
 
     fun `test module from method definition`() = checkNavigation("""
-        mod foo {
+        mod /*caret_after*/foo {
             mod bar {
                 struct S;
-                impl S { fn foo(&self) { /*caret*/} }
-            }
-        }
-    """, """
-        mod /*caret*/foo {
-            mod bar {
-                struct S;
-                impl S { fn foo(&self) { } }
+                impl S { fn foo(&self) { /*caret_before*/} }
             }
         }
     """)
 
     fun `test module from method in trait`() = checkNavigation("""
-        mod foo {
+        mod /*caret_after*/foo {
             mod bar {
-                trait T { fn foo(&self) { /*caret*/} }
-            }
-        }
-    """, """
-        mod /*caret*/foo {
-            mod bar {
-                trait T { fn foo(&self) { } }
+                trait T { fn foo(&self) { /*caret_before*/} }
             }
         }
     """)
@@ -142,16 +102,20 @@ class RsGotoSuperHandlerTest : RsTestBase() {
     // Navigation from a crate root to Cargo.toml is tested in `CargoTomlGotoSuperHandlerTest`
 
     private fun checkNavigationInFiles(@Language("Rust") fileTreeText: String, expected: String) {
-        fileTreeFromText(fileTreeText).createAndOpenFileWithCaretMarker()
-        val target = gotoSuperTarget(myFixture.file)
-        assertEquals(expected.trimIndent(), target?.text)
+        checkMultiNavigationInFiles(fileTreeText, expected)
     }
 
-    private fun checkNavigation(@Language("Rust") before: String, @Language("Rust") after: String) {
-        InlineFile(before)
+    private fun checkMultiNavigationInFiles(@Language("Rust") fileTreeText: String, vararg expected: String) {
+        fileTreeFromText(fileTreeText).createAndOpenFileWithCaretMarker()
+        val target = gotoSuperTarget(myFixture.file)
+        assertEquals(expected.toList().map { it.trimIndent() }.sorted(), target.map { it.text }.sorted())
+    }
+
+    private fun checkNavigation(@Language("Rust") code: String) {
+        InlineFile(code.replace("/*caret_before*/", "<caret>").replace("/*caret_after*/", ""))
         val handler = CodeInsightActions.GOTO_SUPER.forLanguage(RsLanguage)
             ?: error("GotoSuperHandler for Rust was not found.")
         handler.invoke(project, myFixture.editor, myFixture.file)
-        myFixture.checkResult(replaceCaretMarker(after))
+        myFixture.checkResult(code.replace("/*caret_after*/", "<caret>").replace("/*caret_before*/", ""))
     }
 }

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoSuperHandlerTest.kt
@@ -99,6 +99,15 @@ class RsGotoSuperHandlerTest : RsTestBase() {
             mod bar;
     """)
 
+    fun `test multiple mod declarations`() = checkMultiNavigationInFiles("""
+        //- foo.rs
+        /*caret*/    // only comment
+
+        //- main.rs
+        #[path="foo.rs"] mod foo1;
+        #[path="foo.rs"] mod foo2;
+    """, """#[path="foo.rs"] mod foo1;""", """#[path="foo.rs"] mod foo2;""")
+
     // Navigation from a crate root to Cargo.toml is tested in `CargoTomlGotoSuperHandlerTest`
 
     private fun checkNavigationInFiles(@Language("Rust") fileTreeText: String, expected: String) {
@@ -107,8 +116,8 @@ class RsGotoSuperHandlerTest : RsTestBase() {
 
     private fun checkMultiNavigationInFiles(@Language("Rust") fileTreeText: String, vararg expected: String) {
         fileTreeFromText(fileTreeText).createAndOpenFileWithCaretMarker()
-        val target = gotoSuperTarget(myFixture.file)
-        assertEquals(expected.toList().map { it.trimIndent() }.sorted(), target.map { it.text }.sorted())
+        val targets = gotoSuperTargets(myFixture.file)
+        assertEquals(expected.toList().map { it.trimIndent() }.sorted(), targets.map { it.text }.sorted())
     }
 
     private fun checkNavigation(@Language("Rust") code: String) {


### PR DESCRIPTION
Fixes #3757 (fixes #2586) issues "E0603 module is private" when importing a module that is declared multiple times (has multiple `mod foo;` declarations, e.g. in `lib.rs` and `main.rs`). 

Also "Go To Super" action (ctrl+U) now allows choosing a declaration (if multiple):
![image](https://user-images.githubusercontent.com/3221931/81280436-22e6cd00-9061-11ea-813d-1474deed355f.png)

Note that this is a **very** initial support of multiple module inclusions, i.e. now we can just know that a module is declared multiple times and e.g. suppress some inspections in this case.
