### PR TITLE
INSP: improve AddUnsafeFix to find the closest enclosing block

### DIFF
--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -288,20 +288,15 @@ sealed class RsDiagnostic(
     }
 
     class UnsafeError(
-        element: PsiElement,
+        element: RsExpr,
         private val message: String
     ) : RsDiagnostic(element) {
-        override fun prepare(): PreparedAnnotation {
-            val block = element.ancestorStrict<RsBlock>()
-            val fixes = mutableListOf<LocalQuickFix>(SurroundWithUnsafeFix(element as RsExpr))
-            if (block != null) fixes.add(AddUnsafeFix(block))
-            return PreparedAnnotation(
-                ERROR,
-                E0133,
-                message,
-                fixes = fixes
-            )
-        }
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            E0133,
+            message,
+            fixes = listOfNotNull(SurroundWithUnsafeFix(element as RsExpr), AddUnsafeFix.create(element))
+        )
     }
 
     class TypePlaceholderForbiddenError(

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddUnsafeFixTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.annotator.fixes
 import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsUnsafeExpressionAnnotator
 
-class AddUnsafeTest : RsAnnotatorTestBase(RsUnsafeExpressionAnnotator::class) {
+class AddUnsafeFixTest : RsAnnotatorTestBase(RsUnsafeExpressionAnnotator::class) {
     fun `test add unsafe to function`() = checkFixByText("Add unsafe to function", """
         unsafe fn foo() {}
 
@@ -130,6 +130,32 @@ class AddUnsafeTest : RsAnnotatorTestBase(RsUnsafeExpressionAnnotator::class) {
             if true {
                 foo();
             }
+        }
+    """)
+
+    fun `test add unsafe inside if in a block`() = checkFixByText("Add unsafe to block", """
+        unsafe fn foo() -> u32 { 0 }
+
+        fn main() {
+            let x = {
+                if true {
+                    <error>foo()/*caret*/</error>
+                } else {
+                    5
+                }
+            };
+        }
+    """, """
+        unsafe fn foo() -> u32 { 0 }
+
+        fn main() {
+            let x = unsafe {
+                if true {
+                    foo()
+                } else {
+                    5
+                }
+            };
         }
     """)
 


### PR DESCRIPTION
https://github.com/intellij-rust/intellij-rust/pull/5521 fixed `AddUnsafeFix` to work with conditions and loops, but it added `unsafe` to the enclosing function in such cases, which is a bit too pessimistic.

This PR changes it to find the closest enclosing block.