### PR TITLE
Remove build_helper from std dependencies

### DIFF
--- a/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
@@ -40,9 +40,9 @@ object AutoInjectedCrates {
         // Roots
         StdLibInfo(CORE, StdLibType.ROOT),
         StdLibInfo(STD, StdLibType.ROOT, dependencies = listOf("alloc", "panic_unwind", "panic_abort",
-            CORE, "libc", "compiler_builtins", "profiler_builtins", "unwind", "build_helper")),
+            CORE, "libc", "compiler_builtins", "profiler_builtins", "unwind")),
         StdLibInfo("alloc", StdLibType.ROOT, dependencies = listOf(CORE, "compiler_builtins")),
-        StdLibInfo("proc_macro", type = StdLibType.ROOT, dependencies = listOf(STD, "syntax")),
+        StdLibInfo("proc_macro", type = StdLibType.ROOT, dependencies = listOf(STD)),
         StdLibInfo("test", type = StdLibType.ROOT, dependencies = listOf(STD, CORE, "libc", "getopts", "term")),
         // Feature gated
         StdLibInfo("libc", StdLibType.FEATURE_GATED),
@@ -54,9 +54,6 @@ object AutoInjectedCrates {
         StdLibInfo("unwind", StdLibType.FEATURE_GATED, dependencies = listOf(CORE, "libc", "compiler_builtins")),
         StdLibInfo("term", StdLibType.FEATURE_GATED, dependencies = listOf(STD, CORE)),
         StdLibInfo("getopts", StdLibType.FEATURE_GATED, dependencies = listOf(STD, CORE)),
-        // Dependencies
-        StdLibInfo("build_helper", StdLibType.DEPENDENCY),
-        StdLibInfo("syntax", StdLibType.DEPENDENCY, dependencies = listOf(STD, CORE))
     )
 }
 


### PR DESCRIPTION
* `std` [no longer depends](https://github.com/rust-lang/rust/blob/5a6b426e3471382c0385c11b09c2d6b37f70ac49/library/std/Cargo.toml#L13-L36) on `build_helper` (removed in [this commit](https://github.com/rust-lang/rust/commit/8d500572fa8f4110033fa3bc5e925831f6bbd18e#diff-1a7024d46c31d728a04d5e0cafd98df8L47))
* `proc_macro` [no longer depends](https://github.com/rust-lang/rust/blob/5a6b426e3471382c0385c11b09c2d6b37f70ac49/library/proc_macro/Cargo.toml#L7-L8) on `syntax` (removed in [this commit](https://github.com/rust-lang/rust/commit/8cf463bcffea8b6582fec170841b22ae0d6c77ea#diff-08f7810b7aec61ec35fd3dcb7bb0b8f9L11))