### PR TITLE
CARGO: Replace paths to symlink source in cargo metadata

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/BuildScriptsInfo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/BuildScriptsInfo.kt
@@ -12,4 +12,12 @@ class BuildScriptsInfo(private val messages: Map<PackageId, BuildScriptMessage>)
         get() = messages.entries.firstOrNull()?.value?.out_dir != null
 
     operator fun get(packageId: PackageId): BuildScriptMessage? = messages[packageId]
+
+    fun replacePaths(replacer: (String) -> String): BuildScriptsInfo =
+        BuildScriptsInfo(
+            messages.mapValues { (_, message) ->
+                if (message.out_dir == null) return@mapValues message
+                message.copy(out_dir = replacer(message.out_dir))
+            }
+        )
 }

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoProjectResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoProjectResolveTest.kt
@@ -16,6 +16,8 @@ import org.rust.lang.core.crate.impl.CrateGraphTestmarks
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.resolve.NameResolutionTestmarks
 import org.rust.openapiext.pathAsPath
+import org.rustPerformanceTests.fullyRefreshDirectoryInUnitTests
+import java.nio.file.Files
 
 class CargoProjectResolveTest : RsWithToolchainTestBase() {
 
@@ -139,6 +141,60 @@ class CargoProjectResolveTest : RsWithToolchainTestBase() {
     }.run {
         checkReferenceIsResolved<RsPath>("src/main.rs")
         checkReferenceIsResolved<RsPath>("src/bar.rs")
+    }
+
+    fun `test resolve local package under symlink`() = fileTree {
+        toml("Cargo.toml", """
+            [package]
+            name = "hello"
+            version = "0.1.0"
+            authors = []
+
+            [dependencies]
+            foo = { path = "./foo" }
+        """)
+
+        dir("src") {
+            rust("main.rs", """
+                extern crate foo;
+                mod bar;
+
+                fn main() {
+                    foo::hello();
+                }       //^
+            """)
+
+            rust("bar.rs", """
+                use foo::hello;
+
+                pub fn bar() {
+                    hello();
+                }   //^
+            """)
+        }
+
+        dir("foo2") {
+            toml("Cargo.toml", """
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("src") {
+                rust("lib.rs", """
+                    pub fn hello() {}
+                """)
+            }
+        }
+    }.let { fileTree ->
+        if (SystemInfo.isWindows) return@let
+        val rootPath = cargoProjectDirectory.pathAsPath
+        Files.createSymbolicLink(rootPath.resolve("foo"), rootPath.resolve("foo2"))
+
+        val project = fileTree.create()
+        project.checkReferenceIsResolved<RsPath>("src/main.rs")
+        project.checkReferenceIsResolved<RsPath>("src/bar.rs")
     }
 
     fun `test module relations`() = buildProject {


### PR DESCRIPTION
If project directory is `source` which is a symlink to `target` directory, then `cargo metadata` command inside `source` directory produces output with `target` paths. [`CargoMetadata.Project.workspace_root`](https://github.com/intellij-rust/intellij-rust/blob/12b71cbd08c3c79282cedec71abcdd6dba61d9d5/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt#L56-L59) was already replaced to use `source` paths in #4868. This PR replaces other fields, such as [`CargoMetadata.Package.manifest_path`](https://github.com/intellij-rust/intellij-rust/blob/12b71cbd08c3c79282cedec71abcdd6dba61d9d5/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt#L85-L88), to use `source` paths.

Main purpose of this PR is to have [`Crate.rootModFile`](https://github.com/intellij-rust/intellij-rust/blob/12b71cbd08c3c79282cedec71abcdd6dba61d9d5/src/main/kotlin/org/rust/lang/core/crate/Crate.kt#L61-L65) to use `source` path (`source` paths are better because files inside `source` are indexed, and inside `target` are not).