### PR TITLE
REF: Group structs and traits with related impls in move items dialog

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMemberSelectionPanel.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMemberSelectionPanel.kt
@@ -16,7 +16,7 @@ import org.rust.lang.core.psi.RsModItem
 import org.rust.lang.core.psi.ext.RsItemElement
 import javax.swing.Icon
 
-// currently supports only move refactoring requirements
+@Suppress("unused")  // could be used in other refactorings
 class RsMemberSelectionPanel(
     title: String,
     memberInfo: List<RsMemberInfo>

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveMemberSelection.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveMemberSelection.kt
@@ -1,0 +1,100 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.move
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vcs.changes.ui.*
+import com.intellij.ui.ColoredTreeCellRenderer
+import com.intellij.ui.ScrollPaneFactory
+import com.intellij.ui.SeparatorFactory
+import com.intellij.util.ui.tree.TreeUtil
+import java.awt.BorderLayout
+import javax.swing.Icon
+import javax.swing.JPanel
+import javax.swing.tree.DefaultTreeModel
+
+interface RsMoveNodeInfo {
+    fun render(renderer: ColoredTreeCellRenderer)
+    val icon: Icon? get() = null
+    val children: List<RsMoveNodeInfo> get() = emptyList()
+}
+
+class RsMoveMemberSelectionPanel(
+    val project: Project,
+    title: String,
+    nodesAll: List<RsMoveNodeInfo>,
+    nodesSelected: List<RsMoveNodeInfo>
+) : JPanel() {
+
+    val tree: RsMoveMemberSelectionTree = RsMoveMemberSelectionTree(project, nodesAll, nodesSelected)
+
+    init {
+        layout = BorderLayout()
+        val scrollPane = ScrollPaneFactory.createScrollPane(tree)
+        add(SeparatorFactory.createSeparator(title, tree), BorderLayout.NORTH)
+        add(scrollPane, BorderLayout.CENTER)
+    }
+}
+
+class RsMoveMemberSelectionTree(
+    project: Project,
+    nodesAll: List<RsMoveNodeInfo>,
+    nodesSelected: List<RsMoveNodeInfo>
+) : ChangesTreeImpl<RsMoveNodeInfo>(
+    project,
+    true,
+    false,
+    RsMoveNodeInfo::class.java
+) {
+
+    init {
+        setIncludedChanges(nodesSelected)
+        setChangesToDisplay(nodesAll)
+        TreeUtil.collapseAll(this, 0)
+    }
+
+    override fun buildTreeModel(nodeInfos: List<RsMoveNodeInfo>): DefaultTreeModel {
+        return RsMoveMemberSelectionModelBuilder(project, grouping).buildTreeModel(nodeInfos)
+    }
+}
+
+private class RsMoveMemberSelectionModelBuilder(
+    project: Project,
+    grouping: ChangesGroupingPolicyFactory
+) : TreeModelBuilder(project, grouping) {
+
+    fun buildTreeModel(nodeInfos: List<RsMoveNodeInfo>): DefaultTreeModel {
+        fun addNode(nodeInfo: RsMoveNodeInfo, root: ChangesBrowserNode<*>) {
+            val node = RsMoveMemberSelectionNode(nodeInfo)
+            myModel.insertNodeInto(node, root, root.childCount)
+
+            val children = nodeInfo.children
+            if (children.isNotEmpty()) {
+                node.markAsHelperNode()
+                for (child in children) {
+                    addNode(child, node)
+                }
+            }
+        }
+
+        for (node in nodeInfos) {
+            addNode(node, myRoot)
+        }
+        return build()
+    }
+}
+
+private class RsMoveMemberSelectionNode(private val info: RsMoveNodeInfo) : ChangesBrowserNode<RsMoveNodeInfo>(info) {
+    override fun render(
+        renderer: ChangesBrowserNodeRenderer,
+        selected: Boolean,
+        expanded: Boolean,
+        hasFocus: Boolean
+    ) {
+        info.render(renderer)
+        renderer.icon = info.icon
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsDialog.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsDialog.kt
@@ -8,14 +8,20 @@ package org.rust.ide.refactoring.move
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.refactoring.RefactoringBundle.message
 import com.intellij.refactoring.ui.RefactoringDialog
 import com.intellij.refactoring.util.CommonRefactoringUtil
+import com.intellij.ui.ColoredTreeCellRenderer
+import com.intellij.ui.SimpleTextAttributes
 import com.intellij.ui.components.JBTextField
 import com.intellij.ui.layout.panel
 import com.intellij.util.IncorrectOperationException
+import org.apache.commons.lang.StringEscapeUtils
+import org.rust.ide.docs.signature
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsItemElement
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.openapiext.pathToRsFileTextField
@@ -23,6 +29,7 @@ import org.rust.openapiext.toPsiFile
 import org.rust.stdext.mapToSet
 import java.awt.Dimension
 import java.io.File
+import javax.swing.Icon
 import javax.swing.JComponent
 
 class RsMoveTopLevelItemsDialog(
@@ -34,17 +41,18 @@ class RsMoveTopLevelItemsDialog(
     private val sourceFilePath: String = sourceMod.containingFile.virtualFile.path
     private val sourceFileField: JBTextField = JBTextField(sourceFilePath).apply { isEnabled = false }
     private val targetFileChooser: TextFieldWithBrowseButton = createTargetFileChooser(project)
-    private val memberPanel: RsMemberSelectionPanel = createMemberInfoPanel()
+    private val memberPanel: RsMoveMemberSelectionPanel = createMemberSelectionPanel()
 
     private var searchForReferences: Boolean = true
 
     init {
         super.init()
         title = "Move Module Items"
+        validateButtons()
     }
 
     private fun createTargetFileChooser(project: Project): TextFieldWithBrowseButton {
-        return pathToRsFileTextField(disposable, "Choose Destination File", project)
+        return pathToRsFileTextField(disposable, "Choose Destination File", project, ::validateButtons)
             .also {
                 it.text = sourceFilePath
                 it.textField.caretPosition = sourceFilePath.removeSuffix(".rs").length
@@ -52,10 +60,28 @@ class RsMoveTopLevelItemsDialog(
             }
     }
 
-    private fun createMemberInfoPanel(): RsMemberSelectionPanel {
-        val memberInfo = getTopLevelItems()
-            .map { RsMemberInfo(it, itemsToMove.contains(it)) }
-        return RsMemberSelectionPanel("Items to move", memberInfo)
+    private fun createMemberSelectionPanel(): RsMoveMemberSelectionPanel {
+        val topLevelItems = getTopLevelItems()
+
+        val nodesGroupedWithImpls = groupImplsByStructOrTrait(sourceMod, topLevelItems.toSet())
+            .map { RsMoveItemAndImplsInfo(it.key, it.value) }
+        val itemsGroupedWithImpls = nodesGroupedWithImpls.flatMap { it.children }.map { it.member }
+
+        val nodesWithoutGrouping = topLevelItems.subtract(itemsGroupedWithImpls).map { RsMoveMemberInfo(it) }
+        val nodesAll = nodesGroupedWithImpls + nodesWithoutGrouping
+
+        val nodesSelected = nodesAll
+            .flatMap {
+                when (it) {
+                    is RsMoveItemAndImplsInfo -> it.children
+                    is RsMoveMemberInfo -> listOf(it)
+                    else -> error("unexpected node info type: $it")
+                }
+            }
+            .filter { it.member in itemsToMove }
+
+        return RsMoveMemberSelectionPanel(project, "Items to move", nodesAll, nodesSelected)
+            .also { it.tree.setInclusionListener { validateButtons() } }
     }
 
     override fun createCenterPanel(): JComponent {
@@ -71,7 +97,7 @@ class RsMoveTopLevelItemsDialog(
             }
             row {
                 cell(isFullWidth = true) {
-                    checkBox(message("search.for.references"), searchForReferences)
+                    checkBox(message("search.for.references"), ::searchForReferences)
                 }
             }
         }.also { it.preferredSize = Dimension(600, 400) }
@@ -83,8 +109,22 @@ class RsMoveTopLevelItemsDialog(
             .filter { RsMoveTopLevelItemsHandler.canMoveElement(it) }
     }
 
+    override fun areButtonsValid(): Boolean {
+        // `memberPanel` is initialized after `createTargetFileChooser`,
+        // which triggers `areButtonsValid` check
+        @Suppress("SENSELESS_COMPARISON")
+        if (memberPanel == null) return false
+
+        return sourceFilePath != targetFileChooser.text && getSelectedItems().isNotEmpty()
+    }
+
+    private fun getSelectedItems(): Set<RsItemElement> =
+        memberPanel.tree.includedSet
+            .filterIsInstance<RsMoveMemberInfo>()
+            .mapToSet { it.member }
+
     public override fun doAction() {
-        val itemsToMove = memberPanel.table.selectedMemberInfos.mapToSet { it.member }
+        val itemsToMove = getSelectedItems()
         val targetFilePath = targetFileChooser.text
 
         val targetMod = findTargetMod(targetFilePath)
@@ -108,6 +148,51 @@ class RsMoveTopLevelItemsDialog(
         val targetFile = LocalFileSystem.getInstance().findFileByIoFile(File(targetFilePath))
         return targetFile?.toPsiFile(project) as? RsMod
     }
+}
+
+class RsMoveMemberInfo(val member: RsItemElement) : RsMoveNodeInfo {
+    override fun render(renderer: ColoredTreeCellRenderer) {
+        val description = if (member is RsModItem) {
+            "mod ${member.modName}"
+        } else {
+            val descriptionHTML = buildString { member.signature(this) }
+            val description = StringEscapeUtils.unescapeHtml(StringUtil.removeHtmlTags(descriptionHTML))
+            description.replace("(?U)\\s+".toRegex(), " ")
+        }
+        renderer.append(description, SimpleTextAttributes.REGULAR_ATTRIBUTES)
+    }
+
+    override val icon: Icon = member.getIcon(0)
+}
+
+class RsMoveItemAndImplsInfo(
+    private val item: RsItemElement, // struct or trait
+    impls: List<RsImplItem>
+) : RsMoveNodeInfo {
+
+    @Suppress("DialogTitleCapitalization")
+    override fun render(renderer: ColoredTreeCellRenderer) {
+        val name = item.name
+        val keyword = when (item) {
+            is RsStructItem -> "struct"
+            is RsEnumItem -> "enum"
+            is RsTypeAlias -> "type"
+            is RsTraitItem -> "trait"
+            else -> null
+        }
+        if (name == null || keyword == null) {
+            renderer.append("item and impls", SimpleTextAttributes.REGULAR_ATTRIBUTES)
+            return
+        }
+
+        // "$keyword $name and impls"
+        renderer.append("$keyword ", SimpleTextAttributes.REGULAR_ATTRIBUTES)
+        renderer.append(name, SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES)
+        renderer.append(" and impls", SimpleTextAttributes.REGULAR_ATTRIBUTES)
+    }
+
+    override val children: List<RsMoveMemberInfo> =
+        listOf(RsMoveMemberInfo(item)) + impls.map { RsMoveMemberInfo(it) }
 }
 
 val MOVE_TARGET_MOD_KEY: Key<RsMod> = Key("RS_MOVE_TARGET_MOD_KEY")

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsHandler.kt
@@ -163,7 +163,7 @@ private fun collectRelatedImplItems(containingMod: RsMod, items: Set<RsItemEleme
     return groupImplsByStructOrTrait(containingMod, items).values.flatten()
 }
 
-private fun groupImplsByStructOrTrait(containingMod: RsMod, items: Set<RsItemElement>): Map<RsItemElement, List<RsImplItem>> {
+fun groupImplsByStructOrTrait(containingMod: RsMod, items: Set<RsItemElement>): Map<RsItemElement, List<RsImplItem>> {
     return containingMod
         .childrenOfType<RsImplItem>()
         .mapNotNull { impl ->


### PR DESCRIPTION
Add hierarchical view to [move items refactoring](https://github.com/intellij-rust/intellij-rust/issues/3531#issuecomment-643142894) dialog  (impls for a struct are located in a tree hierarchy under the struct). It makes it easier to move struct with all its impls when there are a lot of impls. Thanks @Kobzol for the [suggestion](https://github.com/intellij-rust/intellij-rust/pull/5455#issuecomment-634628733)!

![image](https://user-images.githubusercontent.com/6505554/91423807-b129cd80-e861-11ea-94d2-026d07ec221c.png)
