### PR TITLE
REF: Check visibility conflicts in move top-level items refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveConflictsDetector.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveConflictsDetector.kt
@@ -1,0 +1,164 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.move.common
+
+import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiElement
+import com.intellij.refactoring.util.CommonRefactoringUtil
+import com.intellij.refactoring.util.RefactoringUIUtil
+import com.intellij.util.containers.MultiMap
+import org.rust.ide.refactoring.move.common.RsMoveUtil.addInner
+import org.rust.ide.refactoring.move.common.RsMoveUtil.isInsideMovedElements
+import org.rust.ide.refactoring.move.common.RsMoveUtil.isSimplePath
+import org.rust.ide.refactoring.move.common.RsMoveUtil.startsWithSelf
+import org.rust.ide.utils.getTopmostParentInside
+import org.rust.lang.core.macros.setContext
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+
+class RsMoveConflictsDetector(
+    private val conflicts: MultiMap<PsiElement, String>,
+    private val elementsToMove: List<ElementToMove>,
+    private val sourceMod: RsMod,
+    private val targetMod: RsMod
+) {
+
+    fun detectInsideReferencesVisibilityProblems(insideReferences: List<RsMoveReferenceInfo>) {
+        for (reference in insideReferences) {
+            val pathOld = reference.pathOld
+            val target = reference.target
+            if (reference.pathNewAccessible == null) {
+                addVisibilityConflict(conflicts, pathOld, target)
+            }
+        }
+
+        detectPrivateFieldOrMethodInsideReferences()
+    }
+
+    fun detectOutsideReferencesVisibilityProblems(outsideReferences: List<RsMoveReferenceInfo>) {
+        for (reference in outsideReferences) {
+            if (reference.pathNewAccessible == null) {
+                addVisibilityConflict(conflicts, reference.pathOld, reference.target)
+            }
+        }
+
+        detectPrivateFieldOrMethodOutsideReferences()
+    }
+
+    /**
+     * For now we check only references from [sourceMod],
+     * because to check all references we should find them,
+     * and it would be very slow when moving e.g. many files.
+     */
+    private fun detectPrivateFieldOrMethodInsideReferences() {
+        val movedElementsShallowDescendants = movedElementsShallowDescendantsOfType<RsElement>(elementsToMove)
+        val sourceFile = sourceMod.containingFile
+        val elementsToCheck = sourceFile.descendantsOfType<RsElement>() - movedElementsShallowDescendants
+        detectPrivateFieldOrMethodReferences(elementsToCheck.asSequence(), ::checkVisibilityForInsideReference)
+    }
+
+    /** We create temp child mod of [targetMod] and copy [target] to this temp mod */
+    private fun checkVisibilityForInsideReference(referenceElement: RsElement, target: RsVisible) {
+        if (target.visibility == RsVisibility.Public) return
+        /**
+         * Can't use `target.containingMod` directly,
+         * because if [target] is expanded by macros,
+         * then `containingMod` will return element from other file,
+         * and [getTopmostParentInside] will throw exception.
+         * We expect [target] to be one of [elementsToMove], so [target] should not be expanded by macros.
+         */
+        val targetContainingMod = target.ancestorStrict<RsMod>() ?: return
+        if (targetContainingMod != sourceMod) return  // all moved items belong to `sourceMod`
+        val item = target.getTopmostParentInside(targetContainingMod)
+        // It is enough to check only references to descendants of moved items (not mods),
+        // because if something in inner mod is private, then it was not accessible before move.
+        if (elementsToMove.none { (it as? ItemToMove)?.item == item }) return
+
+        val tempMod = RsPsiFactory(sourceMod.project).createModItem("__tmp__", "")
+        tempMod.setContext(targetMod)
+
+        target.putCopyableUserData(RS_ELEMENT_FOR_CHECK_INSIDE_REFERENCES_VISIBILITY, target)
+        val itemInTempMod = tempMod.addInner(item)
+        val targetInTempMod = itemInTempMod.descendantsOfType<RsVisible>()
+            .singleOrNull { it.getCopyableUserData(RS_ELEMENT_FOR_CHECK_INSIDE_REFERENCES_VISIBILITY) == target }
+            ?: return
+
+        if (!targetInTempMod.isVisibleFrom(referenceElement.containingMod)) {
+            addVisibilityConflict(conflicts, referenceElement, target)
+        }
+        target.putCopyableUserData(RS_ELEMENT_FOR_CHECK_INSIDE_REFERENCES_VISIBILITY, null)
+    }
+
+    private fun detectPrivateFieldOrMethodOutsideReferences() {
+        fun checkVisibility(referenceElement: RsElement, target: RsVisible) {
+            if (!target.isInsideMovedElements(elementsToMove) && !target.isVisibleFrom(targetMod)) {
+                addVisibilityConflict(conflicts, referenceElement, target)
+            }
+        }
+
+        // TODO: Consider using [PsiRecursiveElementVisitor]
+        val elementsToCheck = movedElementsDeepDescendantsOfType<RsElement>(elementsToMove)
+        detectPrivateFieldOrMethodReferences(elementsToCheck, ::checkVisibility)
+    }
+
+    private fun detectPrivateFieldOrMethodReferences(
+        elementsToCheck: Sequence<RsElement>,
+        checkVisibility: (RsElement, RsVisible) -> Unit
+    ) {
+        fun checkVisibility(reference: RsReferenceElement) {
+            val target = reference.reference?.resolve() as? RsVisible ?: return
+            checkVisibility(reference, target)
+        }
+
+        loop@ for (element in elementsToCheck) {
+            when (element) {
+                is RsDotExpr -> {
+                    val fieldReference = element.fieldLookup ?: element.methodCall ?: continue@loop
+                    checkVisibility(fieldReference)
+                }
+                is RsStructLiteralField -> {
+                    val field = element.resolveToDeclaration() ?: continue@loop
+                    checkVisibility(element, field)
+                }
+                is RsPatField -> {
+                    val patBinding = element.patBinding ?: continue@loop
+                    checkVisibility(patBinding)
+                }
+                is RsPatTupleStruct -> {
+                    // It is ok to use `resolve` and not `deepResolve` here
+                    // because type aliases can't be used in destructuring tuple struct:
+                    val struct = element.path.reference?.resolve() as? RsStructItem ?: continue@loop
+                    val fields = struct.tupleFields?.tupleFieldDeclList ?: continue@loop
+                    for (field in fields) {
+                        checkVisibility(element, field)
+                    }
+                }
+                is RsPath -> {
+                    // Conflicts for simple paths are handled using `pathNewAccessible`/`pathNewFallback` machinery
+                    val isInsideSimplePath = element.ancestors
+                        .takeWhile { it is RsPath }
+                        .any { isSimplePath(it as RsPath) }
+                    if (!isInsideSimplePath && !element.startsWithSelf()) {
+                        // Here we handle e.g. UFCS paths: `Struct1::method1`
+                        checkVisibility(element)
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        val RS_ELEMENT_FOR_CHECK_INSIDE_REFERENCES_VISIBILITY: Key<RsElement> =
+            Key("RS_ELEMENT_FOR_CHECK_INSIDE_REFERENCES_VISIBILITY")
+    }
+}
+
+fun addVisibilityConflict(conflicts: MultiMap<PsiElement, String>, reference: RsElement, target: RsElement) {
+    val referenceDescription = RefactoringUIUtil.getDescription(reference.containingMod, true)
+    val targetDescription = RefactoringUIUtil.getDescription(target, true)
+    val message = "$referenceDescription uses $targetDescription which will be inaccessible after move"
+    conflicts.putValue(reference, CommonRefactoringUtil.capitalize(message))
+}

--- a/src/main/kotlin/org/rust/ide/utils/SearchByOffset.kt
+++ b/src/main/kotlin/org/rust/ide/utils/SearchByOffset.kt
@@ -11,8 +11,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.PsiUtilCore
-import org.rust.lang.core.macros.MacroExpansionContext
-import org.rust.lang.core.macros.MacroExpansionContext.*
+import org.rust.lang.core.macros.MacroExpansionContext.STMT
 import org.rust.lang.core.macros.expansionContext
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorOrSelf
@@ -161,7 +160,7 @@ fun PsiFile.findElementAtIgnoreWhitespaceAfter(offset: Int): PsiElement? {
 /**
  * Finds child of [parent] of which given element is descendant.
  */
-private fun PsiElement.getTopmostParentInside(parent: PsiElement): PsiElement {
+fun PsiElement.getTopmostParentInside(parent: PsiElement): PsiElement {
     if (parent == this) return this
 
     var element = this

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -199,9 +199,15 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
         PlatformTestUtil.assertDirectoriesEqual(afterDir, beforeDir)
     }
 
-    protected fun checkByDirectory(@Language("Rust") before: String, @Language("Rust") after: String, action: (TestProject) -> Unit) {
+    protected fun checkByDirectory(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String,
+        expectError: Boolean = false,
+        action: (TestProject) -> Unit
+    ) {
         val testProject = fileTreeFromText(before).create()
         action(testProject)
+        if (expectError) return
         saveAllDocuments()
         fileTreeFromText(after).assertEquals(myFixture.findFileInTempDir("."))
     }

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.refactoring.move
 
+import org.rust.ExpandMacros
 import org.rust.MockEdition
 import org.rust.cargo.project.workspace.CargoWorkspace
 
@@ -23,6 +24,315 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         mod mod2 {
             fn foo() {}
         }
+    """)
+
+    fun `test outside reference to private item of old mod`() = doTestConflictsError("""
+    //- lib.rs
+        mod mod1 {
+            fn foo/*caret*/() { bar(); }
+            fn bar() {}
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test outside reference to private method of struct in old mod using UFCS`() = doTestConflictsError("""
+    //- lib.rs
+        mod mod1 {
+            fn foo/*caret*/() { Bar::bar(); }
+            pub struct Bar {}
+            impl Bar {
+                fn bar() {}  // private
+            }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test outside reference to public method of struct in old mod using UFCS`() = doTest("""
+    //- lib.rs
+        mod mod1 {
+            fn foo/*caret*/() { Bar::bar(); }
+            pub struct Bar {}
+            impl Bar {
+                pub fn bar() {}  // public
+            }
+        }
+        mod mod2/*target*/ {}
+    """, """
+    //- lib.rs
+        mod mod1 {
+            pub struct Bar {}
+            impl Bar {
+                pub fn bar() {}  // public
+            }
+        }
+        mod mod2 {
+            use crate::mod1::Bar;
+
+            fn foo() { Bar::bar(); }
+        }
+    """)
+
+    fun `test inside reference, when new mod is private`() = doTestConflictsError("""
+    //- lib.rs
+        mod mod1 {
+            fn bar() { foo(); }
+            fn foo/*caret*/() {}
+        }
+        mod inner {
+            // private
+            mod mod2/*target*/ {}
+        }
+    """)
+
+    fun `test inside reference from other crate, when new mod is private`() = doTestConflictsError("""
+    //- lib.rs
+        pub fn foo/*caret*/() {}
+        mod mod1/*target*/ {}
+    //- main.rs
+        fn main() {
+            test_package::foo();
+        }
+    """)
+
+    fun `test inside reference to private field`() = doTestConflictsError("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo/*caret*/ { field: i32 }
+            fn bar(foo: &Foo) { let _ = &foo.field; }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to public field`() = doTestNoConflicts("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo/*caret*/ { pub field: i32 }
+            fn bar(foo: &Foo) { let _ = &foo.field; }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to private field in constructor`() = doTestConflictsError("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo/*caret*/ { field: i32 }
+            fn bar() { let _ = Foo { field: 0 }; }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to public field in constructor`() = doTestNoConflicts("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo/*caret*/ { pub field: i32 }
+            fn bar() { let _ = Foo { field: 0 }; }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to private field in destructuring`() = doTestConflictsError("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo/*caret*/ { field: i32 }
+            fn bar(foo: &Foo) { let Foo { field } = foo; }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to public field in destructuring`() = doTestNoConflicts("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo/*caret*/ { pub field: i32 }
+            fn bar(foo: &Foo) { let Foo { field } = foo; }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to private field in destructuring using type alias`() = doTestConflictsError("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo/*caret*/ { field: i32 }
+            type Bar = Foo;
+            fn bar(foo: &Bar) { let Bar { field } = foo; }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to public field in destructuring using type alias`() = doTestNoConflicts("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo/*caret*/ { pub field: i32 }
+            type Bar = Foo;
+            fn bar(foo: &Bar) { let Bar { field } = foo; }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to private field of tuple struct in destructuring 1`() = doTestConflictsError("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo/*caret*/(i32);
+            fn bar(foo: &Foo) { let Foo(_) = foo; }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to private field of tuple struct in destructuring 2`() = doTestConflictsError("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo/*caret*/(pub i32, i32);
+            fn bar(foo: &Foo) { let Foo(_, ..) = foo; }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to public field of tuple struct in destructuring`() = doTestNoConflicts("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo/*caret*/(pub i32);
+            fn bar(foo: &Foo) { let Foo(_) = foo; }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to private method`() = doTestConflictsError("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo {}
+            impl Foo/*caret*/ {
+                fn func(&self) {}
+            }
+            fn bar(foo: &Foo) { foo.func(); }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to public method`() = doTestNoConflicts("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo {}
+            impl Foo/*caret*/ {
+                pub fn func(&self) {}
+            }
+            fn bar(foo: &Foo) { foo.func(); }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to private method UFCS`() = doTestConflictsError("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo {}
+            impl Foo/*caret*/ {
+                fn func() {}
+            }
+            fn bar() { Foo::func(); }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to public method UFCS`() = doTestNoConflicts("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo {}
+            impl Foo/*caret*/ {
+                pub fn func() {}
+            }
+            fn bar() { Foo::func(); }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to enum variant`() = doTestNoConflicts("""
+    //- lib.rs
+        mod mod1 {
+            pub enum Foo/*caret*/ { Foo1, Foo2 }
+            fn bar() { let _ = Foo::Foo1; }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test inside reference to trait method`() = doTestNoConflicts("""
+    //- lib.rs
+        mod mod1 {
+            pub trait Foo/*caret*/ {
+                fn foo(&self) {}
+            }
+            impl Foo for ()/*caret*/ {}
+            fn bar() { ().foo(); }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test self references to private method and fields`() = doTestNoConflicts("""
+    //- lib.rs
+        mod mod1 {
+            struct Foo1/*caret*/ { field: i32 }
+            fn bar1/*caret*/() {
+                let foo1 = Foo1 { field: 0 };
+                let _ = foo1.field;
+                let Foo { field } = foo1;
+            }
+            struct Foo2/*caret*/(i32);
+            fn bar2/*caret*/() {
+                let foo2 = Foo2(0);
+                let _ = foo2.field;
+                let Foo2(_) = foo2;
+            }
+            struct Foo3/*caret*/ {}
+            impl Foo3/*caret*/ {
+                fn func(&self) {}
+            }
+            fn bar3/*caret*/(foo: &Foo3) {
+                Foo3::func(foo);
+                foo.func();
+            }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test outside reference to reexported function in private mod`() = doTestNoConflicts("""
+    //- lib.rs
+        mod mod1 {
+            pub use mod1_inner::*;
+            mod mod1_inner {
+                pub fn bar() {}
+            }
+            fn foo/*caret*/() { mod1_inner::bar(); }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    fun `test outside reference to method of reexported struct in private mod`() = doTestNoConflicts("""
+    //- lib.rs
+        mod mod1 {
+            pub use mod1_inner::*;
+            mod mod1_inner {
+                pub struct Bar;
+                impl Bar {
+                    pub fn bar() {}
+                }
+            }
+            fn foo/*caret*/() { mod1_inner::Bar::bar(); }
+        }
+        mod mod2/*target*/ {}
+    """)
+
+    @ExpandMacros
+    fun `test no exception when source file has reference to expanded item`() = doTestNoConflicts("""
+    //- lib.rs
+        mod mod1 {
+            fn foo/*caret*/() {}
+            fn bar(s: Struct) {
+                s.field;
+            }
+
+            macro_rules! gen_struct {
+                () => { struct Struct { field: i32 } };
+            }
+            gen_struct!();
+        }
+        mod mod2/*target*/ {}
     """)
 
     fun `test absolute outside reference which should be changed because of reexports`() = doTest("""

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTestBase.kt
@@ -15,6 +15,7 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.parentOfType
+import com.intellij.refactoring.BaseRefactoringProcessor
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.TestProject
@@ -28,7 +29,15 @@ import org.rust.stdext.mapToSet
 abstract class RsMoveTopLevelItemsTestBase : RsTestBase() {
 
     protected fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) =
-        checkByDirectory(before.trimIndent(), after.trimIndent(), ::performMove)
+        checkByDirectory(before.trimIndent(), after.trimIndent(), false, ::performMove)
+
+    protected fun doTestConflictsError(@Language("Rust") before: String) =
+        expect<BaseRefactoringProcessor.ConflictsInTestsException> {
+            checkByDirectory(before.trimIndent(), "", true, ::performMove)
+        }
+
+    protected fun doTestNoConflicts(@Language("Rust") before: String) =
+        checkByDirectory(before.trimIndent(), "", true, ::performMove)
 
     private fun performMove(testProject: TestProject) {
         val sourceFile = myFixture.findFileInTempDir(testProject.fileWithCaret).toPsiFile(project)!!


### PR DESCRIPTION
Checks that target of any reference remains accessible after move (in [move items refactoring](https://github.com/intellij-rust/intellij-rust/issues/3531#issuecomment-643142894)) and otherwise shows warning dialog. These cases are checked:
- `RsPath`
- struct/enum field (plain access / struct literal / destructuring)
- struct/trait method call