### PR TITLE
INSP: add remove parameter quick fix to liveness inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsLivenessInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLivenessInspection.kt
@@ -8,6 +8,7 @@ package org.rust.ide.inspections
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.psi.PsiElement
 import org.rust.ide.injected.isDoctestInjection
+import org.rust.ide.inspections.fixes.RemoveParameterFix
 import org.rust.ide.inspections.fixes.RemoveVariableFix
 import org.rust.ide.inspections.fixes.RenameFix
 import org.rust.ide.utils.isCfgUnknown
@@ -74,8 +75,11 @@ class RsLivenessInspection : RsLintInspection() {
         }
 
         val fixes = mutableListOf<LocalQuickFix>(RenameFix(binding, "_$name"))
-        if (kind == Variable && isSimplePat) {
-            fixes.add(RemoveVariableFix(binding, name))
+        if (isSimplePat) {
+            when (kind) {
+                Parameter -> fixes.add(RemoveParameterFix(binding, name))
+                Variable -> fixes.add(RemoveVariableFix(binding, name))
+            }
         }
 
         holder.registerLintProblem(binding, message, *fixes.toTypedArray())

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveParameterFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveParameterFix.kt
@@ -1,0 +1,71 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.psi.util.parentOfType
+import com.intellij.psi.util.parentOfTypes
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsElementTypes.COMMA
+import org.rust.lang.core.psi.ext.*
+
+
+/**
+ * Fix that removes a parameter and all its usages at call sites.
+ */
+class RemoveParameterFix(binding: RsPatBinding, private val bindingName: String) : LocalQuickFixOnPsiElement(binding) {
+    override fun getText() = "Remove parameter `${bindingName}`"
+    override fun getFamilyName() = "Remove parameter"
+
+    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+        val binding = startElement as? RsPatBinding ?: return
+        val patIdent = binding.topLevelPattern as? RsPatIdent ?: return
+        val parameter = patIdent.parent as? RsValueParameter ?: return
+        val function = parameter.parentOfType<RsFunction>() ?: return
+
+        val parameterIndex = function.valueParameterList?.valueParameterList?.indexOf(parameter) ?: -1
+        if (parameterIndex == -1) return
+
+        parameter.deleteElementWithCommas()
+        removeArguments(function, parameterIndex)
+    }
+}
+
+private fun removeArguments(function: RsFunction, parameterIndex: Int) {
+    ReferencesSearch.search(function).forEach {
+        val call = it.element.parentOfTypes(RsCallExpr::class, RsDotExpr::class) ?: return@forEach
+
+        val arguments = when (call) {
+            is RsCallExpr -> call.valueArgumentList
+            is RsDotExpr -> call.methodCall?.valueArgumentList ?: return@forEach
+            else -> return@forEach
+        }
+        val isMethod = function.hasSelfParameters
+        val argumentIndex = when {
+            isMethod && call is RsCallExpr -> parameterIndex + 1 // UFCS
+            else -> parameterIndex
+        }
+        arguments.exprList.getOrNull(argumentIndex)?.deleteElementWithCommas()
+    }
+}
+
+private fun RsElement.deleteElementWithCommas() {
+    val followingComma = getNextNonCommentSibling()
+    if (followingComma?.elementType == COMMA) {
+        followingComma?.delete()
+    } else {
+        val precedingComma = getPrevNonCommentSibling()
+        if (precedingComma?.elementType == COMMA) {
+            precedingComma?.delete()
+        }
+    }
+
+    delete()
+}

--- a/src/test/kotlin/org/rust/ide/inspections/RsLivenessInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsLivenessInspectionTest.kt
@@ -658,4 +658,123 @@ class RsLivenessInspectionTest : RsInspectionsTestBase(RsLivenessInspection::cla
             let <error>test</error> = 1;
         }
     """)
+
+    fun `test no remove on struct literal parameter`() = checkFixIsUnavailable("Remove", """
+        struct S {
+            a: u32
+        }
+        fn foo(S { <warning>a/*caret*/</warning> }: S) {}
+    """)
+
+    fun `test remove function lone parameter`() = checkFixByText("Remove parameter `a`", """
+        fn foo(<warning>a/*caret*/</warning>: u32) {}
+    """, """
+        fn foo() {}
+    """)
+
+    fun `test remove function parameter in the middle`() = checkFixByText("Remove parameter `a`", """
+        fn foo(_: u32, <warning>a/*caret*/</warning>: u32, _: i32) {}
+    """, """
+        fn foo(_: u32, _: i32) {}
+    """)
+
+    fun `test remove function lone argument`() = checkFixByText("Remove parameter `a`", """
+        fn foo(<warning>a/*caret*/</warning>: u32) {}
+        fn bar() {
+            foo(1);
+        }
+    """, """
+        fn foo() {}
+        fn bar() {
+            foo();
+        }
+    """)
+
+    fun `test remove function argument trailing comma`() = checkFixByText("Remove parameter `a`", """
+        fn foo(<warning>a/*caret*/</warning>: u32,) {}
+        fn bar() {
+            foo(1,);
+        }
+    """, """
+        fn foo() {}
+        fn bar() {
+            foo();
+        }
+    """)
+
+    fun `test remove function argument at the beginning`() = checkFixByText("Remove parameter `a`", """
+        fn foo(<warning>a/*caret*/</warning>: u32, _: u32, _: i32) {}
+        fn bar() {
+            foo(1, 2, 3);
+        }
+    """, """
+        fn foo(_: u32, _: i32) {}
+        fn bar() {
+            foo(2, 3);
+        }
+    """)
+
+    fun `test remove function argument in the middle`() = checkFixByText("Remove parameter `a`", """
+        fn foo(_: u32, <warning>a/*caret*/</warning>: u32, _: i32) {}
+        fn bar() {
+            foo(1, 2, 3);
+        }
+    """, """
+        fn foo(_: u32, _: i32) {}
+        fn bar() {
+            foo(1, 3);
+        }
+    """)
+
+    fun `test remove function argument at the end`() = checkFixByText("Remove parameter `a`", """
+        fn foo(_: u32, <warning>a/*caret*/</warning>: u32) {}
+        fn bar() {
+            foo(1, 2);
+        }
+    """, """
+        fn foo(_: u32) {}
+        fn bar() {
+            foo(1);
+        }
+    """)
+
+    fun `test remove method argument UFCS`() = checkFixByText("Remove parameter `a`", """
+        struct S;
+        impl S {
+            fn foo(&self, <warning>a/*caret*/</warning>: u32, _: u32) {}
+        }
+        fn bar() {
+            let s = S;
+            S::foo(s, 1, 2);
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self, _: u32) {}
+        }
+        fn bar() {
+            let s = S;
+            S::foo(s, 2);
+        }
+    """)
+
+    fun `test remove method argument method call`() = checkFixByText("Remove parameter `a`", """
+        struct S;
+        impl S {
+            fn foo(&self, <warning>a/*caret*/</warning>: u32, _: u32) {}
+        }
+        fn bar() {
+            let s = S;
+            s.foo(1, 2);
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self, _: u32) {}
+        }
+        fn bar() {
+            let s = S;
+            s.foo(2);
+        }
+    """)
 }


### PR DESCRIPTION
This PR adds a quick fix to remove an unused parameter, along with its usages in call sites. The call site arguments are removed without any checks for side effects, same as in the Kotlin plugin.

Should we ignore call sites with an incorrect number of arguments?

This PR is based on https://github.com/intellij-rust/intellij-rust/pull/5557 which introduced some common changes. I opened this one for discussion, but #5557 should be merged first, I'll rebase this one after/if it gets merged.

Part of https://github.com/intellij-rust/intellij-rust/pull/3163