### PR TITLE
Show "missing toolchain" notification in Cargo.toml

### DIFF
--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -15,17 +15,14 @@ import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.ui.EditorNotificationPanel
-import org.rust.cargo.project.model.CargoProject
-import org.rust.cargo.project.model.CargoProjectsService
-import org.rust.cargo.project.model.cargoProjects
-import org.rust.cargo.project.model.guessAndSetupRustProject
+import org.rust.cargo.project.model.*
 import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.settings.RustProjectSettingsService.RustSettingsChangedEvent
 import org.rust.cargo.project.settings.RustProjectSettingsService.RustSettingsListener
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.StandardLibrary
-import org.rust.lang.core.psi.isNotRustFile
+import org.rust.lang.core.psi.isRustFile
 
 /**
  * Warn user if rust toolchain or standard library is not properly configured.
@@ -62,7 +59,7 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
         project: Project
     ): RsEditorNotificationPanel? {
         if (isUnitTestMode) return null
-        if (file.isNotRustFile || isNotificationDisabled(file)) return null
+        if (!(file.isRustFile || file.isCargoToml) || isNotificationDisabled(file)) return null
         if (guessAndSetupRustProject(project)) return null
 
         val toolchain = project.toolchain


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3221931/91658023-8b553080-eace-11ea-9d21-fb039dce3568.png)


This also enables automatic project discovery when opening `Cargo.toml` file
