### PR TITLE
REF: Add explicit visibility check in move refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
@@ -237,7 +237,8 @@ class RsMoveCommonProcessor(
             target.qualifiedNameInCrate(targetMod)
                 ?.toRsPathInEmptyTmpMod(codeFragmentFactory, psiFactory, targetMod)
         }
-        val pathNewAccessible = RsImportHelper.findPath(targetMod, target)?.toRsPath(psiFactory)
+        val pathNewAccessible = RsImportHelper.findPath(targetMod, target)
+            ?.toRsPathInEmptyTmpMod(codeFragmentFactory, psiFactory, targetMod)
 
         return RsMoveReferenceInfo(path, pathNewAccessible, pathNewFallback, target)
     }

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
@@ -134,7 +134,10 @@ object RsMoveUtil {
         if (target.containingFile is DummyHolder) LOG.error("Target $target of path '$text' is inside dummy holder")
         val reference = reference ?: return false
         if (!reference.isReferenceTo(target)) return false
+        return isTargetOfEachSubpathAccessible()
+    }
 
+    fun RsPath.isTargetOfEachSubpathAccessible(): Boolean {
         for (subpath in generateSequence(this) { it.path }) {
             val subpathTarget = subpath.reference?.resolve() as? RsVisible ?: continue
             if (!subpathTarget.isVisibleFrom(containingMod)) return false
@@ -217,6 +220,7 @@ fun <T : RsElement> movedElementsDeepDescendantsOfType(
  */
 fun RsVisRestriction.updateScopeIfNecessary(psiFactory: RsPsiFactory, newParent: RsMod) {
     if (crateRoot == newParent.crateRoot) {
+        if (path.kind == PathKind.SELF) return  // `pub(self)`
         // TODO: pass `oldScope` as parameter?
         val oldScope = path.reference?.resolve() as? RsMod ?: return
         val newScope = commonParentMod(oldScope, newParent) ?: return

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
@@ -35,6 +35,17 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         mod mod2/*target*/ {}
     """)
 
+    fun `test outside reference to item which has pub(in old_parent_mod) visibility`() = doTestConflictsError("""
+    //- lib.rs
+        mod mod1 {
+            fn foo/*caret*/() { bar::bar_func(); }
+            pub mod bar {
+                pub(super) fn bar_func() {}  // private for mod2
+            }
+        }
+        mod mod2/*target*/ {}
+    """)
+
     fun `test outside reference to private method of struct in old mod using UFCS`() = doTestConflictsError("""
     //- lib.rs
         mod mod1 {
@@ -483,7 +494,7 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
                 mod mod2 {
                     pub(crate) fn foo1() {}
 
-                    pub(in crate::inner1::inner2) fn foo2() {}
+                    pub(self) fn foo2() {}
 
                     pub(in crate::inner1::inner2) fn foo3() {}
 


### PR DESCRIPTION
[`RsImportHelper` can find private path](https://github.com/intellij-rust/intellij-rust/issues/4000), so we have to explicitly check accessibility of such paths