### PR TITLE
RES: Macro from local import should shadow macro from crate root

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -832,13 +832,11 @@ private class MacroResolver private constructor(private val processor: RsResolve
             return true
         }
 
-        val crateRoot = startElement.contextOrSelf<RsElement>()?.crateRoot as? RsFile
-        if (crateRoot != null) {
-            NameResolutionTestmarks.processSelfCrateExportedMacros.hit()
-            if (processAllScopeEntries(exportedMacrosAsScopeEntries(crateRoot), processor)) return true
-        }
+        if (processRemainedExportedMacros()) return true
 
-        return processRemainedExportedMacros()
+        val crateRoot = startElement.contextOrSelf<RsElement>()?.crateRoot as? RsFile ?: return false
+        NameResolutionTestmarks.processSelfCrateExportedMacros.hit()
+        return processAllScopeEntries(exportedMacrosAsScopeEntries(crateRoot), processor)
     }
 
     /**

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -327,6 +327,23 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test macro from import inside function wins over macro from crate root`() = stubOnlyResolve("""
+    //- lib.rs
+        #[macro_export]
+        macro_rules! foo { () => { /* 1 */ } }
+                    //X
+    //- main.rs
+        mod inner {
+            #[macro_export]
+            macro_rules! foo { () => { /* 2 */ } }
+        }
+        fn main() {
+            use test_package::foo;
+            foo!();
+        }  //^ lib.rs
+    """)
+
     fun `test import macro by non-root use item with aliased extern crate`() = stubOnlyResolve("""
     //- lib.rs
         extern crate dep_lib_target as aliased;


### PR DESCRIPTION
Changes order in which macros are processed: macros from imports first, then macros from crate root scope