### PR TITLE
RES: properly handle `crate::macro_name!` calls while name resolution

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -315,6 +315,7 @@ fun findDependencyCrateByName(context: RsElement, name: String): RsFile? {
             }
             refinedName
         }
+        name == "crate" -> return context.crateRoot as? RsFile
         else -> name
     }
     var found: RsFile? = null

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
@@ -194,5 +194,20 @@ class RsMacroResolveTest : RsResolveTestBase() {
          //^
     """)
 
+    fun `test macro call with crate prefix 1`() = checkByCode("""
+        #[macro_export]
+        macro_rules! foo { () => () }
+                    //X
+        crate::foo!();
+              //^
+    """)
+
+    fun `test macro call with crate prefix 2`() = checkByCode("""
+        macro_rules! foo { () => () }
+
+        crate::foo!();
+              //^ unresolved
+    """)
+
     // More macro tests in [RsPackageLibraryResolveTest] and [RsStubOnlyResolveTest]
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
@@ -6,25 +6,24 @@
 package org.rust.lang.core.resolve
 
 class RsMacroResolveTest : RsResolveTestBase() {
-    private val `$` = '$'
     fun `test resolve simple matching with multiple pattern definition`() = checkByCode("""
         macro_rules! test {
-            ($`$`test:expr) => (
+            ($ test:expr) => (
                //X
-                $`$`test
+                $ test
                  //^
             )
-            ($`$`test:expr) => (
-                $`$`test
+            ($ test:expr) => (
+                $ test
             )
         }
     """)
 
     fun `test resolve simple matching with multiple matching`() = checkByCode("""
         macro_rules! test {
-            ($`$`test:expr, $`$`ty:ty) => (
+            ($ test:expr, $ ty:ty) => (
                //X
-                $`$`test
+                $ test
                  //^
             )
         }
@@ -32,10 +31,10 @@ class RsMacroResolveTest : RsResolveTestBase() {
 
     fun `test resolve simple matching in complex matching`() = checkByCode("""
         macro_rules! test {
-            ($`$`($`$`test:expr),+, $`$`ty:ty) => (
+            ($ ($ test:expr),+, $ ty:ty) => (
               //X
-                $`$`($`$`test),+
-                  //^
+                $ ($ test),+
+                   //^
             )
         }
     """)


### PR DESCRIPTION
Fixes #5755