### PR TITLE
T: improve light tests

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/TestCargoProjectsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/TestCargoProjectsServiceImpl.kt
@@ -88,7 +88,7 @@ class TestCargoProjectsServiceImpl(project: Project) : CargoProjectsServiceImpl(
     }
 
     private fun modifyProjectsSync(f: (List<CargoProjectImpl>) -> CompletableFuture<List<CargoProjectImpl>>) {
-        modifyProjects(makeRootsChange = false, f = f).get(1, TimeUnit.MINUTES) ?: error("Timeout when refreshing a test Cargo project")
+        modifyProjects(f).get(1, TimeUnit.MINUTES) ?: error("Timeout when refreshing a test Cargo project")
     }
 
     @TestOnly

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -5,9 +5,11 @@
 
 package org.rust
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.ContentEntry
 import com.intellij.openapi.roots.ModifiableRootModel
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
 import com.intellij.testFramework.LightProjectDescriptor
@@ -17,6 +19,7 @@ import com.intellij.util.Urls
 import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.RustcInfo
 import org.rust.cargo.project.model.impl.testCargoProjects
+import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.*
 import org.rust.cargo.project.workspace.CargoWorkspaceData
@@ -124,6 +127,16 @@ open class WithRustup(private val delegate: RustProjectDescriptorBase) : RustPro
     override fun setUp(fixture: CodeInsightTestFixture) {
         delegate.setUp(fixture)
         stdlib?.let { VfsRootAccess.allowRootAccess(fixture.testRootDisposable, it.path) }
+        // TODO: use RustupTestFixture somehow
+        val rustSettings = fixture.project.rustSettings
+        rustSettings.modify {
+            it.toolchain = toolchain
+        }
+        Disposer.register(fixture.testRootDisposable, Disposable {
+            rustSettings.modify {
+                it.toolchain = null
+            }
+        })
     }
 }
 


### PR DESCRIPTION
Now any modifications of project settings don't change content roots.
It allows avoiding exceptions like this:
<details><summary>stacktrace</summary>

```stacktrace
CompositeException (2 nested):
------------------------------
[0]: null
[1]: Virtual pointer 'temp:///src/src' hasn't been disposed: --------------Creation trace: 
java.lang.Throwable
	at com.intellij.openapi.util.TraceableDisposable.<init>(TraceableDisposable.java:31)
	at com.intellij.openapi.vfs.impl.VirtualFilePointerImpl.<init>(VirtualFilePointerImpl.java:40)
	at com.intellij.openapi.vfs.impl.VirtualFilePointerManagerImpl.getOrCreate(VirtualFilePointerManagerImpl.java:340)
	at com.intellij.openapi.vfs.impl.VirtualFilePointerManagerImpl.create(VirtualFilePointerManagerImpl.java:219)
	at com.intellij.openapi.vfs.impl.VirtualFilePointerManagerImpl.create(VirtualFilePointerManagerImpl.java:130)
	at com.intellij.openapi.roots.impl.ContentFolderBaseImpl.<init>(ContentFolderBaseImpl.java:54)
	at com.intellij.openapi.roots.impl.SourceFolderImpl.<init>(SourceFolderImpl.java:41)
	at com.intellij.openapi.roots.impl.ContentEntryImpl.addSourceFolder(ContentEntryImpl.java:223)
	at com.intellij.openapi.roots.impl.ContentEntryImpl.addSourceFolder(ContentEntryImpl.java:213)
	at com.intellij.openapi.roots.impl.ContentEntryImpl.addSourceFolder(ContentEntryImpl.java:207)
	at org.rust.cargo.project.model.CargoProjectServiceKt.setup(CargoProjectService.kt:157)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt$setupProjectRoots$1$1$1$2$1.invoke(CargoProjectImpl.kt:499)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt$setupProjectRoots$1$1$1$2$1.invoke(CargoProjectImpl.kt)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt$setupContentRoots$1.consume(CargoProjectImpl.kt:535)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt$setupContentRoots$1.consume(CargoProjectImpl.kt)
	at com.intellij.openapi.roots.ModuleRootModificationUtil.lambda$updateModel$8(ModuleRootModificationUtil.java:126)
	at com.intellij.openapi.roots.ModuleRootModificationUtil.modifyModel(ModuleRootModificationUtil.java:134)
	at com.intellij.openapi.roots.ModuleRootModificationUtil.updateModel(ModuleRootModificationUtil.java:125)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt.setupContentRoots(CargoProjectImpl.kt:534)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt.access$setupContentRoots(CargoProjectImpl.kt:1)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt$setupProjectRoots$1$$special$$inlined$runWriteAction$1$lambda$1$1.invoke(CargoProjectImpl.kt:499)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt$setupProjectRoots$1$$special$$inlined$runWriteAction$1$lambda$1.run(CargoProjectImpl.kt:520)
	at com.intellij.openapi.roots.impl.ProjectRootManagerImpl.mergeRootsChangesDuring(ProjectRootManagerImpl.java:333)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt$setupProjectRoots$1$$special$$inlined$runWriteAction$1.compute(actions.kt:59)
	at com.intellij.openapi.application.impl.ApplicationImpl.lambda$runWriteAction$16(ApplicationImpl.java:989)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteActionWithClass(ApplicationImpl.java:968)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:989)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt$setupProjectRoots$1.invoke(CargoProjectImpl.kt:624)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt$setupProjectRoots$1.invoke(CargoProjectImpl.kt)
	at com.intellij.openapi.application.ActionsKt.invokeAndWaitIfNeeded(actions.kt:29)
	at com.intellij.openapi.application.ActionsKt.invokeAndWaitIfNeeded$default(actions.kt:26)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt.setupProjectRoots(CargoProjectImpl.kt:484)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt.access$setupProjectRoots(CargoProjectImpl.kt:1)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt$doRefresh$2.apply(CargoProjectImpl.kt:478)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt$doRefresh$2.apply(CargoProjectImpl.kt)
	at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:680)
	at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:658)
	at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2094)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt.doRefresh(CargoProjectImpl.kt:466)
	at org.rust.cargo.project.model.impl.CargoProjectImplKt.access$doRefresh(CargoProjectImpl.kt:1)
	at org.rust.cargo.project.model.impl.CargoProjectsServiceImpl$refreshAllProjects$1.invoke(CargoProjectImpl.kt:194)
	at org.rust.cargo.project.model.impl.CargoProjectsServiceImpl$refreshAllProjects$1.invoke(CargoProjectImpl.kt:80)
	at org.rust.stdext.AsyncValue$updateAsync$1.invoke(Concurrency.kt:36)
	at org.rust.stdext.AsyncValue$updateAsync$1.invoke(Concurrency.kt:24)
	at org.rust.stdext.AsyncValue.startUpdateProcessing(Concurrency.kt:60)
	at org.rust.stdext.AsyncValue.updateAsync(Concurrency.kt:48)
	at org.rust.cargo.project.model.impl.CargoProjectsServiceImpl.modifyProjects(CargoProjectImpl.kt:221)
	at org.rust.cargo.project.model.impl.CargoProjectsServiceImpl.modifyProjects$default(CargoProjectImpl.kt:218)
	at org.rust.cargo.project.model.impl.CargoProjectsServiceImpl.refreshAllProjects(CargoProjectImpl.kt:194)
	at org.rust.cargo.project.model.impl.CargoProjectsServiceImpl$$special$$inlined$with$lambda$2.rustSettingsChanged(CargoProjectImpl.kt:95)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.intellij.util.messages.impl.MessageBusImpl.invokeListener(MessageBusImpl.java:632)
	at com.intellij.util.messages.impl.MessageBusImpl.deliverMessage(MessageBusImpl.java:406)
	at com.intellij.util.messages.impl.MessageBusImpl.pumpWaitingBuses(MessageBusImpl.java:384)
	at com.intellij.util.messages.impl.MessageBusImpl.pumpMessages(MessageBusImpl.java:366)
	at com.intellij.util.messages.impl.MessageBusImpl.access$100(MessageBusImpl.java:32)
	at com.intellij.util.messages.impl.MessageBusImpl$MessagePublisher.invoke(MessageBusImpl.java:187)
	at com.sun.proxy.$Proxy82.rustSettingsChanged(Unknown Source)
	at org.rust.cargo.project.settings.impl.RustProjectSettingsServiceImpl.notifySettingsChanged(RustProjectSettingsServiceImpl.kt:79)
	at org.rust.cargo.project.settings.impl.RustProjectSettingsServiceImpl.modify(RustProjectSettingsServiceImpl.kt:69)
	at org.rust.cargo.runconfig.filters.RsBacktraceFilterTest.withDefaultToolchain(RsBacktraceFilterTest.kt:148)
	at org.rust.cargo.runconfig.filters.RsBacktraceFilterTest.test resolve stdlib link(RsBacktraceFilterTest.kt:126)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at junit.framework.TestCase.runTest(TestCase.java:176)
	at com.intellij.testFramework.UsefulTestCase.lambda$runTest$9(UsefulTestCase.java:331)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:462)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:480)
	at com.intellij.testFramework.UsefulTestCase.invokeTestRunnable(UsefulTestCase.java:378)
	at com.intellij.testFramework.UsefulTestCase.runTest(UsefulTestCase.java:350)
	at com.intellij.testFramework.fixtures.BasePlatformTestCase.doRunTests(BasePlatformTestCase.java:114)
	at com.intellij.testFramework.fixtures.BasePlatformTestCase.runTest(BasePlatformTestCase.java:105)
	at org.rust.RsTestBase.runTestEdition2015(RsTestBase.kt:164)
	at org.rust.RsTestBase.runTest(RsTestBase.kt:140)
	at com.intellij.testFramework.UsefulTestCase.defaultRunBare(UsefulTestCase.java:394)
	at com.intellij.testFramework.EdtTestUtil$Companion$runInEdtAndWait$1.invoke(EdtTestUtil.kt:18)
	at com.intellij.testFramework.EdtTestUtil$Companion$runInEdtAndWait$1.invoke(EdtTestUtil.kt:13)
	at com.intellij.testFramework.EdtTestUtilKt$runInEdtAndWait$1.run(EdtTestUtil.kt:50)
	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:201)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:802)
	at com.intellij.openapi.application.impl.ApplicationImpl.lambda$invokeAndWait$8(ApplicationImpl.java:475)
	at com.intellij.openapi.application.impl.LaterInvocator$1.run(LaterInvocator.java:126)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:84)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:132)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:47)
	at com.intellij.openapi.application.impl.FlushQueue$FlushNow.run(FlushQueue.java:188)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:313)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:770)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:740)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:967)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:839)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:450)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:744)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$9(IdeEventQueue.java:449)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:802)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:497)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
-------------Own trace:
com.intellij.openapi.util.TraceableDisposable$DisposalException: 2081296280
	at com.intellij.openapi.util.TraceableDisposable.getStackTrace(TraceableDisposable.java:121)
	at com.intellij.openapi.vfs.impl.VirtualFilePointerTracker.assertPointersAreDisposed(VirtualFilePointerTracker.java:86)
	at com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl.lambda$tearDown$38(CodeInsightTestFixtureImpl.java:1281)
	at com.intellij.testFramework.RunAll.collectExceptions(RunAll.java:57)
	at com.intellij.testFramework.RunAll.runAll(RunAll.java:35)
	at com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl.tearDown(CodeInsightTestFixtureImpl.java:1234)
	at com.intellij.testFramework.fixtures.BasePlatformTestCase.tearDown(BasePlatformTestCase.java:61)
	at org.rust.RsTestBase.tearDown(RsTestBase.kt:75)
	at com.intellij.testFramework.UsefulTestCase.defaultRunBare(UsefulTestCase.java:402)
	at com.intellij.testFramework.EdtTestUtil$Companion$runInEdtAndWait$1.invoke(EdtTestUtil.kt:18)
	at com.intellij.testFramework.EdtTestUtil$Companion$runInEdtAndWait$1.invoke(EdtTestUtil.kt:13)
	at com.intellij.testFramework.EdtTestUtilKt$runInEdtAndWait$1.run(EdtTestUtil.kt:50)
	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:201)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:802)
	at com.intellij.openapi.application.impl.ApplicationImpl.lambda$invokeAndWait$8(ApplicationImpl.java:475)
	at com.intellij.openapi.application.impl.LaterInvocator$1.run(LaterInvocator.java:126)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:84)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:132)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:47)
	at com.intellij.openapi.application.impl.FlushQueue$FlushNow.run(FlushQueue.java:188)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:313)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:770)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:740)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:967)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:839)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:450)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:744)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$9(IdeEventQueue.java:449)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:802)
```

</details>

It's improved version of changes introduced in 450aeefe80165ead1d68064b0d37445fcd2486c6

Also, if you use any inheritor of `WithRustup` project descriptor like `WithStdlibRustProjectDescriptor` in light tests (i.e. want to use stdlib in tests), `toolchain` is properly set up in `RustProjectSettingsService`