### PR TITLE
PERF&MACRO: Take heavy process latch only if there are macros to expand

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -216,7 +216,7 @@ abstract class MacroExpansionTaskBase(
                 doneStages.addAndGet(if (result is EmptyPipeline) Pipeline.STAGES else 2)
 
                 // Enter heavy process mode only if at least one macros is not up-to-date
-                if (result !is EmptyPipeline) {
+                if (result !is EmptyPipeline && result !is RemoveSourceFileIfEmptyPipeline) {
                     heavyProcessRequested = true
                 }
                 result


### PR DESCRIPTION
The regression was introduced in #4700.

This can slightly speed up code highlighting after `cargo refresh`.
It's mostly invisible to users, I guess.

bors r+