### PR TITLE
REF: add unsafe modifier to functions extracted from unsafe functions

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
@@ -120,6 +120,7 @@ class RsExtractFunctionConfig private constructor(
     var name: String = "",
     var visibilityLevelPublic: Boolean = false,
     val isAsync: Boolean = false,
+    val isUnsafe: Boolean = false,
     var parameters: List<Parameter>
 ) {
     val valueParameters: List<Parameter>
@@ -147,6 +148,9 @@ class RsExtractFunctionConfig private constructor(
         }
         if (isAsync) {
             append("async ")
+        }
+        if (isUnsafe) {
+            append("unsafe ")
         }
         append("fn $name$typeParametersText(${if (isOriginal) originalParametersText else parametersText})")
         if (returnValue != null && returnValue.type !is TyUnit) {
@@ -305,7 +309,8 @@ class RsExtractFunctionConfig private constructor(
                 elements,
                 returnValue = returnValue,
                 parameters = parameters,
-                isAsync = isAsync
+                isAsync = isAsync,
+                isUnsafe = fn.isUnsafe
             )
         }
     }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -1212,6 +1212,22 @@ class RsExtractFunctionTest : RsTestBase() {
         false,
         "foo", mutabilityOverride = mapOf("a" to true))
 
+    fun `test extract unsafe function`() = doTest("""
+        unsafe fn bar(ptr: *const u32) -> u32 {
+            <selection>*ptr</selection>
+        }
+    """, """
+        unsafe fn bar(ptr: *const u32) -> u32 {
+            foo(ptr)
+        }
+
+        unsafe fn foo(ptr: *const u32) -> u32 {
+            *ptr
+        }
+    """,
+        false,
+        "foo")
+
     private fun doTest(@Language("Rust") code: String,
                        @Language("Rust") excepted: String,
                        pub: Boolean,


### PR DESCRIPTION
This PR adds `unsafe` to functions extracted from `unsafe` functions. Currently the `unsafe` is added unconditionally, should I improve that?

The extracted statements would have to be scanned for unsafe operations that are not inside an `unsafe` block. Since pretty much the same code is already in `RsUnsafeExpressionAnnotator`, it should be refactored somehow to share the logic.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5814