### PR TITLE
Get rid of `Don't reformat child modules` option

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
@@ -18,36 +18,26 @@ class RustfmtConfigurable(project: Project) : RsConfigurableBase(project) {
     private val runRustfmtOnSaveCheckbox: JBCheckBox = JBCheckBox()
     private var runRustfmtOnSave: Boolean by CheckboxDelegate(runRustfmtOnSaveCheckbox)
 
-    private val useSkipChildrenCheckbox: JBCheckBox = JBCheckBox()
-    private var useSkipChildren: Boolean by CheckboxDelegate(useSkipChildrenCheckbox)
-
     override fun getDisplayName(): String = "Rustfmt"
 
     override fun createComponent(): JComponent? = layout {
         row("Use rustfmt instead of built-in formatter:", useRustfmtCheckbox)
         row("Run rustfmt on Save:", runRustfmtOnSaveCheckbox)
-        row("Don't reformat child modules (nightly only):", useSkipChildrenCheckbox, """
-            Pass `--skip-children` option to rustfmt not to reformat child modules.
-            Used only for nightly toolchain.
-        """)
     }
 
     override fun isModified(): Boolean =
         settings.useRustfmt != useRustfmt
             || settings.runRustfmtOnSave != runRustfmtOnSave
-            || settings.useSkipChildren != useSkipChildren
 
     override fun apply() {
         settings.modify {
             it.useRustfmt = useRustfmt
             it.runRustfmtOnSave = runRustfmtOnSave
-            it.useSkipChildren = useSkipChildren
         }
     }
 
     override fun reset() {
         useRustfmt = settings.useRustfmt
         runRustfmtOnSave = settings.runRustfmtOnSave
-        useSkipChildren = settings.useSkipChildren
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -47,7 +47,6 @@ interface RustProjectSettingsService {
         var doctestInjectionEnabled: Boolean = true,
         var useRustfmt: Boolean = false,
         var runRustfmtOnSave: Boolean = false,
-        var useSkipChildren: Boolean = false
     ) {
         @get:Transient
         @set:Transient
@@ -92,7 +91,6 @@ interface RustProjectSettingsService {
     val doctestInjectionEnabled: Boolean
     val useRustfmt: Boolean
     val runRustfmtOnSave: Boolean
-    val useSkipChildren: Boolean
 
     /*
      * Show a dialog for toolchain configuration

--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -51,7 +51,6 @@ class RustProjectSettingsServiceImpl(
     override val doctestInjectionEnabled: Boolean get() = state.doctestInjectionEnabled
     override val useRustfmt: Boolean get() = state.useRustfmt
     override val runRustfmtOnSave: Boolean get() = state.runRustfmtOnSave
-    override val useSkipChildren: Boolean get() = state.useSkipChildren
 
     override fun getState(): Element {
         val element = Element(serviceName)

--- a/src/main/kotlin/org/rust/cargo/toolchain/Rustfmt.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/Rustfmt.kt
@@ -13,7 +13,6 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.util.text.SemVer
 import org.rust.cargo.project.model.CargoProject
-import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.runconfig.command.workingDirectory
@@ -43,11 +42,6 @@ class Rustfmt(private val rustfmtExecutable: Path) {
 
         val arguments = buildList<String> {
             add("--emit=stdout")
-
-            if (checkSupportForSkipChildrenFlag(cargoProject)) {
-                add("--unstable-features")
-                add("--skip-children")
-            }
 
             val configPath = findConfigPathRecursively(file.parent, stopAt = cargoProject.workingDirectory)
             if (configPath != null) {
@@ -85,19 +79,6 @@ class Rustfmt(private val rustfmtExecutable: Path) {
                 ?.toGeneralCommandLine(project, CargoCommandLine.forProject(cargoProject, "fmt", listOf("--all")))
                 ?.execute(owner, false)
         }
-    }
-
-    private fun checkSupportForSkipChildrenFlag(cargoProject: CargoProject): Boolean {
-        if (!cargoProject.project.rustSettings.useSkipChildren) return false
-        val channel = cargoProject.rustcInfo?.version?.channel
-        if (channel != RustChannel.NIGHTLY) return false
-        return GeneralCommandLine(rustfmtExecutable)
-            .withParameters("-h")
-            .withWorkDirectory(cargoProject.workingDirectory)
-            .execute()
-            ?.stdoutLines
-            ?.contains(" --skip-children ")
-            ?: false
     }
 
     companion object {

--- a/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/RustProjectSettingsServiceTest.kt
@@ -36,7 +36,6 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
               <option name="toolchainHomeDirectory" value="/" />
               <option name="useOffline" value="true" />
               <option name="useRustfmt" value="true" />
-              <option name="useSkipChildren" value="true" />
               <option name="version" value="2" />
             </RustProjectSettings>
         """.trimIndent()
@@ -58,7 +57,6 @@ class RustProjectSettingsServiceTest : LightPlatformTestCase() {
         assertEquals(false, service.doctestInjectionEnabled)
         assertEquals(true, service.useRustfmt)
         assertEquals(true, service.runRustfmtOnSave)
-        assertEquals(true, service.useSkipChildren)
     }
 
     fun `test update from version 1`() {


### PR DESCRIPTION
This option does nothing for a long time. Finally, get rid of it.




![Screenshot from 2020-09-16 22-50-46](https://user-images.githubusercontent.com/3221931/93385561-183e0f00-f86f-11ea-880e-3ec8d9587bb0.png)
