### PR TITLE
TYPE: implement SelfManagingCommenter

### DIFF
--- a/src/main/kotlin/org/rust/ide/commenter/RsCommenter.kt
+++ b/src/main/kotlin/org/rust/ide/commenter/RsCommenter.kt
@@ -5,14 +5,28 @@
 
 package org.rust.ide.commenter
 
+import com.intellij.codeInsight.generation.CommenterDataHolder
+import com.intellij.codeInsight.generation.SelfManagingCommenter
+import com.intellij.codeInsight.generation.SelfManagingCommenterUtil
 import com.intellij.lang.CodeDocumentationAwareCommenter
 import com.intellij.lang.Commenter
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiFile
 import com.intellij.psi.tree.IElementType
+import com.intellij.util.text.CharArrayUtil
 import org.rust.lang.core.parser.RustParserDefinition.Companion.BLOCK_COMMENT
+import org.rust.lang.core.parser.RustParserDefinition.Companion.EOL_COMMENT
+import org.rust.lang.core.parser.RustParserDefinition.Companion.INNER_EOL_DOC_COMMENT
+import org.rust.lang.core.parser.RustParserDefinition.Companion.OUTER_EOL_DOC_COMMENT
+import org.rust.lang.core.psi.RS_EOL_COMMENTS
+import org.rust.lang.doc.psi.RsDocKind
 
-class RsCommenter : Commenter, CodeDocumentationAwareCommenter {
-    // act like there are no doc or line comments, these are handled separately
+data class CommentHolder(val file: PsiFile) : CommenterDataHolder()
+
+class RsCommenter : Commenter, CodeDocumentationAwareCommenter, SelfManagingCommenter<CommentHolder> {
+    // act like there are no doc comments, these are handled in `RsEnterInLineCommentHandler`
     override fun isDocumentationComment(element: PsiComment?) = false
     override fun getDocumentationCommentTokenType(): IElementType? = null
     override fun getDocumentationCommentLinePrefix(): String? = null
@@ -27,8 +41,100 @@ class RsCommenter : Commenter, CodeDocumentationAwareCommenter {
     override fun getBlockCommentPrefix(): String = "/*"
     override fun getBlockCommentSuffix(): String = "*/"
 
-    // for nested comments
-
+    // unused because we implement SelfManagingCommenter
     override fun getCommentedBlockCommentPrefix(): String = "*//*"
     override fun getCommentedBlockCommentSuffix(): String = "*//*"
+
+    override fun getBlockCommentPrefix(selectionStart: Int, document: Document, data: CommentHolder): String? =
+        blockCommentPrefix
+
+    override fun getBlockCommentSuffix(selectionEnd: Int, document: Document, data: CommentHolder): String? =
+        blockCommentSuffix
+
+    override fun getBlockCommentRange(
+        selectionStart: Int,
+        selectionEnd: Int,
+        document: Document,
+        data: CommentHolder
+    ): TextRange? =
+        SelfManagingCommenterUtil.getBlockCommentRange(selectionStart, selectionEnd, document, blockCommentPrefix, blockCommentSuffix)
+
+    override fun insertBlockComment(
+        startOffset: Int,
+        endOffset: Int,
+        document: Document,
+        data: CommentHolder?
+    ): TextRange {
+        val sequence = document.charsSequence
+        val start = CharArrayUtil.shiftForward(sequence, startOffset, " \t\n")
+        val end = CharArrayUtil.shiftBackward(sequence, endOffset - 1, " \t\n")
+        return SelfManagingCommenterUtil.insertBlockComment(start, end + 1, document, blockCommentPrefix, blockCommentSuffix)
+    }
+
+    override fun uncommentBlockComment(
+        startOffset: Int,
+        endOffset: Int,
+        document: Document,
+        data: CommentHolder?
+    ) =
+        SelfManagingCommenterUtil.uncommentBlockComment(startOffset, endOffset, document, blockCommentPrefix, blockCommentSuffix)
+
+    override fun isLineCommented(line: Int, offset: Int, document: Document, data: CommentHolder): Boolean {
+        return getStartLineComment(line, document, data.file)?.isEolComment ?: false
+    }
+
+    override fun commentLine(line: Int, offset: Int, document: Document, data: CommentHolder) {
+        document.insertString(offset, "// ")
+    }
+
+    override fun uncommentLine(line: Int, offset: Int, document: Document, data: CommentHolder) {
+        val element = getStartLineComment(line, document, data.file) ?: return
+        val prefix = getEolCommentPrefix(element.tokenType) ?: return
+        val prefixWithSpace = "$prefix "
+        val length = if (element.text.startsWith(prefixWithSpace)) {
+            prefixWithSpace.length
+        } else {
+            prefix.length
+        }
+        document.deleteString(offset, offset + length)
+    }
+
+    override fun getCommentPrefix(line: Int, document: Document, data: CommentHolder): String? {
+        val token = getStartLineComment(line, document, data.file)?.tokenType ?: return null
+        return getEolCommentPrefix(token)
+    }
+
+    override fun createBlockCommentingState(
+        selectionStart: Int,
+        selectionEnd: Int,
+        document: Document,
+        file: PsiFile
+    ): CommentHolder? =
+        CommentHolder(file)
+
+    override fun createLineCommentingState(
+        startLine: Int,
+        endLine: Int,
+        document: Document,
+        file: PsiFile
+    ): CommentHolder? =
+        CommentHolder(file)
+}
+
+private fun getStartLineComment(line: Int, document: Document, file: PsiFile): PsiComment? {
+    val offset = document.getLineStartOffset(line)
+    val chars = document.charsSequence
+    return file.findElementAt(CharArrayUtil.shiftForward(chars, offset, " \t")) as? PsiComment
+}
+
+private val PsiComment.isEolComment: Boolean
+    get() = this.tokenType in RS_EOL_COMMENTS
+
+private fun getEolCommentPrefix(tokenType: IElementType): String? {
+    return when (tokenType) {
+        EOL_COMMENT -> "//"
+        INNER_EOL_DOC_COMMENT -> RsDocKind.InnerEol.prefix
+        OUTER_EOL_DOC_COMMENT -> RsDocKind.OuterEol.prefix
+        else -> null
+    }
 }

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -208,7 +208,7 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
         myFixture.checkResult(replaceCaretMarker(after))
     }
 
-    protected fun checkEditorAction(
+    protected open fun checkEditorAction(
         @Language("Rust") before: String,
         @Language("Rust") after: String,
         actionId: String,

--- a/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
+++ b/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
@@ -9,6 +9,7 @@ import com.intellij.application.options.CodeStyle
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.EmptyAction
 import com.intellij.openapi.actionSystem.IdeActions
+import com.intellij.openapiext.Testmark
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
@@ -267,13 +268,22 @@ class RsCommenterTest : RsTestBase() {
         optionProperty.set(true)
         try {
             checkEditorAction(before, afterOn, actionId, trimIndent = trimIndent)
-            resetActionManagerState()
             optionProperty.set(false)
             checkEditorAction(before, afterOff, actionId, trimIndent = trimIndent)
-            resetActionManagerState()
         } finally {
             optionProperty.set(initialValue)
         }
+    }
+
+    override fun checkEditorAction(
+        before: String,
+        after: String,
+        actionId: String,
+        trimIndent: Boolean,
+        testmark: Testmark?
+    ) {
+        super.checkEditorAction(before, after, actionId, trimIndent, testmark)
+        resetActionManagerState()
     }
 
     private fun settings(): CommonCodeStyleSettings = CodeStyle.getSettings(project).getCommonSettings(RsLanguage)

--- a/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
+++ b/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
@@ -9,6 +9,7 @@ import com.intellij.application.options.CodeStyle
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.EmptyAction
 import com.intellij.openapi.actionSystem.IdeActions
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.lang.RsLanguage
@@ -254,12 +255,14 @@ class RsCommenterTest : RsTestBase() {
         fn foo() {}
     """, IdeActions.ACTION_COMMENT_LINE)
 
-    private fun checkOption(optionProperty: KMutableProperty0<Boolean>,
-                            @Language("Rust") before: String,
-                            @Language("Rust") afterOn: String,
-                            @Language("Rust") afterOff: String,
-                            actionId: String,
-                            trimIndent: Boolean = true) {
+    private fun checkOption(
+        optionProperty: KMutableProperty0<Boolean>,
+        @Language("Rust") before: String,
+        @Language("Rust") afterOn: String,
+        @Language("Rust") afterOff: String,
+        actionId: String,
+        trimIndent: Boolean = true
+    ) {
         val initialValue = optionProperty.get()
         optionProperty.set(true)
         try {
@@ -273,7 +276,7 @@ class RsCommenterTest : RsTestBase() {
         }
     }
 
-    private fun settings() = CodeStyle.getSettings(project).getCommonSettings(RsLanguage)
+    private fun settings(): CommonCodeStyleSettings = CodeStyle.getSettings(project).getCommonSettings(RsLanguage)
 
     /**
      * Resets [com.intellij.openapi.actionSystem.impl.ActionManagerImpl.myPrevPerformedActionId].
@@ -290,11 +293,8 @@ class RsCommenterTest : RsTestBase() {
     }
 
     override fun tearDown() {
-        try {
-            super.tearDown()
-        } finally {
-            ActionManager.getInstance().unregisterAction(EMPTY_ACTION_ID)
-        }
+        ActionManager.getInstance().unregisterAction(EMPTY_ACTION_ID)
+        super.tearDown()
     }
 
     companion object {

--- a/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
+++ b/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
@@ -79,7 +79,7 @@ class RsCommenterTest : RsTestBase() {
         */}
     """, IdeActions.ACTION_COMMENT_BLOCK)
 
-    fun `test single line uncomment`() = checkEditorAction("""
+    fun `test single line uncomment`() = checkOption(settings()::LINE_COMMENT_ADD_SPACE, """
         //fn d<caret>ouble(x: i32) -> i32 {
         //    x * 2
         }
@@ -87,15 +87,37 @@ class RsCommenterTest : RsTestBase() {
         fn double(x: i32) -> i32 {
         //  <caret>  x * 2
         }
+    """, """
+        fn double(x: i32) -> i32 {
+        //  <caret>  x * 2
+        }
     """, IdeActions.ACTION_COMMENT_LINE)
 
-    fun `test multi line uncomment`() = checkEditorAction("""
+    fun `test single line uncomment with space after`() = checkOption(settings()::LINE_COMMENT_ADD_SPACE, """
+        // fn d<caret>ouble(x: i32) -> i32 {
+        //    x * 2
+        }
+    """, """
+        fn double(x: i32) -> i32 {
+        //  <caret>  x * 2
+        }
+    """, """
+         fn double(x: i32) -> i32 {
+        //   <caret> x * 2
+        }
+    """, IdeActions.ACTION_COMMENT_LINE, trimIndent = false)
+
+    fun `test multi line uncomment`() = checkOption(settings()::LINE_COMMENT_ADD_SPACE, """
         //fn doub<selection>le(x: i32) -> i32 {
         //     x</selection> * 2
         }
     """, """
         fn doub<selection>le(x: i32) -> i32 {
             x</selection> * 2
+        }
+    """, """
+        fn doub<selection>le(x: i32) -> i32 {
+             x</selection> * 2
         }
     """, IdeActions.ACTION_COMMENT_LINE)
 
@@ -119,7 +141,7 @@ class RsCommenterTest : RsTestBase() {
         }
     """, IdeActions.ACTION_COMMENT_BLOCK)
 
-    fun `test single line uncomment with space before`() = checkEditorAction("""
+    fun `test single line uncomment with space before`() = checkOption(settings()::LINE_COMMENT_ADD_SPACE, """
          //fn d<caret>ouble(x: i32) -> i32 {
         //    x * 2
         }
@@ -127,19 +149,13 @@ class RsCommenterTest : RsTestBase() {
          fn double(x: i32) -> i32 {
         //   <caret> x * 2
         }
+    """, """
+         fn double(x: i32) -> i32 {
+        //   <caret> x * 2
+        }
     """, IdeActions.ACTION_COMMENT_LINE, trimIndent = false)
 
-    fun `test single line uncomment with space after`() = checkEditorAction("""
-        // fn d<caret>ouble(x: i32) -> i32 {
-        //     x * 2
-        }
-    """, """
-        fn double(x: i32) -> i32 {
-        //  <caret>   x * 2
-        }
-    """, IdeActions.ACTION_COMMENT_LINE)
-
-    fun `test doc comment uncomment`() = checkEditorAction("""
+    fun `test outer doc comment uncomment`() = checkOption(settings()::LINE_COMMENT_ADD_SPACE, """
         /// doc<caret>
         fn double(x: i32) -> i32 {
             x * 2
@@ -147,6 +163,28 @@ class RsCommenterTest : RsTestBase() {
     """, """
         doc
         fn <caret>double(x: i32) -> i32 {
+            x * 2
+        }
+    """, """
+         doc
+        fn d<caret>ouble(x: i32) -> i32 {
+            x * 2
+        }
+    """, IdeActions.ACTION_COMMENT_LINE)
+
+    fun `test inner doc comment uncomment`() = checkOption(settings()::LINE_COMMENT_ADD_SPACE, """
+        //! doc<caret>
+        fn double(x: i32) -> i32 {
+            x * 2
+        }
+    """, """
+        doc
+        fn <caret>double(x: i32) -> i32 {
+            x * 2
+        }
+    """, """
+         doc
+        fn d<caret>ouble(x: i32) -> i32 {
             x * 2
         }
     """, IdeActions.ACTION_COMMENT_LINE)
@@ -175,7 +213,7 @@ class RsCommenterTest : RsTestBase() {
         }<caret>
     """, IdeActions.ACTION_COMMENT_LINE)
 
-    fun `test single line doc uncomment`() = checkEditorAction("""
+    fun `test outer doc uncomment inside`() = checkEditorAction("""
         ///
         ///<caret>
         ///
@@ -183,6 +221,16 @@ class RsCommenterTest : RsTestBase() {
         ///
 
         <caret>///
+    """, IdeActions.ACTION_COMMENT_LINE)
+
+    fun `test inner doc uncomment inside`() = checkEditorAction("""
+        //!
+        //!<caret>
+        //!
+    """, """
+        //!
+
+        <caret>//!
     """, IdeActions.ACTION_COMMENT_LINE)
 
     fun `test complete block comment`() = checkEditorAction("""
@@ -208,13 +256,14 @@ class RsCommenterTest : RsTestBase() {
                             @Language("Rust") before: String,
                             @Language("Rust") afterOn: String,
                             @Language("Rust") afterOff: String,
-                            actionId: String) {
+                            actionId: String,
+                            trimIndent: Boolean = true) {
         val initialValue = optionProperty.get()
         optionProperty.set(true)
         try {
-            checkEditorAction(before, afterOn, actionId)
+            checkEditorAction(before, afterOn, actionId, trimIndent = trimIndent)
             optionProperty.set(false)
-            checkEditorAction(before, afterOff, actionId)
+            checkEditorAction(before, afterOff, actionId, trimIndent = trimIndent)
         } finally {
             optionProperty.set(initialValue)
         }

--- a/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
+++ b/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
@@ -5,11 +5,15 @@
 
 package org.rust.ide.commenter
 
+import com.intellij.application.options.CodeStyle
 import com.intellij.openapi.actionSystem.IdeActions
+import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
+import org.rust.lang.RsLanguage
+import kotlin.reflect.KMutableProperty0
 
 class RsCommenterTest : RsTestBase() {
-    fun `test single line`() = checkEditorAction("""
+    fun `test single line`() = checkOption(settings()::LINE_COMMENT_ADD_SPACE, """
         fn <caret>double(x: i32) -> i32 {
             x * 2
         }
@@ -17,15 +21,23 @@ class RsCommenterTest : RsTestBase() {
         // fn double(x: i32) -> i32 {
             x <caret>* 2
         }
+    """, """
+        //fn double(x: i32) -> i32 {
+            x<caret> * 2
+        }
     """, IdeActions.ACTION_COMMENT_LINE)
 
-    fun `test multi line`() = checkEditorAction("""
+    fun `test multi line`() = checkOption(settings()::LINE_COMMENT_ADD_SPACE, """
         fn doub<selection>le(x: i32) -> i32 {
             x</selection> * 2
         }
     """, """
         // fn doub<selection>le(x: i32) -> i32 {
         //     x</selection> * 2
+        }
+    """, """
+        //fn doub<selection>le(x: i32) -> i32 {
+        //    x</selection> * 2
         }
     """, IdeActions.ACTION_COMMENT_LINE)
 
@@ -59,12 +71,12 @@ class RsCommenterTest : RsTestBase() {
         </selection>}
     """, """
         fn fib(x: i32) -> i32 {
-            /*match x {
+        /*    match x {
                 0 => 1,
                 1 => 1,
                 _ => fib(x - 2) + fib(x - 1)
-            }*/
-        }
+            }
+        */}
     """, IdeActions.ACTION_COMMENT_BLOCK)
 
     fun `test single line uncomment`() = checkEditorAction("""
@@ -149,13 +161,17 @@ class RsCommenterTest : RsTestBase() {
         }
     """, IdeActions.ACTION_COMMENT_BLOCK)
 
-    fun `test indented single line comment`() = checkEditorAction("""
+    fun `test indented single line comment`() = checkOption(settings()::LINE_COMMENT_ADD_SPACE, """
         fn double(x: i32) -> i32 {
             x<caret> * 2
         }
     """, """
         fn double(x: i32) -> i32 {
             // x * 2
+        }<caret>
+    """, """
+        fn double(x: i32) -> i32 {
+            //x * 2
         }<caret>
     """, IdeActions.ACTION_COMMENT_LINE)
 
@@ -176,4 +192,33 @@ class RsCommenterTest : RsTestBase() {
         <caret>
          */
     """, IdeActions.ACTION_EDITOR_ENTER)
+
+    fun `test move caret after commenting empty line`() = checkOption(settings()::LINE_COMMENT_ADD_SPACE, """
+        <caret>
+        fn foo() {}
+    """, """
+        // <caret>
+        fn foo() {}
+    """, """
+        //<caret>
+        fn foo() {}
+    """, IdeActions.ACTION_COMMENT_LINE)
+
+    private fun checkOption(optionProperty: KMutableProperty0<Boolean>,
+                            @Language("Rust") before: String,
+                            @Language("Rust") afterOn: String,
+                            @Language("Rust") afterOff: String,
+                            actionId: String) {
+        val initialValue = optionProperty.get()
+        optionProperty.set(true)
+        try {
+            checkEditorAction(before, afterOn, actionId)
+            optionProperty.set(false)
+            checkEditorAction(before, afterOff, actionId)
+        } finally {
+            optionProperty.set(initialValue)
+        }
+    }
+
+    private fun settings() = CodeStyle.getSettings(project).getCommonSettings(RsLanguage)
 }

--- a/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
+++ b/src/test/kotlin/org/rust/ide/commenter/RsCommenterTest.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.actionSystem.IdeActions
 import org.rust.RsTestBase
 
 class RsCommenterTest : RsTestBase() {
-
     fun `test single line`() = checkEditorAction("""
         fn <caret>double(x: i32) -> i32 {
             x * 2
@@ -60,13 +59,11 @@ class RsCommenterTest : RsTestBase() {
         </selection>}
     """, """
         fn fib(x: i32) -> i32 {
-            /*
-            match x {
+            /*match x {
                 0 => 1,
                 1 => 1,
                 _ => fib(x - 2) + fib(x - 1)
-            }
-            */
+            }*/
         }
     """, IdeActions.ACTION_COMMENT_BLOCK)
 
@@ -110,7 +107,17 @@ class RsCommenterTest : RsTestBase() {
         }
     """, IdeActions.ACTION_COMMENT_BLOCK)
 
-    fun `test single line uncomment with space`() = checkEditorAction("""
+    fun `test single line uncomment with space before`() = checkEditorAction("""
+         //fn d<caret>ouble(x: i32) -> i32 {
+        //    x * 2
+        }
+    """, """
+         fn double(x: i32) -> i32 {
+        //   <caret> x * 2
+        }
+    """, IdeActions.ACTION_COMMENT_LINE, trimIndent = false)
+
+    fun `test single line uncomment with space after`() = checkEditorAction("""
         // fn d<caret>ouble(x: i32) -> i32 {
         //     x * 2
         }
@@ -120,15 +127,27 @@ class RsCommenterTest : RsTestBase() {
         }
     """, IdeActions.ACTION_COMMENT_LINE)
 
+    fun `test doc comment uncomment`() = checkEditorAction("""
+        /// doc<caret>
+        fn double(x: i32) -> i32 {
+            x * 2
+        }
+    """, """
+        doc
+        fn <caret>double(x: i32) -> i32 {
+            x * 2
+        }
+    """, IdeActions.ACTION_COMMENT_LINE)
+
     fun `test nested block comments`() = checkEditorAction("""
         fn double<selection>(x: i32/* foobar */) -> i32</selection> {
             x * 2
         }
     """, """
-        fn double<selection>/*(x: i32*//* foobar *//*) -> i32*/</selection> {
+        fn double<selection>/*(x: i32/* foobar */) -> i32*/</selection> {
             x * 2
         }
-    """, IdeActions.ACTION_COMMENT_BLOCK) // FIXME
+    """, IdeActions.ACTION_COMMENT_BLOCK)
 
     fun `test indented single line comment`() = checkEditorAction("""
         fn double(x: i32) -> i32 {
@@ -138,6 +157,16 @@ class RsCommenterTest : RsTestBase() {
         fn double(x: i32) -> i32 {
             // x * 2
         }<caret>
+    """, IdeActions.ACTION_COMMENT_LINE)
+
+    fun `test single line doc uncomment`() = checkEditorAction("""
+        ///
+        ///<caret>
+        ///
+    """, """
+        ///
+
+        <caret>///
     """, IdeActions.ACTION_COMMENT_LINE)
 
     fun `test complete block comment`() = checkEditorAction("""


### PR DESCRIPTION
This PR solves https://github.com/intellij-rust/intellij-rust/issues/5388 with a pretty heavyweight solution of implementing `SelfManagingCommenter`. The implementation is pretty basic, but it passes all the original `RsCommenter` tests and some new ones that I have added.

It seems to work for basic use cases, if you can find some counter-examples where it breaks, let me know and I'll add them to the test suite.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5388