### PR TITLE
Introduce `Crate`, `CrateGraphService`

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -373,6 +373,7 @@ data class CargoProjectImpl(
         if (doesProjectLooksLikeRustc()) {
             // rust-lang/rust contains stdlib inside the project
             val std = StandardLibrary.fromPath(manifest.parent.toString())
+                ?.asPartOfCargoProject()
             if (std != null) {
                 return CompletableFuture.completedFuture(withStdlib(TaskResult.Ok(std)))
             }
@@ -395,7 +396,7 @@ data class CargoProjectImpl(
 
     // Checks that the project is https://github.com/rust-lang/rust
     private fun doesProjectLooksLikeRustc(): Boolean {
-        val workspace = workspace ?: return false
+        val workspace = rawWorkspace ?: return false
         // "rustc" package was renamed to "rustc_middle" in https://github.com/rust-lang/rust/pull/70536
         // so starting with rustc 1.42 a stable way to identify it is to try to find any of some possible packages
         val possiblePackages = listOf("rustc", "rustc_middle", "rustc_typeck")

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
@@ -47,6 +47,6 @@ data class CargoWorkspaceData(
     data class Dependency(
         val id: PackageId,
         val name: String? = null,
-        val depKinds: List<CargoWorkspace.DepKindInfo> = listOf(CargoWorkspace.DepKindInfo(CargoWorkspace.DepKind.Normal))
+        val depKinds: List<CargoWorkspace.DepKindInfo> = listOf(CargoWorkspace.DepKindInfo(CargoWorkspace.DepKind.Unclassified))
     )
 }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt
@@ -115,7 +115,7 @@ private fun CargoWorkspace.Package.toCargoLibrary(): CargoLibrary? {
     val excludedRoots = mutableSetOf<VirtualFile>()
     for (target in targets) {
         val crateRoot = target.crateRoot ?: continue
-        if (target.isLib) {
+        if (target.kind.isLib) {
             val crateRootDir = crateRoot.parent
             val commonAncestor = VfsUtilCore.getCommonAncestor(root, crateRootDir)
             when (commonAncestor) {

--- a/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
@@ -11,7 +11,8 @@ import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.cargo.util.StdLibType
 
 class StandardLibrary private constructor(
-    val crates: List<StdCrate>
+    val crates: List<StdCrate>,
+    val isPartOfCargoProject: Boolean = false
 ) {
 
     data class StdCrate(
@@ -19,10 +20,10 @@ class StandardLibrary private constructor(
         val type: StdLibType,
         val crateRootUrl: String,
         val packageRootUrl: String,
-        val dependencies: Collection<String>
-    ) {
-        val id: PackageId get() = "(stdlib) $name"
-    }
+        val dependencies: Collection<String>,
+        val id: PackageId = "(stdlib) $name"
+    )
+    fun asPartOfCargoProject(): StandardLibrary = StandardLibrary(crates, true)
 
     companion object {
         fun fromPath(path: String): StandardLibrary? =

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoExecutableRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoExecutableRunConfigurationProducer.kt
@@ -68,7 +68,7 @@ class CargoExecutableRunConfigurationProducer : CargoRunConfigurationProducer() 
 
         private fun findBinaryTarget(ws: CargoWorkspace, file: VirtualFile): ExecutableTarget? {
             val target = ws.findTargetByCrateRoot(file) ?: return null
-            if (!target.isBin && !target.isExampleBin) return null
+            if (!target.kind.isBin && !target.kind.isExampleBin) return null
             return ExecutableTarget(target)
         }
     }

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -326,7 +326,7 @@ object CargoMetadata {
                 val dependencySet = if (deps != null) {
                     deps.mapToSet { (pkgId, name, depKinds) ->
                         val depKindsLowered = depKinds?.map { it.clean() }
-                            ?: listOf(CargoWorkspace.DepKindInfo(CargoWorkspace.DepKind.Normal))
+                            ?: listOf(CargoWorkspace.DepKindInfo(CargoWorkspace.DepKind.Unclassified))
                         CargoWorkspaceData.Dependency(pkgId, name, depKindsLowered)
                     }
                 } else {

--- a/src/main/kotlin/org/rust/ide/annotator/RsDoctestAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsDoctestAnnotator.kt
@@ -13,12 +13,11 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.tree.injected.InjectionBackgroundSuppressor
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.ide.injected.RsDoctestLanguageInjector
-import org.rust.ide.injected.areDoctestsEnabled
 import org.rust.ide.injected.findDoctestInjectableRanges
 import org.rust.lang.core.psi.RsDocCommentImpl
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.ancestorStrict
-import org.rust.lang.core.psi.ext.containingCargoTarget
+import org.rust.lang.core.psi.ext.containingCrate
 
 /**
  * Adds missing background for injections from [RsDoctestLanguageInjector].
@@ -32,7 +31,7 @@ class RsDoctestAnnotator : AnnotatorBase() {
         if (element !is RsDocCommentImpl) return
         if (!element.project.rustSettings.doctestInjectionEnabled) return
         // only library targets can have doctests
-        if (element.ancestorStrict<RsElement>()?.containingCargoTarget?.areDoctestsEnabled != true) return
+        if (element.ancestorStrict<RsElement>()?.containingCrate?.areDoctestsEnabled != true) return
 
         val startOffset = element.startOffset
         findDoctestInjectableRanges(element).flatten().forEach {

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -359,7 +359,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
 
     private fun checkUnstableAttribute(ref: RsReferenceElement, holder: RsAnnotationHolder) {
         val startElement = ref.referenceNameElement?.takeIf { it.elementType == IDENTIFIER } ?: return
-        if (ref.containingCargoPackage?.origin == PackageOrigin.STDLIB) return
+        if (ref.containingCrate?.origin == PackageOrigin.STDLIB) return
         val element = ref.reference?.resolve() as? RsOuterAttributeOwner ?: return
         for (attr in element.queryAttributes.unstableAttributes) {
             val metaItems = attr.metaItemArgs?.metaItemList ?: continue
@@ -882,7 +882,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     }
 
     private fun checkExternCrate(holder: RsAnnotationHolder, el: RsExternCrateItem) {
-        if (el.reference.multiResolve().isEmpty() && el.containingCargoPackage?.origin == PackageOrigin.WORKSPACE) {
+        if (el.reference.multiResolve().isEmpty() && el.containingCrate?.origin == PackageOrigin.WORKSPACE) {
             if (!el.isEnabledByCfg) return
             RsDiagnostic.CrateNotFoundError(el, el.referenceName).addToHolder(holder)
         }

--- a/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
@@ -39,7 +39,7 @@ class RsFormatMacroAnnotator : AnnotatorBase() {
         val macroPos = macroToFormatPos(formatMacro.macroName) ?: return
         val macroArgs = formatMacro.formatMacroArgument?.formatMacroArgList ?: return
         val macro = formatMacro.path.reference?.resolve() as? RsMacro ?: return
-        if (macro.containingCargoPackage?.origin != PackageOrigin.STDLIB) return
+        if (macro.containingCrate?.origin != PackageOrigin.STDLIB) return
 
         val formatStr = macroArgs
             .getOrNull(macroPos)

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
@@ -78,7 +78,7 @@ class ChangeReturnTypeFix(element: RsElement, private val actualTy: Ty) : LocalQ
             PsiTreeUtil.getContextOfType(element, true, RsFunction::class.java, RsLambdaExpr::class.java)
 
         fun createIfCompatible(element: RsElement, actualTy: Ty): ChangeReturnTypeFix? {
-            if (element.containingCargoPackage?.origin != PackageOrigin.WORKSPACE) return null
+            if (element.containingCrate?.origin != PackageOrigin.WORKSPACE) return null
 
             val owner = findCallableOwner(element)
             val isOverriddenFn = owner is RsFunction && owner.superItem != null

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/MakePublicFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/MakePublicFix.kt
@@ -12,11 +12,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.RsNameIdentifierOwner
-import org.rust.lang.core.psi.ext.RsVisibility
-import org.rust.lang.core.psi.ext.RsVisible
-import org.rust.lang.core.psi.ext.containingCargoPackage
-import org.rust.lang.core.psi.ext.getPrevNonCommentSibling
+import org.rust.lang.core.psi.ext.*
 
 class MakePublicFix(
     element: RsVisible,
@@ -80,7 +76,7 @@ class MakePublicFix(
                 visible.visibility is RsVisibility.Private
                     && visible !is RsEnumVariant
                     && visible.parent.parent !is RsTraitItem
-                    && visible.containingCargoPackage?.origin == PackageOrigin.WORKSPACE
+                    && visible.containingCrate?.origin == PackageOrigin.WORKSPACE
                 -> MakePublicFix(visible, elementName, withinOneCrate)
                 else -> null
             }

--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -143,7 +143,7 @@ abstract class RsDocumentationProviderBase : AbstractDocumentationProvider() {
             if (element !is RsDocAndAttributeOwner ||
                 element !is RsQualifiedNamedElement ||
                 !element.hasExternalDocumentation) return emptyList()
-            val origin = element.containingCargoPackage?.origin
+            val origin = element.containingCrate?.origin
             RsQualifiedName.from(element) to origin
         }
 

--- a/src/main/kotlin/org/rust/ide/icons/RsIconProvider.kt
+++ b/src/main/kotlin/org/rust/ide/icons/RsIconProvider.kt
@@ -7,11 +7,10 @@ package org.rust.ide.icons
 
 import com.intellij.ide.IconProvider
 import com.intellij.psi.PsiElement
-import org.rust.cargo.CargoConstants
 import org.rust.cargo.icons.CargoIcons
+import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.lang.RsConstants
 import org.rust.lang.core.psi.RsFile
-import org.rust.lang.core.psi.ext.containingCargoPackage
 import javax.swing.Icon
 
 class RsIconProvider : IconProvider() {
@@ -31,7 +30,6 @@ class RsIconProvider : IconProvider() {
         (element.name == RsConstants.MAIN_RS_FILE || element.name == RsConstants.LIB_RS_FILE)
             && element.isCrateRoot
 
-    private fun isBuildRs(element: RsFile): Boolean =
-        element.name == CargoConstants.BUILD_RS_FILE
-            && element.containingCargoPackage?.contentRoot == element.containingDirectory?.virtualFile
+    private fun isBuildRs(element: RsFile): Boolean = // TODO containingTarget
+        element.isCrateRoot && element.crate?.kind == CargoWorkspace.TargetKind.CustomBuild
 }

--- a/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
@@ -37,7 +37,7 @@ import org.rust.ide.annotator.createAnnotationsForFile
 import org.rust.ide.annotator.createDisposableOnAnyPsiChange
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.ext.ancestorOrSelf
-import org.rust.lang.core.psi.ext.containingCargoPackage
+import org.rust.lang.core.psi.ext.containingCrate
 import org.rust.stdext.buildList
 import java.util.*
 
@@ -58,7 +58,7 @@ class RsExternalLinterInspection : GlobalSimpleInspectionTool() {
         globalContext: GlobalInspectionContext,
         problemDescriptionsProcessor: ProblemDescriptionsProcessor
     ) {
-        if (file !is RsFile || file.containingCargoPackage?.origin != PackageOrigin.WORKSPACE) return
+        if (file !is RsFile || file.containingCrate?.origin != PackageOrigin.WORKSPACE) return
         val analyzedFiles = globalContext.getUserData(ANALYZED_FILES) ?: return
         analyzedFiles.add(file)
     }

--- a/src/main/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspection.kt
@@ -25,13 +25,13 @@ class RsMainFunctionNotFoundInspection : RsLocalInspectionTool() {
                 if (file is RsFile) {
                     if (file.childOfType<PsiErrorElement>() != null) return
 
-                    val target = file.cargoTarget ?: return
-                    val crateName = if ((target.isBin || target.isExampleBin) && file.isCrateRoot) target.name else return
+                    val crate = file.crate ?: return
+                    if (!(crate.kind.isBin || crate.kind.isExampleBin) || !file.isCrateRoot) return
 
                     if (file.queryAttributes.hasAttribute("no_main")) return
                     if (file.childrenOfType<RsFunction>().lastOrNull { fn -> "main" == fn.name } != null) return
 
-                    RsDiagnostic.MainFunctionNotFound(file, crateName).addToHolder(holder)
+                    RsDiagnostic.MainFunctionNotFound(file, crate.presentableName).addToHolder(holder)
                 }
             }
         }

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/DeriveCopyFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/DeriveCopyFix.kt
@@ -63,7 +63,7 @@ class DeriveCopyFix(element: RsElement) : LocalQuickFixAndIntentionActionOnPsiEl
         fun createIfCompatible(element: RsElement): DeriveCopyFix? {
             val pathExpr = element as? RsPathExpr ?: return null
             val item = (pathExpr.type as? TyAdt)?.item ?: return null
-            if (item.containingCargoPackage?.origin != PackageOrigin.WORKSPACE) return null
+            if (item.containingCrate?.origin != PackageOrigin.WORKSPACE) return null
 
             val implLookup = ImplLookup.relativeTo(element)
 

--- a/src/main/kotlin/org/rust/ide/inspections/import/ui.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/ui.kt
@@ -148,10 +148,10 @@ private class RsElementCellRenderer : DefaultPsiElementCellRenderer() {
         }
 
         private fun textWithIcon(): Pair<String, Icon>? {
-            val pkg = importCandidate?.qualifiedNamedItem?.containingCargoTarget?.pkg ?: return null
-            return when (pkg.origin) {
-                PackageOrigin.STDLIB -> pkg.normName to RsIcons.RUST
-                PackageOrigin.DEPENDENCY, PackageOrigin.TRANSITIVE_DEPENDENCY -> pkg.normName to CargoIcons.ICON
+            val crate = importCandidate?.qualifiedNamedItem?.containingCrate ?: return null
+            return when (crate.origin) {
+                PackageOrigin.STDLIB -> crate.normName to RsIcons.RUST
+                PackageOrigin.DEPENDENCY, PackageOrigin.TRANSITIVE_DEPENDENCY -> crate.normName to CargoIcons.ICON
                 else -> null
             }
         }

--- a/src/main/kotlin/org/rust/ide/refactoring/RsImportOptimizer.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsImportOptimizer.kt
@@ -11,7 +11,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
 import org.rust.cargo.project.workspace.PackageOrigin
-import org.rust.lang.core.psi.ext.asTrivial
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 
@@ -129,7 +128,7 @@ private class UseItemWrapper(val useItem: RsUseItem) {
         basePath?.self != null -> 6
         basePath?.`super` != null -> 5
         basePath?.crate != null -> 4
-        else -> when (basePath?.reference?.resolve()?.containingCargoPackage?.origin) {
+        else -> when (basePath?.reference?.resolve()?.containingCrate?.origin) {
             PackageOrigin.WORKSPACE -> 3
             PackageOrigin.TRANSITIVE_DEPENDENCY -> 2
             PackageOrigin.DEPENDENCY -> 2

--- a/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
@@ -1,0 +1,91 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.crate
+
+import com.intellij.openapi.vfs.VirtualFile
+import org.rust.cargo.CfgOptions
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.lang.core.psi.RsFile
+import java.util.*
+
+/**
+ * An immutable object describes a *crate* from the *rustc* point of view.
+ * In Cargo-based project this is usually a wrapper around [CargoWorkspace.Target]
+ */
+interface Crate {
+    /**
+     * This id can be saved to a disk and then used to find the crate via [CrateGraphService.findCrateById].
+     * Can be `null` for crates that are not represented in the physical filesystem and can't be retrieved
+     * using [CrateGraphService.findCrateById], or for invalid crates (without a root module)
+     */
+    val id: CratePersistentId?
+    val edition: CargoWorkspace.Edition
+
+    val cargoProject: CargoProject
+    val cargoWorkspace: CargoWorkspace
+    val cargoTarget: CargoWorkspace.Target?
+    val kind: CargoWorkspace.TargetKind
+    val origin: PackageOrigin
+
+    val cfgOptions: CfgOptions
+    val features: Collection<CargoWorkspace.Feature>
+
+    /** A map of compile-time environment variables, needed for `env!("FOO")` macros expansion */
+    val env: Map<String, String>
+
+    /** Represents `OUT_DIR` compile-time environment variable. Used for `env!("OUT_DIR")` macros expansion */
+    val outDir: VirtualFile?
+
+    /** Direct dependencies */
+    val dependencies: Collection<Dependency>
+
+    /** All dependencies (including transitive) of this crate. Topological sorted */
+    val flatDependencies: LinkedHashSet<Crate>
+
+    /** Other crates that depends on this crate */
+    val reverseDependencies: List<Crate>
+
+    /**
+     * A cargo package can have cyclic dependencies through `[dev-dependencies]` (see [CrateGraphService] docs).
+     * Cyclic dependencies are not contained in [dependencies], [flatDependencies] or [reverseDependencies].
+     */
+    @JvmDefault
+    val dependenciesWithCyclic: Collection<Dependency>
+        get() = dependencies
+
+    /**
+     * A root module of the crate, also known as "crate root". Usually it's `main.rs` or `lib.rs`.
+     * Use carefully: can be null or invalid ([VirtualFile.isValid])
+     */
+    val rootModFile: VirtualFile?
+    val rootMod: RsFile?
+
+    val areDoctestsEnabled: Boolean
+
+    /** A name to display to a user */
+    val presentableName: String
+
+    /**
+     * A name that can be used as a valid Rust identifier. Usually it is [presentableName] with "-" chars
+     * replaced to "_".
+     *
+     * NOTE that Rust crate doesn't have any kind of "global" name. The actual crate name can be different
+     * in a particular dependent crate. Use [Dependency.normName] instead
+     */
+    val normName: String
+
+    data class Dependency(
+        /** A name of the dependency that can be used in `extern crate name;` or in absolute paths */
+        val normName: String,
+
+        val crate: Crate
+    )
+}
+
+fun Crate.findDependency(normName: String): Crate? =
+    dependencies.find { it.normName == normName }?.crate

--- a/src/main/kotlin/org/rust/lang/core/crate/CrateGraphService.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/CrateGraphService.kt
@@ -1,0 +1,57 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.crate
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Describes the project model in terms of *crates*. Should be preferred to
+ * [org.rust.cargo.project.model.CargoProjectsService] in Rust analysis code
+ * (name resolution, type inference, most of the inspections, etc)
+ *
+ * Crate Graph is [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph),
+ * i.e. it doesn't have cycles, hence we can do
+ * [topological sorting](https://en.wikipedia.org/wiki/Topological_sorting) of crates.
+ *
+ * Use [Project.crateGraph] to get an instance of the service.
+ *
+ * ## Relations to the Cargo project model
+ *
+ * [Crate] is usually a wrapper around [org.rust.cargo.project.workspace.CargoWorkspace.Target].
+ *
+ * ### Duplicated packages
+ *
+ * Multiple [org.rust.cargo.project.model.CargoProject]'s can refer to the *same* package, but
+ * since cargo projects are different, there will be 2 copies of the packages. Each copy can have
+ * specific *features* and *dependencies* (because of different `Cargo.lock` files in different
+ * cargo projects). We trying to merge these packages into a single crate, but we can't merge
+ * different dependencies, so only one variant is preferred for now.
+ *
+ * ### Cyclic dependencies
+ *
+ * A Cargo package can have a cycle dependency on itself through `[dev-dependencies]`. It works in
+ * Cargo because Cargo package basically consists of two crates: one "production" crate and one
+ * `--cfg=test` crate, so "test" crate can depends on "production" one.
+ * We need to avoid cyclic dependencies because we need DAG in order to do topological sorting
+ * of crates, so we just remove cyclic `[dev-dependencies]` from the graph for now.
+ */
+interface CrateGraphService {
+    /**
+     * [Topological sorted](https://en.wikipedia.org/wiki/Topological_sorting)
+     * list of all crates in the project
+     */
+    val topSortedCrates: List<Crate>
+
+    /** See [Crate.id] */
+    fun findCrateById(id: CratePersistentId): Crate?
+
+    fun findCrateByRootMod(rootModFile: VirtualFile): Crate?
+}
+
+val Project.crateGraph: CrateGraphService
+    get() = service()

--- a/src/main/kotlin/org/rust/lang/core/crate/CratePersistentId.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/CratePersistentId.kt
@@ -1,0 +1,16 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.crate
+
+/**
+ * Persistent [Crate] identifier. Guaranteed to be positive 32-bit integer.
+ * This id can be saved to a disk and then used to find the crate
+ *
+ * See [Crate.id]
+ *
+ * See [CrateGraphService.findCrateById]
+ */
+typealias CratePersistentId = Int

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/CargoBasedCrate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/CargoBasedCrate.kt
@@ -1,0 +1,71 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.crate.impl
+
+import com.intellij.openapi.vfs.VirtualFile
+import org.rust.cargo.CfgOptions
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.crate.CratePersistentId
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.rustFile
+import org.rust.openapiext.fileId
+import org.rust.openapiext.toPsiFile
+import java.util.*
+
+class CargoBasedCrate(
+    override var cargoProject: CargoProject,
+    override var cargoTarget: CargoWorkspace.Target,
+    override val dependencies: Collection<Crate.Dependency>,
+    override val flatDependencies: LinkedHashSet<Crate>
+) : Crate {
+    override val reverseDependencies = mutableListOf<CargoBasedCrate>()
+    override var features: Collection<CargoWorkspace.Feature> = cargoTarget.pkg.features
+
+    // These properties are fields (not just delegates to `cargoTarget`) because [Crate] must be immutable
+    override val rootModFile: VirtualFile? = cargoTarget.crateRoot
+    override val id: CratePersistentId? = rootModFile?.fileId
+
+    /** See docs for [org.rust.lang.core.crate.CrateGraphService] */
+    var cyclicDevDeps: List<Crate.Dependency> = emptyList()
+
+    override val dependenciesWithCyclic: Collection<Crate.Dependency>
+        get() = dependencies + cyclicDevDeps
+
+    init {
+        for (dependency in dependencies) {
+            (dependency.crate as CargoBasedCrate).reverseDependencies += this
+        }
+    }
+
+    override val cargoWorkspace: CargoWorkspace get() = cargoTarget.pkg.workspace
+    override val kind: CargoWorkspace.TargetKind get() = cargoTarget.kind
+
+    override val cfgOptions: CfgOptions get() = cargoTarget.pkg.cfgOptions
+    override val env: Map<String, String> get() = cargoTarget.pkg.env
+    override val outDir: VirtualFile? get() = cargoTarget.pkg.outDir
+
+    override val rootMod: RsFile? get() = rootModFile?.toPsiFile(cargoProject.project)?.rustFile
+
+    override val origin: PackageOrigin get() = cargoTarget.pkg.origin
+    override val edition: CargoWorkspace.Edition get() = cargoTarget.edition
+    override val areDoctestsEnabled: Boolean get() = cargoTarget.doctest && cargoTarget.isDoctestable
+    override val presentableName: String get() = cargoTarget.name
+    override val normName: String get() = cargoTarget.normName
+
+    override fun toString(): String = "${cargoTarget.name}(${kind.name})"
+}
+
+// See https://github.com/rust-lang/cargo/blob/5a0c31d81/src/cargo/core/manifest.rs#L775
+private val CargoWorkspace.Target.isDoctestable: Boolean
+    get() {
+        val kind = kind as? CargoWorkspace.TargetKind.Lib ?: return false
+        return CargoWorkspace.LibKind.LIB in kind.kinds ||
+            CargoWorkspace.LibKind.RLIB in kind.kinds ||
+            CargoWorkspace.LibKind.PROC_MACRO in kind.kinds
+    }

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/CrateGraphServiceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/CrateGraphServiceImpl.kt
@@ -1,0 +1,421 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.crate.impl
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.SimpleModificationTracker
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.VirtualFileWithId
+import com.intellij.openapiext.isUnitTestMode
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.util.containers.addIfNotNull
+import gnu.trove.TIntObjectHashMap
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.model.CargoProjectsService
+import org.rust.cargo.project.model.CargoProjectsService.CargoProjectsListener
+import org.rust.cargo.project.model.CargoProjectsService.Companion.CARGO_PROJECTS_TOPIC
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.crate.CrateGraphService
+import org.rust.lang.core.crate.CratePersistentId
+import org.rust.openapiext.CachedValueDelegate
+import org.rust.openapiext.checkReadAccessAllowed
+import org.rust.stdext.enumSetOf
+import org.rust.stdext.exhaustive
+import java.nio.file.Path
+
+class CrateGraphServiceImpl(val project: Project) : CrateGraphService {
+
+    private val cargoProjectsModTracker = SimpleModificationTracker()
+
+    init {
+        project.messageBus.connect().subscribe(CARGO_PROJECTS_TOPIC, object : CargoProjectsListener {
+            override fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>) {
+                cargoProjectsModTracker.incModificationCount()
+            }
+        })
+    }
+
+    private val crateGraph: CrateGraph by CachedValueDelegate {
+        val result = buildCrateGraph(project, project.cargoProjects.allProjects)
+        CachedValueProvider.Result(result, cargoProjectsModTracker, VirtualFileManager.VFS_STRUCTURE_MODIFICATIONS)
+    }
+
+    override val topSortedCrates: List<Crate>
+        get() {
+            checkReadAccessAllowed()
+            return crateGraph.topSortedCrates
+        }
+
+    override fun findCrateById(id: CratePersistentId): Crate? {
+        checkReadAccessAllowed()
+        return crateGraph.idToCrate.get(id)
+    }
+
+    override fun findCrateByRootMod(rootModFile: VirtualFile): Crate? {
+        checkReadAccessAllowed()
+        return if (rootModFile is VirtualFileWithId) findCrateById(rootModFile.id) else null
+    }
+
+}
+
+private data class CrateGraph(
+    val topSortedCrates: List<Crate>,
+    val idToCrate: TIntObjectHashMap<Crate>
+)
+
+private val LOG = Logger.getInstance(CrateGraphServiceImpl::class.java)
+
+private fun buildCrateGraph(project: Project, cargoProjects: Collection<CargoProject>): CrateGraph {
+    val builder = CrateGraphBuilder(project)
+    for (cargoProject in cargoProjects) {
+        val workspace = cargoProject.workspace ?: continue
+        for (pkg in workspace.packages) {
+            try {
+                builder.lowerPackage(ProjectPackage(cargoProject, pkg))
+            } catch (e: CyclicGraphException) {
+                // This should not occur, but if it is, let's just log the exception instead of breaking everything
+                LOG.error(e)
+            }
+        }
+    }
+    return builder.build()
+}
+
+private class CrateGraphBuilder(val project: Project) {
+    private val states = hashMapOf<Path, NodeState>()
+    private val topSortedCrates = mutableListOf<CargoBasedCrate>()
+
+    private val cratesToLowerLater = mutableListOf<NonLibraryCrates>()
+    private val cratesToReplaceTargetLater = mutableListOf<ReplaceProjectAndTarget>()
+
+    fun lowerPackage(pkg: ProjectPackage): CargoBasedCrate? {
+        when (val state = states[pkg.rootDirectory]) {
+            is NodeState.Done -> {
+                val libCrate = state.libCrate
+                if (state.pkgs.add(pkg.pkg)) {
+                    // Duplicated package found. This can occur if a package is used in multiple CargoProjects.
+                    // Merging them into a single crate
+                    if (libCrate != null) {
+                        libCrate.features = mergeFeatures(pkg.pkg.features, libCrate.features)
+                    }
+
+                    // Prefer workspace target
+                    if (pkg.pkg.origin == PackageOrigin.WORKSPACE) {
+                        cratesToReplaceTargetLater += ReplaceProjectAndTarget(state, pkg)
+                    }
+                }
+                return libCrate
+            }
+
+            NodeState.Processing -> throw CyclicGraphException(pkg.pkg.name)
+
+            else -> states[pkg.rootDirectory] = NodeState.Processing
+        }
+
+        val (buildDeps, normalAndNonCyclicDevDeps, cyclicDevDependencies) = lowerPackageDependencies(pkg)
+
+        val customBuildCrate = pkg.pkg.customBuildTarget?.let { target ->
+            CargoBasedCrate(pkg.project, target, buildDeps, buildDeps.flattenTopSortedDeps())
+        }
+        topSortedCrates.addIfNotNull(customBuildCrate)
+
+        val flatNormalAndNonCyclicDevDeps = normalAndNonCyclicDevDeps.flattenTopSortedDeps()
+        val libCrate = pkg.pkg.libTarget?.let { libTarget ->
+            CargoBasedCrate(pkg.project, libTarget, normalAndNonCyclicDevDeps, flatNormalAndNonCyclicDevDeps)
+        }
+
+        val newState = NodeState.Done(libCrate)
+        newState.pkgs += pkg.pkg
+        newState.nonLibraryCrates.addIfNotNull(customBuildCrate)
+
+        states[pkg.rootDirectory] = newState
+        topSortedCrates.addIfNotNull(libCrate)
+
+        lowerNonLibraryCratesLater(NonLibraryCrates(
+            pkg,
+            newState,
+            normalAndNonCyclicDevDeps,
+            cyclicDevDependencies,
+            flatNormalAndNonCyclicDevDeps
+        ))
+
+        return libCrate
+    }
+
+    private class ReplaceProjectAndTarget(
+        val state: NodeState.Done,
+        val pkg: ProjectPackage
+    )
+
+    private fun ReplaceProjectAndTarget.replaceProjectAndTarget() {
+        val libCrate = state.libCrate
+        if (libCrate != null) {
+            pkg.pkg.libTarget?.let {
+                libCrate.cargoTarget = it
+                libCrate.cargoProject = pkg.project
+            }
+        }
+        for (crate in state.nonLibraryCrates) {
+            val newTarget = pkg.pkg.targets.find { it.name == crate.cargoTarget.name }
+                ?: continue
+            crate.cargoTarget = newTarget
+            crate.cargoProject = pkg.project
+        }
+    }
+
+    private data class LoweredPackageDependencies(
+        val buildDeps: List<Crate.Dependency>,
+        val normalAndNonCyclicDevDeps: List<Crate.Dependency>,
+        val cyclicDevDependencies: List<CargoWorkspace.Dependency>
+    )
+
+    private fun lowerPackageDependencies(pkg: ProjectPackage): LoweredPackageDependencies {
+        return when (val dependencies = pkg.pkg.dependencies.classify()) {
+            is SplitDependencies.Classified -> {
+                val buildDeps = lowerDependencies(dependencies.build, pkg)
+                val normalDeps = lowerDependencies(dependencies.normal, pkg)
+                val (nonCyclicDevDeps, cyclicDevDependencies) = lowerDependenciesWithCycles(dependencies.dev, pkg)
+                val normalAndNonCyclicDevDeps = normalDeps + nonCyclicDevDeps
+                LoweredPackageDependencies(buildDeps, normalAndNonCyclicDevDeps, cyclicDevDependencies)
+            }
+            is SplitDependencies.Unclassified -> {
+                // Here we can't distinguish normal/dev/build dependencies because of old Cargo (prior to `1.41.0`).
+                //
+                val (lowered, cyclic) = lowerDependenciesWithCycles(dependencies.dependencies, pkg)
+                LoweredPackageDependencies(lowered, lowered, cyclic)
+            }
+        }
+    }
+
+    private sealed class SplitDependencies {
+        data class Classified(
+            val normal: Collection<CargoWorkspace.Dependency>,
+            val dev: Collection<CargoWorkspace.Dependency>,
+            val build: Collection<CargoWorkspace.Dependency>
+        ) : SplitDependencies()
+
+        // For old Cargo versions prior to `1.41.0`
+        data class Unclassified(val dependencies: Collection<CargoWorkspace.Dependency>) : SplitDependencies()
+    }
+
+    private fun Collection<CargoWorkspace.Dependency>.classify(): SplitDependencies {
+        val unclassified = mutableListOf<CargoWorkspace.Dependency>()
+        val normal = mutableListOf<CargoWorkspace.Dependency>()
+        val dev = mutableSetOf<CargoWorkspace.Dependency>()
+        val build = mutableListOf<CargoWorkspace.Dependency>()
+
+        for (dependency in this) {
+            val visitedDepKinds = enumSetOf<CargoWorkspace.DepKind>()
+
+            for (depKind in dependency.depKinds) {
+                // `cargo metadata` sometimes duplicate `depKinds` for some reason
+                if (!visitedDepKinds.add(depKind.kind)) continue
+
+                when (depKind.kind) {
+                    CargoWorkspace.DepKind.Stdlib -> {
+                        normal += dependency
+                        build += dependency
+                        // No `dev += dependency` because all crates that use `dev` dependencies also use
+                        // `normal` dependencies
+                    }
+                    CargoWorkspace.DepKind.Unclassified -> unclassified += dependency
+                    CargoWorkspace.DepKind.Normal -> normal += dependency
+                    CargoWorkspace.DepKind.Development -> dev += dependency
+                    CargoWorkspace.DepKind.Build -> build += dependency
+                }.exhaustive
+            }
+        }
+
+        dev.removeAll(normal)
+
+        return if (unclassified.isNotEmpty()) {
+            // If these is at least one unclassified dependency, then we're on old Cargo and all dependencies
+            // are unclassified
+            SplitDependencies.Unclassified(unclassified + normal)
+        } else {
+            SplitDependencies.Classified(normal, dev, build)
+        }
+    }
+
+    private fun lowerDependencies(
+        deps: Iterable<CargoWorkspace.Dependency>,
+        pkg: ProjectPackage
+    ): List<Crate.Dependency> {
+        return try {
+            deps.mapNotNull { dep ->
+                lowerPackage(ProjectPackage(pkg.project, dep.pkg))?.let { Crate.Dependency(dep.name, it) }
+            }
+        } catch (e: CyclicGraphException) {
+            states.remove(pkg.rootDirectory)
+            e.pushCrate(pkg.pkg.name)
+            throw e
+        }
+    }
+
+    private data class LoweredAndCyclicDependencies(
+        val lowered: List<Crate.Dependency>,
+        val cyclic: List<CargoWorkspace.Dependency>
+    )
+
+    private fun lowerDependenciesWithCycles(
+        devDependencies: Collection<CargoWorkspace.Dependency>,
+        pkg: ProjectPackage
+    ): LoweredAndCyclicDependencies {
+        val cyclic = mutableListOf<CargoWorkspace.Dependency>()
+        val lowered = devDependencies.mapNotNull { dep ->
+            try {
+                lowerPackage(ProjectPackage(pkg.project, dep.pkg))?.let { Crate.Dependency(dep.name, it) }
+            } catch (ignored: CyclicGraphException) {
+                // This can occur because `dev-dependencies` can cyclic depends on this package
+                CrateGraphTestmarks.cyclicDevDependency.hit()
+                cyclic += dep
+                null
+            }
+        }
+        return LoweredAndCyclicDependencies(lowered, cyclic)
+    }
+
+    private fun lowerNonLibraryCratesLater(ctx: NonLibraryCrates) {
+        if (ctx.cyclicDevDependencies.isEmpty()) {
+            ctx.lowerNonLibraryCrates()
+        } else {
+            cratesToLowerLater += ctx
+        }
+    }
+
+    private class NonLibraryCrates(
+        val pkg: ProjectPackage,
+        val doneState: NodeState.Done,
+        val normalAndNonCyclicTestDeps: List<Crate.Dependency>,
+        val cyclicDevDependencies: List<CargoWorkspace.Dependency>,
+        val flatNormalAndNonCyclicDevDeps: LinkedHashSet<Crate>
+    )
+
+    private fun NonLibraryCrates.lowerNonLibraryCrates() {
+        val cyclicDevDeps = lowerDependencies(cyclicDevDependencies, pkg)
+        val normalAndTestDeps = normalAndNonCyclicTestDeps + cyclicDevDeps
+
+        val libCrate = doneState.libCrate
+        val (depsWithLib, flatDepsWithLib) = if (libCrate != null) {
+            val libDep = Crate.Dependency(libCrate.normName, libCrate)
+
+            val flatDeps = LinkedHashSet<Crate>(flatNormalAndNonCyclicDevDeps)
+            flatDeps += cyclicDevDeps.flattenTopSortedDeps()
+            flatDeps += libCrate
+
+            Pair(normalAndTestDeps + libDep, flatDeps)
+        } else {
+            normalAndTestDeps to flatNormalAndNonCyclicDevDeps
+        }
+
+        val nonLibraryCrates = pkg.pkg.targets.mapNotNull { target ->
+            if (target.kind.isLib || target.kind == CargoWorkspace.TargetKind.CustomBuild) return@mapNotNull null
+
+            CargoBasedCrate(pkg.project, target, depsWithLib, flatDepsWithLib)
+        }
+
+        doneState.nonLibraryCrates += nonLibraryCrates
+        topSortedCrates += nonLibraryCrates
+        if (cyclicDevDeps.isNotEmpty()) {
+            libCrate?.cyclicDevDeps = cyclicDevDeps
+        }
+    }
+
+    fun build(): CrateGraph {
+        for (ctx in cratesToLowerLater) {
+            ctx.lowerNonLibraryCrates()
+        }
+        for (ctx in cratesToReplaceTargetLater) {
+            ctx.replaceProjectAndTarget()
+        }
+
+        topSortedCrates.assertTopSorted()
+
+        val idToCrate = TIntObjectHashMap<Crate>()
+        for (crate in topSortedCrates) {
+            crate.checkInvariants()
+
+            val id = crate.id
+            if (id != null) {
+                idToCrate.put(id, crate)
+            }
+        }
+        return CrateGraph(topSortedCrates, idToCrate)
+    }
+}
+
+private fun Crate.checkInvariants() {
+    if (!isUnitTestMode) return
+
+    flatDependencies.assertTopSorted()
+
+    for (dep in dependencies) {
+        check(dep.crate in flatDependencies) {
+            "Error in structure of crate `$this`: no `${dep.crate}`" +
+                " dependency in flatDependencies: $flatDependencies"
+        }
+    }
+}
+
+private fun Iterable<Crate>.assertTopSorted() {
+    if (!isUnitTestMode) return
+    val set = hashSetOf<Crate>()
+    for (crate in this) {
+        check(crate.dependencies.all { it.crate in set })
+        set += crate
+    }
+}
+
+private fun mergeFeatures(
+    features1: Collection<CargoWorkspace.Feature>,
+    features2: Collection<CargoWorkspace.Feature>
+): Collection<CargoWorkspace.Feature> {
+    val featureMap = features1.associateTo(hashMapOf()) { it.name to it.state }
+    for ((k, v) in features2) {
+        featureMap.merge(k, v) { v1, v2 ->
+            when {
+                v1 == CargoWorkspace.FeatureState.Enabled -> CargoWorkspace.FeatureState.Enabled
+                v2 == CargoWorkspace.FeatureState.Enabled -> CargoWorkspace.FeatureState.Enabled
+                else -> CargoWorkspace.FeatureState.Disabled
+            }
+        }
+    }
+    return featureMap.entries.map { (k, v) -> CargoWorkspace.Feature(k, v) }
+}
+
+private data class ProjectPackage(
+    val project: CargoProject,
+    val pkg: CargoWorkspace.Package,
+    // Extracted to a field due to performance reasons
+    val rootDirectory: Path = pkg.rootDirectory
+)
+
+private sealed class NodeState {
+    data class Done(
+        val libCrate: CargoBasedCrate?,
+        val nonLibraryCrates: MutableList<CargoBasedCrate> = mutableListOf(),
+        val pkgs: MutableSet<CargoWorkspace.Package> = hashSetOf()
+    ) : NodeState()
+
+    object Processing : NodeState()
+}
+
+private class CyclicGraphException(crateName: String) : RuntimeException("Cyclic graph detected") {
+    private val stack: MutableList<String> = mutableListOf(crateName)
+
+    fun pushCrate(crateName: String) {
+        stack += crateName
+    }
+
+    override val message: String?
+        get() = super.message + stack.asReversed().joinToString(prefix = " (", separator = " -> ", postfix = ")")
+}
+

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/DoctestCrate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/DoctestCrate.kt
@@ -1,0 +1,64 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.crate.impl
+
+import com.intellij.openapi.vfs.VirtualFile
+import org.rust.cargo.CfgOptions
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.crate.CratePersistentId
+import org.rust.lang.core.crate.crateGraph
+import org.rust.lang.core.psi.RsFile
+import java.util.*
+
+class DoctestCrate(
+    private val parentCrate: Crate,
+    override val rootMod: RsFile,
+    override val dependencies: Collection<Crate.Dependency>
+) : Crate {
+    override val flatDependencies: LinkedHashSet<Crate> = dependencies.flattenTopSortedDeps()
+
+    override val reverseDependencies: List<Crate> get() = emptyList()
+
+    override val id: CratePersistentId? get() = null
+    override val cargoProject: CargoProject get() = parentCrate.cargoProject
+    override val cargoTarget: CargoWorkspace.Target? get() = null
+    override val cargoWorkspace: CargoWorkspace get() = parentCrate.cargoWorkspace
+    override val kind: CargoWorkspace.TargetKind get() = CargoWorkspace.TargetKind.Test
+
+    override val cfgOptions: CfgOptions get() = CfgOptions.EMPTY
+    override val features: Collection<CargoWorkspace.Feature> get() = emptyList()
+    override val env: Map<String, String> get() = emptyMap()
+    override val outDir: VirtualFile? get() = null
+
+    override val rootModFile: VirtualFile? get() = rootMod.virtualFile
+    override val origin: PackageOrigin get() = parentCrate.origin
+    override val edition: CargoWorkspace.Edition get() = parentCrate.edition
+    override val areDoctestsEnabled: Boolean get() = false
+    override val presentableName: String get() = parentCrate.presentableName + "-doctest"
+    override val normName: String get() = parentCrate.normName + "_doctest"
+
+    override fun toString(): String = "Doctest in ${parentCrate.cargoTarget?.name}"
+
+    companion object {
+        fun inCrate(parentCrate: Crate, doctestModule: RsFile): DoctestCrate {
+            return if (parentCrate.origin != PackageOrigin.STDLIB) {
+                val dependencies = parentCrate.dependenciesWithCyclic +
+                    Crate.Dependency(parentCrate.normName, parentCrate)
+                DoctestCrate(parentCrate, doctestModule, dependencies)
+            } else {
+                // A doctest located in the stdlib is depending on all stdlib crates
+                val stdCrates = parentCrate.cargoProject.project.crateGraph.topSortedCrates
+                    .filter { it.origin == PackageOrigin.STDLIB }
+                    .map { Crate.Dependency(it.normName, it) }
+                    .distinctBy { it.normName }
+                DoctestCrate(parentCrate, doctestModule, dependencies = stdCrates)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/Util.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/Util.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.crate.impl
+
+import com.intellij.openapiext.Testmark
+import org.rust.lang.core.crate.Crate
+
+fun Iterable<Crate.Dependency>.flattenTopSortedDeps(): LinkedHashSet<Crate> {
+    val flatDeps = linkedSetOf<Crate>()
+
+    for (dep in this) {
+        for (flatDep in dep.crate.flatDependencies) {
+            flatDeps += flatDep
+        }
+        flatDeps += dep.crate
+    }
+
+    return flatDeps
+}
+
+object CrateGraphTestmarks {
+    val cyclicDevDependency = Testmark("cyclicDevDependency")
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -31,7 +31,7 @@ import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.ext.bodyHash
-import org.rust.lang.core.psi.ext.containingCargoTarget
+import org.rust.lang.core.psi.ext.containingCrate
 import org.rust.lang.core.psi.ext.resolveToMacro
 import org.rust.lang.core.psi.ext.stubDescendantsOfTypeStrict
 import org.rust.lang.core.resolve.DEFAULT_RECURSION_LIMIT
@@ -351,7 +351,7 @@ class SourceFile(
 
     // Should not be lazy b/c target/pkg/origin can be changed
     private val isBelongToWorkspace: Boolean
-        get() = rootSourceFile.loadPsi()?.containingCargoTarget?.pkg?.origin == PackageOrigin.WORKSPACE
+        get() = rootSourceFile.loadPsi()?.containingCrate?.origin == PackageOrigin.WORKSPACE
 
     /**
      * Checks that [modificationStamp], [infos] content, [ExpandedMacroInfoImpl.macroCallStrongRef] or

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -357,8 +357,8 @@ class MacroExpander(val project: Project) {
  * DON'T TRY THIS AT HOME
  */
 private fun expandDollarCrateVar(call: RsMacroCall, def: RsMacro): String {
-    val defTarget = def.containingCargoTarget
-    val callTarget = call.containingCargoTarget
+    val defTarget = def.containingCrate
+    val callTarget = call.containingCrate
     val crateName = if (defTarget == callTarget) "self" else defTarget?.normName ?: ""
     return MACRO_CRATE_IDENTIFIER_PREFIX + crateName
 }

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -1034,7 +1034,7 @@ class MacroExpansionManagerWaker : CargoProjectsService.CargoProjectsListener {
 
 private fun expandMacroOld(call: RsMacroCall): CachedValueProvider.Result<MacroExpansion?> {
     // Most of std macros contain the only `impl`s which are not supported for now, so ignoring them
-    if (call.containingCargoTarget?.pkg?.origin == PackageOrigin.STDLIB) {
+    if (call.containingCrate?.origin == PackageOrigin.STDLIB) {
         return nullExpansionResult(call)
     }
     return expandMacroToMemoryFile(

--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.ModificationTracker
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileWithId
 import com.intellij.psi.FileViewProvider
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -28,6 +29,9 @@ import org.rust.lang.RsConstants
 import org.rust.lang.RsFileType
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.completion.getOriginalOrSelf
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.crate.crateGraph
+import org.rust.lang.core.crate.impl.DoctestCrate
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.macros.expandedFrom
 import org.rust.lang.core.macros.macroExpansionManagerIfCreated
@@ -69,7 +73,7 @@ class RsFile(
 
     val cargoProject: CargoProject? get() = cachedData.cargoProject
     val cargoWorkspace: CargoWorkspace? get() = cachedData.cargoWorkspace
-    val cargoTarget: CargoWorkspace.Target? get() = cachedData.cargoTarget
+    val crate: Crate? get() = cachedData.crate
     override val crateRoot: RsMod? get() = cachedData.crateRoot
     val isDeeplyEnabledByCfg: Boolean get() = cachedData.isDeeplyEnabledByCfg
 
@@ -102,11 +106,13 @@ class RsFile(
         }
 
         val possibleCrateRoot = this
-
-        val includingMod = RsIncludeMacroIndex.getIncludingMod(possibleCrateRoot)
-        if (includingMod != null) return (includingMod.contextualFile as? RsFile)?.cachedData ?: EMPTY_CACHED_DATA
-
         val crateRootVFile = possibleCrateRoot.virtualFile ?: return EMPTY_CACHED_DATA
+
+        val crate = project.crateGraph.findCrateByRootMod(crateRootVFile)
+        if (crate != null) {
+            // `possibleCrateRoot` is a "real" crate root only if we're able to find a `crate` for it
+            return CachedData(crate.cargoProject, crate.cargoWorkspace, possibleCrateRoot, crate)
+        }
 
         val injectedFromFile = crateRootVFile.getInjectedFromIfDoctestInjection(project)
         if (injectedFromFile != null) {
@@ -114,22 +120,19 @@ class RsFile(
             // Doctest injection file should be a crate root to resolve absolute paths inside injection.
             // Doctest contains a single "extern crate $crateName;" declaration at the top level, so
             // we should be able to resolve it by an absolute path
-            return cached.copy(crateRoot = possibleCrateRoot)
+            val doctestCrate = cached.crate?.let { DoctestCrate.inCrate(it, possibleCrateRoot) }
+            return cached.copy(crateRoot = possibleCrateRoot, crate = doctestCrate)
         }
 
+        val includingMod = RsIncludeMacroIndex.getIncludingMod(possibleCrateRoot)
+        if (includingMod != null) return (includingMod.contextualFile as? RsFile)?.cachedData ?: EMPTY_CACHED_DATA
+
+        // This occurs if the file is not included to the project's module structure, i.e. it's
+        // most parent module is not mentioned in the `Cargo.toml` as a crate root of some target
+        // (usually lib.rs or main.rs). It's anyway useful to know cargoProject&workspace in this case
         val cargoProject = project.cargoProjects.findProjectForFile(crateRootVFile) ?: return EMPTY_CACHED_DATA
         val workspace = cargoProject.workspace ?: return CachedData(cargoProject)
-        val cargoTarget = workspace.findTargetByCrateRoot(crateRootVFile)
-
-        return if (cargoTarget != null) {
-            // `possibleCrateRoot` is a "real" crate root only if we're able to find a target for it
-            CachedData(cargoProject, workspace, cargoTarget, possibleCrateRoot)
-        } else {
-            // This accurs if the file is not included to the project's module structure, i.e. it's
-            // most parent module is not mentioned in the `Cargo.toml` as a crate root of some target
-            // (usually lib.rs or main.rs). It's anyway useful to know cargoProject&workspace in this case
-            CachedData(cargoProject, workspace)
-        }
+        return CachedData(cargoProject, workspace)
     }
 
     override fun setName(name: String): PsiElement {
@@ -159,7 +162,11 @@ class RsFile(
         get() = getOwnedDirectory() != null
 
     override val isCrateRoot: Boolean
-        get() = originalFile == crateRoot
+        get() {
+            val file = originalFile.virtualFile ?: return false
+            return file is VirtualFileWithId && project.crateGraph.findCrateByRootMod(file) != null
+                || file.isDoctestInjection(project)
+        }
 
     override val visibility: RsVisibility get() {
         if (isCrateRoot) return RsVisibility.Public
@@ -191,8 +198,9 @@ class RsFile(
             MOD_DECL_KEY to ModificationTracker.NEVER_CHANGED
         }
         return CachedValuesManager.getCachedValue(originalFile, key) {
+            val decl = if (isCrateRoot) emptyList() else RsModulesIndex.getDeclarationsFor(originalFile)
             CachedValueProvider.Result.create(
-                RsModulesIndex.getDeclarationsFor(originalFile),
+                decl,
                 originalFile.rustStructureOrAnyPsiModificationTracker,
                 cacheDependency
             )
@@ -207,12 +215,8 @@ class RsFile(
 private data class CachedData(
     val cargoProject: CargoProject? = null,
     val cargoWorkspace: CargoWorkspace? = null,
-    val cargoTarget: CargoWorkspace.Target? = null,
-    /**
-     * May be not equal to [cargoTarget]'s [CargoWorkspace.Target.crateRoot].
-     * For example, in the case of doctest injection
-     */
     val crateRoot: RsFile? = null,
+    val crate: Crate? = null,
     val isDeeplyEnabledByCfg: Boolean = true
 )
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -225,9 +225,9 @@ private fun RsDocAndAttributeOwner.evaluateCfg(): ThreeValuedLogic {
     // this will return the library as containing package.
     // When the application now requests certain features, which are not enabled by default in the library
     // we will evaluate features wrongly here
-    val pkg = containingCargoPackage ?: return ThreeValuedLogic.True
-    val features = pkg.features.associate { it.name to it.state }
-    return CfgEvaluator(pkg.workspace.cfgOptions, pkg.cfgOptions, features, pkg.origin).evaluate(cfgAttributes)
+    val crate = containingCrate ?: return ThreeValuedLogic.True
+    val features = crate.features.associate { it.name to it.state }
+    return CfgEvaluator(crate.cargoWorkspace.cfgOptions, crate.cfgOptions, features, crate.origin).evaluate(cfgAttributes)
 }
 
 private val CFG_ATTRIBUTES_ENABLED_KEY = Registry.get("org.rust.lang.cfg.attributes")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -97,10 +97,10 @@ private val RsExpr.value: String? get() {
                 }
                 "env" -> {
                     val expr = macroCall.envMacroArgument?.variableNameExpr as? RsLitExpr ?: return null
-                    val pkg = expr.containingCargoPackage ?: return null
+                    val crate = expr.containingCrate ?: return null
                     when (val variableName = expr.value) {
-                        "OUT_DIR" -> pkg.outDir?.path
-                        else -> pkg.env[variableName]
+                        "OUT_DIR" -> crate.outDir?.path
+                        else -> crate.env[variableName]
                     }
                 }
                 else -> null

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
@@ -13,6 +13,7 @@ import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.util.AutoInjectedCrates.STD
+import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsQualifiedName.ChildItemType.*
 import org.rust.lang.core.psi.ext.RsQualifiedName.ParentItemType.*
@@ -29,7 +30,7 @@ interface RsQualifiedNamedElement : RsNamedElement {
 val RsQualifiedNamedElement.qualifiedName: String?
     get() {
         val inCratePath = crateRelativePath ?: return null
-        val cargoTarget = containingCargoTarget?.normName ?: return null
+        val cargoTarget = containingCrate?.normName ?: return null
         return "$cargoTarget$inCratePath"
     }
 
@@ -224,7 +225,7 @@ data class RsQualifiedName private constructor(
             val crateName = if (parentItem.type == PRIMITIVE) {
                 STD
             } else {
-                element.containingCargoTarget?.normName ?: return null
+                element.containingCrate?.normName ?: return null
             }
 
             val modSegments = if (parentItem.type == PRIMITIVE || parentItem.type == MACRO) {
@@ -243,7 +244,7 @@ data class RsQualifiedName private constructor(
 
         @JvmStatic
         fun from(qualifiedNamedItem: QualifiedNamedItem): RsQualifiedName? {
-            val crateName = qualifiedNamedItem.containingCargoTarget?.normName ?: return null
+            val crateName = qualifiedNamedItem.containingCrate?.normName ?: return null
             val modSegments = mutableListOf<String>()
 
             val (parentItem, childItem) = qualifiedNamedItem.item.toItems() ?: return null
@@ -336,7 +337,7 @@ data class RsQualifiedName private constructor(
                 is RsMacro -> MACRO
                 is RsMod -> {
                     if (isCrateRoot) {
-                        val crateName = containingCargoTarget?.normName ?: return null
+                        val crateName = containingCrate?.normName ?: return null
                         return Item(crateName, CRATE, this)
                     }
                     MOD
@@ -461,7 +462,7 @@ sealed class QualifiedNamedItem(val item: RsQualifiedNamedElement) {
     abstract val itemName: String?
     abstract val isPublic: Boolean
     abstract val superMods: List<ModWithName>?
-    abstract val containingCargoTarget: CargoWorkspace.Target?
+    abstract val containingCrate: Crate?
 
     val parentCrateRelativePath: String?
         get() {
@@ -482,7 +483,7 @@ sealed class QualifiedNamedItem(val item: RsQualifiedNamedElement) {
         }
 
     override fun toString(): String {
-        return "${containingCargoTarget?.normName}::$crateRelativePath"
+        return "${containingCrate?.normName}::$crateRelativePath"
     }
 
     class ExplicitItem(item: RsQualifiedNamedElement) : QualifiedNamedItem(item) {
@@ -490,7 +491,7 @@ sealed class QualifiedNamedItem(val item: RsQualifiedNamedElement) {
         override val isPublic: Boolean get() = (item as? RsVisible)?.isPublic == true
         override val superMods: List<ModWithName>?
             get() = (if (item is RsMod) item.`super` else item.containingMod)?.superMods?.map { ModWithName(it) }
-        override val containingCargoTarget: CargoWorkspace.Target? get() = item.containingCargoTarget
+        override val containingCrate: Crate? get() = item.containingCrate
     }
 
     class ReexportedItem private constructor(
@@ -501,7 +502,7 @@ sealed class QualifiedNamedItem(val item: RsQualifiedNamedElement) {
 
         override val isPublic: Boolean get() = true
         override val superMods: List<ModWithName>? get() = reexportItem.containingMod.superMods.map { ModWithName(it) }
-        override val containingCargoTarget: CargoWorkspace.Target? get() = reexportItem.containingCargoTarget
+        override val containingCrate: Crate? get() = reexportItem.containingCrate
 
         companion object {
             fun from(useSpeck: RsUseSpeck, item: RsQualifiedNamedElement): ReexportedItem {
@@ -528,7 +529,7 @@ sealed class QualifiedNamedItem(val item: RsQualifiedNamedElement) {
                 mods += reexportedModItem.superMods.orEmpty()
                 return mods
             }
-        override val containingCargoTarget: CargoWorkspace.Target? get() = reexportedModItem.containingCargoTarget
+        override val containingCrate: Crate? get() = reexportedModItem.containingCrate
     }
 
     data class ModWithName(val modItem: RsMod, val modName: String? = modItem.modName)
@@ -557,7 +558,7 @@ private fun QualifiedNamedItem.collectImportItems(
     val superMods = superMods.orEmpty()
     superMods.forEachIndexed { index, ancestorMod ->
         val modItem = ancestorMod.modItem
-        val modOriginalName = (if (modItem.isCrateRoot) modItem.containingCargoTarget?.normName else modItem.modName)
+        val modOriginalName = (if (modItem.isCrateRoot) modItem.containingCrate?.normName else modItem.modName)
             ?: return@forEachIndexed
 
         RsReexportIndex.findReexportsByOriginalName(project, modOriginalName)

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsLangItemIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsLangItemIndex.kt
@@ -15,7 +15,7 @@ import com.intellij.util.io.KeyDescriptor
 import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.lang.core.psi.ext.RsItemElement
 import org.rust.lang.core.psi.ext.RsNamedElement
-import org.rust.lang.core.psi.ext.containingCargoPackage
+import org.rust.lang.core.psi.ext.containingCrate
 import org.rust.lang.core.psi.ext.queryAttributes
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.openapiext.checkCommitIsNotInProgress
@@ -37,7 +37,7 @@ class RsLangItemIndex : AbstractStubIndex<String, RsItemElement>() {
             return if (elements.size < 2) {
                 elements.firstOrNull() as? RsNamedElement
             } else {
-                elements.find { it.containingCargoPackage?.normName == crateName } as? RsNamedElement
+                elements.find { it.containingCrate?.normName == crateName } as? RsNamedElement
             }
         }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsTypeAliasIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsTypeAliasIndex.kt
@@ -16,7 +16,7 @@ import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.search.RsWithMacrosProjectScope
 import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.psi.ext.RsAbstractableOwner
-import org.rust.lang.core.psi.ext.containingCargoPackage
+import org.rust.lang.core.psi.ext.containingCrate
 import org.rust.lang.core.psi.ext.owner
 import org.rust.lang.core.psi.isValidProjectMember
 import org.rust.lang.core.resolve.RsProcessor
@@ -51,7 +51,7 @@ class RsTypeAliasIndex : AbstractStubIndex<TyFingerprint, RsTypeAlias>() {
                 val stdlibAliases = mutableListOf<RsTypeAlias>()
                 val workspaceAliases = mutableListOf<RsTypeAlias>()
                 for (alias in aliases) {
-                    val packageOrigin = alias.containingCargoPackage?.origin ?: continue
+                    val packageOrigin = alias.containingCrate?.origin ?: continue
                     when (packageOrigin) {
                         PackageOrigin.STDLIB -> stdlibAliases += alias
                         PackageOrigin.WORKSPACE -> workspaceAliases += alias

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsExternCrateReexportIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsExternCrateReexportIndex.kt
@@ -14,7 +14,7 @@ import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import org.rust.lang.core.psi.RsExternCrateItem
 import org.rust.lang.core.psi.ext.RsMod
-import org.rust.lang.core.psi.ext.containingCargoTarget
+import org.rust.lang.core.psi.ext.containingCrate
 import org.rust.lang.core.psi.rustStructureOrAnyPsiModificationTracker
 import org.rust.lang.core.stubs.RsExternCrateItemStub
 import org.rust.lang.core.stubs.RsFileStub
@@ -39,7 +39,7 @@ class RsExternCrateReexportIndex : StringStubIndexExtension<RsExternCrateItem>()
         fun findReexports(project: Project, crateRoot: RsMod): List<RsExternCrateItem> {
             checkCommitIsNotInProgress(project)
             return CachedValuesManager.getCachedValue(crateRoot) {
-                val targetName = crateRoot.containingCargoTarget?.normName
+                val targetName = crateRoot.containingCrate?.normName
                 val reexports = if (targetName != null) {
                     getElements(KEY, targetName, project, GlobalSearchScope.allScope(project))
                         .filter { externCrateItem -> externCrateItem.reference.resolve() == crateRoot }

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -43,7 +43,10 @@ import com.intellij.psi.impl.PsiDocumentManagerBase
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
 import com.intellij.reference.SoftReference
+import com.intellij.util.CachedValueImpl
 import org.jdom.Element
 import org.jdom.input.SAXBuilder
 import org.rust.cargo.RustfmtWatcher
@@ -330,6 +333,14 @@ fun runWithEnabledFeature(featureId: String, action: () -> Unit) {
         action()
     } finally {
         setFeatureEnabled(featureId, currentValue)
+    }
+}
+
+class CachedValueDelegate<T>(provider: () -> CachedValueProvider.Result<T>) {
+    private val cachedValue: CachedValue<T> = CachedValueImpl(provider)
+
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): T {
+        return cachedValue.value
     }
 }
 

--- a/src/main/kotlin/org/rust/stdext/Collections.kt
+++ b/src/main/kotlin/org/rust/stdext/Collections.kt
@@ -160,6 +160,8 @@ fun <T> dequeOf(): Deque<T> = ArrayDeque<T>()
 fun <T> dequeOf(vararg elements: T): Deque<T> =
     ArrayDeque<T>().apply { addAll(elements) }
 
+inline fun <reified T: Enum<T>> enumSetOf(): EnumSet<T> = EnumSet.noneOf(T::class.java)
+
 typealias LookbackValue<T> = Pair<T, T?>
 
 fun <T> Sequence<T>.withPrevious(): Sequence<LookbackValue<T>> = LookbackSequence(this)

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -848,6 +848,9 @@
                         serviceImplementation="org.rust.cargo.project.model.impl.CargoProjectsServiceImpl"
                         testServiceImplementation="org.rust.cargo.project.model.impl.TestCargoProjectsServiceImpl"/>
 
+        <projectService serviceInterface="org.rust.lang.core.crate.CrateGraphService"
+                        serviceImplementation="org.rust.lang.core.crate.impl.CrateGraphServiceImpl"/>
+
         <toolWindow id="Cargo"
                     anchor="right"
                     factoryClass="org.rust.cargo.project.toolwindow.CargoToolWindowFactory"

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -398,7 +398,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
 
         use dep_lib_target::Foo;
                             //^ dep-lib-new/lib.rs
-    """, NameResolutionTestmarks.otherVersionOfSameCrate)
+    """)
 
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test resolve reference without extern crate item 1 (edition 2018)`() = stubOnlyResolve("""


### PR DESCRIPTION
*Crate graph* is a simplified project model (comparing to complex [cargo project model](https://github.com/intellij-rust/intellij-rust/blob/master/ARCHITECTURE.md#project-model)) described in terms of *crates* (mostly from `rustc` point of view).

Crate is usually a `Target` In terms of Cargo project model

This PR solves these problems:
1. It's just simpler to work with Crate graph then with Cargo project model. Some complex code was simplified
2. Sometimes we want to have a (virtual, dummy, fake) crate where there are no cargo targets, e.g. in the case of `doctest`s
3. Now we have API that allows us to get direct/transitive/reverse dependencies of some crate
4. Now we have topological sorting of crates and persistent crate `id`s, both needed for the new name resolution 2.0
5. In theory, this opens a way to support non cargo-based projects (like #5594) 