### PR TITLE
REF: handle struct field shorthand init in RsInlineValue

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/inlineValue/RsInlineValueProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineValue/RsInlineValueProcessor.kt
@@ -13,6 +13,8 @@ import com.intellij.refactoring.BaseRefactoringProcessor
 import com.intellij.usageView.UsageInfo
 import com.intellij.usageView.UsageViewDescriptor
 import org.rust.ide.refactoring.RsInlineUsageViewDescriptor
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsStructLiteralField
 import org.rust.lang.core.resolve.ref.RsReference
 
 class RsInlineValueProcessor(
@@ -33,9 +35,20 @@ class RsInlineValueProcessor(
     }
 
     override fun performRefactoring(usages: Array<out UsageInfo>) {
+        val factory = RsPsiFactory(project)
         usages.asIterable().forEach loop@{
             val reference = it.reference as? RsReference ?: return@loop
-            reference.element.replace(context.expr)
+            when (val element = reference.element) {
+                is RsStructLiteralField -> {
+                    if (element.colon == null) {
+                        element.addAfter(factory.createColon(), element.referenceNameElement)
+                    }
+                    if (element.expr == null) {
+                        element.addAfter(context.expr, element.colon)
+                    }
+                }
+                else -> element.replace(context.expr)
+            }
         }
         if (mode is InlineValueMode.InlineAllAndRemoveOriginal) {
             context.delete()

--- a/src/test/kotlin/org/rust/ide/refactoring/RsInlineValueTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsInlineValueTest.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.refactoring
 
-import junit.framework.Assert
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.ide.refactoring.inlineValue.InlineValueMode
@@ -177,6 +176,59 @@ class RsInlineValueTest : RsTestBase() {
         }
     """)
 
+    fun `test inline into field init`() = doTest("""
+        struct S {
+            a: u32,
+        }
+
+        fn foo() {
+            let /*caret*/a = 10;
+            S { a: a };
+        }
+    """, """
+        struct S {
+            a: u32,
+        }
+
+        fn foo() {
+            S { a: 10 };
+        }
+    """)
+
+    fun `test inline into field shorthand init`() = doTest("""
+        struct S {
+            a: u32,
+        }
+
+        fn foo() {
+            let /*caret*/a = 10;
+            S { a };
+        }
+    """, """
+        struct S {
+            a: u32,
+        }
+
+        fn foo() {
+            S { a: 10 };
+        }
+    """)
+
+    fun `test inline into tuple struct init`() = doTest("""
+        struct S(u32);
+
+        fn foo() {
+            let /*caret*/a = 10;
+            S { 0: a };
+        }
+    """, """
+        struct S(u32);
+
+        fn foo() {
+            S { 0: 10 };
+        }
+    """)
+
     private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String,
                        mode: InlineValueMode = InlineValueMode.InlineAllAndRemoveOriginal) {
         withMockInlineValueMode(mode) {
@@ -189,8 +241,7 @@ class RsInlineValueTest : RsTestBase() {
             checkEditorAction(code, code, "Inline")
             error("no error found, expected $errorMessage")
         } catch (e: Exception) {
-            Assert.assertEquals(e.message, errorMessage)
+            assertEquals(errorMessage, e.message)
         }
     }
-
 }


### PR DESCRIPTION
This PR fixes `RsInlineValue` so that it properly supports shorthand field init. Inspired by https://github.com/rust-analyzer/rust-analyzer/pull/5888.