### PR TITLE
CARGO: complete dependency attributes in Cargo.toml

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/CargoTomlPsiPattern.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoTomlPsiPattern.kt
@@ -252,6 +252,27 @@ object CargoTomlPsiPattern {
                 or onSpecificDependencyTable
         )
 
+    fun anyDependencyProperty(): PsiElementPattern.Capture<TomlKeyValue> = psiElement<TomlKeyValue>()
+        .withParent(
+            psiElement<TomlInlineTable>().withSuperParent(2, onDependencyTable)
+                or onSpecificDependencyTable
+        )
+
+    val inAnyDependencyKeyValue: PsiElementPattern.Capture<PsiElement> =
+        cargoTomlPsiElement<PsiElement>()
+            .inside(psiElement<TomlKeyValue>(TOML_KEY_VALUE_CONTEXT_NAME))
+            .with("anyDependencyKeyValueCondition") { _, context ->
+                val keyValue = context?.get(TOML_KEY_VALUE_CONTEXT_NAME) ?: return@with false
+                anyDependencyProperty().accepts(keyValue)
+            }
+
+    val onAnyDependencyProperty: PsiElementPattern.Capture<TomlKeyValue>
+        get() = psiElement<TomlKeyValue>()
+            .withParent(
+                psiElement<TomlInlineTable>().withSuperParent(2, onDependencyTable)
+                    or onSpecificDependencyTable
+            )
+
     /**
      * ```
      * [dependencies]

--- a/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlCompletionContributor.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlCompletionContributor.kt
@@ -7,6 +7,7 @@ package org.rust.toml.completion
 
 import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionType.BASIC
+import org.rust.toml.CargoTomlPsiPattern.inAnyDependencyKeyValue
 import org.rust.toml.CargoTomlPsiPattern.inDependencyKeyValue
 import org.rust.toml.CargoTomlPsiPattern.inDependencyPackageFeatureArray
 import org.rust.toml.CargoTomlPsiPattern.inFeatureDependencyArray
@@ -27,6 +28,8 @@ class CargoTomlCompletionContributor : CompletionContributor() {
             extend(BASIC, inDependencyPackageFeatureArray, CargoTomlDependencyFeaturesCompletionProvider())
 
             extend(BASIC, inDependencyKeyValue, CargoTomlDependencyCompletionProvider())
+
+            extend(BASIC, inAnyDependencyKeyValue, CargoTomlDependencyAttributeCompletionProvider())
         }
     }
 }

--- a/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlDependencyAttributeCompletionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlDependencyAttributeCompletionProvider.kt
@@ -1,0 +1,68 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.util.ProcessingContext
+import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.toml.lang.psi.TomlInlineTable
+import org.toml.lang.psi.TomlKeyValueOwner
+import org.toml.lang.psi.TomlTable
+
+class CargoTomlDependencyAttributeCompletionProvider : CompletionProvider<CompletionParameters>() {
+    override fun addCompletions(
+        parameters: CompletionParameters,
+        context: ProcessingContext,
+        result: CompletionResultSet
+    ) {
+        val table = parameters.position.ancestorOrSelf<TomlKeyValueOwner>() ?: return
+        if (table !is TomlTable && table !is TomlInlineTable) return
+        addUniqueKeyCompletion(DEPENDENCY_KEYS, table, result)
+    }
+
+    companion object {
+        private val DEPENDENCY_KEYS = mapOf(
+            "default-features" to "true",
+            "features" to "[]",
+            "git" to "\"\"",
+            "optional" to "false",
+            "package" to "\"\"",
+            "path" to "\"\"",
+            "registry" to "\"\""
+        )
+    }
+}
+
+private fun addUniqueKeyCompletion(
+    keyToValue: Map<String, String>,
+    table: TomlKeyValueOwner,
+    result: CompletionResultSet
+) {
+    val existingKeys = table.entries.map { it.key.text }.toSet()
+    for ((key, value) in keyToValue) {
+        if (key !in existingKeys) {
+            val prefix = "$key = "
+            val completion = "$prefix$value"
+            result.addElement(
+                LookupElementBuilder
+                    .create(completion)
+                    .withInsertHandler { context, _ ->
+                        var start = context.startOffset + prefix.length
+                        var end = context.selectionEndOffset
+                        if (value.startsWith("[") || value.startsWith("\"")) {
+                            start += 1
+                            end -= 1
+                        }
+                        context.editor.selectionModel.setSelection(start, end)
+                        context.editor.caretModel.moveToOffset(start)
+                    }
+            )
+        }
+    }
+}

--- a/toml/src/test/kotlin/org/rust/toml/completion/CargoTomlCompletionTestBase.kt
+++ b/toml/src/test/kotlin/org/rust/toml/completion/CargoTomlCompletionTestBase.kt
@@ -36,4 +36,14 @@ abstract class CargoTomlCompletionTestBase : RsTestBase() {
     ) = completionFixture.doSingleCompletionByFileTree(fileTree, after)
 
     protected fun checkNoCompletion(@Language("TOML") code: String) = completionFixture.checkNoCompletion(code)
+
+    protected fun checkContainsCompletion(
+        @Language("TOML") code: String,
+        variants: List<String>
+    ) = completionFixture.checkContainsCompletion(code, variants)
+
+    protected fun checkNotContainsCompletion(
+        @Language("TOML") code: String,
+        variant: String
+    ) = completionFixture.checkNotContainsCompletion(code, variant)
 }

--- a/toml/src/test/kotlin/org/rust/toml/completion/CargoTomlDependenciesCompletionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/completion/CargoTomlDependenciesCompletionTest.kt
@@ -155,6 +155,38 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
         version = "1.0<caret>"
     """, "dep" to "1.0")
 
+    private val ATTRIBUTE_COMPLETION_LIST = listOf(
+        "default-features = true",
+        "optional = false",
+        "features = []",
+        "git = \"\"",
+        "package = \"\"",
+        "path = \"\"",
+        "registry = \"\""
+    )
+
+    fun `test complete inline dependency keys`() = checkContainsCompletion("""
+        [dependencies]
+        foo = { <caret> }
+    """, ATTRIBUTE_COMPLETION_LIST)
+
+    fun `test complete do not offer existing inline dependency keys`() = checkNotContainsCompletion("""
+        [dependencies]
+        foo = { optional = false, <caret> }
+        <caret>
+    """, "optional = false")
+
+    fun `test complete specific dependency keys`() = checkContainsCompletion("""
+        [dependencies.dep]
+        <caret>
+    """, ATTRIBUTE_COMPLETION_LIST)
+
+    fun `test complete do not offer existing specific dependency keys`() = checkNotContainsCompletion("""
+        [dependencies.dep]
+        optional = false
+        <caret>
+    """, "optional = false")
+
     private fun doTest(
         @Language("TOML") before: String,
         @Language("TOML") after: String,
@@ -168,6 +200,18 @@ class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
     private fun checkNoCompletion(@Language("TOML") code: String, vararg crates: Pair<String, String>) {
         withMockedCrateSearch(crates.map { (name, version) -> CrateDescription(name, version) }) {
             checkNoCompletion(code.trimIndent())
+        }
+    }
+
+    private fun checkContainsCompletion(@Language("TOML") code: String, variants: List<String>, vararg crates: Pair<String, String>) {
+        withMockedCrateSearch(crates.map { (name, version) -> CrateDescription(name, version) }) {
+            checkContainsCompletion(code.trimIndent(), variants)
+        }
+    }
+
+    private fun checkNotContainsCompletion(@Language("TOML") code: String, variant: String, vararg crates: Pair<String, String>) {
+        withMockedCrateSearch(crates.map { (name, version) -> CrateDescription(name, version) }) {
+            checkNotContainsCompletion(code.trimIndent(), variant)
         }
     }
 }


### PR DESCRIPTION
This PR adds completion to dependency keys (`features`, `optional`) etc. in `Cargo.toml` (before only `version` was supported). Right now it only works for specific dependecy tables, I'll add support for inline dependencies (`serde = { version = "1.0" }`) after we flesh out the details.

Questions:
1) Should I complete both the key and the value at once? It seems simpler for the user and it was already done for the case of `value`. i.e. when the user types `opt` and runs completion, it will fill out `optional = false`
2) How should caret/selection be moved? Currently I mark the completed value and put the caret at its beginning. Maybe we could use a smart pointer or something like that? To avoid enter deleting the inserted selected content.

Fixes part 2 of https://github.com/intellij-rust/intellij-rust/issues/4455