### PR TITLE
ANN: use more precise error annotations for missing/extraneous function call arguments

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -704,14 +704,10 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         val realCount = args.exprList.size
         if (realCount < expectedCount) {
             val target = args.rparen ?: args
-            if (variadic) {
-                RsDiagnostic.IncorrectArgumentCountErrorVariadic(target, expectedCount, realCount).addToHolder(holder)
-            } else {
-                RsDiagnostic.IncorrectArgumentCountError(target, expectedCount, realCount).addToHolder(holder)
-            }
+            RsDiagnostic.IncorrectFunctionArgumentCountError(target, expectedCount, realCount, variadic).addToHolder(holder)
         } else if (!variadic && realCount > expectedCount) {
             args.exprList.drop(expectedCount).forEach {
-                RsDiagnostic.IncorrectArgumentCountError(it, expectedCount, realCount).addToHolder(holder)
+                RsDiagnostic.IncorrectFunctionArgumentCountError(it, expectedCount, realCount).addToHolder(holder)
             }
         }
     }

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -702,10 +702,17 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
             else -> null
         } ?: return
         val realCount = args.exprList.size
-        if (variadic && realCount < expectedCount) {
-            RsDiagnostic.TooFewParamsError(args, expectedCount, realCount).addToHolder(holder)
-        } else if (!variadic && realCount != expectedCount) {
-            RsDiagnostic.TooManyParamsError(args, expectedCount, realCount).addToHolder(holder)
+        if (realCount < expectedCount) {
+            val target = args.rparen ?: args
+            if (variadic) {
+                RsDiagnostic.IncorrectArgumentCountErrorVariadic(target, expectedCount, realCount).addToHolder(holder)
+            } else {
+                RsDiagnostic.IncorrectArgumentCountError(target, expectedCount, realCount).addToHolder(holder)
+            }
+        } else if (!variadic && realCount > expectedCount) {
+            args.exprList.drop(expectedCount).forEach {
+                RsDiagnostic.IncorrectArgumentCountError(it, expectedCount, realCount).addToHolder(holder)
+            }
         }
     }
 

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -512,7 +512,7 @@ sealed class RsDiagnostic(
         }
     }
 
-    class TooFewParamsError(
+    class IncorrectArgumentCountErrorVariadic(
         element: PsiElement,
         private val expectedCount: Int,
         private val realCount: Int
@@ -530,7 +530,7 @@ sealed class RsDiagnostic(
         }
     }
 
-    class TooManyParamsError(
+    class IncorrectArgumentCountError(
         element: PsiElement,
         private val expectedCount: Int,
         private val realCount: Int

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -512,37 +512,21 @@ sealed class RsDiagnostic(
         }
     }
 
-    class IncorrectArgumentCountErrorVariadic(
+    class IncorrectFunctionArgumentCountError(
         element: PsiElement,
         private val expectedCount: Int,
-        private val realCount: Int
+        private val realCount: Int,
+        private val variadic: Boolean = false
     ) : RsDiagnostic(element) {
         override fun prepare() = PreparedAnnotation(
             ERROR,
-            E0060,
+            if (variadic) E0060 else E0061,
             errorText()
         )
 
         private fun errorText(): String {
-            return "This function takes at least $expectedCount ${pluralise(expectedCount, "parameter", "parameters")}" +
-                " but $realCount ${pluralise(realCount, "parameter", "parameters")}" +
-                " ${pluralise(realCount, "was", "were")} supplied"
-        }
-    }
-
-    class IncorrectArgumentCountError(
-        element: PsiElement,
-        private val expectedCount: Int,
-        private val realCount: Int
-    ) : RsDiagnostic(element) {
-        override fun prepare() = PreparedAnnotation(
-            ERROR,
-            E0061,
-            errorText()
-        )
-
-        private fun errorText(): String {
-            return "This function takes $expectedCount ${pluralise(expectedCount, "parameter", "parameters")}" +
+            return "This function takes${if (variadic) " at least" else ""}" +
+                " $expectedCount ${pluralise(expectedCount, "parameter", "parameters")}" +
                 " but $realCount ${pluralise(realCount, "parameter", "parameters")}" +
                 " ${pluralise(realCount, "was", "were")} supplied"
         }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -230,11 +230,11 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
 
         unsafe fn test() {
-            variadic_1<error descr="This function takes at least 1 parameter but 0 parameters were supplied [E0060]">()</error>;
+            variadic_1(<error descr="This function takes at least 1 parameter but 0 parameters were supplied [E0060]">)</error>;
             variadic_1(42);
             variadic_1(42, 43);
-            variadic_2<error descr="This function takes at least 2 parameters but 0 parameters were supplied [E0060]">()</error>;
-            variadic_2<error descr="This function takes at least 2 parameters but 1 parameter was supplied [E0060]">(42)</error>;
+            variadic_2(<error descr="This function takes at least 2 parameters but 0 parameters were supplied [E0060]">)</error>;
+            variadic_2(42<error descr="This function takes at least 2 parameters but 1 parameter was supplied [E0060]">)</error>;
             variadic_2(42, 43);
         }
     """)
@@ -249,10 +249,10 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             par_1(true);
             par_3(12, 7.1, "cool");
 
-            par_0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(4)</error>;
-            par_1<error descr="This function takes 1 parameter but 0 parameters were supplied [E0061]">()</error>;
-            par_1<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(true, false)</error>;
-            par_3<error descr="This function takes 3 parameters but 2 parameters were supplied [E0061]">(5, 1.0)</error>;
+            par_0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
+            par_1(<error descr="This function takes 1 parameter but 0 parameters were supplied [E0061]">)</error>;
+            par_1(true, <error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">false</error>);
+            par_3(5, 1.0<error descr="This function takes 3 parameters but 2 parameters were supplied [E0061]">)</error>;
         }
     """)
 
@@ -267,8 +267,8 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             Foo::par_0();
             Foo::par_2(12, 7.1);
 
-            Foo::par_0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(4)</error>;
-            Foo::par_2<error descr="This function takes 2 parameters but 3 parameters were supplied [E0061]">(5, 1.0, "three")</error>;
+            Foo::par_0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
+            Foo::par_2(5, 1.0, <error descr="This function takes 2 parameters but 3 parameters were supplied [E0061]">"three"</error>);
         }
     """)
 
@@ -284,9 +284,9 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             foo.par_0();
             foo.par_2(12, 7.1);
 
-            foo.par_0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(4)</error>;
-            foo.par_2<error descr="This function takes 2 parameters but 3 parameters were supplied [E0061]">(5, 1.0, "three")</error>;
-            foo.par_2<error descr="This function takes 2 parameters but 0 parameters were supplied [E0061]">()</error>;
+            foo.par_0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
+            foo.par_2(5, 1.0, <error descr="This function takes 2 parameters but 3 parameters were supplied [E0061]">"three"</error>);
+            foo.par_2(<error descr="This function takes 2 parameters but 0 parameters were supplied [E0061]">)</error>;
         }
     """)
 
@@ -297,8 +297,8 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             let _ = Foo0();
             let _ = Foo1(1);
 
-            let _ = Foo0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(4)</error>;
-            let _ = Foo1<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(10, false)</error>;
+            let _ = Foo0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
+            let _ = Foo1(10, <error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">false</error>);
         }
     """)
 
@@ -311,8 +311,8 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             let _ = Foo::VAR0();
             let _ = Foo::VAR1(1);
 
-            let _ = Foo::VAR0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(4)</error>;
-            let _ = Foo::VAR1<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(10, false)</error>;
+            let _ = Foo::VAR0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
+            let _ = Foo::VAR1(10, <error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">false</error>);
         }
     """)
 
@@ -326,7 +326,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
         fn main() {
             let foo = Foo;
-            foo.bar<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(10)</error>;
+            foo.bar(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">10</error>);
             foo.bar();
         }
     """)
@@ -967,7 +967,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
             fn main() {
                 unsafe { foo(1, 2, 3); }
-                bar<error>(92)</error>;
+                bar(<error>92</error>);
                 let _ = S {};
             }  //^
 


### PR DESCRIPTION
This PR implements more precise tracking of missing/extraneous function arguments as proposed in https://github.com/intellij-rust/intellij-rust/issues/5606.

![image](https://user-images.githubusercontent.com/4539057/85223635-a3b91880-b3c4-11ea-9790-8f01e0c3f6af.png)

I think that this kind of highlighting is also more consistent with arguments that have a wrong type, as in that case also only the single argument is highlighted, and not the whole function call.

On top of this more fine-grained annotation we can add new quick fixes:
- fill missing arguments with defaults
- remove extraneous argument
- add missing parameter to function declaration

Even though all of them could be implemented even with the old, coarse annotation, I think that with this change the fixes would be easier to use for specific arguments.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5606