### PR TITLE
INSP: add remove variable quick fix to liveness inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsLivenessInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLivenessInspection.kt
@@ -14,6 +14,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psi.ext.descendantsWithMacrosOfType
 import org.rust.lang.core.psi.ext.expansion
+import org.rust.lang.core.psi.ext.topLevelPattern
 import org.rust.lang.core.types.DeclarationKind
 import org.rust.lang.core.types.DeclarationKind.Parameter
 import org.rust.lang.core.types.DeclarationKind.Variable
@@ -61,9 +62,14 @@ class RsLivenessInspection : RsLintInspection() {
         // TODO: remove this check when multi-resolve for `RsOrPats` is implemented
         if (binding.ancestorStrict<RsOrPats>() != null) return
 
-        val message = when (kind) {
-            Parameter -> "Parameter `$name` is never used"
-            Variable -> "Variable `$name` is never used"
+        val isSimplePat = binding.topLevelPattern is RsPatIdent
+        val message = if (isSimplePat) {
+            when (kind) {
+                Parameter -> "Parameter `$name` is never used"
+                Variable -> "Variable `$name` is never used"
+            }
+        } else {
+            "Binding `$name` is never used"
         }
 
         holder.registerProblem(binding, message, ProblemHighlightType.LIKE_UNUSED_SYMBOL, RenameFix(binding, "_$name"))

--- a/src/main/kotlin/org/rust/ide/inspections/RsLivenessInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLivenessInspection.kt
@@ -5,9 +5,11 @@
 
 package org.rust.ide.inspections
 
+import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.psi.PsiElement
 import org.rust.ide.injected.isDoctestInjection
+import org.rust.ide.inspections.fixes.RemoveVariableFix
 import org.rust.ide.inspections.fixes.RenameFix
 import org.rust.ide.utils.isCfgUnknown
 import org.rust.lang.core.psi.*
@@ -72,6 +74,11 @@ class RsLivenessInspection : RsLintInspection() {
             "Binding `$name` is never used"
         }
 
-        holder.registerProblem(binding, message, ProblemHighlightType.LIKE_UNUSED_SYMBOL, RenameFix(binding, "_$name"))
+        val fixes = mutableListOf<LocalQuickFix>(RenameFix(binding, "_$name"))
+        if (kind == Variable && isSimplePat) {
+            fixes.add(RemoveVariableFix(binding, name))
+        }
+
+        holder.registerProblem(binding, message, ProblemHighlightType.LIKE_UNUSED_SYMBOL, *fixes.toTypedArray())
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveVariableFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveVariableFix.kt
@@ -1,0 +1,60 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.parentOfType
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.topLevelPattern
+
+
+/**
+ * Fix that removes a variable.
+ * A heuristic is used whether to also remove its expression or not.
+ */
+class RemoveVariableFix(binding: RsPatBinding, private val bindingName: String) : LocalQuickFixOnPsiElement(binding) {
+    override fun getText() = "Remove variable `${bindingName}`"
+    override fun getFamilyName() = "Remove variable"
+
+    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+        val binding = startElement as? RsPatBinding ?: return
+        val patIdent = binding.topLevelPattern as? RsPatIdent ?: return
+        deleteVariable(patIdent)
+    }
+}
+
+private fun deleteVariable(pat: RsPatIdent) {
+    val decl = pat.parentOfType<RsLetDecl>() ?: return
+    val expr = decl.expr
+
+    if (expr != null && expr.hasSideEffects) {
+        val factory = RsPsiFactory(expr.project)
+        val newExpr = if (decl.semicolon != null) {
+            factory.tryCreateExprStmt(expr.text) ?: expr
+        } else {
+            expr
+        }
+        decl.replace(newExpr)
+    } else {
+        decl.delete()
+    }
+}
+
+private val RsExpr.hasSideEffects: Boolean
+    get() = when (this) {
+        is RsUnitExpr, is RsLitExpr, is RsPathExpr -> false
+        is RsParenExpr -> expr?.hasSideEffects ?: false
+        is RsCastExpr -> expr.hasSideEffects
+        is RsDotExpr -> expr.hasSideEffects || methodCall != null
+        is RsTupleExpr -> exprList.any { it.hasSideEffects }
+        is RsStructLiteral -> structLiteralBody.structLiteralFieldList.any { it.expr?.hasSideEffects ?: false }
+        is RsBinaryExpr -> exprList.any { it.hasSideEffects }
+        is RsUnaryExpr -> expr?.hasSideEffects ?: false
+        else -> true
+    }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -89,6 +89,9 @@ class RsPsiFactory(
     fun tryCreateExpression(text: CharSequence): RsExpr? =
         createFromText("fn main() { let _ = $text; }")
 
+    fun tryCreateExprStmt(text: CharSequence): RsExprStmt? =
+        createFromText("fn main() { $text; }")
+
     fun createTryExpression(expr: RsExpr): RsTryExpr {
         val newElement = createExpressionOfType<RsTryExpr>("a?")
         newElement.expr.replace(expr)

--- a/src/test/kotlin/org/rust/ide/inspections/RsLivenessInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsLivenessInspectionTest.kt
@@ -515,4 +515,140 @@ class RsLivenessInspectionTest : RsInspectionsTestBase(RsLivenessInspection::cla
             a;
         }
     """)
+
+    fun `test no remove on struct field binding`() = checkFixIsUnavailable("Remove", """
+        struct S { a: u32, b: u32 }
+
+        fn foo() {
+            let S { <warning>a/*caret*/</warning>, b } = S { a: 0, b: 0 };
+            let _ = b;
+        }
+    """)
+
+    fun `test no remove on tuple binding`() = checkFixIsUnavailable("Remove", """
+        fn foo() {
+            let (<warning>a/*caret*/</warning>, b) = (1, 2);
+            let _ = b;
+        }
+    """)
+
+    fun `test remove empty variable`() = checkFixByText("Remove variable `a`", """
+        fn foo() {
+            let <warning>a/*caret*/</warning>;
+        }
+    """, """
+        fn foo() {}
+    """)
+
+    fun `test remove empty mut variable`() = checkFixByText("Remove variable `a`", """
+        fn foo() {
+            let <warning>mut a/*caret*/</warning>;
+        }
+    """, """
+        fn foo() {}
+    """)
+
+    fun `test remove empty ref variable`() = checkFixByText("Remove variable `a`", """
+        fn foo() {
+            let <warning>ref a/*caret*/</warning>;
+        }
+    """, """
+        fn foo() {}
+    """)
+
+    fun `test remove variable with a literal`() = checkFixByText("Remove variable `a`", """
+        fn foo() {
+            let <warning>a/*caret*/</warning> = 5;
+        }
+    """, """
+        fn foo() {}
+    """)
+
+    fun `test remove variable with a unit type`() = checkFixByText("Remove variable `a`", """
+        fn foo() {
+            let <warning>a/*caret*/</warning> = ();
+        }
+    """, """
+        fn foo() {}
+    """)
+
+    fun `test remove variable with a path`() = checkFixByText("Remove variable `a`", """
+        struct S;
+        fn foo() {
+            let <warning>a/*caret*/</warning> = S;
+        }
+    """, """
+        struct S;
+        fn foo() {}
+    """)
+
+    fun `test remove variable with a nested expression without side effects`() = checkFixByText("Remove variable `a`", """
+        fn foo() {
+            let b = &5;
+            let <warning>a/*caret*/</warning> = (1 + *b, (3 * 4, -2));
+        }
+    """, """
+        fn foo() {
+            let b = &5;
+        }
+    """)
+
+    fun `test remove variable with a field access`() = checkFixByText("Remove variable `a`", """
+        struct S {
+            a: u32
+        }
+        fn foo() {
+            let s = S { a: 0 };
+            let <warning>a/*caret*/</warning> = s.a;
+        }
+    """, """
+        struct S {
+            a: u32
+        }
+        fn foo() {
+            let s = S { a: 0 };
+        }
+    """)
+
+    fun `test remove variable with a method call`() = checkFixByText("Remove variable `a`", """
+        struct S;
+        impl S {
+            fn bar(&self) {}
+        }
+        fn foo() {
+            let s = S;
+            let <warning>a/*caret*/</warning> = s.bar();
+        }
+    """, """
+        struct S;
+        impl S {
+            fn bar(&self) {}
+        }
+        fn foo() {
+            let s = S;
+            s.bar();
+        }
+    """)
+
+    fun `test remove variable with a function call`() = checkFixByText("Remove variable `a`", """
+        fn bar() -> u32 { 0 }
+        fn foo() {
+            let <warning>a/*caret*/</warning>: u32 = bar();
+        }
+    """, """
+        fn bar() -> u32 { 0 }
+        fn foo() {
+            bar();
+        }
+    """)
+
+    fun `test remove variable with a block`() = checkFixByText("Remove variable `a`", """
+        fn foo() {
+            let <warning>a/*caret*/</warning> = { 0 };
+        }
+    """, """
+        fn foo() {
+            { 0 };
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsLivenessInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsLivenessInspectionTest.kt
@@ -431,14 +431,14 @@ class RsLivenessInspectionTest : RsInspectionsTestBase(RsLivenessInspection::cla
         struct S { x: i32, y: i32 }
 
         fn foo(s: S) {
-            let S { x, <warning descr="Variable `y` is never used">y</warning> } = s;
+            let S { x, <warning descr="Binding `y` is never used">y</warning> } = s;
             x;
         }
     """)
 
     fun `test use binding from tuple`() = checkByText("""
         fn foo() {
-            let (x, <warning descr="Variable `y` is never used">y</warning>) = (1, 2);
+            let (x, <warning descr="Binding `y` is never used">y</warning>) = (1, 2);
             x;
         }
     """)


### PR DESCRIPTION
This PR adds a quick fix to remove an unused variable.

It is only offered on variables with a simple pattern binding (`RsPatIdent`):
```rust
let a/*caret*/ = 5; // offered
let S { a/*caret*/, b } = ...; // not offered
```
We can also support these more complex cases. For example for struct field bindings we can remove the whole binding if the only field was removed or add `..` to the end if the struct has multiple fields, but I'm not sure if it's worth the complexity.

Inspired by Kotlin, I use a very simple heuristic to check whether to also remove the variable expression or not. It's conservative and considers most things to be side effects, but it allows `BinaryExpr`s and `UnaryExpr`s if their arguments are side effect free. In most cases that should be safe, but if `*` or `+` is overloaded, it might remove some side effects in the operator implementations in theory. Is it fine? We can also probably check if the operator is overloaded.

I also modified the inspection warning text slightly, to refer to complex bindings properly, i.e.
```rust
fn foo(S { <warning>a</warning>, b }: S) {}
```
now says `Binding 'a' is unused`, not `Parameter 'a' is unused`. I can revert it if you don't like it.

Part of https://github.com/intellij-rust/intellij-rust/issues/3163