### PR TITLE
RUN: Introduce remote Rust toolchains

### DIFF
--- a/coverage/src/main/kotlin/org/rust/coverage/LcovCoverageReport.kt
+++ b/coverage/src/main/kotlin/org/rust/coverage/LcovCoverageReport.kt
@@ -44,18 +44,14 @@ class LcovCoverageReport {
         private const val LINE_HIT_PREFIX: String = "DA:"
         private const val END_OF_RECORD: String = "end_of_record"
 
-        fun readLcov(
-            lcovFile: File,
-            localBaseDir: String? = null,
-            toLocalPathConverter: (String) -> String = { it }
-        ): LcovCoverageReport {
+        fun readLcov(lcovFile: File, localBaseDir: String? = null): LcovCoverageReport {
             val report = LcovCoverageReport()
             var currentFileName: String? = null
             var lineDataList: MutableList<LineHits>? = null
             lcovFile.forEachLine { line ->
                 when {
                     line.startsWith(SOURCE_FILE_PREFIX) -> {
-                        currentFileName = toLocalPathConverter(line.substring(SOURCE_FILE_PREFIX.length))
+                        currentFileName = line.substring(SOURCE_FILE_PREFIX.length)
                         lineDataList = mutableListOf()
                     }
                     line.startsWith(LINE_HIT_PREFIX) -> {

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -421,7 +421,7 @@ open class CargoProjectsServiceImpl(
      */
     override fun noStateLoaded() {
         // Do nothing: in theory, we might try to do [discoverAndRefresh]
-        // here, but the `RustToolchain` is most likely not ready.
+        // here, but the `RsToolchain` is most likely not ready.
         //
         // So the actual "Let's guess a project model if it is not imported
         // explicitly" happens in [org.rust.ide.notifications.MissingToolchainNotificationProvider]

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -14,6 +14,7 @@ import com.intellij.util.xmlb.annotations.Transient
 import org.jetbrains.annotations.TestOnly
 import org.rust.cargo.toolchain.ExternalLinter
 import org.rust.cargo.toolchain.RsToolchain
+import org.rust.cargo.toolchain.RsToolchainProvider
 import org.rust.cargo.toolchain.RustToolchain
 import org.rust.ide.experiments.RsExperiments
 import org.rust.openapiext.isFeatureEnabled
@@ -55,7 +56,7 @@ interface RustProjectSettingsService {
         @get:Transient
         @set:Transient
         var toolchain: RsToolchain?
-            get() = toolchainHomeDirectory?.let { RsToolchain(Paths.get(it)) }
+            get() = toolchainHomeDirectory?.let { RsToolchainProvider.getToolchain(Paths.get(it)) }
             set(value) {
                 toolchainHomeDirectory = value?.location?.systemIndependentPath
             }

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunStateBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunStateBase.kt
@@ -65,11 +65,7 @@ abstract class CargoRunStateBase(
      */
     fun startProcess(processColors: Boolean): ProcessHandler {
         val commandLine = cargo().toColoredCommandLine(environment.project, prepareCommandLine())
-        val handler = if (processColors) {
-            RsKillableColoredProcessHandler(commandLine)
-        } else {
-            KillableProcessHandler(commandLine)
-        }
+        val handler = if (processColors) RsProcessHandler(commandLine) else KillableProcessHandler(commandLine)
         ProcessTerminatedListener.attach(handler) // shows exit code upon termination
         return handler
     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
@@ -123,7 +123,7 @@ abstract class RsExecutableRunner(
         extensionManager.patchCommandLine(runConfiguration, environment, commandLine, context)
         extensionManager.patchCommandLineState(runConfiguration, environment, state, context)
 
-        val handler = RsKillableColoredProcessHandler(commandLine)
+        val handler = state.toolchain.startProcess(commandLine)
         ProcessTerminatedListener.attach(handler) // shows exit code upon termination
 
         extensionManager.attachExtensionsToProcess(runConfiguration, handler, environment, context)

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
@@ -25,7 +25,6 @@ import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.toolchain.impl.CargoMetadata
 import org.rust.cargo.toolchain.tools.Cargo.Companion.getCargoCommonPatch
-import org.rust.cargo.toolchain.tools.RsTool.Companion.createGeneralCommandLine
 import org.rust.cargo.util.CargoArgsParser.Companion.parseArgs
 import org.rust.openapiext.computeWithCancelableProgress
 import org.rust.stdext.toPath
@@ -80,14 +79,15 @@ abstract class RsExecutableRunner(
         val runCargoCommand = state.prepareCommandLine()
         val workingDirectory = getWorkingDirectory(environment.project, runCargoCommand, artifact)
         val (_, executableArguments) = parseArgs(runCargoCommand.command, runCargoCommand.additionalArguments)
-        val runExecutable = createGeneralCommandLine(
+        val runExecutable = state.toolchain.createGeneralCommandLine(
             binaries.single().toPath(),
             workingDirectory,
             runCargoCommand.redirectInputFrom,
             runCargoCommand.backtraceMode,
             runCargoCommand.environmentVariables,
             executableArguments,
-            runCargoCommand.emulateTerminal
+            runCargoCommand.emulateTerminal,
+            patchToRemote = false
         )
         return showRunContent(state, environment, runExecutable)
     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsProcessHandler.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsProcessHandler.kt
@@ -9,18 +9,15 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.AnsiEscapeDecoder
 import com.intellij.execution.process.KillableProcessHandler
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.registry.Registry
 
 /**
  * Same as [com.intellij.execution.process.KillableColoredProcessHandler], but uses [RsAnsiEscapeDecoder].
  */
-class RsKillableColoredProcessHandler(commandLine: GeneralCommandLine)
-    : KillableProcessHandler(mediate(commandLine, false, false)),
+open class RsProcessHandler(commandLine: GeneralCommandLine)
+    : KillableProcessHandler(commandLine, softKillOnWin),
       AnsiEscapeDecoder.ColoredTextAcceptor {
     private val decoder: AnsiEscapeDecoder = RsAnsiEscapeDecoder()
-
-    init {
-        setShouldKillProcessSoftly(true)
-    }
 
     override fun notifyTextAvailable(text: String, outputType: Key<*>) {
         decoder.escapeText(text, outputType, this)
@@ -28,5 +25,12 @@ class RsKillableColoredProcessHandler(commandLine: GeneralCommandLine)
 
     override fun coloredTextAvailable(text: String, attributes: Key<*>) {
         super.notifyTextAvailable(text, attributes)
+    }
+
+    override fun shouldDestroyProcessRecursively(): Boolean = true
+
+    companion object {
+        private val softKillOnWin: Boolean
+            get() = Registry.`is`("kill.windows.processes.softly", false)
     }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/filters/RegexpFileLinkFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/filters/RegexpFileLinkFilter.kt
@@ -115,7 +115,9 @@ open class RegexpFileLinkFilter(
         return match.groupValues[1]
     }
 
+    // TODO: check
     private fun getSysroot(): String? = project.cargoProjects.allProjects.firstOrNull()?.rustcInfo?.sysroot
+    // TODO: check
     private fun getCargoRoot(): String = project.rustSettings.toolchain?.location?.parent.toString()
 
     sealed class ResolvedPath(val file: VirtualFile) {

--- a/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
@@ -113,7 +113,7 @@ abstract class RsAsyncRunner(
         manager.patchCommandLine(runConfiguration, environment, cmd, context)
         manager.patchCommandLineState(runConfiguration, environment, state, context)
 
-        val handler = RsKillableColoredProcessHandler(cmd)
+        val handler = state.toolchain.startProcess(cmd)
         ProcessTerminatedListener.attach(handler) // shows exit code upon termination
 
         manager.attachExtensionsToProcess(runConfiguration, handler, environment, context)
@@ -143,10 +143,11 @@ abstract class RsAsyncRunner(
         isTestBuild: Boolean
     ): Promise<Binary?> {
         val promise = AsyncPromise<Binary?>()
-        val cargo = state.cargo()
+        val toolchain = state.toolchain
+        val cargo = toolchain.cargo()
 
         val processForUserOutput = ProcessOutput()
-        val processForUser = RsKillableColoredProcessHandler(cargo.toColoredCommandLine(project, command))
+        val processForUser = toolchain.startProcess(cargo.toColoredCommandLine(project, command))
 
         processForUser.addProcessListener(CapturingProcessAdapter(processForUserOutput))
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
@@ -34,7 +34,7 @@ import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.toolchain.impl.CargoMetadata
 import org.rust.cargo.toolchain.tools.Cargo.Companion.getCargoCommonPatch
-import org.rust.cargo.toolchain.tools.RsTool.Companion.createGeneralCommandLine
+import org.rust.cargo.toolchain.tools.cargo
 import org.rust.cargo.util.CargoArgsParser.Companion.parseArgs
 import org.rust.openapiext.JsonUtils.tryParseJsonObject
 import org.rust.openapiext.saveAllDocuments
@@ -74,14 +74,15 @@ abstract class RsAsyncRunner(
 
         val getRunCommand = { executablePath: Path ->
             with(commandLine) {
-                createGeneralCommandLine(
+                state.toolchain.createGeneralCommandLine(
                     executablePath,
                     workingDirectory,
                     redirectInputFrom,
                     backtraceMode,
                     environmentVariables,
                     executableArguments,
-                    emulateTerminal
+                    emulateTerminal,
+                    patchToRemote = false
                 )
             }
         }

--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestEventsConverter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestEventsConverter.kt
@@ -18,6 +18,7 @@ import com.intellij.util.execution.ParametersListUtil
 import jetbrains.buildServer.messages.serviceMessages.ServiceMessageVisitor
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.model.impl.allPackages
+import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.runconfig.test.CargoTestEventsConverter.State.*
@@ -81,7 +82,7 @@ class CargoTestEventsConverter(
             EXECUTABLE_NAME -> {
                 val executableName = text
                     .trim()
-                    .substringAfterLast(File.separator)
+                    .substringAfterLast(project.toolchain?.fileSeparator ?: File.separator)
                     .substringBeforeLast(".")
                     .takeIf { it.isNotEmpty() }
                     ?: error("Can't parse the executable name")

--- a/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandRunStateBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandRunStateBase.kt
@@ -10,7 +10,6 @@ import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.util.execution.ParametersListUtil
-import org.rust.cargo.runconfig.RsKillableColoredProcessHandler
 import org.rust.cargo.toolchain.tools.WasmPack
 import java.io.File
 
@@ -28,7 +27,7 @@ abstract class WasmPackCommandRunStateBase(
             params.drop(1)
         )
 
-        val handler = RsKillableColoredProcessHandler(commandLine)
+        val handler = wasmPack.toolchain.startProcess(commandLine)
         ProcessTerminatedListener.attach(handler) // shows exit code upon termination
         return handler
     }

--- a/src/main/kotlin/org/rust/cargo/toolchain/RsLocalToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsLocalToolchain.kt
@@ -5,9 +5,12 @@
 
 package org.rust.cargo.toolchain
 
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.FileUtil
+import org.rust.cargo.runconfig.RsProcessHandler
 import org.rust.cargo.util.hasExecutable
 import org.rust.cargo.util.pathToExecutable
 import org.rust.stdext.isExecutable
@@ -24,6 +27,8 @@ class RsLocalToolchainProvider : RsToolchainProvider {
 
 open class RsLocalToolchain(location: Path) : RsToolchain(location) {
     override val fileSeparator: String get() = File.separator
+
+    override fun startProcess(commandLine: GeneralCommandLine): ProcessHandler = RsProcessHandler(commandLine)
 
     override fun toLocalPath(remotePath: String): String = remotePath
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/RsLocalToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsLocalToolchain.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.util.io.FileUtil
 import org.rust.cargo.util.hasExecutable
 import org.rust.cargo.util.pathToExecutable
 import org.rust.stdext.isExecutable
+import java.io.File
 import java.nio.file.Path
 
 class RsLocalToolchainProvider : RsToolchainProvider {
@@ -22,6 +23,7 @@ class RsLocalToolchainProvider : RsToolchainProvider {
 }
 
 open class RsLocalToolchain(location: Path) : RsToolchain(location) {
+    override val fileSeparator: String get() = File.separator
 
     override fun expandUserHome(remotePath: String): String = FileUtil.expandUserHome(remotePath)
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/RsLocalToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsLocalToolchain.kt
@@ -25,6 +25,10 @@ class RsLocalToolchainProvider : RsToolchainProvider {
 open class RsLocalToolchain(location: Path) : RsToolchain(location) {
     override val fileSeparator: String get() = File.separator
 
+    override fun toLocalPath(remotePath: String): String = remotePath
+
+    override fun toRemotePath(localPath: String): String = localPath
+
     override fun expandUserHome(remotePath: String): String = FileUtil.expandUserHome(remotePath)
 
     override fun getExecutableName(toolName: String): String = if (SystemInfo.isWindows) "$toolName.exe" else toolName

--- a/src/main/kotlin/org/rust/cargo/toolchain/RsLocalToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsLocalToolchain.kt
@@ -28,6 +28,8 @@ class RsLocalToolchainProvider : RsToolchainProvider {
 open class RsLocalToolchain(location: Path) : RsToolchain(location) {
     override val fileSeparator: String get() = File.separator
 
+    override fun <T : GeneralCommandLine> patchCommandLine(commandLine: T): T = commandLine
+
     override fun startProcess(commandLine: GeneralCommandLine): ProcessHandler = RsProcessHandler(commandLine)
 
     override fun toLocalPath(remotePath: String): String = remotePath

--- a/src/main/kotlin/org/rust/cargo/toolchain/RsLocalToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsLocalToolchain.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.toolchain
+
+import com.intellij.execution.wsl.WSLDistribution
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.io.FileUtil
+import org.rust.cargo.util.hasExecutable
+import org.rust.cargo.util.pathToExecutable
+import org.rust.stdext.isExecutable
+import java.nio.file.Path
+
+class RsLocalToolchainProvider : RsToolchainProvider {
+
+    override fun isApplicable(homePath: Path): Boolean =
+        !homePath.toString().startsWith(WSLDistribution.UNC_PREFIX)
+
+    override fun getToolchain(homePath: Path): RsToolchain = RsLocalToolchain(homePath)
+}
+
+open class RsLocalToolchain(location: Path) : RsToolchain(location) {
+
+    override fun expandUserHome(remotePath: String): String = FileUtil.expandUserHome(remotePath)
+
+    override fun getExecutableName(toolName: String): String = if (SystemInfo.isWindows) "$toolName.exe" else toolName
+
+    override fun pathToExecutable(toolName: String): Path = location.pathToExecutable(toolName)
+
+    override fun hasExecutable(exec: String): Boolean = location.hasExecutable(exec)
+
+    override fun hasCargoExecutable(exec: String): Boolean = pathToCargoExecutable(exec).isExecutable()
+}

--- a/src/main/kotlin/org/rust/cargo/toolchain/RsToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsToolchain.kt
@@ -33,6 +33,10 @@ abstract class RsToolchain(val location: Path) {
 
     fun looksLikeValidToolchain(): Boolean = RsToolchainFlavor.getFlavor(location) != null
 
+    abstract fun toLocalPath(remotePath: String): String
+
+    abstract fun toRemotePath(localPath: String): String
+
     abstract fun expandUserHome(remotePath: String): String
 
     protected abstract fun getExecutableName(toolName: String): String

--- a/src/main/kotlin/org/rust/cargo/toolchain/RsToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsToolchain.kt
@@ -29,6 +29,8 @@ interface RsToolchainProvider {
 abstract class RsToolchain(val location: Path) {
     val presentableLocation: String get() = pathToExecutable(Cargo.NAME).toString()
 
+    abstract val fileSeparator: String
+
     fun looksLikeValidToolchain(): Boolean = RsToolchainFlavor.getFlavor(location) != null
 
     abstract fun expandUserHome(remotePath: String): String

--- a/src/main/kotlin/org/rust/cargo/toolchain/RsToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsToolchain.kt
@@ -5,6 +5,8 @@
 
 package org.rust.cargo.toolchain
 
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.ProcessHandler
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.util.io.exists
 import com.intellij.util.text.SemVer
@@ -32,6 +34,8 @@ abstract class RsToolchain(val location: Path) {
     abstract val fileSeparator: String
 
     fun looksLikeValidToolchain(): Boolean = RsToolchainFlavor.getFlavor(location) != null
+
+    abstract fun startProcess(commandLine: GeneralCommandLine): ProcessHandler
 
     abstract fun toLocalPath(remotePath: String): String
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
@@ -10,7 +10,7 @@ import java.nio.file.Path
 // BACKCOMPAT: 2020.2
 @Deprecated("Use org.rust.cargo.toolchain.RsToolchain")
 @Suppress("DEPRECATION")
-class RustToolchain(location: Path) : RsToolchain(location) {
+class RustToolchain(location: Path) : RsLocalToolchain(location) {
 
     fun rawCargo(): Cargo = Cargo(this)
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -22,6 +22,8 @@ import java.util.*
 
 private val LOG = Logger.getInstance(CargoMetadata::class.java)
 
+typealias PathConverter = (String) -> String
+
 /**
  * Classes mirroring JSON output of `cargo metadata`.
  * Attribute names and snake_case are crucial.
@@ -54,8 +56,12 @@ object CargoMetadata {
          * Path to workspace root folder. Can be null for old cargo version
          */
         val workspace_root: String
-    )
-
+    ) {
+        fun convertPaths(converter: PathConverter): Project = copy(
+            packages = packages.map { it.convertPaths(converter) },
+            workspace_root = converter(workspace_root)
+        )
+    }
 
     data class Package(
         val name: String,
@@ -109,7 +115,12 @@ object CargoMetadata {
          * any additional data.
          */
         val dependencies: List<RawDependency>
-    )
+    ) {
+        fun convertPaths(converter: PathConverter): Package = copy(
+            manifest_path = converter(manifest_path),
+            targets = targets.map { it.convertPaths(converter) }
+        )
+    }
 
     data class RawDependency(
         /** A `package` name (non-normalized) of the dependency */
@@ -203,6 +214,10 @@ object CargoMetadata {
                     else -> CrateType.UNKNOWN
                 }
             }
+
+        fun convertPaths(converter: PathConverter): Target = copy(
+            src_path = converter(src_path)
+        )
     }
 
     enum class TargetKind {
@@ -305,6 +320,10 @@ object CargoMetadata {
                     filenames.filter { !it.endsWith(".dSYM") && !it.endsWith(".pdb") }
                 }
             }
+
+        fun convertPaths(converter: PathConverter): Artifact = copy(
+            target = target.convertPaths(converter)
+        )
 
         companion object {
             fun fromJson(json: JsonObject): Artifact? {

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -151,6 +151,7 @@ open class Cargo(toolchain: RsToolchain, useWrapper: Boolean = false)
             .dropWhile { it != '{' }
         try {
             return Gson().fromJson(json, CargoMetadata.Project::class.java)
+                .convertPaths(toolchain::toLocalPath)
         } catch (e: JsonSyntaxException) {
             throw ExecutionException(e)
         }

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -395,7 +395,7 @@ open class Cargo(toolchain: RsToolchain, useWrapper: Boolean = false)
                 addAll(additionalArguments)
             }
             val rustcExecutable = toolchain.rustc().executable.toString()
-            createGeneralCommandLine(
+            toolchain.createGeneralCommandLine(
                 executable,
                 workingDirectory,
                 redirectInputFrom,
@@ -403,7 +403,7 @@ open class Cargo(toolchain: RsToolchain, useWrapper: Boolean = false)
                 environmentVariables,
                 parameters,
                 emulateTerminal,
-                http
+                http = http
             ).withEnvironment("RUSTC", rustcExecutable)
         }
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/RsTool.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/RsTool.kt
@@ -5,21 +5,13 @@
 
 package org.rust.cargo.toolchain.tools
 
-import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.execution.configurations.PtyCommandLine
-import com.intellij.openapi.util.SystemInfo
-import com.intellij.util.net.HttpConfigurable
-import org.rust.cargo.CargoConstants
-import org.rust.cargo.toolchain.BacktraceMode
 import org.rust.cargo.toolchain.RsToolchain
-import org.rust.cargo.toolchain.withProxyIfNeeded
 import org.rust.openapiext.GeneralCommandLine
 import org.rust.openapiext.withWorkDirectory
-import java.io.File
 import java.nio.file.Path
 
-abstract class RsTool(toolName: String, protected val toolchain: RsToolchain) {
+abstract class RsTool(toolName: String, val toolchain: RsToolchain) {
     open val executable: Path = toolchain.pathToExecutable(toolName)
 
     protected fun createBaseCommandLine(
@@ -37,45 +29,7 @@ abstract class RsTool(toolName: String, protected val toolchain: RsToolchain) {
         .withWorkDirectory(workingDirectory)
         .withParameters(parameters)
         .withCharset(Charsets.UTF_8)
-
-    companion object {
-        fun createGeneralCommandLine(
-            executable: Path,
-            workingDirectory: Path,
-            redirectInputFrom: File?,
-            backtraceMode: BacktraceMode,
-            environmentVariables: EnvironmentVariablesData,
-            parameters: List<String>,
-            emulateTerminal: Boolean,
-            http: HttpConfigurable = HttpConfigurable.getInstance()
-        ): GeneralCommandLine {
-            var commandLine = GeneralCommandLine(executable)
-                .withWorkDirectory(workingDirectory)
-                .withInput(redirectInputFrom)
-                .withEnvironment("TERM", "ansi")
-                .withParameters(parameters)
-                .withCharset(Charsets.UTF_8)
-                .withRedirectErrorStream(true)
-            withProxyIfNeeded(commandLine, http)
-
-            when (backtraceMode) {
-                BacktraceMode.SHORT -> commandLine.withEnvironment(CargoConstants.RUST_BACKTRACE_ENV_VAR, "short")
-                BacktraceMode.FULL -> commandLine.withEnvironment(CargoConstants.RUST_BACKTRACE_ENV_VAR, "full")
-                BacktraceMode.NO -> Unit
-            }
-
-            environmentVariables.configureCommandLine(commandLine, true)
-
-            if (emulateTerminal) {
-                if (!SystemInfo.isWindows) {
-                    commandLine.environment["TERM"] = "xterm-256color"
-                }
-                commandLine = PtyCommandLine(commandLine).withInitialColumns(PtyCommandLine.MAX_COLUMNS)
-            }
-
-            return commandLine
-        }
-    }
+        .also { toolchain.patchCommandLine(it) }
 }
 
 abstract class CargoBinary(binaryName: String, toolchain: RsToolchain) : RsTool(binaryName, toolchain) {

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustc.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustc.kt
@@ -51,7 +51,9 @@ class Rustc(toolchain: RsToolchain) : RustupComponent(NAME, toolchain) {
     }
 
     fun getStdlibFromSysroot(projectDirectory: Path): VirtualFile? {
-        val stdlibPath = getStdlibPathFromSysroot(projectDirectory) ?: return null
+        val stdlibPath = getStdlibPathFromSysroot(projectDirectory)
+            ?.let { toolchain.toLocalPath(it) }
+            ?: return null
         val fs = LocalFileSystem.getInstance()
         return fs.refreshAndFindFileByPath(stdlibPath)
     }

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustup.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustup.kt
@@ -43,11 +43,11 @@ class Rustup(toolchain: RsToolchain, private val projectDirectory: Path) : RsToo
         }
     }
 
-    fun listComponents(): List<Component> =
+    private fun listComponents(): List<Component> =
         createBaseCommandLine(
-            "component", "list",
+            "component", "list", "--installed",
             workingDirectory = projectDirectory
-        ).execute()?.stdoutLines?.map { Component.from(it) }.orEmpty()
+        ).execute()?.stdoutLines?.map { Component(it.trim(), true) }.orEmpty()
 
     fun downloadStdlib(owner: Disposable? = null, listener: ProcessListener? = null): DownloadResult<VirtualFile> {
         // Sometimes we have stdlib but don't have write access to install it (for example, github workflow)
@@ -94,7 +94,7 @@ class Rustup(toolchain: RsToolchain, private val projectDirectory: Path) : RsToo
         val isInstalled = listComponents()
             .find { (name, _) -> name.startsWith(componentName) }
             ?.isInstalled
-            ?: return false
+            ?: return true
 
         return !isInstalled
     }

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1089,9 +1089,20 @@
 
     </extensions>
 
+    <extensions defaultExtensionNs="org.rust">
+
+        <!-- Toolchains -->
+
+        <toolchainProvider implementation="org.rust.cargo.toolchain.RsLocalToolchainProvider"/>
+
+    </extensions>
+
     <extensionPoints>
         <extensionPoint qualifiedName="org.rust.runConfigurationExtension"
                         interface="org.rust.cargo.runconfig.CargoCommandConfigurationExtension"
+                        dynamic="true"/>
+        <extensionPoint qualifiedName="org.rust.toolchainProvider"
+                        interface="org.rust.cargo.toolchain.RsToolchainProvider"
                         dynamic="true"/>
         <extensionPoint qualifiedName="org.rust.toolchainFlavor"
                         interface="org.rust.cargo.toolchain.flavors.RsToolchainFlavor"

--- a/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
@@ -11,7 +11,7 @@ import org.rust.cargo.project.settings.RustProjectSettingsService.MacroExpansion
 import org.rust.cargo.project.settings.impl.RustProjectSettingsServiceImpl
 import org.rust.cargo.project.settings.impl.XML_FORMAT_VERSION
 import org.rust.cargo.toolchain.ExternalLinter
-import org.rust.cargo.toolchain.RsToolchain
+import org.rust.cargo.toolchain.RsLocalToolchain
 import org.rust.openapiext.elementFromXmlString
 import org.rust.openapiext.toXmlString
 import java.nio.file.Paths
@@ -45,7 +45,7 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
         assertEquals(text, actual)
 
         assertEquals(XML_FORMAT_VERSION, service.version)
-        assertEquals(RsToolchain(Paths.get("/")), service.toolchain)
+        assertEquals(RsLocalToolchain(Paths.get("/")), service.toolchain)
         assertEquals(false, service.autoUpdateEnabled)
         assertEquals(ExternalLinter.CLIPPY, service.externalLinter)
         assertEquals("/stdlib", service.explicitPathToStdlib)

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt
@@ -141,7 +141,7 @@ class CargoTest : RsTestBase() {
         return result
     }
 
-    private val toolchain get() = RsToolchain(Paths.get("/usr/bin"))
+    private val toolchain get() = RsLocalToolchain(Paths.get("/usr/bin"))
     private val cargo = toolchain.cargo()
     private val drive = Paths.get("/").toAbsolutePath().toString().toUnixSlashes()
     private val wd = Paths.get("/my-crate")


### PR DESCRIPTION
This is necessary for future integration with external tools via corresponding plugins, such as:
* [Docker](https://plugins.jetbrains.com/plugin/7724-docker) ([example](https://plugins.jetbrains.com/plugin/8595-php-docker))
* [SSH Remote Run](https://plugins.jetbrains.com/plugin/13125-ftp-sftp-connectivity-ex-remote-hosts-access-) ([example](https://plugins.jetbrains.com/plugin/7511-php-remote-interpreter))
* [WSL Support Framework](https://plugins.jetbrains.com/plugin/10024-wsl-support-framework) ([example](https://plugins.jetbrains.com/plugin/13423-php-wsl-support)) (now it's bundled into the IDE)

Depends on https://github.com/intellij-rust/intellij-rust/pull/6278, https://github.com/intellij-rust/intellij-rust/pull/6251 and https://github.com/intellij-rust/intellij-rust/pull/6246.