### PR TITLE
ANN: ignore string format parameters that are not string literals

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
@@ -19,7 +19,10 @@ import org.rust.ide.presentation.render
 import org.rust.lang.core.macros.MacroExpansionMode
 import org.rust.lang.core.macros.macroExpansionManager
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.containingCrate
+import org.rust.lang.core.psi.ext.macroName
+import org.rust.lang.core.psi.ext.startOffset
+import org.rust.lang.core.psi.ext.withSubst
 import org.rust.lang.core.resolve.KnownItems
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.TraitRef
@@ -43,7 +46,7 @@ class RsFormatMacroAnnotator : AnnotatorBase() {
 
         val formatStr = macroArgs
             .getOrNull(macroPos)
-            ?.descendantOfTypeStrict<RsLitExpr>()
+            ?.expr as? RsLitExpr
             ?: return
 
         val parseCtx = parseParameters(formatStr) ?: return

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -462,4 +462,12 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
             println!("{0:E}", <error descr="`S` doesn't implement `UpperExp` (required by {0:E})">s</error>);
         }
     """)
+
+    fun `test ignore format string macro argument`() = checkErrors("""
+        struct S;
+
+        fn main() {
+            println!(concat!("{}", "{}", "{}"), S, S);
+        }
+    """)
 }


### PR DESCRIPTION
This PR modifies `RsFormatMacroAnnotator` to ignore format string arguments that are not string literals.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5994