### PR TITLE
INSP: select a better location for attaching file to modules

### DIFF
--- a/src/test/kotlin/org/rust/ide/inspections/RsDetachedFileInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDetachedFileInspectionTest.kt
@@ -187,6 +187,106 @@ class RsDetachedFileInspectionTest : RsInspectionsTestBase(RsDetachedFileInspect
         //- a/b/mod.rs
     """)
 
+    fun `test attach file find existing mod item`() = checkFixByFileTree("Attach file to lib.rs", """
+        //- lib.rs
+            mod a;
+        //- foo.rs
+        <warning descr="File is not included in module tree, analysis is not available"></warning>/*caret*/
+    """, """
+        //- lib.rs
+            mod a;
+            mod foo;
+        //- foo.rs
+    """)
+
+    fun `test attach file multiple mod items`() = checkFixByFileTree("Attach file to lib.rs", """
+        //- lib.rs
+            mod a;
+            mod b;
+        //- foo.rs
+        <warning descr="File is not included in module tree, analysis is not available"></warning>/*caret*/
+    """, """
+        //- lib.rs
+            mod a;
+            mod b;
+            mod foo;
+        //- foo.rs
+    """)
+
+    fun `test attach file find last existing mod item`() = checkFixByFileTree("Attach file to lib.rs", """
+        //- lib.rs
+            fn test1() {}
+
+            mod a;
+            mod b;
+
+            mod c;
+
+            fn test2() {}
+        //- foo.rs
+        <warning descr="File is not included in module tree, analysis is not available"></warning>/*caret*/
+    """, """
+        //- lib.rs
+            fn test1() {}
+
+            mod a;
+            mod b;
+
+            mod c;
+            mod foo;
+
+            fn test2() {}
+        //- foo.rs
+    """)
+
+    fun `test attach file skip attributes`() = checkFixByFileTree("Attach file to lib.rs", """
+        //- lib.rs
+            #![allow(dead_code)]
+            #![feature(async_closure)]
+        //- foo.rs
+        <warning descr="File is not included in module tree, analysis is not available"></warning>/*caret*/
+    """, """
+        //- lib.rs
+            #![allow(dead_code)]
+            #![feature(async_closure)]
+
+            mod foo;
+        //- foo.rs
+    """)
+
+    fun `test attach file skip attributes with comments`() = checkFixByFileTree("Attach file to lib.rs", """
+        //- lib.rs
+            //! foo
+            //! bar
+            #![allow(dead_code)]
+            #![feature(async_closure)]
+        //- foo.rs
+        <warning descr="File is not included in module tree, analysis is not available"></warning>/*caret*/
+    """, """
+        //- lib.rs
+            //! foo
+            //! bar
+            #![allow(dead_code)]
+            #![feature(async_closure)]
+
+            mod foo;
+        //- foo.rs
+    """)
+
+    fun `test attach file skip comments`() = checkFixByFileTree("Attach file to lib.rs", """
+        //- lib.rs
+            //! foo
+            //! bar
+        //- foo.rs
+        <warning descr="File is not included in module tree, analysis is not available"></warning>/*caret*/
+    """, """
+        //- lib.rs
+            //! foo
+            //! bar
+            mod foo;
+        //- foo.rs
+    """)
+
     private fun checkFixWithMultipleModules(
         @Language("Rust") before: String,
         @Language("Rust") after: String,


### PR DESCRIPTION
This PR adds a simple heuristic to `AttachFileToModuleFix` that tries to find a good place where to insert the `mod` item. If it finds an existing mod items in the file, it will append the new item after the last one. Otherwise, it will skip comments and attributes at the beginning of the module.

If there was a mod item before an attribute in the target module, it could still fail to compile after the fix, but in such case it would also fail to compile before the fix, so I think that is an edge case that we don't have to deal with.

I copied the `firstItem` implementation and changed it slightly so that it also works for empty modules. I can also check if the module is empty and do not use `firstItem` in such case.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5903
Fixes: https://github.com/intellij-rust/intellij-rust/issues/5934