### PR TITLE
REF: Support reexports in move single file refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMovePathHelper.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMovePathHelper.kt
@@ -1,0 +1,96 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.move.common
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.psi.util.parentOfType
+import org.rust.ide.inspections.import.RsImportHelper
+import org.rust.lang.core.psi.RsCodeFragmentFactory
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.RsUseItem
+import org.rust.lang.core.psi.ext.*
+
+/**
+ * Consider we move item with name `foo` from `mod1` to `mod2`
+ * before move we should check visibility conflicts (whether we can update all references to moved item after move)
+ * so for each reference (RsPath) we should find replacement (new RsPath)
+ * this helper checks possible new paths in the following order:
+ * 1. find any public item in `mod2`, find path to it using RsImportHelper, and replace path last segment
+ * 2. find path to `mod2` using RsImportHelper, and add last segment (with moved item name)
+ *
+ * It will not work if there is glob reexport for items in `mod2` and `mod2` has no public items
+ * But it is somewhat strange case (why someone would reexport everything from `mod2` if there are no pub items?)
+ * This can be fixed by adding new item to `mod2` in such cases
+ * (Though it is unclear how to use writeAction only for small amount of time and not for all preprocess usages stage)
+ */
+class RsMovePathHelper(private val project: Project, private val mod: RsMod) {
+
+    private val codeFragmentFactory: RsCodeFragmentFactory = RsCodeFragmentFactory(project)
+    private val existingPublicItem: RsQualifiedNamedElement? = findExistingPublicItem()
+
+    private fun findExistingPublicItem(): RsQualifiedNamedElement? =
+        mod.childrenOfType<RsQualifiedNamedElement>()
+            .filter { it is RsVisibilityOwner && it.visibility == RsVisibility.Public && it.name != null }
+            // reference search works faster for not common names
+            .sortedByDescending { it.name?.length }
+            .firstOrNull { item ->
+                // have to filter existing items which are publicly reexported (not glob)
+                // because for our new item we can't use that (not glob) reexport
+                val itemUsages = ReferencesSearch.search(item, GlobalSearchScope.projectScope(project))
+                itemUsages.none { it.element.parentOfType<RsUseItem>()?.vis != null }
+            }
+
+    fun findPathAfterMove(context: RsElement, element: RsQualifiedNamedElement): RsPath? {
+        val elementName = (element as? RsFile)?.modName ?: element.name ?: return null
+        if (context.containingModOrSelf == mod) return codeFragmentFactory.createPath(elementName, context)
+
+        return findPathAfterMoveUsingOtherItemInMod(context, elementName)
+            ?: findPathAfterMoveUsingMod(context, elementName)
+    }
+
+    private fun findPathAfterMoveUsingOtherItemInMod(context: RsElement, elementName: String): RsPath? {
+        val secondaryElement = existingPublicItem ?: return null
+        val secondaryElementName = secondaryElement.name ?: return null
+        val secondaryPathText = findPath(context, secondaryElement)
+            ?: return null
+        val secondaryPath = codeFragmentFactory.createPath(secondaryPathText, context) ?: return null
+        if (secondaryPath.reference!!.resolve() != secondaryElement) return null
+
+        if (!secondaryPathText.endsWith("::$secondaryElementName")) return null
+        val pathText = secondaryPathText.removeSuffix(secondaryElementName) + elementName
+        return codeFragmentFactory.createPath(pathText, context)
+    }
+
+    private fun findPathAfterMoveUsingMod(context: RsElement, elementName: String): RsPath? {
+        val modPath = findPath(context, mod) ?: return null
+        val elementPath = "$modPath::$elementName"
+        return codeFragmentFactory.createPath(elementPath, context)
+    }
+
+    // basically it returns `element.crateRelativePath`
+    // but if `element.crateRelativePath`, is inaccessible in context (e.g. because of reexports),
+    // then tries to find other path using RsImportHelper
+    private fun findPath(context: RsElement, element: RsQualifiedNamedElement): String? {
+        val pathSimple = findPathSimple(context, element)
+        if (pathSimple != null) return pathSimple
+
+        val path = RsImportHelper.findPath(context, element) ?: return null
+        return convertPathToRelativeIfPossible(context.containingModOrSelf, path)
+    }
+
+    // returns `element.crateRelativePath` if it is accessible from `context`
+    private fun findPathSimple(context: RsElement, element: RsQualifiedNamedElement): String? {
+        val contextMod = context.containingModOrSelf
+        val pathText = element.qualifiedNameRelativeTo(contextMod) ?: return null
+        val path = codeFragmentFactory.createPath(pathText, context) ?: return null
+        return if (path.resolvesToAndAccessible(element)) path.text else null
+    }
+}
+
+private val RsElement.containingModOrSelf: RsMod get() = (this as? RsMod) ?: containingMod

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileReexportTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileReexportTest.kt
@@ -5,11 +5,9 @@
 
 package org.rust.ide.refactoring.move
 
-import org.junit.Ignore
 import org.rust.MockEdition
 import org.rust.cargo.project.workspace.CargoWorkspace
 
-@Ignore
 @MockEdition(CargoWorkspace.Edition.EDITION_2018)
 class RsMoveFileReexportTest : RsMoveFileTestBase() {
     override val dataPath = "org/rust/ide/refactoring/move/fixtures/"
@@ -65,8 +63,8 @@ class RsMoveFileReexportTest : RsMoveFileTestBase() {
         """
     //- main.rs
         mod inner {
-            mod mod1;
-            mod mod2;
+            mod mod1;  // private
+            pub mod mod2;
             pub use mod1::*;
         }
         mod usages {
@@ -82,14 +80,13 @@ class RsMoveFileReexportTest : RsMoveFileTestBase() {
     """, """
     //- main.rs
         mod inner {
-            mod mod1;
-            mod mod2;
+            mod mod1;  // private
+            pub mod mod2;
             pub use mod1::*;
-            pub use mod2::foo;
         }
         mod usages {
             fn test() {
-                crate::inner::foo::func();
+                crate::inner::mod2::foo::func();
             }
         }
     //- inner/mod1/mod.rs
@@ -117,6 +114,7 @@ class RsMoveFileReexportTest : RsMoveFileTestBase() {
     //- inner/mod1/mod.rs
         pub mod foo;
     //- inner/mod2/mod.rs
+        pub fn mod2_func() {}
     //- inner/mod1/foo.rs
         pub fn func() {}
     """, """
@@ -134,6 +132,8 @@ class RsMoveFileReexportTest : RsMoveFileTestBase() {
     //- inner/mod1/mod.rs
     //- inner/mod2/mod.rs
         pub mod foo;
+
+        pub fn mod2_func() {}
     //- inner/mod2/foo.rs
         pub fn func() {}
     """)

--- a/src/test/resources/org/rust/ide/refactoring/move/fixtures/grandparent_module_under_reexport/after/lib.rs
+++ b/src/test/resources/org/rust/ide/refactoring/move/fixtures/grandparent_module_under_reexport/after/lib.rs
@@ -1,11 +1,12 @@
 pub mod inner1 {
+    pub use inner2::*;
+
     mod inner2 {
-        mod inner3 {
+        pub mod inner3 {
             pub mod mod1;
             pub mod mod2;
         }
     }
-    pub use inner2::*;
 }
 mod usages {
     fn test1a() {

--- a/src/test/resources/org/rust/ide/refactoring/move/fixtures/grandparent_module_under_reexport/before/lib.rs
+++ b/src/test/resources/org/rust/ide/refactoring/move/fixtures/grandparent_module_under_reexport/before/lib.rs
@@ -1,11 +1,12 @@
 pub mod inner1 {
+    pub use inner2::*;
+
     mod inner2 {
-        mod inner3 {
+        pub mod inner3 {
             pub mod mod1;
             pub mod mod2;
         }
     }
-    pub use inner2::*;
 }
 mod usages {
     fn test1a() {


### PR DESCRIPTION
Improve updating references to moved file when it is under reexport

We use `RsImportHelper` for finding new paths. Please see comment for `RsMovePathHelper` for detailed description.

---

Some background from #5181:

> Currently move refactoring doesn't work well with reexports (examples are in `RsMoveFileReexportTest`). Main issue is that we replace old paths to moved file with absolute path to new moved file location (`crateRelativePath`). It can cause visibility problems if for example new parent module is private, but grandparent module publicly reexports all items from parent module (I think those kinds of reexports are common in libraries). This issue will be solved in future PRs by using `RsImportHelper` for finding new paths.