### PR TITLE
PERF: set of name resolution optimizations

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -96,7 +96,7 @@ class AutoImportFix(element: RsElement, private val type: Type) : LocalQuickFixO
                 return null
             }
 
-            val superPath = path.superPath()
+            val superPath = path.rootPath()
             val candidates = ImportCandidatesCollector.getImportCandidates(
                 ImportContext.from(project, path, false),
                 basePath.referenceName,

--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -28,9 +28,9 @@ interface RsExpandedElement : RsElement {
     companion object {
         fun getContextImpl(psi: RsExpandedElement, isIndexAccessForbidden: Boolean = false): PsiElement? {
             val project = psi.project
-            project.macroExpansionManager.getContextOfMacroCallExpandedFrom(psi)?.let { return it }
-            psi.getUserData(RS_EXPANSION_CONTEXT)?.let { return it }
             val parent = psi.stubParent
+            project.macroExpansionManager.getContextOfMacroCallExpandedFrom(psi, parent)?.let { return it }
+            psi.getUserData(RS_EXPANSION_CONTEXT)?.let { return it }
             if (parent is RsFile && !isIndexAccessForbidden && !DumbService.isDumb(project)) {
                 RsIncludeMacroIndex.getIncludingMod(parent)?.let { return it }
             }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -9,14 +9,17 @@ import com.intellij.lang.ASTNode
 import com.intellij.navigation.ItemPresentation
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
+import com.intellij.util.CachedValueImpl
 import org.rust.ide.icons.RsIcons
 import org.rust.ide.presentation.getPresentation
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.DEFAULT
 import org.rust.lang.core.psi.RsElementTypes.EXCL
+import org.rust.lang.core.resolve.RsCachedImplItem
 import org.rust.lang.core.stubs.RsImplItemStub
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.RsPsiTypeImplUtil
@@ -72,4 +75,8 @@ abstract class RsImplItemImplMixin : RsStubbedElementImpl<RsImplItemStub>, RsImp
     override val isUnsafe: Boolean get() = unsafe != null
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
+
+    val cachedImplItem: CachedValue<RsCachedImplItem> = CachedValueImpl {
+        CachedValueProvider.Result(RsCachedImplItem(this), project.rustStructureModificationTracker)
+    }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTypeAlias.kt
@@ -9,11 +9,16 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.util.CachedValueImpl
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.RsElementTypes.DEFAULT
 import org.rust.lang.core.psi.RsPsiImplUtil
 import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.psi.rustStructureModificationTracker
+import org.rust.lang.core.resolve.RsCachedTypeAlias
 import org.rust.lang.core.stubs.RsTypeAliasStub
 import org.rust.lang.core.types.RsPsiTypeImplUtil
 import org.rust.lang.core.types.ty.Ty
@@ -44,7 +49,11 @@ abstract class RsTypeAliasImplMixin : RsStubbedNamedElementImpl<RsTypeAliasStub>
 
     override val declaredType: Ty get() = RsPsiTypeImplUtil.declaredType(this)
 
+    override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
+
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 
-    override fun getUseScope(): SearchScope = RsPsiImplUtil.getDeclarationUseScope(this) ?: super.getUseScope()
+    val cachedImplItem: CachedValue<RsCachedTypeAlias> = CachedValueImpl {
+        CachedValueProvider.Result(RsCachedTypeAlias(this), project.rustStructureModificationTracker)
+    }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -490,8 +490,10 @@ class ImplLookup(
             val result = RsTypeAliasIndex.findPotentialAliases(project, fingerprint) {
                 val name = it.name ?: return@findPotentialAliases false
                 val aliasFingerprint = TyFingerprint(name)
-                val isAppropriateAlias = set.add(aliasFingerprint) &&
-                    canCombineTypes(selfTy, it.declaredType, it.generics, it.constGenerics)
+                val isAppropriateAlias = set.add(aliasFingerprint) && run {
+                    val (declaredType, generics, constGenerics) = it.typeAndGenerics
+                    canCombineTypes(selfTy, declaredType, generics, constGenerics)
+                }
                 isAppropriateAlias && processor(aliasFingerprint)
             }
             if (result) return true

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -374,10 +374,16 @@ private fun processQualifiedPathResolveVariants(
         return false
     }
     if (base is RsMod) {
-        val s = base.`super`
-        // `super` is allowed only after `self` and `super`
-        // so we add `super` in completion only when it produces valid path
-        if (s != null && (!isCompletion || isSuperChain(qualifier)) && processor("super", s)) return true
+        val result = processor.lazy("super") {
+            // `super` is allowed only after `self` and `super`
+            // so we add `super` in completion only when it produces valid path
+            if (!isCompletion || isSuperChain(qualifier)) {
+                base.`super`
+            } else {
+                null
+            }
+        }
+        if (result) return true
 
         val containingMod = path.containingMod
         if (Namespace.Macros in ns && base is RsFile && base.isCrateRoot &&
@@ -388,8 +394,9 @@ private fun processQualifiedPathResolveVariants(
         // Proc macro crates are not allowed to export anything but procedural macros,
         // and all possible macro exports are collected above. However, when resolve
         // happens inside proc macro crate itself, all items are allowed
-        val resolveBetweenDifferentTargets = base.containingCrate != path.containingCrate
-        if (resolveBetweenDifferentTargets && base.containingCrate?.kind?.isProcMacro == true) {
+        val baseModContainingCrate = base.containingCrate
+        val resolveBetweenDifferentTargets = baseModContainingCrate != containingMod.containingCrate
+        if (resolveBetweenDifferentTargets && baseModContainingCrate?.kind?.isProcMacro == true) {
             return false
         }
     }
@@ -504,8 +511,7 @@ private fun processUnqualifiedPathResolveVariants(
         }
         if (Namespace.Types in ns) {
             if (processor("self", containingMod)) return true
-            val superMod = containingMod.`super`
-            if (superMod != null && processor("super", superMod)) return true
+            if (processor.lazy("super") { containingMod.`super` }) return true
             if (crateRoot != null && processor("crate", crateRoot)) return true
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -523,8 +523,8 @@ private fun processUnqualifiedPathResolveVariants(
     // In 2018 edition a path is crate-relative if it starts with `crate::` (handled above)
     // or if it's inside "visibility restriction". `::`-qualified path on 2018 edition means that
     // such path is a name of some dependency crate (that should be resolved without `extern crate`)
-    val isCrateRelative = !isEdition2018 && (hasColonColon || path.contextStrict<RsUseItem>() != null)
-        || path.contextStrict<RsVisRestriction>() != null
+    val isCrateRelative = !isEdition2018 && (hasColonColon || path.rootPath().parent is RsUseSpeck)
+        || path.rootPath().parent is RsVisRestriction
     // see https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html#the-crate-keyword-refers-to-the-current-crate
     val isExternCrate = isEdition2018 && hasColonColon
     return when {

--- a/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RsCachedImplItem.kt
@@ -5,14 +5,13 @@
 
 package org.rust.lang.core.resolve
 
-import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.RsTraitRef
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psi.isValidProjectMember
-import org.rust.lang.core.resolve.ref.ResolveCacheDependency
-import org.rust.lang.core.resolve.ref.RsResolveCache
 import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.infer.constGenerics
@@ -49,15 +48,8 @@ class RsCachedImplItem(
     }
 
     companion object {
-        fun forImpl(project: Project, impl: RsImplItem): RsCachedImplItem {
-            return RsResolveCache.getInstance(project)
-                .resolveWithCaching(impl, ResolveCacheDependency.RUST_STRUCTURE, Resolver)!!
-        }
-
-        private object Resolver : (RsImplItem) -> RsCachedImplItem {
-            override fun invoke(impl: RsImplItem): RsCachedImplItem {
-                return RsCachedImplItem(impl)
-            }
+        fun forImpl(impl: RsImplItem): RsCachedImplItem {
+            return (impl as RsImplItemImplMixin).cachedImplItem.value
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/RsCachedTypeAlias.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RsCachedTypeAlias.kt
@@ -1,0 +1,49 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve
+
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.macros.RsExpandedElement
+import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.isValidProjectMember
+import org.rust.lang.core.types.consts.CtConstParameter
+import org.rust.lang.core.types.infer.constGenerics
+import org.rust.lang.core.types.infer.generics
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyTypeParameter
+import kotlin.LazyThreadSafetyMode.PUBLICATION
+
+/**
+ * Used for optimization purposes, to reduce access to cache and PSI tree in some very hot places,
+ * [ImplLookup.processTyFingerprintsWithAliases] in particular
+ */
+class RsCachedTypeAlias(
+    val alias: RsTypeAlias
+) {
+    val name: String? = alias.name
+    val context: RsElement? = RsExpandedElement.getContextImpl(alias) as? RsElement
+
+    val isFreeAndValid: Boolean by lazy(PUBLICATION) {
+        name != null
+            && alias.getOwner { this@RsCachedTypeAlias.context } is RsAbstractableOwner.Free
+            && alias.isValidProjectMember
+    }
+
+    val containingCrate: Crate? by lazy(PUBLICATION) {
+        context?.containingCrate
+    }
+
+    val typeAndGenerics: Triple<Ty, List<TyTypeParameter>, List<CtConstParameter>> by lazy(PUBLICATION) {
+        Triple(alias.declaredType, alias.generics, alias.constGenerics)
+    }
+
+    companion object {
+        fun forAlias(alias: RsTypeAlias): RsCachedTypeAlias {
+            return (alias as RsTypeAliasImplMixin).cachedImplItem.value
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsImplIndex.kt
@@ -47,7 +47,7 @@ class RsImplIndex : AbstractStubIndex<TyFingerprint, RsImplItem>() {
             // Note that `getElements` is intentionally used with intermediate collection instead of
             // `StubIndex.processElements` in order to simplify profiling
             return impls.any {
-                val cachedImpl = RsCachedImplItem.forImpl(project, it)
+                val cachedImpl = RsCachedImplItem.forImpl(it)
                 cachedImpl.isValid && processor(cachedImpl)
             }
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsTypeAliasIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsTypeAliasIndex.kt
@@ -15,10 +15,7 @@ import com.intellij.util.io.KeyDescriptor
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.search.RsWithMacrosProjectScope
 import org.rust.lang.core.psi.RsTypeAlias
-import org.rust.lang.core.psi.ext.RsAbstractableOwner
-import org.rust.lang.core.psi.ext.containingCrate
-import org.rust.lang.core.psi.ext.owner
-import org.rust.lang.core.psi.isValidProjectMember
+import org.rust.lang.core.resolve.RsCachedTypeAlias
 import org.rust.lang.core.resolve.RsProcessor
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsTypeAliasStub
@@ -34,12 +31,13 @@ class RsTypeAliasIndex : AbstractStubIndex<TyFingerprint, RsTypeAlias>() {
         fun findPotentialAliases(
             project: Project,
             tyf: TyFingerprint,
-            processor: RsProcessor<RsTypeAlias>
+            processor: RsProcessor<RsCachedTypeAlias>
         ): Boolean {
             // Note that `getElements` is intentionally used with intermediate collection instead of
             // `StubIndex.processElements` in order to simplify profiling
             val aliases = getElements(KEY, tyf, project, RsWithMacrosProjectScope(project))
-                .filter { it.owner is RsAbstractableOwner.Free && it.isValidProjectMember }
+                .map { RsCachedTypeAlias.forAlias(it) }
+                .filter { it.isFreeAndValid }
 
             // This is basically a hack to make some crates (winapi 0.2) work in a reasonable amount of time.
             // If the number of aliases exceeds the threshold, we prefer ones from stdlib and a workspace over
@@ -48,8 +46,8 @@ class RsTypeAliasIndex : AbstractStubIndex<TyFingerprint, RsTypeAlias>() {
             val filteredAliases = if (aliases.size <= threshold) {
                 aliases
             } else {
-                val stdlibAliases = mutableListOf<RsTypeAlias>()
-                val workspaceAliases = mutableListOf<RsTypeAlias>()
+                val stdlibAliases = mutableListOf<RsCachedTypeAlias>()
+                val workspaceAliases = mutableListOf<RsCachedTypeAlias>()
                 for (alias in aliases) {
                     val packageOrigin = alias.containingCrate?.origin ?: continue
                     when (packageOrigin) {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -274,14 +274,14 @@ class RsInferenceContext(
             val fnName = (variant.element as? RsFunction)?.name
             val impl = lookup.select(resolveTypeVarsIfPossible(traitRef)).ok()?.impl as? RsImplItem ?: continue
             val fn = impl.expandedMembers.functions.find { it.name == fnName } ?: continue
-            val source = TraitImplSource.ExplicitImpl(RsCachedImplItem.forImpl(project, impl))
+            val source = TraitImplSource.ExplicitImpl(RsCachedImplItem.forImpl(impl))
             resolvedPaths[path] = listOf(ResolvedPath.AssocItem(fn, source))
         }
         for ((call, traitRef) in methodRefinements) {
             val variant = resolvedMethods[call]?.firstOrNull() ?: continue
             val impl = lookup.select(resolveTypeVarsIfPossible(traitRef)).ok()?.impl as? RsImplItem ?: continue
             val fn = impl.expandedMembers.functions.find { it.name == variant.name } ?: continue
-            val source = TraitImplSource.ExplicitImpl(RsCachedImplItem.forImpl(project, impl))
+            val source = TraitImplSource.ExplicitImpl(RsCachedImplItem.forImpl(impl))
             resolvedMethods[call] = listOf(variant.copy(element = fn, source = source))
         }
     }


### PR DESCRIPTION
A set of name resolution/type inference optimizations. I measured about 10% highlighting speedup.

1. Get rid of some `getContext()` invocations. `getContext()` is slower than `getParent()`
2. Invoke `mod.super` lazy. 
3. Optimize `RsExpandedElement.getContextImpl`. `getContextImpl` is very hot. Ridding of extra `stubParent` call should slightly speed it up.
4. use `CachedValueImpl` in `RsCachedImplItem`. `CachedValueImpl` seems more lightweight and faster than `RsResolveCache`. Use it in very hot `RsCachedImplItem.forImpl` method.
5. Introduce `RsCachedTypeAlias`. It's used the same way as `RsCachedImplItem`. Such optimization become reasonable after #4936.