### PR TITLE
INT: add Import for intention

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -472,12 +472,6 @@ sealed class ImportInfo {
 
 data class ImportCandidate(val qualifiedNamedItem: QualifiedNamedItem, val info: ImportInfo)
 
-/** For `Foo::bar` in `Foo::bar::baz::quux` returns `Foo::bar::baz::quux` */
-private tailrec fun RsPath.superPath(): RsPath {
-    val parent = context
-    return if (parent is RsPath) parent.superPath() else this
-}
-
 private fun RsPath.namespaceFilter(isCompletion: Boolean): (RsQualifiedNamedElement) -> Boolean = when (context) {
     is RsTypeReference -> { e ->
         when (e) {

--- a/src/main/kotlin/org/rust/ide/intentions/AddImportIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddImportIntention.kt
@@ -1,0 +1,121 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.LocalSearchScope
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.psi.util.parentOfType
+import org.rust.ide.inspections.import.ImportCandidate
+import org.rust.ide.inspections.import.ImportInfo
+import org.rust.ide.inspections.import.import
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve.namespaces
+
+class AddImportIntention : RsElementBaseIntentionAction<AddImportIntention.Context>() {
+    override fun getFamilyName() = "Add import"
+
+    class Context(val path: RsPath, val needsImport: Boolean)
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        // ignore paths in use items
+        if (element.parentOfType<RsUseItem>() != null) return null
+
+        val path = element.parentOfType<RsPath>() ?: return null
+        val importablePath = path.findImportablePath() ?: return null
+        if (importablePath.kind != PathKind.IDENTIFIER ||
+            importablePath.reference == null ||
+            importablePath.isUnresolved) return null
+
+        // ignore paths that cannot be shortened
+        if (importablePath.path == null) return null
+
+        val target = importablePath.reference?.resolve() as? RsQualifiedNamedElement ?: return null
+        val namespace = target.namespaces
+
+        // check if the name is already in scope in the same namespace
+        val existingItem = importablePath.findInScope(importablePath.referenceName, namespace)
+        val sameReference = target == existingItem
+
+        // if name exists, but is a different type, exit
+        if (existingItem != null && !sameReference) {
+            return null
+        }
+
+        text = "Add import for `${importablePath.text}`"
+        return Context(importablePath, existingItem == null)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val path = ctx.path
+
+        if (ctx.needsImport) {
+            val targetItem = path.reference?.resolve() as? RsQualifiedNamedElement ?: return
+            val usePath = path.generateUsePath()
+            val candidate = ImportCandidate(QualifiedNamedItem.ExplicitItem(targetItem),
+                ImportInfo.LocalImportInfo(usePath))
+            candidate.import(ctx.path)
+        }
+
+        val target = ctx.path.reference?.resolve() as? RsQualifiedNamedElement ?: return
+        ReferencesSearch.search(target, LocalSearchScope(path.containingMod)).forEach {
+            if (it.element.parentOfType<RsUseItem>() != null) return@forEach
+            val pathReference = it.element as? RsPath ?: return@forEach
+            pathReference.shorten(target)
+        }
+    }
+}
+
+/**
+ * Shortens the path so that it resolves to `target` without any additional qualification.
+ * a::b::Foo.shorten(Foo) -> Foo
+ * a::b::Foo.shorten(b) -> b::Foo
+ */
+private fun RsPath.shorten(target: RsQualifiedNamedElement) {
+    val resolved = reference?.resolve() as? RsQualifiedNamedElement
+    if (resolved != null) {
+        if (resolved == target) {
+            path?.delete()
+            coloncolon?.delete()
+            return
+        }
+    }
+
+    path?.shorten(target)
+}
+
+/**
+ * Finds the first part of the path that is possibly importable
+ * a::b::Struct::function -> a::b::Struct
+ */
+private fun RsPath.findImportablePath(): RsPath? {
+    val target = reference?.resolve() as? RsQualifiedNamedElement ?: return path?.findImportablePath()
+
+    val canBeImported = when (target) {
+        is RsStructOrEnumItemElement,
+        is RsMod,
+        is RsTraitAlias,
+        is RsTraitItem,
+        is RsTypeAlias,
+        is RsEnumVariant,
+        is RsMacro -> true
+        is RsAbstractable -> !target.owner.isImplOrTrait
+        else -> false
+    }
+    if (canBeImported) {
+        return this
+    }
+    return path?.findImportablePath()
+}
+
+private fun RsPath.generateUsePath(): String = generateSequence(this) { it.path }
+    .map { it.referenceName }
+    .toList()
+    .asReversed()
+    .joinToString("::")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
@@ -42,6 +42,12 @@ tailrec fun RsPath.basePath(): RsPath {
     return if (qualifier == null) this else qualifier.basePath()
 }
 
+/** For `Foo::bar` in `Foo::bar::baz::quux` returns `Foo::bar::baz::quux` */
+tailrec fun RsPath.superPath(): RsPath {
+    val parent = context
+    return if (parent is RsPath) parent.superPath() else this
+}
+
 val RsPath.textRangeOfLastSegment: TextRange
     get() = TextRange(referenceNameElement.startOffset, typeArgumentList?.endOffset ?: referenceNameElement.endOffset)
 

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -807,6 +807,10 @@
             <className>org.rust.ide.intentions.ConvertMethodCallToUFCSIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.AddImportIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 

--- a/src/main/resources/intentionDescriptions/AddImportIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/AddImportIntention/after.rs.template
@@ -1,0 +1,5 @@
+use std::sync::Arc;
+
+fn main() {
+    <spot>Arc::new</spot>(1);
+}

--- a/src/main/resources/intentionDescriptions/AddImportIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/AddImportIntention/before.rs.template
@@ -1,0 +1,4 @@
+fn main() {
+    <spot>std::sync::Arc::new</spot>(1);
+}
+

--- a/src/main/resources/intentionDescriptions/AddImportIntention/description.html
+++ b/src/main/resources/intentionDescriptions/AddImportIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention adds import for a selected path.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/AddImportIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddImportIntentionTest.kt
@@ -1,0 +1,554 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+class AddImportIntentionTest : RsIntentionTestBase(AddImportIntention()) {
+    fun `test not available in use statements`() = doUnavailableTest("""
+        mod foo {
+            pub struct Foo;
+        }
+        use foo::/*caret*/Foo;
+    """)
+
+    fun `test not available for unresolved paths`() = doUnavailableTest("""
+        fn main() {
+            foo::/*caret*/Foo;
+        }
+    """)
+
+    fun `test not available for leaf paths 1`() = doUnavailableTest("""
+        mod foo {
+            pub struct Foo;
+        }
+        use foo::Foo;
+
+        fn main() {
+            /*caret*/Foo;
+        }
+    """)
+
+    fun `test not available for leaf paths 2`() = doUnavailableTest("""
+        mod foo {
+            pub struct Foo;
+        }
+
+        fn main() {
+            /*caret*/foo::Foo;
+        }
+    """)
+
+    fun `test basic import`() = doAvailableTest("""
+        mod foo {
+            pub struct Foo;
+        }
+
+        fn main() {
+            foo::/*caret*/Foo;
+        }
+    """, """
+        use foo::Foo;
+
+        mod foo {
+            pub struct Foo;
+        }
+
+        fn main() {
+            /*caret*/Foo;
+        }
+    """)
+
+    fun `test keep type arguments`() = doAvailableTest("""
+        mod foo {
+            pub struct Foo<'a, T>(pub &'a T);
+        }
+
+        fn main() {
+            foo::/*caret*/Foo::<'_, u32>(&1);
+        }
+    """, """
+        use foo::Foo;
+
+        mod foo {
+            pub struct Foo<'a, T>(pub &'a T);
+        }
+
+        fn main() {
+            /*caret*/Foo::<'_, u32>(&1);
+        }
+    """)
+
+    fun `test keep nested type`() = doAvailableTest("""
+        mod foo {
+            pub struct Foo<T>(pub T);
+        }
+
+        fn main() {
+            foo::/*caret*/Foo::<foo::Foo<u32>>;
+        }
+    """, """
+        use foo::Foo;
+
+        mod foo {
+            pub struct Foo<T>(pub T);
+        }
+
+        fn main() {
+            /*caret*/Foo::<Foo<u32>>;
+        }
+    """)
+
+    fun `test nested path 1`() = doAvailableTest("""
+        mod a {
+            pub mod b {
+                pub mod c {
+                    pub struct Foo;
+                }
+            }
+        }
+
+        fn main() {
+            a::b::c::/*caret*/Foo;
+        }
+    """, """
+        use a::b::c::Foo;
+
+        mod a {
+            pub mod b {
+                pub mod c {
+                    pub struct Foo;
+                }
+            }
+        }
+
+        fn main() {
+            /*caret*/Foo;
+        }
+    """)
+
+    fun `test nested path 2`() = doAvailableTest("""
+        mod a {
+            pub mod b {
+                pub mod c {
+                    pub struct Foo;
+                }
+            }
+        }
+
+        fn main() {
+            a::b::/*caret*/c::Foo;
+        }
+    """, """
+        use a::b::c;
+
+        mod a {
+            pub mod b {
+                pub mod c {
+                    pub struct Foo;
+                }
+            }
+        }
+
+        fn main() {
+            /*caret*/c::Foo;
+        }
+    """)
+
+    fun `test partial import`() = doAvailableTest("""
+        use a::b;
+
+        mod a {
+            pub mod b {
+                pub mod c {
+                    pub struct Foo;
+                }
+            }
+        }
+
+        fn main() {
+            b::c::/*caret*/Foo;
+        }
+    """, """
+        use a::b;
+        use b::c::Foo;
+
+        mod a {
+            pub mod b {
+                pub mod c {
+                    pub struct Foo;
+                }
+            }
+        }
+
+        fn main() {
+            /*caret*/Foo;
+        }
+    """)
+
+    fun `test function call without an owner`() = doAvailableTest("""
+        mod foo {
+            pub fn new() {}
+        }
+
+        fn main() {
+            foo::/*caret*/new();
+        }
+    """, """
+        use foo::new;
+
+        mod foo {
+            pub fn new() {}
+        }
+
+        fn main() {
+            /*caret*/new();
+        }
+    """)
+
+    fun `test function call with an owner`() = doAvailableTest("""
+        mod foo {
+            pub struct Foo;
+            impl Foo {
+                pub fn new() -> Self { Foo }
+            }
+        }
+
+        fn main() {
+            foo::Foo::/*caret*/new();
+        }
+    """, """
+        use foo::Foo;
+
+        mod foo {
+            pub struct Foo;
+            impl Foo {
+                pub fn new() -> Self { Foo }
+            }
+        }
+
+        fn main() {
+            Foo::/*caret*/new();
+        }
+    """)
+
+    fun `test mod`() = doAvailableTest("""
+        mod a {
+            pub mod b {
+                pub mod c {
+
+                }
+            }
+        }
+
+        fn main() {
+            a::b::/*caret*/c;
+        }
+    """, """
+        use a::b;
+
+        mod a {
+            pub mod b {
+                pub mod c {
+
+                }
+            }
+        }
+
+        fn main() {
+            b::/*caret*/c;
+        }
+    """)
+
+    fun `test constant`() = doAvailableTest("""
+        mod a {
+            pub const CONST: u32 = 0;
+        }
+
+        fn main() {
+            a::/*caret*/CONST;
+        }
+    """, """
+        use a::CONST;
+
+        mod a {
+            pub const CONST: u32 = 0;
+        }
+
+        fn main() {
+            /*caret*/CONST;
+        }
+    """)
+
+    fun `test trait`() = doAvailableTest("""
+        mod a {
+            pub trait Trait {}
+        }
+
+        fn main() {
+            let _: &a::/*caret*/Trait;
+        }
+    """, """
+        use a::Trait;
+
+        mod a {
+            pub trait Trait {}
+        }
+
+        fn main() {
+            let _: &/*caret*/Trait;
+        }
+    """)
+
+    fun `test type alias`() = doAvailableTest("""
+        mod a {
+            pub type Type = ();
+        }
+
+        fn main() {
+            let _: a::/*caret*/Type;
+        }
+    """, """
+        use a::Type;
+
+        mod a {
+            pub type Type = ();
+        }
+
+        fn main() {
+            let _: /*caret*/Type;
+        }
+    """)
+
+    fun `test enum`() = doAvailableTest("""
+        mod a {
+            pub enum Enum { V1 }
+        }
+
+        fn main() {
+            let _: a::/*caret*/Enum;
+        }
+    """, """
+        use a::Enum;
+
+        mod a {
+            pub enum Enum { V1 }
+        }
+
+        fn main() {
+            let _: /*caret*/Enum;
+        }
+    """)
+
+    fun `test enum variant`() = doAvailableTest("""
+        mod a {
+            pub enum Enum { V1 }
+        }
+
+        fn main() {
+            a::Enum::/*caret*/V1;
+        }
+    """, """
+        use a::Enum::V1;
+
+        mod a {
+            pub enum Enum { V1 }
+        }
+
+        fn main() {
+            /*caret*/V1;
+        }
+    """)
+
+    fun `test don't import if same name exists in scope`() = doUnavailableTest("""
+        mod foo {
+            pub struct Foo;
+        }
+
+        struct Foo;
+
+        fn main() {
+            foo::/*caret*/Foo;
+        }
+    """)
+
+    fun `test shorten path if import already exists`() = doAvailableTest("""
+        use foo::Foo;
+
+        mod foo {
+            pub struct Foo;
+        }
+
+        fn main() {
+            foo::/*caret*/Foo;
+        }
+    """, """
+        use foo::Foo;
+
+        mod foo {
+            pub struct Foo;
+        }
+
+        fn main() {
+            /*caret*/Foo;
+        }
+    """)
+
+    fun `test import if same name exists in a different namespace`() = doAvailableTest("""
+        mod foo {
+            pub const Foo: u32 = 0;
+        }
+
+        struct Foo {}
+
+        fn main() {
+            foo::/*caret*/Foo;
+        }
+    """, """
+        use foo::Foo;
+
+        mod foo {
+            pub const Foo: u32 = 0;
+        }
+
+        struct Foo {}
+
+        fn main() {
+            /*caret*/Foo;
+        }
+    """)
+
+    fun `test replace usage`() = doAvailableTest("""
+        mod foo {
+            pub struct Foo;
+        }
+
+        fn main() {
+            foo::/*caret*/Foo;
+            foo::Foo;
+        }
+    """, """
+        use foo::Foo;
+
+        mod foo {
+            pub struct Foo;
+        }
+
+        fn main() {
+            /*caret*/Foo;
+            Foo;
+        }
+    """)
+
+    fun `test replace usage inside module`() = doAvailableTest("""
+        mod foo {
+            pub mod bar {
+                pub struct Bar;
+            }
+
+            fn f1() {
+                bar::/*caret*/Bar;
+            }
+            fn f2() {
+                bar::Bar;
+            }
+        }
+
+        fn f3() {
+            foo::bar::Bar;
+        }
+    """, """
+        mod foo {
+            use bar::Bar;
+
+            pub mod bar {
+                pub struct Bar;
+            }
+
+            fn f1() {
+                /*caret*/Bar;
+            }
+            fn f2() {
+                Bar;
+            }
+        }
+
+        fn f3() {
+            foo::bar::Bar;
+        }
+    """)
+
+    fun `test replace usage different path 1`() = doAvailableTest("""
+        use foo::bar;
+        use foo::bar::baz;
+
+        mod foo {
+            pub mod bar {
+                pub mod baz {
+                    pub struct S;
+                }
+            }
+        }
+
+        fn main() {
+            foo::bar::baz::/*caret*/S;
+            bar::baz::S;
+            baz::S;
+        }
+    """, """
+        use foo::bar;
+        use foo::bar::baz;
+        use foo::bar::baz::S;
+
+        mod foo {
+            pub mod bar {
+                pub mod baz {
+                    pub struct S;
+                }
+            }
+        }
+
+        fn main() {
+            S;
+            S;
+            S;
+        }
+    """)
+
+    fun `test replace usage different path 2`() = doAvailableTest("""
+        use foo::bar;
+        use foo::bar::baz;
+
+        mod foo {
+            pub mod bar {
+                pub mod baz {
+                    pub struct S;
+                }
+            }
+        }
+
+        fn main() {
+            foo::bar::/*caret*/baz::S;
+            bar::baz::S;
+            baz::S;
+        }
+    """, """
+        use foo::bar;
+        use foo::bar::baz;
+
+        mod foo {
+            pub mod bar {
+                pub mod baz {
+                    pub struct S;
+                }
+            }
+        }
+
+        fn main() {
+            /*caret*/baz::S;
+            baz::S;
+            baz::S;
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds intention that imports a part of a complex path.

![import](https://user-images.githubusercontent.com/4539057/82907174-8da36e00-9f66-11ea-9f50-7172e104779c.gif)

I'm not very sure about the used import machinery, is it correct? I also looked at `ImportContext`, but this has worked so far. Especially joining parts of the path to put into the use statement seems a bit nasty.

A reverse intention (fully qualify a path) could probably also be useful.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/4006