### PR TITLE
Add registry option to disable macro highlighting

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
@@ -18,6 +18,7 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.util.registry.Registry
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.rust.ide.utils.isEnabledByCfg
@@ -41,11 +42,18 @@ class RsMacroExpansionHighlightingPassFactory(
 
     override fun createHighlightingPass(file: PsiFile, editor: Editor): TextEditorHighlightingPass? {
         if (project.macroExpansionManager.macroExpansionMode !is MacroExpansionMode.New) return null
+        if (!MACRO_HIGHLIGHTING_ENABLED_KEY.asBoolean()) return null
+
         val restrictedRange = FileStatusMap.getDirtyTextRange(editor, passId) ?: return null
         return RsMacroExpansionHighlightingPass(file, restrictedRange, editor.document)
     }
 
     override fun getPassId(): Int = myPassId
+
+    companion object {
+        @JvmStatic
+        private val MACRO_HIGHLIGHTING_ENABLED_KEY = Registry.get("org.rust.lang.highlight.macro.body")
+    }
 }
 
 class RsMacroExpansionHighlightingPass(

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -952,6 +952,8 @@
                      description="Maximum number of type aliases to take into account during `impl`s search"/>
         <registryKey key="org.rust.lang.cfg.attributes" defaultValue="true" restartRequired="false"
                      description="Enable Rust cfg attributes support"/>
+        <registryKey key="org.rust.lang.highlight.macro.body" defaultValue="true" restartRequired="false"
+                     description="Highlight Rust macro call bodies"/>
 
         <!-- Move refactoring -->
 


### PR DESCRIPTION
Add registry option to disable macro highlighting (introduced in #4640)