### PR TITLE
PERF&MACRO: disable some indices for macro expansions

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -236,7 +236,7 @@ class ExpandedMacroStorage(val project: Project) {
     }
 }
 
-private const val STORAGE_VERSION = 10
+private const val STORAGE_VERSION = 11
 private const val RANGE_MAP_ATTRIBUTE_VERSION = 2
 
 class SerializedExpandedMacroStorage private constructor(

--- a/src/main/kotlin/org/rust/lang/core/macros/RsGlobalIndexFilterForMacroExpansionFileSystem.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsGlobalIndexFilterForMacroExpansionFileSystem.kt
@@ -1,0 +1,53 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.find.ngrams.TrigramIndex
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.impl.cache.impl.id.IdIndex
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.util.indexing.GlobalIndexFilter
+import com.intellij.util.indexing.IndexId
+
+/**
+ * Disables some indexes for Rust macro expansions (i.e. for files in [MacroExpansionFileSystem])
+ */
+@Suppress("UnstableApiUsage")
+class RsGlobalIndexFilterForMacroExpansionFileSystem : GlobalIndexFilter {
+
+    /** Please, bump [STORAGE_VERSION] if you change this set */
+    private val disabledIndices: Set<IndexId<*, *>> = setOf(
+        // `IdIndex` is disabled only for performance reasons.
+        // Note that `IdIndex` is used in reference search implementation, so stuff like
+        // `find usages` will not work in macro expansion. If you need reference search
+        // in macro expansions, you should enable `IdIndex`
+        IdIndex.NAME,
+
+        // `TrigramIndex` is disabled for performance reasons and in order to exclude
+        // macro expansions from full-text search results (`Find in Path`, `Ctr+Shift+F`)
+        TrigramIndex.INDEX_ID,
+
+        // `FilenameIndex` is disabled in order to exclude macro expansions from filename
+        // search results (`Ctr+Shift+N`)
+        FilenameIndex.NAME
+    )
+
+    override fun isExcludedFromIndex(virtualFile: VirtualFile, indexId: IndexId<*, *>): Boolean =
+        indexId in disabledIndices && virtualFile.fileSystem is MacroExpansionFileSystem
+
+    /**
+     * In theory this method should be implement like `return indexId in disabledIndices`.
+     * But with such implementation it will force full re-indexation after installing/uninstalling
+     * the plugin. Wa can avoid it.
+     *
+     * We disable indices only for files in [MacroExpansionFileSystem] that are under our control.
+     * It's enough to bump [STORAGE_VERSION] - old files will be deleted from [MacroExpansionFileSystem],
+     * hence indices will be dropped.
+     */
+    override fun affectsIndex(indexId: IndexId<*, *>): Boolean = false
+
+    override fun getVersion(): Int = 0
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -896,6 +896,7 @@
         <cachesInvalidator implementation="org.rust.lang.core.macros.RsMacroExpansionCachesInvalidator"/>
         <virtualFileSystem key="rust_macros" implementationClass="org.rust.lang.core.macros.MacroExpansionFileSystem"/>
         <fileTypeOverrider implementation="org.rust.lang.core.macros.RsFileTypeOverriderForMacroExpansionFileSystem"/>
+        <globalIndexFilter implementation="org.rust.lang.core.macros.RsGlobalIndexFilterForMacroExpansionFileSystem"/>
 
         <!-- REPL Console -->
 


### PR DESCRIPTION
This speeds up macro expansion up to 20%

I disabled IdIndex and TrigramIndex just because we don't use them (in the case of macro expansion) but they affect indexing performance significantly.

I also disabled FilenameIndex in order to exclude macro expansion files from file search.

Note that without IdIndex reference search doesn't work, so if you need searching references in macro expansions you should enable IdIndex again

See macro expansion indexing flame chart. Highlighted area contains stub tree building code, it doesn't change. To the right of it, there are IdIndex and TrigramIndex parts

Before:
![Screenshot from 2020-05-22 11-53-24](https://user-images.githubusercontent.com/3221931/82705067-90107a00-9c7f-11ea-8de3-5c9772f9ff2c.png)

After (now almost nothing but stub tree building :+1: ):
![Screenshot from 2020-05-22 11-53-36](https://user-images.githubusercontent.com/3221931/82705189-dc5bba00-9c7f-11ea-91b1-a14468eab356.png)

