### PR TITLE
INT: add support for guessing return type in CreateFunctionIntention

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Extensions.kt
@@ -86,11 +86,8 @@ val RsPatField.type: Ty
 val RsExpr.type: Ty
     get() = inference?.getExprType(this) ?: TyUnknown
 
-val RsPathExpr.expectedType: Ty?
-    get() = inference?.getExpectedPathExprType(this)
-
-val RsDotExpr.expectedType: Ty?
-    get() = inference?.getExpectedDotExprType(this)
+val RsExpr.expectedType: Ty?
+    get() = inference?.getExpectedExprType(this)
 
 val RsExpr.declaration: RsElement?
     get() = when (this) {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -49,8 +49,7 @@ sealed class Adjustment(open val target: Ty) {
 interface RsInferenceData {
     fun getExprAdjustments(expr: RsExpr): List<Adjustment>
     fun getExprType(expr: RsExpr): Ty
-    fun getExpectedPathExprType(expr: RsPathExpr): Ty
-    fun getExpectedDotExprType(expr: RsDotExpr): Ty
+    fun getExpectedExprType(expr: RsExpr): Ty
     fun getPatType(pat: RsPat): Ty
     fun getPatFieldType(patField: RsPatField): Ty
     fun getResolvedPath(expr: RsPathExpr): List<ResolvedPath>
@@ -70,8 +69,7 @@ class RsInferenceResult(
     val exprTypes: Map<RsExpr, Ty>,
     val patTypes: MutableMap<RsPat, Ty>,
     val patFieldTypes: MutableMap<RsPatField, Ty>,
-    private val expectedPathExprTypes: Map<RsPathExpr, Ty>,
-    private val expectedDotExprTypes: Map<RsDotExpr, Ty>,
+    private val expectedExprTypes: Map<RsExpr, Ty>,
     private val resolvedPaths: Map<RsPathExpr, List<ResolvedPath>>,
     private val resolvedMethods: Map<RsMethodCall, List<MethodResolveVariant>>,
     private val resolvedFields: Map<RsFieldLookup, List<RsElement>>,
@@ -92,11 +90,8 @@ class RsInferenceResult(
     override fun getPatFieldType(patField: RsPatField): Ty =
         patFieldTypes[patField] ?: TyUnknown
 
-    override fun getExpectedPathExprType(expr: RsPathExpr): Ty =
-        expectedPathExprTypes[expr] ?: TyUnknown
-
-    override fun getExpectedDotExprType(expr: RsDotExpr): Ty =
-        expectedDotExprTypes[expr] ?: TyUnknown
+    override fun getExpectedExprType(expr: RsExpr): Ty =
+        expectedExprTypes[expr] ?: TyUnknown
 
     override fun getResolvedPath(expr: RsPathExpr): List<ResolvedPath> =
         resolvedPaths[expr] ?: emptyList()
@@ -127,8 +122,7 @@ class RsInferenceContext(
     private val exprTypes: MutableMap<RsExpr, Ty> = hashMapOf()
     private val patTypes: MutableMap<RsPat, Ty> = hashMapOf()
     private val patFieldTypes: MutableMap<RsPatField, Ty> = hashMapOf()
-    private val expectedPathExprTypes: MutableMap<RsPathExpr, Ty> = hashMapOf()
-    private val expectedDotExprTypes: MutableMap<RsDotExpr, Ty> = hashMapOf()
+    private val expectedExprTypes: MutableMap<RsExpr, Ty> = hashMapOf()
     private val resolvedPaths: MutableMap<RsPathExpr, List<ResolvedPath>> = hashMapOf()
     private val resolvedMethods: MutableMap<RsMethodCall, List<MethodResolveVariant>> = hashMapOf()
     private val resolvedFields: MutableMap<RsFieldLookup, List<RsElement>> = hashMapOf()
@@ -225,8 +219,7 @@ class RsInferenceContext(
         fulfill.selectWherePossible()
 
         exprTypes.replaceAll { _, ty -> fullyResolve(ty) }
-        expectedPathExprTypes.replaceAll { _, ty -> fullyResolve(ty) }
-        expectedDotExprTypes.replaceAll { _, ty -> fullyResolve(ty) }
+        expectedExprTypes.replaceAll { _, ty -> fullyResolve(ty) }
         patTypes.replaceAll { _, ty -> fullyResolve(ty) }
         patFieldTypes.replaceAll { _, ty -> fullyResolve(ty) }
         // replace types in diagnostics for better quick fixes
@@ -238,8 +231,7 @@ class RsInferenceContext(
             exprTypes,
             patTypes,
             patFieldTypes,
-            expectedPathExprTypes,
-            expectedDotExprTypes,
+            expectedExprTypes,
             resolvedPaths,
             resolvedMethods,
             resolvedFields,
@@ -302,12 +294,8 @@ class RsInferenceContext(
         return patFieldTypes[patField] ?: TyUnknown
     }
 
-    override fun getExpectedPathExprType(expr: RsPathExpr): Ty {
-        return expectedPathExprTypes[expr] ?: TyUnknown
-    }
-
-    override fun getExpectedDotExprType(expr: RsDotExpr): Ty {
-        return expectedDotExprTypes[expr] ?: TyUnknown
+    override fun getExpectedExprType(expr: RsExpr): Ty {
+        return expectedExprTypes[expr] ?: TyUnknown
     }
 
     override fun getResolvedPath(expr: RsPathExpr): List<ResolvedPath> {
@@ -330,12 +318,8 @@ class RsInferenceContext(
         patFieldTypes[psi] = ty
     }
 
-    fun writeExpectedPathExprTy(psi: RsPathExpr, ty: Ty) {
-        expectedPathExprTypes[psi] = ty
-    }
-
-    fun writeExpectedDotExprTy(psi: RsDotExpr, ty: Ty) {
-        expectedDotExprTypes[psi] = ty
+    fun writeExpectedExprTy(psi: RsExpr, ty: Ty) {
+        expectedExprTypes[psi] = ty
     }
 
     fun writePath(path: RsPathExpr, resolved: List<ResolvedPath>) {

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -157,8 +157,7 @@ class RsTypeInferenceWalker(
 
         if (expected != null) {
             when (this) {
-                is RsPathExpr -> ctx.writeExpectedPathExprTy(this, expected)
-                is RsDotExpr -> ctx.writeExpectedDotExprTy(this, expected)
+                is RsPathExpr, is RsDotExpr, is RsCallExpr -> ctx.writeExpectedExprTy(this, expected)
             }
         }
 

--- a/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
@@ -203,4 +203,132 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention(
             }
         }
     """)
+
+    fun `test guess return type let decl`() = doAvailableTest("""
+        fn foo() {
+            let x: u32 = bar/*caret*/();
+        }
+    """, """
+        fn foo() {
+            let x: u32 = bar();
+        }
+
+        fn bar() -> u32 {
+            unimplemented!()
+        }
+    """)
+
+    fun `test guess return type assignment`() = doAvailableTest("""
+        fn foo() {
+            let mut x: u32 = 0;
+            x = bar/*caret*/();
+        }
+    """, """
+        fn foo() {
+            let mut x: u32 = 0;
+            x = bar();
+        }
+
+        fn bar() -> u32 {
+            unimplemented!()
+        }
+    """)
+
+    fun `test guess return type function call`() = doAvailableTest("""
+        fn bar(x: u32) {}
+        fn foo() {
+            bar(baz/*caret*/());
+        }
+    """, """
+        fn bar(x: u32) {}
+        fn foo() {
+            bar(baz());
+        }
+
+        fn baz() -> u32 {
+            unimplemented!()
+        }
+    """)
+
+    fun `test guess return type method call`() = doAvailableTest("""
+        struct S;
+        impl S {
+            fn bar(&self, x: u32) {}
+        }
+        fn foo(s: S) {
+            s.bar(baz/*caret*/());
+        }
+    """, """
+        struct S;
+        impl S {
+            fn bar(&self, x: u32) {}
+        }
+        fn foo(s: S) {
+            s.bar(baz());
+        }
+
+        fn baz() -> u32 {
+            unimplemented!()
+        }
+    """)
+
+    fun `test guess return type struct literal`() = doAvailableTest("""
+        struct S {
+            a: u32
+        }
+        fn foo() {
+            S {
+                a: baz/*caret*/()
+            };
+        }
+    """, """
+        struct S {
+            a: u32
+        }
+        fn foo() {
+            S {
+                a: baz()
+            };
+        }
+
+        fn baz() -> u32 {
+            unimplemented!()
+        }
+    """)
+
+    fun `test guess return type self parameter`() = doAvailableTest("""
+        struct S;
+        impl S {
+            fn bar(&self) {}
+        }
+        fn foo() {
+            S::bar(baz/*caret*/());
+        }
+    """, """
+        struct S;
+        impl S {
+            fn bar(&self) {}
+        }
+        fn foo() {
+            S::bar(baz());
+        }
+
+        fn baz() -> &S {
+            unimplemented!()
+        }
+    """)
+
+    fun `test guess return type generic parameter`() = doAvailableTest("""
+        fn foo<T>() {
+            let x: T = bar/*caret*/();
+        }
+    """, """
+        fn foo<T>() {
+            let x: T = bar();
+        }
+
+        fn bar<T>() -> T {
+            unimplemented!()
+        }
+    """)
 }


### PR DESCRIPTION
This PR improves the `CreateFunctionIntention` introduced in https://github.com/intellij-rust/intellij-rust/pull/5505 to guess the expected return type of the created function. A lot of edge cases aren't handled (otherwise this could get quite complex), but I think that's fine, as long as the most obvious situations are working.

This functionality was mentioned in https://github.com/intellij-rust/intellij-rust/issues/3904.