### PR TITLE
HINT: don't show a hint for single lambda param

### DIFF
--- a/src/main/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHints.kt
+++ b/src/main/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHints.kt
@@ -12,6 +12,7 @@ import org.rust.ide.utils.CallInfo
 import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.psi.RsCallExpr
 import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsLambdaExpr
 import org.rust.lang.core.psi.RsMethodCall
 import org.rust.lang.core.psi.ext.startOffset
 import org.rust.stdext.buildList
@@ -50,6 +51,9 @@ object RsInlayParameterHints {
                     return emptyList()
                 }
                 if (callInfo.methodName == callInfo.parameters.getOrNull(0)?.pattern) {
+                    return emptyList()
+                }
+                if (hints.lastOrNull()?.second is RsLambdaExpr) {
                     return emptyList()
                 }
             }

--- a/src/test/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHintsProviderTest.kt
@@ -120,6 +120,13 @@ class RsInlayParameterHintsProviderTest : RsTestBase() {
         }
     """)
 
+    fun `test smart should not annotate single lambda argument`() = checkByText("""
+        fn foo(bar: impl Fn(i32) -> i32) {}
+        fn main() {
+            foo(|x| x);
+        }
+    """)
+
     fun `test fn arg with mut ident`() = checkByText("""
         fn foo(mut arg: u32) {}
         fn main() { foo(/*hint text="arg:"*/0); }


### PR DESCRIPTION
If `Show only smart hints` option is enabled, don't show parameter hints for lambda argument if it is the only argument of the function.

This works for `Iterator.map()` method, i.e. no such artifacts anymore:
![image](https://user-images.githubusercontent.com/3221931/89030570-6a67b700-d339-11ea-9d34-c6eee818dabe.png)


