### PR TITLE
CI: cache evcxr in check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,6 +63,17 @@ jobs:
                   components: rust-src, rustfmt, clippy
                   default: true
 
+            - name: Cache evcxr
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      ~/.cargo/bin/evcxr
+                      ~/.cargo/.crates.toml
+                      ~/.cargo/.crates2.json
+                  key: ${{ runner.os }}-cache-evcxr-${{ matrix.rust-version }}-${{ github.run_id }} # https://github.com/actions/cache/issues/342#issuecomment-673371329
+                  restore-keys: |
+                      ${{ runner.os }}-cache-evcxr-${{ matrix.rust-version }}-
+
             - name: Install evcxr
               if: matrix.os != 'windows-latest' && matrix.rust-version >= '1.40.0' # BACKCOMPAT: Rust 1.39.0
               uses: actions-rs/cargo@v1


### PR DESCRIPTION
This PR caches `evcxr` so that it is not recompiled in every `check` workflow. This should hopefully reduce the runtime of this workflow on Ubuntu by about 2 minutes (~ 10% of the total runtime).

I also tried to cache the `Download` task, but I'm not sure what does it download. When I cached the `deps` folder, it still took a long time to run the download task (it probably also downloads some gradle stuff?).