### PR TITLE
 Use todo!() instead of unimplemented!() in generated bodies of implemented members.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -38,7 +38,6 @@ fan-tom
 farodin91
 FatalCatharsis
 Filippok
-flaghacker
 framlog
 garyttierney
 gejun123456
@@ -56,6 +55,7 @@ JakubAdamWieczorek
 Jezza
 johnthagen
 jonas-schievink
+KarelPeeters
 Keats
 king6cong
 Kobzol

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -38,6 +38,7 @@ fan-tom
 farodin91
 FatalCatharsis
 Filippok
+flaghacker
 framlog
 garyttierney
 gejun123456

--- a/src/main/kotlin/org/rust/ide/intentions/CreateFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/CreateFunctionIntention.kt
@@ -150,7 +150,7 @@ class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionInten
         } else ""
         val paramsText = parameters.joinToString(", ")
 
-        return factory.tryCreateFunction("$visibility $async fn $functionName$genericParams($paramsText)$returnType $whereClause {\n    unimplemented!()\n}")
+        return factory.tryCreateFunction("$visibility $async fn $functionName$genericParams($paramsText)$returnType $whereClause {\n    todo!()\n}")
     }
 
     private fun getTargetItemForFunction(path: RsPath): FunctionInsertionTarget? {

--- a/src/main/kotlin/org/rust/ide/intentions/UnwrapToMatchIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/UnwrapToMatchIntention.kt
@@ -39,7 +39,7 @@ class UnwrapToMatchIntention: RsElementBaseIntentionAction<UnwrapToMatchIntentio
         val generatedCode = buildString {
             append("match ${methodCall.receiver.text} {")
             append("${enumType.valueBranch},")
-            append("${enumType.nonValueMatcher} => unimplemented!(),")
+            append("${enumType.nonValueMatcher} => todo!(),")
             append("}")
         }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
@@ -169,7 +169,7 @@ private fun RsPsiFactory.createTraitMembers(
             is RsTypeAlias ->
                 "    type ${it.escapedName} = ();"
             is RsFunction ->
-                "    ${it.getSignatureText(subst, trait, impl) ?: ""}{\n        unimplemented!()\n    }"
+                "    ${it.getSignatureText(subst, trait, impl) ?: ""}{\n        todo!()\n    }"
             else ->
                 error("Unknown trait member")
         }

--- a/src/main/resources/intentionDescriptions/CreateFunctionIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/CreateFunctionIntention/after.rs.template
@@ -1,5 +1,5 @@
 fn foo(p0: i32, p1: i32) -> u32 {
-    unimplemented!()
+    todo!()
 }
 
 fn bar() {

--- a/src/main/resources/intentionDescriptions/SubstituteAssociatedTypeIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/SubstituteAssociatedTypeIntention/after.rs.template
@@ -1,6 +1,6 @@
 impl Iterator for Foo {
     type Item = i32;
     fn next(&mut self) -> Option<i32> {
-        unimplemented!()
+        todo!()
     }
 }

--- a/src/main/resources/intentionDescriptions/SubstituteAssociatedTypeIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/SubstituteAssociatedTypeIntention/before.rs.template
@@ -1,6 +1,6 @@
 impl Iterator for Foo {
     type Item = i32;
     fn next(&mut self) -> Option<<Self as Iterator>::<spot>Item</spot>> {
-        unimplemented!()
+        todo!()
     }
 }

--- a/src/main/resources/intentionDescriptions/UnwrapToMatchIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/UnwrapToMatchIntention/after.rs.template
@@ -1,6 +1,6 @@
 fn foo(x: Option<i32>) {
     match x {
         Some(x) => x,
-        None => unimplemented!(),
+        None => todo!(),
     };
 }

--- a/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
@@ -137,7 +137,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
     //- lib.rs
         pub fn foo() {
-            unimplemented!()
+            todo!()
         }
     """)
 
@@ -399,7 +399,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         fn bar() {
-            unimplemented!()/*caret*/
+            todo!()/*caret*/
         }
     """)
 
@@ -416,7 +416,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
 
         impl<T> S<T> where T: Trait {
             pub(crate) fn foo(&self, p0: i32, p1: i32) {
-                unimplemented!()
+                todo!()
             }
         }
 
@@ -436,7 +436,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
 
         impl S {
             pub(crate) fn foo(&self) {
-                unimplemented!()
+                todo!()
             }
         }
 
@@ -456,7 +456,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
 
         impl S {
             pub(crate) fn foo<R>(&self, p0: R) {
-                unimplemented!()
+                todo!()
             }
         }
 
@@ -479,7 +479,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
                 self.bar(0);
             }
             fn bar(&self, p0: i32) {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -498,7 +498,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
                 self.bar(t);
             }
             fn bar(&self, p0: T) {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -519,7 +519,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
                 self.bar(t);
             }
             fn bar(&self, p0: T) {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -541,7 +541,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
 
         impl S {
             pub(crate) fn bar(&self, p0: i32, p1: i32) {
-                unimplemented!()
+                todo!()
             }
         }
 
@@ -560,7 +560,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
 
         impl S {
             pub(crate) fn bar(&self, p0: i32, p1: i32) {
-                unimplemented!()
+                todo!()
             }
         }
 
@@ -579,7 +579,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
 
         impl S {
             pub(crate) fn bar(&self, p0: i32, p1: i32) -> u32 {
-                unimplemented!()
+                todo!()
             }
         }
 
@@ -606,7 +606,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
 
         impl S {
             pub(crate) fn bar(&self) {
-                unimplemented!()
+                todo!()
             }
         }
 
@@ -630,7 +630,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
 
         impl S {
             pub(crate) fn bar(&self) {
-                unimplemented!()
+                todo!()
             }
         }
 
@@ -659,7 +659,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
 
         impl S {
             pub fn foo(&self) {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -674,7 +674,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
 
         impl S {
             fn bar(p0: i32, p1: i32) {
-                unimplemented!()
+                todo!()
             }
         }
 
@@ -697,7 +697,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
 
         impl S {
             fn bar(p0: i32, p1: i32) {
-                unimplemented!()
+                todo!()
             }
         }
 
@@ -716,7 +716,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
 
         impl<T> S<T> {
             fn bar(p0: i32, p1: i32) {
-                unimplemented!()
+                todo!()
             }
         }
 
@@ -736,7 +736,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         async fn bar() {
-            unimplemented!()
+            todo!()
         }
     """)
 
@@ -755,7 +755,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         async fn bar() {
-            unimplemented!()
+            todo!()
         }
     """)
 
@@ -778,7 +778,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         async fn bar() {
-            unimplemented!()
+            todo!()
         }
     """)
 
@@ -795,7 +795,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
                 bar().await;
             }
             async fn bar() {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -819,7 +819,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
                 self.bar(1, 2).await;
             }
             async fn bar(&self, p0: i32, p1: i32) {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -845,7 +845,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
                 };
             }
             async fn bar(&self, p0: i32, p1: i32) {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -875,7 +875,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
                 };
             }
             async fn bar(&self, p0: i32, p1: i32) {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -896,7 +896,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
 
         impl S {
             async fn bar(&self, p0: i32, p1: i32) {
-                unimplemented!()
+                todo!()
             }
         }
 
@@ -921,7 +921,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         fn bar() -> u32 {
-            unimplemented!()
+            todo!()
         }
 
         async fn baz(a: u32) {}
@@ -940,7 +940,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
 
         impl S {
             pub(crate) fn bar(&self) -> u32 {
-                unimplemented!()
+                todo!()
             }
         }
 

--- a/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
@@ -78,7 +78,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         fn foo() {
-            unimplemented!()/*caret*/
+            todo!()/*caret*/
         }
     """)
 
@@ -91,7 +91,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
     """, """
         mod foo {
             pub(crate) fn bar() {
-                unimplemented!()/*caret*/
+                todo!()/*caret*/
             }
         }
 
@@ -120,7 +120,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
             fn test() {}
 
             pub(crate) fn bar() {
-                unimplemented!()
+                todo!()
             }
     """)
 
@@ -159,7 +159,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
                 bar();
             }
             fn bar() {
-                unimplemented!()/*caret*/
+                todo!()/*caret*/
             }
         }
     """)
@@ -177,7 +177,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
             }
 
             fn bar() {
-                unimplemented!()/*caret*/
+                todo!()/*caret*/
             }
         }
     """)
@@ -194,7 +194,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         fn foo(p0: i32, p1: &str, p2: &i32) {
-            unimplemented!()
+            todo!()
         }
     """)
 
@@ -214,7 +214,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         fn bar<T, R: Trait1>(p0: R, p1: T, p2: T) where T: Trait2 {
-            unimplemented!()
+            todo!()
         }
     """)
 
@@ -240,7 +240,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         fn bar<'a, R, T: 'a>(p0: T, p1: &R) where R: Trait + for<'d> Fn(&'d i32), T: Trait + Trait2, for<'c> T: Fn(&'c i32) + Trait {
-            unimplemented!()
+            todo!()
         }
     """)
 
@@ -256,7 +256,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
                 baz(t);
             }
             fn baz<T>(p0: T) where T: Bar {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -271,7 +271,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         fn bar() -> u32 {
-            unimplemented!()
+            todo!()
         }
     """)
 
@@ -287,7 +287,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         fn bar() -> u32 {
-            unimplemented!()
+            todo!()
         }
     """)
 
@@ -303,7 +303,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         fn baz() -> u32 {
-            unimplemented!()
+            todo!()
         }
     """)
 
@@ -325,7 +325,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         fn baz() -> u32 {
-            unimplemented!()
+            todo!()
         }
     """)
 
@@ -349,7 +349,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         fn baz() -> u32 {
-            unimplemented!()
+            todo!()
         }
     """)
 
@@ -371,7 +371,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         fn baz() -> &S {
-            unimplemented!()
+            todo!()
         }
     """)
 
@@ -385,7 +385,7 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
 
         fn bar<T>() -> T {
-            unimplemented!()
+            todo!()
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/intentions/UnwrapToMatchIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/UnwrapToMatchIntentionTest.kt
@@ -21,7 +21,7 @@ class UnwrapToMatchIntentionTest: RsIntentionTestBase(UnwrapToMatchIntention::cl
             let a: Option<i32> = Some(42);
             let a = match a {
                 Some(x) => x,
-                None => unimplemented!(),
+                None => todo!(),
             };
         }
     """)
@@ -36,7 +36,7 @@ class UnwrapToMatchIntentionTest: RsIntentionTestBase(UnwrapToMatchIntention::cl
             let a: Result<i32, &str> = Ok(42);
             let a = match a {
                 Ok(x) => x,
-                Err(_) => unimplemented!(),
+                Err(_) => todo!(),
             };
         }
     """)
@@ -53,7 +53,7 @@ class UnwrapToMatchIntentionTest: RsIntentionTestBase(UnwrapToMatchIntention::cl
             let a : Option<&str> = None;
             let a = match a {
                 Some(x) => x,
-                None => unimplemented!(),
+                None => todo!(),
             };
         }
     """)
@@ -76,7 +76,7 @@ class UnwrapToMatchIntentionTest: RsIntentionTestBase(UnwrapToMatchIntention::cl
             let a = Test{};
             match a.b() {
                 Some(x) => x,
-                None => unimplemented!(),
+                None => todo!(),
             }.d().e().f();
         }
 
@@ -99,7 +99,7 @@ class UnwrapToMatchIntentionTest: RsIntentionTestBase(UnwrapToMatchIntention::cl
             let b = Some(50);
             f(a, match b {
                 Some(x) => x,
-                None => unimplemented!(),
+                None => todo!(),
             }, c)
         }
     """)
@@ -114,7 +114,7 @@ class UnwrapToMatchIntentionTest: RsIntentionTestBase(UnwrapToMatchIntention::cl
             let x: Result<i32, &str> = Err("test");
             let x = match x {
                 Ok(x) => x,
-                Err(_) => unimplemented!(),
+                Err(_) => todo!(),
             } + 42;
         }
     """)
@@ -129,7 +129,7 @@ class UnwrapToMatchIntentionTest: RsIntentionTestBase(UnwrapToMatchIntention::cl
             let x = Some(Some(Some(42)));
             let x = match x.unwrap() {
                 Some(x) => x,
-                None => unimplemented!(),
+                None => todo!(),
             }.unwrap();
         }
     """)

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -1225,11 +1225,11 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl Foo for S {
             fn foo(&self) {
-                unimplemented!()
+                todo!()
             }
 
             fn baz(&self) {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -1253,7 +1253,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct Bar;
         impl Foo for Bar {
             fn foo() -> S {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -1277,7 +1277,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct Bar;
         impl Foo for Bar {
             fn foo() -> S<u64> {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -1307,7 +1307,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct Bar;
         impl Foo for Bar {
             fn foo() -> S {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -1331,7 +1331,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct Bar;
         impl Foo for Bar {
             fn foo() -> S<i32, u32> {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -1357,7 +1357,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct Bar;
         impl Foo for Bar {
             fn foo(_: A<i32>) -> A {
-                unimplemented!()
+                todo!()
             }
         }
     """)

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -37,7 +37,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
             struct S;
             impl T for S {
                 fn f1() {
-                    unimplemented!()
+                    todo!()
                 }
             }
         """) {
@@ -84,11 +84,11 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T for S {
             fn f1() {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
 
             fn f4() {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -116,7 +116,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T for S {
             fn f() -> (R, R) {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -146,7 +146,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T for S {
             fn f() -> (R, U) {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -180,7 +180,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T<i32> for S {
             fn f() -> U<i32> {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -204,7 +204,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T for S {
             fn f() -> (R, U) {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -224,7 +224,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T for S {
             fn call(handler: extern fn(bool)) {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -244,7 +244,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T<fn(), extern fn(), fn(bool)> for S {
             fn call(z: fn(bool), x: fn(), y: extern fn()) {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -264,7 +264,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T for S {
             fn call(handler: extern fn()) {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -284,7 +284,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T<extern fn(bool)> for S {
             fn call(handler: extern fn(bool)) {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -313,11 +313,11 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T for S {
             unsafe fn f1() {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
 
             unsafe fn f4() {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -346,11 +346,11 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T for S {
             async fn f1() {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
 
             async fn f4() {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -382,23 +382,23 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T for S {
             fn f1(a: i8, b: i16, c: i32, d: i64) {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
 
             fn f2(a: (i32, u32)) {
-                unimplemented!()
+                todo!()
             }
 
             fn f3(_: u32, _: u64) {
-                unimplemented!()
+                todo!()
             }
 
             fn f4() -> bool {
-                unimplemented!()
+                todo!()
             }
 
             fn f5(a: f64, b: bool) -> (i8, u8) {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -489,7 +489,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T for S {
             fn f1() {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
 
             type T1 = ();
@@ -527,19 +527,19 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T<u8, u16> for S {
             fn f1(_: u8) -> u8 {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
 
             const C1: u8 = 0;
 
             fn f2(_: u16) -> u16 {
-                unimplemented!()
+                todo!()
             }
 
             const C2: u16 = 0;
 
             fn f3(_: u32) -> u32 {
-                unimplemented!()
+                todo!()
             }
 
             const C3: u32 = 0;
@@ -605,43 +605,43 @@ class ImplementMembersHandlerTest : RsTestBase() {
     }
     impl<'b> T<'b> for S<'b> {
         fn f1(&'b self) -> &'b str {
-            <selection>unimplemented!()</selection>
+            <selection>todo!()</selection>
         }
 
         const C1: &'b str = "";
 
         fn f2(_: &'b S<'b>) -> &'b S<'b> {
-            unimplemented!()
+            todo!()
         }
 
         const C2: &'b S<'b> = &S { x: "" };
 
         fn f3(_: &'b A<'b>) -> &'b A<'b> {
-            unimplemented!()
+            todo!()
         }
 
         const C3: &'b A<'b> = &S { x: "" };
 
         fn f4(_: &'b B) -> &'b B {
-            unimplemented!()
+            todo!()
         }
 
         const C4: &'b B = &S { x: "" };
 
         fn f5(_: &'b C) -> &'b C {
-            unimplemented!()
+            todo!()
         }
 
         const C5: &'b C = &S { x: "" };
 
         fn f6(_: &'b D<'b, D<'b, D<'b, S<'b>>>>) -> &'b D<'b, D<'b, D<'b, S<'b>>>> {
-            unimplemented!()
+            todo!()
         }
 
         const C6: &'b D<'b, D<'b, D<'b, S<'b>>>> = &D { x: &() };
 
         fn f7(&self) -> &str {
-            unimplemented!()
+            todo!()
         }
     }
     """)
@@ -667,7 +667,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T for S {
             fn r#type() {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
 
             type r#const = ();
@@ -711,25 +711,25 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
         impl T<1> for S<1> {
             fn f1(_: S<1>) -> S<1> {
-                unimplemented!()
+                todo!()
             }
 
             const C1: S<1> = S;
 
             fn f2(_: S<{}>) -> S<{}> {
-                unimplemented!()
+                todo!()
             }
 
             const C2: S<{}> = S;
 
             fn f3(_: [i32; 1]) -> [i32; 1] {
-                unimplemented!()
+                todo!()
             }
 
             const C3: [i32; 1] = [];
 
             fn f4(_: [i32; {}]) -> [i32; {}] {
-                unimplemented!()
+                todo!()
             }
 
             const C4: [i32; {}] = [];
@@ -760,13 +760,13 @@ class ImplementMembersHandlerTest : RsTestBase() {
         }
         impl <const K: usize> T<{ K }> for S<{ K }> {
             fn f1(_: S<{ K }>) -> S<{ K }> {
-                unimplemented!()
+                todo!()
             }
 
             const C1: S<{ K }> = S;
 
             fn f2(_: [i32; K]) -> [i32; K] {
-                unimplemented!()
+                todo!()
             }
 
             const C2: [i32; K] = [];
@@ -798,7 +798,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
             fn f1() { }
 
             fn f2() {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -825,7 +825,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T for S {
             fn f1() {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
 
             fn f2() { }
@@ -862,7 +862,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T for S {
             fn f1() {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
 
             type T1 = u32;
@@ -907,7 +907,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
             type T1 = u32;
 
             fn f1() {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
 
             const C1: i32 = 0;
@@ -941,7 +941,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
         struct S;
         impl T for S {
             fn x() {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
 
             type y = ();
@@ -974,7 +974,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
             type Item = <selection>()</selection>;
 
             fn foo() -> Self::Item {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -1009,7 +1009,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
             foo!(foo, {});
 
             fn bar() {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
 
             fn baz() {}
@@ -1035,7 +1035,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
 
         impl Baz for Foo {
             fn baz(&self, bar: &mut Bar) {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -1060,7 +1060,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
 
         impl Baz for Foo {
             fn baz(self: Box<Self>, bar: &mut Bar) {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -1086,7 +1086,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
 
         impl Bar for Foo {
             fn bar(&self) -> &dyn A + B {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -1111,7 +1111,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
 
         impl Baz for Foo {
             fn baz(&self) -> Box<dyn Fn(i32, i32) -> i32> {
-                unimplemented!()
+                todo!()
             }
         }
     """)
@@ -1135,7 +1135,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
 
         impl Baz for Foo {
             fn baz(self: *const Self, bar: &mut Bar) {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -1162,7 +1162,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
 
         impl Baz for Foo {
             fn baz(self: Pin<&mut Self>, bar: &mut Bar) {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
         }
     """)
@@ -1189,7 +1189,7 @@ class ImplementMembersHandlerTest : RsTestBase() {
 
         impl<'a> Baz<'a> for Foo {
             fn baz(self: Pin<&'a mut Self>, bar: &mut Bar) {
-                <selection>unimplemented!()</selection>
+                <selection>todo!()</selection>
             }
         }
     """)


### PR DESCRIPTION
This fixes #6043.