### PR TITLE
Add postfix templates for Result/Option wrapping

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -85,6 +85,7 @@ oleg-semenov
 orium
 ortem
 osialr
+panstromek
 pasa
 pavel-v-chernykh
 pcholakov

--- a/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
@@ -33,7 +33,10 @@ class RsPostfixTemplateProvider : PostfixTemplateProvider {
         IterPostfixTemplate("iter", this),
         IterPostfixTemplate("for", this),
         PrintlnPostfixTemplate(this),
-        DbgPostfixTemplate(this)
+        DbgPostfixTemplate(this),
+        OkPostfixTemplate(this),
+        SomePostfixTemplate(this),
+        ErrPostfixTemplate(this)
     )
 
     override fun getTemplates(): Set<PostfixTemplate> = templates

--- a/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
@@ -122,6 +122,30 @@ class DbgPostfixTemplate(provider: RsPostfixTemplateProvider) :
     override fun getElementToRemove(expr: PsiElement): PsiElement = expr
 }
 
+class OkPostfixTemplate(provider: RsPostfixTemplateProvider) :
+    StringBasedPostfixTemplate("ok", "Ok(expr)", RsTopMostInScopeSelector(), provider) {
+
+    override fun getTemplateString(element: PsiElement): String = "Ok(${element.text})"
+
+    override fun getElementToRemove(expr: PsiElement): PsiElement = expr
+}
+
+class SomePostfixTemplate(provider: RsPostfixTemplateProvider) :
+    StringBasedPostfixTemplate("some", "Some(expr)", RsTopMostInScopeSelector(), provider) {
+
+    override fun getTemplateString(element: PsiElement): String = "Some(${element.text})"
+
+    override fun getElementToRemove(expr: PsiElement): PsiElement = expr
+}
+
+class ErrPostfixTemplate(provider: RsPostfixTemplateProvider) :
+    StringBasedPostfixTemplate("err", "Err(expr)", RsTopMostInScopeSelector(), provider) {
+
+    override fun getTemplateString(element: PsiElement): String = "Err(${element.text})"
+
+    override fun getElementToRemove(expr: PsiElement): PsiElement = expr
+}
+
 private val RsExpr.isIntoIterator: Boolean
     get() = implLookup.isIntoIterator(type)
 

--- a/src/main/resources/postfixTemplates/ErrPostfixTemplate/after.rs.template
+++ b/src/main/resources/postfixTemplates/ErrPostfixTemplate/after.rs.template
@@ -1,3 +1,3 @@
-fn foo(slice: &[i32]) {
-    let first = Err(slice[0])
+fn foo(number: i32) -> Result<(), i32> {
+    Err(number)
 }

--- a/src/main/resources/postfixTemplates/ErrPostfixTemplate/after.rs.template
+++ b/src/main/resources/postfixTemplates/ErrPostfixTemplate/after.rs.template
@@ -1,0 +1,3 @@
+fn foo(slice: &[i32]) {
+    let first = Err(slice[0])
+}

--- a/src/main/resources/postfixTemplates/ErrPostfixTemplate/before.rs.template
+++ b/src/main/resources/postfixTemplates/ErrPostfixTemplate/before.rs.template
@@ -1,3 +1,3 @@
-fn foo(slice: &[i32]) {
-    let first = <spot>slice[0]</spot>.err
+fn foo(number: i32) -> Result<(), i32> {
+    <spot>number</spot>.err
 }

--- a/src/main/resources/postfixTemplates/ErrPostfixTemplate/before.rs.template
+++ b/src/main/resources/postfixTemplates/ErrPostfixTemplate/before.rs.template
@@ -1,0 +1,3 @@
+fn foo(slice: &[i32]) {
+    let first = <spot>slice[0]</spot>.err
+}

--- a/src/main/resources/postfixTemplates/ErrPostfixTemplate/description.html
+++ b/src/main/resources/postfixTemplates/ErrPostfixTemplate/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Surrounds the expression with <code>Err(..)</code>.
+</body>
+</html>

--- a/src/main/resources/postfixTemplates/OkPostfixTemplate/after.rs.template
+++ b/src/main/resources/postfixTemplates/OkPostfixTemplate/after.rs.template
@@ -1,0 +1,3 @@
+fn foo(slice: &[i32]) {
+    let first = Ok(slice[0])
+}

--- a/src/main/resources/postfixTemplates/OkPostfixTemplate/after.rs.template
+++ b/src/main/resources/postfixTemplates/OkPostfixTemplate/after.rs.template
@@ -1,3 +1,3 @@
-fn foo(slice: &[i32]) {
-    let first = Ok(slice[0])
+fn foo(number: i32) -> Result<i32, ()> {
+    Ok(number)
 }

--- a/src/main/resources/postfixTemplates/OkPostfixTemplate/before.rs.template
+++ b/src/main/resources/postfixTemplates/OkPostfixTemplate/before.rs.template
@@ -1,3 +1,3 @@
-fn foo(slice: &[i32]) {
-    let first = <spot>slice[0]</spot>.ok
+fn foo(number: i32) -> Result<i32, ()> {
+    <spot>number</spot>.ok
 }

--- a/src/main/resources/postfixTemplates/OkPostfixTemplate/before.rs.template
+++ b/src/main/resources/postfixTemplates/OkPostfixTemplate/before.rs.template
@@ -1,0 +1,3 @@
+fn foo(slice: &[i32]) {
+    let first = <spot>slice[0]</spot>.ok
+}

--- a/src/main/resources/postfixTemplates/OkPostfixTemplate/description.html
+++ b/src/main/resources/postfixTemplates/OkPostfixTemplate/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Surrounds the expression with <code>Ok(..)</code>.
+</body>
+</html>

--- a/src/main/resources/postfixTemplates/SomePostfixTemplate/after.rs.template
+++ b/src/main/resources/postfixTemplates/SomePostfixTemplate/after.rs.template
@@ -1,3 +1,3 @@
-fn foo(slice: &[i32]) {
-    let first = Some(slice[0])
+fn foo(number: i32) -> Option<i32> {
+    Some(number)
 }

--- a/src/main/resources/postfixTemplates/SomePostfixTemplate/after.rs.template
+++ b/src/main/resources/postfixTemplates/SomePostfixTemplate/after.rs.template
@@ -1,0 +1,3 @@
+fn foo(slice: &[i32]) {
+    let first = Some(slice[0])
+}

--- a/src/main/resources/postfixTemplates/SomePostfixTemplate/before.rs.template
+++ b/src/main/resources/postfixTemplates/SomePostfixTemplate/before.rs.template
@@ -1,3 +1,3 @@
-fn foo(slice: &[i32]) {
-    let first = <spot>slice[0]</spot>.some
+fn foo(number: i32) -> Option<i32> {
+    <spot>number</spot>.some
 }

--- a/src/main/resources/postfixTemplates/SomePostfixTemplate/before.rs.template
+++ b/src/main/resources/postfixTemplates/SomePostfixTemplate/before.rs.template
@@ -1,0 +1,3 @@
+fn foo(slice: &[i32]) {
+    let first = <spot>slice[0]</spot>.some
+}

--- a/src/main/resources/postfixTemplates/SomePostfixTemplate/description.html
+++ b/src/main/resources/postfixTemplates/SomePostfixTemplate/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Surrounds the expression with <code>Some(..)</code>.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/template/postfix/ErrPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/ErrPostfixTemplateTest.kt
@@ -8,12 +8,12 @@ package org.rust.ide.template.postfix
 class ErrPostfixTemplateTest : RsPostfixTemplateTest(ErrPostfixTemplate(RsPostfixTemplateProvider())) {
 
     fun `test expr`() = doTest("""
-        fn foo(slice: &[i32]) {
-            let first = slice[0].err/*caret*/;
+        fn foo(number: i32) -> Result<(), i32> {
+            number.err/*caret*/
         }
     """, """
-        fn foo(slice: &[i32]) {
-            let first = Err(slice[0])/*caret*/;
+        fn foo(number: i32) -> Result<(), i32> {
+            Err(number)
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/template/postfix/ErrPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/ErrPostfixTemplateTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.template.postfix
+
+class ErrPostfixTemplateTest : RsPostfixTemplateTest(ErrPostfixTemplate(RsPostfixTemplateProvider())) {
+
+    fun `test expr`() = doTest("""
+        fn foo(slice: &[i32]) {
+            let first = slice[0].err/*caret*/;
+        }
+    """, """
+        fn foo(slice: &[i32]) {
+            let first = Err(slice[0])/*caret*/;
+        }
+    """)
+
+    fun `test not expr`() = doTestNotApplicable("""
+        fn main() {
+            println!("Hello!");.err/*caret*/
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/template/postfix/OkPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/OkPostfixTemplateTest.kt
@@ -8,12 +8,12 @@ package org.rust.ide.template.postfix
 class OkPostfixTemplateTest : RsPostfixTemplateTest(OkPostfixTemplate(RsPostfixTemplateProvider())) {
 
     fun `test expr`() = doTest("""
-        fn foo(slice: &[i32]) {
-            let first = slice[0].ok/*caret*/;
+        fn foo(number: i32) -> Result<i32, ()> {
+            number.ok/*caret*/
         }
     """, """
-        fn foo(slice: &[i32]) {
-            let first = Ok(slice[0])/*caret*/;
+        fn foo(number: i32) -> Result<i32, ()> {
+            Ok(number)
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/template/postfix/OkPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/OkPostfixTemplateTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.template.postfix
+
+class OkPostfixTemplateTest : RsPostfixTemplateTest(OkPostfixTemplate(RsPostfixTemplateProvider())) {
+
+    fun `test expr`() = doTest("""
+        fn foo(slice: &[i32]) {
+            let first = slice[0].ok/*caret*/;
+        }
+    """, """
+        fn foo(slice: &[i32]) {
+            let first = Ok(slice[0])/*caret*/;
+        }
+    """)
+
+    fun `test not expr`() = doTestNotApplicable("""
+        fn main() {
+            println!("Hello!");.ok/*caret*/
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/template/postfix/SomePostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/SomePostfixTemplateTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.template.postfix
+
+class SomePostfixTemplateTest : RsPostfixTemplateTest(SomePostfixTemplate(RsPostfixTemplateProvider())) {
+
+    fun `test expr`() = doTest("""
+        fn foo(slice: &[i32]) {
+            let first = slice[0].some/*caret*/;
+        }
+    """, """
+        fn foo(slice: &[i32]) {
+            let first = Some(slice[0])/*caret*/;
+        }
+    """)
+
+    fun `test not expr`() = doTestNotApplicable("""
+        fn main() {
+            println!("Hello!");.some/*caret*/
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/template/postfix/SomePostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/SomePostfixTemplateTest.kt
@@ -8,12 +8,12 @@ package org.rust.ide.template.postfix
 class SomePostfixTemplateTest : RsPostfixTemplateTest(SomePostfixTemplate(RsPostfixTemplateProvider())) {
 
     fun `test expr`() = doTest("""
-        fn foo(slice: &[i32]) {
-            let first = slice[0].some/*caret*/;
+        fn foo(number: i32) -> Option<i32> {
+            number.some/*caret*/
         }
     """, """
-        fn foo(slice: &[i32]) {
-            let first = Some(slice[0])/*caret*/;
+        fn foo(number: i32) -> Option<i32> {
+            Some(number)
         }
     """)
 


### PR DESCRIPTION
Since all those are trivial, I basically just copy-paste-edited them from `dbg` postfix template, its tests and descriptions. If you think it'd be good to change something or add some specific tests, let me know. This is very lazy job, but it does the job 😄

fixes #5494 

Note: I signed the CLA in the past to contribute to Vue plugin, so I just added my name here.
