### PR TITLE
Add compile only dependency on kotlin stdlib

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,6 +122,10 @@ allprojects {
         }
     }
 
+    dependencies {
+        compileOnly(kotlin("stdlib-jdk8"))
+    }
+
     afterEvaluate {
         tasks.withType<AbstractTestTask> {
             testLogging {


### PR DESCRIPTION
It allows viewing kotlin stdlib source code with comments.

It was already [added before](https://github.com/intellij-rust/intellij-rust/pull/2312/files), and then [removed](https://github.com/intellij-rust/intellij-rust/pull/2738/files#diff-392475fdf2bc320d17762ed97109a121L135) because it caused problems when running tests using JPS (instead of Gradle). I don't find any problems now when using JPS with this compile only dependency, so let's try add it again.