### PR TITLE
RUN: Implement wasm-pack run configuration

### DIFF
--- a/.idea/dictionaries/intellij_rust.xml
+++ b/.idea/dictionaries/intellij_rust.xml
@@ -87,6 +87,7 @@
       <w>unsafety</w>
       <w>valobj</w>
       <w>wasm</w>
+      <w>wasmpack</w>
       <w>xargo</w>
       <w>xpointer</w>
     </words>

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -7,7 +7,6 @@ package org.rust.cargo.runconfig.command
 
 import com.intellij.execution.BeforeRunTask
 import com.intellij.execution.Executor
-import com.intellij.execution.ExternalizablePath
 import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.configurations.*
 import com.intellij.execution.runners.ExecutionEnvironment
@@ -19,8 +18,7 @@ import org.jdom.Element
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.toolchain
-import org.rust.cargo.runconfig.CargoRunState
-import org.rust.cargo.runconfig.CargoTestRunState
+import org.rust.cargo.runconfig.*
 import org.rust.cargo.runconfig.buildtool.CargoBuildTaskProvider
 import org.rust.cargo.runconfig.ui.CargoCommandConfigurationEditor
 import org.rust.cargo.toolchain.BacktraceMode
@@ -196,46 +194,3 @@ class CargoCommandConfiguration(
 }
 
 val CargoProject.workingDirectory: Path get() = manifest.parent
-
-private fun Element.writeString(name: String, value: String) {
-    val opt = org.jdom.Element("option")
-    opt.setAttribute("name", name)
-    opt.setAttribute("value", value)
-    addContent(opt)
-}
-
-private fun Element.readString(name: String): String? =
-    children
-        .find { it.name == "option" && it.getAttributeValue("name") == name }
-        ?.getAttributeValue("value")
-
-private fun Element.writeBool(name: String, value: Boolean) {
-    writeString(name, value.toString())
-}
-
-private fun Element.readBool(name: String): Boolean? =
-    readString(name)?.toBoolean()
-
-private fun <E : Enum<*>> Element.writeEnum(name: String, value: E) {
-    writeString(name, value.name)
-}
-
-private inline fun <reified E : Enum<E>> Element.readEnum(name: String): E? {
-    val variantName = readString(name) ?: return null
-    return try {
-        java.lang.Enum.valueOf(E::class.java, variantName)
-    } catch (_: IllegalArgumentException) {
-        null
-    }
-}
-
-private fun Element.writePath(name: String, value: Path?) {
-    if (value != null) {
-        val s = ExternalizablePath.urlValue(value.toString())
-        writeString(name, s)
-    }
-}
-
-private fun Element.readPath(name: String): Path? {
-    return readString(name)?.let { Paths.get(ExternalizablePath.localPathValue(it)) }
-}

--- a/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
@@ -5,15 +5,11 @@
 
 package org.rust.cargo.runconfig.ui
 
-import com.intellij.execution.ExecutionBundle
 import com.intellij.execution.configuration.EnvironmentVariablesComponent
-import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
-import com.intellij.openapi.ui.LabeledComponent
-import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.ui.SimpleListCellRenderer
@@ -62,15 +58,7 @@ class CargoCommandConfigurationEditor(private val project: Project) : SettingsEd
     }
 
     private val currentWorkingDirectory: Path? get() = workingDirectory.component.text.nullize()?.let { Paths.get(it) }
-    private val workingDirectory = run {
-        val textField = TextFieldWithBrowseButton().apply {
-            val fileChooser = FileChooserDescriptorFactory.createSingleFolderDescriptor().apply {
-                title = ExecutionBundle.message("select.working.directory.message")
-            }
-            addBrowseFolderListener(null, null, null, fileChooser)
-        }
-        LabeledComponent.create(textField, ExecutionBundle.message("run.configuration.working.directory.label"))
-    }
+    private val workingDirectory = WorkingDirectoryComponent()
     private val cargoProject = ComboBox<CargoProject>().apply {
         renderer = SimpleListCellRenderer.create("") { it.presentableName }
         allCargoProjects.forEach { addItem(it) }

--- a/src/main/kotlin/org/rust/cargo/runconfig/ui/WorkingDirectoryComponent.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/ui/WorkingDirectoryComponent.kt
@@ -1,0 +1,23 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.ui
+
+import com.intellij.execution.ExecutionBundle
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.ui.LabeledComponent
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+
+class WorkingDirectoryComponent : LabeledComponent<TextFieldWithBrowseButton>() {
+    init {
+        component = TextFieldWithBrowseButton().apply {
+            val fileChooser = FileChooserDescriptorFactory.createSingleFolderDescriptor().apply {
+                title = ExecutionBundle.message("select.working.directory.message")
+            }
+            addBrowseFolderListener(null, null, null, fileChooser)
+        }
+        text = ExecutionBundle.message("run.configuration.working.directory.label")
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandConfiguration.kt
@@ -1,0 +1,59 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.wasmpack
+
+import com.intellij.execution.Executor
+import com.intellij.execution.configurations.*
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.options.SettingsEditor
+import com.intellij.openapi.project.Project
+import org.jdom.Element
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.runconfig.command.workingDirectory
+import org.rust.cargo.runconfig.readPath
+import org.rust.cargo.runconfig.readString
+import org.rust.cargo.runconfig.wasmpack.ui.WasmPackCommandConfigurationEditor
+import org.rust.cargo.runconfig.writePath
+import org.rust.cargo.runconfig.writeString
+import java.nio.file.Path
+
+class WasmPackCommandConfiguration(
+    project: Project,
+    name: String,
+    factory: ConfigurationFactory
+) : LocatableConfigurationBase<RunProfileState>(project, factory, name),
+    RunConfigurationWithSuppressedDefaultDebugAction {
+
+    var command: String = "build"
+    var workingDirectory: Path? = project.cargoProjects.allProjects.firstOrNull()?.workingDirectory
+
+    override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> =
+        WasmPackCommandConfigurationEditor()
+
+    override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState? {
+        val wasmPack = environment.project.toolchain?.wasmPack() ?: return null
+        val workingDirectory = workingDirectory?.toFile() ?: return null
+
+        return WasmPackCommandRunState(environment, this, wasmPack, workingDirectory)
+    }
+
+    override fun writeExternal(element: Element) {
+        super.writeExternal(element)
+        element.writeString("command", command)
+        element.writePath("workingDirectory", workingDirectory)
+    }
+
+    override fun readExternal(element: Element) {
+        super.readExternal(element)
+        element.readString("command")?.let { command = it }
+        element.readPath("workingDirectory")?.let { workingDirectory = it }
+    }
+
+    override fun suggestedName(): String? {
+        return command.substringBefore(' ').capitalize()
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandConfigurationType.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandConfigurationType.kt
@@ -1,0 +1,36 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.wasmpack
+
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.execution.configurations.ConfigurationTypeBase
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.openapi.project.Project
+import org.rust.ide.icons.RsIcons
+
+class WasmPackCommandConfigurationType : ConfigurationTypeBase(
+    "WasmPackCommandRunConfiguration",
+    "wasm-pack",
+    "wasm-pack command run configuration",
+    RsIcons.WASM_PACK
+) {
+    init {
+        addFactory(WasmPackConfigurationFactory(this))
+    }
+}
+
+class WasmPackConfigurationFactory(type: WasmPackCommandConfigurationType) : ConfigurationFactory(type) {
+
+    override fun getId(): String = ID
+
+    override fun createTemplateConfiguration(project: Project): RunConfiguration {
+        return WasmPackCommandConfiguration(project, "wasm-pack", this)
+    }
+
+    companion object {
+        const val ID: String = "wasm-pack"
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandRunState.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.wasmpack
+
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.psi.search.GlobalSearchScopes
+import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.runconfig.console.CargoConsoleBuilder
+import org.rust.cargo.toolchain.RustToolchain
+import org.rust.cargo.toolchain.WasmPack
+import java.io.File
+
+class WasmPackCommandRunState(
+    environment: ExecutionEnvironment,
+    runConfiguration: WasmPackCommandConfiguration,
+    wasmPack: WasmPack,
+    workingDirectory: File
+): WasmPackCommandRunStateBase(environment, runConfiguration, wasmPack, workingDirectory) {
+    init {
+        val scope = GlobalSearchScopes.executionScope(environment.project, environment.runProfile)
+        consoleBuilder = CargoConsoleBuilder(environment.project, scope)
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandRunStateBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandRunStateBase.kt
@@ -1,0 +1,43 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.wasmpack
+
+import com.intellij.execution.configurations.CommandLineState
+import com.intellij.execution.configurations.PtyCommandLine
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.process.ProcessTerminatedListener
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.util.execution.ParametersListUtil
+import org.rust.cargo.runconfig.RsKillableColoredProcessHandler
+import org.rust.cargo.toolchain.WasmPack
+import java.io.File
+
+abstract class WasmPackCommandRunStateBase(
+    environment: ExecutionEnvironment,
+    val runConfiguration: WasmPackCommandConfiguration,
+    val wasmPack: WasmPack,
+    val workingDirectory: File
+): CommandLineState(environment) {
+    override fun startProcess(): ProcessHandler {
+        val params = ParametersListUtil.parse(runConfiguration.command)
+        var commandLine = wasmPack.createCommandLine(
+            workingDirectory,
+            params.firstOrNull().orEmpty(),
+            params.drop(1)
+        )
+
+        if (!SystemInfo.isWindows) {
+            commandLine = PtyCommandLine(commandLine)
+                .withInitialColumns(PtyCommandLine.MAX_COLUMNS)
+                .withConsoleMode(false)
+        }
+
+        val handler = RsKillableColoredProcessHandler(commandLine)
+        ProcessTerminatedListener.attach(handler) // shows exit code upon termination
+        return handler
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandRunner.kt
@@ -1,0 +1,37 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.wasmpack
+
+import com.intellij.execution.configurations.RunProfile
+import com.intellij.execution.configurations.RunProfileState
+import com.intellij.execution.executors.DefaultRunExecutor
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.execution.ui.RunContentDescriptor
+import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.runconfig.RsDefaultProgramRunnerBase
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.getBuildConfiguration
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildConfiguration
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.toolchain.Cargo.Companion.checkNeedInstallWasmPack
+import org.rust.openapiext.execute
+
+class WasmPackCommandRunner : RsDefaultProgramRunnerBase() {
+    override fun getRunnerId(): String = RUNNER_ID
+
+    override fun canRun(executorId: String, profile: RunProfile): Boolean {
+        if (executorId != DefaultRunExecutor.EXECUTOR_ID || profile !is WasmPackCommandConfiguration) return false
+        return true
+    }
+
+    override fun execute(environment: ExecutionEnvironment) {
+        if (checkNeedInstallWasmPack(environment.project)) return
+        super.execute(environment)
+    }
+
+    companion object {
+        const val RUNNER_ID = "WasmPackRunner"
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/ui/WasmPackCommandConfigurationEditor.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/ui/WasmPackCommandConfigurationEditor.kt
@@ -1,0 +1,45 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.wasmpack.ui
+
+import com.intellij.openapi.options.SettingsEditor
+import com.intellij.openapi.ui.LabeledComponent
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.layout.panel
+import com.intellij.util.text.nullize
+import org.rust.cargo.runconfig.ui.WorkingDirectoryComponent
+import org.rust.cargo.runconfig.wasmpack.WasmPackCommandConfiguration
+import java.nio.file.Path
+import java.nio.file.Paths
+import javax.swing.JComponent
+
+class WasmPackCommandConfigurationEditor : SettingsEditor<WasmPackCommandConfiguration>() {
+    private val command: JBTextField = JBTextField()
+
+    private val currentWorkingDirectory: Path? get() = workingDirectory.component.text.nullize()?.let { Paths.get(it) }
+    private val workingDirectory: LabeledComponent<TextFieldWithBrowseButton> = WorkingDirectoryComponent()
+
+    override fun resetEditorFrom(configuration: WasmPackCommandConfiguration) {
+        command.text = configuration.command
+        workingDirectory.component.text = configuration.workingDirectory?.toString().orEmpty()
+    }
+
+    override fun createEditor(): JComponent = panel {
+        row("Command:") {
+            command(pushX)
+        }
+
+        row(workingDirectory.label) {
+            workingDirectory(growX)
+        }
+    }
+
+    override fun applyEditorTo(configuration: WasmPackCommandConfiguration) {
+        configuration.command = command.text
+        configuration.workingDirectory = currentWorkingDirectory
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -486,6 +486,18 @@ class Cargo(private val cargoExecutable: Path, private val rustcExecutable: Path
             )
         }
 
+        fun checkNeedInstallWasmPack(project: Project): Boolean {
+            val crateName = "wasm-pack"
+            val minVersion = SemVer("v0.9.1", 0, 9, 1)
+            return checkNeedInstallBinaryCrate(
+                project,
+                crateName,
+                NotificationType.ERROR,
+                "Need at least $crateName $minVersion",
+                minVersion
+            )
+        }
+
         private fun checkNeedInstallBinaryCrate(
             project: Project,
             crateName: String,

--- a/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustToolchain.kt
@@ -81,6 +81,8 @@ data class RustToolchain(val location: Path) {
 
     fun evcxr(): Evcxr? = if (hasCargoExecutable(EVCXR)) Evcxr(pathToCargoExecutable(EVCXR)) else null
 
+    fun wasmPack(): WasmPack? = if (hasCargoExecutable(WASM_PACK)) WasmPack(pathToCargoExecutable(WASM_PACK)) else null
+
     val isRustupAvailable: Boolean get() = hasExecutable(RUSTUP)
 
     val presentableLocation: String = pathToExecutable(CARGO).toString()
@@ -122,6 +124,7 @@ data class RustToolchain(val location: Path) {
         private const val XARGO = "xargo"
         private const val GRCOV = "grcov"
         private const val EVCXR = "evcxr"
+        private const val WASM_PACK = "wasm-pack"
 
         const val CARGO_TOML = "Cargo.toml"
         const val CARGO_LOCK = "Cargo.lock"

--- a/src/main/kotlin/org/rust/cargo/toolchain/WasmPack.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/WasmPack.kt
@@ -1,0 +1,32 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.toolchain
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import org.rust.cargo.util.splitOnDoubleDash
+import org.rust.openapiext.GeneralCommandLine
+import java.io.File
+import java.nio.file.Path
+
+class WasmPack(private val wasmPackExecutable: Path) {
+    fun createCommandLine(workingDirectory: File, command: String, args: List<String>): GeneralCommandLine {
+        val (pre, post) = splitOnDoubleDash(args)
+            .let { (pre, post) -> pre.toMutableList() to post.toMutableList() }
+
+        val buildableCommands = setOf("build", "test")
+        val forceColorsOption = "--color=always"
+        if (command in buildableCommands && forceColorsOption !in post) {
+            post.add(forceColorsOption)
+        }
+
+        val allArgs = if (post.isEmpty()) pre else pre + "--" + post
+
+        return GeneralCommandLine(wasmPackExecutable)
+            .withWorkDirectory(workingDirectory)
+            .withParameters(command, *allArgs.toTypedArray())
+            .withRedirectErrorStream(true)
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -821,8 +821,10 @@
         <programRunner implementation="org.rust.cargo.runconfig.CargoCommandRunner"/>
         <programRunner implementation="org.rust.cargo.runconfig.CargoTestCommandRunner"/>
         <programRunner implementation="org.rust.debugger.runconfig.RsDebugAdvertisingRunner"/>
+        <programRunner implementation="org.rust.cargo.runconfig.wasmpack.WasmPackCommandRunner"/>
 
         <configurationType implementation="org.rust.cargo.runconfig.command.CargoCommandConfigurationType"/>
+        <configurationType implementation="org.rust.cargo.runconfig.wasmpack.WasmPackCommandConfigurationType"/>
 
         <runConfigurationProducer
                 implementation="org.rust.cargo.runconfig.command.CompositeCargoRunConfigurationProducer"/>


### PR DESCRIPTION
wasm-pack is a tool that provides building and bundling WebAssembly binary generated by Cargo and wasm-bindgen. It gives developers the ability to seamlessly interop between Rust and JS code.

This request aims to provide an option to run wasm-pack commands as run configuration.

Currently, it supports basic command execution within Run Configurations and installation if it doesn't exist in the system.

<img width="1152" alt="Run Configurations Old" src="https://user-images.githubusercontent.com/6342851/89078539-43d36b80-d38d-11ea-9a56-eaf9af30aa76.png">

<img width="1218" src="https://user-images.githubusercontent.com/6342851/89654603-8f2bd380-d8d1-11ea-85b1-7b031ec48e44.png">

Related to #3066