### PR TITLE
REF: Basic version of move top-level items refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -222,7 +222,7 @@ private fun RsDocAndAttributeOwner.header(buffer: StringBuilder) {
     }
 }
 
-private fun RsDocAndAttributeOwner.signature(builder: StringBuilder) {
+fun RsDocAndAttributeOwner.signature(builder: StringBuilder) {
     val rawLines = when (this) {
         is RsNamedFieldDecl -> listOfNotNull(presentationInfo?.signatureText)
         is RsFunction -> {
@@ -256,6 +256,7 @@ private fun RsDocAndAttributeOwner.signature(builder: StringBuilder) {
             } else emptyList()
         }
         is RsMacro -> listOf("macro <b>$name</b>")
+        is RsImplItem -> declarationText
         else -> emptyList()
     }
     rawLines.joinTo(builder, "<br>")

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMemberSelectionPanel.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMemberSelectionPanel.kt
@@ -1,0 +1,60 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.move
+
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.refactoring.classMembers.MemberInfoBase
+import com.intellij.refactoring.ui.AbstractMemberSelectionTable
+import com.intellij.refactoring.ui.MemberSelectionPanelBase
+import com.intellij.ui.RowIcon
+import org.apache.commons.lang.StringEscapeUtils
+import org.rust.ide.docs.signature
+import org.rust.lang.core.psi.RsModItem
+import org.rust.lang.core.psi.ext.RsItemElement
+import javax.swing.Icon
+
+// currently supports only move refactoring requirements
+class RsMemberSelectionPanel(
+    title: String,
+    memberInfo: List<RsMemberInfo>
+) : MemberSelectionPanelBase<
+    RsItemElement,
+    RsMemberInfo,
+    AbstractMemberSelectionTable<RsItemElement, RsMemberInfo>
+    >(title, RsMemberSelectionTable(memberInfo))
+
+class RsMemberSelectionTable(memberInfo: List<RsMemberInfo>)
+    : AbstractMemberSelectionTable<RsItemElement, RsMemberInfo>(memberInfo, null, null) {
+
+    init {
+        setTableHeader(null)
+    }
+
+    override fun getAbstractColumnValue(memberInfo: RsMemberInfo?): Any? = null
+
+    override fun isAbstractColumnEditable(rowIndex: Int): Boolean = false
+
+    override fun setVisibilityIcon(memberInfo: RsMemberInfo, icon: RowIcon) {
+        // we don't set visibility icon, because
+        // 1) visibility is already included in item text
+        // 2) some items doesn't need visibility icon (e.g. `RsImplItem`)
+        //    and they will be misaligned with those items which has visibility icon
+    }
+
+    override fun getOverrideIcon(memberInfo: RsMemberInfo): Icon? = null
+}
+
+class RsMemberInfo(member: RsItemElement, isChecked: Boolean) : MemberInfoBase<RsItemElement>(member) {
+    init {
+        this.isChecked = isChecked
+        displayName = if (member is RsModItem) {
+            "mod ${member.modName}"
+        } else {
+            val description = buildString { member.signature(this) }
+            StringEscapeUtils.unescapeHtml(StringUtil.removeHtmlTags(description))
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsDialog.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsDialog.kt
@@ -1,0 +1,107 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.move
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.refactoring.RefactoringBundle.message
+import com.intellij.refactoring.ui.RefactoringDialog
+import com.intellij.refactoring.util.CommonRefactoringUtil
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.layout.panel
+import com.intellij.util.IncorrectOperationException
+import org.rust.lang.core.psi.ext.RsItemElement
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.openapiext.pathToRsFileTextField
+import org.rust.openapiext.toPsiFile
+import org.rust.stdext.mapToSet
+import java.awt.Dimension
+import java.io.File
+import javax.swing.JComponent
+
+class RsMoveTopLevelItemsDialog(
+    project: Project,
+    private val itemsToMove: Set<RsItemElement>,
+    private val sourceMod: RsMod
+) : RefactoringDialog(project, false) {
+
+    private val sourceFilePath: String = sourceMod.containingFile.virtualFile.path
+    private val sourceFileField: JBTextField = JBTextField(sourceFilePath).apply { isEnabled = false }
+    private val targetFileChooser: TextFieldWithBrowseButton = createTargetFileChooser(project)
+    private val memberPanel: RsMemberSelectionPanel = createMemberInfoPanel()
+
+    private var searchForReferences: Boolean = true
+
+    init {
+        super.init()
+        title = "Move Module Items"
+    }
+
+    private fun createTargetFileChooser(project: Project): TextFieldWithBrowseButton {
+        return pathToRsFileTextField(disposable, "Choose Destination File", project)
+            .also {
+                it.text = sourceFilePath
+                it.textField.caretPosition = sourceFilePath.removeSuffix(".rs").length
+                it.textField.moveCaretPosition(sourceFilePath.lastIndexOf('/') + 1)
+            }
+    }
+
+    private fun createMemberInfoPanel(): RsMemberSelectionPanel {
+        val memberInfo = getTopLevelItems()
+            .map { RsMemberInfo(it, itemsToMove.contains(it)) }
+        return RsMemberSelectionPanel("Items to move", memberInfo)
+    }
+
+    override fun createCenterPanel(): JComponent {
+        return panel {
+            row("From:") {
+                sourceFileField(growX).withLargeLeftGap()
+            }
+            row("To:") {
+                targetFileChooser(growX).withLargeLeftGap().focused()
+            }
+            row {
+                memberPanel(grow, pushY)
+            }
+            row {
+                cell(isFullWidth = true) {
+                    checkBox(message("search.for.references"), searchForReferences)
+                }
+            }
+        }.also { it.preferredSize = Dimension(600, 400) }
+    }
+
+    private fun getTopLevelItems(): List<RsItemElement> {
+        return sourceMod.children
+            .filterIsInstance<RsItemElement>()
+            .filter { RsMoveTopLevelItemsHandler.canMoveElement(it) }
+    }
+
+    override fun doAction() {
+        val itemsToMove = memberPanel.table.selectedMemberInfos.mapToSet { it.member }
+        val targetFilePath = targetFileChooser.text
+
+        val targetMod = findTargetMod(targetFilePath)
+        if (targetMod == null) {
+            val message = "Target file must be a Rust file"
+            CommonRefactoringUtil.showErrorMessage(message("error.title"), message, null, project)
+            return
+        }
+
+        try {
+            val processor = RsMoveTopLevelItemsProcessor(project, itemsToMove, targetMod, searchForReferences)
+            invokeRefactoring(processor)
+        } catch (e: IncorrectOperationException) {
+            CommonRefactoringUtil.showErrorMessage(message("error.title"), e.message, null, project)
+        }
+    }
+
+    private fun findTargetMod(targetFilePath: String): RsMod? {
+        val targetFile = LocalFileSystem.getInstance().findFileByIoFile(File(targetFilePath))
+        return targetFile?.toPsiFile(project) as? RsMod
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsHandler.kt
@@ -1,0 +1,86 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.move
+
+import com.intellij.lang.Language
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReference
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.parentOfType
+import com.intellij.refactoring.move.MoveCallback
+import com.intellij.refactoring.move.MoveHandlerDelegate
+import com.intellij.refactoring.util.CommonRefactoringUtil
+import org.rust.lang.RsLanguage
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsItemElement
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.descendantOfTypeStrict
+
+class RsMoveTopLevelItemsHandler : MoveHandlerDelegate() {
+
+    override fun supportsLanguage(language: Language): Boolean = language.`is`(RsLanguage)
+
+    override fun canMove(
+        element: Array<out PsiElement>,
+        targetContainer: PsiElement?,
+        reference: PsiReference?
+    ): Boolean {
+        val containingMod = (element.firstOrNull() as? RsElement)?.containingMod ?: return false
+        return element.all { canMoveElement(it) && it.parent == containingMod }
+    }
+
+    // looks like IntelliJ platform never calls this method (and always calls `tryToMove` instead)
+    // but lets implement it just in case
+    override fun doMove(
+        project: Project,
+        elements: Array<out PsiElement>,
+        targetContainer: PsiElement?,
+        moveCallback: MoveCallback?
+    ) = doMove(project, elements)
+
+    override fun tryToMove(
+        element: PsiElement,
+        project: Project,
+        dataContext: DataContext?,
+        reference: PsiReference?,
+        editor: Editor?
+    ): Boolean {
+        val elements = arrayOf(element)
+        // if something is selected, then most likely user wants to move selected items
+        // if cursor is at empty line, then we assume that user wants to move entire file
+        // otherwise we assume that user wants to move item under cursor
+        val hasSelection = editor?.selectionModel?.hasSelection() ?: false
+        if (hasSelection || canMove(elements, null, reference)) {
+            doMove(project, elements)
+            return true
+        }
+        return false
+    }
+
+    private fun doMove(project: Project, elements: Array<out PsiElement>) {
+        val containingMod = PsiTreeUtil.findCommonParent(*elements)?.parentOfType<RsMod>() ?: return
+        val itemsToMove = elements.filterIsInstance<RsItemElement>().toSet()
+
+        if (!CommonRefactoringUtil.checkReadOnlyStatusRecursively(project, itemsToMove, true)) return
+
+        RsMoveTopLevelItemsDialog(project, itemsToMove, containingMod).show()
+    }
+
+    companion object {
+        fun canMoveElement(element: PsiElement): Boolean {
+            if (element is RsModItem && element.descendantOfTypeStrict<RsModDeclItem>() != null) return false
+            return element is RsItemElement
+                && element !is RsModDeclItem
+                && element !is RsUseItem
+                && element !is RsExternCrateItem
+                && element !is RsForeignModItem
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsProcessor.kt
@@ -1,0 +1,63 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.move
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.refactoring.BaseRefactoringProcessor
+import com.intellij.refactoring.move.MoveMultipleElementsViewDescriptor
+import com.intellij.usageView.UsageInfo
+import com.intellij.usageView.UsageViewDescriptor
+import com.intellij.util.IncorrectOperationException
+import org.rust.lang.core.psi.RsModItem
+import org.rust.lang.core.psi.ext.RsItemElement
+import org.rust.lang.core.psi.ext.RsMod
+
+class RsMoveTopLevelItemsProcessor(
+    private val project: Project,
+    private val itemsToMove: Set<RsItemElement>,
+    private val targetMod: RsMod,
+    private val searchForReferences: Boolean
+) : BaseRefactoringProcessor(project) {
+
+    init {
+        if (itemsToMove.isEmpty()) throw IncorrectOperationException("No items to move")
+    }
+
+    override fun findUsages(): Array<UsageInfo> {
+        if (!searchForReferences) return UsageInfo.EMPTY_ARRAY
+        return itemsToMove
+            .flatMap { ReferencesSearch.search(it, GlobalSearchScope.projectScope(project)) }
+            .filterNotNull()
+            .map { UsageInfo(it) }
+            .toTypedArray()
+    }
+
+    override fun performRefactoring(usages: Array<out UsageInfo>) {
+        for (item in itemsToMove) {
+            val space = item.nextSibling as? PsiWhiteSpace
+
+            // have to call `copy` because of rare suspicious `PsiInvalidElementAccessException`
+            targetMod.addInner(item.copy())
+            if (space != null) targetMod.addInner(space.copy())
+
+            space?.delete()
+            item.delete()
+        }
+    }
+
+    override fun createUsageViewDescriptor(usages: Array<out UsageInfo>): UsageViewDescriptor =
+        MoveMultipleElementsViewDescriptor(itemsToMove.toTypedArray(), targetMod.name ?: "")
+
+    override fun getCommandName(): String = "Move items"
+}
+
+// like `PsiElement::add`, but works correctly for `RsModItem`
+private fun RsMod.addInner(element: PsiElement): PsiElement =
+    addBefore(element, if (this is RsModItem) rbrace else null)

--- a/src/main/kotlin/org/rust/openapiext/ui.kt
+++ b/src/main/kotlin/org/rust/openapiext/ui.kt
@@ -8,7 +8,10 @@ package org.rust.openapiext
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.invokeLater
+import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.TextComponentAccessor
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
@@ -16,6 +19,7 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.ui.DocumentAdapter
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.util.Alarm
+import org.rust.lang.RsFileType
 import javax.swing.event.DocumentEvent
 import kotlin.reflect.KProperty
 
@@ -47,11 +51,39 @@ fun pathToDirectoryTextField(
     disposable: Disposable,
     title: String,
     onTextChanged: () -> Unit = {}
+): TextFieldWithBrowseButton =
+    pathTextField(
+        FileChooserDescriptorFactory.createSingleFolderDescriptor(),
+        disposable,
+        title,
+        onTextChanged
+    )
+
+fun pathToRsFileTextField(
+    disposable: Disposable,
+    title: String,
+    project: Project,
+    onTextChanged: () -> Unit = {}
+): TextFieldWithBrowseButton =
+    pathTextField(
+        FileChooserDescriptorFactory
+            .createSingleFileDescriptor(RsFileType)
+            .withRoots(project.guessProjectDir()),
+        disposable,
+        title,
+        onTextChanged
+    )
+
+fun pathTextField(
+    fileChooserDescriptor: FileChooserDescriptor,
+    disposable: Disposable,
+    title: String,
+    onTextChanged: () -> Unit = {}
 ): TextFieldWithBrowseButton {
 
     val component = TextFieldWithBrowseButton(null, disposable)
     component.addBrowseFolderListener(title, null, null,
-        FileChooserDescriptorFactory.createSingleFolderDescriptor(),
+        fileChooserDescriptor,
         TextComponentAccessor.TEXT_FIELD_WHOLE_TEXT
     )
     component.childComponent.document.addDocumentListener(object : DocumentAdapter() {

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -931,6 +931,9 @@
         <refactoring.moveHandler implementation="org.rust.ide.refactoring.move.RsMoveFilesOrDirectoriesHandler"
                                  order="first, before moveJavaFileOrDir, before kotlin.moveFilesOrDirectories"/>
 
+        <refactoring.moveHandler implementation="org.rust.ide.refactoring.move.RsMoveTopLevelItemsHandler"
+                                 order="first, before moveJavaFileOrDir, before kotlin.moveFilesOrDirectories"/>
+
     </extensions>
 
     <extensionPoints>


### PR DESCRIPTION
Initial version of move refactoring for top-level items (#3531). Refactoring is activated by pressing F6, then dialog is shown where user selects items to move:

![image](https://user-images.githubusercontent.com/6505554/82929507-3967b080-9f9d-11ea-9e17-2a5310214de9.png)

Current implementation just moves items, actual work (e.g. updating references) will be added in following pull requests