### PR TITLE
REF: Make moved items public if needed

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesProcessor.kt
@@ -22,6 +22,7 @@ import com.intellij.util.containers.MultiMap
 import org.rust.ide.refactoring.move.common.RsMovePathHelper
 import org.rust.ide.refactoring.move.common.RsMoveReferenceInfo
 import org.rust.ide.refactoring.move.common.RsMoveRetargetReferencesProcessor
+import org.rust.ide.refactoring.move.common.updateScopeIfNecessary
 import org.rust.ide.utils.import.lastElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -258,20 +259,6 @@ class RsMoveFilesOrDirectoriesProcessor(
 }
 
 fun RsElement.isInsideModSubtree(mod: RsMod): Boolean = containingMod.superMods.contains(mod)
-
-// updates `pub(in path)` visibility modifier
-// `path` must be a parent module of the item whose visibility is being declared,
-// so we replace `path` with common parent module of `newParent` and old `path`
-private fun RsVisRestriction.updateScopeIfNecessary(psiFactory: RsPsiFactory, newParent: RsMod) {
-    val oldScope = path.reference?.resolve() as? RsMod ?: return
-    val newScope = commonParentMod(oldScope, newParent) ?: return
-    if (newScope == oldScope) return
-    val newScopePath = newScope.crateRelativePath ?: return
-
-    check(crateRoot == newParent.crateRoot)
-    val newVisRestriction = psiFactory.createVisRestriction("crate$newScopePath")
-    replace(newVisRestriction)
-}
 
 private fun RsMod.insertModDecl(psiFactory: RsPsiFactory, modDecl: PsiElement) {
     val anchor = childrenOfType<RsModDeclItem>().lastElement ?: childrenOfType<RsUseItem>().lastElement

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsProcessor.kt
@@ -56,6 +56,8 @@ class RsMoveTopLevelItemsProcessor(
     }
 
     private fun moveItem(item: RsItemElement): ElementToMove {
+        commonProcessor.updateMovedItemVisibility(item)
+
         val space = item.nextSibling as? PsiWhiteSpace
 
         // have to call `copy` because of rare suspicious `PsiInvalidElementAccessException`

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
@@ -20,6 +20,7 @@ import com.intellij.refactoring.RefactoringBundle.message
 import com.intellij.usageView.UsageInfo
 import com.intellij.util.IncorrectOperationException
 import com.intellij.util.containers.MultiMap
+import org.rust.ide.annotator.fixes.MakePublicFix
 import org.rust.ide.refactoring.move.common.RsMoveUtil.LOG
 import org.rust.ide.refactoring.move.common.RsMoveUtil.containingModStrict
 import org.rust.ide.refactoring.move.common.RsMoveUtil.isAbsolute
@@ -388,6 +389,28 @@ class RsMoveCommonProcessor(
                 LOG.error("Can't restore target ${reference.target}" +
                     " for reference '${reference.pathOld.text}' after move")
             }
+        }
+    }
+
+    fun updateMovedItemVisibility(item: RsItemElement) {
+        when (item.visibility) {
+            is RsVisibility.Private -> {
+                if (conflictsDetector.itemsToMakePublic.contains(item)) {
+                    val itemName = item.name
+                    val containingFile = item.containingFile
+                    if (item !is RsNameIdentifierOwner) {
+                        LOG.error("Unexpected item to make public: $item")
+                        return
+                    }
+                    MakePublicFix(item, itemName, withinOneCrate = false)
+                        .invoke(project, null, containingFile)
+                }
+            }
+            is RsVisibility.Restricted -> run {
+                val visRestriction = item.vis?.visRestriction ?: return@run
+                visRestriction.updateScopeIfNecessary(psiFactory, targetMod)
+            }
+            RsVisibility.Public -> Unit  // already public, keep as is
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
@@ -328,6 +328,8 @@ class RsMoveCommonProcessor(
     }
 
     fun performRefactoring(usages: Array<out UsageInfo>, moveElements: () -> List<ElementToMove>) {
+        updateOutsideReferencesInVisRestrictions()
+
         elementsToMove = moveElements()
 
         val retargetReferencesProcessor = RsMoveRetargetReferencesProcessor(project, sourceMod, targetMod)
@@ -339,6 +341,12 @@ class RsMoveCommonProcessor(
             .map { it.referenceInfo }
         updateInsideReferenceInfosIfNeeded(insideReferences)
         retargetReferencesProcessor.retargetReferences(insideReferences)
+    }
+
+    private fun updateOutsideReferencesInVisRestrictions() {
+        for (visRestriction in movedElementsDeepDescendantsOfType<RsVisRestriction>(elementsToMove)) {
+            visRestriction.updateScopeIfNecessary(psiFactory, targetMod)
+        }
     }
 
     /**

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveConflictsDetector.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveConflictsDetector.kt
@@ -26,12 +26,21 @@ class RsMoveConflictsDetector(
     private val targetMod: RsMod
 ) {
 
+    val itemsToMakePublic: MutableSet<RsElement> = hashSetOf()
+
     fun detectInsideReferencesVisibilityProblems(insideReferences: List<RsMoveReferenceInfo>) {
         for (reference in insideReferences) {
             val pathOld = reference.pathOld
             val target = reference.target
             if (reference.pathNewAccessible == null) {
                 addVisibilityConflict(conflicts, pathOld, target)
+            }
+
+            val usageMod = pathOld.containingMod
+            val isSelfReference = pathOld.isInsideMovedElements(elementsToMove)
+            if (!isSelfReference && !usageMod.superMods.contains(targetMod)) {
+                val itemToMakePublic = (target as? RsFile)?.declaration ?: target
+                itemsToMakePublic.add(itemToMakePublic)
             }
         }
 

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
@@ -335,6 +335,128 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         mod mod2/*target*/ {}
     """)
 
+    fun `test add pub to moved items if necessary`() = doTest("""
+    //- lib.rs
+        mod mod1 {
+            mod foo1/*caret*/ { pub fn foo1_func() {} }
+            fn foo2/*caret*/() {}
+            struct Foo3/*caret*/ {}
+            struct Foo4/*caret*/ { pub field: i32 }
+            struct Foo5/*caret*/ { pub field: i32 }
+            struct Foo6/*caret*/(pub i32);
+            struct Foo7/*caret*/(pub i32);
+            fn bar() {
+                foo1::foo1_func();
+                foo2();
+                let _ = Foo3 {};
+                let _ = Foo4 { field: 0 };
+                let Foo5 { field: _ } = None.unwrap();
+                let _ = Foo6(0);
+                let Foo7(_) = None.unwrap();
+            }
+        }
+        mod mod2/*target*/ {}
+    """, """
+    //- lib.rs
+        mod mod1 {
+            use crate::mod2::{foo1, Foo3, Foo4, Foo5, Foo6, Foo7};
+            use crate::mod2;
+
+            fn bar() {
+                foo1::foo1_func();
+                mod2::foo2();
+                let _ = Foo3 {};
+                let _ = Foo4 { field: 0 };
+                let Foo5 { field: _ } = None.unwrap();
+                let _ = Foo6(0);
+                let Foo7(_) = None.unwrap();
+            }
+        }
+        mod mod2 {
+            pub mod foo1 { pub fn foo1_func() {} }
+
+            pub fn foo2() {}
+
+            pub struct Foo3 {}
+
+            pub struct Foo4 { pub field: i32 }
+
+            pub struct Foo5 { pub field: i32 }
+
+            pub struct Foo6(pub i32);
+
+            pub struct Foo7(pub i32);
+        }
+    """)
+
+    fun `test add pub to moved items if necessary when items has doc comments`() = doTest("""
+    //- lib.rs
+        mod mod1 {
+            // comment 1
+            #[attr1]
+            fn foo1/*caret*/() {}
+            /// comment 2
+            #[attr2]
+            struct Foo2/*caret*/ {}
+            fn bar() {
+                foo1();
+                let _ = Foo2 {};
+            }
+        }
+        mod mod2/*target*/ {}
+    """, """
+    //- lib.rs
+        mod mod1 {
+            use crate::mod2;
+            use crate::mod2::Foo2;
+
+            fn bar() {
+                mod2::foo1();
+                let _ = Foo2 {};
+            }
+        }
+        mod mod2 {
+            // comment 1
+            #[attr1]
+            pub fn foo1() {}
+
+            /// comment 2
+            #[attr2]
+            pub struct Foo2 {}
+        }
+    """)
+
+    fun `test add pub to moved items if necessary when moving to other crate`() = doTest("""
+    //- main.rs
+        mod mod1 {
+            fn foo1/*caret*/() {}
+            pub(self) fn foo2/*caret*/() {}
+            pub(in mod1) fn foo3/*caret*/() {}
+            fn bar() {
+                foo1();
+                foo2();
+                foo3();
+            }
+        }
+    //- lib.rs
+        /*target*/
+    """, """
+    //- main.rs
+        mod mod1 {
+            fn bar() {
+                test_package::foo1();
+                test_package::foo2();
+                test_package::foo3();
+            }
+        }
+    //- lib.rs
+        pub fn foo1() {}
+
+        pub fn foo2() {}
+
+        pub fn foo3() {}
+    """)
+
     fun `test absolute outside reference which should be changed because of reexports`() = doTest("""
     //- lib.rs
         mod inner1 {

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
@@ -457,6 +457,44 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         pub fn foo3() {}
     """)
 
+    fun `test change scope for pub(in) visibility`() = doTest("""
+    //- lib.rs
+        mod inner1 {
+            mod inner2 {
+                mod inner3 {
+                    mod mod1 {
+                        pub(crate) fn foo1/*caret*/() {}
+                        pub(self) fn foo2/*caret*/() {}
+                        pub(super) fn foo3/*caret*/() {}
+                        pub(in super::super) fn foo4/*caret*/() {}
+                        pub(in crate::inner1) fn foo5/*caret*/() {}
+                    }
+                }
+                mod mod2/*target*/ {}
+            }
+        }
+    """, """
+    //- lib.rs
+        mod inner1 {
+            mod inner2 {
+                mod inner3 {
+                    mod mod1 {}
+                }
+                mod mod2 {
+                    pub(crate) fn foo1() {}
+
+                    pub(in crate::inner1::inner2) fn foo2() {}
+
+                    pub(in crate::inner1::inner2) fn foo3() {}
+
+                    pub(in crate::inner1::inner2) fn foo4() {}
+
+                    pub(in crate::inner1) fn foo5() {}
+                }
+            }
+        }
+    """)
+
     fun `test absolute outside reference which should be changed because of reexports`() = doTest("""
     //- lib.rs
         mod inner1 {


### PR DESCRIPTION
Make moved items public if needed (e.g. they are used in old parent mod) in [move items refactoring](https://github.com/intellij-rust/intellij-rust/issues/3531#issuecomment-643142894).

Also change restricted visibility scope of moved items if needed (common parent mod of old scope and new parent mod is used).