### PR TITLE
Index `stdarch` & `backtrace` stdlib parts

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -55,6 +55,7 @@ import org.rust.cargo.project.toolwindow.CargoToolWindow.Companion.initializeToo
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.project.workspace.StandardLibrary
+import org.rust.cargo.project.workspace.additionalRoots
 import org.rust.cargo.runconfig.command.workingDirectory
 import org.rust.cargo.toolchain.RustToolchain
 import org.rust.cargo.toolchain.Rustup
@@ -132,6 +133,9 @@ open class CargoProjectsServiceImpl(
             fun CargoWorkspace.Package.put(cargoProject: CargoProjectImpl) {
                 contentRoot?.put(cargoProject)
                 outDir?.put(cargoProject)
+                for (additionalRoot in additionalRoots()) {
+                    additionalRoot.put(cargoProject)
+                }
                 for (target in targets) {
                     target.crateRoot?.parent?.put(cargoProject)
                 }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -401,6 +401,27 @@ private class DependencyImpl(
     operator fun component3(): List<CargoWorkspace.DepKindInfo> = depKinds
 }
 
+/**
+ * A way to add additional (indexable) source roots for a package.
+ * These hacks are needed for the stdlib that has a weird source structure.
+ */
+fun CargoWorkspace.Package.additionalRoots(): List<VirtualFile> {
+    return if (origin == PackageOrigin.STDLIB) {
+        when (name) {
+            STD -> listOfNotNull(contentRoot?.parent?.findFileByRelativePath("backtrace"))
+            CORE -> contentRoot?.parent?.let {
+                listOfNotNull(
+                    it.findFileByRelativePath("stdarch/crates/core_arch"),
+                    it.findFileByRelativePath("stdarch/crates/std_detect")
+                )
+            } ?: emptyList()
+            else -> emptyList()
+        }
+    } else {
+        emptyList()
+    }
+}
+
 private fun PackageImpl.asPackageData(edition: CargoWorkspace.Edition? = null): CargoWorkspaceData.Package =
     CargoWorkspaceData.Package(
         id = id,

--- a/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt
@@ -95,6 +95,10 @@ private fun makeStdlibLibrary(packages: List<CargoWorkspace.Package>, rustcVersi
     for (pkg in packages) {
         val root = pkg.contentRoot ?: continue
         sourceRoots += root
+        sourceRoots += pkg.additionalRoots()
+    }
+
+    for (root in sourceRoots) {
         excludedRoots += listOfNotNull(root.findChild("tests"), root.findChild("benches"))
     }
 


### PR DESCRIPTION
Expected user-visible change is additional roots of stdlib. `core_arch` and `std_detect` on stable and additionally `backtrace` on nightly. Also, now navigation actions like `Select Opened File` in Project view should properly navigate you if you open any file from described directories of stdlib
![image](https://user-images.githubusercontent.com/2539310/91205894-f8537980-e70e-11ea-93f6-d749ec9a2cab.png)
