### PR TITLE
RUN: Fix environment variables for Coverage runner

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,12 +49,25 @@ jobs:
                   components: rust-src, rustfmt, clippy
                   default: true
 
+            - name: Set up Rust nightly
+              uses: actions-rs/toolchain@v1
+              with:
+                  profile: minimal
+                  toolchain: nightly
+
             - name: Install evcxr
               if: matrix.os != 'windows-latest' && matrix.rust-version >= '1.40.0' # BACKCOMPAT: Rust 1.39.0
               uses: actions-rs/cargo@v1
               with:
                   command: install
                   args: evcxr_repl
+
+            - name: Install grcov
+              uses: actions-rs/cargo@v1
+              with:
+                  command: install
+                  toolchain: nightly
+                  args: grcov
 
             - name: Check environment
               run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,11 @@ before_script:
   - dig +short myip.opendns.com @resolver1.opendns.com || true
   - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $RUST_VERSION -y
   - export PATH=$HOME/.cargo/bin:$PATH
+  - rustup toolchain add nightly
   - rustup component add rust-src
   - rustup component add clippy
   - rustup component add rustfmt
+  - cargo +nightly install grcov
   - if [ ! $RUST_VERSION \< "1.40.0" ]; then cargo install evcxr_repl; fi # BACKCOMPAT: Rust 1.39.0
   - ln -s $(rustc --print sysroot)/lib/rustlib/src/rust/src $RUST_SRC_WITH_SYMLINK
   - ./check-license.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,11 @@ install:
   - appveyor-retry appveyor DownloadFile https://win.rustup.rs -FileName rustup-init.exe
   - rustup-init.exe --default-toolchain %RUST_VERSION% -y
   - set PATH=C:\Users\appveyor\.cargo\bin;%PATH%
+  - rustup toolchain add nightly
   - rustup component add rust-src
   - rustup component add clippy-preview
   - rustup component add rustfmt-preview
+  - cargo +nightly install grcov
   - for /f "delims=*" %%a in ('rustc --print sysroot') do (Mklink /D "C:\Users\appveyor\.rust-src" "%%a\lib\rustlib\src\rust\src\")
 
 build_script:

--- a/coverage/src/main/kotlin/org/rust/coverage/GrcovRunner.kt
+++ b/coverage/src/main/kotlin/org/rust/coverage/GrcovRunner.kt
@@ -16,7 +16,6 @@ import com.intellij.execution.process.OSProcessHandler
 import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.execution.runners.ProgramRunner
 import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.diagnostic.Logger
@@ -52,16 +51,13 @@ class GrcovRunner : RsDefaultProgramRunnerBase() {
     }
 
     override fun execute(environment: ExecutionEnvironment) {
-        val state = environment.state as CargoRunStateBase
-
         if (checkNeedInstallGrcov(environment.project)) return
 
-        state.addCommandLinePatch(cargoCoveragePatch)
-        environment.cargoPatches.add(cargoCoveragePatch)
-
+        val state = environment.state as CargoRunStateBase
         val workingDirectory = state.commandLine.workingDirectory.toFile()
         cleanOldCoverageData(workingDirectory)
 
+        environment.cargoPatches += cargoCoveragePatch
         super.execute(environment)
     }
 

--- a/coverage/src/test/kotlin/org/rust/coverage/RsCoverageTest.kt
+++ b/coverage/src/test/kotlin/org/rust/coverage/RsCoverageTest.kt
@@ -1,0 +1,238 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.coverage
+
+import com.intellij.coverage.CoverageDataManager
+import com.intellij.coverage.CoverageExecutor
+import com.intellij.coverage.CoverageRunnerData
+import com.intellij.execution.ExecutorRegistry
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.runners.ExecutionEnvironmentBuilder
+import com.intellij.execution.runners.ProgramRunner
+import com.intellij.execution.ui.RunContentDescriptor
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.rt.coverage.data.ClassData
+import com.intellij.rt.coverage.data.LineData
+import com.intellij.rt.coverage.data.ProjectData
+import org.rust.FileTreeBuilder
+import org.rust.lang.core.psi.isRustFile
+import org.rust.openapiext.toPsiFile
+import org.rustSlowTests.cargo.runconfig.RunConfigurationTestBase
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+class RsCoverageTest : RunConfigurationTestBase() {
+    private val coverageData: ProjectData?
+        get() = CoverageDataManager.getInstance(project).currentSuitesBundle?.coverageData
+
+    fun `test main`() = doTest {
+        toml("Cargo.toml", """
+            [package]
+            name = "hello"
+            version = "0.1.0"
+            authors = []
+        """)
+
+        dir("src") {
+            rust("main.rs", """
+                fn main() {                     // Hits: 1
+                    println!("Hello, world!");  // Hits: 1
+                }                               // Hits: 1
+            """)
+        }
+    }
+
+    fun `test function call`() = doTest {
+        toml("Cargo.toml", """
+            [package]
+            name = "hello"
+            version = "0.1.0"
+            authors = []
+        """)
+
+        dir("src") {
+            rust("main.rs", """
+                fn foo() {                      // Hits: 1
+                    println!("Hello, world!");  // Hits: 1
+                }                               // Hits: 1
+
+                fn main() {                     // Hits: 1
+                    foo();                      // Hits: 1
+                }                               // Hits: 1
+            """)
+        }
+    }
+
+    fun `test function call from lib`() = doTest {
+        toml("Cargo.toml", """
+            [package]
+            name = "hello"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+        """)
+
+        dir("src") {
+            rust("lib.rs", """
+                pub fn foo() {                  // Hits: 1
+                    println!("Hello, world!");  // Hits: 1
+                }                               // Hits: 1
+            """)
+
+            rust("main.rs", """
+                use hello::foo;
+
+                fn main() {                     // Hits: 1
+                    foo();                      // Hits: 1
+                }                               // Hits: 1
+            """)
+        }
+    }
+
+    fun `test for`() = doTest {
+        toml("Cargo.toml", """
+            [package]
+            name = "hello"
+            version = "0.1.0"
+            authors = []
+        """)
+
+        dir("src") {
+            rust("main.rs", """
+                fn main() {                         // Hits: 1
+                    for i in 1..5 {                 // Hits: 5
+                        println!("Hello, world!");  // Hits: 4
+                    }
+                }                                   // Hits: 1
+            """)
+        }
+    }
+
+    fun `test for function call`() = doTest {
+        toml("Cargo.toml", """
+            [package]
+            name = "hello"
+            version = "0.1.0"
+            authors = []
+        """)
+
+        dir("src") {
+            rust("main.rs", """
+                fn foo() {                      // Hits: 4
+                    println!("Hello, world!");  // Hits: 4
+                }                               // Hits: 4
+
+                fn main() {                     // Hits: 1
+                    for _ in 1..5 {             // Hits: 5
+                        foo();                  // Hits: 4
+                    }
+                }                               // Hits: 1
+            """)
+        }
+    }
+
+    fun `test tests`() {
+        if (SystemInfo.isWindows) return // https://github.com/mozilla/grcov/issues/462
+
+        doTest(runTests = true) {
+            toml("Cargo.toml", """
+            [package]
+            name = "hello"
+            version = "0.1.0"
+            authors = []
+        """)
+
+            dir("src") {
+                rust("lib.rs", """
+                fn foo() {                      // Hits: 2
+                    println!("Hello, world!");  // Hits: 2
+                }                               // Hits: 2
+
+                #[test]
+                fn test1() {                    // Hits: 2
+                    foo();                      // Hits: 1
+                }                               // Hits: 2
+
+                #[test]
+                fn test2() {                    // Hits: 2
+                    foo();                      // Hits: 1
+                }                               // Hits: 2
+            """)
+            }
+        }
+    }
+
+    private fun doTest(runTests: Boolean = false, builder: FileTreeBuilder.() -> Unit) {
+        buildProject(builder)
+
+        val expected = hashMapOf<String, Set<Hits>>()
+        VfsUtil.iterateChildrenRecursively(cargoProjectDirectory, null) { fileOrDir ->
+            if (!fileOrDir.isRustFile) return@iterateChildrenRecursively true
+            val psiFile = fileOrDir.toPsiFile(project) ?: return@iterateChildrenRecursively true
+            expected[fileOrDir.path] = hitsFrom(psiFile.text)
+            true
+        }
+
+        val configuration = createConfiguration()
+        if (runTests) {
+            configuration.command = "test"
+        }
+
+        executeWithCoverage(configuration)
+        runWithInvocationEventsDispatching("Failed to fetch coverage data") { coverageData != null }
+        val projectData = coverageData!!
+
+        val actual = hashMapOf<String, Set<Hits>>()
+        for (path in expected.keys) {
+            val data = projectData.getClassData(path)!!
+            actual[path] = hitsFrom(data)
+        }
+
+        assertEquals(expected, actual)
+    }
+
+    private fun executeWithCoverage(configuration: RunConfiguration): RunContentDescriptor {
+        val future = CompletableFuture<RunContentDescriptor>()
+        val executor = ExecutorRegistry.getInstance().getExecutorById(CoverageExecutor.EXECUTOR_ID)!!
+        val environment = ExecutionEnvironmentBuilder
+            .create(executor, configuration)
+            .runnerSettings(CoverageRunnerData())
+            .build(ProgramRunner.Callback { future.complete(it) })
+        environment.runner.execute(environment)
+        return future.get(10, TimeUnit.SECONDS)!!
+    }
+
+    private fun hitsFrom(text: String): Set<Hits> =
+        text.split('\n')
+            .withIndex()
+            .filter { it.value.contains(MARKER) }
+            .map {
+                val lineNumber = it.index + 1
+                val startIndex = it.value.indexOf(MARKER) + MARKER.length
+                val rawHits = it.value.substring(startIndex).trim()
+                val hits = Integer.parseInt(rawHits)
+                Hits(lineNumber, hits)
+            }.toSortedSet()
+
+    private fun hitsFrom(data: ClassData): Set<Hits> =
+        data.lines
+            .filterIsInstance<LineData>()
+            .map { Hits(it.lineNumber, it.hits) }
+            .toSortedSet()
+
+    private data class Hits(val lineNumber: Int, val count: Int) : Comparable<Hits> {
+        override fun compareTo(other: Hits): Int {
+            val result = lineNumber.compareTo(other.lineNumber)
+            if (result != 0) return result
+            return count.compareTo(other.count)
+        }
+    }
+
+    private companion object {
+        private const val MARKER: String = "// Hits:"
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoTestRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoTestRunState.kt
@@ -35,7 +35,7 @@ class CargoTestRunState(
 
     init {
         consoleBuilder = CargoTestConsoleBuilder(environment.runProfile as RunConfiguration, environment.executor)
-        addCommandLinePatch(cargoTestPatch)
+        commandLinePatches.add(cargoTestPatch)
         createFilters(cargoProject).forEach { consoleBuilder.addFilter(it) }
     }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.util.Key
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.getBuildConfiguration
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildConfiguration
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowEnabled
+import org.rust.cargo.runconfig.buildtool.cargoPatches
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.toolchain.Cargo
 import org.rust.cargo.toolchain.Cargo.Companion.cargoCommonPatch
@@ -51,7 +52,7 @@ abstract class RsExecutableRunner(
             processInvalidToolchain(project, toolchainError)
             return
         }
-        state.addCommandLinePatch(cargoCommonPatch)
+        environment.cargoPatches += cargoCommonPatch
         environment.putUserData(BINARIES, CompletableFuture())
         super.execute(environment)
     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
@@ -79,16 +79,12 @@ object CargoBuildManager {
         val configuration = buildConfiguration.configuration
         val environment = buildConfiguration.environment
 
+        environment.cargoPatches += cargoBuildPatch
         val state = CargoRunState(
             environment,
             configuration,
             configuration.clean().ok ?: return CANCELED_BUILD_RESULT
-        ).apply {
-            addCommandLinePatch(cargoBuildPatch)
-            for (patch in environment.cargoPatches) {
-                addCommandLinePatch(patch)
-            }
-        }
+        )
 
         val cargoProject = state.cargoProject ?: return CANCELED_BUILD_RESULT
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/Utils.kt
@@ -22,10 +22,11 @@ import java.util.concurrent.TimeUnit
 
 typealias CargoPatch = (CargoCommandLine) -> CargoCommandLine
 
-val ExecutionEnvironment.cargoPatches: MutableList<CargoPatch>
-    get() = putUserDataIfAbsent(CARGO_PATCHES, mutableListOf())
+var ExecutionEnvironment.cargoPatches: List<CargoPatch>
+    get() = putUserDataIfAbsent(CARGO_PATCHES, emptyList())
+    set(value) = putUserData(CARGO_PATCHES, value)
 
-private val CARGO_PATCHES: Key<MutableList<CargoPatch>> = Key.create("CARGO.PATCHES")
+private val CARGO_PATCHES: Key<List<CargoPatch>> = Key.create("CARGO.PATCHES")
 
 private val ExecutionEnvironment.executionListener: ExecutionListener
     get() = project.messageBus.syncPublisher(ExecutionManager.EXECUTION_TOPIC)

--- a/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
@@ -61,8 +61,7 @@ abstract class RsAsyncRunner(
     override fun execute(environment: ExecutionEnvironment, state: RunProfileState): Promise<RunContentDescriptor?> {
         saveAllDocuments()
 
-        (state as CargoRunStateBase).addCommandLinePatch(cargoCommonPatch)
-        val commandLine = state.prepareCommandLine()
+        val commandLine = (state as CargoRunStateBase).prepareCommandLine(cargoCommonPatch)
         val (commandArguments, executableArguments) = parseArgs(commandLine.command, commandLine.additionalArguments)
 
         val isTestRun = commandLine.command == "test"


### PR DESCRIPTION
Fixes `Run with Coverage` on the latest versions of the plugin.

Also adds tests for the Coverage runner.

NB: For now, `cargo test` with coverage doesn't work on Windows if MSVC toolchain is used (https://github.com/mozilla/grcov/issues/462)