### PR TITLE
TOML: Fix Cargo.toml dependencies docs urls

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt
@@ -49,12 +49,18 @@ class CargoCrateDocLineMarkerProvider : LineMarkerProvider {
     }
 
     private fun genLineMarkerInfo(anchor: PsiElement, name: String, version: String): LineMarkerInfo<PsiElement> {
+        val urlVersion = when {
+            version.isEmpty() -> "*"
+            version.first().isDigit() -> "^${version}"
+            else -> version
+        }
+
         return LineMarkerInfo(
             anchor,
             anchor.textRange,
             RsIcons.DOCS_MARK,
-            { "Open documentation for `$name@$version`" },
-            { _, _ -> BrowserUtil.browse("https://docs.rs/$name/$version/$name") },
+            { "Open documentation for `$name@$urlVersion`" },
+            { _, _ -> BrowserUtil.browse("https://docs.rs/$name/$urlVersion") },
             GutterIconRenderer.Alignment.LEFT)
 
     }

--- a/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
@@ -43,34 +43,34 @@ class CargoCrateDocLineMarkerProviderTest : RsTestBase() {
 
     fun `test standard version`() = doTestByText("""
         [dependencies]
-        base64 = "0.8.0"  # - Open documentation for `base64@0.8.0`
+        base64 = "0.8.0"  # - Open documentation for `base64@^0.8.0`
 
         [target.'cfg(unix)'.dependencies]
-        base64 = "0.8.0"  # - Open documentation for `base64@0.8.0`
+        base64 = "0.8.0"  # - Open documentation for `base64@^0.8.0`
     """)
 
     fun `test platform specific`() = doTestByText("""
         [target.'cfg(unix)'.dependencies]
-        base64 = "0.8.0"  # - Open documentation for `base64@0.8.0`
+        base64 = "0.8.0"  # - Open documentation for `base64@^0.8.0`
     """)
 
     fun `test standard detailed`() = doTestByText("""
         [dependencies]
-        jquery = { version = "1.0.2", optional = true }  # - Open documentation for `jquery@1.0.2`
+        jquery = { version = "1.0.2", optional = true }  # - Open documentation for `jquery@^1.0.2`
     """)
 
     fun `test standard dev`() = doTestByText("""
         [dev-dependencies]
-        libc = "0.2.33"  # - Open documentation for `libc@0.2.33`
+        libc = "0.2.33"  # - Open documentation for `libc@^0.2.33`
     """)
 
     fun `test standard build`() = doTestByText("""
         [build-dependencies]
-        libc = "0.2.33"  # - Open documentation for `libc@0.2.33`
+        libc = "0.2.33"  # - Open documentation for `libc@^0.2.33`
     """)
 
     fun `test specific crate`() = doTestByText("""
-        [dependencies.clap]  # - Open documentation for `clap@2.27.1`
+        [dependencies.clap]  # - Open documentation for `clap@^2.27.1`
         version = "2.27.1"
     """)
 
@@ -81,14 +81,24 @@ class CargoCrateDocLineMarkerProviderTest : RsTestBase() {
 
     fun `test renamed dependencies`() = doTestByText("""
         [dependencies]
-        config_rs = { package = "config", version = "0.9" }  # - Open documentation for `config@0.9`
+        config_rs = { package = "config", version = "0.9" }  # - Open documentation for `config@^0.9`
     """)
 
     fun `test unescape string literals`() = doTestByText("""
         [dependencies]
-        serde = '1.0.104'  # - Open documentation for `serde@1.0.104`
-        serde_json = { version = '''1.0.104''' }  # - Open documentation for `serde_json@1.0.104`
-        serde_yaml_rs = { package = 'serde_yaml', version = '''0.8.11''' }  # - Open documentation for `serde_yaml@0.8.11`
-        serde_derive_rs = { package = "serde\u005Fderive", version ="1\u002E0\u002E104" }  # - Open documentation for `serde_derive@1.0.104`
+        serde = '1.0.104'  # - Open documentation for `serde@^1.0.104`
+        serde_json = { version = '''1.0.104''' }  # - Open documentation for `serde_json@^1.0.104`
+        serde_yaml_rs = { package = 'serde_yaml', version = '''0.8.11''' }  # - Open documentation for `serde_yaml@^0.8.11`
+        serde_derive_rs = { package = "serde\u005Fderive", version ="1\u002E0\u002E104" }  # - Open documentation for `serde_derive@^1.0.104`
     """)
+
+    fun `test empty version`() = doTestByText("""
+        [dependencies]
+        base64 = ""  # - Open documentation for `base64@*`
+    """)
+
+    fun `test exact version`() = doTestByText("""
+        [dependencies]
+        base64 = "=0.8.0"  # - Open documentation for `base64@=0.8.0`
+    """.trimIndent())
 }


### PR DESCRIPTION
Fixes #5467. Fixes #5411.
Manages version modification to be compatable with docs.rs and fixes urls for crates with dashes.

![image](https://user-images.githubusercontent.com/6342851/83946740-5ad95f80-a81b-11ea-926a-93a9d2d37439.png)

Not sure how incorrect versions should be managed, with other issues of #5440 this could be improved.