### PR TITLE
DBG: don't interrupt debugging session if debugger is not loaded/update

### DIFF
--- a/debugger/src/201/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtilsExt.kt
+++ b/debugger/src/201/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtilsExt.kt
@@ -6,6 +6,7 @@
 package org.rust.debugger.runconfig
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.Messages
 import org.rust.debugger.RsDebuggerToolchainService
 import org.rust.debugger.RsDebuggerToolchainService.LLDBStatus
@@ -23,20 +24,37 @@ object RsDebugRunnerUtilsExt {
             is LLDBStatus.Binaries -> return true
         }
 
-        // TODO: add option to download/update debugger automatically
-        val option = Messages.showDialog(
+        val option = if (!RsDebuggerSettings.getInstance().downloadAutomatically) {
+            showDialog(project, message, action)
+        } else {
+            Messages.OK
+        }
+
+        if (option == Messages.OK) {
+            val result = RsDebuggerToolchainService.getInstance().downloadDebugger(project);
+            if (result is RsDebuggerToolchainService.DownloadResult.Ok) {
+                RsDebuggerSettings.getInstance().lldbPath = result.lldbDir.absolutePath
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun showDialog(project: Project, message: String, action: String): Int {
+        return Messages.showDialog(
             project,
             message,
             RsDebugRunnerUtils.ERROR_MESSAGE_TITLE,
             arrayOf(action),
             Messages.OK,
-            Messages.getErrorIcon()
+            Messages.getErrorIcon(),
+            object : DialogWrapper.DoNotAskOption.Adapter() {
+                override fun rememberChoice(isSelected: Boolean, exitCode: Int) {
+                    if (exitCode == Messages.OK) {
+                        RsDebuggerSettings.getInstance().downloadAutomatically = isSelected
+                    }
+                }
+            }
         )
-        if (option == Messages.OK) {
-            RsDebuggerToolchainService.getInstance().downloadDebugger({
-                RsDebuggerSettings.getInstance().lldbPath = it.absolutePath
-            }, {})
-        }
-        return false
     }
 }

--- a/debugger/src/201/test/kotlin/org/rust/debugger/RsDebuggerToolchainServiceTest.kt
+++ b/debugger/src/201/test/kotlin/org/rust/debugger/RsDebuggerToolchainServiceTest.kt
@@ -7,12 +7,9 @@ package org.rust.debugger
 
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.PlatformUtils
-import com.intellij.util.ui.UIUtil
 import org.rust.RsTestBase
 import org.rust.debugger.RsDebuggerToolchainService.LLDBStatus
 import java.io.File
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 class RsDebuggerToolchainServiceTest : RsTestBase() {
 
@@ -31,23 +28,13 @@ class RsDebuggerToolchainServiceTest : RsTestBase() {
     }
 
     fun `test lldb loading`() {
-        val latch = CountDownLatch(1)
         val toolchainService = RsDebuggerToolchainService.getInstance()
-
         assertEquals(LLDBStatus.NeedToDownload, toolchainService.getLLDBStatus())
 
-        toolchainService.downloadDebugger({
-            lldbDir = it
-            latch.countDown()
-        }, {
-            latch.countDown()
-        })
+        val result = toolchainService.downloadDebugger()
 
-        while (!latch.await(50, TimeUnit.MILLISECONDS)) {
-            UIUtil.dispatchAllInvocationEvents()
-        }
-
-        check(lldbDir != null) { "Failed to load debugger" }
-        check(toolchainService.getLLDBStatus(lldbDir!!.absolutePath) is LLDBStatus.Binaries)
+        check(result is RsDebuggerToolchainService.DownloadResult.Ok) { "Failed to load debugger" }
+        lldbDir = result.lldbDir
+        check(toolchainService.getLLDBStatus(result.lldbDir.absolutePath) is LLDBStatus.Binaries)
     }
 }

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettings.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettings.kt
@@ -22,6 +22,7 @@ class RsDebuggerSettings : XDebuggerSettings<RsDebuggerSettings>("Rust") {
     var gdbRenderers: GDBRenderers = GDBRenderers.DEFAULT
 
     var lldbPath: String? = null
+    var downloadAutomatically: Boolean = false
 
     override fun getState(): RsDebuggerSettings = this
 


### PR DESCRIPTION
Now, if your debugger is not loaded or should be updated, the corresponding dialog and debugger loading don't interrupt debugger session and it continues after successful loading.

![download dbg automatically 2020-05-22 12_07_48](https://user-images.githubusercontent.com/2539310/82651687-2a8f9f80-9c25-11ea-9ad1-b7dd71f57ea0.gif)

Also, there is option, to download/update debugger automatically, i.e. not show dialog at all
![download dbg automatically 2 2020-05-22 12_09_37](https://user-images.githubusercontent.com/2539310/82651666-21063780-9c25-11ea-9986-4b4ed6927309.gif)

Closes #5202