### PR TITLE
COMP: Add `dbgr` postfix completion

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -71,6 +71,7 @@ mbStavola
 mcarlin
 mchernyavsky
 mfarrugi
+mgrachev
 mhaessig
 mibac138
 mitchhentges

--- a/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
@@ -34,6 +34,7 @@ class RsPostfixTemplateProvider : PostfixTemplateProvider {
         IterPostfixTemplate("for", this),
         PrintlnPostfixTemplate(this),
         DbgPostfixTemplate(this),
+        DbgrPostfixTemplate(this),
         OkPostfixTemplate(this),
         SomePostfixTemplate(this),
         ErrPostfixTemplate(this)

--- a/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
@@ -108,6 +108,7 @@ class IterPostfixTemplate(name: String, provider: RsPostfixTemplateProvider) :
 }
 
 class DbgPostfixTemplate(provider: RsPostfixTemplateProvider) : SimpleExprPostfixTemplate("dbg", "dbg!(expr)", provider)
+class DbgrPostfixTemplate(provider: RsPostfixTemplateProvider) : SimpleExprPostfixTemplate("dbgr", "dbg!(&expr)", provider)
 
 class SomePostfixTemplate(provider: RsPostfixTemplateProvider) : SimpleExprPostfixTemplate("some", "Some(expr)", provider)
 class OkPostfixTemplate(provider: RsPostfixTemplateProvider) : SimpleExprPostfixTemplate("ok", "Ok(expr)", provider)

--- a/src/main/resources/postfixTemplates/DbgrPostfixTemplate/after.rs.template
+++ b/src/main/resources/postfixTemplates/DbgrPostfixTemplate/after.rs.template
@@ -1,0 +1,4 @@
+fn foo(slice: &[i32]) {
+    let first = slice[0];
+    dbg!(&first);
+}

--- a/src/main/resources/postfixTemplates/DbgrPostfixTemplate/before.rs.template
+++ b/src/main/resources/postfixTemplates/DbgrPostfixTemplate/before.rs.template
@@ -1,0 +1,4 @@
+fn foo(slice: &[i32]) {
+    let first = slice[0];
+    <spot>first</spot>.dbg
+}

--- a/src/main/resources/postfixTemplates/DbgrPostfixTemplate/description.html
+++ b/src/main/resources/postfixTemplates/DbgrPostfixTemplate/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Creates <code>dbg!</code> macro invocation from expression.
+</body>
+</html>

--- a/src/main/resources/postfixTemplates/DbgrPostfixTemplate/description.html
+++ b/src/main/resources/postfixTemplates/DbgrPostfixTemplate/description.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Creates <code>dbg!</code> macro invocation from expression.
+Creates <code>dbg!</code> macro invocation from expression reference.
 </body>
 </html>

--- a/src/test/kotlin/org/rust/ide/template/postfix/DbgrPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/DbgrPostfixTemplateTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.template.postfix
+
+class DbgrPostfixTemplateTest : RsPostfixTemplateTest(DbgrPostfixTemplate(RsPostfixTemplateProvider())) {
+
+    fun `test expr`() = doTest("""
+        fn foo(slice: &[i32]) {
+            let first = slice[0];
+            first.dbgr/*caret*/;
+        }
+    """, """
+        fn foo(slice: &[i32]) {
+            let first = slice[0];
+            dbg!(&first)/*caret*/;
+        }
+    """)
+
+    fun `test not expr`() = doTestNotApplicable("""
+        fn main() {
+            println!("Hello!");.dbgr/*caret*/
+        }
+    """)
+}


### PR DESCRIPTION
Hi there!

I think it would be useful to convert a value to a reference right away when using `dbg` postfix completion .
Otherwise, we won't be able to use the value in the next line.

```rust
// Old behaviour:
fn foo(slice: &[i32]) {
    let first = slice[0];
    dbg!(first);

   do_something(first); // It won't work
}

// New behaviour:
fn foo(slice: &[i32]) {
    let first = slice[0];
    dbg!(&first);

   do_something(first); // It will work
}
```

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

:)
-->