### PR TITLE
REF: generate setter action

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/generate/BaseGenerateHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/BaseGenerateHandler.kt
@@ -13,7 +13,6 @@ import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
-import org.rust.ide.refactoring.generate.getter.GenerateGetterHandler
 import org.rust.lang.core.psi.RsBaseType
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsPsiFactory

--- a/src/main/kotlin/org/rust/ide/refactoring/generate/GenerateAccessorHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/GenerateAccessorHandler.kt
@@ -5,11 +5,14 @@
 
 package org.rust.ide.refactoring.generate
 
+import com.intellij.openapi.editor.Editor
+import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsStructItem
 import org.rust.lang.core.psi.ext.RsVisibility
 import org.rust.lang.core.psi.ext.expandedMembers
 import org.rust.lang.core.psi.ext.isTupleStruct
+import org.rust.lang.core.types.Substitution
 
 abstract class GenerateAccessorHandler : BaseGenerateHandler() {
     override fun isStructValid(struct: RsStructItem): Boolean {
@@ -22,6 +25,25 @@ abstract class GenerateAccessorHandler : BaseGenerateHandler() {
      * Return the method name of an accessor for the given field.
      */
     abstract fun methodName(member: StructMember): String
+
+    protected abstract fun generateAccessors(
+        struct: RsStructItem,
+        implBlock: RsImplItem?,
+        chosenFields: List<StructMember>,
+        substitution: Substitution,
+        editor: Editor
+    ): List<RsFunction>?
+
+    override fun performRefactoring(
+        struct: RsStructItem,
+        implBlock: RsImplItem?,
+        chosenFields: List<StructMember>,
+        substitution: Substitution,
+        editor: Editor
+    ) {
+        val methods = generateAccessors(struct, implBlock, chosenFields, substitution, editor)
+        methods?.firstOrNull()?.navigate(true)
+    }
 
     override fun isFieldValid(member: StructMember, impl: RsImplItem?): Boolean {
         if (member.field.visibility == RsVisibility.Public) return false

--- a/src/main/kotlin/org/rust/ide/refactoring/generate/GenerateAccessorHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/GenerateAccessorHandler.kt
@@ -1,0 +1,30 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.generate
+
+import org.rust.lang.core.psi.RsImplItem
+import org.rust.lang.core.psi.RsStructItem
+import org.rust.lang.core.psi.ext.RsVisibility
+import org.rust.lang.core.psi.ext.expandedMembers
+import org.rust.lang.core.psi.ext.isTupleStruct
+
+abstract class GenerateAccessorHandler : BaseGenerateHandler() {
+    override fun isStructValid(struct: RsStructItem): Boolean {
+        if (struct.isTupleStruct) return false
+        if (struct.blockFields?.namedFieldDeclList?.isEmpty() != false) return false
+        return true
+    }
+
+    /**
+     * Return the method name of an accessor for the given field.
+     */
+    abstract fun methodName(member: StructMember): String
+
+    override fun isFieldValid(member: StructMember, impl: RsImplItem?): Boolean {
+        if (member.field.visibility == RsVisibility.Public) return false
+        return impl?.expandedMembers?.all { it.name != methodName(member) } ?: true
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/generate/getter/GenerateGetterHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/getter/GenerateGetterHandler.kt
@@ -7,6 +7,7 @@ package org.rust.ide.refactoring.generate.getter
 
 
 import com.intellij.openapi.editor.Editor
+import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.refactoring.generate.BaseGenerateAction
 import org.rust.ide.refactoring.generate.BaseGenerateHandler
 import org.rust.ide.refactoring.generate.GenerateAccessorHandler
@@ -51,7 +52,9 @@ class GenerateGetterHandler : GenerateAccessorHandler() {
             val fieldType = it.field.typeReference?.type?.substitute(substitution) ?: TyUnit
 
             val (borrow, type) = getBorrowAndType(fieldType, it.field)
-            val fnSignature = "pub fn $fieldName(&self) -> $borrow$type"
+            val typeStr = type.renderInsertionSafe(useAliasNames = true)
+
+            val fnSignature = "pub fn $fieldName(&self) -> $borrow$typeStr"
             val fnBody = "${borrow}self.$fieldName"
 
             val accessor = RsPsiFactory(project).createTraitMethodMember("$fnSignature {\n$fnBody\n}")

--- a/src/main/kotlin/org/rust/ide/refactoring/generate/getter/GenerateGetterHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/getter/GenerateGetterHandler.kt
@@ -53,7 +53,7 @@ class GenerateGetterHandler : GenerateAccessorHandler() {
             val fieldType = it.field.typeReference?.type?.substitute(substitution) ?: TyUnit
 
             val (borrow, type) = getBorrowAndType(fieldType, it.field)
-            val typeStr = type.renderInsertionSafe(useAliasNames = true)
+            val typeStr = type.renderInsertionSafe(useAliasNames = true, includeLifetimeArguments = true)
 
             val fnSignature = "pub fn $fieldName(&self) -> $borrow$typeStr"
             val fnBody = "${borrow}self.$fieldName"
@@ -68,7 +68,6 @@ class GenerateGetterHandler : GenerateAccessorHandler() {
 
 private fun getBorrowAndType(type: Ty, context: RsElement): Pair<String, Ty> {
     return when {
-        type is TyReference -> Pair("&", type.referenced)
         type is TyPrimitive -> Pair("", type)
         type is TyAdt -> {
             val item = type.item

--- a/src/main/kotlin/org/rust/ide/refactoring/generate/getter/GenerateGetterHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/getter/GenerateGetterHandler.kt
@@ -9,6 +9,7 @@ package org.rust.ide.refactoring.generate.getter
 import com.intellij.openapi.editor.Editor
 import org.rust.ide.refactoring.generate.BaseGenerateAction
 import org.rust.ide.refactoring.generate.BaseGenerateHandler
+import org.rust.ide.refactoring.generate.GenerateAccessorHandler
 import org.rust.ide.refactoring.generate.StructMember
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsPsiFactory
@@ -29,7 +30,7 @@ class GenerateGetterAction : BaseGenerateAction() {
     override val handler: BaseGenerateHandler = GenerateGetterHandler()
 }
 
-class GenerateGetterHandler : BaseGenerateHandler() {
+class GenerateGetterHandler : GenerateAccessorHandler() {
     override val dialogTitle: String = "Select Fields to Generate Getters"
 
     override fun performRefactoring(
@@ -58,16 +59,7 @@ class GenerateGetterHandler : BaseGenerateHandler() {
         }
     }
 
-    override fun isStructValid(struct: RsStructItem): Boolean {
-        if (struct.isTupleStruct) return false
-        if (struct.blockFields?.namedFieldDeclList?.isEmpty() != false) return false
-        return true
-    }
-
-    override fun isFieldValid(member: StructMember, impl: RsImplItem?): Boolean {
-        if (member.field.visibility == RsVisibility.Public) return false
-        return impl?.expandedMembers?.all { it.name != member.argumentIdentifier } ?: true
-    }
+    override fun methodName(member: StructMember): String = member.argumentIdentifier
 }
 
 private fun getBorrowAndType(type: Ty, context: RsElement): Pair<String, Ty> {

--- a/src/main/kotlin/org/rust/ide/refactoring/generate/getter/GenerateGetterHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/getter/GenerateGetterHandler.kt
@@ -12,6 +12,7 @@ import org.rust.ide.refactoring.generate.BaseGenerateAction
 import org.rust.ide.refactoring.generate.BaseGenerateHandler
 import org.rust.ide.refactoring.generate.GenerateAccessorHandler
 import org.rust.ide.refactoring.generate.StructMember
+import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsStructItem
@@ -34,20 +35,20 @@ class GenerateGetterAction : BaseGenerateAction() {
 class GenerateGetterHandler : GenerateAccessorHandler() {
     override val dialogTitle: String = "Select Fields to Generate Getters"
 
-    override fun performRefactoring(
+    override fun generateAccessors(
         struct: RsStructItem,
         implBlock: RsImplItem?,
         chosenFields: List<StructMember>,
         substitution: Substitution,
         editor: Editor
-    ) {
+    ): List<RsFunction>? {
         checkWriteAccessAllowed()
-        val project = editor.project ?: return
-        val structName = struct.name ?: return
+        val project = editor.project ?: return null
+        val structName = struct.name ?: return null
         val psiFactory = RsPsiFactory(project)
         val impl = getOrCreateImplBlock(implBlock, psiFactory, structName, struct)
 
-        chosenFields.forEach {
+        return chosenFields.map {
             val fieldName = it.argumentIdentifier
             val fieldType = it.field.typeReference?.type?.substitute(substitution) ?: TyUnit
 
@@ -58,7 +59,7 @@ class GenerateGetterHandler : GenerateAccessorHandler() {
             val fnBody = "${borrow}self.$fieldName"
 
             val accessor = RsPsiFactory(project).createTraitMethodMember("$fnSignature {\n$fnBody\n}")
-            impl.members?.addBefore(accessor, impl.members?.rbrace)
+            impl.members?.addBefore(accessor, impl.members?.rbrace) as RsFunction
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/generate/setter/GenerateSetterHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/setter/GenerateSetterHandler.kt
@@ -1,0 +1,66 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.generate.setter
+
+
+import com.intellij.openapi.editor.Editor
+import org.rust.ide.presentation.renderInsertionSafe
+import org.rust.ide.refactoring.generate.BaseGenerateAction
+import org.rust.ide.refactoring.generate.BaseGenerateHandler
+import org.rust.ide.refactoring.generate.GenerateAccessorHandler
+import org.rust.ide.refactoring.generate.StructMember
+import org.rust.ide.refactoring.generate.getter.GenerateGetterHandler
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsImplItem
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsStructItem
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.RsVisibility
+import org.rust.lang.core.psi.ext.expandedMembers
+import org.rust.lang.core.psi.ext.isTupleStruct
+import org.rust.lang.core.resolve.knownItems
+import org.rust.lang.core.types.Substitution
+import org.rust.lang.core.types.implLookup
+import org.rust.lang.core.types.infer.substitute
+import org.rust.lang.core.types.ty.*
+import org.rust.lang.core.types.type
+import org.rust.openapiext.checkWriteAccessAllowed
+
+class GenerateSetterAction : BaseGenerateAction() {
+    override val handler: BaseGenerateHandler = GenerateSetterHandler()
+}
+
+class GenerateSetterHandler : GenerateAccessorHandler() {
+    override val dialogTitle: String = "Select Fields to Generate Setters"
+
+    override fun generateAccessors(
+        struct: RsStructItem,
+        implBlock: RsImplItem?,
+        chosenFields: List<StructMember>,
+        substitution: Substitution,
+        editor: Editor
+    ): List<RsFunction>? {
+        checkWriteAccessAllowed()
+        val project = editor.project ?: return null
+        val structName = struct.name ?: return null
+        val psiFactory = RsPsiFactory(project)
+        val impl = getOrCreateImplBlock(implBlock, psiFactory, structName, struct)
+
+        return chosenFields.map {
+            val fieldName = it.argumentIdentifier
+            val fieldType = it.field.typeReference?.type?.substitute(substitution) ?: TyUnit
+            val typeStr = fieldType.renderInsertionSafe(useAliasNames = true, includeLifetimeArguments = true)
+
+            val fnSignature = "pub fn ${methodName(it)}(&mut self, $fieldName: $typeStr)"
+            val fnBody = "self.$fieldName = $fieldName;"
+
+            val accessor = RsPsiFactory(project).createTraitMethodMember("$fnSignature {\n$fnBody\n}")
+            impl.members?.addBefore(accessor, impl.members?.rbrace) as RsFunction
+        }
+    }
+
+    override fun methodName(member: StructMember): String = "set_${member.argumentIdentifier}"
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1092,6 +1092,12 @@
             <add-to-group group-id="GenerateGroup"/>
         </action>
 
+        <action class="org.rust.ide.refactoring.generate.setter.GenerateSetterAction"
+                id="Rust.GenerateSetter"
+                text="Setter">
+            <add-to-group group-id="GenerateGroup"/>
+        </action>
+
         <action id="Rust.ReexpandMacrosAction"
                 class="org.rust.lang.core.macros.ReexpandMacrosAction"
                 text="Re-Expand All Rust Macros">

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
@@ -213,8 +213,8 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
         }
 
         impl<'a> S<'a> {
-            pub fn a(&self) -> &str {
-                &self.a
+            pub fn a(&self) -> &'a str {
+                self.a
             }
         }
     """)
@@ -231,7 +231,7 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
             a: (u32, u32)
         }
 
-        impl S/*caret*/ {
+        impl S {
             pub fn a(&self) -> (u32, u32) {
                 self.a
             }
@@ -245,14 +245,14 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
             a: (u32, NoCopy)
         }
 
-        impl S/*caret*/ {}
+        impl S {/*caret*/}
     """, listOf(MemberSelection("a: (u32, NoCopy)")), """
         struct NoCopy;
         struct S {
             a: (u32, NoCopy)
         }
 
-        impl S/*caret*/ {
+        impl S {
             pub fn a(&self) -> &(u32, NoCopy) {
                 &self.a
             }

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
@@ -410,4 +410,28 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
             }
         }
     """)
+
+    fun `test move to first generated getter`() = doTest("""
+        struct S {
+            a: i32,
+            b: bool,/*caret*/
+        }
+    """, listOf(
+        MemberSelection("a: i32"),
+        MemberSelection("b: bool")
+    ), """
+        struct S {
+            a: i32,
+            b: bool,
+        }
+
+        impl S {
+            pub fn /*caret*/a(&self) -> i32 {
+                self.a
+            }
+            pub fn b(&self) -> bool {
+                self.b
+            }
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
@@ -388,4 +388,26 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
             }
         }
     """)
+
+    fun `test type alias`() = doTest("""
+        struct T;
+        type Alias = T;
+        struct S {
+            a: Alias
+        }
+
+        impl S/*caret*/ {}
+    """, listOf(MemberSelection("a: Alias")), """
+        struct T;
+        type Alias = T;
+        struct S {
+            a: Alias
+        }
+
+        impl S {
+            pub fn a(&self) -> &Alias {
+                &self.a
+            }
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
@@ -219,6 +219,46 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
         }
     """)
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test tuple copy`() = doTest("""
+        struct S {
+            a: (u32, u32)
+        }
+
+        impl S/*caret*/ {}
+    """, listOf(MemberSelection("a: (u32, u32)")), """
+        struct S {
+            a: (u32, u32)
+        }
+
+        impl S/*caret*/ {
+            pub fn a(&self) -> (u32, u32) {
+                self.a
+            }
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test tuple move`() = doTest("""
+        struct NoCopy;
+        struct S {
+            a: (u32, NoCopy)
+        }
+
+        impl S/*caret*/ {}
+    """, listOf(MemberSelection("a: (u32, NoCopy)")), """
+        struct NoCopy;
+        struct S {
+            a: (u32, NoCopy)
+        }
+
+        impl S/*caret*/ {
+            pub fn a(&self) -> &(u32, NoCopy) {
+                &self.a
+            }
+        }
+    """)
+
     fun `test generic field changed type parameter name`() = doTest("""
         struct S<T> {
             a: T

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateSetterActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateSetterActionTest.kt
@@ -1,0 +1,231 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.generate
+
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+import java.lang.reflect.Member
+
+class GenerateSetterActionTest : RsGenerateBaseTest() {
+    override val generateId: String = "Rust.GenerateSetter"
+
+    fun `test primitive fields`() = doTest("""
+        struct S {
+            a: i32,
+            b: bool,
+        }
+
+        impl S {
+            /*caret*/
+        }
+    """, listOf(
+        MemberSelection("a: i32"),
+        MemberSelection("b: bool")
+    ), """
+        struct S {
+            a: i32,
+            b: bool,
+        }
+
+        impl S {
+            pub fn set_a(&mut self, a: i32) {
+                self.a = a;
+            }
+            pub fn set_b(&mut self, b: bool) {
+                self.b = b;
+            }
+        }
+    """)
+
+    fun `test select field`() = doTest("""
+        struct S {
+            a: i32,
+            b: bool,
+        }
+
+        impl S {
+            /*caret*/
+        }
+    """, listOf(
+        MemberSelection("a: i32"),
+        MemberSelection("b: bool", false)
+    ), """
+        struct S {
+            a: i32,
+            b: bool,
+        }
+
+        impl S {
+            pub fn set_a(&mut self, a: i32) {
+                self.a = a;
+            }
+        }
+    """)
+
+    fun `test reference`() = doTest("""
+        struct S<'a> {
+            a: &'a str
+        }
+
+        impl<'a> S<'a>/*caret*/ {}
+    """, listOf(MemberSelection("a: &'a str")), """
+        struct S<'a> {
+            a: &'a str
+        }
+
+        impl<'a> S<'a> {
+            pub fn set_a(&mut self, a: &'a str) {
+                self.a = a;
+            }
+        }
+    """)
+
+    fun `test generic field changed type parameter name`() = doTest("""
+        struct S<T> {
+            a: T
+        }
+
+        impl<R> S<R>/*caret*/ {}
+    """, listOf(MemberSelection("a: R")), """
+        struct S<T> {
+            a: T
+        }
+
+        impl<R> S<R> {
+            pub fn set_a(&mut self, a: R) {
+                self.a = a;
+            }
+        }
+    """)
+
+    fun `test generic field specific type`() = doTest("""
+        struct S<T> {
+            a: T
+        }
+
+        impl S<u32>/*caret*/ {}
+    """, listOf(MemberSelection("a: u32")), """
+        struct S<T> {
+            a: T
+        }
+
+        impl S<u32> {
+            pub fn set_a(&mut self, a: u32) {
+                self.a = a;
+            }
+        }
+    """)
+
+    fun `test filter fields with a getter`() = doTest("""
+        struct S {
+            a: i32,
+            b: i32,
+        }
+
+        impl S {
+            fn set_a(&self) {}
+            /*caret*/
+        }
+    """, listOf(MemberSelection("b: i32")), """
+        struct S {
+            a: i32,
+            b: i32,
+        }
+
+        impl S {
+            fn set_a(&self) {}
+
+            pub fn set_b(&mut self, b: i32) {
+                self.b = b;
+            }
+        }
+    """)
+
+    fun `test unavailable when all fields have a setter`() = doUnavailableTest("""
+        struct S {
+            a: i32,
+        }
+
+        impl S {
+            fn set_a(&self) {}
+            /*caret*/
+        }
+    """)
+
+    fun `test unrelated method exists`() = doTest("""
+        struct S {
+            a: i32,
+        }
+
+        impl S {
+            fn foo() -> i32 {
+                42
+            }
+            /*caret*/
+        }
+    """, listOf(MemberSelection("a: i32")), """
+        struct S {
+            a: i32,
+        }
+
+        impl S {
+            fn foo() -> i32 {
+                42
+            }
+
+            pub fn set_a(&mut self, a: i32) {
+                self.a = a;
+            }
+        }
+    """)
+
+    fun `test skip pub field`() = doTest("""
+        struct S {
+            a: i32,
+            pub b: i32,
+            pub(crate) c: i32,
+        }
+
+        impl S/*caret*/ {}
+    """, listOf(MemberSelection("a: i32"), MemberSelection("c: i32")), """
+        struct S {
+            a: i32,
+            pub b: i32,
+            pub(crate) c: i32,
+        }
+
+        impl S {
+            pub fn set_a(&mut self, a: i32) {
+                self.a = a;
+            }
+            pub fn set_c(&mut self, c: i32) {
+                self.c = c;
+            }
+        }
+    """)
+
+    fun `test type alias`() = doTest("""
+        struct T;
+        type Alias = T;
+        struct S {
+            a: Alias
+        }
+
+        impl S/*caret*/ {}
+    """, listOf(MemberSelection("a: Alias")), """
+        struct T;
+        type Alias = T;
+        struct S {
+            a: Alias
+        }
+
+        impl S {
+            pub fn set_a(&mut self, a: Alias) {
+                self.a = a;
+            }
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds an action to generate a setter for a struct, mirroring the recently added generate getter action (https://github.com/intellij-rust/intellij-rust/pull/5352).

![setter](https://user-images.githubusercontent.com/4539057/91723607-4e576f80-eb9c-11ea-946c-1f23abb32345.gif)

It also introduces several improvements like better copy type handling, support for type aliases, finding existing impl blocks and navigation to the generated method. Since these are directly applicable to both getters and setters, I included them in this PR, but if you want, I can split them into a separate PR.

Currently, if the action is invoked inside an `impl`, I filter out attributes that would conflict with an existing method:
```rust
struct S { a: u32 }
impl S {
   fn a(&self) {}
   /*caret*/ <- a is not offered, because `a` method exists
}
```
However, if the action is invoked on the struct, all (non-pub) fields are offered, and then if it finds an existing `impl` block with a method with the same name, it will generate the getter/setter and the names will conflict. I think that this behaviour is fine, just wanted to mention it.