### PR TITLE
RES: Add name to RsResolveProcessor

### DIFF
--- a/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
@@ -14,6 +14,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.block
 import org.rust.lang.core.psi.ext.childOfType
 import org.rust.lang.core.resolve.TYPES
+import org.rust.lang.core.resolve.createProcessor
 import org.rust.lang.core.resolve.findPrelude
 import org.rust.lang.core.resolve.processNestedScopesUpwards
 import org.rust.openapiext.toPsiFile
@@ -22,6 +23,7 @@ class RsConsoleCodeFragmentContext(codeFragment: RsReplCodeFragment?) {
 
     // concurrent set is needed because accessed both in `addItemsNamesFromPrelude` and `addToContext`
     private val itemsNames: MutableSet<String> = ContainerUtil.newConcurrentSet()
+
     @Volatile
     private var hasAddedNamesFromPrelude = false
 
@@ -40,10 +42,11 @@ class RsConsoleCodeFragmentContext(codeFragment: RsReplCodeFragment?) {
         val prelude = findPrelude(codeFragment) ?: return
 
         val preludeItemsNames = mutableListOf<String>()
-        processNestedScopesUpwards(prelude, TYPES) {
+        val processor = createProcessor {
             preludeItemsNames += it.name
             false
         }
+        processNestedScopesUpwards(prelude, TYPES, processor)
         itemsNames += preludeItemsNames
         hasAddedNamesFromPrelude = true
     }

--- a/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
@@ -11,6 +11,7 @@ import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.RsQualifiedNamedElement
 import org.rust.lang.core.resolve.TYPES
+import org.rust.lang.core.resolve.createProcessor
 import org.rust.lang.core.resolve.processNestedScopesUpwards
 import org.rust.lang.core.types.Substitution
 import org.rust.lang.core.types.emptySubstitution
@@ -152,12 +153,13 @@ object RsImportHelper {
         }
 
         val toQualifiedName = hashSetOf<RsQualifiedNamedElement>()
-        processNestedScopesUpwards(context, TYPES) { entry ->
-            val group = importSubjects.remove(entry.name) ?: return@processNestedScopesUpwards false
+        val processor = createProcessor { entry ->
+            val group = importSubjects.remove(entry.name) ?: return@createProcessor false
             group.remove(entry.element)
             toQualifiedName.addAll(group)
             importSubjects.isEmpty()
         }
+        processNestedScopesUpwards(context, TYPES, processor)
 
         return TypeReferencesInfo(importSubjects.flatMap { it.value }.toSet(), toQualifiedName)
     }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsMacroCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsMacroCompletionProvider.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.completion
 
 import com.intellij.codeInsight.completion.CompletionParameters
-import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.patterns.ElementPattern
 import com.intellij.patterns.PlatformPatterns.psiElement
@@ -23,8 +22,8 @@ import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psi.unescapedText
 import org.rust.lang.core.psiElement
-import org.rust.lang.core.resolve.ScopeEntry
 import org.rust.lang.core.resolve.collectCompletionVariants
+import org.rust.lang.core.resolve.createProcessor
 import org.rust.lang.core.resolve.processMacroCallVariantsInScope
 import org.rust.lang.core.resolve.processMacrosExportedByCrateName
 import org.rust.lang.core.withPrevSiblingSkipping
@@ -57,7 +56,7 @@ object RsMacroCompletionProvider : RsCompletionProvider() {
         val context = RsCompletionContext(isSimplePath = !is2segmentPath)
 
         collectCompletionVariants(result, context) { originalProcessor ->
-            val processor: (ScopeEntry) -> Boolean = { entry ->
+            val processor = createProcessor(originalProcessor.name) { entry ->
                 val macro = entry.element
                 val hide = mod != null && macro is RsMacro && isHidden(macro, mod)
                 if (!hide) originalProcessor(entry) else false

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -23,6 +23,7 @@ import org.rust.lang.core.psi.RsConstant
 import org.rust.lang.core.psi.RsEnumVariant
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.resolve.Namespace
+import org.rust.lang.core.resolve.createProcessor
 import org.rust.lang.core.resolve.processNestedScopesUpwards
 
 interface RsElement : PsiElement {
@@ -123,7 +124,7 @@ abstract class RsStubbedElementImpl<StubT : StubElement<*>> : StubBasedPsiElemen
 
 fun RsElement.findInScope(name: String, ns: Set<Namespace>): PsiElement? {
     var resolved: PsiElement? = null
-    processNestedScopesUpwards(this, ns) { entry ->
+    val processor = createProcessor(name) { entry ->
         if (entry.name == name && entry.element != null) {
             resolved = entry.element
             true
@@ -131,6 +132,7 @@ fun RsElement.findInScope(name: String, ns: Set<Namespace>): PsiElement? {
             false
         }
     }
+    processNestedScopesUpwards(this, ns, processor)
     return resolved
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemElement.kt
@@ -5,11 +5,11 @@
 
 package org.rust.lang.core.psi.ext
 
-import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.resolve.TYPES
+import org.rust.lang.core.resolve.createProcessor
 import org.rust.lang.core.resolve.processNestedScopesUpwards
 
 /**
@@ -20,10 +20,11 @@ interface RsItemElement : RsVisibilityOwner, RsOuterAttributeOwner, RsExpandedEl
 
 fun <T : RsItemElement> Iterable<T>.filterInScope(scope: RsElement): List<T> {
     val set = toMutableSet()
-    processNestedScopesUpwards(scope, TYPES) {
+    val processor = createProcessor {
         set.remove(it.element)
         set.isEmpty()
     }
+    processNestedScopesUpwards(scope, TYPES, processor)
     return if (set.isEmpty()) toList() else toMutableList().apply { removeAll(set) }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -68,7 +68,7 @@ fun processItemDeclarations(
     val withPrivateImports = ipm != ItemProcessingMode.WITHOUT_PRIVATE_IMPORTS
 
     val directlyDeclaredNames = HashMap<String, Set<Namespace>>()
-    val processor = { e: ScopeEntry ->
+    val processor = createProcessor(originalProcessor.name) { e ->
         val result = originalProcessor(e)
         if (e.isInitialized) {
             val element = e.element

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -101,7 +101,7 @@ fun processDotExprResolveVariants(
     lookup: ImplLookup,
     receiverType: Ty,
     context: RsElement,
-    processor: (DotExprResolveVariant) -> Boolean
+    processor: RsResolveProcessorBase<DotExprResolveVariant>
 ): Boolean {
     if (processFieldExprResolveVariants(lookup, receiverType, processor)) return true
     if (processMethodDeclarationsWithDeref(lookup, receiverType, context, processor)) return true
@@ -112,11 +112,14 @@ fun processDotExprResolveVariants(
 fun processFieldExprResolveVariants(
     lookup: ImplLookup,
     receiverType: Ty,
-    processor: (FieldResolveVariant) -> Boolean
+    originalProcessor: RsResolveProcessorBase<FieldResolveVariant>
 ): Boolean {
     for ((i, ty) in lookup.coercionSequence(receiverType).withIndex()) {
         if (ty !is TyAdt || ty.item !is RsStructItem) continue
-        if (processFieldDeclarations(ty.item) { processor(FieldResolveVariant(it.name, it.element!!, ty, i)) }) return true
+        val processor = createProcessor(originalProcessor.name) {
+            originalProcessor(FieldResolveVariant(it.name, it.element!!, ty, i))
+        }
+        if (processFieldDeclarations(ty.item, processor)) return true
     }
 
     return false
@@ -313,7 +316,7 @@ fun findDependencyCrateByNamePath(context: RsElement, path: RsPath): RsFile? {
 
 fun findDependencyCrateByName(context: RsElement, name: String): RsFile? {
     var found: RsFile? = null
-    processExternCrateResolveVariants(context, false) {
+    val processor = createProcessor(name) {
         if (it.name == name) {
             found = it.element as? RsFile
             true
@@ -321,6 +324,7 @@ fun findDependencyCrateByName(context: RsElement, name: String): RsFile? {
             false
         }
     }
+    processExternCrateResolveVariants(context, false, processor)
     return found
 }
 
@@ -625,18 +629,22 @@ private fun processTraitRelativePath(
     return false
 }
 
-fun processPatBindingResolveVariants(binding: RsPatBinding, isCompletion: Boolean, processor: RsResolveProcessor): Boolean {
+fun processPatBindingResolveVariants(
+    binding: RsPatBinding,
+    isCompletion: Boolean,
+    originalProcessor: RsResolveProcessor
+): Boolean {
     if (binding.parent is RsPatField) {
         val parentPat = binding.parent.parent as RsPatStruct
         val patStruct = parentPat.path.reference?.deepResolve()
         if (patStruct is RsFieldsOwner) {
-            if (processFieldDeclarations(patStruct, processor)) return true
+            if (processFieldDeclarations(patStruct, originalProcessor)) return true
             if (isCompletion) return false
         }
     }
 
-    return processNestedScopesUpwards(binding, if (isCompletion) TYPES_N_VALUES else VALUES) { entry ->
-        processor.lazy(entry.name) {
+    val processor = createProcessor(originalProcessor.name) { entry ->
+        originalProcessor.lazy(entry.name) {
             val element = entry.element ?: return@lazy null
             val isConstant = element.isConstantLike
             val isPathOrDestructable = when (element) {
@@ -646,6 +654,7 @@ fun processPatBindingResolveVariants(binding: RsPatBinding, isCompletion: Boolea
             if (isConstant || (isCompletion && isPathOrDestructable)) element else null
         }
     }
+    return processNestedScopesUpwards(binding, if (isCompletion) TYPES_N_VALUES else VALUES, processor)
 }
 
 fun processLabelResolveVariants(label: RsLabel, processor: RsResolveProcessor): Boolean {
@@ -697,14 +706,15 @@ fun processLifetimeResolveVariants(lifetime: RsLifetime, processor: RsResolvePro
     return false
 }
 
-fun processLocalVariables(place: RsElement, processor: (RsPatBinding) -> Unit) {
+fun processLocalVariables(place: RsElement, originalProcessor: (RsPatBinding) -> Unit) {
     val hygieneFilter = makeHygieneFilter(place)
     walkUp(place, { it is RsItemElement }) { cameFrom, scope ->
-        processLexicalDeclarations(scope, cameFrom, VALUES, hygieneFilter, ItemProcessingMode.WITH_PRIVATE_IMPORTS) { v ->
+        val processor = createProcessor { v ->
             val el = v.element
-            if (el is RsPatBinding) processor(el)
+            if (el is RsPatBinding) originalProcessor(el)
             false
         }
+        processLexicalDeclarations(scope, cameFrom, VALUES, hygieneFilter, ItemProcessingMode.WITH_PRIVATE_IMPORTS, processor)
     }
 }
 
@@ -1299,7 +1309,7 @@ private fun processLexicalDeclarations(
         // Rust allows to defined several bindings in single pattern to the same name,
         // but they all must bind the same variables, hence we can inspect only the first one.
         // See https://github.com/rust-lang/rfcs/blob/master/text/2535-or-patterns.md
-        val patternProcessor: RsResolveProcessor = { e ->
+        val patternProcessor = createProcessor(processor.name) { e ->
             if (e.name !in alreadyProcessedNames) {
                 alreadyProcessedNames += e.name
                 processor(e)
@@ -1375,7 +1385,7 @@ private fun processLexicalDeclarations(
             // ```
             val visited = mutableSetOf<String>()
             if (Namespace.Values in ns) {
-                val shadowingProcessor = { e: ScopeEntry ->
+                val shadowingProcessor = createProcessor(processor.name) { e ->
                     (e.name !in visited) && processor(e).also {
                         if (e.isInitialized && e.element != null) {
                             visited += e.name
@@ -1508,14 +1518,14 @@ private tailrec fun PsiFile.unwrapCodeFragments(): PsiFile {
 
 inline fun processWithShadowingAndUpdateScope(
     prevScope: MutableMap<String, Set<Namespace>>,
-    crossinline processor: RsResolveProcessor,
+    processor: RsResolveProcessor,
     f: (RsResolveProcessor) -> Boolean
 ): Boolean {
     val currScope = mutableMapOf<String, Set<Namespace>>()
-    val shadowingProcessor = lambda@{ e: ScopeEntry ->
+    val shadowingProcessor = createProcessor(processor.name) { e ->
         val prevNs = prevScope[e.name]
         if (prevNs != null && (e.element as? RsNamedElement)?.namespaces?.intersects(prevNs) == true) {
-            return@lambda false
+            return@createProcessor false
         }
         val result = processor(e)
         if (e.isInitialized) {
@@ -1535,13 +1545,15 @@ inline fun processWithShadowingAndUpdateScope(
 
 inline fun processWithShadowing(
     prevScope: Map<String, Set<Namespace>>,
-    crossinline processor: RsResolveProcessor,
+    originalProcessor: RsResolveProcessor,
     f: (RsResolveProcessor) -> Boolean
 ): Boolean {
-    return f { e: ScopeEntry ->
+    val processor = createProcessor(originalProcessor.name) { e ->
         val prevNs = prevScope[e.name]
-        (prevNs == null || (e.element as? RsNamedElement)?.namespaces?.intersects(prevNs) != true) && processor(e)
+        (prevNs == null || (e.element as? RsNamedElement)?.namespaces?.intersects(prevNs) != true)
+            && originalProcessor(e)
     }
+    return f(processor)
 }
 
 fun findPrelude(element: RsElement): RsFile? {


### PR DESCRIPTION
This will be used in new resolve to improve performance (instead of iterating all items in scope, only item with specified name will be processed).

Potentially it can be used in other places, e.g. in [`processModDeclResolveVariants`](https://github.com/intellij-rust/intellij-rust/blob/e2d8902505475453db2ddc9629b3cd2ec9b68ee9/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt#L226)