### PR TITLE
Follow `rustc --print sysroot` stdlib path without Rustup

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
@@ -164,6 +164,7 @@ private fun fetchStdlib(
     val rustup = context.toolchain.rustup(workingDirectory)
     if (rustup == null) {
         val explicitPath = context.project.rustSettings.explicitPathToStdlib
+            ?: context.toolchain.getStdlibFromSysroot(workingDirectory)?.path
         val lib = explicitPath?.let { StandardLibrary.fromPath(it) }
         return when {
             explicitPath == null -> TaskResult.Err("no explicit stdlib or rustup found")

--- a/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
@@ -39,6 +39,8 @@ class RustProjectSettingsPanel(
     private val pathToStdlibField = pathToDirectoryTextField(this,
         "Select directory with standard library source code")
 
+    private var fetchedSysroot: String? = null
+
     private val downloadStdlibLink = Link("Download via rustup", action = {
         val rustup = RustToolchain(Paths.get(pathToToolchainField.text)).rustup
         if (rustup != null) {
@@ -61,7 +63,8 @@ class RustProjectSettingsPanel(
             val toolchain = RustToolchain(Paths.get(pathToToolchainField.text))
             return Data(
                 toolchain = toolchain,
-                explicitPathToStdlib = pathToStdlibField.text.blankToNull()?.takeIf { toolchain.rustup == null }
+                explicitPathToStdlib = pathToStdlibField.text.blankToNull()
+                    ?.takeIf { toolchain.rustup == null && it != fetchedSysroot }
             )
         }
         set(value) {
@@ -106,9 +109,10 @@ class RustProjectSettingsPanel(
 
                 pathToStdlibField.isEditable = !hasRustup
                 pathToStdlibField.button.isEnabled = !hasRustup
-                if (stdlibLocation != null) {
+                if (stdlibLocation != null && (pathToStdlibField.text.isBlank() || hasRustup)) {
                     pathToStdlibField.text = stdlibLocation
                 }
+                fetchedSysroot = stdlibLocation
 
                 if (rustcVersion == null) {
                     toolchainVersion.text = "N/A"


### PR DESCRIPTION
Improves #3779 & #3856, related to #6146.

1. If there is no `Rustup` in the toolchain, use `$(rustc --print sysroot)/lib/rustlib/src/rust` path to stdlib even if explicit path (in the plugin settings) is set to null
2. In the plugin settings UI, when saving the settings, set explicit stdlib path to null if it equals to `$(rustc --print sysroot)/lib/rustlib/src/rust` (or if there is `Rustup` in the toolchain, as before)

So, if a user doesn't have `Rustup` and doesn't change the stdlib path in the plugin settings, the plugin will **follow** `$(rustc --print sysroot)/lib/rustlib/src/rust` path.

User-visible change: Cargo project structure loading (aka Cargo Refresh) with project opened via `Open` action successfully sets up stdlib path when `rustup` doesn't exist but `$(rustc --print sysroot)/lib/rustlib/src/rust` exists. Previously, error notification with `Cargo project update failed: no explicit stdlib or rustup found` text was shown to a user and stdlib wasn't set up