### PR TITLE
TOML: initial formatter implementation

### DIFF
--- a/intellij-toml/src/main/kotlin/org/toml/ide/formatter/TomlFmtBlock.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/formatter/TomlFmtBlock.kt
@@ -1,0 +1,63 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.formatter
+
+import com.intellij.formatting.*
+import com.intellij.lang.ASTNode
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.formatter.FormatterUtil
+import org.toml.ide.formatter.impl.computeIndent
+import org.toml.ide.formatter.impl.computeSpacing
+import org.toml.ide.formatter.impl.isWhitespaceOrEmpty
+import org.toml.lang.psi.TomlElementTypes.ARRAY
+
+class TomlFmtBlock(
+    private val node: ASTNode,
+    private val alignment: Alignment?,
+    private val indent: Indent?,
+    private val wrap: Wrap?,
+    private val ctx: TomlFmtContext
+) : ASTBlock {
+    override fun getNode(): ASTNode = node
+    override fun getTextRange(): TextRange = node.textRange
+    override fun getAlignment(): Alignment? = alignment
+    override fun getIndent(): Indent? = indent
+    override fun getWrap(): Wrap? = wrap
+
+    override fun getSubBlocks(): List<Block> = mySubBlocks
+    private val mySubBlocks: List<Block> by lazy { buildChildren() }
+
+    private fun buildChildren(): List<Block> {
+        return node.getChildren(null)
+            .filter { !it.isWhitespaceOrEmpty() }
+            .map { childNode: ASTNode ->
+                TomlFormattingModelBuilder.createBlock(
+                    node = childNode,
+                    alignment = null,
+                    indent = computeIndent(childNode),
+                    wrap = null,
+                    ctx = ctx
+                )
+            }
+    }
+
+    override fun getSpacing(child1: Block?, child2: Block): Spacing? = computeSpacing(child1, child2, ctx)
+
+    override fun getChildAttributes(newChildIndex: Int): ChildAttributes {
+        val indent = when (node.elementType) {
+            ARRAY -> Indent.getNormalIndent()
+            else -> Indent.getNoneIndent()
+        }
+        return ChildAttributes(indent, null)
+    }
+
+    override fun isLeaf(): Boolean = node.firstChildNode == null
+
+    override fun isIncomplete(): Boolean = myIsIncomplete
+    private val myIsIncomplete: Boolean by lazy { FormatterUtil.isIncomplete(node) }
+
+    override fun toString() = "${node.text} $textRange"
+}

--- a/intellij-toml/src/main/kotlin/org/toml/ide/formatter/TomlFmtContext.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/formatter/TomlFmtContext.kt
@@ -1,0 +1,24 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.formatter
+
+import com.intellij.formatting.SpacingBuilder
+import com.intellij.psi.codeStyle.CodeStyleSettings
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings
+import org.toml.ide.formatter.impl.createSpacingBuilder
+import org.toml.lang.TomlLanguage
+
+data class TomlFmtContext private constructor(
+    val commonSettings: CommonCodeStyleSettings,
+    val spacingBuilder: SpacingBuilder
+) {
+    companion object {
+        fun create(settings: CodeStyleSettings): TomlFmtContext {
+            val commonSettings = settings.getCommonSettings(TomlLanguage)
+            return TomlFmtContext(commonSettings, createSpacingBuilder(commonSettings))
+        }
+    }
+}

--- a/intellij-toml/src/main/kotlin/org/toml/ide/formatter/TomlFormattingModelBuilder.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/formatter/TomlFormattingModelBuilder.kt
@@ -1,0 +1,33 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.formatter
+
+import com.intellij.formatting.*
+import com.intellij.lang.ASTNode
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.codeStyle.CodeStyleSettings
+
+class TomlFormattingModelBuilder : FormattingModelBuilder {
+    override fun getRangeAffectingIndent(file: PsiFile?, offset: Int, elementAtOffset: ASTNode?): TextRange? = null
+
+    override fun createModel(element: PsiElement, settings: CodeStyleSettings): FormattingModel {
+        val ctx = TomlFmtContext.create(settings)
+        val block = createBlock(element.node, null, Indent.getNoneIndent(), null, ctx)
+        return FormattingModelProvider.createFormattingModelForPsiFile(element.containingFile, block, settings)
+    }
+
+    companion object {
+        fun createBlock(
+            node: ASTNode,
+            alignment: Alignment?,
+            indent: Indent?,
+            wrap: Wrap?,
+            ctx: TomlFmtContext
+        ): ASTBlock = TomlFmtBlock(node, alignment, indent, wrap, ctx)
+    }
+}

--- a/intellij-toml/src/main/kotlin/org/toml/ide/formatter/impl/indent.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/formatter/impl/indent.kt
@@ -1,0 +1,22 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.formatter.impl
+
+import com.intellij.formatting.Indent
+import com.intellij.lang.ASTNode
+import org.toml.ide.formatter.TomlFmtBlock
+import org.toml.lang.psi.TomlElementTypes.ARRAY
+
+fun TomlFmtBlock.computeIndent(child: ASTNode): Indent? = when (node.elementType) {
+    ARRAY -> getArrayIndent(child)
+    else -> Indent.getNoneIndent()
+}
+
+private fun getArrayIndent(node: ASTNode): Indent =
+    when {
+        node.isArrayDelimiter() -> Indent.getNoneIndent()
+        else -> Indent.getNormalIndent()
+    }

--- a/intellij-toml/src/main/kotlin/org/toml/ide/formatter/impl/spacing.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/formatter/impl/spacing.kt
@@ -1,0 +1,37 @@
+/*
+* Use of this source code is governed by the MIT license that can be
+* found in the LICENSE file.
+*/
+
+package org.toml.ide.formatter.impl
+
+import com.intellij.formatting.Block
+import com.intellij.formatting.Spacing
+import com.intellij.formatting.SpacingBuilder
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings
+import org.toml.ide.formatter.TomlFmtContext
+import org.toml.lang.psi.TomlElementTypes.*
+import com.intellij.psi.tree.TokenSet.create as ts
+
+fun createSpacingBuilder(commonSettings: CommonCodeStyleSettings): SpacingBuilder {
+    val builder = SpacingBuilder(commonSettings)
+        // ,
+        .after(COMMA).spacing(1, 1, 0, true, 0)
+        .before(COMMA).spaceIf(false)
+        // =
+        .around(EQ).spacing(1, 1, 0, true, 0)
+        // [ ]
+        .after(L_BRACKET).spaceIf(false)
+        .before(R_BRACKET).spaceIf(false)
+        // { }
+        .after(L_CURLY).spaceIf(true)
+        .before(R_CURLY).spaceIf(true)
+        // .
+        .aroundInside(DOT, ts(KEY, TABLE_HEADER)).spaceIf(false)
+
+    return builder
+}
+
+fun Block.computeSpacing(child1: Block?, child2: Block, ctx: TomlFmtContext): Spacing? {
+    return ctx.spacingBuilder.getSpacing(this, child1, child2)
+}

--- a/intellij-toml/src/main/kotlin/org/toml/ide/formatter/impl/utils.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/formatter/impl/utils.kt
@@ -1,0 +1,17 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.formatter.impl
+
+import com.intellij.lang.ASTNode
+import com.intellij.psi.TokenType
+import com.intellij.psi.tree.TokenSet
+import org.toml.lang.psi.TomlElementTypes.*
+
+val ARRAY_DELIMITERS = TokenSet.create(L_BRACKET, R_BRACKET)
+
+fun ASTNode?.isWhitespaceOrEmpty() = this == null || textLength == 0 || elementType == TokenType.WHITE_SPACE
+
+fun ASTNode.isArrayDelimiter(): Boolean = elementType in ARRAY_DELIMITERS

--- a/intellij-toml/src/main/kotlin/org/toml/ide/formatter/settings/TomlCodeStyleSettings.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/formatter/settings/TomlCodeStyleSettings.kt
@@ -1,0 +1,12 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.formatter.settings
+
+import com.intellij.psi.codeStyle.CodeStyleSettings
+import com.intellij.psi.codeStyle.CustomCodeStyleSettings
+
+class TomlCodeStyleSettings(container: CodeStyleSettings) :
+    CustomCodeStyleSettings(TomlCodeStyleSettings::class.java.simpleName, container)

--- a/intellij-toml/src/main/kotlin/org/toml/ide/formatter/settings/TomlCodeStyleSettingsProvider.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/formatter/settings/TomlCodeStyleSettingsProvider.kt
@@ -1,0 +1,34 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.formatter.settings
+
+import com.intellij.application.options.CodeStyleAbstractConfigurable
+import com.intellij.application.options.TabbedLanguageCodeStylePanel
+import com.intellij.openapi.options.Configurable
+import com.intellij.psi.codeStyle.CodeStyleSettings
+import com.intellij.psi.codeStyle.CodeStyleSettingsProvider
+import com.intellij.psi.codeStyle.CustomCodeStyleSettings
+import org.toml.lang.TomlLanguage
+
+class TomlCodeStyleSettingsProvider : CodeStyleSettingsProvider() {
+    override fun createCustomSettings(settings: CodeStyleSettings): CustomCodeStyleSettings = TomlCodeStyleSettings(settings)
+
+    override fun getConfigurableDisplayName(): String = TomlLanguage.displayName
+
+    override fun createSettingsPage(settings: CodeStyleSettings, originalSettings: CodeStyleSettings): Configurable =
+        object : CodeStyleAbstractConfigurable(settings, originalSettings, configurableDisplayName) {
+            override fun createPanel(settings: CodeStyleSettings) = TomlCodeStyleMainPanel(currentSettings, settings)
+            override fun getHelpTopic() = null
+        }
+
+    private class TomlCodeStyleMainPanel(currentSettings: CodeStyleSettings, settings: CodeStyleSettings) :
+        TabbedLanguageCodeStylePanel(TomlLanguage, currentSettings, settings) {
+
+        override fun initTabs(settings: CodeStyleSettings) {
+            addIndentOptionsTab(settings)
+        }
+    }
+}

--- a/intellij-toml/src/main/kotlin/org/toml/ide/formatter/settings/TomlLanguageCodeStyleSettingsProvider.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/formatter/settings/TomlLanguageCodeStyleSettingsProvider.kt
@@ -1,0 +1,33 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.formatter.settings
+
+import com.intellij.application.options.IndentOptionsEditor
+import com.intellij.application.options.SmartIndentOptionsEditor
+import com.intellij.lang.Language
+import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
+import org.toml.lang.TomlLanguage
+
+class TomlLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider() {
+    override fun getLanguage(): Language = TomlLanguage
+    override fun getCodeSample(settingsType: SettingsType): String =
+        when (settingsType) {
+            SettingsType.INDENT_SETTINGS -> INDENT_SAMPLE
+            else -> ""
+        }
+
+    override fun getIndentOptionsEditor(): IndentOptionsEditor? = SmartIndentOptionsEditor()
+}
+
+private fun sample(@org.intellij.lang.annotations.Language("TOML") code: String) = code.trim()
+
+private val INDENT_SAMPLE = sample("""
+[config]
+items = [
+    "foo",
+    "bar"
+]
+""")

--- a/intellij-toml/src/main/kotlin/org/toml/ide/formatter/utils.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/formatter/utils.kt
@@ -1,0 +1,12 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.formatter
+
+import com.intellij.psi.codeStyle.CodeStyleSettings
+import org.toml.ide.formatter.settings.TomlCodeStyleSettings
+
+val CodeStyleSettings.toml: TomlCodeStyleSettings
+    get() = getCustomSettings(TomlCodeStyleSettings::class.java)

--- a/intellij-toml/src/main/resources/META-INF/plugin.xml
+++ b/intellij-toml/src/main/resources/META-INF/plugin.xml
@@ -34,6 +34,13 @@
         <lang.quoteHandler language="TOML" implementationClass="org.toml.ide.TomlQuoteHandler"/>
         <lang.elementManipulator forClass="org.toml.lang.psi.TomlLiteral"
                                  implementationClass="org.toml.lang.psi.TomlStringLiteralManipulator"/>
+
+        <!-- Formatting -->
+        <lang.formatter language="TOML" implementationClass="org.toml.ide.formatter.TomlFormattingModelBuilder"/>
+        <codeStyleSettingsProvider implementation="org.toml.ide.formatter.settings.TomlCodeStyleSettingsProvider"/>
+        <langCodeStyleSettingsProvider
+            implementation="org.toml.ide.formatter.settings.TomlLanguageCodeStyleSettingsProvider"/>
+
         <colorSettingsPage implementation="org.toml.ide.colors.TomlColorSettingsPage"/>
         <indexPatternBuilder implementation="org.toml.ide.todo.TomlTodoIndexPatternBuilder"/>
         <todoIndexer filetype="TOML" implementationClass="org.toml.ide.todo.TomlTodoIndexer"/>

--- a/intellij-toml/src/test/kotlin/org/toml/TomlTestBase.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/TomlTestBase.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.intellij.lang.annotations.Language
+
+abstract class TomlTestBase : BasePlatformTestCase() {
+    @Suppress("TestFunctionName")
+    protected fun InlineFile(@Language("TOML") text: String, name: String = "example.toml") {
+        myFixture.configureByText(name, text)
+    }
+
+    protected fun checkByText(
+        @Language("TOML") before: String,
+        @Language("TOML") after: String,
+        action: () -> Unit
+    ) {
+        InlineFile(before)
+        action()
+        myFixture.checkResult(after)
+    }
+}

--- a/intellij-toml/src/test/kotlin/org/toml/ide/annotator/TomlAnnotationTestBase.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/ide/annotator/TomlAnnotationTestBase.kt
@@ -6,10 +6,10 @@
 package org.toml.ide.annotator
 
 import com.intellij.openapiext.Testmark
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import org.intellij.lang.annotations.Language
+import org.toml.TomlTestBase
 
-abstract class TomlAnnotationTestBase() : BasePlatformTestCase() {
+abstract class TomlAnnotationTestBase : TomlTestBase() {
 
     protected lateinit var annotationFixture: TomlAnnotationTestFixture
 

--- a/intellij-toml/src/test/kotlin/org/toml/ide/formatter/TomlAutoIndentTest.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/ide/formatter/TomlAutoIndentTest.kt
@@ -1,0 +1,23 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.formatter
+
+import org.toml.ide.typing.TomlTypingTestBase
+
+class TomlAutoIndentTest : TomlTypingTestBase() {
+    fun `test new array element`() = doTestByText("""
+        [key]
+        foo = [
+            "text",<caret>
+        ]
+    """, """
+        [key]
+        foo = [
+            "text",
+            <caret>
+        ]
+    """)
+}

--- a/intellij-toml/src/test/kotlin/org/toml/ide/formatter/TomlFormatterTest.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/ide/formatter/TomlFormatterTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.formatter
+
+class TomlFormatterTest : TomlFormatterTestBase() {
+    fun `test spacing`() = doTest("""
+        [  config . subconfig ]
+            list  =   [  1,2,     3   ]
+        key1 . key2='value'
+        object={a=1,b=2}
+    """, """
+        [config.subconfig]
+        list = [1, 2, 3]
+        key1.key2 = 'value'
+        object = { a = 1, b = 2 }
+    """)
+
+    fun `test indent array`() = doTest("""
+        [workspace]
+        members = [
+        "a.rs",
+                "b.rs",
+                    "c.rs"
+        ]
+    """, """
+        [workspace]
+        members = [
+            "a.rs",
+            "b.rs",
+            "c.rs"
+        ]
+    """)
+}

--- a/intellij-toml/src/test/kotlin/org/toml/ide/formatter/TomlFormatterTestBase.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/ide/formatter/TomlFormatterTestBase.kt
@@ -1,0 +1,24 @@
+/*
+* Use of this source code is governed by the MIT license that can be
+* found in the LICENSE file.
+*/
+
+package org.toml.ide.formatter
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.psi.codeStyle.CodeStyleManager
+import com.intellij.psi.formatter.FormatterTestCase
+import org.intellij.lang.annotations.Language
+import org.toml.TomlTestBase
+
+abstract class TomlFormatterTestBase : TomlTestBase() {
+    protected fun doTest(@Language("TOML") before: String, @Language("TOML") after: String) {
+        checkByText(before.trimIndent(), after.trimIndent()) {
+            WriteCommandAction.runWriteCommandAction(project) {
+                val file = myFixture.file
+                CodeStyleManager.getInstance(project)
+                    .reformatText(file, file.textRange.startOffset, file.textRange.endOffset)
+            }
+        }
+    }
+}

--- a/intellij-toml/src/test/kotlin/org/toml/ide/typing/TomlTypingTestBase.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/ide/typing/TomlTypingTestBase.kt
@@ -1,0 +1,16 @@
+/*
+* Use of this source code is governed by the MIT license that can be
+* found in the LICENSE file.
+*/
+
+package org.toml.ide.typing
+
+import org.intellij.lang.annotations.Language
+import org.toml.TomlTestBase
+
+abstract class TomlTypingTestBase : TomlTestBase() {
+    protected fun doTestByText(@Language("TOML") before: String, @Language("TOML") after: String, c: Char = '\n') =
+        checkByText(before.trimIndent(), after.trimIndent()) {
+            myFixture.type(c)
+        }
+}

--- a/intellij-toml/src/test/kotlin/org/toml/ide/wordSelection/TomlSelectionHandlerTestBase.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/ide/wordSelection/TomlSelectionHandlerTestBase.kt
@@ -7,13 +7,14 @@ package org.toml.ide.wordSelection
 
 import com.intellij.codeInsight.editorActions.SelectWordHandler
 import com.intellij.ide.DataManager
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import org.intellij.lang.annotations.Language
+import org.toml.TomlTestBase
 
-abstract class TomlSelectionHandlerTestBase : BasePlatformTestCase() {
+abstract class TomlSelectionHandlerTestBase : TomlTestBase() {
 
     protected fun doTest(@Language("TOML") before: String, @Language("TOML") vararg after: String) {
-        myFixture.configureByText("example.toml", before)
+        InlineFile(before)
+
         val action = SelectWordHandler(null)
         val dataContext = DataManager.getInstance().getDataContext(myFixture.editor.component)
         for (text in after) {

--- a/intellij-toml/src/test/kotlin/org/toml/lang/TomlFileTypeTest.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/lang/TomlFileTypeTest.kt
@@ -7,10 +7,10 @@ package org.toml.lang
 
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.vfs.VfsUtil
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.toml.TomlTestBase
 import org.toml.lang.psi.TomlFileType
 
-class TomlFileTypeTest : BasePlatformTestCase() {
+class TomlFileTypeTest : TomlTestBase() {
 
     fun `test toml file by extension`() = doTest("example.toml")
     fun `test Cargo lock`() = doTest("Cargo.lock")

--- a/intellij-toml/src/test/kotlin/org/toml/lang/psi/TomlPsiFactoryTest.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/lang/psi/TomlPsiFactoryTest.kt
@@ -5,9 +5,9 @@
 
 package org.toml.lang.psi
 
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.toml.TomlTestBase
 
-class TomlPsiFactoryTest : BasePlatformTestCase() {
+class TomlPsiFactoryTest : TomlTestBase() {
     private val factory: TomlPsiFactory get() = TomlPsiFactory(project)
 
     fun `test create literal`() {


### PR DESCRIPTION
This PR implements an initial formatter for TOML. I copied the Rust formatter and stripped it down to only keep things that were required to implement basic spacing formatting.

The [official repository](https://github.com/toml-lang/toml) does not mandate any formatting style and I think that it is a bit inconsistent (space after `[` in outer array, but not in nested array, while for objects it uses spaces after `{` even for nested objects).
There is https://github.com/jumpscale7/python-pretty-toml/blob/master/sample-prettified.toml, but it's also not very specified.

Right now there is only a very basic spacing implementation. Some things are probably OK to enforce (space after `,`, space before and after `=`), but for controversial topics like space after `[`, we should probably introduce an option in TOML code style settings.

After we resolve that, I think that this implementation is already quite useful and could be merged, but we should deal with indents somehow. Right now only `noneIndent` is used and so this:
```rust
multiline = [
      1,
      2
]
```
turns into
```rust
multiline = [
1,
2
]
```
which is not ideal, the explicit indent should be preserved.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5518