### PR TITLE
TY: fix `?` try expr for complex types

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -1038,7 +1038,7 @@ class RsTypeInferenceWalker(
     }
 
     private fun inferTryExprType(expr: RsTryExpr): Ty {
-        val base = expr.expr.inferType() as? TyAdt ?: return TyUnknown
+        val base = resolveTypeVarsWithObligations(expr.expr.inferType()) as? TyAdt ?: return TyUnknown
         if (base.item != items.Result && base.item != items.Option) {
             val tryItem = items.Try ?: return TyUnknown
             val okType = tryItem.findAssociatedType("Ok") ?: return TyUnknown

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -754,6 +754,15 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
+    fun `test "try expr" on a complex type = complex type (correct type vars resolve)`() = stubOnlyTypeInfer("""
+    //- main.rs
+        fn main() {
+            let a = vec![Some(42)].into_iter().next()??;
+            a;
+        } //^ i32
+    """)
+
     fun `test macro impls`() = stubOnlyTypeInfer("""
     //- main.rs
         fn main() {


### PR DESCRIPTION
Previously, `foo?` expr was sometimes inferred to `<unknown>` type even if `foo` is fully inferred as `Result<...>` or `Option<...>`.

 This works for
 ```rust
 let a = vec![Some(42)].into_iter().next()??;
 ```