### PR TITLE
GRD: update native debugger plugin

### DIFF
--- a/gradle-202.properties
+++ b/gradle-202.properties
@@ -2,12 +2,12 @@ ideaVersion=IU-202.6397-EAP-CANDIDATE-SNAPSHOT
 clionVersion=CL-202.6397-EAP-CANDIDATE-SNAPSHOT
 
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions
-nativeDebugPluginVersion=202.6397.20
+nativeDebugPluginVersion=202.6397.59
 # https://plugins.jetbrains.com/plugin/12175-grazie/versions
 graziePluginVersion=202.6397.21
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions
 psiViewerPluginVersion=202-SNAPSHOT.3
 
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
-sinceBuild=202.6250
+sinceBuild=202.6397
 untilBuild=203.*


### PR DESCRIPTION
Previous versions of native debugger plugin contain wrong versions of lldb binaries