### PR TITLE
T: resolve cargo home symlinks on Windows properly

### DIFF
--- a/src/test/kotlin/org/rust/cargo/RustupTestFixture.kt
+++ b/src/test/kotlin/org/rust/cargo/RustupTestFixture.kt
@@ -45,12 +45,12 @@ open class RustupTestFixture(
     }
 
     private fun addCargoHomeToAllowedRoots() {
-        val cargoHome = FileUtil.expandUserHome("~/.cargo")
-        VfsRootAccess.allowRootAccess(testRootDisposable, cargoHome)
+        val cargoHome = Paths.get(FileUtil.expandUserHome("~/.cargo"))
+        VfsRootAccess.allowRootAccess(testRootDisposable, cargoHome.toString())
         // actions-rs/toolchain on CI creates symlink at `~/.cargo` while setting up of Rust toolchain
-        val canonicalCargoHome = File(cargoHome).canonicalPath
+        val canonicalCargoHome = cargoHome.toRealPath()
         if (cargoHome != canonicalCargoHome) {
-            VfsRootAccess.allowRootAccess(testRootDisposable, canonicalCargoHome)
+            VfsRootAccess.allowRootAccess(testRootDisposable, canonicalCargoHome.toString())
         }
     }
 }


### PR DESCRIPTION
`File#canonicalPath` cannot resolve Windows symlinks properly. So `Path#toRealPath` is used
Yet another attempt to fix tests in #5444