### PR TITLE
INSP: check if struct fields are not bound multiple times in struct pats [E0025]

### DIFF
--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1188,6 +1188,19 @@ sealed class RsDiagnostic(
         }
     }
 
+    class RepeatedFieldInStructPattern(
+        private val repeatedField: RsPatField,
+        private val name: String
+    ) : RsDiagnostic(repeatedField) {
+        override fun prepare(): PreparedAnnotation {
+            return PreparedAnnotation(
+                ERROR,
+                E0025,
+                "Field `$name` bound multiple times in the pattern"
+            )
+        }
+    }
+
     class ExtraFieldInTupleStructPattern(
         patTupleStruct: RsPatTupleStruct,
         private val extraFieldsAmount: Int,
@@ -1282,7 +1295,7 @@ sealed class RsDiagnostic(
 }
 
 enum class RsErrorCode {
-    E0004, E0015, E0023, E0026, E0027, E0040, E0046, E0050, E0060, E0061, E0069, E0081, E0084,
+    E0004, E0015, E0023, E0025, E0026, E0027, E0040, E0046, E0050, E0060, E0061, E0069, E0081, E0084,
     E0106, E0107, E0118, E0120, E0121, E0124, E0132, E0133, E0184, E0185, E0186, E0198, E0199,
     E0200, E0201, E0202, E0252, E0261, E0262, E0263, E0267, E0268, E0277,
     E0308, E0322, E0328, E0379, E0384,

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -3725,4 +3725,20 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             RED, GREEN
         }
     """)
+
+    fun `test E0025 struct field bound multiple times`() = checkErrors("""
+        struct Foo { a: i32, b: i32 }
+
+        fn foo(x: Foo) {
+            let Foo { a, <error descr="Field `a` bound multiple times in the pattern [E0025]">a</error>, b } = x;
+        }
+    """)
+
+    fun `test E0025 renamed struct field bound multiple times`() = checkErrors("""
+        struct Foo { a: i32, b: i32 }
+
+        fn foo(x: Foo) {
+            let Foo { a, <error descr="Field `a` bound multiple times in the pattern [E0025]">a: c</error>, b } = x;
+        }
+    """)
 }


### PR DESCRIPTION
This PR inspects struct pats to check if there are not fields bound multiple times.

Related: https://github.com/intellij-rust/intellij-rust/issues/886

TODO:
- [x] Run `RsRealProjectAnalysisTest`