### PR TITLE
ANN: Check if the custom attr override is used by `findInScope`

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1858,7 +1858,9 @@ private fun RsAttr.isBuiltinWithName(target: String): Boolean {
     if (name != target) return false
     if (name !in RS_BUILTIN_ATTRIBUTES) return false
 
-    return !hasInScope(name, MACROS)
+    val procMacro = findInScope(name, MACROS) as? RsFunction ?: return true
+
+    return !procMacro.isAttributeProcMacroDef
 }
 
 private val RsPat.isTopLevel: Boolean

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -149,9 +149,6 @@ fun RsElement.findInScope(name: String, ns: Set<Namespace>): PsiElement? {
     return resolved
 }
 
-fun RsElement.hasInScope(name: String, ns: Set<Namespace>): Boolean =
-    findInScope(name, ns) != null
-
 fun RsElement.getLocalVariableVisibleBindings(): Map<String, RsPatBinding> {
     val bindings = HashMap<String, RsPatBinding>()
     processLocalVariables(this) { variable ->

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1370,7 +1370,7 @@ sealed class RsDiagnostic(
     class DeriveAttrUnsupportedItem(element: RsAttr) : RsDiagnostic(element) {
         override fun prepare(): PreparedAnnotation = PreparedAnnotation(
             ERROR,
-            null,
+            E0774,
             "`derive` may only be applied to structs, enums and unions",
             fixes = listOf(RemoveAttrFix(element as RsAttr))
         )
@@ -1580,7 +1580,7 @@ enum class RsErrorCode {
     E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0429, E0430, E0431, E0433, E0434, E0435, E0449, E0451, E0463,
     E0517, E0518, E0537, E0552, E0554, E0562, E0569, E0583, E0586, E0594,
     E0601, E0603, E0614, E0616, E0618, E0624, E0658, E0666, E0667, E0688, E0695,
-    E0703, E0704, E0728, E0732, E0733, E0741, E0742, E0747;
+    E0703, E0704, E0728, E0732, E0733, E0741, E0742, E0747, E0774;
 
     val code: String
         get() = toString()

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -4264,7 +4264,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
     """)
 
     fun `test use derive attr on unsupported items`() = checkErrors("""
-        <error descr="`derive` may only be applied to structs, enums and unions">#[derive(Debug)]</error>
+        <error descr="`derive` may only be applied to structs, enums and unions [E0774]">#[derive(Debug)]</error>
         type Test = i32;
     """)
 
@@ -4275,6 +4275,28 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         #[derive(Debug)]
         enum Color {
             RED, GREEN
+        }
+    """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test user defined derive proc macro`() = checkByFileTree("""
+    //- dep-proc-macro/lib.rs
+        use proc_macro::TokenStream;
+
+        #[proc_macro_attribute]
+        pub fn derive(attr: TokenStream, item: TokenStream) -> TokenStream {
+            item
+        }
+    //- lib.rs
+        /*caret*/
+        #[dep_proc_macro::derive]
+        fn main() {}
+
+        mod foo {
+            use dep_proc_macro::derive;
+
+            #[derive]
+            fn bar() {}
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveElementFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveElementFixTest.kt
@@ -66,7 +66,7 @@ class RemoveElementFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
     """, checkWeakWarn = true)
 
     fun `test derive on function`() = checkFixByText("Remove attribute `derive`","""
-        <error descr="`derive` may only be applied to structs, enums and unions">#[derive(Debug)]</error>
+        <error descr="`derive` may only be applied to structs, enums and unions [E0774]">#[derive(Debug)]</error>
         fn foo() { }
     """, """
         fn foo() { }


### PR DESCRIPTION
- Check if the custom attr override is used by `findInScope`

- Add new error code `E0774`, which should be part of #886

changelog: Fix detection of  [E0774](https://doc.rust-lang.org/error-index.html#E0774) compiler error