### PR TITLE
Disallow dynamic plugin unloading

### DIFF
--- a/src/201/resources/META-INF/platform-core.xml
+++ b/src/201/resources/META-INF/platform-core.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/src/202/main/kotlin/org/rust/ide/dynamic/RsDynamicPluginListener.kt
+++ b/src/202/main/kotlin/org/rust/ide/dynamic/RsDynamicPluginListener.kt
@@ -1,0 +1,21 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.dynamic
+
+import com.intellij.ide.plugins.CannotUnloadPluginException
+import com.intellij.ide.plugins.DynamicPluginListener
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.openapi.extensions.PluginId
+import org.rust.openapiext.PLUGIN_ID
+
+class RsDynamicPluginListener : DynamicPluginListener {
+    override fun checkUnloadPlugin(pluginDescriptor: IdeaPluginDescriptor) {
+        if (pluginDescriptor.pluginId == PluginId.findId(PLUGIN_ID)) {
+            // See https://github.com/intellij-rust/intellij-rust/issues/4832
+            throw CannotUnloadPluginException("Rust plugin cannot be dynamically unloaded for now")
+        }
+    }
+}

--- a/src/202/main/resources/META-INF/platform-core.xml
+++ b/src/202/main/resources/META-INF/platform-core.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <applicationListeners>
+        <listener class="org.rust.ide.dynamic.RsDynamicPluginListener"
+                  topic="com.intellij.ide.plugins.DynamicPluginListener" />
+    </applicationListeners>
+</idea-plugin>

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1,6 +1,7 @@
 <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude" allow-bundled-update="true">
     <depends>com.intellij.modules.lang</depends>
 
+    <xi:include href="/META-INF/platform-core.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/experiments.xml" xpointer="xpointer(/idea-plugin/*)"/>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
On the 2020.2 platform the Rust plugin can't be loaded again after dynamic unloading (see #4832), so let's disable unloading in order to not confuse our users.

"internal" because the change is not viable for users: the plugin is not actually unloadable today