### PR TITLE
INT: replace usages in DestructureIntention

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFix.kt
@@ -48,7 +48,7 @@ class FillFunctionArgumentsFix(element: PsiElement) : LocalQuickFixAndIntentionA
 
         val factory = RsPsiFactory(project)
         val builder = RsDefaultValueBuilder(parent.knownItems, parent.containingMod, factory)
-        val bindings = RsDefaultValueBuilder.getVisibleBindings(parent)
+        val bindings = parent.getVisibleBindings()
 
         val missingArguments = parameters.drop(actualArgumentCount).take(missingCount).map {
             builder.buildFor(it ?: return@map factory.createExpression("()"), bindings)

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/InitializeWithDefaultValueFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/InitializeWithDefaultValueFix.kt
@@ -13,6 +13,7 @@ import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.rust.lang.core.psi.ext.getVisibleBindings
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.declaration
 import org.rust.lang.core.types.type
@@ -30,7 +31,7 @@ class InitializeWithDefaultValueFix(element: RsElement) : LocalQuickFixAndIntent
         val semicolon = declaration.semicolon ?: return
         val psiFactory = RsPsiFactory(project)
         val initExpr = RsDefaultValueBuilder(declaration.knownItems, declaration.containingMod, psiFactory, true)
-            .buildFor(patBinding.type, RsDefaultValueBuilder.getVisibleBindings(startElement as RsElement))
+            .buildFor(patBinding.type, (startElement as RsElement).getVisibleBindings())
 
         if (declaration.eq == null) {
             declaration.addBefore(psiFactory.createEq(), semicolon)

--- a/src/main/kotlin/org/rust/ide/refactoring/RsMultipleVariableRenamer.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsMultipleVariableRenamer.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring
+
+import com.intellij.ide.DataManager
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.SmartPsiElementPointer
+import com.intellij.refactoring.rename.inplace.VariableInplaceRenameHandler
+import com.intellij.refactoring.rename.inplace.VariableInplaceRenamer
+
+class RsMultipleVariableRenamer(
+    private val elementsToRename: List<SmartPsiElementPointer<PsiNamedElement>>,
+): VariableInplaceRenameHandler() {
+    override fun createRenamer(elementToRename: PsiElement, editor: Editor): VariableInplaceRenamer {
+        return object: VariableInplaceRenamer(elementToRename as PsiNamedElement, editor, elementToRename.project) {
+            override fun performRefactoring(): Boolean {
+                try {
+                    return super.performRefactoring()
+                }
+                finally {
+                    if (elementsToRename.size > 1) {
+                        val element = elementsToRename[1].element
+                        if (element != null) {
+                            val offset = element.textRange?.startOffset
+                            if (offset != null) {
+                                editor.caretModel.moveToOffset(offset)
+                                RsMultipleVariableRenamer(elementsToRename.drop(1)).doRename(
+                                    element, editor, DataManager.getInstance().getDataContext(editor.component))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/utils/StructFieldsExpander.kt
+++ b/src/main/kotlin/org/rust/ide/utils/StructFieldsExpander.kt
@@ -30,7 +30,7 @@ fun addMissingFieldsToStructLiteral(
         body,
         declaration.fields,
         fieldsToAdd,
-        RsDefaultValueBuilder.getVisibleBindings(structLiteral)
+        structLiteral.getVisibleBindings()
     )
     editor?.buildAndRunTemplate(body, addedFields.mapNotNull { it.expr?.createSmartPointer() })
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsDefaultValueBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsDefaultValueBuilder.kt
@@ -8,7 +8,6 @@ package org.rust.lang.core.psi
 import org.rust.ide.inspections.RsFieldInitShorthandInspection
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.KnownItems
-import org.rust.lang.core.resolve.processLocalVariables
 import org.rust.lang.core.types.implLookup
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
@@ -238,17 +237,5 @@ class RsDefaultValueBuilder(
         val fieldType = fieldDecl.typeReference?.type ?: return null
         val fieldLiteral = buildFor(fieldType, bindings)
         return psiFactory.createStructLiteralField(fieldName, fieldLiteral)
-    }
-
-    companion object {
-        fun getVisibleBindings(place: RsElement): Map<String, RsPatBinding> {
-            val bindings = HashMap<String, RsPatBinding>()
-            processLocalVariables(place) { variable ->
-                variable.name?.let {
-                    bindings[it] = variable
-                }
-            }
-            return bindings
-        }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -21,12 +21,10 @@ import org.rust.lang.core.completion.getOriginalOrSelf
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.findDependency
 import org.rust.lang.core.macros.findNavigationTargetIfMacroExpansion
-import org.rust.lang.core.psi.RsConstant
-import org.rust.lang.core.psi.RsElementTypes
-import org.rust.lang.core.psi.RsEnumVariant
-import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.resolve.Namespace
 import org.rust.lang.core.resolve.createProcessor
+import org.rust.lang.core.resolve.processLocalVariables
 import org.rust.lang.core.resolve.processNestedScopesUpwards
 
 interface RsElement : PsiElement {
@@ -141,6 +139,16 @@ fun RsElement.findInScope(name: String, ns: Set<Namespace>): PsiElement? {
 
 fun RsElement.hasInScope(name: String, ns: Set<Namespace>): Boolean =
     findInScope(name, ns) != null
+
+fun RsElement.getVisibleBindings(): Map<String, RsPatBinding> {
+    val bindings = HashMap<String, RsPatBinding>()
+    processLocalVariables(this) { variable ->
+        variable.name?.let {
+            bindings[it] = variable
+        }
+    }
+    return bindings
+}
 
 /**
  * Delete the element along with a neighbour comma.

--- a/src/main/resources/intentionDescriptions/DestructureIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/DestructureIntention/after.rs.template
@@ -3,6 +3,6 @@ struct Point { x: i32, y: i32 }
 fn main() {
     let points = vec![Point { x: 1, y: 2 }];
     for <spot>Point { x, y }</spot> in points {
-        // ...
+        let a = x;
     }
 }

--- a/src/main/resources/intentionDescriptions/DestructureIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/DestructureIntention/before.rs.template
@@ -3,6 +3,6 @@ struct Point { x: i32, y: i32 }
 fn main() {
     let points = vec![Point { x: 1, y: 2 }];
     for <spot>point</spot> in points {
-        // ...
+        let a = point.x;
     }
 }

--- a/src/test/kotlin/org/rust/ide/intentions/DestructureIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/DestructureIntentionTest.kt
@@ -6,13 +6,208 @@
 package org.rust.ide.intentions
 
 class DestructureIntentionTest : RsIntentionTestBase(DestructureIntention::class) {
-
     fun `test destructure variable`() = doAvailableTest("""
         struct S<T, U> { x: T, y: U }
         fn main() { let /*caret*/x = S { x: 0, y: "" }; }
     """, """
         struct S<T, U> { x: T, y: U }
         fn main() { let /*caret*/S { x, y } = S { x: 0, y: "" }; }
+    """)
+
+    fun `test destructure block struct replace fields`() = doAvailableTest("""
+        struct P<T> { p: T }
+        struct S<T, U> { x: P<T>, y: U }
+        fn main() {
+            let /*caret*/s = S { x: P { p: 0 }, y: "" };
+            let z = s.x.p;
+        }
+    """, """
+        struct P<T> { p: T }
+        struct S<T, U> { x: P<T>, y: U }
+        fn main() {
+            let /*caret*/S { x, y } = S { x: P { p: 0 }, y: "" };
+            let z = x.p;
+        }
+    """)
+
+    fun `test destructure block struct replace direct usage`() = doAvailableTest("""
+        struct S { x: u32, y: u32 }
+
+        fn foo(s: S) {}
+        fn main() {
+            let /*caret*/s = S { x: 0, y: 0 };
+            foo(s);
+        }
+    """, """
+        struct S { x: u32, y: u32 }
+
+        fn foo(s: S) {}
+        fn main() {
+            let /*caret*/S { x, y } = S { x: 0, y: 0 };
+            foo(S { x, y });
+        }
+    """)
+
+    fun `test destructure block struct ignore method call`() = doAvailableTest("""
+        struct S { x: u32, y: u32 }
+        impl S {
+            fn foo(&self) {}
+        }
+
+        fn main() {
+            let /*caret*/s = S { x: 0, y: 0 };
+            s.foo();
+        }
+    """, """
+        struct S { x: u32, y: u32 }
+        impl S {
+            fn foo(&self) {}
+        }
+
+        fn main() {
+            let /*caret*/S { x, y } = S { x: 0, y: 0 };
+            s.foo();
+        }
+    """)
+
+    fun `test destructure tuple struct replace fields`() = doAvailableTest("""
+        struct A { a: u32 }
+        struct S(A, u32);
+
+        fn main() {
+            let /*caret*/s = S(A { a: 0 }, 0);
+            let z = s.0.a;
+        }
+    """, """
+        struct A { a: u32 }
+        struct S(A, u32);
+
+        fn main() {
+            let S(_0, _1) = S(A { a: 0 }, 0);
+            let z = _0.a;
+        }
+    """)
+
+    fun `test destructure tuple struct replace direct usage`() = doAvailableTest("""
+        struct S(u32, u32);
+
+        fn foo(s: S) {}
+        fn main() {
+            let /*caret*/s = S(0, 0);
+            foo(s);
+        }
+    """, """
+        struct S(u32, u32);
+
+        fn foo(s: S) {}
+        fn main() {
+            let S(_0, _1) = S(0, 0);
+            foo(S(_0, _1));
+        }
+    """)
+
+    fun `test destructure tuple element method call`() = doAvailableTest("""
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+
+        fn main() {
+            let /*caret*/s = (S, S);
+            s.0.foo();
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+
+        fn main() {
+            let (_0, _1) = (S, S);
+            _0.foo();
+        }
+    """)
+
+    fun `test destructure tuple struct ignore method call`() = doAvailableTest("""
+        struct S(u32, u32);
+        impl S {
+            fn foo(&self) {}
+        }
+
+        fn main() {
+            let /*caret*/s = S(0, 0);
+            s.foo();
+        }
+    """, """
+        struct S(u32, u32);
+        impl S {
+            fn foo(&self) {}
+        }
+
+        fn main() {
+            let S(_0, _1) = S(0, 0);
+            s.foo();
+        }
+    """)
+
+    fun `test destructure tuple replace fields`() = doAvailableTest("""
+        fn main() {
+            let /*caret*/s = (1, 2);
+            let z = s.0;
+            let y = s.1;
+        }
+    """, """
+        fn main() {
+            let (_0, _1) = (1, 2);
+            let z = _0;
+            let y = _1;
+        }
+    """)
+
+    fun `test destructure tuple replace nested named fields`() = doAvailableTest("""
+        struct S { a: u32, b: u32}
+
+        fn main() {
+            let /*caret*/s = (S { a: 0, b: 0 }, S { a: 0, b: 0 });
+            let z = s.0.a;
+            let y = s.1.b;
+        }
+    """, """
+        struct S { a: u32, b: u32}
+
+        fn main() {
+            let (_0, _1) = (S { a: 0, b: 0 }, S { a: 0, b: 0 });
+            let z = _0.a;
+            let y = _1.b;
+        }
+    """)
+
+    fun `test destructure tuple replace nested numeric fields`() = doAvailableTest("""
+        fn main() {
+            let /*caret*/s = ((0, 0), (0, 0));
+            let z = (s.0).0;
+            let y = (s.1).1;
+        }
+    """, """
+        fn main() {
+            let (_0, _1) = ((0, 0), (0, 0));
+            let z = (_0).0;
+            let y = (_1).1;
+        }
+    """)
+
+    fun `test destructure tuple replace direct usage`() = doAvailableTest("""
+        fn foo(_: (i32, i32)) {}
+        fn main() {
+            let /*caret*/s = (1, 2);
+            foo(s);
+        }
+    """, """
+        fn foo(_: (i32, i32)) {}
+        fn main() {
+            let (_0, _1) = (1, 2);
+            foo((_0, _1));
+        }
     """)
 
     fun `test destructure parameter`() = doAvailableTest("""
@@ -157,6 +352,184 @@ class DestructureIntentionTest : RsIntentionTestBase(DestructureIntention::class
 
         fn main() {
             let R {} = foo();
+        }
+    """)
+
+    fun `test ignore existing binding name`() = doAvailableTest("""
+        fn main() {
+            let /*caret*/_0 = (0, 1);
+            let a = _0.0;
+            let b = _0.1;
+        }
+    """, """
+        fn main() {
+            let (_0, _1) = (0, 1);
+            let a = _0;
+            let b = _1;
+        }
+    """)
+
+    fun `test skip existing bindings tuple`() = doAvailableTest("""
+        fn main() {
+            let /*caret*/x = (0, 1);
+            let _0 = 0;
+            let a = x.0;
+            let b = x.1;
+        }
+    """, """
+        fn main() {
+            let (_00, _1) = (0, 1);
+            let _0 = 0;
+            let a = _00;
+            let b = _1;
+        }
+    """)
+
+    fun `test skip existing bindings tuple direct usage`() = doAvailableTest("""
+        fn foo(a: (u32, u32)) {}
+
+        fn main() {
+            let /*caret*/x = (0, 1);
+            let _0 = 0;
+            foo(x);
+        }
+    """, """
+        fn foo(a: (u32, u32)) {}
+
+        fn main() {
+            let (_00, _1) = (0, 1);
+            let _0 = 0;
+            foo((_00, _1));
+        }
+    """)
+
+    fun `test skip existing bindings struct tuple`() = doAvailableTest("""
+        struct S(u32, u32);
+
+        fn main() {
+            let /*caret*/x = S(0, 1);
+            let _0 = 0;
+            let a = x.0;
+            let b = x.1;
+        }
+    """, """
+        struct S(u32, u32);
+
+        fn main() {
+            let S(_00, _1) = S(0, 1);
+            let _0 = 0;
+            let a = _00;
+            let b = _1;
+        }
+    """)
+
+    fun `test skip existing bindings struct tuple direct usage`() = doAvailableTest("""
+        struct S(u32, u32);
+
+        fn foo(s: S) {}
+        fn main() {
+            let /*caret*/x = S(0, 1);
+            let _0 = 0;
+            foo(x);
+        }
+    """, """
+        struct S(u32, u32);
+
+        fn foo(s: S) {}
+        fn main() {
+            let S(_00, _1) = S(0, 1);
+            let _0 = 0;
+            foo(S(_00, _1));
+        }
+    """)
+
+    fun `test skip existing bindings block struct`() = doAvailableTest("""
+        struct S {
+            a: u32,
+            b: u32
+        }
+
+        fn main() {
+            let /*caret*/x = S { a: 0, b: 1 };
+            let a = 0;
+            let b = 1;
+            let c = x.a;
+            let d = x.b;
+        }
+    """, """
+        struct S {
+            a: u32,
+            b: u32
+        }
+
+        fn main() {
+            let S { a: a0, b: b0 } = S { a: 0, b: 1 };
+            let a = 0;
+            let b = 1;
+            let c = a0;
+            let d = b0;
+        }
+    """)
+
+    fun `test skip existing bindings block struct direct usage`() = doAvailableTest("""
+        struct S {
+            a: u32,
+            b: u32
+        }
+
+        fn foo(s: S) {}
+        fn main() {
+            let /*caret*/x = S { a: 0, b: 1 };
+            let a = 0;
+            let b = 1;
+            foo(x);
+        }
+    """, """
+        struct S {
+            a: u32,
+            b: u32
+        }
+
+        fn foo(s: S) {}
+        fn main() {
+            let S { a: a0, b: b0 } = S { a: 0, b: 1 };
+            let a = 0;
+            let b = 1;
+            foo(S { a: a0, b: b0 });
+        }
+    """)
+
+    fun `test skip existing global bindings`() = doAvailableTest("""
+        struct S(u32, u32, u32, u32, u32);
+
+        const _0: i32 = 0;
+        struct _1;
+
+        enum E { _2 }
+        use E::_2;
+
+        fn _3() {}
+
+        fn foo(s: S) {}
+        fn bar<const _4: i32>() {
+            let /*caret*/x = S(0, 1, 2, 3, 4);
+            foo(x);
+        }
+    """, """
+        struct S(u32, u32, u32, u32, u32);
+
+        const _0: i32 = 0;
+        struct _1;
+
+        enum E { _2 }
+        use E::_2;
+
+        fn _3() {}
+
+        fn foo(s: S) {}
+        fn bar<const _4: i32>() {
+            let S(_00, _10, _20, _30, _40) = S(0, 1, 2, 3, 4);
+            foo(S(_00, _10, _20, _30, _40));
         }
     """)
 }


### PR DESCRIPTION
This is a revival of an older PR by @fan-tom (https://github.com/intellij-rust/intellij-rust/pull/4095). It adds support for replacing usages of field/tuple bindings after performing `DestructureIntention`. Both field lookup replacement (`s.0 -> _0`) and whole item replacement (`foo(s) -> foo((_0, _1))`) is supported. Method calls on the original binding are ignored, as the user probably doesn't want to transform them to
`S { x, y }.foo()`.

![replace](https://user-images.githubusercontent.com/4539057/85609233-299fc280-b656-11ea-9048-94f792346395.gif)

To rename multiple introduced bindings at once, I needed something that combines TemplateBuilder (renames multiple things in a single editing session) and `RsInPlaceVariableIntroducer` (renames occurrences of a renamed item). I created `RsMultipleVariableIntroducer`, which invokes the `RsInPlaceVariableIntroducer` repeatedly. It's probably a horrible hack, but it seems to work (at least on my machine :D ).

I rebased the original PR on master, moved reference search from `findAvailableContext` to `invoke` and used a local search scope.
CC @fan-tom

Closes: https://github.com/intellij-rust/intellij-rust/pull/4095
Fixes: https://github.com/intellij-rust/intellij-rust/issues/3684