### PR TITLE
INSP: add inspection to check associated type bindings

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongAssocTypeArgumentsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongAssocTypeArgumentsInspection.kt
@@ -1,0 +1,119 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.completion.isFnLikeTrait
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsAbstractableOwner
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psi.ext.owner
+import org.rust.lang.utils.RsDiagnostic
+import org.rust.lang.utils.addToHolder
+
+/**
+ * Inspection that detects the E0191 and E0220 errors.
+ */
+class RsWrongAssocTypeArgumentsInspection : RsLocalInspectionTool() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+        object : RsVisitor() {
+            override fun visitTraitRef(trait: RsTraitRef) {
+                checkAssocTypes(holder, trait, trait.path)
+            }
+
+            override fun visitPathType(type: RsPathType) {
+                if (type.path.referenceName == "Self") return
+                checkAssocTypes(holder, type, type.path)
+            }
+        }
+
+    private fun checkAssocTypes(holder: RsProblemsHolder, element: RsElement, path: RsPath) {
+        val trait = path.reference?.resolve() as? RsTraitItem ?: return
+        val arguments = path.typeArgumentList
+        val assocArguments = arguments?.assocTypeBindingList
+        val assocArgumentMap = assocArguments
+            ?.mapNotNull { binding ->
+                val name = binding.path.takeIf { path -> !path.hasColonColon }?.referenceName ?: return@mapNotNull null
+                name to binding
+            }
+            .orEmpty()
+            .toMap()
+
+        val assocTypes = trait.associatedTypesTransitively.associateBy { it.identifier.text }
+
+        if (assocArguments != null) {
+            checkUnknownAssocTypes(holder, assocArgumentMap, assocTypes, trait)
+        }
+
+        val parent = element.parent
+        // Do not check missing associated types in:
+        // super trait and generic bounds
+        // impl Trait for ...
+        // Fn traits
+        // impl Trait
+        // type qual
+        if (element.ancestorStrict<RsTypeParamBounds>() != null
+            || (parent is RsImplItem && parent.traitRef == element)
+            || trait.isFnLikeTrait
+            || element.isImplTrait
+            || element.parent is RsTypeQual) {
+            return
+        }
+
+        checkMissingAssocTypes(holder, element, assocArgumentMap, assocTypes)
+    }
+
+    private fun checkUnknownAssocTypes(
+        holder: RsProblemsHolder,
+        assocArguments: Map<String, RsAssocTypeBinding>,
+        assocTypes: Map<String, RsTypeAlias>,
+        trait: RsTraitItem
+    ) {
+        for ((name, argument) in assocArguments) {
+            if (name !in assocTypes) {
+                val traitName = trait.name ?: continue
+                RsDiagnostic.UnknownAssocTypeBinding(argument, name, traitName).addToHolder(holder)
+            }
+        }
+    }
+
+    private fun checkMissingAssocTypes(
+        holder: RsProblemsHolder,
+        element: RsElement,
+        assocArgumentMap: Map<String, RsAssocTypeBinding>,
+        requiredAssocTypes: Map<String, RsTypeAlias>
+    ) {
+        val missingTypes = mutableListOf<MissingAssocTypeBinding>()
+        for ((name, assocType) in requiredAssocTypes) {
+            if (name !in assocArgumentMap) {
+                val trait = (assocType.owner as? RsAbstractableOwner.Trait)?.trait ?: continue
+                val traitName = trait.name ?: continue
+                missingTypes.add(MissingAssocTypeBinding(name, traitName))
+            }
+        }
+        if (missingTypes.isNotEmpty()) {
+            missingTypes.sortBy { it.name }
+            RsDiagnostic.MissingAssocTypeBindings(element, missingTypes).addToHolder(holder)
+        }
+    }
+
+    data class MissingAssocTypeBinding(val name: String, val trait: String)
+}
+
+/**
+ * Detects
+ * fn foo(_: impl Trait)
+ */
+private val PsiElement.isImplTrait: Boolean
+    get() {
+        if (this !is RsTraitRef) return false
+        val grandparent = this.parent.parent
+        if (grandparent !is RsPolybound) return false
+
+        val traitType = grandparent.parent as? RsTraitType ?: return false
+        return traitType.impl != null
+    }

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AddAssocTypeBindingsFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AddAssocTypeBindingsFix.kt
@@ -1,0 +1,52 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.ide.utils.template.buildAndRunTemplate
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.startOffset
+import org.rust.openapiext.createSmartPointer
+
+class AddAssocTypeBindingsFix(
+    element: PsiElement,
+    private val missingTypes: List<String>
+) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+    override fun getText(): String = "Add missing associated types"
+    override fun getFamilyName() = text
+
+    override fun invoke(
+        project: Project,
+        file: PsiFile,
+        editor: Editor?,
+        startElement: PsiElement,
+        endElement: PsiElement
+    ) {
+        val element = startElement as? RsElement ?: return
+        val path = when (element) {
+            is RsTraitRef -> element.path
+            is RsPathType -> element.path
+            else -> return
+        }
+
+        val factory = RsPsiFactory(project)
+        val defaultType = "()"
+
+        val arguments = path.typeArgumentList ?: path.addEmptyTypeArguments(factory)
+        val lastArgument = with(arguments) {
+            (assocTypeBindingList + typeReferenceList + lifetimeList).maxByOrNull { it.startOffset } ?: lt
+        }
+        val missingTypes = missingTypes.map { factory.createAssocTypeBinding(it, defaultType) }
+        val addedArguments = arguments.addElements(missingTypes, lastArgument, factory)
+
+        editor?.buildAndRunTemplate(element, addedArguments.mapNotNull { it.typeReference?.createSmartPointer() })
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveAssocTypeBindingFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveAssocTypeBindingFix.kt
@@ -1,0 +1,32 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RsAssocTypeBinding
+import org.rust.lang.core.psi.RsTypeArgumentList
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.childOfType
+import org.rust.lang.core.psi.ext.deleteWithSurroundingCommaAndWhitespace
+
+class RemoveAssocTypeBindingFix(binding: PsiElement) : LocalQuickFixOnPsiElement(binding) {
+    override fun getFamilyName(): String = text
+    override fun getText(): String = "Remove redundant associated type"
+
+    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+        val binding = startElement as? RsAssocTypeBinding ?: return
+        val parent = binding.parent as? RsTypeArgumentList
+
+        binding.deleteWithSurroundingCommaAndWhitespace()
+
+        if (parent != null && parent.childOfType<RsElement>() == null) {
+            parent.delete()
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/LookupElements.kt
@@ -421,7 +421,7 @@ private val InsertionContext.alreadyHasAngleBrackets: Boolean
 private val InsertionContext.alreadyHasStructBraces: Boolean
     get() = nextCharIs('{')
 
-private val RsElement.isFnLikeTrait: Boolean
+val RsElement.isFnLikeTrait: Boolean
     get() {
         val knownItems = knownItems
         return this == knownItems.Fn ||

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -605,6 +605,10 @@ class RsPsiFactory(
     fun createPat(patText: String): RsPat = tryCreatePat(patText) ?: error("Failed to create pat element")
 
     fun tryCreatePat(patText: String): RsPat? = (createStatement("let $patText;") as RsLetDecl).pat
+
+    fun createAssocTypeBinding(name: String, type: String): RsAssocTypeBinding =
+        createFromText("type T = &dyn Trait<$name=$type>;")
+            ?: error("Failed to created assoc type binding")
 }
 
 private fun String.iff(cond: Boolean) = if (cond) "$this " else " "

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -665,6 +665,11 @@
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsUnnecessaryQualificationsInspection"/>
 
+        <localInspection language="Rust" groupName="Rust"
+                         displayName="Wrong associated type arguments"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.rust.ide.inspections.RsWrongAssocTypeArgumentsInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsWrongAssocTypeArguments.html
+++ b/src/main/resources/inspectionDescriptions/RsWrongAssocTypeArguments.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+Checks if correct associated type arguments were used for a type or a trait reference.
+<br/>
+Corresponds to the <a href="https://doc.rust-lang.org/error-index.html#E0191">E0191</a> and
+<a href="https://doc.rust-lang.org/error-index.html#E0220">E0220</a> Rust errors.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/RsWrongAssocTypeArgumentsInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsWrongAssocTypeArgumentsInspectionTest.kt
@@ -1,0 +1,267 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+
+class RsWrongAssocTypeArgumentsInspectionTest : RsInspectionsTestBase(RsWrongAssocTypeArgumentsInspection::class) {
+    fun `test valid associated type`() = checkByText("""
+        trait Foo {
+            type Bar;
+        }
+        fn foo(_: &dyn Foo<Bar=u32>) {}
+    """)
+
+    fun `test valid supertrait associated type`() = checkByText("""
+        trait A {
+            type A;
+        }
+        trait B: A {}
+        fn foo(_: &dyn B<A=u32>) {}
+    """)
+
+    fun `test do not check missing types in supertrait`() = checkByText("""
+        trait A {
+            type A;
+        }
+        trait B: A {}
+    """)
+
+    fun `test do not check missing types in generic bound`() = checkByText("""
+        trait Foo {
+            type A;
+        }
+        fn foo<T: Foo>(t: T) {}
+    """)
+
+    fun `test E0191 missing associated type`() = checkByText("""
+        trait Trait {
+            type A;
+        }
+        fn foo(_: &dyn <error descr="The value of the associated type `A` (from trait `Trait`) must be specified [E0191]">Trait</error>) {}
+    """)
+
+    fun `test E0191 missing associated type from supertrait`() = checkByText("""
+        trait A {
+            type A;
+        }
+        trait B: A {}
+        fn foo(_: &dyn <error descr="The value of the associated type `A` (from trait `A`) must be specified [E0191]">B</error>) {}
+    """)
+
+    fun `test E0191 multiple missing types`() = checkByText("""
+        trait A {
+            type A;
+        }
+        trait B: A {
+            type B;
+        }
+        fn foo(_: &dyn <error descr="The value of the associated types `A` (from trait `A`), `B` (from trait `B`) must be specified [E0191]">B</error>) {}
+    """)
+
+    fun `test fix E0191 type without generic arguments`() = checkFixByText("Add missing associated types", """
+        trait Foo {
+            type A;
+        }
+        fn foo(_: &dyn <error descr="The value of the associated type `A` (from trait `Foo`) must be specified [E0191]">Foo/*caret*/</error>) {}
+    """, """
+        trait Foo {
+            type A;
+        }
+        fn foo(_: &dyn Foo<A=()>) {}
+    """)
+
+    fun `test fix E0191 type with generic arguments`() = checkFixByText("Add missing associated types", """
+        trait Foo<'a, T> {
+            type A;
+            fn test(&self) -> &'a T;
+        }
+        fn foo<'a>(_: &dyn <error descr="The value of the associated type `A` (from trait `Foo`) must be specified [E0191]">Foo<'a, u32>/*caret*/</error>) {}
+    """, """
+        trait Foo<'a, T> {
+            type A;
+            fn test(&self) -> &'a T;
+        }
+        fn foo<'a>(_: &dyn Foo<'a, u32, A=()>) {}
+    """)
+
+    fun `test fix E0191 type with associated type arguments`() = checkFixByText("Add missing associated types", """
+        trait Foo<'a, T> {
+            type A;
+            type B;
+            fn test(&self) -> &'a T;
+        }
+        fn foo<'a>(_: &dyn <error descr="The value of the associated type `B` (from trait `Foo`) must be specified [E0191]">Foo<'a, u32, A=u32>/*caret*/</error>) {}
+    """, """
+        trait Foo<'a, T> {
+            type A;
+            type B;
+            fn test(&self) -> &'a T;
+        }
+        fn foo<'a>(_: &dyn Foo<'a, u32, A=u32, B=()>) {}
+    """)
+
+    fun `test fix E0191 add types from supertraits`() = checkFixByText("Add missing associated types", """
+        trait A {
+            type A;
+        }
+        trait B: A {
+            type B;
+        }
+        fn foo(_: &dyn <error descr="The value of the associated types `A` (from trait `A`), `B` (from trait `B`) must be specified [E0191]">B<>/*caret*/</error>) {}
+    """, """
+        trait A {
+            type A;
+        }
+        trait B: A {
+            type B;
+        }
+        fn foo(_: &dyn B<A=(), B=()>) {}
+    """)
+
+    fun `test E0220 redundant type`() = checkByText("""
+        trait Trait {}
+        fn foo(_: &dyn Trait<<error descr="Associated type `A` not found for `Trait` [E0220]">A=u32</error>>) {}
+    """)
+
+    fun `test E0220 redundant type in supertrait`() = checkByText("""
+        trait Trait {}
+        trait Trait2: Trait<<error descr="Associated type `A` not found for `Trait` [E0220]">A=u32</error>> {}
+    """)
+
+    fun `test E0220 redundant type in generic bound`() = checkByText("""
+        trait Trait {}
+        fn foo<T: Trait<<error descr="Associated type `A` not found for `Trait` [E0220]">A=u32</error>>>(t: T) {}
+    """)
+
+    fun `test fix E0220 redundant type`() = checkFixByText("Remove redundant associated type", """
+        trait Trait {}
+        fn foo(_: &dyn Trait<<error descr="Associated type `A` not found for `Trait` [E0220]">A=u32/*caret*/</error>>) {}
+    """, """
+        trait Trait {}
+        fn foo(_: &dyn Trait) {}
+    """)
+
+    fun `test fix E0220 redundant type remove comma after`() = checkFixByText("Remove redundant associated type", """
+        trait Trait {
+            type Foo;
+        }
+        fn foo(_: &dyn Trait<<error descr="Associated type `A` not found for `Trait` [E0220]">A=u32/*caret*/</error>, Foo=u32>) {}
+    """, """
+        trait Trait {
+            type Foo;
+        }
+        fn foo(_: &dyn Trait<Foo=u32>) {}
+    """)
+
+    fun `test fix E0220 impl trait target trait`() = checkFixByText("Remove redundant associated type", """
+        trait Trait {}
+        trait Trait2 {}
+        impl Trait2 for Trait<<error descr="Associated type `A` not found for `Trait` [E0220]">A=u32/*caret*/</error>> {}
+    """, """
+        trait Trait {}
+        trait Trait2 {}
+        impl Trait2 for Trait {}
+    """)
+
+    fun `test fix E0220 redundant type base type`() = checkFixByText("Remove redundant associated type", """
+        trait Trait {}
+        fn foo() {
+            let x: Trait<<error descr="Associated type `A` not found for `Trait` [E0220]">A=u32/*caret*/</error>>;
+        }
+    """, """
+        trait Trait {}
+        fn foo() {
+            let x: Trait;
+        }
+    """)
+
+    fun `test impl trait implemented trait`() = checkByText("""
+        trait Trait {
+            type Foo;
+        }
+        impl Trait for () {
+            type Foo = u32;
+        }
+    """)
+
+    fun `test E0191 impl trait target trait`() = checkByText("""
+        trait Trait {
+            type Foo;
+        }
+        trait Trait2 {}
+        impl Trait2 for <error descr="The value of the associated type `Foo` (from trait `Trait`) must be specified [E0191]">Trait</error> {}
+    """)
+
+    fun `test E0191 trait type without dyn`() = checkByText("""
+        trait Trait {
+            type Foo;
+        }
+        fn foo() {
+            let x: <error descr="The value of the associated type `Foo` (from trait `Trait`) must be specified [E0191]">Trait</error>;
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test fn-like traits`() = checkByText("""
+        fn foo1(_: &mut dyn FnOnce(&mut [u8]) -> usize) {}
+        fn foo2(_: &mut dyn FnMut(&mut [u8]) -> usize) {}
+        fn foo3(_: &mut dyn Fn(&mut [u8]) -> usize) {}
+    """)
+
+    fun `test self`() = checkByText("""
+        trait Trait {
+            type FOO;
+
+            fn foo() -> &'static Self {
+                unreachable!()
+            }
+        }
+
+        fn foo1(_: &mut dyn FnOnce(&mut [u8]) -> usize) {}
+        fn foo2(_: &mut dyn FnMut(&mut [u8]) -> usize) {}
+        fn foo3(_: &mut dyn Fn(&mut [u8]) -> usize) {}
+    """)
+
+    fun `test impl argument`() = checkByText("""
+        trait Trait {
+            type FOO;
+        }
+
+        fn foo(_: impl Trait) {}
+    """)
+
+    fun `test impl return type`() = checkByText("""
+        trait Trait {
+            type FOO;
+        }
+
+        impl Trait for () {
+            type FOO = ();
+        }
+
+        fn foo() -> impl Trait {}
+    """)
+
+    fun `test type qual`() = checkByText("""
+        trait Trait {
+            type FOO;
+        }
+        trait Trait2 {}
+
+        fn foo<T: Trait>(t: T) where <T as Trait>::FOO: Trait2 {}
+    """)
+
+    fun `test associated type default`() = checkByText("""
+        #![feature(associated_type_defaults)]
+
+        trait A {
+            type X = i32;
+        }
+        fn func(_: &dyn <error descr="The value of the associated type `X` (from trait `A`) must be specified [E0191]">A</error>) {}
+    """)
+}


### PR DESCRIPTION
This PR adds an inspection and two quick fixes (add missing associated types, remove unknown associated types) that handle missing/erroneous associated type bindings.

![assoc_type](https://user-images.githubusercontent.com/4539057/89266398-296feb00-d636-11ea-8c5c-7fbb31605770.gif)

There is some very similar code between `AddAssocTypeBindingsFix` and `AddTypeArgumentsFix`, which handles inserting new items into type arguments. Should it be extracted? If yes, where?

Related: https://github.com/intellij-rust/intellij-rust/issues/886