### PR TITLE
Enable new macro expansion engine

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,11 +159,12 @@ val Project.dependencyCachePath get(): String {
 
 val channelSuffix = if (channel.isBlank() || channel == "stable") "" else "-$channel"
 val versionSuffix = "-$platformVersion$channelSuffix"
+val majorVersion = "0.3"
 val patchVersion = prop("patchVersion").toInt()
 
 // Special module with run, build and publish tasks
 project(":plugin") {
-    version = "0.2.$patchVersion.${prop("buildNumber")}$versionSuffix"
+    version = "$majorVersion.$patchVersion.${prop("buildNumber")}$versionSuffix"
     intellij {
         pluginName = "intellij-rust"
         val plugins = mutableListOf(

--- a/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
@@ -37,9 +37,9 @@ class RsProjectConfigurable(
             renderer = SimpleListCellRenderer.create("") {
                 @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
                 when (it) {
-                    MacroExpansionEngine.DISABLED -> "Disable (use only if you have problems with macro expansions)"
-                    MacroExpansionEngine.OLD -> "Expand with default engine"
-                    MacroExpansionEngine.NEW -> "Expand with experimental engine (faster, but not yet stable)"
+                    MacroExpansionEngine.DISABLED -> "Disable (select only if you have problems with macro expansion)"
+                    MacroExpansionEngine.OLD -> "Use old engine (some features are not supported) "
+                    MacroExpansionEngine.NEW -> "Use new engine"
                 }
             }
         }

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -12,7 +12,7 @@
         <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="0">
             <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.macros.new.engine" percentOfUsers="0">
+        <experimentalFeature id="org.rust.macros.new.engine" percentOfUsers="100">
             <description>Enables new macro expansion engine by default</description>
         </experimentalFeature>
     </extensions>


### PR DESCRIPTION
Finally, new macro expansion is enabled by default!
Also, I think we need to mark this new epoch of the plugin with increasing of the major version to 0.3

Closes #3628

Fixes #955
Fixes #2128
Fixes #2383
Fixes #2625
Fixes #2787
Fixes #2902
Fixes #3006
Fixes #3087
Fixes #3155
Fixes #3238
Fixes #3259
Fixes #3468
Fixes #3487
Fixes #3560
Fixes #3587
Fixes #3590
Fixes #4063
Fixes #4153
Fixes #4224
Fixes #4310
Fixes #4328
Fixes #4340
Fixes #4519
Fixes #4627
Fixes #4826
Fixes #5088
Fixes #5127
Fixes #5154
Fixes #5248
Fixes #5278
Fixes #5300
Fixes #5346
Fixes #5461
Fixes #5686