### PR TITLE
Mark RsBacktraceFilter constructor as non injectable

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilter.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiDocumentManager
+import com.intellij.serviceContainer.NonInjectable
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.PackageOrigin
@@ -26,7 +27,7 @@ import java.util.regex.Pattern
  * - Turn source code links into hyperlinks.
  * - Dims function hash codes to reduce noise.
  */
-class RsBacktraceFilter(
+class RsBacktraceFilter @NonInjectable constructor(
     private val project: Project,
     private val cargoProjectDir: VirtualFile?,
     private val workspace: CargoWorkspace?

--- a/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterTest.kt
@@ -6,6 +6,7 @@
 package org.rust.cargo.runconfig.filters
 
 import com.intellij.openapi.util.SystemInfo
+import com.intellij.unscramble.AnalyzeStacktraceUtil
 import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
@@ -118,4 +119,9 @@ stack backtrace:
             """,
             "  6: dep_lib::foo",
             "  6: [dep_lib::foo -> lib.rs]")
+
+    fun `test backtrace filter can be safely created as extension`() {
+        val filter = AnalyzeStacktraceUtil.EP_NAME.getExtensions(project).find { it is RsBacktraceFilter }
+        check(filter != null)
+    }
 }


### PR DESCRIPTION
It should explain the platform that it shouldn't use this constructor while creation extension instance


Fixes #5434