### PR TITLE
CI: create a release branch on a schedule from CI

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,6 +1,9 @@
 name: release branch
 
-on: workflow_dispatch
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: '0 1 * * *' # try everyday
 
 jobs:
     make-release-branch:
@@ -18,5 +21,11 @@ jobs:
                   git config --local user.email "action@github.com"
                   git config --local user.name "GitHub Action"
 
+            - name: Check date
+              if: github.event_name == 'schedule'
+              id: check-date
+              run: echo "::set-output name=result::$(python scripts/check_release_branch_date.py)"
+
             - name: Make release branch
+              if: github.event_name != 'schedule' || fromJSON(steps.check-date.outputs.result).create_release_branch
               run: python scripts/make_release_branch.py --token ${{ secrets.WORKFLOW_GITHUB_TOKEN }}

--- a/scripts/check_release_branch_date.py
+++ b/scripts/check_release_branch_date.py
@@ -1,0 +1,22 @@
+import json
+from datetime import datetime, date, timedelta
+from urllib import request
+
+from common import get_patch_version, env
+
+if __name__ == '__main__':
+    repo = env("GITHUB_REPOSITORY")
+    response = request.urlopen(f"https://api.github.com/repos/{repo}/milestones")
+    milestones = json.load(response)
+
+    milestone_version = f"v{get_patch_version()}"
+    milestone = next(milestone for milestone in milestones if milestone["title"] == milestone_version)
+    # TODO: find out more correct way to parse data
+    release_date = datetime.strptime(milestone["due_on"], "%Y-%m-%dT%H:%M:%SZ").date()
+
+    today = date.today()
+    delta = release_date - today
+    week = timedelta(7)
+
+    # Should be synchronized with .github/workflows/release-branch.yml
+    print(json.dumps({"create_release_branch": delta < week}))


### PR DESCRIPTION
These changes add cron trigger for `release-branch.yml` to create release branch on a schedule.
The implementation looks at next milestone each day and if there are less than 7 days before new release, it creates new release branch from master