### PR TITLE
PRJ: Create default run configuration after project generation

### DIFF
--- a/idea/src/main/kotlin/org/rust/ide/idea/RsModuleBuilder.kt
+++ b/idea/src/main/kotlin/org/rust/ide/idea/RsModuleBuilder.kt
@@ -18,6 +18,7 @@ import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.util.Disposer
 import org.rust.cargo.toolchain.RustToolchain
 import org.rust.ide.newProject.ConfigurationData
+import org.rust.ide.newProject.makeDefaultRunConfiguration
 import org.rust.ide.newProject.makeProject
 import org.rust.ide.newProject.openFiles
 
@@ -58,6 +59,7 @@ class RsModuleBuilder : ModuleBuilder() {
                     root, template
                 ) ?: return
 
+                project.makeDefaultRunConfiguration(template)
                 project.openFiles(generatedFiles)
             } catch (e: ExecutionException) {
                 LOG.error(e)

--- a/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandConfigurationType.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandConfigurationType.kt
@@ -7,6 +7,7 @@ package org.rust.cargo.runconfig.wasmpack
 
 import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.ConfigurationTypeBase
+import com.intellij.execution.configurations.ConfigurationTypeUtil
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.openapi.project.Project
 import org.rust.ide.icons.RsIcons
@@ -19,6 +20,13 @@ class WasmPackCommandConfigurationType : ConfigurationTypeBase(
 ) {
     init {
         addFactory(WasmPackConfigurationFactory(this))
+    }
+
+    val factory: ConfigurationFactory get() = configurationFactories.single()
+
+    companion object {
+        fun getInstance(): WasmPackCommandConfigurationType =
+            ConfigurationTypeUtil.findConfigurationType(WasmPackCommandConfigurationType::class.java)
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
@@ -45,6 +45,7 @@ class RsDirectoryProjectGenerator : DirectoryProjectGeneratorBase<ConfigurationD
             cargo.makeProject(project, module, baseDir, template)
         } ?: return
 
+        project.makeDefaultRunConfiguration(template)
         project.openFiles(generatedFiles)
     }
 

--- a/src/main/kotlin/org/rust/ide/newProject/RsProjectTemplate.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsProjectTemplate.kt
@@ -8,18 +8,20 @@ package org.rust.ide.newProject
 import org.rust.ide.icons.RsIcons
 import javax.swing.Icon
 
-sealed class RsProjectTemplate(val name: String, val isBinary: Boolean) {
-    abstract val icon: Icon
-
+sealed class RsProjectTemplate(val name: String, val isBinary: Boolean, val icon: Icon) {
     fun validateProjectName(crateName: String): String? = RsPackageNameValidator.validate(crateName, isBinary)
 }
 
-class RsGenericTemplate(name: String, isBinary: Boolean) : RsProjectTemplate(name, isBinary) {
-    override val icon: Icon = RsIcons.RUST
+sealed class RsGenericTemplate(name: String, isBinary: Boolean) : RsProjectTemplate(name, isBinary, RsIcons.RUST) {
+    object CargoBinaryTemplate : RsGenericTemplate("Binary (application)", true)
+    object CargoLibraryTemplate : RsGenericTemplate("Library", false)
 }
 
-class RsCustomTemplate(name: String, val link: String, isBinary: Boolean = true) : RsProjectTemplate(name, isBinary) {
-    override val icon: Icon = RsIcons.CARGO_GENERATE
+open class RsCustomTemplate(
+    name: String, val url: String
+) : RsProjectTemplate(name, false, RsIcons.CARGO_GENERATE) {
+    object WasmPackTemplate : RsCustomTemplate("WebAssembly Lib", "https://github.com/rustwasm/wasm-pack-template")
+
     val shortLink: String
-        get() = link.substringAfter("//")
+        get() = url.substringAfter("//")
 }

--- a/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt
@@ -47,9 +47,9 @@ class RsNewProjectPanel(
         get() = rustProjectSettings.data.toolchain?.rawCargo()
 
     private val defaultTemplates: List<RsProjectTemplate> = listOf(
-        RsGenericTemplate("Binary (application)", true),
-        RsGenericTemplate("Library", false),
-        RsCustomTemplate("WebAssembly Lib", "https://github.com/rustwasm/wasm-pack-template", false)
+        RsGenericTemplate.CargoBinaryTemplate,
+        RsGenericTemplate.CargoLibraryTemplate,
+        RsCustomTemplate.WasmPackTemplate
     )
 
     private val userTemplates: List<RsCustomTemplate>


### PR DESCRIPTION
Makes default run configurations for projects when generating from built-in templates.

Uses these commands:
* `cargo run` for binary
* `cargo test` for library
* `wasm-pack build` for WebAssembly