### PR TITLE
INT: add support for creating methods in CreateFunctionIntention

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/CreateFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/CreateFunctionIntention.kt
@@ -15,10 +15,10 @@ import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.utils.GenericConstraints
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve.TraitImplSource
 import org.rust.lang.core.types.expectedType
-import org.rust.lang.core.types.ty.Ty
-import org.rust.lang.core.types.ty.TyUnit
-import org.rust.lang.core.types.ty.TyUnknown
+import org.rust.lang.core.types.implLookup
+import org.rust.lang.core.types.ty.*
 import org.rust.lang.core.types.type
 import org.rust.openapiext.buildAndRunTemplate
 import org.rust.openapiext.createSmartPointer
@@ -26,112 +26,186 @@ import org.rust.openapiext.createSmartPointer
 class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionIntention.Context>() {
     override fun getFamilyName() = text
 
-    sealed class Context {
-        data class Function(val callExpr: RsCallExpr, val name: String, val module: RsMod) : Context()
+    sealed class Context(val name: String, val callElement: PsiElement) {
+        abstract val visibility: String
+        abstract val arguments: RsValueArgumentList
+        abstract val returnType: Ty?
+
+        class Function(val callExpr: RsCallExpr, name: String, val module: RsMod) : Context(name, callExpr) {
+            override val visibility: String = if (callExpr.containingMod != module) "pub(crate) " else ""
+            override val arguments: RsValueArgumentList = callExpr.valueArgumentList
+            override val returnType: Ty? = callExpr.expectedType
+        }
+
+        class Method(val methodCall: RsMethodCall, name: String, val item: RsStructOrEnumItemElement)
+            : Context(name, methodCall) {
+            override val visibility: String
+                get() {
+                    val parentImpl = methodCall.parentOfType<RsImplItem>()
+                    // creating a method inside the same impl
+                    return if ((parentImpl?.typeReference?.type as? TyAdt)?.item == item && parentImpl.traitRef == null) {
+                        ""
+                    } else "pub(crate)"
+                }
+            override val arguments: RsValueArgumentList = methodCall.valueArgumentList
+            override val returnType: Ty? = methodCall.parentDotExpr.expectedType
+        }
     }
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
         val path = element.parentOfType<RsPath>()
-        val functionCall = path?.parentOfType<RsCallExpr>() ?: return null
-        if (!path.isUnresolved) return null
+        val functionCall = path?.parentOfType<RsCallExpr>()
+        if (functionCall != null) {
+            if (!path.isUnresolved) return null
+            if (!functionCall.expr.isAncestorOf(path)) return null
 
-        if (!functionCall.expr.isAncestorOf(path)) return null
+            val module = getTargetModuleForFunction(path) ?: return null
+            val name = path.referenceName
+            text = "Create function `$name`"
+            return Context.Function(functionCall, name, module)
+        }
+        val methodCall = element.parentOfType<RsMethodCall>()
+        if (methodCall != null) {
+            if (methodCall.reference.resolve() != null) return null
+            if (element != methodCall.identifier && element != methodCall.valueArgumentList.lparen) return null
 
-        val module = getTargetModuleForFunction(path) ?: return null
-        val name = path.referenceName
-        text = "Create function `$name`"
-        return Context.Function(functionCall, name, module)
+            val name = methodCall.identifier.text
+            val type = methodCall.parentDotExpr.expr.type.stripReferences() as? TyAdt ?: return null
+
+            text = "Create method `$name`"
+            return Context.Method(methodCall, name, type.item)
+        }
+        return null
     }
 
     override fun invoke(project: Project, editor: Editor, ctx: Context) {
-        when (ctx) {
-            is Context.Function -> createFunction(project, editor, ctx)
-        }
-    }
-}
+        val function = buildCallable(project, ctx) ?: return
+        val inserted = insertCallable(ctx, function) ?: return
 
-private fun createFunction(project: Project, editor: Editor, ctx: CreateFunctionIntention.Context.Function) {
-    val functionName = ctx.name
-    val callExpr = ctx.callExpr
-
-    val factory = RsPsiFactory(project)
-    val config = getFunctionConfig(callExpr)
-
-    val genericParams = config.genericConstraints.buildTypeParameters()
-    val params = config.parameters.joinToString(", ")
-    val whereClause = config.genericConstraints.buildWhereClause()
-
-    val vis = if (callExpr.containingMod != ctx.module) "pub(crate) " else ""
-    val returnType = if (config.returnType !is TyUnit) {
-        " -> ${config.returnType.renderInsertionSafe(useAliasNames = true)}"
-    } else ""
-    val function = factory.tryCreateFunction("${vis}fn $functionName$genericParams($params)$returnType $whereClause {\n    unimplemented!()\n}")
-        ?: return
-
-    val sourceFunction = callExpr.parentOfType<RsFunction>() ?: return
-    val inserted = insertFunction(ctx.module, sourceFunction, function)
-
-    if (ctx.module.containingFile == callExpr.containingFile) {
-        val toBeReplaced = inserted.valueParameters.flatMap { listOfNotNull(it.pat, it.typeReference) } +
-            listOfNotNull(inserted.block?.expr)
-        editor.buildAndRunTemplate(inserted, toBeReplaced.map { it.createSmartPointer() })
-    } else {
-        // template builder cannot be used for a different file
-        inserted.navigate(true)
-    }
-}
-
-private fun getTargetModuleForFunction(path: RsPath): RsMod? {
-    if (path.qualifier != null) {
-        val mod = path.qualifier?.reference?.resolve() as? RsMod
-        if (mod?.containingCargoPackage?.origin != PackageOrigin.WORKSPACE) return null
-        if (!isUnitTestMode && !mod.isWritable) return null
-        return mod
-    }
-    return path.containingMod
-}
-
-private data class FunctionConfig(val parameters: List<String>,
-                                  val returnType: Ty,
-                                  val genericConstraints: GenericConstraints)
-
-private fun getFunctionConfig(callExpr: RsCallExpr): FunctionConfig {
-    val parameters = callExpr.valueArgumentList.exprList.mapIndexed { index, expr ->
-        "p$index: ${expr.type.renderInsertionSafe(useAliasNames = true)}"
-    }
-
-    val returnType = callExpr.expectedType.takeIf { it != TyUnknown } ?: TyUnit
-
-    val genericConstraints = GenericConstraints.create(callExpr)
-        .filterByTypes(callExpr.valueArgumentList.exprList.map { it.type }.plus(returnType))
-
-    return FunctionConfig(parameters, returnType, genericConstraints)
-}
-
-private fun insertFunction(
-    targetModule: RsMod,
-    sourceFunction: RsFunction,
-    function: RsFunction
-): RsFunction {
-    if (targetModule == sourceFunction.containingMod) {
-        val impl: RsTraitOrImpl? = when (val owner = sourceFunction.owner) {
-            is RsAbstractableOwner.Trait -> owner.trait
-            is RsAbstractableOwner.Impl -> owner.impl
-            else -> null
-        }
-
-        val target: RsItemElement = impl ?: sourceFunction
-        return target.parent.addAfter(function, target) as RsFunction
-    }
-
-    // add to the end of module/file
-    return if (targetModule is RsModItem) {
-        targetModule.addBefore(function, targetModule.rbrace)
-    } else {
-        if (targetModule.lastChild == null) {
-            targetModule.add(function)
+        if (inserted.containingFile == ctx.callElement.containingFile) {
+            val toBeReplaced = inserted.valueParameters.flatMap { listOfNotNull(it.pat, it.typeReference) } +
+                listOfNotNull(inserted.block?.expr)
+            editor.buildAndRunTemplate(inserted, toBeReplaced.map { it.createSmartPointer() })
         } else {
-            targetModule.addAfter(function, targetModule.lastChild)
+            // template builder cannot be used for a different file
+            inserted.navigate(true)
         }
-    } as RsFunction
+    }
+
+    private fun buildCallable(project: Project, ctx: Context): RsFunction? {
+        val functionName = ctx.name
+
+        val factory = RsPsiFactory(project)
+        val config = getCallableConfig(ctx)
+
+        val genericParams = config.genericConstraints.buildTypeParameters()
+        val parameters = config.parameters.toMutableList()
+        val whereClause = config.genericConstraints.buildWhereClause()
+        val visibility = ctx.visibility
+        if (ctx is Context.Method) {
+            parameters.add(0, "&self")
+        }
+        val returnType = if (config.returnType !is TyUnit) {
+            " -> ${config.returnType.renderInsertionSafe(useAliasNames = true)}"
+        } else ""
+        val paramsText = parameters.joinToString(", ")
+
+        return factory.tryCreateFunction("$visibility fn $functionName$genericParams($paramsText)$returnType $whereClause {\n    unimplemented!()\n}")
+    }
+
+    private fun getTargetModuleForFunction(path: RsPath): RsMod? {
+        if (path.qualifier != null) {
+            val mod = path.qualifier?.reference?.resolve() as? RsMod
+            if (mod?.containingCargoPackage?.origin != PackageOrigin.WORKSPACE) return null
+            if (!isUnitTestMode && !mod.isWritable) return null
+            return mod
+        }
+        return path.containingMod
+    }
+
+    private data class CallableConfig(val parameters: List<String>,
+                                      val returnType: Ty,
+                                      val genericConstraints: GenericConstraints)
+
+    private fun getCallableConfig(ctx: Context): CallableConfig {
+        val callExpr = ctx.callElement
+        val arguments = ctx.arguments
+
+        val parameters = arguments.exprList.mapIndexed { index, expr ->
+            "p$index: ${expr.type.renderInsertionSafe(useAliasNames = true)}"
+        }
+
+        val returnType = ctx.returnType.takeIf { it != TyUnknown } ?: TyUnit
+        val genericConstraints = GenericConstraints.create(callExpr)
+            .filterByTypes(arguments.exprList.map { it.type }.plus(returnType))
+
+        val filteredConstraints = if (ctx is Context.Method) {
+            val params = ctx.callElement.parentOfType<RsImplItem>()?.typeParameters.orEmpty()
+            genericConstraints.withoutTypes(params)
+        } else genericConstraints
+
+        return CallableConfig(parameters, returnType, filteredConstraints)
+    }
+
+    private fun insertCallable(ctx: Context, function: RsFunction): RsFunction? {
+        val sourceFunction = ctx.callElement.parentOfType<RsFunction>() ?: return null
+
+        return when (ctx) {
+            is Context.Function -> insertFunction(ctx.module, sourceFunction, function)
+            is Context.Method -> insertMethod(ctx.item, sourceFunction, function)
+        }
+    }
+
+    private fun insertFunction(
+        targetModule: RsMod,
+        sourceFunction: RsFunction,
+        function: RsFunction
+    ): RsFunction {
+        if (targetModule == sourceFunction.containingMod) {
+            val impl: RsTraitOrImpl? = when (val owner = sourceFunction.owner) {
+                is RsAbstractableOwner.Trait -> owner.trait
+                is RsAbstractableOwner.Impl -> owner.impl
+                else -> null
+            }
+
+            val target: RsItemElement = impl ?: sourceFunction
+            return target.parent.addAfter(function, target) as RsFunction
+        }
+
+        // add to the end of module/file
+        return if (targetModule is RsModItem) {
+            targetModule.addBefore(function, targetModule.rbrace)
+        } else {
+            if (targetModule.lastChild == null) {
+                targetModule.add(function)
+            } else {
+                targetModule.addAfter(function, targetModule.lastChild)
+            }
+        } as RsFunction
+    }
+
+    private fun insertMethod(
+        item: RsStructOrEnumItemElement,
+        sourceFunction: RsFunction,
+        function: RsFunction
+    ): RsFunction? {
+        val impl = getOrCreateImpl(item, sourceFunction)
+        return impl.members?.let {
+            it.addBefore(function, it.rbrace) as RsFunction
+        }
+    }
+
+    private fun getOrCreateImpl(item: RsStructOrEnumItemElement, sourceFunction: RsFunction): RsImplItem {
+        val owner = sourceFunction.owner
+        if (owner is RsAbstractableOwner.Impl) {
+            val impl = owner.impl
+            if (impl.traitRef == null && (impl.typeReference?.type as? TyAdt)?.item == item) {
+                return impl
+            }
+        }
+
+        val newImpl = RsPsiFactory(item.project).createInherentImplItem(item.name
+            ?: "?", item.typeParameterList, item.whereClause)
+        return item.parent.addAfter(newImpl, item) as RsImplItem
+    }
 }

--- a/src/main/kotlin/org/rust/ide/utils/ExtractUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/ExtractUtils.kt
@@ -121,6 +121,11 @@ data class GenericConstraints(
         }
     }
 
+    fun withoutTypes(params: List<RsTypeParameter>): GenericConstraints {
+        val types = typeParameters - params
+        return copy(typeParameters = types)
+    }
+
     companion object {
         /**
          * Recursively finds parent `RsGenericDeclarations` and collects all of their type parameters and

--- a/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
@@ -331,4 +331,257 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention(
             unimplemented!()
         }
     """)
+
+    fun `test navigate to created function`() = doAvailableTest("""
+        fn foo() {
+            bar/*caret*/();
+        }
+    """, """
+        fn foo() {
+            bar();
+        }
+
+        fn bar() {
+            unimplemented!()/*caret*/
+        }
+    """)
+
+    fun `test create method create impl`() = doAvailableTest("""
+        trait Trait {}
+        struct S<T>(T) where T: Trait;
+
+        fn foo(s: S<u32>) {
+            s.foo/*caret*/(1, 2);
+        }
+    """, """
+        trait Trait {}
+        struct S<T>(T) where T: Trait;
+
+        impl<T> S<T> where T: Trait {
+            pub(crate) fn foo(&self, p0: i32, p1: i32) {
+                unimplemented!()
+            }
+        }
+
+        fn foo(s: S<u32>) {
+            s.foo(1, 2);
+        }
+    """)
+
+    fun `test create method no arguments`() = doAvailableTest("""
+        struct S;
+
+        fn foo(s: S) {
+            s.foo/*caret*/();
+        }
+    """, """
+        struct S;
+
+        impl S {
+            pub(crate) fn foo(&self) {
+                unimplemented!()
+            }
+        }
+
+        fn foo(s: S) {
+            s.foo();
+        }
+    """)
+
+    fun `test create generic method`() = doAvailableTest("""
+        struct S;
+
+        fn foo<R>(s: S, r: R) {
+            s.foo/*caret*/(r);
+        }
+    """, """
+        struct S;
+
+        impl S {
+            pub(crate) fn foo<R>(&self, p0: R) {
+                unimplemented!()
+            }
+        }
+
+        fn foo<R>(s: S, r: R) {
+            s.foo(r);
+        }
+    """)
+
+    fun `test create method inside impl`() = doAvailableTest("""
+        struct S;
+        impl S {
+            fn foo(&self) {
+                self.bar/*caret*/(0);
+            }
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self) {
+                self.bar(0);
+            }
+            fn bar(&self, p0: i32) {
+                unimplemented!()
+            }
+        }
+    """)
+
+    fun `test create method inside generic impl`() = doAvailableTest("""
+        struct S<T>(T);
+        impl<T> S<T> {
+            fn foo(&self, t: T) {
+                self.bar/*caret*/(t);
+            }
+        }
+    """, """
+        struct S<T>(T);
+        impl<T> S<T> {
+            fn foo(&self, t: T) {
+                self.bar(t);
+            }
+            fn bar(&self, p0: T) {
+                unimplemented!()
+            }
+        }
+    """)
+
+    fun `test create method inside generic impl with where`() = doAvailableTest("""
+        trait Trait {}
+        struct S<T>(T);
+        impl<T> S<T> where T: Trait {
+            fn foo(&self, t: T) {
+                self.bar/*caret*/(t);
+            }
+        }
+    """, """
+        trait Trait {}
+        struct S<T>(T);
+        impl<T> S<T> where T: Trait {
+            fn foo(&self, t: T) {
+                self.bar(t);
+            }
+            fn bar(&self, p0: T) {
+                unimplemented!()
+            }
+        }
+    """)
+
+    fun `test unavailable inside method arguments`() = doUnavailableTest("""
+        struct S;
+        fn foo(s: S) {
+            s.bar(1, /*caret*/2);
+        }
+    """)
+
+    fun `test available inside method name`() = doAvailableTest("""
+        struct S;
+        fn foo(s: S) {
+            s.b/*caret*/ar(1, 2);
+        }
+    """, """
+        struct S;
+
+        impl S {
+            pub(crate) fn bar(&self, p0: i32, p1: i32) {
+                unimplemented!()
+            }
+        }
+
+        fn foo(s: S) {
+            s.bar(1, 2);
+        }
+    """)
+
+    fun `test available after method name`() = doAvailableTest("""
+        struct S;
+        fn foo(s: S) {
+            s.bar/*caret*/(1, 2);
+        }
+    """, """
+        struct S;
+
+        impl S {
+            pub(crate) fn bar(&self, p0: i32, p1: i32) {
+                unimplemented!()
+            }
+        }
+
+        fn foo(s: S) {
+            s.bar(1, 2);
+        }
+    """)
+
+    fun `test guess method return type`() = doAvailableTest("""
+        struct S;
+        fn foo(s: S) {
+            let a: u32 = s.bar/*caret*/(1, 2);
+        }
+    """, """
+        struct S;
+
+        impl S {
+            pub(crate) fn bar(&self, p0: i32, p1: i32) -> u32 {
+                unimplemented!()
+            }
+        }
+
+        fn foo(s: S) {
+            let a: u32 = s.bar(1, 2);
+        }
+    """)
+
+    fun `test create method inside trait impl`() = doAvailableTest("""
+        trait Trait {
+            fn foo(&self);
+        }
+        struct S;
+        impl Trait for S {
+            fn foo(&self) {
+                self.bar/*caret*/();
+            }
+        }
+    """, """
+        trait Trait {
+            fn foo(&self);
+        }
+        struct S;
+
+        impl S {
+            pub(crate) fn bar(&self) {
+                unimplemented!()
+            }
+        }
+
+        impl Trait for S {
+            fn foo(&self) {
+                self.bar();
+            }
+        }
+    """)
+
+    fun `test create method inside different impl`() = doAvailableTest("""
+        struct S;
+        struct T;
+        impl T {
+            fn foo(&self, s: S) {
+                s.bar/*caret*/();
+            }
+        }
+    """, """
+        struct S;
+
+        impl S {
+            pub(crate) fn bar(&self) {
+                unimplemented!()
+            }
+        }
+
+        struct T;
+        impl T {
+            fn foo(&self, s: S) {
+                s.bar();
+            }
+        }
+    """)
 }


### PR DESCRIPTION
This PR adds support for creatng methods in `CreateFunctionIntention`. Also I previously forget to register the intention and add a description, since it was originally a quick fix, so this PR also fixes that.

![create-method](https://user-images.githubusercontent.com/4539057/91731838-ae074800-eba7-11ea-89a1-3b98d50798e8.gif)
