### PR TITLE
MACRO: don't use new expansion engine for non top-level macros

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -854,6 +854,7 @@ private class MacroExpansionServiceImplInner(
 
                 val calls = runReadActionInSmartMode(dumbService) {
                     val calls = RsMacroCallIndex.getMacroCalls(project, scope)
+                        .filter { it.isTopLevelExpansion }
                     MACRO_LOG.info("Macros to expand: ${calls.size}")
                     calls.groupBy { it.containingFile.virtualFile }
 


### PR DESCRIPTION
This is a king of performance fix - don't expand macros that aren't needed (similar to #5989). Previously the new macro expansion engine was (unintentionally) expand macros in constants & statics (that are stubbed).