### PR TITLE
Inline function arguments correctly

### DIFF
--- a/src/test/kotlin/org/rust/ide/refactoring/RsInlineFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsInlineFunctionTest.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
-import org.junit.Assert
 import org.rust.RsTestBase
 
 class RsInlineFunctionTest : RsTestBase() {
@@ -123,7 +122,8 @@ class RsInlineFunctionTest : RsTestBase() {
     """, """
         fn main() {
             let mut vec = vec![1, 2, 3];
-            vec.push(1);
+            let vec_argument = &mut vec;
+            vec_argument.push(1);
         }
 
     """)
@@ -369,6 +369,31 @@ class RsInlineFunctionTest : RsTestBase() {
             fn test(self) {
                 println!("bla");
             }
+        }
+    """)
+
+    fun `test inline method with struct self parameter and another parameter`() = doTest("""
+        struct S { a: u32, b: u32 }
+
+        impl S {
+            fn /*caret*/foo(&self, a: u32) {
+                println!("{} {} {}", self.a, self.b, a);
+            }
+        }
+
+        fn main() {
+            let s = S { a: 0, b: 0 };
+            S::foo(&s, 1);
+        }
+    """, """
+        struct S { a: u32, b: u32 }
+
+        impl S {}
+
+        fn main() {
+            let s = S { a: 0, b: 0 };
+            let a = 1;
+            println!("{} {} {}", &s.a, &s.b, a);
         }
     """)
 
@@ -653,9 +678,9 @@ class RsInlineFunctionTest : RsTestBase() {
     """)
 
     fun `test inline function with passing by &`() = doTest("""
-        fn f(a: &Vec<i32>) {}
+        fn f(_a: &Vec<i32>) {}
 
-        fn foo() {
+        fn main() {
             let vec = vec![1, 2, 3];
             let vec2 = vec![1, 2, 3];
             let vec3 = vec![1, 2, 3];
@@ -670,16 +695,18 @@ class RsInlineFunctionTest : RsTestBase() {
             f(&vec3);
         }
     """, """
-        fn f(a: &Vec<i32>) {}
+        fn f(_a: &Vec<i32>) {}
 
-        fn foo() {
+        fn main() {
             let vec = vec![1, 2, 3];
             let vec2 = vec![1, 2, 3];
             let vec3 = vec![1, 2, 3];
 
-            println!("{}", vec.len());
+            let vec_argument = &vec;
+            let vec3_argument = &vec3;
+            println!("{}", vec_argument.len());
             println!("{}", vec2.len());
-            f(&vec3);
+            f(&vec3_argument);
 
             println!("{}", vec.len());
         }
@@ -704,8 +731,10 @@ class RsInlineFunctionTest : RsTestBase() {
             let mut vec = vec![1, 2, 3];
             let mut vec2 = vec![1, 2, 3];
 
-            vec.push(123);
-            vec2.push(123);
+            let vec_argument = &mut vec;
+            let vec2_argument = &mut vec2;
+            vec_argument.push(123);
+            vec2_argument.push(123);
 
             println!("{}", vec.len());
         }
@@ -716,7 +745,7 @@ class RsInlineFunctionTest : RsTestBase() {
         fn test(mut v: Vec<i32>) {}
         fn test2(v: &mut Vec<i32>) {}
 
-        fn foo() {
+        fn main() {
             let mut vec = vec![1, 2, 3];
             let mut vec2 = vec![1, 2, 3];
 
@@ -730,12 +759,13 @@ class RsInlineFunctionTest : RsTestBase() {
         fn test(mut v: Vec<i32>) {}
         fn test2(v: &mut Vec<i32>) {}
 
-        fn foo() {
+        fn main() {
             let mut vec = vec![1, 2, 3];
             let mut vec2 = vec![1, 2, 3];
 
+            let mut vec2_argument = &mut vec2;
             test(vec);
-            test2(&mut vec2);
+            test2(&mut vec2_argument);
         }
 
     """)
@@ -803,6 +833,243 @@ class RsInlineFunctionTest : RsTestBase() {
         }
 
     """)
+
+    fun `test inline function with differently named function parameters`() = doTest("""
+            fn main() {
+                let a = foo(bar());
+            }
+            fn /*caret*/foo(i: i32) -> i32 {
+                return i + bar();
+            }
+
+            fn bar() -> i32 {
+                5
+            }
+            """, """
+            fn main() {
+                let i = bar();
+                let a = i + bar();
+            }
+
+            fn bar() -> i32 {
+                5
+            }
+            """)
+
+    fun `test inline function with differently named function parameters with inlined references`() = doTest("""
+            fn main() {
+                let b = 6;
+                let _a = foo(b);
+            }
+            fn /*caret*/foo(i: i32) -> i32 {
+                return i + bar(&i);
+            }
+
+            fn bar(i: &i32) -> &i32 {
+                return i;
+            }
+            """, """
+            fn main() {
+                let b = 6;
+                let i = b;
+                let _a = i + bar(&i);
+            }
+
+            fn bar(i: &i32) -> &i32 {
+                return i;
+            }
+            """)
+
+    fun `test inline function with differently named reference and mutable function parameters`() = doTest("""
+            fn main() {
+                let _a = foo(&bar(), &mut qux(), corge());
+            }
+
+            fn /*caret*/foo(i: &i32, j: &mut i32, mut k: i32) -> i32 {
+                return *i + *j + k + bar();
+            }
+
+            fn bar() -> i32 {
+                let baz = 5;
+                return baz;
+            }
+
+            fn qux() -> i32 {
+                let quux = 5;
+                return quux;
+            }
+
+            fn corge() -> i32 {
+                let grault = 5;
+                return grault;
+            }
+            """, """
+            fn main() {
+                let i = &bar();
+                let j = &mut qux();
+                let mut k = corge();
+                let _a = *i + *j + k + bar();
+            }
+
+            fn bar() -> i32 {
+                let baz = 5;
+                return baz;
+            }
+
+            fn qux() -> i32 {
+                let quux = 5;
+                return quux;
+            }
+
+            fn corge() -> i32 {
+                let grault = 5;
+                return grault;
+            }
+            """)
+
+    fun `test inline function with differently named reference and function argument inlined into multiple places`() = doTest("""
+            fn main() {
+                let mut foo = 1024;
+                let a = divide(bar(&mut foo), bar(&mut foo));
+            }
+
+            // Notice Parameters are supplied and consumed in a different order
+            fn /*caret*/divide(i: &i32, j: &i32) -> i32 {
+                return j / i;
+            }
+
+            fn bar(foo: &mut i32) -> &mut i32 {
+                let foo = foo / 2;
+                return foo;
+            }
+            """, """
+            fn main() {
+                let mut foo = 1024;
+                let i = bar(&mut foo);
+                let j = bar(&mut foo);
+                let a = j / i;
+            }
+
+            fn bar(foo: &mut i32) -> &mut i32 {
+                let foo = foo / 2;
+                return foo;
+            }
+            """)
+
+    fun `test inline function with differently named parameters in a tuple deconstruction`() = doTest("""
+            fn main() {
+                let c = foo((bar(), bar()));
+            }
+            fn /*caret*/foo((a, b): (i32, i32)) -> i32 {
+                return a + b + bar();
+            }
+
+            fn bar() -> i32 {
+                5
+            }
+            """, """
+            fn main() {
+                let (a, b) = (bar(), bar());
+                let c = a + b + bar();
+            }
+
+            fn bar() -> i32 {
+                5
+            }
+            """)
+
+    fun `test inline function with differently named tuple parameter`() = doTest("""
+            fn main() {
+                let c = foo((bar(), bar()));
+            }
+            fn /*caret*/foo(a: (i32, i32)) -> i32 {
+                return a.0 + a.1 + bar();
+            }
+
+            fn bar() -> i32 {
+                5
+            }
+            """, """
+            fn main() {
+                let a = (bar(), bar());
+                let c = a.0 + a.1 + bar();
+            }
+
+            fn bar() -> i32 {
+                5
+            }
+            """)
+
+    fun `test inline function with differently named struct parameter`() = doTest("""
+            fn main() {
+                let _c = foo(bar());
+            }
+            fn /*caret*/foo(a: S) -> i32 {
+                return a.a + a.b + bar().a + bar().b;
+            }
+
+            fn bar() -> S {
+                S{ a:5, b:5 }
+            }
+
+            struct S { a: i32, b: i32 }
+            """, """
+            fn main() {
+                let a = bar();
+                let _c = a.a + a.b + bar().a + bar().b;
+            }
+
+            fn bar() -> S {
+                S{ a:5, b:5 }
+            }
+
+            struct S { a: i32, b: i32 }
+            """)
+
+    fun `test inline function with differently named struct deconstruction`() = doTest("""
+            fn main() {
+                let _c = foo(bar());
+            }
+            fn /*caret*/foo(S { a, b }: S) -> i32 {
+                return a + b + bar().a;
+            }
+
+            fn bar() -> S {
+                S{ a:5, b:5 }
+            }
+
+            struct S { a: i32, b: i32 }
+            """, """
+            fn main() {
+                let S { a, b } = bar();
+                let _c = a + b + bar().a;
+            }
+
+            fn bar() -> S {
+                S{ a:5, b:5 }
+            }
+
+            struct S { a: i32, b: i32 }
+            """)
+
+    fun `test inline function with unary reference expression that can't be removed`() = doTest("""
+            fn main() {
+                let a = 5;
+                foo(&a);
+            }
+
+            fn /*caret*/foo(x: &i32) {
+                println!("{}", *x);
+            }
+            """, """
+            fn main() {
+                let a = 5;
+                let x = &a;
+                println!("{}", *x);
+            }
+
+
+            """)
 
     private fun doTest(@Language("Rust") before: String,
                        @Language("Rust") after: String) {


### PR DESCRIPTION
Currently it replaces function parameters with the function arguments.  Still need to make sure arguments will be resolved in the same order were they not inlined by creating variables for them before the main inline. Here's a Kotlin example:
That's the original file. We'll inline `foo()`
```kotlin
var count = 1
private fun main() {
    val a = foo(bar())
}

private fun foo(number: Int): Int {
    return number * bar() + number
}

private fun bar(): Int {
    return count++
}
```
The original code should get `2 * 3 + 2` inside foo.
My code currently inlines the values directly, like so:
```kotlin
var count = 1
private fun main() {
    val a = bar() * bar() + bar()
}

    private fun bar(): Int {
    return count++
}
```
Which leads the calculation to be `2 * 3 + 4`, because the function will be called an additional time.
The correct inline (as shown by Kotlin) is:
```kotlin
var count = 1
private fun main() {
    val number = bar()
    val a = number * bar() + number
}

    private fun bar(): Int {
    return count++
}
```
Which makes sure number has a single value, assined before any calls for `bar()` happening inside `foo()`.