### PR TITLE
RUN: fold external stack traces

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/filters/FilterUtils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/filters/FilterUtils.kt
@@ -1,0 +1,58 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.filters
+
+object FilterUtils {
+    /**
+     * Normalizes function path:
+     * - Removes angle brackets from the element path, including enclosed contents when necessary.
+     * - Removes closure markers.
+     * Examples:
+     * - <core::option::Option<T>>::unwrap -> core::option::Option::unwrap
+     * - std::panicking::default_hook::{{closure}} -> std::panicking::default_hook
+     */
+    fun normalizeFunctionPath(function: String): String {
+        var str = function
+        while (str.endsWith("::{{closure}}")) {
+            str = str.substringBeforeLast("::")
+        }
+        while (true) {
+            val range = str.findAngleBrackets() ?: break
+            val idx = str.indexOf("::", range.start + 1)
+            str = if (idx < 0 || idx > range.endInclusive) {
+                str.removeRange(range)
+            } else {
+                str.removeRange(IntRange(range.endInclusive, range.endInclusive))
+                    .removeRange(IntRange(range.start, range.start))
+            }
+        }
+        return str
+    }
+
+    /**
+     * Finds the range of the first matching angle brackets within the string.
+     */
+    private fun String.findAngleBrackets(): IntRange? {
+        var start = -1
+        var counter = 0
+        loop@ for ((index, char) in this.withIndex()) {
+            when (char) {
+                '<' -> {
+                    if (start < 0) {
+                        start = index
+                    }
+                    counter += 1
+                }
+                '>' -> counter -= 1
+                else -> continue@loop
+            }
+            if (counter == 0) {
+                return IntRange(start, index)
+            }
+        }
+        return null
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/filters/RegexpFileLinkFilter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/filters/RegexpFileLinkFilter.kt
@@ -43,8 +43,7 @@ open class RegexpFileLinkFilter(
 
     // Line is a single sine, with line separator included
     override fun applyFilter(line: String, entireLength: Int): Filter.Result? {
-        val match = linePattern.matchEntire(line)
-            ?: return null
+        val match = matchLine(line) ?: return null
         val fileGroup = match.groups[1]!!
         val lineNumber = match.groups[2]?.let { zeroBasedNumber(it.value) } ?: 0
         val columnNumber = match.groups[3]?.let { zeroBasedNumber(it.value) } ?: 0
@@ -56,6 +55,8 @@ open class RegexpFileLinkFilter(
             createOpenFileHyperlink(fileGroup.value, lineNumber, columnNumber)
         )
     }
+
+    fun matchLine(line: String): MatchResult? = linePattern.matchEntire(line)
 
     private fun zeroBasedNumber(number: String): Int {
         return try {

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleFolding.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleFolding.kt
@@ -1,0 +1,58 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.console
+
+import com.intellij.execution.ConsoleFolding
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.util.text.StringUtil.pluralize
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.cargo.runconfig.filters.FilterUtils
+import org.rust.cargo.runconfig.filters.RegexpFileLinkFilter
+import org.rust.cargo.runconfig.filters.RsBacktraceFilter
+import org.rust.cargo.runconfig.filters.RsBacktraceItemFilter
+import org.rust.lang.core.resolve.resolveStringPath
+
+/**
+ * Folds backtrace items (function names and source code locations) that do not belong to the
+ * user's workspace.
+ */
+class RsConsoleFolding : ConsoleFolding() {
+    override fun getPlaceholderText(project: Project, lines: List<String>): String? {
+        // We assume that each stacktrace record has two lines (function name and source code location).
+        // Single line folds also cannot be re-folded after they are opened as of 2020.2
+        if (lines.size < 2) return null
+
+        val count = lines.size / 2
+        val callText = pluralize("call", count)
+        return "<$count internal $callText>"
+    }
+
+    override fun shouldFoldLine(project: Project, line: String): Boolean {
+        val functionNameFound = project.cargoProjects.allProjects.any {
+            val functionName = RsBacktraceItemFilter.parseBacktraceRecord(line)?.functionName ?: return@any false
+            val func = FilterUtils.normalizeFunctionPath(functionName)
+            val workspace = it.workspace ?: return@any false
+            val (_, pkg) = resolveStringPath(func, workspace, project) ?: return@any true
+
+            pkg.origin != PackageOrigin.WORKSPACE
+        }
+        if (functionNameFound) return true
+
+        return project.cargoProjects.allProjects.any {
+            val dir = (it.workspaceRootDir ?: it.rootDir) ?: return@any false
+            val filter = RegexpFileLinkFilter(project, dir, RsBacktraceFilter.LINE_REGEX)
+
+            val filePath = filter.matchLine(line)?.groups?.get(1)?.value ?: return@any false
+            val systemIndependentPath = FileUtil.toSystemIndependentName(filePath)
+
+            dir.findFileByRelativePath(systemIndependentPath) == null
+        }
+    }
+
+    override fun shouldBeAttachedToThePreviousLine(): Boolean = false
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -970,6 +970,8 @@
         <refactoring.moveHandler implementation="org.rust.ide.refactoring.move.RsMoveTopLevelItemsHandler"
                                  order="first, before moveJavaFileOrDir, before kotlin.moveFilesOrDirectories"/>
 
+        <console.folding implementation="org.rust.ide.console.RsConsoleFolding"/>
+
     </extensions>
 
     <extensionPoints>

--- a/src/test/kotlin/org/rust/ide/console/RsConsoleFoldingTest.kt
+++ b/src/test/kotlin/org/rust/ide/console/RsConsoleFoldingTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.console
+
+class RsConsoleFoldingTest : RsConsoleFoldingTestBase() {
+    fun `test do not fold unrelated text`() = doFoldingTest("""
+        //- lib.rs
+        fn foo() {}
+    """, """
+        Hello world
+        1 + 1 = 2
+    """)
+
+    fun `test single line`() = doFoldingTest("""
+        //- lib.rs
+        fn foo() {}
+    """, """
+        0: backtrace::backtrace::libunwind::trace
+    """)
+
+    fun `test single call`() = doFoldingTest("""
+        //- lib.rs
+        fn foo() {}
+    """, """
+        //foldstart <1 internal call>
+        0: backtrace::backtrace::libunwind::trace
+            at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
+        //foldend
+        1: test_package::foo
+            at lib.rs:1
+    """)
+
+    fun `test multiple calls`() = doFoldingTest("""
+        //- lib.rs
+        fn foo() {}
+    """, """
+        //foldstart <2 internal calls>
+        0: backtrace::backtrace::libunwind::trace
+            at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
+        1: backtrace::backtrace::libunwind::trace
+            at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
+        //foldend
+        2: test_package::foo
+            at lib.rs:1
+        3: test_package::foo
+            at lib.rs:1
+    """)
+
+    fun `test before and after`() = doFoldingTest("""
+        //- lib.rs
+        fn foo() {}
+    """, """
+        //foldstart <2 internal calls>
+        0: backtrace::backtrace::libunwind::trace
+            at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
+        1: backtrace::backtrace::libunwind::trace
+            at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
+        //foldend
+        2: test_package::foo
+            at lib.rs:1
+        3: test_package::foo
+            at lib.rs:1
+        //foldstart <2 internal calls>
+        4: backtrace::backtrace::libunwind::trace
+            at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
+        5: backtrace::backtrace::libunwind::trace
+            at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
+        //foldend
+    """)
+
+    fun `test non-existent code`() = doFoldingTest("""
+        //- lib.rs
+        fn foo() {}
+    """, """
+        //foldstart <1 internal call>
+        0: foo::bar
+            at foo/bar.rs:1
+        //foldend
+        1: test_package::foo
+            at lib.rs:1
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/console/RsConsoleFoldingTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/console/RsConsoleFoldingTestBase.kt
@@ -1,0 +1,108 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.console
+
+import com.intellij.execution.impl.ConsoleViewImpl
+import com.intellij.execution.process.NopProcessHandler
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.ui.ConsoleViewContentType
+import com.intellij.openapi.util.Disposer
+import org.rust.RsTestBase
+import org.rust.fileTreeFromText
+
+abstract class RsConsoleFoldingTestBase : RsTestBase() {
+    private lateinit var console: ConsoleViewImpl
+
+    public override fun setUp() {
+        super.setUp()
+
+        console = createConsole()
+        console.setUpdateFoldingsEnabled(true)
+    }
+
+    public override fun tearDown() {
+        try {
+            Disposer.dispose(console)
+        } catch (e: Throwable) {
+            addSuppressedException(e)
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    protected fun doFoldingTest(tree: String, text: String) {
+        fileTreeFromText(tree).create()
+
+        val (input, expectedFolds) = createConsoleFoldInput(text)
+
+        val console = console
+        console.print(input, ConsoleViewContentType.NORMAL_OUTPUT)
+        console.flushDeferredText()
+
+        val editor = console.editor
+        val regions = editor.foldingModel.allFoldRegions
+
+        val expectedText = renderTextWithFolds(input, expectedFolds)
+        val actualText = renderTextWithFolds(input,
+            regions.map { Fold(it.placeholderText, it.startOffset, it.endOffset) })
+        assertEquals(expectedText, actualText)
+    }
+
+    private fun createConsole(): ConsoleViewImpl {
+        val console = RsConsoleView(project)
+        console.component // initialize component
+        val processHandler: ProcessHandler = NopProcessHandler()
+        processHandler.startNotify()
+        console.attachToProcess(processHandler)
+        return console
+    }
+
+    companion object {
+        private fun renderTextWithFolds(text: String, folds: List<Fold>): String = buildString {
+            var offset = 0
+            folds.forEach { fold ->
+                append(text.substring(offset until fold.startOffset))
+                append(fold.text)
+                offset = fold.endOffset
+            }
+            append(text.substring(offset))
+        }
+
+        private fun createConsoleFoldInput(text: String): Pair<String, List<Fold>> {
+            val expectedFolds = mutableListOf<Fold>()
+            val input = buildString {
+                var offset = 0
+                var currentText: String? = null
+                var currentStartOffset: Int? = null
+                for (line in text.trimIndent().lineSequence()) {
+                    when {
+                        line.startsWith("//foldstart") -> {
+                            currentText = line.removePrefix("//foldstart ").trim()
+                            currentStartOffset = offset
+                        }
+                        line.startsWith("//foldend") -> {
+                            check(currentText != null)
+                            check(currentStartOffset != null)
+                            expectedFolds.add(Fold(currentText, currentStartOffset, offset - 1))
+                            currentText = null
+                            currentStartOffset = null
+                        }
+                        else -> {
+                            append(line)
+                            append('\n')
+                            offset += line.length + 1
+                        }
+                    }
+                }
+                assertNull(currentText)
+                assertNull(currentStartOffset)
+            }
+            return Pair(input, expectedFolds)
+        }
+
+        private data class Fold(val text: String, val startOffset: Int, val endOffset: Int)
+    }
+}


### PR DESCRIPTION
This PR adds folding for non-project related stacktraces:
![image](https://user-images.githubusercontent.com/4539057/87586389-c2b77b80-c6e0-11ea-9e98-9bc8f7b89801.png)

The implementation needs some refactoring, I first wanted to do a sanity check if you think that this approach is valid.
The console folder is a non-dynamic extension, is there a dynamic alternative?

Related issue: https://github.com/intellij-rust/intellij-rust/issues/4514