### PR TITLE
Parse `DepKind` from `cargo metadata`

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
@@ -46,6 +46,7 @@ data class CargoWorkspaceData(
 
     data class Dependency(
         val id: PackageId,
-        val name: String? = null
+        val name: String? = null,
+        val depKinds: List<CargoWorkspace.DepKindInfo> = listOf(CargoWorkspace.DepKindInfo(CargoWorkspace.DepKind.Normal))
     )
 }


### PR DESCRIPTION
`DepKind` is needed to distinguish `[dependencies]`, `[dev-dependencies]` (for tests) and `[build-dependencies]` (for `build.rs`)