### PR TITLE
INT: convert UFCS to method call

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/ConvertUFCSToMethodCallIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ConvertUFCSToMethodCallIntention.kt
@@ -1,0 +1,66 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+
+class ConvertUFCSToMethodCallIntention : RsElementBaseIntentionAction<ConvertUFCSToMethodCallIntention.Context>() {
+    override fun getText() = "Convert to method call"
+    override fun getFamilyName() = text
+
+    data class Context(val callExpr: RsCallExpr, val function: RsFunction)
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val call = element.ancestorStrict<RsCallExpr>(RsValueArgumentList::class.java) ?: return null
+        val path = (call.expr as? RsPathExpr)?.path ?: return null
+        val function = path.reference?.resolve() as? RsFunction ?: return null
+        if (!function.isMethod) return null
+        if (call.valueArgumentList.exprList.isEmpty()) return null
+
+        return Context(call, function)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val arguments = ctx.callExpr.valueArgumentList.exprList
+        val selfArgument = arguments.getOrNull(0) ?: return
+
+        val name = ctx.function.name ?: return
+        val restArguments = arguments.drop(1)
+        val methodCall = createMethodCall(ctx.function, selfArgument, name, restArguments) ?: return
+        ctx.callExpr.replace(methodCall)
+    }
+}
+
+private fun createMethodCall(
+    function: RsFunction,
+    selfArgument: RsExpr,
+    name: String,
+    restArguments: List<RsExpr>
+): PsiElement? {
+    val self = normalizeSelf(selfArgument, function)
+
+    val factory = RsPsiFactory(selfArgument.project)
+    val call = factory.tryCreateMethodCall(self, name, restArguments)
+    if (call != null) return call
+
+    val parenthesesExpr = factory.tryCreateExpression("(${self.text})") ?: return null
+    return factory.tryCreateMethodCall(parenthesesExpr, name, restArguments)
+}
+
+fun normalizeSelf(selfArgument: RsExpr, function: RsFunction): RsExpr {
+    val isRef = function.selfParameter?.isRef ?: false
+    val normalized = when {
+        isRef && selfArgument is RsUnaryExpr && selfArgument.operatorType in REF_OPERATORS -> selfArgument.expr
+        else -> null
+    }
+    return normalized ?: selfArgument
+}
+
+private val REF_OPERATORS = setOf(UnaryOperator.REF, UnaryOperator.REF_MUT)

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -476,6 +476,9 @@ class RsPsiFactory(
         else -> createExpressionOfType("${expr.text}.$methodNameText()")
     }
 
+    fun tryCreateMethodCall(receiver: RsExpr, methodNameText: String, arguments: List<RsExpr>): RsDotExpr? =
+        tryCreateExpressionOfType("${receiver.text}.$methodNameText(${arguments.joinToString(", ") { it.text }})")
+
     fun createDerefExpr(expr: RsExpr, nOfDerefs: Int = 1): RsExpr =
         if (nOfDerefs > 0)
             when (expr) {
@@ -507,6 +510,8 @@ class RsPsiFactory(
     private inline fun <reified E : RsExpr> createExpressionOfType(text: String): E =
         createExpression(text) as? E
             ?: error("Failed to create ${E::class.simpleName} from `$text`")
+
+    private inline fun <reified E : RsExpr> tryCreateExpressionOfType(text: String): E? = createExpression(text) as? E
 
     fun createDynTraitType(pathText: String): RsTraitType =
         createFromText("type T = &dyn $pathText;}")

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -799,6 +799,10 @@
             <className>org.rust.ide.intentions.IntroduceLocalVariableIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.ConvertUFCSToMethodCallIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 

--- a/src/main/resources/intentionDescriptions/ConvertUFCSToMethodCallIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/ConvertUFCSToMethodCallIntention/after.rs.template
@@ -1,0 +1,9 @@
+struct S;
+impl S {
+    fn foo(&self) {}
+}
+
+fn bar() {
+    let s = S;
+    s.foo();
+}

--- a/src/main/resources/intentionDescriptions/ConvertUFCSToMethodCallIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/ConvertUFCSToMethodCallIntention/before.rs.template
@@ -1,0 +1,9 @@
+struct S;
+impl S {
+    fn foo(&self) {}
+}
+
+fn bar() {
+    let s = S;
+    S::<spot>foo</spot>(&s);
+}

--- a/src/main/resources/intentionDescriptions/ConvertUFCSToMethodCallIntention/description.html
+++ b/src/main/resources/intentionDescriptions/ConvertUFCSToMethodCallIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention converts UFCS (universal function call syntax) call to a method call.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/ConvertUFCSToMethodCallTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ConvertUFCSToMethodCallTest.kt
@@ -1,0 +1,207 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+class ConvertUFCSToMethodCallTest : RsIntentionTestBase(ConvertUFCSToMethodCallIntention()) {
+    fun `test not available for methods`() = doUnavailableTest("""
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+        fn foo(s: S) {
+            s./*caret*/foo();
+        }
+    """)
+
+    fun `test not available for functions`() = doUnavailableTest("""
+        fn foo() {}
+        fn bar() {
+            /*caret*/foo();
+        }
+    """)
+
+    fun `test not available for associated functions`() = doUnavailableTest("""
+        struct S;
+        impl S {
+            fn foo() {}
+        }
+        fn foo() {
+            S::/*caret*/foo();
+        }
+    """)
+
+    fun `test not available without self argument`() = doUnavailableTest("""
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+        fn foo() {
+            S::/*caret*/foo();
+        }
+    """)
+
+    fun `test keep other arguments`() = doAvailableTest("""
+        struct S;
+        impl S {
+            fn foo(&self, _: u32, _: u32) {}
+        }
+        fn foo(s: &S) {
+            S::/*caret*/foo(&s, 1, 2);
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self, _: u32, _: u32) {}
+        }
+        fn foo(s: &S) {
+            s.foo(1, 2);
+        }
+    """)
+
+    fun `test self ref receiver move`() = doAvailableTest("""
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+        fn foo(s: S) {
+            S::/*caret*/foo(&s);
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+        fn foo(s: S) {
+            s.foo();
+        }
+    """)
+
+    fun `test self ref receiver ref`() = doAvailableTest("""
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+        fn foo(s: &S) {
+            S::/*caret*/foo(s);
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+        fn foo(s: &S) {
+            s.foo();
+        }
+    """)
+
+    fun `test self mut ref receiver move`() = doAvailableTest("""
+        struct S;
+        impl S {
+            fn foo(&mut self) {}
+        }
+        fn foo(mut s: S) {
+            S::/*caret*/foo(&mut s);
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&mut self) {}
+        }
+        fn foo(mut s: S) {
+            s.foo();
+        }
+    """)
+
+    fun `test self mut ref receiver mut ref`() = doAvailableTest("""
+        struct S;
+        impl S {
+            fn foo(&mut self) {}
+        }
+        fn foo(s: &mut S) {
+            S::/*caret*/foo(s);
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&mut self) {}
+        }
+        fn foo(s: &mut S) {
+            s.foo();
+        }
+    """)
+
+    fun `test function call self argument`() = doAvailableTest("""
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+        fn bar() -> S { S }
+        fn foo() {
+            S::/*caret*/foo(bar());
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+        fn bar() -> S { S }
+        fn foo() {
+            bar().foo();
+        }
+    """)
+
+    fun `test complex self argument`() = doAvailableTest("""
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+        fn foo() {
+            S::/*caret*/foo(x1() + x2());
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+        fn foo() {
+            (x1() + x2()).foo();
+        }
+    """)
+
+    fun `test generic struct`() = doAvailableTest("""
+        struct S<T>(T);
+        impl<T> S<T> {
+            fn foo(&self, _: &T) {}
+        }
+        fn foo<T>(s: S<T>, t: T) {
+            S::<T>::/*caret*/foo(&s, &t);
+        }
+    """, """
+        struct S<T>(T);
+        impl<T> S<T> {
+            fn foo(&self, _: &T) {}
+        }
+        fn foo<T>(s: S<T>, t: T) {
+            s.foo(&t);
+        }
+    """)
+
+    fun `test trait`() = doAvailableTest("""
+        trait Trait {
+            fn foo(&self);
+        }
+        fn foo(s: &dyn Trait) {
+            <dyn Trait>::/*caret*/foo(s);
+        }
+    """, """
+        trait Trait {
+            fn foo(&self);
+        }
+        fn foo(s: &dyn Trait) {
+            s.foo();
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds an intention that converts a UFCS to a method call.

The implemented self argument coercion is very basic, but it seems to work. If there is a better API that could support `Deref` implementations and any coercions that are not handled now, let me know.

Related: https://github.com/intellij-rust/intellij-rust/pull/5601
Fixes second part of https://github.com/intellij-rust/intellij-rust/issues/4451.