### PR TITLE
UI: Get rid of scrollbar in project creation dialog in CLion

### DIFF
--- a/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/ui/RsNewProjectPanel.kt
@@ -22,6 +22,7 @@ import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBList
 import com.intellij.ui.components.Link
 import com.intellij.ui.layout.LayoutBuilder
+import com.intellij.util.ui.JBUI
 import org.rust.cargo.project.settings.ui.RustProjectSettingsPanel
 import org.rust.cargo.toolchain.Cargo
 import org.rust.ide.newProject.ConfigurationData
@@ -88,6 +89,7 @@ class RsNewProjectPanel(
 
     val templateToolbar: ToolbarDecorator = ToolbarDecorator.createDecorator(templateList)
         .setToolbarPosition(ActionToolbarPosition.BOTTOM)
+        .setPreferredSize(JBUI.size(0, 125))
         .disableUpDownActions()
         .setAddAction {
             AddUserTemplateDialog().show()


### PR DESCRIPTION
I reckon the scrollbar started to appear after recent UI changes. The scrollbar scrolls to nothing, but taking too much space and focus on the right of the form in default non-resizable CLion wizard window.

This PR makes templates pane height fixed to 125px which allows to show 4 default template items and 2 user ones if they have any without scrollbar in the pane itself.

| Before | After |
| ------- | ----- |
| ![](https://user-images.githubusercontent.com/6342851/94624632-8ea32e00-02bf-11eb-869c-25f5aab64ec2.png) | ![](https://user-images.githubusercontent.com/6342851/94624639-9236b500-02bf-11eb-9155-8084ce0e86aa.png) |
