### PR TITLE
INSP: don't apply RsStaticConstNamingInspection for extern statics

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
@@ -174,7 +174,7 @@ class RsStaticConstNamingInspection : RsUpperCaseNamingInspection("Static consta
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) =
         object : RsVisitor() {
             override fun visitConstant(el: RsConstant) {
-                if (el.kind != RsConstantKind.CONST) {
+                if (el.kind != RsConstantKind.CONST && el.owner is RsAbstractableOwner.Free) {
                     inspect(el.identifier, holder)
                 }
             }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsStaticConstNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsStaticConstNamingInspectionTest.kt
@@ -30,4 +30,10 @@ class RsStaticConstNamingInspectionTest : RsInspectionsTestBase(RsStaticConstNam
             let a = STATIC_FOO;
         }
     """)
+
+    fun `test extern static`() = checkByText("""
+        extern {
+            static Bar: i32;
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #6023