### PR TITLE
INT: convert method call to UFCS

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/ConvertMethodCallToUFCSIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ConvertMethodCallToUFCSIntention.kt
@@ -1,0 +1,125 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.rust.ide.inspections.import.AutoImportFix
+import org.rust.ide.inspections.import.import
+import org.rust.ide.presentation.renderInsertionSafe
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve.TraitImplSource
+import org.rust.lang.core.resolve.ref.MethodResolveVariant
+import org.rust.lang.core.types.inference
+import org.rust.lang.core.types.ty.*
+import org.rust.lang.core.types.type
+
+class ConvertMethodCallToUFCSIntention : RsElementBaseIntentionAction<ConvertMethodCallToUFCSIntention.Context>() {
+    override fun getText() = "Convert to UFCS"
+    override fun getFamilyName() = text
+
+    override fun findApplicableContext(
+        project: Project,
+        editor: Editor,
+        element: PsiElement
+    ): Context? {
+        val methodCall = element.parent as? RsMethodCall ?: return null
+        val function = methodCall.reference.resolve() as? RsFunction ?: return null
+        val methodVariants = methodCall.inference?.getResolvedMethod(methodCall).orEmpty()
+        if (methodVariants.isEmpty()) return null
+        return Context(methodCall, function, methodVariants)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val methodCall = ctx.methodCall
+        val function = ctx.function
+        val functionName = function.name ?: return
+
+        val factory = RsPsiFactory(project)
+
+        val selfType = getSelfType(function) ?: return
+        val receiver = methodCall.receiver
+        val prefix = getSelfArgumentPrefix(selfType, receiver)
+        val selfArgument = factory.createExpression("$prefix${receiver.text}")
+
+        val arguments = listOf(selfArgument) + methodCall.valueArgumentList.exprList
+        val ownerName = getOwnerName(ctx.methodVariants)
+        val ufcs = factory.createAssocFunctionCall(ownerName, functionName, arguments)
+
+        val parentDot = methodCall.parentDotExpr
+        val inserted = parentDot.replace(ufcs) as RsCallExpr
+        val path = (inserted.expr as? RsPathExpr)?.path ?: return
+
+        val importCtx = AutoImportFix.findApplicableContext(project, path)
+        importCtx?.candidates?.firstOrNull()?.import(inserted)
+    }
+
+    data class Context(
+        val methodCall: RsMethodCall,
+        val function: RsFunction,
+        val methodVariants: List<MethodResolveVariant>
+    )
+}
+
+private fun getOwnerName(methodVariants: List<MethodResolveVariant>): String {
+    val variant = methodVariants.minBy {
+        if (it.source is TraitImplSource.ExplicitImpl) {
+            0
+        } else {
+            1
+        }
+    } ?: error("Method not resolved to any variant")
+
+    fun renderType(ty: Ty): String = ty.renderInsertionSafe(
+        includeTypeArguments = false,
+        includeLifetimeArguments = false
+    )
+
+    return when (val type = variant.selfTy) {
+        is TyAnon, is TyTraitObject -> (variant.source.value as? RsTraitItem)?.name ?: renderType(type)
+        else -> renderType(type)
+    }
+}
+
+private enum class SelfType {
+    Move,
+    Ref,
+    RefMut
+}
+
+private fun getSelfType(function: RsFunction): SelfType? {
+    val self = function.selfParameter ?: return null
+    val ref = self.isRef
+
+    return when {
+        !ref -> SelfType.Move
+        self.mutability == Mutability.MUTABLE -> SelfType.RefMut
+        else -> SelfType.Ref
+    }
+}
+
+private fun getSelfArgumentPrefix(selfType: SelfType, receiver: RsExpr): String {
+    val type = receiver.type
+    return when (selfType) {
+        SelfType.Move -> ""
+        SelfType.Ref -> {
+            if (type is TyReference) {
+                ""
+            } else {
+                "&"
+            }
+        }
+        SelfType.RefMut -> {
+            if (type is TyReference) {
+                ""
+            } else {
+                "&mut "
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -803,6 +803,10 @@
             <className>org.rust.ide.intentions.ConvertUFCSToMethodCallIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.ConvertMethodCallToUFCSIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 

--- a/src/main/resources/intentionDescriptions/ConvertMethodCallToUFCSIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/ConvertMethodCallToUFCSIntention/after.rs.template
@@ -1,0 +1,9 @@
+struct S;
+impl S {
+    fn foo(&self) {}
+}
+
+fn bar() {
+    let s = S;
+    S::foo(&s);
+}

--- a/src/main/resources/intentionDescriptions/ConvertMethodCallToUFCSIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/ConvertMethodCallToUFCSIntention/before.rs.template
@@ -1,0 +1,9 @@
+struct S;
+impl S {
+    fn foo(&self) {}
+}
+
+fn bar() {
+    let s = S;
+    s.<spot>foo</spot>();
+}

--- a/src/main/resources/intentionDescriptions/ConvertMethodCallToUFCSIntention/description.html
+++ b/src/main/resources/intentionDescriptions/ConvertMethodCallToUFCSIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention converts a method call into UFCS (universal function call syntax) call.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/ConvertMethodCallToUFCSTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ConvertMethodCallToUFCSTest.kt
@@ -1,0 +1,424 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+class ConvertMethodCallToUFCSTest : RsIntentionTestBase(ConvertMethodCallToUFCSIntention()) {
+    fun `test unavailable on function call`() = doUnavailableTest("""
+        fn foo() {}
+        fn bar() {
+            /*caret*/foo();
+        }
+    """)
+
+    fun `test unavailable on unresolved method`() = doUnavailableTest("""
+        struct S;
+
+        fn bar() {
+            let s = S;
+            s./*caret*/foo();
+        }
+    """)
+
+    fun `test unavailable on method args`() = doUnavailableTest("""
+        struct S;
+        impl S {
+            fn foo(&self, _: u32) {}
+        }
+
+        fn bar() {
+            let s = S;
+            s.foo(/*caret*/1);
+        }
+    """)
+
+    fun `test self move`() = doAvailableTest("""
+        struct Foo;
+        impl Foo {
+            fn foo(self) {}
+        }
+        fn foo(foo: Foo) {
+            foo./*caret*/foo();
+        }
+    """, """
+        struct Foo;
+        impl Foo {
+            fn foo(self) {}
+        }
+        fn foo(foo: Foo) {
+            Foo::foo(foo);
+        }
+    """)
+
+    fun `test self ref receiver owned`() = doAvailableTest("""
+        struct Foo;
+        impl Foo {
+            fn foo(&self) {}
+        }
+        fn foo(foo: Foo) {
+            foo./*caret*/foo();
+        }
+    """, """
+        struct Foo;
+        impl Foo {
+            fn foo(&self) {}
+        }
+        fn foo(foo: Foo) {
+            Foo::foo(&foo);
+        }
+    """)
+
+    fun `test self ref receiver ref`() = doAvailableTest("""
+        struct Foo;
+        impl Foo {
+            fn foo(&self) {}
+        }
+        fn foo(foo: &Foo) {
+            foo./*caret*/foo();
+        }
+    """, """
+        struct Foo;
+        impl Foo {
+            fn foo(&self) {}
+        }
+        fn foo(foo: &Foo) {
+            Foo::foo(foo);
+        }
+    """)
+
+    fun `test self mut ref receiver owned`() = doAvailableTest("""
+        struct Foo;
+        impl Foo {
+            fn foo(&mut self) {}
+        }
+        fn foo(mut foo: Foo) {
+            foo./*caret*/foo();
+        }
+    """, """
+        struct Foo;
+        impl Foo {
+            fn foo(&mut self) {}
+        }
+        fn foo(mut foo: Foo) {
+            Foo::foo(&mut foo);
+        }
+    """)
+
+    fun `test self mut ref receiver mut ref`() = doAvailableTest("""
+        struct Foo;
+        impl Foo {
+            fn foo(&mut self) {}
+        }
+        fn foo(foo: &mut Foo) {
+            foo./*caret*/foo();
+        }
+    """, """
+        struct Foo;
+        impl Foo {
+            fn foo(&mut self) {}
+        }
+        fn foo(foo: &mut Foo) {
+            Foo::foo(foo);
+        }
+    """)
+
+    fun `test nested attribute method call`() = doAvailableTest("""
+        struct Bar;
+        struct Foo {
+            bar: Bar
+        }
+        impl Bar {
+            fn bar(&self) {}
+        }
+        fn foo(foo: &Foo) {
+            foo.bar./*caret*/bar();
+        }
+    """, """
+        struct Bar;
+        struct Foo {
+            bar: Bar
+        }
+        impl Bar {
+            fn bar(&self) {}
+        }
+        fn foo(foo: &Foo) {
+            Bar::bar(&foo.bar);
+        }
+    """)
+
+    fun `test trait method call on struct`() = doAvailableTest("""
+        struct Foo;
+        trait Trait {
+            fn foo(&self);
+        }
+        impl Trait for Foo {
+            fn foo(&self) {}
+        }
+
+        fn foo(foo: &Foo) {
+            foo./*caret*/foo();
+        }
+    """, """
+        struct Foo;
+        trait Trait {
+            fn foo(&self);
+        }
+        impl Trait for Foo {
+            fn foo(&self) {}
+        }
+
+        fn foo(foo: &Foo) {
+            Foo::foo(foo);
+        }
+    """)
+
+    fun `test trait method call on generic trait bound`() = doAvailableTest("""
+        trait Trait {
+            fn foo(&self);
+        }
+
+        fn foo<T: Trait>(foo: &T) {
+            foo./*caret*/foo();
+        }
+    """, """
+        trait Trait {
+            fn foo(&self);
+        }
+
+        fn foo<T: Trait>(foo: &T) {
+            T::foo(foo);
+        }
+    """)
+
+    fun `test trait method call on generic trait where`() = doAvailableTest("""
+        trait Trait {
+            fn foo(&self);
+        }
+
+        fn foo<T>(foo: T) where T: Trait {
+            foo./*caret*/foo();
+        }
+    """, """
+        trait Trait {
+            fn foo(&self);
+        }
+
+        fn foo<T>(foo: T) where T: Trait {
+            T::foo(&foo);
+        }
+    """)
+
+    fun `test trait method call on impl trait`() = doAvailableTest("""
+        trait Trait {
+            fn foo(&self);
+        }
+
+        fn foo(foo: impl Trait) {
+            foo./*caret*/foo();
+        }
+    """, """
+        trait Trait {
+            fn foo(&self);
+        }
+
+        fn foo(foo: impl Trait) {
+            Trait::foo(&foo);
+        }
+    """)
+
+    fun `test trait method call on impl trait ref`() = doAvailableTest("""
+        trait Trait {
+            fn foo(&self);
+        }
+
+        fn foo(foo: &impl Trait) {
+            foo./*caret*/foo();
+        }
+    """, """
+        trait Trait {
+            fn foo(&self);
+        }
+
+        fn foo(foo: &impl Trait) {
+            Trait::foo(foo);
+        }
+    """)
+
+    fun `test trait method call on dyn trait`() = doAvailableTest("""
+        trait Trait {
+            fn foo(&self);
+        }
+
+        fn foo(foo: &dyn Trait) {
+            foo./*caret*/foo();
+        }
+    """, """
+        trait Trait {
+            fn foo(&self);
+        }
+
+        fn foo(foo: &dyn Trait) {
+            Trait::foo(foo);
+        }
+    """)
+
+    fun `test target in a different mod `() = doAvailableTest("""
+        mod foo {
+            pub struct Foo;
+            impl Foo {
+                pub fn bar(&self) {}
+            }
+        }
+
+        fn bar(a: foo::Foo) {
+            a./*caret*/bar();
+        }
+    """, """
+        use foo::Foo;
+
+        mod foo {
+            pub struct Foo;
+            impl Foo {
+                pub fn bar(&self) {}
+            }
+        }
+
+        fn bar(a: foo::Foo) {
+            Foo::bar(&a);
+        }
+    """)
+
+    fun `test generic trait`() = doAvailableTest("""
+        trait Trait<T> {
+            fn foo(&self);
+        }
+
+        fn foo<T, R: Trait<T>>(foo: R) {
+            foo./*caret*/foo();
+        }
+    """, """
+        trait Trait<T> {
+            fn foo(&self);
+        }
+
+        fn foo<T, R: Trait<T>>(foo: R) {
+            R::foo(&foo);
+        }
+    """)
+
+    fun `test generic trait bound impl`() = doAvailableTest("""
+        trait Trait<T> {
+            fn foo(&self);
+        }
+
+        fn foo<T, R: Trait<u32>>(foo: R) {
+            foo./*caret*/foo();
+        }
+    """, """
+        trait Trait<T> {
+            fn foo(&self);
+        }
+
+        fn foo<T, R: Trait<u32>>(foo: R) {
+            R::foo(&foo);
+        }
+    """)
+
+    fun `test generic struct`() = doAvailableTest("""
+        struct S<T>(T);
+        impl<T> S<T> {
+            fn foo(&self) {}
+        }
+
+        fn foo<T>(foo: S<T>) {
+            foo./*caret*/foo();
+        }
+    """, """
+        struct S<T>(T);
+        impl<T> S<T> {
+            fn foo(&self) {}
+        }
+
+        fn foo<T>(foo: S<T>) {
+            S::foo(&foo);
+        }
+    """)
+
+    fun `test trait with an associated type`() = doAvailableTest("""
+        trait Trait {
+            type Type;
+            fn foo(&self) -> Self::Type;
+        }
+
+        fn foo(foo: &dyn Trait<Type=u32>) {
+            foo./*caret*/foo();
+        }
+    """, """
+        trait Trait {
+            type Type;
+            fn foo(&self) -> Self::Type;
+        }
+
+        fn foo(foo: &dyn Trait<Type=u32>) {
+            Trait::foo(foo);
+        }
+    """)
+
+    fun `test both inherent impl and trait impl`() = doAvailableTest("""
+        trait Trait {
+            fn foo(&self);
+        }
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+        impl Trait for S {
+            fn foo(&self) {}
+        }
+
+        fn foo(foo: S) {
+            foo./*caret*/foo();
+        }
+    """, """
+        trait Trait {
+            fn foo(&self);
+        }
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+        impl Trait for S {
+            fn foo(&self) {}
+        }
+
+        fn foo(foo: S) {
+            S::foo(&foo);
+        }
+    """)
+
+    fun `test array type`() = doAvailableTest("""
+        trait Trait {
+            fn foo(&self);
+        }
+        impl Trait for [u8] {
+            fn foo(&self) {}
+        }
+
+        fn foo(foo: &[u8]) {
+            foo./*caret*/foo();
+        }
+    """, """
+        trait Trait {
+            fn foo(&self);
+        }
+        impl Trait for [u8] {
+            fn foo(&self) {}
+        }
+
+        fn foo(foo: &[u8]) {
+            <[u8]>::foo(foo);
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds an intention that converts a method call to a UFCS call. I'll add the corresponding intention in the opposite direction in a future PR.

![ufcs](https://user-images.githubusercontent.com/4539057/85004386-c8f51f00-b157-11ea-9254-0e9dafb2058d.gif)

For trait methods, it seems that using `<dyn Trait>::method(...)` is pretty universal, although it's not super pretty. Should we include some heuristic that checks whether it can be replaced by something simpler, for example `Trait::method(...)` or `T::method(...)` for generic types?

Fixes first part of https://github.com/intellij-rust/intellij-rust/issues/4451.