### PR TITLE
COMP: offer rest in struct pats

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
@@ -26,6 +26,7 @@ class RsCompletionContributor : CompletionContributor() {
         extend(CompletionType.BASIC, RsFullMacroArgumentCompletionProvider)
         extend(CompletionType.BASIC, RsCfgAttributeCompletionProvider)
         extend(CompletionType.BASIC, RsAwaitCompletionProvider)
+        extend(CompletionType.BASIC, RsStructPatRestCompletionProvider)
     }
 
     fun extend(type: CompletionType?, provider: RsCompletionProvider) {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsStructPatRestCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsStructPatRestCompletionProvider.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.patterns.PsiElementPattern
+import com.intellij.psi.PsiElement
+import com.intellij.util.ProcessingContext
+import org.rust.lang.core.psi.RsPatStruct
+import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psiElement
+
+object RsStructPatRestCompletionProvider : RsCompletionProvider() {
+    override val elementPattern: PsiElementPattern.Capture<PsiElement>
+        get() =
+            PlatformPatterns
+                .psiElement()
+                .withSuperParent(3, psiElement<RsPatStruct>())
+
+    override fun addCompletions(
+        parameters: CompletionParameters,
+        context: ProcessingContext,
+        result: CompletionResultSet
+    ) {
+        val pat = parameters.position.safeGetOriginalOrSelf().ancestorStrict<RsPatStruct>() ?: return
+        if (pat.children.any { it.text == ".." }) return
+        result.addElement(LookupElementBuilder.create(".."))
+    }
+}

--- a/src/test/kotlin/org/rust/lang/core/completion/RsStructPatRestCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsStructPatRestCompletionTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+class RsStructPatRestCompletionTest : RsCompletionTestBase() {
+    fun `test rest in let struct pat`() = checkContainsCompletion("..", """
+        struct S { a: i32 }
+
+        fn foo() {
+            let S { /*caret*/ } = S { a: 0 };
+        }
+    """)
+
+    fun `test rest in match struct pat`() = checkContainsCompletion("..", """
+        struct S { a: i32 }
+
+        fn foo(s: S) {
+            match s {
+                S { /*caret*/ } => {}
+            }
+        }
+    """)
+
+    fun `test do not offer rest if it's already present`() = checkNotContainsCompletion("..", """
+        struct S { a: i32 }
+
+        fn foo(s: S) {
+            match s {
+                S { a, /*caret*/, .. } => {}
+            }
+        }
+    """)
+
+    fun `test do not offer in struct constructor`() = checkNotContainsCompletion("..", """
+        struct S { a: i32 }
+
+        fn foo() {
+            let s = S { /*caret*/ };
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds completion of `..` in struct patterns, as discussed in https://github.com/intellij-rust/intellij-rust/pull/5660.

Fixes https://github.com/intellij-rust/intellij-rust/issues/4448