### PR TITLE
INSP: create separate Lint group in inspection settings

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspection.kt
@@ -3,10 +3,11 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
+import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.lang.core.psi.RsElementTypes.CSELF
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsMetaItem

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -3,11 +3,11 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.psi.PsiElement
-import org.rust.ide.inspections.RsLintLevel.*
+import org.rust.ide.inspections.lints.RsLintLevel.*
 import org.rust.lang.core.psi.ext.*
 
 /**

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLintInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLintInspection.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import com.intellij.codeInspection.*
 import com.intellij.openapi.project.Project
@@ -12,7 +12,9 @@ import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiNamedElement
-import org.rust.ide.inspections.RsLintLevel.ALLOW
+import org.rust.ide.inspections.RsLocalInspectionTool
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.lints.RsLintLevel.ALLOW
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLintLevel.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLintLevel.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 /**
  * Rust lint warning levels.

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLivenessInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLivenessInspection.kt
@@ -3,11 +3,12 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.psi.PsiElement
 import org.rust.ide.injected.isDoctestInjection
+import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.ide.inspections.fixes.RemoveParameterFix
 import org.rust.ide.inspections.fixes.RemoveVariableFix
 import org.rust.ide.inspections.fixes.RenameFix

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
@@ -3,11 +3,12 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.util.PsiTreeUtil
+import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.ide.inspections.fixes.RenameFix
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
@@ -3,12 +3,13 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-import org.rust.ide.inspections.ReferenceLifetime.*
+import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.ide.inspections.fixes.ElideLifetimesFix
+import org.rust.ide.inspections.lints.ReferenceLifetime.*
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.regions.ReEarlyBound
@@ -59,7 +60,8 @@ private fun couldUseElision(fn: RsFunction): Boolean {
     val typeParametersBounds = fn.typeParameters.flatMap { it.bounds }.map { it.bound }
     if (typeParametersBounds.any { hasNamedReferenceLifetime(it) }) return false
 
-    val (inputLifetimes, outputLifetimes) = collectLifetimesFromFnSignature(fn) ?: return false
+    val (inputLifetimes, outputLifetimes) = collectLifetimesFromFnSignature(fn)
+        ?: return false
 
     // no input lifetimes? easy case!
     if (inputLifetimes.isEmpty()) return false

--- a/src/main/kotlin/org/rust/ide/refactoring/RsNameSuggestions.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsNameSuggestions.kt
@@ -9,7 +9,7 @@ import com.intellij.openapiext.hitOnFalse
 import com.intellij.psi.PsiElement
 import com.intellij.psi.codeStyle.NameUtil
 import com.intellij.psi.util.PsiTreeUtil
-import org.rust.ide.inspections.toSnakeCase
+import org.rust.ide.inspections.lints.toSnakeCase
 import org.rust.ide.refactoring.introduceVariable.IntroduceVariableTestmarks
 import org.rust.ide.utils.CallInfo
 import org.rust.lang.core.psi.*

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -293,7 +293,7 @@
         <localInspection language="Rust" groupName="Rust"
                          displayName="Deprecated element"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsDeprecationInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsDeprecationInspection"/>
 
         <localInspection language="Rust" groupName="Rust"
                          displayName="Approximate Constants"
@@ -343,57 +343,57 @@
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Argument naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsArgumentNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsArgumentNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Associated type naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsAssocTypeNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsAssocTypeNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Constant naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsConstNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsConstNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Enum naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsEnumNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsEnumNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Enum variant naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsEnumVariantNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsEnumVariantNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Function naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsFunctionNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsFunctionNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Lifetime naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsLifetimeNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsLifetimeNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Macro naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsMacroNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsMacroNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Method naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsMethodNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsMethodNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Module naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsModuleNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsModuleNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Static constant naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsStaticConstNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsStaticConstNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Self convention"
@@ -403,32 +403,32 @@
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Struct naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsStructNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsStructNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Field naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsFieldNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsFieldNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Trait naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsTraitNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsTraitNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Type alias naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsTypeAliasNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsTypeAliasNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Type parameter naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsTypeParameterNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsTypeParameterNamingInspection"/>
 
         <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
                          displayName="Variable naming convention"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsVariableNamingInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsVariableNamingInspection"/>
 
         <localInspection language="Rust" groupName="Rust"
                          displayName="Extra semicolon"
@@ -508,7 +508,7 @@
         <localInspection language="Rust" groupName="Rust"
                          displayName="Needless lifetimes"
                          enabledByDefault="true" level="WEAK WARNING"
-                         implementationClass="org.rust.ide.inspections.RsNeedlessLifetimesInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsNeedlessLifetimesInspection"/>
 
         <localInspection language="Rust" groupName="Rust"
                          displayName="Assign to immutable"
@@ -538,7 +538,7 @@
         <localInspection language="Rust" groupName="Rust"
                          displayName="Liveness analysis"
                          enabledByDefault="true" level="WARNING"
-                         implementationClass="org.rust.ide.inspections.RsLivenessInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsLivenessInspection"/>
 
         <localInspection language="Rust" groupName="Rust"
                          displayName="Main function not found"

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -290,7 +290,7 @@
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RsImplicitTraitObjectInspection"/>
 
-        <localInspection language="Rust" groupName="Rust"
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
                          displayName="Deprecated element"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsDeprecationInspection"/>
@@ -340,92 +340,92 @@
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RsDropRefInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Argument naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsArgumentNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Associated type naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsAssocTypeNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Constant naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsConstNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Enum naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsEnumNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Enum variant naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsEnumVariantNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Function naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsFunctionNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Lifetime naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsLifetimeNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Macro naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsMacroNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Method naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsMethodNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Module naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsModuleNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Static constant naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsStaticConstNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Self convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RsSelfConventionInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Struct naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsStructNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Field naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsFieldNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Trait naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsTraitNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Type alias naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsTypeAliasNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Type parameter naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsTypeParameterNamingInspection"/>
 
-        <localInspection language="Rust" groupPath="Rust" groupName="Naming conventions"
+        <localInspection language="Rust" groupPath="Rust,Lints" groupName="Naming conventions"
                          displayName="Variable naming convention"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsVariableNamingInspection"/>
@@ -505,7 +505,7 @@
                          enabledByDefault="true" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.RsSortImplTraitMembersInspection"/>
 
-        <localInspection language="Rust" groupName="Rust"
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
                          displayName="Needless lifetimes"
                          enabledByDefault="true" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsNeedlessLifetimesInspection"/>
@@ -535,7 +535,7 @@
                           enabledByDefault="true" level="ERROR"
                           implementationClass="org.rust.ide.inspections.RsExternalLinterInspection"/>
 
-        <localInspection language="Rust" groupName="Rust"
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
                          displayName="Liveness analysis"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsLivenessInspection"/>

--- a/src/test/kotlin/org/rust/ide/inspections/lints/NamingNotationsTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/NamingNotationsTest.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import junit.framework.TestCase
 

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspectionTest.kt
@@ -3,7 +3,9 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
+
+import org.rust.ide.inspections.RsInspectionsTestBase
 
 /**
  * Tests for Deprecated Attribute inspection.

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsLintLevelTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsLintLevelTest.kt
@@ -3,7 +3,9 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
+
+import org.rust.ide.inspections.RsInspectionsTestBase
 
 /**
  * Tests for lint level detection.

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsLivenessInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsLivenessInspectionTest.kt
@@ -3,10 +3,11 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.ide.inspections.RsInspectionsTestBase
 
 class RsLivenessInspectionTest : RsInspectionsTestBase(RsLivenessInspection::class) {
 

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspectionTest.kt
@@ -3,11 +3,12 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.ide.inspections.RsInspectionsTestBase
 
 class RsNeedlessLifetimesInspectionTest : RsInspectionsTestBase(RsNeedlessLifetimesInspection::class) {
 
@@ -301,23 +302,23 @@ class RsNeedlessLifetimesInspectionTest : RsInspectionsTestBase(RsNeedlessLifeti
 
     fun `test allow`() = checkByText("""
         <weak_warning>fn foo1<'a>(_: &'a str)</weak_warning> {}
-        
+
         #[allow(clippy::needless_lifetimes)]
         fn foo2<'a>(_: &'a str) {}
-        
+
         #[allow(clippy::complexity)]
         fn foo3<'a>(_: &'a str) {}
-        
+
         #[allow(clippy::all)]
         fn foo4<'a>(_: &'a str) {}
-        
+
         #[allow(clippy)]
         fn foo5<'a>(_: &'a str) {}
     """)
 
     fun `test global allow`() = checkByText("""
         #![allow(clippy::needless_lifetimes)]
-        
+
         fn foo1<'a>(_: &'a str) {}
 
         fn foo2<'a>(_: &'a str) {}

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsArgumentNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsArgumentNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
-import org.rust.ide.inspections.RsArgumentNamingInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.lints.RsArgumentNamingInspection
 
 class RsArgumentNamingInspectionTest: RsInspectionsTestBase(RsArgumentNamingInspection::class) {
     fun `test function arguments`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsAssocTypeNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsAssocTypeNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
-import org.rust.ide.inspections.RsAssocTypeNamingInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.lints.RsAssocTypeNamingInspection
 
 class RsAssocTypeNamingInspectionTest : RsInspectionsTestBase(RsAssocTypeNamingInspection::class) {
     fun `test associated types`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsConstNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsConstNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
-import org.rust.ide.inspections.RsConstNamingInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.lints.RsConstNamingInspection
 
 class RsConstNamingInspectionTest : RsInspectionsTestBase(RsConstNamingInspection::class) {
     fun `test constants`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsEnumNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsEnumNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
-import org.rust.ide.inspections.RsEnumNamingInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.lints.RsEnumNamingInspection
 
 class RsEnumNamingInspectionTest : RsInspectionsTestBase(RsEnumNamingInspection::class) {
     fun `test enums`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsEnumVariantNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsEnumVariantNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
-import org.rust.ide.inspections.RsEnumVariantNamingInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.lints.RsEnumVariantNamingInspection
 
 class RsEnumVariantNamingInspectionTest : RsInspectionsTestBase(RsEnumVariantNamingInspection::class) {
     fun `test enum variants`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsFieldNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsFieldNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
-import org.rust.ide.inspections.RsFieldNamingInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.lints.RsFieldNamingInspection
 
 class RsFieldNamingInspectionTest : RsInspectionsTestBase(RsFieldNamingInspection::class) {
     fun `test enum variant fields`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsFunctionNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsFunctionNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
-import org.rust.ide.inspections.RsFunctionNamingInspection
 import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.lints.RsFunctionNamingInspection
 
 class RsFunctionNamingInspectionTest : RsInspectionsTestBase(RsFunctionNamingInspection::class) {
     fun `test functions`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsLifetimeNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsLifetimeNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
 import org.rust.ide.inspections.RsInspectionsTestBase
-import org.rust.ide.inspections.RsLifetimeNamingInspection
+import org.rust.ide.inspections.lints.RsLifetimeNamingInspection
 
 class RsLifetimeNamingInspectionTest : RsInspectionsTestBase(RsLifetimeNamingInspection::class) {
     fun `test lifetimes`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsMacroNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsMacroNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
 import org.rust.ide.inspections.RsInspectionsTestBase
-import org.rust.ide.inspections.RsMacroNamingInspection
+import org.rust.ide.inspections.lints.RsMacroNamingInspection
 
 class RsMacroNamingInspectionTest : RsInspectionsTestBase(RsMacroNamingInspection::class) {
     fun `test macros`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsMethodNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsMethodNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
 import org.rust.ide.inspections.RsInspectionsTestBase
-import org.rust.ide.inspections.RsMethodNamingInspection
+import org.rust.ide.inspections.lints.RsMethodNamingInspection
 
 class RsMethodNamingInspectionTest : RsInspectionsTestBase(RsMethodNamingInspection::class) {
     fun `test methods`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsModuleNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsModuleNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
 import org.rust.ide.inspections.RsInspectionsTestBase
-import org.rust.ide.inspections.RsModuleNamingInspection
+import org.rust.ide.inspections.lints.RsModuleNamingInspection
 
 class RsModuleNamingInspectionTest : RsInspectionsTestBase(RsModuleNamingInspection::class) {
     fun `test modules`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsStaticConstNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsStaticConstNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
 import org.rust.ide.inspections.RsInspectionsTestBase
-import org.rust.ide.inspections.RsStaticConstNamingInspection
+import org.rust.ide.inspections.lints.RsStaticConstNamingInspection
 
 class RsStaticConstNamingInspectionTest : RsInspectionsTestBase(RsStaticConstNamingInspection::class) {
     fun `test statics`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsStructNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsStructNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
 import org.rust.ide.inspections.RsInspectionsTestBase
-import org.rust.ide.inspections.RsStructNamingInspection
+import org.rust.ide.inspections.lints.RsStructNamingInspection
 
 class RsStructNamingInspectionTest : RsInspectionsTestBase(RsStructNamingInspection::class) {
     fun `test structs`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTraitNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTraitNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
 import org.rust.ide.inspections.RsInspectionsTestBase
-import org.rust.ide.inspections.RsTraitNamingInspection
+import org.rust.ide.inspections.lints.RsTraitNamingInspection
 
 class RsTraitNamingInspectionTest : RsInspectionsTestBase(RsTraitNamingInspection::class) {
     fun `test traits`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTypeAliasNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTypeAliasNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
 import org.rust.ide.inspections.RsInspectionsTestBase
-import org.rust.ide.inspections.RsTypeAliasNamingInspection
+import org.rust.ide.inspections.lints.RsTypeAliasNamingInspection
 
 class RsTypeAliasNamingInspectionTest : RsInspectionsTestBase(RsTypeAliasNamingInspection::class) {
     fun `test type aliases`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTypeParameterNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTypeParameterNamingInspectionTest.kt
@@ -3,10 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
 import org.rust.ide.inspections.RsInspectionsTestBase
-import org.rust.ide.inspections.RsTypeParameterNamingInspection
+import org.rust.ide.inspections.lints.RsTypeParameterNamingInspection
 
 class RsTypeParameterNamingInspectionTest : RsInspectionsTestBase(RsTypeParameterNamingInspection::class) {
     fun `test type parameters`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsVariableNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsVariableNamingInspectionTest.kt
@@ -3,12 +3,12 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.naming
+package org.rust.ide.inspections.lints.naming
 
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsInspectionsTestBase
-import org.rust.ide.inspections.RsVariableNamingInspection
+import org.rust.ide.inspections.lints.RsVariableNamingInspection
 
 class RsVariableNamingInspectionTest : RsInspectionsTestBase(RsVariableNamingInspection::class) {
     fun `test variables`() = checkByText("""


### PR DESCRIPTION
All inspections related to compiler lints are supposed to be placed into this group

Also, moved all corresponding inspections into `lints` package

Related to #5888 