### PR TITLE
Detect integer overflow and division by zero errors

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -39,13 +39,14 @@ import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.resolve.namespaces
 import org.rust.lang.core.resolve.ref.deepResolve
 import org.rust.lang.core.types.*
-import org.rust.lang.core.types.consts.asLong
+import org.rust.lang.core.types.consts.asInteger
 import org.rust.lang.core.types.infer.containsTyOfClass
 import org.rust.lang.core.types.infer.substitute
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.utils.*
 import org.rust.lang.utils.RsDiagnostic.IncorrectFunctionArgumentCountError.FunctionType
 import org.rust.lang.utils.evaluation.evaluate
+import java.math.BigInteger
 
 class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     override fun isForceHighlightParents(file: PsiFile): Boolean = file is RsFile
@@ -408,14 +409,14 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     private fun checkDuplicateEnumVariants(holder: RsAnnotationHolder, o: RsEnumBody) {
         data class VariantInfo(val variant: RsEnumVariant, val alreadyReported: Boolean)
 
-        var discrCounter = 0L
+        var discrCounter = BigInteger.ZERO
         val reprType = (o.parent as? RsEnumItem)?.reprType ?: return
-        val indexToVariantMap = hashMapOf<Long, VariantInfo>()
+        val indexToVariantMap = hashMapOf<BigInteger, VariantInfo>()
         for (variant in o.enumVariantList) {
             val expr = variant.variantDiscriminant?.expr
-            val int = if (expr != null) expr.evaluate(reprType).asLong() ?: return else null
+            val int = if (expr != null) expr.evaluate(reprType).asInteger() ?: return else null
             val idx = int ?: discrCounter
-            discrCounter = idx + 1
+            discrCounter = idx.inc()
 
             val previous = indexToVariantMap[idx]
             if (previous != null) {

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -414,7 +414,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         val indexToVariantMap = hashMapOf<BigInteger, VariantInfo>()
         for (variant in o.enumVariantList) {
             val expr = variant.variantDiscriminant?.expr
-            val int = if (expr != null) expr.evaluate(reprType).asInteger() ?: return else null
+            val int = if (expr != null) expr.evaluate(reprType).value.asInteger() ?: return else null
             val idx = int ?: discrCounter
             discrCounter = idx.inc()
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsRedundantElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsRedundantElseInspection.kt
@@ -59,7 +59,7 @@ class RsRedundantElseInspection : RsLocalInspectionTool() {
             }
         private val RsCondition.isRedundant: Boolean
             get() {
-                return patList?.all { pat -> pat.isIrrefutable } ?: (this.expr.evaluate().asBool() ?: false)
+                return patList?.all { pat -> pat.isIrrefutable } ?: (this.expr.evaluate().value.asBool() ?: false)
             }
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsDivisionByZeroInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsDivisionByZeroInspection.kt
@@ -1,0 +1,21 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.utils.evaluation.ConstEvaluationDiagnostic
+
+class RsDivisionByZeroInspection : RsIntegerConstEvaluationInspection() {
+
+    override fun customProblemType(owner: PsiElement, expr: RsExpr): ProblemType {
+        return ProblemType.Lint(RsLint.UnconditionalPanic, "Attempt to divide by zero")
+    }
+
+    override fun acceptDiagnostic(diagnostic: ConstEvaluationDiagnostic): Boolean {
+        return diagnostic is ConstEvaluationDiagnostic.DivisionByZero
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsIntegerConstEvaluationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsIntegerConstEvaluationInspection.kt
@@ -1,0 +1,89 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.isAncestor
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.lints.RsIntegerConstEvaluationInspection.ProblemType.Error
+import org.rust.ide.inspections.lints.RsIntegerConstEvaluationInspection.ProblemType.Lint
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.ancestors
+import org.rust.lang.core.psi.ext.isConst
+import org.rust.lang.core.types.ty.TyInteger
+import org.rust.lang.core.types.type
+import org.rust.lang.utils.RsDiagnostic
+import org.rust.lang.utils.addToHolder
+import org.rust.lang.utils.evaluation.ConstEvaluationDiagnostic
+import org.rust.lang.utils.evaluation.evaluate
+
+abstract class RsIntegerConstEvaluationInspection : RsLintInspection() {
+
+    override fun getLint(element: PsiElement): RsLint? {
+        if (element !is RsExpr) return null
+        return (problemType(element) as? Lint)?.lint
+    }
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor? {
+        return object : RsVisitor() {
+            override fun visitExpr(o: RsExpr) {
+                if (o.type !is TyInteger) return
+                val parent = o.parent
+                if (!isIntegerExprOwner(parent)) return
+
+                val evaluationResult = o.evaluate(collectDiagnostics = true)
+
+                for (diagnostic in evaluationResult.diagnostics) {
+                    if (!o.isAncestor(diagnostic.expr)) continue
+                    registerProblem(holder, diagnostic)
+                }
+            }
+        }
+    }
+
+    private fun isIntegerExprOwner(element: PsiElement): Boolean {
+        if (element is RsExpr && element.type is TyInteger) return false
+        if (element is RsBlock && element.parent is RsBlockExpr) return false
+        return true
+    }
+
+    private fun registerProblem(holder: RsProblemsHolder, diagnostic: ConstEvaluationDiagnostic) {
+        if (acceptDiagnostic(diagnostic)) {
+            val problemType = problemType(diagnostic.expr) ?: return
+            when (problemType) {
+                is Lint -> holder.registerLintProblem(diagnostic.expr, problemType.message)
+                is Error -> problemType.diagnostic.addToHolder(holder)
+            }
+        }
+    }
+
+    protected open fun problemType(expr: RsExpr): ProblemType? {
+        val owner = expr.ancestors.firstOrNull(::isIntegerExprOwner) ?: return null
+
+        return when (owner) {
+            is RsVariantDiscriminant,
+            is RsTypeArgumentList,
+            is RsArrayType,
+            is RsArrayExpr -> Error(RsDiagnostic.ConstantEvaluationFailed(expr, "Evaluation of constant value failed"))
+            is RsConstant -> {
+                if (owner.isConst) {
+                    Lint(RsLint.ConstErr, "Any use of this value will cause an error")
+                } else {
+                    Error(RsDiagnostic.ConstantEvaluationFailed(expr, "Could not evaluate static initializer"))
+                }
+            }
+            else -> customProblemType(owner, expr)
+        }
+    }
+
+    protected abstract fun customProblemType(owner: PsiElement, expr: RsExpr): ProblemType
+    protected abstract fun acceptDiagnostic(diagnostic: ConstEvaluationDiagnostic): Boolean
+
+    protected sealed class ProblemType {
+        data class Lint(val lint: RsLint, val message: String) : ProblemType()
+        class Error(val diagnostic: RsDiagnostic) : ProblemType()
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsIntegerOverflowInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsIntegerOverflowInspection.kt
@@ -1,0 +1,54 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.psi.PsiElement
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsLitExpr
+import org.rust.lang.core.psi.RsUnaryExpr
+import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.ext.UnaryOperator
+import org.rust.lang.core.psi.ext.operatorType
+import org.rust.lang.core.types.consts.asLong
+import org.rust.lang.core.types.ty.TyInteger
+import org.rust.lang.core.types.type
+import org.rust.lang.utils.evaluation.ConstExpr
+import org.rust.lang.utils.evaluation.toConstExpr
+import org.rust.lang.utils.evaluation.validValuesRange
+
+class RsIntegerOverflowInspection : RsLintInspection() {
+    override fun getLint(element: PsiElement): RsLint = RsLint.OverflowingLiterals
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
+        object : RsVisitor() {
+            override fun visitLitExpr(o: RsLitExpr) {
+                val type = o.type
+                if (type !is TyInteger) return
+
+                val parent = o.parent
+                val expr: RsExpr = if (parent is RsUnaryExpr && parent.operatorType == UnaryOperator.MINUS) {
+                    parent
+                } else {
+                    o
+                }
+
+                val value = evaluate(expr.toConstExpr()) ?: return
+                if (overflows(value, type)) {
+                    holder.registerProblem(expr, "literal out of range for $type")
+                }
+            }
+        }
+
+    private fun evaluate(expr: ConstExpr<*>?): Long? = when {
+        expr is ConstExpr.Constant -> expr.const.asLong()
+        expr is ConstExpr.Value.Integer -> expr.value
+        expr is ConstExpr.Unary && expr.operator == UnaryOperator.MINUS -> evaluate(expr.expr)?.let { -it }
+        else -> null
+    }
+
+    private fun overflows(value: Long, type: TyInteger): Boolean = value !in type.validValuesRange
+}

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -73,7 +73,9 @@ enum class RsLint(
             }
     },
 
-    UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY);
+    UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY),
+
+    OverflowingLiterals("overflowing_literals", defaultLevel = DENY);
 
     protected open fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
         when (level) {

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -45,6 +45,11 @@ enum class RsLint(
             }
     },
 
+    OverflowingLiterals("overflowing_literals", defaultLevel = DENY),
+    ArithmeticOverflow("arithmetic_overflow", defaultLevel = DENY),
+    UnconditionalPanic("unconditional_panic", defaultLevel = DENY),
+    ConstErr("const_err", defaultLevel = DENY),
+
     NeedlessLifetimes("clippy::needless_lifetimes", listOf("clippy::complexity", "clippy::all", "clippy")) {
         override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
             when (level) {
@@ -73,9 +78,7 @@ enum class RsLint(
             }
     },
 
-    UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY),
-
-    OverflowingLiterals("overflowing_literals", defaultLevel = DENY);
+    UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY);
 
     protected open fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
         when (level) {

--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRendering.kt
@@ -199,7 +199,7 @@ private fun StringBuilder.appendPath(path: RsPath, subst: Substitution, renderLi
 }
 
 private fun StringBuilder.appendConstExpr(expr: RsExpr, subst: Substitution) {
-    when (val const = expr.evaluate().substitute(subst)) { // may trigger resolve
+    when (val const = expr.evaluate().value.substitute(subst)) { // may trigger resolve
         is CtValue -> append(const)
         is CtConstParameter -> append("{ $const }")
         else -> append("{}")

--- a/src/main/kotlin/org/rust/ide/utils/BooleanExprSimplifier.kt
+++ b/src/main/kotlin/org/rust/ide/utils/BooleanExprSimplifier.kt
@@ -117,6 +117,6 @@ class BooleanExprSimplifier(val project: Project) {
 
         private fun canBeEvaluated(expr: RsExpr): Boolean = eval(expr) != null
 
-        private fun eval(expr: RsExpr): Boolean? = expr.evaluate(TyBool, resolver = null).asBool()
+        private fun eval(expr: RsExpr): Boolean? = expr.evaluate(TyBool, resolver = null).value.asBool()
     }
 }

--- a/src/main/kotlin/org/rust/ide/utils/checkMatch/CheckMatchUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/checkMatch/CheckMatchUtils.kt
@@ -92,7 +92,7 @@ val Matrix.firstColumn: List<Pattern> get() = mapNotNull { row -> row.firstOrNul
 fun List<RsMatchArm>.calculateMatrix(): Matrix =
     flatMap { arm -> arm.patList.map { listOf(it.lower) } }
 
-private val RsExpr.value: Value<*>?
+private val RsExpr.value: Value<*, *>?
     get() = (evaluate().value as? CtValue)?.expr
 
 // lower_pattern_unadjusted

--- a/src/main/kotlin/org/rust/ide/utils/checkMatch/CheckMatchUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/checkMatch/CheckMatchUtils.kt
@@ -93,7 +93,7 @@ fun List<RsMatchArm>.calculateMatrix(): Matrix =
     flatMap { arm -> arm.patList.map { listOf(it.lower) } }
 
 private val RsExpr.value: Value<*>?
-    get() = (evaluate() as? CtValue)?.expr
+    get() = (evaluate().value as? CtValue)?.expr
 
 // lower_pattern_unadjusted
 private val RsPat.kind: PatternKind

--- a/src/main/kotlin/org/rust/ide/utils/checkMatch/Constructor.kt
+++ b/src/main/kotlin/org/rust/ide/utils/checkMatch/Constructor.kt
@@ -20,15 +20,15 @@ sealed class Constructor {
 
     /** The constructor of all patterns that don't vary by constructor, e.g. struct patterns and fixed-length arrays */
     object Single : Constructor() {
-        override fun coveredByRange(from: Value<*>, to: Value<*>, included: Boolean): Boolean = true
+        override fun coveredByRange(from: Value<*, *>, to: Value<*, *>, included: Boolean): Boolean = true
     }
 
     /** Enum variants */
     data class Variant(val variant: RsEnumVariant) : Constructor()
 
     /** Literal values */
-    data class ConstantValue(val value: Value<*>) : Constructor() {
-        override fun coveredByRange(from: Value<*>, to: Value<*>, included: Boolean): Boolean =
+    data class ConstantValue(val value: Value<*, *>) : Constructor() {
+        override fun coveredByRange(from: Value<*, *>, to: Value<*, *>, included: Boolean): Boolean =
             if (included) {
                 value >= from && value <= to
             } else {
@@ -37,9 +37,9 @@ sealed class Constructor {
     }
 
     /** Ranges of literal values (`2..=5` and `2..5`) */
-    data class ConstantRange(val start: Value<*>, val end: Value<*>, val includeEnd: Boolean = false) :
+    data class ConstantRange(val start: Value<*, *>, val end: Value<*, *>, val includeEnd: Boolean = false) :
         Constructor() {
-        override fun coveredByRange(from: Value<*>, to: Value<*>, included: Boolean): Boolean =
+        override fun coveredByRange(from: Value<*, *>, to: Value<*, *>, included: Boolean): Boolean =
             if (includeEnd) {
                 ((end < to) || (included && to == end)) && (start >= from)
             } else {
@@ -70,7 +70,7 @@ sealed class Constructor {
         else -> 0
     }
 
-    open fun coveredByRange(from: Value<*>, to: Value<*>, included: Boolean): Boolean = false
+    open fun coveredByRange(from: Value<*, *>, to: Value<*, *>, included: Boolean): Boolean = false
 
     fun subTypes(type: Ty): List<Ty> = when (type) {
         is TyTuple -> type.types
@@ -117,7 +117,7 @@ sealed class Constructor {
     }
 }
 
-private operator fun Value<*>.compareTo(other: Value<*>): Int {
+private operator fun Value<*, *>.compareTo(other: Value<*, *>): Int {
     return when {
         this is Value.Bool && other is Value.Bool -> value.compareTo(other.value)
         this is Value.Integer && other is Value.Integer -> value.compareTo(other.value)

--- a/src/main/kotlin/org/rust/ide/utils/checkMatch/Constructor.kt
+++ b/src/main/kotlin/org/rust/ide/utils/checkMatch/Constructor.kt
@@ -100,7 +100,7 @@ sealed class Constructor {
     companion object {
         private fun allConstructorsLazy(ty: Ty): Sequence<Constructor> =
             when {
-                ty is TyBool -> sequenceOf(true, false).map { ConstantValue(Value.Bool(it)) }
+                ty is TyBool -> sequenceOf(true, false).map { ConstantValue(Value.Bool(it, null)) }
 
                 ty is TyAdt && ty.item is RsEnumItem -> ty.item.variants.asSequence().map { Variant(it) }
 

--- a/src/main/kotlin/org/rust/ide/utils/checkMatch/PatternKind.kt
+++ b/src/main/kotlin/org/rust/ide/utils/checkMatch/PatternKind.kt
@@ -25,9 +25,9 @@ sealed class PatternKind {
     /** &P, &mut P, etc */
     data class Deref(val subPattern: Pattern) : PatternKind()
 
-    data class Const(val value: Value<*>) : PatternKind()
+    data class Const(val value: Value<*, *>) : PatternKind()
 
-    data class Range(val lc: Value<*>, val rc: Value<*>, val isInclusive: Boolean) : PatternKind()
+    data class Range(val lc: Value<*, *>, val rc: Value<*, *>, val isInclusive: Boolean) : PatternKind()
 
 
     interface SliceField {

--- a/src/main/kotlin/org/rust/lang/core/psi/RsLiteralKind.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsLiteralKind.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.util.TextRange
 import org.rust.lang.core.lexer.RsEscapesLexer
 import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.utils.unescapeRust
+import java.math.BigInteger
 
 interface RsComplexLiteral {
     val node: ASTNode
@@ -38,7 +39,7 @@ sealed class RsLiteralKind(val node: ASTNode) {
 
         override val offsets: LiteralOffsets by lazy { offsetsForNumber(node) }
 
-        val value: Long? get() {
+        val value: BigInteger? get() {
             val textValue = offsets.value?.substring(node.text) ?: return null
             val (start, radix) = when (textValue.take(2)) {
                 "0x" -> 2 to 16
@@ -48,7 +49,7 @@ sealed class RsLiteralKind(val node: ASTNode) {
             }
             val cleanTextValue = textValue.substring(start).filter { it != '_' }
             return try {
-                java.lang.Long.parseLong(cleanTextValue, radix)
+                BigInteger(cleanTextValue, radix)
             } catch (e: NumberFormatException) {
                 null
             }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt
@@ -7,10 +7,11 @@ package org.rust.lang.core.psi.ext
 
 import org.rust.lang.core.psi.RsArrayType
 import org.rust.lang.core.stubs.RsArrayTypeStub
-import org.rust.lang.core.types.consts.asLong
+import org.rust.lang.core.types.consts.asInteger
 import org.rust.lang.core.types.ty.TyInteger
 import org.rust.lang.utils.evaluation.evaluate
+import java.math.BigInteger
 
 val RsArrayType.isSlice: Boolean get() = (greenStub as? RsArrayTypeStub)?.isSlice ?: (expr == null)
 
-val RsArrayType.arraySize: Long? get() = expr?.evaluate(TyInteger.USize)?.asLong()
+val RsArrayType.arraySize: BigInteger? get() = expr?.evaluate(TyInteger.USize)?.asInteger()

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsArrayType.kt
@@ -14,4 +14,4 @@ import java.math.BigInteger
 
 val RsArrayType.isSlice: Boolean get() = (greenStub as? RsArrayTypeStub)?.isSlice ?: (expr == null)
 
-val RsArrayType.arraySize: BigInteger? get() = expr?.evaluate(TyInteger.USize)?.asInteger()
+val RsArrayType.arraySize: BigInteger? get() = expr?.evaluate(TyInteger.USize)?.value?.asInteger()

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsLitExpr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsLitExpr.kt
@@ -25,6 +25,7 @@ import org.rust.lang.core.stubs.RsPlaceholderStub
 import org.rust.lang.core.stubs.RsStubLiteralKind
 import org.rust.lang.core.types.ty.TyFloat
 import org.rust.lang.core.types.ty.TyInteger
+import java.math.BigInteger
 
 val RsLitExpr.stubKind: RsStubLiteralKind?
     get() {
@@ -41,7 +42,7 @@ val RsLitExpr.stubKind: RsStubLiteralKind?
     }
 
 val RsLitExpr.booleanValue: Boolean? get() = (stubKind as? RsStubLiteralKind.Boolean)?.value
-val RsLitExpr.integerValue: Long? get() = (stubKind as? RsStubLiteralKind.Integer)?.value
+val RsLitExpr.integerValue: BigInteger? get() = (stubKind as? RsStubLiteralKind.Integer)?.value
 val RsLitExpr.floatValue: Double? get() = (stubKind as? RsStubLiteralKind.Float)?.value
 val RsLitExpr.charValue: String? get() = (stubKind as? RsStubLiteralKind.Char)?.value
 val RsLitExpr.stringValue: String? get() = (stubKind as? RsStubLiteralKind.String)?.value

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -260,7 +260,7 @@ fun <T : RsElement> instantiatePathGenerics(
     val constParameters = element.constParameters.map { CtConstParameter(it) }
     val constArguments = path.typeArgumentList?.exprList?.withIndex()?.map { (i, expr) ->
         val expectedTy = constParameters.getOrNull(i)?.parameter?.typeReference?.type ?: TyUnknown
-        expr.evaluate(expectedTy, resolver)
+        expr.evaluate(expectedTy, resolver).value
     }
     val constSubst = constParameters.withIndex().associate { (i, param) ->
         val value = constArguments?.getOrNull(i)

--- a/src/main/kotlin/org/rust/lang/core/types/consts/CtValue.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/consts/CtValue.kt
@@ -6,13 +6,14 @@
 package org.rust.lang.core.types.consts
 
 import org.rust.lang.utils.evaluation.ConstExpr
+import java.math.BigInteger
 
 fun Const.asBool(): Boolean? {
     if (this !is CtValue) return null
     return (expr as? ConstExpr.Value.Bool)?.value
 }
 
-fun Const.asLong(): Long? {
+fun Const.asInteger(): BigInteger? {
     if (this !is CtValue) return null
     return (expr as? ConstExpr.Value.Integer)?.value
 }

--- a/src/main/kotlin/org/rust/lang/core/types/consts/CtValue.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/consts/CtValue.kt
@@ -18,6 +18,6 @@ fun Const.asInteger(): BigInteger? {
     return (expr as? ConstExpr.Value.Integer)?.value
 }
 
-data class CtValue(val expr: ConstExpr.Value<*>) : Const() {
+data class CtValue(val expr: ConstExpr.Value<*, *>) : Const() {
     override fun toString(): String = expr.toString()
 }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -93,7 +93,7 @@ fun inferTypeReferenceType(type: RsTypeReference, defaultTraitObjectRegion: Regi
             if (type.isSlice) {
                 TySlice(componentType)
             } else {
-                val const = type.expr?.evaluate(TyInteger.USize) ?: CtUnknown
+                val const = type.expr?.evaluate(TyInteger.USize)?.value ?: CtUnknown
                 TyArray(componentType, const)
             }
         }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
@@ -157,7 +157,7 @@ private fun inferSlicePatsTypes(
             return CtUnknown
         }
 
-        return ConstExpr.Value.Integer(restSize, TyInteger.USize).toConst()
+        return ConstExpr.Value.Integer(restSize, TyInteger.USize, null).toConst()
     }
 
     val (elementType, restType) = when (sliceType) {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
@@ -18,6 +18,7 @@ import org.rust.lang.core.types.ty.Mutability.IMMUTABLE
 import org.rust.lang.core.types.type
 import org.rust.lang.utils.evaluation.ConstExpr
 import org.rust.lang.utils.evaluation.toConst
+import java.math.BigInteger
 
 fun RsPat.extractBindings(fcx: RsTypeInferenceWalker, type: Ty, defBm: RsBindingModeKind = BindByValue(IMMUTABLE)) {
     when (this) {
@@ -150,8 +151,8 @@ private fun inferSlicePatsTypes(
             return CtUnknown
         }
 
-        val restSize = arraySize - patList.size.toLong() + 1
-        if (restSize < 0) {
+        val restSize = arraySize - patList.size.toBigInteger() + BigInteger.ONE
+        if (restSize.signum() < 0) {
             PatternMatchingTestMarks.negativeRestSize.hit()
             return CtUnknown
         }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -302,7 +302,7 @@ class RsTypeInferenceWalker(
             is RsStubLiteralKind.String -> {
                 // TODO infer the actual lifetime
                 if (stubKind.isByte) {
-                    val size = stubKind.value?.length?.toLong()
+                    val size = stubKind.value?.length?.toBigInteger()
                     val const = size?.let { ConstExpr.Value.Integer(it, TyInteger.USize).toConst() } ?: CtUnknown
                     TyReference(TyArray(TyInteger.U8, const), Mutability.IMMUTABLE, ReStatic)
                 } else {
@@ -1294,7 +1294,7 @@ class RsTypeInferenceWalker(
         } else {
             val elementTypes = expr.arrayElements?.map { it.inferType(expectedElemTy) }
             val size = if (elementTypes != null) {
-                val size = elementTypes.size.toLong()
+                val size = elementTypes.size.toBigInteger()
                 ConstExpr.Value.Integer(size, TyInteger.USize).toConst()
             } else {
                 CtUnknown

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -303,7 +303,7 @@ class RsTypeInferenceWalker(
                 // TODO infer the actual lifetime
                 if (stubKind.isByte) {
                     val size = stubKind.value?.length?.toBigInteger()
-                    val const = size?.let { ConstExpr.Value.Integer(it, TyInteger.USize).toConst() } ?: CtUnknown
+                    val const = size?.let { ConstExpr.Value.Integer(it, TyInteger.USize, null).toConst() } ?: CtUnknown
                     TyReference(TyArray(TyInteger.U8, const), Mutability.IMMUTABLE, ReStatic)
                 } else {
                     TyReference(TyStr, Mutability.IMMUTABLE, ReStatic)
@@ -652,7 +652,7 @@ class RsTypeInferenceWalker(
         val resolver = PathExprResolver.fromContext(ctx)
         val constArguments = methodCall.constArguments.withIndex().map { (i, expr) ->
             val expectedTy = constParameters.getOrNull(i)?.parameter?.typeReference?.type ?: TyUnknown
-            expr.evaluate(expectedTy, resolver)
+            expr.evaluate(expectedTy, resolver).value
         }
         val constSubst = constParameters.zip(constArguments).toMap()
 
@@ -1289,13 +1289,13 @@ class RsTypeInferenceWalker(
                 ?: return TySlice(TyUnknown)
             val sizeExpr = expr.sizeExpr
             sizeExpr?.inferType(TyInteger.USize)
-            val size = sizeExpr?.evaluate(TyInteger.USize, PathExprResolver.fromContext(ctx)) ?: CtUnknown
+            val size = sizeExpr?.evaluate(TyInteger.USize, PathExprResolver.fromContext(ctx))?.value ?: CtUnknown
             elementType to size
         } else {
             val elementTypes = expr.arrayElements?.map { it.inferType(expectedElemTy) }
             val size = if (elementTypes != null) {
                 val size = elementTypes.size.toBigInteger()
-                ConstExpr.Value.Integer(size, TyInteger.USize).toConst()
+                ConstExpr.Value.Integer(size, TyInteger.USize, null).toConst()
             } else {
                 CtUnknown
             }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyArray.kt
@@ -6,12 +6,13 @@
 package org.rust.lang.core.types.ty
 
 import org.rust.lang.core.types.consts.Const
-import org.rust.lang.core.types.consts.asLong
+import org.rust.lang.core.types.consts.asInteger
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
+import java.math.BigInteger
 
 data class TyArray(val base: Ty, val const: Const) : Ty(base.flags or const.flags) {
-    val size: Long? get() = const.asLong()
+    val size: BigInteger? get() = const.asInteger()
 
     override fun superFoldWith(folder: TypeFolder): Ty =
         TyArray(base.foldWith(folder), const.foldWith(folder))

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
@@ -60,7 +60,7 @@ object TyStr : TyPrimitive() {
 
 abstract class TyNumeric : TyPrimitive()
 
-sealed class TyInteger(override val name: String, val ordinal: Int) : TyNumeric() {
+sealed class TyInteger(override val name: String, val ordinal: Int, val signed: Boolean) : TyNumeric() {
 
     // This fixes NPE caused by java classes initialization order. Details:
     // Kotlin `object`s compile into java classes with `INSTANCE` static field
@@ -94,19 +94,19 @@ sealed class TyInteger(override val name: String, val ordinal: Int) : TyNumeric(
         }
     }
 
-    object U8: TyInteger("u8", 0)
-    object U16: TyInteger("u16", 1)
-    object U32: TyInteger("u32", 2)
-    object U64: TyInteger("u64", 3)
-    object U128: TyInteger("u128", 4)
-    object USize : TyInteger("usize", 5)
+    object U8: TyInteger("u8", 0, false)
+    object U16: TyInteger("u16", 1, false)
+    object U32: TyInteger("u32", 2, false)
+    object U64: TyInteger("u64", 3, false)
+    object U128: TyInteger("u128", 4, false)
+    object USize : TyInteger("usize", 5, false)
 
-    object I8: TyInteger("i8", 6)
-    object I16: TyInteger("i16", 7)
-    object I32: TyInteger("i32", 8)
-    object I64: TyInteger("i64", 9)
-    object I128: TyInteger("i128", 10)
-    object ISize: TyInteger("isize", 11)
+    object I8: TyInteger("i8", 6, true)
+    object I16: TyInteger("i16", 7, true)
+    object I32: TyInteger("i32", 8, true)
+    object I64: TyInteger("i64", 9, true)
+    object I128: TyInteger("i128", 10, true)
+    object ISize: TyInteger("isize", 11, true)
 }
 
 sealed class TyFloat(override val name: String, val ordinal: Int) : TyNumeric() {

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -51,6 +51,7 @@ import org.rust.lang.utils.RsErrorCode.*
 import org.rust.lang.utils.Severity.*
 import org.rust.stdext.buildList
 import org.rust.stdext.buildMap
+import java.math.BigInteger
 
 private val REF_STR_TY = TyReference(TyStr, Mutability.IMMUTABLE)
 private val MUT_REF_STR_TY = TyReference(TyStr, Mutability.MUTABLE)
@@ -581,7 +582,7 @@ sealed class RsDiagnostic(
 
     class DuplicateEnumDiscriminant(
         variant: RsEnumVariant,
-        private val id: Long
+        private val id: BigInteger
     ) : RsDiagnostic(variant.variantDiscriminant?.expr ?: variant) {
         override fun prepare(): PreparedAnnotation = PreparedAnnotation(
             ERROR,

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1316,9 +1316,7 @@ sealed class RsDiagnostic(
         )
     }
 
-    class ReprAttrUnsupportedItem(element: PsiElement,
-                                  private val errorText: String
-    ) : RsDiagnostic(element) {
+    class ReprAttrUnsupportedItem(element: PsiElement, private val errorText: String) : RsDiagnostic(element) {
         override fun prepare(): PreparedAnnotation = PreparedAnnotation(
             ERROR,
             E0517,
@@ -1327,9 +1325,7 @@ sealed class RsDiagnostic(
         )
     }
 
-    class UnrecognizedReprAttribute(element: PsiElement,
-                                    private val reprName: String
-    ) : RsDiagnostic(element) {
+    class UnrecognizedReprAttribute(element: PsiElement, private val reprName: String) : RsDiagnostic(element) {
         override fun prepare(): PreparedAnnotation = PreparedAnnotation(
             ERROR,
             E0552,
@@ -1391,10 +1387,18 @@ sealed class RsDiagnostic(
             fixes = fixes
         )
     }
+
+    class ConstantEvaluationFailed(expr: RsExpr, private val message: String) : RsDiagnostic(expr) {
+        override fun prepare(): PreparedAnnotation = PreparedAnnotation(
+            ERROR,
+            E0080,
+            message
+        )
+    }
 }
 
 enum class RsErrorCode {
-    E0004, E0015, E0023, E0025, E0026, E0027, E0040, E0046, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
+    E0004, E0015, E0023, E0025, E0026, E0027, E0040, E0046, E0050, E0054, E0057, E0060, E0061, E0069, E0080, E0081, E0084,
     E0106, E0107, E0116, E0117, E0118, E0120, E0121, E0124, E0132, E0133, E0184, E0185, E0186, E0198, E0199,
     E0200, E0201, E0202, E0252, E0261, E0262, E0263, E0267, E0268, E0277,
     E0308, E0322, E0328, E0364, E0365, E0379, E0384,

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExpr.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExpr.kt
@@ -16,6 +16,7 @@ import org.rust.lang.core.types.infer.TypeFoldable
 import org.rust.lang.core.types.infer.TypeFolder
 import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.ty.*
+import java.math.BigInteger
 
 fun ConstExpr<*>.toConst(): Const =
     when (this) {
@@ -66,7 +67,7 @@ sealed class ConstExpr<T : Ty>(val flags: TypeFlags = 0) : TypeFoldable<ConstExp
             override fun toString(): String = value.toString()
         }
 
-        data class Integer(val value: Long, override val expectedTy: TyInteger) : Value<TyInteger>() {
+        data class Integer(val value: BigInteger, override val expectedTy: TyInteger) : Value<TyInteger>() {
             override fun toString(): String = value.toString()
         }
 

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExprBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/ConstExprBuilder.kt
@@ -10,6 +10,7 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
+import java.math.BigInteger
 
 fun RsExpr.toConstExpr(
     expectedTy: Ty = type,
@@ -83,9 +84,9 @@ private abstract class ConstExprBuilder<T : Ty, V> {
 private class IntegerConstExprBuilder(
     override val expectedTy: TyInteger,
     override val resolver: PathExprResolver?
-) : ConstExprBuilder<TyInteger, Long>() {
-    override val RsLitExpr.value: Long? get() = integerValue
-    override fun Long.wrap(): ConstExpr.Value.Integer = ConstExpr.Value.Integer(this, expectedTy)
+) : ConstExprBuilder<TyInteger, BigInteger>() {
+    override val RsLitExpr.value: BigInteger? get() = integerValue
+    override fun BigInteger.wrap(): ConstExpr.Value.Integer = ConstExpr.Value.Integer(this, expectedTy)
 
     override fun buildInner(expr: RsExpr?, depth: Int): ConstExpr<TyInteger>? {
         return when (expr) {

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -612,6 +612,11 @@
                          enabledByDefault="true" level="ERROR"
                          implementationClass="org.rust.ide.inspections.lints.RsIntegerOverflowInspection"/>
 
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
+                         displayName="Division by zero"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.rust.ide.inspections.lints.RsDivisionByZeroInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -607,6 +607,11 @@
                          enabledByDefault="true" level="ERROR"
                          implementationClass="org.rust.ide.inspections.lints.RsUnknownCrateTypesInspection"/>
 
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
+                         displayName="Integer overflow"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.rust.ide.inspections.lints.RsIntegerOverflowInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsDivisionByZero.html
+++ b/src/main/resources/inspectionDescriptions/RsDivisionByZero.html
@@ -1,0 +1,1 @@
+Checks if integer expressions do not contain division by zero.

--- a/src/main/resources/inspectionDescriptions/RsIntegerOverflow.html
+++ b/src/main/resources/inspectionDescriptions/RsIntegerOverflow.html
@@ -1,1 +1,1 @@
-Checks if integer literals do not overflow their types.
+Checks if integer expressions do not overflow their types.

--- a/src/main/resources/inspectionDescriptions/RsIntegerOverflow.html
+++ b/src/main/resources/inspectionDescriptions/RsIntegerOverflow.html
@@ -1,0 +1,1 @@
+Checks if integer literals do not overflow their types.

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsDivisionByZeroInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsDivisionByZeroInspectionTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+class RsDivisionByZeroInspectionTest : RsInspectionsTestBase(RsDivisionByZeroInspection::class) {
+
+    fun `test division by zero`() = checkByText("""
+        fn main() {
+            (<error descr="Attempt to divide by zero">1 / 0</error>) + (<error descr="Attempt to divide by zero">2 / 0</error>);
+        }
+    """)
+
+    fun `test division by zero in const value evaluation E0080`() = checkByText("""
+        static C: u8 = <error descr="Could not evaluate static initializer [E0080]">128 / 0</error>;
+
+        #[repr(u8)]
+        pub enum E {
+            V = <error descr="Evaluation of constant value failed [E0080]">0xF0 / 0</error>
+        }
+
+        fn foo<const N: i16>() {}
+
+        fn main() {
+            let a: [i8; <error descr="Evaluation of constant value failed [E0080]">1 / 0</error>];
+            let b = [1; <error descr="Evaluation of constant value failed [E0080]">1 / 0</error>];
+
+            foo::<{ <error descr="Evaluation of constant value failed [E0080]">256 / 0</error> }>();
+        }
+    """)
+
+    fun `test division by zero in const item initializer`() = checkByText("""
+        const C: u8 = <error descr="Any use of this value will cause an error">1 / 0</error>;
+    """)
+
+    fun `test allow arithmetic overflow`() = checkByText("""
+        #![allow(unconditional_panic)]
+
+        fn main() {
+            let _: u16 = 1 / 0;
+        }
+    """)
+
+    fun `test allow const err`() = checkByText("""
+        #![allow(const_err)]
+
+        const C: u8 = 1 / 0;
+    """)
+
+    fun `test do not load ast`() = checkByFileTree("""
+    //- main.rs
+        mod foo;
+
+        /*caret*/const C1: u8 = <error descr="Any use of this value will cause an error">1 / 0</error> + foo::C2;
+    //- foo.rs
+        pub const C2: u8 = 1 / 0;
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsIntegerOverflowInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsIntegerOverflowInspectionTest.kt
@@ -7,154 +7,160 @@ package org.rust.ide.inspections.lints
 
 import org.rust.ide.inspections.RsInspectionsTestBase
 
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+
+@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsIntegerOverflowInspectionTest : RsInspectionsTestBase(RsIntegerOverflowInspection::class) {
-    fun `test explicit type`() = checkByText("""
+    fun `test literal out of range`() = checkByText("""
         fn main() {
-            let _: u16 = <error descr="literal out of range for u16">100_000_000</error>;
+            let _: u8 = <error descr="Literal out of range for u8">256</error>;
+            let _: u16 = <error descr="Literal out of range for u16">65_536</error>;
+            let _: u32 = <error descr="Literal out of range for u32">4_294_967_296</error>;
+            let _: u64 = <error descr="Literal out of range for u64">18_446_744_073_709_551_616</error>;
+            let _: u128 = <error descr="Literal out of range for u128">340_282_366_920_938_463_463_374_607_431_768_211_456</error>;
+            let _: usize = <error descr="Literal out of range for usize">18_446_744_073_709_551_616</error>;
+
+            // Compiler produces E0600 here instead of `Literal out of range`. It should be handled by RsErrorAnnotator
+            let _: u8 = -1;
+            let _: u16 = -1;
+            let _: u32 = -1;
+            let _: u64 = -1;
+            let _: u128 = -1;
+            let _: usize = -1;
+
+            let _: i8 = <error descr="Literal out of range for i8">128</error>;
+            let _: i16 = <error descr="Literal out of range for i16">32_768</error>;
+            let _: i32 = <error descr="Literal out of range for i32">2_147_483_648</error>;
+            let _: i64 = <error descr="Literal out of range for i64">9_223_372_036_854_775_808</error>;
+            let _: i128 = <error descr="Literal out of range for i128">170_141_183_460_469_231_731_687_303_715_884_105_728</error>;
+            let _: isize = <error descr="Literal out of range for isize">9_223_372_036_854_775_808</error>;
+
+            let _: i8 = <error descr="Literal out of range for i8">-129</error>;
+            let _: i16 = <error descr="Literal out of range for i16">-32_769</error>;
+            let _: i32 = <error descr="Literal out of range for i32">-2_147_483_649</error>;
+            let _: i64 = <error descr="Literal out of range for i64">-9_223_372_036_854_775_809</error>;
+            let _: i128 = <error descr="Literal out of range for i128">-170_141_183_460_469_231_731_687_303_715_884_105_729</error>;
+            let _: isize = <error descr="Literal out of range for isize">-9_223_372_036_854_775_809</error>;
         }
     """)
 
-    fun `test inferred type`() = checkByText("""
+    fun `test integer type bounds`() = checkByText("""
         fn main() {
-            let _ = <error descr="literal out of range for i32">3_000_000_000</error>;
+            let _: u8 = 255;
+            let _: u16 = 65_535;
+            let _: u32 = 4_294_967_295;
+            let _: u64 = 18_446_744_073_709_551_615;
+            let _: u128 = 340_282_366_920_938_463_463_374_607_431_768_211_455;
+            let _: usize = 18_446_744_073_709_551_615;
+
+            let _: u8 = 0;
+            let _: u16 = 0;
+            let _: u32 = 0;
+            let _: u64 = 0;
+            let _: u128 = 0;
+            let _: usize = 0;
+
+            let _: i8 = 127;
+            let _: i16 = 32_767;
+            let _: i32 = 2_147_483_647;
+            let _: i64 = 9_223_372_036_854_775_807;
+            let _: i128 = 170_141_183_460_469_231_731_687_303_715_884_105_727;
+            let _: isize = 9_223_372_036_854_775_807;
+
+            let _: i8 = -128;
+            let _: i16 = -32_768;
+            let _: i32 = -2_147_483_648;
+            let _: i64 = -9_223_372_036_854_775_808;
+            let _: i128 = -170_141_183_460_469_231_731_687_303_715_884_105_728;
+            let _: isize = -9_223_372_036_854_775_808;
         }
     """)
 
-    fun `test hexadecimal literal`() = checkByText("""
+    fun `test overflow in arithmetic operations`() = checkByText("""
         fn main() {
-            let _: u8 = <error descr="literal out of range for u8">0xFFF</error>;
+            (<error descr="This arithmetic operation will overflow">0u8 - 1</error>) + (<error descr="This arithmetic operation will overflow">127i8 + 123</error>);
+            (<error descr="This arithmetic operation will overflow">256u16 * 256</error>) + (<error descr="This arithmetic operation will overflow">1 << 500</error>);
         }
     """)
 
-    fun `test enum repr`() = checkByText("""
+    fun `test literal out of range in const expr`() = checkByText("""
+        const C: i8 = <error descr="Literal out of range for i8">128</error>;
+        static S: u8 = <error descr="Literal out of range for u8">256</error>;
+
         #[repr(u8)]
-        pub enum Color {
-            White = <error descr="literal out of range for u8">256</error>,
+        pub enum E {
+            V = <error descr="Literal out of range for u8">0xFF1</error>
+        }
+
+        fn foo<const N: i16>() {}
+
+        fn main() {
+            foo::<<error descr="Literal out of range for i16">65536</error>>();
         }
     """)
 
-    fun `test allow overflow`() = checkByText("""
+    fun `test overflow in const value evaluation E0080`() = checkByText("""
+        static C: u8 = <error descr="Could not evaluate static initializer [E0080]">128 + 128</error>;
+
+        #[repr(u8)]
+        pub enum E {
+            V = <error descr="Evaluation of constant value failed [E0080]">0xF0 * 0o10</error>
+        }
+
+        fn foo<const N: i16>() {}
+
+        fn main() {
+            let a: [i8; <error descr="Evaluation of constant value failed [E0080]">1 << 500</error>];
+            let b = [1; <error descr="Evaluation of constant value failed [E0080]">1 << 129</error>];
+
+            foo::<{ <error descr="Evaluation of constant value failed [E0080]">256 * 256</error> }>();
+        }
+    """)
+
+    fun `test overflow in const item initializer`() = checkByText("""
+        const C: u8 = <error descr="Any use of this value will cause an error">1 - 2</error>;
+    """)
+
+    fun `test allow overflowing literals`() = checkByText("""
         #![allow(overflowing_literals)]
+
+        const C: i8 = 128;
+        static S: u8 = 256;
+
+        #[repr(u8)]
+        pub enum E {
+            V = 0xFF1
+        }
+
+        fn foo<const N: i16>() {}
+
         fn main() {
             let _: u16 = 100_000_000;
+            foo::<65536>();
         }
     """)
 
-    fun `test u8 no overflow`() = checkByText("""
+    fun `test allow arithmetic overflow`() = checkByText("""
+        #![allow(arithmetic_overflow)]
+
         fn main() {
-            0u8;
-            255u8;
+            let _: u16 = 0 - 1;
         }
     """)
 
-    fun `test u8 overflow`() = checkByText("""
-        fn main() {
-            <error descr="literal out of range for u8">256u8</error>;
-        }
+    fun `test allow const err`() = checkByText("""
+        #![allow(const_err)]
+
+        const C: u8 = 1 - 2;
     """)
 
-    fun `test u16 no overflow`() = checkByText("""
-        fn main() {
-            0u16;
-            65535u16;
-        }
-    """)
+    fun `test do not load ast`() = checkByFileTree("""
+    //- main.rs
+        mod foo;
 
-    fun `test u16 overflow`() = checkByText("""
-        fn main() {
-            <error descr="literal out of range for u16">65536u16</error>;
-        }
-    """)
-
-    fun `test u32 no overflow`() = checkByText("""
-        fn main() {
-            0u32;
-            4_294_967_295u32;
-        }
-    """)
-
-    fun `test u32 overflow`() = checkByText("""
-        fn main() {
-            <error descr="literal out of range for u32">4_294_967_296u32</error>;
-        }
-    """)
-
-    fun `test u64 no overflow`() = checkByText("""
-        fn main() {
-            0u64;
-            9_223_372_036_854_775_807u64;
-        }
-    """)
-
-    fun `test u64 overflow`() = checkByText("""
-        fn main() {
-            <error descr="literal out of range for u64">9_223_372_036_854_775_807u64</error>;
-        }
-    """)
-
-    fun `test infer signed literal`() = checkByText("""
-        fn main() {
-            let _: i8 = <error descr="literal out of range for i8">-129i8</error>;
-        }
-    """)
-
-    fun `test i8 no overflow`() = checkByText("""
-        fn main() {
-            -128i8;
-            0i8;
-            127i8;
-        }
-    """)
-
-    fun `test i8 overflow`() = checkByText("""
-        fn main() {
-            <error descr="literal out of range for i8">-129i8</error>;
-            <error descr="literal out of range for i8">128i8</error>;
-        }
-    """)
-
-    fun `test i16 no overflow`() = checkByText("""
-        fn main() {
-            -32768i16;
-            0i16;
-            32767i16;
-        }
-    """)
-
-    fun `test i16 overflow`() = checkByText("""
-        fn main() {
-            <error descr="literal out of range for i16">-32769i16</error>;
-            <error descr="literal out of range for i16">32768i16</error>;
-        }
-    """)
-
-    fun `test i32 no overflow`() = checkByText("""
-        fn main() {
-            -2_147_483_648i32;
-            0i32;
-            2_147_483_647i32;
-        }
-    """)
-
-    fun `test i32 overflow`() = checkByText("""
-        fn main() {
-            <error descr="literal out of range for i32">-2_147_483_649i32</error>;
-            <error descr="literal out of range for i32">2_147_483_648i32</error>;
-        }
-    """)
-
-    fun `test i64 no overflow`() = checkByText("""
-        fn main() {
-            -9_223_372_036_854_775_808i64;
-            0i64;
-            9_223_372_036_854_775_807i64;
-        }
-    """)
-
-    fun `test i64 overflow`() = checkByText("""
-        fn main() {
-            <error descr="literal out of range for i64">-9_223_372_036_854_775_809i64</error>;
-            <error descr="literal out of range for i64">9_223_372_036_854_775_808i64</error>;
-        }
+        /*caret*/const C1: u8 = <error descr="Literal out of range for u8">256</error> + foo::C2;
+    //- foo.rs
+        pub const C2: u8 = 256;
     """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsIntegerOverflowInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsIntegerOverflowInspectionTest.kt
@@ -1,0 +1,160 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class RsIntegerOverflowInspectionTest : RsInspectionsTestBase(RsIntegerOverflowInspection::class) {
+    fun `test explicit type`() = checkByText("""
+        fn main() {
+            let _: u16 = <error descr="literal out of range for u16">100_000_000</error>;
+        }
+    """)
+
+    fun `test inferred type`() = checkByText("""
+        fn main() {
+            let _ = <error descr="literal out of range for i32">3_000_000_000</error>;
+        }
+    """)
+
+    fun `test hexadecimal literal`() = checkByText("""
+        fn main() {
+            let _: u8 = <error descr="literal out of range for u8">0xFFF</error>;
+        }
+    """)
+
+    fun `test enum repr`() = checkByText("""
+        #[repr(u8)]
+        pub enum Color {
+            White = <error descr="literal out of range for u8">256</error>,
+        }
+    """)
+
+    fun `test allow overflow`() = checkByText("""
+        #![allow(overflowing_literals)]
+        fn main() {
+            let _: u16 = 100_000_000;
+        }
+    """)
+
+    fun `test u8 no overflow`() = checkByText("""
+        fn main() {
+            0u8;
+            255u8;
+        }
+    """)
+
+    fun `test u8 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for u8">256u8</error>;
+        }
+    """)
+
+    fun `test u16 no overflow`() = checkByText("""
+        fn main() {
+            0u16;
+            65535u16;
+        }
+    """)
+
+    fun `test u16 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for u16">65536u16</error>;
+        }
+    """)
+
+    fun `test u32 no overflow`() = checkByText("""
+        fn main() {
+            0u32;
+            4_294_967_295u32;
+        }
+    """)
+
+    fun `test u32 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for u32">4_294_967_296u32</error>;
+        }
+    """)
+
+    fun `test u64 no overflow`() = checkByText("""
+        fn main() {
+            0u64;
+            9_223_372_036_854_775_807u64;
+        }
+    """)
+
+    fun `test u64 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for u64">9_223_372_036_854_775_807u64</error>;
+        }
+    """)
+
+    fun `test infer signed literal`() = checkByText("""
+        fn main() {
+            let _: i8 = <error descr="literal out of range for i8">-129i8</error>;
+        }
+    """)
+
+    fun `test i8 no overflow`() = checkByText("""
+        fn main() {
+            -128i8;
+            0i8;
+            127i8;
+        }
+    """)
+
+    fun `test i8 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for i8">-129i8</error>;
+            <error descr="literal out of range for i8">128i8</error>;
+        }
+    """)
+
+    fun `test i16 no overflow`() = checkByText("""
+        fn main() {
+            -32768i16;
+            0i16;
+            32767i16;
+        }
+    """)
+
+    fun `test i16 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for i16">-32769i16</error>;
+            <error descr="literal out of range for i16">32768i16</error>;
+        }
+    """)
+
+    fun `test i32 no overflow`() = checkByText("""
+        fn main() {
+            -2_147_483_648i32;
+            0i32;
+            2_147_483_647i32;
+        }
+    """)
+
+    fun `test i32 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for i32">-2_147_483_649i32</error>;
+            <error descr="literal out of range for i32">2_147_483_648i32</error>;
+        }
+    """)
+
+    fun `test i64 no overflow`() = checkByText("""
+        fn main() {
+            -9_223_372_036_854_775_808i64;
+            0i64;
+            9_223_372_036_854_775_807i64;
+        }
+    """)
+
+    fun `test i64 overflow`() = checkByText("""
+        fn main() {
+            <error descr="literal out of range for i64">-9_223_372_036_854_775_809i64</error>;
+            <error descr="literal out of range for i64">9_223_372_036_854_775_808i64</error>;
+        }
+    """)
+}


### PR DESCRIPTION
These changes:
* use `BigInteger` instead of `Long` to cover all valid values for large types like `u128`
* detect literal and arithmetic integer overflow in const expressions
* detect unconditional division by zero

Note, these changes do not highlight errors like `-1u8`

Part of #5888

Closes #5568
Closes #5585