### PR TITLE
REF: do refactoring and inplace rename within a single write command

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/introduceParameter/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceParameter/impl.kt
@@ -92,7 +92,7 @@ private class ParamIntroducer(
         } else {
             findFunctionUsages(function)
         }
-        val newParameter = project.runWriteCommandAction {
+        project.runWriteCommandAction {
             appendNewArgument(functionUsages, expr)
             if (replaceForTrait) {
                 getTraitAndImpls(traitFunction)
@@ -102,16 +102,13 @@ private class ParamIntroducer(
             val newParam = introduceParam(function, suggestedNames.default, typeRef)
             val name = psiFactory.createExpression(suggestedNames.default)
             exprs.forEach { it.replace(name) }
-            moveEditorToNameElement(editor, newParam)
-        }
+            val newParameter = moveEditorToNameElement(editor, newParam)
 
-        val documentManager = PsiDocumentManager.getInstance(project)
-        documentManager.commitDocument(editor.document)
-        documentManager.doPostponedOperationsAndUnblockDocument(editor.document)
-
-        if (newParameter != null) {
-            RsInPlaceVariableIntroducer(newParameter, editor, project, "choose a parameter")
-                .performInplaceRefactoring(suggestedNames.all)
+            if (newParameter != null) {
+                PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
+                RsInPlaceVariableIntroducer(newParameter, editor, project, "choose a parameter")
+                    .performInplaceRefactoring(suggestedNames.all)
+            }
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceVariable/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceVariable/impl.kt
@@ -62,16 +62,16 @@ private class ExpressionReplacer(
      */
     fun inlineLet(project: Project, editor: Editor, expr: RsExpr, elementToReplace: PsiElement) {
         val suggestedNames = expr.suggestedNames()
-        val nameElem: RsPatBinding? = project.runWriteCommandAction {
+        project.runWriteCommandAction {
             val statement = psiFactory.createLetDeclaration(suggestedNames.default, expr)
             val newStatement = elementToReplace.replace(statement)
-            moveEditorToNameElement(editor, newStatement)
-        }
+            val nameElem = moveEditorToNameElement(editor, newStatement)
 
-        PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
-        if (nameElem != null) {
-            RsInPlaceVariableIntroducer(nameElem, editor, project, "choose a variable")
-                .performInplaceRefactoring(suggestedNames.all)
+            if (nameElem != null) {
+                PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
+                RsInPlaceVariableIntroducer(nameElem, editor, project, "choose a variable")
+                    .performInplaceRefactoring(suggestedNames.all)
+            }
         }
     }
 
@@ -83,16 +83,16 @@ private class ExpressionReplacer(
         val let = createLet(suggestedNames.default)
         val name = psiFactory.createExpression(suggestedNames.default)
 
-        val nameElem: RsPatBinding? = project.runWriteCommandAction {
+        project.runWriteCommandAction {
             val newElement = introduceLet(project, anchor, let)
             exprs.forEach { it.replace(name) }
-            moveEditorToNameElement(editor, newElement)
-        }
+            val nameElem = moveEditorToNameElement(editor, newElement)
 
-        PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
-        if (nameElem != null) {
-            RsInPlaceVariableIntroducer(nameElem, editor, project, "choose a variable")
-                .performInplaceRefactoring(suggestedNames.all)
+            if (nameElem != null) {
+                PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
+                RsInPlaceVariableIntroducer(nameElem, editor, project, "choose a variable")
+                    .performInplaceRefactoring(suggestedNames.all)
+            }
         }
     }
 


### PR DESCRIPTION
Now it's enough to press Ctrl+Z single time to undo a refactoring (previously 2 was needed)

Works for `introduce constant`, `introduce parameter` and `introduce variable` refactorings