### PR TITLE
RUN: Add target completion for cargo command

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Rustup.kt
@@ -35,6 +35,16 @@ class Rustup(
         }
     }
 
+    data class Target(val name: String, val isInstalled: Boolean) {
+        companion object {
+            fun from(line: String): Target {
+                val name = line.substringBefore(' ')
+                val isInstalled = line.substringAfter(' ') == "(installed)"
+                return Target(name, isInstalled)
+            }
+        }
+    }
+
     fun listComponents(): List<Component> =
         GeneralCommandLine(rustup)
             .withWorkDirectory(projectDirectory)
@@ -42,6 +52,15 @@ class Rustup(
             .execute()
             ?.stdoutLines
             ?.map { Component.from(it) }
+            ?: emptyList()
+
+    fun listTargets(): List<Target> =
+        GeneralCommandLine(rustup)
+            .withWorkDirectory(projectDirectory)
+            .withParameters("target", "list")
+            .execute()
+            ?.stdoutLines
+            ?.map { Target.from(it) }
             ?: emptyList()
 
     fun downloadStdlib(): DownloadResult<VirtualFile> {

--- a/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
@@ -50,7 +50,7 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
         listOf(
             "--release", "--jobs",
             "--features", "--all-features", "--no-default-features",
-            "--verbose", "--quiet",
+            "--verbose", "--quiet", "--target",
             "--bin", "--example", "--package",
             "--manifest-path"
         )

--- a/src/test/kotlin/org/rust/ide/actions/runAnything/cargo/CargoRunAnythingProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/runAnything/cargo/CargoRunAnythingProviderTest.kt
@@ -43,7 +43,7 @@ class CargoRunAnythingProviderTest : RsTestBase() {
     fun `test options completion`() {
         val runOptions = listOf(
             "--bin", "--example", "--package", "--jobs", "--release", "--manifest-path", "--verbose", "--quiet",
-            "--features", "--all-features", "--no-default-features"
+            "--target", "--features", "--all-features", "--no-default-features"
         ).map { "cargo run $it" }
         assertSameElements(provider.getValues(dataContext, "cargo run "), runOptions)
         assertSameElements(provider.getValues(dataContext, "cargo run -"), runOptions)


### PR DESCRIPTION
Adds a `--target` suggestion to cargo command run configuration and run anything. After the option argument itself, suggests a list of installed target triples from `rustup target list`.

<img width="500" src="https://user-images.githubusercontent.com/6342851/92031803-db9fed00-ed71-11ea-9944-a9b77f88923e.png">
