### PR TITLE
UI: move download link to proper place

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/ui/RustProjectSettingsPanel.kt
@@ -86,7 +86,7 @@ class RustProjectSettingsPanel(
         row("Toolchain location:") { wrapComponent(pathToToolchainField)(growX, pushX) }
         row("Toolchain version:") { toolchainVersion() }
         row("Standard library:") { wrapComponent(pathToStdlibField)(growX, pushX) }
-        row { downloadStdlibLink() }
+        row("") { downloadStdlibLink() }
     }
 
     @Throws(ConfigurationException::class)


### PR DESCRIPTION
Fixes bug introduced in #6166

**Before:**
<img width="759" alt="Screen Shot 2020-09-28 at 17 06 10" src="https://user-images.githubusercontent.com/2539310/94442972-43005f80-01ad-11eb-893d-875acff3f5f4.png">

**After:**
![image](https://user-images.githubusercontent.com/2539310/94443004-4dbaf480-01ad-11eb-9025-6296afe9b9fb.png)
