### PR TITLE
COMP: don't insert double parentheses

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -1237,4 +1237,45 @@ class RsCompletionTest : RsCompletionTestBase() {
     """, """
         fn foo(f: &FnOnce(/*caret*/)) {}
     """)
+
+    fun `test do not insert second parenthesis 1`() = checkCompletion("foo", """
+        fn foo() {}
+        fn foo2() {}
+        fn main() {
+            foo/*caret*/
+        }
+    """, """
+        fn foo() {}
+        fn foo2() {}
+        fn main() {
+            foo()/*caret*/
+        }
+    """, completionChar = '(', testmark = Testmarks.doNotAddOpenParenCompletionChar)
+
+    fun `test do not insert second parenthesis 2`() = checkCompletion("V1", """
+        enum E {
+            V1(i32),
+            V2(i32)
+        }
+        fn main() {
+            E::V/*caret*/
+        }
+    """, """
+        enum E {
+            V1(i32),
+            V2(i32)
+        }
+        fn main() {
+            E::V1(/*caret*/)
+        }
+    """, completionChar = '(', testmark = Testmarks.doNotAddOpenParenCompletionChar)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test do not insert second parenthesis 3`() = checkCompletion("FnOnce", """
+        struct FnOnceStruct;
+        fn foo(f: FnOnce/*caret*/) {}
+    """, """
+        struct FnOnceStruct;
+        fn foo(f: FnOnce(/*caret*/)) {}
+    """, completionChar = '(', testmark = Testmarks.doNotAddOpenParenCompletionChar)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.completion
 
+import com.intellij.openapiext.Testmark
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.intellij.lang.annotations.Language
@@ -75,8 +76,10 @@ abstract class RsCompletionTestBase : RsTestBase() {
     protected fun checkCompletion(
         lookupString: String,
         @Language("Rust") before: String,
-        @Language("Rust") after: String
-    ) = completionFixture.checkCompletion(lookupString, before, after)
+        @Language("Rust") after: String,
+        completionChar: Char = '\n',
+        testmark: Testmark? = null
+    ) = completionFixture.checkCompletion(lookupString, before, after, completionChar, testmark)
 
     protected fun checkNotContainsCompletion(
         variant: String,

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.completion
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFileFilter
+import com.intellij.openapiext.Testmark
 import com.intellij.psi.impl.PsiManagerEx
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import com.intellij.testFramework.fixtures.impl.BaseFixture
@@ -66,13 +67,20 @@ abstract class RsCompletionTestFixtureBase<IN>(
     fun checkCompletion(
         lookupString: String,
         before: IN,
-        @Language("Rust") after: String
-    ) = checkByText(before, after.trimIndent()) {
-        val items = myFixture.completeBasic()
-            ?: return@checkByText // single completion was inserted
-        val lookupItem = items.find { it.lookupString == lookupString } ?: return@checkByText
-        myFixture.lookup.currentItem = lookupItem
-        myFixture.type('\n')
+        @Language("Rust") after: String,
+        completionChar: Char,
+        testmark: Testmark?
+    ) {
+        val action = {
+            checkByText(before, after.trimIndent()) {
+                val items = myFixture.completeBasic()
+                    ?: return@checkByText // single completion was inserted
+                val lookupItem = items.find { it.lookupString == lookupString } ?: return@checkByText
+                myFixture.lookup.currentItem = lookupItem
+                myFixture.type(completionChar)
+            }
+        }
+        testmark?.checkHit(action)
     }
 
     fun checkNoCompletion(code: IN) {


### PR DESCRIPTION
When a user types `(` while completion, platform `com.intellij.codeInsight.completion.DefaultCharFilter` invokes completion with selected item.
And if the plugin inserts `()` for the item (for example, function), a user gets double parentheses.

These changes disable insertion of typed `(` in described cases

Fixes #5783