### PR TITLE
INT: disable SubstituteAssociatedTypeIntention for type aliases

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/SubstituteAssociatedTypeIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/SubstituteAssociatedTypeIntention.kt
@@ -16,7 +16,9 @@ import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.psi.RsTypeReference
+import org.rust.lang.core.psi.ext.RsAbstractableOwner
 import org.rust.lang.core.psi.ext.endOffsetInParent
+import org.rust.lang.core.psi.ext.owner
 import org.rust.lang.core.types.type
 
 class SubstituteAssociatedTypeIntention : RsElementBaseIntentionAction<SubstituteAssociatedTypeIntention.Context>() {
@@ -29,6 +31,7 @@ class SubstituteAssociatedTypeIntention : RsElementBaseIntentionAction<Substitut
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
         val path = element.parentOfType<RsPath>() ?: return null
         val typeAlias = path.reference?.resolve() as? RsTypeAlias ?: return null
+        if (!typeAlias.owner.isImplOrTrait) return null
         val type = typeAlias.typeReference ?: return null
         return Context(path, type)
     }

--- a/src/test/kotlin/org/rust/ide/intentions/SubstituteAssociatedTypeIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SubstituteAssociatedTypeIntentionTest.kt
@@ -6,6 +6,13 @@
 package org.rust.ide.intentions
 
 class SubstituteAssociatedTypeIntentionTest : RsIntentionTestBase(SubstituteAssociatedTypeIntention()) {
+    fun `test unavailable on type alias`() = doUnavailableTest("""
+        type Alias = u32;
+        fn foo() -> Alias/*caret*/ {
+            unimplemented!()
+        }
+    """)
+
     fun `test unavailable on trait associated type`() = doUnavailableTest("""
         trait Trait {
             type Item;
@@ -198,20 +205,26 @@ class SubstituteAssociatedTypeIntentionTest : RsIntentionTestBase(SubstituteAsso
     """)
 
     fun `test import after substitution`() = doAvailableTest("""
-        use foo::B;
-
         mod foo {
-            pub struct A;
-            pub type B = A;
+            pub struct S;
+            pub trait Trait {
+                type Item = S;
+            }
         }
-        fn foo() -> /*caret*/B { unreachable!() }
+        fn foo<T: foo::Trait>() -> T::/*caret*/Item {
+            unimplemented!()
+        }
     """, """
-        use foo::{B, A};
+        use foo::S;
 
         mod foo {
-            pub struct A;
-            pub type B = A;
+            pub struct S;
+            pub trait Trait {
+                type Item = S;
+            }
         }
-        fn foo() -> A { unreachable!() }
+        fn foo<T: foo::Trait>() -> S {
+            unimplemented!()
+        }
     """)
 }


### PR DESCRIPTION
`SubstituteAssociatedTypeIntention` has also worked for type aliases. It is OK in basic cases, but for generic type aliases (which cannot occur currently for associated types on stable - this is the infamous GAT feature) it doesn't work properly. There are some issues with propagating type arguments and also with handling the alias itself - it's only properly supported for ADTs currently. So for now I think that we should disable this intention for type aliases. 

Fixes: https://github.com/intellij-rust/intellij-rust/issues/6030