### PR TITLE
INSP: fix false positive unresolved reference error

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -118,6 +118,10 @@ class AutoImportFix(element: RsElement, private val type: Type) : LocalQuickFixO
         /** Import traits for type-related UFCS method calls and assoc items */
         fun findApplicableContextForAssocItemPath(project: Project, path: RsPath): Context? {
             val parent = path.parent as? RsPathExpr ?: return null
+
+            val qualifierElement = path.qualifier?.reference?.resolve()
+            if (qualifierElement is RsTraitItem) return null
+
             val resolved = path.inference?.getResolvedPath(parent) ?: return null
             val sources = resolved.map {
                 if (it !is ResolvedPath.AssocItem) return null

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -160,6 +160,33 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         }
     """, false)
 
+    fun `test no unresolved reference for UFCS with trait`() = checkByText("""
+        mod foo {
+            pub trait Bar {
+                fn baz(&self) {}
+            }
+        }
+        struct S;
+        use foo::Bar;
+        impl Bar for S {}
+        fn main() {
+            Bar::baz(&S)
+        }
+    """)
+
+    fun `test no unresolved reference for UFCS with qualified trait`() = checkByText("""
+        mod foo {
+            pub trait Bar {
+                fn baz(&self) {}
+            }
+        }
+        struct S;
+        impl foo::Bar for S {}
+        fn main() {
+            foo::Bar::baz(&S)
+        }
+    """)
+
     private fun checkByText(@Language("Rust") text: String, ignoreWithoutQuickFix: Boolean) {
         val inspection = inspection as RsUnresolvedReferenceInspection
         val defaultValue = inspection.ignoreWithoutQuickFix


### PR DESCRIPTION
Previously, the plugin shows it when you call trait method via UFCS, trait name was not in the scope and trait is used via a qualified path

Fixes #5965