### PR TITLE
Don't provide color highlighting in batch mode

### DIFF
--- a/common/src/test/kotlin/com/intellij/ide/annotator/BatchMode.kt
+++ b/common/src/test/kotlin/com/intellij/ide/annotator/BatchMode.kt
@@ -1,0 +1,15 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package com.intellij.ide.annotator
+
+/**
+ * Launch annotation test in batch mode.
+ *
+ * See [com.intellij.lang.annotation.AnnotationHolder.isBatchMode]
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class BatchMode

--- a/common/src/test/kotlin/com/intellij/utils.kt
+++ b/common/src/test/kotlin/com/intellij/utils.kt
@@ -1,0 +1,13 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package com.intellij
+
+import junit.framework.TestCase
+
+
+/** Tries to find the specified annotation on the current test method and then on the current class */
+inline fun <reified T : Annotation> TestCase.findAnnotationInstance(): T? =
+    javaClass.getMethod(name).getAnnotation(T::class.java) ?: javaClass.getAnnotation(T::class.java)

--- a/grazie/src/test/kotlin/org/rust/grazie/RsGrammarCheckingTest.kt
+++ b/grazie/src/test/kotlin/org/rust/grazie/RsGrammarCheckingTest.kt
@@ -17,7 +17,7 @@ import org.rust.ide.inspections.RsInspectionsTestBase
 class RsGrammarCheckingTest : RsInspectionsTestBase(GrazieInspection::class) {
 
     override fun createAnnotationFixture(): RsAnnotationTestFixture =
-        RsAnnotationTestFixture(myFixture, inspectionClasses = listOf(inspectionClass), baseFileName = "lib.rs")
+        RsAnnotationTestFixture(this, myFixture, inspectionClasses = listOf(inspectionClass), baseFileName = "lib.rs")
 
     override fun setUp() {
         super.setUp()

--- a/intellij-toml/src/main/kotlin/org/toml/ide/annotator/TomlHighlightingAnnotator.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/annotator/TomlHighlightingAnnotator.kt
@@ -15,6 +15,7 @@ import org.toml.lang.psi.TomlElementTypes
 
 class TomlHighlightingAnnotator : AnnotatorBase() {
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
+        if (holder.isBatchMode) return
         // Although we use only elementType info, it's not possible to do it by lexer
         // because numbers and dates can be used as keys too (for example, `123 = 123` is correct toml)
         // and proper element types are set by parser.

--- a/intellij-toml/src/test/kotlin/org/toml/ide/annotator/TomlAnnotationTestBase.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/ide/annotator/TomlAnnotationTestBase.kt
@@ -26,7 +26,8 @@ abstract class TomlAnnotationTestBase : TomlTestBase() {
 
     protected abstract fun createAnnotationFixture(): TomlAnnotationTestFixture
 
-    protected fun checkHighlighting(@Language("TOML") text: String) = annotationFixture.checkHighlighting(text)
+    protected fun checkHighlighting(@Language("TOML") text: String, ignoreExtraHighlighting: Boolean = true) =
+        annotationFixture.checkHighlighting(text, ignoreExtraHighlighting)
 
     protected fun checkByText(
         @Language("TOML") text: String,

--- a/intellij-toml/src/test/kotlin/org/toml/ide/annotator/TomlAnnotationTestFixture.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/ide/annotator/TomlAnnotationTestFixture.kt
@@ -9,12 +9,14 @@ import com.intellij.codeInspection.InspectionProfileEntry
 import com.intellij.ide.annotator.AnnotationTestFixtureBase
 import com.intellij.ide.annotator.AnnotatorBase
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import junit.framework.TestCase
 import kotlin.reflect.KClass
 
 class TomlAnnotationTestFixture(
+    testCase: TestCase,
     codeInsightFixture: CodeInsightTestFixture,
     annotatorClasses: List<KClass<out AnnotatorBase>> = emptyList(),
     inspectionClasses: List<KClass<out InspectionProfileEntry>> = emptyList()
-) : AnnotationTestFixtureBase(codeInsightFixture, annotatorClasses, inspectionClasses) {
+) : AnnotationTestFixtureBase(testCase, codeInsightFixture, annotatorClasses, inspectionClasses) {
     override val baseFileName: String = "example.toml"
 }

--- a/intellij-toml/src/test/kotlin/org/toml/ide/annotator/TomlAnnotatorTestBase.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/ide/annotator/TomlAnnotatorTestBase.kt
@@ -11,5 +11,5 @@ import kotlin.reflect.KClass
 abstract class TomlAnnotatorTestBase(private val annotatorClass: KClass<out AnnotatorBase>) : TomlAnnotationTestBase() {
 
     override fun createAnnotationFixture(): TomlAnnotationTestFixture =
-        TomlAnnotationTestFixture(myFixture, annotatorClasses = listOf(annotatorClass))
+        TomlAnnotationTestFixture(this, myFixture, annotatorClasses = listOf(annotatorClass))
 }

--- a/intellij-toml/src/test/kotlin/org/toml/ide/annotator/TomlHighlightingAnnotatorTest.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/ide/annotator/TomlHighlightingAnnotatorTest.kt
@@ -5,6 +5,8 @@
 
 package org.toml.ide.annotator
 
+import com.intellij.ide.annotator.BatchMode
+
 class TomlHighlightingAnnotatorTest : TomlAnnotatorTestBase(TomlHighlightingAnnotator::class) {
 
     fun `test numbers`() = checkHighlighting("""
@@ -28,4 +30,13 @@ class TomlHighlightingAnnotatorTest : TomlAnnotatorTestBase(TomlHighlightingAnno
         <KEY>k5 = { <KEY>k6</KEY> = 123, <KEY>k7</KEY> = 2019-11-08 }
         [<KEY>foo</KEY>.<KEY>bar</KEY>]
     """)
+
+    @BatchMode
+    fun `test no highlighting in batch mode`() = checkHighlighting("""
+        k1 = 123
+        k2 = 1.0
+        k3 = [ 2020-07-30 ]
+        k4 = { f1 = 10, f2 = 20.0 }
+        [foo.bar]
+    """, ignoreExtraHighlighting = false)
 }

--- a/src/main/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotator.kt
@@ -18,6 +18,7 @@ import org.rust.lang.core.psi.ext.rangeWithSurroundingLineBreaks
 
 class RsCfgDisabledCodeAnnotator : AnnotatorBase() {
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
+        if (holder.isBatchMode) return
         if (element is RsDocAndAttributeOwner && !element.isEnabledByCfg) {
             holder.createCfgDisabledAnnotation(element.rangeWithSurroundingLineBreaks)
         }

--- a/src/main/kotlin/org/rust/ide/annotator/RsDoctestAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsDoctestAnnotator.kt
@@ -28,6 +28,7 @@ import org.rust.lang.core.psi.ext.containingCrate
  */
 class RsDoctestAnnotator : AnnotatorBase() {
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
+        if (holder.isBatchMode) return
         if (element !is RsDocCommentImpl) return
         if (!element.project.rustSettings.doctestInjectionEnabled) return
         // only library targets can have doctests

--- a/src/main/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotator.kt
@@ -10,6 +10,7 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
 import org.rust.ide.colors.RsColor
 import org.rust.ide.utils.isEnabledByCfg
@@ -28,9 +29,11 @@ class RsEdition2018KeywordsAnnotator : AnnotatorBase() {
             isEdition2018 && isIdentifier && isNameIdentifier(element) ->
                 holder.newAnnotation(HighlightSeverity.ERROR, "`${element.text}` is reserved keyword in Edition 2018").create()
 
-            isEdition2018 && !isIdentifier && isEnabledByCfg ->
-                holder.newSilentAnnotation(HighlightSeverity.WEAK_WARNING)
+            isEdition2018 && !isIdentifier && isEnabledByCfg -> {
+                val severity = if (isUnitTestMode) RsColor.KEYWORD.testSeverity else HighlightSeverity.INFORMATION
+                holder.newSilentAnnotation(severity)
                     .textAttributes(RsColor.KEYWORD.textAttributesKey).create()
+            }
 
             isEdition2018 && !isIdentifier && !isEnabledByCfg -> {
                 val colorScheme = EditorColorsManager.getInstance().globalScheme
@@ -38,7 +41,7 @@ class RsEdition2018KeywordsAnnotator : AnnotatorBase() {
                 val cfgDisabledCodeTextAttributes = colorScheme.getAttributes(RsColor.CFG_DISABLED_CODE.textAttributesKey)
                 val cfgDisabledKeywordTextAttributes = TextAttributes.merge(keywordTextAttributes, cfgDisabledCodeTextAttributes)
 
-                holder.newSilentAnnotation(HighlightSeverity.WEAK_WARNING)
+                holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
                     .enforcedTextAttributes(cfgDisabledKeywordTextAttributes).create()
             }
 

--- a/src/main/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotator.kt
@@ -30,19 +30,23 @@ class RsEdition2018KeywordsAnnotator : AnnotatorBase() {
                 holder.newAnnotation(HighlightSeverity.ERROR, "`${element.text}` is reserved keyword in Edition 2018").create()
 
             isEdition2018 && !isIdentifier && isEnabledByCfg -> {
-                val severity = if (isUnitTestMode) RsColor.KEYWORD.testSeverity else HighlightSeverity.INFORMATION
-                holder.newSilentAnnotation(severity)
-                    .textAttributes(RsColor.KEYWORD.textAttributesKey).create()
+                if (!holder.isBatchMode) {
+                    val severity = if (isUnitTestMode) RsColor.KEYWORD.testSeverity else HighlightSeverity.INFORMATION
+                    holder.newSilentAnnotation(severity)
+                        .textAttributes(RsColor.KEYWORD.textAttributesKey).create()
+                }
             }
 
             isEdition2018 && !isIdentifier && !isEnabledByCfg -> {
-                val colorScheme = EditorColorsManager.getInstance().globalScheme
-                val keywordTextAttributes = colorScheme.getAttributes(RsColor.KEYWORD.textAttributesKey)
-                val cfgDisabledCodeTextAttributes = colorScheme.getAttributes(RsColor.CFG_DISABLED_CODE.textAttributesKey)
-                val cfgDisabledKeywordTextAttributes = TextAttributes.merge(keywordTextAttributes, cfgDisabledCodeTextAttributes)
+                if (!holder.isBatchMode) {
+                    val colorScheme = EditorColorsManager.getInstance().globalScheme
+                    val keywordTextAttributes = colorScheme.getAttributes(RsColor.KEYWORD.textAttributesKey)
+                    val cfgDisabledCodeTextAttributes = colorScheme.getAttributes(RsColor.CFG_DISABLED_CODE.textAttributesKey)
+                    val cfgDisabledKeywordTextAttributes = TextAttributes.merge(keywordTextAttributes, cfgDisabledCodeTextAttributes)
 
-                holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
-                    .enforcedTextAttributes(cfgDisabledKeywordTextAttributes).create()
+                    holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+                        .enforcedTextAttributes(cfgDisabledKeywordTextAttributes).create()
+                }
             }
 
             !isEdition2018 && !isIdentifier ->

--- a/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
@@ -53,14 +53,18 @@ class RsFormatMacroAnnotator : AnnotatorBase() {
             holder.newAnnotation(HighlightSeverity.ERROR, error.error).range(error.range).create()
         }
 
-        highlightParametersOutside(parseCtx, holder)
+        if (!holder.isBatchMode) {
+            highlightParametersOutside(parseCtx, holder)
+        }
 
         // skip advanced checks and highlighting if there are syntax errors
         if (errors.isNotEmpty()) {
             return
         }
 
-        highlightParametersInside(parseCtx, holder)
+        if (!holder.isBatchMode) {
+            highlightParametersInside(parseCtx, holder)
+        }
 
         val suppressTraitErrors = !isUnitTestMode &&
             (element.project.macroExpansionManager.macroExpansionMode !is MacroExpansionMode.New

--- a/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
@@ -263,7 +263,8 @@ private fun highlightParametersOutside(ctx: ParseContext, holder: AnnotationHold
 private fun highlightParametersInside(ctx: ParseContext, holder: AnnotationHolder) {
     fun highlight(range: IntRange?, offset: Int, color: RsColor = RsColor.IDENTIFIER) {
         if (range != null && !range.isEmpty()) {
-            holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+            val highlightSeverity = if (isUnitTestMode) color.testSeverity else HighlightSeverity.INFORMATION
+            holder.newSilentAnnotation(highlightSeverity)
                 .range(ctx.toSourceRange(range, offset))
                 .textAttributes(color.textAttributesKey)
                 .create()

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -29,6 +29,7 @@ import org.rust.openapiext.getOrPut
 class RsHighlightingAnnotator : AnnotatorBase() {
 
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
+        if (holder.isBatchMode) return
         val color = when (element) {
             is LeafPsiElement -> highlightLeaf(element, holder)
             is RsAttr -> RsColor.ATTRIBUTE

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotator.kt
@@ -25,6 +25,7 @@ import org.rust.lang.core.types.type
 class RsHighlightingMutableAnnotator : AnnotatorBase() {
 
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
+        if (holder.isBatchMode) return
         val ref = when (element) {
             is RsPath -> element.reference?.resolve() ?: return
             is RsSelfParameter -> element

--- a/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
@@ -120,6 +120,7 @@ class RsUnsafeExpressionAnnotator : AnnotatorBase() {
     }
 
     private fun AnnotationHolder.createUnsafeAnnotation(textRange: TextRange, message: String) {
+        if (isBatchMode) return
         val color = RsColor.UNSAFE_CODE
         val severity = if (isUnitTestMode) color.testSeverity else HighlightSeverity.INFORMATION
 

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -6,6 +6,7 @@
 package org.rust
 
 import com.intellij.TestCase
+import com.intellij.findAnnotationInstance
 import com.intellij.injected.editor.VirtualFileWindow
 import com.intellij.lang.LanguageCommenters
 import com.intellij.lang.injection.InjectedLanguageManager
@@ -48,10 +49,6 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
         return annotation.descriptor.objectInstance
             ?: error("Only Kotlin objects defined with `object` keyword are allowed")
     }
-
-    /** Tries to find the specified annotation on the current test method and then on the current class */
-    private inline fun <reified T : Annotation> findAnnotationInstance(): T? =
-        javaClass.getMethod(name).getAnnotation(T::class.java) ?: javaClass.getAnnotation(T::class.java)
 
     override fun isWriteActionRequired(): Boolean = false
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestBase.kt
@@ -7,6 +7,7 @@ package org.rust.ide.annotator
 
 import com.intellij.openapiext.Testmark
 import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
+import junit.framework.TestCase
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.fileTreeFromText
@@ -28,7 +29,8 @@ abstract class RsAnnotationTestBase : RsTestBase() {
 
     protected abstract fun createAnnotationFixture(): RsAnnotationTestFixture
 
-    protected fun checkHighlighting(@Language("Rust") text: String) = annotationFixture.checkHighlighting(text)
+    protected fun checkHighlighting(@Language("Rust") text: String, ignoreExtraHighlighting: Boolean = true) =
+        annotationFixture.checkHighlighting(text, ignoreExtraHighlighting)
     protected fun checkInfo(@Language("Rust") text: String) = annotationFixture.checkInfo(text)
     protected fun checkWarnings(@Language("Rust") text: String) = annotationFixture.checkWarnings(text)
     protected fun checkErrors(@Language("Rust") text: String) = annotationFixture.checkErrors(text)

--- a/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestFixture.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAnnotationTestFixture.kt
@@ -12,6 +12,7 @@ import com.intellij.openapiext.Testmark
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture.*
 import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
+import junit.framework.TestCase
 import org.intellij.lang.annotations.Language
 import org.rust.TestProject
 import org.rust.createAndOpenFileWithCaretMarker
@@ -19,11 +20,12 @@ import org.rust.fileTreeFromText
 import kotlin.reflect.KClass
 
 class RsAnnotationTestFixture(
+    testCase: TestCase,
     codeInsightFixture: CodeInsightTestFixture,
     annotatorClasses: List<KClass<out AnnotatorBase>> = emptyList(),
     inspectionClasses: List<KClass<out InspectionProfileEntry>> = emptyList(),
     override val baseFileName: String = "main.rs"
-) : AnnotationTestFixtureBase(codeInsightFixture, annotatorClasses, inspectionClasses) {
+) : AnnotationTestFixtureBase(testCase, codeInsightFixture, annotatorClasses, inspectionClasses) {
 
     fun checkByFileTree(
         @Language("Rust") text: String,

--- a/src/test/kotlin/org/rust/ide/annotator/RsAnnotatorTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsAnnotatorTestBase.kt
@@ -11,5 +11,5 @@ import kotlin.reflect.KClass
 abstract class RsAnnotatorTestBase(private val annotatorClass: KClass<out AnnotatorBase>) : RsAnnotationTestBase() {
 
     override fun createAnnotationFixture(): RsAnnotationTestFixture =
-        RsAnnotationTestFixture(myFixture, annotatorClasses = listOf(annotatorClass))
+        RsAnnotationTestFixture(this, myFixture, annotatorClasses = listOf(annotatorClass))
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotatorTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator
 
+import com.intellij.ide.annotator.BatchMode
 import org.rust.MockAdditionalCfgOptions
 import org.rust.MockEdition
 import org.rust.cargo.project.workspace.CargoWorkspace
@@ -64,4 +65,13 @@ class RsCfgDisabledCodeAnnotatorTest : RsAnnotatorTestBase(RsCfgDisabledCodeAnno
         </CFG_DISABLED_CODE>
         }
     """)
+
+    @BatchMode
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test no highlighting in batch mode`() = checkHighlighting("""
+        #[cfg(not(intellij_rust))]
+        fn foo() {
+            let x = 1;
+        }
+    """, ignoreExtraHighlighting = false)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsDoctestAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsDoctestAnnotatorTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator
 
+import com.intellij.ide.annotator.BatchMode
 import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
 
@@ -110,6 +111,14 @@ class RsDoctestAnnotatorTest : RsAnnotatorTestBase(RsDoctestAnnotator::class) {
         /// ```
         fn foo() {}
     """, checkInfo = true)
+
+    @BatchMode
+    fun `test no highlighting in batch mod`() = doTest("""
+        |/// ```
+        |/// <inject>let a = 0;
+        |</inject>/// ```
+        |fn foo() {}
+        |""")
 
     fun doTest(code: String) = checkByFileTree(
         "//- lib.rs\n/*caret*/${code.trimMargin()}",

--- a/src/test/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotatorTest.kt
@@ -7,8 +7,14 @@ package org.rust.ide.annotator
 
 import org.rust.MockEdition
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ide.colors.RsColor
 
 class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018KeywordsAnnotator::class) {
+
+    override fun setUp() {
+        super.setUp()
+        annotationFixture.registerSeverities(listOf(RsColor.KEYWORD.testSeverity))
+    }
 
     fun `test edition 2018 keywords in edition 2015`() = checkErrors("""
         fn main() {
@@ -55,12 +61,12 @@ class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018Keyw
 
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test async in edition 2018`() = checkErrors("""
-        async fn foo() {}
+        <KEYWORD>async</KEYWORD> fn foo() {}
 
         fn main() {
-            async { () };
-            async || { () };
-            async move || { () };
+            <KEYWORD>async</KEYWORD> { () };
+            <KEYWORD>async</KEYWORD> || { () };
+            <KEYWORD>async</KEYWORD> move || { () };
         }
     """)
 
@@ -73,7 +79,7 @@ class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018Keyw
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test try in edition 2018`() = checkErrors("""
         fn main() {
-            try { () };
+            <KEYWORD>try</KEYWORD> { () };
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotatorTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator
 
+import com.intellij.ide.annotator.BatchMode
 import org.rust.MockEdition
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.colors.RsColor
@@ -105,4 +106,14 @@ class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018Keyw
             let y = f().<error descr="`await` is reserved keyword in Edition 2018">await</error>();
         }
     """)
+
+    @BatchMode
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test no keyword highlighting in batch mode`() = checkHighlighting("""
+        async fn foo() {}
+        fn main() {
+            try { () };
+            let x = foo().await;
+        }
+    """, ignoreExtraHighlighting = false)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -28,11 +28,11 @@ class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::c
 
         fn main() {
             println!("<error descr="Invalid reference to positional argument 0 (no arguments were given)">{}</error>");
-            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<error descr="Invalid reference to positional argument 1 (there is 1 argument)">1</error>}</FORMAT_SPECIFIER>", 1);
-            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{1}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<error descr="Invalid reference to positional argument 3 (there are 2 arguments)">3</error>}</FORMAT_SPECIFIER>", 1, 1);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<error descr="Invalid reference to positional argument 1 (there is 1 argument)">1</error>}</FORMAT_SPECIFIER>", 1);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<IDENTIFIER>1</IDENTIFIER>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<error descr="Invalid reference to positional argument 3 (there are 2 arguments)">3</error>}</FORMAT_SPECIFIER>", 1, 1);
             println!("Hello <FORMAT_SPECIFIER>{:<error descr="Invalid reference to positional argument 1 (there is 1 argument)">1${'$'}</error>}</FORMAT_SPECIFIER>", 1);
             println!("<FORMAT_SPECIFIER>{<error descr="There is no argument named `foo`">foo</error>}</FORMAT_SPECIFIER>");
-            println!("Hello <FORMAT_SPECIFIER>{:<error descr="There is no argument named `foo`">foo$</error>}</FORMAT_SPECIFIER>", 1);
+            println!("Hello <FORMAT_SPECIFIER>{:<error descr="There is no argument named `foo`">foo${'$'}</error>}</FORMAT_SPECIFIER>", 1);
         }
     """)
 
@@ -41,7 +41,7 @@ class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::c
 
         fn main() {
             println!("", <error descr="Argument never used">1.2</error>);
-            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER>", 1, <error descr="Argument never used">1.2</error>);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER>", 1, <error descr="Argument never used">1.2</error>);
             println!("", <error descr="Named argument never used">foo=1.2</error>);
         }
     """)
@@ -62,17 +62,17 @@ class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::c
 
         fn main() {
             println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", 1);
-            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", 1);
-            println!("<FORMAT_SPECIFIER>{foo}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", foo=1);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", 1);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>foo</IDENTIFIER>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", foo=1);
             println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", 1, 1);
             println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", foo=1);
 
-            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER>", foo=1);
-            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{1:?}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER>", 1, Debug);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER>", foo=1);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<IDENTIFIER>1</IDENTIFIER>:<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER>", 1, Debug);
 
-            println!("<FORMAT_SPECIFIER>{foo}</FORMAT_SPECIFIER>", foo=1);
-            println!("<FORMAT_SPECIFIER>{bar:?}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{foo}</FORMAT_SPECIFIER>", foo=1, bar=Debug);
-            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{foo}</FORMAT_SPECIFIER>", foo=1);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>foo</IDENTIFIER>}</FORMAT_SPECIFIER>", foo=1);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>bar</IDENTIFIER>:<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<IDENTIFIER>foo</IDENTIFIER>}</FORMAT_SPECIFIER>", foo=1, bar=Debug);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<IDENTIFIER>foo</IDENTIFIER>}</FORMAT_SPECIFIER>", foo=1);
         }
     """)
 
@@ -164,7 +164,7 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
             //~^ ERROR invalid format string
 
             format!("
-            <FORMAT_SPECIFIER>{asdf
+            <FORMAT_SPECIFIER>{<IDENTIFIER>asdf</IDENTIFIER>
             }</FORMAT_SPECIFIER>
             ", asdf=1);
             // ok - this is supported
@@ -218,21 +218,21 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
 
         fn main(){
             println!("<FORMAT_SPECIFIER>{{</FORMAT_SPECIFIER><FORMAT_SPECIFIER>}}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{0}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{0:}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:?}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:#?}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:e}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{x:}</FORMAT_SPECIFIER>", x=S);
-            println!("<FORMAT_SPECIFIER>{0:x}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{0:x?}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{0:0<}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{1:0$}</FORMAT_SPECIFIER>", 1, S);
-            println!("<FORMAT_SPECIFIER>{1:00$}</FORMAT_SPECIFIER>", 1, S);
-            println!("<FORMAT_SPECIFIER>{0:10x}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{0:1$.10x}</FORMAT_SPECIFIER>", S, 1);
-            println!("<FORMAT_SPECIFIER>{0:a$.b${'$'}x}</FORMAT_SPECIFIER>", S, a=2, b=3);
-            println!("<FORMAT_SPECIFIER>{number:*>+#0width$.10x?}</FORMAT_SPECIFIER>", number=S, width=1);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:#<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>e</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>x</IDENTIFIER>:}</FORMAT_SPECIFIER>", x=S);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:<FUNCTION>x</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:<FUNCTION>x?</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:0<}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>1</IDENTIFIER>:<IDENTIFIER>0${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>", 1, S);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>1</IDENTIFIER>:0<IDENTIFIER>0${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>", 1, S);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:<IDENTIFIER>10</IDENTIFIER><FUNCTION>x</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:<IDENTIFIER>1${'$'}</IDENTIFIER>.<IDENTIFIER>10</IDENTIFIER><FUNCTION>x</FUNCTION>}</FORMAT_SPECIFIER>", S, 1);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:<IDENTIFIER>a${'$'}</IDENTIFIER>.<IDENTIFIER>b${'$'}</IDENTIFIER><FUNCTION>x</FUNCTION>}</FORMAT_SPECIFIER>", S, a=2, b=3);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>number</IDENTIFIER>:*>+#0<IDENTIFIER>width${'$'}</IDENTIFIER>.<IDENTIFIER>10</IDENTIFIER><FUNCTION>x?</FUNCTION>}</FORMAT_SPECIFIER>", number=S, width=1);
             println!("<FORMAT_SPECIFIER>{:-}</FORMAT_SPECIFIER> <FORMAT_SPECIFIER>{:#}</FORMAT_SPECIFIER> <FORMAT_SPECIFIER>{:+#}</FORMAT_SPECIFIER>", S, S, S);
             println!("");
             println!("<FORMAT_SPECIFIER>\x7B}</FORMAT_SPECIFIER>", S);
@@ -248,17 +248,17 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         fn main() {
             let s = S;
             println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Display` (required by {})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:?}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:?})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:x?}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:x?})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:X?}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:X?})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:#?}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:#?})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:o}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Octal` (required by {:o})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:x}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `LowerHex` (required by {:x})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:X}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `UpperHex` (required by {:X})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:p}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Pointer` (required by {:p})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:b}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Binary` (required by {:b})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:e}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `LowerExp` (required by {:e})">s</error>);
-            println!("<FORMAT_SPECIFIER>{0:E}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `UpperExp` (required by {0:E})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:?})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>x?</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:x?})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>X?</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:X?})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:#<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:#?})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>o</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Octal` (required by {:o})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>x</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `LowerHex` (required by {:x})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>X</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `UpperHex` (required by {:X})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>p</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Pointer` (required by {:p})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>b</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Binary` (required by {:b})">s</error>);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>e</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `LowerExp` (required by {:e})">s</error>);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:<FUNCTION>E</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `UpperExp` (required by {0:E})">s</error>);
         }
     """)
 
@@ -296,17 +296,17 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
 
         fn main() {
             println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:?}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:x?}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:X?}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:#?}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:o}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:x}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:X}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:p}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:b}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:e}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:E}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>x?</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>X?</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:#<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>o</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>x</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>X</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>p</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>b</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>e</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_SPECIFIER>{:<FUNCTION>E</FUNCTION>}</FORMAT_SPECIFIER>", S);
         }
     """)
 
@@ -345,12 +345,12 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
 
         fn main() {
             let a = 5;
-            println!("Hello <FORMAT_SPECIFIER>{:1${'$'}}</FORMAT_SPECIFIER>!", 1, a);
+            println!("Hello <FORMAT_SPECIFIER>{:<IDENTIFIER>1${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 1, a);
 
-            println!("Hello <FORMAT_SPECIFIER>{:1${'$'}}</FORMAT_SPECIFIER>!", 1, 5);
-            println!("Hello <FORMAT_SPECIFIER>{1:0${'$'}}</FORMAT_SPECIFIER>!", 5, 1);
-            println!("Hello <FORMAT_SPECIFIER>{1:0${'$'}.2${'$'}}</FORMAT_SPECIFIER>!", 1, 1, 4);
-            println!("Hello <FORMAT_SPECIFIER>{:width${'$'}}</FORMAT_SPECIFIER>!", 1, width = 5);
+            println!("Hello <FORMAT_SPECIFIER>{:<IDENTIFIER>1${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 1, 5);
+            println!("Hello <FORMAT_SPECIFIER>{<IDENTIFIER>1</IDENTIFIER>:<IDENTIFIER>0${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 5, 1);
+            println!("Hello <FORMAT_SPECIFIER>{<IDENTIFIER>1</IDENTIFIER>:<IDENTIFIER>0${'$'}</IDENTIFIER>.<IDENTIFIER>2${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 1, 1, 4);
+            println!("Hello <FORMAT_SPECIFIER>{:<IDENTIFIER>width${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 1, width = 5);
         }
     """)
 
@@ -358,9 +358,9 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         $implDisplayI32
 
         fn main() {
-            println!("Hello <FORMAT_SPECIFIER>{:1${'$'}}</FORMAT_SPECIFIER>!", 1, <error descr="Width specifier must be of type `usize`">"asd"</error>);
-            println!("Hello <FORMAT_SPECIFIER>{:.1${'$'}}</FORMAT_SPECIFIER>!", 1, <error descr="Precision specifier must be of type `usize`">2.0</error>);
-            println!("Hello <FORMAT_SPECIFIER>{:1${'$'}.1${'$'}}</FORMAT_SPECIFIER>!", 1, <error descr="Width specifier must be of type `usize`"><error descr="Precision specifier must be of type `usize`">2.0</error></error>);
+            println!("Hello <FORMAT_SPECIFIER>{:<IDENTIFIER>1${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 1, <error descr="Width specifier must be of type `usize`">"asd"</error>);
+            println!("Hello <FORMAT_SPECIFIER>{:.<IDENTIFIER>1${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 1, <error descr="Precision specifier must be of type `usize`">2.0</error>);
+            println!("Hello <FORMAT_SPECIFIER>{:<IDENTIFIER>1${'$'}</IDENTIFIER>.<IDENTIFIER>1${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 1, <error descr="Precision specifier must be of type `usize`"><error descr="Width specifier must be of type `usize`">2.0</error></error>);
         }
     """)
 
@@ -368,11 +368,11 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         $implDisplayI32
 
         fn main() {
-            println!("<FORMAT_SPECIFIER>{:.*}</FORMAT_SPECIFIER>", 1, 2);
-            println!("<FORMAT_SPECIFIER>{0:.*}</FORMAT_SPECIFIER>", 1);
-            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{name:.*}</FORMAT_SPECIFIER>", 1, 3, name=2);
-            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{2:.*}</FORMAT_SPECIFIER>", 1, 5, 2);
-            println!("<FORMAT_SPECIFIER>{:a${'$'}.*}</FORMAT_SPECIFIER>!", 5, 1, a=3);
+            println!("<FORMAT_SPECIFIER>{:.<IDENTIFIER>*</IDENTIFIER>}</FORMAT_SPECIFIER>", 1, 2);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:.<IDENTIFIER>*</IDENTIFIER>}</FORMAT_SPECIFIER>", 1);
+            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<IDENTIFIER>name</IDENTIFIER>:.<IDENTIFIER>*</IDENTIFIER>}</FORMAT_SPECIFIER>", 1, 3, name=2);
+            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<IDENTIFIER>2</IDENTIFIER>:.<IDENTIFIER>*</IDENTIFIER>}</FORMAT_SPECIFIER>", 1, 5, 2);
+            println!("<FORMAT_SPECIFIER>{:<IDENTIFIER>a${'$'}</IDENTIFIER>.<IDENTIFIER>*</IDENTIFIER>}</FORMAT_SPECIFIER>!", 5, 1, a=3);
         }
     """)
 
@@ -385,8 +385,8 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         }
 
         fn main() {
-            println!("<FORMAT_SPECIFIER>{:.*}</FORMAT_SPECIFIER>!", <error descr="Precision specifier must be of type `usize`">"asd"</error>, S);
-            println!("<FORMAT_SPECIFIER>{0:.*}</FORMAT_SPECIFIER>!", <error descr="Precision specifier must be of type `usize`">S</error>);
+            println!("<FORMAT_SPECIFIER>{:.<IDENTIFIER>*</IDENTIFIER>}</FORMAT_SPECIFIER>!", <error descr="Precision specifier must be of type `usize`">"asd"</error>, S);
+            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:.<IDENTIFIER>*</IDENTIFIER>}</FORMAT_SPECIFIER>!", <error descr="Precision specifier must be of type `usize`">S</error>);
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator
 
+import com.intellij.ide.annotator.BatchMode
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.colors.RsColor
@@ -438,6 +439,27 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
             println!(b"format", 1);
             println!(br"format", 1);
             println!(br##"format"##, 1);
+        }
+    """)
+
+    @BatchMode
+    fun `test only errors in batch mode`() = checkErrors("""
+        struct S;
+
+        fn main() {
+            let s = S;
+            println!("{}", <error descr="`S` doesn't implement `Display` (required by {})">s</error>);
+            println!("{:?}", <error descr="`S` doesn't implement `Debug` (required by {:?})">s</error>);
+            println!("{:x?}", <error descr="`S` doesn't implement `Debug` (required by {:x?})">s</error>);
+            println!("{:X?}", <error descr="`S` doesn't implement `Debug` (required by {:X?})">s</error>);
+            println!("{:#?}", <error descr="`S` doesn't implement `Debug` (required by {:#?})">s</error>);
+            println!("{:o}", <error descr="`S` doesn't implement `Octal` (required by {:o})">s</error>);
+            println!("{:x}", <error descr="`S` doesn't implement `LowerHex` (required by {:x})">s</error>);
+            println!("{:X}", <error descr="`S` doesn't implement `UpperHex` (required by {:X})">s</error>);
+            println!("{:p}", <error descr="`S` doesn't implement `Pointer` (required by {:p})">s</error>);
+            println!("{:b}", <error descr="`S` doesn't implement `Binary` (required by {:b})">s</error>);
+            println!("{:e}", <error descr="`S` doesn't implement `LowerExp` (required by {:e})">s</error>);
+            println!("{0:E}", <error descr="`S` doesn't implement `UpperExp` (required by {0:E})">s</error>);
         }
     """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator
 
+import com.intellij.ide.annotator.BatchMode
 import com.intellij.ide.todo.TodoConfiguration
 import org.intellij.lang.annotations.Language
 import org.rust.*
@@ -224,6 +225,40 @@ class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator:
             () => {};
         }
     """)
+
+    @BatchMode
+    @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
+    fun `test no highlighting in batch mode`() = checkHighlighting("""
+        extern crate dep_lib_target;
+
+        use std::io::Read;
+
+        const FOO: i32 = 0;
+        static BAR: i32 = 0;
+
+        struct Q(i32);
+        struct S { field: T }
+
+        trait T {
+            fn foo();
+        }
+        union U { }
+        impl T for U {
+            default fn foo() {}
+        }
+
+        fn main() {
+            let s = S { field: T(92) };
+            s.field.0;
+        }
+
+        fn foo() -> bool {
+            let a: u8 = 42;
+            let b: f32 = 10.0;
+            let c: &str = "example";
+            char::is_lowercase('a')
+        }
+    """, ignoreExtraHighlighting = false)
 
     private fun checkHighlightingWithMacro(@Language("Rust") text: String) {
         checkHighlighting(text)

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotatorTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator
 
+import com.intellij.ide.annotator.BatchMode
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.colors.RsColor.MUT_BINDING
@@ -41,4 +42,15 @@ class RsHighlightingMutableAnnotatorTest : RsAnnotatorTestBase(RsHighlightingMut
             let b = <MUT_PARAMETER>para</MUT_PARAMETER>;
         }
     """)
+
+    @BatchMode
+    fun `test no highlighting in batch mode`() = checkHighlighting("""
+        struct Foo {}
+        impl Foo {
+            fn bar(&mut self, mut par: i32) {
+                let mut a = 1;
+                self.bar();
+            }
+        }
+    """, ignoreExtraHighlighting = false)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
@@ -49,6 +49,7 @@ class RsMacroExpansionHighlightingPassTest : RsAnnotationTestBase() {
 
     override fun createAnnotationFixture(): RsAnnotationTestFixture =
         RsAnnotationTestFixture(
+            this,
             myFixture,
             annotatorClasses = listOf(RsHighlightingAnnotator::class, RsCfgDisabledCodeAnnotator::class)
         )

--- a/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsUnsafeExpressionHighlightingAnnotatorTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator
 
+import com.intellij.ide.annotator.BatchMode
 import org.rust.ide.colors.RsColor
 
 class RsUnsafeExpressionHighlightingAnnotatorTest : RsAnnotatorTestBase(RsUnsafeExpressionAnnotator::class) {
@@ -84,4 +85,20 @@ class RsUnsafeExpressionHighlightingAnnotatorTest : RsAnnotatorTestBase(RsUnsafe
             let val = <UNSAFE_CODE descr="Unsafe dereference of raw pointer">*</UNSAFE_CODE>char_ptr;
         }
     """)
+
+    @BatchMode
+    fun `test no highlighting in batch mode`() = checkHighlighting("""
+        struct S;
+        impl S {
+            unsafe fn foo(&self) {}
+        }
+        unsafe fn bar() { S.foo(); }
+        static mut FOO : u8 = 0;
+
+        fn main() {
+            let char_ptr: *const char = 42 as *const _;
+            let val = unsafe { *char_ptr };
+            unsafe { FOO += 1; }
+        }
+    """, ignoreExtraHighlighting = false)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsInspectionsTestBase.kt
@@ -16,7 +16,7 @@ abstract class RsInspectionsTestBase(
 ) : RsAnnotationTestBase() {
 
     override fun createAnnotationFixture(): RsAnnotationTestFixture =
-        RsAnnotationTestFixture(myFixture, inspectionClasses = listOf(inspectionClass))
+        RsAnnotationTestFixture(this, myFixture, inspectionClasses = listOf(inspectionClass))
 
     protected lateinit var inspection: InspectionProfileEntry
 

--- a/src/test/kotlin/org/rust/ide/inspections/RsMultipleInspectionsTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsMultipleInspectionsTestBase.kt
@@ -15,6 +15,6 @@ abstract class RsMultipleInspectionsTestBase(
 ) : RsAnnotationTestBase() {
 
     override fun createAnnotationFixture(): RsAnnotationTestFixture {
-        return RsAnnotationTestFixture(myFixture, inspectionClasses = inspectionClasses.toList())
+        return RsAnnotationTestFixture(this, myFixture, inspectionClasses = inspectionClasses.toList())
     }
 }


### PR DESCRIPTION
It prevents empty items in `Inspection Result` tool window

Also, improve highlighting tests of 2018 edition keywords and format string literal

Fixes #3034
Fixes #5776