### PR TITLE
Fix exception during code folding of invalid macro calls

### DIFF
--- a/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt
+++ b/src/main/kotlin/org/rust/ide/folding/RsFoldingBuilder.kt
@@ -95,7 +95,12 @@ class RsFoldingBuilder : CustomFoldingBuilder(), DumbAware {
 
         override fun visitModItem(o: RsModItem) = foldBetween(o, o.lbrace, o.rbrace)
 
-        override fun visitMacroArgument(o: RsMacroArgument) = foldBetween(o, o.lbrace, o.rbrace)
+        override fun visitMacroArgument(o: RsMacroArgument) {
+            val macroCall = o.parent as? RsMacroCall
+            if (macroCall?.bracesKind == MacroBraces.BRACES) {
+                foldBetween(o, o.lbrace, o.rbrace)
+            }
+        }
 
         override fun visitValueParameterList(o: RsValueParameterList) {
             if (o.valueParameterList.isEmpty()) return

--- a/src/test/resources/org/rust/ide/folding/fixtures/macro_brace_arg.rs
+++ b/src/test/resources/org/rust/ide/folding/fixtures/macro_brace_arg.rs
@@ -4,3 +4,5 @@ fn test() <fold text='{...}'>{
 }</fold>
 
 awesome_invoke! <fold text='{...}'>{ }</fold>
+
+awesome_invoke! (} {);


### PR DESCRIPTION
<details>
  <summary>Exception stacktrace</summary>
  
  ```

java.lang.IllegalArgumentException: Invalid range specified: (933, 917); 
	at com.intellij.openapi.util.TextRange.assertProperRange(TextRange.java:236)
	at com.intellij.openapi.util.TextRange.assertProperRange(TextRange.java:231)
	at com.intellij.openapi.util.TextRange.assertProperRange(TextRange.java:227)
	at com.intellij.openapi.util.TextRange.<init>(TextRange.java:40)
	at com.intellij.openapi.util.TextRange.<init>(TextRange.java:29)
	at org.rust.ide.folding.RsFoldingBuilder$FoldingVisitor.foldBetween(RsFoldingBuilder.kt:128)
	at org.rust.ide.folding.RsFoldingBuilder$FoldingVisitor.visitMacroArgument(RsFoldingBuilder.kt:98)
	at org.rust.lang.core.psi.impl.RsMacroArgumentImpl.accept(RsMacroArgumentImpl.java:21)
	at org.rust.lang.core.psi.impl.RsMacroArgumentImpl.accept(RsMacroArgumentImpl.java:25)
	at org.rust.ide.folding.RsFoldingBuilder$buildLanguageFoldRegions$1.execute(RsFoldingBuilder.kt:58)
	at com.intellij.psi.util.PsiTreeUtil$4.visitElement(PsiTreeUtil.java:911)
	at com.intellij.psi.impl.PsiElementBase.accept(PsiElementBase.java:273)
	at org.rust.lang.core.psi.impl.RsMacroArgumentImpl.accept(RsMacroArgumentImpl.java:26)
	at com.intellij.psi.PsiWalkingState.visit(PsiWalkingState.java:70)
	at com.intellij.psi.PsiWalkingState.visit(PsiWalkingState.java:27)
	at com.intellij.util.WalkingState.walkChildren(WalkingState.java:65)
	at com.intellij.util.WalkingState.elementStarted(WalkingState.java:52)
	at com.intellij.psi.PsiWalkingState.elementStarted(PsiWalkingState.java:79)
	at com.intellij.psi.PsiRecursiveElementWalkingVisitor.visitElement(PsiRecursiveElementWalkingVisitor.java:48)
	at com.intellij.psi.util.PsiTreeUtil$4.visitElement(PsiTreeUtil.java:912)
	at com.intellij.psi.PsiElementVisitor.visitFile(PsiElementVisitor.java:35)
	at com.intellij.psi.PsiRecursiveElementWalkingVisitor.visitFile(PsiRecursiveElementWalkingVisitor.java:70)
	at com.intellij.extapi.psi.PsiFileBase.accept(PsiFileBase.java:60)
	at com.intellij.psi.util.PsiTreeUtil.processElements(PsiTreeUtil.java:908)
	at org.rust.ide.folding.RsFoldingBuilder.buildLanguageFoldRegions(RsFoldingBuilder.kt:58)
	at com.intellij.lang.folding.CustomFoldingBuilder.buildFoldRegions(CustomFoldingBuilder.java:44)
	at com.intellij.lang.folding.LanguageFolding.buildFoldingDescriptorsNoPlaceholderCaching(LanguageFolding.java:92)
	at com.intellij.lang.folding.LanguageFolding.buildFoldingDescriptors(LanguageFolding.java:75)
	at com.intellij.codeInsight.folding.impl.FoldingUpdate.getFoldingsFor(FoldingUpdate.java:261)
	at com.intellij.codeInsight.folding.impl.FoldingUpdate.getFoldingsFor(FoldingUpdate.java:228)
	at com.intellij.codeInsight.folding.impl.FoldingUpdate.getUpdateResult(FoldingUpdate.java:82)
	at com.intellij.codeInsight.folding.impl.FoldingUpdate.lambda$updateFoldRegions$0(FoldingUpdate.java:71)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:54)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$1(CachedValueBase.java:235)
	at com.intellij.openapi.util.RecursionManager$1.doPreventingRecursion(RecursionManager.java:113)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:72)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:236)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:43)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:73)
	at com.intellij.codeInsight.folding.impl.FoldingUpdate.updateFoldRegions(FoldingUpdate.java:68)
	at com.intellij.codeInsight.folding.impl.CodeFoldingManagerImpl.updateFoldRegions(CodeFoldingManagerImpl.java:221)
	at com.intellij.codeInsight.folding.impl.CodeFoldingManagerImpl.updateFoldRegionsAsync(CodeFoldingManagerImpl.java:207)
	at com.intellij.codeInsight.daemon.impl.CodeFoldingPass.doCollectInformation(CodeFoldingPass.java:42)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:54)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$1(PassExecutorService.java:396)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1110)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:389)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:629)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:581)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:388)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:364)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:170)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:182)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:362)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:184)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
  ```
  
</details>

Works for:

```
awesome_invoke! (} {);
```
