### PR TITLE
ANN: check if the `main` function exists [E0601]

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspection.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.ext.childrenOfType
+import org.rust.lang.core.psi.ext.queryAttributes
+import org.rust.lang.utils.RsDiagnostic
+import org.rust.lang.utils.addToHolder
+
+class RsMainFunctionNotFoundInspection : RsLocalInspectionTool() {
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor? {
+        return object : RsVisitor() {
+            override fun visitFile(file: PsiFile) {
+                if (file is RsFile) {
+                    val target = file.cargoTarget ?: return
+                    val crateName = if ((target.isBin || target.isExampleBin) && file.isCrateRoot) target.name else return
+
+                    if (file.queryAttributes.hasAttribute("no_main")) return
+                    if (file.childrenOfType<RsFunction>().lastOrNull { fn -> "main" == fn.name } != null) return
+
+                    RsDiagnostic.MainFunctionNotFound(file, crateName).addToHolder(holder)
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AddMainFnFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AddMainFnFix.kt
@@ -1,0 +1,24 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RsPsiFactory
+
+class AddMainFnFix(file: PsiElement) : LocalQuickFixAndIntentionActionOnPsiElement(file) {
+
+    override fun getFamilyName(): String = "Add `fn main()`"
+
+    override fun getText(): String = familyName
+
+    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
+        file.add(RsPsiFactory(project).createFunction("fn main() { }"))
+    }
+}

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -22,6 +22,7 @@ import org.rust.ide.inspections.RsExperimentalChecksInspection
 import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.ide.inspections.RsTypeCheckInspection
 import org.rust.ide.inspections.checkMatch.Pattern
+import org.rust.ide.inspections.fixes.AddMainFnFix
 import org.rust.ide.inspections.fixes.AddRemainingArmsFix
 import org.rust.ide.inspections.fixes.AddWildcardArmFix
 import org.rust.ide.refactoring.implementMembers.ImplementMembersFix
@@ -1205,6 +1206,17 @@ sealed class RsDiagnostic(
             )
         }
     }
+
+    class MainFunctionNotFound(file: RsFile, private val crateName: String) : RsDiagnostic(file) {
+        override fun prepare(): PreparedAnnotation {
+            return PreparedAnnotation(
+                ERROR,
+                E0601,
+                "`main` function not found in crate `$crateName`",
+                fixes = listOf(AddMainFnFix(element))
+            )
+        }
+    }
 }
 
 enum class RsErrorCode {
@@ -1214,7 +1226,7 @@ enum class RsErrorCode {
     E0308, E0322, E0328, E0379, E0384,
     E0403, E0404, E0407, E0415, E0424, E0426, E0428, E0433, E0449, E0451, E0463,
     E0518, E0562, E0569, E0583, E0586, E0594,
-    E0603, E0614, E0616, E0618, E0624, E0658, E0666, E0667, E0688, E0695,
+    E0601, E0603, E0614, E0616, E0618, E0624, E0658, E0666, E0667, E0688, E0695,
     E0704, E0732;
 
     val code: String

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -535,6 +535,11 @@
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RsLivenessInspection"/>
 
+        <localInspection language="Rust" groupName="Rust"
+                         displayName="Main function not found"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.rust.ide.inspections.RsMainFunctionNotFoundInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsMainFunctionNotFound.html
+++ b/src/main/resources/inspectionDescriptions/RsMainFunctionNotFound.html
@@ -1,0 +1,1 @@
+Checks if the <code>main</code> function exists in the binary crates.

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -27,6 +27,7 @@ import org.rust.cargo.project.workspace.StandardLibrary
 import org.rust.cargo.toolchain.RustToolchain
 import org.rust.cargo.util.DownloadResult
 import java.nio.file.Paths
+import java.util.*
 
 object DefaultDescriptor : RustProjectDescriptorBase()
 
@@ -63,14 +64,18 @@ open class RustProjectDescriptorBase : LightProjectDescriptor() {
             CargoWorkspaceData(packages, emptyMap()), CfgOptions.DEFAULT)
     }
 
-    protected fun testCargoPackage(contentRoot: String, name: String = "test-package") = CargoWorkspaceData.Package(
+    protected fun testCargoPackage(contentRoot: String, name: String = "test-package") = Package(
         id = "$name 0.0.1",
         contentRootUrl = contentRoot,
         name = name,
         version = "0.0.1",
         targets = listOf(
             Target("$contentRoot/main.rs", name, TargetKind.Bin, edition = Edition.EDITION_2015, doctest = true),
-            Target("$contentRoot/lib.rs", name, TargetKind.Lib(LibKind.LIB), edition = Edition.EDITION_2015, doctest = true)
+            Target("$contentRoot/lib.rs", name, TargetKind.Lib(LibKind.LIB), edition = Edition.EDITION_2015, doctest = true),
+            Target("$contentRoot/bin/a.rs", name, TargetKind.Bin, edition = Edition.EDITION_2015, doctest = true),
+            Target("$contentRoot/bench/a.rs", name, TargetKind.Bench, edition = Edition.EDITION_2015, doctest = true),
+            Target("$contentRoot/example/a.rs", name, TargetKind.ExampleBin, edition = Edition.EDITION_2015, doctest = true),
+            Target("$contentRoot/example-lib/a.rs", name, TargetKind.ExampleLib(EnumSet.of(LibKind.LIB)), edition = Edition.EDITION_2015, doctest = true)
         ),
         source = null,
         origin = PackageOrigin.WORKSPACE,
@@ -124,10 +129,11 @@ open class WithCustomStdlibRustProjectDescriptor(
         StandardLibrary.fromPath(path)
     }
 
-    override val skipTestReason: String? get() {
-        if (stdlib == null) return "No stdlib"
-        return delegate.skipTestReason
-    }
+    override val skipTestReason: String?
+        get() {
+            if (stdlib == null) return "No stdlib"
+            return delegate.skipTestReason
+        }
 
     override fun testCargoProject(module: Module, contentRoot: String): CargoWorkspace =
         delegate.testCargoProject(module, contentRoot).withStdlib(stdlib!!, CfgOptions.DEFAULT)

--- a/src/test/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspectionTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import org.rust.ProjectDescriptor
+import org.rust.WithDependencyRustProjectDescriptor
+
+class RsMainFunctionNotFoundInspectionTest : RsInspectionsTestBase(RsMainFunctionNotFoundInspection::class) {
+
+    fun `test does not exist main function`() = checkByFileTree("""
+    //- main.rs
+        <error descr="`main` function not found in crate `test-package` [E0601]"> /*caret*/ </error>
+    """)
+
+    fun `test has nested main function`() = checkByFileTree("""
+    //- main.rs
+        <error descr="`main` function not found in crate `test-package` [E0601]">fn foo() {
+             fn main() {
+                /*caret*/
+             }
+        }</error>
+    """)
+
+    fun `test exists no_main attr`() = checkByFileTree("""
+    //- main.rs
+        #![no_main]/*caret*/
+    """)
+
+    fun `test exists main function`() = checkByFileTree("""
+    //- main.rs
+       fn main() {
+            /*caret*/
+       }
+    """)
+
+    fun `test that the main function does not exist in the custom bin`() = checkByFileTree("""
+    //- bin/a.rs
+        <error descr="`main` function not found in crate `test-package` [E0601]"> /*caret*/ </error>
+    """)
+
+    fun `test for nested main function in custom bin`() = checkByFileTree("""
+    //- bin/a.rs
+        <error descr="`main` function not found in crate `test-package` [E0601]">fn foo() {
+            fn main() {
+                /*caret*/
+            }
+        }</error>
+    """)
+
+    fun `test that no_main attr exists in the custom bin`() = checkByFileTree("""
+    //- bin/a.rs
+        #![no_main]
+        /*caret*/
+    """)
+
+    fun `test main function in custom binTest main function in custom bin`() = checkByFileTree("""
+    //- bin/a.rs
+        fn main() {
+            /*caret*/
+        }
+    """)
+
+    fun `test that the main function does not exist in the custom example bin`() = checkByFileTree("""
+    //- example/a.rs
+        <error descr="`main` function not found in crate `test-package` [E0601]"> /*caret*/ </error>
+    """)
+
+    fun `test for nested main function in custom example bin`() = checkByFileTree("""
+    //- example/a.rs
+        <error descr="`main` function not found in crate `test-package` [E0601]">fn foo() {
+            fn main() {
+                /*caret*/
+            }
+        }</error>
+    """)
+
+    fun `test that no_main attr exists in the custom example bin`() = checkByFileTree("""
+    //- example/a.rs
+        #![no_main]
+        /*caret*/
+    """)
+
+    fun `test main function in custom example bin`() = checkByFileTree("""
+    //- example/a.rs
+        fn main() {
+            /*caret*/
+        }
+    """)
+
+    fun `test that the main function does not exist in the bench`() = checkByFileTree("""
+    //- bench/a.rs
+        fn foo() { /*caret*/ }
+    """)
+
+    fun `test that the main function does not exist in the example lib`() = checkByFileTree("""
+    //- example-lib/a.rs
+        fn foo() { /*caret*/ }
+    """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test that the main function does not exist in the external binary crate`() = checkByFileTree("""
+    //- dep-lib/lib.rs
+        fn foo() { /*caret*/ }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/inspections/fixes/AddMainFnFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/fixes/AddMainFnFixTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.RsMainFunctionNotFoundInspection
+
+class AddMainFnFixTest : RsInspectionsTestBase(RsMainFunctionNotFoundInspection::class) {
+
+    fun `test fix`() = checkFixByFileTree("Add `fn main()`", """
+    //- main.rs
+        <error descr="`main` function not found in crate `test-package` [E0601]"> /*caret*/ </error>
+    """, """
+    //- main.rs
+        /*caret*/fn main() {}
+    """)
+
+    fun `test the fix in a custom bin`() = checkFixByFileTree("Add `fn main()`", """
+    //- bin/a.rs
+        <error descr="`main` function not found in crate `test-package` [E0601]"> /*caret*/ </error>
+    """, """
+    //- bin/a.rs
+        /*caret*/fn main() {}
+    """)
+
+    fun `test the fix in a custom example bin`() = checkFixByFileTree("Add `fn main()`", """
+    //- example/a.rs
+        <error descr="`main` function not found in crate `test-package` [E0601]"> /*caret*/ </error>
+    """, """
+    //- example/a.rs
+        /*caret*/fn main() {}
+    """)
+}


### PR DESCRIPTION
Closed #5477

<del>There is currently no way to quickly test `[[bin]]`, so I did not add a test. ;(</del>