### PR TITLE
INSP: attach module without a parent to a parent module in AttachFileToModuleFix

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AttachFileToModuleFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AttachFileToModuleFix.kt
@@ -77,6 +77,9 @@ class AttachFileToModuleFix(
             val modules = mutableListOf<RsMod>()
 
             if (file.isModuleFile) {
+                // module file in parent directory
+                modules.addIfNotNull(findModule(file, project, directory.parent?.findFileByRelativePath(RsConstants.MOD_RS_FILE)))
+
                 // package target roots in parent directory
                 for (target in pkg.targets) {
                     val crateRoot = target.crateRoot ?: continue
@@ -90,8 +93,7 @@ class AttachFileToModuleFix(
 
                 // module file in parent directory
                 if (pkg.edition == CargoWorkspace.Edition.EDITION_2018) {
-                    val parent = directory.parent
-                    modules.addIfNotNull(findModule(file, project, parent?.findFileByRelativePath("${directory.name}.rs")))
+                    modules.addIfNotNull(findModule(file, project, directory.parent?.findFileByRelativePath("${directory.name}.rs")))
                 }
 
                 // package target roots in the same directory

--- a/src/test/kotlin/org/rust/ide/inspections/RsDetachedFileInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDetachedFileInspectionTest.kt
@@ -153,7 +153,7 @@ class RsDetachedFileInspectionTest : RsInspectionsTestBase(RsDetachedFileInspect
         //- foo.rs
     """, "lib.rs")
 
-    fun `test attach module file`() = checkFixWithMultipleModules("""
+    fun `test attach module file 1`() = checkFixWithMultipleModules("""
         //- main.rs
             fn main() {}
         //- lib.rs
@@ -169,6 +169,23 @@ class RsDetachedFileInspectionTest : RsInspectionsTestBase(RsDetachedFileInspect
             fn test() {}
         //- a/mod.rs
     """, "lib.rs")
+
+    fun `test attach module file 2`() = checkFixByFileTree("Attach file to mod.rs", """
+        //- lib.rs
+            mod a;
+        //- a/mod.rs
+            fn foo() {}
+        //- a/b/mod.rs
+        <warning descr="File is not included in module tree, analysis is not available"></warning>/*caret*/
+    """, """
+        //- lib.rs
+            mod a;
+        //- a/mod.rs
+            mod b;
+
+            fn foo() {}
+        //- a/b/mod.rs
+    """)
 
     private fun checkFixWithMultipleModules(
         @Language("Rust") before: String,


### PR DESCRIPTION
https://github.com/intellij-rust/intellij-rust/pull/5490 added a quick fix to attach a file to a nearby module. However, for `mod.rs` files it offered only crate root files (`lib.rs`, `main.rs`) and not parent modules. So in this case:

```rust
//- foo/mod.rs
/* nothing to see here */
//- foo/bar/mod.rs
/* caret*/
```
The quick fix wasn't offered at `/*caret*/`.

After this PR, the quick fix is offered and the example code is transformed into this:

```rust
//- foo/mod.rs
mod bar;
//- foo/bar/mod.rs
```