### PR TITLE
Avoid resolve in `RsVisible.isPublic` for restricted visibility

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -166,6 +166,11 @@ class RsFile(
         return declaration?.visibility ?: RsVisibility.Private
     }
 
+    override val isPublic: Boolean get() {
+        if (isCrateRoot) return true
+        return declaration?.isPublic ?: false
+    }
+
     val attributes: Attributes
         get() {
             val stub = greenStub as RsFileStub?

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumVariant.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumVariant.kt
@@ -24,6 +24,7 @@ abstract class RsEnumVariantImplMixin : RsStubbedNamedElementImpl<RsEnumVariantS
     override fun getIcon(flags: Int): Icon = RsIcons.ENUM_VARIANT
 
     override val visibility: RsVisibility get() = parentEnum.visibility
+    override val isPublic: Boolean get() = parentEnum.isPublic
 
     override val crateRelativePath: String? get() {
         val variantName = name ?: return null
@@ -32,4 +33,3 @@ abstract class RsEnumVariantImplMixin : RsStubbedNamedElementImpl<RsEnumVariantS
 
     override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
 }
-

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -34,7 +34,7 @@ abstract class RsImplItemImplMixin : RsStubbedElementImpl<RsImplItemStub>, RsImp
 
     override fun getIcon(flags: Int) = RsIcons.IMPL
 
-    val isPublic: Boolean get() = false // pub does not affect impls at all
+    override val isPublic: Boolean get() = false // pub does not affect impls at all
 
     override fun getPresentation(): ItemPresentation = getPresentation(this)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsVisibility.kt
@@ -13,6 +13,7 @@ import javax.swing.Icon
 
 interface RsVisible : RsElement {
     val visibility: RsVisibility
+    val isPublic: Boolean  // restricted visibility considered as public
 }
 
 interface RsVisibilityOwner : RsVisible {
@@ -23,9 +24,11 @@ interface RsVisibilityOwner : RsVisible {
     @JvmDefault
     override val visibility: RsVisibility
         get() = vis?.visibility ?: RsVisibility.Private
-}
 
-val RsVisible.isPublic get() = visibility != RsVisibility.Private
+    @JvmDefault
+    override val isPublic: Boolean
+        get() = vis != null
+}
 
 fun RsVisibilityOwner.iconWithVisibility(flags: Int, icon: Icon): Icon {
     val visibilityIcon = when (vis?.stubKind) {


### PR DESCRIPTION
Changes `RsVisible.isPublic` to not use `RsVisible.visible`, and instead just check `RsVisibilityOwner.vis`

This potentially could speed up [`expandedItemsCached`](https://github.com/intellij-rust/intellij-rust/blob/637cdc69ba611a95818516c89d01df527b60b116/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt#L70) a bit