### PR TITLE
REF: add suggested rename refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringSupport.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringSupport.kt
@@ -1,0 +1,43 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.suggested
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.refactoring.suggested.*
+import org.rust.lang.core.psi.RsPatBinding
+import org.rust.lang.core.psi.RsPatIdent
+import org.rust.lang.core.psi.ext.RsNameIdentifierOwner
+import org.rust.lang.core.psi.ext.isReferenceToConstant
+
+class RsSuggestedRefactoringSupport : SuggestedRefactoringSupport {
+    override val availability: SuggestedRefactoringAvailability
+        get() = SuggestedRefactoringAvailability.RenameOnly(this)
+    override val execution: SuggestedRefactoringExecution
+        get() = SuggestedRefactoringExecution.RenameOnly(this)
+    override val stateChanges: SuggestedRefactoringStateChanges
+        get() = SuggestedRefactoringStateChanges.RenameOnly(this)
+    override val ui: SuggestedRefactoringUI
+        get() = SuggestedRefactoringUI.RenameOnly
+
+    override fun importsRange(psiFile: PsiFile): TextRange? = null
+
+    override fun isDeclaration(psiElement: PsiElement): Boolean = when (psiElement) {
+        is RsPatBinding -> psiElement.parent is RsPatIdent && !psiElement.isReferenceToConstant
+        is RsNameIdentifierOwner -> true
+        else -> false
+    }
+
+    override fun isIdentifierPart(c: Char): Boolean = Character.isUnicodeIdentifierStart(c)
+    override fun isIdentifierStart(c: Char): Boolean = Character.isUnicodeIdentifierPart(c)
+
+    override fun nameRange(declaration: PsiElement): TextRange? = getRange(declaration)
+    override fun signatureRange(declaration: PsiElement): TextRange? = getRange(declaration)
+
+    private fun getRange(declaration: PsiElement): TextRange? =
+        (declaration as? RsNameIdentifierOwner)?.nameIdentifier?.textRange
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -73,6 +73,7 @@
 
         <lang.refactoringSupport language="Rust"
                                  implementationClass="org.rust.ide.refactoring.RsRefactoringSupportProvider"/>
+        <suggestedRefactoringSupport language="Rust" implementationClass="org.rust.ide.refactoring.suggested.RsSuggestedRefactoringSupport"/>
 
         <!-- Commenter -->
 

--- a/src/test/kotlin/org/rust/ide/refactoring/suggested/RsRenameSuggestedRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/suggested/RsRenameSuggestedRefactoringTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.suggested
+
+import com.intellij.openapi.actionSystem.IdeActions
+
+class RsRenameSuggestedRefactoringTest : RsSuggestedRefactoringTestBase() {
+    fun `test rename local variable`() = doTestRename("""
+        fn foo() {
+            let a/*caret*/ = 0;
+            let b = a;
+        }
+    """, """
+        fn foo() {
+            let ax/*caret*/ = 0;
+            let b = ax;
+        }
+    """, "a", "ax"
+    ) { myFixture.type("x") }
+
+    fun `test rename add number`() = doTestRename("""
+        fn foo() {
+            let a/*caret*/ = 0;
+            let b = a;
+        }
+    """, """
+        fn foo() {
+            let a5/*caret*/ = 0;
+            let b = a5;
+        }
+    """, "a", "a5"
+    ) { myFixture.type("5") }
+
+    fun `test delete and rename`() = doTestRename("""
+        fn foo() {
+            let /*caret*/a = 0;
+            let b = a;
+        }
+    """, """
+        fn foo() {
+            let x/*caret*/ = 0;
+            let b = x;
+        }
+    """, "a", "x"
+    ) {
+        myFixture.performEditorAction(IdeActions.ACTION_EDITOR_DELETE)
+        myFixture.type("x")
+    }
+
+    fun `test delete and use invalid name`() = doUnavailableTest("""
+        fn foo() {
+            let /*caret*/a = 0;
+            let b = a;
+        }
+    """) {
+            myFixture.performEditorAction(IdeActions.ACTION_EDITOR_DELETE)
+            myFixture.type("5")
+        }
+
+    fun `test rename nested binding`() = doTestRename("""
+        fn foo() {
+            let (a/*caret*/, b) = (0, 0);
+            let b = a;
+        }
+    """, """
+        fn foo() {
+            let (ax/*caret*/, b) = (0, 0);
+            let b = ax;
+        }
+    """, "a", "ax"
+    ) { myFixture.type("x") }
+
+    fun `test rename function`() = doTestRename("""
+        fn foo/*caret*/() {
+            let a = 5;
+        }
+        fn bar() {
+            foo();
+        }
+    """, """
+        fn foox/*caret*/() {
+            let a = 5;
+        }
+        fn bar() {
+            foox();
+        }
+    """, "foo", "foox"
+    ) { myFixture.type("x") }
+
+    fun `test rename struct`() = doTestRename("""
+        struct S/*caret*/;
+        fn bar(s: S) {}
+    """, """
+        struct Sx/*caret*/;
+        fn bar(s: Sx) {}
+    """, "S", "Sx"
+    ) { myFixture.type("x") }
+
+    fun `test rename struct field`() = doTestRename("""
+        struct S {
+            a/*caret*/: u32
+        }
+        fn bar(s: S) {
+            let x = s.a;
+        }
+    """, """
+        struct S {
+            ax/*caret*/: u32
+        }
+        fn bar(s: S) {
+            let x = s.ax;
+        }
+    """, "a", "ax"
+    ) { myFixture.type("x") }
+
+    fun `test rename trait`() = doTestRename("""
+        trait Trait/*caret*/ {}
+        fn bar<T: Trait>(t: T) {}
+    """, """
+        trait Traitx/*caret*/ {}
+        fn bar<T: Traitx>(t: T) {}
+    """, "Trait", "Traitx"
+    ) { myFixture.type("x") }
+
+    fun `test rename macro`() = doTestRename("""
+        macro_rules! foo/*caret*/ {
+            () => {}
+        }
+        fn bar() {
+            foo!();
+        }
+    """, """
+        macro_rules! foox/*caret*/ {
+            () => {}
+        }
+        fn bar() {
+            foox!();
+        }
+    """, "foo", "foox"
+    ) { myFixture.type("x") }
+}

--- a/src/test/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.suggested
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.command.executeCommand
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.impl.source.PostprocessReformattingAspect
+import com.intellij.refactoring.RefactoringBundle
+import org.rust.RsTestBase
+
+abstract class RsSuggestedRefactoringTestBase : RsTestBase() {
+    protected fun doUnavailableTest(
+        initialText: String,
+        editingAction: () -> Unit
+    ) {
+        InlineFile(initialText).withCaret()
+
+        myFixture.testHighlighting(false, false, false, myFixture.file.virtualFile)
+        executeEditingAction(editingAction)
+
+        val intention = suggestedRefactoringIntention()
+        assertNull("Refactoring must not be available", intention)
+    }
+
+    protected fun doTestRename(
+        initialText: String,
+        textAfterRefactoring: String,
+        oldName: String,
+        newName: String,
+        editingAction: () -> Unit
+    ) {
+        doTest(
+            replaceCaretMarker(initialText).trimIndent(),
+            RefactoringBundle.message("suggested.refactoring.rename.intention.text", oldName, newName),
+            replaceCaretMarker(textAfterRefactoring).trimIndent(),
+            editingAction
+        )
+    }
+
+    private fun doTest(
+        initialText: String,
+        actionName: String,
+        textAfterRefactoring: String,
+        action: () -> Unit
+    ) {
+        InlineFile(initialText).withCaret()
+
+        myFixture.testHighlighting(false, false, false, myFixture.file.virtualFile)
+        executeEditingAction(action)
+
+        val intention = suggestedRefactoringIntention()
+        assertNotNull("No refactoring available", intention)
+        assertEquals("Action name", actionName, intention!!.text)
+
+        val editor = myFixture.editor
+        executeCommand(project) {
+            intention.invoke(project, editor, myFixture.file)
+
+            runWriteAction {
+                PostprocessReformattingAspect.getInstance(project).doPostponedFormatting()
+            }
+        }
+
+        val index = textAfterRefactoring.indexOf("<caret>")
+        if (index >= 0) {
+            val text = textAfterRefactoring.substring(0, index) +
+                textAfterRefactoring.substring(index + "<caret>".length)
+            assertEquals(text, editor.document.text)
+
+            assertEquals("Caret position", index, editor.caretModel.offset)
+        } else {
+            assertEquals(textAfterRefactoring, editor.document.text)
+        }
+    }
+
+    private fun suggestedRefactoringIntention(): IntentionAction? =
+        myFixture.availableIntentions.firstOrNull { it.familyName == "Suggested Refactoring" }
+
+    protected fun executeEditingAction(
+        action: () -> Unit,
+        wrapIntoCommandAndWriteActionAndCommitAll: Boolean = true
+    ) {
+        val psiDocumentManager = PsiDocumentManager.getInstance(project)
+        if (wrapIntoCommandAndWriteActionAndCommitAll) {
+            executeCommand {
+                runWriteAction {
+                    action()
+                    psiDocumentManager.commitAllDocuments()
+                    psiDocumentManager.doPostponedOperationsAndUnblockDocument(myFixture.editor.document)
+                }
+            }
+        } else {
+            action()
+        }
+
+        psiDocumentManager.commitAllDocuments()
+    }
+}


### PR DESCRIPTION
This PR adds support for the new suggested refactoring. Since change signature refactoring is not implemented for Rust yet, I only added basic support for renaming local bindings.

![rename](https://user-images.githubusercontent.com/4539057/89916312-c4992f80-dbf7-11ea-93de-cc6a12945ba3.gif)

I copy-pasted the test infrastructure from the Kotlin plugin, because I couldn't get `com.intellij.refactoring.suggested.BaseSuggestedRefactoringTest` to work, as it couldn't autoload some Java `PsiElementFactory` class during runtime. However, even after copying the tests, they do not work. When I perform a change in the test file text and commit it, the refactoring suggestion intention is not offered. Yet when I do the exact same change in the IDE, it works fine. Any hints on what I could be missing?

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5909