### PR TITLE
REF: add basic implementation of change signature refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt
@@ -56,7 +56,7 @@ fun updateMutable(project: Project, binding: RsNamedElement, mutable: Boolean = 
             if (type is RsRefLikeType) {
                 val typeReference = type.typeReference ?: return
                 val newParameterExpr = RsPsiFactory(project)
-                    .createValueParameter(parameter.pat?.text!!, typeReference, mutable, type.lifetime)
+                    .createValueParameter(parameter.pat?.text!!, typeReference, mutable, lifetime = type.lifetime)
                 parameter.replace(newParameterExpr)
                 return
             }

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveParameterFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveParameterFix.kt
@@ -9,9 +9,7 @@ import com.intellij.codeInspection.LocalQuickFixOnPsiElement
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.parentOfType
-import com.intellij.psi.util.parentOfTypes
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 
@@ -32,7 +30,7 @@ class RemoveParameterFix(binding: RsPatBinding, private val bindingName: String)
         val parameterIndex = function.valueParameterList?.valueParameterList?.indexOf(parameter) ?: -1
         if (parameterIndex == -1) return
 
-        parameter.deleteWithSurroundingComma()
+        parameter.deleteWithSurroundingCommaAndWhitespace()
         removeArguments(function, parameterIndex)
     }
 }
@@ -50,6 +48,6 @@ private fun removeArguments(function: RsFunction, parameterIndex: Int) {
             isMethod && call is RsCallExpr -> parameterIndex + 1 // UFCS
             else -> parameterIndex
         }
-        arguments.exprList.getOrNull(argumentIndex)?.deleteWithSurroundingComma()
+        arguments.exprList.getOrNull(argumentIndex)?.deleteWithSurroundingCommaAndWhitespace()
     }
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/RsRefactoringSupportProvider.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsRefactoringSupportProvider.kt
@@ -8,6 +8,8 @@ package org.rust.ide.refactoring
 import com.intellij.lang.refactoring.RefactoringSupportProvider
 import com.intellij.psi.PsiElement
 import com.intellij.refactoring.RefactoringActionHandler
+import com.intellij.refactoring.changeSignature.ChangeSignatureHandler
+import org.rust.ide.refactoring.changeSignature.RsChangeSignatureHandler
 import org.rust.ide.refactoring.extractFunction.RsExtractFunctionHandler
 import org.rust.ide.refactoring.introduceConstant.RsIntroduceConstantHandler
 import org.rust.ide.refactoring.introduceParameter.RsIntroduceParameterHandler
@@ -16,7 +18,6 @@ import org.rust.lang.core.macros.isExpandedFromMacro
 import org.rust.lang.core.psi.ext.RsNameIdentifierOwner
 
 class RsRefactoringSupportProvider : RefactoringSupportProvider() {
-
     override fun isMemberInplaceRenameAvailable(element: PsiElement, context: PsiElement?): Boolean =
         element is RsNameIdentifierOwner && !element.isExpandedFromMacro
 
@@ -31,4 +32,6 @@ class RsRefactoringSupportProvider : RefactoringSupportProvider() {
     override fun getExtractMethodHandler(): RefactoringActionHandler = RsExtractFunctionHandler()
 
     override fun getIntroduceParameterHandler(): RefactoringActionHandler = RsIntroduceParameterHandler()
+
+    override fun getChangeSignatureHandler(): ChangeSignatureHandler = RsChangeSignatureHandler()
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
@@ -1,0 +1,162 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.changeSignature
+
+import com.intellij.lang.Language
+import com.intellij.psi.PsiElement
+import com.intellij.refactoring.changeSignature.ChangeInfo
+import com.intellij.refactoring.changeSignature.ParameterInfo
+import com.intellij.refactoring.changeSignature.ParameterInfo.NEW_PARAMETER
+import org.rust.ide.refactoring.RsFunctionSignatureConfig
+import org.rust.lang.RsLanguage
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyUnit
+import org.rust.lang.core.types.type
+
+/**
+ * This class just holds [config].
+ * It is required by [com.intellij.refactoring.changeSignature.ChangeSignatureProcessorBase].
+ */
+class RsSignatureChangeInfo(val config: RsChangeFunctionSignatureConfig) : ChangeInfo {
+    override fun getNewParameters(): Array<ParameterInfo> = arrayOf()
+    override fun isParameterSetOrOrderChanged(): Boolean = config.parameterSetOrOrderChanged()
+    override fun isParameterTypesChanged(): Boolean = false
+    override fun isParameterNamesChanged(): Boolean = false
+    override fun isGenerateDelegate(): Boolean = false
+
+    override fun isReturnTypeChanged(): Boolean = config.returnTypeDisplay?.text == config.function.retType?.typeReference?.text
+
+    override fun getNewName(): String = config.name
+    override fun isNameChanged(): Boolean = config.nameChanged()
+
+    override fun getMethod(): PsiElement = config.function
+    override fun getLanguage(): Language = RsLanguage
+}
+
+/**
+ * This type is needed to distinguish from empty and invalid type references entered in the dialog.
+ */
+sealed class ParameterType {
+    object Empty: ParameterType()
+    class Invalid(override val text: String): ParameterType()
+    class Valid(val typeReference: RsTypeReference): ParameterType() {
+        override val text: String = typeReference.text
+    }
+
+    open val text: String = ""
+
+    companion object {
+        fun fromTypeReference(typeReference: RsTypeReference?): ParameterType {
+            if (typeReference == null) return Empty
+            return Valid(typeReference)
+        }
+        fun fromText(typeReference: RsTypeReference?, text: String): ParameterType = when {
+            text.isBlank() -> Empty
+            typeReference == null -> Invalid(text)
+            else -> Valid(typeReference)
+        }
+    }
+}
+
+/**
+ * This type needs to be comparable by identity, not value.
+ */
+class Parameter(
+    val factory: RsPsiFactory,
+    var patText: String,
+    var type: ParameterType,
+    val index: Int = NEW_PARAMETER
+) {
+    val typeReference: RsTypeReference
+        get() = parseTypeReference() ?: factory.createType("()")
+
+    fun parseTypeReference(): RsTypeReference? = (type as? ParameterType.Valid)?.typeReference
+    fun parsePat(): RsPat? = factory.tryCreatePat(patText)
+
+    val pat: RsPat
+        get() = parsePat() ?: factory.createPat("_")
+}
+
+/**
+ * This class holds information about function's properties (name, return type, parameters, etc.).
+ * It is designed to be changed (mutably) in the Change Signature dialog.
+ *
+ * After the dialog finishes, the refactoring will compare the state of the original function with the modified config
+ * and perform the necessary adjustments.
+ */
+class RsChangeFunctionSignatureConfig private constructor(
+    function: RsFunction,
+    var name: String,
+    val originalParameters: List<Parameter>,
+    var returnTypeDisplay: RsTypeReference?,
+    var visibility: RsVis? = null,
+    var isAsync: Boolean = false,
+    var isUnsafe: Boolean = false
+) : RsFunctionSignatureConfig(function) {
+    override fun typeParameters(): List<RsTypeParameter> = function.typeParameters
+
+    val returnTypeReference: RsTypeReference
+        get() = returnTypeDisplay ?: RsPsiFactory(function.project).createType("()")
+
+    val allowsVisibilityChange: Boolean
+        get() = !(function.owner is RsAbstractableOwner.Trait || function.owner.isTraitImpl)
+
+    val parameters: MutableList<Parameter> = originalParameters.toMutableList()
+
+    private val originalName: String = function.name.orEmpty()
+
+    val returnType: Ty
+        get() = returnTypeDisplay?.type ?: TyUnit
+
+    private val parametersText: String
+        get() {
+            val selfText = listOfNotNull(function.selfParameter?.text)
+            val parametersText = parameters.map { "${it.pat.text}: ${it.typeReference.text}" }
+            return (selfText + parametersText).joinToString(", ")
+        }
+
+    fun signature(): String = buildString {
+        visibility?.let { append("${it.text} ") }
+
+        if (isAsync) {
+            append("async ")
+        }
+        if (isUnsafe) {
+            append("unsafe ")
+        }
+        append("fn $name$typeParametersText($parametersText)")
+        if (returnType !is TyUnit) {
+            append(" -> ${returnTypeReference.text}")
+        }
+        append(whereClausesText)
+    }
+
+    fun createChangeInfo(): ChangeInfo = RsSignatureChangeInfo(this)
+    fun nameChanged(): Boolean = name != originalName
+    fun parameterSetOrOrderChanged(): Boolean = parameters.map { it.index } != originalParameters.indices.toList()
+
+    companion object {
+        fun create(function: RsFunction): RsChangeFunctionSignatureConfig {
+            val factory = RsPsiFactory(function.project)
+            val parameters = function.valueParameters.mapIndexed { index, parameter ->
+                val patText = parameter.pat?.text ?: "_"
+                val type = ParameterType.fromTypeReference(parameter.typeReference)
+                Parameter(factory, patText, type, index)
+            }
+            return RsChangeFunctionSignatureConfig(
+                function,
+                function.name.orEmpty(),
+                parameters,
+                function.retType?.typeReference,
+                function.vis,
+                function.isAsync,
+                function.isUnsafe
+            )
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureDialog.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureDialog.kt
@@ -1,0 +1,400 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.changeSignature
+
+import com.intellij.openapi.editor.event.DocumentEvent
+import com.intellij.openapi.editor.event.DocumentListener
+import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.options.ConfigurationException
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapiext.isUnitTestMode
+import com.intellij.psi.PsiCodeFragment
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.refactoring.BaseRefactoringProcessor
+import com.intellij.refactoring.changeSignature.*
+import com.intellij.refactoring.ui.ComboBoxVisibilityPanel
+import com.intellij.ui.components.CheckBox
+import com.intellij.ui.treeStructure.Tree
+import com.intellij.util.Consumer
+import com.intellij.util.ui.JBUI
+import net.miginfocom.swing.MigLayout
+import org.jetbrains.annotations.TestOnly
+import org.rust.ide.refactoring.isValidRustVariableIdentifier
+import org.rust.lang.RsFileType
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.openapiext.document
+import java.awt.BorderLayout
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Insets
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+typealias ChangeFunctionSignatureMock = (config: RsChangeFunctionSignatureConfig) -> Unit
+
+private var MOCK: ChangeFunctionSignatureMock? = null
+
+fun showChangeFunctionSignatureDialog(
+    project: Project,
+    config: RsChangeFunctionSignatureConfig
+) {
+    if (isUnitTestMode) {
+        val mock = MOCK ?: error("You should set mock UI via `withMockChangeFunctionSignature`")
+        mock(config)
+        RsChangeSignatureProcessor(project, config.createChangeInfo()).run()
+    } else {
+        ChangeSignatureDialog(project, SignatureDescriptor(config)).show()
+    }
+}
+
+@TestOnly
+fun withMockChangeFunctionSignature(mock: ChangeFunctionSignatureMock, action: () -> Unit) {
+    MOCK = mock
+    try {
+        action()
+    } finally {
+        MOCK = null
+    }
+}
+
+private class SignatureParameter(val factory: RsPsiFactory, val parameter: Parameter) : ParameterInfo {
+    override fun getName(): String = parameter.patText
+    override fun getOldIndex(): Int = parameter.index
+    override fun getDefaultValue(): String? = null
+    override fun setName(name: String?) {
+        if (name != null) {
+            parameter.patText = name
+        }
+    }
+
+    override fun getTypeText(): String = parameter.type.text
+
+    override fun isUseAnySingleVariable(): Boolean = false
+    override fun setUseAnySingleVariable(b: Boolean) {}
+}
+
+private class SignatureDescriptor(val config: RsChangeFunctionSignatureConfig)
+    : MethodDescriptor<SignatureParameter, String> {
+    val function: RsFunction = config.function
+
+    override fun getName(): String = config.name
+
+    override fun getParameters(): List<SignatureParameter> {
+        val factory = RsPsiFactory(config.function.project)
+        return config.parameters.map { SignatureParameter(factory, it) }
+    }
+
+    override fun getParametersCount(): Int = config.parameters.size
+    override fun getMethod(): PsiElement = config.function
+
+    override fun getVisibility(): String = ""
+
+    /**
+     * This needs to be false, because the default dialog only offers combo boxes for visibility, but we need
+     * arbitrary strings.
+     */
+    override fun canChangeVisibility(): Boolean = false
+
+    override fun canChangeParameters(): Boolean = true
+    override fun canChangeName(): Boolean = true
+    override fun canChangeReturnType(): MethodDescriptor.ReadWriteOption = MethodDescriptor.ReadWriteOption.ReadWrite
+}
+
+private class ModelItem(val function: RsFunction, parameter: SignatureParameter)
+    : ParameterTableModelItemBase<SignatureParameter>(
+    parameter,
+    createTypeCodeFragment(function, parameter.parameter.parseTypeReference()),
+    createTypeCodeFragment(function, parameter.parameter.parseTypeReference()),
+) {
+    override fun isEllipsisType(): Boolean = false
+}
+
+private class TableModel(val descriptor: SignatureDescriptor, val onUpdate: () -> Unit)
+    : ParameterTableModelBase<SignatureParameter, ModelItem>(
+    descriptor.function,
+    descriptor.function,
+    NameColumn<SignatureParameter, ModelItem>(descriptor.function.project, "Pattern:"),
+    SignatureTypeColumn(descriptor)
+) {
+    private val factory: RsPsiFactory = RsPsiFactory(descriptor.function.project)
+
+    init {
+        addTableModelListener {
+            onUpdate()
+        }
+    }
+
+    override fun createRowItem(parameterInfo: SignatureParameter?): ModelItem {
+        val parameter = if (parameterInfo == null) {
+            val newParameter = createNewParameter(descriptor)
+            descriptor.config.parameters.add(newParameter)
+            SignatureParameter(factory, newParameter)
+        } else parameterInfo
+
+        return ModelItem(descriptor.function, parameter)
+    }
+
+    override fun removeRow(index: Int) {
+        descriptor.config.parameters.removeAt(index)
+        super.removeRow(index)
+    }
+
+    /**
+     * Swap order of parameters.
+     */
+    override fun fireTableRowsUpdated(firstRow: Int, lastRow: Int) {
+        val parameters = descriptor.config.parameters
+        val tmp = parameters[firstRow]
+        parameters[firstRow] = parameters[lastRow]
+        parameters[lastRow] = tmp
+
+        super.fireTableRowsUpdated(firstRow, lastRow)
+    }
+
+    private fun createNewParameter(descriptor: SignatureDescriptor): Parameter =
+        Parameter(factory, "p${descriptor.parametersCount}", ParameterType.Empty)
+
+    private class SignatureTypeColumn(descriptor: SignatureDescriptor)
+        : TypeColumn<SignatureParameter, ModelItem>(descriptor.function.project, RsFileType) {
+        override fun setValue(item: ModelItem?, value: PsiCodeFragment?) {
+            val fragment = value as? RsTypeReferenceCodeFragment ?: return
+            if (item != null) {
+                item.parameter.parameter.type = ParameterType.fromText(fragment.typeReference, fragment.text)
+            }
+        }
+    }
+}
+
+private class ChangeSignatureDialog(project: Project, descriptor: SignatureDescriptor) :
+    ChangeSignatureDialogBase<SignatureParameter,
+        RsFunction,
+        String,
+        SignatureDescriptor,
+        ModelItem,
+        TableModel
+        >(project, descriptor, false, descriptor.method) {
+    private var isValid: Boolean = true
+
+    private val config: RsChangeFunctionSignatureConfig
+        get() = myMethod.config
+
+    private var visibilityComboBox: VisibilityComboBox? = null
+
+    override fun getFileType(): LanguageFileType = RsFileType
+
+    override fun placeReturnTypeBeforeName(): Boolean = false
+
+    override fun createNorthPanel(): JComponent? {
+        val panel = super.createNorthPanel() ?: return null
+        // Make all two (or three) elements the same size
+        myNameField.setPreferredWidth(-1)
+        myReturnTypeField.setPreferredWidth(-1)
+
+        if (config.allowsVisibilityChange) {
+            val visibilityPanel = JPanel(BorderLayout(0, 2))
+            val visibilityLabel = JLabel("Visibility:")
+            visibilityPanel.add(visibilityLabel, BorderLayout.NORTH)
+
+            val visibility = VisibilityComboBox(project, config.visibility) { updateSignature() }
+            visibilityLabel.labelFor = visibility.component
+            visibilityPanel.add(visibility.component, BorderLayout.SOUTH)
+            visibilityComboBox = visibility
+
+            // Place visibility before function name and return type
+            val layout = panel.layout as GridBagLayout
+            val nameConstraints = layout.getConstraints(myNamePanel).clone() as GridBagConstraints
+            nameConstraints.gridx = 1
+            layout.setConstraints(myNamePanel, nameConstraints)
+
+            val myReturnTypePanel = myReturnTypeField.parent
+            val returnTypeConstraints = layout.getConstraints(myReturnTypePanel).clone() as GridBagConstraints
+            returnTypeConstraints.gridx = 2
+            layout.setConstraints(myReturnTypePanel, returnTypeConstraints)
+
+            val gbc = GridBagConstraints(0, 0, 1, 1, 1.0, 1.0,
+                GridBagConstraints.WEST,
+                GridBagConstraints.HORIZONTAL,
+                Insets(0, 0, 0, 0),
+                0, 0)
+            panel.add(visibilityPanel, gbc)
+        }
+        return panel
+    }
+
+    override fun createSouthAdditionalPanel(): JPanel {
+        val asyncBox = CheckBox("Async", config.isAsync)
+        asyncBox.addChangeListener {
+            config.isAsync = asyncBox.isSelected
+            updateSignature()
+        }
+        val unsafeBox = CheckBox("Unsafe", config.isUnsafe)
+        unsafeBox.addChangeListener {
+            config.isUnsafe = unsafeBox.isSelected
+            updateSignature()
+        }
+
+        return JPanel().apply {
+            layout = MigLayout("align center center, insets 0 ${JBUI.scale(10)} 0 0")
+            add(asyncBox)
+            add(unsafeBox)
+        }
+    }
+
+    override fun createParametersInfoModel(
+        descriptor: SignatureDescriptor
+    ): TableModel = TableModel(descriptor, ::updateSignature)
+
+    override fun createRefactoringProcessor(): BaseRefactoringProcessor =
+        RsChangeSignatureProcessor(project, config.createChangeInfo())
+
+    override fun createReturnTypeCodeFragment(): PsiCodeFragment =
+        createTypeCodeFragment(myMethod.function, myMethod.function.retType?.typeReference)
+
+    override fun createCallerChooser(
+        title: String?,
+        treeToReuse: Tree?,
+        callback: Consumer<MutableSet<RsFunction>>?
+    ): CallerChooserBase<RsFunction>? = null
+
+    override fun validateAndCommitData(): String? {
+        // Needed to update return/parameter type references
+        config.function.project.rustPsiManager.incRustStructureModificationCount()
+        return validateAndUpdateData()
+    }
+    override fun areButtonsValid(): Boolean = isValid
+
+    override fun updateSignature() {
+        updateState()
+        super.updateSignature()
+    }
+    override fun updateSignatureAlarmFired() {
+        super.updateSignatureAlarmFired()
+        validateButtons()
+    }
+
+    override fun canRun() {
+        val error = validateAndUpdateData()
+        if (error != null) {
+            throw ConfigurationException(error)
+        }
+
+        super.canRun()
+    }
+
+    /**
+     * Updates the config from UI elements that are not updated automatically and also the validity state of the dialog.
+     */
+    private fun updateState() {
+        isValid = validateAndUpdateData() == null
+    }
+
+    private fun validateAndUpdateData(): String? {
+        val factory = RsPsiFactory(config.function.project)
+
+        if (myNameField != null) {
+            val functionName = myNameField.text
+            if (validateName(functionName)) {
+                config.name = functionName
+            } else return "Function name must be a valid Rust identifier"
+        }
+
+        if (myReturnTypeField != null) {
+            val returnTypeText = myReturnTypeField.text
+            val returnType = if (returnTypeText.isBlank()) {
+                factory.createType("()")
+            } else {
+                (myReturnTypeCodeFragment as? RsTypeReferenceCodeFragment)?.typeReference
+            }
+            if (returnType != null) {
+                config.returnTypeDisplay = returnType
+            } else {
+                return "Function return type must be a valid Rust type"
+            }
+        }
+
+        val visField = visibilityComboBox
+        if (visField != null) {
+            if (visField.hasValidVisibility) {
+                config.visibility = visField.visibility
+            } else {
+                return "Function visibility must be a valid visibility specifier"
+            }
+        }
+
+        for ((index, parameter) in config.parameters.withIndex()) {
+            if (parameter.parsePat() == null) {
+                return "Parameter $index has invalid pattern"
+            }
+            if (parameter.type is ParameterType.Empty) {
+                return "Please enter type for parameter $index"
+            }
+            if (parameter.type is ParameterType.Invalid) {
+                return "Type entered for parameter $index is invalid"
+            }
+        }
+
+        return null
+    }
+
+    override fun calculateSignature(): String = config.signature()
+
+    /**
+     * This is unused, since visibility is handled with a custom input.
+     */
+    override fun createVisibilityControl(): ComboBoxVisibilityPanel<String> =
+        object : ComboBoxVisibilityPanel<String>("", arrayOf()) {}
+}
+
+private fun createTypeCodeFragment(
+    context: RsElement,
+    type: RsTypeReference?
+): PsiCodeFragment {
+    val freshFile = RsPsiFactory(context.project).createFile("fn main() {}")
+    freshFile.originalFile = context.containingFile as RsFile
+
+    val fragment = RsTypeReferenceCodeFragment(
+        context.project,
+        type?.text.orEmpty(),
+        context = freshFile,
+        importTarget = freshFile
+    )
+    val document = fragment.document!!
+    document.addDocumentListener(object : DocumentListener {
+        override fun documentChanged(event: DocumentEvent) {
+            PsiDocumentManager.getInstance(context.project).commitDocument(document)
+        }
+    })
+    return fragment
+}
+
+private fun validateName(name: String): Boolean = name.isNotBlank() && isValidRustVariableIdentifier(name)
+
+private class VisibilityComboBox(project: Project, initialVis: RsVis?, onChange: () -> Unit) {
+    private val combobox: ComboBox<String> = ComboBox<String>(createVisibilityHints(initialVis), 80)
+    private val factory: RsPsiFactory = RsPsiFactory(project)
+
+    val component: JComponent = combobox
+
+    val hasValidVisibility: Boolean
+        get() = (combobox.selectedItem as String).isBlank() || visibility != null
+    val visibility: RsVis?
+        get() = factory.tryCreateVis(combobox.selectedItem as String)
+
+    init {
+        combobox.isEditable = true
+        combobox.selectedItem = initialVis?.text.orEmpty()
+        combobox.addActionListener {
+            onChange()
+        }
+    }
+}
+
+private fun createVisibilityHints(initialVis: RsVis?): Array<String> =
+    setOf(initialVis?.text.orEmpty(), "", "pub", "pub(crate)", "pub(super)").toTypedArray()

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureHandler.kt
@@ -1,0 +1,91 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.changeSignature
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapiext.isUnitTestMode
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.refactoring.RefactoringBundle
+import com.intellij.refactoring.changeSignature.ChangeSignatureHandler
+import com.intellij.refactoring.util.CommonRefactoringUtil
+import org.rust.RsBundle
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.ext.*
+import org.rust.openapiext.editor
+import org.rust.openapiext.elementUnderCaretInEditor
+
+class RsChangeSignatureHandler : ChangeSignatureHandler {
+    override fun getTargetNotFoundMessage(): String = "The caret should be positioned at a function or method"
+
+    override fun findTargetMember(element: PsiElement): RsFunction? = element.ancestorOrSelf()
+
+    override fun invoke(project: Project, elements: Array<out PsiElement>, dataContext: DataContext?) {
+        val function = elements.singleOrNull() as? RsFunction ?: return
+        invokeOnFunction(function, dataContext?.editor)
+    }
+
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?, dataContext: DataContext?) {
+        val function = dataContext?.elementUnderCaretInEditor as? RsFunction ?: return
+        invokeOnFunction(function, editor)
+    }
+
+    private fun invokeOnFunction(function: RsFunction, editor: Editor?) {
+        val targetFunction = getSuperMethod(function) ?: function
+        showRefactoringDialog(targetFunction, editor)
+    }
+
+    private fun showRefactoringDialog(function: RsFunction, editor: Editor?) {
+        val config = RsChangeFunctionSignatureConfig.create(function)
+        val project = function.project
+
+        val error = checkFunction(function)
+        if (error == null) {
+            showChangeFunctionSignatureDialog(project, config)
+        } else if (editor != null) {
+            showCannotRefactorErrorHint(project, editor, error)
+        }
+    }
+
+    private fun showCannotRefactorErrorHint(project: Project, editor: Editor, message: String) {
+        CommonRefactoringUtil.showErrorHint(project, editor,
+            RefactoringBundle.getCannotRefactorMessage(message),
+            RefactoringBundle.message("changeSignature.refactoring.name"),
+            "refactoring.changeSignature"
+        )
+    }
+
+    private fun checkFunction(function: RsFunction): String? {
+        if (function.valueParameters != function.rawValueParameters) {
+            return RsBundle.message("refactoring.change.signature.error.cfg.disabled.parameters")
+        }
+        return null
+    }
+}
+
+private fun getSuperMethod(function: RsFunction): RsFunction? {
+    val superMethod = function.superItem as? RsFunction ?: return null
+    val functionName = function.name ?: return null
+    val traitName = (superMethod.owner as? RsAbstractableOwner.Trait)?.trait?.name ?: return null
+
+    val message = RsBundle.message("refactoring.change.signature.refactor.super.function",
+        functionName,
+        traitName
+    )
+    val choice: Int = if (isUnitTestMode) {
+        Messages.YES
+    } else {
+        Messages.showYesNoCancelDialog(function.project, message, RsBundle.message("refactoring.change.signature.name"),
+            Messages.getQuestionIcon())
+    }
+    return when (choice) {
+        Messages.YES -> superMethod
+        else -> null
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureProcessor.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.changeSignature
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Ref
+import com.intellij.openapiext.isUnitTestMode
+import com.intellij.psi.PsiElement
+import com.intellij.refactoring.changeSignature.ChangeInfo
+import com.intellij.refactoring.changeSignature.ChangeSignatureProcessorBase
+import com.intellij.refactoring.changeSignature.ChangeSignatureUsageProcessor
+import com.intellij.refactoring.rename.RenameUtil
+import com.intellij.usageView.BaseUsageViewDescriptor
+import com.intellij.usageView.UsageInfo
+import com.intellij.usageView.UsageViewDescriptor
+import com.intellij.util.containers.ContainerUtil
+import com.intellij.util.containers.MultiMap
+
+/**
+ * The main implementation resides in [RsChangeSignatureUsageProcessor].
+ */
+class RsChangeSignatureProcessor(project: Project, changeInfo: ChangeInfo)
+    : ChangeSignatureProcessorBase(project, changeInfo) {
+    override fun createUsageViewDescriptor(usages: Array<out UsageInfo>): UsageViewDescriptor =
+        BaseUsageViewDescriptor(changeInfo.method)
+
+    override fun preprocessUsages(refUsages: Ref<Array<UsageInfo?>>): Boolean {
+        val conflicts = MultiMap<PsiElement, String>()
+        collectConflictsFromExtensions(refUsages, conflicts, myChangeInfo)
+        return showConflicts(conflicts, refUsages.get())
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureUsageProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureUsageProcessor.kt
@@ -1,0 +1,142 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.changeSignature
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Ref
+import com.intellij.psi.PsiElement
+import com.intellij.refactoring.changeSignature.ChangeInfo
+import com.intellij.refactoring.changeSignature.ChangeSignatureUsageProcessor
+import com.intellij.refactoring.rename.ResolveSnapshotProvider
+import com.intellij.usageView.UsageInfo
+import com.intellij.util.containers.MultiMap
+import org.rust.RsBundle
+import org.rust.ide.presentation.getPresentation
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsImplItem
+import org.rust.lang.core.psi.ext.*
+
+class RsChangeSignatureUsageProcessor : ChangeSignatureUsageProcessor {
+    override fun findUsages(changeInfo: ChangeInfo?): Array<UsageInfo> {
+        if (changeInfo !is RsSignatureChangeInfo) return emptyArray()
+        val function = changeInfo.config.function
+        val usages = findFunctionUsages(function).toMutableList()
+        if (function.owner is RsAbstractableOwner.Trait) {
+            function.searchForImplementations().filterIsInstance<RsFunction>().forEach { method ->
+                usages.add(RsFunctionUsage.MethodImplementation(method))
+                usages.addAll(findFunctionUsages(method))
+            }
+        }
+
+        return usages.toTypedArray()
+    }
+
+    override fun findConflicts(changeInfo: ChangeInfo?, refUsages: Ref<Array<UsageInfo>>): MultiMap<PsiElement, String> {
+        if (changeInfo !is RsSignatureChangeInfo) return MultiMap.empty()
+        val map = MultiMap<PsiElement, String>()
+        val config = changeInfo.config
+        val function = config.function
+
+        findNameConflicts(function, config, map)
+        findVisibilityConflicts(function, config, refUsages.get(), map)
+
+        return map
+    }
+
+    override fun processUsage(
+        changeInfo: ChangeInfo?,
+        usageInfo: UsageInfo?,
+        beforeMethodChange: Boolean,
+        usages: Array<out UsageInfo>?
+    ): Boolean {
+        if (beforeMethodChange) return false
+
+        if (changeInfo !is RsSignatureChangeInfo) return false
+        if (usageInfo !is RsFunctionUsage) return false
+        val config = changeInfo.config
+        if (usageInfo is RsFunctionUsage.MethodImplementation) {
+            processFunction(config.function.project, config, usageInfo.overriddenMethod)
+        } else {
+            processFunctionUsage(config, usageInfo)
+        }
+
+        return true
+    }
+
+    override fun processPrimaryMethod(changeInfo: ChangeInfo?): Boolean {
+        if (changeInfo !is RsSignatureChangeInfo) return false
+        val config = changeInfo.config
+        val function = config.function
+        val project = function.project
+
+        processFunction(project, config, function)
+        return true
+    }
+
+    override fun shouldPreviewUsages(changeInfo: ChangeInfo?, usages: Array<out UsageInfo>?): Boolean = false
+
+    override fun setupDefaultValues(
+        changeInfo: ChangeInfo?,
+        refUsages: Ref<Array<UsageInfo>>?,
+        project: Project?
+    ): Boolean {
+        return true
+    }
+
+    override fun registerConflictResolvers(
+        snapshots: MutableList<ResolveSnapshotProvider.ResolveSnapshot>?,
+        resolveSnapshotProvider: ResolveSnapshotProvider,
+        usages: Array<out UsageInfo>?,
+        changeInfo: ChangeInfo?
+    ) {
+    }
+}
+
+private fun findVisibilityConflicts(
+    function: RsFunction,
+    config: RsChangeFunctionSignatureConfig,
+    usages: Array<UsageInfo>,
+    map: MultiMap<PsiElement, String>
+) {
+    val functionUsages = usages.filterIsInstance<RsFunctionUsage>()
+    val clone = function.copy() as RsFunction
+    changeVisibility(clone, config)
+
+    for (usage in functionUsages) {
+        val sourceModule = usage.element.containingMod
+        if (!clone.isVisibleFrom(sourceModule)) {
+            val moduleName = sourceModule.qualifiedName.orEmpty()
+            map.putValue(usage.element, RsBundle.message("refactoring.change.signature.visibility.conflict", moduleName))
+        }
+    }
+}
+
+private fun findNameConflicts(
+    function: RsFunction,
+    config: RsChangeFunctionSignatureConfig,
+    map: MultiMap<PsiElement, String>
+) {
+    val (owner, items) = when (val owner = function.owner) {
+        is RsAbstractableOwner.Impl -> owner.impl to owner.impl.expandedMembers
+        is RsAbstractableOwner.Trait -> owner.trait to owner.trait.expandedMembers
+        else -> {
+            val parent = function.parent as RsItemsOwner
+            val items = parent.expandedItemsCached.named[config.name] ?: return
+            parent to items
+        }
+    }
+    for (item in items) {
+        if (item == function) continue
+        if (!item.isEnabledByCfgSelf) continue
+
+        if (item.name == config.name) {
+            val presentation = getPresentation(owner)
+            val prefix = if (owner is RsImplItem) "impl " else ""
+            val ownerName = "${prefix}${presentation.presentableText.orEmpty()} ${presentation.locationString.orEmpty()}"
+            map.putValue(item, RsBundle.message("refactoring.change.signature.name.conflict", config.name, ownerName))
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
@@ -1,0 +1,297 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.changeSignature
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.refactoring.changeSignature.ParameterInfo
+import com.intellij.refactoring.rename.RenameUtil
+import com.intellij.usageView.UsageInfo
+import org.rust.ide.refactoring.findBinding
+import org.rust.ide.utils.import.RsImportHelper
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsElementTypes.COMMA
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.ty.TyUnit
+
+sealed class RsFunctionUsage(val element: RsElement) : UsageInfo(element) {
+    open val isCallUsage: Boolean = false
+
+    class FunctionCall(val call: RsCallExpr) : RsFunctionUsage(call) {
+        override val isCallUsage: Boolean = true
+    }
+
+    class MethodCall(val call: RsMethodCall) : RsFunctionUsage(call) {
+        override val isCallUsage: Boolean = true
+    }
+
+    class Reference(val path: RsPath) : RsFunctionUsage(path)
+    class MethodImplementation(val overriddenMethod: RsFunction) : RsFunctionUsage(overriddenMethod)
+}
+
+fun findFunctionUsages(function: RsFunction): Sequence<RsFunctionUsage> = function.findUsages().map {
+    when (it) {
+        is RsCallExpr -> RsFunctionUsage.FunctionCall(it)
+        is RsMethodCall -> RsFunctionUsage.MethodCall(it)
+        is RsPath -> RsFunctionUsage.Reference(it)
+        else -> error("unreachable")
+    }
+}
+
+fun processFunctionUsage(config: RsChangeFunctionSignatureConfig, usage: RsFunctionUsage) {
+    val function = config.function
+    val factory = RsPsiFactory(function.project)
+    if (config.nameChanged()) {
+        renameFunctionUsage(factory, usage, config)
+    }
+    if (usage.isCallUsage && config.parameterSetOrOrderChanged()) {
+        changeArguments(factory, usage, config, function.isMethod)
+    }
+}
+
+fun processFunction(
+    project: Project,
+    config: RsChangeFunctionSignatureConfig,
+    function: RsFunction
+) {
+    val factory = RsPsiFactory(project)
+
+    if (config.nameChanged()) {
+        rename(factory, function, config)
+    }
+    changeVisibility(function, config)
+    changeReturnType(factory, function, config)
+
+    changeParameters(factory, function, config)
+    changeAsync(factory, function, config)
+    changeUnsafe(factory, function, config)
+}
+
+private fun rename(factory: RsPsiFactory, function: RsFunction, config: RsChangeFunctionSignatureConfig) {
+    function.identifier.replace(factory.createIdentifier(config.name))
+}
+
+private fun renameFunctionUsage(
+    factory: RsPsiFactory,
+    usage: RsFunctionUsage,
+    config: RsChangeFunctionSignatureConfig
+) {
+    val identifier = factory.createIdentifier(config.name)
+    when (usage) {
+        is RsFunctionUsage.Reference -> usage.path.referenceNameElement?.replace(identifier)
+        is RsFunctionUsage.FunctionCall -> {
+            val path = (usage.call.expr as? RsPathExpr)?.path ?: return
+            path.referenceNameElement?.replace(identifier)
+        }
+        is RsFunctionUsage.MethodCall -> usage.call.identifier.replace(identifier)
+    }
+}
+
+fun changeVisibility(function: RsFunction, config: RsChangeFunctionSignatureConfig) {
+    if (function.vis?.text == config.visibility?.text) return
+
+    function.vis?.delete()
+
+    val vis = config.visibility
+    if (vis != null) {
+        function.addBefore(vis, function.firstChild)
+    }
+}
+
+private fun changeReturnType(factory: RsPsiFactory, function: RsFunction, config: RsChangeFunctionSignatureConfig) {
+    if (!areTypesEqual(function.retType?.typeReference, config.returnTypeReference)) {
+        function.retType?.delete()
+        if (config.returnType !is TyUnit) {
+            val ret = factory.createRetType(config.returnTypeReference.text)
+            function.addAfter(ret, function.valueParameterList) as RsRetType
+            RsImportHelper.importTypeReferencesFromTy(function, config.returnType, useAliases = true)
+        }
+    }
+}
+
+private fun changeArguments(
+    factory: RsPsiFactory,
+    usage: RsFunctionUsage,
+    config: RsChangeFunctionSignatureConfig,
+    isMethod: Boolean
+) {
+    val arguments = when (usage) {
+        is RsFunctionUsage.FunctionCall -> usage.call.valueArgumentList
+        is RsFunctionUsage.MethodCall -> usage.call.valueArgumentList
+        else -> error("unreachable")
+    }
+    val argumentsCopy = arguments.copy() as RsValueArgumentList
+    val argumentsList = argumentsCopy.exprList
+    val isUFCS = isMethod && usage is RsFunctionUsage.FunctionCall
+    fixParametersOrder(
+        factory,
+        arguments,
+        argumentsCopy,
+        if (isUFCS) argumentsList.first() else null,
+        if (isUFCS) argumentsList.drop(1) else argumentsList,
+        config
+    ) { null }
+}
+
+private fun changeParameters(factory: RsPsiFactory, function: RsFunction, config: RsChangeFunctionSignatureConfig) {
+    val parameters = function.valueParameterList ?: return
+
+    importParameterTypes(config.parameters, function)
+    changeParametersNameAndType(factory, parameters.valueParameterList, config.parameters)
+    if (!config.parameterSetOrOrderChanged()) return
+
+    val parametersCopy = parameters.copy() as RsValueParameterList
+    fixParametersOrder(
+        factory,
+        parameters,
+        parametersCopy,
+        parametersCopy.selfParameter,
+        parametersCopy.valueParameterList,
+        config
+    ) { factory.createValueParameter(it.patText, it.typeReference, reference = false) }
+}
+
+private fun renameParameter(factory: RsPsiFactory, parameter: RsValueParameter, newName: String) {
+    val identifier = factory.createIdentifier(newName)
+
+    val binding = parameter.pat?.findBinding()
+    if (binding != null) {
+        val usages = RenameUtil.findUsages(binding, newName, false, false, emptyMap())
+        for (info in usages) {
+            RenameUtil.rename(info, newName)
+        }
+    }
+
+    binding?.identifier?.replace(identifier)
+}
+
+private fun fixParametersOrder(
+    factory: RsPsiFactory,
+    /** [RsValueArgumentList] or [RsValueParameterList] */
+    parameters: RsElement,
+    parametersCopy: RsElement,
+    parameterSelf: RsElement?,
+    parametersList: List<RsElement>,
+    config: RsChangeFunctionSignatureConfig,
+    createNewParameter: (Parameter) -> PsiElement?
+) {
+    if (parametersList.size != config.originalParameters.size) return
+    val descriptors = config.parameters
+
+    // remove old parameters
+    val lparen = parameters.firstChild
+    val rparen = parameters.lastChild
+    if (lparen.nextSibling != rparen) {
+        parameters.deleteChildRange(lparen.nextSibling, rparen.prevSibling)
+    }
+    if (descriptors.isEmpty() && parameterSelf == null) return
+
+    // collect parameters psi in right order
+    val isMultiline = parametersCopy.textContains('\n')
+    val selfGroup = parameterSelf?.collectSurroundingWhiteSpaceAndComments()
+    val groupsWithoutSelf = descriptors.map { descriptor ->
+        if (descriptor.index == ParameterInfo.NEW_PARAMETER) {
+            val newline = if (isMultiline) factory.createNewline() else null
+            val psi = createNewParameter(descriptor)
+            listOfNotNull(newline, psi)
+        } else {
+            val psi = parametersList[descriptor.index]
+            psi.collectSurroundingWhiteSpaceAndComments()
+        }
+    }
+    val groups = listOfNotNull(selfGroup) + groupsWithoutSelf
+
+    // add parameters one by one
+    val rspace = parametersCopy.lastChild.prevSibling as? PsiWhiteSpace
+    val isSingleParameter = groups.size == 1 && descriptors.size < config.originalParameters.size
+    val hasTrailingComma = parametersList.lastOrNull()?.getNextNonCommentSibling()?.elementType == COMMA
+    for (group in groups) {
+        if (group !== groups.first()) {
+            parameters.addBefore(factory.createComma(), rparen)
+        }
+        for (element in group) {
+            if (element === rspace) continue  // will be added after loop
+            parameters.addBefore(element, rparen)
+        }
+    }
+
+    if (isSingleParameter) {
+        val lspace = parameters.firstChild.nextSibling
+        if (lspace is PsiWhiteSpace) lspace.delete()
+    } else {
+        if (hasTrailingComma && isMultiline) {
+            parameters.addBefore(factory.createComma(), rparen)
+        }
+
+        if (rspace != null) parameters.addBefore(rspace, rparen)
+    }
+}
+
+private fun PsiElement.collectSurroundingWhiteSpaceAndComments(): List<PsiElement> {
+    val first = getPrevNonCommentSibling()?.nextSibling ?: this
+    val last = getNextNonCommentSibling() ?: nextSibling
+    val elements = generateSequence(first) { it.nextSibling?.takeIf { next -> next !== last } }
+    return elements.toList()
+}
+
+private fun importParameterTypes(descriptors: List<Parameter>, context: RsElement) {
+    for (descriptor in descriptors) {
+        RsImportHelper.importTypeReferencesFromElements(context, setOf(descriptor.typeReference), useAliases = true)
+    }
+}
+
+private fun changeParametersNameAndType(
+    factory: RsPsiFactory,
+    parameters: List<RsValueParameter>,
+    descriptors: List<Parameter>
+) {
+    for (descriptor in descriptors) {
+        if (descriptor.index != ParameterInfo.NEW_PARAMETER) {
+            val psi = parameters[descriptor.index]
+            changeParameterNameAndType(factory, psi, descriptor)
+        }
+    }
+}
+
+fun changeParameterNameAndType(factory: RsPsiFactory, psi: RsValueParameter, descriptor: Parameter) {
+    if (descriptor.patText != psi.pat?.text) {
+        if (descriptor.pat is RsPatIdent && psi.pat is RsPatIdent) {
+            renameParameter(factory, psi, descriptor.patText)
+        } else {
+            psi.pat?.replace(descriptor.pat)
+        }
+    }
+    if (!areTypesEqual(descriptor.typeReference, psi.typeReference)) {
+        psi.typeReference?.replace(descriptor.typeReference)
+    }
+}
+
+private fun changeAsync(factory: RsPsiFactory, function: RsFunction, config: RsChangeFunctionSignatureConfig) {
+    val async = function.node.findChildByType(RsElementTypes.ASYNC)?.psi
+    if (config.isAsync) {
+        if (async == null) {
+            val asyncKw = factory.createAsyncKeyword()
+            function.addBefore(asyncKw, function.unsafe ?: function.fn)
+        }
+    } else {
+        async?.delete()
+    }
+}
+
+private fun changeUnsafe(factory: RsPsiFactory, function: RsFunction, config: RsChangeFunctionSignatureConfig) {
+    if (config.isUnsafe) {
+        if (function.unsafe == null) {
+            val unsafe = factory.createUnsafeKeyword()
+            function.addBefore(unsafe, function.fn)
+        }
+    } else {
+        function.unsafe?.delete()
+    }
+}
+
+private fun areTypesEqual(t1: RsTypeReference?, t2: RsTypeReference?): Boolean = (t1?.text ?: "()") == (t2?.text
+    ?: "()")

--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.search.LocalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.siblings
 import org.rust.ide.presentation.renderInsertionSafe
+import org.rust.ide.refactoring.RsFunctionSignatureConfig
 import org.rust.ide.utils.findStatementsOrExprInRange
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -114,7 +115,7 @@ class Parameter private constructor(
 }
 
 class RsExtractFunctionConfig private constructor(
-    val containingFunction: RsFunction,
+    function: RsFunction,
     val elements: List<PsiElement>,
     val returnValue: ReturnValue? = null,
     var name: String = "",
@@ -122,7 +123,7 @@ class RsExtractFunctionConfig private constructor(
     val isAsync: Boolean = false,
     val isUnsafe: Boolean = false,
     var parameters: List<Parameter>
-) {
+): RsFunctionSignatureConfig(function) {
     val valueParameters: List<Parameter>
         get() = parameters.filter { !it.isSelf }
 
@@ -137,6 +138,32 @@ class RsExtractFunctionConfig private constructor(
 
     val signature: String
         get() = signature(false)
+
+    private val parameterTypes: List<Ty>
+        get() = parameters.mapNotNull { it.type }
+
+    private val returnType: Ty
+        get() = returnValue?.type ?: TyUnit
+
+    private fun typeParameterBounds(): Map<Ty, Set<Ty>> =
+        function.typeParameters.associate { typeParameter ->
+            val type = typeParameter.declaredType
+            val bounds = mutableSetOf<Ty>()
+            typeParameter.bounds.flatMapTo(bounds) {
+                it.bound.traitRef?.path?.typeArguments?.flatMap { it.type.types() }.orEmpty()
+            }
+            type to bounds
+        }
+
+    override fun typeParameters(): List<RsTypeParameter> {
+        val bounds = typeParameterBounds()
+        val paramAndReturnTypes = mutableSetOf<Ty>()
+        (parameterTypes + returnType).forEach {
+            paramAndReturnTypes.addAll(it.types())
+            paramAndReturnTypes.addAll(it.dependTypes(bounds))
+        }
+        return function.typeParameters.filter { it.declaredType in paramAndReturnTypes }
+    }
 
     /**
      * - Original signature is used when the extracted function is inserting to the source code
@@ -189,44 +216,6 @@ class RsExtractFunctionConfig private constructor(
                 bodyContent.joinToString(separator = "\n", prefix = "{\n", postfix = "\n}")
             }
             append(body)
-        }
-
-    private val typeParametersText: String
-        get() {
-            val typeParams = typeParameters()
-            if (typeParams.isEmpty()) return ""
-            return typeParams.joinToString(separator = ",", prefix = "<", postfix = ">") { it.text }
-        }
-
-    private val whereClausesText: String
-        get() {
-            val wherePredList = containingFunction.whereClause?.wherePredList ?: return ""
-            if (wherePredList.isEmpty()) return ""
-            val typeParams = typeParameters().map { it.declaredType }
-            if (typeParams.isEmpty()) return ""
-            val filtered = wherePredList.filter { it.typeReference?.type in typeParams }
-            if (filtered.isEmpty()) return ""
-            return filtered.joinToString(separator = ",", prefix = " where ") { it.text }
-        }
-
-    private fun typeParameters(): List<RsTypeParameter> {
-        val bounds = typeParameterBounds()
-        val paramAndReturnTypes = mutableSetOf<Ty>()
-        (parameters.mapNotNull { it.type } + listOfNotNull(returnValue?.type)).forEach {
-            paramAndReturnTypes.addAll(it.types())
-            paramAndReturnTypes.addAll(it.dependTypes(bounds))
-        }
-        return containingFunction.typeParameters.filter { it.declaredType in paramAndReturnTypes }
-    }
-
-    private fun typeParameterBounds(): Map<Ty, Set<Ty>> =
-        containingFunction.typeParameters.associate { typeParameter ->
-            val type = typeParameter.declaredType
-            val bounds = mutableSetOf<Ty>()
-            typeParameter.bounds.flatMapTo(bounds) {
-                it.bound.traitRef?.path?.typeArguments?.flatMap { it.type.types() }.orEmpty()
-            }
-            type to bounds
         }
 
     companion object {
@@ -316,7 +305,7 @@ class RsExtractFunctionConfig private constructor(
     }
 }
 
-private fun Ty.types(): Set<Ty> {
+fun Ty.types(): Set<Ty> {
     val types = mutableSetOf<Ty>()
 
     fun collect(type: Ty) {
@@ -329,7 +318,7 @@ private fun Ty.types(): Set<Ty> {
     return types
 }
 
-private fun Ty.dependTypes(boundMap: Map<Ty, Set<Ty>>): Set<Ty> {
+fun Ty.dependTypes(boundMap: Map<Ty, Set<Ty>>): Set<Ty> {
     val types = mutableSetOf<Ty>()
 
     fun collect(type: Ty) {

--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
@@ -47,7 +47,7 @@ class RsExtractFunctionHandler : RefactoringActionHandler {
     }
 
     private fun addExtractedFunction(project: Project, config: RsExtractFunctionConfig, psiFactory: RsPsiFactory): RsFunction? {
-        val owner = config.containingFunction.owner
+        val owner = config.function.owner
 
         val function = psiFactory.createFunction(config.functionText)
         val psiParserFacade = PsiParserFacade.SERVICE.getInstance(project)
@@ -65,8 +65,8 @@ class RsExtractFunctionHandler : RefactoringActionHandler {
             }
             else -> {
                 val newline = psiParserFacade.createWhiteSpaceFromText("\n\n")
-                val end = config.containingFunction.block?.rbrace ?: return null
-                config.containingFunction.addAfter(function, config.containingFunction.addAfter(newline, end)) as? RsFunction
+                val end = config.function.block?.rbrace ?: return null
+                config.function.addAfter(function, config.function.addAfter(newline, end)) as? RsFunction
             }
         }
     }
@@ -99,7 +99,7 @@ class RsExtractFunctionHandler : RefactoringActionHandler {
         stmt += if (firstParameter != null && firstParameter.isSelf) {
             "self.${config.name}(${config.argumentsText})"
         } else {
-            val type = when (val owner = config.containingFunction.owner) {
+            val type = when (val owner = config.function.owner) {
                 is RsAbstractableOwner.Impl -> {
                     owner.impl.typeReference?.text?.let {
                         if (owner.impl.typeParameterList == null) it else "<$it>"

--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/ui.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/ui.kt
@@ -117,7 +117,8 @@ private class DialogExtractFunctionUi(
 }
 
 private class RsSignatureComponent(
-    signature: String, project: Project
+    signature: String,
+    project: Project
 ) : MethodSignatureComponent(signature, project, RsFileType) {
     private val myFileName = "dummy." + RsFileType.defaultExtension
 

--- a/src/main/kotlin/org/rust/ide/refactoring/functionSignature.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/functionSignature.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring
+
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsTypeParameter
+import org.rust.lang.core.types.type
+
+/**
+ * Helper class for storing and formatting information about the signature of a function.
+ */
+abstract class RsFunctionSignatureConfig(val function: RsFunction) {
+    protected val typeParametersText: String
+        get() {
+            val typeParams = typeParameters()
+            if (typeParams.isEmpty()) return ""
+            return typeParams.joinToString(separator = ", ", prefix = "<", postfix = ">") { it.text }
+        }
+
+    protected val whereClausesText: String
+        get() {
+            val wherePredList = function.whereClause?.wherePredList ?: return ""
+            if (wherePredList.isEmpty()) return ""
+            val typeParams = typeParameters().map { it.declaredType }
+            if (typeParams.isEmpty()) return ""
+            val filtered = wherePredList.filter { it.typeReference?.type in typeParams }
+            if (filtered.isEmpty()) return ""
+            return filtered.joinToString(separator = ", ", prefix = " where ") { it.text }
+        }
+
+    protected abstract fun typeParameters(): List<RsTypeParameter>
+}

--- a/src/main/kotlin/org/rust/ide/search/RsFindUsagesProvider.kt
+++ b/src/main/kotlin/org/rust/ide/search/RsFindUsagesProvider.kt
@@ -20,6 +20,6 @@ class RsFindUsagesProvider : FindUsagesProvider {
     override fun getHelpId(element: PsiElement) = HelpID.FIND_OTHER_USAGES
 
     override fun getType(element: PsiElement) = ""
-    override fun getDescriptiveName(element: PsiElement) = ""
+    override fun getDescriptiveName(element: PsiElement) = (element as? RsNamedElement)?.name.orEmpty()
     override fun getNodeText(element: PsiElement, useFullName: Boolean) = ""
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
@@ -26,20 +26,23 @@ abstract class RsCodeFragment(
     fileViewProvider: FileViewProvider,
     contentElementType: IElementType,
     open val context: RsElement,
-    forceCachedPsi: Boolean = true
-) : RsFileBase(fileViewProvider), PsiCodeFragment {
+    forceCachedPsi: Boolean = true,
+    val importTarget: RsItemsOwner? = null,
+) : RsFileBase(fileViewProvider), PsiCodeFragment, RsItemsOwner {
 
     constructor(
         project: Project,
         text: CharSequence,
         contentElementType: IElementType,
-        context: RsElement
+        context: RsElement,
+        importTarget: RsItemsOwner? = null,
     ) : this(
         PsiManagerEx.getInstanceEx(project).fileManager.createFileViewProvider(
             LightVirtualFile("fragment.rs", RsLanguage, text), true
         ),
         contentElementType,
-        context
+        context,
+        importTarget = importTarget
     )
 
     override val containingMod: RsMod
@@ -123,8 +126,13 @@ class RsStatementCodeFragment(project: Project, text: CharSequence, context: RsE
     val stmt: RsStmt? get() = childOfType()
 }
 
-class RsTypeReferenceCodeFragment(project: Project, text: CharSequence, context: RsElement)
-    : RsCodeFragment(project, text, RsCodeFragmentElementType.TYPE_REF, context),
+class RsTypeReferenceCodeFragment(
+    project: Project,
+    text: CharSequence,
+    context: RsElement,
+    importTarget: RsItemsOwner? = null,
+)
+    : RsCodeFragment(project, text, RsCodeFragmentElementType.TYPE_REF, context, importTarget = importTarget),
       RsNamedElement {
     val typeReference: RsTypeReference? get() = childOfType()
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -8,8 +8,10 @@ package org.rust.lang.core.psi.ext
 import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.extapi.psi.StubBasedPsiElementBase
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileSystemItem
+import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.stubs.StubElement
 import org.rust.cargo.project.model.CargoProject
@@ -142,7 +144,7 @@ fun RsElement.hasInScope(name: String, ns: Set<Namespace>): Boolean =
 
 /**
  * Delete the element along with a neighbour comma.
- * If a comma follow the element, it will be deleted.
+ * If a comma follows the element, it will be deleted.
  * Else if a comma precedes the element, it will be deleted.
  *
  * It is useful to remove elements that are parts of comma separated lists (parameters, arguments, use specks, ...).
@@ -160,3 +162,20 @@ fun RsElement.deleteWithSurroundingComma() {
 
     delete()
 }
+
+/**
+ * Delete the element along with all surrounding whitespace and a single surrounding comma.
+ * See [deleteWithSurroundingComma].
+ */
+fun RsElement.deleteWithSurroundingCommaAndWhitespace() {
+    while (nextSibling?.isWhitespaceOrComment == true) {
+        nextSibling?.delete()
+    }
+    while (prevSibling?.isWhitespaceOrComment == true) {
+        prevSibling?.delete()
+    }
+    deleteWithSurroundingComma()
+}
+
+private val PsiElement.isWhitespaceOrComment
+    get(): Boolean = this is PsiWhiteSpace || this is PsiComment

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -77,6 +77,9 @@
                                  implementationClass="org.rust.ide.refactoring.RsRefactoringSupportProvider"/>
         <suggestedRefactoringSupport language="Rust" implementationClass="org.rust.ide.refactoring.suggested.RsSuggestedRefactoringSupport"/>
 
+        <refactoring.changeSignatureUsageProcessor implementation="org.rust.ide.refactoring.changeSignature.RsChangeSignatureUsageProcessor"
+                                                   id="Rust"/>
+
         <!-- Commenter -->
 
         <lang.commenter language="Rust" implementationClass="org.rust.ide.commenter.RsCommenter"/>

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -53,3 +53,9 @@ action.Rust.ToggleNewResolve.text=Rust: Toggle experimental name resolution engi
 
 group.Rust.MacroExpansionActions.text=Show Macro Expansion
 group.Rust.Tools.text=Rust
+
+refactoring.change.signature.name=Change Signature
+refactoring.change.signature.error.cfg.disabled.parameters=Cannot change signature of function with cfg-disabled parameters
+refactoring.change.signature.name.conflict=The name {0} conflicts with an existing item in {1}
+refactoring.change.signature.visibility.conflict=The function will not be visible from {0} after the refactoring
+refactoring.change.signature.refactor.super.function=Method {0} implements base method of trait {1}.\nDo you want to refactor the base method?

--- a/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
@@ -1,0 +1,1064 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring
+
+import com.intellij.refactoring.BaseRefactoringProcessor
+import org.intellij.lang.annotations.Language
+import org.rust.MockAdditionalCfgOptions
+import org.rust.MockEdition
+import org.rust.RsTestBase
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ide.refactoring.changeSignature.Parameter
+import org.rust.ide.refactoring.changeSignature.ParameterType
+import org.rust.ide.refactoring.changeSignature.RsChangeFunctionSignatureConfig
+import org.rust.ide.refactoring.changeSignature.withMockChangeFunctionSignature
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.stdext.removeLast
+
+class RsChangeSignatureTest : RsTestBase() {
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test unavailable if a parameter is cfg-disabled`() = checkError("""
+        fn foo/*caret*/(#[cfg(not(intellij_rust))] a: u32) {}
+    """, """Cannot perform refactoring.
+Cannot change signature of function with cfg-disabled parameters""")
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test available if a parameter is cfg-enabled`() = doTest("""
+        fn foo/*caret*/(#[cfg(intellij_rust)] a: u32) {}
+    """, """
+        fn bar(#[cfg(intellij_rust)] a: u32) {}
+    """) {
+        name = "bar"
+    }
+
+    fun `test do not change anything`() = doTest("""
+        async unsafe fn foo/*caret*/(a: u32, b: bool) -> u32 { 0 }
+        fn bar() {
+            unsafe { foo(1, true); }
+        }
+    """, """
+        async unsafe fn foo(a: u32, b: bool) -> u32 { 0 }
+        fn bar() {
+            unsafe { foo(1, true); }
+        }
+    """) {}
+
+    fun `test rename function reference`() = doTest("""
+        fn foo/*caret*/() {}
+        fn id<T>(t: T) {}
+
+        fn baz() {
+            id(foo)
+        }
+    """, """
+        fn bar/*caret*/() {}
+        fn id<T>(t: T) {}
+
+        fn baz() {
+            id(bar)
+        }
+    """) {
+        name = "bar"
+    }
+
+    fun `test rename function import`() = doTest("""
+        mod bar {
+            pub fn foo/*caret*/() {}
+        }
+        use bar::{foo};
+    """, """
+        mod bar {
+            pub fn baz/*caret*/() {}
+        }
+        use bar::{baz};
+    """) {
+        name = "baz"
+    }
+
+    fun `test rename function`() = doTest("""
+        fn foo/*caret*/() {}
+    """, """
+        fn bar() {}
+    """) {
+        name = "bar"
+    }
+
+    fun `test rename function change usage`() = doTest("""
+        fn foo/*caret*/() {}
+        fn test() {
+            foo()
+        }
+    """, """
+        fn bar() {}
+        fn test() {
+            bar()
+        }
+    """) {
+        name = "bar"
+    }
+
+    fun `test rename function change complex path usage`() = doTest("""
+        mod inner {
+            pub fn foo/*caret*/() {}
+        }
+        fn test() {
+            inner::foo()
+        }
+    """, """
+        mod inner {
+            pub fn bar() {}
+        }
+        fn test() {
+            inner::bar()
+        }
+    """) {
+        name = "bar"
+    }
+
+    fun `test rename method change usage`() = doTest("""
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self) {}
+        }
+
+        fn test(s: S) {
+            s.foo();
+        }
+    """, """
+        struct S;
+        impl S {
+            fn bar(&self) {}
+        }
+
+        fn test(s: S) {
+            s.bar();
+        }
+    """) {
+        name = "bar"
+    }
+
+    fun `test change visibility`() = doTest("""
+        pub fn foo/*caret*/() {}
+    """, """
+        pub(crate) fn foo() {}
+    """) {
+        visibility = createVisibility("pub(crate)")
+    }
+
+    fun `test remove visibility`() = doTest("""
+        pub fn foo/*caret*/() {}
+    """, """
+        fn foo() {}
+    """) {
+        visibility = null
+    }
+
+    fun `test change return type`() = doTest("""
+        fn foo/*caret*/() -> i32 { 0 }
+    """, """
+        fn foo() -> u32 { 0 }
+    """) {
+        returnTypeDisplay = createType("u32")
+    }
+
+    fun `test change return type lifetime`() = doTest("""
+        fn foo<'a, 'b>/*caret*/(a: &'a u32, b: &'b u32) -> &'a i32 { 0 }
+    """, """
+        fn foo<'a, 'b>(a: &'a u32, b: &'b u32) -> &'b i32 { 0 }
+    """) {
+        returnTypeDisplay = createType("&'b i32")
+    }
+
+    fun `test add return type`() = doTest("""
+        fn foo/*caret*/() {}
+    """, """
+        fn foo() -> u32 {}
+    """) {
+        returnTypeDisplay = createType("u32")
+    }
+
+    fun `test add return type with lifetime`() = doTest("""
+        fn foo/*caret*/<'a>(a: &'a u32) { a }
+                          //^
+    """, """
+        fn foo/*caret*/<'a>(a: &'a u32) -> &'a u32 { a }
+                          //^
+    """) {
+        returnTypeDisplay = createType("&'a u32")
+    }
+
+    fun `test add return type with default type arguments`() = doTest("""
+        struct S<T, R=u32>(T, R);
+        fn foo/*caret*/(s: S<bool>) { unimplemented!() }
+                      //^
+    """, """
+        struct S<T, R=u32>(T, R);
+        fn foo/*caret*/(s: S<bool>) -> S<bool> { unimplemented!() }
+                      //^
+    """) {
+        val parameter = findElementInEditor<RsValueParameter>()
+        returnTypeDisplay = parameter.typeReference!!
+    }
+
+    fun `test remove return type`() = doTest("""
+        fn foo/*caret*/() -> u32 { 0 }
+    """, """
+        fn foo() { 0 }
+    """) {
+        returnTypeDisplay = createType("()")
+    }
+
+    fun `test remove return type without block`() = doTest("""
+        trait Trait {
+            fn foo/*caret*/() -> i32;
+        }
+    """, """
+        trait Trait {
+            fn foo() -> u32;
+        }
+    """) {
+        returnTypeDisplay = createType("u32")
+    }
+
+    fun `test remove only parameter`() = doTest("""
+        fn foo/*caret*/(a: u32) {
+            let c = a;
+        }
+        fn bar() {
+            foo(0);
+        }
+    """, """
+        fn foo() {
+            let c = a;
+        }
+        fn bar() {
+            foo();
+        }
+    """) {
+        parameters.removeAt(0)
+    }
+
+    fun `test remove first parameter`() = doTest("""
+        fn foo/*caret*/(a: u32, b: u32) {
+            let c = a;
+        }
+        fn bar() {
+            foo(0, 1);
+        }
+    """, """
+        fn foo(b: u32) {
+            let c = a;
+        }
+        fn bar() {
+            foo(1);
+        }
+    """) {
+        parameters.removeAt(0)
+    }
+
+    fun `test remove middle parameter`() = doTest("""
+        fn foo/*caret*/(a: u32, b: u32, c: u32) {
+            let c = a;
+        }
+        fn bar() {
+            foo(0, 1, 2);
+        }
+    """, """
+        fn foo(a: u32, c: u32) {
+            let c = a;
+        }
+        fn bar() {
+            foo(0, 2);
+        }
+    """) {
+        parameters.removeAt(1)
+    }
+
+    fun `test remove last parameter`() = doTest("""
+        fn foo/*caret*/(a: u32, b: u32) {}
+        fn bar() {
+            foo(0, 1);
+        }
+    """, """
+        fn foo(a: u32) {}
+        fn bar() {
+            foo(0);
+        }
+    """) {
+        parameters.removeLast()
+    }
+
+    fun `test remove last parameter (multiline)`() = doTest("""
+        fn foo/*caret*/(
+            a: u32,
+            b: u32,
+        ) {}
+        fn bar() {
+            foo(
+                0,
+                1
+            );
+        }
+    """, """
+        fn foo(a: u32) {}
+        fn bar() {
+            foo(0);
+        }
+    """) {
+        parameters.removeLast()
+    }
+
+    fun `test remove last method parameter (multiline)`() = doTest("""
+        struct S;
+        impl S {
+            fn foo/*caret*/(
+                &self,
+                a: u32,
+            ) {}
+        }
+        fn bar(s: S) {
+            s.foo(
+                0,
+            );
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+        fn bar(s: S) {
+            s.foo();
+        }
+    """) {
+        parameters.removeLast()
+    }
+
+    fun `test remove parameter trailing comma`() = doTest("""
+        fn foo/*caret*/(a: u32, b: u32,) {}
+    """, """
+        fn foo(a: u32) {}
+    """) {
+        parameters.removeLast()
+    }
+
+    fun `test remove method parameter trailing comma`() = doTest("""
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self, a: u32, b: u32,) {}
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self, a: u32) {}
+        }
+    """) {
+        parameters.removeLast()
+    }
+
+    fun `test remove last parameter trailing comma`() = doTest("""
+        fn foo/*caret*/(a: u32,) {}
+    """, """
+        fn foo() {}
+    """) {
+        parameters.clear()
+    }
+
+    fun `test remove last method parameter trailing comma`() = doTest("""
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self, a: u32,) {}
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self) {}
+        }
+    """) {
+        parameters.clear()
+    }
+
+    fun `test add only parameter`() = doTest("""
+        fn foo/*caret*/() {}
+        fn bar() {
+            foo();
+        }
+    """, """
+        fn foo(a: u32) {}
+        fn bar() {
+            foo();
+        }
+    """) {
+        parameters.add(parameter("a", "u32"))
+    }
+
+    fun `test add last parameter`() = doTest("""
+        fn foo/*caret*/(a: u32) {}
+        fn bar() {
+            foo(0);
+        }
+    """, """
+        fn foo(a: u32, b: u32) {}
+        fn bar() {
+            foo(0, );
+        }
+    """) {
+        parameters.add(parameter("b", "u32"))
+    }
+
+    fun `test add parameter in the middle (multiline)`() = doTest("""
+        fn foo/*caret*/(
+            a: u32,
+            c: u32,
+        ) {}
+        fn bar() {
+            foo(
+                0,
+                1,
+            );
+        }
+    """, """
+        fn foo(
+            a: u32,
+            b: u32,
+            c: u32,
+        ) {}
+        fn bar() {
+            foo(
+                0,
+                ,
+                1,
+            );
+        }
+    """) {
+        parameters.add(1, parameter("b", "u32"))
+    }
+
+    fun `test add multiple parameters`() = doTest("""
+        fn foo/*caret*/(a: u32) {}
+        fn bar() {
+            foo(0);
+        }
+    """, """
+        fn foo(a: u32, b: u32, c: u32) {}
+        fn bar() {
+            foo(0, , );
+        }
+    """) {
+        parameters.add(parameter("b", "u32"))
+        parameters.add(parameter("c", "u32"))
+    }
+
+    fun `test add parameter with lifetime`() = doTest("""
+        fn foo/*caret*/<'a>(a: &'a u32) {}
+                          //^
+    """, """
+        fn foo/*caret*/<'a>(a: &'a u32, b: &'a u32) {}
+                          //^
+    """) {
+        val parameter = findElementInEditor<RsValueParameter>()
+        parameters.add(parameter("b", parameter.typeReference!!))
+    }
+
+    fun `test add parameter with default type arguments`() = doTest("""
+        struct S<T, R=u32>(T, R);
+        fn foo/*caret*/(a: S<bool>) { unimplemented!() }
+                      //^
+    """, """
+        struct S<T, R=u32>(T, R);
+        fn foo/*caret*/(a: S<bool>, b: S<bool>) { unimplemented!() }
+                      //^
+    """) {
+        val parameter = findElementInEditor<RsValueParameter>()
+        parameters.add(parameter("b", parameter.typeReference!!))
+    }
+
+    fun `test add parameter to method`() = doTest("""
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self) {}
+        }
+        fn bar(s: S) {
+            s.foo();
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self, a: u32) {}
+        }
+        fn bar(s: S) {
+            s.foo();
+        }
+    """) {
+        parameters.add(parameter("a", "u32"))
+    }
+
+    fun `test swap parameters`() = doTest("""
+        fn foo/*caret*/(a: u32, b: u32) {}
+        fn bar() {
+            foo(0, 1);
+        }
+    """, """
+        fn foo(b: u32, a: u32) {}
+        fn bar() {
+            foo(1, 0);
+        }
+    """) {
+        swapParameters(0, 1)
+    }
+
+    fun `test swap method parameters`() = doTest("""
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self, a: u32, b: u32) {}
+        }
+        fn bar(s: S) {
+            s.foo(0, 1);
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self, b: u32, a: u32) {}
+        }
+        fn bar(s: S) {
+            s.foo(1, 0);
+        }
+    """) {
+        swapParameters(0, 1)
+    }
+
+    fun `test remove only method parameter`() = doTest("""
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self, a: u32) {}
+        }
+        fn bar(s: S) {
+            S::foo(&s, 0);
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self) {}
+        }
+        fn bar(s: S) {
+            S::foo(&s);
+        }
+    """) {
+        parameters.clear()
+    }
+
+    fun `test swap method parameters UFCS`() = doTest("""
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self, a: u32, b: u32) {}
+        }
+        fn bar(s: S) {
+            S::foo(&s, 0, 1);
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self, b: u32, a: u32) {}
+        }
+        fn bar(s: S) {
+            S::foo(&s, 1, 0);
+        }
+    """) {
+        swapParameters(0, 1)
+    }
+
+    fun `test add method parameter UFCS`() = doTest("""
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self) {}
+        }
+        fn bar(s: S) {
+            S::foo(&s);
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self, a: u32) {}
+        }
+        fn bar(s: S) {
+            S::foo(&s, );
+        }
+    """) {
+        parameters.add(parameter("a", "u32"))
+    }
+
+    fun `test delete method parameter UFCS`() = doTest("""
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self, a: u32, b: u32) {}
+        }
+        fn bar(s: S) {
+            S::foo(&s, 0, 1);
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo/*caret*/(&self, b: u32) {}
+        }
+        fn bar(s: S) {
+            S::foo(&s, 1);
+        }
+    """) {
+        parameters.removeAt(0)
+    }
+
+    fun `test swap parameters with comments`() = doTest("""
+        fn foo/*caret*/( /*a0*/ a /*a1*/ : u32 /*a2*/ , /*b0*/ b: u32 /*b1*/ ) {}
+        fn bar() {
+            foo(0, 1);
+        }
+    """, """
+        fn foo(/*b0*/ b: u32 /*b1*/, /*a0*/ a /*a1*/ : u32 /*a2*/) {}
+        fn bar() {
+            foo(1, 0);
+        }
+    """) {
+        swapParameters(0, 1)
+    }
+
+    fun `test swap arguments with comments`() = doTest("""
+        fn foo/*caret*/(a: u32, b: u32) {}
+        fn bar() {
+            foo( /*a0*/ 0 /*a1*/  /*a2*/ , /*b0*/ 1 /*b1*/ );
+        }
+    """, """
+        fn foo(b: u32, a: u32) {}
+        fn bar() {
+            foo(/*b0*/ 1 /*b1*/, /*a0*/ 0 /*a1*/  /*a2*/);
+        }
+    """) {
+        swapParameters(0, 1)
+    }
+
+    fun `test multiple move`() = doTest("""
+        fn foo/*caret*/(a: u32, b: u32, c: u32) {}
+        fn bar() {
+            foo(0, 1, 2);
+        }
+    """, """
+        fn foo(b: u32, c: u32, a: u32) {}
+        fn bar() {
+            foo(1, 2, 0);
+        }
+    """) {
+        swapParameters(0, 1)
+        swapParameters(1, 2)
+    }
+
+    fun `test swap back`() = doTest("""
+        fn foo/*caret*/(a: u32, b: u32, c: u32) {}
+        fn bar() {
+            foo(0, 1, 2);
+        }
+    """, """
+        fn foo(a: u32, b: u32, c: u32) {}
+        fn bar() {
+            foo(0, 1, 2);
+        }
+    """) {
+        swapParameters(0, 1)
+        swapParameters(1, 0)
+    }
+
+    fun `test move and add parameter`() = doTest("""
+        fn foo/*caret*/(a: u32, b: u32) {}
+        fn bar() {
+            foo(0, 1);
+        }
+    """, """
+        fn foo(b: u32, a: u32) {}
+        fn bar() {
+            foo(1, );
+        }
+    """) {
+        parameters[0] = parameters[1]
+        parameters[1] = parameter("a", "u32")
+    }
+
+    fun `test rename parameter ident with ident`() = doTest("""
+        fn foo/*caret*/(a: u32) {
+            let _ = a;
+            let _ = a + 1;
+        }
+    """, """
+        fn foo(b: u32) {
+            let _ = b;
+            let _ = b + 1;
+        }
+    """) {
+        parameters[0].patText = "b"
+    }
+
+    fun `test rename parameter complex pat with ident`() = doTest("""
+        fn foo/*caret*/((a, b): (u32, u32)) {
+            let _ = a;
+        }
+    """, """
+        fn foo(x: (u32, u32)) {
+            let _ = a;
+        }
+    """) {
+        parameters[0].patText = "x"
+    }
+
+    fun `test rename parameter ident with complex pat`() = doTest("""
+        fn foo/*caret*/(a: (u32, u32)) {
+            let _ = a;
+        }
+    """, """
+        fn foo((x, y): (u32, u32)) {
+            let _ = a;
+        }
+    """) {
+        parameters[0].patText = "(x, y)"
+    }
+
+    fun `test change parameter type`() = doTest("""
+        fn foo/*caret*/(a: u32) {}
+    """, """
+        fn foo(a: i32) {}
+    """) {
+        parameters[0].type = createParamType("i32")
+    }
+
+    fun `test wrong argument count`() = doTest("""
+        fn foo/*caret*/(a: u32) {}
+        fn bar() {
+            foo(1, 2, 3)
+        }
+    """, """
+        fn foo() {}
+        fn bar() {
+            foo(1, 2, 3)
+        }
+    """) {
+        parameters.clear()
+    }
+
+    fun `test add async`() = doTest("""
+        fn foo/*caret*/(a: u32) {}
+    """, """
+        async fn foo(a: u32) {}
+    """) {
+        isAsync = true
+    }
+
+    fun `test remove async`() = doTest("""
+        async fn foo/*caret*/(a: u32) {}
+    """, """
+        fn foo(a: u32) {}
+    """) {
+        isAsync = false
+    }
+
+    fun `test add unsafe`() = doTest("""
+        fn foo/*caret*/(a: u32) {}
+    """, """
+        unsafe fn foo(a: u32) {}
+    """) {
+        isUnsafe = true
+    }
+
+    fun `test remove unsafe`() = doTest("""
+        unsafe fn foo/*caret*/(a: u32) {}
+    """, """
+        fn foo(a: u32) {}
+    """) {
+        isUnsafe = false
+    }
+
+    fun `test add async unsafe and visibility`() = doTest("""
+        fn foo/*caret*/(a: u32) {}
+    """, """
+        pub async unsafe fn foo(a: u32) {}
+    """) {
+        isAsync = true
+        isUnsafe = true
+        visibility = createVisibility("pub")
+    }
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test import return type in different module`() = doTest("""
+        mod foo {
+            pub struct S;
+                     //^
+        }
+        mod bar {
+            fn baz/*caret*/() {}
+        }
+    """, """
+        mod foo {
+            pub struct S;
+                     //^
+        }
+        mod bar {
+            use crate::foo::S;
+
+            fn baz/*caret*/() -> S {}
+        }
+    """) {
+        returnTypeDisplay = referToType("S", findElementInEditor<RsStructItem>())
+    }
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test import new parameter type in different module`() = doTest("""
+        mod foo {
+            pub struct S;
+                     //^
+        }
+        mod bar {
+            fn baz/*caret*/() {}
+        }
+    """, """
+        mod foo {
+            pub struct S;
+                     //^
+        }
+        mod bar {
+            use crate::foo::S;
+
+            fn baz/*caret*/(s: S) {}
+        }
+    """) {
+        parameters.add(parameter("s", referToType("S", findElementInEditor<RsStructItem>())))
+    }
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test import changed parameter type in different module`() = doTest("""
+        mod foo {
+            pub struct S;
+                     //^
+        }
+        mod bar {
+            fn baz/*caret*/(s: u32) {}
+        }
+    """, """
+        mod foo {
+            pub struct S;
+                     //^
+        }
+        mod bar {
+            use crate::foo::S;
+
+            fn baz/*caret*/(s: S) {}
+        }
+    """) {
+        parameters[0].type = ParameterType.Valid(referToType("S", findElementInEditor<RsStructItem>()))
+    }
+
+    fun `test name conflict module`() = checkConflicts("""
+        fn foo/*caret*/() {}
+        fn bar() {}
+    """, setOf("The name bar conflicts with an existing item in main.rs (in test_package)")) {
+        name = "bar"
+    }
+
+    fun `test name conflict impl`() = checkConflicts("""
+        struct S;
+
+        impl S {
+            fn foo/*caret*/() {}
+            fn bar() {}
+        }
+    """, setOf("The name bar conflicts with an existing item in impl S (in test_package)")) {
+        name = "bar"
+    }
+
+    fun `test name conflict trait`() = checkConflicts("""
+        struct S;
+        trait Trait {
+            fn foo/*caret*/();
+            fn bar();
+        }
+    """, setOf("The name bar conflicts with an existing item in Trait (in test_package)")) {
+        name = "bar"
+    }
+
+    fun `test visibility conflict function call`() = checkConflicts("""
+        mod foo {
+            pub fn bar/*caret*/() {}
+        }
+        fn baz() {
+            foo::bar();
+        }
+    """, setOf("The function will not be visible from test_package after the refactoring")) {
+        visibility = null
+    }
+
+    fun `test visibility conflict method call`() = checkConflicts("""
+        mod foo {
+            pub struct S;
+            impl S {
+                pub fn bar/*caret*/(&self) {}
+            }
+        }
+        mod foo2 {
+            fn baz(s: super::foo::S) {
+                s.bar();
+            }
+        }
+    """, setOf("The function will not be visible from test_package::foo2 after the refactoring")) {
+        visibility = null
+    }
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test no visibility conflict disabled function`() = doTest("""
+        fn bar/*caret*/() {}
+
+        #[cfg(not(intellij_rust))]
+        fn foo() {}
+    """, """
+        fn foo/*caret*/() {}
+
+        #[cfg(not(intellij_rust))]
+        fn foo() {}
+    """) {
+        name = "foo"
+    }
+
+    fun `test no visibility conflict restricted mod`() = doTest("""
+        mod foo2 {
+            mod foo {
+                fn bar/*caret*/() {}
+            }
+            fn baz() {
+                foo::bar();
+            }
+        }
+
+    """, """
+        mod foo2 {
+            mod foo {
+                pub(in super) fn bar/*caret*/() {}
+            }
+            fn baz() {
+                foo::bar();
+            }
+        }
+
+    """) {
+        visibility = createVisibility("pub(in super)")
+    }
+
+    private val overriddenMethodWithUsagesBefore: String = """
+        trait Trait {
+            fn foo/*trait*/(&self);
+        }
+
+        struct S;
+        impl Trait for S {
+            fn foo/*impl*/(&self) {}
+        }
+
+        fn bar1(t: &dyn Trait) {
+            t.foo();
+        }
+        fn bar2(s: S) {
+            s.foo();
+        }
+        fn bar3<T: Trait>(t: &T) {
+            t.foo();
+        }
+    """
+
+    private val overriddenMethodWithUsagesAfter: String = """
+        trait Trait {
+            fn bar(&self) -> u32;
+        }
+
+        struct S;
+        impl Trait for S {
+            fn bar(&self) -> u32 {}
+        }
+
+        fn bar1(t: &dyn Trait) {
+            t.bar();
+        }
+        fn bar2(s: S) {
+            s.bar();
+        }
+        fn bar3<T: Trait>(t: &T) {
+            t.bar();
+        }
+    """
+
+    fun `test change overridden methods and usages when invoked on trait`() = doTest(
+        overriddenMethodWithUsagesBefore.replace("/*trait*/", "/*caret*/").replace("/*impl*/", ""),
+        overriddenMethodWithUsagesAfter
+    ) {
+        name = "bar"
+        returnTypeDisplay = createType("u32")
+    }
+
+    fun `test change overridden methods and usages when invoked on impl`() = doTest(
+        overriddenMethodWithUsagesBefore.replace("/*impl*/", "/*caret*/").replace("/*trait*/", ""),
+        overriddenMethodWithUsagesAfter
+    ) {
+        name = "bar"
+        returnTypeDisplay = createType("u32")
+    }
+
+    private fun RsChangeFunctionSignatureConfig.swapParameters(a: Int, b: Int) {
+        val param = parameters[a]
+        parameters[a] = parameters[b]
+        parameters[b] = param
+    }
+
+    private fun createVisibility(vis: String): RsVis = RsPsiFactory(project).createVis(vis)
+    private fun createType(text: String): RsTypeReference = RsPsiFactory(project).createType(text)
+    private fun createParamType(text: String): ParameterType = ParameterType.Valid(createType(text))
+    private fun parameter(patText: String, type: String): Parameter = parameter(patText, createType(type))
+    private fun parameter(patText: String, type: RsTypeReference): Parameter
+        = Parameter(RsPsiFactory(project), patText, ParameterType.Valid(type))
+
+    /**
+     * Refer to existing type in the test code snippet.
+     */
+    private fun referToType(text: String, context: RsElement): RsTypeReference
+        = RsTypeReferenceCodeFragment(myFixture.project, text, context).typeReference!!
+
+    private fun doTest(
+        @Language("Rust") code: String,
+        @Language("Rust") expected: String,
+        modifyConfig: RsChangeFunctionSignatureConfig.() -> Unit
+    ) {
+        withMockChangeFunctionSignature({ config ->
+            modifyConfig.invoke(config)
+        }) {
+            checkEditorAction(code, expected, "ChangeSignature", trimIndent = false)
+        }
+    }
+
+    private fun checkConflicts(
+        @Language("Rust") code: String,
+        expectedConflicts: Set<String>,
+        modifyConfig: RsChangeFunctionSignatureConfig.() -> Unit
+    ) {
+        try {
+            doTest(code, code, modifyConfig)
+            if (expectedConflicts.isNotEmpty()) {
+                error("No conflicts found, expected $expectedConflicts")
+            }
+        }
+        catch (e: BaseRefactoringProcessor.ConflictsInTestsException) {
+            assertEquals(expectedConflicts, e.messages.toSet())
+        }
+    }
+
+    private fun checkError(@Language("Rust") code: String, errorMessage: String) {
+        try {
+            checkEditorAction(code, code, "ChangeSignature")
+            error("No error found, expected $errorMessage")
+        } catch (e: Exception) {
+            assertEquals(errorMessage, e.message)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the `Change signature` refactoring.

![change-signature](https://user-images.githubusercontent.com/4539057/101150376-74b7fb80-3620-11eb-9c69-b0bf671a815c.gif)

The current implementation has basic functionality.
- ~How should the user be able to enter the name and type of parameters? I suggest that we use `RsPat` for name and `Ty` or `RsTypeReference` for types instead of plain strings, so that after the user enters something, we try to parse it and if it fails, we will not allow the dialog to proceed.~
- ~Currently, if a new parameter is added, it will not be filled with a default value at call sites, so that the user will not forget to update the call sites. This mirrors the behaviour of Kotlin.~
- ~Should the dialog offer things like `async`, `unsafe`, `extern` or variadic args? If yes, we need to let the user enter any possible value for these attributes. I think that it's worth to do it only if we can actually refactor something after changing them. Maybe removing/adding await/unsafe from call sites?~
- ~Originally I wanted to unify the Change signature and Extract function UI (and some data structures), but I realized that they actually differ quite a lot and it would complicate the code too much I think. I checked the Kotlin plugin and it has two different dialogs for these refactorings, so I think that it's ok.~
- ~I wanted to move all surrounding whitespace and comments when a parameter is moved from one place to another, but I'm having a difficulty making it work. The commented code in `insertItemWithComma` didn't work, basically if I try to do something like this:~
```kotlin
val inserted = parent.addBefore(<some whitespace>, anchor)
```
~the `inserted` will contain `anchor` instead of the inserted whitespace. This breaks copying of successive whitespace and comment elements, which I tried to do in a loop. Any hints of what might be wrong here?~

I'm not a huge fan of the signature config being mutable, but it makes UI and test code simpler and it also helps with detection of modified parameters (so I don't have to generate a GUID or something like that for them).

~The logic about detecting moved/removed/added parameters is slightly convoluted, it could be probably simplified, but I want to leave that for a final refactoring. It's not as simple as it sounds, as we must detect what parameters were removed, what were added and what were just moved, these operations have different semantics, even if they end up with the same result in the signature (see `test move and add parameter` and `test swap parameters`).~

Fixes: https://github.com/intellij-rust/intellij-rust/issues/4927

changelog: Add the Change Signature refactoring for functions and methods.