### PR TITLE
REF: Handle selection in move top-level items refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsHandler.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.editor.CaretModel
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.SelectionModel
 import com.intellij.openapi.project.Project
+import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiReference
@@ -78,7 +79,12 @@ class RsMoveTopLevelItemsHandler : MoveHandlerDelegate() {
 
         val relatedImplItems = collectRelatedImplItems(containingMod, itemsToMove)
         val itemsToMoveAll = itemsToMove + relatedImplItems
-        RsMoveTopLevelItemsDialog(project, itemsToMoveAll, containingMod).show()
+        val dialog = RsMoveTopLevelItemsDialog(project, itemsToMoveAll, containingMod)
+        if (isUnitTestMode) {
+            dialog.doAction()
+        } else {
+            dialog.show()
+        }
     }
 
     private fun collectInitialItems(project: Project, editor: Editor): Pair<Set<RsItemElement>, RsMod>? {
@@ -145,6 +151,7 @@ private inline fun <reified T : RsElement> findCommonAncestorStrictOfType(elemen
 }
 
 private fun collectRelatedImplItems(containingMod: RsMod, items: Set<RsItemElement>): List<RsImplItem> {
+    if (isUnitTestMode) return emptyList()
     // For struct `Foo` we should collect:
     // * impl Foo { ... }
     // * impl ... for Foo { ... }

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsHandler.kt
@@ -7,43 +7,50 @@ package org.rust.ide.refactoring.move
 
 import com.intellij.lang.Language
 import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.CaretModel
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.SelectionModel
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.psi.util.parentOfType
 import com.intellij.refactoring.move.MoveCallback
 import com.intellij.refactoring.move.MoveHandlerDelegate
 import com.intellij.refactoring.util.CommonRefactoringUtil
+import org.rust.ide.utils.collectElements
+import org.rust.ide.utils.getElementRange
+import org.rust.ide.utils.getTopmostParentInside
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyAdt
 import org.rust.lang.core.types.type
+import org.rust.openapiext.toPsiFile
 
 class RsMoveTopLevelItemsHandler : MoveHandlerDelegate() {
 
     override fun supportsLanguage(language: Language): Boolean = language.`is`(RsLanguage)
 
     override fun canMove(
-        element: Array<out PsiElement>,
+        elements: Array<out PsiElement>,
         targetContainer: PsiElement?,
         reference: PsiReference?
     ): Boolean {
-        val containingMod = (element.firstOrNull() as? RsElement)?.containingMod ?: return false
-        return element.all { canMoveElement(it) && it.parent == containingMod }
+        val containingMod = (elements.firstOrNull() as? RsElement)?.containingMod ?: return false
+        return elements.all { canMoveElement(it) && it.parent == containingMod }
     }
 
-    // looks like IntelliJ platform never calls this method (and always calls `tryToMove` instead)
-    // but lets implement it just in case
+    // Invoked in non-editor context (e.g file structure view)
     override fun doMove(
         project: Project,
         elements: Array<out PsiElement>,
         targetContainer: PsiElement?,
         moveCallback: MoveCallback?
-    ) = doMove(project, elements)
+    ) = doMove(project, elements.toList(), null)
 
+    // Invoked in editor context
     override fun tryToMove(
         element: PsiElement,
         project: Project,
@@ -51,27 +58,68 @@ class RsMoveTopLevelItemsHandler : MoveHandlerDelegate() {
         reference: PsiReference?,
         editor: Editor?
     ): Boolean {
-        val elements = arrayOf(element)
-        // if something is selected, then most likely user wants to move selected items
-        // if cursor is at empty line, then we assume that user wants to move entire file
-        // otherwise we assume that user wants to move item under cursor
         val hasSelection = editor?.selectionModel?.hasSelection() ?: false
-        if (hasSelection || canMove(elements, null, reference)) {
-            doMove(project, elements)
+        if (hasSelection || element !is PsiFile) {
+            doMove(project, listOf(element), editor)
             return true
         }
         return false
     }
 
-    private fun doMove(project: Project, elements: Array<out PsiElement>) {
-        val containingMod = PsiTreeUtil.findCommonParent(*elements)?.parentOfType<RsMod>() ?: return
-        val itemsToMove = elements.filterIsInstance<RsItemElement>().toSet()
+    private fun doMove(project: Project, elements: List<PsiElement>, editor: Editor?) {
+        val (itemsToMove, containingMod) = editor?.let { collectInitialItems(project, editor) }
+            ?: run {
+                val containingMod = findCommonAncestorStrictOfType<RsMod>(elements) ?: return
+                val items = elements.filterIsInstance<RsItemElement>().toSet()
+                items to containingMod
+            }
 
         if (!CommonRefactoringUtil.checkReadOnlyStatusRecursively(project, itemsToMove, true)) return
 
         val relatedImplItems = collectRelatedImplItems(containingMod, itemsToMove)
         val itemsToMoveAll = itemsToMove + relatedImplItems
         RsMoveTopLevelItemsDialog(project, itemsToMoveAll, containingMod).show()
+    }
+
+    private fun collectInitialItems(project: Project, editor: Editor): Pair<Set<RsItemElement>, RsMod>? {
+        val file = editor.document.toPsiFile(project) ?: return null
+        val selection = editor.selectionModel
+        return if (selection.hasSelection()) {
+            collectItemsInsideSelection(file, selection)
+        } else {
+            collectedItemsUnderCaret(file, editor.caretModel)
+        }
+    }
+
+    private fun collectItemsInsideSelection(file: PsiFile, selection: SelectionModel): Pair<Set<RsItemElement>, RsMod>? {
+        val (leafElement1, leafElement2) = file.getElementRange(selection.selectionStart, selection.selectionEnd)
+            ?: return null
+        val element1 = leafElement1.ancestorOrSelf<RsElement>() ?: return null
+        val element2 = leafElement2.ancestorOrSelf<RsElement>() ?: return null
+        val containingMod = findCommonAncestorStrictOfType<RsMod>(listOf(element1, element2)) ?: return null
+        val item1 = element1.getTopmostParentInside(containingMod)
+        val item2 = element2.getTopmostParentInside(containingMod)
+        val items = collectElements(item1, item2.nextSibling) { it is RsItemElement }
+            .mapTo(mutableSetOf()) { it as RsItemElement }
+        return items to containingMod
+    }
+
+    private fun collectedItemsUnderCaret(file: PsiFile, caretModel: CaretModel): Pair<Set<RsItemElement>, RsMod>? {
+        val elements = caretModel.allCarets.mapNotNull {
+            val offset = it.offset
+            val leafElement = file.findElementAt(offset)
+            val element = if (offset > 0 && leafElement is PsiWhiteSpace) {
+                // Workaround for situation when cursor is after item
+                file.findElementAt(offset - 1)
+            } else {
+                leafElement
+            }
+            element?.ancestorOrSelf<RsItemElement>()
+        }
+        val containingMod = findCommonAncestorStrictOfType<RsMod>(elements) ?: return null
+        val items = elements.mapNotNull { it.getTopmostParentInside(containingMod) as? RsItemElement }
+        if (items.isEmpty()) return null
+        return items.toSet() to containingMod
     }
 
     companion object {
@@ -83,6 +131,16 @@ class RsMoveTopLevelItemsHandler : MoveHandlerDelegate() {
                 && element !is RsExternCrateItem
                 && element !is RsForeignModItem
         }
+    }
+}
+
+/** Mostly needed for case when [elements] contains only one [RsMod] */
+private inline fun <reified T : RsElement> findCommonAncestorStrictOfType(elements: List<PsiElement>): T? {
+    val parent = PsiTreeUtil.findCommonParent(elements) ?: return null
+    return if (elements.contains(parent)) {
+        parent.ancestorStrict()
+    } else {
+        parent.ancestorOrSelf()
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/utils/SearchByOffset.kt
+++ b/src/main/kotlin/org/rust/ide/utils/SearchByOffset.kt
@@ -170,7 +170,7 @@ fun PsiElement.getTopmostParentInside(parent: PsiElement): PsiElement {
     return element
 }
 
-private fun collectElements(start: PsiElement, stop: PsiElement?, pred: (PsiElement) -> Boolean): Array<out PsiElement> {
+fun collectElements(start: PsiElement, stop: PsiElement?, pred: (PsiElement) -> Boolean): Array<out PsiElement> {
     check(stop == null || start.parent == stop.parent)
 
     val psiSeq = generateSequence(start) {

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -976,11 +976,13 @@
             `before kotlin.moveFilesOrDirectories` is needed because otherwise
             incorrect handler can be used: https://youtrack.jetbrains.com/issue/IDEA-237769
         -->
-        <refactoring.moveHandler implementation="org.rust.ide.refactoring.move.RsMoveFilesOrDirectoriesHandler"
+        <refactoring.moveHandler id="rust.moveFilesOrDirectories"
+                                 implementation="org.rust.ide.refactoring.move.RsMoveFilesOrDirectoriesHandler"
                                  order="first, before moveJavaFileOrDir, before kotlin.moveFilesOrDirectories"/>
 
-        <refactoring.moveHandler implementation="org.rust.ide.refactoring.move.RsMoveTopLevelItemsHandler"
-                                 order="first, before moveJavaFileOrDir, before kotlin.moveFilesOrDirectories"/>
+        <refactoring.moveHandler id="rust.moveTopLevelItems"
+                                 implementation="org.rust.ide.refactoring.move.RsMoveTopLevelItemsHandler"
+                                 order="first, before moveJavaFileOrDir, before kotlin.moveFilesOrDirectories, before rust.moveFilesOrDirectories"/>
 
         <console.folding implementation="org.rust.ide.console.RsConsoleFolding"/>
 

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsSelectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsSelectionTest.kt
@@ -1,0 +1,273 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.move
+
+import org.rust.MockEdition
+import org.rust.cargo.project.workspace.CargoWorkspace
+
+@MockEdition(CargoWorkspace.Edition.EDITION_2018)
+class RsMoveTopLevelItemsSelectionTest : RsMoveTopLevelItemsTestBase() {
+
+    fun `test cursor before item`() = doTest("""
+    //- lib.rs
+        /*caret*/fn foo() {}
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+    //- main.rs
+        fn foo() {}
+    """)
+
+    fun `test cursor inside item`() = doTest("""
+    //- lib.rs
+        fn foo/*caret*/() {}
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+    //- main.rs
+        fn foo() {}
+    """)
+
+    fun `test cursor after item`() = doTest("""
+    //- lib.rs
+        fn foo() {}/*caret*/
+        fn bar() {}
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+        fn bar() {}
+    //- main.rs
+        fn foo() {}
+    """)
+
+    fun `test selected start of item`() = doTest("""
+    //- lib.rs
+        <selection>f</selection>n foo() {}
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+    //- main.rs
+        fn foo() {}
+    """)
+
+    fun `test selected middle of item`() = doTest("""
+    //- lib.rs
+        fn <selection>f</selection>oo() {}
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+    //- main.rs
+        fn foo() {}
+    """)
+
+    fun `test selected end of item`() = doTest("""
+    //- lib.rs
+        fn foo() {<selection>}</selection>
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+    //- main.rs
+        fn foo() {}
+    """)
+
+    fun `test selected two items`() = doTest("""
+    //- lib.rs
+        fn foo1() {}
+        <selection>fn foo2() {}
+        fn foo3() {}</selection>
+        fn foo4() {}
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+        fn foo1() {}
+
+        fn foo4() {}
+    //- main.rs
+        fn foo2() {}
+
+        fn foo3() {}
+    """)
+
+    fun `test selected two items at end of file`() = doTest("""
+    //- lib.rs
+        fn foo1() {}
+        <selection>fn foo2() {}
+        fn foo3() {}</selection>
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+        fn foo1() {}
+    //- main.rs
+        fn foo2() {}
+
+        fn foo3() {}
+    """)
+
+    fun `test selected two items partially`() = doTest("""
+    //- lib.rs
+        fn foo1() {}
+        fn foo2<selection>() {}
+        fn foo3()</selection> {}
+        fn foo4() {}
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+        fn foo1() {}
+
+        fn foo4() {}
+    //- main.rs
+        fn foo2() {}
+
+        fn foo3() {}
+    """)
+
+    fun `test selected two items with surrounding whitespace`() = doTest("""
+    //- lib.rs
+        <selection>
+        fn foo1() {}
+        fn foo2() {}
+        </selection>
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+    //- main.rs
+        fn foo1() {}
+
+        fn foo2() {}
+    """)
+
+    fun `test selected two items with file attribute`() = doTest("""
+    //- lib.rs
+        <selection>#![attr]
+        fn foo1() {}
+        fn foo2() {}</selection>
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+        #![attr]
+    //- main.rs
+        fn foo1() {}
+
+        fn foo2() {}
+    """)
+
+    fun `test selected two items inside inline mod 1`() = doTest("""
+    //- lib.rs
+        mod mod1 {
+            <selection>fn foo1() {}
+            fn foo2() {}</selection>
+        }
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+        mod mod1 {}
+    //- main.rs
+        fn foo1() {}
+
+        fn foo2() {}
+    """)
+
+    fun `test selected two items inside inline mod 2`() = doTest("""
+    //- lib.rs
+        mod mod1 {
+            fn foo1() {}
+            <selection>fn foo2() {}
+            fn foo3() {}</selection>
+            fn foo4() {}
+        }
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+        mod mod1 {
+            fn foo1() {}
+
+            fn foo4() {}
+        }
+    //- main.rs
+        fn foo2() {}
+
+        fn foo3() {}
+    """)
+
+    fun `test selected three items`() = doTest("""
+    //- lib.rs
+        fn foo1() {}
+        <selection>fn foo2() {}
+        fn foo3() {}
+        fn foo4() {}</selection>
+        fn foo5() {}
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+        fn foo1() {}
+
+        fn foo5() {}
+    //- main.rs
+        fn foo2() {}
+
+        fn foo3() {}
+
+        fn foo4() {}
+    """)
+
+    fun `test selected three items partially`() = doTest("""
+    //- lib.rs
+        fn foo1() {}
+        fn foo2<selection>() {}
+        fn foo3() {}
+        fn foo4()</selection> {}
+        fn foo5() {}
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+        fn foo1() {}
+
+        fn foo5() {}
+    //- main.rs
+        fn foo2() {}
+
+        fn foo3() {}
+
+        fn foo4() {}
+    """)
+
+    fun `test selected empty inline mod`() = doTest("""
+    //- lib.rs
+        <selection>mod foo {}</selection>
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+    //- main.rs
+        mod foo {}
+    """)
+
+    fun `test selected non-empty inline mod`() = doTest("""
+    //- lib.rs
+        <selection>mod foo { fn func() {} }</selection>
+    //- main.rs
+        /*target*/
+    """, """
+    //- lib.rs
+    //- main.rs
+        mod foo { fn func() {} }
+    """)
+}


### PR DESCRIPTION
Use selected in the editor items as initial items to move.

Also we now always use Move Items when refactoring is performed from editor (previously we used Move File if refactoring is performed from editor and cursor is at empty line). Most other languages has same behaviour (Kotlin, C++, JavaScript).