### PR TITLE
Improve `RemoveTypeArguments`

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveTypeArguments.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveTypeArguments.kt
@@ -8,29 +8,38 @@ package org.rust.ide.inspections.fixes
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.openapi.project.Project
-import org.rust.lang.core.psi.RsBaseType
-import org.rust.lang.core.psi.RsCallExpr
-import org.rust.lang.core.psi.RsMethodCall
-import org.rust.lang.core.psi.RsPathExpr
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
 
-class RemoveTypeArguments : LocalQuickFix {
+class RemoveTypeArguments(
+    private val startIndex: Int,
+    private val endIndex: Int
+) : LocalQuickFix {
 
-    override fun getName() = "Remove all type arguments"
-    override fun getFamilyName() = name
+    override fun getFamilyName() = "Remove redundant type arguments"
 
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
         val element = descriptor.psiElement as? RsElement ?: return
-        val typeArgumentList = when (element) {
-            is RsMethodCall -> element.typeArgumentList
-            is RsCallExpr -> (element.expr as RsPathExpr?)?.path?.typeArgumentList
-            is RsBaseType -> element.path?.typeArgumentList
+        when (element) {
+            is RsBaseType ->
+                element.path?.typeArgumentList
+            is RsMethodCall ->
+                element.typeArgumentList
+            is RsCallExpr ->
+                (element.expr as? RsPathExpr)?.path?.typeArgumentList
             else -> null
-        } ?: return
+        }?.removeTypeParameters() ?: return
+    }
 
-        val lifetime = typeArgumentList.lifetimeList.size
-        if (lifetime == 0) {
-            typeArgumentList.delete()
+    private fun RsTypeArgumentList.removeTypeParameters() {
+        if (lifetimeList.size > 0) return
+
+        if (startIndex == 0) delete()
+        else {
+            val startElement = typeReferenceList[startIndex - 1].nextSibling
+            val endElement = typeReferenceList[endIndex - 1]
+
+            deleteChildRange(startElement, endElement)
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -999,7 +999,7 @@ sealed class RsDiagnostic(
     class WrongNumberOfTypeArguments(
         element: PsiElement,
         private val errorText: String,
-        val fixes: List<LocalQuickFix> = emptyList()
+        private val fixes: List<LocalQuickFix>
     ) : RsDiagnostic(element) {
         override fun prepare(): PreparedAnnotation {
             return PreparedAnnotation(

--- a/src/test/kotlin/org/rust/ide/inspections/RsWrongTypeArgumentsNumberInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsWrongTypeArgumentsNumberInspectionTest.kt
@@ -26,6 +26,7 @@ class RsWrongTypeArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWrongTy
             ok1: Foo1<u32>,
             ok2: Foo2<u32, bool>,
             ok3: Foo2to3<u8, u8>,
+            ok4: Foo2to3<u8, u8, u8>
         }
 
         struct Err {
@@ -103,7 +104,7 @@ class RsWrongTypeArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWrongTy
         }
     """)
 
-    fun `test fix no type arguments struct`() = checkFixByText("Remove all type arguments", """
+    fun `test fix no type arguments struct`() = checkFixByText("Remove redundant type arguments", """
         struct Foo0;
         impl <error>Foo0/*caret*/<u8></error> {}
     """, """
@@ -111,7 +112,7 @@ class RsWrongTypeArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWrongTy
         impl Foo0 {}
     """)
 
-    fun `test fix no type arguments method`() = checkFixByText("Remove all type arguments", """
+    fun `test fix no type arguments method`() = checkFixByText("Remove redundant type arguments", """
         struct Test;
 
         impl Test {
@@ -135,7 +136,7 @@ class RsWrongTypeArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWrongTy
         }
     """)
 
-    fun `test fix no type function call`() = checkFixByText("Remove all type arguments", """
+    fun `test fix no type function call`() = checkFixByText("Remove redundant type arguments", """
         fn foo() {}
 
         fn main() {
@@ -161,6 +162,30 @@ class RsWrongTypeArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWrongTy
         fn foo() {}
         fn main() {
             (foo)();
+        }
+    """)
+
+    fun `test fix struct with multiple type arguments`() = checkFixByText("Remove redundant type arguments", """
+        struct Foo<T, U> { t: T, u: U }
+        struct Err {
+            err1: <error descr="Wrong number of type arguments: expected 2, found 4 [E0107]">Foo<u32, i32, u32, u32/*caret*/></error>,
+        }
+    """, """
+        struct Foo<T, U> { t: T, u: U }
+        struct Err {
+            err1: Foo<u32, i32>,
+        }
+    """)
+
+    fun `test fix struct with default type arguments`() = checkFixByText("Remove redundant type arguments", """
+        struct Foo<T, U = i32> { t: T, u: U }
+        struct Err {
+            err1: <error descr="Wrong number of type arguments: expected at most 2, found 4 [E0107]">Foo<u32, i32, u32, u32/*caret*/></error>,
+        }
+    """, """
+        struct Foo<T, U = i32> { t: T, u: U }
+        struct Err {
+            err1: Foo<u32, i32>,
         }
     """)
 }


### PR DESCRIPTION
Improve quick repair to remove redundant content instead of all content.