### PR TITLE
Fix compilation error when using kotlin 1.4 compiler

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedElement.kt
@@ -53,7 +53,7 @@ where StubT : RsNamedStub, StubT : StubElement<*> {
 
     override fun getName(): String? {
         val stub = greenStub
-        return if (stub != null) stub.name else nameIdentifier?.unescapedText
+        return if (stub !== null) stub.name else nameIdentifier?.unescapedText
     }
 
     override fun setName(name: String): PsiElement? {


### PR DESCRIPTION
Fixes compilation error:
```
.../intellij-rust/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedElement.kt:56:25
Kotlin: Overload resolution ambiguity: 
public open fun equals(other: Any?): Boolean defined in com.intellij.psi.stubs.StubElement
public open fun equals(other: Any?): Boolean defined in org.rust.lang.core.stubs.RsNamedStub
```