### PR TITLE
TYPE: Fix run icon display

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoExecutableRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoExecutableRunConfigurationProducer.kt
@@ -56,7 +56,7 @@ class CargoExecutableRunConfigurationProducer : CargoRunConfigurationProducer() 
     companion object {
         fun isMainFunction(fn: RsFunction): Boolean {
             val ws = fn.cargoWorkspace ?: return false
-            return fn.name == "main" && findBinaryTarget(ws, fn.containingFile.virtualFile) != null
+            return fn.parent is RsFile && fn.name == "main" && findBinaryTarget(ws, fn.containingFile.virtualFile) != null
         }
 
         private fun findBinaryTarget(location: Location<*>): ExecutableTarget? {


### PR DESCRIPTION
The run icon is not displayed when `main function` is declared in a nested method.