### PR TITLE
RUN: add --ignored to command line for ignored tests

### DIFF
--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/TestRunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/TestRunConfigurationProducerTest.kt
@@ -332,4 +332,11 @@ class TestRunConfigurationProducerTest : RunConfigurationProducerTestBase() {
             ?.toPsiDirectory(project)!!
         checkOnFiles(packageRoot)
     }
+
+    fun `test ignored test is run with ignored option`() {
+        testProject {
+            lib("foo", "src/lib.rs", "#[ignore] #[test] fn test_foo() { /*caret*/assert!(true); }").open()
+        }
+        checkOnLeaf()
+    }
 }

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ignored_test_is_run_with_ignored_option.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ignored_test_is_run_with_ignored_option.xml
@@ -1,0 +1,15 @@
+<configurations>
+  <configuration name="Test test_foo" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="channel" value="DEFAULT" />
+    <option name="command" value="test --package test-package --lib test_foo -- --ignored --exact" />
+    <option name="allFeatures" value="false" />
+    <option name="nocapture" value="false" />
+    <option name="emulateTerminal" value="false" />
+    <option name="backtrace" value="SHORT" />
+    <option name="workingDirectory" value="file:///my-crate" />
+    <envs />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</configurations>


### PR DESCRIPTION
This PR adds `--ignored` to test run configurations created from a single test function that has a
`#[ignore]` attribute. I think that this behaviour is reasonable, i.e. if I test a directory or multiple files, ignored tests are ignored, but if I explicitly want to run a single ignored test, it will not be ignored.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5045