### PR TITLE
ANN: add quick fix to fill missing arguments in function call

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -864,7 +864,9 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         val realCount = args.exprList.size
         if (realCount < expectedCount) {
             val target = args.rparen ?: args
-            RsDiagnostic.IncorrectFunctionArgumentCountError(target, expectedCount, realCount, functionType).addToHolder(holder)
+            RsDiagnostic.IncorrectFunctionArgumentCountError(target, expectedCount, realCount, functionType, listOf(
+                FillFunctionArgumentsFix(args)
+            )).addToHolder(holder)
         } else if (!functionType.variadic && realCount > expectedCount) {
             args.exprList.drop(expectedCount).forEach {
                 RsDiagnostic.IncorrectFunctionArgumentCountError(it, expectedCount, realCount, functionType).addToHolder(holder)
@@ -1307,7 +1309,7 @@ private fun AnnotationSession.fileDuplicatesMap(): MutableMap<PsiElement, Map<Na
     return map
 }
 
-private fun RsCallExpr.expectedParamsCount(): Pair<Int, FunctionType>? {
+fun RsCallExpr.expectedParamsCount(): Pair<Int, FunctionType>? {
     val path = (expr as? RsPathExpr)?.path ?: return null
     val el = path.reference?.resolve()
     return when (el) {
@@ -1339,7 +1341,7 @@ private fun RsCallExpr.expectedParamsCount(): Pair<Int, FunctionType>? {
     }
 }
 
-private fun RsMethodCall.expectedParamsCount(): Pair<Int, FunctionType>? {
+fun RsMethodCall.expectedParamsCount(): Pair<Int, FunctionType>? {
     val fn = reference.resolve() as? RsFunction ?: return null
     return fn.valueParameterList?.valueParameterList?.size?.let {
         Pair(it, if (fn.isVariadic) FunctionType.VARIADIC_FUNCTION else FunctionType.FUNCTION)

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFix.kt
@@ -1,0 +1,107 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.parentOfType
+import org.rust.ide.annotator.expectedParamsCount
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve.knownItems
+import org.rust.lang.core.types.selfType
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyReference
+import org.rust.lang.core.types.type
+import org.rust.openapiext.buildAndRunTemplate
+import org.rust.openapiext.createSmartPointer
+
+class FillFunctionArgumentsFix(element: PsiElement) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+    override fun getText(): String = "Fill missing arguments"
+    override fun getFamilyName(): String = text
+
+    override fun invoke(
+        project: Project,
+        file: PsiFile,
+        editor: Editor?,
+        startElement: PsiElement,
+        endElement: PsiElement
+    ) {
+        val arguments = startElement.parentOfType<RsValueArgumentList>(true) ?: return
+        val parent = arguments.parent as? RsElement ?: return
+
+        val parameters = getParameterTypes(parent) ?: return
+        val requiredParameterCount = when (parent) {
+            is RsCallExpr -> parent.expectedParamsCount()?.first
+            is RsMethodCall -> parent.expectedParamsCount()?.first
+            else -> null
+        } ?: return
+
+        val actualArgumentCount = arguments.exprList.size
+        val missingCount = requiredParameterCount - actualArgumentCount
+        if (missingCount < 1) return
+
+        val factory = RsPsiFactory(project)
+        val builder = RsDefaultValueBuilder(parent.knownItems, parent.containingMod, factory)
+        val bindings = RsDefaultValueBuilder.getVisibleBindings(parent)
+
+        val missingArguments = parameters.drop(actualArgumentCount).take(missingCount).map {
+            builder.buildFor(it ?: return@map factory.createExpression("()"), bindings)
+        }
+        val newArguments = factory.tryCreateValueArgumentList(arguments.exprList + missingArguments) ?: return
+        val inserted = arguments.replace(newArguments) as RsValueArgumentList
+
+        val insertedArguments = inserted.exprList.drop(actualArgumentCount)
+        editor?.buildAndRunTemplate(inserted, insertedArguments.map { it.createSmartPointer() })
+    }
+}
+
+private fun getParameterTypes(element: PsiElement): List<Ty?>? {
+    return when (element) {
+        is RsCallExpr -> {
+            when (val target = (element.expr as? RsPathExpr)?.path?.reference?.resolve()) {
+                is RsFunction -> {
+                    val valueParameters = target.valueParameters.map { it.typeReference?.type }
+                    if (target.isMethod) {
+                        listOf(getSelfType(target, element)) + valueParameters
+                    }
+                    else {
+                        valueParameters
+                    }
+                }
+                is RsFieldsOwner -> target.tupleFields?.tupleFieldDeclList?.map { it.typeReference.type }
+                else -> null
+            }
+        }
+        is RsMethodCall -> (element.reference.resolve() as? RsFunction)?.valueParameterList?.valueParameterList?.map {
+            it.typeReference?.type
+        }
+        else -> null
+    }
+}
+
+fun getSelfType(function: RsFunction, call: RsCallExpr): Ty? {
+    val selfParameter = function.selfParameter ?: return null
+    if (selfParameter.typeReference?.type != null) {
+        return selfParameter.typeReference?.type
+    }
+    val owner = when (val owner = function.owner) {
+        is RsAbstractableOwner.Impl -> owner.impl.selfType
+        is RsAbstractableOwner.Trait -> {
+            val pathExpr = call.expr as? RsPathExpr
+            val typeOwner = pathExpr?.path?.qualifier?.reference?.resolve() as? RsTypeDeclarationElement
+            typeOwner?.declaredType ?: owner.trait.selfType
+        }
+        else -> return null
+    }
+    return when {
+        selfParameter.isRef -> TyReference(owner, selfParameter.mutability)
+        else -> owner
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -474,6 +474,9 @@ class RsPsiFactory(
     fun tryCreateMethodCall(receiver: RsExpr, methodNameText: String, arguments: List<RsExpr>): RsDotExpr? =
         tryCreateExpressionOfType("${receiver.text}.$methodNameText(${arguments.joinToString(", ") { it.text }})")
 
+    fun tryCreateValueArgumentList(arguments: List<RsExpr>): RsValueArgumentList? =
+        createFromText("fn bar() { foo(${arguments.joinToString(", ") { it.text }}); }")
+
     fun createDerefExpr(expr: RsExpr, nOfDerefs: Int = 1): RsExpr =
         if (nOfDerefs > 0)
             when (expr) {

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -532,12 +532,14 @@ sealed class RsDiagnostic(
         element: PsiElement,
         private val expectedCount: Int,
         private val realCount: Int,
-        private val functionType: FunctionType = FunctionType.FUNCTION
+        private val functionType: FunctionType = FunctionType.FUNCTION,
+        private val fixes: List<LocalQuickFix> = emptyList()
     ) : RsDiagnostic(element) {
         override fun prepare() = PreparedAnnotation(
             ERROR,
             functionType.errorCode,
-            errorText()
+            errorText(),
+            fixes = fixes
         )
 
         private fun errorText(): String {

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFixTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.rust.ide.annotator.RsAnnotatorTestBase
+import org.rust.ide.annotator.RsErrorAnnotator
+
+class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
+    fun `test simple call`() = checkFixByText("Fill missing arguments", """
+        fn foo(a: u32) {}
+
+        fn main() {
+            foo(<error>/*caret*/)</error>;
+        }
+    """, """
+        fn foo(a: u32) {}
+
+        fn main() {
+            foo(0);
+        }
+    """)
+
+    fun `test multiple arguments`() = checkFixByText("Fill missing arguments", """
+        fn foo(a: u32, b: u32, c: &str) {}
+
+        fn main() {
+            foo(1<error>/*caret*/)</error>;
+        }
+    """, """
+        fn foo(a: u32, b: u32, c: &str) {}
+
+        fn main() {
+            foo(1, 0, "");
+        }
+    """)
+
+    fun `test ufcs self value`() = checkFixByText("Fill missing arguments", """
+        struct S;
+        impl S {
+            fn foo(self, a: u32) {}
+        }
+        fn foo() {
+            S::foo(<error>/*caret*/)</error>;
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(self, a: u32) {}
+        }
+        fn foo() {
+            S::foo(S, 0);
+        }
+    """)
+
+    fun `test ufcs self ref`() = checkFixByText("Fill missing arguments", """
+        struct S;
+        impl S {
+            fn foo(&self, a: u32) {}
+        }
+        fn foo() {
+            S::foo(<error>/*caret*/)</error>;
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self, a: u32) {}
+        }
+        fn foo() {
+            S::foo(&S, 0);
+        }
+    """)
+
+    fun `test ufcs self mut ref`() = checkFixByText("Fill missing arguments", """
+        struct S;
+        impl S {
+            fn foo(&mut self, a: u32) {}
+        }
+        fn foo() {
+            S::foo(<error>/*caret*/)</error>;
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&mut self, a: u32) {}
+        }
+        fn foo() {
+            S::foo(&mut S, 0);
+        }
+    """)
+
+    fun `test ufcs generic trait bound`() = checkFixByText("Fill missing arguments", """
+        trait Trait {
+            fn foo(&mut self, a: u32) {}
+        }
+        fn foo<T: Trait>() {
+            T::foo(<error>/*caret*/)</error>;
+        }
+    """, """
+        trait Trait {
+            fn foo(&mut self, a: u32) {}
+        }
+        fn foo<T: Trait>() {
+            T::foo(&mut (), 0);
+        }
+    """)
+
+    fun `test method call`() = checkFixByText("Fill missing arguments", """
+        struct S;
+        impl S {
+            fn foo(&self, a: u32, b: u32) {}
+        }
+        fn foo(s: S) {
+            s.foo(1<error>/*caret*/)</error>;
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self, a: u32, b: u32) {}
+        }
+        fn foo(s: S) {
+            s.foo(1, 0);
+        }
+    """)
+
+    fun `test tuple struct`() = checkFixByText("Fill missing arguments", """
+        struct S(u32, u32);
+        fn foo() {
+            S(<error>/*caret*/)</error>;
+        }
+    """, """
+        struct S(u32, u32);
+        fn foo() {
+            S(0, 0);
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds a quick fix that fills missing arguments in function calls with default values.

![fill](https://user-images.githubusercontent.com/4539057/85442278-4f629400-b590-11ea-9c4f-b07ce260321a.gif)

I also wanted to support generic type parameter substitution, like this:
```rust
struct S<T>(T);
impl<R> S<R> {
    fn foo(&self, t: R) {}
}
fn foo(s: S<u32>) {
    s.foo(/*caret*/);
    vvv
    s.foo(0);
}
```
But I don't know how to substitute the type parameters (my naive attempt doesn't work). @vlad20012 is there a straightforward way of doing that?