### PR TITLE
FIX: replace all occurrences of bare expressions in RsIntroduceVariableHandler

### DIFF
--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceVariableHandlerTest.kt
@@ -302,6 +302,20 @@ class RsIntroduceVariableHandlerTest : RsTestBase() {
         }
     """)
 
+    fun `test replace lone expression`() = doTest("""
+        fn main() {
+            /*caret*/1;
+            let a = 1;
+            let b = 1;
+        }
+    """, emptyList(), 0, """
+        fn main() {
+            let i = 1;
+            let a = i;
+            let b = i;
+        }
+    """, replaceAll = true)
+
     private fun doTest(
         @Language("Rust") before: String,
         expressions: List<String>,


### PR DESCRIPTION
`RsIntroduceVariableHandler` wasn't replacing all occurrences of the selected expression in some cases, I added occurrence replacement to the `inlineLet` method.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5327