### PR TITLE
Fix exception in the cargo toolwindow init

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -9,6 +9,7 @@ import com.intellij.execution.ExecutionException
 import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.invokeAndWaitIfNeeded
 import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.application.runWriteAction
@@ -34,6 +35,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapiext.isUnitTestMode
+import com.intellij.ui.GuiUtils
 import com.intellij.util.Consumer
 import com.intellij.util.indexing.LightDirectoryIndex
 import com.intellij.util.io.exists
@@ -103,7 +105,9 @@ open class CargoProjectsServiceImpl(
             subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsService.CargoProjectsListener {
                 override fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>) {
                     StartupManager.getInstance(project).runAfterOpened {
-                        initializeToolWindow(project)
+                        GuiUtils.invokeLaterIfNeeded({
+                            initializeToolWindow(project)
+                        }, ModalityState.NON_MODAL)
                     }
                 }
             })


### PR DESCRIPTION
Fix for #5999. Looks like `runAfterOpened` can run outside of EDT.

<details>
  <summary>Stacktrace</summary>
  
  ```
  Access is allowed from event dispatch thread with IW lock only.

com.intellij.openapi.diagnostic.RuntimeExceptionWithAttachments: EventQueue.isDispatchThread()=false Toolkit.getEventQueue()=com.intellij.ide.IdeEventQueue@6d984235
Current thread: Thread[ApplicationImpl pooled thread 11,4,Idea Thread Group] 1697154984
SystemEventQueueThread: Thread[AWT-EventQueue-0,6,Idea Thread Group] 1894364389
	at com.intellij.openapi.application.impl.ApplicationImpl.assertIsDispatchThread(ApplicationImpl.java:1061)
	at com.intellij.openapi.application.impl.ApplicationImpl.assertIsDispatchThread(ApplicationImpl.java:1043)
	at com.intellij.openapi.wm.impl.ToolWindowManagerImpl.doRegisterToolWindow(ToolWindowManagerImpl.kt:986)
	at com.intellij.openapi.wm.impl.ToolWindowManagerImpl.initToolWindow(ToolWindowManagerImpl.kt:530)
	at com.intellij.openapi.wm.impl.ToolWindowManagerImpl.initToolWindow(ToolWindowManagerImpl.kt:512)
	at org.rust.cargo.project.toolwindow.CargoToolWindow$Companion.initializeToolWindow(CargoToolWindow.kt:151)
	at org.rust.cargo.project.model.impl.CargoProjectsServiceImpl$$special$$inlined$with$lambda$3$1.run(CargoProjectImpl.kt:106)
	at com.intellij.ide.startup.impl.StartupManagerImpl.runActivity(StartupManagerImpl.java:436)
	at com.intellij.ide.startup.impl.StartupManagerImpl.runActivities(StartupManagerImpl.java:392)
	at com.intellij.ide.startup.impl.StartupManagerImpl.runPostStartupActivitiesRegisteredDynamically(StartupManagerImpl.java:334)
	at com.intellij.ide.startup.impl.StartupManagerImpl.runPostStartupActivities(StartupManagerImpl.java:247)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:170)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:629)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:581)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:157)
	at com.intellij.openapi.progress.util.BackgroundTaskUtil.runUnderDisposeAwareIndicator(BackgroundTaskUtil.java:254)
	at com.intellij.ide.startup.impl.StartupManagerImpl.lambda$projectOpened$1(StartupManagerImpl.java:154)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:652)
	at java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:649)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:649)
	at java.lang.Thread.run(Thread.java:748)
  ```
</details>