### PR TITLE
Fix crash during the plugin unloading on 2020.2

### DIFF
--- a/gradle-202.properties
+++ b/gradle-202.properties
@@ -9,5 +9,5 @@ graziePluginVersion=202.6250.6
 psiViewerPluginVersion=202-SNAPSHOT.3
 
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
-sinceBuild=202.5792
+sinceBuild=202.6250
 untilBuild=203.*

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -644,7 +644,10 @@ private class MacroExpansionServiceImplInner(
         PsiManager.getInstance(project).addPsiTreeChangeListener(treeChangeListener, disposable)
         ApplicationManager.getApplication().addApplicationListener(treeChangeListener, disposable)
 
-        registerIndexableSet(disposable)
+        // BACKCOMPAT: 2020.1
+        if (ApplicationInfo.getInstance().build < BUILD_202) {
+            registerIndexableSet(disposable)
+        }
 
         val connect = project.messageBus.connect(disposable)
 
@@ -671,6 +674,7 @@ private class MacroExpansionServiceImplInner(
      * Work together with [RsIndexableSetContributor]. Really looks
      * like a platform bug that [RsIndexableSetContributor] is not enough.
      */
+    // BACKCOMPAT: 2020.1
     private fun registerIndexableSet(disposable: Disposable) {
         FileBasedIndex.getInstance().registerIndexableSet(object : IndexableFileSet {
             override fun isInSet(file: VirtualFile): Boolean =
@@ -694,6 +698,7 @@ private class MacroExpansionServiceImplInner(
         }, disposable)
     }
 
+    // BACKCOMPAT: 2020.1
     private fun FileBasedIndex.registerIndexableSet(indexableSet: IndexableFileSet, disposable: Disposable) {
         registerIndexableSet(indexableSet, project)
         Disposer.register(disposable, Disposable { removeIndexableSet(indexableSet) })


### PR DESCRIPTION
The Rust plugin is still not unloadable, but it doesn't crash at least.

Under the hood: `registerIndexableSet` isn't needed on the latest EAP, `IndexableSetContributor` is enough.

Part of #4832