### PR TITLE
INT: add remaining arms and add wildcard arm intentions

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/checkMatch/RsNonExhaustiveMatchInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/checkMatch/RsNonExhaustiveMatchInspection.kt
@@ -7,13 +7,9 @@ package org.rust.ide.inspections.checkMatch
 
 import org.rust.ide.inspections.RsLocalInspectionTool
 import org.rust.ide.inspections.RsProblemsHolder
-import org.rust.ide.utils.checkMatch.*
+import org.rust.ide.utils.checkMatch.checkExhaustive
 import org.rust.lang.core.psi.RsMatchExpr
 import org.rust.lang.core.psi.RsVisitor
-import org.rust.lang.core.psi.ext.arms
-import org.rust.lang.core.types.infer.containsTyOfClass
-import org.rust.lang.core.types.ty.TyUnknown
-import org.rust.lang.core.types.type
 import org.rust.lang.utils.RsDiagnostic
 import org.rust.lang.utils.addToHolder
 
@@ -22,32 +18,8 @@ class RsNonExhaustiveMatchInspection : RsLocalInspectionTool() {
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
         override fun visitMatchExpr(matchExpr: RsMatchExpr) {
-            val exprType = matchExpr.expr?.type ?: return
-            if (exprType.containsTyOfClass(TyUnknown::class.java)) return
-            try {
-                checkExhaustive(matchExpr, holder)
-            } catch (todo: NotImplementedError) {
-            } catch (e: CheckMatchException) {
-            }
-        }
-    }
-
-    private fun checkExhaustive(match: RsMatchExpr, holder: RsProblemsHolder) {
-        val matchedExprType = match.expr?.type ?: return
-
-        val matrix = match.arms
-            .filter { it.matchArmGuard == null }
-            .calculateMatrix()
-            .takeIf { it.isWellTyped() }
-            ?: return
-
-        val wild = Pattern.wild(matchedExprType)
-        val useful = isUseful(matrix, listOf(wild), true, match.crateRoot, isTopLevel = true)
-
-        /** If `_` pattern is useful, the match is not exhaustive */
-        if (useful is Usefulness.UsefulWithWitness) {
-            val patterns = useful.witnesses.mapNotNull { it.patterns.singleOrNull() }
-            RsDiagnostic.NonExhaustiveMatch(match, patterns).addToHolder(holder)
+            val patterns = matchExpr.checkExhaustive() ?: return
+            RsDiagnostic.NonExhaustiveMatch(matchExpr, patterns).addToHolder(holder)
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/checkMatch/RsNonExhaustiveMatchInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/checkMatch/RsNonExhaustiveMatchInspection.kt
@@ -7,6 +7,7 @@ package org.rust.ide.inspections.checkMatch
 
 import org.rust.ide.inspections.RsLocalInspectionTool
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.utils.checkMatch.*
 import org.rust.lang.core.psi.RsMatchExpr
 import org.rust.lang.core.psi.RsVisitor
 import org.rust.lang.core.psi.ext.arms

--- a/src/main/kotlin/org/rust/ide/inspections/checkMatch/RsUnreachablePatternsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/checkMatch/RsUnreachablePatternsInspection.kt
@@ -12,6 +12,7 @@ import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.ide.inspections.fixes.SubstituteTextFix
 import org.rust.ide.inspections.lints.RsLint
 import org.rust.ide.inspections.lints.RsLintInspection
+import org.rust.ide.utils.checkMatch.*
 import org.rust.lang.core.psi.RsElementTypes.OR
 import org.rust.lang.core.psi.RsMatchArm
 import org.rust.lang.core.psi.RsMatchExpr

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AddRemainingArmsFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AddRemainingArmsFix.kt
@@ -15,9 +15,8 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.types.type
 
 open class AddRemainingArmsFix(match: RsMatchExpr, val patterns: List<Pattern>) : LocalQuickFixOnPsiElement(match) {
-    override fun getFamilyName() = "Add remaining patterns"
-
-    override fun getText() = familyName
+    override fun getFamilyName(): String = NAME
+    override fun getText(): String = familyName
 
     override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
         val oldMatchBody = (startElement as? RsMatchExpr)?.matchBody ?: return
@@ -38,14 +37,21 @@ open class AddRemainingArmsFix(match: RsMatchExpr, val patterns: List<Pattern>) 
 
     open fun createNewArms(psiFactory: RsPsiFactory, oldMatchBody: RsMatchBody): List<RsMatchArm> =
         psiFactory.createMatchBody(patterns, oldMatchBody).matchArmList
+
+    companion object {
+        const val NAME = "Add remaining patterns"
+    }
 }
 
 class AddWildcardArmFix(match: RsMatchExpr) : AddRemainingArmsFix(match, emptyList()) {
-    override fun getFamilyName() = "Add _ pattern"
-
-    override fun getText() = familyName
+    override fun getFamilyName(): String = NAME
+    override fun getText(): String = familyName
 
     override fun createNewArms(psiFactory: RsPsiFactory, oldMatchBody: RsMatchBody): List<RsMatchArm> = listOf(
         psiFactory.createMatchBody(listOf(Pattern.wild())).matchArmList.first()
     )
+
+    companion object {
+        const val NAME = "Add _ pattern"
+    }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AddRemainingArmsFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AddRemainingArmsFix.kt
@@ -9,7 +9,7 @@ import com.intellij.codeInspection.LocalQuickFixOnPsiElement
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import org.rust.ide.inspections.checkMatch.Pattern
+import org.rust.ide.utils.checkMatch.Pattern
 import org.rust.ide.utils.import.RsImportHelper.importTypeReferencesFromTy
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.types.type

--- a/src/main/kotlin/org/rust/ide/intentions/AddRemainingArmsIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddRemainingArmsIntention.kt
@@ -1,0 +1,51 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.rust.ide.inspections.fixes.AddRemainingArmsFix
+import org.rust.ide.utils.checkMatch.Pattern
+import org.rust.ide.utils.checkMatch.checkExhaustive
+import org.rust.lang.core.psi.RsMatchBody
+import org.rust.lang.core.psi.RsMatchExpr
+
+open class AddRemainingArmsIntention : RsElementBaseIntentionAction<AddRemainingArmsIntention.Context>() {
+
+    override fun getText(): String = AddRemainingArmsFix.NAME
+    override fun getFamilyName(): String = text
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val matchExpr = when (val parent = element.context) {
+            is RsMatchExpr -> parent
+            is RsMatchBody -> parent.context as? RsMatchExpr
+            else -> null
+        } ?: return null
+
+        val textRange = matchExpr.match.textRange
+        val caretOffset = editor.caretModel.offset
+        // `RsNonExhaustiveMatchInspection` register its quick fixes only for `match` keyword.
+        // At the same time, platform shows these quick fixes even when caret is located just after the keyword,
+        // i.e. `match/*caret*/`.
+        // So disable this intention for such range not to provide two the same actions to a user
+        if (caretOffset >= textRange.startOffset && caretOffset <= textRange.endOffset) return null
+
+        val patterns = matchExpr.checkExhaustive() ?: return null
+        return Context(matchExpr, patterns)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val (matchExpr, patterns) = ctx
+        createQuickFix(matchExpr, patterns).invoke(project, matchExpr.containingFile, matchExpr, matchExpr)
+    }
+
+    protected open fun createQuickFix(matchExpr: RsMatchExpr, patterns: List<Pattern>): AddRemainingArmsFix {
+        return AddRemainingArmsFix(matchExpr, patterns)
+    }
+
+    data class Context(val matchExpr: RsMatchExpr, val patterns: List<Pattern>)
+}

--- a/src/main/kotlin/org/rust/ide/intentions/AddWildcardArmIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddWildcardArmIntention.kt
@@ -1,0 +1,20 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import org.rust.ide.inspections.fixes.AddRemainingArmsFix
+import org.rust.ide.inspections.fixes.AddWildcardArmFix
+import org.rust.ide.utils.checkMatch.Pattern
+import org.rust.lang.core.psi.RsMatchExpr
+
+class AddWildcardArmIntention : AddRemainingArmsIntention() {
+
+    override fun getText(): String = AddWildcardArmFix.NAME
+
+    override fun createQuickFix(matchExpr: RsMatchExpr, patterns: List<Pattern>): AddRemainingArmsFix {
+        return AddWildcardArmFix(matchExpr)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/utils/checkMatch/CheckMatchUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/checkMatch/CheckMatchUtils.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.checkMatch
+package org.rust.ide.utils.checkMatch
 
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*

--- a/src/main/kotlin/org/rust/ide/utils/checkMatch/Constructor.kt
+++ b/src/main/kotlin/org/rust/ide/utils/checkMatch/Constructor.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.checkMatch
+package org.rust.ide.utils.checkMatch
 
 import org.rust.lang.core.psi.RsEnumItem
 import org.rust.lang.core.psi.RsEnumVariant

--- a/src/main/kotlin/org/rust/ide/utils/checkMatch/Pattern.kt
+++ b/src/main/kotlin/org/rust/ide/utils/checkMatch/Pattern.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.checkMatch
+package org.rust.ide.utils.checkMatch
 
 import org.rust.lang.core.psi.RsEnumItem
 import org.rust.lang.core.psi.RsEnumVariant

--- a/src/main/kotlin/org/rust/ide/utils/checkMatch/PatternKind.kt
+++ b/src/main/kotlin/org/rust/ide/utils/checkMatch/PatternKind.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.checkMatch
+package org.rust.ide.utils.checkMatch
 
 import org.rust.lang.core.psi.RsEnumItem
 import org.rust.lang.core.psi.RsEnumVariant

--- a/src/main/kotlin/org/rust/ide/utils/checkMatch/Usefulness.kt
+++ b/src/main/kotlin/org/rust/ide/utils/checkMatch/Usefulness.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections.checkMatch
+package org.rust.ide.utils.checkMatch
 
 import org.rust.lang.core.psi.RsEnumItem
 import org.rust.lang.core.psi.ext.RsMod

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -8,7 +8,7 @@ package org.rust.lang.core.psi
 import com.intellij.openapi.project.Project
 import com.intellij.psi.*
 import com.intellij.util.LocalTimeCounter
-import org.rust.ide.inspections.checkMatch.Pattern
+import org.rust.ide.utils.checkMatch.Pattern
 import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.lang.RsFileType
 import org.rust.lang.RsLanguage

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -22,7 +22,6 @@ import org.rust.ide.annotator.fixes.*
 import org.rust.ide.inspections.RsExperimentalChecksInspection
 import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.ide.inspections.RsTypeCheckInspection
-import org.rust.ide.inspections.checkMatch.Pattern
 import org.rust.ide.inspections.fixes.AddMainFnFix
 import org.rust.ide.inspections.fixes.AddRemainingArmsFix
 import org.rust.ide.inspections.fixes.AddWildcardArmFix
@@ -31,6 +30,7 @@ import org.rust.ide.presentation.render
 import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.presentation.shortPresentableText
 import org.rust.ide.refactoring.implementMembers.ImplementMembersFix
+import org.rust.ide.utils.checkMatch.Pattern
 import org.rust.ide.utils.import.RsImportHelper.getTypeReferencesInfoFromTys
 import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.psi.*

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -824,6 +824,14 @@
             <className>org.rust.ide.intentions.CreateFunctionIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.AddRemainingArmsIntention</className>
+            <category>Rust</category>
+        </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.AddWildcardArmIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 

--- a/src/main/resources/intentionDescriptions/AddRemainingArmsIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/AddRemainingArmsIntention/after.rs.template
@@ -1,0 +1,6 @@
+fn foo(x: Option<i32>) {
+    <spot>match x {
+        None => {}
+        Some(_) => {}
+    }</spot>
+}

--- a/src/main/resources/intentionDescriptions/AddRemainingArmsIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/AddRemainingArmsIntention/before.rs.template
@@ -1,0 +1,5 @@
+fn foo(x: Option<i32>) {
+    <spot>match x {
+        None => {}
+    }</spot>
+}

--- a/src/main/resources/intentionDescriptions/AddRemainingArmsIntention/description.html
+++ b/src/main/resources/intentionDescriptions/AddRemainingArmsIntention/description.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+Adds remaining patterns in <code>match</code> expression if the expression is not exhaustive,
+i.e. not all possible patterns are covered.
+</body>
+</html>

--- a/src/main/resources/intentionDescriptions/AddWildcardArmIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/AddWildcardArmIntention/after.rs.template
@@ -1,0 +1,6 @@
+fn foo(x: Option<i32>) {
+    <spot>match x {
+        None => {}
+        _ => {}
+    }</spot>
+}

--- a/src/main/resources/intentionDescriptions/AddWildcardArmIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/AddWildcardArmIntention/before.rs.template
@@ -1,0 +1,5 @@
+fn foo(x: Option<i32>) {
+    <spot>match x {
+        None => {}
+    }</spot>
+}

--- a/src/main/resources/intentionDescriptions/AddWildcardArmIntention/description.html
+++ b/src/main/resources/intentionDescriptions/AddWildcardArmIntention/description.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+Adds `_` pattern in <code>match</code> expression if the expression is not exhaustive,
+i.e. not all possible patterns are covered.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/AddRemainingArmsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddRemainingArmsIntentionTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+/**
+ * More tests for base functionality can be found in [org.rust.ide.inspections.match.RsNonExhaustiveMatchInspectionTest]
+ */
+class AddRemainingArmsIntentionTest : RsIntentionTestBase(AddRemainingArmsIntention::class) {
+
+    fun `test empty match`() = doAvailableTest("""
+        enum E { A, B, C }
+        fn main() {
+            let a = E::A;
+            match a {
+                /*caret*/
+            }
+        }
+    """, """
+        enum E { A, B, C }
+        fn main() {
+            let a = E::A;
+            match a {
+                E::A => {}
+                E::B => {}
+                E::C => {}
+            }
+        }
+    """)
+
+    fun `test empty non-exhaustive match`() = doAvailableTest("""
+        fn main() {
+            let a = true;
+            match a/*caret*/ {
+                true => {}
+            }
+        }
+    """, """
+        fn main() {
+            let a = true;
+            match a {
+                true => {}
+                false => {}
+            }
+        }
+    """)
+
+    fun `test do not duplicate inspection quick fixes 1`() = doUnavailableTest("""
+        enum E { A, B, C }
+        fn main() {
+            let a = E::A;
+            /*caret*/match a {
+
+            }
+        }
+    """)
+
+    fun `test do not duplicate inspection quick fixes 2`() = doUnavailableTest("""
+        enum E { A, B, C }
+        fn main() {
+            let a = E::A;
+            match/*caret*/ a {
+
+            }
+        }
+    """)
+
+    fun `test do not suggest from nested code`() = doUnavailableTest("""
+        enum E { A, B, C }
+        fn main() {
+            let a = E::A;
+            match a {
+                E::A => { /*caret*/ }
+            }
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/intentions/AddWildcardArmIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddWildcardArmIntentionTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+/**
+ * More tests for base functionality can be found in [org.rust.ide.inspections.match.RsNonExhaustiveMatchInspectionTest]
+ */
+class AddWildcardArmIntentionTest : RsIntentionTestBase(AddWildcardArmIntention::class) {
+
+    fun `test empty match`() = doAvailableTest("""
+        enum E { A, B, C }
+        fn main() {
+            let a = E::A;
+            match a {
+                /*caret*/
+            }
+        }
+    """, """
+        enum E { A, B, C }
+        fn main() {
+            let a = E::A;
+            match a {
+                _ => {}
+            }
+        }
+    """)
+
+    fun `test empty non-exhaustive match`() = doAvailableTest("""
+        fn main() {
+            let a = true;
+            match a/*caret*/ {
+                true => {}
+            }
+        }
+    """, """
+        fn main() {
+            let a = true;
+            match a {
+                true => {}
+                _ => {}
+            }
+        }
+    """)
+
+    fun `test do not duplicate inspection quick fixes 1`() = doUnavailableTest("""
+        enum E { A, B, C }
+        fn main() {
+            let a = E::A;
+            /*caret*/match a {
+
+            }
+        }
+    """)
+
+    fun `test do not duplicate inspection quick fixes 2`() = doUnavailableTest("""
+        enum E { A, B, C }
+        fn main() {
+            let a = E::A;
+            match/*caret*/ a {
+
+            }
+        }
+    """)
+
+    fun `test do not suggest from nested code`() = doUnavailableTest("""
+        enum E { A, B, C }
+        fn main() {
+            let a = E::A;
+            match a {
+                E::A => { /*caret*/ }
+            }
+        }
+    """)
+}


### PR DESCRIPTION
Restores functionality to add missing patterns in `match` expression inside match block that was removed in #5720. Previously, this feature was provided by `Fill match arms` intention. New intentions work exactly the same as `Add remaining patterns` and `Add _ pattern` but in different places. As a result, new intentions support more cases than old `Fill match arms` which supported only enums and only empty `match` expression

Closes #6124