### PR TITLE
RUN: add custom text for assert test diff

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestConsoleProperties.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestConsoleProperties.kt
@@ -7,11 +7,13 @@ package org.rust.cargo.runconfig.test
 
 import com.intellij.execution.Executor
 import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.testframework.Printer
 import com.intellij.execution.testframework.TestConsoleProperties
 import com.intellij.execution.testframework.sm.SMCustomMessagesParsing
 import com.intellij.execution.testframework.sm.runner.OutputToGeneralTestEventsConverter
 import com.intellij.execution.testframework.sm.runner.SMTRunnerConsoleProperties
 import com.intellij.execution.testframework.sm.runner.SMTestLocator
+import com.intellij.execution.ui.ConsoleViewContentType
 
 class CargoTestConsoleProperties(
     config: RunConfiguration,
@@ -28,6 +30,14 @@ class CargoTestConsoleProperties(
         testFrameworkName: String,
         consoleProperties: TestConsoleProperties
     ): OutputToGeneralTestEventsConverter = CargoTestEventsConverter(testFrameworkName, consoleProperties)
+
+    override fun printExpectedActualHeader(printer: Printer, expected: String, actual: String) {
+        printer.print("\n", ConsoleViewContentType.ERROR_OUTPUT)
+        printer.print("Left:  ", ConsoleViewContentType.SYSTEM_OUTPUT)
+        printer.print("$actual\n", ConsoleViewContentType.ERROR_OUTPUT)
+        printer.print("Right: ", ConsoleViewContentType.SYSTEM_OUTPUT)
+        printer.print(expected, ConsoleViewContentType.ERROR_OUTPUT)
+    }
 
     companion object {
         const val TEST_FRAMEWORK_NAME: String = "Cargo Test"


### PR DESCRIPTION
This PR uses `printExpectedActualHeader` to use `Left` and `Right` strings for test assertion differences, instead of `Actual` and `Expected`. The order and text is still incorrect when the diff is opened, but at least now the initial text is correct.

![image](https://user-images.githubusercontent.com/4539057/85592857-d2462600-b646-11ea-8415-75b9b8760a46.png)

Fixes: https://github.com/intellij-rust/intellij-rust/issues/3814