### PR TITLE
RES: fix mod path attributes to another dirs

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMod.kt
@@ -53,10 +53,16 @@ interface RsMod : RsQualifiedNamedElement, RsItemsOwner, RsVisible {
         if (this is RsFile && name == RsConstants.MOD_RS_FILE || isCrateRoot) return contextualFile.originalFile.parent
 
         val explicitPath = pathAttribute
+        val superMod = `super`
+        val superModDir = { superMod?.getOwnedDirectory(createIfNotExists) }
         val (parentDirectory, path) = if (explicitPath != null) {
-            contextualFile.originalFile.parent to explicitPath
+            when {
+                this is RsFile -> return contextualFile.originalFile.parent
+                superMod is RsFile -> contextualFile.originalFile.parent to explicitPath
+                else -> superModDir() to explicitPath
+            }
         } else {
-            `super`?.getOwnedDirectory(createIfNotExists) to name
+            superModDir() to name
         }
         if (parentDirectory == null || path == null) return null
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -101,6 +101,34 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         pub fn baz() {}
     """, NameResolutionTestmarks.modDeclExplicitPathInNonInlineModule)
 
+    fun `test module path to different directory 1`() = stubOnlyResolve("""
+    //- main.rs
+        #[path = "src2/foo.rs"]
+        mod foo;
+
+        type T = foo::bar::S;
+                         //^ src2/bar/mod.rs
+    //- src2/foo.rs
+        pub mod bar;
+    //- src2/bar/mod.rs
+        pub struct S;
+    """, NameResolutionTestmarks.modDeclExplicitPathInNonInlineModule)
+
+    fun `test module path to different directory 2`() = stubOnlyResolve("""
+    //- main.rs
+        fn main() {
+            inner::foo::bar::func();
+        }                  //^ inner/src2/bar.rs
+
+        mod inner {
+            #[path = "src2/foo.rs"]
+            pub mod foo;
+        }
+    //- inner/src2/foo.rs
+        pub mod bar;
+    //- inner/src2/bar.rs
+        pub fn func() {}
+    """)
 
     fun `test invalid path`() = stubOnlyResolve("""
     //- main.rs
@@ -338,6 +366,25 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
         }
     //- bar/baz.rs
         pub fn baz() {}
+    """)
+
+    fun `test inline module path in non crate root 2`() = stubOnlyResolve("""
+    //- main.rs
+        mod foo;
+    //- foo.rs
+        pub mod bar {
+            #[path="baz2"]
+            pub mod baz {
+                pub mod quux;
+            }
+        }
+
+        fn foo() {
+            self::bar::baz::quux::eggs();
+                                 //^ foo/bar/baz2/quux.rs
+        }
+    //- foo/bar/baz2/quux.rs
+        pub fn eggs() {}
     """)
 
     fun `test use from child`() = stubOnlyResolve("""


### PR DESCRIPTION
Fixes name resolution of nested modules in modules
liked to a project with path attributes from
another directories, e.g.
```rust
#[path = "../foo/foo.rs"]
mod foo;
```

Closes #5917