### PR TITLE
Fix exception during stub indexing

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt
@@ -37,6 +37,10 @@ abstract class RsExternCrateItemImplMixin : RsStubbedNamedElementImpl<RsExternCr
 
     override val referenceName: String get() = greenStub?.name ?: super.referenceName
 
+    override fun getName(): String? = referenceName
+
+    override fun getNameIdentifier(): PsiElement? = referenceNameElement
+
     override fun getIcon(flags: Int) = RsIcons.CRATE
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -49,7 +49,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
     override fun getType() = Type
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
-        private const val STUB_VERSION = 196
+        private const val STUB_VERSION = 197
 
         // Bump this number if Stub structure changes
         override fun getStubVersion(): Int = RustParserDefinition.PARSER_VERSION + STUB_VERSION
@@ -311,7 +311,7 @@ abstract class RsAttributeOwnerStubBase<T: RsElement>(
 
 class RsExternCrateItemStub(
     parent: StubElement<*>?, elementType: IStubElementType<*, *>,
-    override val name: String?,
+    override val name: String,
     override val flags: Int
 ) : RsAttributeOwnerStubBase<RsExternCrateItem>(parent, elementType),
     RsNamedStub {
@@ -320,7 +320,7 @@ class RsExternCrateItemStub(
 
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
             RsExternCrateItemStub(parentStub, this,
-                dataStream.readNameAsString(),
+                dataStream.readNameAsString()!!,
                 dataStream.readUnsignedByte()
             )
 
@@ -334,7 +334,7 @@ class RsExternCrateItemStub(
             RsExternCrateItemImpl(stub, this)
 
         override fun createStub(psi: RsExternCrateItem, parentStub: StubElement<*>?) =
-            RsExternCrateItemStub(parentStub, this, psi.name, RsAttributeOwnerStub.extractFlags(psi))
+            RsExternCrateItemStub(parentStub, this, psi.referenceName, RsAttributeOwnerStub.extractFlags(psi))
 
         override fun indexStub(stub: RsExternCrateItemStub, sink: IndexSink) = sink.indexExternCrate(stub)
     }


### PR DESCRIPTION
<details>
  <summary>Stacktrace</summary>

```
java.lang.AssertionError: file=FILE; tree=Element(FILE)
 each of class class org.rust.lang.core.psi.impl.RsExternCrateItemImpl; valid=true; ref=com.intellij.psi.impl.source.SubstrateRef$StubRef@ba9737b
 each of class class org.rust.lang.core.psi.RsFile; valid=true; same file=true; current tree= Element(FILE); stubTree=null; physical=false
 each stub RsExternCrateItemStub
 each stub RsFileStub{myFile=FILE, myInvalidationReason=null, myStubRoots=[RsFileStub], stubTree=null}
	at com.intellij.extapi.psi.StubBasedPsiElementBase.notBoundInExistingAst(StubBasedPsiElementBase.java:226)
	at com.intellij.extapi.psi.StubBasedPsiElementBase.getNode(StubBasedPsiElementBase.java:139)
	at com.intellij.extapi.psi.ASTDelegatePsiElement.findChildByType(ASTDelegatePsiElement.java:183)
	at org.rust.lang.core.psi.impl.RsExternCrateItemImpl.getIdentifier(RsExternCrateItemImpl.java:62)
	at org.rust.lang.core.psi.ext.RsExternCrateItemImplMixin.getReferenceNameElement(RsExternCrateItem.kt:34)
	at org.rust.lang.core.psi.ext.RsMandatoryReferenceElement.getReferenceName(RsReferenceElement.kt:38)
	at org.rust.lang.core.psi.ext.RsExternCrateItemImplMixin.getReferenceName(RsExternCrateItem.kt:38)
	at org.rust.lang.core.stubs.index.RsExternCrateReexportIndex$Companion.index(RsExternCrateReexportIndex.kt:35)
	at org.rust.lang.core.stubs.StubIndexingKt.indexExternCrate(StubIndexing.kt:18)
	at org.rust.lang.core.stubs.RsExternCrateItemStub$Type.indexStub(StubImplementations.kt:339)
	at org.rust.lang.core.stubs.RsExternCrateItemStub$Type.indexStub(StubImplementations.kt:319)
	at com.intellij.psi.stubs.ObjectStubTree.indexStubTree(ObjectStubTree.java:78)
	at com.intellij.psi.stubs.SerializedStubTree.indexTree(SerializedStubTree.java:197)
	at com.intellij.psi.stubs.SerializedStubTree.serializeStub(SerializedStubTree.java:69)
	at com.intellij.psi.stubs.StubUpdatingIndex$1.lambda$computeValue$0(StubUpdatingIndex.java:147)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:894)
	at com.intellij.openapi.application.ReadAction.compute(ReadAction.java:61)
	at com.intellij.psi.stubs.StubUpdatingIndex$1.computeValue(StubUpdatingIndex.java:126)
	at com.intellij.psi.stubs.StubUpdatingIndex$1.computeValue(StubUpdatingIndex.java:99)
	at com.intellij.util.indexing.SingleEntryCompositeIndexer.computeValue(SingleEntryCompositeIndexer.java:27)
	at com.intellij.util.indexing.SingleEntryIndexer.map(SingleEntryIndexer.java:28)
	at com.intellij.util.indexing.SingleEntryIndexer.map(SingleEntryIndexer.java:17)
	at com.intellij.util.indexing.impl.MapReduceIndex.mapByIndexer(MapReduceIndex.java:317)
	at com.intellij.util.indexing.impl.MapReduceIndex.mapInput(MapReduceIndex.java:309)
	at com.intellij.util.indexing.VfsAwareMapReduceIndex.mapInput(VfsAwareMapReduceIndex.java:150)
	at com.intellij.util.indexing.VfsAwareMapReduceIndex.mapInput(VfsAwareMapReduceIndex.java:40)
	at com.intellij.util.indexing.impl.MapReduceIndex.calculateUpdateData(MapReduceIndex.java:267)
	at com.intellij.util.indexing.impl.MapReduceIndex.update(MapReduceIndex.java:239)
	at com.intellij.util.indexing.FileBasedIndexImpl.updateSingleIndex(FileBasedIndexImpl.java:1253)
	at com.intellij.util.indexing.FileBasedIndexImpl.lambda$doIndexFileContent$20(FileBasedIndexImpl.java:1181)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.freezeFileTypeTemporarilyIn(FileTypeManagerImpl.java:722)
	at com.intellij.util.indexing.FileBasedIndexImpl.doIndexFileContent(FileBasedIndexImpl.java:1161)
	at com.intellij.util.indexing.FileBasedIndexImpl.indexFileContent(FileBasedIndexImpl.java:1147)
	at com.intellij.util.indexing.UnindexedFilesUpdater.lambda$indexFiles$1(UnindexedFilesUpdater.java:128)
	at com.intellij.openapi.project.CacheUpdateRunner.lambda$null$1(CacheUpdateRunner.java:224)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1106)
	at com.intellij.openapi.project.CacheUpdateRunner.lambda$null$2(CacheUpdateRunner.java:240)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:164)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:625)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:570)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:61)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:151)
	at com.intellij.openapi.project.CacheUpdateRunner.lambda$createRunnable$3(CacheUpdateRunner.java:237)
	at com.intellij.util.ConcurrencyUtil.runUnderThreadName(ConcurrencyUtil.java:210)
	at com.intellij.util.ConcurrencyUtil.lambda$underThreadNameRunnable$3(ConcurrencyUtil.java:198)
	at com.intellij.util.RunnableCallable.call(RunnableCallable.java:20)
	at com.intellij.util.RunnableCallable.call(RunnableCallable.java:11)
	at com.intellij.openapi.application.impl.ApplicationImpl$1.call(ApplicationImpl.java:255)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```
</details>