### PR TITLE
Fix "unreachable" exception

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/RsCachedTypeAlias.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/RsCachedTypeAlias.kt
@@ -6,9 +6,11 @@
 package org.rust.lang.core.resolve
 
 import org.rust.lang.core.crate.Crate
-import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.RsTypeAlias
-import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.RsAbstractableOwner
+import org.rust.lang.core.psi.ext.RsTypeAliasImplMixin
+import org.rust.lang.core.psi.ext.containingCrate
+import org.rust.lang.core.psi.ext.owner
 import org.rust.lang.core.psi.isValidProjectMember
 import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.infer.constGenerics
@@ -25,16 +27,15 @@ class RsCachedTypeAlias(
     val alias: RsTypeAlias
 ) {
     val name: String? = alias.name
-    val context: RsElement? = RsExpandedElement.getContextImpl(alias) as? RsElement
 
     val isFreeAndValid: Boolean by lazy(PUBLICATION) {
         name != null
-            && alias.getOwner { this@RsCachedTypeAlias.context } is RsAbstractableOwner.Free
+            && alias.owner is RsAbstractableOwner.Free
             && alias.isValidProjectMember
     }
 
     val containingCrate: Crate? by lazy(PUBLICATION) {
-        context?.containingCrate
+        alias.containingCrate
     }
 
     val typeAndGenerics: Triple<Ty, List<TyTypeParameter>, List<CtConstParameter>> by lazy(PUBLICATION) {


### PR DESCRIPTION
The bug was introduced in #5926. I used `alias.getOwner` incorrectly =(

<details>
  <summary>Stacktrace</summary>
  
  ```
  java.lang.IllegalStateException: unreachable
    	at org.rust.lang.core.resolve.RsCachedTypeAlias$isFreeAndValid$2.invoke(RsCachedTypeAlias.kt:57)
    	at org.rust.lang.core.resolve.RsCachedTypeAlias$isFreeAndValid$2.invoke(RsCachedTypeAlias.kt:24)
    	at kotlin.SafePublicationLazyImpl.getValue(LazyJVM.kt:107)
    	at org.rust.lang.core.resolve.RsCachedTypeAlias.isFreeAndValid(RsCachedTypeAlias.kt)
    	at org.rust.lang.core.resolve.indexes.RsTypeAliasIndex$Companion.findPotentialAliases(RsTypeAliasIndex.kt:40)
    	at org.rust.lang.core.resolve.ImplLookup.processTyFingerprintsWithAliases(ImplLookup.kt:490)
    	at org.rust.lang.core.resolve.ImplLookup.assembleImplCandidates(ImplLookup.kt:675)
    	at org.rust.lang.core.resolve.ImplLookup.assembleCandidates(ImplLookup.kt:657)
    	at org.rust.lang.core.resolve.ImplLookup.selectCandidate(ImplLookup.kt:566)
    	at org.rust.lang.core.resolve.ImplLookup.access$selectCandidate(ImplLookup.kt:236)
    	at org.rust.lang.core.resolve.ImplLookup$selectWithoutConfirm$2.invoke(ImplLookup.kt:556)
    	at org.rust.lang.core.resolve.ImplLookup$selectWithoutConfirm$2.invoke(ImplLookup.kt:236)
    	at org.rust.stdext.Cache$Companion$fromConcurrentMap$1.getOrPut(Cache.kt:41)
    	at org.rust.lang.core.resolve.ImplLookup.selectWithoutConfirm(ImplLookup.kt:556)
    	at org.rust.lang.core.resolve.ImplLookup.select(ImplLookup.kt:551)
          ...
  ```
</details>