### PR TITLE
INSP: Fix non_exhaustive false positive in same crate

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -65,6 +65,7 @@ lundibundi
 madisp
 majecty
 maraisr
+MarkDrobnak
 matklad
 mbStavola
 mcarlin


### PR DESCRIPTION
Fixes #4896 by checking if the enum was declared in the same crate or not. I'm not sure if using `crateRoot` is the right approach, so feedback is welcome!

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->
