### PR TITLE
CI: initial regression testing

### DIFF
--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -1,0 +1,101 @@
+name: regressions
+
+on: workflow_dispatch
+
+jobs:
+    calculate-base-commit:
+        runs-on: ubuntu-latest
+        outputs:
+            base-commit: ${{ steps.base-commit.outputs.base-commit }}
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
+            - name: Calculate base commit
+              id: base-commit
+              run: echo "::set-output name=base-commit::$(git merge-base origin/master ${{ github.sha }})"
+
+            - name: Show commits
+              run: |
+                  echo "current commit:"
+                  git log ${{ github.sha }} -n 1 --pretty=short
+                  echo "base commit:"
+                  git log ${{ steps.base-commit.outputs.base-commit }} -n 1 --pretty=short
+
+    check:
+        needs: [ calculate-base-commit ]
+        name: ${{ matrix.project.name }}
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                project:
+                    - name: cargo
+                      path: cargo
+                      repository: rust-lang/cargo
+                      exclude_paths: ""
+        env:
+            PROJECT_PATH: ${{ matrix.project.path }}
+            PROJECT_URL: https://github.com/${{ matrix.project.url }}
+            PROJECT_EXCLUDE_PATHS: ${{ matrix.project.exclude_paths }}
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
+            - uses: actions/checkout@v2
+              with:
+                  repository: ${{ matrix.project.repository }}
+                  ref: master
+                  path: testData/${{ matrix.project.name }}
+
+            - name: Set up JDK 1.8
+              uses: actions/setup-java@v1
+              with:
+                  java-version: 1.8
+
+            - name: Set up Python
+              uses: actions/setup-python@v1
+              with:
+                  python-version: 3.7
+
+            - name: Set up Rust
+              uses: actions-rs/toolchain@v1
+              with:
+                  profile: minimal
+                  toolchain: stable
+                  components: rust-src
+                  default: true
+
+            - name: Download
+              uses: eskatos/gradle-command-action@v1
+              with:
+                  arguments: ":resolveDependencies -Pkotlin.incremental=false"
+
+            - name: Check with changes
+              uses: eskatos/gradle-command-action@v1
+              env:
+                  PROJECT_NAME: ${{ matrix.project.name }}_with_changes
+              with:
+                  arguments: "clean :test --tests \"org.rustPerformanceTests.CustomRealProjectAnalysisTest.test\""
+
+            - name: Checkout base version
+              run: git checkout ${{ needs.calculate-base-commit.outputs.base-commit }}
+
+            - name: Check without changes
+              uses: eskatos/gradle-command-action@v1
+              env:
+                  PROJECT_NAME: ${{ matrix.project.name }}_without_changes
+              with:
+                  arguments: "clean :test --tests \"org.rustPerformanceTests.CustomRealProjectAnalysisTest.test\""
+
+            - name: Calculate regressions
+              run: python scripts/calculate_regressions.py --name ${{ matrix.project.name }}
+
+            - name: Upload results
+              if: ${{ always() }}
+              uses: actions/upload-artifact@v2
+              with:
+                  name: ${{ matrix.project.name }}
+                  path: regressions/

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -39,6 +39,7 @@ jobs:
             PROJECT_PATH: ${{ matrix.project.path }}
             PROJECT_URL: https://github.com/${{ matrix.project.url }}
             PROJECT_EXCLUDE_PATHS: ${{ matrix.project.exclude_paths }}
+            ORG_GRADLE_PROJECT_showStandardStreams: true
         steps:
             - uses: actions/checkout@v2
               with:

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -1,6 +1,6 @@
 name: regressions
 
-on: workflow_dispatch
+on: [ workflow_dispatch, pull_request ]
 
 jobs:
     calculate-base-commit:
@@ -12,9 +12,23 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Calculate base commit
+            # In case of `workflow_dispatch` event, `github.sha` points to latest commit of chosen branch
+            # So, we need to find the latest common commit for master branch and chosen one
+            # to calculate difference only for branch changes
+            - name: Calculate base commit for workflow_dispatch event
+              if: github.event_name == 'workflow_dispatch'
+              run: echo "::set-env name=BASE_COMMIT::$(git merge-base origin/master ${{ github.sha }})"
+
+            # For pull request event, GitHub produces additional merge commit with `master` branch and PR branch as parents
+            # In this case, we want to check difference between master branch and merge commit
+            # so emit hash of `origin/master` branch itself as base commit
+            - name: Calculate base commit for pull_request event
+              if: github.event_name == 'pull_request'
+              run: echo "::set-env name=BASE_COMMIT::$(git log origin/master -n 1 --format=format:%H)"
+
+            - name: Emit base commit
               id: base-commit
-              run: echo "::set-output name=base-commit::$(git merge-base origin/master ${{ github.sha }})"
+              run: echo "::set-output name=base-commit::$BASE_COMMIT"
 
             - name: Show commits
               run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,6 +99,10 @@ allprojects {
             val isRootProject = project.name in listOf("plugin", "intellij-toml")
             enabled = isRootProject && prop("enableBuildSearchableOptions").toBoolean()
         }
+
+        test {
+            testLogging.showStandardStreams = prop("showStandardStreams").toBoolean()
+        }
     }
 
     configure<JavaPluginConvention> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,7 @@ publishChannel=dev
 githubToken=token
 
 showTestStatus=false
+showStandardStreams=false
 enableBuildSearchableOptions=false
 
 org.gradle.jvmargs=-Xmx2g

--- a/scripts/calculate_regressions.py
+++ b/scripts/calculate_regressions.py
@@ -1,0 +1,71 @@
+import argparse
+import dataclasses
+import json
+from dataclasses import dataclass
+from typing import List, Iterable, Optional, Dict
+
+
+@dataclass(frozen=True)
+class Annotation(object):
+    filePath: str
+    line: int
+    column: int
+    highlightedText: str
+    error: str
+    inspectionToolId: Optional[str]
+
+    def __str__(self) -> str:
+        if self.inspectionToolId is not None:
+            suffix = f" by {self.inspectionToolId}"
+        else:
+            suffix = ""
+        return f"{self.filePath}:{self.line}:{self.column} '{self.highlightedText}' ({self.error}){suffix}"
+
+    @staticmethod
+    def from_dict(raw_dict: Dict) -> "Annotation":
+        return Annotation(raw_dict["filePath"],
+                          raw_dict["line"],
+                          raw_dict["column"],
+                          raw_dict["highlightedText"],
+                          raw_dict["error"],
+                          raw_dict.get("inspectionToolId"))
+
+
+def read_data(path: str) -> List[Annotation]:
+    with open(path) as json_file:
+        data = json.load(json_file)
+    return [Annotation.from_dict(value) for value in data]
+
+
+def dump_as_json(annotations: Iterable[Annotation], path: str) -> None:
+    json_array = [dataclasses.asdict(a) for a in annotations]
+    with open(path, mode="w") as file:
+        json.dump(json_array, file, indent=4)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--name", type=str, help="github token")
+
+    args = parser.parse_args()
+
+    # Should be synchronized with `org.rustPerformanceTests.CustomRealProjectAnalysisTest`
+    without_changes = set(read_data(f"regressions/{args.name}_without_changes.json"))
+    with_changes = set(read_data(f"regressions/{args.name}_with_changes.json"))
+
+    fixed = without_changes - with_changes
+    new = with_changes - without_changes
+
+    dump_as_json(fixed, f"regressions/{args.name}_fixed.json")
+    dump_as_json(new, f"regressions/{args.name}_new.json")
+
+    print(f"{len(fixed)} annotations fixed")
+    for ann in fixed:
+        print(ann)
+    print()
+    print(f"{len(new)} annotations introduced")
+    for ann in new:
+        print(ann)
+
+    if len(new) > 0:
+        raise Exception("New regressions detected")

--- a/src/test/kotlin/org/rustPerformanceTests/CustomRealProjectAnalysisTest.kt
+++ b/src/test/kotlin/org/rustPerformanceTests/CustomRealProjectAnalysisTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rustPerformanceTests
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import java.io.File
+
+/**
+ * Provides ability to check plugin analysis on custom real project.
+ * It's supposed to be used by CI
+ */
+class CustomRealProjectAnalysisTest : RsRealProjectAnalysisTest() {
+
+    fun test() {
+        val name = System.getenv(PROJECT_NAME) ?: error("$PROJECT_NAME variable is not specified")
+        val path = System.getenv(PROJECT_PATH) ?: name
+        val url = System.getenv(PROJECT_URL).orEmpty()
+        val exclude = System.getenv(PROJECT_EXCLUDE_PATHS)?.takeIf { it.isNotEmpty() }?.split(",").orEmpty()
+        val info = RealProjectInfo(name, path, url, exclude)
+
+        val consumer = JsonConsumer(info)
+        doTest(info, consumer)
+    }
+
+    companion object {
+        const val PROJECT_NAME = "PROJECT_NAME"
+        const val PROJECT_PATH = "PROJECT_PATH"
+        const val PROJECT_URL = "PROJECT_URL"
+        const val PROJECT_EXCLUDE_PATHS = "PROJECT_EXCLUDE_PATHS"
+    }
+
+    private class JsonConsumer(private val info: RealProjectInfo): AnnotationConsumer {
+
+        private val annotations = mutableListOf<Annotation>()
+
+        override fun consumeAnnotation(annotation: Annotation) {
+            annotations += annotation
+        }
+
+        override fun finish() {
+            val testDir = File("regressions")
+            testDir.mkdirs()
+            JsonMapper().writerWithDefaultPrettyPrinter()
+                .writeValue(File(testDir, "${info.name}.json"), annotations)
+        }
+    }
+}

--- a/src/test/kotlin/org/rustPerformanceTests/CustomRealProjectAnalysisTest.kt
+++ b/src/test/kotlin/org/rustPerformanceTests/CustomRealProjectAnalysisTest.kt
@@ -40,6 +40,7 @@ class CustomRealProjectAnalysisTest : RsRealProjectAnalysisTest() {
             annotations += annotation
         }
 
+        // Should be synchronized with `scripts/calculate_regressions.py`
         override fun finish() {
             val testDir = File("regressions")
             testDir.mkdirs()

--- a/src/test/kotlin/org/rustPerformanceTests/RsRealProjectAnalysisTest.kt
+++ b/src/test/kotlin/org/rustPerformanceTests/RsRealProjectAnalysisTest.kt
@@ -7,8 +7,8 @@ package org.rustPerformanceTests
 
 import com.intellij.codeInspection.ex.InspectionToolRegistrar
 import com.intellij.ide.annotator.AnnotatorBase
+import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.util.Disposer
-import org.junit.ComparisonFailure
 import org.rust.ide.annotator.RsErrorAnnotator
 import org.rust.ide.inspections.RsLocalInspectionTool
 import org.rust.lang.RsFileType
@@ -16,9 +16,8 @@ import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.macros.macroExpansionManager
 import org.rust.lang.core.psi.RsFile
 import org.rust.openapiext.toPsiFile
-import java.lang.reflect.Field
 
-class RsRealProjectAnalysisTest : RsRealProjectTestBase() {
+open class RsRealProjectAnalysisTest : RsRealProjectTestBase() {
 
     /** Don't run it on Rustc! It's a kind of stress-test */
     fun `test analyze rustc`() = doTest(RUSTC)
@@ -35,7 +34,12 @@ class RsRealProjectAnalysisTest : RsRealProjectTestBase() {
 
     private val earlyTestRootDisposable = Disposer.newDisposable()
 
-    private fun doTest(info: RealProjectInfo, failOnFirstFileWithErrors: Boolean = false) {
+    protected fun doTest(info: RealProjectInfo, failOnFirstFileWithErrors: Boolean = false) {
+        val errorConsumer = if (failOnFirstFileWithErrors) FAIL_FAST else COLLECT_ALL_EXCEPTIONS
+        doTest(info, errorConsumer)
+    }
+
+    protected fun doTest(info: RealProjectInfo, consumer: AnnotationConsumer) {
         Disposer.register(
             earlyTestRootDisposable,
             project.macroExpansionManager.setUnitTestExpansionModeAndDirectory(MacroExpansionScope.ALL, name)
@@ -46,7 +50,7 @@ class RsRealProjectAnalysisTest : RsRealProjectTestBase() {
             .filterIsInstance<RsLocalInspectionTool>()
         myFixture.enableInspections(*inspections.toTypedArray())
 
-        println("Opening the project")
+        println("Opening the project `${info.name}`")
         val base = openRealProject(info) ?: return
 
         println("Collecting files to analyze")
@@ -56,56 +60,74 @@ class RsRealProjectAnalysisTest : RsRealProjectTestBase() {
                 file is RsFile && file.crateRoot != null && file.cargoWorkspace != null
             }
         }
-
-        if (failOnFirstFileWithErrors) {
-            println("Analyzing...")
-            myFixture.testHighlightingAllFiles(
-                /* checkWarnings = */ false,
-                /* checkInfos = */ false,
-                /* checkWeakWarnings = */ false,
-                *filesToCheck.toTypedArray()
-            )
-        } else {
-            val exceptions = filesToCheck.mapNotNull { file ->
-                val path = file.path.substring(base.path.length + 1)
-                println("Analyzing $path")
-                try {
-                    myFixture.testHighlighting(
-                        /* checkWarnings = */ false,
-                        /* checkInfos = */ false,
-                        /* checkWeakWarnings = */ false,
-                        file
-                    )
-                    null
-                } catch (e: ComparisonFailure) {
-                    e to path
-                }
-            }
-
-            if (exceptions.isNotEmpty()) {
-                error("Error annotations found:\n\n" + exceptions.joinToString("\n\n") { (e, path) ->
-                    "$path:\n${e.detailMessage}"
-                })
+        for (file in filesToCheck) {
+            val path = file.path.substring(base.path.length + 1)
+            println("Analyzing $path")
+            myFixture.openFileInEditor(file)
+            val infos = myFixture.doHighlighting(HighlightSeverity.ERROR)
+            val text = myFixture.editor.document.text
+            for (highlightInfo in infos) {
+                val position = myFixture.editor.offsetToLogicalPosition(highlightInfo.startOffset)
+                val annotation = Annotation(
+                    path,
+                    position.line,
+                    position.column,
+                    text.substring(highlightInfo.startOffset, highlightInfo.endOffset),
+                    highlightInfo.description,
+                    highlightInfo.inspectionToolId
+                )
+                consumer.consumeAnnotation(annotation)
             }
         }
+        consumer.finish()
     }
 
     override fun tearDown() {
         Disposer.dispose(earlyTestRootDisposable)
         super.tearDown()
     }
-}
 
-private val THROWABLE_DETAILED_MESSAGE_FIELD: Field = run {
-    val field = Throwable::class.java.getDeclaredField("detailMessage")
-    field.isAccessible = true
-    field
-}
+    companion object {
 
-/**
- * Retrieves original value of detailMessage field of [Throwable] class.
- * It is needed because [ComparisonFailure] overrides [Throwable.message]
- * method so we can't get the original value without reflection
- */
-private val Throwable.detailMessage: CharSequence
-    get() = THROWABLE_DETAILED_MESSAGE_FIELD.get(this) as CharSequence
+        val FAIL_FAST = object : AnnotationConsumer {
+            override fun consumeAnnotation(annotation: Annotation) {
+                error(annotation.toString())
+            }
+            override fun finish() {}
+        }
+
+        val COLLECT_ALL_EXCEPTIONS = object : AnnotationConsumer {
+
+            val annotations = mutableListOf<Annotation>()
+
+            override fun consumeAnnotation(annotation: Annotation) {
+                annotations += annotation
+            }
+
+            override fun finish() {
+                if (annotations.isNotEmpty()) {
+                    error("Error annotations found:\n\n" + annotations.joinToString("\n\n"))
+                }
+            }
+        }
+    }
+
+    interface AnnotationConsumer {
+        fun consumeAnnotation(annotation: Annotation)
+        fun finish()
+    }
+
+    data class Annotation(
+        val filePath: String,
+        val line: Int,
+        val column: Int,
+        val highlightedText: String,
+        val error: String,
+        val inspectionToolId: String?
+    ) {
+        override fun toString(): String {
+            val suffix = if (inspectionToolId != null) " by $inspectionToolId" else ""
+            return "$filePath:$line:$column '$highlightedText' ($error)$suffix"
+        }
+    }
+}


### PR DESCRIPTION
Currently, each developer can launch `org.rustPerformanceTests.RsRealProjectAnalysisTest` to analyze if they introduce some new false-positive errors. It works somehow but has a lot of cons:
- a developer may forget to launch regression tests
- these tests should be launched locally that consumes CPU and a lot of time
- there no way to get diff between the previous set of errors and the current one. It's important since the plugin produces some false positives (unfortunately) and you have to compare previous results with new ones manually

This PR introduces new `regressions` GitHub workflow that should automate the launch of regression tests and help us to identify regressions earlier. This implementation includes:
- new `CustomRealProjectAnalysisTest`. It can be configured via set of environment variables to run the plugin analysis on custom rust project. To implement it I've made some refactoring in `RsRealProjectAnalysisTest`
- `regressions` workflow itself. It's triggered automatically in each PR in the repository (not sure that it's ok but let's try). Also, you can trigger it with desired branch manually via GitHub UI. What workflow does:
    * checkout all real rust projects specified in the workflow. Currently, the workflow contains only one project - Cargo. The list will be extended in future
    * launches `org.rustPerformanceTests.RsRealProjectAnalysisTest` twice for each real project: with and without changes of the corresponding branch/PR. All produced error annotations are stored into json format
    * calculate diff between two sets of changes to determine what errors were fixed and what were introduced. If there is at least one new error annotation, workflow task fails.
    * all results saved as an artifact of the workflow (artifact per real project)

Further possible improvements:
* extend list of real projects
* better error handling. Currently, our analysis may fail on some projects and produce an exception. Currently, it fails the corresponding test. We should collect such errors as well.
* support not only error annotations to have an ability to check regressions for any inspection/annotator
* reduce total time of execution. Currently, the workflow compiles plugin project for each real project twice. Probably, we can move out project compilation, save the result and use it for each real project


How to test (possible variant):
* push these changes to main branch of your fork of this repo
* create a new branch and make some changes that lead to new error. For example, you can apply this [patch](https://github.com/intellij-rust/intellij-rust/files/5075343/regression.patch.zip)
* push created branch and run `regressions` workflow for it (manually or via PR creation). It should fail and you can check the corresponding results in artifacts

