### PR TITLE
CI: improve presentation of regression annotations

### DIFF
--- a/scripts/calculate_regressions.py
+++ b/scripts/calculate_regressions.py
@@ -21,6 +21,9 @@ class Annotation(object):
             suffix = ""
         return f"{self.filePath}:{self.line}:{self.column} '{self.highlightedText}' ({self.error}){suffix}"
 
+    def __lt__(self, other):
+        return (self.filePath, self.line, self.column) < (other.filePath, other.line, other.column)
+
     @staticmethod
     def from_dict(raw_dict: Dict) -> "Annotation":
         return Annotation(raw_dict["filePath"],
@@ -53,8 +56,8 @@ if __name__ == '__main__':
     without_changes = set(read_data(f"regressions/{args.name}_without_changes.json"))
     with_changes = set(read_data(f"regressions/{args.name}_with_changes.json"))
 
-    fixed = without_changes - with_changes
-    new = with_changes - without_changes
+    fixed = sorted(without_changes - with_changes)
+    new = sorted(with_changes - without_changes)
 
     dump_as_json(fixed, f"regressions/{args.name}_fixed.json")
     dump_as_json(new, f"regressions/{args.name}_new.json")

--- a/scripts/calculate_regressions.py
+++ b/scripts/calculate_regressions.py
@@ -48,7 +48,7 @@ def dump_as_json(annotations: Iterable[Annotation], path: str) -> None:
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("--name", type=str, help="github token")
+    parser.add_argument("--name", type=str, help="project name", required=True)
 
     args = parser.parse_args()
 

--- a/src/test/kotlin/org/rustPerformanceTests/CustomRealProjectAnalysisTest.kt
+++ b/src/test/kotlin/org/rustPerformanceTests/CustomRealProjectAnalysisTest.kt
@@ -7,6 +7,7 @@ package org.rustPerformanceTests
 
 import com.fasterxml.jackson.databind.json.JsonMapper
 import java.io.File
+import java.util.*
 
 /**
  * Provides ability to check plugin analysis on custom real project.
@@ -45,7 +46,11 @@ class CustomRealProjectAnalysisTest : RsRealProjectAnalysisTest() {
             val testDir = File("regressions")
             testDir.mkdirs()
             JsonMapper().writerWithDefaultPrettyPrinter()
-                .writeValue(File(testDir, "${info.name}.json"), annotations)
+                .writeValue(File(testDir, "${info.name}.json"), annotations.sortedWith(
+                    Comparator.comparing(Annotation::filePath)
+                        .thenComparingInt(Annotation::line)
+                        .thenComparingInt(Annotation::column)
+                ))
         }
     }
 }

--- a/src/test/kotlin/org/rustPerformanceTests/RsRealProjectAnalysisTest.kt
+++ b/src/test/kotlin/org/rustPerformanceTests/RsRealProjectAnalysisTest.kt
@@ -76,8 +76,9 @@ open class RsRealProjectAnalysisTest : RsRealProjectTestBase() {
                 val position = myFixture.editor.offsetToLogicalPosition(highlightInfo.startOffset)
                 val annotation = Annotation(
                     path,
-                    position.line,
-                    position.column,
+                    // Use 1-based indexing to be compatible with editor UI and `Go to Line/Column` action
+                    position.line + 1,
+                    position.column + 1,
                     text.substring(highlightInfo.startOffset, highlightInfo.endOffset),
                     highlightInfo.description,
                     highlightInfo.inspectionToolId


### PR DESCRIPTION
These changes:
- use 1-based indices for line/column in regression annotation to be compatible with editor UI and `Go to Line/Column` action
- sort regression annotations