### PR TITLE
PRJ: Force cargo-generate to skip name conversion

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Cargo.kt
@@ -251,6 +251,7 @@ class Cargo(private val cargoExecutable: Path, private val rustcExecutable: Path
         val path = directory.pathAsPath
         val name = path.fileName.toString().replace(' ', '_')
         val args = mutableListOf("--name", name, "--git", template)
+        args.add("--force") // enforce cargo-generate not to do underscores to hyphens name conversion
 
         // TODO: Rewrite this for the future versions of cargo-generate when init subcommand will be available
         // See https://github.com/ashleygwilliams/cargo-generate/issues/193


### PR DESCRIPTION
Fixes #5957

By default, cargo-generate convert project names with underscores to names with hyphens. This behavior can be disabled with `--force` flag, therefore it should present in the `generate` command invocation when creating a new project.