### PR TITLE
ACT: replace `IntellijRustDollarCrate` with a crate name in `show macro expansion` action

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/macroExpansion/MacroExpansionViewUtils.kt
+++ b/src/main/kotlin/org/rust/ide/actions/macroExpansion/MacroExpansionViewUtils.kt
@@ -92,15 +92,15 @@ private fun getMacroExpansionViewTitle(macroToExpand: RsMacroCall, expandRecursi
     }
 
 private fun getMacroExpansions(macroToExpand: RsMacroCall, expandRecursively: Boolean): MacroExpansion? {
-    if (!expandRecursively) {
-        return macroToExpand.expansion
-    }
-
     if (macroToExpand.expansion == null) {
         return null
     }
 
-    val expansionText = macroToExpand.expandAllMacrosRecursively()
+    val expansionText = if (expandRecursively) {
+        macroToExpand.expandAllMacrosRecursively(replaceDollarCrate = true)
+    } else {
+        macroToExpand.expandMacrosRecursively(depthLimit = 1, replaceDollarCrate = true)
+    }
 
     return parseExpandedTextWithContext(
         macroToExpand.expansionContext,

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -535,7 +535,7 @@ private fun processUnqualifiedPathResolveVariants(
     }
 }
 
-private fun RsPath.resolveDollarCrateIdentifier(): Crate? {
+fun RsPath.resolveDollarCrateIdentifier(): Crate? {
     NameResolutionTestmarks.dollarCrateMagicIdentifier.hit()
     val dollarCrateSource = findMacroCallFromWhichLeafIsExpanded() ?: this
     val macro = dollarCrateSource.findMacroCallExpandedFromNonRecursive()?.resolveToMacro()

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
@@ -78,7 +78,7 @@ abstract class RsMacroExpansionTestBase : RsTestBase() {
         errorMessage: String,
         mark: Testmark? = null
     ) {
-        val expand = { macroCall.expandAllMacrosRecursively() }
+        val expand = { macroCall.expandAllMacrosRecursively(replaceDollarCrate = false) }
         val expandedText = mark?.checkHit(expand) ?: expand()
 
         if (!StringUtil.equalsIgnoreWhitespaces(expectedExpansion, expandedText)) {


### PR DESCRIPTION
No such artifacts anymore:

![image](https://user-images.githubusercontent.com/3221931/88556640-ee682900-d031-11ea-836f-eec7c27f9632.png)

Now `IntellijRustDollarCrate` is replaced with a crate name prefixed by `::`, e.g. `::foobar`

![image](https://user-images.githubusercontent.com/3221931/88557852-700c8680-d033-11ea-84e2-5c3a1bb20fb1.png)
