### PR TITLE
PRJ: Project generation with cargo-generate

### DIFF
--- a/idea/src/main/kotlin/org/rust/ide/idea/CargoConfigurationWizardStep.kt
+++ b/idea/src/main/kotlin/org/rust/ide/idea/CargoConfigurationWizardStep.kt
@@ -28,7 +28,7 @@ class CargoConfigurationWizardStep private constructor(
     private val projectDescriptor: ProjectDescriptor? = null
 ) : ModuleWizardStep() {
 
-    private val newProjectPanel = RsNewProjectPanel(showProjectTypeCheckbox = projectDescriptor == null)
+    private val newProjectPanel = RsNewProjectPanel(showProjectTypeSelection = projectDescriptor == null)
 
     override fun getComponent(): JComponent = layout {
         newProjectPanel.attachTo(this)

--- a/src/main/kotlin/org/rust/ide/newProject/ConfigurationData.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/ConfigurationData.kt
@@ -9,5 +9,5 @@ import org.rust.cargo.project.settings.ui.RustProjectSettingsPanel
 
 data class ConfigurationData(
     val settings: RustProjectSettingsPanel.Data,
-    val createBinary: Boolean
+    val template: RsProjectTemplate
 )

--- a/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
@@ -6,14 +6,12 @@
 package org.rust.ide.newProject
 
 import com.intellij.facet.ui.ValidationResult
-import com.intellij.ide.util.PsiNavigationSupport
 import com.intellij.ide.util.projectWizard.AbstractNewProjectStep
 import com.intellij.ide.util.projectWizard.CustomStepProjectGenerator
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.impl.welcomeScreen.AbstractActionWithPanel
-import com.intellij.openapiext.isHeadlessEnvironment
 import com.intellij.platform.DirectoryProjectGenerator
 import com.intellij.platform.DirectoryProjectGeneratorBase
 import com.intellij.platform.ProjectGeneratorPeer
@@ -35,25 +33,19 @@ class RsDirectoryProjectGenerator : DirectoryProjectGeneratorBase<ConfigurationD
 
     override fun validate(baseDirPath: String): ValidationResult {
         val crateName = File(baseDirPath).nameWithoutExtension
-        val isBinary = peer?.settings?.createBinary == true
-        val message = RsPackageNameValidator.validate(crateName, isBinary) ?: return ValidationResult.OK
+        val message = peer?.settings?.template?.validateProjectName(crateName) ?: return ValidationResult.OK
         return ValidationResult(message)
     }
 
     override fun generateProject(project: Project, baseDir: VirtualFile, data: ConfigurationData, module: Module) {
-        val (settings, createBinary) = data
+        val (settings, template) = data
+        val cargo = settings.toolchain?.rawCargo() ?: return
+
         val generatedFiles = project.computeWithCancelableProgress("Generating Cargo project...") {
-            settings.toolchain?.rawCargo()?.init(project, module, baseDir, createBinary)
+            cargo.makeProject(project, module, baseDir, template)
         } ?: return
 
-        // Open new files
-        if (!isHeadlessEnvironment) {
-            val navigation = PsiNavigationSupport.getInstance()
-            navigation.createNavigatable(project, generatedFiles.manifest, -1).navigate(false)
-            for (file in generatedFiles.sourceFiles) {
-                navigation.createNavigatable(project, file, -1).navigate(true)
-            }
-        }
+        project.openFiles(generatedFiles)
     }
 
     override fun createStep(projectGenerator: DirectoryProjectGenerator<ConfigurationData>,

--- a/src/main/kotlin/org/rust/ide/newProject/RsProjectGeneratorPeer.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsProjectGeneratorPeer.kt
@@ -15,7 +15,7 @@ import javax.swing.JComponent
 
 class RsProjectGeneratorPeer : GeneratorPeerImpl<ConfigurationData>() {
 
-    private val newProjectPanel = RsNewProjectPanel(showProjectTypeCheckbox = true) { checkValid?.run() }
+    private val newProjectPanel = RsNewProjectPanel(showProjectTypeSelection = true) { checkValid?.run() }
     private var checkValid: Runnable? = null
 
     override fun getSettings(): ConfigurationData = newProjectPanel.data

--- a/src/main/kotlin/org/rust/ide/newProject/RsProjectTemplate.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsProjectTemplate.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.newProject
+
+import com.intellij.icons.AllIcons
+import org.rust.ide.icons.RsIcons
+import javax.swing.Icon
+
+sealed class RsProjectTemplate(val name: String, val isBinary: Boolean) {
+    abstract val icon: Icon
+
+    fun validateProjectName(crateName: String): String? = RsPackageNameValidator.validate(crateName, isBinary)
+}
+
+class RsGenericTemplate(name: String, isBinary: Boolean) : RsProjectTemplate(name, isBinary) {
+    override val icon: Icon = RsIcons.RUST
+}
+
+class RsCustomTemplate(name: String, val link: String, isBinary: Boolean = true) : RsProjectTemplate(name, isBinary) {
+    override val icon: Icon = AllIcons.Vcs.Vendors.Github
+    val shortLink: String
+        get() = link.substringAfter("//")
+}

--- a/src/main/kotlin/org/rust/ide/newProject/Utils.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/Utils.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.newProject
+
+import com.intellij.ide.util.PsiNavigationSupport
+import com.intellij.openapi.application.invokeLater
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapiext.isHeadlessEnvironment
+import org.rust.cargo.toolchain.Cargo
+import org.rust.cargo.toolchain.Cargo.Companion.GeneratedFilesHolder
+
+fun Project.openFiles(files: GeneratedFilesHolder) = invokeLater {
+    if (!isHeadlessEnvironment) {
+        val navigation = PsiNavigationSupport.getInstance()
+        navigation.createNavigatable(this, files.manifest, -1).navigate(false)
+        for (file in files.sourceFiles) {
+            navigation.createNavigatable(this, file, -1).navigate(true)
+        }
+    }
+}
+
+fun Cargo.makeProject(
+    project: Project,
+    module: Module,
+    baseDir: VirtualFile,
+    template: RsProjectTemplate
+): GeneratedFilesHolder? = when (template) {
+    is RsGenericTemplate -> init(project, module, baseDir, template.isBinary)
+    is RsCustomTemplate -> generate(project, module, baseDir, template.link)
+}

--- a/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt
@@ -5,52 +5,160 @@
 
 package org.rust.ide.newProject.ui
 
+import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessListener
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.options.ConfigurationException
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.ui.MessageType
+import com.intellij.openapi.ui.popup.util.PopupUtil
 import com.intellij.openapi.util.Disposer
-import com.intellij.ui.components.JBRadioButton
+import com.intellij.openapi.util.Key
+import com.intellij.ui.ColoredListCellRenderer
+import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBList
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.Link
 import org.rust.cargo.project.settings.ui.RustProjectSettingsPanel
+import org.rust.cargo.toolchain.Cargo
 import org.rust.ide.newProject.ConfigurationData
+import org.rust.ide.newProject.RsCustomTemplate
+import org.rust.ide.newProject.RsGenericTemplate
+import org.rust.ide.newProject.RsProjectTemplate
 import org.rust.ide.ui.RsLayoutBuilder
-import java.awt.event.ItemEvent
-import java.awt.event.ItemListener
-import javax.swing.ButtonGroup
+import org.rust.openapiext.UiDebouncer
+import javax.swing.JList
+import javax.swing.ListSelectionModel
+import javax.swing.ScrollPaneConstants
 
 class RsNewProjectPanel(
-    private val showProjectTypeCheckbox: Boolean,
-    updateListener: (() -> Unit)? = null
+    private val showProjectTypeSelection: Boolean,
+    private val updateListener: (() -> Unit)? = null
 ) : Disposable {
 
     private val rustProjectSettings = RustProjectSettingsPanel(updateListener = updateListener)
-    private val templateButtons = listOf(JBRadioButton("Binary (application)", true), JBRadioButton("Library"))
-    private val checkboxListener = ItemListener {
-        if (it.stateChange == ItemEvent.SELECTED) updateListener?.invoke()
+
+    private val cargo: Cargo?
+        get() = rustProjectSettings.data.toolchain?.rawCargo()
+
+    private val templateList = JBList(
+        RsGenericTemplate("Binary (application)", true),
+        RsGenericTemplate("Library", false),
+        RsCustomTemplate("WebAssembly Lib", "https://github.com/rustwasm/wasm-pack-template", false)
+    ).apply {
+        selectionMode = ListSelectionModel.SINGLE_SELECTION
+        selectedIndex = 0
+        addListSelectionListener { update() }
+        cellRenderer = object : ColoredListCellRenderer<RsProjectTemplate>() {
+            override fun customizeCellRenderer(
+                list: JList<out RsProjectTemplate>,
+                value: RsProjectTemplate,
+                index: Int,
+                selected: Boolean,
+                hasFocus: Boolean
+            ) {
+                icon = value.icon
+                append(value.name)
+
+                if (value is RsCustomTemplate) {
+                    append(" ")
+                    append(value.shortLink, SimpleTextAttributes.GRAYED_ATTRIBUTES)
+                }
+            }
+        }
     }
 
-    init {
-        templateButtons.forEach { it.addItemListener(checkboxListener) }
+    private val selectedTemplate: RsProjectTemplate
+        get() = templateList.selectedValue
+
+    private val templatePane = JBScrollPane(templateList).apply {
+        horizontalScrollBarPolicy = ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
     }
 
-    val data: ConfigurationData get() = ConfigurationData(rustProjectSettings.data, templateButtons[0].isSelected)
+    private var needInstallCargoGenerate = false
+    private val downloadCargoGenerateLink = Link("Install cargo-generate using Cargo", action = {
+        val cargo = cargo ?: return@Link
+
+        object : Task.Modal(null, "Installing cargo-generate", true) {
+            var exitCode = 0
+
+            override fun onSuccess() {
+                if (exitCode != 0) {
+                    PopupUtil.showBalloonForComponent(
+                        templatePane,
+                        "Failed to install cargo-generate",
+                        MessageType.ERROR,
+                        true,
+                        this@RsNewProjectPanel
+                    )
+                }
+
+                update()
+            }
+
+            override fun run(indicator: ProgressIndicator) {
+                indicator.isIndeterminate = true
+                cargo.installCargoGenerate(this@RsNewProjectPanel, listener = object : ProcessListener {
+                    override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
+                        indicator.text = "Installing using Cargo..."
+                        indicator.text2 = event.text.trim()
+                    }
+
+                    override fun processTerminated(event: ProcessEvent) {
+                        exitCode = event.exitCode
+                    }
+
+                    override fun startNotified(event: ProcessEvent) {}
+
+                })
+            }
+        }.queue()
+    }).apply { isVisible = false }
+
+    private val updateDebouncer = UiDebouncer(this)
+
+    val data: ConfigurationData get() = ConfigurationData(rustProjectSettings.data, selectedTemplate)
 
     fun attachTo(layout: RsLayoutBuilder) = with(layout) {
         rustProjectSettings.attachTo(this)
-        if (showProjectTypeCheckbox) {
-            val buttonGroup = ButtonGroup()
-            templateButtons.forEachIndexed { index, button ->
-                buttonGroup.add(button)
-                row(if (index == 0) "Project template:" else "", button)
-            }
+
+        if (showProjectTypeSelection) {
+            component(JBLabel("Project template:"))
+            component(templatePane)
+            component(downloadCargoGenerateLink)
         }
+
+        update()
+    }
+
+    fun update() {
+        updateDebouncer.run(
+            onPooledThread = {
+                when (selectedTemplate) {
+                    is RsGenericTemplate -> false
+                    is RsCustomTemplate -> cargo?.checkNeedInstallCargoGenerate() ?: false
+                }
+            },
+            onUiThread = { needInstall ->
+                downloadCargoGenerateLink.isVisible = needInstall
+                needInstallCargoGenerate = needInstall
+                updateListener?.invoke()
+            }
+        )
     }
 
     @Throws(ConfigurationException::class)
     fun validateSettings() {
         rustProjectSettings.validateSettings()
+
+        if (needInstallCargoGenerate) {
+            throw ConfigurationException("cargo-generate is needed to create a project from a custom template")
+        }
     }
 
     override fun dispose() {
-        templateButtons.forEach { it.removeItemListener(checkboxListener) }
         Disposer.dispose(rustProjectSettings)
     }
 }

--- a/src/main/kotlin/org/rust/ide/ui/layout.kt
+++ b/src/main/kotlin/org/rust/ide/ui/layout.kt
@@ -32,6 +32,7 @@ fun layout(block: RsLayoutBuilder.() -> Unit): JPanel {
 interface RsLayoutBuilder {
     fun row(text: String = "", component: JComponent, toolTip: String = "")
     fun block(text: String, block: RsLayoutBuilder.() -> Unit)
+    fun component(component: JComponent)
 }
 
 private class RsLayoutBuilderImpl(
@@ -51,9 +52,18 @@ private class RsLayoutBuilderImpl(
         val labeledComponent = LabeledComponent.create(component, text, BorderLayout.WEST).apply {
             (layout as? BorderLayout)?.hgap = HGAP
             border = JBUI.Borders.empty(VERTICAL_OFFSET, HORIZONTAL_OFFSET)
+            toolTipText = toolTip.trimIndent()
         }
-        labeledComponent.toolTipText = toolTip.trimIndent()
+
         labeledComponents += labeledComponent
         panel.add(labeledComponent)
+    }
+
+    override fun component(component: JComponent) {
+        val innerPanel = JPanel(BorderLayout()).apply {
+            border = JBUI.Borders.empty(VERTICAL_OFFSET, HORIZONTAL_OFFSET)
+            add(component, BorderLayout.NORTH)
+        }
+        panel.add(innerPanel)
     }
 }


### PR DESCRIPTION
Currently, it is project generation using cargo-generate merged with standard cargo templates.

## CLion
<img width="912" alt="image" src="https://user-images.githubusercontent.com/6342851/88849247-4baad880-d1f2-11ea-8eb6-17f8e9b178ab.png">

## IntelliJ IDEA
<img width="929" alt="Frame 1(3)" src="https://user-images.githubusercontent.com/6342851/88853074-dc37e780-d1f7-11ea-8570-bcdef26ef108.png">

Related to #3066

Additionally:
Closes #5746
