### PR TITLE
Deduplicate cargo projects

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -445,7 +445,7 @@ data class CargoProjectImpl(
     override val manifest: Path,
     private val projectService: CargoProjectsServiceImpl,
     override val userDisabledFeatures: UserDisabledFeatures = UserDisabledFeatures.EMPTY,
-    private val rawWorkspace: CargoWorkspace? = null,
+    val rawWorkspace: CargoWorkspace? = null,
     private val stdlib: StandardLibrary? = null,
     override val rustcInfo: RustcInfo? = null,
     override val workspaceStatus: UpdateStatus = UpdateStatus.NeedsUpdate,
@@ -529,6 +529,7 @@ val CargoProjectsService.allTargets: Sequence<CargoWorkspace.Target>
 private fun hasAtLeastOneValidProject(projects: Collection<CargoProject>) =
     projects.any { it.manifest.exists() }
 
+/** Keep in sync with [org.rust.cargo.project.model.impl.deduplicateProjects] */
 private fun isExistingProject(projects: Collection<CargoProject>, manifest: Path): Boolean {
     if (projects.any { it.manifest == manifest }) return true
     return projects.mapNotNull { it.workspace }.flatMap { it.packages }

--- a/src/test/kotlin/org/rust/cargo/project/model/impl/CargoProjectDeduplicationTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/impl/CargoProjectDeduplicationTest.kt
@@ -1,0 +1,194 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.model.impl
+
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.vfs.VfsUtil
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.fileTree
+import org.rust.openapiext.pathAsPath
+import org.rust.singleProject
+
+class CargoProjectDeduplicationTest : RsWithToolchainTestBase() {
+    fun `test subproject is removed when become a member of attached workspace`() = fileTree {
+        dir("root-project") {
+            toml("Cargo.toml", """
+                #[workspace]
+                #members = ["subproject"]
+
+                [package]
+                name = "root-project"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("src") { rust("lib.rs", "") }
+
+            dir("subproject") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "subproject"
+                    version = "0.1.0"
+                    authors = []
+                """)
+
+                dir("src") { rust("lib.rs", "") }
+            }
+        }
+    }.run {
+        create(project, cargoProjectDirectory)
+        val rootProjectManifest = cargoProjectDirectory.findFileByRelativePath("root-project/Cargo.toml")!!
+        project.testCargoProjects.attachCargoProject(rootProjectManifest.pathAsPath)
+        project.testCargoProjects.attachCargoProject(cargoProjectDirectory.pathAsPath.resolve("root-project/subproject/Cargo.toml"))
+        assertEquals(2, project.testCargoProjects.allProjects.size)
+        runWriteAction {
+            VfsUtil.saveText(rootProjectManifest, VfsUtil.loadText(rootProjectManifest).replace("#", ""))
+        }
+        project.testCargoProjects.refreshAllProjectsSync()
+        assertEquals(rootProjectManifest.pathAsPath, project.testCargoProjects.singleProject().manifest)
+    }
+
+    fun `test 2 subprojects are removed when become members of attached workspace`() = fileTree {
+        dir("root-project") {
+            toml("__Cargo.toml", """
+                [workspace]
+                members = ["subproject_1", "subproject_2"]
+            """)
+
+            dir("subproject_1") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "subproject_1"
+                    version = "0.1.0"
+                    authors = []
+                """)
+
+                dir("src") { rust("lib.rs", "") }
+            }
+
+            dir("subproject_2") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "subproject_2"
+                    version = "0.1.0"
+                    authors = []
+                """)
+
+                dir("src") { rust("lib.rs", "") }
+            }
+        }
+    }.run {
+        create(project, cargoProjectDirectory)
+        project.testCargoProjects.attachCargoProject(cargoProjectDirectory.pathAsPath.resolve("root-project/subproject_1/Cargo.toml"))
+        project.testCargoProjects.attachCargoProject(cargoProjectDirectory.pathAsPath.resolve("root-project/subproject_2/Cargo.toml"))
+        assertEquals(2, project.testCargoProjects.allProjects.size)
+        val rootProjectManifest = cargoProjectDirectory.findFileByRelativePath("root-project/__Cargo.toml")!!
+        runWriteAction {
+            rootProjectManifest.rename(null, "Cargo.toml")
+        }
+        project.testCargoProjects.attachCargoProject(rootProjectManifest.pathAsPath)
+        project.testCargoProjects.refreshAllProjectsSync()
+        assertEquals(rootProjectManifest.pathAsPath, project.testCargoProjects.singleProject().manifest)
+    }
+
+    fun `test one subproject is removed and one is excluded when become members of attached workspace`() = fileTree {
+        dir("root-project") {
+            toml("Cargo.toml", """
+                #[workspace]
+                #members = ["subproject_1"]
+                #exclude = ["subproject_2"]
+
+                [package]
+                name = "root-project"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("src") { rust("lib.rs", "") }
+
+            dir("subproject_1") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "subproject_1"
+                    version = "0.1.0"
+                    authors = []
+                """)
+
+                dir("src") { rust("lib.rs", "") }
+            }
+
+            dir("subproject_2") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "subproject_2"
+                    version = "0.1.0"
+                    authors = []
+                """)
+
+                dir("src") { rust("lib.rs", "") }
+            }
+        }
+    }.run {
+        create(project, cargoProjectDirectory)
+        val rootProjectManifest = cargoProjectDirectory.findFileByRelativePath("root-project/Cargo.toml")!!
+        val includedProjectManifest = cargoProjectDirectory.pathAsPath.resolve("root-project/subproject_1/Cargo.toml")
+        val excludedProjectManifest = cargoProjectDirectory.pathAsPath.resolve("root-project/subproject_2/Cargo.toml")
+        project.testCargoProjects.attachCargoProject(includedProjectManifest)
+        project.testCargoProjects.attachCargoProject(excludedProjectManifest)
+        assertEquals(2, project.testCargoProjects.allProjects.size)
+        runWriteAction {
+            VfsUtil.saveText(rootProjectManifest, VfsUtil.loadText(rootProjectManifest).replace("#", ""))
+        }
+        project.testCargoProjects.attachCargoProject(rootProjectManifest.pathAsPath)
+        project.testCargoProjects.refreshAllProjectsSync()
+        assertEquals(
+            listOf(
+                rootProjectManifest.pathAsPath,
+                excludedProjectManifest
+            ).sorted(),
+            project.testCargoProjects.allProjects.map { it.manifest }.sorted()
+        )
+    }
+
+    fun `test subproject is not removed is added as an external dependency to another project`() = fileTree {
+        dir("root-project") {
+            toml("Cargo.toml", """
+                [package]
+                name = "root-project"
+                version = "0.1.0"
+                authors = []
+
+                #[dependencies]
+                #subproject = { path = "./subproject" }
+            """)
+
+            dir("src") { rust("lib.rs", "") }
+
+            dir("subproject") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "subproject"
+                    version = "0.1.0"
+                    authors = []
+                """)
+
+                dir("src") { rust("lib.rs", "") }
+            }
+        }
+    }.run {
+        create(project, cargoProjectDirectory)
+        val rootProjectManifest = cargoProjectDirectory.findFileByRelativePath("root-project/Cargo.toml")!!
+        project.testCargoProjects.attachCargoProject(rootProjectManifest.pathAsPath)
+        project.testCargoProjects.attachCargoProject(cargoProjectDirectory.pathAsPath.resolve("root-project/subproject/Cargo.toml"))
+        assertEquals(2, project.testCargoProjects.allProjects.size)
+        runWriteAction {
+            VfsUtil.saveText(rootProjectManifest, VfsUtil.loadText(rootProjectManifest).replace("#", ""))
+        }
+        project.testCargoProjects.refreshAllProjectsSync()
+        check(project.testCargoProjects.allProjects.size == 2)
+        check(project.testCargoProjects.allProjects.all { it.workspace != null })
+    }
+}


### PR DESCRIPTION
There are 2 kinds of cargo project duplication:
1. Direct duplication: when there are 2 projects with the same
 `CargoProject.manifest` value. Looks like it's impossible to
 make such duplication without editing `workspace.xml`.
2. Duplication of workspace members: when there is a project
 with cargo workspace consist of several packages and one of them
 is also added as a separate `CargoProject`. It's possible to
 make such duplication: initially, there should be 2 independent
 `CargoProject`s, but then, one of them should become a workspace
 member of the other project (a user can do this by modifying
 `Cargo.toml`)

Let's remove duplicated projects during `CargoSyncTask`