### PR TITLE
PRJ: Project generation with custom user templates

### DIFF
--- a/src/main/kotlin/org/rust/ide/newProject/state/RsUserTemplatesState.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/state/RsUserTemplatesState.kt
@@ -1,0 +1,29 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.newProject.state
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+@State(name = "RsUserTemplatesState", storages = [Storage("rust.usertemplates.xml")])
+class RsUserTemplatesState : PersistentStateComponent<RsUserTemplatesState> {
+
+    var templates = mutableListOf<RsUserTemplate>()
+
+    override fun getState(): RsUserTemplatesState = this
+
+    override fun loadState(state: RsUserTemplatesState) = XmlSerializerUtil.copyBean(state, this)
+
+    companion object {
+        val instance: RsUserTemplatesState
+            get() = ServiceManager.getService(RsUserTemplatesState::class.java)
+    }
+}
+
+data class RsUserTemplate(var name: String = "", var url: String = "")

--- a/src/main/kotlin/org/rust/ide/newProject/ui/AddUserTemplateDialog.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/ui/AddUserTemplateDialog.kt
@@ -1,0 +1,71 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.newProject.ui
+
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.DocumentAdapter
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.layout.panel
+import org.rust.ide.newProject.state.RsUserTemplate
+import org.rust.ide.newProject.state.RsUserTemplatesState
+import java.awt.Dimension
+import javax.swing.JComponent
+import javax.swing.event.DocumentEvent
+
+class AddUserTemplateDialog : DialogWrapper(null) {
+    private val repoUrlField: JBTextField = JBTextField().apply {
+        preferredSize = Dimension(400, 0)
+        document.addDocumentListener(object : DocumentAdapter() {
+            override fun textChanged(event: DocumentEvent) = suggestName(event)
+        })
+    }
+
+    private val nameField: JBTextField = JBTextField()
+
+    init {
+        title = "Add a custom template"
+        setOKButtonText("Add")
+        init()
+    }
+
+    override fun getPreferredFocusedComponent(): JComponent? = repoUrlField
+
+    override fun createCenterPanel(): JComponent? = panel {
+        row("Template URL:") {
+            repoUrlField(comment = "A git repository URL to generate from")
+        }
+        row("Name:") {
+            nameField()
+        }
+    }
+
+    override fun doOKAction() {
+        // TODO: Find a better way to handle dialog form validation
+        if (nameField.text.isBlank()) return
+        if (RsUserTemplatesState.instance.templates.any { it.name == nameField.text }) return
+
+        RsUserTemplatesState.instance.templates.add(
+            RsUserTemplate(nameField.text, repoUrlField.text)
+        )
+
+        super.doOKAction()
+    }
+
+    private fun suggestName(event: DocumentEvent) {
+        if (nameField.text.isNotBlank()) return
+        if (event.length != repoUrlField.text.length) return
+        if (KNOWN_URL_PREFIXES.none { repoUrlField.text.startsWith(it) }) return
+
+        nameField.text = repoUrlField.text
+            .removeSuffix("/")
+            .removeSuffix(".git")
+            .substringAfterLast("/")
+    }
+
+    companion object {
+        private val KNOWN_URL_PREFIXES = listOf("http://", "https://")
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -10,6 +10,7 @@
         <!-- Project Creation -->
         <projectOpenProcessor id="Cargo" implementation="org.rust.cargo.project.CargoProjectOpenProcessor"/>
         <directoryProjectGenerator implementation="org.rust.ide.newProject.RsDirectoryProjectGenerator"/>
+        <applicationService serviceImplementation="org.rust.ide.newProject.state.RsUserTemplatesState"/>
 
         <!-- File-type Factory -->
 


### PR DESCRIPTION
Provides support for persistent user templates URLs in the New Project wizard.

<img width="929" alt="User Templates" src="https://user-images.githubusercontent.com/6342851/89682480-776b4400-d8ff-11ea-98b5-a0a47d698de4.png">

Depends on #5715