### PR TITLE
REF: add inline value refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionHandler.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.refactoring.inline
+package org.rust.ide.refactoring.inlineFunction
 
 import com.intellij.codeInsight.TargetElementUtil
 import com.intellij.lang.Language
@@ -22,10 +22,6 @@ import org.rust.lang.core.resolve.ref.RsReference
 
 class RsInlineFunctionHandler : InlineActionHandler() {
     override fun isEnabledOnElement(element: PsiElement): Boolean = canInlineElement(element)
-
-    override fun isEnabledOnElement(element: PsiElement, editor: Editor?): Boolean =
-        isEnabledOnElement(element)
-
     override fun inlineElement(project: Project, editor: Editor, element: PsiElement) {
         val function = element as RsFunction
 
@@ -52,7 +48,7 @@ class RsInlineFunctionHandler : InlineActionHandler() {
         }
 
         if (function.block == null) {
-            errorHint(project, editor,"Cannot inline an empty function")
+            errorHint(project, editor, "Cannot inline an empty function")
             return
         }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionProcessor.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.refactoring.inline
+package org.rust.ide.refactoring.inlineFunction
 
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
@@ -15,12 +15,11 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.LocalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.refactoring.BaseRefactoringProcessor
-import com.intellij.refactoring.RefactoringBundle
 import com.intellij.usageView.UsageInfo
-import com.intellij.usageView.UsageViewBundle
 import com.intellij.usageView.UsageViewDescriptor
 import com.intellij.util.IncorrectOperationException
 import com.intellij.util.containers.MultiMap
+import org.rust.ide.refactoring.RsInlineUsageViewDescriptor
 import org.rust.ide.surroundWith.addStatements
 import org.rust.lang.core.cfg.ExitPoint
 import org.rust.lang.core.psi.*
@@ -119,19 +118,7 @@ class RsInlineFunctionProcessor(
     override fun getCommandName(): String = "Inline function ${function.declaration}"
 
     override fun createUsageViewDescriptor(usages: Array<out UsageInfo>): UsageViewDescriptor {
-        return object : UsageViewDescriptor {
-            override fun getCommentReferencesText(usagesCount: Int, filesCount: Int) =
-                RefactoringBundle.message("comments.elements.header",
-                    UsageViewBundle.getOccurencesString(usagesCount, filesCount))
-
-            override fun getCodeReferencesText(usagesCount: Int, filesCount: Int) =
-                RefactoringBundle.message("invocations.to.be.inlined",
-                    UsageViewBundle.getReferencesString(usagesCount, filesCount))
-
-            override fun getElements() = arrayOf(function)
-
-            override fun getProcessedElementsHeader() = "Function to inline"
-        }
+        return RsInlineUsageViewDescriptor(function, "Function to inline")
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/ui.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/ui.kt
@@ -1,0 +1,70 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.inlineFunction
+
+import com.intellij.openapi.project.Project
+import com.intellij.refactoring.RefactoringBundle
+import org.rust.ide.refactoring.RsInlineDialog
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.ext.declaration
+import org.rust.lang.core.resolve.ref.RsReference
+
+class RsInlineFunctionDialog(
+    private val function: RsFunction,
+    private val refElement: RsReference?,
+    private val allowInlineThisOnly: Boolean,
+    project: Project = function.project,
+    occurrencesNumber: Int = initOccurrencesNumber(function)
+) : RsInlineDialog(function, refElement, project, occurrencesNumber) {
+    init {
+        init()
+    }
+
+    public override fun doAction() {
+        val inlineThisOnly = allowInlineThisOnly && isInlineThisOnly
+        invokeRefactoring(RsInlineFunctionProcessor(
+            project,
+            function,
+            refElement,
+            inlineThisOnly,
+            !inlineThisOnly && !isKeepTheDeclaration
+        ))
+    }
+
+    override fun getBorderTitle(): String =
+        RefactoringBundle.message("inline.method.border.title")
+
+    override fun getLabelText(occurrences: String): String {
+        return RefactoringBundle.message(
+            "inline.method.method.label",
+            function.declaration,
+            occurrences
+        )
+    }
+
+    override fun getInlineAllText(): String {
+        val text =
+            if (function.isWritable && !allowInlineThisOnly) {
+                "all.invocations.and.remove.the.method"
+            } else {
+                "all.invocations.in.project"
+            }
+        return RefactoringBundle.message(text)
+    }
+
+    override fun getInlineThisText(): String =
+        RefactoringBundle.message("this.invocation.only.and.keep.the.method")
+
+    override fun getKeepTheDeclarationText(): String =
+        if (function.isWritable) {
+            "Inline all references and keep the method"
+        } else {
+            super.getKeepTheDeclarationText()
+        }
+
+    override fun getHelpId(): String =
+        "refactoring.inlineMethod"
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/inlineValue/RsInlineValueHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineValue/RsInlineValueHandler.kt
@@ -1,0 +1,159 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.inlineValue
+
+import com.intellij.codeInsight.TargetElementUtil
+import com.intellij.lang.Language
+import com.intellij.lang.refactoring.InlineActionHandler
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.WindowManager
+import com.intellij.openapiext.isUnitTestMode
+import com.intellij.psi.PsiElement
+import com.intellij.refactoring.RefactoringBundle
+import com.intellij.refactoring.util.CommonRefactoringUtil
+import org.jetbrains.annotations.TestOnly
+import org.rust.lang.RsLanguage
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsNameIdentifierOwner
+import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.rust.lang.core.resolve.ref.RsReference
+
+class RsInlineValueHandler : InlineActionHandler() {
+    override fun isEnabledForLanguage(language: Language): Boolean = language is RsLanguage
+    override fun inlineElement(project: Project, editor: Editor, element: PsiElement) {
+        var reference = TargetElementUtil.findReference(editor, editor.caretModel.offset) as? RsReference
+
+        // if invoked directly on the target value, ignore the reference
+        if (reference?.element == element) {
+            reference = null
+        }
+        val context = getContext(project, editor, element, reference) ?: return
+
+        val dialog = RsInlineValueDialog(context)
+        if (!isUnitTestMode && dialog.shouldBeShown()) {
+            dialog.show()
+            if (!dialog.isOK) {
+                val statusBar = WindowManager.getInstance().getStatusBar(project)
+                statusBar?.info = RefactoringBundle.message("press.escape.to.remove.the.highlighting")
+            }
+        } else {
+            val processor = getProcessor(project, context)
+            processor.setPreviewUsages(false)
+            processor.run()
+        }
+    }
+
+    override fun canInlineElement(element: PsiElement): Boolean {
+        return (element is RsConstant && element.navigationElement is RsConstant) ||
+            (element is RsPatBinding && element.navigationElement is RsPatBinding)
+    }
+}
+
+private var MOCK: InlineValueMode? = null
+
+@TestOnly
+fun withMockInlineValueMode(mock: InlineValueMode, action: () -> Unit) {
+    MOCK = mock
+    try {
+        action()
+    } finally {
+        MOCK = null
+    }
+}
+
+private fun getProcessor(project: Project, context: InlineValueContext): RsInlineValueProcessor {
+    val mode = if (isUnitTestMode && MOCK != null) {
+        MOCK!!
+    } else {
+        InlineValueMode.InlineAllAndRemoveOriginal
+    }
+
+    return RsInlineValueProcessor(
+        project,
+        context,
+        mode
+    )
+}
+
+private fun getContext(
+    project: Project,
+    editor: Editor,
+    element: PsiElement,
+    reference: RsReference?
+): InlineValueContext? =
+    getVariableDeclContext(project, editor, element, reference)
+        ?: getConstantContext(project, editor, element, reference)
+
+private fun getConstantContext(
+    project: Project,
+    editor: Editor,
+    element: PsiElement,
+    reference: RsReference?
+): InlineValueContext? {
+    val const = element as? RsConstant ?: return null
+    val expr = const.expr
+    if (expr == null) {
+        showErrorHint(project, editor, "cannot inline constant without an expression")
+        return null
+    }
+
+    return InlineValueContext.Constant(const, expr, reference)
+}
+
+private fun getVariableDeclContext(
+    project: Project,
+    editor: Editor,
+    element: PsiElement,
+    reference: RsReference?
+): InlineValueContext? {
+    val binding = element as? RsPatBinding ?: return null
+    val decl = binding.ancestorOrSelf<RsLetDecl>()
+    val expr = decl?.expr
+    if (expr == null) {
+        showErrorHint(project, editor, "cannot inline variable without an expression")
+        return null
+    }
+    if (decl.pat !is RsPatIdent) {
+        showErrorHint(project, editor, "cannot inline variable without an identifier")
+        return null
+    }
+    return InlineValueContext.Variable(binding, decl, expr, reference)
+}
+
+sealed class InlineValueContext(val element: RsNameIdentifierOwner, val expr: RsExpr, val reference: RsReference?) {
+    abstract fun delete()
+
+    class Constant(constant: RsConstant, expr: RsExpr, reference: RsReference? = null)
+        : InlineValueContext(constant, expr, reference) {
+        override fun delete() {
+            element.delete()
+        }
+    }
+
+    class Variable(variable: RsPatBinding, private val decl: RsLetDecl, expr: RsExpr, reference: RsReference? = null)
+        : InlineValueContext(variable, expr, reference) {
+        override fun delete() {
+            decl.delete()
+        }
+    }
+}
+
+sealed class InlineValueMode {
+    object InlineThisOnly : InlineValueMode()
+    object InlineAllAndKeepOriginal : InlineValueMode()
+    object InlineAllAndRemoveOriginal : InlineValueMode()
+}
+
+private fun showErrorHint(project: Project, editor: Editor, message: String) {
+    CommonRefactoringUtil.showErrorHint(
+        project,
+        editor,
+        message,
+        RefactoringBundle.message("inline.variable.title"),
+        "refactoring.inline"
+    )
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/inlineValue/RsInlineValueProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineValue/RsInlineValueProcessor.kt
@@ -1,0 +1,50 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.inlineValue
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiReference
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.refactoring.BaseRefactoringProcessor
+import com.intellij.usageView.UsageInfo
+import com.intellij.usageView.UsageViewDescriptor
+import org.rust.ide.refactoring.RsInlineUsageViewDescriptor
+import org.rust.lang.core.resolve.ref.RsReference
+
+class RsInlineValueProcessor(
+    private val project: Project,
+    private val context: InlineValueContext,
+    private val mode: InlineValueMode
+) : BaseRefactoringProcessor(project) {
+    override fun findUsages(): Array<UsageInfo> {
+        if (mode is InlineValueMode.InlineThisOnly && context.reference != null) {
+            return arrayOf(UsageInfo(context.reference))
+        }
+
+        val projectScope = GlobalSearchScope.projectScope(project)
+        val usages = mutableListOf<PsiReference>()
+        usages.addAll(ReferencesSearch.search(context.element, projectScope).findAll())
+
+        return usages.map(::UsageInfo).toTypedArray()
+    }
+
+    override fun performRefactoring(usages: Array<out UsageInfo>) {
+        usages.asIterable().forEach loop@{
+            val reference = it.reference as? RsReference ?: return@loop
+            reference.element.replace(context.expr)
+        }
+        if (mode is InlineValueMode.InlineAllAndRemoveOriginal) {
+            context.delete()
+        }
+    }
+
+    override fun getCommandName(): String = "Inline ${context.type} ${context.name}"
+
+    override fun createUsageViewDescriptor(usages: Array<out UsageInfo>): UsageViewDescriptor {
+        return RsInlineUsageViewDescriptor(context.element, "${context.type.capitalize()} to inline")
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/inlineValue/ui.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineValue/ui.kt
@@ -1,0 +1,72 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.inlineValue
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.refactoring.RefactoringBundle
+import org.rust.ide.refactoring.RsInlineDialog
+
+class RsInlineValueDialog(
+    private val context: InlineValueContext,
+    project: Project = context.element.project,
+    occurrencesNumber: Int = initOccurrencesNumber(context.element)
+) : RsInlineDialog(context.element, context.reference, project, occurrencesNumber) {
+    init {
+        init()
+    }
+
+    override fun doAction() {
+        invokeRefactoring(getProcessor())
+    }
+
+    private fun getProcessor(): RsInlineValueProcessor {
+        val mode = when {
+            isInlineThisOnly -> InlineValueMode.InlineThisOnly
+            isKeepTheDeclaration -> InlineValueMode.InlineAllAndKeepOriginal
+            else -> InlineValueMode.InlineAllAndRemoveOriginal
+        }
+
+        return RsInlineValueProcessor(project, context, mode)
+    }
+
+    override fun getBorderTitle(): String =
+        RefactoringBundle.message("inline.field.border.title")
+
+    override fun getLabelText(occurrences: String): String {
+        return "${context.type.capitalize()} ${context.name} $occurrences"
+    }
+
+    override fun getInlineAllText(): String {
+        val text =
+            if (context.element.isWritable) {
+                "all.references.and.remove.the.local"
+            } else {
+                "all.invocations.in.project"
+            }
+        return RefactoringBundle.message(text)
+    }
+
+    override fun getInlineThisText(): String =
+        "Inline this only and keep the ${context.type}"
+
+    override fun getKeepTheDeclarationText(): String =
+        if (context.element.isWritable) {
+            "Inline all references and keep the ${context.type}"
+        } else {
+            super.getKeepTheDeclarationText()
+        }
+
+    override fun getHelpId(): String = "refactoring.inlineVariable"
+}
+
+val InlineValueContext.type: String
+    get() = when (this) {
+        is InlineValueContext.Variable -> "variable"
+        is InlineValueContext.Constant -> "constant"
+    }
+val InlineValueContext.name: String
+    get() = this.element.name ?: ""

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -867,7 +867,8 @@
 
         <lang.namesValidator language="Rust" implementationClass="org.rust.ide.refactoring.RsNamesValidator"/>
 
-        <inlineActionHandler implementation="org.rust.ide.refactoring.inline.RsInlineFunctionHandler"/>
+        <inlineActionHandler implementation="org.rust.ide.refactoring.inlineFunction.RsInlineFunctionHandler"/>
+        <inlineActionHandler implementation="org.rust.ide.refactoring.inlineValue.RsInlineValueHandler"/>
 
         <!-- Postfix templates -->
         <codeInsight.template.postfixTemplateProvider language="Rust"

--- a/src/test/kotlin/org/rust/ide/refactoring/RsInlineFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsInlineFunctionTest.kt
@@ -6,704 +6,739 @@
 package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
+import org.junit.Assert
 import org.rust.RsTestBase
 
 class RsInlineFunctionTest : RsTestBase() {
-    override val dataPath = "org/rust/lang/refactoring/fixtures/inline_function/"
-
     fun `test inline function without parameters and a return value`() = doTest("""
-            fn main() {
-                test();
-            }
-            fn /*caret*/test() {
-                println!("test");
-                println!("test2");
-            }""", """
-            fn main() {
-                println!("test");
-                println!("test2");
-            }
-            """)
+        fn main() {
+            test();
+        }
+        fn /*caret*/test() {
+            println!("test");
+            println!("test2");
+        }
+    """, """
+        fn main() {
+            println!("test");
+            println!("test2");
+        }
+
+    """)
 
     fun `test inline function with parameter and no return value`() = doTest("""
-            fn main() {
-                let bar = 10i32;
-                foo(bar);
-            }
-            fn /*caret*/foo(bar: i32) {
-                println!("{}", bar);
-            }""", """
-            fn main() {
-                let bar = 10i32;
-                println!("{}", bar);
-            }
-            """)
+        fn main() {
+            let bar = 10i32;
+            foo(bar);
+        }
+        fn /*caret*/foo(bar: i32) {
+            println!("{}", bar);
+        }
+    """, """
+        fn main() {
+            let bar = 10i32;
+            println!("{}", bar);
+        }
+
+    """)
 
     fun `test inline function with return value and no parameters`() = doTest("""
-            fn main() {
-                let baz = foo();
-            }
-            fn /*caret*/foo() -> i32 {
-                return 10i32;
-            }""", """
-            fn main() {
-                let baz = 10i32;
-            }
-            """)
+        fn main() {
+            let baz = foo();
+        }
+        fn /*caret*/foo() -> i32 {
+            return 10i32;
+        }
+    """, """
+        fn main() {
+            let baz = 10i32;
+        }
+
+    """)
 
     fun `test inline function with return value and no parameters, with value assigned inside function`() = doTest("""
-            fn main() {
-                let baz = foo();
-            }
-            fn /*caret*/foo() -> i32 {
-                let bar = 10i32;
-                return bar;
-            }""", """
-            fn main() {
-                let bar = 10i32;
-                let baz = bar;
-            }
-            """)
+        fn main() {
+            let baz = foo();
+        }
+        fn /*caret*/foo() -> i32 {
+            let bar = 10i32;
+            return bar;
+        }
+    """, """
+        fn main() {
+            let bar = 10i32;
+            let baz = bar;
+        }
+
+    """)
 
     fun `test inline function with return value and no parameters, with range operator`() = doTest("""
-            fn main() {
-                for i in 0..foo() {}
-            }
-            fn /*caret*/foo() -> i32 { 42 }""", """
-            fn main() {
-                for i in 0..42 {}
-            }
-            """)
+        fn main() {
+            for i in 0..foo() {}
+        }
+        fn /*caret*/foo() -> i32 { 42 }
+    """, """
+        fn main() {
+            for i in 0..42 {}
+        }
+
+    """)
 
     fun `test inline function with return value and no parameters, with range operator and assignment in function`() = doTest("""
-            fn main() {
-                for i in 0..foo() {}
-            }
-            fn /*caret*/foo() -> i32 {
-                let bar = 10i32;
-                return bar;
-            }""", """
-            fn main() {
-                let bar = 10i32;
-                for i in 0..bar {}
-            }
-            """)
+        fn main() {
+            for i in 0..foo() {}
+        }
+        fn /*caret*/foo() -> i32 {
+            let bar = 10i32;
+            return bar;
+        }
+    """, """
+        fn main() {
+            let bar = 10i32;
+            for i in 0..bar {}
+        }
+
+    """)
 
     fun `test inline function with return value and no parameters, inside boolean expression`() = doTest("""
-            fn main() {
-                if foo() > 5 {}
-            }
-            fn /*caret*/foo() -> i32 { 42 }""", """
-            fn main() {
-                if 42 > 5 {}
-            }
-            """)
+        fn main() {
+            if foo() > 5 {}
+        }
+        fn /*caret*/foo() -> i32 { 42 }
+    """, """
+        fn main() {
+            if 42 > 5 {}
+        }
+
+    """)
 
     fun `test inline input parameter with mutability`() = doTest("""
-            fn main() {
-                let mut vec = vec![1, 2, 3];
-                foo(&mut vec);
-            }
-            fn /*caret*/foo(vec: &mut Vec<i32>) {
-                vec.push(1);
-            }""", """
-            fn main() {
-                let mut vec = vec![1, 2, 3];
-                vec.push(1);
-            }
-            """)
+        fn main() {
+            let mut vec = vec![1, 2, 3];
+            foo(&mut vec);
+        }
+        fn /*caret*/foo(vec: &mut Vec<i32>) {
+            vec.push(1);
+        }
+    """, """
+        fn main() {
+            let mut vec = vec![1, 2, 3];
+            vec.push(1);
+        }
+
+    """)
 
     fun `test inline function with 2 parameters and no return value`() = doTest("""
-            fn main() {
-                let bar = 10i32;
-                let baz = 20i32;
-                foo(bar, baz);
-            }
-            fn /*caret*/foo(bar: i32, baz: i32) {
-                println!("{}, {}", bar, baz);
-            }""", """
-            fn main() {
-                let bar = 10i32;
-                let baz = 20i32;
-                println!("{}, {}", bar, baz);
-            }
-            """)
+        fn main() {
+            let bar = 10i32;
+            let baz = 20i32;
+            foo(bar, baz);
+        }
+        fn /*caret*/foo(bar: i32, baz: i32) {
+            println!("{}, {}", bar, baz);
+        }
+    """, """
+        fn main() {
+            let bar = 10i32;
+            let baz = 20i32;
+            println!("{}, {}", bar, baz);
+        }
+
+    """)
 
     fun `test inline function with tuple return value`() = doTest("""
-            fn main() {
-                let (barCopy, bazCopy) = foo();
-                println!("{}", bar);
-                println!("{}", baz);
-            }
-            fn /*caret*/foo() -> (i32, i32) {
-                let bar = 10i32;
-                let baz = 20i32;
-                (bar, baz)
-            }""", """
-            fn main() {
-                let bar = 10i32;
-                let baz = 20i32;
-                let (barCopy, bazCopy) = (bar, baz);
-                println!("{}", bar);
-                println!("{}", baz);
-            }
-            """)
+        fn main() {
+            let (barCopy, bazCopy) = foo();
+            println!("{}", bar);
+            println!("{}", baz);
+        }
+        fn /*caret*/foo() -> (i32, i32) {
+            let bar = 10i32;
+            let baz = 20i32;
+            (bar, baz)
+        }
+    """, """
+        fn main() {
+            let bar = 10i32;
+            let baz = 20i32;
+            let (barCopy, bazCopy) = (bar, baz);
+            println!("{}", bar);
+            println!("{}", baz);
+        }
+
+    """)
 
     fun `test inline function with expression return value`() = doTest("""
-            fn bar() -> (i32, i32) {
-                let baz = 20i32;
-                foo(baz);
-            }
-            fn /*caret*/foo(baz: i32) -> (i32, i32) {
-                let qux = 10i32;
-                (baz, qux)
-            }""", """
-            fn bar() -> (i32, i32) {
-                let baz = 20i32;
-                let qux = 10i32;
-                (baz, qux)
-            }
-            """)
+        fn bar() -> (i32, i32) {
+            let baz = 20i32;
+            foo(baz);
+        }
+        fn /*caret*/foo(baz: i32) -> (i32, i32) {
+            let qux = 10i32;
+            (baz, qux)
+        }
+    """, """
+        fn bar() -> (i32, i32) {
+            let baz = 20i32;
+            let qux = 10i32;
+            (baz, qux)
+        }
+
+    """)
 
     fun `test inline public function`() = doTest("""
-            fn main() {
-                foo();
-            }
-            pub fn /*caret*/foo() {
-                println!("test");
-                println!("test2");
-            }""", """
-            fn main() {
-                println!("test");
-                println!("test2");
-            }
-            """)
+        fn main() {
+            foo();
+        }
+        pub fn /*caret*/foo() {
+            println!("test");
+            println!("test2");
+        }
+    """, """
+        fn main() {
+            println!("test");
+            println!("test2");
+        }
+
+    """)
 
     fun `test inline method`() = doTest("""
-            struct S;
-            impl S {
-                fn foo() {
-                    S::bar();
-                }
+        struct S;
+        impl S {
+            fn foo() {
+                S::bar();
+            }
 
-                fn /*caret*/bar() {
-                    println!("test");
-                    println!("test2");
-                }
+            fn /*caret*/bar() {
+                println!("test");
+                println!("test2");
             }
-            """, """
-            struct S;
-            impl S {
-                fn foo() {
-                    println!("test");
-                    println!("test2");
-                }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo() {
+                println!("test");
+                println!("test2");
             }
-            """)
+        }
+    """)
 
     fun `test inline method with generics`() = doTest("""
-            struct S<T>(T);
-            impl<T> S<T> {
-                fn foo() {
-                    <S<T>>::bar();
-                }
+        struct S<T>(T);
+        impl<T> S<T> {
+            fn foo() {
+                <S<T>>::bar();
+            }
 
-                fn /*caret*/bar() {
-                    println!("Hello!");
-                }
+            fn /*caret*/bar() {
+                println!("Hello!");
             }
-            """, """
-            struct S<T>(T);
-            impl<T> S<T> {
-                fn foo() {
-                    println!("Hello!");
-                }
+        }
+    """, """
+        struct S<T>(T);
+        impl<T> S<T> {
+            fn foo() {
+                println!("Hello!");
             }
-            """)
+        }
+    """)
 
     fun `test inline method with self parameter`() = doTest("""
-            struct S;
-            impl S {
-                fn foo(self) {
-                    self.bar();
-                }
-
-                fn /*caret*/bar(self) {
-                    println!("test");
-                    println!("test2");
-                    self.test();
-                }
-
-                fn test(self) {
-                    println!("bla");
-                }
+        struct S;
+        impl S {
+            fn foo(self) {
+                self.bar();
             }
-            """, """
-            struct S;
-            impl S {
-                fn foo(self) {
-                    println!("test");
-                    println!("test2");
-                    self.test();
-                }
 
-                fn test(self) {
-                    println!("bla");
-                }
+            fn /*caret*/bar(self) {
+                println!("test");
+                println!("test2");
+                self.test();
             }
-            """)
+
+            fn test(self) {
+                println!("bla");
+            }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(self) {
+                println!("test");
+                println!("test2");
+                self.test();
+            }
+
+            fn test(self) {
+                println!("bla");
+            }
+        }
+    """)
 
     fun `test inline method with ref self parameter`() = doTest("""
-            struct S;
-            impl S {
-                fn foo(&self) {
-                    self.bar();
-                }
-
-                fn /*caret*/bar(&self) {
-                    println!("test");
-                    println!("test2");
-                    self.test();
-                }
-
-                fn test(&self) {
-                    println!("bla");
-                }
+        struct S;
+        impl S {
+            fn foo(&self) {
+                self.bar();
             }
-            """, """
-            struct S;
-            impl S {
-                fn foo(&self) {
-                    println!("test");
-                    println!("test2");
-                    self.test();
-                }
 
-                fn test(&self) {
-                    println!("bla");
-                }
+            fn /*caret*/bar(&self) {
+                println!("test");
+                println!("test2");
+                self.test();
             }
-            """)
+
+            fn test(&self) {
+                println!("bla");
+            }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self) {
+                println!("test");
+                println!("test2");
+                self.test();
+            }
+
+            fn test(&self) {
+                println!("bla");
+            }
+        }
+    """)
 
     fun `test inline method with ref mut self parameter`() = doTest("""
-            struct S;
-            impl S {
-                fn foo(&mut self) {
-                    self.bar();
-                }
-
-                fn /*caret*/bar(&mut self) {
-                    println!("test");
-                    println!("test2");
-                    self.test();
-                }
-
-                fn test(&mut self) {
-                    println!("bla");
-                }
+        struct S;
+        impl S {
+            fn foo(&mut self) {
+                self.bar();
             }
-            """, """
-            struct S;
-            impl S {
-                fn foo(&mut self) {
-                    println!("test");
-                    println!("test2");
-                    self.test();
-                }
 
-                fn test(&mut self) {
-                    println!("bla");
-                }
+            fn /*caret*/bar(&mut self) {
+                println!("test");
+                println!("test2");
+                self.test();
             }
-            """)
+
+            fn test(&mut self) {
+                println!("bla");
+            }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&mut self) {
+                println!("test");
+                println!("test2");
+                self.test();
+            }
+
+            fn test(&mut self) {
+                println!("bla");
+            }
+        }
+    """)
 
     fun `test inline method with self parameter and another parameter`() = doTest("""
-            struct S;
-            impl S {
-                fn foo(self) {
-                    let test = 10i32;
-                    self.bar(test);
-                }
-
-                fn /*caret*/bar(self, test: i32) {
-                    println!("{}", test);
-                    self.test();
-                }
-
-                fn test(self) {
-                    println!("bla");
-                }
+        struct S;
+        impl S {
+            fn foo(self) {
+                let test = 10i32;
+                self.bar(test);
             }
-            """, """
-            struct S;
-            impl S {
-                fn foo(self) {
-                    let test = 10i32;
-                    println!("{}", test);
-                    self.test();
-                }
 
-                fn test(self) {
-                    println!("bla");
-                }
+            fn /*caret*/bar(self, test: i32) {
+                println!("{}", test);
+                self.test();
             }
-            """)
+
+            fn test(self) {
+                println!("bla");
+            }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(self) {
+                let test = 10i32;
+                println!("{}", test);
+                self.test();
+            }
+
+            fn test(self) {
+                println!("bla");
+            }
+        }
+    """)
 
     fun `test inline method with public visibility`() = doTest("""
-            struct S;
-            impl S {
-                fn foo() {
-                    S::bar();
-                }
+        struct S;
+        impl S {
+            fn foo() {
+                S::bar();
+            }
 
-                pub fn /*caret*/bar() {
-                    println!("test");
-                    println!("test2");
-                }
+            pub fn /*caret*/bar() {
+                println!("test");
+                println!("test2");
             }
-            """, """
-            struct S;
-            impl S {
-                fn foo() {
-                    println!("test");
-                    println!("test2");
-                }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo() {
+                println!("test");
+                println!("test2");
             }
-            """)
+        }
+    """)
 
     fun `test inline trait method`() = doTest("""
-            struct S;
+        struct S;
 
-            trait Bar {
-                fn foo();
+        trait Bar {
+            fn foo();
+        }
+
+        impl Bar for S {
+            fn foo() {
+                S::bar();
             }
+        }
 
-            impl Bar for S {
-                fn foo() {
-                    S::bar();
-                }
+        impl S {
+            fn /*caret*/bar() {
+                println!("test");
+                println!("test2");
             }
+        }
+    """, """
+        struct S;
 
-            impl S {
-                fn /*caret*/bar() {
-                    println!("test");
-                    println!("test2");
-                }
+        trait Bar {
+            fn foo();
+        }
+
+        impl Bar for S {
+            fn foo() {
+                println!("test");
+                println!("test2");
             }
-            """, """
-            struct S;
+        }
 
-            trait Bar {
-                fn foo();
-            }
-
-            impl Bar for S {
-                fn foo() {
-                    println!("test");
-                    println!("test2");
-                }
-            }
-
-            impl S {}
-            """)
+        impl S {}
+    """)
 
     fun `test inline method in a trait`() = doTest("""
-            trait Foo {
-                fn foo(&self) {
-                    let b = 1;
-                    Self::bar(b);
-                }
+        trait Foo {
+            fn foo(&self) {
+                let b = 1;
+                Self::bar(b);
+            }
 
-                fn /*caret*/bar(b: i32) {
-                    println!("{}", b);
-                }
+            fn /*caret*/bar(b: i32) {
+                println!("{}", b);
             }
-            """, """
-            trait Foo {
-                fn foo(&self) {
-                    let b = 1;
-                    println!("{}", b);
-                }
+        }
+    """, """
+        trait Foo {
+            fn foo(&self) {
+                let b = 1;
+                println!("{}", b);
             }
-            """)
+        }
+    """)
 
     fun `test inline function with generic parameters`() = doTest("""
-            fn foo<A, B, C, D>(a: A, b: B, c: Option<C>, d: Option<D>) {
-                bar(a, b, c, d)
-            }
-            fn /*caret*/bar<A, B, C, D>(a: A, b: B, c: Option<C>, d: Option<D>) -> () {
-                a;
-                b;
-                c;
-                d;
-                println!("test")
-            }
-            """, """
-            fn foo<A, B, C, D>(a: A, b: B, c: Option<C>, d: Option<D>) {
-                a;
-                b;
-                c;
-                d;
-                println!("test")
-            }
-            """)
+        fn foo<A, B, C, D>(a: A, b: B, c: Option<C>, d: Option<D>) {
+            bar(a, b, c, d)
+        }
+        fn /*caret*/bar<A, B, C, D>(a: A, b: B, c: Option<C>, d: Option<D>) -> () {
+            a;
+            b;
+            c;
+            d;
+            println!("test")
+        }
+    """, """
+        fn foo<A, B, C, D>(a: A, b: B, c: Option<C>, d: Option<D>) {
+            a;
+            b;
+            c;
+            d;
+            println!("test")
+        }
+
+    """)
 
     fun `test inline function with generic parameters and return value`() = doTest("""
-            fn foo<T: Default>() -> T {
-                bar()
-            }
-            fn /*caret*/bar<T: Default>() -> T {
-                T::default()
-            }
-            """, """
-            fn foo<T: Default>() -> T {
-                T::default()
-            }
-            """)
+        fn foo<T: Default>() -> T {
+            bar()
+        }
+        fn /*caret*/bar<T: Default>() -> T {
+            T::default()
+        }
+    """, """
+        fn foo<T: Default>() -> T {
+            T::default()
+        }
+
+    """)
 
     fun `test inline function with generic parameters and return generic option value`() = doTest("""
-            fn foo<T: Default>() -> Option<T> {
-                bar()
-            }
-            fn /*caret*/bar<T: Default>() -> Option<T> {
-                Some(T::default())
-            }
-            """, """
-            fn foo<T: Default>() -> Option<T> {
-                Some(T::default())
-            }
-            """)
+        fn foo<T: Default>() -> Option<T> {
+            bar()
+        }
+        fn /*caret*/bar<T: Default>() -> Option<T> {
+            Some(T::default())
+        }
+    """, """
+        fn foo<T: Default>() -> Option<T> {
+            Some(T::default())
+        }
+
+    """)
 
     fun `test inline function with generic parameters and where clauses`() = doTest("""
-            trait Trait1 {}
-            trait Trait2 {}
-            trait Trait3 {}
-            fn foo<T, U>(t: T, u: U) where T: Trait1 + Trait2, U: Trait3 {
-                bar(t, u)
-            }
-            fn /*caret*/bar<T, U>(t: T, u: U) -> () where T: Trait1 + Trait2, U: Trait3 {
-                t;
-                u;
-                println!("test")
-            }
-            """, """
-            trait Trait1 {}
-            trait Trait2 {}
-            trait Trait3 {}
-            fn foo<T, U>(t: T, u: U) where T: Trait1 + Trait2, U: Trait3 {
-                t;
-                u;
-                println!("test")
-            }
-            """)
+        trait Trait1 {}
+        trait Trait2 {}
+        trait Trait3 {}
+        fn foo<T, U>(t: T, u: U) where T: Trait1 + Trait2, U: Trait3 {
+            bar(t, u)
+        }
+        fn /*caret*/bar<T, U>(t: T, u: U) -> () where T: Trait1 + Trait2, U: Trait3 {
+            t;
+            u;
+            println!("test")
+        }
+    """, """
+        trait Trait1 {}
+        trait Trait2 {}
+        trait Trait3 {}
+        fn foo<T, U>(t: T, u: U) where T: Trait1 + Trait2, U: Trait3 {
+            t;
+            u;
+            println!("test")
+        }
+
+    """)
 
     fun `test inline function with bounded generic parameters`() = doTest("""
-            trait Foo<T> {}
-            trait Bar<T> {}
-            trait Baz<T> {}
-            fn foo<T, F: Foo<T>, B: Bar<Baz<F>>>(b: B) {
-                bar(b);
-            }
-            fn /*caret*/bar<T, F: Foo<T>, B: Bar<Baz<F>>>(b: B) {
-                b;
-            }
-            """, """
-            trait Foo<T> {}
-            trait Bar<T> {}
-            trait Baz<T> {}
-            fn foo<T, F: Foo<T>, B: Bar<Baz<F>>>(b: B) {
-                b;
-            }
-            """)
+        trait Foo<T> {}
+        trait Bar<T> {}
+        trait Baz<T> {}
+        fn foo<T, F: Foo<T>, B: Bar<Baz<F>>>(b: B) {
+            bar(b);
+        }
+        fn /*caret*/bar<T, F: Foo<T>, B: Bar<Baz<F>>>(b: B) {
+            b;
+        }
+    """, """
+        trait Foo<T> {}
+        trait Bar<T> {}
+        trait Baz<T> {}
+        fn foo<T, F: Foo<T>, B: Bar<Baz<F>>>(b: B) {
+            b;
+        }
+
+    """)
 
     fun `test inline function with bounded generic parameters and where clauses`() = doTest("""
-            trait T1 {}
-            trait T2 {}
-            trait Foo<T> {}
-            trait Bar<T> {}
-            trait Baz<T> {}
-            fn foo<T: T1, U, F: Foo<T>, B>(b: B, u: U) where T: T2, B: Bar<F> + Baz<F> {
-                bar(b);
-                u;
-            }
-            fn /*caret*/bar<T: T1, F: Foo<T>, B>(b: B) where T: T2, B: Bar<F> + Baz<F> {
-                b;
-            }
-            """, """
-            trait T1 {}
-            trait T2 {}
-            trait Foo<T> {}
-            trait Bar<T> {}
-            trait Baz<T> {}
-            fn foo<T: T1, U, F: Foo<T>, B>(b: B, u: U) where T: T2, B: Bar<F> + Baz<F> {
-                b;
-                u;
-            }
-            """)
+        trait T1 {}
+        trait T2 {}
+        trait Foo<T> {}
+        trait Bar<T> {}
+        trait Baz<T> {}
+        fn foo<T: T1, U, F: Foo<T>, B>(b: B, u: U) where T: T2, B: Bar<F> + Baz<F> {
+            bar(b);
+            u;
+        }
+        fn /*caret*/bar<T: T1, F: Foo<T>, B>(b: B) where T: T2, B: Bar<F> + Baz<F> {
+            b;
+        }
+    """, """
+        trait T1 {}
+        trait T2 {}
+        trait Foo<T> {}
+        trait Bar<T> {}
+        trait Baz<T> {}
+        fn foo<T: T1, U, F: Foo<T>, B>(b: B, u: U) where T: T2, B: Bar<F> + Baz<F> {
+            b;
+            u;
+        }
+
+    """)
 
     fun `test inline function with passing primitive`() = doTest("""
-            fn foo() {
-                let i = 1;
-                let f = 1.1;
-                let b = true;
-                let c = 'c';
+        fn foo() {
+            let i = 1;
+            let f = 1.1;
+            let b = true;
+            let c = 'c';
 
-                bar(i, f, b, c);
+            bar(i, f, b, c);
 
-                println!("{}", i);
-                println!("{}", f);
-                println!("{}", b);
-                println!("{}", c);
-            }
-            fn /*caret*/bar(i: i32, f: f64, b: bool, c: char) {
-                println!("{}", i);
-                println!("{}", f);
-                println!("{}", b);
-                println!("{}", c);
-            }
-            """, """
-            fn foo() {
-                let i = 1;
-                let f = 1.1;
-                let b = true;
-                let c = 'c';
+            println!("{}", i);
+            println!("{}", f);
+            println!("{}", b);
+            println!("{}", c);
+        }
+        fn /*caret*/bar(i: i32, f: f64, b: bool, c: char) {
+            println!("{}", i);
+            println!("{}", f);
+            println!("{}", b);
+            println!("{}", c);
+        }
+    """, """
+        fn foo() {
+            let i = 1;
+            let f = 1.1;
+            let b = true;
+            let c = 'c';
 
-                println!("{}", i);
-                println!("{}", f);
-                println!("{}", b);
-                println!("{}", c);
+            println!("{}", i);
+            println!("{}", f);
+            println!("{}", b);
+            println!("{}", c);
 
-                println!("{}", i);
-                println!("{}", f);
-                println!("{}", b);
-                println!("{}", c);
-            }
-            """)
+            println!("{}", i);
+            println!("{}", f);
+            println!("{}", b);
+            println!("{}", c);
+        }
+
+    """)
 
     fun `test inline function with passing reference`() = doTest("""
-            fn foo() {
-                let s = "str";
-                bar(s);
-                println!("{}", s);
-            }
-            fn /*caret*/bar(s: &str) {
-                println!("{}", s);
-            }
-            """, """
-            fn foo() {
-                let s = "str";
-                println!("{}", s);
-                println!("{}", s);
-            }
-            """)
+        fn foo() {
+            let s = "str";
+            bar(s);
+            println!("{}", s);
+        }
+        fn /*caret*/bar(s: &str) {
+            println!("{}", s);
+        }
+    """, """
+        fn foo() {
+            let s = "str";
+            println!("{}", s);
+            println!("{}", s);
+        }
+
+    """)
 
     fun `test inline function with passing copy trait`() = doTest("""
-            #[derive(Copy, Clone, Debug)]
-            struct Copyable;
+        #[derive(Copy, Clone, Debug)]
+        struct Copyable;
 
-            fn foo() {
-                let copy = Copyable;
-                bar(copy);
-                println!("{:?}", copy);
-            }
-            fn /*caret*/bar(copy: Copyable) {
-                println!("{:?}", copy);
-            }
-            """, """
-            #[derive(Copy, Clone, Debug)]
-            struct Copyable;
+        fn foo() {
+            let copy = Copyable;
+            bar(copy);
+            println!("{:?}", copy);
+        }
+        fn /*caret*/bar(copy: Copyable) {
+            println!("{:?}", copy);
+        }
+    """, """
+        #[derive(Copy, Clone, Debug)]
+        struct Copyable;
 
-            fn foo() {
-                let copy = Copyable;
-                println!("{:?}", copy);
-                println!("{:?}", copy);
-            }
-            """)
+        fn foo() {
+            let copy = Copyable;
+            println!("{:?}", copy);
+            println!("{:?}", copy);
+        }
+
+    """)
 
     fun `test inline function with passing by &`() = doTest("""
-            fn f(a: &Vec<i32>) {}
+        fn f(a: &Vec<i32>) {}
 
-            fn foo() {
-                let vec = vec![1, 2, 3];
-                let vec2 = vec![1, 2, 3];
-                let vec3 = vec![1, 2, 3];
+        fn foo() {
+            let vec = vec![1, 2, 3];
+            let vec2 = vec![1, 2, 3];
+            let vec3 = vec![1, 2, 3];
 
-                bar(&vec, vec2, &vec3);
+            bar(&vec, vec2, &vec3);
 
-                println!("{}", vec.len());
-            }
-            fn /*caret*/bar(vec: &Vec<i32>, vec2: Vec<i32>, vec3: &Vec<i32>) {
-                println!("{}", vec.len());
-                println!("{}", vec2.len());
-                f(&vec3);
-            }
-            """, """
-            fn f(a: &Vec<i32>) {}
+            println!("{}", vec.len());
+        }
+        fn /*caret*/bar(vec: &Vec<i32>, vec2: Vec<i32>, vec3: &Vec<i32>) {
+            println!("{}", vec.len());
+            println!("{}", vec2.len());
+            f(&vec3);
+        }
+    """, """
+        fn f(a: &Vec<i32>) {}
 
-            fn foo() {
-                let vec = vec![1, 2, 3];
-                let vec2 = vec![1, 2, 3];
-                let vec3 = vec![1, 2, 3];
+        fn foo() {
+            let vec = vec![1, 2, 3];
+            let vec2 = vec![1, 2, 3];
+            let vec3 = vec![1, 2, 3];
 
-                println!("{}", vec.len());
-                println!("{}", vec2.len());
-                f(&vec3);
+            println!("{}", vec.len());
+            println!("{}", vec2.len());
+            f(&vec3);
 
-                println!("{}", vec.len());
-            }
-            """)
+            println!("{}", vec.len());
+        }
+
+    """)
 
     fun `test inline function with passing by &mut`() = doTest("""
-            fn foo() {
-                let mut vec = vec![1, 2, 3];
-                let mut vec2 = vec![1, 2, 3];
+        fn foo() {
+            let mut vec = vec![1, 2, 3];
+            let mut vec2 = vec![1, 2, 3];
 
-                bar(&mut vec, &mut vec2);
+            bar(&mut vec, &mut vec2);
 
-                println!("{}", vec.len());
-            }
-            fn /*caret*/bar(vec: &mut Vec<i32>, vec2: &mut Vec<i32>) {
-                vec.push(123);
-                vec2.push(123);
-            }
-            """, """
-            fn foo() {
-                let mut vec = vec![1, 2, 3];
-                let mut vec2 = vec![1, 2, 3];
+            println!("{}", vec.len());
+        }
+        fn /*caret*/bar(vec: &mut Vec<i32>, vec2: &mut Vec<i32>) {
+            vec.push(123);
+            vec2.push(123);
+        }
+    """, """
+        fn foo() {
+            let mut vec = vec![1, 2, 3];
+            let mut vec2 = vec![1, 2, 3];
 
-                vec.push(123);
-                vec2.push(123);
+            vec.push(123);
+            vec2.push(123);
 
-                println!("{}", vec.len());
-            }
-            """)
+            println!("{}", vec.len());
+        }
+
+    """)
 
     fun `test inline function with passing by mut`() = doTest("""
-            fn test(mut v: Vec<i32>) {}
-            fn test2(v: &mut Vec<i32>) {}
+        fn test(mut v: Vec<i32>) {}
+        fn test2(v: &mut Vec<i32>) {}
 
-            fn foo() {
-                let mut vec = vec![1, 2, 3];
-                let mut vec2 = vec![1, 2, 3];
+        fn foo() {
+            let mut vec = vec![1, 2, 3];
+            let mut vec2 = vec![1, 2, 3];
 
-                bar(vec, &mut vec2);
-            }
-            fn /*caret*/bar(mut vec: Vec<i32>, mut vec2: &mut Vec<i32>) {
-                test(vec);
-                test2(&mut vec2);
-            }
-            """, """
-            fn test(mut v: Vec<i32>) {}
-            fn test2(v: &mut Vec<i32>) {}
+            bar(vec, &mut vec2);
+        }
+        fn /*caret*/bar(mut vec: Vec<i32>, mut vec2: &mut Vec<i32>) {
+            test(vec);
+            test2(&mut vec2);
+        }
+    """, """
+        fn test(mut v: Vec<i32>) {}
+        fn test2(v: &mut Vec<i32>) {}
 
-            fn foo() {
-                let mut vec = vec![1, 2, 3];
-                let mut vec2 = vec![1, 2, 3];
+        fn foo() {
+            let mut vec = vec![1, 2, 3];
+            let mut vec2 = vec![1, 2, 3];
 
-                test(vec);
-                test2(&mut vec2);
-            }
-            """)
+            test(vec);
+            test2(&mut vec2);
+        }
+
+    """)
 
     fun `test extract a complex function as example`() = doTest("""
         fn parse_test(call: Call) -> JsResult<JsValue> {
@@ -729,7 +764,6 @@ class RsInlineFunctionTest : RsTestBase() {
             RenderTask(file, test).schedule(callback);
             Ok(JsNull::new().upcast())
         }
-
         fn /*caret*/foo(call: _) -> (usize, _, _) {
             let scope = call.scope;
             let test = call.arguments.require(scope, 0)?.check::<JsInteger>()?.value() as usize;
@@ -738,7 +772,7 @@ class RsInlineFunctionTest : RsTestBase() {
             let file = get_file_or_return_null!(file).clone();
             (test, callback, file)
         }
-        """, """
+    """, """
         fn parse_test(call: Call) -> JsResult<JsValue> {
             let scope = call.scope;
             let test = call.arguments.require(scope, 0)?.check::<JsInteger>()?.value() as usize;
@@ -768,11 +802,11 @@ class RsInlineFunctionTest : RsTestBase() {
             Ok(JsNull::new().upcast())
         }
 
-        """)
+    """)
 
-    private fun doTest(@Language("Rust") code: String,
-                       @Language("Rust") excepted: String) {
-        checkByText(code, excepted) {
+    private fun doTest(@Language("Rust") before: String,
+                       @Language("Rust") after: String) {
+        checkByText(before.trimIndent(), after.trimIndent()) {
             myFixture.performEditorAction("Inline")
         }
     }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsInlineValueTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsInlineValueTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring
+
+import junit.framework.Assert
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+import org.rust.ide.refactoring.inlineValue.InlineValueMode
+import org.rust.ide.refactoring.inlineValue.withMockInlineValueMode
+
+class RsInlineValueTest : RsTestBase() {
+    fun `test cannot inline decl without expression`() = checkError("""
+        fn foo() {
+            let a/*caret*/;
+        }
+    """, "cannot inline variable without an expression")
+
+    fun `test cannot inline const without expression`() = checkError("""
+        fn foo() {
+            const /*caret*/a: u32;
+        }
+    """, "cannot inline constant without an expression")
+
+    fun `test inline variable`() = doTest("""
+        fn foo() {
+            let /*caret*/a = 5;
+            let b = a;
+        }
+    """, """
+        fn foo() {
+            let b = 5;
+        }
+    """)
+
+    fun `test inline constant`() = doTest("""
+        const /*caret*/CONST: u32 = 5;
+
+        fn foo() {
+            let a = CONST;
+        }
+    """, """
+        fn foo() {
+            let a = 5;
+        }
+    """)
+
+    fun `test inline all usages`() = doTest("""
+        fn foo() {
+            let /*caret*/a = 5;
+            let b = a;
+            let c = a;
+        }
+    """, """
+        fn foo() {
+            let b = 5;
+            let c = 5;
+        }
+    """)
+
+    fun `test inline all usages from reference`() = doTest("""
+        fn foo() {
+            let a = 5;
+            let b = /*caret*/a;
+            let c = a;
+        }
+    """, """
+        fn foo() {
+            let b = 5;
+            let c = 5;
+        }
+    """)
+
+    fun `test inline single usage only`() = doTest("""
+        fn foo() {
+            let a = 5;
+            let b = a/*caret*/;
+            let c = a;
+        }
+    """, """
+        fn foo() {
+            let a = 5;
+            let b = 5;
+            let c = a;
+        }
+    """, mode = InlineValueMode.InlineThisOnly)
+
+    fun `test inline and keep original`() = doTest("""
+        fn foo() {
+            let /*caret*/a = 5;
+            let b = a;
+            let c = a;
+        }
+    """, """
+        fn foo() {
+            let a = 5;
+            let b = 5;
+            let c = 5;
+        }
+    """, mode = InlineValueMode.InlineAllAndKeepOriginal)
+
+    fun `test inline usage inside expression`() = doTest("""
+        fn foo() {
+            let /*caret*/a = 5;
+            let b = 2 * a + 1 + a;
+        }
+    """, """
+        fn foo() {
+            let b = 2 * 5 + 1 + 5;
+        }
+    """)
+
+    fun `test inline function call`() = doTest("""
+        fn bar() -> u32 { 0 }
+
+        fn foo() {
+            let /*caret*/a = bar();
+            let b = a + a;
+        }
+    """, """
+        fn bar() -> u32 { 0 }
+
+        fn foo() {
+            let b = bar() + bar();
+        }
+    """)
+
+    fun `test inline struct literal`() = doTest("""
+        struct S {
+            a: u32,
+            b: u64
+        }
+
+        fn foo() {
+            let /*caret*/a = S { a: 0, b: 0 };
+            let b = a;
+        }
+    """, """
+        struct S {
+            a: u32,
+            b: u64
+        }
+
+        fn foo() {
+            let b = S { a: 0, b: 0 };
+        }
+    """)
+
+    fun `test inline method call`() = doTest("""
+        struct S {
+            a: u32,
+            b: u64
+        }
+
+        impl S {
+            fn foo(&self) {}
+        }
+
+        fn foo() {
+            let /*caret*/a = S { a: 0, b: 0 };
+            let b = a.foo();
+        }
+    """, """
+        struct S {
+            a: u32,
+            b: u64
+        }
+
+        impl S {
+            fn foo(&self) {}
+        }
+
+        fn foo() {
+            let b = S { a: 0, b: 0 }.foo();
+        }
+    """)
+
+    private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String,
+                       mode: InlineValueMode = InlineValueMode.InlineAllAndRemoveOriginal) {
+        withMockInlineValueMode(mode) {
+            checkEditorAction(before, after, "Inline")
+        }
+    }
+
+    private fun checkError(@Language("Rust") code: String, errorMessage: String) {
+        try {
+            checkEditorAction(code, code, "Inline")
+            error("no error found, expected $errorMessage")
+        } catch (e: Exception) {
+            Assert.assertEquals(e.message, errorMessage)
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds support for inlining variables and constants. Right now the original variable is inlined and removed. If it does not have any usages, an error is reported. In Kotlin, there is an additional dialog that asks if the original expression should be kept or not, should I also include it here?

I wasn't sure which test infrastructure to use as it's not a classic refactoring, so I added some manual test functions, but it's not a lot of code.

~Functions could also be inlined, should that be handled inside this refactoring?~

Fixes: https://github.com/intellij-rust/intellij-rust/issues/1095