### PR TITLE
RUN: Fix benches flag in cargo command completion

### DIFF
--- a/src/main/kotlin/org/rust/cargo/util/CargoCommandCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/util/CargoCommandCompletionProvider.kt
@@ -159,7 +159,7 @@ class CargoCommandCompletionProvider(
             flag("tests")
 
             targetBench()
-            flag("bench")
+            flag("benches")
         }
 
         fun pkg() = opt("package") { ctx ->


### PR DESCRIPTION
According to the [cargo docs](https://doc.rust-lang.org/cargo/commands/cargo-check.html) it should have a `--bench` option, which we have with `targetBench()` to use a specific bench target and `--benches` to use all bench targets.