### PR TITLE
CI: improve release actions script

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -55,9 +55,9 @@ jobs:
                   git config --local user.email "action@github.com"
                   git config --local user.name "GitHub Action"
 
-#            - name: Update changelog link
-#              if: github.event_name == 'repository_dispatch' && github.event.action == 'stable-release'
-#              run: python scripts/update-changelog-link.py --token ${{ secrets.GITHUB_TOKEN }}
+            - name: Update changelog link
+              if: github.event_name == 'repository_dispatch' && github.event.action == 'stable-release' && github.event.client_payload.update_changelog
+              run: python scripts/update-changelog-link.py --token ${{ secrets.GITHUB_TOKEN }}
 
     get-channel:
         runs-on: ubuntu-latest

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -79,10 +79,21 @@ Release branches are used to build beta and stable plugin builds.
 
 Most of release actions can be done automatically via GitHub workflow. 
 There is `scripts/release-actions.py` script to trigger them.
-Syntax: `python scripts/release-actions.py --token github_token --command release_command`.
+Syntax: `python release-actions.py release_command --token github_token`.
+Alternatively, you can provide `IR_GITHUB_TOKEN` environment variable to provide github token.
+It allows you to omit `--token` option.
 
 See [instruction](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line)
 how to create personal github token. Note, it should have `repo` scope.
+
+Note, we use [pipenv](https://pipenv.pypa.io/en/latest/) to manage python version, dependencies and virtual environment.
+See [instruction](https://pipenv.pypa.io/en/latest/install/#installing-pipenv) how to install it.
+To run any command, just execute the following:
+```
+cd scripts
+pipenv install # to install dependencies
+pipenv run python release-actions.py release_command --token github_token # to run script in virtual environment
+```
 
 Available commands:
 * `release-branch` - creates new release branch `release-%release_version%` from `master` one
@@ -95,6 +106,8 @@ Note, the corresponding workflow is triggered on schedule, so you don't usually 
 * `stable-release` - updates changelog link in `plugin/src/main/resources/META-INF/plugin.xml`, commits changes, 
 pushes into `master` and cherry-picks the corresponding changes into release branch.
 After that, it builds the plugin from release branch and publishes it into `stable` channel on [Marketplace].
+
+Note, each command may provide additional options. Add `--help` option to get actual option list.  
 
 Release notes live in [intellij-rust.github.io](https://github.com/intellij-rust/intellij-rust.github.io).
 To write notes, run `./changelog.py`. It goes thorough all pull requests from the corresponding milestone and 

--- a/scripts/Pipfile
+++ b/scripts/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 
 [packages]
 requests = "*"
+click = "*"
 
 [requires]
 python_version = "3.7"

--- a/scripts/release-actions.py
+++ b/scripts/release-actions.py
@@ -2,10 +2,13 @@ import functools
 
 import click
 import requests
+from typing import Dict, Any, Optional
 
 
-def send_github_event(token: str, event_name: str):
-    payload = {"event_type": event_name}
+def send_github_event(token: str, event_name: str, client_payload: Optional[Dict[str, Any]] = None):
+    if client_payload is None:
+        client_payload = {}
+    payload = {"event_type": event_name, "client_payload": client_payload}
     headers = {"Authorization": f"token {token}",
                "Accept": "application/vnd.github.v3+json"}
     response = requests.post("https://api.github.com/repos/intellij-rust/intellij-rust/dispatches",
@@ -48,9 +51,10 @@ def beta_release(token: str):
 
 
 @cli.command(help="Build plugin and publish it to stable channel")
+@click.option("--update-changelog/--no-update-changelog", default=True, help="Update changelog link in plugin.xml")
 @token_option
-def stable_release(token: str):
-    send_github_event(token, "stable-release")
+def stable_release(token: str, update_changelog: bool):
+    send_github_event(token, "stable-release", {"update_changelog": update_changelog})
 
 
 cli.add_command(release_branch)


### PR DESCRIPTION
* use [click](https://click.palletsprojects.com/) library instead of argparse
* update command syntax. Now you don't need to pass `--command` flag to specify a command
* github token can be provided via `IR_GITHUB_TOKEN` environment variable
* added `--no-update-changelog` option for `stable-release` command to omit changelog link update. Useful for releases with hotfixes