### PR TITLE
Fix lazy's LazyThreadSafetyMode

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyTypeParameter.kt
@@ -24,10 +24,10 @@ class TyTypeParameter private constructor(
 ) : Ty(HAS_TY_TYPE_PARAMETER_MASK) {
 
     private val traitBounds: Collection<BoundElement<RsTraitItem>>
-        by lazy(LazyThreadSafetyMode.NONE, traitBoundsSupplier)
+        by lazy(LazyThreadSafetyMode.PUBLICATION, traitBoundsSupplier)
 
     val regionBounds: Collection<Region>
-        by lazy(LazyThreadSafetyMode.NONE, regionBoundsSupplier)
+        by lazy(LazyThreadSafetyMode.PUBLICATION, regionBoundsSupplier)
 
     override fun equals(other: Any?): Boolean = other is TyTypeParameter && other.parameter == parameter
     override fun hashCode(): Int = parameter.hashCode()


### PR DESCRIPTION
Looks like `TyTypeParameter.traitBounds` can be accessed from multiple threads (probably `TyTypeParameter` is cached and then a cached value is accessed from multiple threads), so we should use `LazyThreadSafetyMode.PUBLICATION`.

<details>
  <summary>Otherwise it causes such exceptions</summary>
  
  ```
kotlin.KotlinNullPointerException
	at kotlin.UnsafeLazyImpl.getValue(Lazy.kt:81)
	at org.rust.lang.core.types.ty.TyTypeParameter.getTraitBounds(TyTypeParameter.kt)
	at org.rust.lang.core.types.ty.TyTypeParameter.getTraitBoundsTransitively(TyTypeParameter.kt:37)
	at org.rust.lang.core.resolve.ImplLookup.getEnvBoundTransitivelyFor(ImplLookup.kt:290)
	at org.rust.lang.core.resolve.ImplLookup.assembleCandidates(ImplLookup.kt:641)
	at org.rust.lang.core.resolve.ImplLookup.selectCandidate(ImplLookup.kt:564)
	at org.rust.lang.core.resolve.ImplLookup.access$selectCandidate(ImplLookup.kt:236)
	at org.rust.lang.core.resolve.ImplLookup$selectWithoutConfirm$2.invoke(ImplLookup.kt:554)
	at org.rust.lang.core.resolve.ImplLookup$selectWithoutConfirm$2.invoke(ImplLookup.kt:236)
	at org.rust.stdext.Cache$Companion$fromConcurrentMap$1.getOrPut(Cache.kt:41)
	at org.rust.lang.core.resolve.ImplLookup.selectWithoutConfirm(ImplLookup.kt:554)
	at org.rust.lang.core.resolve.ImplLookup.select(ImplLookup.kt:549)
	at org.rust.lang.core.resolve.ImplLookup.selectProjection(ImplLookup.kt:836)
	at org.rust.lang.core.resolve.ImplLookup.selectProjection$default(ImplLookup.kt:834)
	at org.rust.lang.core.resolve.ImplLookup.selectProjection(ImplLookup.kt:828)
	at org.rust.lang.core.resolve.ImplLookup.findDerefTarget(ImplLookup.kt:805)
	at org.rust.lang.core.resolve.ImplLookup.deref(ImplLookup.kt:801)
	at org.rust.lang.core.resolve.ImplLookup$coercionSequence$1.invoke(ImplLookup.kt:791)
	at org.rust.lang.core.resolve.ImplLookup$coercionSequence$1.invoke(ImplLookup.kt:236)
	at kotlin.sequences.GeneratorSequence$iterator$1.calcNext(Sequences.kt:544)
	at kotlin.sequences.GeneratorSequence$iterator$1.hasNext(Sequences.kt:562)
	at kotlin.sequences.TakeSequence$iterator$1.hasNext(Sequences.kt:374)
	at org.rust.lang.core.resolve.NameResolutionKt.processFieldExprResolveVariants(NameResolution.kt:115)
	at org.rust.lang.core.resolve.ref.RsMethodCallReferenceImplKt$resolveFieldLookupReferenceWithReceiverType$1.invoke(RsMethodCallReferenceImpl.kt:64)
	at org.rust.lang.core.resolve.ref.RsMethodCallReferenceImplKt$resolveFieldLookupReferenceWithReceiverType$1.invoke(RsMethodCallReferenceImpl.kt)
	at org.rust.lang.core.resolve.ProcessorsKt.collectResolveVariantsAsScopeEntries(Processors.kt:96)
	at org.rust.lang.core.resolve.ref.RsMethodCallReferenceImplKt.resolveFieldLookupReferenceWithReceiverType(RsMethodCallReferenceImpl.kt:63)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferFieldExprType(TypeInferenceWalker.kt:788)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferDotExprType(TypeInferenceWalker.kt:815)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:173)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType$default(TypeInferenceWalker.kt:154)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferBinaryExprType(TypeInferenceWalker.kt:934)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:182)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType$default(TypeInferenceWalker.kt:154)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.processStatement(TypeInferenceWalker.kt:150)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferType(TypeInferenceWalker.kt:108)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferTypeCoercableTo(TypeInferenceWalker.kt:101)
	at org.rust.lang.core.types.infer.RsTypeInferenceWalker.inferFnBody(TypeInferenceWalker.kt:96)
	at org.rust.lang.core.types.infer.RsInferenceContext.infer(TypeInference.kt:175)
	at org.rust.lang.core.types.infer.TypeInferenceKt$inferTypesIn$1.compute(TypeInference.kt:34)
	at org.rust.lang.core.types.infer.TypeInferenceKt$inferTypesIn$1.compute(TypeInference.kt)
	at com.intellij.openapi.util.RecursionManager$1.doPreventingRecursion(RecursionManager.java:113)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:72)
	at org.rust.openapiext.UtilsKt.recursionGuard(utils.kt:66)
	at org.rust.lang.core.types.infer.TypeInferenceKt.inferTypesIn(TypeInference.kt:34)
	at org.rust.lang.core.types.ExtensionsKt$inference$1.compute(Extensions.kt:69)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:153)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:54)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$1(CachedValueBase.java:235)
	at com.intellij.openapi.util.RecursionManager$1.doPreventingRecursion(RecursionManager.java:113)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:72)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:236)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:43)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:76)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:150)
	at org.rust.lang.core.types.ExtensionsKt.getInference(Extensions.kt:68)
	at org.rust.lang.core.types.ExtensionsKt.getInference(Extensions.kt:162)
	at org.rust.lang.core.types.ExtensionsKt.getType(Extensions.kt:78)
	at org.rust.ide.annotator.RsHighlightingMutableAnnotatorKt.isMut(RsHighlightingMutableAnnotator.kt:80)
	at org.rust.ide.annotator.RsHighlightingMutableAnnotatorKt.access$isMut$p(RsHighlightingMutableAnnotator.kt:1)
	at org.rust.ide.annotator.RsHighlightingMutableAnnotator.distinctAnnotation(RsHighlightingMutableAnnotator.kt:50)
	at org.rust.ide.annotator.RsHighlightingMutableAnnotator.annotateInternal(RsHighlightingMutableAnnotator.kt:34)
	at com.intellij.ide.annotator.AnnotatorBase.annotate(AnnotatorBase.kt:21)
	at com.intellij.codeInsight.daemon.impl.DefaultHighlightVisitor.runAnnotators(DefaultHighlightVisitor.java:136)
	at com.intellij.codeInsight.daemon.impl.DefaultHighlightVisitor.visit(DefaultHighlightVisitor.java:116)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.runVisitors(GeneralHighlightingPass.java:338)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.lambda$collectHighlights$5(GeneralHighlightingPass.java:271)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.analyzeByVisitors(GeneralHighlightingPass.java:297)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.lambda$analyzeByVisitors$6(GeneralHighlightingPass.java:300)
	at com.intellij.codeInsight.daemon.impl.DefaultHighlightVisitor.analyze(DefaultHighlightVisitor.java:96)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.analyzeByVisitors(GeneralHighlightingPass.java:300)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.collectHighlights(GeneralHighlightingPass.java:268)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.collectInformationWithProgress(GeneralHighlightingPass.java:214)
	at com.intellij.codeInsight.daemon.impl.ProgressableTextEditorHighlightingPass.doCollectInformation(ProgressableTextEditorHighlightingPass.java:81)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:54)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$1(PassExecutorService.java:399)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1110)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:392)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:629)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:581)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:391)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:367)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:170)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:182)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:365)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:181)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
  ```
  
</details>
