### PR TITLE
REF: Support reexports in move items refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesProcessor.kt
@@ -220,10 +220,10 @@ class RsMoveFilesOrDirectoriesProcessor(
 
         val references = usages.mapNotNull { usage ->
             val pathOld = usage.element as? RsPath ?: return@mapNotNull null
-            val pathNew = insideReferencesMap[pathOld]
-                ?: getPathNewFallback(pathOld)
-                ?: return@mapNotNull null
-            RsMoveReferenceInfo(pathOld, pathNew, movedFile)
+            val pathNewAccessible = insideReferencesMap[pathOld]
+            val pathNewFallback = getPathNewFallback(pathOld)
+            if (pathNewAccessible == null && pathNewFallback == null) return@mapNotNull null
+            RsMoveReferenceInfo(pathOld, pathNewAccessible, pathNewFallback, movedFile)
         }
         RsMoveRetargetReferencesProcessor(project, oldParentMod, newParentMod).retargetReferences(references)
     }

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
@@ -25,6 +25,179 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         }
     """)
 
+    fun `test absolute outside reference which should be changed because of reexports`() = doTest("""
+    //- lib.rs
+        mod inner1 {
+            pub use bar::*;
+            mod mod1 {
+                fn foo/*caret*/() { crate::inner1::bar::bar_func(); }
+            }
+            // private
+            mod bar { pub fn bar_func() {} }
+        }
+        mod mod2/*target*/ {}
+    """, """
+    //- lib.rs
+        mod inner1 {
+            pub use bar::*;
+            mod mod1 {}
+            // private
+            mod bar { pub fn bar_func() {} }
+        }
+        mod mod2 {
+            fn foo() { crate::inner1::bar_func(); }
+        }
+    """)
+
+    fun `test outside reference to reexported item`() = doTest("""
+    //- lib.rs
+        mod mod1 {
+            pub use mod1_inner::bar;
+            mod mod1_inner {
+                pub fn bar() {}
+            }
+            fn foo/*caret*/() { mod1_inner::bar(); }
+        }
+        mod mod2/*target*/ {}
+    """, """
+    //- lib.rs
+        mod mod1 {
+            pub use mod1_inner::bar;
+            mod mod1_inner {
+                pub fn bar() {}
+            }
+        }
+        mod mod2 {
+            use crate::mod1;
+
+            fn foo() { mod1::bar(); }
+        }
+    """)
+
+    fun `test inside reference, moved item under reexport before move`() = doTest("""
+    //- lib.rs
+        mod inner {
+            pub use mod1::*;
+            // private
+            mod mod1 {
+                pub fn foo/*caret*/() {}
+            }
+            pub mod mod2/*target*/ {}
+        }
+        mod usage {
+            fn test() { crate::inner::foo(); }
+        }
+    """, """
+    //- lib.rs
+        mod inner {
+            pub use mod1::*;
+            // private
+            mod mod1 {}
+            pub mod mod2 {
+                pub fn foo() {}
+            }
+        }
+        mod usage {
+            fn test() { crate::inner::mod2::foo(); }
+        }
+    """)
+
+    fun `test inside reference, moved item under reexport after move`() = doTest("""
+    //- lib.rs
+        mod inner {
+            pub use mod2::*;
+            pub mod mod1 {
+                pub fn foo/*caret*/() {}
+            }
+            // private
+            mod mod2/*target*/ {
+                pub fn bar() {}
+            }
+        }
+        mod usage {
+            fn test() { crate::inner::mod1::foo(); }
+        }
+    """, """
+    //- lib.rs
+        mod inner {
+            pub use mod2::*;
+            pub mod mod1 {}
+            // private
+            mod mod2 {
+                pub fn bar() {}
+
+                pub fn foo() {}
+            }
+        }
+        mod usage {
+            fn test() { crate::inner::foo(); }
+        }
+    """)
+
+    fun `test inside reference, both source and target parent modules under reexport`() = doTest("""
+    //- lib.rs
+        mod inner1 {
+            pub use inner2::*;
+            mod inner2 {
+                pub mod mod1 {
+                    pub fn foo/*caret*/() {}
+                }
+                pub mod mod2/*target*/ {}
+            }
+        }
+        mod usage {
+            fn test() { crate::inner1::mod1::foo(); }
+        }
+    """, """
+    //- lib.rs
+        mod inner1 {
+            pub use inner2::*;
+            mod inner2 {
+                pub mod mod1 {}
+                pub mod mod2 {
+                    pub fn foo() {}
+                }
+            }
+        }
+        mod usage {
+            fn test() { crate::inner1::mod2::foo(); }
+        }
+    """)
+
+    fun `test inside reference, grandparent module under reexport`() = doTest("""
+    //- lib.rs
+        mod inner1 {
+            pub use inner2::*;
+            mod inner2 {  // private
+                pub mod mod1 {
+                    pub fn foo/*caret*/() {}
+                }
+                pub mod mod2/*target*/ {}
+            }
+        }
+
+        fn test1() { inner1::mod1::foo(); }
+        mod usages {
+            fn test2() { crate::inner1::mod1::foo(); }
+        }
+    """, """
+    //- lib.rs
+        mod inner1 {
+            pub use inner2::*;
+            mod inner2 {  // private
+                pub mod mod1 {}
+                pub mod mod2 {
+                    pub fn foo() {}
+                }
+            }
+        }
+
+        fn test1() { inner1::mod2::foo(); }
+        mod usages {
+            fn test2() { crate::inner1::mod2::foo(); }
+        }
+    """)
+
     fun `test move to other crate simple`() = doTest("""
     //- main.rs
         mod mod1 {


### PR DESCRIPTION
Support reexports in [move items refactoring](https://github.com/intellij-rust/intellij-rust/issues/3531#issuecomment-643142894). Reexports are handled using `RsMovePathHelper` (introduced in #5484)

---

![6](https://user-images.githubusercontent.com/6505554/90095365-dee32280-dd49-11ea-9e07-098ce00e7241.gif)
