### PR TITLE
REF: Update references in move items refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
@@ -1,0 +1,380 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.move.common
+
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiReference
+import com.intellij.psi.impl.source.DummyHolder
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.refactoring.RefactoringBundle.message
+import com.intellij.usageView.UsageInfo
+import org.rust.ide.refactoring.move.common.RsMoveUtil.LOG
+import org.rust.ide.refactoring.move.common.RsMoveUtil.containingModStrict
+import org.rust.ide.refactoring.move.common.RsMoveUtil.isAbsolute
+import org.rust.ide.refactoring.move.common.RsMoveUtil.isInsideMovedElements
+import org.rust.ide.refactoring.move.common.RsMoveUtil.isSimplePath
+import org.rust.ide.refactoring.move.common.RsMoveUtil.resolvesToAndAccessible
+import org.rust.ide.refactoring.move.common.RsMoveUtil.startsWithSuper
+import org.rust.ide.refactoring.move.common.RsMoveUtil.textNormalized
+import org.rust.ide.refactoring.move.common.RsMoveUtil.toRsPath
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.openapiext.computeWithCancelableProgress
+
+class ItemToMove(val item: RsItemElement) : ElementToMove()
+class ModToMove(val mod: RsMod) : ElementToMove()
+
+sealed class ElementToMove {
+    val element: RsElement
+        get() = when (this) {
+            is ItemToMove -> item
+            is ModToMove -> mod
+        }
+
+    companion object {
+        fun fromItem(item: RsItemElement): ElementToMove = when (item) {
+            is RsModItem -> ModToMove(item)
+            else -> ItemToMove(item)
+        }
+    }
+}
+
+/**
+ * Move refactoring supports moving files (to other directory) or top level items (to other file)
+ *
+ * ## High-level description
+ * 1. Check conflicts (if new mod already has item with same name)
+ * 2. Check visibility conflicts (target of any reference should remain accessible after move).
+ *    We should check: `RsPath`, struct/enum field (struct literal, destructuring), struct/trait method call.
+ *     - references from moved items (both to old mod and to other mods)
+ *     - references to moved items (both from old mod and from other mods)
+ * 3. Update `pub(in path)` visibility modifiers for moved items if necessary
+ * 4. Move items to new mod
+ *     - make moved items public if necessary
+ *     - also make public items in old mod if necessary (TODO)
+ * 5. Update outside references (from moved items - both to old mod and to other mods)
+ *     - replace relative paths (which starts with `super::`)
+ *     - add necessary imports (including trait imports - for trait methods)
+ *         - usual imports (which already are in old mod)
+ *         - imports to items in old mod (which are used by moved items)
+ *     - replace paths which are still not resolved - e.g. previously path is absolute,
+ *       but after move we should use path through reexports)
+ * 6. Update inside references (to moved items - both from old mod and from other mods)
+ *     - change existing imports
+ *         - remove import if it is in new mod
+ *     - fix unresolved paths (including trait methods)
+ *
+ * ## Implementation notes
+ * Most important class is [RsMoveReferenceInfo].
+ * It is used both for inside and outside references and for each [RsPath] provides new path to replace old path with.
+ *
+ * "Move file" and "Move items" has different processors (because of different UX).
+ * So this class is created to be used by both processors.
+ * It provides following methods:
+ * 1. [findUsages] — just finds usages and convert them to our class [RsMoveUsageInfo]
+ * 2. [preprocessUsages]
+ *     - creates [RsMoveReferenceInfo] for all references
+ *     - checks visibility conflicts
+ * 3. [performRefactoring]
+ *     - moves items/files
+ *     - updates references using [RsMoveRetargetReferencesProcessor]
+ */
+class RsMoveCommonProcessor(
+    private val project: Project,
+    private var elementsToMove: List<ElementToMove>,
+    private val targetMod: RsMod
+) {
+
+    private val psiFactory: RsPsiFactory = RsPsiFactory(project)
+    private val codeFragmentFactory: RsCodeFragmentFactory = RsCodeFragmentFactory(project)
+
+    private val sourceMod: RsMod = elementsToMove
+        .map { it.element.containingModStrict }
+        .distinct()
+        .singleOrNull()
+        ?: error("Elements to move must belong to single parent mod")
+
+    fun findUsages(): Array<RsMoveUsageInfo> {
+        return elementsToMove
+            .flatMap { ReferencesSearch.search(it.element, GlobalSearchScope.projectScope(project)) }
+            .filterNotNull()
+            .mapNotNull { createMoveUsageInfo(it) }
+            // sorting is needed for stable results in tests
+            .sortedWith(compareBy({ it.element.containingMod.crateRelativePath }, { it.element.startOffset }))
+            .toTypedArray()
+    }
+
+    private fun createMoveUsageInfo(reference: PsiReference): RsMoveUsageInfo? {
+        val element = reference.element
+        val target = reference.resolve() ?: return null
+
+        // `use path1::{path2, path3}`
+        //              ~~~~~  ~~~~~ TODO: don't ignore such paths
+        if (element.ancestorStrict<RsUseGroup>() != null) return null
+
+        return when {
+            element is RsModDeclItem && target is RsFile -> RsModDeclUsageInfo(element, target)
+            element is RsPath && target is RsQualifiedNamedElement -> RsPathUsageInfo(element, reference, target)
+            else -> null
+        }
+    }
+
+    fun preprocessUsages(usages: Array<UsageInfo>): Boolean {
+        val title = message("refactoring.preprocess.usages.progress")
+        return try {
+            // we need to use `computeWithCancelableProgress` and not `runWithCancelableProgress`
+            // because otherwise any exceptions will be silently ignored
+            // (exception will only be written to log, `runWithCancelableProgress` will return `true`)
+            project.computeWithCancelableProgress(title) {
+                runReadAction {
+                    // TODO: two threads
+                    collectOutsideReferences()
+                    preprocessInsideReferences(usages)
+                }
+            }
+            true
+        } catch (e: ProcessCanceledException) {
+            false
+        }
+    }
+
+    private fun collectOutsideReferences(): List<RsMoveReferenceInfo> {
+        // we should collect:
+        // - absolute references (starts with "::", "crate" or some crate name) to source or target crate
+        // - references which starts with "super"
+        // - references from old mod scope:
+        //     - to items in old mod
+        //     - to something which is imported in old mod
+
+        val references = mutableListOf<RsMoveReferenceInfo>()
+        for (path in movedElementsDeepDescendantsOfType<RsPath>(elementsToMove)) {
+            if (path.parent is RsVisRestriction) continue
+            if (path.containingMod != sourceMod  // path inside nested mod of moved element
+                && !path.isAbsolute()
+                && !path.startsWithSuper()
+            ) continue
+            if (!isSimplePath(path)) continue
+            // TODO: support references to macros
+            //  is is complicated: https://doc.rust-lang.org/reference/macros-by-example.html#scoping-exporting-and-importing
+            //  also RsImportHelper currently does not work for macros: https://github.com/intellij-rust/intellij-rust/issues/4073
+            val macroCall = path.ancestorStrict<RsMacroCall>()
+            if (macroCall != null && macroCall.path.isAncestorOf(path)) continue
+
+            // `use path1::{path2, path3}`
+            //              ~~~~~  ~~~~~ TODO: don't ignore such paths
+            if (path.ancestorStrict<RsUseGroup>() != null) continue
+
+            val target = path.reference?.resolve() as? RsQualifiedNamedElement ?: continue
+            // ignore relative references from child modules of moved file
+            // because we handle them as inside references (in `preprocessInsideReferences`)
+            val isSelfReference = target.isInsideMovedElements(elementsToMove)
+            if (isSelfReference) continue
+
+            val reference = createOutsideReferenceInfo(path, target) ?: continue
+            path.putCopyableUserData(RS_MOVE_REFERENCE_INFO_KEY, reference)
+            references += reference
+        }
+        return references
+    }
+
+    private fun createOutsideReferenceInfo(path: RsPath, target: RsQualifiedNamedElement): RsMoveReferenceInfo? {
+        if (path.isAbsolute()) {
+            // when moving from binary to library crate, we should change path `library_crate::...` to `crate::...`
+            // when moving from one library crate to another, we should change path `crate::...` to `first_library::...`
+            val basePathTarget = path.basePath().reference?.resolve() as? RsMod
+            if (basePathTarget != null
+                && basePathTarget.crateRoot != sourceMod.crateRoot
+                && basePathTarget.crateRoot != targetMod.crateRoot
+            ) return null  // not needed to change path
+
+            // ideally this check is enough and above check is not needed
+            // but for some paths (e.g. `base64::decode`) `pathNew.reference.resolve()` is null,
+            // though actually path will be resolved correctly after move
+            val pathNew = path.textNormalized.toRsPath(codeFragmentFactory, targetMod)
+            if (pathNew != null && pathNew.resolvesToAndAccessible(target)) return null  // not needed to change path
+        }
+
+        val pathNewText = target.qualifiedNameInCrate(targetMod)
+        val pathNew = pathNewText?.toRsPath(psiFactory) ?: return null
+
+        return RsMoveReferenceInfo(path, pathNew, target)
+    }
+
+    private fun preprocessInsideReferences(usages: Array<UsageInfo>): List<RsMoveReferenceInfo> {
+        val pathUsages = usages.filterIsInstance<RsPathUsageInfo>()
+        for (usage in pathUsages) {
+            usage.referenceInfo = createInsideReferenceInfo(usage.element, usage.target)
+        }
+
+        val originalReferences = pathUsages.map { it.referenceInfo }
+        for (usage in pathUsages) {
+            usage.referenceInfo = convertToFullReference(usage.referenceInfo) ?: usage.referenceInfo
+
+            val target = usage.referenceInfo.target
+            target.putCopyableUserData(RS_TARGET_BEFORE_MOVE_KEY, target)
+
+            val pathOld = usage.referenceInfo.pathOld
+            if (pathOld.isInsideMovedElements(elementsToMove)) {
+                pathOld.putCopyableUserData(RS_PATH_OLD_BEFORE_MOVE_KEY, pathOld)
+            }
+        }
+        return originalReferences
+    }
+
+    private fun createInsideReferenceInfo(path: RsPath, target: RsQualifiedNamedElement): RsMoveReferenceInfo {
+        val isSelfReference = path.isInsideMovedElements(elementsToMove)
+        if (isSelfReference) {
+            // after move path will be in `targetMod`
+            // so we can refer to moved item just with its name
+            check(target.containingModStrict == sourceMod)  // any inside reference is reference to moved item
+            if (path.containingMod == sourceMod) {
+                val pathNew = target.name?.toRsPath(codeFragmentFactory, targetMod)
+                if (pathNew != null) return RsMoveReferenceInfo(path, pathNew, target)
+            }
+        }
+
+        val targetModPath = targetMod.qualifiedNameRelativeTo(path.containingMod)
+        val targetName = target.name
+        val pathNewText = if (targetModPath != null && targetName != null) "$targetModPath::$targetName" else null
+        val pathNew = pathNewText?.toRsPath(codeFragmentFactory, context = path.context as? RsElement ?: path)
+        return RsMoveReferenceInfo(path, pathNew, target)
+    }
+
+    /**
+     * This method is needed in order to work with references to [RsItemElement]s, and not with references to [RsMod]s.
+     * It is needed when one of moved elements is [RsMod].
+     */
+    private fun convertToFullReference(reference: RsMoveReferenceInfo): RsMoveReferenceInfo? {
+        // Examples:
+        // `mod1::mod2::mod3::Struct::func::<R>();`
+        //  ^~~~~~~~~^ reference.pathOld
+        //  ^~~~~~~~~~~~~~~~~~~~~~~^ pathOld
+        //
+        // `use mod1::mod2::mod3;`
+        //      ^~~~~~~~~^ reference.pathOld
+        //      ^~~~~~~~~~~~~~~^ pathOld
+
+        if (isSimplePath(reference.pathOld) || reference.isInsideUseDirective) return null
+        val pathOld = reference.pathOld.ancestors
+            .takeWhile { it is RsPath }
+            .map { it as RsPath }
+            .firstOrNull { isSimplePath(it) }
+            ?: return null
+        if (!pathOld.textNormalized.startsWith(reference.pathOld.textNormalized)) {
+            LOG.error("Expected '${pathOld.text}' to starts with '${reference.pathOld.text}'")
+            return null
+        }
+
+        if (pathOld.containingFile is DummyHolder) LOG.error("Path '${pathOld.text}' is inside dummy holder")
+        val target = pathOld.reference?.resolve() as? RsQualifiedNamedElement ?: return null
+
+        fun convertPathToFull(path: RsPath): RsPath? {
+            val pathFullText = pathOld.textNormalized
+                .replaceFirst(reference.pathOld.textNormalized, path.textNormalized)
+            val pathFull = pathFullText.toRsPath(codeFragmentFactory, path) ?: return null
+            if (pathFull.containingFile is DummyHolder) LOG.error("Path '${pathFull.text}' is inside dummy holder")
+            return pathFull
+        }
+
+        val pathNew = reference.pathNew?.let { convertPathToFull(it) }
+        return RsMoveReferenceInfo(pathOld, pathNew, target)
+    }
+
+    fun performRefactoring(usages: Array<out UsageInfo>, moveElements: () -> List<ElementToMove>) {
+        elementsToMove = moveElements()
+
+        val retargetReferencesProcessor = RsMoveRetargetReferencesProcessor(project, sourceMod, targetMod)
+        val outsideReferences = restoreOutsideReferenceInfosAfterMove()
+        retargetReferencesProcessor.retargetReferences(outsideReferences)
+
+        val insideReferences = usages
+            .filterIsInstance<RsPathUsageInfo>()
+            .map { it.referenceInfo }
+        updateInsideReferenceInfosIfNeeded(insideReferences)
+        retargetReferencesProcessor.retargetReferences(insideReferences)
+    }
+
+    /**
+     * Each outside reference is associated with some [RsPath] inside moved items.
+     * After move this [RsPath] is invalidated and new [RsPath] is created.
+     * We store [RsMoveReferenceInfo] for outside reference in copyable user data for this [RsPath].
+     */
+    private fun restoreOutsideReferenceInfosAfterMove(): List<RsMoveReferenceInfo> {
+        return movedElementsDeepDescendantsOfType<RsPath>(elementsToMove)
+            .mapNotNullTo(mutableListOf()) { pathOld ->
+                val reference = pathOld.getCopyableUserData(RS_MOVE_REFERENCE_INFO_KEY)
+                    ?: return@mapNotNullTo null
+                pathOld.putCopyableUserData(RS_MOVE_REFERENCE_INFO_KEY, null)
+                // because after move new `RsElement`s are created
+                reference.pathOld = pathOld
+                reference
+            }
+    }
+
+    /**
+     * After move old items are invalidated and new items ([RsElement]s) are created.
+     * Thus we have to change `target` for inside references and change `pathOld` for self references.
+     */
+    private fun updateInsideReferenceInfosIfNeeded(references: List<RsMoveReferenceInfo>) {
+        fun <T : RsElement> createMapping(key: Key<T>, aClass: Class<T>): Map<T, T> {
+            return movedElementsShallowDescendantsOfType(elementsToMove, aClass)
+                .mapNotNull { element ->
+                    val elementOld = element.getCopyableUserData(key) ?: return@mapNotNull null
+                    element.putCopyableUserData(key, null)
+                    elementOld to element
+                }
+                .toMap()
+        }
+
+        val pathMapping = createMapping(RS_PATH_OLD_BEFORE_MOVE_KEY, RsPath::class.java)
+        val targetMapping = createMapping(RS_TARGET_BEFORE_MOVE_KEY, RsQualifiedNamedElement::class.java)
+        for (reference in references) {
+            pathMapping[reference.pathOld]?.let { pathOld ->
+                reference.pathOld = pathOld
+            }
+
+            val targetRestored = targetMapping[reference.target]
+            // it is ok if `targetRestored` is null when target was inside a file which is a submodule of moved items
+            // (so after move existing `target` remains valid)
+            if (targetRestored != null) {
+                reference.target = targetRestored
+            } else if (reference.target.containingFile is DummyHolder) {
+                LOG.error("Can't restore target ${reference.target}" +
+                    " for reference '${reference.pathOld.text}' after move")
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Used for outside references (excluding references from nested moved files).
+         * We store [RsMoveReferenceInfo] in `copyableUserData` for [RsPath] corresponding to reference,
+         * so after move we could restore [RsMoveReferenceInfo].
+         * (We have to do it because after move new psi elements are created)
+         */
+        private val RS_MOVE_REFERENCE_INFO_KEY: Key<RsMoveReferenceInfo> = Key.create("RS_MOVE_REFERENCE_INFO_KEY")
+
+        /**
+         * Used by self references (we treat them as inside references).
+         * We store `pathOld` of such reference in `copyableUserData` for `pathOld` itself.
+         * So after move we can create mapping between original [RsPath] in [sourceMod] and its copy in [targetMod],
+         * and use this mapping to update `pathOld` in [RsMoveReferenceInfo]
+         */
+        private val RS_PATH_OLD_BEFORE_MOVE_KEY: Key<RsPath> = Key.create("RS_PATH_OLD_BEFORE_MOVE_KEY")
+
+        /**
+         * Used by inside references (to descendants of moved items - but only in same file as [sourceMod]).
+         * We store `target` of such reference in `copyableUserData` for `target` itself.
+         * So after move we can create mapping between original [RsElement] in [sourceMod] and its copy in [targetMod],
+         * and use this mapping to update `target` in [RsMoveReferenceInfo].
+         */
+        private val RS_TARGET_BEFORE_MOVE_KEY: Key<RsQualifiedNamedElement> = Key.create("RS_TARGET_BEFORE_MOVE_KEY")
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMovePathHelper.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMovePathHelper.kt
@@ -9,6 +9,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.parentOfType
+import org.rust.ide.refactoring.move.common.RsMoveUtil.containingModOrSelf
+import org.rust.ide.refactoring.move.common.RsMoveUtil.resolvesToAndAccessible
 import org.rust.ide.utils.import.RsImportHelper
 import org.rust.lang.core.psi.RsCodeFragmentFactory
 import org.rust.lang.core.psi.RsFile
@@ -92,5 +94,3 @@ class RsMovePathHelper(private val project: Project, private val mod: RsMod) {
         return if (path.resolvesToAndAccessible(element)) path.text else null
     }
 }
-
-private val RsElement.containingModOrSelf: RsMod get() = (this as? RsMod) ?: containingMod

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveRetargetReferencesProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveRetargetReferencesProcessor.kt
@@ -6,6 +6,11 @@
 package org.rust.ide.refactoring.move.common
 
 import com.intellij.openapi.project.Project
+import org.rust.ide.refactoring.move.common.RsMoveUtil.containingModStrict
+import org.rust.ide.refactoring.move.common.RsMoveUtil.isAbsolute
+import org.rust.ide.refactoring.move.common.RsMoveUtil.resolvesToAndAccessible
+import org.rust.ide.refactoring.move.common.RsMoveUtil.startsWithSuper
+import org.rust.ide.refactoring.move.common.RsMoveUtil.textNormalized
 import org.rust.lang.core.psi.RsCodeFragmentFactory
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsPath

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
@@ -5,59 +5,179 @@
 
 package org.rust.ide.refactoring.move.common
 
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.psi.PsiReference
+import com.intellij.psi.impl.source.DummyHolder
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.usageView.UsageInfo
 import org.rust.ide.utils.import.insertUseItem
-import org.rust.lang.core.psi.RsBlock
-import org.rust.lang.core.psi.RsPath
-import org.rust.lang.core.psi.RsPsiFactory
-import org.rust.lang.core.psi.RsUseItem
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 
+sealed class RsMoveUsageInfo(open val element: RsElement) : UsageInfo(element)
+
+class RsModDeclUsageInfo(override val element: RsModDeclItem, val file: RsFile) : RsMoveUsageInfo(element)
+
+class RsPathUsageInfo(
+    override val element: RsPath,
+    private val rsReference: PsiReference,
+    val target: RsQualifiedNamedElement
+) : RsMoveUsageInfo(element) {
+    lateinit var referenceInfo: RsMoveReferenceInfo
+
+    override fun getReference(): PsiReference = rsReference
+}
+
 class RsMoveReferenceInfo(
-    val pathOld: RsPath,
+    var pathOld: RsPath,
     val pathNew: RsPath?,
     // == `pathOld.reference.resolve()`
-    val target: RsQualifiedNamedElement
+    // mutable because it can be inside moved elements, so after move we have to change it
+    var target: RsQualifiedNamedElement
 ) {
     val isInsideUseDirective: Boolean get() = pathOld.ancestorStrict<RsUseItem>() != null
 }
 
-fun RsPath.isAbsolute(): Boolean {
-    if (basePath().hasColonColon) return true
-    if (startsWithSuper()) return false
+/**
+ * Ideally all these functions should have package-private visibility and be at top-level.
+ * But unfortunately there is no package-private visibility,
+ * so we put functions inside object to decrease their priority in completion in other files.
+ */
+object RsMoveUtil {
 
-    val basePathTarget = basePath().reference?.resolve() as? RsMod ?: return false
-    return basePathTarget.isCrateRoot
+    fun String.toRsPath(psiFactory: RsPsiFactory): RsPath? =
+        psiFactory.tryCreatePath(this) ?: run {
+            LOG.error("Can't create RsPath from '$this'")
+            null
+        }
+
+    fun String.toRsPath(codeFragmentFactory: RsCodeFragmentFactory, context: RsElement): RsPath? =
+        codeFragmentFactory.createPath(this, context) ?: run {
+            LOG.error("Can't create RsPath from '$this' in context $context")
+            null
+        }
+
+    fun RsPath.isAbsolute(): Boolean {
+        if (basePath().hasColonColon) return true
+        if (startsWithSuper()) return false
+
+        if (containingFile is DummyHolder) LOG.error("Path '$text' is inside dummy holder")
+        val basePathTarget = basePath().reference?.resolve() as? RsMod ?: return false
+        return basePathTarget.isCrateRoot
+    }
+
+    fun RsPath.startsWithSuper(): Boolean = basePath().referenceName == "super"
+
+    private fun RsPath.startsWithSelf(): Boolean = basePath().referenceName == "self"
+
+    private fun RsPath.startsWithCSelf(): Boolean = basePath().referenceName == "Self"
+
+    /**
+     * Like `text`, but without spaces and comments.
+     * Expected to be used for paths without type qualifiers and type arguments.
+     */
+    val RsPath.textNormalized: String
+        get() {
+            val parts = listOfNotNull(path?.textNormalized, coloncolon?.text, referenceName)
+            return parts.joinToString("")
+        }
+
+    /**
+     * Path is simple if target of all subpaths is [RsMod]
+     * (target of whole path could be [RsMod] or [RsItemElement]).
+     * These paths are simple:
+     * - `mod1::mod2::Struct1`
+     * - `mod1::mod2::func1`
+     * - `mod1::mod2::mod3` (when `parent` is not [RsPath])
+     * These are not:
+     * - `Struct1::func1`
+     * - `Vec::<i32>::new()`
+     * - `Self::Item1`
+     */
+    fun isSimplePath(path: RsPath): Boolean {
+        // TODO: don't ignore `self::`, only `Self::` ?
+        if (path.startsWithSelf() || path.startsWithCSelf()) return false
+        val target = path.reference?.resolve() ?: return false
+        if (target is RsMod && path.parent is RsPath) return false
+
+        val subpaths = generateSequence(path.path) { it.path }
+        return subpaths.all { it.reference?.resolve() is RsMod }
+    }
+
+    fun RsPath.resolvesToAndAccessible(target: RsQualifiedNamedElement): Boolean {
+        if (containingFile is DummyHolder) LOG.error("Path '$text' is inside dummy holder")
+        if (target.containingFile is DummyHolder) LOG.error("Target $target of path '$text' is inside dummy holder")
+        val reference = reference ?: return false
+        if (!reference.isReferenceTo(target)) return false
+
+        for (subpath in generateSequence(this) { it.path }) {
+            val subpathTarget = subpath.reference?.resolve() as? RsVisible ?: continue
+            if (!subpathTarget.isVisibleFrom(containingMod)) return false
+        }
+        return true
+    }
+
+    val RsElement.containingModOrSelf: RsMod get() = (this as? RsMod) ?: containingMod
+
+    /**
+     * @return `super` instead of `this` for [RsFile]
+     *
+     * ([RsMod.containingMod] returns `super` when mod is [RsModItem] and `this` when mod is [RsFile])
+     */
+    val RsElement.containingModStrict: RsMod
+        get() = when (this) {
+            is RsMod -> `super` ?: this
+            else -> containingMod
+        }
+
+    // TODO: possible performance improvement: iterate over RsElement ancestors only once
+    fun RsElement.isInsideMovedElements(elementsToMove: List<ElementToMove>): Boolean {
+        if (containingFile is RsCodeFragment) LOG.error("Unexpected containingFile: $containingFile")
+        return elementsToMove.any {
+            when (it) {
+                is ItemToMove -> PsiTreeUtil.isAncestor(it.item, this, false)
+                is ModToMove -> containingModOrSelf.superMods.contains(it.mod)
+            }
+        }
+    }
+
+    val LOG: Logger = Logger.getInstance(RsMoveUtil::class.java)
 }
 
-fun RsPath.startsWithSuper(): Boolean = basePath().referenceName == "super"
-
-// like `text`, but without spaces and comments
-// expected to be used for paths without type qualifiers and type arguments
-val RsPath.textNormalized: String
-    get() {
-        val parts = listOfNotNull(path?.textNormalized, coloncolon?.text, referenceName)
-        return parts.joinToString("")
+fun <T : RsElement> movedElementsShallowDescendantsOfType(
+    elementsToMove: List<ElementToMove>,
+    aClass: Class<T>
+): List<T> {
+    return elementsToMove.flatMap {
+        val element = it.element
+        if (element is RsFile) return@flatMap emptyList<T>()
+        PsiTreeUtil.findChildrenOfAnyType(element, false, aClass)
     }
-
-fun RsPath.resolvesToAndAccessible(target: RsQualifiedNamedElement): Boolean {
-    val reference = reference ?: return false
-    if (!reference.isReferenceTo(target)) return false
-
-    for (subpath in generateSequence(this) { it.path }) {
-        val subpathTarget = subpath.reference?.resolve() as? RsVisible ?: continue
-        if (!subpathTarget.isVisibleFrom(containingMod)) return false
-    }
-    return true
 }
 
-// returns `super` instead of `this` for `RsFile`
-// actually it is a bit inconsistent that `containingMod` for `RsMod`
-// returns `super` when mod is `RsModItem` and `this` when mod is `RsFile`
-val RsElement.containingModStrict: RsMod
-    get() = when (this) {
-        is RsMod -> `super` ?: this
-        else -> containingMod
-    }
+inline fun <reified T : RsElement> movedElementsDeepDescendantsOfType(elementsToMove: List<ElementToMove>): Sequence<T> =
+    movedElementsDeepDescendantsOfType(elementsToMove, T::class.java)
+
+fun <T : RsElement> movedElementsDeepDescendantsOfType(
+    elementsToMove: List<ElementToMove>,
+    aClass: Class<T>
+): Sequence<T> {
+    return elementsToMove.asSequence()
+        .flatMap { elementToMove ->
+            when (elementToMove) {
+                is ItemToMove -> PsiTreeUtil.findChildrenOfAnyType(elementToMove.item, false, aClass).asSequence()
+                is ModToMove -> {
+                    val mod = elementToMove.mod
+                    val childModules = mod.childModules
+                        .filter { it.containingFile != mod.containingFile }
+                        .map { ModToMove(it) }
+                    val childModulesDescendants = movedElementsDeepDescendantsOfType(childModules, aClass)
+                    val selfDescendants = PsiTreeUtil.findChildrenOfAnyType(mod, false, aClass).asSequence()
+                    selfDescendants + childModulesDescendants
+                }
+            }
+        }
+}
 
 fun addImport(psiFactory: RsPsiFactory, context: RsElement, usePath: String) {
     if (!usePath.contains("::")) return

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
@@ -87,7 +87,7 @@ val RsMod.superMods: List<RsMod> get() {
 fun RsMod.hasChildModules(): Boolean =
     expandedItemsExceptImplsAndUses.any { it is RsModDeclItem || it is RsModItem && it.hasChildModules() }
 
-private val RsMod.childModules: List<RsMod>
+val RsMod.childModules: List<RsMod>
     get() = expandedItemsExceptImplsAndUses
         .mapNotNull {
             when (it) {


### PR DESCRIPTION
Update references in [move items refactoring](https://github.com/intellij-rust/intellij-rust/issues/3531#issuecomment-643142894):
* Inside references (to moved items - both from old mod and from other mods)
* Outside references (from moved items - both to old mod and to other mods)

---

Please see comment for `RsMoveCommonProcessor` for detailed description

I will add tests later (after merging #5665), but anyway all existing tests can be found [here](https://github.com/intellij-rust/intellij-rust/blob/diralik/move/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt)