### PR TITLE
Fix "Incorrect CachedValue use" exception in RsFile

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -203,7 +203,7 @@ class RsFile(
             MOD_DECL_KEY to ModificationTracker.NEVER_CHANGED
         }
         return CachedValuesManager.getCachedValue(originalFile, key) {
-            val decl = if (isCrateRoot) emptyList() else RsModulesIndex.getDeclarationsFor(originalFile)
+            val decl = if (originalFile.isCrateRoot) emptyList() else RsModulesIndex.getDeclarationsFor(originalFile)
             CachedValueProvider.Result.create(
                 decl,
                 originalFile.rustStructureOrAnyPsiModificationTracker,


### PR DESCRIPTION
The bug was introduced in #5690

<details>
  <summary>Stacktrace</summary>
  
  ```
  java.lang.Throwable: Incorrect CachedValue use: same CV with different captured context, this can cause unstable results and invalid PSI access.
Field this$0 in class org.rust.lang.core.psi.RsFile$declarations$1 has non-equivalent values:
  FILE (org.rust.lang.core.psi.RsFile) and
  FILE (org.rust.lang.core.psi.RsFile)
Either make `equals()` hold for these values, or avoid this dependency, e.g. by extracting CV provider into a static method.
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:143)
	at com.intellij.util.CachedValueStabilityChecker.complain(CachedValueStabilityChecker.java:163)
	at com.intellij.util.CachedValueStabilityChecker.checkFieldEquivalence(CachedValueStabilityChecker.java:130)
	at com.intellij.util.CachedValueStabilityChecker.checkFieldEquivalence(CachedValueStabilityChecker.java:126)
	at com.intellij.util.CachedValueStabilityChecker.checkProvidersEquivalent(CachedValueStabilityChecker.java:81)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:71)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:150)
	at org.rust.lang.core.psi.RsFile.getDeclarations(RsFile.kt:205)
	at org.rust.lang.core.psi.RsFile.getDeclaration(RsFile.kt:190)
    ...
  ```
</details> 

bors r+