### PR TITLE
INT: allow extracting non-root modules in ExtractInlineModuleIntention

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt
@@ -20,11 +20,8 @@ class ExtractInlineModuleIntention : RsElementBaseIntentionAction<RsModItem>() {
     override fun getFamilyName() = "Extract inline module structure"
     override fun getText() = "Extract inline module"
 
-    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsModItem? {
-        val mod = element.ancestorOrSelf<RsModItem>() ?: return null
-        if (mod.`super`?.ownsDirectory != true) return null
-        return mod
-    }
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsModItem? =
+        element.ancestorOrSelf()
 
     override fun invoke(project: Project, editor: Editor, ctx: RsModItem) {
         val modName = ctx.name ?: return

--- a/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt
@@ -36,6 +36,63 @@ class ExtractInlineModuleIntentionTest : RsTestBase() {
         }
     )
 
+    fun `test extract non-root module`() = doTest(
+        fileTree {
+            rust("main.rs", """
+                mod foo;
+
+                fn main() {}
+            """)
+            rust("foo.rs", """
+                mod /*caret*/bar {
+                    fn baz() {}
+                }
+            """)
+        },
+        fileTree {
+            rust("main.rs", """
+                mod foo;
+
+                fn main() {}
+            """)
+            rust("foo.rs", """
+                mod bar;
+            """)
+            dir("foo") {
+                rust("bar.rs", """
+                    fn baz() {}
+                """)
+            }
+        }
+    )
+
+    fun `test keep existing file content`() = doTest(
+        fileTree {
+            rust("main.rs", """
+                mod /*caret*/foo {
+                    fn b() {}
+                }
+
+                fn main() {}
+            """)
+            rust("foo.rs", """
+                fn a() {}
+            """)
+        },
+        fileTree {
+            rust("main.rs", """
+                mod foo;
+
+                fn main() {}
+            """)
+            rust("foo.rs", """
+                fn a() {}
+
+                fn b() {}
+            """)
+        }
+    )
+
     fun `test extracting module preserves attributes and visibility`() = ExtractInlineModuleIntention.Testmarks.copyAttrs.checkHit {
         doTest(
             fileTree {


### PR DESCRIPTION
Since Rust now supports it, this PR modifies `ExtractInlineModuleIntention` to work for non-root module files. It also adds a test that checks that an existing module file is not overwritten.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/4878