### PR TITLE
COMP: add colon after struct literal field if no matching binding is found

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -296,14 +296,44 @@ class RsCompletionTest : RsCompletionTestBase() {
         impl S { fn foo(test: &self::/*caret*/) {}}
     """)
 
-    fun `test struct field`() = doSingleCompletion("""
+    fun `test struct field no binding with same name`() = doSingleCompletion("""
         struct S { foobarbaz: i32 }
         fn main() {
+            let foobar: i32 = 0;
             let _ = S { foo/*caret*/ };
         }
     """, """
         struct S { foobarbaz: i32 }
         fn main() {
+            let foobar: i32 = 0;
+            let _ = S { foobarbaz: /*caret*/ };
+        }
+    """)
+
+    fun `test struct field no binding with same type`() = doSingleCompletion("""
+        struct S { foobarbaz: i32 }
+        fn main() {
+            let foobarbaz = "foo";
+            let _ = S { foo/*caret*/ };
+        }
+    """, """
+        struct S { foobarbaz: i32 }
+        fn main() {
+            let foobarbaz = "foo";
+            let _ = S { foobarbaz: /*caret*/ };
+        }
+    """)
+
+    fun `test struct field matching binding`() = doSingleCompletion("""
+        struct S { foobarbaz: i32 }
+        fn main() {
+            let foobarbaz: i32 = 0;
+            let _ = S { foo/*caret*/ };
+        }
+    """, """
+        struct S { foobarbaz: i32 }
+        fn main() {
+            let foobarbaz: i32 = 0;
             let _ = S { foobarbaz/*caret*/ };
         }
     """)
@@ -328,7 +358,7 @@ class RsCompletionTest : RsCompletionTestBase() {
     """, """
         enum E { X { bazbarfoo: i32 } }
         fn main() {
-            let _ = E::X { bazbarfoo/*caret*/ }
+            let _ = E::X { bazbarfoo: /*caret*/ }
         }
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPartialParseCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPartialParseCompletionTest.kt
@@ -90,7 +90,7 @@ class RsPartialParseCompletionTest : RsCompletionTestBase() {
         }
     """)
 
-    fun `test struct field 1`() = @Suppress("DEPRECATION") checkSingleCompletion("foobar", """
+    fun `test struct field 1`() = doSingleCompletion("""
         struct S {
             foobar: i32,
             frobnicator: i32,
@@ -99,6 +99,18 @@ class RsPartialParseCompletionTest : RsCompletionTestBase() {
         fn main() {
             let _ = S {
                 foo/*caret*/
+                frobnicator: 92
+            };
+        }
+    """, """
+        struct S {
+            foobar: i32,
+            frobnicator: i32,
+        }
+
+        fn main() {
+            let _ = S {
+                foobar: /*caret*/
                 frobnicator: 92
             };
         }
@@ -151,9 +163,12 @@ class RsPartialParseCompletionTest : RsCompletionTestBase() {
         executeSoloCompletion()
     }
 
-    fun `test struct field 2`() = @Suppress("DEPRECATION") checkSingleCompletion("bar", """
+    fun `test struct field 2`() = doSingleCompletion("""
         struct S { foo: i32, bar: i32}
         fn main() { let _ = S { foo: 2, .ba/*caret*/ } }
+    """, """
+        struct S { foo: i32, bar: i32}
+        fn main() { let _ = S { foo: 2, .bar: /*caret*/ } }
     """)
 
     fun `test function parameter`() = doSingleCompletion("""
@@ -164,4 +179,3 @@ class RsPartialParseCompletionTest : RsCompletionTestBase() {
         fn foo(x: i32, foo bar: i32, baz: Frobnicate/*caret*/) {}
     """)
 }
-


### PR DESCRIPTION
This PR adds `: ` after completed struct field literal if no matching (same name and same type) local binding is found.

![complete](https://user-images.githubusercontent.com/4539057/85712274-73d18400-b6e8-11ea-9869-8bc1b5852b64.gif)

There were 2 failing tests (`RsPartialParseCompletionTest#test struct field 1` and `RsPartialParseCompletionTest#test struct field 2`). If I used `foobar:` or `foobar: ` as the target completion, they still failed. I changed them to use `doSingleCompletion`.

Fixes second part of https://github.com/intellij-rust/intellij-rust/issues/4448