### PR TITLE
Notify user about unsupported toolchain version

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
@@ -109,6 +109,8 @@ data class RustToolchain(val location: Path) {
         const val CARGO_LOCK = "Cargo.lock"
         const val XARGO_TOML = "Xargo.toml"
 
+        val MIN_SUPPORTED_TOOLCHAIN = SemVer.parseFromText("1.32.0")!!
+
         fun suggest(): RustToolchain? = Suggestions.all().mapNotNull {
             val candidate = RustToolchain(it.toPath().toAbsolutePath())
             if (candidate.looksLikeValidToolchain()) candidate else null


### PR DESCRIPTION
We have a minimal supported Rust toolchain version. Today it is `1.32.0` (but I want to bump it to `1.39.0` in #5690). An older toolchain can lead to random bugs, or the plugin can be totally unusable. For now, we don't notify a user about outdated toolchain. I propose such notification:

![image](https://user-images.githubusercontent.com/3221931/86597197-18cf4500-bfa4-11ea-8477-0e0b3473e77f.png)
