### PR TITLE
RUN: resolve stdlib and Cargo source code hyperlinks in backtrace

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/filters/RegexpFileLinkFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/filters/RegexpFileLinkFilter.kt
@@ -6,14 +6,15 @@
 package org.rust.cargo.runconfig.filters
 
 import com.intellij.execution.filters.Filter
-import com.intellij.execution.filters.HyperlinkInfo
 import com.intellij.execution.filters.OpenFileHyperlinkInfo
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
 import org.intellij.lang.annotations.Language
-import org.rust.openapiext.findFileByMaybeRelativePath
-import java.io.File
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.settings.rustSettings
+import java.nio.file.Paths
 
 /**
  * Base class for regexp-based output filters that extract
@@ -32,6 +33,9 @@ open class RegexpFileLinkFilter(
         // TODO: named groups when Kotlin supports them
         @Language("RegExp")
         val FILE_POSITION_RE = """((?:\p{Alpha}:)?[0-9 a-z_A-Z\-\\./]+):([0-9]+)(?::([0-9]+))?"""
+
+        @Language("RegExp")
+        private val RUSTC_ABSOLUTE_PATH_RE = Regex("""/rustc/\w+/(.*)""")
     }
 
     init {
@@ -49,10 +53,24 @@ open class RegexpFileLinkFilter(
         val columnNumber = match.groups[3]?.let { zeroBasedNumber(it.value) } ?: 0
 
         val lineStart = entireLength - line.length
+
+        val file = resolveFilePath(fileGroup.value)
+        val link = file?.let { OpenFileHyperlinkInfo(project, file.file, lineNumber, columnNumber) }
+
+        val grayedOut = if (file == null) {
+            false
+        } else {
+            file !is ResolvedPath.Workspace
+        }
+
+        val end = match.groups[3]?.range?.last
+            ?: match.groups[2]?.range?.last
+            ?: fileGroup.range.last
         return Filter.Result(
-            lineStart + fileGroup.range.start,
-            lineStart + fileGroup.range.endInclusive + 1,
-            createOpenFileHyperlink(fileGroup.value, lineNumber, columnNumber)
+            lineStart + fileGroup.range.first,
+            lineStart + end + 1,
+            link,
+            grayedOut
         )
     }
 
@@ -66,9 +84,44 @@ open class RegexpFileLinkFilter(
         }
     }
 
-    private fun createOpenFileHyperlink(fileName: String, line: Int, column: Int): HyperlinkInfo? {
-        val platformNeutralName = fileName.replace(File.separatorChar, '/')
-        val file = cargoProjectDirectory.findFileByMaybeRelativePath(platformNeutralName) ?: return null
-        return OpenFileHyperlinkInfo(project, file, line, column)
+    private fun resolveFilePath(fileName: String): ResolvedPath? {
+        val path = FileUtil.toSystemIndependentName(fileName)
+        val file = cargoProjectDirectory.findFileByRelativePath(path)
+        if (file != null) return ResolvedPath.Workspace(file)
+
+        val externalPath = resolveStdlibPath(fileName) ?: resolveCargoPath(fileName)
+        if (externalPath != null) return externalPath
+
+        // try to resolve absolute path
+        return cargoProjectDirectory.fileSystem.findFileByPath(path)?.let { ResolvedPath.Unknown(it) }
+    }
+
+    private fun resolveCargoPath(path: String): ResolvedPath? {
+        if (!path.startsWith("/cargo")) return null
+        val fullPath = Paths.get(getCargoRoot(), path.removePrefix("/cargo")).toString()
+        return cargoProjectDirectory.fileSystem.findFileByPath(fullPath)?.let { ResolvedPath.CargoDependency(it) }
+    }
+
+    private fun resolveStdlibPath(path: String): ResolvedPath? {
+        val sysroot = getSysroot() ?: return null
+        val normalizedPath = normalizeStdLibPath(path)
+        val fullPath = "$sysroot/lib/rustlib/src/rust/$normalizedPath"
+        return cargoProjectDirectory.fileSystem.findFileByPath(fullPath)?.let { ResolvedPath.Stdlib(it) }
+    }
+
+    // /rustc/<commit hash>/src/libstd/... -> src/libstd/...
+    private fun normalizeStdLibPath(path: String): String {
+        val match = RUSTC_ABSOLUTE_PATH_RE.matchEntire(path) ?: return path
+        return match.groupValues[1]
+    }
+
+    private fun getSysroot(): String? = project.cargoProjects.allProjects.firstOrNull()?.rustcInfo?.sysroot
+    private fun getCargoRoot(): String = project.rustSettings.toolchain?.location?.parent.toString()
+
+    sealed class ResolvedPath(val file: VirtualFile) {
+        class Workspace(file: VirtualFile) : ResolvedPath(file)
+        class Stdlib(file: VirtualFile) : ResolvedPath(file)
+        class CargoDependency(file: VirtualFile) : ResolvedPath(file)
+        class Unknown(file: VirtualFile) : ResolvedPath(file)
     }
 }

--- a/src/test/kotlin/org/rust/cargo/runconfig/filters/HighlightFilterTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/filters/HighlightFilterTestBase.kt
@@ -48,25 +48,27 @@ abstract class HighlightFilterTestBase : RsTestBase() {
         checkHighlights(filter, before, after, lineIndex)
     }
 
-    protected fun checkHighlights(filter: Filter, before: String, after: String, lineIndex: Int = 0) {
-        val line = before.splitLinesKeepSeparators()[lineIndex]
-        val result = checkNotNull(filter.applyFilter(line, before.length)) {
-            "No match in \"${StringUtil.escapeStringCharacters(line)}\""
-        }
-        var checkText = before
-        val items = ArrayList(result.resultItems)
-        items.sortByDescending { it.getHighlightEndOffset() }
-        items.forEach { item ->
-            val range = IntRange(item.getHighlightStartOffset(), item.getHighlightEndOffset() - 1)
-            var itemText = before.substring(range)
-            (item.getHyperlinkInfo() as? OpenFileHyperlinkInfo)?.let { link ->
-                itemText = "$itemText -> ${link.descriptor?.file?.name}"
+    companion object {
+        fun checkHighlights(filter: Filter, before: String, after: String, lineIndex: Int = 0) {
+            val line = before.splitLinesKeepSeparators()[lineIndex]
+            val result = checkNotNull(filter.applyFilter(line, before.length)) {
+                "No match in \"${StringUtil.escapeStringCharacters(line)}\""
             }
-            checkText = checkText.replaceRange(range, "[$itemText]")
+            var checkText = before
+            val items = ArrayList(result.resultItems)
+            items.sortByDescending { it.highlightEndOffset }
+            items.forEach { item ->
+                val range = IntRange(item.highlightStartOffset, item.highlightEndOffset - 1)
+                var itemText = before.substring(range)
+                (item.getHyperlinkInfo() as? OpenFileHyperlinkInfo)?.let { link ->
+                    itemText = "$itemText -> ${link.descriptor?.file?.name}"
+                }
+                checkText = checkText.replaceRange(range, "[$itemText]")
+            }
+            checkText = checkText.splitLinesKeepSeparators()[lineIndex]
+            assertEquals(after, checkText)
         }
-        checkText = checkText.splitLinesKeepSeparators()[lineIndex]
-        assertEquals(after, checkText)
-    }
 
-    private fun String.splitLinesKeepSeparators() = split("(?<=\n)".toRegex())
+        private fun String.splitLinesKeepSeparators() = split("(?<=\n)".toRegex())
+    }
 }

--- a/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterCargoTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterCargoTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.filters
+
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.runconfig.filters.HighlightFilterTestBase.Companion.checkHighlights
+import org.rust.fileTree
+
+/**
+ * Cargo tests for [RsBacktraceFilter]
+ */
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+class RsBacktraceFilterCargoTest : RsWithToolchainTestBase() {
+    private val filter: RsBacktraceFilter
+        get() = RsBacktraceFilter(project, cargoProjectDirectory, project.cargoProjects.allProjects.single().workspace)
+
+    fun `test resolve cargo crate`() {
+        fileTree {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+
+                [dependencies]
+                left-pad = "=1.0.1"
+            """)
+
+            dir("src") {
+                rust("lib.rs", "")
+            }
+        }.create()
+
+        checkHighlights(
+            filter,
+            " at /cargo/registry/src/github.com-1ecc6299db9ec823/left-pad-1.0.1/src/lib.rs:21",
+            " at [/cargo/registry/src/github.com-1ecc6299db9ec823/left-pad-1.0.1/src/lib.rs:21 -> lib.rs]"
+        )
+    }
+}

--- a/src/test/kotlin/org/rust/cargo/runconfig/filters/RsConsoleFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/filters/RsConsoleFilterTest.kt
@@ -12,32 +12,31 @@ class RsConsoleFilterTest : HighlightFilterTestBase() {
     fun `test type error`() =
         checkHighlights(filter,
             "src/main.rs:4:5: 4:12 error: this function takes 0 parameters but 1 parameter was supplied [E0061]",
-            "[src/main.rs -> main.rs]:4:5: 4:12 error: this function takes 0 parameters but 1 parameter was supplied [E0061]")
+            "[src/main.rs:4:5 -> main.rs]: 4:12 error: this function takes 0 parameters but 1 parameter was supplied [E0061]")
 
     fun `test offsets for several lines`() =
         checkHighlights(filter,
             """/home/user/.multirust/toolchains/beta/bin/cargo run
    Compiling rustraytracer v0.1.0 (file:///home/user/projects/rustraytracer)
 src/main.rs:25:26: 25:40 error: no method named `read_to_string` found for type `core::result::Result<std::fs::File, std::io::error::Error>` in the current scope""",
-            "[src/main.rs -> main.rs]:25:26: 25:40 error: no method named `read_to_string` found for type `core::result::Result<std::fs::File, std::io::error::Error>` in the current scope", 2)
+            "[src/main.rs:25:26 -> main.rs]: 25:40 error: no method named `read_to_string` found for type `core::result::Result<std::fs::File, std::io::error::Error>` in the current scope", 2)
 
     fun `test new error format`() =
         checkHighlights(filter,
             """error: the trait bound `std::string::String: std::ops::Index<_>` is not satisfied [--explain E0277]
  --> src/main.rs:4:5""",
-            " --> [src/main.rs -> main.rs]:4:5", 1)
+            " --> [src/main.rs:4:5 -> main.rs]", 1)
 
     fun `test new error format more spaces`() =
         checkHighlights(filter,
             """error: the trait bound `std::string::String: std::ops::Index<_>` is not satisfied [--explain E0277]
    --> src/main.rs:4:5""",
-            "   --> [src/main.rs -> main.rs]:4:5", 1)
+            "   --> [src/main.rs:4:5 -> main.rs]", 1)
 
     fun `test new error format new line`() =
         checkHighlights(filter,
             """error: the trait bound `std::string::String: std::ops::Index<_>` is not satisfied [--explain E0277]
  --> src/main.rs:4:5
 """,
-            " --> [src/main.rs -> main.rs]:4:5\n", 1)
-
+            " --> [src/main.rs:4:5 -> main.rs]\n", 1)
 }

--- a/src/test/kotlin/org/rust/cargo/runconfig/filters/RsPanicFilterTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/filters/RsPanicFilterTest.kt
@@ -15,12 +15,12 @@ class RsPanicFilterTest : HighlightFilterTestBase() {
     fun `test one line`() =
         checkHighlights(filter,
             "thread 'main' panicked at 'something went wrong', src/main.rs:24",
-            "thread 'main' panicked at 'something went wrong', [src/main.rs -> main.rs]:24")
+            "thread 'main' panicked at 'something went wrong', [src/main.rs:24 -> main.rs]")
 
     fun `test one line with line separator`() =
         checkHighlights(filter,
             "thread 'main' panicked at 'something went wrong', src/main.rs:24\n",
-            "thread 'main' panicked at 'something went wrong', [src/main.rs -> main.rs]:24\n")
+            "thread 'main' panicked at 'something went wrong', [src/main.rs:24 -> main.rs]\n")
 
     fun `test full output`() =
         checkHighlights(filter,
@@ -29,6 +29,5 @@ class RsPanicFilterTest : HighlightFilterTestBase() {
     Finished debug [unoptimized + debuginfo] target(s) in 1.20 secs
      Running `target/debug/panics`
 thread 'main' panicked at 'something went wrong', src/main.rs:24""",
-            "thread 'main' panicked at 'something went wrong', [src/main.rs -> main.rs]:24", 4)
-
+            "thread 'main' panicked at 'something went wrong', [src/main.rs:24 -> main.rs]", 4)
 }


### PR DESCRIPTION
This PR adds support for resolving source code links to stdlib and crate files in backtraces. Is there a way to test this properly? The Rust toolchain is `null` in tests and the test file system doesn't see absolute paths from the user's `.cargo` and `.rustup` folders.

Fixes part of https://github.com/intellij-rust/intellij-rust/issues/4514