### PR TITLE
RES: do not resolve std macros when no_std is present

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -561,6 +561,47 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                  //^ unresolved
     """)
 
+    fun `test resolve std macro with no_std attribute`() = stubOnlyResolve("""
+    //- main.rs
+        #![no_std]
+
+        fn foo() {
+            println!("{}");
+            //^ unresolved
+        }
+    """)
+
+    fun `test resolve std macro with no_std attribute in a different file`() = stubOnlyResolve("""
+    //- main.rs
+        #![no_std]
+        mod foo;
+    //- foo.rs
+        fn foo() {
+            println!("{}");
+            //^ unresolved
+        }
+    """)
+
+    fun `test resolve core macro with no_std attribute`() = stubOnlyResolve("""
+    //- main.rs
+        #![no_std]
+
+        fn foo() {
+            panic!("{}");
+            //^ ...libcore/macros.rs|...libcore/macros/mod.rs
+        }
+    """)
+
+    fun `test resolve core macro with no_core attribute`() = stubOnlyResolve("""
+    //- main.rs
+        #![no_core]
+
+        fn foo() {
+            panic!("{}");
+            //^ unresolved
+        }
+    """)
+
     fun `test inherent impl have higher priority than derived`() = checkByCode("""
         #[derive(Clone)]
         struct S;


### PR DESCRIPTION
Previously, stdlib macros like `println` were successfully resolved even if `#![no_std]` was present, this PR changes that.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5431