### PR TITLE
TY: exclude negative impls from type inference

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -16,6 +16,7 @@ import org.rust.ide.presentation.getPresentation
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.DEFAULT
+import org.rust.lang.core.psi.RsElementTypes.EXCL
 import org.rust.lang.core.stubs.RsImplItemStub
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.RsPsiTypeImplUtil
@@ -23,6 +24,10 @@ import org.rust.lang.core.types.ty.Ty
 
 val RsImplItem.default: PsiElement?
     get() = node.findChildByType(DEFAULT)?.psi
+
+/** `impl !Sync for Bar` vs `impl Foo for Bar` */
+val RsImplItem.isNegativeImpl: Boolean
+    get() = greenStub?.isNegativeImpl ?: (node.findChildByType(EXCL) != null)
 
 val RsImplItem.isReservationImpl: Boolean
     get() = queryAttributes.hasAttribute("rustc_reservation_impl")

--- a/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
@@ -9,10 +9,7 @@ import com.intellij.openapi.project.Project
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTraitRef
-import org.rust.lang.core.psi.ext.RsAbstractable
-import org.rust.lang.core.psi.ext.expandedMembers
-import org.rust.lang.core.psi.ext.isReservationImpl
-import org.rust.lang.core.psi.ext.resolveToBoundTrait
+import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psi.isValidProjectMember
 import org.rust.lang.core.resolve.ref.ResolveCacheDependency
 import org.rust.lang.core.resolve.ref.RsResolveCache
@@ -34,7 +31,7 @@ class RsCachedImplItem(
     val impl: RsImplItem
 ) {
     private val traitRef: RsTraitRef? = impl.traitRef
-    val isValid: Boolean = impl.isValidProjectMember && !impl.isReservationImpl
+    val isValid: Boolean = impl.isValidProjectMember && !impl.isReservationImpl && !impl.isNegativeImpl
     val isInherent: Boolean get() = traitRef == null
 
     val implementedTrait: BoundElement<RsTraitItem>? by lazy(PUBLICATION) { traitRef?.resolveToBoundTrait() }

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -1522,4 +1522,17 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
           //^ <unknown>
         }
     """)
+
+    fun `test negative impl is ignored`() = testExpr("""
+        struct S;
+        trait Clone: Sized { fn clone(&self) -> Self { unimplemented!() } }
+        impl Clone for S {}
+        impl !Clone for &mut S {}
+        fn main() {
+            let a = &mut S;
+            let b = a.clone();
+            b;
+          //^ S
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -795,4 +795,17 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ i32
     """)
+
+    // There is `impl<T: ?Sized> !Clone for &mut T {}`
+    fun `test clone through mut ref`() = stubOnlyTypeInfer("""
+    //- main.rs
+        #[derive(Clone)]
+        pub struct S;
+
+        fn main() {
+            let a = &mut S;
+            let b = a.clone();
+            b;
+        } //^ S
+    """)
 }


### PR DESCRIPTION
We don't support negative impls for now (e.g. `impl !Sync for Bar`), but previously we wrongly treated them as usual impls (without `!`). Now just ignore them

Fixes #5575 false-positive because now there is `impl<T: ?Sized> !Clone for &mut T {}` in the stdlib