### PR TITLE
fix exception in RsFileTypeOverriderForMacroExpansionFileSystem

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/RsFileTypeOverriderForMacroExpansionFileSystem.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsFileTypeOverriderForMacroExpansionFileSystem.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.macros
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.fileTypes.impl.FileTypeOverrider
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.newvfs.impl.StubVirtualFile
 import org.rust.lang.RsFileType
 
 /**
@@ -18,7 +19,7 @@ import org.rust.lang.RsFileType
 @Suppress("UnstableApiUsage")
 class RsFileTypeOverriderForMacroExpansionFileSystem : FileTypeOverrider {
     override fun getOverriddenFileType(file: VirtualFile): FileType? {
-        return if (!file.isDirectory && file.fileSystem is MacroExpansionFileSystem) {
+        return if (file !is StubVirtualFile && !file.isDirectory && file.fileSystem is MacroExpansionFileSystem) {
             RsFileType
         } else {
             null


### PR DESCRIPTION
<details>
  <summary>Stacktrace</summary>

```

java.lang.UnsupportedOperationException: /Users/jasonmcpeak/projects/payrailz-app/packages/pz-ontrac/src/components/modules/paymentOps/BillerManagement/Automatch/Templates/Scopes/__stories__/ScopesAddEditCard.stories.js
	at com.intellij.openapi.vfs.newvfs.impl.StubVirtualFile.unsupported(StubVirtualFile.java:212)
	at com.intellij.openapi.vfs.newvfs.impl.StubVirtualFile.getFileSystem(StubVirtualFile.java:30)
	at org.rust.lang.core.macros.RsFileTypeOverriderForMacroExpansionFileSystem.getOverriddenFileType(RsFileTypeOverriderForMacroExpansionFileSystem.kt:21)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.lambda$getFileTypeByFile$13(FileTypeManagerImpl.java:575)
	at com.intellij.openapi.extensions.impl.ExtensionProcessingHelper.computeSafeIfAny(ExtensionProcessingHelper.java:54)
	at com.intellij.openapi.extensions.ExtensionPointName.computeSafeIfAny(ExtensionPointName.java:57)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.getFileTypeByFile(FileTypeManagerImpl.java:575)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.getFileTypeByFile(FileTypeManagerImpl.java:569)
	at com.intellij.openapi.vfs.VirtualFile.getFileType(VirtualFile.java:346)
	at com.intellij.openapi.fileTypes.ex.FileTypeChooser.getKnownFileTypeOrAssociate(FileTypeChooser.java:125)
	at com.intellij.openapi.fileTypes.ex.FileTypeChooser.getKnownFileTypeOrAssociate(FileTypeChooser.java:137)
	at com.intellij.refactoring.copy.CopyFilesOrDirectoriesDialog.doAction(CopyFilesOrDirectoriesDialog.java:292)
	at com.intellij.refactoring.ui.RefactoringDialog.doRefactorAction(RefactoringDialog.java:136)
	at com.intellij.refactoring.ui.RefactoringDialog$RefactorAction.actionPerformed(RefactoringDialog.java:219)
	at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1967)
	at java.desktop/javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2308)
	at java.desktop/javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:405)
	at java.desktop/javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
	at java.desktop/javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:270)
	at java.desktop/java.awt.Component.processMouseEvent(Component.java:6650)
	at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3345)
	at java.desktop/java.awt.Component.processEvent(Component.java:6415)
	at java.desktop/java.awt.Container.processEvent(Container.java:2263)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5025)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2321)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4857)
	at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4918)
	at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4547)
	at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4488)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2307)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2773)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4857)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:778)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:727)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:95)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:751)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:749)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:748)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:965)
	at com.intellij.ide.IdeEventQueue.dispatchMouseEvent(IdeEventQueue.java:903)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:835)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:449)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:732)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$9(IdeEventQueue.java:448)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:816)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:502)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:117)
	at java.desktop/java.awt.WaitDispatchSupport$2.run(WaitDispatchSupport.java:190)
	at java.desktop/java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:235)
	at java.desktop/java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:233)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.desktop/java.awt.WaitDispatchSupport.enter(WaitDispatchSupport.java:233)
	at java.desktop/java.awt.Dialog.show(Dialog.java:1063)
	at com.intellij.openapi.ui.impl.DialogWrapperPeerImpl$MyDialog.show(DialogWrapperPeerImpl.java:708)
	at com.intellij.openapi.ui.impl.DialogWrapperPeerImpl.show(DialogWrapperPeerImpl.java:437)
	at com.intellij.openapi.ui.DialogWrapper.doShow(DialogWrapper.java:1697)
	at com.intellij.openapi.ui.DialogWrapper.show(DialogWrapper.java:1656)
	at com.intellij.refactoring.ui.RefactoringDialog.show(RefactoringDialog.java:103)
	at com.intellij.openapi.ui.DialogWrapper.showAndGet(DialogWrapper.java:1670)
	at com.intellij.refactoring.copy.CopyFilesOrDirectoriesHandler.doCopyAsFiles(CopyFilesOrDirectoriesHandler.java:114)
	at com.intellij.refactoring.copy.CopyFilesOrDirectoriesHandler.copyAsFiles(CopyFilesOrDirectoriesHandler.java:99)
	at com.intellij.refactoring.copy.CopyFilesOrDirectoriesHandler.doCopy(CopyFilesOrDirectoriesHandler.java:78)
	at com.intellij.refactoring.copy.CopyHandler.doCopy(CopyHandler.java:51)
	at com.intellij.ide.CopyPasteDelegator$MyEditable.pasteAfterCopy(CopyPasteDelegator.java:193)
	at com.intellij.ide.CopyPasteDelegator$MyEditable.lambda$performDefaultPaste$0(CopyPasteDelegator.java:142)
	at com.intellij.openapi.project.DumbService.computeWithAlternativeResolveEnabled(DumbService.java:353)
	at com.intellij.ide.CopyPasteDelegator$MyEditable.performDefaultPaste(CopyPasteDelegator.java:137)
	at com.intellij.ide.CopyPasteDelegator$MyEditable.performPaste(CopyPasteDelegator.java:122)
	at com.intellij.ide.actions.PasteAction.actionPerformed(PasteAction.java:35)
	at com.intellij.openapi.actionSystem.ex.ActionUtil.performActionDumbAware(ActionUtil.java:295)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher$1.performAction(IdeKeyEventDispatcher.java:598)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.lambda$processAction$3(IdeKeyEventDispatcher.java:659)
	at com.intellij.openapi.application.TransactionGuardImpl.performUserActivity(TransactionGuardImpl.java:94)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.processAction(IdeKeyEventDispatcher.java:658)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.processAction(IdeKeyEventDispatcher.java:608)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.processActionOrWaitSecondStroke(IdeKeyEventDispatcher.java:505)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.inInitState(IdeKeyEventDispatcher.java:459)
	at com.intellij.openapi.keymap.impl.IdeKeyEventDispatcher.dispatchKeyEvent(IdeKeyEventDispatcher.java:217)
	at com.intellij.ide.IdeEventQueue.dispatchKeyEvent(IdeEventQueue.java:887)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:832)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:449)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:743)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$9(IdeEventQueue.java:448)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:816)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:502)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```
</details>

bors r+