### PR TITLE
TOML: add folding builder

### DIFF
--- a/intellij-toml/src/main/kotlin/org/toml/ide/folding/TomlFoldingBuilder.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/folding/TomlFoldingBuilder.kt
@@ -1,0 +1,72 @@
+package org.toml.ide.folding;
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingBuilderEx
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.toml.lang.psi.*
+
+class TomlFoldingBuilder : FoldingBuilderEx(), DumbAware {
+    override fun buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
+        if (root !is TomlFile) return emptyArray()
+
+        val visitor = TomlFoldingVisitor()
+        root.accept(visitor)
+        return visitor.folds.toTypedArray()
+    }
+
+    override fun getPlaceholderText(node: ASTNode): String = when (node.elementType) {
+        TomlElementTypes.ARRAY -> "[...]"
+        else -> "{...}"
+    }
+
+    override fun isCollapsedByDefault(node: ASTNode): Boolean = false
+}
+
+private class TomlFoldingVisitor: TomlRecursiveVisitor() {
+    val folds: List<FoldingDescriptor>
+        get() = descriptors
+    private val descriptors: MutableList<FoldingDescriptor> = mutableListOf()
+
+    override fun visitTable(element: TomlTable) {
+        if (element.entries.isNotEmpty()) {
+            foldChildren(element, element.header.nextSibling, element.lastChild)
+            super.visitTable(element)
+        }
+    }
+
+    override fun visitArrayTable(element: TomlArrayTable) {
+        if (element.entries.isNotEmpty()) {
+            foldChildren(element, element.header.nextSibling, element.lastChild)
+            super.visitArrayTable(element)
+        }
+    }
+
+    override fun visitInlineTable(element: TomlInlineTable) {
+        if (element.entries.isNotEmpty()) {
+            fold(element)
+            super.visitInlineTable(element)
+        }
+    }
+
+    override fun visitArray(element: TomlArray) {
+        if (element.elements.isNotEmpty()) {
+            fold(element)
+            super.visitArray(element)
+        }
+    }
+
+    private fun fold(element: PsiElement) {
+        descriptors += FoldingDescriptor(element.node, element.textRange)
+    }
+
+    private fun foldChildren(element: PsiElement, firstChild: PsiElement, lastChild: PsiElement) {
+        val start = firstChild.textRange.startOffset
+        val end = lastChild.textRange.endOffset
+        descriptors += FoldingDescriptor(element.node, TextRange(start, end))
+    }
+}

--- a/intellij-toml/src/main/resources/META-INF/plugin.xml
+++ b/intellij-toml/src/main/resources/META-INF/plugin.xml
@@ -41,6 +41,9 @@
         <langCodeStyleSettingsProvider
             implementation="org.toml.ide.formatter.settings.TomlLanguageCodeStyleSettingsProvider"/>
 
+        <!-- Folding -->
+        <lang.foldingBuilder language="TOML" implementationClass="org.toml.ide.folding.TomlFoldingBuilder"/>
+
         <colorSettingsPage implementation="org.toml.ide.colors.TomlColorSettingsPage"/>
         <indexPatternBuilder implementation="org.toml.ide.todo.TomlTodoIndexPatternBuilder"/>
         <todoIndexer filetype="TOML" implementationClass="org.toml.ide.todo.TomlTodoIndexer"/>

--- a/intellij-toml/src/test/kotlin/org/toml/TomlTestBase.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/TomlTestBase.kt
@@ -5,10 +5,15 @@
 
 package org.toml
 
+import com.intellij.TestCase
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import org.intellij.lang.annotations.Language
 
 abstract class TomlTestBase : BasePlatformTestCase() {
+    open val dataPath: String = ""
+
+    override fun getTestDataPath(): String = "${TestCase.testResourcesPath}/$dataPath"
+
     @Suppress("TestFunctionName")
     protected fun InlineFile(@Language("TOML") text: String, name: String = "example.toml") {
         myFixture.configureByText(name, text)
@@ -22,5 +27,13 @@ abstract class TomlTestBase : BasePlatformTestCase() {
         InlineFile(before)
         action()
         myFixture.checkResult(after)
+    }
+
+    protected val testName: String
+        get() = getTestName(true)
+
+    override fun getTestName(lowercaseFirstLetter: Boolean): String {
+        val camelCase = super.getTestName(lowercaseFirstLetter)
+        return TestCase.camelOrWordsToSnake(camelCase)
     }
 }

--- a/intellij-toml/src/test/kotlin/org/toml/ide/folding/TomlFoldingBuilderTest.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/ide/folding/TomlFoldingBuilderTest.kt
@@ -14,6 +14,7 @@ class TomlFoldingBuilderTest : TomlTestBase() {
     fun `test array table`() = doTest()
     fun `test inline table`() = doTest()
     fun `test array`() = doTest()
+    fun `test custom regions`() = doTest()
 
     private fun doTest() {
         val fileName = "$testName.toml"

--- a/intellij-toml/src/test/kotlin/org/toml/ide/folding/TomlFoldingBuilderTest.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/ide/folding/TomlFoldingBuilderTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.folding
+
+import org.toml.TomlTestBase
+
+class TomlFoldingBuilderTest : TomlTestBase() {
+    override val dataPath = "org/toml/ide/folding/fixtures"
+
+    fun `test table`() = doTest()
+    fun `test array table`() = doTest()
+    fun `test inline table`() = doTest()
+    fun `test array`() = doTest()
+
+    private fun doTest() {
+        val fileName = "$testName.toml"
+        myFixture.testFolding("$testDataPath/$fileName")
+    }
+}

--- a/intellij-toml/src/test/resources/org/toml/ide/folding/fixtures/array.toml
+++ b/intellij-toml/src/test/resources/org/toml/ide/folding/fixtures/array.toml
@@ -1,0 +1,4 @@
+[table]<fold text='{...}'>
+a = <fold text='[...]'>[1, 2, 3]</fold>
+b = []
+c = <fold text='[...]'>[<fold text='{...}'>{ a = 5 }</fold>]</fold></fold>

--- a/intellij-toml/src/test/resources/org/toml/ide/folding/fixtures/array_table.toml
+++ b/intellij-toml/src/test/resources/org/toml/ide/folding/fixtures/array_table.toml
@@ -1,0 +1,5 @@
+[[table]]<fold text='{...}'>
+a = 1
+b = 2</fold>
+
+[[empty_table]]

--- a/intellij-toml/src/test/resources/org/toml/ide/folding/fixtures/custom_regions.toml
+++ b/intellij-toml/src/test/resources/org/toml/ide/folding/fixtures/custom_regions.toml
@@ -1,0 +1,12 @@
+<fold text='...'>#region
+[table]<fold text='{...}'>
+a = 1
+b = 2</fold>
+#endregion</fold>
+
+[table2]<fold text='{...}'>
+a = 1
+<fold text='...'>#region
+b = 2
+#endregion</fold>
+c = 3</fold>

--- a/intellij-toml/src/test/resources/org/toml/ide/folding/fixtures/inline_table.toml
+++ b/intellij-toml/src/test/resources/org/toml/ide/folding/fixtures/inline_table.toml
@@ -1,0 +1,3 @@
+[table]<fold text='{...}'>
+a = <fold text='{...}'>{ a = 1, b = <fold text='[...]'>[2, 3]</fold> }</fold>
+b = {}</fold>

--- a/intellij-toml/src/test/resources/org/toml/ide/folding/fixtures/table.toml
+++ b/intellij-toml/src/test/resources/org/toml/ide/folding/fixtures/table.toml
@@ -1,0 +1,5 @@
+[table]<fold text='{...}'>
+a = 1
+b = 2</fold>
+
+[empty_table]


### PR DESCRIPTION
This PR adds a folding provider for TOML.

![fold](https://user-images.githubusercontent.com/4539057/92448228-99830b00-f1b8-11ea-9971-08c1ac8081dc.gif)

Since there is no `TomlVisitor`, I just used `PsiTreeUtil.processElements` to go through all PSI elements recursively.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/6083

changelog: Provide folding in TOML files. Currently, it supports tables, arrays, and custom folding regions