### PR TITLE
INSP: add quick fix to convert immutable reference to mutable reference

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/ChangeRefToMutableFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/ChangeRefToMutableFix.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsUnaryExpr
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.UnaryOperator
+import org.rust.lang.core.psi.ext.operatorType
+
+
+/**
+ * Fix that converts the given immutable reference to a mutable reference.
+ * @param expr An element, that represents an immutable reference.
+ */
+class ChangeRefToMutableFix(expr: RsElement) : LocalQuickFixOnPsiElement(expr) {
+    override fun getText() = "Change reference to mutable"
+    override fun getFamilyName() = text
+
+    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+        val ref = startElement as? RsUnaryExpr ?: return
+        if (ref.operatorType != UnaryOperator.REF) return
+        val innerExpr = ref.expr ?: return
+
+        val mutableExpr = RsPsiFactory(project).tryCreateExpression("&mut ${innerExpr.text}") ?: return
+        startElement.replace(mutableExpr)
+    }
+}

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ChangeRefToMutableFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ChangeRefToMutableFixTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.typecheck
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.RsTypeCheckInspection
+
+class ChangeRefToMutableFixTest : RsInspectionsTestBase(RsTypeCheckInspection::class) {
+    fun `test simple`() = checkFixByText("Change reference to mutable", """
+        fn foo(t: &mut u32) {}
+        fn bar() {
+            let mut x: u32 = 5;
+            foo(/*caret*/<error>&x</error>);
+        }
+    """, """
+        fn foo(t: &mut u32) {}
+        fn bar() {
+            let mut x: u32 = 5;
+            foo(&mut x);
+        }
+    """)
+
+    fun `test immutable variable`() = checkFixByText("Change reference to mutable", """
+        fn foo(t: &mut u32) {}
+        fn bar() {
+            let x: u32 = 5;
+            foo(/*caret*/<error>&x</error>);
+        }
+    """, """
+        fn foo(t: &mut u32) {}
+        fn bar() {
+            let x: u32 = 5;
+            foo(&mut x);
+        }
+    """)
+
+    fun `test nested references`() = checkFixByText("Change reference to mutable", """
+        fn foo(t: &mut &u32) {}
+        fn bar() {
+            let mut x: u32 = 5;
+            foo(/*caret*/<error>&x</error>);
+        }
+    """, """
+        fn foo(t: &mut &u32) {}
+        fn bar() {
+            let mut x: u32 = 5;
+            foo(&mut x);
+        }
+    """)
+
+    fun `test unknown inner type`() = checkFixByText("Change reference to mutable", """
+        struct S<T>(T);
+        impl<T> S<T> {
+            fn new() -> Self { unreachable!() }
+        }
+
+        fn foo(t: &mut S<u32>) {}
+        fn bar() {
+            let mut x = S::new();
+            foo(/*caret*/<error>&x</error>);
+        }
+    """, """
+        struct S<T>(T);
+        impl<T> S<T> {
+            fn new() -> Self { unreachable!() }
+        }
+
+        fn foo(t: &mut S<u32>) {}
+        fn bar() {
+            let mut x = S::new();
+            foo(&mut x);
+        }
+    """)
+
+    fun `test unavailable on mut reference`() = checkFixIsUnavailable("Change reference to mutable", """
+        fn foo(t: &mut u32) {}
+        fn bar() {
+            let mut x: u32 = 5;
+            foo(/*caret*/&mut x);
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds a quick fix to convert an immutable reference to a mutable one:
![refmut](https://user-images.githubusercontent.com/4539057/84370594-c125ff80-abd8-11ea-96ff-dbd407d3455c.gif)

The last test should be enabled if/after https://github.com/intellij-rust/intellij-rust/pull/5548 gets merged.

Umbrella issue: https://github.com/intellij-rust/intellij-rust/issues/1730
Fixes: https://github.com/intellij-rust/intellij-rust/issues/2472