### PR TITLE
Fix cache invalidation when editing function-local macro

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
@@ -85,9 +85,14 @@ val RsItemsOwner.expandedItemsCached: RsCachedItems
             }
             false
         }
+        val localModTracker = if (this is RsBlock) {
+            findModificationTrackerOwner(strict = true)
+        } else {
+            null
+        }
         CachedValueProvider.Result.create(
             RsCachedItems(namedImports.optimizeList(), starImports.optimizeList(), rest.optimizeList()),
-            rustStructureOrAnyPsiModificationTracker
+            listOfNotNull(rustStructureOrAnyPsiModificationTracker, localModTracker)
         )
     }
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveCacheTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveCacheTest.kt
@@ -219,6 +219,20 @@ class RsResolveCacheTest : RsTestBase() {
         }             //^
     """, "\b2")
 
+    fun `test edit function-local macro`() = checkResolvedToXY("""
+        macro_rules! as_is { ($($ t:tt)*) => { $($ t)* }; }
+        struct S1;
+             //Y
+        fn main() {
+            as_is! { struct S1/*caret*/; }
+                          //X
+            let a: S1;
+        }        //^
+    """, "\b2")
+
+    override val followMacroExpansions: Boolean
+        get() = true
+
     private fun checkResolvedToXY(@Language("Rust") code: String, textToType: String) {
         InlineFile(code).withCaret()
 


### PR DESCRIPTION
Fixes possible `PsiInvalidAccessException` and wrong name resolution in some cases