### PR TITLE
CARGO: Fix finding location of evcxr and grcov on arch linux

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapiext.isUnitTestMode
+import com.intellij.util.io.exists
 import com.intellij.util.text.SemVer
 import org.rust.openapiext.*
 import java.io.File
@@ -76,21 +77,38 @@ data class RustToolchain(val location: Path) {
 
     fun rustfmt(): Rustfmt = Rustfmt(pathToExecutable(RUSTFMT))
 
-    fun grcov(): Grcov? = if (hasExecutable(GRCOV)) Grcov(pathToExecutable(GRCOV)) else null
+    fun grcov(): Grcov? = if (hasCargoExecutable(GRCOV)) Grcov(pathToCargoExecutable(GRCOV)) else null
 
-    fun evcxr(): Evcxr? = if (hasExecutable(EVCXR)) Evcxr(pathToExecutable(EVCXR)) else null
+    fun evcxr(): Evcxr? = if (hasCargoExecutable(EVCXR)) Evcxr(pathToCargoExecutable(EVCXR)) else null
 
     val isRustupAvailable: Boolean get() = hasExecutable(RUSTUP)
 
     val presentableLocation: String = pathToExecutable(CARGO).toString()
 
+    // for executables from toolchain
     private fun pathToExecutable(toolName: String): Path {
         val exeName = if (SystemInfo.isWindows) "$toolName.exe" else toolName
         return location.resolve(exeName).toAbsolutePath()
     }
 
+    // for executables installed using `cargo install`
+    private fun pathToCargoExecutable(toolName: String): Path {
+        // Binaries installed by `cargo install` (e.g. Grcov, Evcxr) are placed in ~/.cargo/bin by default:
+        // https://doc.rust-lang.org/cargo/commands/cargo-install.html
+        // But toolchain root may be different (e.g. on Arch Linux it is usually /usr/bin)
+        val path = pathToExecutable(toolName)
+        if (path.exists()) return path
+
+        val exeName = if (SystemInfo.isWindows) "$toolName.exe" else toolName
+        val cargoBinPath = File(FileUtil.expandUserHome("~/.cargo/bin")).toPath()
+        return cargoBinPath.resolve(exeName).toAbsolutePath()
+    }
+
     private fun hasExecutable(exec: String): Boolean =
         Files.isExecutable(pathToExecutable(exec))
+
+    private fun hasCargoExecutable(exec: String): Boolean =
+        Files.isExecutable(pathToCargoExecutable(exec))
 
     data class VersionInfo(
         val rustc: RustcVersion?


### PR DESCRIPTION
Some Arch Linux users [install `rustup` from repositories](https://wiki.archlinux.org/index.php/rust#Arch_Linux_package) (instead of `curl sh.rustup.rs`). In that case toolchain location is `/usr/bin`, but binaries installed by `cargo install` will be in `~/.cargo/bin`. So we have to manually check `~/.cargo/bin` when searching for `evcxr` or `grcov` binaries

Fixes #5316