### PR TITLE
INT: add intention to implement a trait for a struct/enum

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AddTypeArguments.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AddTypeArguments.kt
@@ -30,48 +30,60 @@ class AddTypeArguments(element: RsElement) : LocalQuickFixAndIntentionActionOnPs
         endElement: PsiElement
     ) {
         val element = startElement as? RsElement ?: return
-        val (typeArguments, declaration) = getTypeArgumentsAndDeclaration(element) ?: return
-
-        val requiredParameters = declaration.requiredGenericParameters
-        if (requiredParameters.isEmpty()) return
-
+        val (typeArguments, _) = getTypeArgumentsAndDeclaration(element) ?: return
         val argumentCount = typeArguments?.typeReferenceList?.size ?: 0
-        if (argumentCount >= requiredParameters.size) return
 
-        val factory = RsPsiFactory(project)
-        val missingTypes = requiredParameters.drop(argumentCount).map { it.name ?: "_" }
+        val replaced = addTypeArguments(element) ?: return
+        editor?.buildAndRunTemplate(element, replaced.typeReferenceList.drop(argumentCount).map { it.createSmartPointer() })
+    }
+}
 
-        val replaced = if (typeArguments != null) {
-            var anchor = with(typeArguments) {
-                typeReferenceList.lastOrNull() ?: lifetimeList.lastOrNull() ?: lt
-            }
-            val nextSibling = anchor.getNextNonCommentSibling()
-            val addCommaAfter = nextSibling?.isComma == true
-            if (addCommaAfter && nextSibling != null) {
-                anchor = nextSibling
-            }
+/**
+ * Adds missing type arguments to the given element.
+ *
+ * Return an instance of the replaced type arguments, if any were added.
+ */
+fun addTypeArguments(element: RsElement): RsTypeArgumentList? {
+    val project = element.project
+    val (typeArguments, declaration) = getTypeArgumentsAndDeclaration(element) ?: return null
 
-            for (type in missingTypes) {
-                if (anchor.elementType != LT && !anchor.isComma) {
-                    anchor = typeArguments.addAfter(factory.createComma(), anchor)
-                }
-                anchor = typeArguments.addAfter(factory.createType(type), anchor)
-            }
+    val requiredParameters = declaration.requiredGenericParameters
+    if (requiredParameters.isEmpty()) return null
 
-            if (addCommaAfter) {
-                typeArguments.addAfter(factory.createComma(), anchor)
-            }
+    val argumentCount = typeArguments?.typeReferenceList?.size ?: 0
+    if (argumentCount >= requiredParameters.size) return null
 
-            typeArguments
-        } else {
-            val newArgumentList = factory.createTypeArgumentList(missingTypes)
+    val factory = RsPsiFactory(project)
+    val missingTypes = requiredParameters.drop(argumentCount).map { it.name ?: "_" }
 
-            // this can only happen for type references (base types/trait refs)
-            val path = getPath(element) ?: return
-            path.addAfter(newArgumentList, path.identifier) as RsTypeArgumentList
+    return if (typeArguments != null) {
+        var anchor = with(typeArguments) {
+            typeReferenceList.lastOrNull() ?: lifetimeList.lastOrNull() ?: lt
+        }
+        val nextSibling = anchor.getNextNonCommentSibling()
+        val addCommaAfter = nextSibling?.isComma == true
+        if (addCommaAfter && nextSibling != null) {
+            anchor = nextSibling
         }
 
-        editor?.buildAndRunTemplate(element, replaced.typeReferenceList.drop(argumentCount).map { it.createSmartPointer() })
+        for (type in missingTypes) {
+            if (anchor.elementType != LT && !anchor.isComma) {
+                anchor = typeArguments.addAfter(factory.createComma(), anchor)
+            }
+            anchor = typeArguments.addAfter(factory.createType(type), anchor)
+        }
+
+        if (addCommaAfter) {
+            typeArguments.addAfter(factory.createComma(), anchor)
+        }
+
+        typeArguments
+    } else {
+        val newArgumentList = factory.createTypeArgumentList(missingTypes)
+
+        // this can only happen for type references (base types/trait refs)
+        val path = getPath(element) ?: return null
+        path.addAfter(newArgumentList, path.identifier) as RsTypeArgumentList
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/intentions/addFmtStringArgument/AddFmtStringArgumentIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/addFmtStringArgument/AddFmtStringArgumentIntention.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.RsCodeFragmentPopup
 import org.rust.ide.intentions.RsElementBaseIntentionAction
 import org.rust.lang.core.macros.expansionContext
 import org.rust.lang.core.macros.isExprOrStmtContext
@@ -61,9 +62,9 @@ class AddFmtStringArgumentIntention : RsElementBaseIntentionAction<AddFmtStringA
         if (isUnitTestMode) {
             addFmtStringArgument(project, editor, ctx, codeFragment, caretOffsetInLiteral, placeholderNumber)
         } else {
-            RsAddFmtStringArgumentPopup.show(editor, project, codeFragment) {
+            RsCodeFragmentPopup.show(editor, project, codeFragment, {
                 addFmtStringArgument(project, editor, ctx, codeFragment, caretOffsetInLiteral, placeholderNumber)
-            }
+            })
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/intentions/addFmtStringArgument/AddFmtStringArgumentIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/addFmtStringArgument/AddFmtStringArgumentIntention.kt
@@ -62,7 +62,7 @@ class AddFmtStringArgumentIntention : RsElementBaseIntentionAction<AddFmtStringA
         if (isUnitTestMode) {
             addFmtStringArgument(project, editor, ctx, codeFragment, caretOffsetInLiteral, placeholderNumber)
         } else {
-            RsCodeFragmentPopup.show(editor, project, codeFragment, {
+            RsCodeFragmentPopup.show(editor, project, codeFragment, "Add format argument", {
                 addFmtStringArgument(project, editor, ctx, codeFragment, caretOffsetInLiteral, placeholderNumber)
             })
         }

--- a/src/main/kotlin/org/rust/ide/intentions/addTraitImpl/AddTraitImplIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/addTraitImpl/AddTraitImplIntention.kt
@@ -1,0 +1,141 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions.addTraitImpl
+
+import com.google.common.annotations.VisibleForTesting
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapiext.isUnitTestMode
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.ide.inspections.fixes.addTypeArguments
+import org.rust.ide.inspections.import.AutoImportFix
+import org.rust.ide.intentions.RsCodeFragmentPopup
+import org.rust.ide.intentions.RsElementBaseIntentionAction
+import org.rust.ide.refactoring.implementMembers.generateTraitMembers
+import org.rust.ide.utils.import.import
+import org.rust.lang.core.parser.RustParserUtil
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsStructOrEnumItemElement
+import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psi.ext.resolveToBoundTrait
+import org.rust.lang.core.resolve.Namespace
+import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.types.TraitRef
+import org.rust.lang.core.types.asTy
+import org.rust.lang.core.types.implLookup
+import org.rust.openapiext.runWriteCommandAction
+
+class AddTraitImplIntention : RsElementBaseIntentionAction<AddTraitImplIntention.Context>() {
+    override fun getText() = "Implement trait"
+    override fun getFamilyName() = text
+
+    class Context(val type: RsStructOrEnumItemElement, val name: String)
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val struct = element.ancestorStrict<RsStructOrEnumItemElement>() ?: return null
+        val name = struct.name ?: return null
+        return Context(struct, name)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val traitFragment = RsPathCodeFragment(project, PATH_FRAGMENT_TEXT, true, ctx.type,
+            RustParserUtil.PathParsingMode.TYPE, setOf(Namespace.Types))
+
+        if (isUnitTestMode) {
+            addTraitImplementations(editor, ctx, traitFragment.path)
+        } else {
+            RsCodeFragmentPopup.show(editor, project, traitFragment, {
+                addTraitImplementations(editor, ctx, traitFragment.path)
+            }) {
+                val trait = traitFragment.path?.reference?.resolve() as? RsTraitItem
+                if (trait != null) {
+                    null
+                } else {
+                    "Could not resolve `${traitFragment.text} to a trait`"
+                }
+            }
+        }
+    }
+
+    override fun startInWriteAction(): Boolean = false
+    override fun getElementToMakeWritable(currentFile: PsiFile): PsiElement = currentFile
+
+    private fun addTraitImplementations(editor: Editor, ctx: Context, path: RsPath?) {
+        val trait = path?.reference?.resolve() as? RsTraitItem ?: return
+        val project = ctx.type.project
+        val factory = RsPsiFactory(project)
+        val traits = mutableListOf<Pair<RsTraitItem, RsTraitRef?>>()
+        collectSuperTraits(trait, null, traits, mutableSetOf())
+
+        val implLookup = ctx.type.implLookup
+        val type = ctx.type.asTy()
+
+        val impls = project.runWriteCommandAction {
+            val impls = mutableListOf<RsImplItem>()
+            for ((traitCandidate, traitRef) in traits) {
+                val ref = traitRef?.resolveToBoundTrait() ?: BoundElement(traitCandidate)
+                val canSelect = implLookup.canSelect(TraitRef(type, ref))
+                if (!canSelect) {
+                    val impl = implementTrait(factory, traitCandidate, ctx) ?: continue
+                    impls.add(impl)
+                    val traitPath = impl.traitRef?.path ?: continue
+                    AutoImportFix.findApplicableContext(project, traitPath)?.candidates?.firstOrNull()?.import(impl)
+                }
+            }
+            impls
+        }
+        impls.forEach {
+            generateTraitMembers(it, editor)
+        }
+    }
+
+    private fun implementTrait(
+        factory: RsPsiFactory,
+        trait: RsTraitItem,
+        ctx: Context
+    ): RsImplItem? {
+        val traitName = trait.name ?: return null
+        val impl = factory.createTraitImplItem(ctx.name, traitName, ctx.type.typeParameterList, ctx.type.whereClause)
+        val insertedImpl = ctx.type.parent.addAfter(impl, ctx.type) as RsImplItem
+
+        val traitParameters = trait.typeParameterList
+        val traitRef = insertedImpl.traitRef
+        if (traitRef != null && traitParameters != null) {
+            if (ctx.type.typeParameterList == null) {
+                insertedImpl.addAfter(traitParameters.copy(), insertedImpl.impl)
+                addTypeArguments(traitRef)
+            } else {
+                traitRef.addAfter(factory.createTypeArgumentList(emptyList()), traitRef.path)
+            }
+        }
+
+        return insertedImpl
+    }
+
+    companion object {
+        @JvmField
+        @VisibleForTesting
+        var PATH_FRAGMENT_TEXT: String = ""
+    }
+}
+
+private fun collectSuperTraits(
+    trait: RsTraitItem,
+    ref: RsTraitRef?,
+    ordered: MutableList<Pair<RsTraitItem, RsTraitRef?>>,
+    visited: MutableSet<RsTraitItem>
+) {
+    if (trait !in visited) {
+        visited.add(trait)
+        ordered.add(Pair(trait, ref))
+    }
+
+    trait.typeParamBounds?.polyboundList?.forEach {
+        val superTrait = it.bound.traitRef?.path?.reference?.resolve() as? RsTraitItem ?: return@forEach
+        collectSuperTraits(superTrait, it.bound.traitRef, ordered, visited)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/intentions/ui.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ui.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.intentions
 
+import com.intellij.codeInsight.hint.HintManager
 import com.intellij.codeInsight.intention.impl.QuickEditAction
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.editor.Editor
@@ -41,11 +42,12 @@ object RsCodeFragmentPopup {
         editor: Editor,
         project: Project,
         codeFragment: RsCodeFragment,
+        title: String,
         onComplete: () -> Unit,
-        validate: (() -> String?)? = null
+        validate: (() -> String?)? = null,
     ) {
         val editorTextField = createEditorTextField(project, codeFragment) ?: return
-        showBalloon(editor, project, editorTextField, onComplete, validate)
+        showBalloon(editor, project, editorTextField, onComplete, validate, title)
     }
 
     private fun createEditorTextField(project: Project, codeFragment: RsCodeFragment): EditorTextField? {
@@ -87,7 +89,8 @@ object RsCodeFragmentPopup {
         parent: Disposable,
         editorTextField: EditorTextField,
         onComplete: () -> Unit,
-        validate: (() -> String?)?
+        validate: (() -> String?)?,
+        title: String
     ) {
         val balloon = JBPopupFactory.getInstance().createBalloonBuilder(editorTextField)
             .setShadow(true)
@@ -96,7 +99,9 @@ object RsCodeFragmentPopup {
             .setHideOnKeyOutside(false)
             .setFillColor(UIUtil.getPanelBackground())
             .setBorderInsets(JBUI.insets(3))
+            .setTitle(title)
             .createBalloon()
+
         Disposer.register(parent, balloon)
 
         val keyListener = object : KeyAdapter() {
@@ -108,7 +113,7 @@ object RsCodeFragmentPopup {
                             balloon.hide()
                             onComplete()
                         } else {
-                            // TODO: show error
+                            HintManager.getInstance().showErrorHint(editor, error)
                         }
                     }
                     KeyEvent.VK_ESCAPE -> balloon.hide()

--- a/src/main/kotlin/org/rust/ide/intentions/ui.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ui.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.intentions.addFmtStringArgument
+package org.rust.ide.intentions
 
 import com.intellij.codeInsight.intention.impl.QuickEditAction
 import com.intellij.openapi.Disposable
@@ -30,10 +30,22 @@ import java.awt.event.KeyAdapter
 import java.awt.event.KeyEvent
 import java.awt.event.KeyListener
 
-object RsAddFmtStringArgumentPopup {
-    fun show(editor: Editor, project: Project, codeFragment: RsCodeFragment, onComplete: () -> Unit) {
+object RsCodeFragmentPopup {
+    /**
+     * Shows a popup with a code fragment.
+     * @param validate: Validate the entered value.
+     *  If it returns null, the value is OK.
+     *  If it returns a string, it is displayed as an error.
+     */
+    fun show(
+        editor: Editor,
+        project: Project,
+        codeFragment: RsCodeFragment,
+        onComplete: () -> Unit,
+        validate: (() -> String?)? = null
+    ) {
         val editorTextField = createEditorTextField(project, codeFragment) ?: return
-        showBalloon(editor, project, editorTextField, onComplete)
+        showBalloon(editor, project, editorTextField, onComplete, validate)
     }
 
     private fun createEditorTextField(project: Project, codeFragment: RsCodeFragment): EditorTextField? {
@@ -70,7 +82,13 @@ object RsAddFmtStringArgumentPopup {
         return editorTextField
     }
 
-    private fun showBalloon(editor: Editor, parent: Disposable, editorTextField: EditorTextField, onComplete: () -> Unit) {
+    private fun showBalloon(
+        editor: Editor,
+        parent: Disposable,
+        editorTextField: EditorTextField,
+        onComplete: () -> Unit,
+        validate: (() -> String?)?
+    ) {
         val balloon = JBPopupFactory.getInstance().createBalloonBuilder(editorTextField)
             .setShadow(true)
             .setAnimationCycle(0)
@@ -85,8 +103,13 @@ object RsAddFmtStringArgumentPopup {
             override fun keyPressed(e: KeyEvent) {
                 when (e.keyCode) {
                     KeyEvent.VK_ENTER -> {
-                        balloon.hide()
-                        onComplete()
+                        val error = validate?.invoke()
+                        if (error == null) {
+                            balloon.hide()
+                            onComplete()
+                        } else {
+                            // TODO: show error
+                        }
                     }
                     KeyEvent.VK_ESCAPE -> balloon.hide()
                 }

--- a/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
@@ -6,7 +6,7 @@
 package org.rust.ide.refactoring.implementMembers
 
 import com.intellij.codeInsight.hint.HintManager
-import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.command.WriteCommandAction.runWriteCommandAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.ScrollType
 import com.intellij.psi.PsiElement
@@ -44,7 +44,7 @@ fun generateTraitMembers(impl: RsImplItem, editor: Editor?) {
 
     val chosen = showTraitMemberChooser(implInfo, impl.project)
     if (chosen.isEmpty()) return
-    runWriteAction {
+    runWriteCommandAction(impl.project) {
         // Non-null was checked by `findMembersToImplement`.
         insertNewTraitMembers(chosen, impl, trait, editor)
     }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -269,6 +269,26 @@ class RsPsiFactory(
             ?: error("Failed to create an inherent impl with name: `$name`")
     }
 
+    fun createTraitImplItem(
+        name: String,
+        trait: String,
+        typeParameterList: RsTypeParameterList? = null,
+        whereClause: RsWhereClause? = null
+    ): RsImplItem {
+        val whereText = whereClause?.text ?: ""
+        val typeParameterListText = typeParameterList?.text ?: ""
+        val typeArgumentListText = if (typeParameterList == null) {
+            ""
+        } else {
+            val parameterNames = typeParameterList.lifetimeParameterList.map { it.quoteIdentifier.text } +
+                typeParameterList.typeParameterList.map { it.name }
+            parameterNames.joinToString(", ", "<", ">")
+        }
+
+        return createFromText("impl $typeParameterListText $trait for $name $typeArgumentListText $whereText {  }")
+            ?: error("Failed to create an inherent impl with name: `$name`")
+    }
+
     fun createWhereClause(
         lifetimeBounds: List<RsLifetimeParameter>,
         typeBounds: List<RsTypeParameter>

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -913,6 +913,10 @@
             <className>org.rust.ide.intentions.createFromUsage.CreateTupleStructIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.addTraitImpl.AddTraitImplIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 

--- a/src/main/resources/intentionDescriptions/AddTraitImplIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/AddTraitImplIntention/after.rs.template
@@ -1,0 +1,12 @@
+trait Trait {
+    fun foo(&self);
+}
+struct <spot>MyStruct</spot> {
+
+}
+
+impl Trait for MyStruct {
+    fun foo(&self) {
+        unimplemented!();
+    }
+}

--- a/src/main/resources/intentionDescriptions/AddTraitImplIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/AddTraitImplIntention/before.rs.template
@@ -1,0 +1,6 @@
+trait Trait {
+    fun foo(&self) {}
+}
+struct <spot>MyStruct</spot> {
+
+}

--- a/src/main/resources/intentionDescriptions/AddTraitImplIntention/description.html
+++ b/src/main/resources/intentionDescriptions/AddTraitImplIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention implements a trait for a struct.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/AddTraitImplIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddTraitImplIntentionTest.kt
@@ -160,7 +160,7 @@ class AddTraitImplIntentionTest : RsIntentionTestBase(AddTraitImplIntention::cla
             const FOO: u32 = 0;
 
             fn foo(&self) {
-                unimplemented!()
+                todo!()
             }
         }
     """, "Trait", "foo", "FOO")
@@ -182,7 +182,7 @@ class AddTraitImplIntentionTest : RsIntentionTestBase(AddTraitImplIntention::cla
 
         impl Trait for S {
             fn foo(&self) {
-                unimplemented!()
+                todo!()
             }
         }
     """, "Trait", "foo")

--- a/src/test/kotlin/org/rust/ide/intentions/AddTraitImplIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddTraitImplIntentionTest.kt
@@ -1,0 +1,211 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.project.Project
+import org.intellij.lang.annotations.Language
+import org.rust.ide.intentions.addTraitImpl.AddTraitImplIntention
+import org.rust.ide.refactoring.implementMembers.RsTraitMemberChooserMember
+import org.rust.ide.refactoring.implementMembers.TraitMemberChooser
+import org.rust.ide.refactoring.implementMembers.withMockTraitMemberChooser
+
+class AddTraitImplIntentionTest : RsIntentionTestBase(AddTraitImplIntention::class) {
+    fun `test empty trait`() = doTest("""
+        trait Trait {}
+
+        struct S/*caret*/;
+    """, """
+        trait Trait {}
+
+        struct S;
+
+        impl Trait for S {}
+    """, "Trait")
+
+    fun `test generic struct`() = doTest("""
+        trait Trait {}
+
+        struct S<'a, R, T>(R, &'a T)/*caret*/;
+    """, """
+        trait Trait {}
+
+        struct S<'a, R, T>(R, &'a T);
+
+        impl<'a, R, T> Trait for S<'a, R, T> {}
+    """, "Trait")
+
+    fun `test generic trait`() = doTest("""
+        trait Trait<R, T> {}
+
+        struct S/*caret*/;
+    """, """
+        trait Trait<R, T> {}
+
+        struct S;
+
+        impl<R, T> Trait<R, T> for S {}
+    """, "Trait")
+
+    fun `test generic struct and trait`() = doTest("""
+        trait Trait<A, B> {}
+
+        struct S<'a, R, T>(R, &'a T)/*caret*/;
+    """, """
+        trait Trait<A, B> {}
+
+        struct S<'a, R, T>(R, &'a T);
+
+        impl<'a, R, T> Trait<> for S<'a, R, T> {}
+    """, "Trait")
+
+    fun `test import trait from module`() = doTest("""
+        mod foo {
+            pub trait Trait {}
+        }
+
+        struct S/*caret*/;
+    """, """
+        use foo::Trait;
+
+        mod foo {
+            pub trait Trait {}
+        }
+
+        struct S;
+
+        impl Trait for S {}
+    """, "foo::Trait")
+
+    fun `test implement all supertraits`() = doTest("""
+        trait Trait3 {}
+        trait Trait2: Trait3 {}
+        trait Trait1: Trait2 {}
+
+        struct S/*caret*/;
+    """, """
+        trait Trait3 {}
+        trait Trait2: Trait3 {}
+        trait Trait1: Trait2 {}
+
+        struct S;
+
+        impl Trait3 for S {}
+
+        impl Trait2 for S {}
+
+        impl Trait1 for S {}
+    """, "Trait1")
+
+    fun `test implement each supertrait only once`() = doTest("""
+        trait Trait3 {}
+        trait Trait2: Trait3 {}
+        trait Trait1: Trait2 + Trait3 {}
+
+        struct S/*caret*/;
+    """, """
+        trait Trait3 {}
+        trait Trait2: Trait3 {}
+        trait Trait1: Trait2 + Trait3 {}
+
+        struct S;
+
+        impl Trait3 for S {}
+
+        impl Trait2 for S {}
+
+        impl Trait1 for S {}
+    """, "Trait1")
+
+    fun `test do not implement already implemented traits`() = doTest("""
+        trait Trait3 {}
+        trait Trait2: Trait3 {}
+        trait Trait1: Trait2 + Trait3 {}
+
+        struct S/*caret*/;
+
+        impl Trait2 for S {}
+    """, """
+        trait Trait3 {}
+        trait Trait2: Trait3 {}
+        trait Trait1: Trait2 + Trait3 {}
+
+        struct S/*caret*/;
+
+        impl Trait3 for S {}
+
+        impl Trait1 for S {}
+
+        impl Trait2 for S {}
+    """, "Trait1")
+
+    fun `test implement all trait items`() = doTestWithMemberSelection("""
+        trait Trait {
+            const FOO: u32;
+            fn foo(&self);
+        }
+
+        struct S/*caret*/;
+    """, """
+        trait Trait {
+            const FOO: u32;
+            fn foo(&self);
+        }
+
+        struct S;
+
+        impl Trait for S {
+            const FOO: u32 = 0;
+
+            fn foo(&self) {
+                unimplemented!()
+            }
+        }
+    """, "Trait", "foo", "FOO")
+
+    fun `test implement selected trait items`() = doTestWithMemberSelection("""
+        trait Trait {
+            const FOO: u32;
+            fn foo(&self);
+        }
+
+        struct S/*caret*/;
+    """, """
+        trait Trait {
+            const FOO: u32;
+            fn foo(&self);
+        }
+
+        struct S;
+
+        impl Trait for S {
+            fn foo(&self) {
+                unimplemented!()
+            }
+        }
+    """, "Trait", "foo")
+
+    private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String, fragmentText: String) {
+        AddTraitImplIntention.PATH_FRAGMENT_TEXT = fragmentText
+        doAvailableTest(before, after)
+    }
+
+    private fun doTestWithMemberSelection(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String,
+        fragmentText: String,
+        vararg selectedItems: String
+    ) {
+        withMockTraitMemberChooser(object : TraitMemberChooser {
+            override fun invoke(
+                project: Project,
+                all: List<RsTraitMemberChooserMember>,
+                selectedByDefault: List<RsTraitMemberChooserMember>
+            ): List<RsTraitMemberChooserMember> = all.filter { it.member.name in selectedItems }
+        }) {
+            doTest(before, after, fragmentText)
+        }
+    }
+}


### PR DESCRIPTION
This PR attempts to add a refactoring action which would generate a trait `impl` for a struct/enum. For now, I would only enable this action directly from a struct/enum. Later we can possibly add it anywhere in the top level of a module so that the user can select the struct/enum.

We still have to select the trait and I need some guidance here. I don't know which method should I use (or write) to find all available traits that could be implemented. I looked at `NameResolution.kt`, but didn't find what I wanted.

My intention of what this refactoring should do:
1) User starts the action with `Generate Trait impl` on a struct/enum
2) Text input is shown to the user, she uses it to find the corresponding trait
3) `impl $trait for $struct` is created in the struct's file, the corresponding trait is imported and then `ImplementMembersFix` is executed on the impl to generate the missing methods.

Right now the implementation is just a sketch, as I didn't know how to find the available traits.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/4123
Fixes: https://github.com/intellij-rust/intellij-rust/issues/7342