### PR TITLE
COMP: add file system completion for string literals in path context

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
@@ -8,7 +8,10 @@ package org.rust.lang.core
 import com.intellij.patterns.*
 import com.intellij.patterns.PlatformPatterns.psiElement
 import com.intellij.patterns.StandardPatterns.or
-import com.intellij.psi.*
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiErrorElement
+import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.tree.TokenSet
 import com.intellij.util.ProcessingContext
 import org.rust.lang.core.psi.*
@@ -127,11 +130,12 @@ object RsPsiPattern {
 
     val onTrait: PsiElementPattern.Capture<PsiElement> = onItem<RsTraitItem>()
 
-    val onDropFn: PsiElementPattern.Capture<PsiElement> get() {
-        val dropTraitRef = psiElement<RsTraitRef>().withText("Drop")
-        val implBlock = psiElement<RsImplItem>().withChild(dropTraitRef)
-        return psiElement().withSuperParent(6, implBlock)
-    }
+    val onDropFn: PsiElementPattern.Capture<PsiElement>
+        get() {
+            val dropTraitRef = psiElement<RsTraitRef>().withText("Drop")
+            val implBlock = psiElement<RsImplItem>().withChild(dropTraitRef)
+            return psiElement().withSuperParent(6, implBlock)
+        }
 
     val onTestFn: PsiElementPattern.Capture<PsiElement> = onItem(psiElement<RsFunction>()
         .withChild(psiElement<RsOuterAttr>().withText("#[test]")))
@@ -213,7 +217,7 @@ inline fun <reified I : PsiElement> PsiElementPattern.Capture<PsiElement>.withSu
     return this.withSuperParent(level, I::class.java)
 }
 
-inline infix fun <reified I : PsiElement> ElementPattern<I>.or(pattern: ElementPattern<I>): PsiElementPattern.Capture<PsiElement> {
+inline infix fun <reified I : PsiElement> ElementPattern<I>.or(pattern: ElementPattern<out I>): PsiElementPattern.Capture<PsiElement> {
     return psiElement().andOr(this, pattern)
 }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
@@ -79,6 +79,8 @@ class KnownItems(
     val RefCell: RsStructOrEnumItemElement? get() = findItem("core::cell::RefCell")
     val UnsafeCell: RsStructOrEnumItemElement? get() = findItem("core::cell::UnsafeCell")
     val Mutex: RsStructOrEnumItemElement? get() = findItem("std::sync::mutex::Mutex")
+    val Path: RsStructOrEnumItemElement? get() = findItem("std::path::Path")
+    val PathBuf: RsStructOrEnumItemElement? get() = findItem("std::path::PathBuf")
 
     val Iterator: RsTraitItem? get() = findItem("core::iter::Iterator")
     val IntoIterator: RsTraitItem? get() = findItem("core::iter::IntoIterator")
@@ -118,14 +120,18 @@ class KnownItems(
     val Clone: RsTraitItem? get() = findLangItem("clone")
     val Copy: RsTraitItem? get() = findLangItem("copy")
     val PartialEq: RsTraitItem? get() = findLangItem("eq")
+
     // `Eq` trait doesn't have its own lang attribute, so use `findItem` to find it
     val Eq: RsTraitItem? get() = findItem("core::cmp::Eq")
+
     // In some old versions of stdlib `PartialOrd` trait has a lang attribute with value "ord",
     // but in the new stdlib it is "partial_ord" ("ord" is used for "Ord" trait). So we try
     // "partial_ord", and on failure we resolve it by path
     val PartialOrd: RsTraitItem? get() = findLangItem("partial_ord") ?: findItem("core::cmp::PartialOrd")
+
     // Some old versions of stdlib contain `Ord` trait without lang attribute
     val Ord: RsTraitItem? get() = findItem("core::cmp::Ord")
+
     // Some stdlib versions don't have direct `#[lang="debug_trait"]` attribute on `Debug` trait.
     // In this case, fully qualified name search is used
     val Debug: RsTraitItem? get() = findLangItem("debug_trait") ?: findItem("core::fmt::Debug")

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLitExprReferenceContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsLitExprReferenceContributor.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.resolve.ref
 
 import com.intellij.openapi.util.Condition
+import com.intellij.patterns.PsiElementPattern
 import com.intellij.psi.*
 import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReference
 import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReferenceSet
@@ -15,12 +16,22 @@ import org.rust.lang.core.RsPsiPattern.includeMacroLiteral
 import org.rust.lang.core.RsPsiPattern.pathAttrLiteral
 import org.rust.lang.core.or
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.RsMod
-import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psiElement
+import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.resolve.KnownItems
+import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.types.implLookupAndKnownItems
+import org.rust.lang.core.types.positionalTypeArguments
+import org.rust.lang.core.types.ty.TyAdt
+import org.rust.lang.core.types.ty.TyAnon
+import org.rust.lang.core.types.ty.TyTypeParameter
+import org.rust.lang.core.types.type
+import org.rust.lang.core.with
 
 class RsLitExprReferenceContributor : PsiReferenceContributor() {
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
-        registrar.registerReferenceProvider(includeMacroLiteral or pathAttrLiteral, RsFileReferenceProvider())
+        registrar.registerReferenceProvider(includeMacroLiteral or pathAttrLiteral or pathValueLiteral, RsFileReferenceProvider())
     }
 }
 
@@ -30,7 +41,8 @@ private class RsFileReferenceProvider : PsiReferenceProvider() {
         if (stringLiteral.isByte) return emptyArray()
         val startOffset = stringLiteral.offsets.value?.startOffset ?: return emptyArray()
         val fs = element.containingFile.originalFile.virtualFile.fileSystem
-        return RsLiteralFileReferenceSet(stringLiteral.value ?: "", element, startOffset, fs.isCaseSensitive).allReferences
+        val literalValue = stringLiteral.value ?: ""
+        return RsLiteralFileReferenceSet(literalValue, element, startOffset, fs.isCaseSensitive).allReferences
     }
 }
 
@@ -43,12 +55,11 @@ private class RsLiteralFileReferenceSet(
 
     override fun getDefaultContexts(): Collection<PsiFileSystemItem> {
         return when (val parent = element.parent) {
-            is RsIncludeMacroArgument -> parentDirectoryContext
             is RsMetaItem -> {
                 val item = parent.ancestorStrict<RsModDeclItem>() ?: parent.ancestorStrict<RsMod>()
                 listOfNotNull(item?.containingMod?.getOwnedDirectory())
             }
-            else -> emptyList()
+            else -> parentDirectoryContext
         }
     }
 
@@ -60,5 +71,72 @@ private class RsLiteralFileReferenceSet(
             }
             else -> super.getReferenceCompletionFilter()
         }
+    }
+}
+
+private val pathValueLiteral: PsiElementPattern.Capture<RsLitExpr> = psiElement<RsLitExpr>()
+    .with("onPathLiteral") { expr -> expr.kind is RsLiteralKind.String && isPathLitExpr(expr) }
+
+private fun isPathLitExpr(expr: RsLitExpr): Boolean {
+    val (function, arguments) = getFunctionAndArguments(expr) ?: return false
+    val owner = function.owner as? RsAbstractableOwner.Impl
+    val ownerType = (owner?.impl?.typeReference?.type as? TyAdt)?.item
+    val (implLookup, knownItems) = expr.implLookupAndKnownItems
+    val isCallExpr = arguments.parent is RsCallExpr
+
+    return when {
+        // Path::new(<literal>)
+        function.name == "new" &&
+            owner?.isInherent == true &&
+            ownerType == knownItems.Path -> true
+        // PathBuf::from(<literal>)
+        function.name == "from" &&
+            ownerType == knownItems.PathBuf &&
+            owner?.impl?.traitRef?.path?.reference?.resolve() == knownItems.From -> true
+        // fn foo<P: AsRef<Path>>(p: P) -> foo(<literal>)
+        // or fn foo(p: impl AsRef<Path>) -> foo(<literal>)
+        else -> {
+            var argumentIndex = arguments.exprList.indexOf(expr)
+
+            // UFCS of a method
+            if (function.hasSelfParameters && isCallExpr) {
+                argumentIndex -= 1
+            }
+
+            if (argumentIndex < 0) return false
+
+            val parameter = function.valueParameters.getOrNull(argumentIndex) ?: return false
+            isAsRefPathGeneric(implLookup, knownItems, parameter) || isImplAsRefPath(knownItems, parameter)
+        }
+    }
+}
+
+// fn foo<P: AsRef<Path>>(p: P)
+private fun isAsRefPathGeneric(lookup: ImplLookup, knownItems: KnownItems, parameter: RsValueParameter): Boolean {
+    val type = parameter.typeReference?.type as? TyTypeParameter ?: return false
+    return lookup.getEnvBoundTransitivelyFor(type).any { isAsRefPath(knownItems, it) }
+}
+
+// fn foo(p: impl AsRef<Path>)
+private fun isImplAsRefPath(knownItems: KnownItems, parameter: RsValueParameter): Boolean {
+    val type = parameter.typeReference?.type as? TyAnon ?: return false
+    return type.traits.any { isAsRefPath(knownItems, it) }
+}
+
+private fun isAsRefPath(knownItems: KnownItems, trait: BoundElement<RsTraitItem>): Boolean =
+    trait.element == knownItems.AsRef && (trait.positionalTypeArguments.getOrNull(0) as? TyAdt)?.item == knownItems.Path
+
+private fun getFunctionAndArguments(expr: RsLitExpr): Pair<RsFunction, RsValueArgumentList>? {
+    return when (val grandParent = expr.context?.context) {
+        is RsCallExpr -> {
+            val path = (grandParent.expr as? RsPathExpr)?.path ?: return null
+            val function = path.reference?.resolve() as? RsFunction ?: return null
+            function to grandParent.valueArgumentList
+        }
+        is RsMethodCall -> {
+            val function = grandParent.reference.resolve() as? RsFunction ?: return null
+            function to grandParent.valueArgumentList
+        }
+        else -> null
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -675,6 +675,178 @@ class RsCompletionTest : RsCompletionTestBase() {
        }
     """)
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test complete paths in path constructor 1`() = doSingleCompletionByFileTree("""
+    //- main.rs
+        fn main() {
+            std::path::Path::new("fo/*caret*/");
+        }
+    //- foo.rs
+        pub struct Foo;
+    """, """
+        fn main() {
+            std::path::Path::new("foo.rs/*caret*/");
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test complete paths in path constructor 2`() = doSingleCompletionByFileTree("""
+    //- main.rs
+        use std::path::Path;
+        fn main() {
+            Path::new("fo/*caret*/");
+        }
+    //- foo.rs
+        pub struct Foo;
+    """, """
+        use std::path::Path;
+        fn main() {
+            Path::new("foo.rs/*caret*/");
+        }
+    """)
+
+    // enable once name resolution of <Foo as Trait>::function is fixed
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test do not complete paths in path trait impl`() {
+        expect<IllegalStateException> {
+            checkNoCompletionByFileTree("""
+        //- main.rs
+            use std::path::Path;
+            trait Foo {
+                fn new(x: &str) -> i32;
+            }
+            impl Foo for Path {
+                fn new(x: &str) -> i32 {
+                    123
+                }
+            }
+            fn main() {
+                <Path as Foo>::new("fo/*caret*/");
+            }
+        //- foo.rs
+            pub struct Foo;
+        """)
+        }
+    }
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test complete paths in pathbuf constructor`() = doSingleCompletionByFileTree("""
+    //- main.rs
+        fn main() {
+            std::path::PathBuf::from("fo/*caret*/");
+        }
+    //- foo.rs
+        pub struct Foo;
+    """, """
+        fn main() {
+            std::path::PathBuf::from("foo.rs/*caret*/");
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test complete paths in asref path`() = doSingleCompletionByFileTree("""
+    //- main.rs
+        fn main() {
+            std::fs::canonicalize("fo/*caret*/");
+        }
+    //- foo.rs
+        pub struct Foo;
+    """, """
+        fn main() {
+            std::fs::canonicalize("foo.rs/*caret*/");
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test complete paths in method call`() = doSingleCompletionByFileTree("""
+    //- main.rs
+        struct Bar;
+        impl Bar {
+            fn foo<T: AsRef<std::path::Path>>(&self, path: T) {}
+        }
+
+        fn main() {
+            Bar.foo("fo/*caret*/");
+        }
+    //- foo.rs
+        pub struct Foo;
+    """, """
+        struct Bar;
+        impl Bar {
+            fn foo<T: AsRef<std::path::Path>>(&self, path: T) {}
+        }
+
+        fn main() {
+            Bar.foo("foo.rs/*caret*/");
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test complete paths in ufcs call`() = doSingleCompletionByFileTree("""
+    //- main.rs
+        struct Bar;
+        impl Bar {
+            fn foo<T: AsRef<std::path::Path>>(&self, path: T) {}
+        }
+
+        fn main() {
+            Bar::foo(&Bar, "fo/*caret*/");
+        }
+    //- foo.rs
+        pub struct Foo;
+    """, """
+        struct Bar;
+        impl Bar {
+            fn foo<T: AsRef<std::path::Path>>(&self, path: T) {}
+        }
+
+        fn main() {
+            Bar::foo(&Bar, "foo.rs/*caret*/");
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test do not complete paths in self parameter of ufcs call`() = checkNoCompletionByFileTree("""
+    //- main.rs
+        struct Bar;
+        impl Bar {
+            fn foo<T: AsRef<std::path::Path>>(&self, path: T) {}
+        }
+
+        fn main() {
+            Bar::foo("fo/*caret*/");
+        }
+    //- foo.rs
+        pub struct Foo;
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test complete paths in impl asref`() = doSingleCompletionByFileTree("""
+    //- main.rs
+        fn foo(path: impl AsRef<std::path::Path>) {}
+
+        fn main() {
+            foo("fo/*caret*/");
+        }
+    //- foo.rs
+        pub struct Foo;
+    """, """
+        fn foo(path: impl AsRef<std::path::Path>) {}
+
+        fn main() {
+            foo("foo.rs/*caret*/");
+        }
+    """)
+
+    fun `test do not complete paths in string literal`() = checkNoCompletionByFileTree("""
+    //- main.rs
+        fn main() {
+            let s = "fo/*caret*/";
+        }
+    //- foo.rs
+        pub struct Foo;
+    """)
+
     fun `test complete paths in include macro`() = doSingleCompletionByFileTree("""
     //- main.rs
         include!("fo/*caret*/");


### PR DESCRIPTION
This PR adds file system completion suggestions for string literals that are in a "path" context. A path context right now is:
1) `Path::new(<>)`
2) `PathBuf::from(<>)`
3) function argument of a call that is of type `AsRef<Path>`, e.g. `std::fs::canonicalize(<>)`

I think that this feature has been suggested to me by someone in some issue here (maybe @Undin ?), but maybe I'm wrong. Anyway, I think that it's a pretty nice feature, I know it for example from PyCharm and the `open` function. I'm not sure about the performance implications of filtering the path context string literals though. What do you think?

The change in `ElementPattern<I>.or` had to be made because `or` of `ElementPattern<I>` and `ElementPattern<I>` produced `ElementPattern<PsiElement>` and I needed to `or` three things, which I didn't know how to do without a cast (the variance there is messy).

![path](https://user-images.githubusercontent.com/4539057/82762917-18b82300-9e04-11ea-9437-2ebc60436484.gif)

Closes #5162