### PR TITLE
INT: Add block brackets on closure return type fix

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeReturnTypeFix.kt
@@ -15,10 +15,7 @@ import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.presentation.render
 import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.utils.import.RsImportHelper.importTypeReferencesFromTy
-import org.rust.lang.core.psi.RsFunction
-import org.rust.lang.core.psi.RsLambdaExpr
-import org.rust.lang.core.psi.RsPsiFactory
-import org.rust.lang.core.psi.RsRetExpr
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyUnit
@@ -67,7 +64,12 @@ class ChangeReturnTypeFix(element: RsElement, private val actualTy: Ty) : LocalQ
                 is RsLambdaExpr -> owner.valueParameterList
                 else -> return
             }
+
             owner.addAfter(retType, parameters)
+
+            if (owner is RsLambdaExpr && owner.expr !is RsBlockExpr) {
+                owner.expr?.replace(psiFactory.createBlockExpr(owner.expr?.text ?: return))
+            }
         }
 
         importTypeReferencesFromTy(owner, actualTy, useAliases = true)


### PR DESCRIPTION
Fixes #5675

Wraps closure in a block on change return type quick-fix.

<img width="735" src="https://user-images.githubusercontent.com/6342851/89232672-9791bf00-d5f0-11ea-9bd9-fd08409abfc0.png">

<img width="572" src="https://user-images.githubusercontent.com/6342851/89232860-125ada00-d5f1-11ea-8a79-0dea887142b2.png">