### PR TITLE
Use the proper grammar for path fragments in macro_rules!

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -75,6 +75,7 @@ mibac138
 mitchhentges
 mkaput
 mrhota
+mrobakowski
 msmorgan
 netvl
 nicholastmosher

--- a/src/main/kotlin/org/rust/lang/core/macros/FragmentKind.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/FragmentKind.kt
@@ -44,7 +44,7 @@ enum class FragmentKind(private val kind: String) {
                 .enter_section_(adaptBuilder, 0, 0, null)
 
             val parsed = when (this) {
-                Path -> RustParser.ValuePathGenericArgs(adaptBuilder, 0)
+                Path -> RustParser.TypePathGenericArgsNoTypeQual(adaptBuilder, 0)
                 Expr -> RustParser.Expr(adaptBuilder, 0, -1)
                 Ty -> RustParser.TypeReference(adaptBuilder, 0)
                 Pat -> RustParser.Pat(adaptBuilder, 0)

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -278,7 +278,7 @@ class MacroExpander(val project: Project) {
     }
 
     companion object {
-        const val EXPANDER_VERSION = 3
+        const val EXPANDER_VERSION = 4
         private val USELESS_PARENS_EXPRS = tokenSetOf(
             LIT_EXPR, MACRO_EXPR, PATH_EXPR, PAREN_EXPR, TUPLE_EXPR, ARRAY_EXPR, UNIT_EXPR
         )

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -85,6 +85,17 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         fn foo() { let a = bar::<u8>::baz::<u8>; }
     """)
 
+    fun `test type-like path`() = doTest("""
+        macro_rules! foo {
+            ($ i:path) => {
+                struct Foo<F: $ i> { inner: F }
+            }
+        }
+        foo! { Bar<Baz> }
+    """, """
+        struct Foo<F: Bar<Baz>> { inner: F }
+    """)
+
     fun `test expr`() = doTest("""
         macro_rules! foo {
             ($ i:expr) => ( fn bar() { $ i; } )


### PR DESCRIPTION
This PR changes the grammar used by the macro expander to match on `path` fragments. The Rust Reference [specifies](https://doc.rust-lang.org/stable/reference/macros-by-example.html#metavariables) that a path fragment should be parsed as a type-like path:
> * `path`: a _[TypePath](https://doc.rust-lang.org/stable/reference/paths.html#paths-in-types)_ style path

Before this PR value-like paths were used, which caused some macros to fail to expand.

Closes #5357 

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
