### PR TITLE
PSI: Make RsForeignModItem implement RsItemsOwner

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -675,6 +675,7 @@ upper ModDeclItem ::= mod identifier ';' {
 upper ForeignModItem ::= ExternAbi ForeignModBody {
   name = ""
   implements = [ "org.rust.lang.core.psi.ext.RsItemElement"
+                 "org.rust.lang.core.psi.ext.RsItemsOwner"
                  "org.rust.lang.core.psi.ext.RsInnerAttributeOwner" ]
   mixin = "org.rust.lang.core.psi.ext.RsForeignModItemImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsForeignModStub"

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
@@ -66,7 +66,7 @@ val RsItemsOwner.expandedItemsCached: RsCachedItems
                 is RsImplItem -> Unit
 
                 // Optimization: prepare use items to reduce PSI tree access in hotter code
-                is RsUseItem ->  {
+                is RsUseItem -> {
                     val isPublic = it.isPublic
                     it.useSpeck?.forEachLeafSpeck { speck ->
                         if (speck.isStarImport) {
@@ -80,6 +80,8 @@ val RsItemsOwner.expandedItemsCached: RsCachedItems
                         }
                     }
                 }
+
+                is RsForeignModItem -> rest += it.expandedItemsExceptImplsAndUses
 
                 else -> rest.add(it)
             }


### PR DESCRIPTION
`RsForeignModItem` is naturally an item's owner, so it would be reasonable for it to implement `RsItemsOwner` interface