### PR TITLE
INSP: change RsVariableMutableInspection to a LintInspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLint.kt
@@ -13,14 +13,15 @@ import org.rust.lang.core.psi.ext.*
  */
 enum class RsLint(
     val id: String,
-    val groupIds: List<String> = emptyList(),
-    val defaultLevel: RsLintLevel = RsLintLevel.WARN
+    private val groupIds: List<String> = emptyList(),
+    private val defaultLevel: RsLintLevel = RsLintLevel.WARN
 ) {
     NonSnakeCase("non_snake_case", listOf("bad_style")),
     NonCamelCaseTypes("non_camel_case_types", listOf("bad_style")),
     NonUpperCaseGlobals("non_upper_case_globals", listOf("bad_style")),
     Deprecated("deprecated"),
     UnusedVariables("unused_variables", listOf("unused")),
+    UnusedMutable("unused_mut", listOf("unused")),
     NeedlessLifetimes("clippy::needless_lifetimes", listOf("clippy::complexity", "clippy::all", "clippy"));
 
     /**

--- a/src/main/kotlin/org/rust/ide/inspections/RsVariableMutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsVariableMutableInspection.kt
@@ -15,8 +15,10 @@ import org.rust.lang.core.psi.ext.descendantsOfType
 import org.rust.lang.core.psi.ext.mutability
 import org.rust.lang.core.psi.ext.selfParameter
 
-class RsVariableMutableInspection : RsLocalInspectionTool() {
-    override fun getDisplayName() = "No mutable required"
+class RsVariableMutableInspection : RsLintInspection() {
+    override fun getLint(element: PsiElement): RsLint = RsLint.UnusedMutable
+
+    override fun getDisplayName() = "variable does not need to be mutable"
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitPatBinding(o: RsPatBinding) {

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -456,8 +456,8 @@
                          implementationClass="org.rust.ide.inspections.RsSimplifyBooleanExpressionInspection"/>
 
         <localInspection language="Rust" groupName="Rust"
-                         displayName="No mutable required"
-                         enabledByDefault="false" level="WARNING"
+                         displayName="Unnecessarily mutable variable"
+                         enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RsVariableMutableInspection"/>
 
         <localInspection language="Rust" groupName="Rust"

--- a/src/test/kotlin/org/rust/ide/inspections/RsVariableMutableInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsVariableMutableInspectionTest.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.inspections
 
 class RsVariableMutableInspectionTest : RsInspectionsTestBase(RsVariableMutableInspection::class) {
-
     fun `test should annotate unused variable`() = checkByText("""
         fn main() {
             let <warning>mut f</warning> = 10;


### PR DESCRIPTION
This PR changes `RsVariableMutableInspection`, introduced in https://github.com/intellij-rust/intellij-rust/pull/1143, to a `RsLintInspection` and enables it by default.

I think that this inspection is incredibly useful. I have been using the Rust plugin for more than two years and I had no clue about its existence, so I think that it would be good if we enable it by default, at least in nightly builds for now, to gather possible false positives.

I'll try to find cases where false positives happen and try to fix them to make this inspection better. If you know about any one reason why this shouldn't be enabled by default except for false positives, let me know.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/1004