### PR TITLE
ANN: add quick fix to change local variable type

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertLetDeclTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertLetDeclTypeFix.kt
@@ -1,0 +1,42 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.ide.presentation.renderInsertionSafe
+import org.rust.lang.core.psi.RsLetDecl
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.types.ty.Ty
+
+/**
+ * Change the declared type of a local variable.
+ */
+class ConvertLetDeclTypeFix(
+    decl: RsLetDecl,
+    private val fixText: String,
+    private val ty: Ty
+) : LocalQuickFixAndIntentionActionOnPsiElement(decl) {
+    override fun getFamilyName(): String = "Convert type of local variable"
+    override fun getText(): String = fixText
+
+    override fun invoke(
+        project: Project,
+        file: PsiFile,
+        editor: Editor?,
+        startElement: PsiElement,
+        endElement: PsiElement
+    ) {
+        val decl = startElement as? RsLetDecl ?: return
+        val factory = RsPsiFactory(project)
+        val type = factory.tryCreateType(ty.renderInsertionSafe(useAliasNames = true)) ?: return
+
+        decl.typeReference?.replace(type)
+    }
+}

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertLetDeclTypeFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ConvertLetDeclTypeFixTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.RsTypeCheckInspection
+
+class ConvertLetDeclTypeFixTest : RsInspectionsTestBase(RsTypeCheckInspection::class) {
+    fun `test unavailable on variable write`() = checkFixIsUnavailable("Change type of", """
+        fn main() {
+            let mut  a = 5;
+            a = <error>/*caret*/"asd"</error>;
+        }
+    """)
+
+    fun `test unavailable on variable without type`() = checkFixIsUnavailable("Change type of", """
+        fn main() {
+            let a = /*caret*/"asd";
+        }
+    """)
+
+    fun `test unavailable on complex pattern`() = checkFixIsUnavailable("Change type of", """
+        fn main() {
+            let (a, b) = /*caret*/"asd";
+        }
+    """)
+
+    fun `test unavailable on type that cannot be used for decl`() = checkFixIsUnavailable("Change type of", """
+        trait T {}
+
+        fn foo(x: &impl T) {
+            let y: i32 = <error>/*caret*/x</error>;
+        }
+    """)
+
+    fun `test simple type`() = checkFixByText("Change type of `a` to `&str`", """
+        fn main() {
+            let a: u32 = <error>/*caret*/"asd"</error>;
+        }
+    """, """
+        fn main() {
+            let a: &str = "asd";
+        }
+    """)
+
+    fun `test ref binding`() = checkFixByText("Change type of `a` to `&str`", """
+        fn main() {
+            let ref a: u32 = <error>/*caret*/"asd"</error>;
+        }
+    """, """
+        fn main() {
+            let ref a: &str = "asd";
+        }
+    """)
+
+    fun `test mut binding`() = checkFixByText("Change type of `a` to `&str`", """
+        fn main() {
+            let mut a: u32 = <error>/*caret*/"asd"</error>;
+        }
+    """, """
+        fn main() {
+            let mut a: &str = "asd";
+        }
+    """)
+
+    fun `test aliased type`() = checkFixByText("Change type of `a` to `T`", """
+        struct S;
+        type T = S;
+
+        fn bar() -> T { unimplemented!(); }
+        fn foo() {
+            let a: u32 = <error>/*caret*/bar()</error>;
+        }
+    """, """
+        struct S;
+        type T = S;
+
+        fn bar() -> T { unimplemented!(); }
+        fn foo() {
+            let a: T = bar();
+        }
+    """)
+
+    fun `test numeric type`() = checkFixByText("Change type of `a` to `u64`", """
+        fn foo() {
+            let a: u32 = <error>/*caret*/0u64</error>;
+        }
+    """, """
+        fn foo() {
+            let a: u64 = 0u64;
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds a very simple quick fix that changes the type of a `let` declaration.

![change](https://user-images.githubusercontent.com/4539057/85586328-21895800-b641-11ea-8edc-237737416ddd.gif)

Umbrella issue: https://github.com/intellij-rust/intellij-rust/issues/1730