### PR TITLE
CARGO: Use package name for cargo project if possible

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -338,8 +338,11 @@ data class CargoProjectImpl(
         rawWorkspace.withStdlib(stdlib, rawWorkspace.cfgOptions, rustcInfo)
     }
 
-    override val presentableName: String
-        get() = workingDirectory.fileName.toString()
+    override val presentableName: String by lazy {
+        workspace?.packages?.singleOrNull {
+            it.origin == PackageOrigin.WORKSPACE && it.rootDirectory == workingDirectory
+        }?.name ?: workingDirectory.fileName.toString()
+    }
 
     private val rootDirCache = AtomicReference<VirtualFile>()
     override val rootDir: VirtualFile?


### PR DESCRIPTION
With #5929, fixes #5922.

When the root is not a package (e.g. with [virtual manifest](https://doc.rust-lang.org/cargo/reference/workspaces.html)), falls back to root directory name.

<img width="600" src="https://user-images.githubusercontent.com/6342851/91005705-3605b480-e5e0-11ea-898d-02d07ab816ca.gif">

<img width="700" src="https://user-images.githubusercontent.com/6342851/91005907-b9bfa100-e5e0-11ea-86d5-8d03b54f65c1.png">