### PR TITLE
Get rid of `PackageOrigin.TRANSITIVE_DEPENDENCY`

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -327,14 +327,6 @@ private class WorkspaceImpl(
                 }
             }
 
-            // Figure out packages origins:
-            // - if a package is a workspace member it's WORKSPACE (handled in constructor)
-            // - if a package is a direct dependency of a workspace member, it's DEPENDENCY
-            // - otherwise, it's TRANSITIVE_DEPENDENCY (handled in constructor as well)
-            result.packages.filter { it.origin == PackageOrigin.WORKSPACE }
-                .flatMap { it.dependencies }
-                .forEach { it.pkg.origin = PackageOrigin.min(it.pkg.origin, PackageOrigin.DEPENDENCY) }
-
             return result
         }
     }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/PackageOrigin.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/PackageOrigin.kt
@@ -8,28 +8,19 @@ package org.rust.cargo.project.workspace
 /**
  * Defines a reason a package is in a project.
  */
-enum class PackageOrigin(private val level: Int) {
+enum class PackageOrigin {
     /**
      * The package comes from the standard library.
      */
-    STDLIB(0),
+    STDLIB,
 
     /**
      * The package is a part of our workspace.
      */
-    WORKSPACE(1),
+    WORKSPACE,
 
     /**
-     * The package is a dependency defined in Cargo.toml.
+     * Other external dependencies (that are not [WORKSPACE])
      */
-    DEPENDENCY(2),
-
-    /**
-     * The package is a dependency of one of our dependencies.
-     */
-    TRANSITIVE_DEPENDENCY(3);
-
-    companion object {
-        fun min(o1: PackageOrigin, o2: PackageOrigin) = if (o1.level < o2.level) o1 else o2
-    }
+    DEPENDENCY;
 }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt
@@ -22,6 +22,7 @@ import org.rust.cargo.toolchain.RustcVersion
 import org.rust.ide.icons.RsIcons
 import org.rust.openapiext.checkReadAccessAllowed
 import org.rust.stdext.buildList
+import org.rust.stdext.exhaustive
 import javax.swing.Icon
 
 /**
@@ -74,10 +75,9 @@ private val CargoProject.ideaLibraries: Collection<CargoLibrary>
         for (pkg in workspace.packages) {
             when (pkg.origin) {
                 STDLIB -> stdlibPackages += pkg
-                DEPENDENCY,
-                TRANSITIVE_DEPENDENCY -> dependencyPackages += pkg
-                else -> Unit
-            }
+                DEPENDENCY -> dependencyPackages += pkg
+                WORKSPACE -> Unit
+            }.exhaustive
         }
 
         return buildList {

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -365,7 +365,7 @@ object CargoMetadata {
             version,
             targets.mapNotNull { it.clean(root) },
             source,
-            origin = if (isWorkspaceMember) PackageOrigin.WORKSPACE else PackageOrigin.TRANSITIVE_DEPENDENCY,
+            origin = if (isWorkspaceMember) PackageOrigin.WORKSPACE else PackageOrigin.DEPENDENCY,
             edition = edition.cleanEdition(),
             features = features,
             cfgOptions = cfgOptions,

--- a/src/main/kotlin/org/rust/ide/inspections/import/ui.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/ui.kt
@@ -151,7 +151,7 @@ private class RsElementCellRenderer : DefaultPsiElementCellRenderer() {
             val crate = importCandidate?.qualifiedNamedItem?.containingCrate ?: return null
             return when (crate.origin) {
                 PackageOrigin.STDLIB -> crate.normName to RsIcons.RUST
-                PackageOrigin.DEPENDENCY, PackageOrigin.TRANSITIVE_DEPENDENCY -> crate.normName to CargoIcons.ICON
+                PackageOrigin.DEPENDENCY -> crate.normName to CargoIcons.ICON
                 else -> null
             }
         }

--- a/src/main/kotlin/org/rust/ide/refactoring/RsImportOptimizer.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsImportOptimizer.kt
@@ -130,10 +130,9 @@ private class UseItemWrapper(val useItem: RsUseItem) {
         basePath?.crate != null -> 4
         else -> when (basePath?.reference?.resolve()?.containingCrate?.origin) {
             PackageOrigin.WORKSPACE -> 3
-            PackageOrigin.TRANSITIVE_DEPENDENCY -> 2
             PackageOrigin.DEPENDENCY -> 2
             PackageOrigin.STDLIB -> 1
-            else -> 3
+            null -> 3
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
@@ -89,3 +89,6 @@ interface Crate {
 
 fun Crate.findDependency(normName: String): Crate? =
     dependencies.find { it.normName == normName }?.crate
+
+fun Crate.hasDirectDependency(other: Crate): Boolean =
+    dependencies.any { it.crate == other }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -284,8 +284,7 @@ fun processExternCrateResolveVariants(
     val explicitDepsFirst = crate.dependenciesWithCyclic.sortedBy {
         when (it.crate.origin) {
             PackageOrigin.WORKSPACE,
-            PackageOrigin.DEPENDENCY,
-            PackageOrigin.TRANSITIVE_DEPENDENCY -> {
+            PackageOrigin.DEPENDENCY -> {
                 NameResolutionTestmarks.shadowingStdCrates.hit()
                 0
             }

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -196,14 +196,12 @@ object WithDependencyRustProjectDescriptor : RustProjectDescriptorBase() {
             testCargoPackage(contentRoot),
             externalPackage("$contentRoot/dep-lib", "lib.rs", "dep-lib", "dep-lib-target"),
             externalPackage("", null, "nosrc-lib", "nosrc-lib-target"),
-            externalPackage("$contentRoot/trans-lib", "lib.rs", "trans-lib",
-                origin = PackageOrigin.TRANSITIVE_DEPENDENCY),
+            externalPackage("$contentRoot/trans-lib", "lib.rs", "trans-lib"),
             externalPackage("$contentRoot/dep-lib-new", "lib.rs", "dep-lib", "dep-lib-target",
-                version = "0.0.2", origin = PackageOrigin.TRANSITIVE_DEPENDENCY),
+                version = "0.0.2"),
             externalPackage("$contentRoot/dep-proc-macro", "lib.rs", "dep-proc-macro", libKind = LibKind.PROC_MACRO),
             externalPackage("$contentRoot/dep-lib-2", "lib.rs", "dep-lib-2", "dep-lib-target-2"),
-            externalPackage("$contentRoot/trans-lib-2", "lib.rs", "trans-lib-2",
-                origin = PackageOrigin.TRANSITIVE_DEPENDENCY),
+            externalPackage("$contentRoot/trans-lib-2", "lib.rs", "trans-lib-2"),
             externalPackage("$contentRoot/no-source-lib", "lib.rs", "no-source-lib").copy(source = null)
         )
 


### PR DESCRIPTION
This PackageOrigin kind was very confusing
and buggy because one package may look like
transitive or not from different points of view.