### PR TITLE
UI: use recommended guidelines for settings UI

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/configurable/CargoConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/CargoConfigurable.kt
@@ -28,9 +28,8 @@ class CargoConfigurable(project: Project) : RsConfigurableBase(project, "Cargo")
         return panel {
             row {
                 checkBox(
-                    "Watch Cargo.toml",
-                    state::autoUpdateEnabled,
-                    comment = "Update project automatically if `Cargo.toml` changes"
+                    "Update project automatically if Cargo.toml changes",
+                    state::autoUpdateEnabled
                 )
             }
             row {

--- a/src/main/kotlin/org/rust/cargo/project/configurable/CargoConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/CargoConfigurable.kt
@@ -6,95 +6,77 @@
 package org.rust.cargo.project.configurable
 
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.EnumComboBoxModel
-import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.layout.CCFlags
 import com.intellij.ui.layout.panel
+import com.intellij.ui.layout.toBinding
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.toolchain.ExternalLinter
 import org.rust.cargo.util.CargoCommandCompletionProvider
 import org.rust.cargo.util.RsCommandLineEditor
-import org.rust.openapiext.CheckboxDelegate
-import org.rust.openapiext.ComboBoxDelegate
-import org.rust.openapiext.row
-import javax.swing.JComponent
 
-class CargoConfigurable(project: Project) : RsConfigurableBase(project) {
-
-    private val autoUpdateEnabledCheckbox: JBCheckBox = JBCheckBox()
-    private var autoUpdateEnabled: Boolean by CheckboxDelegate(autoUpdateEnabledCheckbox)
-
-    private val externalLinterComboBox: ComboBox<ExternalLinter> = ComboBox(EnumComboBoxModel(ExternalLinter::class.java))
-    private var externalLinter: ExternalLinter by ComboBoxDelegate(externalLinterComboBox)
-
-    private val runExternalLinterOnTheFlyCheckbox: JBCheckBox = JBCheckBox()
-    private var runExternalLinterOnTheFly: Boolean by CheckboxDelegate(runExternalLinterOnTheFlyCheckbox)
-
-    private val useOfflineCheckbox: JBCheckBox = JBCheckBox()
-    private var useOffline: Boolean by CheckboxDelegate(useOfflineCheckbox)
-
-    private val compileAllTargetsCheckBox = JBCheckBox()
-    private var compileAllTargets: Boolean by CheckboxDelegate(compileAllTargetsCheckBox)
+class CargoConfigurable(project: Project) : RsConfigurableBase(project, "Cargo") {
 
     private lateinit var externalLinterArguments: RsCommandLineEditor
 
-    override fun getDisplayName(): String = "Cargo"
-
-    override fun createComponent(): JComponent = panel {
+    override fun createPanel(): DialogPanel {
         externalLinterArguments = RsCommandLineEditor(
-            project, CargoCommandCompletionProvider(project.cargoProjects, "check ") { null }
+            project,
+            CargoCommandCompletionProvider(project.cargoProjects, "check ") { null }
         )
+        return panel {
+            row {
+                checkBox(
+                    "Watch Cargo.toml",
+                    state::autoUpdateEnabled,
+                    comment = "Update project automatically if `Cargo.toml` changes"
+                )
+            }
+            row {
+                checkBox(
+                    "Compile all project targets if possible",
+                    state::compileAllTargets,
+                    comment = "Pass <b>--target-all</b> option to Сargo <b>build</b>/<b>check</b> command"
+                )
+            }
+            row {
+                checkBox(
+                    "Offline mode",
+                    state::useOffline,
+                    comment = "Pass <b>--offline</b> option to Cargo not to perform network requests"
+                )
+            }
 
-        row("Watch Cargo.toml:", """
-            Update project automatically if `Cargo.toml` changes.
-        """) { autoUpdateEnabledCheckbox() }
-        row("Compile all project targets if possible:", """
-            Pass `--target-all` option to cargo build/check command.
-        """) { compileAllTargetsCheckBox() }
-        row("Offline mode:", """
-            Pass `--offline` option to cargo not to perform network requests.
-        """) { useOfflineCheckbox() }
+            titledRow("External Linter") {
+                subRowIndent = 0
+                row("External tool:") {
+                    comboBox(
+                        EnumComboBoxModel(ExternalLinter::class.java),
+                        state::externalLinter,
+                    ).comment("External tool to use for code analysis")
+                }
 
-        titledRow("External Linter") {
-            subRowIndent = 0
-            row("External tool:", """
-                External tool to use for code analysis.
-            """) { externalLinterComboBox(growX, pushX) }
-            row("Additional arguments:", """
-                Additional arguments to pass to `cargo check` or `cargo clippy` command.
-            """) { externalLinterArguments(growX, pushX) }
-            row("Run external linter to analyze code on the fly:", """
-                Enable external linter to add code highlighting based on the used linter result.
-                Can be CPU-consuming.
-            """) { runExternalLinterOnTheFlyCheckbox() }
+                row("Additional arguments:") {
+                    externalLinterArguments(CCFlags.growX)
+                        .comment("Additional arguments to pass to <b>cargo check</b> or <b>cargo clippy</b> command")
+                        .withBinding(
+                            componentGet = { it.text },
+                            componentSet = { component, value -> component.text = value },
+                            modelBinding = state::externalLinterArguments.toBinding()
+                        )
+                }
+                row {
+                    checkBox(
+                        "Run external linter to analyze code on the fly",
+                        state::runExternalLinterOnTheFly,
+                        comment = """
+                            Enable external linter to add code highlighting based on the used linter result.
+                            Can be CPU-consuming
+                        """.trimIndent()
+                    )
+                }
+            }
         }
-    }
-
-    override fun isModified(): Boolean =
-        autoUpdateEnabled != settings.autoUpdateEnabled
-            || externalLinter != settings.externalLinter
-            || runExternalLinterOnTheFly != settings.runExternalLinterOnTheFly
-            || compileAllTargets != settings.compileAllTargets
-            || useOffline != settings.useOffline
-            || externalLinterArguments.text != settings.externalLinterArguments
-
-    override fun apply() {
-        settings.modify {
-            it.autoUpdateEnabled = autoUpdateEnabled
-            it.externalLinter = externalLinter
-            it.runExternalLinterOnTheFly = runExternalLinterOnTheFly
-            it.externalLinterArguments = externalLinterArguments.text
-            it.compileAllTargets = compileAllTargets
-            it.useOffline = useOffline
-        }
-    }
-
-    override fun reset() {
-        autoUpdateEnabled = settings.autoUpdateEnabled
-        externalLinter = settings.externalLinter
-        runExternalLinterOnTheFly = settings.runExternalLinterOnTheFly
-        externalLinterArguments.text = settings.externalLinterArguments
-        compileAllTargets = settings.compileAllTargets
-        useOffline = settings.useOffline
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/configurable/RsConfigurableBase.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RsConfigurableBase.kt
@@ -5,16 +5,29 @@
 
 package org.rust.cargo.project.configurable
 
-import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.options.BoundConfigurable
+import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.project.Project
 import com.intellij.util.PlatformUtils
+import org.jetbrains.annotations.Nls
 import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.settings.rustSettings
 
-abstract class RsConfigurableBase(protected val project: Project) : Configurable {
+abstract class RsConfigurableBase(protected val project: Project, @Nls displayName: String) :
+    BoundConfigurable(displayName) {
 
-    protected val settings: RustProjectSettingsService = project.rustSettings
+    protected val state: RustProjectSettingsService.State = project.rustSettings.settingsState
 
     // Currently, we have help page only for CLion
     override fun getHelpTopic(): String? = if (PlatformUtils.isCLion()) "rustsupport" else null
+
+    @Throws(ConfigurationException::class)
+    final override fun apply() {
+        super.apply()
+        doApply()
+        project.rustSettings.settingsState = state
+    }
+
+    @Throws(ConfigurationException::class)
+    protected open fun doApply() {}
 }

--- a/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RustfmtConfigurable.kt
@@ -6,38 +6,12 @@
 package org.rust.cargo.project.configurable
 
 import com.intellij.openapi.project.Project
-import com.intellij.ui.components.JBCheckBox
+import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.layout.panel
-import org.rust.openapiext.CheckboxDelegate
-import javax.swing.JComponent
 
-class RustfmtConfigurable(project: Project) : RsConfigurableBase(project) {
-    private val useRustfmtCheckbox: JBCheckBox = JBCheckBox()
-    private var useRustfmt: Boolean by CheckboxDelegate(useRustfmtCheckbox)
-
-    private val runRustfmtOnSaveCheckbox: JBCheckBox = JBCheckBox()
-    private var runRustfmtOnSave: Boolean by CheckboxDelegate(runRustfmtOnSaveCheckbox)
-
-    override fun getDisplayName(): String = "Rustfmt"
-
-    override fun createComponent(): JComponent = panel {
-        row("Use rustfmt instead of built-in formatter:") { useRustfmtCheckbox() }
-        row("Run rustfmt on Save:") { runRustfmtOnSaveCheckbox() }
-    }
-
-    override fun isModified(): Boolean =
-        settings.useRustfmt != useRustfmt
-            || settings.runRustfmtOnSave != runRustfmtOnSave
-
-    override fun apply() {
-        settings.modify {
-            it.useRustfmt = useRustfmt
-            it.runRustfmtOnSave = runRustfmtOnSave
-        }
-    }
-
-    override fun reset() {
-        useRustfmt = settings.useRustfmt
-        runRustfmtOnSave = settings.runRustfmtOnSave
+class RustfmtConfigurable(project: Project) : RsConfigurableBase(project, "Rustfmt") {
+    override fun createPanel(): DialogPanel = panel {
+        row { checkBox("Use rustfmt instead of built-in formatter", state::useRustfmt) }
+        row { checkBox("Run rustfmt on Save", state::runRustfmtOnSave) }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -78,6 +78,12 @@ interface RustProjectSettingsService {
     @TestOnly
     fun modifyTemporary(parentDisposable: Disposable, action: (State) -> Unit)
 
+    /**
+     * Returns current state of the service.
+     * Note, result is a copy of service state, so you need to set modified state back to apply changes
+     */
+    var settingsState: State
+
     val version: Int?
     val toolchain: RustToolchain?
     val explicitPathToStdlib: String?


### PR DESCRIPTION
These changes:
* use embedded checkbox label
* use inline text help (comments) instead of Swing tooltips
* use more features of platform UI DSl that allows dropping mutable variables to keep intermediate state, implement `reset`, `isModified` and `apply` methods almost automatically

Also, these changes introduce mutable `RustProjectSettingsService.settingsState` property to make usage of binding related UI DSL methods convenient

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/2539310/94463156-30922000-01c5-11eb-9a39-561af7cc76a3.png) | ![image](https://user-images.githubusercontent.com/2539310/94463356-78b14280-01c5-11eb-9790-d0a747839f27.png) |
| ![image](https://user-images.githubusercontent.com/2539310/94463598-dc3b7000-01c5-11eb-8f81-e206242eb611.png) | ![image](https://user-images.githubusercontent.com/2539310/94463407-91b9f380-01c5-11eb-9da5-de3f64b2b54b.png) |
| ![image](https://user-images.githubusercontent.com/2539310/94463336-6fc07100-01c5-11eb-91e9-add191e17725.png) | ![image](https://user-images.githubusercontent.com/2539310/94463384-88308b80-01c5-11eb-812e-8d57fad0bb21.png) |



