### PR TITLE
COMP: prefer trait methods before private inherent methods

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -145,6 +145,7 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
         processResolveVariants(
             lookup,
             receiverTy,
+            element,
             filterCompletionVariantsByVisibility(
                 filterMethodCompletionVariantsByTraitBounds(processor, lookup, receiverTy),
                 receiver.containingMod

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.*
 
-interface RsAbstractable : RsNameIdentifierOwner, RsExpandedElement {
+interface RsAbstractable : RsNameIdentifierOwner, RsExpandedElement, RsVisible {
     val isAbstract: Boolean
 }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMethodCallReferenceImpl.kt
@@ -51,7 +51,7 @@ fun resolveMethodCallReferenceWithReceiverType(
     methodCall: RsMethodCall
 ): List<MethodResolveVariant> {
     return collectResolveVariantsAsScopeEntries(methodCall.referenceName) {
-        processMethodCallExprResolveVariants(lookup, receiverType, it)
+        processMethodCallExprResolveVariants(lookup, receiverType, methodCall, it)
     }
 }
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
@@ -65,6 +65,30 @@ class RsMultiResolveTest : RsResolveTestBase() {
         }   //^
     """)
 
+    fun `test trait method and private inherent method`() = doTest("""
+        use foo::{Foo, Trait};
+
+        mod foo {
+            pub struct Foo;
+            impl Foo {
+                fn get(&self) { println!("struct"); }
+            }
+
+            pub trait Trait {
+                fn get(&self);
+            }
+            impl Trait for Foo {
+                fn get(&self) { println!("trait"); }
+            }
+        }
+
+        fn main() {
+            let f = foo::Foo;
+            f.get();
+            //^
+        }
+    """)
+
     private fun doTest(@Language("Rust") code: String) {
         InlineFile(code)
         val element = findElementInEditor<RsReferenceElement>()


### PR DESCRIPTION
Name resolution filters items by their visibility, however in the case of the mentioned issue, it is too late. Trait methods are filtered too deeply if an inherent method exists with the same name.

This PR changes it so that inherent methods are not preferred if they are not visible, thus fixing the previously given false positive.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/3436