### PR TITLE
FMT: Add an option to use rustfmt instead of build-in formatter

### DIFF
--- a/src/main/kotlin/org/rust/cargo/RustfmtWatcher.kt
+++ b/src/main/kotlin/org/rust/cargo/RustfmtWatcher.kt
@@ -109,7 +109,7 @@ class RustfmtWatcher {
         private fun Rustfmt.reformatDocument(cargoProject: CargoProject, document: Document) {
             checkIsDispatchThread()
             if (!document.isWritable) return
-            val formattedText = reformatDocumentText(cargoProject, document) ?: return
+            val formattedText = reformatDocumentTextOrNull(cargoProject, document) ?: return
             DocumentUtil.writeInRunUndoTransparentAction { document.setText(formattedText) }
         }
     }

--- a/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
@@ -12,6 +12,9 @@ import org.rust.openapiext.CheckboxDelegate
 import javax.swing.JComponent
 
 class RustfmtConfigurable(project: Project) : RsConfigurableBase(project) {
+    private val useRustfmtCheckbox: JBCheckBox = JBCheckBox()
+    private var useRustfmt: Boolean by CheckboxDelegate(useRustfmtCheckbox)
+
     private val runRustfmtOnSaveCheckbox: JBCheckBox = JBCheckBox()
     private var runRustfmtOnSave: Boolean by CheckboxDelegate(runRustfmtOnSaveCheckbox)
 
@@ -21,6 +24,7 @@ class RustfmtConfigurable(project: Project) : RsConfigurableBase(project) {
     override fun getDisplayName(): String = "Rustfmt"
 
     override fun createComponent(): JComponent? = layout {
+        row("Use rustfmt instead of built-in formatter:", useRustfmtCheckbox)
         row("Run rustfmt on Save:", runRustfmtOnSaveCheckbox)
         row("Don't reformat child modules (nightly only):", useSkipChildrenCheckbox, """
             Pass `--skip-children` option to rustfmt not to reformat child modules.
@@ -29,16 +33,20 @@ class RustfmtConfigurable(project: Project) : RsConfigurableBase(project) {
     }
 
     override fun isModified(): Boolean =
-        settings.runRustfmtOnSave != runRustfmtOnSave || settings.useSkipChildren != useSkipChildren
+        settings.useRustfmt != useRustfmt
+            || settings.runRustfmtOnSave != runRustfmtOnSave
+            || settings.useSkipChildren != useSkipChildren
 
     override fun apply() {
         settings.modify {
+            it.useRustfmt = useRustfmt
             it.runRustfmtOnSave = runRustfmtOnSave
             it.useSkipChildren = useSkipChildren
         }
     }
 
     override fun reset() {
+        useRustfmt = settings.useRustfmt
         runRustfmtOnSave = settings.runRustfmtOnSave
         useSkipChildren = settings.useSkipChildren
     }

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -5,11 +5,13 @@
 
 package org.rust.cargo.project.settings
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import com.intellij.util.io.systemIndependentPath
 import com.intellij.util.messages.Topic
 import com.intellij.util.xmlb.annotations.Transient
+import org.jetbrains.annotations.TestOnly
 import org.rust.cargo.toolchain.ExternalLinter
 import org.rust.cargo.toolchain.RustToolchain
 import org.rust.ide.experiments.RsExperiments
@@ -72,6 +74,9 @@ interface RustProjectSettingsService {
      * After setting change,
      */
     fun modify(action: (State) -> Unit)
+
+    @TestOnly
+    fun modifyTemporary(parentDisposable: Disposable, action: (State) -> Unit)
 
     val version: Int?
     val toolchain: RustToolchain?

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -45,6 +45,7 @@ interface RustProjectSettingsService {
         var macroExpansionEngine: MacroExpansionEngine = defaultMacroExpansionEngine,
         @AffectsHighlighting
         var doctestInjectionEnabled: Boolean = true,
+        var useRustfmt: Boolean = false,
         var runRustfmtOnSave: Boolean = false,
         var useSkipChildren: Boolean = false
     ) {
@@ -89,6 +90,7 @@ interface RustProjectSettingsService {
     val useOffline: Boolean
     val macroExpansionEngine: MacroExpansionEngine
     val doctestInjectionEnabled: Boolean
+    val useRustfmt: Boolean
     val runRustfmtOnSave: Boolean
     val useSkipChildren: Boolean
 

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -49,6 +49,7 @@ class RustProjectSettingsServiceImpl(
     override val useOffline: Boolean get() = state.useOffline
     override val macroExpansionEngine: MacroExpansionEngine get() = state.macroExpansionEngine
     override val doctestInjectionEnabled: Boolean get() = state.doctestInjectionEnabled
+    override val useRustfmt: Boolean get() = state.useRustfmt
     override val runRustfmtOnSave: Boolean get() = state.runRustfmtOnSave
     override val useSkipChildren: Boolean get() = state.useSkipChildren
 

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/SerializationUtils.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/SerializationUtils.kt
@@ -27,6 +27,7 @@ const val COMPILE_ALL_TARGETS: String = "compileAllTargets"
 const val USE_OFFLINE: String = "useOffline"
 const val MACRO_EXPANSION_ENGINE: String = "macroExpansionEngine"
 const val DOCTEST_INJECTION_ENABLED: String = "doctestInjectionEnabled"
+const val USE_RUSTFMT: String = "useRustfmt"
 const val RUN_RUSTFMT_ON_SAVE: String = "runRustfmtOnSave"
 const val USE_SKIP_CHILDREN: String = "useSkipChildren"
 

--- a/src/main/kotlin/org/rust/ide/actions/RustfmtFileAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RustfmtFileAction.kt
@@ -45,7 +45,7 @@ class RustfmtFileAction : DumbAwareAction() {
     private fun reformatDocumentAndGetText(cargoProject: CargoProject, rustfmt: Rustfmt, document: Document): String? {
         return try {
             if (checkNeedInstallRustfmt(cargoProject.project, cargoProject.workingDirectory)) return null
-            rustfmt.reformatDocumentText(cargoProject, document)
+            rustfmt.reformatDocumentTextOrNull(cargoProject, document)
         } catch (e: ExecutionException) {
             // Just easy way to know that something wrong happened
             if (isUnitTestMode) throw e

--- a/src/main/kotlin/org/rust/ide/formatter/RustfmtExternalFormatProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/RustfmtExternalFormatProcessor.kt
@@ -1,0 +1,190 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.formatter
+
+import com.intellij.application.options.CodeStyle
+import com.intellij.codeInsight.actions.ReformatCodeProcessor
+import com.intellij.execution.ExecutionException
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.ex.ApplicationManagerEx
+import com.intellij.openapi.command.CommandProcessor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapiext.Testmark
+import com.intellij.psi.PsiFile
+import com.intellij.psi.codeStyle.ExternalFormatProcessor
+import com.intellij.psi.formatter.FormatterUtil
+import com.intellij.psi.impl.source.codeStyle.CodeFormatterFacade
+import com.intellij.psi.impl.source.codeStyle.PostFormatProcessor
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.settings.rustSettings
+import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.runconfig.command.workingDirectory
+import org.rust.cargo.toolchain.Rustfmt
+import org.rust.cargo.toolchain.Rustup.Companion.checkNeedInstallRustfmt
+import org.rust.ide.formatter.RustfmtExternalFormatProcessor.Companion.formatWithRustfmtOrBuiltinFormatter
+import org.rust.ide.formatter.processors.RsPostFormatProcessor
+import org.rust.ide.formatter.processors.RsTrailingCommaFormatProcessor
+import org.rust.ide.notifications.showBalloon
+import org.rust.lang.RsLanguage
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.ext.endOffset
+import org.rust.lang.core.psi.ext.startOffset
+import org.rust.openapiext.createSmartPointer
+import org.rust.openapiext.document
+
+/**
+ * Replaces builtin intellij formatter with `Rustfmt` in the case of whole file formatting if
+ * [org.rust.cargo.project.settings.RustProjectSettingsService.useRustfmt] option is enabled.
+ * Used in a couple with [RsPostFormatProcessor].
+ *
+ * ## How the API works
+ *
+ * If [activeForFile] returns `true` for a file:
+ * 1. [format] is invoked by the platform directly (instead of any other formatting machinery),
+ * 2. OR the platform invokes all [PostFormatProcessor.processText], eventually invokes
+ *  [RsPostFormatProcessor.processText] that delegates to [formatWithRustfmtOrBuiltinFormatter].
+ *
+ * [RsPostFormatProcessor] should be the only `postFormatProcessor` in the plugin.
+ *
+ * ## How we use the API
+ *
+ * `Rustfmt` is used only when formatting is requested by user explicitly. Otherwise, we
+ * delegate formatting to the builtin formatter.
+ * Also, `Rustfmt` doesn't support formatting a part of a file, so we use it only in the case
+ * of whole file formatting. If part-file formatting is requested, we delegate it to the
+ * builtin formatter
+ */
+@Suppress("UnstableApiUsage")
+class RustfmtExternalFormatProcessor : ExternalFormatProcessor {
+
+    override fun getId(): String = "rustfmt"
+
+    override fun activeForFile(source: PsiFile): Boolean = isActiveForFile(source)
+
+    // Never used by the platform?
+    override fun indent(source: PsiFile, lineStartOffset: Int): String? = null
+
+    override fun format(
+        source: PsiFile,
+        range: TextRange,
+        canChangeWhiteSpacesOnly: Boolean,
+        keepLineBreaks: Boolean // Always `false`?
+    ): TextRange? {
+        return formatWithRustfmtOrBuiltinFormatter(source, range, canChangeWhiteSpacesOnly)
+    }
+
+    companion object {
+        fun isActiveForFile(source: PsiFile): Boolean =
+            source is RsFile && source.project.rustSettings.useRustfmt
+
+        private data class RustfmtContext(
+            val rustfmt: Rustfmt,
+            val cargoProject: CargoProject,
+            val document: Document
+        )
+
+        private fun getRustfmtContext(source: PsiFile): RustfmtContext? {
+            if (source !is RsFile) return null
+            val file = source.virtualFile ?: return null
+            val document = file.document ?: return null
+            val project = source.project
+            val cargoProject = project.cargoProjects.findProjectForFile(file) ?: return null
+            val rustfmt = project.toolchain?.rustfmt() ?: return null
+            return RustfmtContext(rustfmt, cargoProject, document)
+        }
+
+        fun formatWithRustfmtOrBuiltinFormatter(
+            source: PsiFile,
+            range: TextRange,
+            canChangeWhiteSpacesOnly: Boolean,
+        ): TextRange? {
+            val tryRustfmt = !canChangeWhiteSpacesOnly
+                && source.textRange == range
+                && getFormattingReason() == FormattingReason.ReformatCode
+            if (tryRustfmt) {
+                val context = getRustfmtContext(source)
+                if (context != null) {
+                    return formatWithRustfmt(source, range, context)
+                }
+            }
+
+            // Delegate unsupported cases to the built-in formatter
+            return formatWithBuiltin(source, range, canChangeWhiteSpacesOnly)
+        }
+
+        private fun formatWithRustfmt(source: PsiFile, range: TextRange, context: RustfmtContext): TextRange? {
+            Testmarks.rustfmtUsed.hit()
+
+            val (rustfmt, cargoProject, document) = context
+            val project = source.project
+
+            var text: String? = null
+           ApplicationManagerEx.getApplicationEx().runWriteActionWithCancellableProgressInDispatchThread("title", project, null) {
+                if (checkNeedInstallRustfmt(project, cargoProject.workingDirectory)) {
+                    return@runWriteActionWithCancellableProgressInDispatchThread
+                }
+
+                try {
+                    text = rustfmt.reformatDocumentText(cargoProject, document)
+                } catch (e: ExecutionException) {
+                    e.message?.let { project.showBalloon(it, NotificationType.ERROR) }
+                }
+            }
+
+            text?.let {
+                document.setText(it)
+            }
+
+            return range
+        }
+
+        /**
+         * Mimics to [com.intellij.psi.impl.source.codeStyle.CodeStyleManagerImpl.reformatText] and
+         * [com.intellij.psi.impl.source.codeStyle.CodeStyleManagerImpl.formatRanges]
+         */
+        private fun formatWithBuiltin(source: PsiFile, range: TextRange, canChangeWhiteSpacesOnly: Boolean): TextRange? {
+            val start = source.findElementAt(range.startOffset)?.createSmartPointer()
+            val end = source.findElementAt(range.endOffset)?.createSmartPointer()
+            val atEnd = range.endOffset == source.endOffset
+
+            val formatter = CodeFormatterFacade(CodeStyle.getSettings(source), RsLanguage, canChangeWhiteSpacesOnly)
+            formatter.processRange(source.node, range.startOffset, range.endOffset)
+
+            if (!canChangeWhiteSpacesOnly) {
+                Testmarks.builtinPostProcess.hit()
+                val startOffset = if (range.startOffset == 0) 0 else start?.element?.startOffset
+                val endOffset = if (atEnd) source.endOffset else end?.element?.endOffset
+                if (startOffset != null && endOffset != null) {
+                    RsTrailingCommaFormatProcessor.processText(
+                        source,
+                        TextRange(startOffset, endOffset),
+                        CodeStyle.getSettings(source)
+                    )
+                }
+            }
+            return range
+        }
+
+        private enum class FormattingReason {
+            ReformatCode,
+            ReformatCodeBeforeCommit,
+            Implicit
+        }
+
+        private fun getFormattingReason(): FormattingReason = when (CommandProcessor.getInstance().currentCommandName) {
+            ReformatCodeProcessor.getCommandName() -> FormattingReason.ReformatCode
+            FormatterUtil.getReformatBeforeCommitCommandName() -> FormattingReason.ReformatCodeBeforeCommit
+            else -> FormattingReason.Implicit
+        }
+    }
+
+    object Testmarks {
+        val rustfmtUsed: Testmark = Testmark("rustfmtUsed")
+        val builtinPostProcess: Testmark = Testmark("builtinPostProcess")
+    }
+}

--- a/src/main/kotlin/org/rust/ide/formatter/processors/RsPostFormatProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/processors/RsPostFormatProcessor.kt
@@ -1,0 +1,43 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.formatter.processors
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.codeStyle.CodeStyleSettings
+import com.intellij.psi.impl.source.codeStyle.PostFormatProcessor
+import org.rust.ide.formatter.RustfmtExternalFormatProcessor
+import org.rust.lang.core.psi.RsFile
+
+/**
+ * Used in a couple with [RustfmtExternalFormatProcessor].
+ * Should be the only `postFormatProcessor` in the plugin
+ * (see [RustfmtExternalFormatProcessor] docs for more details)
+ */
+class RsPostFormatProcessor : PostFormatProcessor {
+    override fun processElement(source: PsiElement, settings: CodeStyleSettings): PsiElement {
+        if (source !is RsFile) return source
+
+        return RsTrailingCommaFormatProcessor.processElement(source, settings)
+    }
+
+    @Suppress("UnstableApiUsage")
+    override fun processText(source: PsiFile, rangeToReformat: TextRange, settings: CodeStyleSettings): TextRange {
+        if (source !is RsFile) return rangeToReformat
+
+        return if (RustfmtExternalFormatProcessor.isActiveForFile(source)) {
+            RustfmtExternalFormatProcessor.formatWithRustfmtOrBuiltinFormatter(
+                source,
+                rangeToReformat,
+                canChangeWhiteSpacesOnly = false
+            ) ?: rangeToReformat
+        } else {
+            // Builtin formatter has just been used, perform post-processing
+            RsTrailingCommaFormatProcessor.processText(source, rangeToReformat, settings)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/formatter/processors/RsTrailingCommaFormatProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/processors/RsTrailingCommaFormatProcessor.kt
@@ -10,7 +10,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor
 import com.intellij.psi.codeStyle.CodeStyleSettings
-import com.intellij.psi.impl.source.codeStyle.PostFormatProcessor
 import com.intellij.psi.impl.source.codeStyle.PostFormatProcessorHelper
 import org.rust.ide.formatter.impl.CommaList
 import org.rust.ide.formatter.rust
@@ -21,13 +20,13 @@ import org.rust.lang.core.psi.ext.elementType
 import org.rust.lang.core.psi.ext.getNextNonCommentSibling
 import org.rust.lang.core.psi.ext.getPrevNonCommentSibling
 
-class RsTrailingCommaFormatProcessor : PostFormatProcessor {
-    override fun processElement(source: PsiElement, settings: CodeStyleSettings): PsiElement {
+object RsTrailingCommaFormatProcessor {
+    fun processElement(source: PsiElement, settings: CodeStyleSettings): PsiElement {
         doProcess(source, settings, null)
         return source
     }
 
-    override fun processText(source: PsiFile, rangeToReformat: TextRange, settings: CodeStyleSettings): TextRange {
+    fun processText(source: PsiFile, rangeToReformat: TextRange, settings: CodeStyleSettings): TextRange {
         return doProcess(source, settings, rangeToReformat).resultTextRange
     }
 

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -61,10 +61,13 @@
 
         <!-- Formatter -->
 
+        <!--suppress PluginXmlValidity -->
+        <externalFormatProcessor implementation="org.rust.ide.formatter.RustfmtExternalFormatProcessor"/>
         <lang.formatter language="Rust" implementationClass="org.rust.ide.formatter.RsFormattingModelBuilder"/>
-        <postFormatProcessor implementation="org.rust.ide.formatter.processors.RsTrailingCommaFormatProcessor"/>
         <preFormatProcessor implementation="org.rust.ide.formatter.processors.RsMatchArmCommaFormatProcessor"/>
         <preFormatProcessor implementation="org.rust.ide.formatter.processors.RsStatementSemicolonFormatProcessor"/>
+        <postFormatProcessor implementation="org.rust.ide.formatter.processors.RsPostFormatProcessor"/>
+        <!-- Please ADD NO MORE `PostFormatProcessor`s! Follow `RsTrailingCommaFormatProcessor` design if needed -->
 
         <!-- Refactoring support -->
 

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -5,11 +5,9 @@
 
 package org.rust
 
-import com.intellij.openapi.Disposable
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.ContentEntry
 import com.intellij.openapi.roots.ModifiableRootModel
-import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
 import com.intellij.testFramework.LightProjectDescriptor
@@ -129,14 +127,9 @@ open class WithRustup(private val delegate: RustProjectDescriptorBase) : RustPro
         stdlib?.let { VfsRootAccess.allowRootAccess(fixture.testRootDisposable, it.path) }
         // TODO: use RustupTestFixture somehow
         val rustSettings = fixture.project.rustSettings
-        rustSettings.modify {
+        rustSettings.modifyTemporary(fixture.testRootDisposable) {
             it.toolchain = toolchain
         }
-        Disposer.register(fixture.testRootDisposable, Disposable {
-            rustSettings.modify {
-                it.toolchain = null
-            }
-        })
     }
 }
 

--- a/src/test/kotlin/org/rust/cargo/RustupTestFixture.kt
+++ b/src/test/kotlin/org/rust/cargo/RustupTestFixture.kt
@@ -37,12 +37,7 @@ open class RustupTestFixture(
         super.setUp()
         stdlib?.let { VfsRootAccess.allowRootAccess(testRootDisposable, it.path) }
         if (toolchain != null) {
-            project.rustSettings.modify { it.toolchain = toolchain }
+            project.rustSettings.modifyTemporary(testRootDisposable) { it.toolchain = toolchain }
         }
-    }
-
-    override fun tearDown() {
-        project.rustSettings.modify { it.toolchain = null }
-        super.tearDown()
     }
 }

--- a/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
@@ -35,6 +35,7 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
               <option name="runRustfmtOnSave" value="true" />
               <option name="toolchainHomeDirectory" value="/" />
               <option name="useOffline" value="true" />
+              <option name="useRustfmt" value="true" />
               <option name="useSkipChildren" value="true" />
               <option name="version" value="2" />
             </RustProjectSettings>
@@ -55,6 +56,7 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
         assertEquals(true, service.useOffline)
         assertEquals(MacroExpansionEngine.DISABLED, service.macroExpansionEngine)
         assertEquals(false, service.doctestInjectionEnabled)
+        assertEquals(true, service.useRustfmt)
         assertEquals(true, service.runRustfmtOnSave)
         assertEquals(true, service.useSkipChildren)
     }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ApplySuggestionFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ApplySuggestionFixTest.kt
@@ -17,7 +17,7 @@ class ApplySuggestionFixTest : RsWithToolchainTestBase() {
 
     override fun setUp() {
         super.setUp()
-        project.rustSettings.modify { it.runExternalLinterOnTheFly = true }
+        project.rustSettings.modifyTemporary(testRootDisposable) { it.runExternalLinterOnTheFly = true }
     }
 
     fun `test rustc suggestion (machine applicable)`() = checkFixByText("""
@@ -86,7 +86,7 @@ class ApplySuggestionFixTest : RsWithToolchainTestBase() {
         @Language("Rust") after: String,
         externalLinter: ExternalLinter = ExternalLinter.DEFAULT
     ) {
-        project.rustSettings.modify { it.externalLinter = externalLinter }
+        project.rustSettings.modifyTemporary(testRootDisposable) { it.externalLinter = externalLinter }
         fileTree {
             toml("Cargo.toml", """
                 [package]

--- a/src/test/kotlin/org/rustSlowTests/RsExternalLinterPassTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsExternalLinterPassTest.kt
@@ -19,7 +19,7 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
 
     override fun setUp() {
         super.setUp()
-        project.rustSettings.modify { it.runExternalLinterOnTheFly = true }
+        project.rustSettings.modifyTemporary(testRootDisposable) { it.runExternalLinterOnTheFly = true }
     }
 
     fun `test no errors if everything is ok`() = doTest("""
@@ -159,7 +159,7 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
         @Language("Rust") mainRs: String,
         externalLinter: ExternalLinter = ExternalLinter.DEFAULT
     ) {
-        project.rustSettings.modify { it.externalLinter = externalLinter }
+        project.rustSettings.modifyTemporary(testRootDisposable) { it.externalLinter = externalLinter }
         fileTree {
             toml("Cargo.toml", """
                 [package]


### PR DESCRIPTION
Closes https://github.com/intellij-rust/intellij-rust/issues/5191. c.c. #1087

In this implementation, `Rustfmt` can be used **only** when formatting the **whole file** by: 
1. `Code | Reformat Code` (`Ctrl + Alt + L`) action **without text selection**
2. `Code | Reformat File ...` (`Ctrl + Alt + Shift + L`) action with `Whole file` option

E.g. `Rustfmt` can't be used when committing to git with `Reformat code Before Commit` option (it doesn't clear how to achieve this).

By default, the built-in formatter is still ALWAYS used. `Rustfmt` can be enabled in `Settings | Languages & Frameworks | Rust | Rustfmt`.

NB: rustfmt has an unstable option to restrict reformatting to specific sets of lines (https://github.com/rust-lang/rustfmt/issues/3397).