### PR TITLE
HINT: special case for `impl Iterator` types

### DIFF
--- a/src/main/kotlin/org/rust/ide/hints/RsInlayTypeHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/RsInlayTypeHintsProvider.kt
@@ -26,8 +26,6 @@ import org.rust.lang.core.types.declaration
 import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.ty.walk
 import org.rust.lang.core.types.type
-import org.rust.stdext.dequeOf
-import org.rust.stdext.nextOrNull
 import javax.swing.JPanel
 
 class RsInlayTypeHintsProvider : InlayHintsProvider<RsInlayTypeHintsProvider.Settings> {
@@ -47,7 +45,7 @@ class RsInlayTypeHintsProvider : InlayHintsProvider<RsInlayTypeHintsProvider.Set
     override fun createConfigurable(settings: Settings): ImmediateConfigurable = object : ImmediateConfigurable {
         val showForVariables = "Show for variables"
         val showForLambdas = "Show for closures"
-        val showForIterators = "Show for iterators"
+        val showForIterators = "Show for loop variables"
         val showForPlaceholders = "Show for type placeholders"
         val showObviousTypes = "Show obvious types"
 
@@ -95,7 +93,7 @@ class RsInlayTypeHintsProvider : InlayHintsProvider<RsInlayTypeHintsProvider.Set
     override fun getCollectorFor(file: PsiFile, editor: Editor, settings: Settings, sink: InlayHintsSink): InlayHintsCollector? =
         object : FactoryInlayHintsCollector(editor) {
 
-            val typeHintsFactory = RsTypeHintsPresentationFactory(factory, settings.showObviousTypes)
+            val typeHintsFactory = RsTypeHintsPresentationFactory(null, factory, settings.showObviousTypes)
 
             override fun collect(element: PsiElement, editor: Editor, sink: InlayHintsSink): Boolean {
                 if (file.project.service<DumbService>().isDumb) return true

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -854,10 +854,10 @@ class ImplLookup(
         assocType: RsTypeAlias,
         recursionDepth: Int = 0
     ): SelectionResult<TyWithObligations<Ty>?> {
-        return selectStrict(ref, recursionDepth).map {
-            lookupAssociatedType(ref.selfTy, it, assocType)
+        return selectStrict(ref, recursionDepth).map { selection ->
+            lookupAssociatedType(ref.selfTy, selection, assocType)
                 ?.let { ctx.normalizeAssociatedTypesIn(it, recursionDepth) }
-                ?.withObligations(it.nestedObligations)
+                ?.withObligations(selection.nestedObligations)
         }
     }
 
@@ -870,6 +870,24 @@ class ImplLookup(
             .map { selectProjectionStrict(TraitRef(it, ref.trait), assocType, recursionDepth) }
             .firstOrNull { it.isOk() }
             ?: SelectionResult.Err
+
+    fun selectAllProjectionsStrict(ref: TraitRef): Map<RsTypeAlias, Ty>? = ctx.probe {
+        val selection = select(ref).ok() ?: return@probe null
+        val assocValues = ref.trait.element.associatedTypesTransitively.associateWith { assocType ->
+            lookupAssociatedType(ref.selfTy, selection, assocType)
+                ?.let { ctx.normalizeAssociatedTypesIn(it) }
+                ?.withObligations(selection.nestedObligations)
+                ?: TyWithObligations(TyUnknown)
+        }
+        val fulfill = FulfillmentContext(ctx, this)
+        assocValues.values.flatMap { it.obligations }.forEach(fulfill::registerPredicateObligation)
+
+        if (fulfill.selectUntilError()) {
+            assocValues.mapValues { (_, v) -> ctx.resolveTypeVarsIfPossible(v.value) }
+        } else {
+            null
+        }
+    }
 
     private fun lookupAssociatedType(selfTy: Ty, res: Selection, assocType: RsTypeAlias): Ty? {
         return when (selfTy) {

--- a/src/test/kotlin/org/rust/ide/hints/RsChainMethodTypeHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RsChainMethodTypeHintsProviderTest.kt
@@ -112,6 +112,19 @@ class RsChainMethodTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsChainMetho
         }
     """)
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test iterator special case`() = doTest("""
+        fn main() {
+            vec![1, 2, 3]
+                .into_iter()/*hint text="[:  [impl  [Iterator [< [Item = i32] >]] ]]"*/
+                .map(|x| x as u8)/*hint text="[:  [impl  [Iterator [< [Item = u8] >]] ]]"*/
+                .map(|x| x as u16)/*hint text="[:  [impl  [Iterator [< [Item = u16] >]] ]]"*/
+                .filter(|x| x % 2 == 0)/*hint text="[:  [impl  [Iterator [< [Item = u16] >]] ]]"*/
+                .for_each(|x| {})
+            ;
+        }
+    """)
+
     @Suppress("UnstableApiUsage")
     private fun doTest(@Language("Rust") code: String, showSameConsecutiveTypes: Boolean = true) {
         val service = InlayHintsSettings.instance()

--- a/src/test/kotlin/org/rust/ide/hints/RsInlayTypeHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RsInlayTypeHintsProviderTest.kt
@@ -383,4 +383,11 @@ class RsInlayTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsInlayTypeHintsPr
             let y/*hint text="[:  [V [< [u8 ,  f32] >]]]"*/ = x;
         }
     """)
+
+//    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+//    fun `test iterator special case`() = checkByText("""
+//        fn main() {
+//            let xs/*hint text="[:  [impl  [Iterator [< [Item = i32] >]] ]]"*/ = vec![1,2,3].into_iter();
+//        }
+//    """)
 }


### PR DESCRIPTION
Now any type that implements `Iterator` trait is rendered in inline hints as `impl Iterator<Item=...>` in chained method call hints (#5276). It can be enabled for usual type hints in the future.

![image](https://user-images.githubusercontent.com/3221931/81700318-2e773100-9471-11ea-8a9f-0cfc05a34375.png)

Fixes #1803

c.c. @Kobzol 