### PR TITLE
STUB: Add helper methods for new resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -40,6 +40,8 @@ import org.rust.lang.core.resolve.DEFAULT_RECURSION_LIMIT
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.openapiext.*
 import org.rust.stdext.HashCode
+import org.rust.stdext.readHashCodeNullable
+import org.rust.stdext.writeHashCodeNullable
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import java.io.IOException
@@ -950,32 +952,6 @@ private fun DataOutputStream.writeUTFNullable(str: String?) {
 private fun DataInputStream.readUTFNullable(): String? {
     return if (readBoolean()) {
         readUTF()
-    } else {
-        null
-    }
-}
-
-private fun DataOutputStream.writeHashCode(hash: HashCode) =
-    write(hash.toByteArray())
-
-private fun DataInputStream.readHashCode(): HashCode {
-    val bytes = ByteArray(HashCode.ARRAY_LEN)
-    readFully(bytes)
-    return HashCode.fromByteArray(bytes)
-}
-
-private fun DataOutputStream.writeHashCodeNullable(hash: HashCode?) {
-    if (hash == null) {
-        writeBoolean(false)
-    } else {
-        writeBoolean(true)
-        writeHashCode(hash)
-    }
-}
-
-private fun DataInputStream.readHashCodeNullable(): HashCode? {
-    return if (readBoolean()) {
-        readHashCode()
     } else {
         null
     }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsStubElementTypes.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsStubElementTypes.kt
@@ -1,0 +1,28 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi
+
+import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.stubs.StubElement
+import com.intellij.psi.tree.IElementType
+import org.rust.lang.core.psi.ext.RsElement
+
+/** Contains constants from [RsElementTypes] with correct types */
+object RsStubElementTypes {
+    val INCLUDE_MACRO_ARGUMENT: StubElementType<RsIncludeMacroArgument> = cast(RsElementTypes.INCLUDE_MACRO_ARGUMENT)
+    val USE_GROUP: StubElementType<RsUseGroup> = cast(RsElementTypes.USE_GROUP)
+    val ENUM_BODY: StubElementType<RsEnumBody> = cast(RsElementTypes.ENUM_BODY)
+    val BLOCK_FIELDS: StubElementType<RsBlockFields> = cast(RsElementTypes.BLOCK_FIELDS)
+    val VIS_RESTRICTION: StubElementType<RsVisRestriction> = cast(RsElementTypes.VIS_RESTRICTION)
+}
+
+/** Is needed to avoid very long type names */
+private typealias StubElementType<T> = IStubElementType<StubElement<T>, T>
+
+@Suppress("UNCHECKED_CAST")
+private fun <T : RsElement?> cast(type: IElementType): IStubElementType<StubElement<T>, T> {
+    return type as IStubElementType<StubElement<T>, T>
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsEnumItem.kt
@@ -16,6 +16,7 @@ import org.rust.lang.core.psi.RsEnumVariant
 import org.rust.lang.core.psi.RsPsiImplUtil
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.stubs.RsEnumItemStub
+import org.rust.lang.core.stubs.RsEnumVariantStub
 import org.rust.lang.core.types.RsPsiTypeImplUtil
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyInteger
@@ -49,6 +50,12 @@ val RsEnumItem.isStdOptionOrResult: Boolean get() {
 
 val RsEnumItem.variants: List<RsEnumVariant>
     get() = enumBody?.enumVariantList.orEmpty()
+
+val RsEnumItemStub.variants: List<RsEnumVariantStub>
+    get() {
+        val enumBody = enumBody ?: return emptyList()
+        return enumBody.childrenStubs.filterIsInstance<RsEnumVariantStub>()
+    }
 
 // A repr attribute like #[repr(u16)] changes the discriminant type of an enum
 // https://doc.rust-lang.org/nomicon/other-reprs.html#repru-repri

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt
@@ -18,6 +18,7 @@ import org.rust.lang.core.resolve.ref.RsReference
 import org.rust.lang.core.stubs.RsExternCrateItemStub
 
 val RsExternCrateItem.nameWithAlias: String get() = alias?.name ?: referenceName
+val RsExternCrateItemStub.nameWithAlias: String get() = alias?.name ?: name
 
 val RsExternCrateItem.hasMacroUse: Boolean get() =
     greenStub?.hasMacroUse ?: queryAttributes.hasAttribute("macro_use")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
@@ -102,10 +102,14 @@ private fun RsMacro.guessPreferredBraces(): MacroBraces {
 private val MACRO_BODY_HASH_KEY: Key<CachedValue<HashCode>> = Key.create("MACRO_BODY_HASH_KEY")
 
 val RsMacro.bodyHash: HashCode?
-    get() = CachedValuesManager.getCachedValue(this, MACRO_BODY_HASH_KEY) {
-        val body = greenStub?.macroBody ?: macroBody?.text
-        val hash = body?.let { HashCode.compute(it) }
-        CachedValueProvider.Result.create(hash, modificationTracker)
+    get() {
+        val stub = greenStub
+        if (stub !== null) return stub.bodyHash
+        return CachedValuesManager.getCachedValue(this, MACRO_BODY_HASH_KEY) {
+            val body = macroBody?.text
+            val hash = body?.let { HashCode.compute(it) }
+            CachedValueProvider.Result.create(hash, modificationTracker)
+        }
     }
 
 private val MACRO_GRAPH_KEY: Key<CachedValue<MacroGraph?>> = Key.create("MACRO_GRAPH_KEY")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
+import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.macros.*
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.*
@@ -60,15 +61,20 @@ val RsMacroCall.bodyTextRange: TextRange?
     get() {
         val stub = greenStub
         return if (stub != null) {
-            val bodyStartOffset = stub.bodyStartOffset
-            val macroBody = stub.macroBody
-            if (bodyStartOffset != -1 && macroBody != null) {
-                TextRange(bodyStartOffset, bodyStartOffset + macroBody.length)
-            } else {
-                null
-            }
+            stub.bodyTextRange
         } else {
             macroArgumentElement?.textRange?.let { TextRange(it.startOffset + 1, it.endOffset - if (it.length == 1) 0 else 1) }
+        }
+    }
+
+val RsMacroCallStub.bodyTextRange: TextRange?
+    get() {
+        val bodyStartOffset = bodyStartOffset
+        val macroBody = macroBody
+        return if (bodyStartOffset != -1 && macroBody !== null) {
+            TextRange(bodyStartOffset, bodyStartOffset + macroBody.length)
+        } else {
+            null
         }
     }
 
@@ -81,7 +87,10 @@ private val MACRO_ARGUMENT_TYPES: TokenSet = tokenSetOf(
 val RsMacroCall.macroArgumentElement: RsElement?
     get() = node.findChildByType(MACRO_ARGUMENT_TYPES)?.psi as? RsElement
 
-private val RsExpr.value: String? get() {
+val RsExpr.value: String? get() = getValue(null)
+
+/** [crateOrNull] is passed to avoid trigger resolve */
+private fun RsExpr.getValue(crateOrNull: Crate?): String? {
     return when (this) {
         is RsLitExpr -> stringValue
         is RsMacroExpr -> {
@@ -91,15 +100,15 @@ private val RsExpr.value: String? get() {
                     val exprList = macroCall.concatMacroArgument?.exprList ?: return null
                     buildString {
                         for (expr in exprList) {
-                            val value = expr.value ?: return null
+                            val value = expr.getValue(crateOrNull) ?: return null
                             append(value)
                         }
                     }
                 }
                 "env" -> {
                     val expr = macroCall.envMacroArgument?.variableNameExpr as? RsLitExpr ?: return null
-                    val crate = expr.containingCrate ?: return null
-                    when (val variableName = expr.value) {
+                    val crate = crateOrNull ?: expr.containingCrate ?: return null
+                    when (val variableName = expr.getValue(crate)) {
                         "OUT_DIR" -> crate.outDir?.path
                         else -> crate.env[variableName]
                     }
@@ -116,6 +125,13 @@ fun RsMacroCall.findIncludingFile(): RsFile? {
     val path = includeMacroArgument?.expr?.value ?: return null
     val file = (findMacroCallExpandedFrom() ?: this).containingFile?.originalFile?.virtualFile ?: return null
     return file.parent?.findFileByMaybeRelativePath(path)?.toPsiFile(project)?.rustFile
+}
+
+/** [crate] is passed to avoid trigger resolve */
+fun RsMacroCallStub.getIncludeMacroArgument(crate: Crate): String? {
+    val includeMacroArgument = findChildStubByType(RsStubElementTypes.INCLUDE_MACRO_ARGUMENT) ?: return null
+    // TODO: Don't use psi
+    return includeMacroArgument.psi.expr?.getValue(crate)
 }
 
 val RsMacroCall.bodyHash: HashCode?

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -119,10 +119,14 @@ fun RsMacroCall.findIncludingFile(): RsFile? {
 }
 
 val RsMacroCall.bodyHash: HashCode?
-    get() = CachedValuesManager.getCachedValue(this) {
-        val body = macroBody
-        val hash = body?.let { HashCode.compute(it) }
-        CachedValueProvider.Result.create(hash, modificationTracker)
+    get() {
+        val stub = greenStub
+        if (stub !== null) return stub.bodyHash
+        return CachedValuesManager.getCachedValue(this) {
+            val body = macroBody
+            val hash = body?.let { HashCode.compute(it) }
+            CachedValueProvider.Result.create(hash, modificationTracker)
+        }
     }
 
 fun RsMacroCall.resolveToMacro(): RsMacro? =

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
@@ -38,8 +38,13 @@ val RsPath.kind: PathKind get() {
 /** For `Foo::bar::baz::quux` path returns `Foo` */
 tailrec fun RsPath.basePath(): RsPath {
     val qualifier = path
-    @Suppress("IfThenToElvis")
-    return if (qualifier == null) this else qualifier.basePath()
+    return if (qualifier === null) this else qualifier.basePath()
+}
+
+/** For `Foo::bar::baz::quux` path returns `Foo` */
+tailrec fun RsPathStub.basePath(): RsPathStub {
+    val qualifier = path
+    return if (qualifier === null) this else qualifier.basePath()
 }
 
 /** For `Foo::bar` in `Foo::bar::baz::quux` returns `Foo::bar::baz::quux` */

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseItem.kt
@@ -19,3 +19,7 @@ abstract class RsUseItemImplMixin : RsStubbedElementImpl<RsUseItemStub>, RsUseIt
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 }
+
+// #[prelude_import]
+val RsUseItem.hasPreludeImport: Boolean
+    get() = greenStub?.hasPreludeImport ?: queryAttributes.hasAttribute("prelude_import")

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseSpeck.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseSpeck.kt
@@ -13,6 +13,7 @@ import org.rust.lang.core.psi.RsUseSpeck
 import org.rust.lang.core.stubs.RsUseSpeckStub
 
 val RsUseSpeck.isStarImport: Boolean get() = greenStub?.isStarImport ?: (mul != null) // I hate operator precedence
+val RsUseSpeck.hasColonColon: Boolean get() = greenStub?.hasColonColon ?: (coloncolon != null)
 val RsUseSpeck.qualifier: RsPath? get() {
     val parentUseSpeck = (context as? RsUseGroup)?.parentUseSpeck ?: return null
     return parentUseSpeck.pathOrQualifier

--- a/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
@@ -5,10 +5,12 @@
 
 package org.rust.lang.core.resolve
 
+import com.intellij.psi.stubs.StubElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.isProcMacroDef
+import org.rust.lang.core.stubs.*
 import java.util.*
 
 enum class Namespace(val itemName: String) {
@@ -37,7 +39,7 @@ val RsNamedElement.namespaces: Set<Namespace> get() = when (this) {
     is RsConstant -> VALUES
     is RsFunction -> if (this.isProcMacroDef) MACROS else VALUES
 
-    is RsEnumVariant -> if (blockFields == null) VALUES else TYPES
+    is RsEnumVariant -> namespaces
 
     is RsStructItem -> if (blockFields == null) TYPES_N_VALUES else TYPES
 
@@ -47,6 +49,31 @@ val RsNamedElement.namespaces: Set<Namespace> get() = when (this) {
 
     else -> TYPES_N_VALUES
 }
+
+val StubElement<*>.namespaces: Set<Namespace> get() = when (this) {
+    is RsModItemStub,
+    is RsModDeclItemStub,
+    is RsEnumItemStub,
+    is RsTraitItemStub,
+    is RsTypeParameterStub,
+    is RsTypeAliasStub -> TYPES
+
+    is RsConstantStub -> VALUES
+    is RsFunctionStub -> if (isProcMacroDef) MACROS else VALUES
+
+    is RsEnumVariantStub -> namespaces
+
+    is RsStructItemStub -> if (blockFields == null) TYPES_N_VALUES else TYPES
+
+    is RsLifetimeParameterStub -> LIFETIMES
+
+    is RsMacroStub, is RsMacro2Stub -> MACROS
+
+    else -> TYPES_N_VALUES
+}
+
+inline val RsEnumVariant.namespaces: Set<Namespace> get() = if (blockFields === null) VALUES else TYPES
+inline val RsEnumVariantStub.namespaces: Set<Namespace> get() = if (blockFields === null) VALUES else TYPES
 
 val RsUseSpeck.namespaces: Set<Namespace>
     get() = path

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -52,7 +52,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
     override fun getType() = Type
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
-        private const val STUB_VERSION = 201
+        private const val STUB_VERSION = 202
 
         // Bump this number if Stub structure changes
         override fun getStubVersion(): Int = RustParserDefinition.PARSER_VERSION + STUB_VERSION
@@ -324,6 +324,9 @@ class RsExternCrateItemStub(
 ) : RsAttributeOwnerStubBase<RsExternCrateItem>(parent, elementType),
     RsNamedStub {
 
+    val alias: RsAliasStub?
+        get() = findChildStubByType(RsAliasStub.Type)
+
     object Type : RsStubElementType<RsExternCrateItemStub, RsExternCrateItem>("EXTERN_CRATE_ITEM") {
 
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
@@ -354,6 +357,12 @@ class RsUseItemStub(
     override val flags: Int
 ) : RsAttributeOwnerStubBase<RsUseItem>(parent, elementType) {
 
+    val useSpeck: RsUseSpeckStub?
+        get() = findChildStubByType(RsUseSpeckStub.Type)
+    // stored in stub as an optimization
+    val hasPreludeImport: Boolean
+        get() = BitUtil.isSet(flags, HAS_PRELUDE_IMPORT_MASK)
+
     object Type : RsStubElementType<RsUseItemStub, RsUseItem>("USE_ITEM") {
 
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
@@ -366,35 +375,62 @@ class RsUseItemStub(
         override fun createPsi(stub: RsUseItemStub) =
             RsUseItemImpl(stub, this)
 
-        override fun createStub(psi: RsUseItem, parentStub: StubElement<*>?) =
-            RsUseItemStub(parentStub, this, RsAttributeOwnerStub.extractFlags(psi))
+        override fun createStub(psi: RsUseItem, parentStub: StubElement<*>?): RsUseItemStub {
+            var flags = RsAttributeOwnerStub.extractFlags(psi)
+            flags = BitUtil.set(flags, HAS_PRELUDE_IMPORT_MASK, psi.hasPreludeImport)
+            return RsUseItemStub(parentStub, this, flags)
+        }
+    }
+
+    companion object {
+        private val HAS_PRELUDE_IMPORT_MASK: Int = makeBitMask(RsAttributeOwnerStub.USED_BITS + 0)
     }
 }
 
 class RsUseSpeckStub(
     parent: StubElement<*>?, elementType: IStubElementType<*, *>,
-    val isStarImport: Boolean
+    val isStarImport: Boolean,
+    /** Needed to distinguish `use {aaa, bbb};` and `use ::{aaa, bbb};` */
+    val hasColonColon: Boolean,
 ) : RsElementStub<RsUseSpeck>(parent, elementType) {
+
+    val path: RsPathStub?
+        get() = findChildStubByType(RsPathStub.Type)
+    val alias: RsAliasStub?
+        get() = findChildStubByType(RsAliasStub.Type)
+    val useGroup: StubElement<RsUseGroup>?
+        get() = findChildStubByType(RsStubElementTypes.USE_GROUP)
 
     object Type : RsStubElementType<RsUseSpeckStub, RsUseSpeck>("USE_SPECK") {
 
-        override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
-            RsUseSpeckStub(parentStub, this,
-                dataStream.readBoolean()
+        override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): RsUseSpeckStub {
+            val flags = dataStream.readUnsignedByte()
+            return RsUseSpeckStub(
+                parentStub, this,
+                BitUtil.isSet(flags, IS_STAR_IMPORT_MASK),
+                BitUtil.isSet(flags, HAS_COLON_COLON_MASK),
             )
+        }
 
-        override fun serialize(stub: RsUseSpeckStub, dataStream: StubOutputStream) =
-            with(dataStream) {
-                writeBoolean(stub.isStarImport)
-            }
+        override fun serialize(stub: RsUseSpeckStub, dataStream: StubOutputStream) {
+            var flags = 0
+            flags = BitUtil.set(flags, IS_STAR_IMPORT_MASK, stub.isStarImport)
+            flags = BitUtil.set(flags, HAS_COLON_COLON_MASK, stub.hasColonColon)
+            dataStream.writeByte(flags)
+        }
 
         override fun createPsi(stub: RsUseSpeckStub) =
             RsUseSpeckImpl(stub, this)
 
         override fun createStub(psi: RsUseSpeck, parentStub: StubElement<*>?) =
-            RsUseSpeckStub(parentStub, this, psi.isStarImport)
+            RsUseSpeckStub(parentStub, this, psi.isStarImport, psi.hasColonColon)
 
         override fun indexStub(stub: RsUseSpeckStub, sink: IndexSink) = sink.indexUseSpeck(stub)
+    }
+
+    companion object {
+        private val IS_STAR_IMPORT_MASK: Int = makeBitMask(0)
+        private val HAS_COLON_COLON_MASK: Int = makeBitMask(1)
     }
 }
 
@@ -405,6 +441,8 @@ class RsStructItemStub(
 ) : RsAttributeOwnerStubBase<RsStructItem>(parent, elementType),
     RsNamedStub {
 
+    val blockFields: StubElement<RsBlockFields>?
+        get() = findChildStubByType(RsStubElementTypes.BLOCK_FIELDS)
     val isUnion: Boolean
         get() = BitUtil.isSet(flags, IS_UNION_MASK)
 
@@ -447,6 +485,9 @@ class RsEnumItemStub(
 ) : RsAttributeOwnerStubBase<RsEnumItem>(parent, elementType),
     RsNamedStub {
 
+    val enumBody: StubElement<RsEnumBody>?
+        get() = findChildStubByType(RsStubElementTypes.ENUM_BODY)
+
     object Type : RsStubElementType<RsEnumItemStub, RsEnumItem>("ENUM_ITEM") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): RsEnumItemStub =
             RsEnumItemStub(parentStub, this,
@@ -479,6 +520,9 @@ class RsEnumVariantStub(
     override val flags: Int
 ) : RsAttributeOwnerStubBase<RsEnumVariant>(parent, elementType),
     RsNamedStub {
+
+    val blockFields: StubElement<RsBlockFields>?
+        get() = findChildStubByType(RsStubElementTypes.BLOCK_FIELDS)
 
     object Type : RsStubElementType<RsEnumVariantStub, RsEnumVariant>("ENUM_VARIANT") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): RsEnumVariantStub =
@@ -513,6 +557,10 @@ class RsModDeclItemStub(
 ) : RsAttributeOwnerStubBase<RsModDeclItem>(parent, elementType),
     RsNamedStub {
 
+    val pathAttribute: String?
+        // TODO: Don't use psi
+        get() = if (hasAttrs) psi.pathAttribute else null
+
     object Type : RsStubElementType<RsModDeclItemStub, RsModDeclItem>("MOD_DECL_ITEM") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
             RsModDeclItemStub(parentStub, this,
@@ -544,6 +592,10 @@ class RsModItemStub(
     override val flags: Int
 ) : RsAttributeOwnerStubBase<RsModItem>(parent, elementType),
     RsNamedStub {
+
+    val pathAttribute: String?
+        // TODO: Don't use psi
+        get() = if (hasAttrs) psi.pathAttribute else null
 
     object Type : RsStubElementType<RsModItemStub, RsModItem>("MOD_ITEM") {
 
@@ -932,6 +984,9 @@ class RsPathStub(
     val startOffset: Int
 ) : StubBase<RsPath>(parent, elementType) {
 
+    val path: RsPathStub?
+        get() = findChildStubByType(Type)
+
     object Type : RsStubElementType<RsPathStub, RsPath>("PATH") {
         override fun shouldCreateStub(node: ASTNode): Boolean = createStubIfParentIsStub(node)
 
@@ -1270,6 +1325,13 @@ class RsMacroStub(
 ) : RsAttributeOwnerStubBase<RsMacro>(parent, elementType),
     RsNamedStub {
 
+    // stored in stub as an optimization
+    val hasMacroExport: Boolean
+        get() = BitUtil.isSet(flags, HAS_MACRO_EXPORT)
+    // stored in stub as an optimization
+    val hasMacroExportLocalInnerMacros: Boolean
+        get() = BitUtil.isSet(flags, HAS_MACRO_EXPORT_LOCAL_INNER_MACROS)
+
     object Type : RsStubElementType<RsMacroStub, RsMacro>("MACRO") {
         override fun shouldCreateStub(node: ASTNode): Boolean =
             node.treeParent.elementType in RS_MOD_OR_FILE
@@ -1295,17 +1357,27 @@ class RsMacroStub(
         override fun createPsi(stub: RsMacroStub): RsMacro =
             RsMacroImpl(stub, this)
 
-        override fun createStub(psi: RsMacro, parentStub: StubElement<*>?) = RsMacroStub(
-            parentStub,
-            this,
-            psi.name,
-            psi.macroBody?.text,
-            psi.bodyHash,
-            psi.preferredBraces,
-            RsAttributeOwnerStub.extractFlags(psi)
-        )
+        override fun createStub(psi: RsMacro, parentStub: StubElement<*>?): RsMacroStub {
+            var flags = RsAttributeOwnerStub.extractFlags(psi)
+            flags = BitUtil.set(flags, HAS_MACRO_EXPORT, psi.hasMacroExport)
+            flags = BitUtil.set(flags, HAS_MACRO_EXPORT_LOCAL_INNER_MACROS, psi.hasMacroExportLocalInnerMacros)
+            return RsMacroStub(
+                parentStub,
+                this,
+                psi.name,
+                psi.macroBody?.text,
+                psi.bodyHash,
+                psi.preferredBraces,
+                flags
+            )
+        }
 
         override fun indexStub(stub: RsMacroStub, sink: IndexSink) = sink.indexMacro(stub)
+    }
+
+    companion object {
+        private val HAS_MACRO_EXPORT: Int = makeBitMask(RsAttributeOwnerStub.USED_BITS + 0)
+        private val HAS_MACRO_EXPORT_LOCAL_INNER_MACROS: Int = makeBitMask(RsAttributeOwnerStub.USED_BITS + 1)
     }
 }
 
@@ -1348,6 +1420,9 @@ class RsMacroCallStub(
     val bodyStartOffset: Int,
     override val flags: Int
 ) : RsAttributeOwnerStubBase<RsMacroCall>(parent, elementType) {
+
+    val path: RsPathStub
+        get() = findChildStubByType(RsPathStub.Type)!! // guaranteed to be non-null by the grammar
 
     object Type : RsStubElementType<RsMacroCallStub, RsMacroCall>("MACRO_CALL") {
         override fun shouldCreateStub(node: ASTNode): Boolean {
@@ -1746,6 +1821,12 @@ class RsVisStub(
     parent: StubElement<*>?, elementType: IStubElementType<*, *>,
     val kind: RsVisStubKind
 ) : StubBase<RsVis>(parent, elementType) {
+
+    /** Equivalent of `RsVis.visRestriction.path` */
+    val visRestrictionPath: RsPathStub? get() {
+        val visRestriction = findChildStubByType(RsStubElementTypes.VIS_RESTRICTION)
+        return visRestriction?.findChildStubByType(RsPathStub.Type)
+    }
 
     object Type : RsStubElementType<RsVisStub, RsVis>("VIS") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -35,7 +35,10 @@ import org.rust.lang.core.stubs.BlockMayHaveStubsHeuristic.getAndClearCached
 import org.rust.lang.core.types.ty.TyFloat
 import org.rust.lang.core.types.ty.TyInteger
 import org.rust.openapiext.ancestors
+import org.rust.stdext.HashCode
 import org.rust.stdext.makeBitMask
+import org.rust.stdext.readHashCodeNullable
+import org.rust.stdext.writeHashCodeNullable
 
 class RsFileStub : PsiFileStubImpl<RsFile> {
     val attributes: RsFile.Attributes
@@ -1261,6 +1264,7 @@ class RsMacroStub(
     parent: StubElement<*>?, elementType: IStubElementType<*, *>,
     override val name: String?,
     val macroBody: String?,
+    val bodyHash: HashCode?,
     val preferredBraces: MacroBraces,
     override val flags: Int
 ) : RsAttributeOwnerStubBase<RsMacro>(parent, elementType),
@@ -1274,6 +1278,7 @@ class RsMacroStub(
             RsMacroStub(parentStub, this,
                 dataStream.readNameAsString(),
                 dataStream.readUTFFastAsNullable(),
+                dataStream.readHashCodeNullable(),
                 dataStream.readEnum(),
                 dataStream.readUnsignedByte()
             )
@@ -1282,6 +1287,7 @@ class RsMacroStub(
             with(dataStream) {
                 writeName(stub.name)
                 writeUTFFastAsNullable(stub.macroBody)
+                writeHashCodeNullable(stub.bodyHash)
                 writeEnum(stub.preferredBraces)
                 writeByte(stub.flags)
             }
@@ -1294,6 +1300,7 @@ class RsMacroStub(
             this,
             psi.name,
             psi.macroBody?.text,
+            psi.bodyHash,
             psi.preferredBraces,
             RsAttributeOwnerStub.extractFlags(psi)
         )
@@ -1337,6 +1344,7 @@ class RsMacro2Stub(
 class RsMacroCallStub(
     parent: StubElement<*>?, elementType: IStubElementType<*, *>,
     val macroBody: String?,
+    val bodyHash: HashCode?,
     val bodyStartOffset: Int,
     override val flags: Int
 ) : RsAttributeOwnerStubBase<RsMacroCall>(parent, elementType) {
@@ -1350,6 +1358,7 @@ class RsMacroCallStub(
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
             RsMacroCallStub(parentStub, this,
                 dataStream.readUTFFastAsNullable(),
+                dataStream.readHashCodeNullable(),
                 dataStream.readVarInt(),
                 dataStream.readUnsignedByte()
             )
@@ -1357,6 +1366,7 @@ class RsMacroCallStub(
         override fun serialize(stub: RsMacroCallStub, dataStream: StubOutputStream) =
             with(dataStream) {
                 writeUTFFastAsNullable(stub.macroBody)
+                writeHashCodeNullable(stub.bodyHash)
                 writeVarInt(stub.bodyStartOffset)
                 writeByte(stub.flags)
             }
@@ -1368,6 +1378,7 @@ class RsMacroCallStub(
             parentStub,
             this,
             psi.macroBody,
+            psi.bodyHash,
             psi.bodyTextRange?.startOffset ?: -1,
             RsAttributeOwnerStub.extractFlags(psi)
         )

--- a/src/main/kotlin/org/rust/stdext/HashCode.kt
+++ b/src/main/kotlin/org/rust/stdext/HashCode.kt
@@ -7,6 +7,8 @@ package org.rust.stdext
 
 import com.intellij.util.io.DigestUtil
 import org.apache.commons.codec.binary.Hex
+import java.io.DataInput
+import java.io.DataOutput
 import java.io.Serializable
 
 /**
@@ -50,3 +52,29 @@ import java.io.Serializable
 }
 
 fun HashCode.getLeading64bits(): Long = toByteArray().getLeading64bits()
+
+fun DataOutput.writeHashCode(hash: HashCode) =
+    write(hash.toByteArray())
+
+fun DataInput.readHashCode(): HashCode {
+    val bytes = ByteArray(HashCode.ARRAY_LEN)
+    readFully(bytes)
+    return HashCode.fromByteArray(bytes)
+}
+
+fun DataOutput.writeHashCodeNullable(hash: HashCode?) {
+    if (hash == null) {
+        writeBoolean(false)
+    } else {
+        writeBoolean(true)
+        writeHashCode(hash)
+    }
+}
+
+fun DataInput.readHashCodeNullable(): HashCode? {
+    return if (readBoolean()) {
+        readHashCode()
+    } else {
+        null
+    }
+}


### PR DESCRIPTION
Added helper methods for stubs which will be used in new resolve.

Also:
* Added `hasColonColon` flag to `RsUseSpeckStub` to distinguish `use {aaa, bbb};` and `use ::{aaa, bbb};`
* Added `bodyHash` to macro and macro call stubs as an optimization