### PR TITLE
PRJ: Use project name instead of root dir in IDEA when generating project

### DIFF
--- a/idea/src/main/kotlin/org/rust/ide/idea/RsModuleBuilder.kt
+++ b/idea/src/main/kotlin/org/rust/ide/idea/RsModuleBuilder.kt
@@ -52,11 +52,14 @@ class RsModuleBuilder : ModuleBuilder() {
                 val template = configurationData?.template ?: return
                 val cargo = toolchain.rawCargo()
                 val project = modifiableRootModel.project
+                val name = project.name.replace(' ', '_')
 
                 val generatedFiles = cargo.makeProject(
                     project,
                     modifiableRootModel.module,
-                    root, template
+                    root,
+                    name,
+                    template
                 ) ?: return
 
                 project.makeDefaultRunConfiguration(template)

--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -217,11 +217,11 @@ class Cargo(private val cargoExecutable: Path, private val rustcExecutable: Path
         project: Project,
         owner: Disposable,
         directory: VirtualFile,
+        name: String,
         createBinary: Boolean,
         vcs: String? = null
     ): GeneratedFilesHolder {
         val path = directory.pathAsPath
-        val name = path.fileName.toString().replace(' ', '_')
         val crateType = if (createBinary) "--bin" else "--lib"
 
         val args = mutableListOf(crateType, "--name", name)
@@ -246,11 +246,11 @@ class Cargo(private val cargoExecutable: Path, private val rustcExecutable: Path
         project: Project,
         owner: Disposable,
         directory: VirtualFile,
-        template: String
+        name: String,
+        templateUrl: String
     ): GeneratedFilesHolder? {
         val path = directory.pathAsPath
-        val name = path.fileName.toString().replace(' ', '_')
-        val args = mutableListOf("--name", name, "--git", template)
+        val args = mutableListOf("--name", name, "--git", templateUrl)
         args.add("--force") // enforce cargo-generate not to do underscores to hyphens name conversion
 
         // TODO: Rewrite this for the future versions of cargo-generate when init subcommand will be available
@@ -261,7 +261,7 @@ class Cargo(private val cargoExecutable: Path, private val rustcExecutable: Path
 
         // Move all the generated files to the project root and delete the subdir itself
         val generatedDir = try {
-            File(path.toString(), project.name)
+            File(path.toString(), name)
         } catch (e: NullPointerException) {
             LOG.warn("Failed to generate project using cargo-generate")
             return null

--- a/src/main/kotlin/org/rust/ide/actions/RsCreateCrateAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsCreateCrateAction.kt
@@ -53,7 +53,7 @@ class RsCreateCrateAction : RunCargoCommandActionBase(CargoIcons.ICON) {
         val targetDir = runWriteAction {
             root.createChildDirectory(this, name)
         }
-        cargo.init(project, project, targetDir, binary, "none")
+        cargo.init(project, project, targetDir, name, binary, "none")
 
         val manifest = targetDir.findChild(RustToolchain.CARGO_TOML)
         manifest?.let {

--- a/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
@@ -41,8 +41,9 @@ class RsDirectoryProjectGenerator : DirectoryProjectGeneratorBase<ConfigurationD
         val (settings, template) = data
         val cargo = settings.toolchain?.rawCargo() ?: return
 
+        val name = project.name.replace(' ', '_')
         val generatedFiles = project.computeWithCancelableProgress("Generating Cargo project...") {
-            cargo.makeProject(project, module, baseDir, template)
+            cargo.makeProject(project, module, baseDir, name, template)
         } ?: return
 
         project.makeDefaultRunConfiguration(template)

--- a/src/main/kotlin/org/rust/ide/newProject/Utils.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/Utils.kt
@@ -25,10 +25,11 @@ fun Cargo.makeProject(
     project: Project,
     module: Module,
     baseDir: VirtualFile,
+    name: String,
     template: RsProjectTemplate
 ): GeneratedFilesHolder? = when (template) {
-    is RsGenericTemplate -> init(project, module, baseDir, template.isBinary)
-    is RsCustomTemplate -> generate(project, module, baseDir, template.url)
+    is RsGenericTemplate -> init(project, module, baseDir, name, template.isBinary)
+    is RsCustomTemplate -> generate(project, module, baseDir, name, template.url)
 }
 
 fun Project.openFiles(files: GeneratedFilesHolder) = invokeLater {


### PR DESCRIPTION
Related to #5922

Fixes the first part of the issue. Now cargo package name for a new project will be actually the project name and not the root dir.

Also, fixes the problem of generating projects with custom templates when the project name and the root dir are different.