### PR TITLE
RUN: Suggest configuration name from command

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -168,6 +168,8 @@ class CargoCommandConfiguration(
         return CleanConfiguration.Ok(cmd, toolchain)
     }
 
+    override fun suggestedName(): String? = command.substringBefore(' ').capitalize()
+
     companion object {
         fun findCargoProject(project: Project, additionalArgs: List<String>, workingDirectory: Path?): CargoProject? {
             val cargoProjects = project.cargoProjects


### PR DESCRIPTION
Implements `suggestedName()` for `CargoCommandConfiguration` to provide a configuration name suggestion.

Currently, it is just capitalized cargo command. I'm not sure if we need to add anything else there.

<img width="600" src="https://user-images.githubusercontent.com/6342851/90320827-f9d1b480-df4c-11ea-881a-4a21b04ea3bc.gif">
