### PR TITLE
FMT: add line break after opening brace in struct blocks

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFix.kt
@@ -45,10 +45,12 @@ class CreateStructFieldFromConstructorFix(
             val rBrace = structBlockFields.rbrace ?: return
             ensureTrailingComma(structBlockFields.namedFieldDeclList)
             structBlockFields.addBefore(psiFactory.createBlockFields(pub, fieldName, fieldType).children.first(), rBrace)
+            structBlockFields.addBefore(psiFactory.createComma(), rBrace)
         } else {
             val identifier = struct.identifier ?: return
-            struct.addAfter(psiFactory.createBlockFields(pub, fieldName, fieldType), identifier)
+            val blockFields = struct.addAfter(psiFactory.createBlockFields(pub, fieldName, fieldType), identifier) as RsBlockFields
             struct.semicolon?.delete()
+            blockFields.addBefore(psiFactory.createComma(), blockFields.rbrace)
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/impl/spacing.kt
@@ -159,6 +159,14 @@ fun Block.computeSpacing(child1: Block?, child2: Block, ctx: RsFmtContext): Spac
             elementType2 == RustParserDefinition.EOL_COMMENT ->
                 return createKeepingFirstColumnSpacing(1, Int.MAX_VALUE, true, ctx.commonSettings.KEEP_BLANK_LINES_IN_CODE)
 
+        // struct S {\n a: u32...
+            elementType1 == LBRACE &&
+                child2.node?.treeParent?.elementType == BLOCK_FIELDS &&
+                psi2.parent?.parent is RsStructItem &&
+                elementType2 != RBRACE -> {
+                return createSpacing(1, 1, 1, true, 0)
+            }
+
         // #[attr]\n<comment>\n => #[attr] <comment>\n etc.
             psi1 is RsOuterAttr && psi2 is PsiComment
             -> return createSpacing(1, 1, 0, true, 0)

--- a/src/main/kotlin/org/rust/ide/formatter/processors/RsTrailingCommaFormatProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/processors/RsTrailingCommaFormatProcessor.kt
@@ -14,8 +14,10 @@ import com.intellij.psi.impl.source.codeStyle.PostFormatProcessorHelper
 import org.rust.ide.formatter.impl.CommaList
 import org.rust.ide.formatter.rust
 import org.rust.lang.RsLanguage
+import org.rust.lang.core.psi.RsBlockFields
 import org.rust.lang.core.psi.RsElementTypes.COMMA
 import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsStructItem
 import org.rust.lang.core.psi.ext.elementType
 import org.rust.lang.core.psi.ext.getNextNonCommentSibling
 import org.rust.lang.core.psi.ext.getPrevNonCommentSibling
@@ -83,7 +85,12 @@ fun CommaList.addTrailingCommaForElement(list: PsiElement): Boolean {
     )
     if (!trailingSpace.contains('\n')) return false
 
-    if (list.firstChild.getNextNonCommentSibling() == lastElement) return false
+    if (list.firstChild.getNextNonCommentSibling() == lastElement) {
+        // allow trailing comma only for struct block fields with a single item
+        if (list !is RsBlockFields || list.parent !is RsStructItem) {
+            return false
+        }
+    }
 
     val comma = RsPsiFactory(list.project).createComma()
     list.addAfter(comma, lastElement)

--- a/src/main/kotlin/org/rust/ide/refactoring/convertStruct/RsConvertToNamedFieldsProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/convertStruct/RsConvertToNamedFieldsProcessor.kt
@@ -127,10 +127,14 @@ class RsConvertToNamedFieldsProcessor(
             }
         }
 
-        //convert struct itself
+        val isStruct = element is RsStructItem
+        val separator = if (isStruct) ",\n" else ", "
+        val end = if (isStruct && types.isNotEmpty()) ",\n}" else "}"
+
+        // convert struct itself
         val fields = types
             .zip(newNames)
-            .joinToString(",\n", "{", "}") { (tupleField, name) ->
+            .joinToString(separator, "{", end) { (tupleField, name) ->
                 "${tupleField.text.substring(0, tupleField.typeReference.startOffsetInParent)}$name: ${tupleField.typeReference.text}"
             }
         val newFieldsElement = rsPsiFactory.createStruct("struct A$fields")

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFixTest.kt
@@ -106,7 +106,9 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
             }
         }
     """, """
-        struct S { foo: i32 }
+        struct S {
+            foo: i32
+        }
 
         impl S {
             fn new(foo: i32) -> S {
@@ -152,7 +154,9 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
             }
         }
     """, """
-        struct S { foo: i32 }
+        struct S {
+            foo: i32
+        }
 
         impl S {
             fn new() -> S {
@@ -171,7 +175,9 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
             }
         }
     """, """
-        struct S { foo: i32 }
+        struct S {
+            foo: i32
+        }
 
         impl S {
             fn new(bar: i32) -> S {
@@ -223,7 +229,9 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
         }
     """, """
         mod foo {
-            pub struct S { pub foo: i32 }
+            pub struct S {
+                pub foo: i32
+            }
         }
 
         impl foo::S {
@@ -246,7 +254,9 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
             }
         }
     """, """
-        struct S { x: i32 }
+        struct S {
+            x: i32
+        }
 
         impl S {
             fn new((x, y): (i32, i64)) -> S {

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/CreateStructFieldFromConstructorFixTest.kt
@@ -25,7 +25,7 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
     """, """
         struct S {
             foo: String,
-            bar: i32
+            bar: i32,
         }
 
         impl S {
@@ -52,7 +52,7 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
     """, """
         struct S {
             foo: String,
-            baz: i64
+            baz: i64,
         }
 
         impl S {
@@ -82,7 +82,7 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
         struct S {
             foo: String,
             baz: i64,
-            bar: i32
+            bar: i32,
         }
 
         impl S {
@@ -107,7 +107,7 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
         }
     """, """
         struct S {
-            foo: i32
+            foo: i32,
         }
 
         impl S {
@@ -132,7 +132,7 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
         }
     """, """
         struct S {
-            foo: i32
+            foo: i32,
         }
 
         impl S {
@@ -155,7 +155,7 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
         }
     """, """
         struct S {
-            foo: i32
+            foo: i32,
         }
 
         impl S {
@@ -176,7 +176,7 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
         }
     """, """
         struct S {
-            foo: i32
+            foo: i32,
         }
 
         impl S {
@@ -202,7 +202,7 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
     """, """
         mod foo {
             pub struct S {
-                pub foo: i32
+                pub foo: i32,
             }
         }
 
@@ -230,7 +230,7 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
     """, """
         mod foo {
             pub struct S {
-                pub foo: i32
+                pub foo: i32,
             }
         }
 
@@ -255,7 +255,7 @@ class CreateStructFieldFromConstructorFixTest : RsAnnotatorTestBase(RsExpression
         }
     """, """
         struct S {
-            x: i32
+            x: i32,
         }
 
         impl S {

--- a/src/test/kotlin/org/rust/ide/formatter/RsFormatterLineBreaksTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsFormatterLineBreaksTest.kt
@@ -242,7 +242,9 @@ class RsFormatterLineBreaksTest : RsFormatterTestBase() {
                 92};
         }
     """, """
-        struct S1 { f: i32 }
+        struct S1 {
+            f: i32
+        }
 
         struct S2 {
             f: i32

--- a/src/test/kotlin/org/rust/ide/formatter/RsFormatterLineBreaksTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsFormatterLineBreaksTest.kt
@@ -243,15 +243,15 @@ class RsFormatterLineBreaksTest : RsFormatterTestBase() {
         }
     """, """
         struct S1 {
-            f: i32
+            f: i32,
         }
 
         struct S2 {
-            f: i32
+            f: i32,
         }
 
         struct S3 {
-            f: i32
+            f: i32,
         }
 
         enum E {

--- a/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsFormatterTest.kt
@@ -325,7 +325,7 @@ class RsFormatterTest : RsFormatterTestBase() {
 
         struct Foo<T> where T: for<'a,
                                    'b> Fn(i32) -> () {
-            a: T
+            a: T,
         }
     """, """
         struct Foo<T: A + B + 'c,
@@ -336,7 +336,7 @@ class RsFormatterTest : RsFormatterTestBase() {
 
         struct Foo<T> where T: for<'a,
             'b> Fn(i32) -> () {
-            a: T
+            a: T,
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/formatter/RsTrailingCommaFormatProcessorTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsTrailingCommaFormatProcessorTest.kt
@@ -40,9 +40,13 @@ class RsTrailingCommaFormatProcessorTest : RsFormatterTestBase() {
     """, """
         use foo::{bar, baz};
 
-        struct S1 { a: i32 }
+        struct S1 {
+            a: i32
+        }
 
-        struct S2 { a: i32 }
+        struct S2 {
+            a: i32,
+        }
 
         enum E {
             V { a: i32 }

--- a/src/test/kotlin/org/rust/ide/formatter/RsTrailingCommaFormatProcessorTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsTrailingCommaFormatProcessorTest.kt
@@ -41,7 +41,7 @@ class RsTrailingCommaFormatProcessorTest : RsFormatterTestBase() {
         use foo::{bar, baz};
 
         struct S1 {
-            a: i32
+            a: i32,
         }
 
         struct S2 {

--- a/src/test/kotlin/org/rust/ide/refactoring/ConvertToNamedFieldsRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/ConvertToNamedFieldsRefactoringTest.kt
@@ -138,7 +138,9 @@ class ConvertToNamedFieldsRefactoringTest : RsTestBase() {
             let s = S::new(0);
         }
     """, """
-        struct S { _0: u32 }
+        struct S {
+            _0: u32
+        }
 
         impl S {
             fn new(v: u32) -> S {
@@ -167,7 +169,9 @@ class ConvertToNamedFieldsRefactoringTest : RsTestBase() {
         }
     """, """
         mod nested {
-            pub struct S { pub _0: u32 }
+            pub struct S {
+                pub _0: u32
+            }
 
             impl S {
                 pub fn new(v: u32) -> S {

--- a/src/test/kotlin/org/rust/ide/refactoring/ConvertToNamedFieldsRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/ConvertToNamedFieldsRefactoringTest.kt
@@ -16,7 +16,7 @@ class ConvertToNamedFieldsRefactoringTest : RsTestBase() {
     """, """
         struct Test {
             pub _0: usize,
-            _1: i32
+            _1: i32,
         }
     """)
 
@@ -36,10 +36,7 @@ class ConvertToNamedFieldsRefactoringTest : RsTestBase() {
         }
     """, """
         enum Test{
-            A {
-                _0: usize,
-                _1: i32
-            },
+            A { _0: usize, _1: i32 },
             B
         }
         fn main(){
@@ -59,7 +56,7 @@ class ConvertToNamedFieldsRefactoringTest : RsTestBase() {
     """, """
         struct Test {
             pub _0: usize,
-            _1: i32
+            _1: i32,
         }
 
         fn main (){
@@ -81,7 +78,7 @@ class ConvertToNamedFieldsRefactoringTest : RsTestBase() {
     """, """
         struct Test {
             pub _0: usize,
-            _1: i32
+            _1: i32,
         }
 
         fn main (){
@@ -108,7 +105,7 @@ class ConvertToNamedFieldsRefactoringTest : RsTestBase() {
     """, """
         struct Test {
             pub _0: usize,
-            _1: i32
+            _1: i32,
         }
 
         fn main (){
@@ -139,7 +136,7 @@ class ConvertToNamedFieldsRefactoringTest : RsTestBase() {
         }
     """, """
         struct S {
-            _0: u32
+            _0: u32,
         }
 
         impl S {
@@ -170,7 +167,7 @@ class ConvertToNamedFieldsRefactoringTest : RsTestBase() {
     """, """
         mod nested {
             pub struct S {
-                pub _0: u32
+                pub _0: u32,
             }
 
             impl S {
@@ -191,7 +188,9 @@ class ConvertToNamedFieldsRefactoringTest : RsTestBase() {
         struct Test/*caret*/<T>(T) where T: Trait ;
     """, """
         trait Trait {}
-        struct Test<T> where T: Trait { _0: T }
+        struct Test<T> where T: Trait {
+            _0: T,
+        }
     """)
 
     fun `test where clause (multiline)`() = doAvailableTest("""
@@ -208,7 +207,7 @@ class ConvertToNamedFieldsRefactoringTest : RsTestBase() {
                 T2: Trait
         {
             _0: T1,
-            _1: T2
+            _1: T2,
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractEnumVariantTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractEnumVariantTest.kt
@@ -42,7 +42,11 @@ class RsExtractEnumVariantTest : RsTestBase() {
             V2
         }
     """, """
-        struct /*caret*/V1 { pub a: i32, pub b: bool, pub c: String }
+        struct /*caret*/V1 {
+            pub a: i32,
+            pub b: bool,
+            pub c: String
+        }
 
         enum A {
             V1(V1),
@@ -107,7 +111,9 @@ class RsExtractEnumVariantTest : RsTestBase() {
     """, """
         trait Trait {}
 
-        struct /*caret*/V1<T> where T: Trait { pub a: T }
+        struct /*caret*/V1<T> where T: Trait {
+            pub a: T
+        }
 
         enum A<T> where T: Trait {
             V1(V1<T>),
@@ -133,7 +139,10 @@ class RsExtractEnumVariantTest : RsTestBase() {
             fn foo() -> S;
         }
 
-        struct /*caret*/V1<'a, 'b, T, S, U> where 'a: 'b, T: Trait + Trait2<S, Item=U> { pub a: &'a T, pub b: &'b T }
+        struct /*caret*/V1<'a, 'b, T, S, U> where 'a: 'b, T: Trait + Trait2<S, Item=U> {
+            pub a: &'a T,
+            pub b: &'b T
+        }
 
         enum A<'a, 'b, 'c, T, S, R, U> where T: Trait + Trait2<S, Item=U>, R: Trait, 'a: 'b + 'c, 'b: 'c {
             V1(V1<'a, 'b, T, S, U>),
@@ -146,7 +155,10 @@ class RsExtractEnumVariantTest : RsTestBase() {
             /*caret*/V1 { a: &'a u32, b: &'b u32 }
         }
     """, """
-        struct /*caret*/V1<'a: 'b, 'b: 'a> { pub a: &'a u32, pub b: &'b u32 }
+        struct /*caret*/V1<'a: 'b, 'b: 'a> {
+            pub a: &'a u32,
+            pub b: &'b u32
+        }
 
         enum A<'a: 'b, 'b: 'a> {
             V1(V1<'a, 'b>)
@@ -198,7 +210,9 @@ class RsExtractEnumVariantTest : RsTestBase() {
     """, """
         trait Trait {}
 
-        struct /*caret*/V1<const T: usize> { pub a: [u32; T] }
+        struct /*caret*/V1<const T: usize> {
+            pub a: [u32; T]
+        }
 
         enum A<const T: usize> {
             V1(V1<{ T }>),
@@ -309,7 +323,11 @@ class RsExtractEnumVariantTest : RsTestBase() {
             }
         }
     """, """
-        struct /*caret*/V1 { pub x: u32, pub y: bool, pub z: i32 }
+        struct /*caret*/V1 {
+            pub x: u32,
+            pub y: bool,
+            pub z: i32
+        }
 
         enum A {
             V1(V1)
@@ -340,7 +358,11 @@ class RsExtractEnumVariantTest : RsTestBase() {
             let v = E::V1 { x: 42, y: 50 /* comment */, z: 3 };
         }
     """, """
-        struct /*caret*/V1 { pub x: i32, pub y: u32, pub z: u32 }
+        struct /*caret*/V1 {
+            pub x: i32,
+            pub y: u32,
+            pub z: u32
+        }
 
         enum E {
             V1(V1),
@@ -384,7 +406,11 @@ class RsExtractEnumVariantTest : RsTestBase() {
             V2
         }
     """, """
-        pub struct /*caret*/V1 { pub a: i32, pub b: bool, pub c: String }
+        pub struct /*caret*/V1 {
+            pub a: i32,
+            pub b: bool,
+            pub c: String
+        }
 
         pub enum A {
             V1(V1),
@@ -398,7 +424,12 @@ class RsExtractEnumVariantTest : RsTestBase() {
             V2
         }
     """, """
-        struct /*caret*/V1 { /* comment */pub a: i32, /* comment */pub b: i32, pub c: i32, pub(crate) d: i32 }
+        struct /*caret*/V1 {
+            /* comment */pub a: i32,
+            /* comment */pub b: i32,
+            pub c: i32,
+            pub(crate) d: i32
+        }
 
         enum A {
             V1(V1),
@@ -437,7 +468,10 @@ class RsExtractEnumVariantTest : RsTestBase() {
         use a::{E, V1};
 
         mod a {
-            pub struct /*caret*/V1 { pub x: i32, pub y: i32 }
+            pub struct /*caret*/V1 {
+                pub x: i32,
+                pub y: i32
+            }
 
             pub enum E {
                 V1(V1),
@@ -502,7 +536,10 @@ class RsExtractEnumVariantTest : RsTestBase() {
         struct V1;
 
         mod a {
-            pub struct /*caret*/V1 { pub x: i32, pub y: i32 }
+            pub struct /*caret*/V1 {
+                pub x: i32,
+                pub y: i32
+            }
 
             pub enum E {
                 V1(V1),
@@ -525,7 +562,10 @@ class RsExtractEnumVariantTest : RsTestBase() {
     """, """
         #[derive(Debug, Clone)]
         #[repr(C)]
-        pub struct /*caret*/V1 { pub x: i32, pub y: i32 }
+        pub struct /*caret*/V1 {
+            pub x: i32,
+            pub y: i32
+        }
 
         #[derive(Debug, Clone)]
         #[repr(C)]
@@ -542,7 +582,10 @@ class RsExtractEnumVariantTest : RsTestBase() {
             V2
         }
     """, """
-        pub struct /*caret*/V1 { pub x: i32, pub y: i32 }
+        pub struct /*caret*/V1 {
+            pub x: i32,
+            pub y: i32
+        }
 
         #[attr]
         pub enum E {

--- a/src/test/resources/org/rust/ide/formatter/fixtures/expressions_after.rs
+++ b/src/test/resources/org/rust/ide/formatter/fixtures/expressions_after.rs
@@ -1,5 +1,5 @@
 struct S {
-    foo: bool
+    foo: bool,
 }
 
 fn main() {

--- a/src/test/resources/org/rust/ide/formatter/fixtures/issue569_after.rs
+++ b/src/test/resources/org/rust/ide/formatter/fixtures/issue569_after.rs
@@ -1,7 +1,7 @@
 struct Foo<T> where T: for<'a, 'b> Fn(i32) -> () {
-    a: T
+    a: T,
 }
 
 struct Client<'a> {
-    auth_fn: &'a for<'b> Fn(&'b str) -> Cow<'a, str>
+    auth_fn: &'a for<'b> Fn(&'b str) -> Cow<'a, str>,
 }

--- a/src/test/resources/org/rust/ide/formatter/fixtures/items_after.rs
+++ b/src/test/resources/org/rust/ide/formatter/fixtures/items_after.rs
@@ -34,5 +34,5 @@ struct Foo<T> where T: for<
     'a,
     'b
 > Fn(i32) -> () {
-    a: T
+    a: T,
 }


### PR DESCRIPTION
This PR forces a line break after a left opening brace in struct blocks. This should bring struct block formatting closer to rustfmt. This change will probably ruin more tests, let's see what CI says.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5282