### PR TITLE
FIX: support tuple struct fields in MakePublicFix

### DIFF
--- a/src/test/kotlin/org/rust/ide/annotator/fixes/MakePublicFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/MakePublicFixTest.kt
@@ -475,6 +475,30 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
+    fun `test make tuple struct field public`() = checkFixByText("Make `0` public", """
+        mod foo {
+            pub(crate) struct Bar(i32);
+            impl Bar {
+                pub(crate) fn new() -> Bar { Bar(0) }
+            }
+        }
+        fn main() {
+            let foo = foo::Bar::new();
+            foo.<error>0/*caret*/</error>;
+        }
+    """, """
+        mod foo {
+            pub(crate) struct Bar(pub(crate) i32);
+            impl Bar {
+                pub(crate) fn new() -> Bar { Bar(0) }
+            }
+        }
+        fn main() {
+            let foo = foo::Bar::new();
+            foo.0/*caret*/;
+        }
+    """)
+
     fun `test make type alias public`() = checkFixByText("Make `Bar` public", """
         mod foo {
             type Bar = i32;


### PR DESCRIPTION
This PR fixes the `Make public`  quick fix to support tuple struct fields. Previously it was throwing an exception when used on a tuple struct field, because it was unconditionally casting the element to `RsNameIdentifierOwner`.