### PR TITLE
T: improve intention tests

### DIFF
--- a/intelliLang/src/test/kotlin/org/rust/ide/intentions/InjectLanguageIntentionTest.kt
+++ b/intelliLang/src/test/kotlin/org/rust/ide/intentions/InjectLanguageIntentionTest.kt
@@ -16,7 +16,7 @@ import org.intellij.plugins.intelliLang.inject.InjectLanguageAction
 import org.intellij.plugins.intelliLang.inject.InjectedLanguage
 import org.rust.lang.core.psi.ext.ancestorOrSelf
 
-class InjectLanguageIntentionTest : RsIntentionTestBase(InjectLanguageAction()) {
+class InjectLanguageIntentionTest : RsIntentionTestBase(InjectLanguageAction::class) {
     fun `test available inside string`() = checkAvailable("""
         const C: &str = "/*caret*/";
     """)

--- a/src/test/kotlin/org/rust/ide/intentions/AddCurlyBracesIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddCurlyBracesIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class AddCurlyBracesIntentionTest : RsIntentionTestBase(AddCurlyBracesIntention()) {
+class AddCurlyBracesIntentionTest : RsIntentionTestBase(AddCurlyBracesIntention::class) {
 
     fun `test add curly braces simple`() = doAvailableTest(
         "use std::m/*caret*/em;",

--- a/src/test/kotlin/org/rust/ide/intentions/AddDeriveIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddDeriveIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class AddDeriveIntentionTest : RsIntentionTestBase(AddDeriveIntention()) {
+class AddDeriveIntentionTest : RsIntentionTestBase(AddDeriveIntention::class) {
 
     fun `test add derive struct`() = doAvailableTest("""
         struct Te/*caret*/st {}

--- a/src/test/kotlin/org/rust/ide/intentions/AddElseIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddElseIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class AddElseIntentionTest : RsIntentionTestBase(AddElseIntention()) {
+class AddElseIntentionTest : RsIntentionTestBase(AddElseIntention::class) {
 
     fun test1() = doUnavailableTest("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/intentions/AddFmtStringArgumentIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddFmtStringArgumentIntentionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.intentions
 import org.intellij.lang.annotations.Language
 import org.rust.ide.intentions.addFmtStringArgument.AddFmtStringArgumentIntention
 
-class AddFmtStringArgumentIntentionTest : RsIntentionTestBase(AddFmtStringArgumentIntention()) {
+class AddFmtStringArgumentIntentionTest : RsIntentionTestBase(AddFmtStringArgumentIntention::class) {
     fun `test no args`() = doTest("""
         fn main() {
             println!("x = /*caret*/");

--- a/src/test/kotlin/org/rust/ide/intentions/AddImplIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddImplIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class AddImplIntentionTest : RsIntentionTestBase(AddImplIntention()) {
+class AddImplIntentionTest : RsIntentionTestBase(AddImplIntention::class) {
     fun `test simple struct`() = doAvailableTest("""
         struct Hey/*caret*/ {
             var: i32

--- a/src/test/kotlin/org/rust/ide/intentions/AddImportIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddImportIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class AddImportIntentionTest : RsIntentionTestBase(AddImportIntention()) {
+class AddImportIntentionTest : RsIntentionTestBase(AddImportIntention::class) {
     fun `test not available in use statements`() = doUnavailableTest("""
         mod foo {
             pub struct Foo;

--- a/src/test/kotlin/org/rust/ide/intentions/AddStructFieldsLiteralIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddStructFieldsLiteralIntentionTest.kt
@@ -6,235 +6,199 @@
 package org.rust.ide.intentions
 
 class AddStructFieldsLiteralIntentionTest : RsIntentionTestBase(AddStructFieldsLiteralIntention::class) {
-    fun `test smoke struct literal`() = doAvailableTest(
-        """
-            struct Foo { bar: i32, baz: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1 };
-                let bar = Foo { bar: 2, ./*caret*/.foo };
-            }
-        """,
-        """
-            struct Foo { bar: i32, baz: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1 };
-                let bar = Foo { bar: 2, baz: 0/*caret*/ };
-            }
-        """
-    )
+    fun `test smoke struct literal`() = doAvailableTest("""
+        struct Foo { bar: i32, baz: i32 }
 
-    fun `test smoke struct literal with space after dots`() = doAvailableTest(
-        """
-            struct Foo { bar: i32, baz: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1 };
-                let bar = Foo { bar: 2, ./*caret*/. foo };
-            }
-        """,
-        """
-            struct Foo { bar: i32, baz: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1 };
-                let bar = Foo { bar: 2, baz: 0/*caret*/ };
-            }
-        """
-    )
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1 };
+            let bar = Foo { bar: 2, ./*caret*/.foo };
+        }
+    """, """
+        struct Foo { bar: i32, baz: i32 }
 
-    fun `test struct literal with comment after dots`() = doAvailableTest(
-        """
-            struct Foo { bar: i32, baz: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1 };
-                let bar = Foo { bar: 2, ./*caret*/./*comment*/foo };
-            }
-        """,
-        """
-            struct Foo { bar: i32, baz: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1 };
-                let bar = Foo { bar: 2, /*comment*/ baz: 0/*caret*/ };
-            }
-        """
-    )
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1 };
+            let bar = Foo { bar: 2, baz: 0/*caret*/ };
+        }
+    """)
 
-    fun `test struct literal with inner struct`() = doAvailableTest(
-        """
-            struct Foo { bar: i32, baz: i32, quux: Bar }
-            
-            struct Bar { spam: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1, quux: Bar { spam: 2 } };
-                let bar = Foo { bar: 2, ./*caret*/.foo};
-            }
-        """,
-        """
-            struct Foo { bar: i32, baz: i32, quux: Bar }
-            
-            struct Bar { spam: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1, quux: Bar { spam: 2 } };
-                let bar = Foo { bar: 2, baz: 0/*caret*/, quux: Bar {} };
-            }
-        """
-    )
+    fun `test smoke struct literal with space after dots`() = doAvailableTest("""
+        struct Foo { bar: i32, baz: i32 }
 
-    fun `test struct literal with inner tuple struct`() = doAvailableTest(
-        """
-            struct Foo { bar: i32, baz: i32, quux: Bar }
-            
-            struct Bar(i32);
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1, quux: Bar(2) };
-                let bar = Foo { bar: 2, ./*caret*/.foo};
-            }
-        """,
-        """
-            struct Foo { bar: i32, baz: i32, quux: Bar }
-            
-            struct Bar(i32);
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1, quux: Bar(2) };
-                let bar = Foo { bar: 2, baz: 0/*caret*/, quux: Bar() };
-            }
-        """
-    )
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1 };
+            let bar = Foo { bar: 2, ./*caret*/. foo };
+        }
+    """, """
+        struct Foo { bar: i32, baz: i32 }
 
-    fun `test struct literal with second field`() = doAvailableTest(
-        """
-            struct Foo { bar: i32, baz: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1 };
-                let bar = Foo { baz: 2, ./*caret*/.foo };
-            }
-        """,
-        """
-            struct Foo { bar: i32, baz: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1 };
-                let bar = Foo { bar: 0/*caret*/, baz: 2, };
-            }
-        """
-    )
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1 };
+            let bar = Foo { bar: 2, baz: 0/*caret*/ };
+        }
+    """)
 
-    fun `test struct literal with second field in the middle`() = doAvailableTest(
-        """
-            struct Foo { bar: i32, baz: i32, quux: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1, quux: 2 };
-                let bar = Foo { baz: 2, ./*caret*/.foo };
-            }
-        """,
-        """
-            struct Foo { bar: i32, baz: i32, quux: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1, quux: 2 };
-                let bar = Foo { bar: 0/*caret*/, baz: 2, quux: 0 };
-            }
-        """
-    )
+    fun `test struct literal with comment after dots`() = doAvailableTest("""
+        struct Foo { bar: i32, baz: i32 }
 
-    fun `test struct literal with non existent field`() = doAvailableTest(
-        """
-            struct Foo { bar: i32, baz: i32, quux: i32 }
-            
-            fn f() {
-                let bar = Foo { baz: 2, ./*caret*/.foo };
-            }
-        """,
-        """
-            struct Foo { bar: i32, baz: i32, quux: i32 }
-            
-            fn f() {
-                let bar = Foo { bar: 0/*caret*/, baz: 2, quux: 0 };
-            }
-        """
-    )
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1 };
+            let bar = Foo { bar: 2, ./*caret*/./*comment*/foo };
+        }
+    """, """
+        struct Foo { bar: i32, baz: i32 }
 
-    fun `test struct literal with no fields`() = doAvailableTest(
-        """
-            struct Foo { bar: i32, baz: i32 }
-            
-            fn f() {
-                let bar = Foo { ./*caret*/.foo };
-            }
-        """,
-        """
-            struct Foo { bar: i32, baz: i32 }
-            
-            fn f() {
-                let bar = Foo { bar: 0/*caret*/, baz: 0 };
-            }
-        """
-    )
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1 };
+            let bar = Foo { bar: 2, /*comment*/ baz: 0/*caret*/ };
+        }
+    """)
 
-    fun `test tuple struct literal`() = doAvailableTest(
-        """
-            struct Foo(i32, i32);
-            
-            fn f() {
-                let foo = Foo { 0: 0, 1: 1 };
-                let bar = Foo { ./*caret*/.foo };
-            }
-        """,
-        """
-            struct Foo(i32, i32);
-            
-            fn f() {
-                let foo = Foo { 0: 0, 1: 1 };
-                let bar = Foo { 0: 0/*caret*/, 1: 0 };
-            }
-        """
-    )
+    fun `test struct literal with inner struct`() = doAvailableTest("""
+        struct Foo { bar: i32, baz: i32, quux: Bar }
 
-    fun `test tuple struct literal with second field`() = doAvailableTest(
-        """
-            struct Foo(i32, i32);
-            
-            fn f() {
-                let foo = Foo { 0: 0, 1: 1 };
-                let bar = Foo { 1: 2, ./*caret*/.foo };
-            }
-        """,
-        """
-            struct Foo(i32, i32);
-            
-            fn f() {
-                let foo = Foo { 0: 0, 1: 1 };
-                let bar = Foo { 0: 0/*caret*/, 1: 2, };
-            }
-        """
-    )
+        struct Bar { spam: i32 }
 
-    fun `test base struct in parentheses`() = doAvailableTest(
-        """
-            struct Foo { bar: i32, baz: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1 };
-                let bar = Foo { bar: 2, ./*caret*/.(foo) };
-            }
-        """,
-        """
-            struct Foo { bar: i32, baz: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1 };
-                let bar = Foo { bar: 2, baz: 0/*caret*/ };
-            }
-        """
-    )
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1, quux: Bar { spam: 2 } };
+            let bar = Foo { bar: 2, ./*caret*/.foo};
+        }
+    """, """
+        struct Foo { bar: i32, baz: i32, quux: Bar }
+
+        struct Bar { spam: i32 }
+
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1, quux: Bar { spam: 2 } };
+            let bar = Foo { bar: 2, baz: 0/*caret*/, quux: Bar {} };
+        }
+    """)
+
+    fun `test struct literal with inner tuple struct`() = doAvailableTest("""
+        struct Foo { bar: i32, baz: i32, quux: Bar }
+
+        struct Bar(i32);
+
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1, quux: Bar(2) };
+            let bar = Foo { bar: 2, ./*caret*/.foo};
+        }
+    """, """
+        struct Foo { bar: i32, baz: i32, quux: Bar }
+
+        struct Bar(i32);
+
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1, quux: Bar(2) };
+            let bar = Foo { bar: 2, baz: 0/*caret*/, quux: Bar() };
+        }
+    """)
+
+    fun `test struct literal with second field`() = doAvailableTest("""
+        struct Foo { bar: i32, baz: i32 }
+
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1 };
+            let bar = Foo { baz: 2, ./*caret*/.foo };
+        }
+    """, """
+        struct Foo { bar: i32, baz: i32 }
+
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1 };
+            let bar = Foo { bar: 0/*caret*/, baz: 2, };
+        }
+    """)
+
+    fun `test struct literal with second field in the middle`() = doAvailableTest("""
+        struct Foo { bar: i32, baz: i32, quux: i32 }
+
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1, quux: 2 };
+            let bar = Foo { baz: 2, ./*caret*/.foo };
+        }
+    """, """
+        struct Foo { bar: i32, baz: i32, quux: i32 }
+
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1, quux: 2 };
+            let bar = Foo { bar: 0/*caret*/, baz: 2, quux: 0 };
+        }
+    """)
+
+    fun `test struct literal with non existent field`() = doAvailableTest("""
+        struct Foo { bar: i32, baz: i32, quux: i32 }
+
+        fn f() {
+            let bar = Foo { baz: 2, ./*caret*/.foo };
+        }
+    """, """
+        struct Foo { bar: i32, baz: i32, quux: i32 }
+
+        fn f() {
+            let bar = Foo { bar: 0/*caret*/, baz: 2, quux: 0 };
+        }
+    """)
+
+    fun `test struct literal with no fields`() = doAvailableTest("""
+        struct Foo { bar: i32, baz: i32 }
+
+        fn f() {
+            let bar = Foo { ./*caret*/.foo };
+        }
+    """, """
+        struct Foo { bar: i32, baz: i32 }
+
+        fn f() {
+            let bar = Foo { bar: 0/*caret*/, baz: 0 };
+        }
+    """)
+
+    fun `test tuple struct literal`() = doAvailableTest("""
+        struct Foo(i32, i32);
+
+        fn f() {
+            let foo = Foo { 0: 0, 1: 1 };
+            let bar = Foo { ./*caret*/.foo };
+        }
+    """, """
+        struct Foo(i32, i32);
+
+        fn f() {
+            let foo = Foo { 0: 0, 1: 1 };
+            let bar = Foo { 0: 0/*caret*/, 1: 0 };
+        }
+    """)
+
+    fun `test tuple struct literal with second field`() = doAvailableTest("""
+        struct Foo(i32, i32);
+
+        fn f() {
+            let foo = Foo { 0: 0, 1: 1 };
+            let bar = Foo { 1: 2, ./*caret*/.foo };
+        }
+    """, """
+        struct Foo(i32, i32);
+
+        fn f() {
+            let foo = Foo { 0: 0, 1: 1 };
+            let bar = Foo { 0: 0/*caret*/, 1: 2, };
+        }
+    """)
+
+    fun `test base struct in parentheses`() = doAvailableTest("""
+        struct Foo { bar: i32, baz: i32 }
+
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1 };
+            let bar = Foo { bar: 2, ./*caret*/.(foo) };
+        }
+    """, """
+        struct Foo { bar: i32, baz: i32 }
+
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1 };
+            let bar = Foo { bar: 2, baz: 0/*caret*/ };
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/AddStructFieldsLiteralIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddStructFieldsLiteralIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class AddStructFieldsLiteralIntentionTest : RsIntentionTestBase(AddStructFieldsLiteralIntention()) {
+class AddStructFieldsLiteralIntentionTest : RsIntentionTestBase(AddStructFieldsLiteralIntention::class) {
     fun `test smoke struct literal`() = doAvailableTest(
         """
             struct Foo { bar: i32, baz: i32 }

--- a/src/test/kotlin/org/rust/ide/intentions/AddStructFieldsLiteralRecursiveTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddStructFieldsLiteralRecursiveTest.kt
@@ -6,76 +6,67 @@
 package org.rust.ide.intentions
 
 class AddStructFieldsLiteralRecursiveTest : RsIntentionTestBase(AddStructFieldsLiteralRecursiveIntention::class) {
-    fun `test struct literal with inner struct`() = doAvailableTest(
-        """
-            struct Foo { bar: i32, baz: i32, quux: Bar }
-            
-            struct Bar { spam: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1, quux: Bar { spam: 2} };
-                let bar = Foo { bar: 2, ./*caret*/.foo };
-            }
-        """,
-        """
-            struct Foo { bar: i32, baz: i32, quux: Bar }
-            
-            struct Bar { spam: i32 }
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1, quux: Bar { spam: 2} };
-                let bar = Foo { bar: 2, baz: 0/*caret*/, quux: Bar { spam: 0 } };
-            }
-        """
-    )
+    fun `test struct literal with inner struct`() = doAvailableTest("""
+        struct Foo { bar: i32, baz: i32, quux: Bar }
 
-    fun `test struct literal with inner tuple struct`() = doAvailableTest(
-        """
-            struct Foo { bar: i32, baz: i32, quux: Bar }
-            
-            struct Bar(i32);
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1, quux: Bar(2) };
-                let bar = Foo { bar: 2, ./*caret*/.foo };
-            }
-        """,
-        """
-            struct Foo { bar: i32, baz: i32, quux: Bar }
-            
-            struct Bar(i32);
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1, quux: Bar(2) };
-                let bar = Foo { bar: 2, baz: 0/*caret*/, quux: Bar(0) };
-            }
-        """
-    )
+        struct Bar { spam: i32 }
 
-    fun `test struct literal with double inner tuple structs`() = doAvailableTest(
-        """
-            struct Foo { bar: i32, baz: i32, quux: Bar }
-            
-            struct Bar(Baz, i32);
-            
-            struct Baz(i32, f64);
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1, quux: Bar(Baz(1, 3.14), 2) };
-                let bar = Foo { bar: 2, ./*caret*/.foo };
-            }
-        """,
-        """
-            struct Foo { bar: i32, baz: i32, quux: Bar }
-            
-            struct Bar(Baz, i32);
-            
-            struct Baz(i32, f64);
-            
-            fn f() {
-                let foo = Foo { bar: 0, baz: 1, quux: Bar(Baz(1, 3.14), 2) };
-                let bar = Foo { bar: 2, baz: 0/*caret*/, quux: Bar(Baz(0, 0.0), 0) };
-            }
-        """
-    )
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1, quux: Bar { spam: 2} };
+            let bar = Foo { bar: 2, ./*caret*/.foo };
+        }
+    """, """
+        struct Foo { bar: i32, baz: i32, quux: Bar }
+
+        struct Bar { spam: i32 }
+
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1, quux: Bar { spam: 2} };
+            let bar = Foo { bar: 2, baz: 0/*caret*/, quux: Bar { spam: 0 } };
+        }
+    """)
+
+    fun `test struct literal with inner tuple struct`() = doAvailableTest("""
+        struct Foo { bar: i32, baz: i32, quux: Bar }
+
+        struct Bar(i32);
+
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1, quux: Bar(2) };
+            let bar = Foo { bar: 2, ./*caret*/.foo };
+        }
+    """, """
+        struct Foo { bar: i32, baz: i32, quux: Bar }
+
+        struct Bar(i32);
+
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1, quux: Bar(2) };
+            let bar = Foo { bar: 2, baz: 0/*caret*/, quux: Bar(0) };
+        }
+    """)
+
+    fun `test struct literal with double inner tuple structs`() = doAvailableTest("""
+        struct Foo { bar: i32, baz: i32, quux: Bar }
+
+        struct Bar(Baz, i32);
+
+        struct Baz(i32, f64);
+
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1, quux: Bar(Baz(1, 3.14), 2) };
+            let bar = Foo { bar: 2, ./*caret*/.foo };
+        }
+    """, """
+        struct Foo { bar: i32, baz: i32, quux: Bar }
+
+        struct Bar(Baz, i32);
+
+        struct Baz(i32, f64);
+
+        fn f() {
+            let foo = Foo { bar: 0, baz: 1, quux: Bar(Baz(1, 3.14), 2) };
+            let bar = Foo { bar: 2, baz: 0/*caret*/, quux: Bar(Baz(0, 0.0), 0) };
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/AddStructFieldsLiteralRecursiveTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddStructFieldsLiteralRecursiveTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class AddStructFieldsLiteralRecursiveTest : RsIntentionTestBase(AddStructFieldsLiteralRecursiveIntention()) {
+class AddStructFieldsLiteralRecursiveTest : RsIntentionTestBase(AddStructFieldsLiteralRecursiveIntention::class) {
     fun `test struct literal with inner struct`() = doAvailableTest(
         """
             struct Foo { bar: i32, baz: i32, quux: Bar }

--- a/src/test/kotlin/org/rust/ide/intentions/AddStructFieldsPatIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddStructFieldsPatIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class AddStructFieldsPatIntentionTest : RsIntentionTestBase(AddStructFieldsPatIntention()) {
+class AddStructFieldsPatIntentionTest : RsIntentionTestBase(AddStructFieldsPatIntention::class) {
     fun `test simple case match`() = doAvailableTest("""
         struct Foo {
             a: i32,

--- a/src/test/kotlin/org/rust/ide/intentions/ChopArgumentListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ChopArgumentListIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class ChopArgumentListIntentionTest : RsIntentionTestBase(ChopArgumentListIntention()) {
+class ChopArgumentListIntentionTest : RsIntentionTestBase(ChopArgumentListIntention::class) {
     fun `test one parameter`() = doUnavailableTest("""
         fn foo(p1: i32) {}
         fn main() {

--- a/src/test/kotlin/org/rust/ide/intentions/ChopFieldListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ChopFieldListIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class ChopFieldListIntentionTest : RsIntentionTestBase(ChopFieldListIntention()) {
+class ChopFieldListIntentionTest : RsIntentionTestBase(ChopFieldListIntention::class) {
     fun `test one parameter`() = doUnavailableTest("""
         struct S { /*caret*/x: i32 }
     """)
@@ -40,7 +40,7 @@ class ChopFieldListIntentionTest : RsIntentionTestBase(ChopFieldListIntention())
     """)
 
     fun `test has some line breaks 2`() = doAvailableTest("""
-        struct S { 
+        struct S {
             x: i32, y: i32, z: i32/*caret*/
         }
     """, """
@@ -52,15 +52,15 @@ class ChopFieldListIntentionTest : RsIntentionTestBase(ChopFieldListIntention())
     """)
 
     fun `test has comment`() = doUnavailableTest("""
-        struct S { 
-            /*caret*/x: i32, /* comment */ 
+        struct S {
+            /*caret*/x: i32, /* comment */
             y: i32,
             z: i32
         }
     """)
 
     fun `test has comment 2`() = doAvailableTest("""
-        struct S { 
+        struct S {
             /*caret*/x: i32, /*
                 comment
             */y: i32,

--- a/src/test/kotlin/org/rust/ide/intentions/ChopLiteralFieldListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ChopLiteralFieldListIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class ChopLiteralFieldListIntentionTest : RsIntentionTestBase(ChopLiteralFieldListIntention()) {
+class ChopLiteralFieldListIntentionTest : RsIntentionTestBase(ChopLiteralFieldListIntention::class) {
     fun `test one parameter`() = doUnavailableTest("""
         struct S { x: i32 }
         fn foo {

--- a/src/test/kotlin/org/rust/ide/intentions/ChopParameterListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ChopParameterListIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class ChopParameterListIntentionTest : RsIntentionTestBase(ChopParameterListIntention()) {
+class ChopParameterListIntentionTest : RsIntentionTestBase(ChopParameterListIntention::class) {
     fun `test one parameter`() = doUnavailableTest("""
         fn foo(/*caret*/p1: i32) {}
     """)

--- a/src/test/kotlin/org/rust/ide/intentions/ChopVariantListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ChopVariantListIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class ChopVariantListIntentionTest : RsIntentionTestBase(ChopVariantListIntention()) {
+class ChopVariantListIntentionTest : RsIntentionTestBase(ChopVariantListIntention::class) {
     fun `test one parameter`() = doUnavailableTest("""
         enum E { /*caret*/A }
     """)

--- a/src/test/kotlin/org/rust/ide/intentions/ConvertMethodCallToUFCSTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ConvertMethodCallToUFCSTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class ConvertMethodCallToUFCSTest : RsIntentionTestBase(ConvertMethodCallToUFCSIntention()) {
+class ConvertMethodCallToUFCSTest : RsIntentionTestBase(ConvertMethodCallToUFCSIntention::class) {
     fun `test unavailable on function call`() = doUnavailableTest("""
         fn foo() {}
         fn bar() {

--- a/src/test/kotlin/org/rust/ide/intentions/ConvertUFCSToMethodCallTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ConvertUFCSToMethodCallTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class ConvertUFCSToMethodCallTest : RsIntentionTestBase(ConvertUFCSToMethodCallIntention()) {
+class ConvertUFCSToMethodCallTest : RsIntentionTestBase(ConvertUFCSToMethodCallIntention::class) {
     fun `test not available for methods`() = doUnavailableTest("""
         struct S;
         impl S {

--- a/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention()) {
+class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention::class) {
     fun `test unavailable on resolved function`() = doUnavailableTest("""
         fn foo() {}
 

--- a/src/test/kotlin/org/rust/ide/intentions/DemorgansLawIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/DemorgansLawIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class DemorgansLawIntentionTest : RsIntentionTestBase(DemorgansLawIntention()) {
+class DemorgansLawIntentionTest : RsIntentionTestBase(DemorgansLawIntention::class) {
 
     fun `test or`() = doAvailableTest("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/intentions/DestructureIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/DestructureIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class DestructureIntentionTest : RsIntentionTestBase(DestructureIntention()) {
+class DestructureIntentionTest : RsIntentionTestBase(DestructureIntention::class) {
 
     fun `test destructure variable`() = doAvailableTest("""
         struct S<T, U> { x: T, y: U }

--- a/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/FillMatchArmsIntentionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.intentions
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 
-class FillMatchArmsIntentionTest : RsIntentionTestBase(FillMatchArmsIntention()) {
+class FillMatchArmsIntentionTest : RsIntentionTestBase(FillMatchArmsIntention::class) {
 
     fun `test simple enum variants`() = doAvailableTest("""
         enum FooBar {

--- a/src/test/kotlin/org/rust/ide/intentions/FlattenUseStatementsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/FlattenUseStatementsIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class FlattenUseStatementsIntentionTest : RsIntentionTestBase(FlattenUseStatementsIntention()) {
+class FlattenUseStatementsIntentionTest : RsIntentionTestBase(FlattenUseStatementsIntention::class) {
     fun `test use statement with alias`() = doAvailableTest("""
         use std::collections::{
             /*caret*/HashMap as HM,
@@ -260,10 +260,7 @@ class FlattenUseStatementsIntentionTest : RsIntentionTestBase(FlattenUseStatemen
         use quux::eggs;
     """)
 
-    fun `test cannot nest if non common base path exist`() = doAvailableTest("""
-        use a1::/*caret*/b::c;
-        use a2::b::c;
-    """, """
+    fun `test cannot nest if non common base path exist`() = doUnavailableTest("""
         use a1::/*caret*/b::c;
         use a2::b::c;
     """)
@@ -279,10 +276,7 @@ class FlattenUseStatementsIntentionTest : RsIntentionTestBase(FlattenUseStatemen
         use ::a1::b2::c;
     """)
 
-    fun `test starts with colon colon with no colon colon`() = doAvailableTest("""
-        use ::a1/*caret*/::b::c;
-        use a1::b::c;
-    """, """
+    fun `test starts with colon colon with no colon colon`() = doUnavailableTest("""
         use ::a1/*caret*/::b::c;
         use a1::b::c;
     """)

--- a/src/test/kotlin/org/rust/ide/intentions/FlipBinaryExpressionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/FlipBinaryExpressionIntentionTest.kt
@@ -7,7 +7,7 @@ package org.rust.ide.intentions
 
 import org.rust.lang.core.psi.RsElementTypes.*
 
-class FlipBinaryExpressionIntentionTest : RsIntentionTestBase(FlipBinaryExpressionIntention()) {
+class FlipBinaryExpressionIntentionTest : RsIntentionTestBase(FlipBinaryExpressionIntention::class) {
 
     fun `test all available operators`() {
         val operators = FlipBinaryExpressionIntention.COMMUNICATIVE_OPERATORS +

--- a/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt
@@ -9,7 +9,7 @@ import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention()) {
+class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::class) {
     fun `test option with some`() = doAvailableTest("""
         fn main() {
             let x = Some(42);

--- a/src/test/kotlin/org/rust/ide/intentions/ImplTraitToTypeParamIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ImplTraitToTypeParamIntentionTest.kt
@@ -7,7 +7,7 @@ package org.rust.ide.intentions
 
 import org.rust.ide.intentions.ImplTraitToTypeParamIntention.Companion.outerImplTestMark
 
-class ImplTraitToTypeParamIntentionTest : RsIntentionTestBase(ImplTraitToTypeParamIntention()) {
+class ImplTraitToTypeParamIntentionTest : RsIntentionTestBase(ImplTraitToTypeParamIntention::class) {
     fun `test simple`() = doAvailableTest("""
         trait Trait{}
         fn test(arg: impl/*caret*/ Trait) {}

--- a/src/test/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/IntroduceLocalVariableIntentionTest.kt
@@ -10,7 +10,7 @@ package org.rust.ide.intentions
  * [org.rust.ide.refactoring.introduceVariable.RsIntroduceVariableHandler], so most of tests from
  * [org.rust.ide.refactoring.RsIntroduceVariableHandlerTest] are also applicable.
  */
-class IntroduceLocalVariableIntentionTest : RsIntentionTestBase(IntroduceLocalVariableIntention()) {
+class IntroduceLocalVariableIntentionTest : RsIntentionTestBase(IntroduceLocalVariableIntention::class) {
     fun `test unavailable if there is a variable`() = doUnavailableTest("""
         fn main() {
             let a = /*caret*/foo();

--- a/src/test/kotlin/org/rust/ide/intentions/InvertIfIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/InvertIfIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class InvertIfIntentionTest : RsIntentionTestBase(InvertIfIntention()) {
+class InvertIfIntentionTest : RsIntentionTestBase(InvertIfIntention::class) {
     fun `test if let unavailable`() = doUnavailableTest("""
         fn foo(a: Option<i32>) {
             if/*caret*/ let Some(x) = a {} else {}

--- a/src/test/kotlin/org/rust/ide/intentions/JoinArgumentListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/JoinArgumentListIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class JoinArgumentListIntentionTest : RsIntentionTestBase(JoinArgumentListIntention()) {
+class JoinArgumentListIntentionTest : RsIntentionTestBase(JoinArgumentListIntention::class) {
     fun `test one parameter`() = doAvailableTest("""
         fn foo(p1: i32) {}
         fn main() {

--- a/src/test/kotlin/org/rust/ide/intentions/JoinFieldListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/JoinFieldListIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class JoinFieldListIntentionTest : RsIntentionTestBase(JoinFieldListIntention()) {
+class JoinFieldListIntentionTest : RsIntentionTestBase(JoinFieldListIntention::class) {
     fun `test one parameter`() = doAvailableTest("""
         struct S {
             /*caret*/x: i32

--- a/src/test/kotlin/org/rust/ide/intentions/JoinLiteralFieldListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/JoinLiteralFieldListIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class JoinLiteralFieldListIntentionTest : RsIntentionTestBase(JoinLiteralFieldListIntention()) {
+class JoinLiteralFieldListIntentionTest : RsIntentionTestBase(JoinLiteralFieldListIntention::class) {
     fun `test one parameter`() = doAvailableTest("""
         struct S { x: i32 }
         fn foo() {

--- a/src/test/kotlin/org/rust/ide/intentions/JoinParameterListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/JoinParameterListIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class JoinParameterListIntentionTest : RsIntentionTestBase(JoinParameterListIntention()) {
+class JoinParameterListIntentionTest : RsIntentionTestBase(JoinParameterListIntention::class) {
     fun `test one parameter`() = doAvailableTest("""
         fn foo(
             /*caret*/p1: i32

--- a/src/test/kotlin/org/rust/ide/intentions/JoinVariantListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/JoinVariantListIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class JoinVariantListIntentionTest : RsIntentionTestBase(JoinVariantListIntention()) {
+class JoinVariantListIntentionTest : RsIntentionTestBase(JoinVariantListIntention::class) {
     fun `test one parameter`() = doAvailableTest("""
         enum E {
             /*caret*/A

--- a/src/test/kotlin/org/rust/ide/intentions/MatchToIfLetIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/MatchToIfLetIntentionTest.kt
@@ -9,7 +9,7 @@ import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention()) {
+class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::class) {
     fun `test unavailable all void arms`() = doUnavailableTest("""
         enum MyOption {
             Nothing,

--- a/src/test/kotlin/org/rust/ide/intentions/MoveGuardToMatchArmIntentionITest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/MoveGuardToMatchArmIntentionITest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class MoveGuardToMatchArmIntentionTest : RsIntentionTestBase(MoveGuardToMatchArmIntention()) {
+class MoveGuardToMatchArmIntentionTest : RsIntentionTestBase(MoveGuardToMatchArmIntention::class) {
     fun `test unavailable without match arm`() = doUnavailableTest("""
         fn main() {
             match 1 {

--- a/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToParameterListIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToParameterListIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class MoveTypeConstraintToParameterListIntentionTest : RsIntentionTestBase(MoveTypeConstraintToParameterListIntention()) {
+class MoveTypeConstraintToParameterListIntentionTest : RsIntentionTestBase(MoveTypeConstraintToParameterListIntention::class) {
 
     fun `test lifetimes and traits`() = doAvailableTest(
         """ fn foo<'a, 'b, 'c, T, U>() /*caret*/where 'b: 'a, 'c:'a, T: Clone, U: Copy {} """,

--- a/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToWhereClauseIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/MoveTypeConstraintToWhereClauseIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class MoveTypeConstraintToWhereClauseIntentionTest : RsIntentionTestBase(MoveTypeConstraintToWhereClauseIntention()) {
+class MoveTypeConstraintToWhereClauseIntentionTest : RsIntentionTestBase(MoveTypeConstraintToWhereClauseIntention::class) {
     fun `test function with return`() = doAvailableTest(
         """ fn foo<T: Send,/*caret*/ F: Sync>(t: T, f: F) -> i32 { 0 } """,
         """ fn foo<T, F>(t: T, f: F) -> i32 where T: Send, F: Sync/*caret*/ { 0 } """

--- a/src/test/kotlin/org/rust/ide/intentions/NestUseStatementsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/NestUseStatementsIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class NestUseStatementsIntentionTest : RsIntentionTestBase(NestUseStatementsIntention()) {
+class NestUseStatementsIntentionTest : RsIntentionTestBase(NestUseStatementsIntention::class) {
     fun `test simple use statements`() = doAvailableTest("""
         use /*caret*/std::error;
         use std::io;
@@ -225,10 +225,7 @@ class NestUseStatementsIntentionTest : RsIntentionTestBase(NestUseStatementsInte
         use quux::eggs;
     """)
 
-    fun `test cannot nest if non common base path exist`() = doAvailableTest("""
-        use a1::/*caret*/b::c;
-        use a2::b::c;
-    """, """
+    fun `test cannot nest if non common base path exist`() = doUnavailableTest("""
         use a1::/*caret*/b::c;
         use a2::b::c;
     """)
@@ -244,10 +241,7 @@ class NestUseStatementsIntentionTest : RsIntentionTestBase(NestUseStatementsInte
 
     """)
 
-    fun `test starts with colon colon with no colon colon`() = doAvailableTest("""
-        use ::a1/*caret*/::b::c;
-        use a1::b::c;
-    """, """
+    fun `test starts with colon colon with no colon colon`() = doUnavailableTest("""
         use ::a1/*caret*/::b::c;
         use a1::b::c;
     """)

--- a/src/test/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class RemoveCurlyBracesIntentionTest : RsIntentionTestBase(RemoveCurlyBracesIntention()) {
+class RemoveCurlyBracesIntentionTest : RsIntentionTestBase(RemoveCurlyBracesIntention::class) {
 
     fun `test remove curly braces simple`() = doAvailableTest(
         "use std::{m/*caret*/em};",

--- a/src/test/kotlin/org/rust/ide/intentions/RemoveDbgIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RemoveDbgIntentionTest.kt
@@ -6,7 +6,7 @@
 package org.rust.ide.intentions
 
 
-class RemoveDbgIntentionTest : RsIntentionTestBase(RemoveDbgIntention()) {
+class RemoveDbgIntentionTest : RsIntentionTestBase(RemoveDbgIntention::class) {
 
     fun `test remove dbg! from expr`() = doAvailableTest("""
         fn test() {

--- a/src/test/kotlin/org/rust/ide/intentions/ReplaceBlockCommentWithLineCommentIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ReplaceBlockCommentWithLineCommentIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class ReplaceBlockCommentWithLineCommentIntentionTest : RsIntentionTestBase(ReplaceBlockCommentWithLineCommentIntention()) {
+class ReplaceBlockCommentWithLineCommentIntentionTest : RsIntentionTestBase(ReplaceBlockCommentWithLineCommentIntention::class) {
 
     fun `test convert single block comment`() = doAvailableTest("""
         /* /*caret*/Hello, World! */

--- a/src/test/kotlin/org/rust/ide/intentions/ReplaceLineCommentWithBlockCommentIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ReplaceLineCommentWithBlockCommentIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class ReplaceLineCommentWithBlockCommentIntentionTest : RsIntentionTestBase(ReplaceLineCommentWithBlockCommentIntention()) {
+class ReplaceLineCommentWithBlockCommentIntentionTest : RsIntentionTestBase(ReplaceLineCommentWithBlockCommentIntention::class) {
 
     fun `test convert single line comment to block`() = doAvailableTest("""
         // /*caret*/Hello, World!

--- a/src/test/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentionBaseTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentionBaseTest.kt
@@ -5,11 +5,22 @@
 
 package org.rust.ide.intentions
 
+import com.intellij.codeInsight.intention.IntentionManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import org.rust.ide.actions.macroExpansion.MacroExpansionViewDetails
 
-class RsShowMacroExpansionIntentionBaseTest : RsIntentionTestBase(RsShowMacroExpansionIntention) {
+class RsShowMacroExpansionIntentionBaseTest : RsIntentionTestBase(RsShowMacroExpansionIntention::class) {
+
+    override fun setUp() {
+        super.setUp()
+        IntentionManager.getInstance().addAction(RsShowMacroExpansionIntention)
+    }
+
+    override fun tearDown() {
+        IntentionManager.getInstance().unregisterIntention(RsShowMacroExpansionIntention)
+        super.tearDown()
+    }
 
     fun `test that intention is not available outside of the macros`() {
         doUnavailableTest("""

--- a/src/test/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentionBaseTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentionBaseTest.kt
@@ -22,23 +22,18 @@ class RsShowMacroExpansionIntentionBaseTest : RsIntentionTestBase(RsShowMacroExp
         super.tearDown()
     }
 
-    fun `test that intention is not available outside of the macros`() {
-        doUnavailableTest("""
-            foo!();
-            /*caret*/foo();
-        """)
-    }
+    fun `test that intention is not available outside of the macros`() = doUnavailableTest("""
+        foo!();
+        /*caret*/foo();
+    """)
 
-    fun `test that intention is available on the macros, but does not change it`() {
-        doAvailableTest("""
-            /*caret*/foo!();
-            foo();
-        """, """
-            foo!();
-            foo();
-        """)
-    }
-
+    fun `test that intention is available on the macros, but does not change it`() = doAvailableTest("""
+        /*caret*/foo!();
+        foo();
+    """, """
+        foo!();
+        foo();
+    """)
 }
 
 object RsShowMacroExpansionIntention : RsShowMacroExpansionIntentionBase(expandRecursively = true) {

--- a/src/test/kotlin/org/rust/ide/intentions/SetImmutableIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SetImmutableIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class SetImmutableIntentionTest : RsIntentionTestBase(SetImmutableIntention()) {
+class SetImmutableIntentionTest : RsIntentionTestBase(SetImmutableIntention::class) {
     fun `test set mutable variable`() = doAvailableTest(
         """ fn main() { let var: &mut i3/*caret*/2 = 52; } """,
         """ fn main() { let var: &i3/*caret*/2 = 52; } """

--- a/src/test/kotlin/org/rust/ide/intentions/SetMutableIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SetMutableIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class SetMutableIntentionTest : RsIntentionTestBase(SetMutableIntention()) {
+class SetMutableIntentionTest : RsIntentionTestBase(SetMutableIntention::class) {
     fun `test set mutable variable`() = doAvailableTest(
         """ fn main() { let var: &i3/*caret*/2 = 52; } """,
         """ fn main() { let var: &mut i3/*caret*/2 = 52; } """

--- a/src/test/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SimplifyBooleanExpressionIntentionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.intentions
 /**
  * @author Moklev Vyacheslav
  */
-class SimplifyBooleanExpressionIntentionTest : RsIntentionTestBase(SimplifyBooleanExpressionIntention()) {
+class SimplifyBooleanExpressionIntentionTest : RsIntentionTestBase(SimplifyBooleanExpressionIntention::class) {
     fun `test or`() = doAvailableTest("""
         fn main() {
             let a = true /*caret*/|| false;

--- a/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
@@ -8,7 +8,7 @@ package org.rust.ide.intentions
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 
-class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplicitlyIntention()) {
+class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplicitlyIntention::class) {
     fun `test inferred type`() = doAvailableTest(
         """ fn main() { let var/*caret*/ = 42; } """,
         """ fn main() { let var: i32 = 42; } """

--- a/src/test/kotlin/org/rust/ide/intentions/SplitIfIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SplitIfIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class SplitIfIntentionTest : RsIntentionTestBase(SplitIfIntention()) {
+class SplitIfIntentionTest : RsIntentionTestBase(SplitIfIntention::class) {
 
     fun test1() = doUnavailableTest("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/intentions/SubstituteAssociatedTypeIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SubstituteAssociatedTypeIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class SubstituteAssociatedTypeIntentionTest : RsIntentionTestBase(SubstituteAssociatedTypeIntention()) {
+class SubstituteAssociatedTypeIntentionTest : RsIntentionTestBase(SubstituteAssociatedTypeIntention::class) {
     fun `test unavailable on type alias`() = doUnavailableTest("""
         type Alias = u32;
         fn foo() -> Alias/*caret*/ {

--- a/src/test/kotlin/org/rust/ide/intentions/ToggleIgnoreTestIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ToggleIgnoreTestIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class ToggleIgnoreTestIntentionTest : RsIntentionTestBase(ToggleIgnoreTestIntention()) {
+class ToggleIgnoreTestIntentionTest : RsIntentionTestBase(ToggleIgnoreTestIntention::class) {
     fun `test add ignore`() = doAvailableTest("""
         #[test]
         fn foo/*caret*/() {}

--- a/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class UnElideLifetimesIntentionTest : RsIntentionTestBase(UnElideLifetimesIntention()) {
+class UnElideLifetimesIntentionTest : RsIntentionTestBase(UnElideLifetimesIntention::class) {
     fun `test unavailable`() = doUnavailableTest(
         """
         fn bar/*caret*/(x: i32) -> i32 {}

--- a/src/test/kotlin/org/rust/ide/intentions/UnwrapSingleExprIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/UnwrapSingleExprIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class UnwrapSingleExprIntentionTest : RsIntentionTestBase(UnwrapSingleExprIntention()) {
+class UnwrapSingleExprIntentionTest : RsIntentionTestBase(UnwrapSingleExprIntention::class) {
     fun `test available lambda unwrap braces single expression`() = doAvailableTest("""
         fn main() {
             {

--- a/src/test/kotlin/org/rust/ide/intentions/UnwrapToMatchIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/UnwrapToMatchIntentionTest.kt
@@ -9,7 +9,7 @@ import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-class UnwrapToMatchIntentionTest: RsIntentionTestBase(UnwrapToMatchIntention()) {
+class UnwrapToMatchIntentionTest: RsIntentionTestBase(UnwrapToMatchIntention::class) {
 
     fun `test option base case`() = doAvailableTest("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/intentions/UnwrapToTryIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/UnwrapToTryIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class UnwrapToTryIntentionTest : RsIntentionTestBase(UnwrapToTryIntention()) {
+class UnwrapToTryIntentionTest : RsIntentionTestBase(UnwrapToTryIntention::class) {
     fun `test available 1`() = doAvailableTest("""
         fn main() {
             let a = a.unwrap/*caret*/();

--- a/src/test/kotlin/org/rust/ide/intentions/WrapLambdaExprIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/WrapLambdaExprIntentionTest.kt
@@ -5,7 +5,7 @@
 
 package org.rust.ide.intentions
 
-class WrapLambdaExprIntentionTest : RsIntentionTestBase(WrapLambdaExprIntention()) {
+class WrapLambdaExprIntentionTest : RsIntentionTestBase(WrapLambdaExprIntention::class) {
     fun `test available wrap braces`() = doAvailableTest(
         """
         fn main() {


### PR DESCRIPTION
* Look for necessary intention action only among registered intentions (i.e. ask platform to get list of available intentions). Should help to avoid fixes like #6050
* Fix formatting in some tests