### PR TITLE
Fix ArrayIndexOutOfBoundsException in macro completion

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/FragmentKind.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/FragmentKind.kt
@@ -10,6 +10,7 @@ import com.intellij.lang.parser.GeneratedParserUtilBase
 import com.intellij.psi.tree.TokenSet
 import org.rust.lang.core.parser.RustParser
 import org.rust.lang.core.parser.RustParserUtil
+import org.rust.lang.core.parser.clearFrame
 import org.rust.lang.core.psi.RS_KEYWORDS
 import org.rust.lang.core.psi.RS_LITERALS
 import org.rust.lang.core.psi.RsElementTypes
@@ -33,6 +34,7 @@ enum class FragmentKind(private val kind: String) {
     Lifetime("lifetime");
 
     fun parse(builder: PsiBuilder): Boolean {
+        builder.clearFrame()
         return when (this) {
             Ident -> parseIdentifier(builder)
             Path -> RustParser.TypePathGenericArgsNoTypeQual(builder, 0)

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -311,7 +311,7 @@ class MacroExpander(val project: Project) {
     }
 
     companion object {
-        const val EXPANDER_VERSION = 7
+        const val EXPANDER_VERSION = 8
         private val USELESS_PARENS_EXPRS = tokenSetOf(
             LIT_EXPR, MACRO_EXPR, PATH_EXPR, PAREN_EXPR, TUPLE_EXPR, ARRAY_EXPR, UNIT_EXPR
         )

--- a/src/main/kotlin/org/rust/lang/core/parser/util.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/util.kt
@@ -57,3 +57,12 @@ fun PsiBuilder.Marker.close(result: Boolean): Boolean {
     }
     return result
 }
+
+fun PsiBuilder.clearFrame() {
+    val state = GeneratedParserUtilBase.ErrorState.get(this)
+    val currentFrame = state.currentFrame
+    if (currentFrame != null) {
+        currentFrame.errorReportedAt = -1
+        currentFrame.lastVariantAt = -1
+    }
+}


### PR DESCRIPTION
Possibly fixes this exception during macro completion:

<details>
  <summary>Stacktrace</summary>
  
  ```
  java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 256
	at gnu.trove.TIntArrayList.get(TIntArrayList.java:234)
	at com.intellij.lang.impl.MarkerProduction.getStartMarkerAt(MarkerProduction.java:122)
	at com.intellij.lang.impl.PsiBuilderImpl.error(PsiBuilderImpl.java:889)
	at com.intellij.lang.impl.PsiBuilderAdapter.error(PsiBuilderAdapter.java:100)
	at com.intellij.lang.parser.GeneratedParserUtilBase.reportError(GeneratedParserUtilBase.java:807)
	at com.intellij.lang.parser.GeneratedParserUtilBase.reportFrameError(GeneratedParserUtilBase.java:825)
	at com.intellij.lang.parser.GeneratedParserUtilBase.enter_section_(GeneratedParserUtilBase.java:462)
	at com.intellij.lang.parser.GeneratedParserUtilBase.enter_section_(GeneratedParserUtilBase.java:454)
	at org.rust.lang.core.parser.RustParser.Expr(RustParser.java:6892)
	at org.rust.lang.core.macros.FragmentKind.parse(FragmentKind.kt:39)
	at org.rust.lang.core.macros.MacroGraphWalker.processMatcher(MacroGraphWalker.kt:99)
	at org.rust.lang.core.macros.MacroGraphWalker.run(MacroGraphWalker.kt:61)
	at org.rust.lang.core.completion.RsPartialMacroArgumentCompletionProvider.addCompletions(RsPartialMacroArgumentCompletionProvider.kt:55)
	at com.intellij.codeInsight.completion.CompletionProvider.addCompletionVariants(CompletionProvider.java:32)
	at com.intellij.codeInsight.completion.CompletionContributor.fillCompletionVariants(CompletionContributor.java:155)
	at com.intellij.codeInsight.completion.CompletionService.getVariantsFromContributors(CompletionService.java:76)
	at com.intellij.codeInsight.completion.CompletionResultSet.runRemainingContributors(CompletionResultSet.java:154)
	at com.intellij.codeInsight.completion.CompletionResultSet.runRemainingContributors(CompletionResultSet.java:146)
	at com.intellij.codeInsight.completion.CompletionResultSet.runRemainingContributors(CompletionResultSet.java:142)
	at com.intellij.codeInsight.template.impl.LiveTemplateCompletionContributor$1.addCompletions(LiveTemplateCompletionContributor.java:88)
	at com.intellij.codeInsight.completion.CompletionProvider.addCompletionVariants(CompletionProvider.java:32)
	at com.intellij.codeInsight.completion.CompletionContributor.fillCompletionVariants(CompletionContributor.java:155)
	at com.intellij.codeInsight.completion.CompletionService.getVariantsFromContributors(CompletionService.java:76)
	at com.intellij.codeInsight.completion.CompletionService.getVariantsFromContributors(CompletionService.java:59)
	at com.intellij.codeInsight.completion.CompletionService.performCompletion(CompletionService.java:132)
	at com.intellij.codeInsight.completion.BaseCompletionService.performCompletion(BaseCompletionService.java:36)
	at com.intellij.codeInsight.completion.CompletionProgressIndicator.lambda$calculateItems$10(CompletionProgressIndicator.java:854)
	at com.intellij.util.indexing.FileBasedIndex.lambda$ignoreDumbMode$0(FileBasedIndex.java:149)
	at com.intellij.util.indexing.FileBasedIndexImpl.ignoreDumbMode(FileBasedIndexImpl.java:650)
	at com.intellij.util.indexing.FileBasedIndex.ignoreDumbMode(FileBasedIndex.java:148)
	at com.intellij.codeInsight.completion.CompletionProgressIndicator.calculateItems(CompletionProgressIndicator.java:850)
	at com.intellij.codeInsight.completion.CompletionProgressIndicator.runContributors(CompletionProgressIndicator.java:838)
	at com.intellij.codeInsight.completion.CodeCompletionHandlerBase.lambda$startContributorThread$6(CodeCompletionHandlerBase.java:352)
	at com.intellij.codeInsight.completion.AsyncCompletion.lambda$tryReadOrCancel$5(CompletionThreading.java:172)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1110)
	at com.intellij.codeInsight.completion.AsyncCompletion.tryReadOrCancel(CompletionThreading.java:170)
	at com.intellij.codeInsight.completion.CodeCompletionHandlerBase.lambda$startContributorThread$7(CodeCompletionHandlerBase.java:344)
	at com.intellij.codeInsight.completion.AsyncCompletion.lambda$startThread$0(CompletionThreading.java:95)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:170)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:629)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:581)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:157)
	at com.intellij.codeInsight.completion.AsyncCompletion.lambda$startThread$1(CompletionThreading.java:91)
	at com.intellij.util.RunnableCallable.call(RunnableCallable.java:20)
	at com.intellij.util.RunnableCallable.call(RunnableCallable.java:11)
	at com.intellij.openapi.application.impl.ApplicationImpl$1.call(ApplicationImpl.java:268)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:668)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:665)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:665)
	at java.base/java.lang.Thread.run(Thread.java:834)
  ```
</details>