### PR TITLE
INSP: suppress snake_case naming lint for #[no_mangle] functions

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsNamingInspection.kt
@@ -10,10 +10,7 @@ import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.inspections.fixes.RenameFix
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.RsAbstractableOwner
-import org.rust.lang.core.psi.ext.RsConstantKind
-import org.rust.lang.core.psi.ext.kind
-import org.rust.lang.core.psi.ext.owner
+import org.rust.lang.core.psi.ext.*
 
 /**
  * Base class for naming inspections. Implements the core logic of checking names
@@ -206,6 +203,13 @@ class RsFunctionNamingInspection : RsSnakeCaseNamingInspection("Function") {
                 }
             }
         }
+
+    override fun isSuppressedFor(element: PsiElement): Boolean {
+        if (super.isSuppressedFor(element)) return true
+
+        val function = element.parent as? RsFunction ?: return false
+        return function.isExtern && function.findOuterAttr("no_mangle") != null
+    }
 }
 
 class RsMethodNamingInspection : RsSnakeCaseNamingInspection("Method") {

--- a/src/test/kotlin/org/rust/ide/inspections/naming/RsFunctionNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/naming/RsFunctionNamingInspectionTest.kt
@@ -46,4 +46,14 @@ class RsFunctionNamingInspectionTest : RsInspectionsTestBase(RsFunctionNamingIns
             r#extern();
         }
     """)
+
+    fun `test no_mangle function`() = checkByText("""
+        #[no_mangle]
+        pub fn <warning descr="Function `Foo` should have a snake case name such as `foo`">Foo</warning>() {}
+    """)
+
+    fun `test no_mangle extern function`() = checkByText("""
+        #[no_mangle]
+        pub unsafe extern fn Foo() {}
+    """)
 }


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/4274