### PR TITLE
TY: support associated type bounds in paths

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1790,4 +1790,26 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ X
     """)
+
+    fun `test assoc type bound in path selection`() = testExpr("""
+        struct X;
+        trait Foo<T> {}
+        fn foo<A: Foo<B>, B>(_: A) -> B { unimplemented!() }
+        trait Bar { type Item; }
+        fn bar<T: Bar<Item: Foo<X>>>(_: T, b: T::Item) {
+            let a = foo(b);
+            a;
+        } //^ X
+    """)
+
+    fun `test assoc type bound in nested path selection`() = testExpr("""
+        struct X;
+        trait Foo<T> {}
+        fn foo<A: Foo<B>, B>(_: A) -> B { unimplemented!() }
+        trait Bar { type Item; }
+        fn bar<T: Bar<Item: Bar<Item: Foo<X>>>>(_: T, b: <T::Item as Bar>::Item) {
+            let a = foo(b);
+            a;
+        } //^ X
+    """)
 }


### PR DESCRIPTION
Support nightly feature `#![feature(associated_type_bounds)]` ([RFC 2289](https://github.com/rust-lang/rfcs/blob/master/text/2289-associated-type-bounds.md)). 

This enables correct type inference for associated type bounds like this:

```rust
fn foo<T: Iterator<Item: Debug>>(i: T) {

}
```

Related to PRs #4974 and #4478

Part of #4476, also a part of #5714