### PR TITLE
STUB: improve block stub creation

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -119,7 +119,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
  *   block, so it is processed earlier). The value is then removed from the cache because it is no longer needed
  *   and should be invalidated after each PSI change.
  *
- * See tests in `RsLazyCodeBlockIsNotExpandedDuringStubBuildingTest`
+ * See tests in `RsCodeBlockStubCreationTest`
  */
 private object BlockMayHaveStubsHeuristic {
     private val RS_HAS_ITEMS_OR_ATTRS: Key<Boolean> = Key.create("RS_HAS_ITEMS_OR_ATTRS")

--- a/src/test/kotlin/org/rust/lang/core/stubs/RsLazyBlockStubCreationTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/stubs/RsLazyBlockStubCreationTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.stubs
+
+import org.intellij.lang.annotations.Language
+import org.rust.fileTreeFromText
+
+class RsLazyBlockStubCreationTest : RsLazyBlockStubCreationTestBase() {
+
+    fun `test raw ref`() = doTest("""
+    //- main.rs
+        fn main() {
+            let a = 123;
+            let b = &raw const a;
+        }
+    """)
+
+    private fun doTest(@Language("Rust") fileTreeText: String) {
+        fileTreeFromText(fileTreeText).create()
+        checkRustFiles(myFixture.findFileInTempDir("."), emptyList())
+    }
+}

--- a/src/test/kotlin/org/rust/lang/core/stubs/RsLazyBlockStubCreationTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/stubs/RsLazyBlockStubCreationTestBase.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rustSlowTests
+package org.rust.lang.core.stubs
 
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
@@ -18,25 +18,17 @@ import com.intellij.psi.impl.source.tree.TreeUtil
 import com.intellij.util.LocalTimeCounter
 import junit.framework.TestCase
 import org.rust.RsTestBase
-import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.RsFileType
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.descendantsOfType
-import org.rust.lang.core.stubs.RsFileStub
 import org.rustPerformanceTests.fullyRefreshDirectoryInUnitTests
 
-class RsLazyCodeBlockIsNotExpandedDuringStubBuildingTest : RsTestBase() {
-    override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
+/**
+ * Base class for tests to check that block elements are not parsed if they don't contain stub elements
+ */
+abstract class RsLazyBlockStubCreationTestBase : RsTestBase() {
 
-    fun `test stdlib source`() {
-        val sources = rustSrcDir()
-        checkRustFiles(
-            sources,
-            ignored = setOf("tests", "test", "doc", "etc", "grammar")
-        )
-    }
-
-    private fun checkRustFiles(directory: VirtualFile, ignored: Collection<String>) {
+    protected fun checkRustFiles(directory: VirtualFile, ignored: Collection<String>) {
         val files = collectRustFiles(directory, ignored)
             .mapNotNull { it.toInMemoryPsiFile() as? RsFile }
 
@@ -145,6 +137,4 @@ class RsLazyCodeBlockIsNotExpandedDuringStubBuildingTest : RsTestBase() {
     }
 
     private val RsBlock.isParsed get() = (node as LazyParseableElement).isParsed
-
-    private fun rustSrcDir(): VirtualFile = projectDescriptor.stdlib!!
 }

--- a/src/test/kotlin/org/rustSlowTests/RsCompilerSourcesLazyBlockStubCreationTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsCompilerSourcesLazyBlockStubCreationTest.kt
@@ -1,0 +1,24 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rustSlowTests
+
+import com.intellij.openapi.vfs.VirtualFile
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.lang.core.stubs.RsLazyBlockStubCreationTestBase
+
+class RsCompilerSourcesLazyBlockStubCreationTest : RsLazyBlockStubCreationTestBase() {
+    override fun getProjectDescriptor() = WithStdlibRustProjectDescriptor
+
+    fun `test stdlib source`() {
+        val sources = rustSrcDir()
+        checkRustFiles(
+            sources,
+            ignored = setOf("tests", "test", "doc", "etc", "grammar")
+        )
+    }
+
+    private fun rustSrcDir(): VirtualFile = projectDescriptor.stdlib!!
+}


### PR DESCRIPTION
* handle `raw const` operator  and not to create stubs in this case
* extract common code of the corresponding tests into `RsLazyBlockStubCreationTestBase`