### PR TITLE
PERF&MACRO: optimize macro resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -1548,7 +1548,6 @@ fun isSuperChain(path: RsPath): Boolean {
 
 object NameResolutionTestmarks {
     val shadowingStdCrates = Testmark("shadowingStdCrates")
-    val missingMacroExport = Testmark("missingMacroExport")
     val missingMacroUse = Testmark("missingMacroUse")
     val processSelfCrateExportedMacros = Testmark("processSelfCrateExportedMacros")
     val dollarCrateMagicIdentifier = Testmark("dollarCrateMagicIdentifier")

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -49,7 +49,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
     override fun getType() = Type
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
-        private const val STUB_VERSION = 197
+        private const val STUB_VERSION = 198
 
         // Bump this number if Stub structure changes
         override fun getStubVersion(): Int = RustParserDefinition.PARSER_VERSION + STUB_VERSION

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -77,7 +77,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
     //- lib.rs
         // Missing #[macro_export] here
         macro_rules! foo_bar { () => {} }
-    """, NameResolutionTestmarks.missingMacroExport)
+    """)
 
     fun `test macro rules missing macro_use`() = stubOnlyResolve("""
     //- main.rs


### PR DESCRIPTION
Speeds up this path in macro resolution:
![image](https://user-images.githubusercontent.com/3221931/81411321-e2637e00-914a-11ea-9fff-f12e4045fe9d.png)


After the PR:
![image](https://user-images.githubusercontent.com/3221931/81412219-36229700-914c-11ea-9c88-3ee8d3e5ed0d.png)
