### PR TITLE
FIX: disable downgrade module and promote to module refactorings for unavailable files in editor

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/RsDowngradeModuleToFile.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsDowngradeModuleToFile.kt
@@ -26,6 +26,15 @@ import org.rust.openapiext.checkWriteAccessAllowed
 class RsDowngradeModuleToFile : BaseRefactoringAction() {
     override fun isEnabledOnElements(elements: Array<out PsiElement>): Boolean = elements.all { it.isDirectoryMod }
 
+    override fun isAvailableOnElementInEditorAndFile(
+        element: PsiElement,
+        editor: Editor,
+        file: PsiFile,
+        context: DataContext
+    ): Boolean {
+        return file.isDirectoryMod
+    }
+
     override fun getHandler(dataContext: DataContext): RefactoringActionHandler = Handler
 
     override fun isAvailableInEditorOnly(): Boolean = false
@@ -63,13 +72,14 @@ private fun contractModule(fileOrDirectory: PsiFileSystemItem) {
     dir.delete()
 }
 
-private val PsiElement.isDirectoryMod: Boolean get() {
-    return when (this) {
-        is RsFile -> name == RsConstants.MOD_RS_FILE && containingDirectory?.children?.size == 1
-        is PsiDirectory -> {
-            val child = children.singleOrNull()
-            child is RsFile && child.name == RsConstants.MOD_RS_FILE
+private val PsiElement.isDirectoryMod: Boolean
+    get() {
+        return when (this) {
+            is RsFile -> name == RsConstants.MOD_RS_FILE && containingDirectory?.children?.size == 1
+            is PsiDirectory -> {
+                val child = children.singleOrNull()
+                child is RsFile && child.name == RsConstants.MOD_RS_FILE
+            }
+            else -> false
         }
-        else -> false
     }
-}

--- a/src/main/kotlin/org/rust/ide/refactoring/RsPromoteModuleToDirectoryAction.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsPromoteModuleToDirectoryAction.kt
@@ -24,14 +24,22 @@ import org.rust.openapiext.checkWriteAccessAllowed
 
 class RsPromoteModuleToDirectoryAction : BaseRefactoringAction() {
     override fun isEnabledOnElements(elements: Array<out PsiElement>): Boolean =
-        elements.all { it is RsFile && it.name != RsConstants.MOD_RS_FILE }
+        elements.all { it.isPromotable }
+
+    override fun isAvailableOnElementInEditorAndFile(
+        element: PsiElement,
+        editor: Editor,
+        file: PsiFile,
+        context: DataContext
+    ): Boolean {
+        return file.isPromotable
+    }
 
     override fun getHandler(dataContext: DataContext): RefactoringActionHandler = Handler
 
     override fun isAvailableInEditorOnly(): Boolean = false
 
     override fun isAvailableForLanguage(language: Language): Boolean = language.`is`(RsLanguage)
-
 
     private object Handler : RefactoringActionHandler {
         override fun invoke(project: Project, editor: Editor, file: PsiFile, dataContext: DataContext?) {
@@ -59,3 +67,6 @@ class RsPromoteModuleToDirectoryAction : BaseRefactoringAction() {
         }
     }
 }
+
+private val PsiElement.isPromotable
+    get() = this is RsFile && this.name != RsConstants.MOD_RS_FILE


### PR DESCRIPTION
Both `RsDowngradeModuleToFile` and `RsPromoteModuleToDirectoryAction` refactorings were available on all Rust PsiElements all of the time, without checking if their corresponding file is valid for the refactoring. Invoking such refactoring could have a nasty effect, for example it could delete a whole (non-empty) source directory.

I modified them to only be available if the corresponding file in the editor is valid for the refactoring. We can also ban them altogether from the editor and only enable it from the Project tree.