### PR TITLE
DOC: add option to choose external documentation base URL

### DIFF
--- a/src/main/kotlin/org/rust/ide/lineMarkers/RsCrateDocLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/RsCrateDocLineMarkerProvider.kt
@@ -10,6 +10,7 @@ import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.psi.PsiElement
+import org.rust.ide.docs.getExternalDocumentationBaseUrl
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.psi.RsExternCrateItem
 import org.rust.lang.core.psi.ext.containingCargoPackage
@@ -26,11 +27,13 @@ class RsCrateDocLineMarkerProvider : LineMarkerProvider {
         val crate = parent.containingCargoPackage?.findDependency(crateName) ?: return null
         if (crate.pkg.source == null) return null
 
+        val baseUrl = getExternalDocumentationBaseUrl()
+
         return RsLineMarkerInfoUtils.create(
             element,
             element.textRange,
             RsIcons.DOCS_MARK,
-            { _, _ -> BrowserUtil.browse("https://docs.rs/${crate.pkg.name}/${crate.pkg.version}/${crate.normName}") },
+            { _, _ -> BrowserUtil.browse("$baseUrl${crate.pkg.name}/${crate.pkg.version}/${crate.normName}") },
             GutterIconRenderer.Alignment.LEFT
         ) { "Open documentation for `${crate.pkg.normName}`" }
     }

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1230,6 +1230,11 @@
             default="ASK_EVERY_TIME"
             groupKey="advanced.setting.rust.group"
         />
+        <advancedSetting
+            id="org.rust.external.doc.url"
+            default="https://docs.rs/"
+            groupKey="advanced.setting.rust.group"
+        />
     </extensions>
 
     <extensions defaultExtensionNs="org.rust">

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -237,6 +237,7 @@ copy.paste.convert.json.to.struct.dialog.title=Generate Rust Struct from JSON
 copy.paste.convert.json.to.struct.dialog.text=The inserted text seems to be a JSON object. Do you want to generate a Rust struct from it?
 advanced.setting.rust.group=Rust
 advanced.setting.org.rust.convert.json.to.struct=Enable JSON to Rust conversion on paste
+advanced.setting.org.rust.external.doc.url=Base URL for external documentation
 
 inspection.UnusedMustUse.description.type.attribute=Unused {0} that must be used
 inspection.UnusedMustUse.description.function.attribute=Unused return value of {0} that must be used

--- a/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.docs
 
 import org.rust.CheckTestmarkHit
+import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibAndDependencyRustProjectDescriptor
 import org.rust.ide.docs.RsDocumentationProvider.Testmarks
@@ -163,4 +164,28 @@ class RsExternalDocUrlTest : RsDocumentationProviderTest() {
         pub enum Foo { FOO, BAR }
                 //^
     """, null)
+
+    fun `test custom documentation URL`() = doCustomUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        #[macro_export]
+        macro_rules! foo {
+                    //^
+            () => { unimplemented!() };
+        }
+    """, "file:///mydoc/", "file:///mydoc/dep-lib/0.0.1/dep_lib_target/macro.foo.html")
+
+    fun `test custom documentation URL add slash`() = doCustomUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        #[macro_export]
+        macro_rules! foo {
+                    //^
+            () => { unimplemented!() };
+        }
+    """, "file:///mydoc", "file:///mydoc/dep-lib/0.0.1/dep_lib_target/macro.foo.html")
+
+    private fun doCustomUrlTestByFileTree(@Language("Rust") text: String, docBaseUrl: String, expectedUrl: String) {
+        withExternalDocumentationBaseUrl(docBaseUrl) {
+            doUrlTestByFileTree(text, expectedUrl)
+        }
+    }
 }

--- a/toml/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.psi.PsiElement
 import com.intellij.util.io.URLUtil
 import org.rust.cargo.CargoConstants
+import org.rust.ide.docs.getExternalDocumentationBaseUrl
 import org.rust.ide.icons.RsIcons
 import org.rust.ide.lineMarkers.RsLineMarkerInfoUtils
 import org.rust.lang.core.psi.ext.elementType
@@ -59,11 +60,12 @@ class CargoCrateDocLineMarkerProvider : LineMarkerProvider {
             else -> version
         }
 
+        val baseUrl = getExternalDocumentationBaseUrl()
         return RsLineMarkerInfoUtils.create(
             anchor,
             anchor.textRange,
             RsIcons.DOCS_MARK,
-            { _, _ -> BrowserUtil.browse("https://docs.rs/$name/${URLUtil.encodeURIComponent(urlVersion)}") },
+            { _, _ -> BrowserUtil.browse("$baseUrl$name/${URLUtil.encodeURIComponent(urlVersion)}") },
             GutterIconRenderer.Alignment.LEFT
         ) { "Open documentation for `$name@$urlVersion`" }
     }

--- a/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
@@ -12,6 +12,7 @@ import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
 import org.rust.ide.MockBrowserLauncher
+import org.rust.ide.docs.withExternalDocumentationBaseUrl
 import org.rust.ide.lineMarkers.invokeNavigationHandler
 
 @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
@@ -91,6 +92,11 @@ class CargoCrateDocLineMarkerProviderTest : CargoTomlLineMarkerProviderTestBase(
         a.b = "1"
     """)
 
+    fun `test custom url`() = doCustomUrlTest("""
+        [dependencies]
+        base64 = "0.8.0"  # - Open documentation for `base64@^0.8.0`
+    """, "https://foo.bar", "https://foo.bar/base64/%5E0.8.0")
+
     private fun doTest(@Language("Toml") source: String, vararg expectedUrls: String) {
         doTestByText(source)
 
@@ -106,5 +112,11 @@ class CargoCrateDocLineMarkerProviderTest : CargoTomlLineMarkerProviderTestBase(
             actualUrls += launcher.lastUrl!!
         }
         assertEquals(expectedUrls.toList(), actualUrls)
+    }
+
+    private fun doCustomUrlTest(@Language("Toml") source: String, docBaseUrl: String, vararg expectedUrls: String) {
+        withExternalDocumentationBaseUrl(docBaseUrl) {
+            doTest(source, *expectedUrls)
+        }
     }
 }


### PR DESCRIPTION
This PR adds a configurable URL which serves as a base for external documentation links (for `extern crate` doc links and for the documentation provider). Maybe we could also add a similar option for `stdlib` documentation links?

Fixes: https://github.com/intellij-rust/intellij-rust/issues/3594

changelog: You can now set a custom base URL for external documentation using the `org.rust.external.doc.url` Advanced setting. The default value is `https://docs.rs/`.