### PR TITLE
MACRO: fix groups substitution

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -668,6 +668,24 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         fn bar() { 1; 2; }
     """)
 
+    fun `test merged groups`() = doTest("""
+        macro_rules! foo {
+            (($($ a:ident)*) ; ($($ b:block)*)) => {
+                $(
+                    fn $ a () $ b
+                )*
+            };
+        }
+
+        foo! {
+            (bar baz) ;
+            ({ 0; } { 1; })
+        }
+    """, """
+        fn bar() { 0; }
+        fn baz() { 1; }
+    """)
+
     fun `test impl members context`() = checkSingleMacro("""
         macro_rules! foo {
             () => {


### PR DESCRIPTION
I used another algorithm for group matching inspired by rust-analyzer. It should be more close to rustc's version, I hope.

The new algorithm also speeds up macro expansion a bit.

Fixes #5775