### PR TITLE
HINT: allow comparison of consecutive iterator special case types in chain method hints

### DIFF
--- a/src/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
@@ -23,12 +23,18 @@ import com.intellij.util.ui.JBUI
 import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.RsDotExpr
+import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsMethodCall
-import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.ext.childOfType
 import org.rust.lang.core.psi.ext.endOffset
 import org.rust.lang.core.psi.ext.parentDotExpr
+import org.rust.lang.core.resolve.ImplLookup
+import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.types.TraitRef
+import org.rust.lang.core.types.implLookupAndKnownItems
 import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyAnon
 import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.type
 import javax.swing.JPanel
@@ -67,14 +73,20 @@ class RsChainMethodTypeHintsProvider : InlayHintsProvider<RsChainMethodTypeHints
 
     override fun createSettings(): Settings = Settings()
 
-    override fun getCollectorFor(file: PsiFile, editor: Editor, settings: Settings, sink: InlayHintsSink): InlayHintsCollector? =
+    override fun getCollectorFor(
+        file: PsiFile,
+        editor: Editor,
+        settings: Settings,
+        sink: InlayHintsSink
+    ): InlayHintsCollector? =
         object : FactoryInlayHintsCollector(editor) {
+            val typeHintsFactory = RsTypeHintsPresentationFactory(factory, true)
 
-            val typeHintsFactory = RsTypeHintsPresentationFactory(
-                if (settings.iteratorSpecialCase) file as? RsElement else null,
-                factory,
-                true
-            )
+            private val lookupAndIteratorTrait: Pair<ImplLookup?, BoundElement<RsTraitItem>?> by lazy(LazyThreadSafetyMode.PUBLICATION) {
+                val (lookup, items) = (file as? RsFile)?.implLookupAndKnownItems ?: null to null
+                val iterator = items?.Iterator?.let { BoundElement(it) }
+                lookup to iterator
+            }
 
             override fun collect(element: PsiElement, editor: Editor, sink: InlayHintsSink): Boolean {
                 if (DumbService.isDumb(element.project)) return true
@@ -82,26 +94,39 @@ class RsChainMethodTypeHintsProvider : InlayHintsProvider<RsChainMethodTypeHints
                 if (!element.isLastInChain) return true
                 if (!element.isEnabledByCfg) return true
 
+                val (lookup, iterator) = lookupAndIteratorTrait
+
                 val chain = collectChain(element)
                 var lastType: Ty? = null
                 for (call in chain.dropLast(1)) {
-                    if (call.type != TyUnknown && call.isLastOnLine) {
-                        if (settings.showSameConsecutiveTypes || call.type != lastType) {
-                            presentTypeForMethodCall(call)
+                    val type = normalizeType(call.type, lookup, iterator)
+                    if (type != TyUnknown && call.isLastOnLine) {
+                        if (settings.showSameConsecutiveTypes || type != lastType) {
+                            presentTypeForMethodCall(call, type)
                         }
-                        lastType = call.type
+                        lastType = type
                     }
                 }
 
                 return true
             }
 
-            private fun presentTypeForMethodCall(call: RsMethodCall) {
+            private fun presentTypeForMethodCall(call: RsMethodCall, type: Ty) {
                 val project = call.project
-                val type = call.type
                 val presentation = typeHintsFactory.typeHint(type)
                 val finalPresentation = presentation.withDisableAction(project)
                 sink.addInlineElement(call.endOffset, true, finalPresentation)
+            }
+
+            /**
+             * Returns fake impl Iterator<Item=...> type if [type] implements the Iterator trait and
+             * `iteratorSpecialCase` setting is enabled.
+             * */
+            private fun normalizeType(type: Ty, lookup: ImplLookup?, iteratorTrait: BoundElement<RsTraitItem>?): Ty {
+                if (!settings.iteratorSpecialCase || iteratorTrait == null) return type
+
+                val assoc = lookup?.selectAllProjectionsStrict(TraitRef(type, iteratorTrait)) ?: return type
+                return TyAnon(null, listOf(iteratorTrait.copy(assoc = assoc)))
             }
         }
 

--- a/src/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
@@ -96,7 +96,7 @@ class RsInlayTypeHintsProvider : InlayHintsProvider<RsInlayTypeHintsProvider.Set
     override fun getCollectorFor(file: PsiFile, editor: Editor, settings: Settings, sink: InlayHintsSink): InlayHintsCollector? =
         object : FactoryInlayHintsCollector(editor) {
 
-            val typeHintsFactory = RsTypeHintsPresentationFactory(null, factory, settings.showObviousTypes)
+            val typeHintsFactory = RsTypeHintsPresentationFactory(factory, settings.showObviousTypes)
 
             override fun collect(element: PsiElement, editor: Editor, sink: InlayHintsSink): Boolean {
                 if (file.project.service<DumbService>().isDumb) return true

--- a/src/test/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProviderTest.kt
@@ -125,6 +125,30 @@ class RsChainMethodTypeHintsProviderTest : RsInlayTypeHintsTestBase(RsChainMetho
         }
     """)
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test iterator consecutive types`() = doTest("""
+        struct S<T>(T);
+
+        impl<T> std::iter::Iterator for S<T> {
+            type Item = ();
+
+            fn next(&self) -> Option<Self::Item> { None }
+        }
+
+        impl<T> S<T> {
+            fn foo(self) -> S<Self> { unreachable!(); }
+        }
+
+        fn main() {
+            S(0)
+                .foo()/*hint text="[:  [impl  [Iterator [< [Item = ()] >]] ]]"*/
+                .foo()
+                .foo()
+                .foo();
+            ;
+        }
+    """, showSameConsecutiveTypes = false)
+
     @Suppress("UnstableApiUsage")
     private fun doTest(@Language("Rust") code: String, showSameConsecutiveTypes: Boolean = true) {
         val service = InlayHintsSettings.instance()


### PR DESCRIPTION
This PR changes the special case for iterators in `RsChainMethodTypeHintsProvider`. Now the top-level type of something that implements `Iterator` is changed to `impl Iterator` so that consecutive special.cased iterator types can be folded. Before only the rendering was changed, so consecutive types were not properly folded if they implemented the same `Iterator<Item=X>`.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5433