### PR TITLE
Fix go-to-declaration from assoc type binding on 2020.2

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -221,8 +221,7 @@ private AnyTypeArgument ::= AssocTypeBinding | TypeReference | Lifetime | ConstA
 private ConstArgument ::= (BlockExpr | LitExpr | &('-' LitExpr) UnaryExpr)
 
 AssocTypeBinding ::= identifier (AssocTypeBindingType | AssocTypeBindingBound) {
-  implements = [ "org.rust.lang.core.psi.ext.RsNameIdentifierOwner"
-                 "org.rust.lang.core.psi.ext.RsMandatoryReferenceElement" ]
+  implements = [ "org.rust.lang.core.psi.ext.RsMandatoryReferenceElement" ]
   mixin = "org.rust.lang.core.psi.ext.RsAssocTypeBindingMixin"
   stubClass = "org.rust.lang.core.stubs.RsAssocTypeBindingStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAssocTypeBinding.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAssocTypeBinding.kt
@@ -19,7 +19,7 @@ import org.rust.lang.core.stubs.RsAssocTypeBindingStub
 val RsAssocTypeBinding.parentPath: RsPath?
     get() = ancestorStrict()
 
-abstract class RsAssocTypeBindingMixin : RsStubbedNamedElementImpl<RsAssocTypeBindingStub>,
+abstract class RsAssocTypeBindingMixin : RsStubbedElementImpl<RsAssocTypeBindingStub>,
                                          RsAssocTypeBinding {
 
     constructor(node: ASTNode) : super(node)
@@ -30,5 +30,5 @@ abstract class RsAssocTypeBindingMixin : RsStubbedNamedElementImpl<RsAssocTypeBi
 
     override val referenceNameElement: PsiElement get() = identifier
 
-    override val referenceName: String get() = greenStub?.name ?: super.referenceName
+    override val referenceName: String get() = greenStub?.referenceName ?: super.referenceName
 }

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -49,7 +49,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
     override fun getType() = Type
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
-        private const val STUB_VERSION = 198
+        private const val STUB_VERSION = 199
 
         // Bump this number if Stub structure changes
         override fun getStubVersion(): Int = RustParserDefinition.PARSER_VERSION + STUB_VERSION
@@ -1667,26 +1667,25 @@ private fun RsStubLiteralKind?.serialize(dataStream: StubOutputStream) {
 
 class RsAssocTypeBindingStub(
     parent: StubElement<*>?, elementType: IStubElementType<*, *>,
-    override val name: String?
-) : StubBase<RsAssocTypeBinding>(parent, elementType),
-    RsNamedStub {
+    val referenceName: String
+) : StubBase<RsAssocTypeBinding>(parent, elementType) {
 
     object Type : RsStubElementType<RsAssocTypeBindingStub, RsAssocTypeBinding>("ASSOC_TYPE_BINDING") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
             RsAssocTypeBindingStub(parentStub, this,
-                dataStream.readNameAsString()
+                dataStream.readNameAsString()!!
             )
 
         override fun serialize(stub: RsAssocTypeBindingStub, dataStream: StubOutputStream) =
             with(dataStream) {
-                writeName(stub.name)
+                writeName(stub.referenceName)
             }
 
         override fun createPsi(stub: RsAssocTypeBindingStub): RsAssocTypeBinding =
             RsAssocTypeBindingImpl(stub, this)
 
         override fun createStub(psi: RsAssocTypeBinding, parentStub: StubElement<*>?) =
-            RsAssocTypeBindingStub(parentStub, this, psi.identifier.text)
+            RsAssocTypeBindingStub(parentStub, this, psi.referenceName)
     }
 }
 

--- a/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoDeclarationTest.kt
+++ b/src/test/kotlin/org/rust/ide/navigation/goto/RsGotoDeclarationTest.kt
@@ -155,6 +155,14 @@ class RsGotoDeclarationTest : RsTestBase() {
         }
     """)
 
+    fun `test associated type binding`() = doTest("""
+        trait Foo { type Item; }
+        type T = dyn Foo</*caret*/Item = i32>;
+    """, """
+        trait Foo { type /*caret*/Item; }
+        type T = dyn Foo<Item = i32>;
+    """)
+
     private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) =
         checkEditorAction(before, after, IdeActions.ACTION_GOTO_DECLARATION)
 }


### PR DESCRIPTION
Fixes "Go To Declaration" (Ctrl + B) action in this case on the 2020.2 platform
```rust
trait Foo { type Item; }
type T = dyn Foo</*caret*/Item = i32>;
``` 
Part of #5537