### PR TITLE
MACRO: enable new macro expansion engine in nightly builds

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -12,6 +12,8 @@ import com.intellij.util.messages.Topic
 import com.intellij.util.xmlb.annotations.Transient
 import org.rust.cargo.toolchain.ExternalLinter
 import org.rust.cargo.toolchain.RustToolchain
+import org.rust.ide.experiments.RsExperiments
+import org.rust.openapiext.isFeatureEnabled
 import java.nio.file.Paths
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.findAnnotation
@@ -38,7 +40,7 @@ interface RustProjectSettingsService {
         @AffectsHighlighting
         var compileAllTargets: Boolean = true,
         var useOffline: Boolean = false,
-        var macroExpansionEngine: MacroExpansionEngine = MacroExpansionEngine.OLD,
+        var macroExpansionEngine: MacroExpansionEngine = defaultMacroExpansionEngine,
         var showTestToolWindow: Boolean = true,
         @AffectsHighlighting
         var doctestInjectionEnabled: Boolean = true,
@@ -97,6 +99,13 @@ interface RustProjectSettingsService {
             "rust settings changes",
             RustSettingsListener::class.java
         )
+
+        private val defaultMacroExpansionEngine: MacroExpansionEngine
+            get() = if (isFeatureEnabled(RsExperiments.MACROS_NEW_ENGINE)) {
+                MacroExpansionEngine.NEW
+            } else {
+                MacroExpansionEngine.OLD
+            }
     }
 
     interface RustSettingsListener {

--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -10,4 +10,5 @@ object RsExperiments {
     const val FETCH_OUT_DIR = "org.rust.cargo.fetch.out.dir"
     const val EVALUATE_BUILD_SCRIPTS = "org.rust.cargo.evaluate.build.scripts"
     const val MOVE_REFACTORING = "org.rust.ide.refactoring.move"
+    const val MACROS_NEW_ENGINE = "org.rust.macros.new.engine"
 }

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -12,5 +12,8 @@
         <experimentalFeature id="org.rust.ide.refactoring.move" percentOfUsers="100">
             <description>Move refactoring</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.macros.new.engine" percentOfUsers="100">
+            <description>Enables new macro expansion engine by default</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -12,5 +12,8 @@
         <experimentalFeature id="org.rust.ide.refactoring.move" percentOfUsers="0">
             <description>Move refactoring</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.macros.new.engine" percentOfUsers="0">
+            <description>Enables new macro expansion engine by default</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
It should affect only users with nightly builds

See #3628 for more details about new macro expansion engine