### PR TITLE
INSP: check if supertrait is implemented

### DIFF
--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -26,6 +26,7 @@ import org.rust.ide.inspections.fixes.AddMainFnFix
 import org.rust.ide.inspections.fixes.AddRemainingArmsFix
 import org.rust.ide.inspections.fixes.AddWildcardArmFix
 import org.rust.ide.inspections.fixes.ChangeRefToMutableFix
+import org.rust.ide.presentation.shortPresentableText
 import org.rust.ide.refactoring.implementMembers.ImplementMembersFix
 import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.psi.*
@@ -942,6 +943,21 @@ sealed class RsDiagnostic(
             header = escapeString("the trait bound `$ty: std::marker::Sized` is not satisfied"),
             description = escapeString("`$ty` does not have a constant size known at compile-time"),
             fixes = listOf(ConvertToReferenceFix(element), ConvertToBoxFix(element))
+        )
+    }
+
+    class SuperTraitIsNotImplemented(
+        element: RsTraitRef,
+        type: Ty,
+        private val missingTrait: String
+    ) : RsDiagnostic(element) {
+        private val typeText = type.shortPresentableText
+
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            E0277,
+            header = escapeString("the trait bound `$typeText: $missingTrait` is not satisfied"),
+            description = escapeString("the trait `$missingTrait` is not implemented for `$typeText`")
         )
     }
 


### PR DESCRIPTION
This PR adds inspection that checks if a supertrait is implemented:
```rust
trait A {}
trait C: A {}

struct S;
impl <error descr="the trait bound `[S]: A` is not satisfied [E0277]">C</error> for S {}
```

All supertraits of the trait are checked, but the check is not recursive (i.e. supertraits of supertraits are not checked). If you try to implement the missing trait, the recursive requirements will pop on that `impl`, so that should be fine.

I'm also thinking of adding a quick fix that would add `impl MissingTrait for Type` above the impl with the error and apply `ImplementMembersFix` right away. Do you agree?

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5194