### PR TITLE
RUN: Add build task for wasm-pack configurations

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildTaskProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildTaskProvider.kt
@@ -3,32 +3,17 @@
  * found in the LICENSE file.
  */
 
-// BACKCOMPAT: 2019.2
-@file:Suppress("DEPRECATION")
-
 package org.rust.cargo.runconfig.buildtool
 
-import com.intellij.execution.BeforeRunTask
-import com.intellij.execution.BeforeRunTaskProvider
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.util.Key
-import com.intellij.task.ProjectTaskManager
-import com.intellij.task.ProjectTaskNotification
-import com.intellij.task.ProjectTaskResult
-import org.rust.cargo.runconfig.buildtool.CargoBuildManager.createBuildEnvironment
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.getBuildConfiguration
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
-import java.util.concurrent.CompletableFuture
-import javax.swing.Icon
 
-class CargoBuildTaskProvider : BeforeRunTaskProvider<CargoBuildTaskProvider.BuildTask>() {
+class CargoBuildTaskProvider : RsBuildTaskProvider<CargoBuildTaskProvider.BuildTask>() {
     override fun getId(): Key<BuildTask> = ID
-    override fun getName(): String = "Build"
-    override fun getIcon(): Icon = AllIcons.Actions.Compile
-    override fun isSingleton(): Boolean = true
 
     override fun createTask(runConfiguration: RunConfiguration): BuildTask? =
         if (runConfiguration is CargoCommandConfiguration) BuildTask() else null
@@ -40,27 +25,11 @@ class CargoBuildTaskProvider : BeforeRunTaskProvider<CargoBuildTaskProvider.Buil
         task: BuildTask
     ): Boolean {
         if (configuration !is CargoCommandConfiguration) return false
-
         val buildConfiguration = getBuildConfiguration(configuration) ?: return true
-        val buildEnvironment = createBuildEnvironment(buildConfiguration)
-            ?.also { environment.copyUserDataTo(it) }
-            ?: return false
-        val buildableElement = CargoBuildConfiguration(buildConfiguration, buildEnvironment)
-
-        val result = CompletableFuture<Boolean>()
-        ProjectTaskManager.getInstance(configuration.project).build(arrayOf(buildableElement), object: ProjectTaskNotification {
-            override fun finished(executionResult: ProjectTaskResult) {
-                result.complete(executionResult.errors == 0 && !executionResult.isAborted)
-            }
-        })
-        return result.get()
+        return doExecuteTask(buildConfiguration, environment)
     }
 
-    class BuildTask : BeforeRunTask<BuildTask>(ID) {
-        init {
-            isEnabled = true
-        }
-    }
+    class BuildTask : RsBuildTaskProvider.BuildTask<BuildTask>(ID)
 
     companion object {
         @JvmField

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/RsBuildTaskProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/RsBuildTaskProvider.kt
@@ -1,0 +1,42 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.buildtool
+
+import com.intellij.execution.BeforeRunTask
+import com.intellij.execution.BeforeRunTaskProvider
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.util.Key
+import com.intellij.task.ProjectTaskManager
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.createBuildEnvironment
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import java.util.concurrent.CompletableFuture
+import javax.swing.Icon
+
+abstract class RsBuildTaskProvider<T : RsBuildTaskProvider.BuildTask<T>> : BeforeRunTaskProvider<T>() {
+    override fun getName(): String = "Build"
+    override fun getIcon(): Icon = AllIcons.Actions.Compile
+    override fun isSingleton(): Boolean = true
+
+    protected fun doExecuteTask(buildConfiguration: CargoCommandConfiguration, environment: ExecutionEnvironment): Boolean {
+        val buildEnvironment = createBuildEnvironment(buildConfiguration)
+            ?.also { environment.copyUserDataTo(it) }
+            ?: return false
+        val buildableElement = CargoBuildConfiguration(buildConfiguration, buildEnvironment)
+
+        val result = CompletableFuture<Boolean>()
+        ProjectTaskManager.getInstance(environment.project).build(buildableElement).onProcessed {
+            result.complete(!it.hasErrors() && !it.isAborted)
+        }
+        return result.get()
+    }
+
+    abstract class BuildTask<T : BuildTask<T>>(providerId: Key<T>) : BeforeRunTask<T>(providerId) {
+        init {
+            isEnabled = true
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackBuildTaskProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackBuildTaskProvider.kt
@@ -1,0 +1,75 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.wasmpack
+
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.util.Key
+import com.intellij.util.execution.ParametersListUtil
+import org.rust.cargo.runconfig.buildtool.RsBuildTaskProvider
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.runconfig.command.CargoCommandConfigurationType
+import org.rust.cargo.util.splitOnDoubleDash
+import org.rust.openapiext.project
+import org.rust.stdext.buildList
+
+class WasmPackBuildTaskProvider : RsBuildTaskProvider<WasmPackBuildTaskProvider.BuildTask>() {
+    override fun getId(): Key<BuildTask> = ID
+
+    override fun createTask(runConfiguration: RunConfiguration): BuildTask? =
+        if (runConfiguration is WasmPackCommandConfiguration) BuildTask() else null
+
+    override fun executeTask(
+        context: DataContext,
+        configuration: RunConfiguration,
+        environment: ExecutionEnvironment,
+        task: BuildTask
+    ): Boolean {
+        if (configuration !is WasmPackCommandConfiguration) return false
+
+        val project = context.project ?: return false
+        val configurationArgs = ParametersListUtil.parse(configuration.command)
+        val (preArgs, postArgs) = splitOnDoubleDash(configurationArgs)
+        val configurationCommand = configurationArgs.firstOrNull() ?: return false
+
+        val parameters = buildList<String> {
+            add("build")
+            addAll(postArgs)
+
+            if (configurationCommand == "test") {
+                add("--tests")
+            }
+
+            if ("--dev" !in preArgs) {
+                add("--release")
+            }
+
+            if ("--target" !in postArgs) {
+                add("--target")
+                add(WASM_TARGET)
+            }
+        }
+        val buildCommand = ParametersListUtil.join(parameters)
+
+        val buildConfiguration = CargoCommandConfiguration(
+            project, configuration.name, CargoCommandConfigurationType.getInstance().factory
+        ).apply {
+            command = buildCommand
+            workingDirectory = configuration.workingDirectory
+        }
+
+        return doExecuteTask(buildConfiguration, environment)
+    }
+
+    class BuildTask : RsBuildTaskProvider.BuildTask<BuildTask>(ID)
+
+    companion object {
+        val ID: Key<BuildTask> = Key.create("WASM_PACK.BUILD_TASK_PROVIDER")
+
+        private const val WASM_TARGET: String = "wasm32-unknown-unknown"
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackCommandConfiguration.kt
@@ -5,6 +5,7 @@
 
 package org.rust.cargo.runconfig.wasmpack
 
+import com.intellij.execution.BeforeRunTask
 import com.intellij.execution.Executor
 import com.intellij.execution.configurations.*
 import com.intellij.execution.runners.ExecutionEnvironment
@@ -55,8 +56,15 @@ class WasmPackCommandConfiguration(
         element.readPath("workingDirectory")?.let { workingDirectory = it }
     }
 
-    override fun suggestedName(): String? {
-        return command.substringBefore(' ').capitalize()
+    override fun suggestedName(): String = command.substringBefore(' ').capitalize()
+
+    override fun getBeforeRunTasks(): List<BeforeRunTask<*>> {
+        val tasks = super.getBeforeRunTasks()
+        return if (tasks.none { it is WasmPackBuildTaskProvider.BuildTask }) {
+            tasks + WasmPackBuildTaskProvider.BuildTask()
+        } else {
+            tasks
+        }
     }
 
     fun setFromCmd(cmd: WasmPackCommandLine) {

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -833,6 +833,7 @@
              producer instead of registering it here. -->
 
         <stepsBeforeRunProvider implementation="org.rust.cargo.runconfig.buildtool.CargoBuildTaskProvider"/>
+        <stepsBeforeRunProvider implementation="org.rust.cargo.runconfig.wasmpack.WasmPackBuildTaskProvider"/>
 
         <projectTaskRunner implementation="org.rust.cargo.runconfig.buildtool.CargoBuildTaskRunner"/>
 


### PR DESCRIPTION
Adds `Before launch` task for `wasm-pack` run configurations. Emulates the first part of wasm-pack process — executing `cargo build` with specific arguments like `--target wasm32-unknown-unknown`.

Provides a way to show cargo build tool window before `wasm-pack` packing instead of raw printing in the terminal.

The implementation is mostly similar to `CargoBuildTaskProvider`.

Related to #3066
