### PR TITLE
Fix possible NPEs in some LocalQuickFix.getText()

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
@@ -25,19 +25,21 @@ import org.rust.lang.core.types.ty.TyUnit
 
 
 class ChangeReturnTypeFix(element: RsElement, private val actualTy: Ty) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
-    override fun getFamilyName(): String = "Change return type"
-    override fun getText(): String {
-        val (item, name) = when (val callable = findCallableOwner(startElement)) {
-            is RsFunction -> {
-                val item = if (callable.owner.isImplOrTrait) " of method" else " of function"
-                val name = callable.name?.let { " '$it'" } ?: ""
-                item to name
+    private val _text: String = run {
+            val (item, name) = when (val callable = findCallableOwner(element)) {
+                is RsFunction -> {
+                    val item = if (callable.owner.isImplOrTrait) " of method" else " of function"
+                    val name = callable.name?.let { " '$it'" } ?: ""
+                    item to name
+                }
+                is RsLambdaExpr -> " of closure" to ""
+                else -> "" to ""
             }
-            is RsLambdaExpr -> " of closure" to ""
-            else -> "" to ""
+            "Change return type$item$name to '${actualTy.render(useAliasNames = true)}'"
         }
-        return "Change return type$item$name to '${actualTy.render(useAliasNames = true)}'"
-    }
+
+    override fun getText(): String = _text
+    override fun getFamilyName(): String = "Change return type"
 
     override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
         val owner = findCallableOwner(startElement) ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveRefFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveRefFix.kt
@@ -23,11 +23,13 @@ import org.rust.lang.core.psi.ext.operatorType
 class RemoveRefFix private constructor(
     expr: RsUnaryExpr
 ) : LocalQuickFixOnPsiElement(expr) {
-    override fun getText() = when ((startElement as RsUnaryExpr).operatorType) {
+    private val _text: String = when (val operatorType = expr.operatorType) {
         UnaryOperator.REF -> "Remove &"
         UnaryOperator.REF_MUT -> "Remove &mut"
-        else -> error("unreachable")
+        else -> error("Illegal operator type: expected REF or REF_MUT, got $operatorType")
     }
+
+    override fun getText() = _text
     override fun getFamilyName() = "Remove reference"
 
     override fun invoke(project: Project, file: PsiFile, expr: PsiElement, endElement: PsiElement) {


### PR DESCRIPTION
<details>
  <summary>Exception stacktrace</summary>
  
  ```


kotlin.TypeCastException: null cannot be cast to non-null type org.rust.lang.core.psi.RsUnaryExpr
	at org.rust.ide.inspections.fixes.RemoveRefFix.getText(RemoveRefFix.kt:26)
	at com.intellij.codeInspection.LocalQuickFixOnPsiElement.getName(LocalQuickFixOnPsiElement.java:53)
	at com.intellij.codeInspection.ex.QuickFixWrapper.getFamilyName(QuickFixWrapper.java:58)
	at com.intellij.codeInspection.ex.QuickFixWrapper.getText(QuickFixWrapper.java:52)
	at com.intellij.codeInsight.intention.impl.IntentionActionWithTextCaching.<init>(IntentionActionWithTextCaching.java:53)
	at com.intellij.codeInsight.intention.impl.IntentionActionWithTextCaching.<init>(IntentionActionWithTextCaching.java:48)
	at com.intellij.codeInsight.intention.impl.CachedIntentions.wrapAction(CachedIntentions.java:243)
	at com.intellij.codeInsight.intention.impl.CachedIntentions.wrapActionsTo(CachedIntentions.java:222)
	at com.intellij.codeInsight.intention.impl.CachedIntentions.wrapAndUpdateActions(CachedIntentions.java:134)
	at com.intellij.codeInsight.daemon.impl.ShowIntentionsPass.doCollectInformation(ShowIntentionsPass.java:228)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:54)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$1(PassExecutorService.java:396)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1110)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:389)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:629)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:581)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:388)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:364)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:170)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:182)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:362)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:184)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)

  ```
  
</details>
