### PR TITLE
COMP: fix IndexNotReadyException while completion

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsAwaitCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsAwaitCompletionProvider.kt
@@ -1,0 +1,67 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.util.Key
+import com.intellij.patterns.ElementPattern
+import com.intellij.patterns.PatternCondition
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.PsiElement
+import com.intellij.util.ProcessingContext
+import org.rust.lang.core.psi.RsElementTypes
+import org.rust.lang.core.psi.RsFieldLookup
+import org.rust.lang.core.psi.ext.findAssociatedType
+import org.rust.lang.core.psi.ext.isEdition2018
+import org.rust.lang.core.psi.ext.receiver
+import org.rust.lang.core.psi.ext.withSubst
+import org.rust.lang.core.psiElement
+import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.types.TraitRef
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyUnknown
+import org.rust.lang.core.types.type
+
+object RsAwaitCompletionProvider : RsCompletionProvider() {
+
+    private val AWAIT_TY: Key<Ty> = Key.create("AWAIT_TY")
+
+    override val elementPattern: ElementPattern<out PsiElement>
+        get() {
+            val parent = psiElement<RsFieldLookup>()
+                .with(object : PatternCondition<RsFieldLookup>("RsPostfixAwait") {
+                    override fun accepts(t: RsFieldLookup, context: ProcessingContext?): Boolean {
+                        if (context == null || !t.isEdition2018) return false
+                        val receiver = t.receiver.safeGetOriginalOrSelf()
+                        val lookup = ImplLookup.relativeTo(receiver)
+                        val awaitTy = receiver.type.lookupFutureOutputTy(lookup)
+                        if (awaitTy is TyUnknown) return false
+                        context.put(AWAIT_TY, awaitTy)
+                        return true
+                    }
+                })
+
+            return PlatformPatterns.psiElement(RsElementTypes.IDENTIFIER).withParent(parent)
+        }
+
+    override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+        val awaitTy = context.get(AWAIT_TY) ?: return
+        val awaitBuilder = LookupElementBuilder
+            .create("await")
+            .bold()
+            .withTypeText(awaitTy.toString())
+        result.addElement(awaitBuilder.withPriority(KEYWORD_PRIORITY * 1.0001))
+    }
+
+    private fun Ty.lookupFutureOutputTy(lookup: ImplLookup): Ty {
+        val futureTrait = lookup.items.Future ?: return TyUnknown
+        val outputType = futureTrait.findAssociatedType("Output") ?: return TyUnknown
+        val selection = lookup.selectProjectionStrict(TraitRef(this, futureTrait.withSubst()), outputType)
+        return selection.ok()?.value ?: TyUnknown
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
@@ -24,6 +24,7 @@ class RsCompletionContributor : CompletionContributor() {
         extend(CompletionType.BASIC, RsPartialMacroArgumentCompletionProvider)
         extend(CompletionType.BASIC, RsFullMacroArgumentCompletionProvider)
         extend(CompletionType.BASIC, RsCfgAttributeCompletionProvider)
+        extend(CompletionType.BASIC, RsAwaitCompletionProvider)
     }
 
     fun extend(type: CompletionType?, provider: RsCompletionProvider) {

--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.macros
 
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
@@ -26,10 +27,11 @@ interface RsExpandedElement : RsElement {
 
     companion object {
         fun getContextImpl(psi: RsExpandedElement, isIndexAccessForbidden: Boolean = false): PsiElement? {
-            psi.project.macroExpansionManager.getContextOfMacroCallExpandedFrom(psi)?.let { return it }
+            val project = psi.project
+            project.macroExpansionManager.getContextOfMacroCallExpandedFrom(psi)?.let { return it }
             psi.getUserData(RS_EXPANSION_CONTEXT)?.let { return it }
             val parent = psi.stubParent
-            if (parent is RsFile && !isIndexAccessForbidden) {
+            if (parent is RsFile && !isIndexAccessForbidden && !DumbService.isDumb(project)) {
                 RsIncludeMacroIndex.getIncludingMod(parent)?.let { return it }
             }
             return parent

--- a/src/test/kotlin/org/rust/lang/core/completion/RsAwaitCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsAwaitCompletionTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import org.rust.MockEdition
+import org.rust.cargo.project.workspace.CargoWorkspace
+
+class RsAwaitCompletionTest : RsCompletionTestBase() {
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
+    fun `test postfix await 2015 (anon)`() = checkCompletion("await", """
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+        fn foo() -> impl Future<Output=i32> { unimplemented!() }
+        fn main() {
+            foo()./*caret*/;
+        }
+    """, """
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+        fn foo() -> impl Future<Output=i32> { unimplemented!() }
+        fn main() {
+            foo()./*caret*/;
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
+    fun `test postfix await 2015 (adt)`() = checkCompletion("await", """
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+        struct S;
+        impl Future for S { type Output = i32; }
+        fn foo() -> S { unimplemented!() }
+        fn main() {
+            foo()./*caret*/;
+        }
+    """, """
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+        struct S;
+        impl Future for S { type Output = i32; }
+        fn foo() -> S { unimplemented!() }
+        fn main() {
+            foo()./*caret*/;
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test postfix await 2018 (anon)`() = checkCompletion("await", """
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+        fn foo() -> impl Future<Output=i32> { unimplemented!() }
+        fn main() {
+            foo()./*caret*/;
+        }
+    """, """
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+        fn foo() -> impl Future<Output=i32> { unimplemented!() }
+        fn main() {
+            foo().await/*caret*/;
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test postfix await 2018 (adt)`() = checkCompletion("await", """
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+        struct S;
+        impl Future for S { type Output = i32; }
+        fn foo() -> S { unimplemented!() }
+        fn main() {
+            foo()./*caret*/;
+        }
+    """, """
+        #[lang = "core::future::future::Future"]
+        trait Future { type Output; }
+        struct S;
+        impl Future for S { type Output = i32; }
+        fn foo() -> S { unimplemented!() }
+        fn main() {
+            foo().await/*caret*/;
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -126,6 +126,18 @@ class RsCompletionTest : RsCompletionTestBase() {
         }
     """)
 
+    fun `test use self`() = doSingleCompletion("""
+        use se/*caret*/
+    """, """
+        use self::/*caret*/
+    """)
+
+    fun `test use super`() = doSingleCompletion("""
+        mod m { use su/*caret*/ }
+    """, """
+        mod m { use super::/*caret*/ }
+    """)
+
     fun `test use glob`() = doSingleCompletion("""
         mod foo { pub fn quux() {} }
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
@@ -72,6 +72,12 @@ abstract class RsCompletionTestBase : RsTestBase() {
         @Language("Rust") code: String
     ) = completionFixture.checkContainsCompletion(code, variant)
 
+    protected fun checkCompletion(
+        lookupString: String,
+        @Language("Rust") before: String,
+        @Language("Rust") after: String
+    ) = completionFixture.checkCompletion(lookupString, before, after)
+
     protected fun checkNotContainsCompletion(
         variant: String,
         @Language("Rust") code: String

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
@@ -83,7 +83,7 @@ abstract class RsCompletionTestBase : RsTestBase() {
         @Language("Rust") code: String
     ) = completionFixture.checkNotContainsCompletion(code, variant)
 
-    protected fun checkNoCompletion(@Language("Rust") code: String) = completionFixture.checkNoCompletion(code)
+    protected open fun checkNoCompletion(@Language("Rust") code: String) = completionFixture.checkNoCompletion(code)
 
     protected fun checkNoCompletionByFileTree(@Language("Rust") code: String) =
         completionFixture.checkNoCompletionByFileTree(code)

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.vfs.VirtualFileFilter
 import com.intellij.psi.impl.PsiManagerEx
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.testFramework.fixtures.impl.BaseFixture
+import org.intellij.lang.annotations.Language
 import org.rust.*
 
 abstract class RsCompletionTestFixtureBase<IN>(
@@ -60,6 +61,18 @@ abstract class RsCompletionTestFixtureBase<IN>(
         })
         executeSoloCompletion()
         myFixture.checkResult(replaceCaretMarker(after.trimIndent()))
+    }
+
+    fun checkCompletion(
+        lookupString: String,
+        before: IN,
+        @Language("Rust") after: String
+    ) = checkByText(before, after.trimIndent()) {
+        val items = myFixture.completeBasic()
+            ?: return@checkByText // single completion was inserted
+        val lookupItem = items.find { it.lookupString == lookupString } ?: return@checkByText
+        myFixture.lookup.currentItem = lookupItem
+        myFixture.type('\n')
     }
 
     fun checkNoCompletion(code: IN) {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
@@ -5,7 +5,9 @@
 
 package org.rust.lang.core.completion
 
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.project.DumbServiceImpl
+import com.intellij.openapi.util.BuildNumber
 import org.intellij.lang.annotations.Language
 import org.rust.lang.core.completion.RsKeywordCompletionContributor.Companion.CONDITION_KEYWORDS
 
@@ -13,34 +15,56 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
 
     override fun setUp() {
         super.setUp()
-        DumbServiceImpl.getInstance(project).isDumb = true
+        if (isAtLeast201) {
+            DumbServiceImpl.getInstance(project).isDumb = true
+        }
     }
 
     override fun tearDown() {
-        DumbServiceImpl.getInstance(project).isDumb = false
+        if (isAtLeast201) {
+            DumbServiceImpl.getInstance(project).isDumb = false
+        }
         super.tearDown()
     }
 
-    fun `test break in for loop`() = @Suppress("DEPRECATION") checkSingleCompletion("break", """
+    fun `test break in for loop`() = checkCompletion("break", """
         fn foo() {
             for _ in 0..4 {
                 bre/*caret*/
             }
         }
+    """, """
+        fn foo() {
+            for _ in 0..4 {
+                break/*caret*/
+            }
+        }
     """)
 
-    fun `test break in loop`() = @Suppress("DEPRECATION") checkSingleCompletion("break", """
+    fun `test break in loop`() = checkCompletion("break", """
         fn foo() {
             loop {
                 br/*caret*/
             }
         }
+    """, """
+        fn foo() {
+            loop {
+                break/*caret*/
+            }
+        }
     """)
 
-    fun `test break in while loop`() = @Suppress("DEPRECATION") checkSingleCompletion("break", """
+    fun `test break in while loop`() = checkCompletion("break", """
         fn foo() {
             while true {
                 brea/*caret*/
+            }
+        }
+    """, """
+        fn foo() {
+            while true {
+                break/*caret*/
             }
         }
     """)
@@ -67,70 +91,116 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         }
     """)
 
-    fun `test continue in for loop`() = @Suppress("DEPRECATION") checkSingleCompletion("continue", """
+    fun `test continue in for loop`() = checkCompletion("continue", """
         fn foo() {
             for _ in 0..4 {
                 cont/*caret*/
             }
         }
+    """, """
+        fn foo() {
+            for _ in 0..4 {
+                continue/*caret*/
+            }
+        }
     """)
 
-    fun `test continue in loop`() = @Suppress("DEPRECATION") checkSingleCompletion("continue", """
+    fun `test continue in loop`() = checkCompletion("continue", """
         fn foo() {
             loop {
                 cont/*caret*/
             }
         }
+    """, """
+        fn foo() {
+            loop {
+                continue/*caret*/
+            }
+        }
     """)
 
-    fun `test continue in while loop`() = @Suppress("DEPRECATION") checkSingleCompletion("continue", """
+    fun `test continue in while loop`() = checkCompletion("continue", """
         fn foo() {
             while true {
                 conti/*caret*/
             }
         }
+    """, """
+        fn foo() {
+            while true {
+                continue/*caret*/
+            }
+        }
     """)
 
-    fun `test const`() = @Suppress("DEPRECATION") checkSingleCompletion("const", """
+    fun `test const`() = checkCompletion("const", """
         con/*caret*/
+    """, """
+        const /*caret*/
     """)
 
-    fun `test pub const`() = @Suppress("DEPRECATION") checkSingleCompletion("const", """
+    fun `test pub const`() = checkCompletion("const", """
         pub con/*caret*/
+    """, """
+        pub const /*caret*/
     """)
 
-    fun `test enum`() = @Suppress("DEPRECATION") checkSingleCompletion("enum", """
+    fun `test enum`() = checkCompletion("enum", """
         enu/*caret*/
+    """, """
+        enum /*caret*/
     """)
 
-    fun `test enum at the file very beginning`() = @Suppress("DEPRECATION") checkSingleCompletion("enum", "enu/*caret*/")
+    fun `test enum at the file very beginning`() = checkCompletion("enum",
+        "enu/*caret*/",
+        "enum /*caret*/"
+    )
 
-    fun `test pub enum`() = @Suppress("DEPRECATION") checkSingleCompletion("enum", """
+    fun `test pub enum`() = checkCompletion("enum", """
         pub enu/*caret*/
+    """, """
+        pub enum /*caret*/
     """)
 
-    fun `test enum within mod`() = @Suppress("DEPRECATION") checkSingleCompletion("enum", """
+    fun `test enum within mod`() = checkCompletion("enum", """
         mod foo {
             en/*caret*/
         }
-    """)
-
-    fun `test enum within fn`() = @Suppress("DEPRECATION") checkSingleCompletion("enum", """
-        fn foo() {
-            en/*caret*/
+    """, """
+        mod foo {
+            enum /*caret*/
         }
     """)
 
-    fun `test enum within fn nested block`() = @Suppress("DEPRECATION") checkSingleCompletion("enum", """
+    fun `test enum within fn`() = checkCompletion("enum", """
+        fn foo() {
+            en/*caret*/
+        }
+    """, """
+        fn foo() {
+            enum /*caret*/
+        }
+    """)
+
+    fun `test enum within fn nested block`() = checkCompletion("enum", """
         fn foo() {{
             en/*caret*/
         }}
+    """, """
+        fn foo() {{
+            enum /*caret*/
+        }}
     """)
 
-    fun `test enum within fn after other stmt`() = @Suppress("DEPRECATION") checkSingleCompletion("enum", """
+    fun `test enum within fn after other stmt`() = checkCompletion("enum", """
         fn foo() {
             let _ = 10;
             en/*caret*/
+        }
+    """, """
+        fn foo() {
+            let _ = 10;
+            enum /*caret*/
         }
     """)
 
@@ -150,24 +220,34 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         mod en/*caret*/
     """)
 
-    fun `test extern`() = @Suppress("DEPRECATION") checkSingleCompletion("extern", """
+    fun `test extern`() = checkCompletion("extern", """
         ext/*caret*/
+    """, """
+        extern /*caret*/
     """)
 
-    fun `test pub extern`() = @Suppress("DEPRECATION") checkSingleCompletion("extern", """
+    fun `test pub extern`() = checkCompletion("extern", """
         pub ext/*caret*/
+    """, """
+        pub extern /*caret*/
     """)
 
-    fun `test unsafe extern`() = @Suppress("DEPRECATION") checkSingleCompletion("extern", """
+    fun `test unsafe extern`() = checkCompletion("extern", """
         unsafe ext/*caret*/
+    """, """
+        unsafe extern /*caret*/
     """)
 
-    fun `test pub unsafe extern`() = @Suppress("DEPRECATION") checkSingleCompletion("extern", """
+    fun `test pub unsafe extern`() = checkCompletion("extern", """
         pub unsafe ext/*caret*/
+    """, """
+        pub unsafe extern /*caret*/
     """)
 
-    fun `test extern crate`() = @Suppress("DEPRECATION") checkSingleCompletion("crate", """
+    fun `test extern crate`() = checkCompletion("crate", """
         extern cr/*caret*/
+    """, """
+        extern crate /*caret*/
     """)
 
     fun `test crate not applied at file beginning`() = checkNoCompletion("crat/*caret*/")
@@ -184,40 +264,63 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         pub f/*caret*/
     """)
 
-    fun `test extern fn`() = @Suppress("DEPRECATION") checkSingleCompletion("fn", """
+    fun `test extern fn`() = checkCompletion("fn", """
         extern f/*caret*/
+    """, """
+        extern fn /*caret*/
     """)
 
-    fun `test unsafe fn`() = @Suppress("DEPRECATION") checkSingleCompletion("fn", """
+    fun `test unsafe fn`() = checkCompletion("fn", """
         unsafe f/*caret*/
+    """, """
+        unsafe fn /*caret*/
     """)
 
-    fun `test impl`() = @Suppress("DEPRECATION") checkSingleCompletion("impl", """
+    fun `test impl`() = checkCompletion("impl", """
         imp/*caret*/
+    """, """
+        impl /*caret*/
     """)
 
-    fun `test unsafe impl`() = @Suppress("DEPRECATION") checkSingleCompletion("impl", """
+    fun `test unsafe impl`() = checkCompletion("impl", """
         unsafe im/*caret*/
+    """, """
+        unsafe impl /*caret*/
     """)
 
-    fun `test let within fn`() = @Suppress("DEPRECATION") checkSingleCompletion("let", """
+    fun `test let within fn`() = checkCompletion("let", """
         fn main() {
             let a = 12;
             le/*caret*/
         }
+    """, """
+        fn main() {
+            let a = 12;
+            let /*caret*/
+        }
     """)
 
-    fun `test let within assoc fn`() = @Suppress("DEPRECATION") checkSingleCompletion("let", """
+    fun `test let within assoc fn`() = checkCompletion("let", """
         struct Foo;
         impl Foo {
             fn shutdown() { le/*caret*/ }
         }
+    """, """
+        struct Foo;
+        impl Foo {
+            fn shutdown() { let /*caret*/ }
+        }
     """)
 
-    fun `test let within method`() = @Suppress("DEPRECATION") checkSingleCompletion("let", """
+    fun `test let within method`() = checkCompletion("let", """
         struct Foo;
         impl Foo {
             fn calc(&self) { le/*caret*/ }
+        }
+    """, """
+        struct Foo;
+        impl Foo {
+            fn calc(&self) { let /*caret*/ }
         }
     """)
 
@@ -229,37 +332,59 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         }
     """)
 
-    fun `test mod`() = @Suppress("DEPRECATION") checkSingleCompletion("mod", """
+    fun `test mod`() = checkCompletion("mod", """
         mo/*caret*/
+    """, """
+        mod /*caret*/
     """)
 
-    fun `test pub mod`() = @Suppress("DEPRECATION") checkSingleCompletion("mod", """
+    fun `test pub mod`() = checkCompletion("mod", """
         pub mo/*caret*/
+    """, """
+        pub mod /*caret*/
     """)
 
-    fun `test mut`() = @Suppress("DEPRECATION") checkSingleCompletion("mut", """
+    fun `test mut`() = checkCompletion("mut", """
         fn main() {
-            let m/*caret*/
+            let mu/*caret*/
+        }
+    """, """
+        fn main() {
+            let mut /*caret*/
         }
     """)
 
-    fun `test return within fn`() = @Suppress("DEPRECATION") checkSingleCompletion("return", """
+    fun `test return within fn`() = checkCompletion("return", """
         fn main() {
             re/*caret*/
         }
+    """, """
+        fn main() {
+            return;/*caret*/
+        }
     """)
 
-    fun `test return within assoc fn`() = @Suppress("DEPRECATION") checkSingleCompletion("return", """
+    fun `test return within assoc fn`() = checkCompletion("return", """
         struct Foo;
         impl Foo {
             fn shutdown() { retu/*caret*/ }
         }
+    """, """
+        struct Foo;
+        impl Foo {
+            fn shutdown() { return;/*caret*/ }
+        }
     """)
 
-    fun `test return within method`() = @Suppress("DEPRECATION") checkSingleCompletion("return", """
+    fun `test return within method`() = checkCompletion("return", """
         struct Foo;
         impl Foo {
             fn print(&self) { retu/*caret*/ }
+        }
+    """, """
+        struct Foo;
+        impl Foo {
+            fn print(&self) { return;/*caret*/ }
         }
     """)
 
@@ -279,56 +404,82 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         const retu/*caret*/
     """)
 
-    fun `test static`() = @Suppress("DEPRECATION") checkSingleCompletion("static", """
+    fun `test static`() = checkCompletion("static", """
         sta/*caret*/
+    """, """
+        static /*caret*/
     """)
 
-    fun `test pub static`() = @Suppress("DEPRECATION") checkSingleCompletion("static", """
+    fun `test pub static`() = checkCompletion("static", """
         pub stat/*caret*/
+    """, """
+        pub static /*caret*/
     """)
 
-    fun `test struct`() = @Suppress("DEPRECATION") checkSingleCompletion("struct", """
+    fun `test struct`() = checkCompletion("struct", """
         str/*caret*/
+    """, """
+        struct /*caret*/
     """)
 
-    fun `test pub struct`() = @Suppress("DEPRECATION") checkSingleCompletion("struct", """
+    fun `test pub struct`() = checkCompletion("struct", """
         pub str/*caret*/
+    """, """
+        pub struct /*caret*/
     """)
 
-    fun `test trait`() = @Suppress("DEPRECATION") checkSingleCompletion("trait", """
+    fun `test trait`() = checkCompletion("trait", """
         tra/*caret*/
+    """, """
+        trait /*caret*/
     """)
 
-    fun `test pub trait`() = @Suppress("DEPRECATION") checkSingleCompletion("trait", """
+    fun `test pub trait`() = checkCompletion("trait", """
         pub tra/*caret*/
+    """, """
+        pub trait /*caret*/
     """)
 
-    fun `test unsafe trait`() = @Suppress("DEPRECATION") checkSingleCompletion("trait", """
+    fun `test unsafe trait`() = checkCompletion("trait", """
         unsafe tra/*caret*/
+    """, """
+        unsafe trait /*caret*/
     """)
 
-    fun `test type`() = @Suppress("DEPRECATION") checkSingleCompletion("type", """
+    fun `test type`() = checkCompletion("type", """
         typ/*caret*/
+    """, """
+        type /*caret*/
     """)
 
-    fun `test pub type`() = @Suppress("DEPRECATION") checkSingleCompletion("type", """
+    fun `test pub type`() = checkCompletion("type", """
         pub typ/*caret*/
+    """, """
+        pub type /*caret*/
     """)
 
-    fun `test unsafe`() = @Suppress("DEPRECATION") checkSingleCompletion("unsafe", """
+    fun `test unsafe`() = checkCompletion("unsafe", """
         uns/*caret*/
+    """, """
+        unsafe /*caret*/
     """)
 
-    fun `test pub unsafe`() = @Suppress("DEPRECATION") checkSingleCompletion("unsafe", """
+    fun `test pub unsafe`() = checkCompletion("unsafe", """
         pub unsa/*caret*/
+    """, """
+        pub unsafe /*caret*/
     """)
 
-    fun `test use`() = @Suppress("DEPRECATION") checkSingleCompletion("use", """
+    fun `test use`() = checkCompletion("use", """
         us/*caret*/
+    """, """
+        use /*caret*/
     """)
 
-    fun `test pub use`() = @Suppress("DEPRECATION") checkSingleCompletion("use", """
+    fun `test pub use`() = checkCompletion("use", """
         pub us/*caret*/
+    """, """
+        pub use /*caret*/
     """)
 
     fun `test else`() = checkCompletion("else", """
@@ -366,12 +517,16 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         "fn foo() -> i32 { return /*caret*/}"
     )
 
-    fun `test where in generic function`() = @Suppress("DEPRECATION") checkSingleCompletion("where", """
+    fun `test where in generic function`() = checkCompletion("where", """
         fn foo<T>(t: T) whe/*caret*/
+    """, """
+        fn foo<T>(t: T) where /*caret*/
     """)
 
-    fun `test where in generic function with ret type`() = @Suppress("DEPRECATION") checkSingleCompletion("where", """
+    fun `test where in generic function with ret type`() = checkCompletion("where", """
         fn foo<T>(t: T) -> i32 whe/*caret*/
+    """, """
+        fn foo<T>(t: T) -> i32 where /*caret*/
     """)
 
     fun `test where in not generic function`() = checkNoCompletion("""
@@ -382,40 +537,56 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         fn foo() -> i32 whe/*caret*/
     """)
 
-    fun `test where in trait method`() = @Suppress("DEPRECATION") checkSingleCompletion("where", """
+    fun `test where in trait method`() = checkCompletion("where", """
         trait Foo {
             fn foo() whe/*caret*/
         }
-    """)
-
-    fun `test where in method`() = @Suppress("DEPRECATION") checkSingleCompletion("where", """
-        impl Foo {
-            fn foo() whe/*caret*/
+    """, """
+        trait Foo {
+            fn foo() where /*caret*/
         }
     """)
 
-    fun `test where in generic struct`() = @Suppress("DEPRECATION") checkSingleCompletion("where", """
-        struct Foo<T> whe/*caret*/
+    fun `test where in method`() = checkCompletion("where", """
+        impl Foo {
+            fn foo() whe/*caret*/
+        }
+    """, """
+        impl Foo {
+            fn foo() where /*caret*/
+        }
     """)
 
-    fun `test where in generic tuple struct`() = @Suppress("DEPRECATION") checkSingleCompletion("where", """
+    fun `test where in generic struct`() = checkCompletion("where", """
+        struct Foo<T> whe/*caret*/
+    """, """
+        struct Foo<T> where /*caret*/
+    """)
+
+    fun `test where in generic tuple struct`() = checkCompletion("where", """
         struct Foo<T>(T) whe/*caret*/
+    """, """
+        struct Foo<T>(T) where /*caret*/
     """)
 
     fun `test where in not generic struct`() = checkNoCompletion("""
         struct Foo whe/*caret*/
     """)
 
-    fun `test where in generic enum`() = @Suppress("DEPRECATION") checkSingleCompletion("where", """
+    fun `test where in generic enum`() = checkCompletion("where", """
         enum Foo<T> whe/*caret*/
+    """, """
+        enum Foo<T> where /*caret*/
     """)
 
     fun `test where in not generic enum`() = checkNoCompletion("""
         enum Foo whe/*caret*/
     """)
 
-    fun `test where in generic type alias`() = @Suppress("DEPRECATION") checkSingleCompletion("where", """
+    fun `test where in generic type alias`() = checkCompletion("where", """
         type Foo<T> whe/*caret*/
+    """, """
+        type Foo<T> where /*caret*/
     """)
 
     fun `test where in not generic type alias`() = checkNoCompletion("""
@@ -434,20 +605,28 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         }
     """)
 
-    fun `test where in trait`() = @Suppress("DEPRECATION") checkSingleCompletion("where", """
+    fun `test where in trait`() = checkCompletion("where", """
         trait Foo whe/*caret*/
+    """, """
+        trait Foo where /*caret*/
     """)
 
-    fun `test where in generic trait`() = @Suppress("DEPRECATION") checkSingleCompletion("where", """
+    fun `test where in generic trait`() = checkCompletion("where", """
         trait Foo<T> whe/*caret*/
+    """, """
+        trait Foo<T> where /*caret*/
     """)
 
-    fun `test where in impl`() = @Suppress("DEPRECATION") checkSingleCompletion("where", """
+    fun `test where in impl`() = checkCompletion("where", """
         impl Foo whe/*caret*/
+    """, """
+        impl Foo where /*caret*/
     """)
 
-    fun `test where in trait impl`() = @Suppress("DEPRECATION") checkSingleCompletion("where", """
+    fun `test where in trait impl`() = checkCompletion("where", """
         impl<T> Foo<T> for Bar whe/*caret*/
+    """, """
+        impl<T> Foo<T> for Bar where /*caret*/
     """)
 
     fun `test if|match in start of statement`() = checkCompletion(CONDITION_KEYWORDS, """
@@ -626,11 +805,11 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
     fun `test unsafe fn in impl`() = checkCompletion("fn", """
         impl Foo {
             unsafe f/*caret*/
-        }    
+        }
     """, """
         impl Foo {
             unsafe fn /*caret*/
-        }    
+        }
     """)
 
     fun `test pub member keyword in inherent impl`() = checkCompletion(MEMBERS_KEYWORDS, """
@@ -681,6 +860,18 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         }
     """)
 
+    // Smart mode is used for not completion tests to disable additional results
+    // from language agnostic `com.intellij.codeInsight.completion.WordCompletionContributor`
+    override fun checkNoCompletion(@Language("Rust") code: String) {
+        val dumbService = DumbServiceImpl.getInstance(project)
+        val oldValue = dumbService.isDumb
+        try {
+            dumbService.isDumb = false
+            super.checkNoCompletion(code)
+        } finally {
+            dumbService.isDumb = oldValue
+        }
+    }
 
     private fun checkCompletion(
         lookupStrings: List<String>,
@@ -694,5 +885,14 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
 
     companion object {
         private val MEMBERS_KEYWORDS = listOf("fn", "type", "const", "unsafe")
+
+        // BACKCOMPAT: 2019.3
+        private val BUILD: BuildNumber = BuildNumber.fromString("201")!!
+
+        // Platform completion code doesn't insert dummy identifier because of `WordCompletionContributor` (it's enabled only in dumb mode).
+        // It leads to different PSI for completion and out psi patterns don't work.
+        // Fixed in 2020.1 in platform
+        private val isAtLeast201: Boolean
+            get() = ApplicationInfo.getInstance().build >= BUILD
     }
 }


### PR DESCRIPTION
There were two problems:
* completion psi patterns use `PsiElement#getContext` method. But our implementation of `getContext` uses indices sometimes that leads to `IndexNotReadyException` because keyword completion may be called in dumb mode. Now we make index lookup only in smart mode
* `await` keyword completion uses type inference, i.e. uses indices sometimes as well => it should be called only in smart mode. The corresponding completion provider was moved from keyword completion contributor to be invoked only in smart mode (CC @mchernyavsky)

Tests improvements:
* `RsKeywordCompletionContributorTest` now check completion in dumb mode
* usages of deprecated `checkSingleCompletion` in `RsKeywordCompletionContributorTest` were replaced with `checkCompletion`

Fixes #5123