### PR TITLE
CI: improve check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,15 @@ on:
     pull_request:
 
 jobs:
+    # TODO: drop it when GitHub supports its by itself
+    cancel-previous:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Cancel Previous Runs
+              uses: styfle/cancel-workflow-action@0.4.1
+              with:
+                  access_token: ${{ github.token }}
+
     check-license:
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,6 +33,7 @@ jobs:
                       platform-version: 201
 
         runs-on: ${{ matrix.os }}
+        timeout-minutes: 60
         env:
             ORG_GRADLE_PROJECT_baseIDE: ${{ matrix.base-ide }}
             ORG_GRADLE_PROJECT_platformVersion: ${{ matrix.platform-version }}


### PR DESCRIPTION
* Use 60 min timeout for `check-plugin` job instead of default value (360 for now)
* Cancel previous jobs on `push` event. Unfortunately, GitHub Actions can't cancel previous runs on the same workflow by default so do it ourselves