### PR TITLE
CI: release beta and stable toml builds from GitHub workflow

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -21,4 +21,4 @@ jobs:
                   git config --local user.name "GitHub Action"
 
             - name: Make release branch
-              run: python scripts/make_release_branch.py --token ${{ secrets.GITHUB_TOKEN }}
+              run: python scripts/make_release_branch.py --token ${{ secrets.WORKFLOW_GITHUB_TOKEN }}

--- a/.github/workflows/rust-nightly.yml
+++ b/.github/workflows/rust-nightly.yml
@@ -106,5 +106,5 @@ jobs:
 
             - name: Save commits
               run: |
-                  python scripts/save_tag.py --token ${{ secrets.GITHUB_TOKEN }} --tag rust-nightly --commit ${{ needs.fetch-latest-changes.outputs.rust-commit }}
-                  python scripts/save_tag.py --token ${{ secrets.GITHUB_TOKEN }} --tag toml-nightly --commit ${{ needs.fetch-latest-changes.outputs.toml-commit }}
+                  python scripts/save_tag.py --token ${{ secrets.WORKFLOW_GITHUB_TOKEN }} --tag rust-nightly --commit ${{ needs.fetch-latest-changes.outputs.rust-commit }}
+                  python scripts/save_tag.py --token ${{ secrets.WORKFLOW_GITHUB_TOKEN }} --tag toml-nightly --commit ${{ needs.fetch-latest-changes.outputs.toml-commit }}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -57,7 +57,7 @@ jobs:
 
             - name: Update changelog link
               if: github.event_name == 'repository_dispatch' && github.event.action == 'stable-release' && github.event.client_payload.update_changelog
-              run: python scripts/update-changelog-link.py --token ${{ secrets.GITHUB_TOKEN }}
+              run: python scripts/update-changelog-link.py --token ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
 
     get-channel:
         runs-on: ubuntu-latest
@@ -164,5 +164,5 @@ jobs:
 
             - name: Save commits
               run: |
-                  python scripts/save_tag.py --token ${{ secrets.GITHUB_TOKEN }} --tag rust-${{ needs.get-channel.outputs.channel }} --commit ${{ needs.fetch-latest-changes.outputs.rust-commit }}
-                  python scripts/save_tag.py --token ${{ secrets.GITHUB_TOKEN }} --tag toml-${{ needs.get-channel.outputs.channel }} --commit ${{ needs.fetch-latest-changes.outputs.toml-commit }}
+                  python scripts/save_tag.py --token ${{ secrets.WORKFLOW_GITHUB_TOKEN }} --tag rust-${{ needs.get-channel.outputs.channel }} --commit ${{ needs.fetch-latest-changes.outputs.rust-commit }}
+                  python scripts/save_tag.py --token ${{ secrets.WORKFLOW_GITHUB_TOKEN }} --tag toml-${{ needs.get-channel.outputs.channel }} --commit ${{ needs.fetch-latest-changes.outputs.toml-commit }}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -73,8 +73,43 @@ jobs:
                   echo "::set-output name=channel::beta"
                 fi
 
+    fetch-latest-changes:
+        runs-on: ubuntu-latest
+        needs: [ get-release-branch, update-changelog-link, get-channel ]
+        outputs:
+            rust-commit: ${{ steps.fetch-commits.outputs.rust-commit }}
+            rust-release: ${{ steps.fetch-commits.outputs.rust-release }}
+            toml-commit: ${{ steps.fetch-commits.outputs.toml-commit }}
+            toml-release: ${{ steps.fetch-commits.outputs.toml-release }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  ref: ${{ needs.get-release-branch.outputs.release-branch }}
+                  fetch-depth: 0
+
+            - name: Set up Python
+              uses: actions/setup-python@v1
+              with:
+                  python-version: 3.7
+
+            - name: Fetch latest commits
+              id: fetch-commits
+              run: |
+                  echo "::set-output name=rust-commit::$(git log -n 1 --format=format:%H)"
+                  echo "::set-output name=rust-release::$(python scripts/get_tag_commit.py --tag "rust-${{ needs.get-channel.outputs.channel }}")"
+                  echo "::set-output name=toml-commit::$(git log -n 1 --format=format:%H intellij-toml *gradle*)"
+                  echo "::set-output name=toml-release::$(python scripts/get_tag_commit.py --tag "toml-${{ needs.get-channel.outputs.channel }}")"
+
+            - name: Show commits
+              run: |
+                  echo "rust-commit: ${{ steps.fetch-commits.outputs.rust-commit }}"
+                  echo "rust-release: ${{ steps.fetch-commits.outputs.rust-release }}"
+                  echo "toml-commit: ${{ steps.fetch-commits.outputs.toml-commit }}"
+                  echo "toml-release: ${{ steps.fetch-commits.outputs.toml-release }}"
+
     build:
-        needs: [ generate-build-number, get-release-branch, update-changelog-link, get-channel ]
+        needs: [ generate-build-number, get-release-branch, update-changelog-link, get-channel, fetch-latest-changes ]
         runs-on: ubuntu-latest
         strategy:
             fail-fast: true
@@ -102,11 +137,32 @@ jobs:
                   echo "::set-env name=ORG_GRADLE_PROJECT_publishToken::${{ secrets.plugin_bot_token }}"
 
             - name: Publish rust plugin
+              if: needs.fetch-latest-changes.outputs.rust-commit != needs.fetch-latest-changes.outputs.rust-release
               uses: eskatos/gradle-command-action@v1
               with:
                   arguments: :plugin:publishPlugin
 
             - name: Publish toml plugin
+              if: needs.fetch-latest-changes.outputs.toml-commit != needs.fetch-latest-changes.outputs.toml-release
               uses: eskatos/gradle-command-action@v1
               with:
                   arguments: :intellij-toml:publishPlugin
+
+    save-commit:
+        needs: [ get-channel, fetch-latest-changes, build ]
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
+            - name: Set up Python
+              uses: actions/setup-python@v1
+              with:
+                  python-version: 3.7
+
+            - name: Save commits
+              run: |
+                  python scripts/save_tag.py --token ${{ secrets.GITHUB_TOKEN }} --tag rust-${{ needs.get-channel.outputs.channel }} --commit ${{ needs.fetch-latest-changes.outputs.rust-commit }}
+                  python scripts/save_tag.py --token ${{ secrets.GITHUB_TOKEN }} --tag toml-${{ needs.get-channel.outputs.channel }} --commit ${{ needs.fetch-latest-changes.outputs.toml-commit }}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -91,12 +91,22 @@ jobs:
               with:
                   java-version: 1.8
 
-            - name: Build & publish
-              env:
-                  CI: true
-                  ORG_GRADLE_PROJECT_buildNumber: ${{ needs.generate-build-number.outputs.build_number }}
-                  ORG_GRADLE_PROJECT_platformVersion: ${{ matrix.platform-version }}
-                  ORG_GRADLE_PROJECT_enableBuildSearchableOptions: true
-                  ORG_GRADLE_PROJECT_publishChannel: ${{ needs.get-channel.outputs.channel }}
-                  ORG_GRADLE_PROJECT_publishToken: ${{ secrets.plugin_bot_token }}
-              run: ./gradlew :plugin:buildPlugin :plugin:publishPlugin
+            - name: Set up env variables
+                # see https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+              run: |
+                  echo "::set-env name=CI::true"
+                  echo "::set-env name=ORG_GRADLE_PROJECT_buildNumber::${{ needs.generate-build-number.outputs.build_number }}"
+                  echo "::set-env name=ORG_GRADLE_PROJECT_platformVersion::${{ matrix.platform-version }}"
+                  echo "::set-env name=ORG_GRADLE_PROJECT_enableBuildSearchableOptions::true"
+                  echo "::set-env name=ORG_GRADLE_PROJECT_publishChannel::${{ needs.get-channel.outputs.channel }}"
+                  echo "::set-env name=ORG_GRADLE_PROJECT_publishToken::${{ secrets.plugin_bot_token }}"
+
+            - name: Publish rust plugin
+              uses: eskatos/gradle-command-action@v1
+              with:
+                  arguments: :plugin:publishPlugin
+
+            - name: Publish toml plugin
+              uses: eskatos/gradle-command-action@v1
+              with:
+                  arguments: :intellij-toml:publishPlugin


### PR DESCRIPTION
Did the same thing as I implemented in #5649 but for beta and stable builds

Also, fix the case when the latest meaningful commit modifies github workflow. Previously, it leads to fail of `save-commit` job because token generated for github workflow run by default doesn't have permissions to modify workflow files (including creation of tag for existent commit with workflow modification).
To avoid errors in such cases, our script should use custom github token with the corresponding (workflow) permissions