### PR TITLE
MACRO: more consistency checks

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.macros
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.progress.ProgressManager
@@ -96,7 +97,7 @@ class ExpandedMacroStorage(val project: Project) {
                 getOrCreateSourceFile(file) ?: error("Non-root source files are not supported")
             }
         }
-        return runReadActionInSmartMode(project) {
+        return runReadAction {
             makeValidationTask(false, v2)
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -17,7 +17,6 @@ import com.intellij.openapi.util.ModificationTracker
 import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
-import com.intellij.openapi.vfs.VirtualFileWithId
 import com.intellij.openapi.vfs.newvfs.FileAttribute
 import com.intellij.psi.PsiAnchor
 import com.intellij.psi.PsiDocumentManager
@@ -133,7 +132,8 @@ class ExpandedMacroStorage(val project: Project) {
         callHash: HashCode?,
         defHash: HashCode?,
         expansionFile: VirtualFile?,
-        ranges: RangeMap?
+        ranges: RangeMap?,
+        expansionTextHash: Long
     ): ExpandedMacroInfoImpl {
         checkWriteAccessAllowed()
         _modificationTracker.incModificationCount()
@@ -146,6 +146,7 @@ class ExpandedMacroStorage(val project: Project) {
             expansionFile,
             defHash,
             callHash,
+            expansionTextHash,
             oldInfo.macroCallStubIndex,
             oldInfo.macroCallStrongRef
         )
@@ -237,7 +238,7 @@ class ExpandedMacroStorage(val project: Project) {
     }
 }
 
-private const val STORAGE_VERSION = 11
+private const val STORAGE_VERSION = 12
 private const val RANGE_MAP_ATTRIBUTE_VERSION = 2
 
 class SerializedExpandedMacroStorage private constructor(
@@ -547,7 +548,7 @@ class SourceFile(
         val psi = loadPsi() ?: return
         val calls = prefetchedCalls ?: psi.stubDescendantsOfTypeStrict<RsMacroCall>().filter { it.isTopLevelExpansion }
         val newInfos = calls.map { call ->
-            ExpandedMacroInfoImpl(this, null, null, call.bodyHash, call.calcStubIndex())
+            ExpandedMacroInfoImpl.newStubLinked(this, call)
         }
         switchToStubRefsInReadAction(RefKind.FRESH) { infos ->
             check(infos.isEmpty())
@@ -590,7 +591,7 @@ class SourceFile(
                 bindList += Pair(info, call.calcStubIndex())
             } else {
                 Testmarks.refsRecoverNotHit.hit()
-                infosToAdd += ExpandedMacroInfoImpl(this, null, null, call.bodyHash, call.calcStubIndex())
+                infosToAdd += ExpandedMacroInfoImpl.newStubLinked(this, call)
             }
         }
 
@@ -821,6 +822,7 @@ private tailrec fun SourceFile.findRootSourceFile(): SourceFile {
 interface ExpandedMacroInfo {
     val sourceFile: SourceFile
     val expansionFile: VirtualFile?
+    val expansionFileHash: Long
     fun getMacroCall(): RsMacroCall?
     fun isUpToDate(call: RsMacroCall, def: RsMacro?): Boolean
     fun getExpansion(): MacroExpansion?
@@ -831,6 +833,7 @@ class ExpandedMacroInfoImpl(
     override val expansionFile: VirtualFile?,
     private val defHash: HashCode?,
     val callHash: HashCode?,
+    override val expansionFileHash: Long = 0,
     var macroCallStubIndex: Int = -1,
     var macroCallStrongRef: RsMacroCall? = null
 ) : ExpandedMacroInfo {
@@ -867,8 +870,14 @@ class ExpandedMacroInfoImpl(
             writeUTFNullable(expansionFileUrl)
             writeHashCodeNullable(defHash)
             writeHashCodeNullable(callHash)
+            writeLong(expansionFileHash)
             writeInt(macroCallStubIndex)
         }
+    }
+
+    companion object {
+        fun newStubLinked(sf: SourceFile, call: RsMacroCall): ExpandedMacroInfoImpl =
+            ExpandedMacroInfoImpl(sf, null, null, call.bodyHash, macroCallStubIndex = call.calcStubIndex())
     }
 }
 
@@ -876,6 +885,7 @@ private data class SerializedExpandedMacroInfo(
     val expansionFileUrl: String?,
     val callHash: HashCode?,
     val defHash: HashCode?,
+    val expansionFileHash: Long,
     val stubIndex: Int
 ) {
     fun toExpandedMacroInfo(sourceFile: SourceFile): ExpandedMacroInfoImpl? {
@@ -889,6 +899,7 @@ private data class SerializedExpandedMacroInfo(
             file,
             callHash,
             defHash,
+            expansionFileHash,
             stubIndex
         )
     }
@@ -899,6 +910,7 @@ private data class SerializedExpandedMacroInfo(
                 data.readUTFNullable(),
                 data.readHashCodeNullable(),
                 data.readHashCodeNullable(),
+                data.readLong(),
                 data.readInt()
             )
         }
@@ -958,8 +970,6 @@ private fun StubBasedPsiElement<*>.calcStubIndex(): Int {
     return index
 }
 
-private val VirtualFile.fileId: Int
-    get() = (this as VirtualFileWithId).id
 
 /** We use [WeakReference] because uncached [loadRangeMap] is quite cheap */
 private val MACRO_RANGE_MAP_CACHE_KEY: Key<WeakReference<RangeMap>> = Key.create("MACRO_RANGE_MAP_CACHE_KEY")

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -59,6 +59,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.ForkJoinTask
 import java.util.concurrent.TimeUnit
+import kotlin.system.measureTimeMillis
 
 interface MacroExpansionManager {
     val indexableDirectory: VirtualFile?
@@ -496,9 +497,7 @@ private class MacroExpansionServiceImplInner(
             override fun run(indicator: ProgressIndicator) {
                 checkReadAccessNotAllowed()
                 val vfs = MacroExpansionFileSystem.getInstance()
-                if (vfs.exists(dirs.expansionDirPath)) {
-                    vfs.cleanDirectory(dirs.expansionDirPath)
-                }
+                vfs.cleanDirectoryIfExists(dirs.expansionDirPath)
                 vfs.createDirectoryIfNotExistsOrDummy(dirs.expansionDirPath)
                 dirs.dataFile.delete()
                 WriteAction.runAndWait<Throwable> {
@@ -521,9 +520,13 @@ private class MacroExpansionServiceImplInner(
             override fun run(indicator: ProgressIndicator) {
                 checkReadAccessNotAllowed()
 
-                refreshExpansionDirectory()
-                findAndDeleteLeakedExpansionFiles()
-                findAndRemoveInvalidExpandedMacroInfosFromStorage()
+                val duration = measureTimeMillis {
+                    refreshExpansionDirectory()
+                    findAndDeleteLeakedExpansionFiles()
+                    findAndRemoveInvalidExpandedMacroInfosFromStorage()
+                }
+
+                MACRO_LOG.info("Done consistency check in $duration ms")
             }
 
             private fun refreshExpansionDirectory() {
@@ -534,9 +537,9 @@ private class MacroExpansionServiceImplInner(
             private fun findAndDeleteLeakedExpansionFiles() {
                 val toDelete = mutableListOf<VirtualFile>()
                 runReadAction {
-                    VfsUtil.iterateChildrenRecursively(expansionsDirVi, null, ContentIterator {
-                        if (!it.isDirectory && storage.getInfoForExpandedFile(it) == null) {
-                            toDelete += it
+                    VfsUtil.iterateChildrenRecursively(expansionsDirVi, null, ContentIterator { file ->
+                        if (!file.isValidExpansionFile()) {
+                            toDelete += file
                         }
                         true
                     })
@@ -546,6 +549,26 @@ private class MacroExpansionServiceImplInner(
                     toDelete.forEach { batch.deleteFile(it) }
                     WriteAction.runAndWait<Throwable> {
                         batch.applyToVfs(async = false)
+                    }
+                }
+            }
+
+            private fun VirtualFile.isValidExpansionFile(): Boolean {
+                if (isDirectory) return true
+                val info = storage.getInfoForExpandedFile(this)
+                return if (info == null) {
+                    false
+                } else {
+                    when (val result = VfsInternals.getUpToDateContentHash(this)) {
+                        VfsInternals.ContentHashResult.Disabled -> true // Skip the check if hashes are disabled
+                        is VfsInternals.ContentHashResult.Ok -> {
+                            info.expansionFileHash == result.hash.getLeading64bits()
+                        }
+                        is VfsInternals.ContentHashResult.Err -> {
+                            // See `MacroExpansionFileSystem.contentsToByteArray`
+                            MACRO_LOG.warn(result.error)
+                            false
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ContentIterator
 import com.intellij.openapi.roots.ex.ProjectRootManagerEx
@@ -800,7 +801,7 @@ private class MacroExpansionServiceImplInner(
             ::createExpandedSearchScope,
             stepModificationTracker
         ) {
-            override fun getMacrosToExpand(): Sequence<List<Extractable>> {
+            override fun getMacrosToExpand(dumbService: DumbService): Sequence<List<Extractable>> {
                 val mode = expansionMode
 
                 val scope = when (mode.toScope()) {
@@ -809,7 +810,7 @@ private class MacroExpansionServiceImplInner(
                     MacroExpansionScope.NONE -> return emptySequence() // GlobalSearchScope.EMPTY_SCOPE
                 }
 
-                val calls = runReadActionInSmartMode(project) {
+                val calls = runReadActionInSmartMode(dumbService) {
                     val calls = RsMacroCallIndex.getMacroCalls(project, scope)
                     MACRO_LOG.info("Macros to expand: ${calls.size}")
                     calls.groupBy { it.containingFile.virtualFile }
@@ -839,7 +840,7 @@ private class MacroExpansionServiceImplInner(
             ::createExpandedSearchScope,
             stepModificationTracker
         ) {
-            override fun getMacrosToExpand(): Sequence<List<Extractable>> {
+            override fun getMacrosToExpand(dumbService: DumbService): Sequence<List<Extractable>> {
                 return runReadAction { storage.makeValidationTask(workspaceOnly) }
             }
 

--- a/src/main/kotlin/org/rust/lang/core/macros/VfsInternals.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/VfsInternals.kt
@@ -1,0 +1,66 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.google.common.annotations.VisibleForTesting
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
+import com.intellij.openapi.vfs.newvfs.persistent.PersistentFSImpl
+import com.intellij.util.BitUtil
+import com.intellij.util.io.DigestUtil
+import org.rust.openapiext.fileId
+import org.rust.stdext.HashCode
+import java.io.IOException
+import java.security.MessageDigest
+
+object VfsInternals {
+    /** [com.intellij.openapi.vfs.newvfs.persistent.PersistentFS.MUST_RELOAD_CONTENT] */
+    @VisibleForTesting
+    val MUST_RELOAD_CONTENT: Int = 0x08
+
+    /** [com.intellij.openapi.vfs.newvfs.persistent.FSRecords.CONTENT_HASH_DIGEST] */
+    private val CONTENT_HASH_DIGEST: MessageDigest = DigestUtil.sha1()
+
+    @VisibleForTesting
+    fun isMarkedForContentReload(file: VirtualFile) =
+        BitUtil.isSet(PersistentFS.getInstance().getFileAttributes(file.fileId), MUST_RELOAD_CONTENT)
+
+    @VisibleForTesting
+    @Throws(IOException::class)
+    fun reloadFileIfNeeded(file: VirtualFile) {
+        if (isMarkedForContentReload(file)) {
+            file.contentsToByteArray(false)
+        }
+    }
+
+    /** `null` means disabled hashing or invalid file */
+    @VisibleForTesting
+    fun getContentHashIfStored(file: VirtualFile): HashCode? =
+        (PersistentFS.getInstance() as PersistentFSImpl).getContentHashIfStored(file)
+            ?.let { HashCode.fromByteArray(it) }
+
+    fun calculateContentHash(fileContent: ByteArray): HashCode =
+        HashCode.fromByteArray(DigestUtil.calculateContentHash(CONTENT_HASH_DIGEST, fileContent))
+
+    fun getUpToDateContentHash(file: VirtualFile): ContentHashResult {
+        try {
+            reloadFileIfNeeded(file) // Re-computes the hash code if the file is changed
+        } catch (e: IOException) {
+            // See `MacroExpansionFileSystem.xcontentsToByteArray`
+            return ContentHashResult.Err(e)
+        }
+
+        // `null` means disabled file hashes
+        val hash = getContentHashIfStored(file)
+        return if (hash == null) ContentHashResult.Disabled else ContentHashResult.Ok(hash)
+    }
+
+    sealed class ContentHashResult {
+        object Disabled : ContentHashResult()
+        class Ok(val hash: HashCode) : ContentHashResult()
+        class Err(val error: IOException) : ContentHashResult()
+    }
+}

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -8,10 +8,11 @@ package org.rust.openapiext
 import com.intellij.concurrency.SensitiveProgressWrapper
 import com.intellij.ide.plugins.IdeaPluginDescriptor
 import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DataContext
-import com.intellij.openapi.application.*
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.Experiments
+import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.application.ex.ApplicationUtil
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Document
@@ -35,6 +36,7 @@ import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.VirtualFileWithId
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.*
 import com.intellij.psi.search.GlobalSearchScope
@@ -48,7 +50,6 @@ import org.rust.ide.annotator.RsExternalLinterPass
 import java.lang.reflect.Field
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.reflect.KProperty
 
@@ -123,6 +124,9 @@ val Document.virtualFile: VirtualFile?
 
 val VirtualFile.document: Document?
     get() = FileDocumentManager.getInstance().getDocument(this)
+
+val VirtualFile.fileId: Int
+    get() = (this as VirtualFileWithId).id
 
 inline fun <Key, reified Psi : PsiElement> getElements(
     indexKey: StubIndexKey<Key, Psi>,

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -244,10 +244,10 @@ fun pluginDirInSystem(): Path = Paths.get(PathManager.getSystemPath()).resolve("
 
 val String.escaped: String get() = StringUtil.escapeXmlEntities(this)
 
-fun <T> runReadActionInSmartMode(project: Project, action: () -> T): T {
+fun <T> runReadActionInSmartMode(dumbService: DumbService, action: () -> T): T {
     ProgressManager.checkCanceled()
-    if (project.isDisposed) throw ProcessCanceledException()
-    return DumbService.getInstance(project).runReadActionInSmartMode(Computable {
+    if (dumbService.project.isDisposed) throw ProcessCanceledException()
+    return dumbService.runReadActionInSmartMode(Computable {
         ProgressManager.checkCanceled()
         action()
     })
@@ -255,6 +255,7 @@ fun <T> runReadActionInSmartMode(project: Project, action: () -> T): T {
 
 fun <T : Any> executeUnderProgressWithWriteActionPriorityWithRetries(indicator: ProgressIndicator, action: () -> T): T {
     checkReadAccessNotAllowed()
+    indicator.checkCanceled()
     var result: T? = null
     do {
         val success = runWithWriteActionPriority(SensitiveProgressWrapper(indicator)) {

--- a/src/main/kotlin/org/rust/stdext/HashCode.kt
+++ b/src/main/kotlin/org/rust/stdext/HashCode.kt
@@ -5,9 +5,9 @@
 
 package org.rust.stdext
 
+import com.intellij.util.io.DigestUtil
 import org.apache.commons.codec.binary.Hex
 import java.io.Serializable
-import java.security.MessageDigest
 
 /**
  * Abstracts byte array of cryptographic hash to provide appropriate equals/hashCode methods.
@@ -37,7 +37,7 @@ import java.security.MessageDigest
 
     companion object {
         const val ARRAY_LEN: Int = 20
-        private val SHA1 by ThreadLocalDelegate { MessageDigest.getInstance("SHA-1") }
+        private val SHA1 by ThreadLocalDelegate { DigestUtil.sha1() }
 
         fun compute(input: String): HashCode =
             HashCode(SHA1.digest(input.toByteArray()))
@@ -48,3 +48,5 @@ import java.security.MessageDigest
         }
     }
 }
+
+fun HashCode.getLeading64bits(): Long = toByteArray().getLeading64bits()

--- a/src/main/kotlin/org/rust/stdext/Utils.kt
+++ b/src/main/kotlin/org/rust/stdext/Utils.kt
@@ -9,6 +9,8 @@ package org.rust.stdext
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VirtualFile
 import org.apache.commons.lang.RandomStringUtils
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -42,3 +44,6 @@ fun String.pluralize(): String = StringUtil.pluralize(this)
 
 fun randomLowercaseAlphabetic(length: Int): String =
     RandomStringUtils.random(length, "0123456789abcdefghijklmnopqrstuvwxyz")
+
+fun ByteArray.getLeading64bits(): Long =
+    ByteBuffer.wrap(this).also { it.order(ByteOrder.BIG_ENDIAN) }.getLong(0)


### PR DESCRIPTION
We still have some unexplained bugs in the macro expansion engine. E.g. false-positive "Use of moved value" for i32 - this can be explained by unexplained disappearing of macro expansions =/
I failed to investigate it, so I just add more asserts, more logs and do more attempts to recover things if something got wrong. Maybe we'll catch the reason later.