### PR TITLE
TOML: recover parser on errors in arrays

### DIFF
--- a/intellij-toml/src/main/grammars/TomlParser.bnf
+++ b/intellij-toml/src/main/grammars/TomlParser.bnf
@@ -66,8 +66,18 @@ Literal ::= Number | Date | BOOLEAN
 private Number ::= <<remap 'BARE_KEY_OR_NUMBER' 'NUMBER'>> | NUMBER
 private Date ::= <<remap 'BARE_KEY_OR_DATE' 'DATE_TIME'>> | DATE_TIME
 
+private Value_first ::= BARE_KEY_OR_NUMBER | NUMBER | BARE_KEY_OR_DATE | DATE_TIME
+                      | BOOLEAN
+                      | BASIC_STRING | LITERAL_STRING
+                      | MULTILINE_BASIC_STRING | MULTILINE_LITERAL_STRING
+                      | '[' | '{'
+
 Array ::= '[' ArrayElement* ']' { pin = 1 }
-private ArrayElement ::= Value (','|&']') { pin = 1 }
+private ArrayElement ::= !']' Value (','|&']') {
+  pin = 1
+  recoverWhile = ArrayElement_recover
+}
+private ArrayElement_recover ::= !(']' | Value_first) { consumeTokenMethod = "consumeTokenFast" }
 
 Table ::= TableHeader NewLineKeyValue*
 TableHeader ::= '[' ShortKey ('.' ShortKey)* ']' {

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/invalid.toml
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/invalid.toml
@@ -6,6 +6,12 @@ key14 = 1.foo
 key21 = "" [invalid]
 key22 = ""
 
+key31 = [invalid]
+key32 = [invalid, "valid"]
+key33 = ["valid", invalid, "valid"]
+key34 = [invalid, ["valid"]]
+key35 = [invalid, 42]
+
 [header1] invalid = ""
 key = ""
 

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/invalid.txt
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/invalid.txt
@@ -70,6 +70,93 @@ TOML File
     TomlLiteral
       PsiElement(BASIC_STRING)('""')
   PsiWhiteSpace('\n\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('key31')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlArray
+      PsiElement([)('[')
+      PsiErrorElement:<literal>, '[' or '{' expected, got 'invalid'
+        <empty list>
+      PsiElement(BARE_KEY)('invalid')
+      PsiElement(])(']')
+  PsiWhiteSpace('\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('key32')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlArray
+      PsiElement([)('[')
+      PsiErrorElement:<literal>, '[' or '{' expected, got 'invalid'
+        <empty list>
+      PsiElement(BARE_KEY)('invalid')
+      PsiElement(,)(',')
+      PsiWhiteSpace(' ')
+      TomlLiteral
+        PsiElement(BASIC_STRING)('"valid"')
+      PsiElement(])(']')
+  PsiWhiteSpace('\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('key33')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlArray
+      PsiElement([)('[')
+      TomlLiteral
+        PsiElement(BASIC_STRING)('"valid"')
+      PsiElement(,)(',')
+      PsiWhiteSpace(' ')
+      PsiErrorElement:'invalid' unexpected
+        PsiElement(BARE_KEY)('invalid')
+      PsiElement(,)(',')
+      PsiWhiteSpace(' ')
+      TomlLiteral
+        PsiElement(BASIC_STRING)('"valid"')
+      PsiElement(])(']')
+  PsiWhiteSpace('\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('key34')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlArray
+      PsiElement([)('[')
+      PsiErrorElement:<literal>, '[' or '{' expected, got 'invalid'
+        <empty list>
+      PsiElement(BARE_KEY)('invalid')
+      PsiElement(,)(',')
+      PsiWhiteSpace(' ')
+      TomlArray
+        PsiElement([)('[')
+        TomlLiteral
+          PsiElement(BASIC_STRING)('"valid"')
+        PsiElement(])(']')
+      PsiElement(])(']')
+  PsiWhiteSpace('\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('key35')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlArray
+      PsiElement([)('[')
+      PsiErrorElement:<literal>, '[' or '{' expected, got 'invalid'
+        <empty list>
+      PsiElement(BARE_KEY)('invalid')
+      PsiElement(,)(',')
+      PsiWhiteSpace(' ')
+      TomlLiteral
+        PsiElement(NUMBER)('42')
+      PsiElement(])(']')
+  PsiWhiteSpace('\n\n')
   TomlTable
     TomlTableHeader
       PsiElement([)('[')


### PR DESCRIPTION
Better TOML parser recovery in the case of broken array literals. Needed for completion inside arrays