### PR TITLE
COMP: Deprioritize completion of &mut self methods for const references and bindings

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -58,7 +58,7 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
         val processedPathNames = hashSetOf<String>()
 
         val context = RsCompletionContext(
-            element.implLookup,
+            element,
             getExpectedTypeForEnclosingPathOrDotExpr(element),
             isSimplePath = RsPsiPattern.simplePathPattern.accepts(parameters.position)
         )
@@ -193,7 +193,7 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
             removeAll(processedPathNames)
         }
 
-        val context = RsCompletionContext(path.implLookup, expectedTy, isSimplePath = true)
+        val context = RsCompletionContext(path, expectedTy, isSimplePath = true)
         for (elementName in result.prefixMatcher.sortMatching(keys)) {
             val candidates = ImportCandidatesCollector.getImportCandidates(importContext, elementName, elementName) {
                 !(it.item is RsMod || it.item is RsModDeclItem || it.item.parent is RsMembers)
@@ -240,10 +240,12 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
 }
 
 data class RsCompletionContext(
-    val lookup: ImplLookup? = null,
+    val context: RsElement? = null,
     val expectedTy: Ty? = null,
     val isSimplePath: Boolean = false
-)
+) {
+    val lookup: ImplLookup? = context?.implLookup
+}
 
 private fun filterAssocTypes(
     path: RsPath,

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionSortingTest.kt
@@ -99,6 +99,78 @@ class RsCompletionSortingTest : RsTestBase() {
         RsFunction::class to "foo4"
     ))
 
+    fun `test const before mut for const reference`() = doTest("""
+        struct S;
+
+        impl S {
+            fn foo1(&mut self) {}
+            fn foo2(&mut self) {}
+            fn foo3(&self) {}
+            fn foo4(&self) {}
+        }
+
+        fn foo(a: &S) { a./*caret*/ }
+    """, listOf(
+        RsFunction::class to "foo3",
+        RsFunction::class to "foo4",
+        RsFunction::class to "foo1",
+        RsFunction::class to "foo2"
+    ))
+
+    fun `test const before mut for const binding`() = doTest("""
+        struct S;
+
+        impl S {
+            fn foo1(&mut self) {}
+            fn foo2(&mut self) {}
+            fn foo3(&self) {}
+            fn foo4(&self) {}
+        }
+
+        fn foo(a: S) { a./*caret*/ }
+    """, listOf(
+        RsFunction::class to "foo3",
+        RsFunction::class to "foo4",
+        RsFunction::class to "foo1",
+        RsFunction::class to "foo2"
+    ))
+
+    fun `test mut reference`() = doTest("""
+        struct S;
+
+        impl S {
+            fn foo1(&mut self) {}
+            fn foo2(&mut self) {}
+            fn foo3(&self) {}
+            fn foo4(&self) {}
+        }
+
+        fn foo(a: &mut S) { a./*caret*/ }
+    """, listOf(
+        RsFunction::class to "foo1",
+        RsFunction::class to "foo2",
+        RsFunction::class to "foo3",
+        RsFunction::class to "foo4"
+    ))
+
+    fun `test mut binding`() = doTest("""
+        struct S;
+
+        impl S {
+            fn foo1(&mut self) {}
+            fn foo2(&mut self) {}
+            fn foo3(&self) {}
+            fn foo4(&self) {}
+        }
+
+        fn foo(mut a: S) { a./*caret*/ }
+    """, listOf(
+        RsFunction::class to "foo1",
+        RsFunction::class to "foo2",
+        RsFunction::class to "foo3",
+        RsFunction::class to "foo4"
+    ))
+
     fun `test assoc fns before methods`() = doTest("""
         struct S;
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsLookupElementTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsLookupElementTest.kt
@@ -333,7 +333,7 @@ class RsLookupElementTest : RsTestBase() {
     ) {
         InlineFile(code)
         val element = findElementInEditor<RsReferenceElement>()
-        val context = RsCompletionContext(element.implLookup)
+        val context = RsCompletionContext(element)
         val processedPathNames = mutableSetOf<String>()
 
         val lookups = mutableListOf<LookupElement>()


### PR DESCRIPTION
This PR attempts to sort methods in completion based on mutability of `self`. If a method call is performed on a const reference or a non-mut binding,`&mut self` methods will be deprioritized.

The implementation needs additional work that I wanted to discuss here. I needed to somehow pass the method call (`RsFieldLookup`) to `ScopedBaseCompletionEntity::getBasePriority` (I didn't know how else to get it from there). `ImplLookup` was already being passed down the completion chain, so I just slapped the element to the lookup, which is not optimal. Is there an easier way of passing down the element? Should I add it to the `RsCompletionContext` and pass it down the completion chain of methods and processors?

The implementation now uses a very simple heuristic for deciding if the method should be deprioritized. Let me know if I should improve it (or how :) ).

Completion could possibly receive a larger overhaul to support use cases like smart completion (https://github.com/intellij-rust/intellij-rust/issues/5196).

Fixes: https://github.com/intellij-rust/intellij-rust/issues/1409