### PR TITLE
Fix exception during find usages in macro 2.0

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1306,6 +1306,7 @@ upper Macro ::= "macro_rules" '!' identifier ShallowMacroBody <<macroSemicolon>>
   implements = [ "org.rust.lang.core.psi.ext.RsNameIdentifierOwner"
                  "org.rust.lang.core.psi.ext.RsOuterAttributeOwner"
                  "org.rust.lang.core.psi.ext.RsQualifiedNamedElement"
+                 "org.rust.lang.core.psi.ext.RsMacroDefinitionBase"
                  "org.rust.lang.core.macros.RsExpandedElement"
                  "org.rust.lang.core.psi.ext.RsModificationTrackerOwner" ]
   extends = "org.rust.lang.core.psi.ext.RsMacroImplMixin"
@@ -1356,7 +1357,8 @@ upper Macro2 ::= MACRO_KW identifier ( Macro2FunctionLikeBody | Macro2MatchLikeB
   name = ""
   implements = [ "org.rust.lang.core.psi.ext.RsNameIdentifierOwner"
                  "org.rust.lang.core.psi.ext.RsItemElement"
-                 "org.rust.lang.core.psi.ext.RsQualifiedNamedElement" ]
+                 "org.rust.lang.core.psi.ext.RsQualifiedNamedElement"
+                 "org.rust.lang.core.psi.ext.RsMacroDefinitionBase" ]
   extends = "org.rust.lang.core.psi.ext.RsMacro2ImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsMacro2Stub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroBinding.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroBinding.kt
@@ -8,7 +8,6 @@ package org.rust.lang.core.psi.ext
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.search.SearchScope
-import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.RsMacroBinding
 import org.rust.lang.core.psi.RsPsiImplUtil.localOrMacroSearchScope
 
@@ -17,7 +16,7 @@ abstract class RsMacroBindingImplMixin(node: ASTNode) : RsNamedElementImpl(node)
     override fun getNameIdentifier(): PsiElement? = metaVarIdentifier
 
     override fun getUseScope(): SearchScope {
-        val owner = contextStrict<RsMacro>() ?: error("Macro binding outside of a macro")
+        val owner = contextStrict<RsMacroDefinitionBase>() ?: error("Macro binding outside of a macro")
         return localOrMacroSearchScope(owner)
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroDefinitionBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroDefinitionBase.kt
@@ -1,0 +1,11 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi.ext
+
+/**
+ * [org.rust.lang.core.psi.RsMacro] or [org.rust.lang.core.psi.RsMacro2]
+ */
+interface RsMacroDefinitionBase : RsElement


### PR DESCRIPTION
```
macro foobar($i/*caret*/:tt) { // find usages here
    $i
}
```

<details>
  <summary>Exception stacktrace</summary>
  
  ```
java.lang.IllegalStateException: Macro binding outside of a macro
	at org.rust.lang.core.psi.ext.RsMacroBindingImplMixin.getUseScope(RsMacroBinding.kt:20)
	at com.intellij.psi.impl.search.PsiSearchHelperImpl.getUseScope(PsiSearchHelperImpl.java:69)
	at com.intellij.psi.search.searches.ReferencesSearch$SearchParameters.getEffectiveSearchScope(ReferencesSearch.java:111)
	at com.intellij.psi.impl.search.CachesBasedRefSearcher.processQuery(CachesBasedRefSearcher.java:54)
	at com.intellij.psi.impl.search.CachesBasedRefSearcher.processQuery(CachesBasedRefSearcher.java:19)
	at com.intellij.openapi.application.QueryExecutorBase.execute(QueryExecutorBase.java:77)
	at com.intellij.util.ExecutorsQuery.processResults(ExecutorsQuery.java:28)
	at com.intellij.util.AbstractQuery.doProcessResults(AbstractQuery.java:96)
	at com.intellij.util.AbstractQuery.delegateProcessResults(AbstractQuery.java:119)
	at com.intellij.util.MergeQuery.processResults(MergeQuery.java:26)
	at com.intellij.util.AbstractQuery.doProcessResults(AbstractQuery.java:96)
	at com.intellij.util.AbstractQuery.delegateProcessResults(AbstractQuery.java:119)
	at com.intellij.util.UniqueResultsQuery.processResults(UniqueResultsQuery.java:35)
	at com.intellij.util.AbstractQuery.doProcessResults(AbstractQuery.java:96)
	at com.intellij.util.AbstractQuery.forEach(AbstractQuery.java:88)
	at com.intellij.util.AbstractQuery.findAll(AbstractQuery.java:30)
	at com.intellij.find.findUsages.FindUsagesHandlerBase.findReferencesToHighlight(FindUsagesHandlerBase.java:123)
	at com.intellij.codeInsight.daemon.impl.IdentifierHighlighterPass.getReferences(IdentifierHighlighterPass.java:302)
	at com.intellij.codeInsight.daemon.impl.IdentifierHighlighterPass.getUsages(IdentifierHighlighterPass.java:272)
	at com.intellij.codeInsight.daemon.impl.IdentifierHighlighterPass.lambda$highlightTargetUsages$2(IdentifierHighlighterPass.java:252)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:126)
	at com.intellij.codeInsight.daemon.impl.IdentifierHighlighterPass.highlightTargetUsages(IdentifierHighlighterPass.java:251)
	at com.intellij.codeInsight.daemon.impl.IdentifierHighlighterPass.highlightReferencesAndDeclarations(IdentifierHighlighterPass.java:227)
	at com.intellij.codeInsight.daemon.impl.IdentifierHighlighterPass.doCollectInformation(IdentifierHighlighterPass.java:90)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:54)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$1(PassExecutorService.java:397)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1124)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:390)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:628)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:580)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:59)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:389)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:365)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:170)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:182)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:363)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:184)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
  ```
  
</details>

Btw find usages for macro meta-variables doesn't work for macros 2.0 as well as navigation, the PR fixes exception only