### PR TITLE
Introduce line marker for wasm_bindgen attributes in WebAssembly projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,7 @@ The current Rust plugin modules:
 * `:duplicates` - support `Duplicated code fragment` inspection
 * `:coverage` - integration with [coverage](https://github.com/JetBrains/intellij-community/tree/master/plugins/coverage-common) plugin
 * `:grazie` - integration with [grazie](https://plugins.jetbrains.com/plugin/12175-grazie) plugin 
+* `:js` - interop with JavaScript language
 
 If you want to implement integration with another plugin/IDE, you should create a new gradle module for that.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,7 +182,8 @@ project(":plugin") {
             project(":intellij-toml"),
             "IntelliLang",
             graziePlugin,
-            psiViewerPlugin
+            psiViewerPlugin,
+            "JavaScriptLanguage"
         )
         if (baseIDE == "idea") {
             plugins += listOf(
@@ -205,6 +206,7 @@ project(":plugin") {
         implementation(project(":intelliLang"))
         implementation(project(":duplicates"))
         implementation(project(":grazie"))
+        implementation(project(":js"))
     }
 
     tasks {
@@ -403,6 +405,18 @@ project(":coverage") {
 project(":grazie") {
     intellij {
         setPlugins(graziePlugin)
+    }
+    dependencies {
+        implementation(project(":"))
+        implementation(project(":common"))
+        testImplementation(project(":", "testOutput"))
+        testImplementation(project(":common", "testOutput"))
+    }
+}
+
+project(":js") {
+    intellij {
+        setPlugins("JavaScriptLanguage")
     }
     dependencies {
         implementation(project(":"))

--- a/js/src/main/kotlin/org/rust/js/RsWasmBindgenLineMarkerProvider.kt
+++ b/js/src/main/kotlin/org/rust/js/RsWasmBindgenLineMarkerProvider.kt
@@ -1,0 +1,103 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.js
+
+import com.intellij.codeInsight.daemon.DefaultGutterIconNavigationHandler
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
+import com.intellij.lang.javascript.psi.JSElement
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptClass
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptEnum
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptFunction
+import com.intellij.navigation.GotoRelatedItem
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.util.findDescendantOfType
+import icons.JavaScriptPsiIcons
+import org.rust.lang.core.psi.RsEnumItem
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsImplItem
+import org.rust.lang.core.psi.RsStructItem
+import org.rust.lang.core.psi.ext.RsOuterAttributeOwner
+import org.rust.lang.core.psi.ext.RsVisibilityOwner
+import org.rust.lang.core.psi.ext.containingCargoPackage
+import org.rust.lang.core.psi.ext.findOuterAttr
+import org.rust.lang.core.psi.impl.RsBaseTypeImpl
+import java.nio.file.InvalidPathException
+import java.nio.file.Paths
+
+@Suppress("NAME_SHADOWING")
+class RsWasmBindgenLineMarkerProvider : RelatedItemLineMarkerProvider() {
+    override fun getLineMarkerInfo(element: PsiElement): RelatedItemLineMarkerInfo<*>? {
+        val element = element as? RsOuterAttributeOwner ?: return null
+        if (element !is RsFunction && element !is RsEnumItem && element !is RsStructItem && element !is RsImplItem) {
+            return null
+        }
+
+        // Check the package has wasm-bindgen as dependency
+        val cargoPackage = element.containingCargoPackage ?: return null
+        if (cargoPackage.dependencies.none { it.pkg.name == "wasm-bindgen" }) {
+            return null
+        }
+
+        // Only public elements are exposed in bindings
+        if (element is RsVisibilityOwner && element !is RsImplItem && !element.isPublic) {
+            return null
+        }
+
+        val attr = element.findOuterAttr("wasm_bindgen") ?: return null
+
+        val basePath = cargoPackage.contentRoot?.path ?: return null
+        val expectedName = cargoPackage.normName
+
+        // Expecting to find related generated typescript declarations in pkg/ folder of current package
+        val expectedPath = try {
+            Paths.get(basePath, "pkg/$expectedName.d.ts").toString()
+        } catch (e: InvalidPathException) {
+            LOG.error(e)
+            return null
+        }
+        val tsFile = LocalFileSystem.getInstance().findFileByPath(expectedPath) ?: return null
+        val tsPsiFile = PsiManager.getInstance(element.project).findFile(tsFile) ?: return null
+
+        // Trying to find the correlating element with the same name
+        val destination = when (element) {
+            // If it is impl, then resolving to the related struct and using its name
+            is RsImplItem -> {
+                val reference = (element.typeReference as? RsBaseTypeImpl) ?: return null
+                val struct = (reference.path?.reference?.resolve() as? RsStructItem) ?: return null
+                findRelatedTsElement(struct, tsPsiFile)
+            }
+            else -> findRelatedTsElement(element, tsPsiFile)
+        } ?: return null
+
+        return RelatedItemLineMarkerInfo(
+            attr,
+            attr.textRange,
+            JavaScriptPsiIcons.FileTypes.TypeScriptFile,
+            { "Go to generated declaration" },
+            DefaultGutterIconNavigationHandler(listOf(destination), "Generated declarations"),
+            GutterIconRenderer.Alignment.RIGHT,
+            { listOf(GotoRelatedItem(destination)) }
+        )
+    }
+
+    private fun findRelatedTsElement(element: RsOuterAttributeOwner, tsPsiFile: PsiFile): JSElement? =
+        when (element) {
+            is RsFunction -> tsPsiFile.findDescendantOfType<TypeScriptFunction> { it.name == element.name }
+            is RsEnumItem -> tsPsiFile.findDescendantOfType<TypeScriptEnum> { it.name == element.name }
+            is RsStructItem -> tsPsiFile.findDescendantOfType<TypeScriptClass> { it.name == element.name }
+            else -> null
+        }
+
+    companion object {
+        private val LOG: Logger = Logger.getInstance(RsWasmBindgenLineMarkerProvider::class.java)
+    }
+}

--- a/js/src/main/resources/META-INF/js-only.xml
+++ b/js/src/main/resources/META-INF/js-only.xml
@@ -1,0 +1,4 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+    </extensions>
+</idea-plugin>

--- a/js/src/main/resources/META-INF/js-only.xml
+++ b/js/src/main/resources/META-INF/js-only.xml
@@ -1,4 +1,5 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
+        <codeInsight.lineMarkerProvider language="Rust" implementationClass="org.rust.js.RsWasmBindgenLineMarkerProvider"/>
     </extensions>
 </idea-plugin>

--- a/js/src/test/resources/META-INF/plugin.xml
+++ b/js/src/test/resources/META-INF/plugin.xml
@@ -1,0 +1,5 @@
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude" allow-bundled-update="true">
+    <id>org.rust.js</id>
+    <xi:include href="/META-INF/rust-core.xml" xpointer="xpointer(/idea-plugin/*)"/>
+    <depends optional="true" config-file="js-only.xml">JavaScript</depends>
+</idea-plugin>

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -27,6 +27,7 @@
     <depends optional="true" config-file="duplicates-only.xml">com.intellij.modules.duplicatesDetector</depends>
     <depends optional="true" config-file="coverage-only.xml">com.intellij.modules.coverage</depends>
     <depends optional="true" config-file="grazie-only.xml">tanvd.grazi</depends>
+    <depends optional="true" config-file="js-only.xml">JavaScript</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- although Rust module type is only created by IDEA, we need it in other IDEs as well

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,5 +12,6 @@ include(
     "intelliLang",
     "duplicates",
     "grazie",
+    "js",
     "intellij-toml"
 )


### PR DESCRIPTION
Expected workflow: navigating from Rust statement to JS one. Then having the ability to navigate to JS parts related to it.

### Current implementation
<img width="1060" src="https://user-images.githubusercontent.com/6342851/90410167-b1340b80-e0b2-11ea-9144-de4703509744.png">

### How it works
<img width="600" src="https://user-images.githubusercontent.com/6342851/90269585-856e1700-de61-11ea-9ffd-ac4067e2a80a.gif">

Related to #3066