### PR TITLE
QDOC: fix some corner cases in doc rendered

### DIFF
--- a/src/main/kotlin/org/rust/lang/doc/RsDocPipeline.kt
+++ b/src/main/kotlin/org/rust/lang/doc/RsDocPipeline.kt
@@ -141,7 +141,7 @@ private class RsCodeFenceProvider(private val context: PsiElement) : GeneratingP
         var skipNextEOL = false
         var lastChildWasContent = false
 
-        loop@for (child in childrenToConsider) {
+        loop@ for (child in childrenToConsider) {
             if (isContentStarted && child.type in listOf(MarkdownTokenTypes.CODE_FENCE_CONTENT, MarkdownTokenTypes.EOL)) {
                 if (skipNextEOL && child.type == MarkdownTokenTypes.EOL) {
                     skipNextEOL = false
@@ -152,12 +152,14 @@ private class RsCodeFenceProvider(private val context: PsiElement) : GeneratingP
                 //   * `# ` prefix is used to mark lines that should be skipped in rendered documentation.
                 //   * `##` prefix is converted to `#`
                 // See https://github.com/rust-lang/rust/blob/5182cc1ca65d05f16ee5e1529707ac6f63233ca9/src/librustdoc/html/markdown.rs#L114 for more details
+                val trimmedLine = rawLine.trimStart()
                 val codeLine = when {
-                    rawLine.startsWith("# ") -> {
+                    // `#` or `# `
+                    trimmedLine.startsWith("#") && trimmedLine.getOrNull(1)?.equals(' ') != false -> {
                         skipNextEOL = true
                         continue@loop
                     }
-                    rawLine.startsWith("##") -> rawLine.removePrefix("#")
+                    trimmedLine.startsWith("##") -> trimmedLine.removePrefix("#")
                     else -> rawLine
                 }
 

--- a/src/test/kotlin/org/rust/ide/docs/RsCodeHighlightingInQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsCodeHighlightingInQuickDocumentationTest.kt
@@ -109,8 +109,13 @@ class RsCodeHighlightingInQuickDocumentationTest : RsDocumentationProviderTest()
         /// ```
         /// #[attr1]
         /// ##[attr2]
+        ///    ##[attr3]
+        /// #
+        ///   #
         /// let foo = Foo;
         /// # let foo2 = Foo;
+        ///    # let foo3 = Foo;
+        ///    let foo4 = Foo;
         /// ```
         struct Foo;
               //^
@@ -119,7 +124,9 @@ class RsCodeHighlightingInQuickDocumentationTest : RsDocumentationProviderTest()
         struct <b>Foo</b></pre></div>
         <div class='content'><p>Some doc.</p><h2>Example</h2><pre>#[attr1]
         #[attr2]
+        #[attr3]
         <span style="...">let </span>foo = Foo;
+           <span style="...">let </span>foo4 = Foo;
         </pre>
         </div>
     """)


### PR DESCRIPTION
* properly handle single `#` lines
* don't take into account spaces before `#`

Fixes #5631