### PR TITLE
ANN: Fix exception with invalid rustc annotation

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/RustcMessage.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustcMessage.kt
@@ -95,7 +95,7 @@ data class RustcSpan(
         fun toOffset(document: Document, line: Int, column: Int): Int? {
             val line = line - 1
             val column = column - 1
-            if (line >= document.lineCount) return null
+            if (line < 0 || line >= document.lineCount) return null
             return (document.getLineStartOffset(line) + column)
                 .takeIf { it <= document.textLength }
         }


### PR DESCRIPTION
<details>
  <summary>Exception stacktrace</summary>
  
  ```

java.lang.IndexOutOfBoundsException: Wrong line: -1. Available lines count: 0
    at com.intellij.openapi.editor.impl.LineSet.checkLineIndex(LineSet.java:198)
    at com.intellij.openapi.editor.impl.LineSet.getLineStart(LineSet.java:179)
    at com.intellij.openapi.editor.impl.DocumentImpl.getLineStartOffset(DocumentImpl.java:996)
    at org.rust.cargo.toolchain.RustcSpan$Companion.toOffset(RustcMessage.kt:99)
    at org.rust.cargo.toolchain.RustcSpan.toTextRange(RustcMessage.kt:84)
    at org.rust.ide.annotator.RsExternalLinterFilteredMessage$Companion.filterMessage(RsExternalLinterUtils.kt:242)
    at org.rust.ide.annotator.RsExternalLinterUtilsKt.createAnnotationsForFile(RsExternalLinterUtils.kt:178)
    at org.rust.ide.annotator.RsExternalLinterPass$doApply$1.annotate(RsExternalLinterPass.kt:111)
    at com.intellij.codeInsight.daemon.impl.AnnotationHolderImpl.runAnnotatorWithContext(AnnotationHolderImpl.java:199)
    at org.rust.ide.annotator.RsExternalLinterPass.doApply(RsExternalLinterPass.kt:110)
    at org.rust.ide.annotator.RsExternalLinterPass.access$doApply(RsExternalLinterPass.kt:37)
    at org.rust.ide.annotator.RsExternalLinterPass$doApplyInformationToEditor$update$1$run$1$$special$$inlined$runReadAction$1.compute(actions.kt:59)
    at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:855)
    at org.rust.ide.annotator.RsExternalLinterPass$doApplyInformationToEditor$update$1$run$1.run(RsExternalLinterPass.kt:185)
    at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:170)
    at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:629)
    at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:581)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
    at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:157)
    at com.intellij.openapi.progress.util.BackgroundTaskUtil.runUnderDisposeAwareIndicator(BackgroundTaskUtil.java:251)
    at org.rust.ide.annotator.RsExternalLinterPass$doApplyInformationToEditor$update$1.run(RsExternalLinterPass.kt:86)
    at com.intellij.util.ui.update.MergingUpdateQueue.execute(MergingUpdateQueue.java:333)
    at com.intellij.util.ui.update.MergingUpdateQueue.execute(MergingUpdateQueue.java:323)
    at com.intellij.util.ui.update.MergingUpdateQueue.lambda$flush$1(MergingUpdateQueue.java:273)
    at com.intellij.util.ui.update.MergingUpdateQueue.flush(MergingUpdateQueue.java:287)
    at com.intellij.util.ui.update.MergingUpdateQueue.run(MergingUpdateQueue.java:242)
    at com.intellij.util.concurrency.QueueProcessor.runSafely(QueueProcessor.java:238)
    at com.intellij.util.Alarm$Request.runSafely(Alarm.java:369)
    at com.intellij.util.Alarm$Request.run(Alarm.java:356)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    at com.intellij.util.concurrency.SchedulingWrapper$MyScheduledFutureTask.run(SchedulingWrapper.java:220)
    at com.intellij.util.concurrency.BoundedTaskExecutor.doRun(BoundedTaskExecutor.java:215)
    at com.intellij.util.concurrency.BoundedTaskExecutor.access$200(BoundedTaskExecutor.java:26)
    at com.intellij.util.concurrency.BoundedTaskExecutor$1.execute(BoundedTaskExecutor.java:194)
    at com.intellij.util.ConcurrencyUtil.runUnderThreadName(ConcurrencyUtil.java:207)
    at com.intellij.util.concurrency.BoundedTaskExecutor$1.run(BoundedTaskExecutor.java:183)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:668)
    at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:665)
    at java.base/java.security.AccessController.doPrivileged(Native Method)
    at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:665)
    at java.base/java.lang.Thread.run(Thread.java:834)

  ```
  
</details>
