### PR TITLE
Properly check spelling in lifetimes

### DIFF
--- a/src/test/kotlin/org/rust/ide/spellchecker/RsSpellCheckerTest.kt
+++ b/src/test/kotlin/org/rust/ide/spellchecker/RsSpellCheckerTest.kt
@@ -7,9 +7,10 @@ package org.rust.ide.spellchecker
 
 import com.intellij.spellchecker.inspections.SpellCheckingInspection
 import org.intellij.lang.annotations.Language
-import org.rust.RsTestBase
+import org.rust.ide.inspections.RsInspectionsTestBase
 
-class RsSpellCheckerTest : RsTestBase() {
+class RsSpellCheckerTest : RsInspectionsTestBase(SpellCheckingInspection::class) {
+
     fun `test comments`() = doTest("""// Hello, <TYPO descr="Typo: In word 'Wodrl'">Wodrl</TYPO>!""")
 
     fun `test string literals`() = doTest("""
@@ -52,12 +53,8 @@ class RsSpellCheckerTest : RsTestBase() {
     """)
 
     private fun doTest(@Language("Rust") text: String, processComments: Boolean = true, processLiterals: Boolean = true) {
-        val inspection = SpellCheckingInspection()
-        inspection.processLiterals = processLiterals
-        inspection.processComments = processComments
-
-        myFixture.configureByText("main.rs", text)
-        myFixture.enableInspections(inspection)
-        myFixture.testHighlighting(false, false, true, "main.rs")
+        (inspection as SpellCheckingInspection).processLiterals = processLiterals
+        (inspection as SpellCheckingInspection).processComments = processComments
+        checkByText(text, checkWarn = false, checkWeakWarn = true, checkInfo = false)
     }
 }

--- a/src/test/kotlin/org/rust/ide/spellchecker/RsSpellCheckerTest.kt
+++ b/src/test/kotlin/org/rust/ide/spellchecker/RsSpellCheckerTest.kt
@@ -38,12 +38,17 @@ class RsSpellCheckerTest : RsTestBase() {
         fn r#<TYPO>wodrl</TYPO>() {}
     """)
 
+    fun `test lifetimes`() = doTest("""
+        const FOO: & 'static str = "123";
+        fn foo<'<TYPO>wodrl</TYPO>>(x: &'<TYPO>wodrl</TYPO> str) {}
+    """)
+
     fun `test do not highlight word from rust bundled dictionary`() = doTest("""
         pub struct Bar;
         impl<T> Deref for Bar {
             type Target = ();
             fn deref(&self) -> &Self::Target { unimplemented!() }
-        }         
+        }
     """)
 
     private fun doTest(@Language("Rust") text: String, processComments: Boolean = true, processLiterals: Boolean = true) {


### PR DESCRIPTION
These changes fix text extraction from lifetime identifiers for spell checking and fix false-positive typo annotations in lifetimes like `'static`

Fixes #5551