### PR TITLE
FIX: crate resolve for `use crate_name::crate_name`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
@@ -126,7 +126,14 @@ private fun RsElement.processItem(processor: (RsItemElement) -> Boolean): Boolea
 
 private val RsPath.isAtom: Boolean
     get() = when (kind) {
-        PathKind.IDENTIFIER -> qualifier == null
+        PathKind.IDENTIFIER -> {
+            val qual = qualifier
+            if (qual == null) {
+                true
+            } else {
+                qual.isAtom && qual.referenceName == referenceName
+            }
+        }
         PathKind.SELF -> qualifier?.isAtom == true
         else -> false
     }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -663,6 +663,17 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                           //^ dep-lib/lib.rs
     """, ItemResolutionTestmarks.extraAtomUse)
 
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test extra use of crate name 3`() = stubOnlyResolve("""
+    //- dep-lib/lib.rs
+        pub struct Foo;
+        pub struct dep_lib_target;
+    //- lib.rs
+        use dep_lib_target::dep_lib_target;
+        use dep_lib_target::Foo;
+                           //^ dep-lib/lib.rs
+    """, ItemResolutionTestmarks.extraAtomUse)
+
     // Issue https://github.com/intellij-rust/intellij-rust/issues/3912
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test star import of item with the same name as extern crate`() = stubOnlyResolve("""


### PR DESCRIPTION
This PR attempts to fix resolving when `use crate_name::crate_name` is used in a crate with 2018 edition. This situation was previously fixed for `use crate_name;`, `use crate_name::{self};` and other use cases such as re-exports and aliases (https://github.com/intellij-rust/intellij-rust/pull/3850, https://github.com/intellij-rust/intellij-rust/pull/4168).

The name resolution machinery is a complex beast, so I'm not sure if this is the proper change to make, but it fixed the issue and all resolve tests passed locally, so let's see what CI says.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/4509 (hopefully)