### PR TITLE
Exclude "build" dir from index in rustc project

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -393,7 +393,7 @@ data class CargoProjectImpl(
     }
 
     // Checks that the project is https://github.com/rust-lang/rust
-    private fun doesProjectLooksLikeRustc(): Boolean {
+    fun doesProjectLooksLikeRustc(): Boolean {
         val workspace = rawWorkspace ?: return false
         // "rustc" package was renamed to "rustc_middle" in https://github.com/rust-lang/rust/pull/70536
         // so starting with rustc 1.42 a stable way to identify it is to try to find any of some possible packages
@@ -496,6 +496,12 @@ private fun setupProjectRoots(project: Project, cargoProjects: List<CargoProject
                 for (cargoProject in cargoProjects) {
                     cargoProject.workspaceRootDir?.setupContentRoots(project) { contentRoot ->
                         addExcludeFolder(FileUtil.join(contentRoot.url, CargoConstants.ProjectLayout.target))
+                    }
+
+                    if ((cargoProject as? CargoProjectImpl)?.doesProjectLooksLikeRustc() == true) {
+                        cargoProject.workspaceRootDir?.setupContentRoots(project) { contentRoot ->
+                            addExcludeFolder(FileUtil.join(contentRoot.url, "build"))
+                        }
                     }
 
                     val alreadySetUp = hashSetOf<CargoWorkspace.Package>()


### PR DESCRIPTION
https://github.com/rust-lang/rust uses `build` directory instead of `target`. So let's exclude `build` as well as `target`