### PR TITLE
COMP: do not offer let and return inside struct literals and pats

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt
@@ -138,6 +138,8 @@ class RsKeywordCompletionContributor : CompletionContributor(), DumbAware {
         psiElement()
             .inside(psiElement<RsFunction>())
             .andNot(psiElement().withParent(RsModItem::class.java))
+            .andNot(psiElement().withSuperParent(2, RsStructLiteralBody::class.java))
+            .andNot(psiElement().withSuperParent(3, RsPatStruct::class.java))
 
     private fun statementBeginningPattern(vararg startWords: String): PsiElementPattern.Capture<PsiElement> =
         psiElement(IDENTIFIER).and(RsPsiPattern.onStatementBeginning(*startWords))

--- a/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
@@ -854,6 +854,38 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         }
     """)
 
+    fun `test no return in struct literal`() = checkNotContainsCompletion("return", """
+        struct S { a: u32, b: u32 }
+        fn foo() {
+            let s = S { /*caret*/ };
+        }
+    """)
+
+    fun `test no let in struct literal`() = checkNotContainsCompletion("let", """
+        struct S { a: u32, b: u32 }
+        fn foo() {
+            let s = S { /*caret*/ };
+        }
+    """)
+
+    fun `test no return in struct pat`() = checkNotContainsCompletion("return", """
+        struct S { a: u32, b: u32 }
+        fn foo(s: S) {
+            match s {
+                S { /*caret*/ } => {}
+            }
+        }
+    """)
+
+    fun `test no let in struct pat`() = checkNotContainsCompletion("let", """
+        struct S { a: u32, b: u32 }
+        fn foo(s: S) {
+            match s {
+                S { /*caret*/ } => {}
+            }
+        }
+    """)
+
     // Smart mode is used for not completion tests to disable additional results
     // from language agnostic `com.intellij.codeInsight.completion.WordCompletionContributor`
     override fun checkNoCompletion(@Language("Rust") code: String) {


### PR DESCRIPTION
This PR changes keyword completion so that `return` and `let` are not offered directly inside struct literals and struct pats.

Fixes first part of https://github.com/intellij-rust/intellij-rust/issues/4448