### PR TITLE
QDOC: improve documentation rendering

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldDecl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldDecl.kt
@@ -5,12 +5,21 @@
 
 package org.rust.lang.core.psi.ext
 
+import org.rust.lang.core.psi.RsEnumVariant
 import org.rust.lang.core.psi.RsTypeReference
 
-val RsFieldDecl.parentStruct: RsFieldsOwner? get() = stubAncestorStrict()
+val RsFieldDecl.owner: RsFieldsOwner? get() = stubAncestorStrict()
 
 val RsFieldDecl.escapedName: String? get() = (this as? RsNamedElement)?.escapedName ?: name
 
 interface RsFieldDecl : RsOuterAttributeOwner, RsVisibilityOwner {
     val typeReference: RsTypeReference?
+
+    @JvmDefault
+    override val visibility: RsVisibility
+        get() = (owner as? RsEnumVariant)?.visibility ?: super.visibility
+
+    @JvmDefault
+    override val isPublic: Boolean
+        get() = (owner as? RsEnumVariant)?.isPublic ?: super.isPublic
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedFieldDecl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsNamedFieldDecl.kt
@@ -21,7 +21,7 @@ abstract class RsNamedFieldDeclImplMixin : RsStubbedNamedElementImpl<RsNamedFiel
     constructor(stub: RsNamedFieldDeclStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
     override fun getIcon(flags: Int): Icon =
-        if (parent.parent is RsEnumVariant) RsIcons.FIELD else iconWithVisibility(flags, RsIcons.FIELD)
+        if (owner is RsEnumVariant) RsIcons.FIELD else iconWithVisibility(flags, RsIcons.FIELD)
 
     // temporary solution.
     override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
@@ -345,7 +345,7 @@ data class RsQualifiedName private constructor(
                 is RsTypeAlias -> TYPE
                 is RsFunction -> FN
                 is RsConstant -> CONSTANT
-                is RsMacro -> MACRO
+                is RsMacro, is RsMacro2 -> MACRO
                 is RsMod -> {
                     if (isCrateRoot) {
                         val crateName = containingCrate?.normName ?: return null

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
@@ -302,7 +302,7 @@ data class RsQualifiedName private constructor(
                     }
                 }
                 is RsEnumVariant -> element.parentEnum
-                is RsNamedFieldDecl -> element.parentStruct
+                is RsNamedFieldDecl -> element.owner
                 else -> return null
             }
             return parentItem?.toParentItem()

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
@@ -71,7 +71,7 @@ data class RsQualifiedName private constructor(
     val crateName: String,
     val modSegments: List<String>,
     val parentItem: Item,
-    val childItem: Item?
+    val childItems: List<Item>
 ) {
 
     fun toUrlPath(): String {
@@ -80,7 +80,7 @@ data class RsQualifiedName private constructor(
         val (pageName, anchor) = if (parentItem.type == MOD || parentItem.type == CRATE) {
             "index.html" to ""
         } else {
-            "$parentItem.html" to (if (childItem != null) "#$childItem" else "")
+            "$parentItem.html" to if (childItems.isNotEmpty()) childItems.joinToString(separator = ".", prefix = "#") else ""
         }
         segments += pageName
         return segments.joinToString(separator = "/", postfix = anchor)
@@ -88,7 +88,7 @@ data class RsQualifiedName private constructor(
 
     /** Tries to find rust qualified name element related to this qualified name */
     fun findPsiElement(psiManager: PsiManager, context: RsElement): RsQualifiedNamedElement? {
-        val item = childItem ?: parentItem
+        val item = childItems.lastOrNull() ?: parentItem
 
         // If it's link to crate, try to find the corresponding `lib.rs` file
         if (item.type == CRATE) {
@@ -154,7 +154,7 @@ data class RsQualifiedName private constructor(
         crossinline transform: (T) -> QualifiedNamedItem?
     ): RsQualifiedNamedElement? {
         var result: RsQualifiedNamedElement? = null
-        val item = childItem ?: parentItem
+        val item = childItems.lastOrNull() ?: parentItem
         StubIndex.getInstance().processElements(
             indexKey,
             keyProducer(item.name),
@@ -182,26 +182,26 @@ data class RsQualifiedName private constructor(
             val segments = path.split("/")
             if (segments.size < 2) return null
 
-            val (parentItem, childItem) = if (segments.size == 2 && segments[1] == "index.html") {
-                Item(segments[0], CRATE) to null
+            val (parentItem, childItems) = if (segments.size == 2 && segments[1] == "index.html") {
+                Item(segments[0], CRATE) to emptyList()
             } else {
                 // Last segment contains info about item type and name
                 // and it should have the following structure:
-                // parentItem ( '#' childItem )?
+                // parentItem ( '#' childItem (. childItem)? )?
                 val itemParts = segments.last().split("#")
                 val parentRaw = itemParts[0]
-                val childRaw = itemParts.getOrNull(1)
+                val childrenRaw = itemParts.getOrNull(1)
 
                 val parentItem = parentItem(segments[segments.lastIndex - 1], parentRaw) ?: return null
-                val childItem = if (childRaw != null) {
-                    childItem(childRaw) ?: return null
+                val childItems = if (childrenRaw != null) {
+                    childItems(childrenRaw) ?: return null
                 } else {
-                    null
+                    emptyList()
                 }
-                parentItem to childItem
+                parentItem to childItems
             }
 
-            return RsQualifiedName(segments[0], segments.subList(1, segments.lastIndex), parentItem, childItem)
+            return RsQualifiedName(segments[0], segments.subList(1, segments.lastIndex), parentItem, childItems)
         }
 
         private fun parentItem(prevSegment: String, raw: String): Item? {
@@ -216,22 +216,25 @@ data class RsQualifiedName private constructor(
             return Item(parts[1], type)
         }
 
-        private fun childItem(raw: String): Item? {
+        private fun childItems(raw: String): List<Item>? {
             val parts = raw.split(".")
-            if (parts.size != 2) return null
-            val type = ChildItemType.fromString(parts[0]) ?: return null
-            return Item(parts[1], type)
+            if (parts.size != 2 && parts.size != 4) return null
+
+            return parts.windowed(size = 2, step = 2).map { (type, name) ->
+                val itemType = ChildItemType.fromString(type) ?: return null
+                Item(name, itemType)
+            }
         }
 
         @JvmStatic
         fun from(element: RsQualifiedNamedElement): RsQualifiedName? {
             val parent = parentItem(element)
 
-            val (parentItem, childItem) = if (parent != null) {
-                parent to (element.toChildItem() ?: return null)
+            val (parentItem, childItems) = if (parent != null) {
+                parent to (element.toChildItems() ?: return null)
             } else {
                 val parentItem = element.toParentItem() ?: return null
-                parentItem to null
+                parentItem to emptyList()
             }
             val crateName = if (parentItem.type == PRIMITIVE) {
                 STD
@@ -250,7 +253,7 @@ data class RsQualifiedName private constructor(
                     .map { it.modName ?: return null }
             }
 
-            return RsQualifiedName(crateName, modSegments, parentItem, childItem)
+            return RsQualifiedName(crateName, modSegments, parentItem, childItems)
         }
 
         @JvmStatic
@@ -276,17 +279,17 @@ data class RsQualifiedName private constructor(
         @JvmStatic
         fun from(path: RsPath): RsQualifiedName? {
             val primitiveType = TyPrimitive.fromPath(path) ?: return null
-            return RsQualifiedName(STD, emptyList(), Item.primitive(primitiveType.name), null)
+            return RsQualifiedName(STD, emptyList(), Item.primitive(primitiveType.name), emptyList())
         }
 
-        private fun RsQualifiedNamedElement.toItems(): Pair<Item, Item?>? {
+        private fun RsQualifiedNamedElement.toItems(): Pair<Item, List<Item>>? {
             val parent = parentItem(this)
 
             return if (parent != null) {
-                parent to (toChildItem() ?: return null)
+                parent to (toChildItems() ?: return null)
             } else {
                 val parentItem = toParentItem() ?: return null
-                parentItem to null
+                parentItem to emptyList()
             }
         }
 
@@ -302,7 +305,10 @@ data class RsQualifiedName private constructor(
                     }
                 }
                 is RsEnumVariant -> element.parentEnum
-                is RsNamedFieldDecl -> element.owner
+                is RsNamedFieldDecl -> {
+                    val owner = element.owner
+                    (owner as? RsEnumVariant)?.parentEnum ?: owner
+                }
                 else -> return null
             }
             return parentItem?.toParentItem()
@@ -359,17 +365,29 @@ data class RsQualifiedName private constructor(
             return Item(name, itemType, this)
         }
 
-        private fun RsQualifiedNamedElement.toChildItem(): Item? {
+        private fun RsQualifiedNamedElement.toChildItems(): List<Item>? {
             val name = name ?: return null
+            val result = mutableListOf<Item>()
             val type = when (this) {
                 is RsEnumVariant -> VARIANT
-                is RsNamedFieldDecl -> if (parentStruct != null) STRUCTFIELD else return null
+                is RsNamedFieldDecl -> {
+                    when (val owner = owner) {
+                        is RsStructItem -> STRUCTFIELD
+                        is RsEnumVariant -> {
+                            val variantName = owner.name ?: return null
+                            result += Item(variantName, VARIANT, owner)
+                            FIELD
+                        }
+                        else -> return null
+                    }
+                }
                 is RsTypeAlias -> ASSOCIATEDTYPE
                 is RsConstant -> ASSOCIATEDCONSTANT
                 is RsFunction -> if (isAbstract) TYMETHOD else METHOD
                 else -> return null
             }
-            return Item(name, type, this)
+            result += Item(name, type, this)
+            return result
         }
     }
 
@@ -441,6 +459,7 @@ data class RsQualifiedName private constructor(
 
     enum class ChildItemType : ItemType {
         VARIANT,
+        FIELD,
         STRUCTFIELD,
         ASSOCIATEDTYPE,
         ASSOCIATEDCONSTANT,
@@ -453,6 +472,7 @@ data class RsQualifiedName private constructor(
             fun fromString(name: String): ChildItemType? {
                 return when (name) {
                     "variant" -> VARIANT
+                    "field" -> FIELD
                     "structfield" -> STRUCTFIELD
                     "associatedtype" -> ASSOCIATEDTYPE
                     "associatedconstant" -> ASSOCIATEDCONSTANT

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTupleFieldDecl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTupleFieldDecl.kt
@@ -16,7 +16,7 @@ import org.rust.lang.core.stubs.RsPlaceholderStub
 import javax.swing.Icon
 
 val RsTupleFieldDecl.position: Int?
-    get() = parentStruct?.positionalFields?.withIndex()?.firstOrNull { it.value === this }?.index
+    get() = owner?.positionalFields?.withIndex()?.firstOrNull { it.value === this }?.index
 
 
 abstract class RsTupleFieldDeclImplMixin : RsStubbedElementImpl<RsPlaceholderStub>, RsTupleFieldDecl {
@@ -24,7 +24,7 @@ abstract class RsTupleFieldDeclImplMixin : RsStubbedElementImpl<RsPlaceholderStu
     constructor(stub: RsPlaceholderStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
 
     override fun getIcon(flags: Int): Icon =
-        if (parent.parent is RsEnumVariant) RsIcons.FIELD else iconWithVisibility(flags, RsIcons.FIELD)
+        if (owner is RsEnumVariant) RsIcons.FIELD else iconWithVisibility(flags, RsIcons.FIELD)
 
     override fun getName(): String? = position?.toString()
 

--- a/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
@@ -99,6 +99,12 @@ class RsExternalDocUrlTest : RsDocumentationProviderTest() {
         }
     """, null, Testmarks.notExportedMacro)
 
+    fun `test macro 2`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        pub macro Bar() {}
+                 //^
+    """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/macro.Bar.html")
+
     fun `test not external url for workspace package`() = doUrlTestByFileTree("""
         //- lib.rs
         pub enum Foo { FOO, BAR }

--- a/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlTest.kt
@@ -27,6 +27,15 @@ class RsExternalDocUrlTest : RsDocumentationProviderTest() {
         }
     """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/struct.Foo.html#associatedconstant.BAR")
 
+    fun `test enum variant field`() = doUrlTestByFileTree("""
+        //- dep-lib/lib.rs
+        pub enum Foo {
+            Bar {
+                baz: i32
+            }  //^
+        }
+    """, "https://docs.rs/dep-lib/0.0.1/dep_lib_target/enum.Foo.html#variant.Bar.field.baz")
+
     fun `test item with restricted visibility`() = doUrlTestByFileTree("""
         //- dep-lib/lib.rs
         pub(crate) enum Foo { V1, V2 }

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -807,6 +807,24 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <div class='content'><p>Documented</p></div>
     """)
 
+    fun `test enum variant field`() = doTest("""
+        enum Foo {
+            Bar {
+                /// Documented
+                baz: i32
+            }
+        }
+
+        fn foo(f: Foo) {
+            if let Foo::Bar { baz: x } = f {}
+                             //^
+        }
+    """, """
+        <div class='definition'><pre>test_package::Foo::Bar
+        <b>baz</b>: i32</pre></div>
+        <div class='content'><p>Documented</p></div>
+    """)
+
     fun `test type parameter`() = doTest("""
         fn foo<T>() { unimplemented!() }
              //^

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -682,6 +682,20 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <div class='content'><p>Outer documentation</p></div>
     """)
 
+    fun `test macro 2 outer docs`() = doTest("""
+        pub struct Foo;
+
+        /// Outer doc
+        /// [link](Foo)
+        pub macro Bar() {}
+                 //^
+    """, """
+        <div class='definition'><pre>test_package::Bar
+        </pre></div>
+        <div class='content'><p>Outer doc
+        <a href="psi_element://test_package/Foo">link</a></p></div>
+    """)
+
     fun `test qualified name`() = doTest("""
         mod q {
             /// Blurb.

--- a/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsResolveLinkTest.kt
@@ -183,6 +183,17 @@ class RsResolveLinkTest : RsTestBase() {
               //^
     """, "test_package/struct.Foo.html#structfield.foo")
 
+    fun `test enum variant field fqn link`() = doTest("""
+        pub enum Foo {
+            Bar {
+                baz: i32
+            }  //X
+        }
+
+        struct S;
+             //^
+    """, "test_package/enum.Foo.html#variant.Bar.field.baz")
+
     fun `test assoc type fqn link 1`() = doTest("""
         trait Foo {
             type Bar;


### PR DESCRIPTION
These changes fixes documentation rendering for fields of enum variant and macro 2.0.

Fixes #5984