### PR TITLE
CI: Show number of regressions as github messages

### DIFF
--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -113,6 +113,9 @@ jobs:
               with:
                   arguments: "clean :test --tests \"org.rustPerformanceTests.CustomRealProjectAnalysisTest.test\""
 
+            - name: Checkout current version
+              run: git checkout ${{ github.sha }}
+
             - name: Calculate regressions
               run: python scripts/calculate_regressions.py --name ${{ matrix.project.name }}
 

--- a/scripts/calculate_regressions.py
+++ b/scripts/calculate_regressions.py
@@ -59,12 +59,17 @@ if __name__ == '__main__':
     dump_as_json(fixed, f"regressions/{args.name}_fixed.json")
     dump_as_json(new, f"regressions/{args.name}_new.json")
 
-    print(f"{len(fixed)} annotations fixed")
-    for ann in fixed:
-        print(ann)
+    print(f"total annotations: {len(without_changes)} without changes, {len(with_changes)} with changes")
+    # should be single line (second and subsequent lines are not displayed)
+    print(f"::warning file={args.name}:: {len(new)} annotations introduced, {len(fixed)} annotations fixed")
     print()
+
     print(f"{len(new)} annotations introduced")
     for ann in new:
+        print(ann)
+    print()
+    print(f"{len(fixed)} annotations fixed")
+    for ann in fixed:
         print(ann)
 
     if len(new) > 0:


### PR DESCRIPTION
Extends great [regression workflow](https://github.com/intellij-rust/intellij-rust/pull/5932) by showing number of regressions as [github messages](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message), so it will be possible to quickly inspect number of regressions for all crates (cargo, tokio and amethyst) on single page. [Example messages](https://github.com/intellij-rust/intellij-rust/actions/runs/257629920) (for this pull request).

Also:
* Swap order of annotations (`introduced` first, then `fixed`) - I think `introduced annotations` are more useful
* Checkout back to tested commit before calculating regressions, so it will be easier to test changes to `calculate_regressions.py`