### PR TITLE
INSP: support `nonstandard_style` attribute for naming inspections

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -18,9 +18,9 @@ enum class RsLint(
     val groupIds: List<String> = emptyList(),
     val defaultLevel: RsLintLevel = WARN
 ) {
-    NonSnakeCase("non_snake_case", listOf("bad_style")),
-    NonCamelCaseTypes("non_camel_case_types", listOf("bad_style")),
-    NonUpperCaseGlobals("non_upper_case_globals", listOf("bad_style")),
+    NonSnakeCase("non_snake_case", listOf("bad_style", "nonstandard_style")),
+    NonCamelCaseTypes("non_camel_case_types", listOf("bad_style", "nonstandard_style")),
+    NonUpperCaseGlobals("non_upper_case_globals", listOf("bad_style", "nonstandard_style")),
     Deprecated("deprecated") {
         override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
             when (level) {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsConstNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsConstNamingInspectionTest.kt
@@ -19,6 +19,11 @@ class RsConstNamingInspectionTest : RsInspectionsTestBase(RsConstNamingInspectio
         const const_foo: u32 = 12;
     """)
 
+    fun `test constants suppression nonstandard style`() = checkByText("""
+        #[allow(nonstandard_style)]
+        const const_foo: u32 = 12;
+    """)
+
     fun `test constants fix`() = checkFixByText("Rename to `CONST_FOO`", """
         const <warning descr="Constant `ConstFoo` should have an upper case name such as `CONST_FOO`">Con<caret>stFoo</warning>: u32 = 42;
         fn const_use() {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsModuleNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsModuleNamingInspectionTest.kt
@@ -33,6 +33,11 @@ class RsModuleNamingInspectionTest : RsInspectionsTestBase(RsModuleNamingInspect
         mod moduleA/*caret*/ {}
     """)
 
+    fun `test modules suppression nonstandard style`() = checkByText("""
+        #[allow(nonstandard_style)]
+        mod moduleA {}
+    """)
+
     fun `test modules fix`() = checkFixByText("Rename to `mod_foo`", """
         mod <warning descr="Module `modFoo` should have a snake case name such as `mod_foo`">modF<caret>oo</warning> {
             pub const ONE: u32 = 1;

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTraitNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTraitNamingInspectionTest.kt
@@ -19,6 +19,11 @@ class RsTraitNamingInspectionTest : RsInspectionsTestBase(RsTraitNamingInspectio
         trait trait_foo {}
     """)
 
+    fun `test traits suppression nonstandard style`() = checkByText("""
+        #[allow(nonstandard_style)]
+        trait trait_foo {}
+    """)
+
     fun `test traits fix`() = checkFixByText("Rename to `HotFix`", """
         trait <warning descr="Trait `hot_fix` should have a camel case name such as `HotFix`">ho<caret>t_fix</warning> {}
         struct Patch {}


### PR DESCRIPTION
It's new name for `bad_style` attribute

Related to #5888