### PR TITLE
PERF&MACRO: slightly optimize macro matching

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -19,7 +19,7 @@ import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.util.SmartList
 import org.rust.lang.core.parser.RustParserUtil.collapsedTokenType
-import org.rust.lang.core.parser.createRustPsiBuilder
+import org.rust.lang.core.parser.createAdaptedRustPsiBuilder
 import org.rust.lang.core.parser.rawLookupText
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.*
@@ -124,7 +124,7 @@ class MacroExpander(val project: Project) {
         def: RsMacro,
         call: RsMacroCall
     ): Triple<RsMacroCase, MacroSubstitution, RangeMap>? {
-        val (macroCallBody, ranges) = project.createRustPsiBuilder(call.macroBody ?: return null).lowerDocComments()
+        val (macroCallBody, ranges) = project.createAdaptedRustPsiBuilder(call.macroBody ?: return null).lowerDocComments()
         macroCallBody.eof() // skip whitespace
         var start = macroCallBody.mark()
         val macroCaseList = def.macroBodyStubbed?.macroCaseList ?: return null
@@ -175,7 +175,7 @@ class MacroExpander(val project: Project) {
             }
         }
 
-        return this@MacroExpander.project.createRustPsiBuilder(sb) to RangeMap.from(ranges)
+        return this@MacroExpander.project.createAdaptedRustPsiBuilder(sb) to RangeMap.from(ranges)
     }
 
     private fun PsiBuilder.hasDocComments(): Boolean {
@@ -278,7 +278,7 @@ class MacroExpander(val project: Project) {
     }
 
     companion object {
-        const val EXPANDER_VERSION = 4
+        const val EXPANDER_VERSION = 5
         private val USELESS_PARENS_EXPRS = tokenSetOf(
             LIT_EXPR, MACRO_EXPR, PATH_EXPR, PAREN_EXPR, TUPLE_EXPR, ARRAY_EXPR, UNIT_EXPR
         )

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroGraphWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroGraphWalker.kt
@@ -9,7 +9,7 @@ import com.intellij.lang.PsiBuilder
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import org.rust.lang.core.macros.MGNodeData.*
-import org.rust.lang.core.parser.createRustPsiBuilder
+import org.rust.lang.core.parser.createAdaptedRustPsiBuilder
 import java.util.*
 import kotlin.math.min
 
@@ -42,7 +42,7 @@ class MacroGraphWalker(
         descriptor = state.descriptor
     }
 
-    private val builder = project.createRustPsiBuilder(callBody).also { it.eof() } // skip whitespace
+    private val builder = project.createAdaptedRustPsiBuilder(callBody).also { it.eof() } // skip whitespace
     private val processStack: Deque<State> = ArrayDeque()
     private var position: MacroGraphNode = graph.getNode(0)
     private var status: Status = Status.Active

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
@@ -597,7 +597,8 @@ object RustParserUtil : GeneratedParserUtilBase() {
     fun parseMacroBodyLazy(builder: PsiBuilder, level: Int): Boolean =
         parseTokenTreeLazy(builder, level, MACRO_BODY)
 
-    private fun parseTokenTreeLazy(builder: PsiBuilder, level: Int, tokenTypeToCollapse: IElementType): Boolean {
+    @JvmStatic
+    fun parseTokenTreeLazy(builder: PsiBuilder, level: Int, tokenTypeToCollapse: IElementType): Boolean {
         val firstToken = builder.tokenType
         if (firstToken == null || firstToken !in LEFT_BRACES) return false
         val rightBrace = MacroBraces.fromTokenOrFail(firstToken).closeToken


### PR DESCRIPTION
Some optimization in `FragmentKind.parse`: do less Grammar Kit stuff, use more lightweight parsing methods.

This slightly speeds up macro expansion