### PR TITLE
COMP: offer only struct fields in struct pat

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -612,7 +612,10 @@ fun processPatBindingResolveVariants(binding: RsPatBinding, isCompletion: Boolea
     if (binding.parent is RsPatField) {
         val parentPat = binding.parent.parent as RsPatStruct
         val patStruct = parentPat.path.reference?.deepResolve()
-        if (patStruct is RsFieldsOwner && processFieldDeclarations(patStruct, processor)) return true
+        if (patStruct is RsFieldsOwner) {
+            if (processFieldDeclarations(patStruct, processor)) return true
+            if (isCompletion) return false
+        }
     }
 
     return processNestedScopesUpwards(binding, if (isCompletion) TYPES_N_VALUES else VALUES) { entry ->

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -320,6 +320,14 @@ class RsCompletionTest : RsCompletionTestBase() {
         }
     """)
 
+    fun `test no outside type in struct field pattern`() = checkNotContainsCompletion("T", """
+        struct T;
+        struct S { a: i32 }
+        fn main() {
+            let S { /*caret*/ } = S{ a: 0 };
+        }
+    """)
+
     fun `test enum field`() = doSingleCompletion("""
         enum E { X { bazbarfoo: i32 } }
         fn main() {


### PR DESCRIPTION
This PR filters out unnecessary completions offered in struct pats.
It also adds `..` to completion, but I'm not sure if that's the right way to do it, so it's in a separate commit.

Fixes third part of https://github.com/intellij-rust/intellij-rust/issues/4448