### PR TITLE
CARGO: fetch cargo metadata even with compilation error

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -143,8 +143,14 @@ class Cargo(private val cargoExecutable: Path) {
     ): BuildScriptsInfo? {
         if (!isFeatureEnabled(RsExperiments.EVALUATE_BUILD_SCRIPTS)) return null
         val additionalArgs = listOf("--message-format", "json")
-        val processOutput = CargoCommandLine("check", projectDirectory, additionalArgs)
-            .execute(owner, listener = listener)
+        val commandLine = CargoCommandLine("check", projectDirectory, additionalArgs)
+
+        val processOutput = try {
+            commandLine.execute(owner, listener = listener)
+        } catch (e: ExecutionException) {
+            LOG.warn(e)
+            return null
+        }
 
         // BACKCOMPAT: 2019.3
         @Suppress("DEPRECATION")

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoGeneratedItemsResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoGeneratedItemsResolveTest.kt
@@ -790,6 +790,31 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
         }
     }
 
+    @MinRustcVersion("1.32.0")
+    fun `test do not fail on compilation error`() = withEnabledEvaluateBuildScriptsFeature {
+        buildProject {
+            toml("Cargo.toml", """
+                [package]
+                name = "intellij-rust-test"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("src") {
+                rust("main.rs", """
+                    pub mod bar;
+                    fn main() {
+                        println!("{}", bar::message());
+                                            //^
+                    }
+                """)
+                rust("bar.rs", """
+                    pub fn message() -> String { } // compilation error
+                """)
+            }
+        }.checkReferenceIsResolved<RsPath>("src/main.rs", toFile = ".../src/bar.rs")
+    }
+
     private fun withEnabledFetchOutDirFeature(action: () -> Unit) =
         runWithEnabledFeature(RsExperiments.FETCH_OUT_DIR, action)
 

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoGeneratedItemsResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoGeneratedItemsResolveTest.kt
@@ -744,7 +744,7 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
                         f.write_all(text).unwrap()
                     }
                 """)
-            }
+            }.checkReferenceIsResolved<RsPath>("src/main.rs", toFile = ".../gen/hello.rs")
         }
     }
 
@@ -786,7 +786,7 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
                         ).unwrap();
                     }
                 """)
-            }
+            }.checkReferenceIsResolved<RsPath>("src/main.rs", toFile = ".../hello.rs")
         }
     }
 


### PR DESCRIPTION
Previously, if `org.rust.cargo.evaluate.build.scripts` feature was enabled and there was compilation error, fetching workspace data failed

Fixes #5016