### PR TITLE
TY: infer Try impl for try expressions

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -1039,8 +1039,11 @@ class RsTypeInferenceWalker(
 
     private fun inferTryExprType(expr: RsTryExpr): Ty {
         val base = expr.expr.inferType() as? TyAdt ?: return TyUnknown
-        // TODO: make it work with generic `std::ops::Try` trait
-        if (base.item != items.Result && base.item != items.Option) return TyUnknown
+        if (base.item != items.Result && base.item != items.Option) {
+            val tryItem = items.Try ?: return TyUnknown
+            val okType = tryItem.findAssociatedType("Ok") ?: return TyUnknown
+            return ctx.normalizeAssociatedTypesIn(TyProjection.valueOf(base, BoundElement(tryItem), okType)).value
+        }
         TypeInferenceMarks.questionOperator.hit()
         return base.typeArguments.getOrElse(0) { TyUnknown }
     }

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -151,6 +151,75 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test try expr custom type`() = testExpr("""
+        struct S;
+
+        #[lang = "core::result::Result"]
+        enum Result<T, E> { Ok(T), Err(E) }
+
+        #[lang = "core::ops::try::Try"]
+        trait Try { type Ok; type Error; }
+
+        impl Try for S {
+            type Ok = u32;
+            type Error = u64;
+
+            fn into_result(self) -> Result<Self::Ok, Self::Error> {
+                unimplemented!()
+            }
+
+            fn from_error(v: Self::Error) -> Self {
+                unimplemented!()
+            }
+
+            fn from_ok(v: Self::Ok) -> Self {
+                unimplemented!()
+            }
+        }
+
+        fn foo() -> Result<u32, u64> {
+            let s = S;
+            let y = s?;
+            y;
+          //^ u32
+            Result::Ok(0)
+        }
+    """)
+
+    fun `test try expr custom generic type`() = testExpr("""
+        struct S<T>(T);
+
+        #[lang = "core::result::Result"]
+        enum Result<T, E> { Ok(T), Err(E) }
+
+        #[lang = "core::ops::try::Try"]
+        trait Try { type Ok; type Error; }
+
+        impl<T> Try for S<T> {
+            type Ok = T;
+            type Error = u64;
+
+            fn into_result(self) -> Result<Self::Ok, Self::Error> {
+                unimplemented!()
+            }
+
+            fn from_error(v: Self::Error) -> Self {
+                unimplemented!()
+            }
+
+            fn from_ok(v: Self::Ok) -> Self {
+                unimplemented!()
+            }
+        }
+
+        fn foo(s: S<u32>) -> Result<u32, u64> {
+            let y = s?;
+            y;
+          //^ u32
+            Result::Ok(0)
+        }
+    """)
+
     fun `test generator expr`() = testExpr("""
         #[lang = "core::ops::generator::Generator"]
         trait Generator { type Yield; type Return; }


### PR DESCRIPTION
This PR adds support for inferring try expressions (`<expr>?`) where the type of `<expr>` is not `Result` nor `Option`, but it implements the `core::ops::try::Try` trait. The fast path for results and options is kept in the code.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5731