### PR TITLE
INSP: add inspection for E0364/E0365 errors

### DIFF
--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1293,13 +1293,26 @@ sealed class RsDiagnostic(
             fixes = listOf(RemoveReprValueFix(element))
         )
     }
+
+    class InvalidReexport(
+        element: PsiElement,
+        private val name: String,
+        private val exportedItem: RsItemElement
+    ) : RsDiagnostic(element) {
+        override fun prepare(): PreparedAnnotation = PreparedAnnotation(
+            ERROR,
+            if (exportedItem is RsMod) E0365 else E0364,
+            "`$name` is private, and cannot be re-exported",
+            fixes = listOf(MakePublicFix(exportedItem, exportedItem.name, false))
+        )
+    }
 }
 
 enum class RsErrorCode {
     E0004, E0015, E0023, E0025, E0026, E0027, E0040, E0046, E0050, E0060, E0061, E0069, E0081, E0084,
     E0106, E0107, E0118, E0120, E0121, E0124, E0132, E0133, E0184, E0185, E0186, E0198, E0199,
     E0200, E0201, E0202, E0252, E0261, E0262, E0263, E0267, E0268, E0277,
-    E0308, E0322, E0328, E0379, E0384,
+    E0308, E0322, E0328, E0364, E0365, E0379, E0384,
     E0403, E0404, E0407, E0415, E0424, E0426, E0428, E0433, E0435, E0449, E0451, E0463,
     E0517, E0518, E0552, E0562, E0569, E0583, E0586, E0594,
     E0601, E0603, E0614, E0616, E0618, E0624, E0658, E0666, E0667, E0688, E0695,

--- a/src/test/kotlin/org/rust/ide/annotator/RsInvalidReexportErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsInvalidReexportErrorAnnotatorTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+import org.rust.MockEdition
+import org.rust.cargo.project.workspace.CargoWorkspace
+
+@MockEdition(CargoWorkspace.Edition.EDITION_2018)
+class RsInvalidReexportErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
+    fun `test reexport of public item from accessible module`() = checkErrors("""
+        mod foo {
+            mod bar {
+                pub struct Foo;
+                pub mod foo {}
+            }
+            pub use bar::Foo;
+            pub use bar::foo;
+        }
+    """)
+
+    fun `test E0603 reexport of public item from inaccessible module`() = checkErrors("""
+        mod foo {
+            mod bar {
+                mod baz {}
+            }
+            pub use <error descr="Module `bar::baz` is private [E0603]">bar::baz</error>;
+        }
+    """)
+
+    fun `test E0365 reexport of private module`() = checkErrors("""
+        mod foo {
+            mod bar {}
+            pub use <error descr="`bar` is private, and cannot be re-exported [E0365]">bar</error> as baz;
+        }
+    """)
+
+    fun `test E0365 star reexport of private module`() = checkErrors("""
+        mod foo {
+            mod bar {}
+            pub use bar::*;
+        }
+    """)
+
+    fun `test E0364 reexport of private item`() = checkErrors("""
+        mod foo {
+            struct Foo;
+            pub use <error descr="`Foo` is private, and cannot be re-exported [E0364]">Foo</error> as Bar;
+        }
+    """)
+
+    fun `test E0364 reexport of private item from parent module`() = checkErrors("""
+        mod foo {
+            fn foo() {}
+
+            mod bar {
+                pub use super::<error descr="`foo` is private, and cannot be re-exported [E0364]">foo</error>;
+            }
+        }
+    """)
+
+    fun `test reexport item with duplicated name`() = checkErrors("""
+        mod foo {
+            pub struct <error descr="A type named `A` has already been defined in this module [E0428]">A</error> { a: u32 }
+            struct <error descr="A type named `A` has already been defined in this module [E0428]">A</error>;
+            pub use A as B;
+        }
+    """)
+
+    fun `test reexport multiple namespaces`() = checkErrors("""
+        mod foo {
+            pub struct A { a: u32 }
+            const A: u32 = 0;
+
+            pub use A as B;
+        }
+        mod bar {
+            struct A { a: u32 }
+            pub const A: u32 = 0;
+
+            pub use A as B;
+        }
+    """)
+
+    fun `test reexport module path 1`() = checkErrors("""
+        mod foo {
+            mod bar {
+                pub(in crate) struct Foo;
+            }
+            mod baz {
+                pub(in super) use super::bar::Foo;
+            }
+        }
+    """)
+
+    fun `test reexport module path 2`() = checkErrors("""
+        mod foo {
+            mod bar {
+                pub(in super) struct Foo;
+            }
+            mod baz {
+                pub(in super) use super::bar::Foo;
+            }
+        }
+    """)
+
+    fun `test reexport module path 3`() = checkErrors("""
+        mod foo {
+            mod bar {
+                pub struct Foo;
+            }
+            mod baz {
+                pub(in super) use super::bar::Foo;
+            }
+        }
+    """)
+
+    fun `test E0364 reexport module path 4`() = checkErrors("""
+        mod foo {
+            mod bar {
+                pub(in super) struct Foo;
+            }
+            mod baz {
+                pub(in crate) use super::bar::<error descr="`Foo` is private, and cannot be re-exported [E0364]">Foo</error>;
+            }
+        }
+    """)
+
+    fun `test E0364 reexport module path 5`() = checkErrors("""
+        mod foo {
+            mod bar {
+                pub(in crate) struct Foo;
+            }
+            mod baz {
+                pub use super::bar::<error descr="`Foo` is private, and cannot be re-exported [E0364]">Foo</error>;
+            }
+        }
+    """)
+
+    fun `test E0365 self reexport`() = checkErrors("""
+        mod foo {
+            mod bar {}
+            pub use bar::{<error descr="`bar` is private, and cannot be re-exported [E0365]">self</error> as baz};
+        }
+    """)
+
+    fun `test E0365 group reexport`() = checkErrors("""
+        mod foo {
+            mod bar {
+                pub mod foo {}
+                pub(in super) mod baz {}
+            }
+            pub use bar::{foo, <error descr="`baz` is private, and cannot be re-exported [E0365]">baz</error>};
+        }
+    """)
+
+    fun `test E0365 reexport parent`() = checkErrors("""
+        mod foo {
+            pub use super::{<error descr="`foo` is private, and cannot be re-exported [E0365]">foo</error>};
+        }
+    """)
+
+    fun `test reexport of private item into the same module`() = checkErrors("""
+        mod foo {
+            mod bar {}
+            pub(in crate::foo) use bar as baz;
+        }
+    """)
+
+    fun `test reexport of private item into child module`() = checkErrors("""
+        mod foo {
+            mod bar {
+                pub(in crate::foo::bar) use crate::foo::bar as qwe;
+            }
+        }
+    """)
+
+    fun `test reexport of private item into sibling child module`() = checkErrors("""
+        mod foo {
+            mod bar {}
+            mod baz {
+                pub(in crate::foo::baz) use crate::foo::bar as qwe;
+            }
+        }
+    """)
+
+    fun `test rename of private item`() = checkErrors("""
+        mod foo {
+            mod bar {}
+            use bar as baz;
+        }
+    """)
+}


### PR DESCRIPTION
The implementation differs from rustc in that the error annotation doesn't include the reexport alias, if there is any:
```rust
mod foo {
    mod bar {}
    pub use <error>bar as baz</error>; // rustc annotation
    pub use <error>bar</error> as baz; // plugin annotation
}
```

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5759

TODO:
- [x] run real project analysis test