### PR TITLE
Feature inline diverging function

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineFunction/RsInlineFunctionProcessor.kt
@@ -132,14 +132,14 @@ class RsInlineFunctionProcessor(
 
     companion object {
         fun doesFunctionHaveMultipleReturns(fn: RsFunction): Boolean {
-            var entryCount = 0
+            val entryPoints =  mutableListOf<ExitPoint>()
             val sink: (ExitPoint) -> Unit = {
                 if (it !is ExitPoint.TryExpr) {
-                    ++entryCount
+                    entryPoints.add(it)
                 }
             }
             ExitPoint.process(fn, sink)
-            return entryCount > 1
+            return entryPoints.count() > 1 && entryPoints.dropLast(1).any { it is ExitPoint.Return }
         }
 
         fun isFunctionRecursive(fn: RsFunction): Boolean {


### PR DESCRIPTION
- [x] Allow refactoring if all but the last exit point aren't `return` statements

- [x] Assure the `return` statement is the last statement in the function, and isn't nested in any other expression. Meaning it is at the end of the body.

changelog: Allow inlining functions (using `Inline Function` refactoring) with diverging exit points (like `panic!()`).