### PR TITLE
QDOC: render aliased types for let bindings

### DIFF
--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -17,6 +17,7 @@ import org.rust.cargo.project.workspace.PackageOrigin.STDLIB
 import org.rust.cargo.util.AutoInjectedCrates.STD
 import org.rust.ide.presentation.presentableQualifiedName
 import org.rust.ide.presentation.presentationInfo
+import org.rust.ide.presentation.render
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyPrimitive
@@ -73,7 +74,7 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
 
     private fun generateDoc(element: RsPatBinding, buffer: StringBuilder) {
         val presentationInfo = element.presentationInfo ?: return
-        val type = element.type.toString().escaped
+        val type = element.type.render(useAliasNames = true).escaped
         buffer += presentationInfo.type
         buffer += " "
         buffer.b { it += presentationInfo.name }

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -743,6 +743,18 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <div class='definition'><pre>variable <b>x</b>: S&lt;i32&gt;</pre></div>
     """)
 
+    fun `test variable type alias`() = doTest("""
+        struct S;
+        type T = S;
+
+        fn main() {
+            let x: T = S;
+              //^
+        }
+    """, """
+        <div class='definition'><pre>variable <b>x</b>: T</pre></div>
+    """)
+
     fun `test tuple destructuring`() = doTest("""
         fn main() {
             let (a, b) = (1, ("foo", 1));


### PR DESCRIPTION
This PR changes the rendered output of local variables in quick documentation to include type aliases.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/4365