### PR TITLE
Fix `AnnotationHolderImpl` not running in context

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
@@ -201,7 +201,9 @@ class RsExternalLinterInspection : GlobalSimpleInspectionTool() {
             for (file in analyzedFiles) {
                 if (!file.isValid) continue
                 val annotationHolder = AnnotationHolderImpl(AnnotationSession(file))
-                annotationHolder.createAnnotationsForFile(file, annotationResult)
+                annotationHolder.runAnnotatorWithContext(file) { _, holder ->
+                    holder.createAnnotationsForFile(file, annotationResult)
+                }
                 addAll(convertToProblemDescriptors(annotationHolder, file))
             }
         }


### PR DESCRIPTION
Fixed #5682

Bug introduced by https://github.com/intellij-rust/intellij-rust/pull/5506/commits/c24e3fb404811087cec9c308e2375df1cfc32928