### PR TITLE
INSP: add RsIntegerOverflowInspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsIntegerOverflowInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsIntegerOverflowInspection.kt
@@ -1,0 +1,54 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsLitExpr
+import org.rust.lang.core.psi.RsUnaryExpr
+import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.ext.UnaryOperator
+import org.rust.lang.core.psi.ext.operatorType
+import org.rust.lang.core.types.consts.asLong
+import org.rust.lang.core.types.ty.TyInteger
+import org.rust.lang.core.types.type
+import org.rust.lang.utils.evaluation.ConstExpr
+import org.rust.lang.utils.evaluation.toConstExpr
+import org.rust.lang.utils.evaluation.validValuesRange
+
+class RsIntegerOverflowInspection : RsLintInspection() {
+    override fun getLint(element: PsiElement): RsLint = RsLint.OverflowingLiterals
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+        object : RsVisitor() {
+            override fun visitLitExpr(o: RsLitExpr) {
+                val type = o.type
+                if (type !is TyInteger) return
+
+                val parent = o.parent
+                val expr: RsExpr = if (parent is RsUnaryExpr && parent.operatorType == UnaryOperator.MINUS) {
+                    parent
+                } else {
+                    o
+                }
+
+                val value = evaluate(expr.toConstExpr()) ?: return
+                if (overflows(value, type)) {
+                    holder.registerProblem(expr, "literal out of range for $type")
+                }
+            }
+        }
+
+    private fun evaluate(expr: ConstExpr<*>?): Long? = when {
+        expr is ConstExpr.Constant -> expr.const.asLong()
+        expr is ConstExpr.Value.Integer -> expr.value
+        expr is ConstExpr.Unary && expr.operator == UnaryOperator.MINUS -> evaluate(expr.expr)?.let { -it }
+        else -> null
+    }
+
+    private fun overflows(value: Long, type: TyInteger): Boolean = value !in type.validValuesRange
+}

--- a/src/main/kotlin/org/rust/ide/inspections/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLint.kt
@@ -43,7 +43,9 @@ enum class RsLint(
                 WARN -> ProblemHighlightType.WEAK_WARNING
                 else -> super.toHighlightingType(level)
             }
-    };
+    },
+
+    OverflowingLiterals("overflowing_literals", defaultLevel = DENY);
 
     protected open fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
         when (level) {

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExprEvaluator.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExprEvaluator.kt
@@ -168,11 +168,11 @@ private fun <T : Ty> simplifyToInteger(expr: ConstExpr<T>): ConstExpr<T> {
 private fun Long.validValueOrNull(ty: TyInteger): Long? = takeIf { it in ty.validValuesRange }
 
 // It returns wrong values for large types like `i128` or `usize`, but looks like it's enough for real cases
-private val TyInteger.validValuesRange: LongRange
+val TyInteger.validValuesRange: LongRange
     get() = when (this) {
-        TyInteger.U8 -> LongRange(0, 1L shl 8)
-        TyInteger.U16 -> LongRange(0, 1L shl 16)
-        TyInteger.U32 -> LongRange(0, 1L shl 32)
+        TyInteger.U8 -> LongRange(0, (1L shl 8) - 1)
+        TyInteger.U16 -> LongRange(0, (1L shl 16) - 1)
+        TyInteger.U32 -> LongRange(0, (1L shl 32) - 1)
         TyInteger.U64 -> LongRange(0, Long.MAX_VALUE)
         TyInteger.U128 -> LongRange(0, Long.MAX_VALUE)
         TyInteger.USize -> LongRange(0, Long.MAX_VALUE)

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -550,6 +550,11 @@
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RsDetachedFileInspection"/>
 
+        <localInspection language="Rust" groupName="Rust"
+                         displayName="Integer overflow"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.rust.ide.inspections.RsIntegerOverflowInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsIntegerOverflow.html
+++ b/src/main/resources/inspectionDescriptions/RsIntegerOverflow.html
@@ -1,0 +1,1 @@
+Checks if integer literals do not overflow their types.

--- a/src/test/kotlin/org/rust/ide/inspections/RsIntegerOverflowInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsIntegerOverflowInspectionTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+class RsIntegerOverflowInspectionTest : RsInspectionsTestBase(RsIntegerOverflowInspection::class) {
+    fun `test explicit type`() = checkByText("""
+        fn main() {
+            let _: u16 = <error descr="literal out of range for u16">100_000_000</error>;
+        }
+    """)
+
+    fun `test inferred type`() = checkByText("""
+        fn main() {
+            let _ = <error descr="literal out of range for i32">3_000_000_000</error>;
+        }
+    """)
+
+    fun `test hexadecimal literal`() = checkByText("""
+        fn main() {
+            let _: u8 = <error descr="literal out of range for u8">0xFFF</error>;
+        }
+    """)
+
+    fun `test enum repr`() = checkByText("""
+        #[repr(u8)]
+        pub enum Color {
+            White = <error descr="literal out of range for u8">256</error>,
+        }
+    """)
+
+    fun `test allow overflow`() = checkByText("""
+        #![allow(overflowing_literals)]
+        fn main() {
+            let _: u16 = 100_000_000;
+        }
+    """)
+
+    fun `test u8 no overflow`() = checkByText("""
+        fn main() {
+            0u8;
+            255u8;
+        }
+    """)
+
+    fun `test u8 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for u8">256u8</error>;
+        }
+    """)
+
+    fun `test u16 no overflow`() = checkByText("""
+        fn main() {
+            0u16;
+            65535u16;
+        }
+    """)
+
+    fun `test u16 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for u16">65536u16</error>;
+        }
+    """)
+
+    fun `test u32 no overflow`() = checkByText("""
+        fn main() {
+            0u32;
+            4_294_967_295u32;
+        }
+    """)
+
+    fun `test u32 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for u32">4_294_967_296u32</error>;
+        }
+    """)
+
+    fun `test u64 no overflow`() = checkByText("""
+        fn main() {
+            0u64;
+            9_223_372_036_854_775_807u64;
+        }
+    """)
+
+    fun `test u64 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for u64">9_223_372_036_854_775_807u64</error>;
+        }
+    """)
+
+    fun `test infer signed literal`() = checkByText("""
+        fn main() {
+            let _: i8 = <error descr="literal out of range for i8">-129i8</error>;
+        }
+    """)
+
+    fun `test i8 no overflow`() = checkByText("""
+        fn main() {
+            -128i8;
+            0i8;
+            127i8;
+        }
+    """)
+
+    fun `test i8 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for i8">-129i8</error>;
+            <error descr="literal out of range for i8">128i8</error>;
+        }
+    """)
+
+    fun `test i16 no overflow`() = checkByText("""
+        fn main() {
+            -32768i16;
+            0i16;
+            32767i16;
+        }
+    """)
+
+    fun `test i16 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for i16">-32769i16</error>;
+            <error descr="literal out of range for i16">32768i16</error>;
+        }
+    """)
+
+    fun `test i32 no overflow`() = checkByText("""
+        fn main() {
+            -2_147_483_648i32;
+            0i32;
+            2_147_483_647i32;
+        }
+    """)
+
+    fun `test i32 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for i32">-2_147_483_649i32</error>;
+            <error descr="literal out of range for i32">2_147_483_648i32</error>;
+        }
+    """)
+
+    fun `test i64 no overflow`() = checkByText("""
+        fn main() {
+            -9_223_372_036_854_775_808i64;
+            0i64;
+            9_223_372_036_854_775_807i64;
+        }
+    """)
+
+    fun `test i64 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for i64">-9_223_372_036_854_775_809i64</error>;
+            <error descr="literal out of range for i64">9_223_372_036_854_775_808i64</error>;
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds inspection that checks integer literal overflows.

I tried to reuse `ConstExprEvaluator` as much as I could, but I ended up rewriting a small evaluation function to have better control of the result. There was also an off-by-one error in some of the integer ranges of `ConstExprEvaluator`. 

There are some unresolved things:
1) `isize/usize`: should we query the pointer size of the architecture of the corresponding Rust target? Or just treat it as `i64/u64`? Or ignore this type altogether?
2) Large types (`i64`, `u64`, `i128`, `u128`) cannot be fully represented by `Long`, which is used by the const evaluator. Rustc fully checks `u64` and `i64`, but it gives up at a certain point and when the integer literal is too large, the compilation fails with an error, so it cannot check all of `i128`/`u128`.

Possible solutions of 2):
- Simply ignore the overflow check if the literal is unrepresentable by `Long`. I think that this solution is ok, as users are unlikely to write such large literals.
- Rewrite a part of the const expr evaluator using `BigInteger`.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5568