### PR TITLE
RES: Fix resolve of mod declarations inside inline mod with path attribute

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
@@ -54,7 +54,13 @@ interface RsMod : RsQualifiedNamedElement, RsItemsOwner, RsVisible {
 
         val explicitPath = pathAttribute
         val (parentDirectory, path) = if (explicitPath != null) {
-            contextualFile.originalFile.parent to explicitPath
+            // https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute
+            val parentDirectory = if (`super` is RsFile) {
+                contextualFile.originalFile.parent
+            } else {
+                `super`?.getOwnedDirectory(createIfNotExists)
+            }
+            parentDirectory to explicitPath
         } else {
             `super`?.getOwnedDirectory(createIfNotExists) to name
         }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -323,6 +323,23 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         pub fn baz() {}
     """, NameResolutionTestmarks.modDeclExplicitPathInInlineModule)
 
+    fun `test module inside inline module with path`() = stubOnlyResolve("""
+    //- main.rs
+        mod foo {
+            #[path="qwe"]
+            pub mod bar {
+                pub mod baz;
+            }
+        }
+
+        fn main() {
+            self::foo::bar::baz::func();
+                               //^ foo/qwe/baz.rs
+        }
+    //- foo/qwe/baz.rs
+        pub fn func() {}
+    """)
+
     fun `test inline module path in non crate root`() = stubOnlyResolve("""
     //- main.rs
         mod foo;


### PR DESCRIPTION
In this code:
```rust
mod foo {
    #[path="qwe"]
    pub mod bar {
        pub mod baz;
    }
}
```

Fixes resolve of `baz` (assuming file `foo/qwe/baz.rs` exists)