### PR TITLE
Fix PsiInvalidElementAccessException in RsExternalLinterPass

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterPass.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterPass.kt
@@ -68,6 +68,8 @@ class RsExternalLinterPass(
     }
 
     override fun doApplyInformationToEditor() {
+        if (file !is RsFile) return
+
         if (annotationInfo == null || !isAnnotationPassEnabled) {
             disposable = myProject
             doFinish(emptyList())


### PR DESCRIPTION
<details>
  <summary>Exception stacktrace</summary>
  
  ```


com.intellij.psi.PsiInvalidElementAccessException: Element: class com.intellij.lang.javascript.psi.impl.JSFileImpl #TypeScript JSX  because: different providers: com.intellij.lang.javascript.JSFileViewProviderFactory$JSFileViewProvider{vFile=file:///home/pepa/dev/pool@master/web-ui/packages/slushpool/app/root/modules/user/actions/auth.tsx, vFileId=89892, content=VirtualFileContent{size=6159}, eventSystemEnabled=true}(5e3c1e87); com.intellij.lang.javascript.JSFileViewProviderFactory$JSFileViewProvider{vFile=file:///home/pepa/dev/pool@master/web-ui/packages/slushpool/app/root/modules/user/actions/auth.tsx, vFileId=89892, content=VirtualFileContent{size=6159}, eventSystemEnabled=true}(2398b94d)
invalidated at: see attachment
	at com.intellij.psi.util.PsiUtilCore.ensureValid(PsiUtilCore.java:477)
	at com.intellij.psi.impl.source.PsiFileImpl.getTextLength(PsiFileImpl.java:322)
	at org.rust.ide.annotator.RsExternalLinterPass$doFinish$$inlined$invokeLater$1.run(actions.kt:84)
	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:201)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:802)
	at com.intellij.openapi.application.impl.ApplicationImpl.lambda$invokeLater$4(ApplicationImpl.java:322)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:84)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:132)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:47)
	at com.intellij.openapi.application.impl.FlushQueue$FlushNow.run(FlushQueue.java:188)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:313)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:776)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:727)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:746)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:965)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:838)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:449)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:744)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$9(IdeEventQueue.java:448)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:802)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:496)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)

  ```
  
</details>
