### PR TITLE
INSP: convert while true inspection into lint one

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -37,6 +37,14 @@ enum class RsLint(
             }
     },
 
+    WhileTrue("while_true") {
+        override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
+            when (level) {
+                WARN -> ProblemHighlightType.WEAK_WARNING
+                else -> super.toHighlightingType(level)
+            }
+    },
+
     NeedlessLifetimes("clippy::needless_lifetimes", listOf("clippy::complexity", "clippy::all", "clippy")) {
         override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
             when (level) {

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsWhileTrueLoopInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsWhileTrueLoopInspection.kt
@@ -3,12 +3,14 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.ide.utils.skipParenExprDown
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.endOffsetInParent
@@ -16,8 +18,9 @@ import org.rust.lang.core.psi.ext.endOffsetInParent
 /**
  * Change `while true` to `loop`.
  */
-class RsWhileTrueLoopInspection : RsLocalInspectionTool() {
+class RsWhileTrueLoopInspection : RsLintInspection() {
     override fun getDisplayName() = "While true loop"
+    override fun getLint(element: PsiElement): RsLint? = RsLint.WhileTrue
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
         override fun visitWhileExpr(o: RsWhileExpr) {
@@ -26,10 +29,10 @@ class RsWhileTrueLoopInspection : RsLocalInspectionTool() {
             val block = o.block ?: return
             val label = o.labelDecl?.text ?: ""
             if (expr.textMatches("true")) {
-                holder.registerProblem(
+                holder.registerLintProblem(
                     o,
-                    TextRange.create(o.`while`.startOffsetInParent, condition.endOffsetInParent),
                     "Denote infinite loops with `loop { ... }`",
+                    TextRange.create(o.`while`.startOffsetInParent, condition.endOffsetInParent),
                     object : LocalQuickFix {
                         override fun getName() = "Use `loop`"
 

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -440,10 +440,10 @@
                          enabledByDefault="true" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.RsTryMacroInspection"/>
 
-        <localInspection language="Rust" groupName="Rust"
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
                          displayName="While true loop"
                          enabledByDefault="true" level="WEAK WARNING"
-                         implementationClass="org.rust.ide.inspections.RsWhileTrueLoopInspection"/>
+                         implementationClass="org.rust.ide.inspections.lints.RsWhileTrueLoopInspection"/>
 
         <localInspection language="Rust" groupName="Rust"
                          displayName="println!(&quot;&quot;) usage"

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsWhileTrueLoopInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsWhileTrueLoopInspectionTest.kt
@@ -3,9 +3,10 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import org.intellij.lang.annotations.Language
+import org.rust.ide.inspections.RsInspectionsTestBase
 
 class RsWhileTrueLoopInspectionTest : RsInspectionsTestBase(RsWhileTrueLoopInspection::class) {
     fun `test simple`() = checkFix("""
@@ -63,6 +64,13 @@ class RsWhileTrueLoopInspectionTest : RsInspectionsTestBase(RsWhileTrueLoopInspe
                 let a = 42;
                 println!("{}", a);
             }
+        }
+    """)
+
+    fun `test allow while_true`() = checkWarnings("""
+        #[allow(while_true)]
+        fn main() {
+            while true {}
         }
     """)
 


### PR DESCRIPTION
After this change, the plugin will be able to provide all features described in #5888 for "while true" inspection, i.e. automatic suppression by `#[allow(while_true)]` and suppression quick fixes


![2020-08-08 00 50 06](https://user-images.githubusercontent.com/2539310/89691267-2b28ff80-d911-11ea-960b-c30d250ca73a.gif)

Depends on #5889

Part of #5888