### PR TITLE
RUN: Fix exception on build cancel

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildContext.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildContext.kt
@@ -39,8 +39,8 @@ class CargoBuildContext(
     private val buildSemaphore: Semaphore = project.getUserData(BUILD_SEMAPHORE_KEY)
         ?: (project as UserDataHolderEx).putUserDataIfAbsent(BUILD_SEMAPHORE_KEY, Semaphore(1))
 
-    lateinit var indicator: ProgressIndicator
-    lateinit var processHandler: ProcessHandler
+    var indicator: ProgressIndicator? = null
+    var processHandler: ProcessHandler? = null
 
     val started: Long = System.currentTimeMillis()
     var finished: Long = started
@@ -50,12 +50,12 @@ class CargoBuildContext(
     var warnings: Int = 0
 
     fun waitAndStart(): Boolean {
-        indicator.pushState()
+        indicator?.pushState()
         try {
-            indicator.text = "Waiting for the current build to finish..."
-            indicator.text2 = ""
+            indicator?.text = "Waiting for the current build to finish..."
+            indicator?.text2 = ""
             while (true) {
-                indicator.checkCanceled()
+                indicator?.checkCanceled()
                 try {
                     if (buildSemaphore.tryAcquire(100, TimeUnit.MILLISECONDS)) break
                 } catch (e: InterruptedException) {
@@ -66,13 +66,13 @@ class CargoBuildContext(
             canceled()
             return false
         } finally {
-            indicator.popState()
+            indicator?.popState()
         }
         return true
     }
 
     fun finished(isSuccess: Boolean) {
-        val isCanceled = indicator.isCanceled
+        val isCanceled = indicator?.isCanceled ?: false
 
         finished = System.currentTimeMillis()
         buildSemaphore.release()

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildEventsConverter.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildEventsConverter.kt
@@ -204,11 +204,11 @@ class CargoBuildEventsConverter(private val context: CargoBuildContext) : BuildO
             return Progress(current, total)
         }
 
-        fun updateIndicator(indicator: ProgressIndicator, title: String, description: String, progress: Progress) {
-            indicator.isIndeterminate = progress.total < 0
-            indicator.text = title
-            indicator.text2 = description
-            indicator.fraction = progress.fraction
+        fun ProgressIndicator.update(title: String, description: String, progress: Progress) {
+            isIndeterminate = progress.total < 0
+            text = title
+            text2 = description
+            fraction = progress.fraction
         }
 
         val activeTaskNames = message
@@ -217,12 +217,7 @@ class CargoBuildEventsConverter(private val context: CargoBuildContext) : BuildO
             .map { it.substringBefore("(").trim() }
         finishNonActiveTasks(activeTaskNames)
 
-        updateIndicator(
-            context.indicator,
-            context.progressTitle,
-            message.substringAfter(":").trim(),
-            parseProgress(message)
-        )
+        context.indicator?.update(context.progressTitle, message.substringAfter(":").trim(), parseProgress(message))
     }
 
     private fun handleFinishedMessage(failedTaskName: String?, messageConsumer: Consumer<in BuildEvent>) {

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
@@ -116,8 +116,8 @@ object CargoBuildManager {
             }
 
             processHandler = state.startProcess(emulateTerminal = true)
-            processHandler.addProcessListener(CargoBuildAdapter(this, buildProgressListener))
-            processHandler.startNotify()
+            processHandler?.addProcessListener(CargoBuildAdapter(this, buildProgressListener))
+            processHandler?.startNotify()
         }
     }
 
@@ -145,7 +145,7 @@ object CargoBuildManager {
                                 if (!wasCanceled && indicator.isCanceled) {
                                     wasCanceled = true
                                     synchronized(processCreationLock) {
-                                        context.processHandler.destroyProcess()
+                                        context.processHandler?.destroyProcess()
                                     }
                                 }
 
@@ -168,8 +168,8 @@ object CargoBuildManager {
             }
         }
 
-        context.indicator.text = context.progressTitle
-        context.indicator.text2 = ""
+        context.indicator?.text = context.progressTitle
+        context.indicator?.text2 = ""
 
         ApplicationManager.getApplication().executeOnPooledThread {
             if (!context.waitAndStart()) return@executeOnPooledThread
@@ -184,7 +184,8 @@ object CargoBuildManager {
             @Suppress("DEPRECATION")
             TransactionGuard.submitTransaction(context.project, Runnable {
                 synchronized(processCreationLock) {
-                    if (context.indicator.isCanceled) {
+                    val isCanceled = context.indicator?.isCanceled ?: false
+                    if (isCanceled) {
                         context.canceled()
                         return@Runnable
                     }


### PR DESCRIPTION
Fixes this exception:
<details>
  <summary>Stacktrace</summary>
  
  ```
kotlin.UninitializedPropertyAccessException: lateinit property processHandler has not been initialized
    at org.rust.cargo.runconfig.buildtool.CargoBuildContext.getProcessHandler(CargoBuildContext.kt:43)
    at org.rust.cargo.runconfig.buildtool.CargoBuildManager$execute$1$1.run(CargoBuildManager.kt:148)
    at com.intellij.openapi.progress.impl.CoreProgressManager$TaskRunnable.run(CoreProgressManager.java:935)
    at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcessWithProgressAsync$5(CoreProgressManager.java:442)
    at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$3(ProgressRunner.java:235)
    at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:170)
    at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:629)
    at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:581)
    at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
    at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:157)
    at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$4(ProgressRunner.java:235)
    at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:668)
    at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:665)
    at java.base/java.security.AccessController.doPrivileged(Native Method)
    at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:665)
    at java.base/java.lang.Thread.run(Thread.java:834)
  ```
</details>
