### PR TITLE
TY: infer type parameters from assoc type bindings

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -731,7 +731,7 @@ class ImplLookup(
                     .mapTypeValues { (_, v) -> ctx.resolveTypeVarsIfPossible(v) }
                     .mapConstValues { (_, v) -> ctx.resolveTypeVarsIfPossible(v) } +
                     mapOf(TyTypeParameter.self() to ref.selfTy).toTypeSubst()
-                val obligations = ctx.instantiateBounds(candidate.impl.bounds, candidateSubst, newRecDepth).toList()
+                val obligations = ctx.instantiateBounds(candidate.impl.predicates, candidateSubst, newRecDepth).toList()
                 Selection(candidate.impl, obligations, candidateSubst)
             }
             is SelectionCandidate.DerivedTrait -> {

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1838,4 +1838,17 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ X
     """)
+
+    fun `test infer type parameter from associated type binding`() = testExpr("""
+        trait Foo { type Item; }
+        fn foo<A, B>(a: A) -> B where A: Foo<Item = B> { unimplemented!() }
+
+        struct S;
+        impl Foo for S { type Item = i32; }
+
+        fn main() {
+            let a = foo(S);
+            a;
+        } //^ i32
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -550,6 +550,16 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test iterator cloned`() = stubOnlyTypeInfer("""
+    //- main.rs
+        fn main() {
+            let a = vec![1, 2].iter()
+                .cloned()
+                .next();
+            a;
+        } //^ Option<i32>
+    """)
+
     fun `test vec push`() = stubOnlyTypeInfer("""
     //- main.rs
         use std::vec::Vec;


### PR DESCRIPTION
E.g. correctly infer `B` from `A: Foo` in this case:

```rust
trait Foo {
    type Item;
}
fn foo<A, B>(a: A) -> B
    where A: Foo<Item = B>
```

Fixes #4505 type inference for `Iterator.cloned()`