### PR TITLE
Fix #6183

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -84,6 +84,7 @@ nicholastmosher
 ninjabear
 oistein
 oleg-semenov
+ondralukes
 orium
 ortem
 osialr

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddMutableFix.kt
@@ -65,7 +65,11 @@ fun updateMutable(project: Project, binding: RsNamedElement, mutable: Boolean = 
             binding.replace(newPatBinding)
         }
         is RsSelfParameter -> {
-            val newSelf = RsPsiFactory(project).createSelf(true)
+            val newSelf: RsSelfParameter = if (binding.isRef) {
+                RsPsiFactory(project).createSelfReference(true)
+            } else {
+                RsPsiFactory(project).createSelf(true)
+            }
             binding.replace(newSelf)
         }
     }

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddSelfFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddSelfFix.kt
@@ -27,7 +27,7 @@ class AddSelfFix(function: RsFunction) : LocalQuickFixAndIntentionActionOnPsiEle
         val valueParameterList = function.valueParameterList
         val lparen = valueParameterList?.firstChild
 
-        val self = psiFactory.createSelf()
+        val self = psiFactory.createSelfReference()
 
         valueParameterList?.addAfter(self, lparen)
         if (hasParameters) {

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/ElideLifetimesFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/ElideLifetimesFix.kt
@@ -63,7 +63,7 @@ private class LifetimeRemover : RsVisitor() {
 
     override fun visitSelfParameter(selfParameter: RsSelfParameter) {
         if (selfParameter.lifetime != null) {
-            val newSelfParameter = RsPsiFactory(selfParameter.project).createSelf(selfParameter.mutability.isMut)
+            val newSelfParameter = RsPsiFactory(selfParameter.project).createSelfReference(selfParameter.mutability.isMut)
             selfParameter.replace(newSelfParameter)
         }
         selfParameter.typeReference?.let { visitTypeReference(it) }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -72,6 +72,11 @@ class RsPsiFactory(
     }
 
     fun createSelf(mutable: Boolean = false): RsSelfParameter {
+        return createFromText<RsFunction>("fn main(${if (mutable) "mut " else ""}self){}")?.selfParameter
+            ?: error("Failed to create self element")
+    }
+
+    fun createSelfReference(mutable: Boolean = false): RsSelfParameter {
         return createFromText<RsFunction>("fn main(&${if (mutable) "mut " else ""}self){}")?.selfParameter
             ?: error("Failed to create self element")
     }

--- a/src/test/kotlin/org/rust/ide/inspections/fixes/AddMutableFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/fixes/AddMutableFixTest.kt
@@ -261,4 +261,48 @@ class AddMutableFixTest : RsMultipleInspectionsTestBase(
             }
         }
     """)
+
+    fun `test fix E0594 assign to field of immutable binding`() = checkFixByText("Make `self` mutable", """
+        struct A {
+            x: i32
+        }
+
+        impl A {
+            fn foo(self) {
+                <error>self.x/*caret*/ = 4</error>;
+            }
+        }
+    """, """
+        struct A {
+            x: i32
+        }
+
+        impl A {
+            fn foo(mut self) {
+                self.x = 4;
+            }
+        }
+    """)
+
+    fun `test fix E0596 borrow self as mutable`() = checkFixByText("Make `self` mutable", """
+        struct A {}
+
+        impl A {
+            fn foo(self) {
+                <error descr="Cannot borrow immutable local variable `self` as mutable">self/*caret*/</error>.bar();
+            }
+
+            fn bar(&mut self){}
+        }
+    """, """
+        struct A {}
+
+        impl A {
+            fn foo(mut self) {
+                self.bar();
+            }
+
+            fn bar(&mut self){}
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #6183 
``Make `self` mutable`` suggestion in the following code changes `self` to `&mut self` instead of `mut self`
```rust
struct TestStruct{
    a: i32
}

impl TestStruct{
    pub fn test(self){
        self.a = 4;
    }
}
```

