### PR TITLE
INSP: improve integration with Grazie plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ val baseVersion = when (baseIDE) {
 }
 
 val nativeDebugPlugin = "com.intellij.nativeDebug:${prop("nativeDebugPluginVersion")}"
-val graziePlugin = "tanvd.grazi:${prop("graziePluginVersion")}"
+val graziePlugin = if (baseIDE == "idea") "grazie" else "tanvd.grazi:${prop("graziePluginVersion")}"
 val psiViewerPlugin = "PsiViewer:${prop("psiViewerPluginVersion")}"
 
 plugins {

--- a/grazie/src/main/kotlin/org/rust/grazie/RsGrammarCheckingStrategy.kt
+++ b/grazie/src/main/kotlin/org/rust/grazie/RsGrammarCheckingStrategy.kt
@@ -6,22 +6,22 @@
 package org.rust.grazie
 
 import com.intellij.grazie.grammar.strategy.GrammarCheckingStrategy
+import com.intellij.grazie.grammar.strategy.GrammarCheckingStrategy.TextDomain
 import com.intellij.grazie.grammar.strategy.StrategyUtils
 import com.intellij.grazie.grammar.strategy.impl.RuleGroup
 import com.intellij.grazie.utils.LinkedSet
 import com.intellij.psi.PsiElement
 import org.rust.ide.injected.findDoctestInjectableRanges
-import org.rust.lang.core.psi.RsDocCommentImpl
-import org.rust.lang.core.psi.RsLitExpr
-import org.rust.lang.core.psi.RsLiteralKind
-import org.rust.lang.core.psi.ext.stubKind
-import org.rust.lang.core.psi.kind
-import org.rust.lang.core.stubs.RsStubLiteralKind
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.elementType
 
 class RsGrammarCheckingStrategy : GrammarCheckingStrategy {
-    override fun isMyContextRoot(element: PsiElement): Boolean =
-        element is RsDocCommentImpl || element is RsLitExpr && element.stubKind is RsStubLiteralKind.String
 
+    override fun isMyContextRoot(element: PsiElement): Boolean =
+        getContextRootTextDomain(element) != TextDomain.NON_TEXT
+
+    // BACKCOMPAT: 2020.2
+    @Suppress("UnstableApiUsage", "OverridingDeprecatedMember")
     override fun isTypoAccepted(root: PsiElement, typoRange: IntRange, ruleRange: IntRange): Boolean {
         if (root !is RsDocCommentImpl) return true
 
@@ -33,12 +33,21 @@ class RsGrammarCheckingStrategy : GrammarCheckingStrategy {
     override fun getIgnoredRuleGroup(root: PsiElement, child: PsiElement): RuleGroup? = RuleGroup.LITERALS
 
     override fun getStealthyRanges(root: PsiElement, text: CharSequence): LinkedSet<IntRange> {
-        return when (root) {
-            is RsLitExpr -> {
-                val valueTextRange = (root.kind as? RsLiteralKind.String)?.offsets?.value ?: return linkedSetOf()
-                linkedSetOf(0 until valueTextRange.startOffset, valueTextRange.endOffset until text.length)
-            }
-            else -> StrategyUtils.indentIndexes(text, setOf(' ', '/', '!'))
+        val parent = root.parent
+        return if (parent is RsLitExpr) {
+            val valueTextRange = (parent.kind as? RsLiteralKind.String)?.offsets?.value ?: return linkedSetOf()
+            linkedSetOf(0 until valueTextRange.startOffset, valueTextRange.endOffset until text.length)
+        } else {
+            StrategyUtils.indentIndexes(text, setOf(' ', '/', '!'))
+        }
+    }
+
+    override fun getContextRootTextDomain(root: PsiElement): TextDomain {
+        return when (root.elementType) {
+            in RS_ALL_STRING_LITERALS -> TextDomain.LITERALS
+            in RS_DOC_COMMENTS -> TextDomain.DOCS
+            in RS_REGULAR_COMMENTS -> TextDomain.COMMENTS
+            else -> TextDomain.NON_TEXT
         }
     }
 }

--- a/grazie/src/main/kotlin/org/rust/grazie/RsGrammarCheckingStrategy.kt
+++ b/grazie/src/main/kotlin/org/rust/grazie/RsGrammarCheckingStrategy.kt
@@ -13,7 +13,9 @@ import com.intellij.psi.PsiElement
 import org.rust.ide.injected.findDoctestInjectableRanges
 import org.rust.lang.core.psi.RsDocCommentImpl
 import org.rust.lang.core.psi.RsLitExpr
+import org.rust.lang.core.psi.RsLiteralKind
 import org.rust.lang.core.psi.ext.stubKind
+import org.rust.lang.core.psi.kind
 import org.rust.lang.core.stubs.RsStubLiteralKind
 
 class RsGrammarCheckingStrategy : GrammarCheckingStrategy {
@@ -30,6 +32,13 @@ class RsGrammarCheckingStrategy : GrammarCheckingStrategy {
 
     override fun getIgnoredRuleGroup(root: PsiElement, child: PsiElement): RuleGroup? = RuleGroup.LITERALS
 
-    override fun getStealthyRanges(root: PsiElement, text: CharSequence): LinkedSet<IntRange> =
-        StrategyUtils.indentIndexes(text, setOf(' ', '/', '!'))
+    override fun getStealthyRanges(root: PsiElement, text: CharSequence): LinkedSet<IntRange> {
+        return when (root) {
+            is RsLitExpr -> {
+                val valueTextRange = (root.kind as? RsLiteralKind.String)?.offsets?.value ?: return linkedSetOf()
+                linkedSetOf(0 until valueTextRange.startOffset, valueTextRange.endOffset until text.length)
+            }
+            else -> StrategyUtils.indentIndexes(text, setOf(' ', '/', '!'))
+        }
+    }
 }

--- a/grazie/src/test/kotlin/org/rust/grazie/RsGrammarCheckingTest.kt
+++ b/grazie/src/test/kotlin/org/rust/grazie/RsGrammarCheckingTest.kt
@@ -9,7 +9,11 @@ import com.intellij.grazie.GrazieConfig
 import com.intellij.grazie.ide.inspection.grammar.GrazieInspection
 import com.intellij.grazie.ide.language.LanguageGrammarChecking
 import com.intellij.grazie.jlanguage.Lang
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.util.BuildNumber
+import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.PlatformTestUtil
+import org.intellij.lang.annotations.Language
 import org.rust.IgnoreInPlatform
 import org.rust.ide.annotator.RsAnnotationTestFixture
 import org.rust.ide.inspections.RsInspectionsTestBase
@@ -24,36 +28,94 @@ class RsGrammarCheckingTest : RsInspectionsTestBase(GrazieInspection::class) {
         val strategy = LanguageGrammarChecking.getStrategies().first { it is RsGrammarCheckingStrategy }
         val currentState = GrazieConfig.get()
         if (strategy.getID() !in currentState.enabledGrammarStrategies || currentState.enabledLanguages != enabledLanguages) {
-            GrazieConfig.update { state ->
+            updateSettings { state ->
                 state.copy(
                     enabledGrammarStrategies = state.enabledGrammarStrategies + strategy.getID(),
                     enabledLanguages = enabledLanguages
                 )
             }
-            PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+        }
+        Disposer.register(testRootDisposable) {
+            updateSettings { currentState }
         }
     }
 
-    fun `test check literals`() = checkByText("""
+    fun `test check literals`() = doTest("""
         fn foo() {
             let literal = "<TYPO>There is two apples</TYPO>";
             let raw_literal = r"<TYPO>There is two apples</TYPO>";
             let binary_literal = b"<TYPO>There is two apples</TYPO>";
         }
-    """)
+    """, checkInStringLiterals = true)
+
+    fun `test check comments`() = doTest("""
+        fn foo() {
+            // <TYPO>There is two apples</TYPO>
+            /* <TYPO>There is two apples</TYPO> */
+            let literal = 123;
+        }
+    """, checkInComments = true)
+
+    fun `test check doc comments`() = doTest("""
+        /// <TYPO>There is two apples</TYPO>
+        mod foo {
+            //! <TYPO>There is two apples</TYPO>
+
+            /** <TYPO>There is two apples</TYPO> */
+            fn bar() {}
+        }
+    """, checkInDocumentation = true)
 
     // BACKCOMPAT: 2020.2. Proofreading was broken in grazie plugin for 2020.2 in injected code
     @IgnoreInPlatform(202)
-    fun `test check doc comments`() = checkByText("""
+    fun `test check injected Rust code in doc comments`() = doTest("""
         ///
         /// ```
         /// let literal = "<TYPO>There is two apples</TYPO>";
         /// for i in 1..10 {}
         /// ```
         pub fn foo() {}
-    """)
+    """, checkInStringLiterals = true)
+
+    private fun doTest(
+        @Language("Rust") text: String,
+        checkInStringLiterals: Boolean = false,
+        checkInComments: Boolean = false,
+        checkInDocumentation: Boolean = false
+    ) {
+        updateSettings { state ->
+            val newContext = state.checkingContext.copy(
+                isCheckInStringLiteralsEnabled = checkInStringLiterals,
+                isCheckInCommentsEnabled = checkInComments,
+                isCheckInDocumentationEnabled = checkInDocumentation
+            )
+            state.copy(checkingContext = newContext)
+        }
+        checkByText(text)
+
+        // BACKCOMPAT: 2020.2. GrazieInspection is always enabled for any element for 2020.2
+        if (ApplicationInfo.getInstance().build >= BUILD_203) {
+            updateSettings { state ->
+                val newContext = state.checkingContext.copy(
+                    isCheckInStringLiteralsEnabled = false,
+                    isCheckInCommentsEnabled = false,
+                    isCheckInDocumentationEnabled = false
+                )
+                state.copy(checkingContext = newContext)
+            }
+
+            checkByText(text.replace("<TYPO.*?>(.*?)</TYPO>".toRegex(), "$1"))
+        }
+    }
+
+    private fun updateSettings(change: (GrazieConfig.State) -> GrazieConfig.State) {
+        GrazieConfig.update(change)
+        PlatformTestUtil.dispatchAllEventsInIdeEventQueue()
+    }
 
     companion object {
         private val enabledLanguages = setOf(Lang.AMERICAN_ENGLISH)
+
+        private val BUILD_203: BuildNumber = BuildNumber.fromString("203")!!
     }
 }

--- a/grazie/src/test/kotlin/org/rust/grazie/RsGrammarCheckingTest.kt
+++ b/grazie/src/test/kotlin/org/rust/grazie/RsGrammarCheckingTest.kt
@@ -42,18 +42,16 @@ class RsGrammarCheckingTest : RsInspectionsTestBase(GrazieInspection::class) {
         }
     """)
 
-    // https://github.com/intellij-rust/intellij-rust/issues/5530
-    @IgnoreInPlatform(203)
-    fun `test check doc comments`() = expect<AssertionError> {
-        checkByText("""
-            ///
-            /// ```
-            /// let literal = "<TYPO>There is two apples</TYPO>";
-            /// for i in 1..10 {}
-            /// ```
-            pub fn foo() {}
-        """)
-    }
+    // BACKCOMPAT: 2020.2. Proofreading was broken in grazie plugin for 2020.2 in injected code
+    @IgnoreInPlatform(202)
+    fun `test check doc comments`() = checkByText("""
+        ///
+        /// ```
+        /// let literal = "<TYPO>There is two apples</TYPO>";
+        /// for i in 1..10 {}
+        /// ```
+        pub fn foo() {}
+    """)
 
     companion object {
         private val enabledLanguages = setOf(Lang.AMERICAN_ENGLISH)

--- a/grazie/src/test/kotlin/org/rust/grazie/RsGrammarCheckingTest.kt
+++ b/grazie/src/test/kotlin/org/rust/grazie/RsGrammarCheckingTest.kt
@@ -34,7 +34,6 @@ class RsGrammarCheckingTest : RsInspectionsTestBase(GrazieInspection::class) {
         }
     }
 
-    @IgnoreInPlatform(203)
     fun `test check literals`() = checkByText("""
         fn foo() {
             let literal = "<TYPO>There is two apples</TYPO>";


### PR DESCRIPTION
These changes:
* Fix incorrect proofreading annotations on raw and binary string literals. The bug can be reproduced only in 2020.3
![image](https://user-images.githubusercontent.com/2539310/94344465-4fa77b00-0028-11eb-863b-9b79f10b6ca3.png)
* Properly support domain options (`String literals`, `Comments` and `Documentation`) in `Preferences | Editor | Proofreading | Grammar`
* Provide source code of Grazie plugin while development when `baseIDE` in `gradle.properties` is `idea`. Previously, IDE always shows only class files