### PR TITLE
RUN: Add autocompletion for partial `cargo` word in Run Anything

### DIFF
--- a/src/test/kotlin/org/rust/ide/actions/runAnything/CargoRunAnythingProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/runAnything/CargoRunAnythingProviderTest.kt
@@ -33,6 +33,7 @@ class CargoRunAnythingProviderTest : RsTestBase() {
         val commands = listOf(
             "build", "check", "clean", "doc", "run", "test", "bench", "update", "search", "publish", "install"
         ).map { "cargo $it" }
+        assertSameElements(provider.getValues(dataContext, "car"), commands)
         assertSameElements(provider.getValues(dataContext, "cargo"), commands)
         assertSameElements(provider.getValues(dataContext, "cargo "), commands)
         assertSameElements(provider.getValues(dataContext, "cargo ru"), commands)


### PR DESCRIPTION
Fixes #5867

<img width="934" src="https://user-images.githubusercontent.com/6342851/89351034-d5a6e580-d6b9-11ea-8cf0-21b61f2f1f8f.png">
