### PR TITLE
CI: set PR milestone automatically

### DIFF
--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -1,0 +1,20 @@
+name: milestones
+
+on:
+    pull_request:
+        types: [ closed ]
+
+jobs:
+    set_milestone:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Set up Python
+              uses: actions/setup-python@v1
+              with:
+                  python-version: 3.7
+
+            - name: Set milestone
+              if: github.event.pull_request.merged && github.event.pull_request.milestone == null
+              run: python scripts/set_milestone.py --token ${{ github.token }} --pull-request ${{ github.event.pull_request.number }}

--- a/scripts/check_release_branch_date.py
+++ b/scripts/check_release_branch_date.py
@@ -1,16 +1,12 @@
 import json
 from datetime import datetime, date, timedelta
-from urllib import request
 
-from common import get_patch_version, env
+from common import env
+from github import get_current_milestone
 
 if __name__ == '__main__':
     repo = env("GITHUB_REPOSITORY")
-    response = request.urlopen(f"https://api.github.com/repos/{repo}/milestones")
-    milestones = json.load(response)
-
-    milestone_version = f"v{get_patch_version()}"
-    milestone = next(milestone for milestone in milestones if milestone["title"] == milestone_version)
+    milestone = get_current_milestone(repo)
     # TODO: find out more correct way to parse data
     release_date = datetime.strptime(milestone["due_on"], "%Y-%m-%dT%H:%M:%SZ").date()
 

--- a/scripts/github.py
+++ b/scripts/github.py
@@ -1,0 +1,21 @@
+# TODO: think about using library for GitHub API
+import json
+from typing import Dict
+from urllib.request import Request, urlopen
+
+from common import get_patch_version
+
+
+def get_current_milestone(repo: str) -> Dict:
+    response = urlopen(f"https://api.github.com/repos/{repo}/milestones")
+    milestones = json.load(response)
+    milestone_version = f"v{get_patch_version()}"
+    return next(milestone for milestone in milestones if milestone["title"] == milestone_version)
+
+
+def set_milestone(token: str, repo: str, issue_number: int, milestone_number: int) -> None:
+    data = json.dumps({"milestone": milestone_number}).encode()
+    headers = {"Authorization": f"token {token}",
+               "Accept": "application/vnd.github.v3+json"}
+    request = Request(f"https://api.github.com/repos/{repo}/issues/{issue_number}", data, headers, method="PATCH")
+    urlopen(request)

--- a/scripts/github.py
+++ b/scripts/github.py
@@ -10,7 +10,10 @@ def get_current_milestone(repo: str) -> Dict:
     response = urlopen(f"https://api.github.com/repos/{repo}/milestones")
     milestones = json.load(response)
     milestone_version = f"v{get_patch_version()}"
-    return next(milestone for milestone in milestones if milestone["title"] == milestone_version)
+    result = next((milestone for milestone in milestones if milestone["title"] == milestone_version), None)
+    if result is None:
+        raise AssertionError(f"Milestone `{milestone_version}` doesn't exist")
+    return result
 
 
 def set_milestone(token: str, repo: str, issue_number: int, milestone_number: int) -> None:

--- a/scripts/set_milestone.py
+++ b/scripts/set_milestone.py
@@ -1,0 +1,16 @@
+import argparse
+
+from common import env
+from github import get_current_milestone, set_milestone
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--token", type=str, help="GitHub token", required=True)
+    parser.add_argument("--pull-request", type=int, help="Pull request number", required=True)
+
+    args = parser.parse_args()
+
+    repo = env("GITHUB_REPOSITORY")
+    milestone = get_current_milestone(repo)
+
+    set_milestone(args.token, repo, args.pull_request, milestone["number"])


### PR DESCRIPTION
We use milestones to mark pull requests that are included into the corresponding release.
We use it:
- for changelog template creation
- to get our users full list of release changes
- while regression investigation in published release builds

But we have to set milestones manually. As a result, a developer can forget to do it (and it actually happens).
These changes provides new GitHub workflow to set current milestone to each merged PR automatically if it doesn't have it yet