### PR TITLE
GRD: make 2020.2 default platform for development

### DIFF
--- a/gradle-202.properties
+++ b/gradle-202.properties
@@ -1,10 +1,10 @@
-ideaVersion=IU-202.6250-EAP-CANDIDATE-SNAPSHOT
-clionVersion=CL-202.6250-EAP-CANDIDATE-SNAPSHOT
+ideaVersion=IU-202.6397-EAP-CANDIDATE-SNAPSHOT
+clionVersion=CL-202.6397-EAP-CANDIDATE-SNAPSHOT
 
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions
-nativeDebugPluginVersion=202.6250.13
+nativeDebugPluginVersion=202.6397.20
 # https://plugins.jetbrains.com/plugin/12175-grazie/versions
-graziePluginVersion=202.6250.6
+graziePluginVersion=202.6397.21
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions
 psiViewerPluginVersion=202-SNAPSHOT.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 propertiesPluginEnvironmentNameProperty=platformVersion
 # Supported platforms: 201, 202
-platformVersion=201
+platformVersion=202
 # Supported IDEs: idea, clion
 baseIDE=idea
 


### PR DESCRIPTION
Also, update 2020.2 EAPs