### PR TITLE
INT: add intention to substitute an associated type

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/SubstituteAssociatedTypeIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/SubstituteAssociatedTypeIntention.kt
@@ -1,0 +1,56 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import org.rust.ide.presentation.renderInsertionSafe
+import org.rust.ide.utils.import.RsImportHelper
+import org.rust.lang.core.parser.RustParserUtil
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.psi.RsTypeReference
+import org.rust.lang.core.psi.ext.endOffsetInParent
+import org.rust.lang.core.types.type
+
+class SubstituteAssociatedTypeIntention : RsElementBaseIntentionAction<SubstituteAssociatedTypeIntention.Context>() {
+    override fun getText() = "Substitute associated type"
+    override fun getFamilyName() = text
+
+    data class Context(val path: RsPath,
+                       val typeAliasReference: RsTypeReference)
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val path = element.parentOfType<RsPath>() ?: return null
+        val typeAlias = path.reference?.resolve() as? RsTypeAlias ?: return null
+        val type = typeAlias.typeReference ?: return null
+        return Context(path, type)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val factory = RsPsiFactory(project)
+        val typeRef = ctx.typeAliasReference
+        val isTypeContext = ctx.path.parentOfType<RsTypeReference>() != null
+        val createdPath = factory.tryCreatePath(typeRef.type.renderInsertionSafe(), RustParserUtil.PathParsingMode.TYPE)
+            ?: return
+
+        // S<u32> -> S::<u32> in expression context
+        val insertedPath: RsPath = if (!isTypeContext && createdPath.typeArgumentList != null) {
+            val end = createdPath.identifier?.endOffsetInParent ?: 0
+            val pathText = createdPath.text
+            val newPath = pathText.substring(0, end) + "::" + pathText.substring(end)
+            val path = factory.tryCreatePath(newPath, RustParserUtil.PathParsingMode.TYPE) ?: return
+            ctx.path.replace(path) as RsPath
+        } else {
+            ctx.path.replace(createdPath) as RsPath
+        }
+
+        RsImportHelper.importTypeReferencesFromTy(insertedPath, typeRef.type)
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -811,6 +811,10 @@
             <className>org.rust.ide.intentions.AddImportIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.SubstituteAssociatedTypeIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 

--- a/src/main/resources/intentionDescriptions/SubstituteAssociatedTypeIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/SubstituteAssociatedTypeIntention/after.rs.template
@@ -1,0 +1,6 @@
+impl Iterator for Foo {
+    type Item = i32;
+    fn next(&mut self) -> Option<i32> {
+        unimplemented!()
+    }
+}

--- a/src/main/resources/intentionDescriptions/SubstituteAssociatedTypeIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/SubstituteAssociatedTypeIntention/before.rs.template
@@ -1,0 +1,6 @@
+impl Iterator for Foo {
+    type Item = i32;
+    fn next(&mut self) -> Option<<Self as Iterator>::<spot>Item</spot>> {
+        unimplemented!()
+    }
+}

--- a/src/main/resources/intentionDescriptions/SubstituteAssociatedTypeIntention/description.html
+++ b/src/main/resources/intentionDescriptions/SubstituteAssociatedTypeIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention substitutes an associated type for its type value.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/SubstituteAssociatedTypeIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SubstituteAssociatedTypeIntentionTest.kt
@@ -1,0 +1,217 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+class SubstituteAssociatedTypeIntentionTest : RsIntentionTestBase(SubstituteAssociatedTypeIntention()) {
+    fun `test unavailable on trait associated type`() = doUnavailableTest("""
+        trait Trait {
+            type Item;
+        }
+        fn foo<T: Trait>() -> T::/*caret*/Item {
+            unimplemented!()
+        }
+    """)
+
+    fun `test trait associated type with a default`() = doAvailableTest("""
+        trait Trait {
+            type Item = u32;
+        }
+        fn foo<T: Trait>() -> T::/*caret*/Item {
+            unimplemented!()
+        }
+    """, """
+        trait Trait {
+            type Item = u32;
+        }
+        fn foo<T: Trait>() -> u32 {
+            unimplemented!()
+        }
+    """)
+
+    fun `test associated type in type context`() = doAvailableTest("""
+        trait Trait {
+            type Item;
+            fn foo(&self) -> Self::Item;
+        }
+        impl Trait for () {
+            type Item = i32;
+
+            fn foo(&self) -> <Self as Trait>::/*caret*/Item {
+                unimplemented!()
+            }
+        }
+    """, """
+        trait Trait {
+            type Item;
+            fn foo(&self) -> Self::Item;
+        }
+        impl Trait for () {
+            type Item = i32;
+
+            fn foo(&self) -> i32 {
+                unimplemented!()
+            }
+        }
+    """)
+
+    fun `test associated type in type context with type parameters`() = doAvailableTest("""
+        struct S<R>(R);
+        trait Trait<T> {
+            type Item;
+            fn foo(&self, item: Self::Item) -> T;
+        }
+        impl<T> Trait<T> for () {
+            type Item = S<T>;
+
+            fn foo(&self, item: Self::/*caret*/Item) -> T {
+                unimplemented!()
+            }
+        }
+    """, """
+        struct S<R>(R);
+        trait Trait<T> {
+            type Item;
+            fn foo(&self, item: Self::Item) -> T;
+        }
+        impl<T> Trait<T> for () {
+            type Item = S<T>;
+
+            fn foo(&self, item: S<T>) -> T {
+                unimplemented!()
+            }
+        }
+    """)
+
+    fun `test associated type in expression context`() = doAvailableTest("""
+        struct S;
+        impl S {
+            fn bar() {}
+        }
+        trait Trait {
+            type Item;
+            fn foo(&self);
+        }
+        impl Trait for () {
+            type Item = S;
+
+            fn foo(&self) {
+                <Self as Trait>::/*caret*/Item::bar();
+            }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn bar() {}
+        }
+        trait Trait {
+            type Item;
+            fn foo(&self);
+        }
+        impl Trait for () {
+            type Item = S;
+
+            fn foo(&self) {
+                S::bar();
+            }
+        }
+    """)
+
+    fun `test associated type in expression context with type parameters`() = doAvailableTest("""
+        struct S<R>(R);
+        impl<R> S<R> {
+            fn bar() {}
+        }
+        trait Trait {
+            type Item;
+            fn foo(&self);
+        }
+        impl Trait for () {
+            type Item = S<u32>;
+
+            fn foo(&self) {
+                <Self as Trait>::/*caret*/Item::bar();
+            }
+        }
+    """, """
+        struct S<R>(R);
+        impl<R> S<R> {
+            fn bar() {}
+        }
+        trait Trait {
+            type Item;
+            fn foo(&self);
+        }
+        impl Trait for () {
+            type Item = S<u32>;
+
+            fn foo(&self) {
+                S::<u32>::bar();
+            }
+        }
+    """)
+
+    fun `test associated type in expression context with type qual`() = doAvailableTest("""
+        struct S<R>(R);
+        impl<R> S<R> {
+            fn bar() {}
+        }
+        impl Trait for S<u32> {
+            type Item = Self;
+            fn foo(&self) {}
+        }
+
+        trait Trait {
+            type Item;
+            fn foo(&self);
+        }
+        impl Trait for () {
+            type Item = <S<u32> as Trait>::Item;
+
+            fn foo(&self) {
+                <Self as Trait>::/*caret*/Item::bar();
+            }
+        }
+    """, """
+        struct S<R>(R);
+        impl<R> S<R> {
+            fn bar() {}
+        }
+        impl Trait for S<u32> {
+            type Item = Self;
+            fn foo(&self) {}
+        }
+
+        trait Trait {
+            type Item;
+            fn foo(&self);
+        }
+        impl Trait for () {
+            type Item = <S<u32> as Trait>::Item;
+
+            fn foo(&self) {
+                S::<u32>::bar();
+            }
+        }
+    """)
+
+    fun `test import after substitution`() = doAvailableTest("""
+        use foo::B;
+
+        mod foo {
+            pub struct A;
+            pub type B = A;
+        }
+        fn foo() -> /*caret*/B { unreachable!() }
+    """, """
+        use foo::{B, A};
+
+        mod foo {
+            pub struct A;
+            pub type B = A;
+        }
+        fn foo() -> A { unreachable!() }
+    """)
+}


### PR DESCRIPTION
This PR adds an intention to substitute an associated type with its value.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/2766