### PR TITLE
TOML: add option to indent table keys

### DIFF
--- a/intellij-toml/core/src/main/kotlin/org/toml/ide/formatter/TomlFmtContext.kt
+++ b/intellij-toml/core/src/main/kotlin/org/toml/ide/formatter/TomlFmtContext.kt
@@ -9,16 +9,19 @@ import com.intellij.formatting.SpacingBuilder
 import com.intellij.psi.codeStyle.CodeStyleSettings
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings
 import org.toml.ide.formatter.impl.createSpacingBuilder
+import org.toml.ide.formatter.settings.TomlCodeStyleSettings
 import org.toml.lang.TomlLanguage
 
 data class TomlFmtContext(
     val commonSettings: CommonCodeStyleSettings,
+    val tomlSettings: TomlCodeStyleSettings,
     val spacingBuilder: SpacingBuilder
 ) {
     companion object {
         fun create(settings: CodeStyleSettings): TomlFmtContext {
             val commonSettings = settings.getCommonSettings(TomlLanguage)
-            return TomlFmtContext(commonSettings, createSpacingBuilder(commonSettings))
+            val tomlSettings = settings.toml
+            return TomlFmtContext(commonSettings, tomlSettings, createSpacingBuilder(commonSettings))
         }
     }
 }

--- a/intellij-toml/core/src/main/kotlin/org/toml/ide/formatter/impl/indent.kt
+++ b/intellij-toml/core/src/main/kotlin/org/toml/ide/formatter/impl/indent.kt
@@ -8,10 +8,18 @@ package org.toml.ide.formatter.impl
 import com.intellij.formatting.Indent
 import com.intellij.lang.ASTNode
 import org.toml.ide.formatter.TomlFmtBlock
-import org.toml.lang.psi.TomlElementTypes.ARRAY
+import org.toml.ide.formatter.settings.TomlCodeStyleSettings
+import org.toml.lang.psi.TomlElementTypes.*
 
-fun TomlFmtBlock.computeIndent(child: ASTNode): Indent? = when (node.elementType) {
+fun TomlFmtBlock.computeIndent(child: ASTNode, settings: TomlCodeStyleSettings): Indent? = when (node.elementType) {
     ARRAY -> getArrayIndent(child)
+    TABLE, ARRAY_TABLE -> {
+        if (settings.INDENT_TABLE_KEYS && child.elementType == KEY_VALUE) {
+            Indent.getNormalIndent()
+        } else {
+            Indent.getNoneIndent()
+        }
+    }
     else -> Indent.getNoneIndent()
 }
 

--- a/intellij-toml/core/src/main/kotlin/org/toml/ide/formatter/settings/TomlCodeStyleSettings.kt
+++ b/intellij-toml/core/src/main/kotlin/org/toml/ide/formatter/settings/TomlCodeStyleSettings.kt
@@ -9,4 +9,10 @@ import com.intellij.psi.codeStyle.CodeStyleSettings
 import com.intellij.psi.codeStyle.CustomCodeStyleSettings
 
 class TomlCodeStyleSettings(container: CodeStyleSettings) :
-    CustomCodeStyleSettings(TomlCodeStyleSettings::class.java.simpleName, container)
+    CustomCodeStyleSettings(TomlCodeStyleSettings::class.java.simpleName, container) {
+    @JvmField var INDENT_TABLE_KEYS = INDENT_TABLE_KEYS_DEFAULT
+
+    companion object {
+        val INDENT_TABLE_KEYS_DEFAULT = false
+    }
+}

--- a/intellij-toml/core/src/main/kotlin/org/toml/ide/formatter/settings/TomlLanguageCodeStyleSettingsProvider.kt
+++ b/intellij-toml/core/src/main/kotlin/org/toml/ide/formatter/settings/TomlLanguageCodeStyleSettingsProvider.kt
@@ -10,11 +10,10 @@ import com.intellij.application.options.CodeStyleAbstractPanel
 import com.intellij.application.options.IndentOptionsEditor
 import com.intellij.application.options.SmartIndentOptionsEditor
 import com.intellij.lang.Language
-import com.intellij.psi.codeStyle.CodeStyleConfigurable
-import com.intellij.psi.codeStyle.CodeStyleSettings
-import com.intellij.psi.codeStyle.CustomCodeStyleSettings
-import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
+import com.intellij.psi.codeStyle.*
+import org.toml.ide.formatter.settings.TomlCodeStyleSettings.Companion.INDENT_TABLE_KEYS_DEFAULT
 import org.toml.lang.TomlLanguage
+import javax.swing.JCheckBox
 
 class TomlLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider() {
     override fun getLanguage(): Language = TomlLanguage
@@ -38,13 +37,55 @@ class TomlLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider(
             else -> ""
         }
 
-    override fun getIndentOptionsEditor(): IndentOptionsEditor = SmartIndentOptionsEditor()
+    override fun getIndentOptionsEditor(): IndentOptionsEditor = TomlIndentOptionsEditor()
 }
 
+
+private class TomlIndentOptionsEditor: SmartIndentOptionsEditor() {
+    private lateinit var indentTableKeys: JCheckBox
+
+    override fun addComponents() {
+        super.addComponents()
+        indentTableKeys = JCheckBox("Indent table keys")
+        add(indentTableKeys)
+    }
+
+    override fun isModified(settings: CodeStyleSettings?, options: CommonCodeStyleSettings.IndentOptions?): Boolean {
+        val modified = super.isModified(settings, options)
+        val indentTableKeysOption = getTomlSettings(settings)?.INDENT_TABLE_KEYS ?: INDENT_TABLE_KEYS_DEFAULT
+        return modified || IndentOptionsEditor.isFieldModified(indentTableKeys, indentTableKeysOption)
+    }
+
+    override fun apply(settings: CodeStyleSettings?, options: CommonCodeStyleSettings.IndentOptions?) {
+        super.apply(settings, options)
+        getTomlSettings(settings)?.INDENT_TABLE_KEYS = indentTableKeys.isSelected
+    }
+
+    override fun reset(settings: CodeStyleSettings, options: CommonCodeStyleSettings.IndentOptions) {
+        super.reset(settings, options)
+        indentTableKeys.isSelected = getTomlSettings(settings)?.INDENT_TABLE_KEYS ?: INDENT_TABLE_KEYS_DEFAULT
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        super.setEnabled(enabled)
+        indentTableKeys.isEnabled = enabled
+    }
+
+    override fun setVisible(visible: Boolean) {
+        super.setVisible(visible)
+        indentTableKeys.isVisible = visible
+    }
+
+    companion object {
+        private fun getTomlSettings(settings: CodeStyleSettings?): TomlCodeStyleSettings? =
+            settings?.getCustomSettings(TomlCodeStyleSettings::class.java)
+    }
+}
 private fun sample(@org.intellij.lang.annotations.Language("TOML") code: String) = code.trim()
 
 private val INDENT_SAMPLE = sample("""
 [config]
+foo = "bar"
 items = [
     "foo",
     "bar"

--- a/intellij-toml/core/src/test/kotlin/org/toml/ide/formatter/TomlAutoIndentTest.kt
+++ b/intellij-toml/core/src/test/kotlin/org/toml/ide/formatter/TomlAutoIndentTest.kt
@@ -20,4 +20,26 @@ class TomlAutoIndentTest : TomlTypingTestBase() {
             <caret>
         ]
     """)
+
+    fun `test new key value inside table`() = doOptionTest(tomlSettings()::INDENT_TABLE_KEYS, """
+        [foo]
+        bar = 1
+
+        [key]
+            foo = 1<caret>
+    """, """
+        [foo]
+        bar = 1
+
+        [key]
+            foo = 1
+            <caret>
+    """, """
+        [foo]
+        bar = 1
+
+        [key]
+            foo = 1
+        <caret>
+    """)
 }

--- a/intellij-toml/core/src/test/kotlin/org/toml/ide/formatter/TomlFormatterTest.kt
+++ b/intellij-toml/core/src/test/kotlin/org/toml/ide/formatter/TomlFormatterTest.kt
@@ -33,4 +33,56 @@ class TomlFormatterTest : TomlFormatterTestBase() {
             "c.rs"
         ]
     """)
+
+    fun `test indent table key`() = doOptionTest(tomlSettings()::INDENT_TABLE_KEYS, """
+        [workspace]
+        key1 = "bar"
+        key2 = 5
+        key3 = [
+            1,
+            2
+        ]
+    """, """
+        [workspace]
+            key1 = "bar"
+            key2 = 5
+            key3 = [
+                1,
+                2
+            ]
+    """, """
+        [workspace]
+        key1 = "bar"
+        key2 = 5
+        key3 = [
+            1,
+            2
+        ]
+    """)
+
+    fun `test indent array table key`() = doOptionTest(tomlSettings()::INDENT_TABLE_KEYS, """
+        [[workspace]]
+        key1 = "bar"
+        key2 = 5
+        key3 = [
+            1,
+            2
+        ]
+    """, """
+        [[workspace]]
+            key1 = "bar"
+            key2 = 5
+            key3 = [
+                1,
+                2
+            ]
+    """, """
+        [[workspace]]
+        key1 = "bar"
+        key2 = 5
+        key3 = [
+            1,
+            2
+        ]
+    """)
 }

--- a/intellij-toml/core/src/test/kotlin/org/toml/ide/formatter/TomlFormatterTestBase.kt
+++ b/intellij-toml/core/src/test/kotlin/org/toml/ide/formatter/TomlFormatterTestBase.kt
@@ -5,10 +5,13 @@
 
 package org.toml.ide.formatter
 
+import com.intellij.application.options.CodeStyle
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.psi.codeStyle.CodeStyleManager
+import com.intellij.psi.codeStyle.CodeStyleSettings
 import org.intellij.lang.annotations.Language
 import org.toml.TomlTestBase
+import kotlin.reflect.KMutableProperty0
 
 abstract class TomlFormatterTestBase : TomlTestBase() {
     protected fun doTest(@Language("TOML") before: String, @Language("TOML") after: String) {
@@ -20,4 +23,24 @@ abstract class TomlFormatterTestBase : TomlTestBase() {
             }
         }
     }
+
+    protected fun doOptionTest(
+        optionProperty: KMutableProperty0<Boolean>,
+        @Language("TOML") before: String,
+        @Language("TOML") afterOn: String = before,
+        @Language("TOML") afterOff: String = before
+    ) {
+        val initialValue = optionProperty.get()
+        optionProperty.set(true)
+        try {
+            doTest(before.trimIndent(), afterOn.trimIndent())
+            optionProperty.set(false)
+            doTest(before.trimIndent(), afterOff.trimIndent())
+        } finally {
+            optionProperty.set(initialValue)
+        }
+    }
+
+    private fun commonSettings(): CodeStyleSettings = CodeStyle.getSettings(project)
+    protected fun tomlSettings() = commonSettings().toml
 }

--- a/intellij-toml/core/src/test/kotlin/org/toml/ide/typing/TomlTypingTestBase.kt
+++ b/intellij-toml/core/src/test/kotlin/org/toml/ide/typing/TomlTypingTestBase.kt
@@ -5,12 +5,37 @@
 
 package org.toml.ide.typing
 
+import com.intellij.application.options.CodeStyle
+import com.intellij.psi.codeStyle.CodeStyleSettings
 import org.intellij.lang.annotations.Language
 import org.toml.TomlTestBase
+import org.toml.ide.formatter.toml
+import kotlin.reflect.KMutableProperty0
 
 abstract class TomlTypingTestBase : TomlTestBase() {
     protected fun doTestByText(@Language("TOML") before: String, @Language("TOML") after: String, c: Char = '\n') =
         checkByText(before.trimIndent(), after.trimIndent()) {
             myFixture.type(c)
         }
+
+    protected fun doOptionTest(
+        optionProperty: KMutableProperty0<Boolean>,
+        @Language("TOML") before: String,
+        @Language("TOML") afterOn: String = before,
+        @Language("TOML") afterOff: String = before,
+        c: Char = '\n'
+    ) {
+        val initialValue = optionProperty.get()
+        optionProperty.set(true)
+        try {
+            doTestByText(before.trimIndent(), afterOn.trimIndent(), c)
+            optionProperty.set(false)
+            doTestByText(before.trimIndent(), afterOff.trimIndent(), c)
+        } finally {
+            optionProperty.set(initialValue)
+        }
+    }
+
+    private fun commonSettings(): CodeStyleSettings = CodeStyle.getSettings(project)
+    protected fun tomlSettings() = commonSettings().toml
 }


### PR DESCRIPTION
This PR adds an option to TOML indent code style settings to indent table and array table keys.

![indent](https://user-images.githubusercontent.com/4539057/90762478-65b57380-e2e5-11ea-94a0-c666bdd1c8ac.gif)

If I understand it correctly, indent style options need to be provided via `IndentOptionsEditor` and not via `LanguageCodeStyleSettingsProvider::customizeSettings`, therefore I extended `SmartIndentOptionsEditor` with a new checkbox.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5969
