### PR TITLE
INSP: do not trigger RsMainFunctionNotFoundInspection for files with a root error

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspection.kt
@@ -6,10 +6,12 @@
 package org.rust.ide.inspections
 
 import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.ext.childOfType
 import org.rust.lang.core.psi.ext.childrenOfType
 import org.rust.lang.core.psi.ext.queryAttributes
 import org.rust.lang.utils.RsDiagnostic
@@ -21,6 +23,8 @@ class RsMainFunctionNotFoundInspection : RsLocalInspectionTool() {
         return object : RsVisitor() {
             override fun visitFile(file: PsiFile) {
                 if (file is RsFile) {
+                    if (file.childOfType<PsiErrorElement>() != null) return
+
                     val target = file.cargoTarget ?: return
                     val crateName = if ((target.isBin || target.isExampleBin) && file.isCrateRoot) target.name else return
 

--- a/src/test/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspectionTest.kt
@@ -15,6 +15,21 @@ class RsMainFunctionNotFoundInspectionTest : RsInspectionsTestBase(RsMainFunctio
         <error descr="`main` function not found in crate `test-package` [E0601]"> /*caret*/ </error>
     """)
 
+    fun `test do not show if an error exists`() = checkByFileTree("""
+    //- main.rs
+        fn foo( <error>{</error>/*caret*/}
+        fn main<error>(</error>) {}
+    """)
+
+    fun `test show if a nested error exists`() = checkByFileTree("""
+    //- main.rs
+        <error descr="`main` function not found in crate `test-package` [E0601]">
+        fn foo() {
+            fn bar( <error>{</error>/*caret*/}
+        }<EOLError></EOLError>
+        </error>
+    """)
+
     fun `test has nested main function`() = checkByFileTree("""
     //- main.rs
         <error descr="`main` function not found in crate `test-package` [E0601]">fn foo() {


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/5541