### PR TITLE
HINT: fix inlay hints for type placeholders

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -30,7 +30,7 @@ fun inferTypeReferenceType(type: RsTypeReference, defaultTraitObjectRegion: Regi
         is RsBaseType -> when (val kind = type.kind) {
             RsBaseTypeKind.Unit -> TyUnit
             RsBaseTypeKind.Never -> TyNever
-            RsBaseTypeKind.Underscore -> TyInfer.TyVar()
+            RsBaseTypeKind.Underscore -> TyInfer.TyVar(type)
             is RsBaseTypeKind.Path -> {
                 val path = kind.path
                 val primitiveType = TyPrimitive.fromPath(path)

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyInfer.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyInfer.kt
@@ -13,7 +13,7 @@ import org.rust.lang.core.types.infer.VarValue
 sealed class TyInfer : Ty(HAS_TY_INFER_MASK) {
     // Note these classes must NOT be `data` classes and must provide equality by identity
     class TyVar(
-        val origin: Ty? = null,
+        val origin: Any? = null,
         override var parent: NodeOrValue = VarValue(null, 0)
     ) : TyInfer(), Node
 

--- a/src/test/kotlin/org/rust/ide/hints/RsInlayTypeHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/RsInlayTypeHintsProviderTest.kt
@@ -108,6 +108,33 @@ class RsInlayTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsInlayTypeHintsPr
         }
     """)
 
+    fun `test no placeholder hints in expression`() = checkByText("""
+        struct S<A, B> (A, B);
+
+        fn main() {
+            let a: S<i32, _/*hint text="[:  u8]"*/> = S::<_, u8>(1, 2);
+        }
+    """)
+
+    fun `test no placeholder hints if wrong types`() = checkByText("""
+        struct S1<T> (T);
+        struct S2<T> (T);
+
+        //noinspection RsTypeCheck
+        fn main() {
+            let a: S1<_> = S2(1);
+        }
+    """)
+
+    fun `test placeholder hint alias`() = checkByText("""
+        struct S<A, B> (A, B);
+        type T<C> = S<i32, C>;
+
+        fn main() {
+            let a: T<_/*hint text="[:  u8]"*/> = S::<_, u8>(1, 2);
+        }
+    """)
+
 
     fun `test smart should not annotate tuples`() = checkByText("""
         enum Option<T> {


### PR DESCRIPTION
The bug was introduced in #5197

Fixes #5443, fixes #5428