### PR TITLE
TY: fix nested projections normalization

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/Fold.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Fold.kt
@@ -125,7 +125,14 @@ fun <T : TypeFoldable<T>> TypeFoldable<T>.foldCtConstParameterWith(folder: (CtCo
 fun <T> TypeFoldable<T>.foldTyProjectionWith(folder: (TyProjection) -> Ty): T =
     foldWith(object : TypeFolder {
         override fun foldTy(ty: Ty): Ty = when {
-            ty is TyProjection -> folder(ty)
+            ty is TyProjection -> {
+                val foldedTy = if (ty.type.hasTyProjection || ty.trait.hasTyProjection) {
+                    ty.superFoldWith(this) as TyProjection
+                } else {
+                    ty
+                }
+                folder(foldedTy)
+            }
             ty.hasTyProjection -> ty.superFoldWith(this)
             else -> ty
         }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1065,6 +1065,32 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ D
     """)
 
+    fun `test nested projections`() = testExpr("""
+        trait Trait1 {
+            type Item1;
+            fn foo(&self) -> Self::Item1 { unimplemented!() }
+        }
+        trait Trait2 { type Item2; }
+
+        struct X<T>(T);
+        struct Y;
+        struct Z;
+
+        impl<T> Trait1 for X<T>
+            where T: Trait2,
+                  T::Item2: Trait1
+        {
+            type Item1 = <<T as Trait2>::Item2 as Trait1>::Item1;
+        }
+        impl Trait2 for Y { type Item2 = Z; }
+        impl Trait1 for Z { type Item1 = i32; }
+
+        fn main() {
+            let a = X(Y).foo();
+            a;
+        } //^ i32
+    """)
+
     fun `test simple unification`() = testExpr("""
         struct S<T>(T);
 

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -6,8 +6,10 @@
 package org.rust.lang.core.type
 
 import org.rust.ExpandMacros
+import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyFloat
@@ -781,5 +783,16 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
             let b = a.clone(); // `S<X>` is not `Clone`, so resolved to std `impl for &T`
             b;
         } //^ &S<X>
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test await pin future`() = stubOnlyTypeInfer("""
+    //- main.rs
+        use std::future::Future;
+        use std::pin::Pin;
+        async fn foo<T: Future<Output=i32>>(p: Pin<&mut T>) {
+            let a = p.await;
+            a;
+        } //^ i32
     """)
 }


### PR DESCRIPTION
This fixes `Pin<&mut impl Future<Output=i32>>` awaiting:

```rust
async fn foo<T: Future<Output=i32>>(p: Pin<&mut T>) {
    let a = p.await;
    a;
} //^ i32
```