### PR TITLE
Fix `Synchronous execution on EDT` when creating new project (except IDEA)

### DIFF
--- a/idea/src/main/kotlin/org/rust/ide/idea/RsModuleBuilder.kt
+++ b/idea/src/main/kotlin/org/rust/ide/idea/RsModuleBuilder.kt
@@ -43,6 +43,9 @@ class RsModuleBuilder : ModuleBuilder() {
         // Just work if user "creates new project" over an existing one.
         if (toolchain != null && root.findChild(RustToolchain.CARGO_TOML) == null) {
             try {
+                // TODO: rewrite this somehow to fix `Synchronous execution on EDT` exception
+                // The problem is that `setupRootModel` is called on EDT under write action
+                // so `$ cargo init` invocation blocks UI thread
                 toolchain.rawCargo().init(
                     modifiableRootModel.project,
                     modifiableRootModel.module,

--- a/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
@@ -18,6 +18,7 @@ import com.intellij.platform.DirectoryProjectGenerator
 import com.intellij.platform.DirectoryProjectGeneratorBase
 import com.intellij.platform.ProjectGeneratorPeer
 import org.rust.ide.icons.RsIcons
+import org.rust.openapiext.computeWithCancelableProgress
 import java.io.File
 import javax.swing.Icon
 
@@ -41,7 +42,9 @@ class RsDirectoryProjectGenerator : DirectoryProjectGeneratorBase<ConfigurationD
 
     override fun generateProject(project: Project, baseDir: VirtualFile, data: ConfigurationData, module: Module) {
         val (settings, createBinary) = data
-        val generatedFiles = settings.toolchain?.rawCargo()?.init(project, module, baseDir, createBinary) ?: return
+        val generatedFiles = project.computeWithCancelableProgress("Generating Cargo project...") {
+            settings.toolchain?.rawCargo()?.init(project, module, baseDir, createBinary)
+        } ?: return
 
         // Open new files
         if (!isHeadlessEnvironment) {


### PR DESCRIPTION
Part of #4147

When creating a Rust project in CLion and other IDEs except IDEA, `RsDirectoryProjectGenerator#generateProject` is called on EDT without write action. Now `cargo init` is wrapped into `computeWithCancelableProgress` in this case.

When creating a Rust project in IDEA, `RsModuleBuilder#setupRootModel` is called on EDT under write action. This case should be handled somehow in the future, but so far it still causes the exception.