### PR TITLE
Fix exception `PsiElementBase.notNullChild` after variable inlining

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/inlineValue/RsInlineValueProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/inlineValue/RsInlineValueProcessor.kt
@@ -13,6 +13,8 @@ import com.intellij.refactoring.BaseRefactoringProcessor
 import com.intellij.usageView.UsageInfo
 import com.intellij.usageView.UsageViewDescriptor
 import org.rust.ide.refactoring.RsInlineUsageViewDescriptor
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.RsPathExpr
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.RsStructLiteralField
 import org.rust.lang.core.resolve.ref.RsReference
@@ -46,6 +48,10 @@ class RsInlineValueProcessor(
                     if (element.expr == null) {
                         element.addAfter(context.expr, element.colon)
                     }
+                }
+                is RsPath -> when (val parent = element.parent) {
+                    is RsPathExpr -> parent.replace(context.expr)
+                    else -> Unit // Can't replace RsPath to RsExpr
                 }
                 else -> element.replace(context.expr)
             }

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -26,6 +26,7 @@ import com.intellij.psi.impl.PsiManagerEx
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.testFramework.LightProjectDescriptor
 import com.intellij.testFramework.PlatformTestUtil
+import com.intellij.testFramework.PsiTestUtil
 import com.intellij.testFramework.UsefulTestCase
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.text.SemVer
@@ -236,6 +237,7 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
     ) {
         InlineFile(before)
         action()
+        PsiTestUtil.checkPsiStructureWithCommit(myFixture.file, PsiTestUtil::checkPsiMatchesTextIgnoringNonCode)
         myFixture.checkResult(replaceCaretMarker(after))
     }
 


### PR DESCRIPTION
RsPath can't be replaced with `RsExpr`. Instead, parent `RsPathExpr` should be replaced.

Typical stacktrace ends with this:
```
java.lang.Throwable: 10
 parent=let b = 10;
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:143)
	at com.intellij.psi.impl.PsiElementBase.notNullChild(PsiElementBase.java:284)
	at org.rust.lang.core.psi.impl.RsPathExprImpl.getPath(RsPathExprImpl.java:43)
```

Also, I enhanced tests in order to catch such bugs in the future.

c.c. @Kobzol 