### PR TITLE
REF: find occurrences for introduce constant/variable outside functions

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extraxtExpressionUtils.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extraxtExpressionUtils.kt
@@ -13,9 +13,10 @@ import org.rust.ide.utils.findExpressionAtCaret
 import org.rust.ide.utils.findExpressionInRange
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsItemElement
 import org.rust.lang.core.psi.ext.ancestorOrSelf
 import org.rust.lang.core.psi.ext.ancestors
-import java.util.ArrayList
+import java.util.*
 
 fun findCandidateExpressionsToExtract(editor: Editor, file: RsFile): List<RsExpr> {
     val selection = editor.selectionModel
@@ -40,8 +41,10 @@ fun findCandidateExpressionsToExtract(editor: Editor, file: RsFile): List<RsExpr
  * Finds occurrences in the sub scope of expr, so that all will be replaced if replace all is selected.
  */
 fun findOccurrences(expr: RsExpr): List<RsExpr> {
-    val block = expr.ancestorOrSelf<RsBlock>() ?: return emptyList()
-    return findOccurrences(block, expr)
+    val parent = expr.ancestorOrSelf<RsBlock>()
+        ?: expr.ancestorOrSelf<RsItemElement>() // outside a function, try to find a parent
+        ?: return emptyList()
+    return findOccurrences(parent, expr)
 }
 
 fun findOccurrences(parent: RsElement, expr: RsExpr): List<RsExpr> {

--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceConstantTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceConstantTest.kt
@@ -118,6 +118,35 @@ class RsIntroduceConstantTest : RsTestBase() {
         }
     """)
 
+    fun `test constant at file scope`() = doTest("""
+        const BUFFER: [u8; /*caret*/1000] = [1000; 1000];
+    """, listOf("file"), 0, """
+        const I: usize = 1000;
+        const BUFFER: [u8; I] = [I; I];
+    """, replaceAll = true)
+
+    fun `test type alias at file scope`() = doTest("""
+        type ARRAY = [u8; /*caret*/1000];
+    """, listOf("file"), 0, """
+        const I: usize = 1000;
+
+        type ARRAY = [u8; I];
+    """)
+
+    fun `test type inside a struct`() = doTest("""
+        struct S {
+            a: [u8; /*caret*/1000],
+            b: [u8; 1000]
+        }
+    """, listOf("file"), 0, """
+        const I: usize = 1000;
+
+        struct S {
+            a: [u8; I],
+            b: [u8; I]
+        }
+    """, replaceAll = true)
+
     private fun doTest(
         @Language("Rust") before: String,
         candidate: List<String>,


### PR DESCRIPTION
This PR modifies `findOccurrences` in `extraxtExpressionUtils.kt` so that it can find a corresponding context even if the extracted item is outside a function.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5844