### PR TITLE
Don't run inspections on files outside a valid project

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsApproxConstantInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsApproxConstantInspection.kt
@@ -13,7 +13,7 @@ import org.rust.lang.core.psi.kind
 import kotlin.math.*
 
 class RsApproxConstantInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
         override fun visitLitExpr(o: RsLitExpr) {
             val literal = o.kind
             if (literal is RsLiteralKind.Float) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAssertEqualInspection.kt
@@ -19,7 +19,7 @@ import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.types.type
 
 class RsAssertEqualInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
 
         override fun visitMacroCall(o: RsMacroCall) {
             if (o.macroName != "assert") return

--- a/src/main/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAssignToImmutableInspection.kt
@@ -20,7 +20,7 @@ import org.rust.lang.utils.addToHolder
 
 class RsAssignToImmutableInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitBinaryExpr(expr: RsBinaryExpr) {
                 if (expr.isAssignBinaryExpr) checkAssignment(expr, holder)

--- a/src/main/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsBorrowCheckerInspection.kt
@@ -17,7 +17,7 @@ import org.rust.lang.core.types.type
 
 class RsBorrowCheckerInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitMethodCall(o: RsMethodCall) {
                 val fn = o.reference.resolve() as? RsFunction ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/RsCStringPointerInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsCStringPointerInspection.kt
@@ -11,7 +11,7 @@ import org.rust.lang.core.psi.ext.parentDotExpr
 class RsCStringPointerInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Unsafe CString pointer"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitMethodCall(asPtrCall: RsMethodCall) {
                 if (asPtrCall.referenceName != "as_ptr") return

--- a/src/main/kotlin/org/rust/ide/inspections/RsDanglingElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDanglingElseInspection.kt
@@ -54,6 +54,8 @@ class RsDanglingElseInspection : RsLocalInspectionTool() {
             }
         }
 
+    override val isSyntaxOnly: Boolean = true
+
     private val PsiElement.rightSiblings: Sequence<PsiElement>
         get() = generateSequence(this.nextSibling) { it.nextSibling }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/RsDanglingElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDanglingElseInspection.kt
@@ -26,7 +26,7 @@ import org.rust.lang.core.psi.ext.startOffset
 class RsDanglingElseInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Dangling else"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitElseBranch(expr: RsElseBranch) {
                 val elseEl = expr.`else`

--- a/src/main/kotlin/org/rust/ide/inspections/RsDetachedFileInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDetachedFileInspection.kt
@@ -62,6 +62,8 @@ class RsDetachedFileInspection : RsLocalInspectionTool() {
         return null
     }
 
+    override val isSyntaxOnly: Boolean = true
+
     private fun isInspectionEnabled(project: Project, file: VirtualFile): Boolean =
         !PropertiesComponent.getInstance(project).getBoolean(file.disablingKey, false)
 

--- a/src/main/kotlin/org/rust/ide/inspections/RsDiagnosticBasedInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDiagnosticBasedInspection.kt
@@ -11,7 +11,7 @@ import org.rust.lang.core.types.inference
 import org.rust.lang.utils.addToHolder
 
 abstract class RsDiagnosticBasedInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
         override fun visitFunction(o: RsFunction) = collectDiagnostics(holder, o)
         override fun visitConstant(o: RsConstant) = collectDiagnostics(holder, o)
         override fun visitArrayType(o: RsArrayType) = collectDiagnostics(holder, o)

--- a/src/main/kotlin/org/rust/ide/inspections/RsDoubleNegInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDoubleNegInspection.kt
@@ -27,6 +27,8 @@ class RsDoubleNegInspection : RsLocalInspectionTool() {
             }
         }
 
+    override val isSyntaxOnly: Boolean = true
+
     private val RsExpr?.isNegation: Boolean
         get() = this is RsUnaryExpr && minus != null
 }

--- a/src/main/kotlin/org/rust/ide/inspections/RsDoubleNegInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDoubleNegInspection.kt
@@ -18,7 +18,7 @@ import org.rust.lang.core.psi.RsVisitor
 class RsDoubleNegInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Double negation"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitUnaryExpr(expr: RsUnaryExpr) {
                 if (expr.isNegation && expr.expr.isNegation) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsDropRefInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDropRefInspection.kt
@@ -21,7 +21,7 @@ import org.rust.lang.core.types.type
 class RsDropRefInspection : RsLocalInspectionTool() {
     override fun getDisplayName(): String = "Drop reference"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitCallExpr(expr: RsCallExpr) = inspectExpr(expr, holder)
         }

--- a/src/main/kotlin/org/rust/ide/inspections/RsDuplicatedTraitMethodBindingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDuplicatedTraitMethodBindingInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.psi.PsiElementVisitor
 import org.rust.ide.refactoring.findBinding
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsPatBinding
@@ -16,7 +15,7 @@ import org.rust.lang.core.psi.ext.owner
 class RsDuplicatedTraitMethodBindingInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Duplicated trait method parameter binding"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitFunction(function: RsFunction) {
                 if (function.owner !is RsAbstractableOwner.Trait) return

--- a/src/main/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsExtraSemicolonInspection.kt
@@ -8,7 +8,6 @@ package org.rust.ide.inspections
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElementVisitor
 import org.rust.lang.core.dfa.ExitPoint
 import org.rust.lang.core.psi.RsExprStmt
 import org.rust.lang.core.psi.RsFunction
@@ -26,7 +25,7 @@ import org.rust.lang.core.types.type
 class RsExtraSemicolonInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Extra semicolon"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitFunction(o: RsFunction) = inspect(holder, o)
         }

--- a/src/main/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspection.kt
@@ -34,6 +34,8 @@ class RsFieldInitShorthandInspection : RsLocalInspectionTool() {
         }
     }
 
+    override val isSyntaxOnly: Boolean = true
+
     companion object {
         fun applyShorthandInit(field: RsStructLiteralField) {
             field.expr?.delete()

--- a/src/main/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsFieldInitShorthandInspection.kt
@@ -15,7 +15,7 @@ import org.rust.lang.core.psi.RsVisitor
 
 
 class RsFieldInitShorthandInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
         override fun visitStructLiteralField(o: RsStructLiteralField) {
             val init = o.expr ?: return
             if (!(init is RsPathExpr && init.text == o.identifier?.text)) return

--- a/src/main/kotlin/org/rust/ide/inspections/RsLiftInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLiftInspection.kt
@@ -34,6 +34,8 @@ class RsLiftInspection : RsLocalInspectionTool() {
         }
     }
 
+    override val isSyntaxOnly: Boolean = true
+
     private fun RsProblemsHolder.register(expr: RsExpr, keyword: PsiElement) {
         val keywordName = keyword.text
         registerProblem(

--- a/src/main/kotlin/org/rust/ide/inspections/RsLiftInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLiftInspection.kt
@@ -10,13 +10,12 @@ import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.openapiext.Testmark
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiElementVisitor
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
 
 class RsLiftInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor {
         return object : RsVisitor() {
             override fun visitIfExpr(o: RsIfExpr) {
                 if (o.parent is RsElseBranch) return

--- a/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt
@@ -12,12 +12,13 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
 import org.rust.ide.utils.isEnabledByCfg
+import org.rust.lang.core.psi.RsVisitor
 
 abstract class RsLocalInspectionTool : LocalInspectionTool() {
     final override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
         buildVisitor(RsProblemsHolder(holder), isOnTheFly) ?: super.buildVisitor(holder, isOnTheFly)
 
-    open fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor? = null
+    open fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor? = null
 }
 
 class RsProblemsHolder(private val holder: ProblemsHolder) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt
@@ -8,17 +8,52 @@ package org.rust.ide.inspections
 import com.intellij.codeInspection.*
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
+import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
+import org.rust.cargo.project.settings.toolchain
 import org.rust.ide.utils.isEnabledByCfg
+import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsVisitor
 
 abstract class RsLocalInspectionTool : LocalInspectionTool() {
+    final override fun buildVisitor(
+        holder: ProblemsHolder,
+        isOnTheFly: Boolean,
+        session: LocalInspectionToolSession
+    ): PsiElementVisitor {
+        val file = session.file
+        return if (file is RsFile && isApplicableTo(file)) {
+            buildVisitor(holder, isOnTheFly)
+        } else {
+            PsiElementVisitor.EMPTY_VISITOR
+        }
+    }
+
     final override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
         buildVisitor(RsProblemsHolder(holder), isOnTheFly) ?: super.buildVisitor(holder, isOnTheFly)
 
     open fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor? = null
+
+    open val isSyntaxOnly: Boolean = false
+
+    /**
+     * Syntax-only inspections are applicable to any [RsFile].
+     *
+     * Other inspections should analyze only files that:
+     * - belong to a workspace
+     * - are included in module tree, i.e. have a crate root
+     * - belong to a project with a configured and valid Rust toolchain
+     */
+    private fun isApplicableTo(file: RsFile): Boolean {
+        if (isUnitTestMode) return true
+        if (isSyntaxOnly) return true
+
+        return file.cargoWorkspace != null
+            && file.crateRoot != null
+            && file.project.toolchain?.looksLikeValidToolchain() == true
+    }
 }
 
 class RsProblemsHolder(private val holder: ProblemsHolder) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsMainFunctionNotFoundInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsFile
@@ -19,7 +18,7 @@ import org.rust.lang.utils.addToHolder
 
 class RsMainFunctionNotFoundInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitFile(file: PsiFile) {
                 if (file is RsFile) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsMissingElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsMissingElseInspection.kt
@@ -24,7 +24,7 @@ import org.rust.lang.core.psi.ext.startOffset
 class RsMissingElseInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Missing else"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitExprStmt(expr: RsExprStmt) {
                 val firstIf = expr.extractIf() ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsReassignImmutableInspection.kt
@@ -16,7 +16,7 @@ import org.rust.lang.utils.addToHolder
 
 class RsReassignImmutableInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitBinaryExpr(expr: RsBinaryExpr) {
                 val left = expr.left.takeIf { it.isImmutable } ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/RsRedundantElseInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsRedundantElseInspection.kt
@@ -25,7 +25,7 @@ import org.rust.lang.utils.evaluation.evaluate
 class RsRedundantElseInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Redundant else"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitElseBranch(expr: RsElseBranch) {
                 if (!expr.isRedundant) return

--- a/src/main/kotlin/org/rust/ide/inspections/RsSelfConventionInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSelfConventionInspection.kt
@@ -16,7 +16,7 @@ import org.rust.stdext.typeAscription
 
 class RsSelfConventionInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitFunction(m: RsFunction) {
                 val traitOrImpl = when (val owner = m.owner) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSimplifyBooleanExpressionInspection.kt
@@ -17,7 +17,7 @@ import org.rust.lang.core.psi.RsVisitor
 class RsSimplifyBooleanExpressionInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Simplify boolean expression"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
 
         override fun visitExpr(expr: RsExpr) {
             if (expr.isPure() == true && BooleanExprSimplifier.canBeSimplified(expr)) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSimplifyPrintInspection.kt
@@ -22,7 +22,7 @@ class RsSimplifyPrintInspection : RsLocalInspectionTool() {
     @Suppress("DialogTitleCapitalization")
     override fun getDisplayName(): String = "println!(\"\") usage"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
 
         override fun visitMacroCall(o: RsMacroCall) {
             val macroName = o.macroName

--- a/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
@@ -16,7 +16,7 @@ import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.*
 
 class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
         override fun visitImplItem(impl: RsImplItem) {
             val trait = impl.traitRef?.resolveToTrait() ?: return
             val typeRef = impl.typeReference ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspection.kt
@@ -7,7 +7,6 @@ package org.rust.ide.inspections
 
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiElementVisitor
 import org.rust.ide.inspections.fixes.SubstituteTextFix
 import org.rust.lang.core.psi.RsBinaryExpr
 import org.rust.lang.core.psi.RsExpr
@@ -26,7 +25,7 @@ import org.rust.lang.core.psi.ext.startOffset
 class RsSuspiciousAssignmentInspection : RsLocalInspectionTool() {
     override fun getDisplayName() = "Suspicious assignment"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitBinaryExpr(expr: RsBinaryExpr) {
                 if (expr.operator.text != "=") return

--- a/src/main/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSuspiciousAssignmentInspection.kt
@@ -63,6 +63,8 @@ class RsSuspiciousAssignmentInspection : RsLocalInspectionTool() {
             }
         }
 
+    override val isSyntaxOnly: Boolean = true
+
     /**
      * Computes the distance between the start points of this PSI element and another one.
      */

--- a/src/main/kotlin/org/rust/ide/inspections/RsTraitImplementationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsTraitImplementationInspection.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.inspections
 
-import com.intellij.psi.PsiElementVisitor
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsVisitor
@@ -18,7 +17,7 @@ import org.rust.lang.utils.addToHolder
 
 class RsTraitImplementationInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
         override fun visitImplItem(impl: RsImplItem) {
             val traitRef = impl.traitRef ?: return
             val trait = traitRef.resolveToTrait() ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/RsTryMacroInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsTryMacroInspection.kt
@@ -24,7 +24,7 @@ class RsTryMacroInspection : RsLocalInspectionTool() {
     @Suppress("DialogTitleCapitalization")
     override fun getDisplayName(): String = "try! macro usage"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
         override fun visitMacroCall(o: RsMacroCall) {
             val isApplicable = o.isExprOrStmtContext && o.macroName == "try" && o.exprMacroArgument?.expr != null
             if (!isApplicable) return

--- a/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
@@ -8,7 +8,6 @@ package org.rust.ide.inspections
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ui.MultipleCheckboxOptionsPanel
-import com.intellij.psi.PsiElementVisitor
 import org.rust.ide.inspections.import.AutoImportFix
 import org.rust.ide.inspections.import.AutoImportHintFix
 import org.rust.ide.settings.RsCodeInsightSettings
@@ -25,7 +24,7 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
 
     override fun getDisplayName() = "Unresolved reference"
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
 
             override fun visitPath(path: RsPath) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongGenericArgumentsNumberInspection.kt
@@ -20,7 +20,7 @@ import org.rust.lang.utils.addToHolder
  * Inspection that detects the E0107 error.
  */
 class RsWrongGenericArgumentsNumberInspection : RsLocalInspectionTool() {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitBaseType(type: RsBaseType) {
                 if (!isPathValid(type.path)) return

--- a/src/main/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsWrongLifetimeParametersNumberInspection.kt
@@ -17,7 +17,7 @@ import org.rust.lang.utils.addToHolder
 
 class RsWrongLifetimeParametersNumberInspection : RsLocalInspectionTool() {
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitBaseType(type: RsBaseType) {
                 // Don't apply generic declaration checks to Fn-traits and `Self`

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspection.kt
@@ -9,7 +9,6 @@ import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiElementVisitor
 import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.dyn
@@ -20,7 +19,7 @@ import org.rust.lang.core.resolve.ref.deepResolve
 class RsBareTraitObjectsInspection : RsLintInspection() {
     override fun getLint(element: PsiElement): RsLint = RsLint.BareTraitObjects
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitTypeReference(typeReference: RsTypeReference) {
                 if (!typeReference.isEdition2018) return

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsDeprecationInspection.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.inspections.lints
 
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiElementVisitor
 import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.lang.core.psi.RsElementTypes.CSELF
 import org.rust.lang.core.psi.RsFile
@@ -20,7 +19,7 @@ class RsDeprecationInspection : RsLintInspection() {
 
     override fun getLint(element: PsiElement): RsLint = RsLint.Deprecated
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
         override fun visitElement(ref: RsElement) {
             // item is non-inline module declaration or not reference element
             if (ref is RsModDeclItem || ref !is RsReferenceElement) return

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLintInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLintInspection.kt
@@ -22,6 +22,8 @@ abstract class RsLintInspection : RsLocalInspectionTool() {
 
     protected abstract fun getLint(element: PsiElement): RsLint?
 
+    override val isSyntaxOnly: Boolean = true
+
     protected fun RsProblemsHolder.registerLintProblem(
         element: PsiElement,
         descriptionTemplate: String,

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLivenessInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLivenessInspection.kt
@@ -27,7 +27,7 @@ class RsLivenessInspection : RsLintInspection() {
 
     override fun getLint(element: PsiElement): RsLint = RsLint.UnusedVariables
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitFunction(func: RsFunction) {
                 // Disable inside doc tests

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
@@ -170,7 +170,7 @@ fun String.toSnakeCase(upper: Boolean): String {
 //
 
 class RsArgumentNamingInspection : RsSnakeCaseNamingInspection("Argument") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitPatBinding(el: RsPatBinding) {
                 if (el.parent?.parent is RsValueParameter) {
@@ -181,7 +181,7 @@ class RsArgumentNamingInspection : RsSnakeCaseNamingInspection("Argument") {
 }
 
 class RsConstNamingInspection : RsUpperCaseNamingInspection("Constant") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitConstant(el: RsConstant) {
                 if (el.kind == RsConstantKind.CONST) {
@@ -192,7 +192,7 @@ class RsConstNamingInspection : RsUpperCaseNamingInspection("Constant") {
 }
 
 class RsStaticConstNamingInspection : RsUpperCaseNamingInspection("Static constant") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitConstant(el: RsConstant) {
                 if (el.kind != RsConstantKind.CONST && el.owner is RsAbstractableOwner.Free) {
@@ -203,21 +203,21 @@ class RsStaticConstNamingInspection : RsUpperCaseNamingInspection("Static consta
 }
 
 class RsEnumNamingInspection : RsCamelCaseNamingInspection("Type", "Enum") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitEnumItem(el: RsEnumItem) = inspect(el.identifier, holder)
         }
 }
 
 class RsEnumVariantNamingInspection : RsCamelCaseNamingInspection("Enum variant") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitEnumVariant(el: RsEnumVariant) = inspect(el.identifier, holder)
         }
 }
 
 class RsFunctionNamingInspection : RsSnakeCaseNamingInspection("Function") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitFunction(el: RsFunction) {
                 if (el.owner is RsAbstractableOwner.Free) {
@@ -235,7 +235,7 @@ class RsFunctionNamingInspection : RsSnakeCaseNamingInspection("Function") {
 }
 
 class RsMethodNamingInspection : RsSnakeCaseNamingInspection("Method") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitFunction(el: RsFunction) = when (el.owner) {
                 is RsAbstractableOwner.Trait, is RsAbstractableOwner.Impl -> inspect(el.identifier, holder)
@@ -245,21 +245,21 @@ class RsMethodNamingInspection : RsSnakeCaseNamingInspection("Method") {
 }
 
 class RsLifetimeNamingInspection : RsSnakeCaseNamingInspection("Lifetime") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitLifetimeParameter(el: RsLifetimeParameter) = inspect(el.quoteIdentifier, holder)
         }
 }
 
 class RsMacroNamingInspection : RsSnakeCaseNamingInspection("Macro") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitMacro(el: RsMacro) = inspect(el.nameIdentifier, holder)
         }
 }
 
 class RsModuleNamingInspection : RsSnakeCaseNamingInspection("Module") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitModDeclItem(el: RsModDeclItem) = inspect(el.identifier, holder)
             override fun visitModItem(el: RsModItem) = inspect(el.identifier, holder)
@@ -267,28 +267,28 @@ class RsModuleNamingInspection : RsSnakeCaseNamingInspection("Module") {
 }
 
 class RsStructNamingInspection : RsCamelCaseNamingInspection("Type", "Struct") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitStructItem(el: RsStructItem) = inspect(el.identifier, holder)
         }
 }
 
 class RsFieldNamingInspection : RsSnakeCaseNamingInspection("Field") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitNamedFieldDecl(el: RsNamedFieldDecl) = inspect(el.identifier, holder)
         }
 }
 
 class RsTraitNamingInspection : RsCamelCaseNamingInspection("Trait") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitTraitItem(el: RsTraitItem) = inspect(el.identifier, holder)
         }
 }
 
 class RsTypeAliasNamingInspection : RsCamelCaseNamingInspection("Type", "Type alias") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitTypeAlias(el: RsTypeAlias) {
                 if (el.owner is RsAbstractableOwner.Free) {
@@ -299,7 +299,7 @@ class RsTypeAliasNamingInspection : RsCamelCaseNamingInspection("Type", "Type al
 }
 
 class RsAssocTypeNamingInspection : RsCamelCaseNamingInspection("Type", "Associated type") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitTypeAlias(el: RsTypeAlias) {
                 if (el.owner is RsAbstractableOwner.Trait) {
@@ -311,14 +311,14 @@ class RsAssocTypeNamingInspection : RsCamelCaseNamingInspection("Type", "Associa
 
 
 class RsTypeParameterNamingInspection : RsCamelCaseNamingInspection("Type parameter") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitTypeParameter(el: RsTypeParameter) = inspect(el.identifier, holder)
         }
 }
 
 class RsVariableNamingInspection : RsSnakeCaseNamingInspection("Variable") {
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitPatBinding(el: RsPatBinding) {
                 val pattern = PsiTreeUtil.getTopmostParentOfType(el, RsPat::class.java) ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
@@ -25,6 +25,8 @@ abstract class RsNamingInspection(
 ) : RsLintInspection() {
     override fun getDisplayName(): String = "$elementTitle naming convention"
 
+    override val isSyntaxOnly: Boolean = true
+
     fun inspect(id: PsiElement?, holder: RsProblemsHolder, fix: Boolean = true) {
         if (id == null) return
         val name = id.unescapedText

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsWhileTrueLoopInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsWhileTrueLoopInspection.kt
@@ -22,7 +22,7 @@ class RsWhileTrueLoopInspection : RsLintInspection() {
     override fun getDisplayName() = "While true loop"
     override fun getLint(element: PsiElement): RsLint = RsLint.WhileTrue
 
-    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
         override fun visitWhileExpr(o: RsWhileExpr) {
             val condition = o.condition ?: return
             val expr = condition.skipParenExprDown() as? RsLitExpr ?: return

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsWhileTrueLoopInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsWhileTrueLoopInspection.kt
@@ -47,4 +47,6 @@ class RsWhileTrueLoopInspection : RsLintInspection() {
             }
         }
     }
+
+    override val isSyntaxOnly: Boolean = true
 }


### PR DESCRIPTION
Currently, our inspections run on any Rust files, including cases when Rust toolchain is not configured, or invalid or when a file does not belong to a Cargo project.

Now most of the inspections analyze only files that:
1. Have configured and valid toolchain
2. Belong to Cargo project and with workspace
3. Are included in the module tree

Special cases:
* Lightweight inspections (like syntax-only or naming lints) does not require (1)-(3)
* `RsDetachedFileInspection` does not require (3)
