### PR TITLE
ANN: show type errors for references containing unknown types if mutability differs

### DIFF
--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
@@ -291,7 +291,7 @@ class RsTypeCheckInspectionTest : RsInspectionsTestBase(RsTypeCheckInspection::c
     fun `test no type mismatch E0308 on reference coecrion of partially unknown type`() = checkByText("""
         struct Bar;
         fn foo(a: &Bar) {}
-        
+
         fn main() {
             foo(&Unknown);
         }
@@ -315,6 +315,19 @@ class RsTypeCheckInspectionTest : RsInspectionsTestBase(RsTypeCheckInspection::c
                 return <error>3.0</error>;
                 <error>"4"</error>
             };
+        }
+    """)
+
+    fun `test wrong ref mutability with unknown generic type`() = checkErrors("""
+        struct S<T>(T);
+        impl<T> S<T> {
+            fn new() -> Self { unreachable!() }
+        }
+
+        fn foo(t: &mut S<u64>) {}
+        fn bar() {
+            let mut s = S::new();
+            foo(<error>&s</error>);
         }
     """)
 }


### PR DESCRIPTION
This PR changes error annotation to show a type error if you give an immutable reference where a mutable reference is expected, even if the type behind the reference is not fully resolved. I think that this is useful, because even if the types are unresolved, passing `&` where `&mut` is expected will be an error in any case and if we show the annotation (and solve it with a quick fix, that I'll send a separate PR for), it can help with actually resolving the type (this happens in the linked issue).

Fixes: https://github.com/intellij-rust/intellij-rust/issues/4705