### PR TITLE
INT: add intention to create a function from an unresolved function call

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/CreateFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/CreateFunctionIntention.kt
@@ -1,0 +1,127 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapiext.isUnitTestMode
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.ide.presentation.renderInsertionSafe
+import org.rust.ide.utils.GenericConstraints
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.type
+import org.rust.openapiext.buildAndRunTemplate
+import org.rust.openapiext.createSmartPointer
+
+class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionIntention.Context>() {
+    override fun getFamilyName() = text
+
+    sealed class Context {
+        data class Function(val callExpr: RsCallExpr, val name: String, val module: RsMod) : Context()
+    }
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val path = element.parentOfType<RsPath>()
+        val functionCall = path?.parentOfType<RsCallExpr>() ?: return null
+        if (!path.isUnresolved) return null
+
+        if (!functionCall.expr.isAncestorOf(path)) return null
+
+        val module = getTargetModuleForFunction(path) ?: return null
+        val name = path.referenceName
+        text = "Create function `$name`"
+        return Context.Function(functionCall, name, module)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        when (ctx) {
+            is Context.Function -> createFunction(project, editor, ctx)
+        }
+    }
+}
+
+private fun createFunction(project: Project, editor: Editor, ctx: CreateFunctionIntention.Context.Function) {
+    val functionName = ctx.name
+    val callExpr = ctx.callExpr
+
+    val factory = RsPsiFactory(project)
+    val config = getFunctionConfig(callExpr)
+
+    val genericParams = config.genericConstraints.buildTypeParameters()
+    val params = config.parameters.joinToString(", ")
+    val whereClause = config.genericConstraints.buildWhereClause()
+
+    val vis = if (callExpr.containingMod != ctx.module) "pub(crate) " else ""
+    val function = factory.tryCreateFunction("${vis}fn $functionName$genericParams($params)$whereClause {\n    unimplemented!()\n}")
+        ?: return
+
+    val sourceFunction = callExpr.parentOfType<RsFunction>() ?: return
+    val inserted = insertFunction(ctx.module, sourceFunction, function)
+
+    if (ctx.module.containingFile == callExpr.containingFile) {
+        val toBeReplaced = inserted.valueParameters.flatMap { listOfNotNull(it.pat, it.typeReference) } +
+            listOfNotNull(inserted.block?.expr)
+        editor.buildAndRunTemplate(inserted, toBeReplaced.map { it.createSmartPointer() })
+    } else {
+        // template builder cannot be used for a different file
+        inserted.navigate(true)
+    }
+}
+
+private fun getTargetModuleForFunction(path: RsPath): RsMod? {
+    if (path.qualifier != null) {
+        val mod = path.qualifier?.reference?.resolve() as? RsMod
+        if (mod?.containingCargoPackage?.origin != PackageOrigin.WORKSPACE) return null
+        if (!isUnitTestMode && !mod.isWritable) return null
+        return mod
+    }
+    return path.containingMod
+}
+
+private data class FunctionConfig(val parameters: List<String>,
+                                  val genericConstraints: GenericConstraints)
+
+private fun getFunctionConfig(callExpr: RsCallExpr): FunctionConfig {
+    val parameters = callExpr.valueArgumentList.exprList.mapIndexed { index, expr ->
+        "p$index: ${expr.type.renderInsertionSafe(useAliasNames = true)}"
+    }
+
+    val genericConstraints = GenericConstraints.create(callExpr)
+        .filterByTypes(callExpr.valueArgumentList.exprList.map { it.type })
+
+    return FunctionConfig(parameters, genericConstraints)
+}
+
+private fun insertFunction(
+    targetModule: RsMod,
+    sourceFunction: RsFunction,
+    function: RsFunction
+): RsFunction {
+    if (targetModule == sourceFunction.containingMod) {
+        val impl: RsTraitOrImpl? = when (val owner = sourceFunction.owner) {
+            is RsAbstractableOwner.Trait -> owner.trait
+            is RsAbstractableOwner.Impl -> owner.impl
+            else -> null
+        }
+
+        val target = impl ?: sourceFunction
+        return target.parent.addAfter(function, target) as RsFunction
+    }
+
+    // add to the end of module/file
+    return if (targetModule is RsModItem) {
+        targetModule.addBefore(function, targetModule.rbrace)
+    } else {
+        if (targetModule.lastChild == null) {
+            targetModule.add(function)
+        } else {
+            targetModule.addAfter(function, targetModule.lastChild)
+        }
+    } as RsFunction
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/extractEnumVariant/RsExtractEnumVariantProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractEnumVariant/RsExtractEnumVariantProcessor.kt
@@ -18,16 +18,9 @@ import com.intellij.usageView.UsageInfo
 import com.intellij.usageView.UsageViewDescriptor
 import org.rust.ide.refactoring.RsInPlaceVariableIntroducer
 import org.rust.ide.utils.import.RsImportHelper
+import org.rust.ide.utils.GenericConstraints
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
-import org.rust.lang.core.types.consts.Const
-import org.rust.lang.core.types.consts.CtConstParameter
-import org.rust.lang.core.types.infer.TypeVisitor
-import org.rust.lang.core.types.infer.hasCtConstParameters
-import org.rust.lang.core.types.infer.hasTyTypeParameters
-import org.rust.lang.core.types.ty.Ty
-import org.rust.lang.core.types.ty.TyTypeParameter
-import org.rust.lang.core.types.type
 
 class RsExtractEnumVariantProcessor(
     project: Project,
@@ -52,9 +45,11 @@ class RsExtractEnumVariantProcessor(
         }
 
         val enum = ctx.parentEnum
-        val parameters = filterTypeParameters(element.typeReferences, enum.typeParameterList)
-        val typeParametersText = parameters.format()
-        val whereClause = buildWhereClause(enum.whereClause, parameters)
+        val genericConstraints = GenericConstraints.create(ctx)
+            .filterByTypeReferences(element.typeReferences)
+
+        val typeParametersText = genericConstraints.buildTypeParameters()
+        val whereClause = genericConstraints.buildWhereClause()
         val attributes = findTransitiveAttributes(enum, TRANSITIVE_ATTRIBUTES)
 
         val struct = element.createStruct(
@@ -230,130 +225,6 @@ private class StructVariant(fields: RsBlockFields, factory: RsPsiFactory) : Vari
     }
 }
 
-private data class CollectTypeParametersVisitor(
-    val parameters: Map<String, RsTypeParameter>,
-    val collected: MutableSet<RsTypeParameter>
-) : RsRecursiveVisitor() {
-    override fun visitTypeReference(ref: RsTypeReference) {
-        super.visitTypeReference(ref)
-        val type = ref.type as? TyTypeParameter ?: return
-        val parameter = parameters[type.name] ?: return
-        collected.add(parameter)
-        parameter.bounds.forEach { bound ->
-            bound.accept(this)
-        }
-    }
-}
-
-private fun gatherTypeParameters(
-    references: List<RsTypeReference>,
-    parameters: List<RsTypeParameter>
-): List<RsTypeParameter> {
-    val parameterMap = parameters.filter { it.name != null }.associateBy { it.name!! }
-    val collected = mutableSetOf<RsTypeParameter>()
-    for (ref in references) {
-        ref.accept(CollectTypeParametersVisitor(parameterMap, collected))
-    }
-    return collected.sortedBy { parameters.indexOf(it) }
-}
-
-private data class CollectLifetimesVisitor(
-    val parameters: Map<String, RsTypeParameter>,
-    val lifetimeMap: Map<String, RsLifetimeParameter>,
-    val collected: MutableSet<RsLifetimeParameter>
-) : RsRecursiveVisitor() {
-
-    override fun visitTypeReference(ref: RsTypeReference) {
-        super.visitTypeReference(ref)
-        val type = ref.type as? TyTypeParameter ?: return
-        val parameter = parameters[type.name] ?: return
-        parameter.bounds.forEach { bound ->
-            bound.accept(this)
-        }
-    }
-
-    override fun visitLifetime(lifetime: RsLifetime) {
-        super.visitLifetime(lifetime)
-        val parameter = lifetimeMap[lifetime.name] ?: return
-        if (parameter !in collected) {
-            collected.add(parameter)
-            parameter.accept(this)
-        }
-    }
-}
-
-private fun gatherLifetimes(
-    references: List<RsTypeReference>,
-    lifetimes: List<RsLifetimeParameter>,
-    parameters: List<RsTypeParameter>
-): List<RsLifetimeParameter> {
-    val parameterMap = parameters.filter { it.name != null }.associateBy { it.name!! }
-    val lifetimeMap = lifetimes.filter { it.name != null }.associateBy { it.name!! }
-    val collected = mutableSetOf<RsLifetimeParameter>()
-
-    for (ref in references) {
-        ref.accept(CollectLifetimesVisitor(parameterMap, lifetimeMap, collected))
-    }
-
-    return collected.sortedBy { lifetimes.indexOf(it) }
-}
-
-
-private data class HasConstParameterVisitor(val parameter: RsConstParameter) : TypeVisitor {
-
-    override fun visitTy(ty: Ty): Boolean =
-        if (ty.hasCtConstParameters) ty.superVisitWith(this) else false
-
-    override fun visitConst(const: Const): Boolean =
-        when {
-            const is CtConstParameter -> const.parameter == parameter
-            const.hasCtConstParameters -> const.superVisitWith(this)
-            else -> false
-        }
-}
-
-private data class HasTypeParameterVisitor(
-    val parameters: Map<String, RsTypeParameter>,
-    val ref: RsTypeReference
-) : TypeVisitor {
-    override fun visitTy(ty: Ty): Boolean =
-        when {
-            ty is TyTypeParameter -> ty.name in parameters
-            ty.hasTyTypeParameters -> ty.superVisitWith(this)
-            else -> false
-        }
-}
-
-private data class Parameters(
-    val lifetimes: List<RsLifetimeParameter> = emptyList(),
-    val typeParameters: List<RsTypeParameter> = emptyList(),
-    val constParameters: List<RsConstParameter> = emptyList()
-) {
-    fun format(): String {
-        val all = lifetimes + typeParameters + constParameters
-        return if (all.isNotEmpty()) {
-            all.joinToString(", ", prefix = "<", postfix = ">") { it.text }
-        } else {
-            ""
-        }
-    }
-}
-
-private fun filterTypeParameters(
-    references: List<RsTypeReference>,
-    parameters: RsTypeParameterList?
-): Parameters {
-    if (parameters == null) return Parameters()
-    val typeParameters = gatherTypeParameters(references, parameters.typeParameterList)
-    val lifetimes = gatherLifetimes(references, parameters.lifetimeParameterList, typeParameters)
-    val constParameters = parameters.constParameterList
-        .filter { param -> references.any { matchesConstParameter(it, param) } }
-    return Parameters(lifetimes, typeParameters, constParameters)
-}
-
-private fun matchesConstParameter(ref: RsTypeReference, parameter: RsConstParameter): Boolean =
-    ref.type.visitWith(HasConstParameterVisitor(parameter))
-
 private fun offerStructRename(
     project: Project,
     editor: Editor,
@@ -378,61 +249,6 @@ private fun createElement(variant: RsEnumVariant, factory: RsPsiFactory): Varian
         else -> error("unreachable")
     }
 }
-
-private fun buildWhereClause(whereClause: RsWhereClause?, parameters: Parameters): String {
-    val where = whereClause ?: return ""
-    if (where.wherePredList.isEmpty()) return ""
-
-    val parameterMap = parameters.typeParameters.filter { it.name != null }.associateBy { it.name!! }
-    val lifetimeMap = parameters.lifetimes.filter { it.name != null }.associateBy { it.name!! }
-    val predicates = where.wherePredList.mapNotNull { predicate ->
-        val typeRef = predicate.typeReference
-        if (typeRef != null && hasTypeParameter(typeRef, parameterMap)) {
-            return@mapNotNull predicate.text
-        }
-
-        val lifetime = predicate.lifetime
-        if (lifetime != null) {
-            return@mapNotNull createLifetimePredicate(
-                predicate,
-                lifetime,
-                predicate.lifetimeParamBounds,
-                lifetimeMap
-            )
-        }
-
-        null
-    }
-
-    return if (predicates.isNotEmpty()) {
-        predicates.joinToString(separator = ",", prefix = " where ")
-    } else {
-        ""
-    }
-}
-
-/**
- * Create a predicate if the lifetime is in the map and at least one of its bounds is in the map.
- * Bounds that are not in the map are removed.
- */
-private fun createLifetimePredicate(
-    predicate: RsWherePred,
-    lifetime: RsLifetime,
-    lifetimeParamBounds: RsLifetimeParamBounds?,
-    lifetimeMap: Map<String, RsLifetimeParameter>
-): String? {
-    if (lifetime.name !in lifetimeMap) return null
-    if (lifetimeParamBounds == null) return predicate.text
-    val bounds = lifetimeParamBounds.lifetimeList.filter { it.name in lifetimeMap }
-    return if (bounds.isNotEmpty()) {
-        "${lifetime.text}: ${bounds.joinToString(" + ") { it.text }}"
-    } else {
-        null
-    }
-}
-
-private fun hasTypeParameter(ref: RsTypeReference, map: Map<String, RsTypeParameter>): Boolean =
-    HasTypeParameterVisitor(map, ref).visitTy(ref.type)
 
 private fun findTransitiveAttributes(enum: RsEnumItem, supportedAttributes: Set<String>): List<RsOuterAttr> =
     enum.outerAttrList.filter { it.metaItem.name in supportedAttributes }

--- a/src/main/kotlin/org/rust/ide/utils/ExtractUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/ExtractUtils.kt
@@ -1,0 +1,299 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.utils
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import com.intellij.util.containers.addIfNotNull
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.consts.Const
+import org.rust.lang.core.types.consts.CtConstParameter
+import org.rust.lang.core.types.infer.TypeVisitor
+import org.rust.lang.core.types.infer.hasCtConstParameters
+import org.rust.lang.core.types.infer.hasTyTypeParameters
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyTypeParameter
+import org.rust.lang.core.types.type
+
+/**
+ * This file contains tools for extracting a subset of related type/const parameters, lifetimes and their constraints
+ * from a given set of types.
+ */
+
+
+/**
+ * Holds type parameters, lifetimes, const parameters and where clauses.
+ * It serves as a combination of several `RsGenericDeclaration`s.
+ *
+ * Can be filtered by a set of types/type references to only returns parameters/constraints that are needed by these
+ * given types/type references.
+ */
+data class GenericConstraints(
+    val lifetimes: List<RsLifetimeParameter> = emptyList(),
+    val typeParameters: List<RsTypeParameter> = emptyList(),
+    val constParameters: List<RsConstParameter> = emptyList(),
+    val whereClauses: List<RsWhereClause> = emptyList()
+) {
+    fun filterByTypeReferences(references: List<RsTypeReference>): GenericConstraints {
+        val types = references.map { it.type }
+        val typeParameters = gatherTypeParameters(types, typeParameters)
+        val lifetimes = gatherLifetimesFromTypeReferences(references, lifetimes, typeParameters)
+        val constParameters = constParameters.filter { param -> types.any { matchesConstParameter(it, param) } }
+        return GenericConstraints(lifetimes, typeParameters, constParameters, whereClauses)
+    }
+
+    fun filterByTypes(types: List<Ty>): GenericConstraints {
+        val typeParameters = gatherTypeParameters(types, typeParameters)
+        val constParameters = constParameters
+            .filter { param -> types.any { matchesConstParameter(it, param) } }
+        return GenericConstraints(gatherLifetimesFromTypeParameters(lifetimes, typeParameters),
+            typeParameters, constParameters, whereClauses)
+    }
+
+    fun buildTypeParameters(): String {
+        val all = lifetimes + typeParameters + constParameters
+        return if (all.isNotEmpty()) {
+            all.joinToString(", ", prefix = "<", postfix = ">") { it.text }
+        } else {
+            ""
+        }
+    }
+
+    fun buildWhereClause(): String {
+        val wherePredList = whereClauses.flatMap { it.wherePredList }
+
+        val parameterMap = typeParameters.filter { it.name != null }.associateBy { it.name!! }
+        val lifetimeMap = lifetimes.filter { it.name != null }.associateBy { it.name!! }
+        val parameterToBounds = mutableMapOf<String, MutableSet<String>>()
+        val lifetimeToBounds = mutableMapOf<String, MutableSet<String>>()
+
+        fun normalizePredicate(text: String, name: String): String = text.removePrefix("$name:").trim()
+        fun addIfMissing(map: MutableMap<String, MutableSet<String>>, key: String) {
+            if (key !in map) {
+                map[key] = mutableSetOf()
+            }
+        }
+
+        loop@ for (predicate in wherePredList) {
+            val typeRef = predicate.typeReference
+            val lifetime = predicate.lifetime
+            when {
+                // type bound
+                typeRef != null && hasTypeParameter(typeRef, parameterMap) -> {
+                    val parameterText = (predicate.forLifetimes?.text?.plus(" ") ?: "") + typeRef.text
+                    addIfMissing(parameterToBounds, parameterText)
+                    predicate.typeParamBounds?.polyboundList?.forEach {
+                        parameterToBounds[parameterText]?.add(it.text)
+                    }
+                }
+                // lifetime bound
+                lifetime != null -> {
+                    val lifetimePredicate = createLifetimePredicate(
+                        predicate,
+                        lifetime,
+                        predicate.lifetimeParamBounds,
+                        lifetimeMap
+                    ) ?: continue@loop
+                    val name = lifetime.name ?: continue@loop
+                    addIfMissing(lifetimeToBounds, name)
+                    lifetimeToBounds[name]?.add(normalizePredicate(lifetimePredicate, name))
+                }
+            }
+        }
+
+        fun mapBounds(map: Map<String, Set<String>>, key: String): String? {
+            val bounds = map[key] ?: return null
+            if (bounds.isEmpty()) return null
+            return "$key: ${bounds.sorted().joinToString(" + ")}"
+        }
+
+        val bounds = lifetimeToBounds.keys.sorted().mapNotNull { mapBounds(lifetimeToBounds, it) } +
+            parameterToBounds.keys.sorted().mapNotNull { mapBounds(parameterToBounds, it) }
+
+        return if (bounds.isNotEmpty()) {
+            bounds.joinToString(separator = ",", prefix = " where ")
+        } else {
+            ""
+        }
+    }
+
+    companion object {
+        /**
+         * Recursively finds parent `RsGenericDeclarations` and collects all of their type parameters and
+         * their constraints.
+         */
+        fun create(context: PsiElement): GenericConstraints {
+            val typeParameters = mutableSetOf<RsTypeParameter>()
+            val lifetimes = mutableSetOf<RsLifetimeParameter>()
+            val constParameters = mutableSetOf<RsConstParameter>()
+            val whereClauses = mutableListOf<RsWhereClause>()
+
+            var genericDecl: RsGenericDeclaration? = (context as? RsGenericDeclaration) ?: context.parentOfType()
+            while (genericDecl != null) {
+                typeParameters += genericDecl.typeParameters
+                lifetimes += genericDecl.lifetimeParameters
+                constParameters += genericDecl.constParameters
+                whereClauses.addIfNotNull(genericDecl.whereClause)
+
+                if (genericDecl is RsAbstractable && genericDecl.owner.javaClass !in TRANSITIVE_GENERIC_OWNERS) break
+
+                genericDecl = genericDecl.parentOfType()
+            }
+
+            return GenericConstraints(lifetimes.toList(), typeParameters.toList(), constParameters.toList(), whereClauses)
+        }
+
+        private val TRANSITIVE_GENERIC_OWNERS = listOf(
+            RsAbstractableOwner.Impl::class.java,
+            RsAbstractableOwner.Trait::class.java
+        )
+    }
+}
+
+private fun gatherTypeParameters(
+    types: List<Ty>,
+    parameters: List<RsTypeParameter>
+): List<RsTypeParameter> {
+    val parameterMap = parameters.filter { it.name != null }.associateBy { it.name!! }
+    val collected = mutableSetOf<RsTypeParameter>()
+    val visitor = CollectTypeParametersTypeVisitor(parameterMap, collected)
+    for (type in types) {
+        type.visitWith(visitor)
+    }
+    return collected.sortedBy { parameters.indexOf(it) }
+}
+
+private data class CollectLifetimesVisitor(
+    val parameters: Map<String, RsTypeParameter>,
+    val lifetimeMap: Map<String, RsLifetimeParameter>,
+    val collected: MutableSet<RsLifetimeParameter>
+) : RsRecursiveVisitor() {
+
+    override fun visitTypeReference(ref: RsTypeReference) {
+        super.visitTypeReference(ref)
+        val type = ref.type as? TyTypeParameter ?: return
+        val parameter = parameters[type.name] ?: return
+        parameter.bounds.forEach { bound ->
+            bound.accept(this)
+        }
+    }
+
+    override fun visitLifetime(lifetime: RsLifetime) {
+        super.visitLifetime(lifetime)
+        val parameter = lifetimeMap[lifetime.name] ?: return
+        if (parameter !in collected) {
+            collected.add(parameter)
+            parameter.accept(this)
+        }
+    }
+}
+
+private fun gatherLifetimesFromTypeReferences(
+    references: List<RsTypeReference>,
+    lifetimes: List<RsLifetimeParameter>,
+    parameters: List<RsTypeParameter>
+): List<RsLifetimeParameter> = gatherLifetimes(lifetimes, parameters, references)
+
+private fun gatherLifetimesFromTypeParameters(
+    lifetimes: List<RsLifetimeParameter>,
+    parameters: List<RsTypeParameter>
+): List<RsLifetimeParameter> = gatherLifetimes(lifetimes, parameters, parameters)
+
+private fun gatherLifetimes(
+    lifetimes: List<RsLifetimeParameter>,
+    parameters: List<RsTypeParameter>,
+    elements: List<PsiElement>
+): List<RsLifetimeParameter> {
+    val parameterMap = parameters.filter { it.name != null }.associateBy { it.name!! }
+    val lifetimeMap = lifetimes.filter { it.name != null }.associateBy { it.name!! }
+    val collected = mutableSetOf<RsLifetimeParameter>()
+
+    for (element in elements) {
+        element.accept(CollectLifetimesVisitor(parameterMap, lifetimeMap, collected))
+    }
+
+    return collected.sortedBy { lifetimes.indexOf(it) }
+}
+
+private data class CollectTypeParametersTypeVisitor(
+    val parameters: Map<String, RsTypeParameter>,
+    val collected: MutableSet<RsTypeParameter>
+) : TypeVisitor {
+    override fun visitTy(ty: Ty): Boolean {
+        return when {
+            ty is TyTypeParameter -> {
+                val type = ty as? TyTypeParameter ?: return true
+                val parameter = parameters[type.name] ?: return true
+                collected.add(parameter)
+
+                parameter.bounds.forEach { bound ->
+                    bound.accept(CollectTypeParametersVisitor(this))
+                }
+                return true
+            }
+            ty.hasTyTypeParameters -> ty.superVisitWith(this)
+            else -> super.visitTy(ty)
+        }
+    }
+}
+
+private data class CollectTypeParametersVisitor(val typeVisitor: CollectTypeParametersTypeVisitor) : RsRecursiveVisitor() {
+    override fun visitTypeReference(ref: RsTypeReference) {
+        ref.type.visitWith(typeVisitor)
+        super.visitTypeReference(ref)
+    }
+}
+
+private data class HasConstParameterVisitor(val parameter: RsConstParameter) : TypeVisitor {
+
+    override fun visitTy(ty: Ty): Boolean =
+        if (ty.hasCtConstParameters) ty.superVisitWith(this) else false
+
+    override fun visitConst(const: Const): Boolean =
+        when {
+            const is CtConstParameter -> const.parameter == parameter
+            const.hasCtConstParameters -> const.superVisitWith(this)
+            else -> false
+        }
+}
+
+private data class HasTypeParameterVisitor(
+    val parameters: Map<String, RsTypeParameter>
+) : TypeVisitor {
+    override fun visitTy(ty: Ty): Boolean =
+        when {
+            ty is TyTypeParameter -> ty.name in parameters
+            ty.hasTyTypeParameters -> ty.superVisitWith(this)
+            else -> false
+        }
+}
+
+private fun matchesConstParameter(type: Ty, parameter: RsConstParameter): Boolean =
+    type.visitWith(HasConstParameterVisitor(parameter))
+
+private fun hasTypeParameter(ref: RsTypeReference, map: Map<String, RsTypeParameter>): Boolean =
+    HasTypeParameterVisitor(map).visitTy(ref.type)
+
+/**
+ * Create a predicate if the lifetime is in the map and at least one of its bounds is in the map.
+ * Bounds that are not in the map are removed.
+ */
+private fun createLifetimePredicate(
+    predicate: RsWherePred,
+    lifetime: RsLifetime,
+    lifetimeParamBounds: RsLifetimeParamBounds?,
+    lifetimeMap: Map<String, RsLifetimeParameter>
+): String? {
+    if (lifetime.name !in lifetimeMap) return null
+    if (lifetimeParamBounds == null) return predicate.text
+    val bounds = lifetimeParamBounds.lifetimeList.filter { it.name in lifetimeMap }
+    return if (bounds.isNotEmpty()) {
+        "${lifetime.text}: ${bounds.joinToString(" + ") { it.text }}"
+    } else {
+        null
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -384,8 +384,9 @@ class RsPsiFactory(
             ?: error("Failed to create unsafe element")
 
     fun createFunction(text: String): RsFunction =
-        createFromText(text)
-            ?: error("Failed to create function element: $text")
+        tryCreateFunction(text) ?: error("Failed to create function element: $text")
+
+    fun tryCreateFunction(text: String): RsFunction? = createFromText(text)
 
     fun createRetType(ty: String): RsRetType =
         createFromText("fn foo() -> $ty {}")

--- a/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
@@ -1,0 +1,206 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention()) {
+    fun `test unavailable on resolved function`() = doUnavailableTest("""
+        fn foo() {}
+
+        fn main() {
+            /*caret*/foo();
+        }
+    """)
+
+    fun `test unavailable on arguments`() = doUnavailableTest("""
+        fn main() {
+            foo(1/*caret*/);
+        }
+    """)
+
+    fun `test unavailable on path argument`() = doUnavailableTest("""
+        fn foo(a: u32) {}
+
+        fn main() {
+            foo(bar::baz/*caret*/);
+        }
+    """)
+
+    fun `test create function`() = doAvailableTest("""
+        fn main() {
+            /*caret*/foo();
+        }
+    """, """
+        fn main() {
+            foo();
+        }
+
+        fn foo() {
+            unimplemented!()/*caret*/
+        }
+    """)
+
+    fun `test create function in an existing module`() = doAvailableTest("""
+        mod foo {}
+
+        fn main() {
+            foo::bar/*caret*/();
+        }
+    """, """
+        mod foo {
+            pub(crate) fn bar() {
+                unimplemented!()/*caret*/
+            }
+        }
+
+        fn main() {
+            foo::bar();
+        }
+    """)
+
+    fun `test create function in an existing file`() = doAvailableTestWithFileTreeComplete("""
+        //- main.rs
+            mod foo;
+
+            fn main() {
+                foo::bar/*caret*/();
+            }
+        //- foo.rs
+            fn test() {}
+    """, """
+        //- main.rs
+            mod foo;
+
+            fn main() {
+                foo::bar();
+            }
+        //- foo.rs
+            fn test() {}
+
+            pub(crate) fn bar() {
+                unimplemented!()
+            }
+    """)
+
+    fun `test unresolved function call in a missing module`() = doUnavailableTest("""
+        fn main() {
+            foo::bar/*caret*/();
+        }
+    """)
+
+    fun `test unresolved function call in a nested function`() = doAvailableTest("""
+        fn main() {
+            fn foo() {
+                /*caret*/bar();
+            }
+        }
+    """, """
+        fn main() {
+            fn foo() {
+                bar();
+            }
+            fn bar() {
+                unimplemented!()/*caret*/
+            }
+        }
+    """)
+
+    fun `test unresolved function call inside a module`() = doAvailableTest("""
+        mod foo {
+            fn main() {
+                /*caret*/bar();
+            }
+        }
+    """, """
+        mod foo {
+            fn main() {
+                bar();
+            }
+
+            fn bar() {
+                unimplemented!()/*caret*/
+            }
+        }
+    """)
+
+    fun `test simple parameters`() = doAvailableTest("""
+        fn main() {
+            let a = 5;
+            foo/*caret*/(1, "hello", &a);
+        }
+    """, """
+        fn main() {
+            let a = 5;
+            foo(1, "hello", &a);
+        }
+
+        fn foo(p0: i32, p1: &str, p2: &i32) {
+            unimplemented!()
+        }
+    """)
+
+    fun `test generic parameters`() = doAvailableTest("""
+        trait Trait1 {}
+        trait Trait2 {}
+
+        fn foo<T, X, R: Trait1>(t1: T, t2: T, r: R) where T: Trait2 {
+            bar/*caret*/(r, t1, t2);
+        }
+    """, """
+        trait Trait1 {}
+        trait Trait2 {}
+
+        fn foo<T, X, R: Trait1>(t1: T, t2: T, r: R) where T: Trait2 {
+            bar(r, t1, t2);
+        }
+
+        fn bar<T, R: Trait1>(p0: R, p1: T, p2: T) where T: Trait2 {
+            unimplemented!()
+        }
+    """)
+
+    fun `test complex generic constraints inside impl`() = doAvailableTest("""
+        struct S<T>(T);
+        trait Trait {}
+        trait Trait2 {}
+
+        impl<'a, 'b, T: 'a> S<T> where for<'c> T: Trait + Fn(&'c i32) {
+            fn foo<R>(t: T, r: &R) where T: Trait2 + Trait, R: Trait + for<'d> Fn(&'d i32) {
+                bar/*caret*/(t, r);
+            }
+        }
+    """, """
+        struct S<T>(T);
+        trait Trait {}
+        trait Trait2 {}
+
+        impl<'a, 'b, T: 'a> S<T> where for<'c> T: Trait + Fn(&'c i32) {
+            fn foo<R>(t: T, r: &R) where T: Trait2 + Trait, R: Trait + for<'d> Fn(&'d i32) {
+                bar(t, r);
+            }
+        }
+
+        fn bar<'a, R, T: 'a>(p0: T, p1: &R) where R: Trait + for<'d> Fn(&'d i32), T: Trait + Trait2, for<'c> T: Fn(&'c i32) + Trait {
+            unimplemented!()
+        }
+    """)
+
+    fun `test nested function generic parameters`() = doAvailableTest("""
+        fn foo<T>() where T: Foo {
+            fn bar<T>(t: T) where T: Bar {
+                baz/*caret*/(t);
+            }
+        }
+    """, """
+        fn foo<T>() where T: Foo {
+            fn bar<T>(t: T) where T: Bar {
+                baz(t);
+            }
+            fn baz<T>(p0: T) where T: Bar {
+                unimplemented!()
+            }
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
@@ -20,10 +20,22 @@ abstract class RsIntentionTestBase(val intention: IntentionAction) : RsTestBase(
         myFixture.checkResult(replaceCaretMarker(after.trimIndent()))
     }
 
-    protected fun doAvailableTestWithFileTree(@Language("Rust") fileStructureBefore: String, @Language("Rust") openedFileAfter: String) {
+    protected fun doAvailableTestWithFileTree(
+        @Language("Rust") fileStructureBefore: String,
+        @Language("Rust") openedFileAfter: String
+    ) {
         fileTreeFromText(fileStructureBefore).createAndOpenFileWithCaretMarker()
         launchAction()
         myFixture.checkResult(replaceCaretMarker(openedFileAfter.trimIndent()))
+    }
+
+    protected fun doAvailableTestWithFileTreeComplete(
+        @Language("Rust") fileStructureBefore: String,
+        @Language("Rust") fileStructureAfter: String
+    ) {
+        fileTreeFromText(fileStructureBefore).createAndOpenFileWithCaretMarker()
+        launchAction()
+        fileTreeFromText(replaceCaretMarker(fileStructureAfter)).check(myFixture)
     }
 
     private fun launchAction() {

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractEnumVariantTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractEnumVariantTest.kt
@@ -133,7 +133,7 @@ class RsExtractEnumVariantTest : RsTestBase() {
             fn foo() -> S;
         }
 
-        struct /*caret*/V1<'a, 'b, T, S, U> where T: Trait + Trait2<S, Item=U>, 'a: 'b { pub a: &'a T, pub b: &'b T }
+        struct /*caret*/V1<'a, 'b, T, S, U> where 'a: 'b, T: Trait + Trait2<S, Item=U> { pub a: &'a T, pub b: &'b T }
 
         enum A<'a, 'b, 'c, T, S, R, U> where T: Trait + Trait2<S, Item=U>, R: Trait, 'a: 'b + 'c, 'b: 'c {
             V1(V1<'a, 'b, T, S, U>),


### PR DESCRIPTION
This PR adds a quick fix to `RsUnresolvedReferenceInspection` which creates a new function for unresolved function call. I took inspiration from a similar quick fix present in the IntelliJ Kotlin plugin.

![convert2](https://user-images.githubusercontent.com/4539057/83786020-6d745d00-a692-11ea-8c54-a8143ac3020c.gif)

It also copies over generic parameters of the call parameters and their bounds:
![convert1](https://user-images.githubusercontent.com/4539057/83786015-6c433000-a692-11ea-98ec-aad582f51f7b.gif)

Currently, the fix is offered only on function calls (not method calls) to avoid potential false positives for methods generated by procedural macros. The fix is also only offered if the parent module of the path exists (i.e. for `a::b::function`, `a::b` must resolve to an existing module) and is part of the workspace (so that it won't try to create a function in `stdlib`).

There are several things left to resolve:
1) When the function is created in a different module, it will need to be visible from the caller location and also the types used in the function signature will have to be imported (this may not always be possible though, if some of the types are private). Should we support this scenario? The Kotlin plugin doesn't support it.
2) When the function call parameters contain types with generic/const parameters, they will need to be copied to the created function, along with their bounds and `where` clauses. Right now I copy generic and const types present in the parameters along with their `where` clauses, but I do not copy lifetimes. The Kotlin plugin only copies generic parameters and doesn't copy `where` clauses.
I was able to reuse most of the code from `RsExtractEnumVariantProcessor` which basically takes a generic declaration and a set of types (or type references) and returns a subset of generic parameters/const parameters/lifetimes that are present in these types. This subset should be copied over to the new function. The naming here is.. not nice (`GenericParameters`). This code should probably be refactored and extracted into a separate module, as it's needed both here and in `RsExtractEnumVariantProcessor`. Where should I eventually put it?
3) Where to create the function? Right now if the path resolves to the same module as the caller, I find some `RsItemElement` parent of the caller and put the function before it. If it resolves to a different module, I put the function at the beginning of that module. Or should we allow the user to select where to place the function, similar to `RsIntroduceConstantHandler`?
4) Should we also enable the fix for method calls?

Fixes: https://github.com/intellij-rust/intellij-rust/issues/3581
Fixes: https://github.com/intellij-rust/intellij-rust/issues/3904
Fixes: https://github.com/intellij-rust/intellij-rust/issues/5301