### PR TITLE
Fix cyclic stdlib dependencies

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -193,7 +193,7 @@ private class WorkspaceImpl(
         // so we have to rebuild the whole workspace from scratch instead of
         // *just* adding in the stdlib.
 
-        val stdAll = stdlib.crates.map { it.id }.toSet()
+        val stdAll = stdlib.crates.associateBy { it.id }
         val stdGated = stdlib.crates.filter { it.type == StdLibType.FEATURE_GATED }.map { it.id }.toSet()
         val stdRoots = stdlib.crates.filter { it.type == StdLibType.ROOT }.map { it.id }.toSet()
 
@@ -209,7 +209,8 @@ private class WorkspaceImpl(
             val newIdToPackage = result.packages.associateBy { it.id }
             val stdlibDependencies = result.packages.filter { it.origin == PackageOrigin.STDLIB }.map { DependencyImpl(it) }
             newIdToPackage.forEach { (id, pkg) ->
-                if (id !in stdAll) {
+                val stdCrate = stdAll[id]
+                if (stdCrate == null) {
                     pkg.dependencies.addAll(oldIdToPackage[id]?.dependencies.orEmpty().mapNotNull { (pkg, name) ->
                         val dependencyPackage = newIdToPackage[pkg.id] ?: return@mapNotNull null
                         DependencyImpl(dependencyPackage, name)
@@ -218,7 +219,11 @@ private class WorkspaceImpl(
                     val explicitDeps = pkg.dependencies.map { it.pkg.id }.toSet()
                     pkg.dependencies.addAll(stdlibDependencies.filter { it.pkg.id in stdGated && it.pkg.id !in explicitDeps })
                 } else {
-                    pkg.dependencies.addAll(stdlibDependencies)
+                    // `pkg` is a crate from stdlib
+                    val stdCrateDeps = stdCrate.dependencies.mapNotNull { stdDep ->
+                        stdlibDependencies.find { it.name == stdDep }
+                    }
+                    pkg.dependencies.addAll(stdCrateDeps)
                 }
             }
         }

--- a/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
@@ -30,7 +30,7 @@ enum class StdLibType {
 data class StdLibInfo (
     val name: String,
     val type: StdLibType,
-    val srcDir: String = "lib" + name,
+    val srcDir: String = "lib$name",
     val dependencies: List<String> = emptyList()
 )
 
@@ -39,35 +39,25 @@ object AutoInjectedCrates {
     const val CORE: String = "core"
     val stdlibCrates = listOf(
         // Roots
-        StdLibInfo(STD, StdLibType.ROOT, dependencies = listOf("alloc_jemalloc", "alloc_system", "panic_abort", "rand",
-            "compiler_builtins", "unwind", "rustc_asan", "rustc_lsan", "rustc_msan", "rustc_tsan",
-            "build_helper")),
         StdLibInfo(CORE, StdLibType.ROOT),
-        StdLibInfo("alloc", StdLibType.ROOT),
-        StdLibInfo("collections", StdLibType.ROOT),
-        StdLibInfo("libc", StdLibType.ROOT, srcDir = "liblibc/src"),
-        StdLibInfo("panic_unwind", type = StdLibType.ROOT),
-        StdLibInfo("proc_macro", type = StdLibType.ROOT),
-        StdLibInfo("rustc_unicode", type = StdLibType.ROOT),
-        StdLibInfo("std_unicode", type = StdLibType.ROOT),
-        StdLibInfo("test", dependencies = listOf("getopts", "term"), type = StdLibType.ROOT),
+        StdLibInfo(STD, StdLibType.ROOT, dependencies = listOf("alloc", "panic_unwind", "panic_abort",
+            CORE, "libc", "compiler_builtins", "profiler_builtins", "unwind", "build_helper")),
+        StdLibInfo("alloc", StdLibType.ROOT, dependencies = listOf(CORE, "compiler_builtins")),
+        StdLibInfo("proc_macro", type = StdLibType.ROOT, dependencies = listOf(STD, "syntax")),
+        StdLibInfo("test", type = StdLibType.ROOT, dependencies = listOf(STD, CORE, "libc", "getopts", "term")),
         // Feature gated
-        StdLibInfo("alloc_jemalloc", StdLibType.FEATURE_GATED),
-        StdLibInfo("alloc_system", StdLibType.FEATURE_GATED),
-        StdLibInfo("compiler_builtins", StdLibType.FEATURE_GATED),
-        StdLibInfo("getopts", StdLibType.FEATURE_GATED),
-        StdLibInfo("panic_unwind", StdLibType.FEATURE_GATED),
-        StdLibInfo("panic_abort", StdLibType.FEATURE_GATED),
-        StdLibInfo("rand", StdLibType.FEATURE_GATED),
-        StdLibInfo("term", StdLibType.FEATURE_GATED),
-        StdLibInfo("unwind", StdLibType.FEATURE_GATED),
+        StdLibInfo("libc", StdLibType.FEATURE_GATED, srcDir = "liblibc/src"),
+        StdLibInfo("panic_unwind", type = StdLibType.FEATURE_GATED, dependencies = listOf(CORE, "libc", "alloc",
+            "unwind", "compiler_builtins")),
+        StdLibInfo("compiler_builtins", StdLibType.FEATURE_GATED, dependencies = listOf(CORE)),
+        StdLibInfo("profiler_builtins", StdLibType.FEATURE_GATED, dependencies = listOf(CORE, "compiler_builtins")),
+        StdLibInfo("panic_abort", StdLibType.FEATURE_GATED, dependencies = listOf(CORE, "libc", "compiler_builtins")),
+        StdLibInfo("unwind", StdLibType.FEATURE_GATED, dependencies = listOf(CORE, "libc", "compiler_builtins")),
+        StdLibInfo("term", StdLibType.FEATURE_GATED, dependencies = listOf(STD, CORE)),
+        StdLibInfo("getopts", StdLibType.FEATURE_GATED, dependencies = listOf(STD, CORE)),
         // Dependencies
         StdLibInfo("build_helper", StdLibType.DEPENDENCY, srcDir = "build_helper"),
-        StdLibInfo("rustc_asan", StdLibType.DEPENDENCY),
-        StdLibInfo("rustc_lsan", StdLibType.DEPENDENCY),
-        StdLibInfo("rustc_msan", StdLibType.DEPENDENCY),
-        StdLibInfo("rustc_tsan", StdLibType.DEPENDENCY),
-        StdLibInfo("syntax", StdLibType.DEPENDENCY)
+        StdLibInfo("syntax", StdLibType.DEPENDENCY, dependencies = listOf(STD, CORE))
     )
 }
 


### PR DESCRIPTION
Previously we had cyclic dependencies between stdlib crates like `std -> core -> std -> core`.

This was a bug in our internal project model. Looks like it was not affected our users anyhow.

I fix it because stdlib dependencies stop us from doing topological sort of crates that in turn is needed for the new name resolution engine.

Also, I removed ancient stdlib parts.
