### PR TITLE
MACRO: support `include!` macro calls generated by another macro call

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -113,8 +113,7 @@ private val RsExpr.value: String? get() {
 fun RsMacroCall.findIncludingFile(): RsFile? {
     if (macroName != "include") return null
     val path = includeMacroArgument?.expr?.value ?: return null
-    // TODO: it doesn't work if `include!()` macro call comes from other macro
-    val file = containingFile?.originalFile?.virtualFile ?: return null
+    val file = (findMacroCallExpandedFrom() ?: this).containingFile?.originalFile?.virtualFile ?: return null
     return file.parent?.findFileByMaybeRelativePath(path)?.toPsiFile(project)?.rustFile
 }
 

--- a/src/test/kotlin/org/rust/ide/notifications/DetachedFileNotificationProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/notifications/DetachedFileNotificationProviderTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.notifications
 
+import org.rust.ExpandMacros
 import org.rust.fileTree
 
 class DetachedFileNotificationProviderTest : RsNotificationProviderTestBase() {
@@ -15,18 +16,28 @@ class DetachedFileNotificationProviderTest : RsNotificationProviderTestBase() {
         super.setUp()
         fileTree {
             rust("main.rs", """
+                macro_rules! generate_include {
+                    (${'$'}package: tt) => {
+                        include!(${'$'}package);
+                    };
+                }
+
                 include!("bar.rs");
+                generate_include!("qqq.rs");
                 mod foo;
                 fn main() {}
             """)
             rust("foo.rs", "")
             rust("bar.rs", "")
             rust("baz.rs", "")
+            rust("qqq.rs", "")
         }.create()
     }
 
     fun `test no notification for attached root file`() = doTest("main.rs")
     fun `test no notification for attached module file`() = doTest("foo.rs")
     fun `test notification for included file`() = doTest("bar.rs")
+    @ExpandMacros
+    fun `test notification for included file via macro call`() = doTest("qqq.rs")
     fun `test notification for detached file`() = doTest("baz.rs", DetachedFileNotificationProvider.DETACHED_FILE)
 }


### PR DESCRIPTION
Note, full support (name resolution and completion for code from including file in included one and correct module hierarchy recognition, i.e. absence of false positive "File is not included in module tree" editor notification), is available only when new macro expansion engine is enabled (#3628)

See https://github.com/intellij-rust/intellij-rust/issues/1908#issuecomment-593026377 for real world use case

Closes #5036