### PR TITLE
NAV: allow navigation from RsAbstractable to its implementations

### DIFF
--- a/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
@@ -8,16 +8,18 @@ package org.rust.ide.lineMarkers
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
+import com.intellij.ide.util.DefaultPsiElementCellRenderer
+import com.intellij.openapi.util.Condition
 import com.intellij.openapi.util.NotNullLazyValue
 import com.intellij.psi.PsiElement
 import com.intellij.util.Query
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.psi.RsEnumItem
-import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsStructItem
 import org.rust.lang.core.psi.RsTraitItem
-import org.rust.lang.core.psi.ext.searchForImplementations
-import org.rust.lang.core.psi.ext.union
+import org.rust.lang.core.psi.ext.*
+import org.rust.openapiext.filterQuery
+import org.rust.openapiext.mapQuery
 
 /**
  * Annotates trait declaration with an icon on the gutter that allows to jump to
@@ -40,25 +42,49 @@ class RsImplsLineMarkerProvider : LineMarkerProvider {
             val info = NavigationGutterIconBuilder
                 .create(RsIcons.IMPLEMENTED)
                 .setTargets(targets)
-                .setPopupTitle("Go to implementation")
+                .setPopupTitle("Go to implementation of ${el.text}")
                 .setTooltipText("Has implementations")
+                .setCellRenderer(GoToImplRenderer())
                 .createLineMarkerInfo(el)
 
             result.add(info)
         }
     }
 
+    private class GoToImplRenderer : DefaultPsiElementCellRenderer() {
+        override fun getElementText(element: PsiElement?): String {
+            return super.getElementText(getTarget(element))
+        }
+
+        override fun getContainerText(element: PsiElement?, name: String?): String? {
+            return super.getContainerText(getTarget(element), name)
+        }
+
+        private fun getTarget(element: PsiElement?): PsiElement? = when (element) {
+            is RsAbstractable -> when (val owner = element.owner) {
+                is RsAbstractableOwner.Impl -> owner.impl
+                is RsAbstractableOwner.Trait -> owner.trait
+                else -> element
+            }
+            else -> element
+        }
+    }
+
     companion object {
-        fun implsQuery(psi: PsiElement): Query<RsImplItem>? {
+        fun implsQuery(psi: PsiElement): Query<RsElement>? {
             val parent = psi.parent
-            return when  {
+            val query: Query<RsElement> = when {
                 // For performance reasons (see LineMarkerProvider.getLineMarkerInfo)
                 // we need to add the line marker only to leaf elements
-                parent is RsTraitItem && parent.identifier == psi -> parent.searchForImplementations()
-                parent is RsStructItem && parent.identifier == psi -> parent.searchForImplementations()
-                parent is RsEnumItem && parent.identifier == psi -> parent.searchForImplementations()
+                parent is RsTraitItem && parent.identifier == psi -> parent.searchForImplementations().mapQuery { it }
+                parent is RsStructItem && parent.identifier == psi -> parent.searchForImplementations().mapQuery { it }
+                parent is RsEnumItem && parent.identifier == psi -> parent.searchForImplementations().mapQuery { it }
+                parent is RsAbstractable &&
+                    parent.identifyingElement == psi &&
+                    parent.owner is RsAbstractableOwner.Trait -> parent.searchForImplementations().mapQuery { it }
                 else -> return null
             }
+            return query.filterQuery(Condition { it != null })
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/navigation/goto/RsImplsSearch.kt
+++ b/src/main/kotlin/org/rust/ide/navigation/goto/RsImplsSearch.kt
@@ -28,17 +28,9 @@ class RsImplsSearch : QueryExecutorBase<PsiElement, DefinitionsScopedSearch.Sear
             is RsStructItem -> psi.searchForImplementations()
             is RsEnumItem -> psi.searchForImplementations()
             is RsTraitItem -> psi.searchForImplementations()
-            is RsAbstractable -> {
-                val owner = psi.owner as? RsAbstractableOwner.Trait ?: return
-                owner.trait
-                    .searchForImplementations()
-                    .mapQuery {
-                        PsiTreeUtil.findChildrenOfType(it.members, psi.javaClass)
-                            .find { it.name == psi.name }
-                    }.filterQuery(Condition { it != null })
-            }
+            is RsAbstractable -> psi.searchForImplementations()
             else -> return
-        }
+        }.filterQuery(Condition { it != null })
         query.forEach(Processor { consumer.process(it) })
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructOrEnumItemElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsStructOrEnumItemElement.kt
@@ -38,9 +38,9 @@ val RsStructOrEnumItemElement.firstKeyword: PsiElement?
     }
 
 fun RsStructOrEnumItemElement.searchForImplementations(): Query<RsImplItem> {
-    return ReferencesSearch.search(this, this.useScope)
+    return ReferencesSearch.search(this, useScope)
         .mapQuery { ref ->
             PsiTreeUtil.getTopmostParentOfType(ref.element, RsTypeReference::class.java)?.parent
         }
-        .filterIsInstanceQuery<RsImplItem>()
+        .filterIsInstanceQuery()
 }

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsLineMarkerProviderTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsLineMarkerProviderTestBase.kt
@@ -34,15 +34,22 @@ abstract class RsLineMarkerProviderTestBase : RsTestBase() {
         text.split('\n')
             .withIndex()
             .filter { it.value.contains(MARKER) }
-            .map { Pair(it.index, it.value.substring(it.value.indexOf(MARKER) + MARKER.length).trim()) }
+            .flatMap { row ->
+                row.value
+                    .substring(row.value.indexOf(MARKER) + MARKER.length)
+                    .trim()
+                    .split(',')
+                    .map { Pair(row.index, it) }
+            }
+            .sortedWith(compareBy({ it.first }, { it.second }))
 
     private fun markersFrom(editor: Editor, project: Project) =
         DaemonCodeAnalyzerImpl.getLineMarkers(editor.document, project)
             .map {
                 Pair(editor.document.getLineNumber(it.element?.textRange?.startOffset as Int),
-                    it.lineMarkerTooltip)
+                    it.lineMarkerTooltip ?: "null")
             }
-            .sortedBy { it.first }
+            .sortedWith(compareBy({ it.first }, { it.second }))
 
     private companion object {
         val MARKER = "// - "

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsMethodLineSeparatorProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsMethodLineSeparatorProviderTest.kt
@@ -27,14 +27,14 @@ class RsMethodLineSeparatorProviderTest : RsLineMarkerProviderTestBase() {
     fun `test trait`() {
         doTest("""
             trait Foo { // - Has implementations
-                const C1: i32 = 1;
-                fn f1();
-                fn f2();
-                fn f3() { // - null
+                const C1: i32 = 1; // - Has implementations
+                fn f1(); // - null,Has implementations
+                fn f2(); // - null,Has implementations
+                fn f3() { // - Has implementations
                 }
-                fn f4() { // - null
+                fn f4() { // - null,Has implementations
                 }
-                fn f5(); // - null
+                fn f5(); // - null,Has implementations
             }
         """)
     }

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsTraitItemImplLineMarkerProviderTest.kt
@@ -9,17 +9,16 @@ package org.rust.ide.lineMarkers
  * Tests for Trait member (const, fn, type) Implementation Line Marker
  */
 class RsTraitItemImplLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
-
     fun `test impl`() = doTestByText("""
         trait Foo {         // - Has implementations
-            fn foo(&self);
-            fn bar(&self) {
+            fn foo(&self);  // - Has implementations
+            fn bar(&self) { // - Has implementations
                 self.foo();
             }
-            type T1;
-            type T2 = ();
-            const C1: u32;
-            const C2: u32 = 1;
+            type T1;        // - Has implementations
+            type T2 = ();   // - Has implementations
+            const C1: u32;  // - Has implementations
+            const C2: u32 = 1;  // - Has implementations
         }
         struct Bar {} // - Has implementations
         impl Foo for Bar {
@@ -39,15 +38,15 @@ class RsTraitItemImplLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
         Foo // - Has implementations
         {
             fn
-            foo
+            foo     // - Has implementations
             (&self);
 
             type
-            T1
+            T1      // - Has implementations
             ;
 
             const
-            C1
+            C1      // - Has implementations
             : u32;
         }
         struct


### PR DESCRIPTION
This is a revival of an old PR by @kumbayo (https://github.com/intellij-rust/intellij-rust/pull/2163), which allows navigation from functions/constants/associated types to their corresponding implementations.

The corresponding implementation place is rendered as `<Trait for Type>::function`.

Closes: https://github.com/intellij-rust/intellij-rust/pull/2163
Fixes: https://github.com/intellij-rust/intellij-rust/issues/2122
Part of: https://github.com/intellij-rust/intellij-rust/issues/2849