### PR TITLE
Rename `RsDocAndAttributeOwner.isEnabledByCfg`

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotator.kt
@@ -13,13 +13,13 @@ import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
 import org.rust.ide.colors.RsColor
 import org.rust.lang.core.psi.ext.RsDocAndAttributeOwner
-import org.rust.lang.core.psi.ext.isEnabledByCfg
+import org.rust.lang.core.psi.ext.isEnabledByCfgSelf
 import org.rust.lang.core.psi.ext.rangeWithSurroundingLineBreaks
 
 class RsCfgDisabledCodeAnnotator : AnnotatorBase() {
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         if (holder.isBatchMode) return
-        if (element is RsDocAndAttributeOwner && !element.isEnabledByCfg) {
+        if (element is RsDocAndAttributeOwner && !element.isEnabledByCfgSelf) {
             holder.createCfgDisabledAnnotation(element.rangeWithSurroundingLineBreaks)
         }
     }

--- a/src/main/kotlin/org/rust/ide/utils/CfgUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/CfgUtils.kt
@@ -8,11 +8,11 @@ package org.rust.ide.utils
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.ext.RsDocAndAttributeOwner
 import org.rust.lang.core.psi.ext.ancestors
-import org.rust.lang.core.psi.ext.isCfgUnknown
-import org.rust.lang.core.psi.ext.isEnabledByCfg
+import org.rust.lang.core.psi.ext.isCfgUnknownSelf
+import org.rust.lang.core.psi.ext.isEnabledByCfgSelf
 
 val PsiElement.isEnabledByCfg: Boolean
-    get() = ancestors.filterIsInstance<RsDocAndAttributeOwner>().all { it.isEnabledByCfg }
+    get() = ancestors.filterIsInstance<RsDocAndAttributeOwner>().all { it.isEnabledByCfgSelf }
 
 val PsiElement.isCfgUnknown: Boolean
-    get() = ancestors.filterIsInstance<RsDocAndAttributeOwner>().any { it.isCfgUnknown }
+    get() = ancestors.filterIsInstance<RsDocAndAttributeOwner>().any { it.isCfgUnknownSelf }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -244,10 +244,10 @@ private val CACHED_DATA_KEY: Key<CachedValue<CachedData>> = Key.create("CACHED_D
 private val CACHED_DATA_MACROS_KEY: Key<CachedValue<CachedData>> = Key.create("CACHED_DATA_MACROS_KEY")
 
 private tailrec fun PsiElement.contextualFileAndIsEnabledByCfgOnThisWay(): Pair<PsiFile, Boolean> {
-    if (this is RsDocAndAttributeOwner && !isEnabledByCfg) return contextualFile to false
+    if (this is RsDocAndAttributeOwner && !isEnabledByCfgSelf) return contextualFile to false
     val contextOrMacro = (this as? RsExpandedElement)?.expandedFrom ?: context!!
     return if (contextOrMacro is PsiFile) {
-        contextOrMacro to (contextOrMacro !is RsDocAndAttributeOwner || contextOrMacro.isEnabledByCfg)
+        contextOrMacro to (contextOrMacro !is RsDocAndAttributeOwner || contextOrMacro.isEnabledByCfgSelf)
     } else {
         contextOrMacro.contextualFileAndIsEnabledByCfgOnThisWay()
     }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -205,10 +205,10 @@ class QueryAttributes(
  *
  * HACK: do not check on [RsFile] as [RsFile.queryAttributes] would access the PSI
  */
-val RsDocAndAttributeOwner.isEnabledByCfg: Boolean
+val RsDocAndAttributeOwner.isEnabledByCfgSelf: Boolean
     get() = evaluateCfg() != ThreeValuedLogic.False
 
-val RsDocAndAttributeOwner.isCfgUnknown: Boolean
+val RsDocAndAttributeOwner.isCfgUnknownSelf: Boolean
     get() = evaluateCfg() == ThreeValuedLogic.Unknown
 
 private fun RsDocAndAttributeOwner.evaluateCfg(): ThreeValuedLogic {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt
@@ -22,11 +22,11 @@ val RsFieldsOwner.fields: List<RsFieldDecl>
 
 /** Returns those named fields that are not disabled by cfg attributes */
 val RsFieldsOwner.namedFields: List<RsNamedFieldDecl>
-    get() = blockFields?.namedFieldDeclList?.filter { it.isEnabledByCfg }.orEmpty()
+    get() = blockFields?.namedFieldDeclList?.filter { it.isEnabledByCfgSelf }.orEmpty()
 
 /** Returns those positional (tuple) fields that are not disabled by cfg attributes */
 val RsFieldsOwner.positionalFields: List<RsTupleFieldDecl>
-    get() = tupleFields?.tupleFieldDeclList?.filter { it.isEnabledByCfg }.orEmpty()
+    get() = tupleFields?.tupleFieldDeclList?.filter { it.isEnabledByCfgSelf }.orEmpty()
 
 /**
  * If some field of a struct is private (not visible from [mod]),
@@ -46,7 +46,7 @@ fun RsFieldsOwner.canBeInstantiatedIn(mod: RsMod): Boolean =
     fields.all { it.isVisibleFrom(mod) }
 
 val RsFieldsOwner.fieldTypes: List<Ty>
-    get() = fields.filter { it.isEnabledByCfg }.mapNotNull { it.typeReference?.type }
+    get() = fields.filter { it.isEnabledByCfgSelf }.mapNotNull { it.typeReference?.type }
 
 /**
  * True for:

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
@@ -120,10 +120,10 @@ private fun RsItemsOwner.processExpandedItemsInternal(processor: (RsItemElement)
 }
 
 private fun RsElement.processItem(processor: (RsItemElement) -> Boolean): Boolean {
-    if (this is RsDocAndAttributeOwner && !this.isEnabledByCfg) return false
+    if (this is RsDocAndAttributeOwner && !this.isEnabledByCfgSelf) return false
 
     return when (this) {
-        is RsMacroCall -> processExpansionRecursively { it is RsItemElement && it.isEnabledByCfg && processor(it) }
+        is RsMacroCall -> processExpansionRecursively { it is RsItemElement && it.isEnabledByCfgSelf && processor(it) }
         is RsItemElement -> processor(this)
         else -> false
     }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -186,7 +186,7 @@ private fun RsMacroCall.processExpansionRecursively(processor: (RsExpandedElemen
 
 private fun RsExpandedElement.processRecursively(processor: (RsExpandedElement) -> Boolean, depth: Int): Boolean {
     return when (this) {
-        is RsMacroCall -> isEnabledByCfg && processExpansionRecursively(processor, depth + 1)
+        is RsMacroCall -> isEnabledByCfgSelf && processExpansionRecursively(processor, depth + 1)
         else -> processor(this)
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -951,14 +951,14 @@ private class MacroResolvingVisitor(
     }
 
     override fun visitModItem(item: RsModItem) {
-        if (missingMacroUse.hitOnFalse(item.hasMacroUse) && item.isEnabledByCfg) {
+        if (missingMacroUse.hitOnFalse(item.hasMacroUse) && item.isEnabledByCfgSelf) {
             val elements = visibleMacros(item)
             visitorResult = processAll(if (reverse) elements.asReversed() else elements, processor)
         }
     }
 
     override fun visitModDeclItem(item: RsModDeclItem) {
-        if (missingMacroUse.hitOnFalse(item.hasMacroUse) && item.isEnabledByCfg) {
+        if (missingMacroUse.hitOnFalse(item.hasMacroUse) && item.isEnabledByCfgSelf) {
             val mod = item.reference.resolve() as? RsMod ?: return
             val elements = visibleMacros(mod)
             visitorResult = processAll(if (reverse) elements.asReversed() else elements, processor)
@@ -966,7 +966,7 @@ private class MacroResolvingVisitor(
     }
 
     override fun visitExternCrateItem(item: RsExternCrateItem) {
-        if (!item.isEnabledByCfg) return
+        if (!item.isEnabledByCfgSelf) return
         val mod = item.reference.resolve() as? RsFile ?: return
         if (missingMacroUse.hitOnFalse(item.hasMacroUse)) {
             // If extern crate has `#[macro_use]` attribute
@@ -1054,7 +1054,7 @@ private fun exportedMacrosInternal(scope: RsFile): List<ScopeEntry> {
 
         val externCrates = scope.stubChildrenOfType<RsExternCrateItem>()
         for (item in externCrates) {
-            if (!item.isEnabledByCfg) continue
+            if (!item.isEnabledByCfgSelf) continue
             val reexportedMacros = reexportedMacros(item)
             if (reexportedMacros != null) {
                 addAll(reexportedMacros.toScopeEntries())
@@ -1128,7 +1128,7 @@ private fun collectMacrosImportedWithUseItem(
     val twoSegmentPaths = collect2segmentPaths(root)
 
     // Check cfg only if there are paths we interested in
-    if (twoSegmentPaths.isEmpty() || !useItem.isEnabledByCfg) return emptyList()
+    if (twoSegmentPaths.isEmpty() || !useItem.isEnabledByCfgSelf) return emptyList()
 
     return buildList {
         for ((crateName, macroName) in twoSegmentPaths) {

--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -67,7 +67,7 @@ fun collectPathResolveVariants(
 
         if (e.name == referenceName) {
             val element = e.element ?: return@f false
-            if (element !is RsDocAndAttributeOwner || element.isEnabledByCfg) {
+            if (element !is RsDocAndAttributeOwner || element.isEnabledByCfgSelf) {
                 result += BoundElement(element, e.subst)
             }
         }
@@ -83,7 +83,7 @@ fun collectResolveVariants(referenceName: String, f: (RsResolveProcessor) -> Uni
 
         if (e.name == referenceName) {
             val element = e.element ?: return@f false
-            if (element !is RsDocAndAttributeOwner || element.isEnabledByCfg) {
+            if (element !is RsDocAndAttributeOwner || element.isEnabledByCfgSelf) {
                 result += element
             }
         }
@@ -102,7 +102,7 @@ fun <T : ScopeEntry> collectResolveVariantsAsScopeEntries(referenceName: String,
         if (e.name == referenceName) {
             // de-lazying. See `RsResolveProcessor.lazy`
             val element = e.element ?: return@f false
-            if (element !is RsDocAndAttributeOwner || element.isEnabledByCfg) {
+            if (element !is RsDocAndAttributeOwner || element.isEnabledByCfgSelf) {
                 result += e
             }
         }
@@ -116,7 +116,7 @@ fun pickFirstResolveVariant(referenceName: String, f: (RsResolveProcessor) -> Un
     f { e ->
         if (e.name == referenceName) {
             val element = e.element
-            if (element != null && (element !is RsDocAndAttributeOwner || element.isEnabledByCfg)) {
+            if (element != null && (element !is RsDocAndAttributeOwner || element.isEnabledByCfgSelf)) {
                 result = element
                 return@f true
             }
@@ -134,7 +134,7 @@ fun collectCompletionVariants(
     f { e ->
         val element = e.element ?: return@f false
         if (element is RsFunction && element.isTest) return@f false
-        if (element !is RsDocAndAttributeOwner || element.isEnabledByCfg) {
+        if (element !is RsDocAndAttributeOwner || element.isEnabledByCfgSelf) {
             result.addElement(createLookupElement(
                 scopeEntry = e,
                 context = context


### PR DESCRIPTION
There are two methods with name `isEnabledByCfg`:
* [`PsiElement.isEnabledByCfg`](https://github.com/intellij-rust/intellij-rust/blob/7dec3d603b1569a2285c2e5e36b1965e100db800/src/main/kotlin/org/rust/ide/utils/CfgUtils.kt#L14)
* [`RsDocAndAttributeOwner.isEnabledByCfg`](https://github.com/intellij-rust/intellij-rust/blob/b36c3a591cce1182674b037e64e47ede2ae021e3/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt#L208)

If I understand correctly, first method checks cfg-attributes of item and all its parent modules, and thus is preffered to use. And second method only checks cfg-attributes of item, thus should be used in specific situations (expanded items, etc). I think it would be better if these methods would have different names to prevent accidental misuse