### PR TITLE
CI: release nightly toml from github actions

### DIFF
--- a/.github/workflows/rust-nightly.yml
+++ b/.github/workflows/rust-nightly.yml
@@ -19,8 +19,41 @@ jobs:
                   token: ${{ secrets.github_token }}
                   prefix: rust
 
+    fetch-latest-changes:
+        runs-on: ubuntu-latest
+        outputs:
+            rust-commit: ${{ steps.fetch-commits.outputs.rust-commit }}
+            rust-nightly: ${{ steps.fetch-commits.outputs.rust-nightly }}
+            toml-commit: ${{ steps.fetch-commits.outputs.toml-commit }}
+            toml-nightly: ${{ steps.fetch-commits.outputs.toml-nightly }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
+            - name: Set up Python
+              uses: actions/setup-python@v1
+              with:
+                  python-version: 3.7
+
+            - name: Fetch latest commits
+              id: fetch-commits
+              run: |
+                  echo "::set-output name=rust-commit::$(git log -n 1 --format=format:%H)"
+                  echo "::set-output name=rust-nightly::$(python scripts/get_tag_commit.py --tag "rust-nightly")"
+                  echo "::set-output name=toml-commit::$(git log -n 1 --format=format:%H intellij-toml *gradle*)"
+                  echo "::set-output name=toml-nightly::$(python scripts/get_tag_commit.py --tag "toml-nightly")"
+
+            - name: Show commits
+              run: |
+                  echo "rust-commit: ${{ steps.fetch-commits.outputs.rust-commit }}"
+                  echo "rust-nightly: ${{ steps.fetch-commits.outputs.rust-nightly }}"
+                  echo "toml-commit: ${{ steps.fetch-commits.outputs.toml-commit }}"
+                  echo "toml-nightly: ${{ steps.fetch-commits.outputs.toml-nightly }}"
+
     build:
-        needs: generate-build-number
+        needs: [ generate-build-number, fetch-latest-changes ]
         runs-on: ubuntu-latest
         strategy:
             fail-fast: true
@@ -46,11 +79,32 @@ jobs:
                   echo "::set-env name=ORG_GRADLE_PROJECT_publishToken::${{ secrets.plugin_bot_token }}"
 
             - name: Publish rust plugin
+              if: needs.fetch-latest-changes.outputs.rust-commit != needs.fetch-latest-changes.outputs.rust-nightly
               uses: eskatos/gradle-command-action@v1
               with:
                   arguments: :plugin:publishPlugin
 
             - name: Publish toml plugin
+              if: needs.fetch-latest-changes.outputs.toml-commit != needs.fetch-latest-changes.outputs.toml-nightly
               uses: eskatos/gradle-command-action@v1
               with:
                   arguments: :intellij-toml:publishPlugin
+
+    save-commit:
+        needs: [ build, fetch-latest-changes ]
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
+            - name: Set up Python
+              uses: actions/setup-python@v1
+              with:
+                  python-version: 3.7
+
+            - name: Save commits
+              run: |
+                  python scripts/save_tag.py --token ${{ secrets.GITHUB_TOKEN }} --tag rust-nightly --commit ${{ needs.fetch-latest-changes.outputs.rust-commit }}
+                  python scripts/save_tag.py --token ${{ secrets.GITHUB_TOKEN }} --tag toml-nightly --commit ${{ needs.fetch-latest-changes.outputs.toml-commit }}

--- a/.github/workflows/rust-nightly.yml
+++ b/.github/workflows/rust-nightly.yml
@@ -35,12 +35,22 @@ jobs:
               with:
                   java-version: 1.8
 
-            - name: Build & publish
-              env:
-                  CI: true
-                  ORG_GRADLE_PROJECT_buildNumber: ${{ needs.generate-build-number.outputs.build_number }}
-                  ORG_GRADLE_PROJECT_platformVersion: ${{ matrix.platform-version }}
-                  ORG_GRADLE_PROJECT_enableBuildSearchableOptions: true
-                  ORG_GRADLE_PROJECT_publishChannel: nightly
-                  ORG_GRADLE_PROJECT_publishToken: ${{ secrets.plugin_bot_token }}
-              run: ./gradlew :plugin:buildPlugin :plugin:publishPlugin
+            - name: Set up env variables
+              # see https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+              run: |
+                  echo "::set-env name=CI::true"
+                  echo "::set-env name=ORG_GRADLE_PROJECT_buildNumber::${{ needs.generate-build-number.outputs.build_number }}"
+                  echo "::set-env name=ORG_GRADLE_PROJECT_platformVersion::${{ matrix.platform-version }}"
+                  echo "::set-env name=ORG_GRADLE_PROJECT_enableBuildSearchableOptions::true"
+                  echo "::set-env name=ORG_GRADLE_PROJECT_publishChannel::nightly"
+                  echo "::set-env name=ORG_GRADLE_PROJECT_publishToken::${{ secrets.plugin_bot_token }}"
+
+            - name: Publish rust plugin
+              uses: eskatos/gradle-command-action@v1
+              with:
+                  arguments: :plugin:publishPlugin
+
+            - name: Publish toml plugin
+              uses: eskatos/gradle-command-action@v1
+              with:
+                  arguments: :intellij-toml:publishPlugin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,25 +94,26 @@ allprojects {
         instrumentCode = false
         ideaDependencyCachePath = dependencyCachePath
         sandboxDirectory = "$buildDir/$baseIDE-sandbox-$platformVersion"
-
-        tasks {
-            withType<PatchPluginXmlTask> {
-                sinceBuild(prop("sinceBuild"))
-                untilBuild(prop("untilBuild"))
-            }
-
-            buildSearchableOptions {
-                enabled = prop("enableBuildSearchableOptions").toBoolean()
-            }
-        }
     }
 
-    tasks.withType<KotlinCompile> {
-        kotlinOptions {
-            jvmTarget = "1.8"
-            languageVersion = "1.3"
-            apiVersion = "1.3"
-            freeCompilerArgs = listOf("-Xjvm-default=enable")
+    tasks {
+        withType<KotlinCompile> {
+            kotlinOptions {
+                jvmTarget = "1.8"
+                languageVersion = "1.3"
+                apiVersion = "1.3"
+                freeCompilerArgs = listOf("-Xjvm-default=enable")
+            }
+        }
+        withType<PatchPluginXmlTask> {
+            sinceBuild(prop("sinceBuild"))
+            untilBuild(prop("untilBuild"))
+        }
+
+        buildSearchableOptions {
+            // buildSearchableOptions task doesn't make sense for non-root subprojects
+            val isRootProject = project.name in listOf("plugin", "intellij-toml")
+            enabled = isRootProject && prop("enableBuildSearchableOptions").toBoolean()
         }
     }
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -26,11 +26,20 @@ def inc_patch_version():
         properties.write(new_text)
 
 
-def git_command(*args) -> str:
-    print(["git"] + list(args))
-    result = subprocess.run(["git"] + list(args), check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+def git_command(*args, print_stdout=True, check=True) -> str:
+    if print_stdout:
+        print(["git"] + list(args))
+
+    try:
+        result = subprocess.run(["git"] + list(args), check=check, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        if print_stdout:
+            print(e.output)
+        raise e
+
     stdout_str = result.stdout.decode("utf-8").strip()
-    print(stdout_str)
+    if print_stdout:
+        print(stdout_str)
     return stdout_str
 
 

--- a/scripts/get_tag_commit.py
+++ b/scripts/get_tag_commit.py
@@ -1,0 +1,17 @@
+import argparse
+from subprocess import CalledProcessError
+
+from common import git_command
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tag", type=str, required=True, help="tag name")
+
+    args = parser.parse_args()
+
+    try:
+        commit_hash = git_command("rev-list", "-n", "1", args.tag, print_stdout=False)
+    except CalledProcessError:
+        commit_hash = ""
+
+    print(commit_hash)

--- a/scripts/save_tag.py
+++ b/scripts/save_tag.py
@@ -1,0 +1,17 @@
+import argparse
+
+from common import construct_repository_url, git_command
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--token", type=str, help="github token", required=True)
+    parser.add_argument("--tag", type=str, help="tag name", required=True)
+    parser.add_argument("--commit", type=str, help="commit hash", required=True)
+
+    args = parser.parse_args()
+
+    repo_url = construct_repository_url(args.token)
+
+    git_command("tag", "-d", args.tag, check=False)
+    git_command("tag", args.tag, args.commit)
+    git_command("push", "-f", repo_url, args.tag)


### PR DESCRIPTION
The current changes:
* publish nightly builds of toml plugin together with rust plugin
* check if there are changes in repo that can affect particular plugin not to publish the same builds
* disable `buildSearchableOptions` tasks for all non-root gradle projects to speed up publishing. It doesn't affect final builds because result of `buildSearchableOptions` task of non-root gradle project is not included in final build