### PR TITLE
FIX: render types with a fully qualified name when needed

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
@@ -14,11 +14,14 @@ import com.intellij.psi.util.PsiTreeUtil
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.presentation.render
 import org.rust.ide.presentation.renderInsertionSafe
+import org.rust.ide.utils.import.RsImportHelper.getTypeReferencesInfoFromTys
 import org.rust.ide.utils.import.RsImportHelper.importTypeReferencesFromTy
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyUnit
+import org.rust.lang.core.types.ty.TyUnknown
+import org.rust.lang.core.types.type
 
 
 class ChangeReturnTypeFix(
@@ -26,48 +29,64 @@ class ChangeReturnTypeFix(
     private val actualTy: Ty
 ) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
     private val _text: String = run {
-            val (item, name) = when (val callable = findCallableOwner(element)) {
-                is RsFunction -> {
-                    val item = if (callable.owner.isImplOrTrait) " of method" else " of function"
-                    val name = callable.name?.let { " '$it'" } ?: ""
-                    item to name
-                }
-                is RsLambdaExpr -> " of closure" to ""
-                else -> "" to ""
+        val callable = findCallableOwner(startElement)
+
+        val (item, name) = when (callable) {
+            is RsFunction -> {
+                val item = if (callable.owner.isImplOrTrait) " of method" else " of function"
+                val name = callable.name?.let { " '$it'" } ?: ""
+                item to name
             }
-            "Change return type$item$name to '${actualTy.render(useAliasNames = true)}'"
+            is RsLambdaExpr -> " of closure" to ""
+            else -> "" to ""
         }
+
+        val useQualifiedName = if (callable != null) {
+            getTypeReferencesInfoFromTys(callable, actualTy, useAliases = true).toQualify
+        } else {
+            emptySet()
+        }
+
+        val rendered = actualTy.render(
+            context = element,
+            useQualifiedName = useQualifiedName,
+            useAliasNames = true
+        )
+        "Change return type$item$name to '$rendered'"
+    }
 
     override fun getText(): String = _text
     override fun getFamilyName(): String = "Change return type"
 
-    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
+    override fun invoke(
+        project: Project,
+        file: PsiFile,
+        editor: Editor?,
+        startElement: PsiElement,
+        endElement: PsiElement
+    ) {
         val owner = findCallableOwner(startElement) ?: return
-
-        val oldRetType = when (owner) {
-            is RsFunction -> owner.retType
-            is RsLambdaExpr -> owner.retType
-            else -> return
-        }
+        val oldRetType = owner.returnType
 
         if (actualTy is TyUnit) {
             oldRetType?.delete()
             return
         }
 
-        val psiFactory = RsPsiFactory(project)
-        val text = actualTy.renderInsertionSafe(includeLifetimeArguments = true, useAliasNames = true)
-        val retType = psiFactory.createRetType(text)
+        val oldTy = oldRetType?.typeReference?.type ?: TyUnknown
+        val (_, useQualifiedName) = getTypeReferencesInfoFromTys(owner, actualTy, oldTy, useAliases = true)
+        val text = actualTy.renderInsertionSafe(
+            context = startElement as? RsElement,
+            useQualifiedName = useQualifiedName,
+            includeLifetimeArguments = true,
+            useAliasNames = true
+        )
+        val retType = RsPsiFactory(project).createRetType(text)
 
         if (oldRetType != null) {
             oldRetType.replace(retType)
         } else {
-            val parameters = when (owner) {
-                is RsFunction -> owner.valueParameterList
-                is RsLambdaExpr -> owner.valueParameterList
-                else -> return
-            }
-            owner.addAfter(retType, parameters)
+            owner.addAfter(retType, owner.valueParameters)
         }
 
         importTypeReferencesFromTy(owner, actualTy, useAliases = true)
@@ -101,3 +120,18 @@ class ChangeReturnTypeFix(
         }
     }
 }
+
+private val RsElement.valueParameters: RsValueParameterList?
+    get() = when (this) {
+        is RsFunction -> valueParameterList
+        is RsLambdaExpr -> valueParameterList
+        else -> null
+    }
+
+
+private val RsElement.returnType: RsRetType?
+    get() = when (this) {
+        is RsFunction -> retType
+        is RsLambdaExpr -> retType
+        else -> null
+    }

--- a/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
@@ -31,7 +31,7 @@ object RsImportHelper {
     }
 
     fun importTypeReferencesFromTy(context: RsElement, ty: Ty, useAliases: Boolean = false) {
-        val (toImport, _) = getTypeReferencesInfoFromTy(context, ty, useAliases)
+        val (toImport, _) = getTypeReferencesInfoFromTys(context, ty, useAliases = useAliases)
         importElements(context, toImport)
     }
 
@@ -74,11 +74,11 @@ object RsImportHelper {
     /**
      * Traverse types in `elemTy` and collects all items that unresolved in current context.
      */
-    private fun getTypeReferencesInfoFromTy(
+    fun getTypeReferencesInfoFromTys(
         context: RsElement,
-        elemTy: Ty,
-        useAliases: Boolean
-    ): TypeReferencesInfo = getTypeReferencesInfo(context, listOf(elemTy)) { ty, result ->
+        vararg elemTys: Ty,
+        useAliases: Boolean = false
+    ): TypeReferencesInfo = getTypeReferencesInfo(context, elemTys.toList()) { ty, result ->
         collectImportSubjectsFromTy(ty, emptySubstitution, result, useAliases)
     }
 
@@ -161,13 +161,13 @@ object RsImportHelper {
 
         return TypeReferencesInfo(importSubjects.flatMap { it.value }.toSet(), toQualifiedName)
     }
-
-    /**
-     * @param toImport  Set of unresolved items that should be imported
-     * @param toQualify Set of unresolved items that can't be imported
-     */
-    private data class TypeReferencesInfo(
-        val toImport: Set<RsQualifiedNamedElement>,
-        val toQualify: Set<RsQualifiedNamedElement>
-    )
 }
+
+/**
+ * @param toImport  Set of unresolved items that should be imported
+ * @param toQualify Set of unresolved items that can't be imported
+ */
+data class TypeReferencesInfo(
+    val toImport: Set<RsQualifiedNamedElement>,
+    val toQualify: Set<RsQualifiedNamedElement>
+)

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
@@ -127,6 +127,30 @@ class RsTypeCheckInspectionTest : RsInspectionsTestBase(RsTypeCheckInspection::c
         }
     """)
 
+    fun `test type mismatch same type name`() = checkByText("""
+        mod a {
+            pub struct Foo;
+        }
+        struct Foo;
+        fn foo() -> Foo {
+            <error descr="mismatched types [E0308]expected `Foo`, found `test_package::a::Foo`">a::Foo</error>
+        }
+    """)
+
+    fun `test type mismatch same type name behind alias`() = checkByText("""
+        mod a {
+            pub struct Foo {}
+            pub type Bar = Foo;
+            impl Bar {
+                pub fn new() -> Bar { Foo {} }
+            }
+        }
+        struct Bar;
+        fn foo() -> Bar {
+            <error descr="mismatched types [E0308]expected `Bar`, found `test_package::a::Bar`">a::Bar::new()</error>
+        }
+    """)
+
     fun `test type mismatch E0308 unconstrained integer`() = checkByText("""
         struct S;
         fn main () {


### PR DESCRIPTION
This PR enhances `TypeRenderer` to render (fully) qualified names for types when needed. This is basically only needed when two types are displayed together to disambiguate them if their name is the same, but they are different types. Two instances of this scenario that I found is in the type mismatch diagnostic and in `ChangeReturnTypeFix`, so I changed both of them to use the qualified name type renderer in this PR.

Fixes https://github.com/intellij-rust/intellij-rust/issues/3223, fixes https://github.com/intellij-rust/intellij-rust/issues/5452.