### PR TITLE
REPL: Clear variables view after :clear command

### DIFF
--- a/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
@@ -80,6 +80,10 @@ class RsConsoleCodeFragmentContext(codeFragment: RsReplCodeFragment?) {
         return commands.joinToString("\n")
     }
 
+    fun clearAllCommands() {
+        commands.clear()
+    }
+
     companion object {
         fun createContext(project: Project, originalCrateRoot: RsFile?, commands: List<String> = listOf("")): RsBlock {
             // command may contain functions/structs with same names as in previous commands

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleCommunication.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleCommunication.kt
@@ -17,7 +17,11 @@ class RsConsoleCommunication(private val consoleView: RsConsoleView) {
         isExecuting = true
 
         val codeFragment = consoleView.codeFragment ?: return
-        if (codeFragment.text.isEmpty()) return
+        val codeFragmentText = codeFragment.text.trim()
+        if (codeFragmentText.isEmpty()) return
+        if (codeFragmentText.startsWith(":")) {
+            consoleView.handleEvcxrCommand(codeFragmentText)
+        }
         lastCommandContext = RsConsoleOneCommandContext(codeFragment)
     }
 

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleView.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleView.kt
@@ -135,6 +135,12 @@ class RsConsoleView(project: Project) : LanguageConsoleImpl(project, VIRTUAL_FIL
         }
     }
 
+    fun handleEvcxrCommand(command: String) {
+        if (command == ":clear") {
+            codeFragmentContext.clearAllCommands()
+        }
+    }
+
     override fun dispose() {
         super.dispose()
         variablesView?.let { Disposer.dispose(it) }


### PR DESCRIPTION
Clear [REPL console variables view](https://github.com/intellij-rust/intellij-rust/pull/4998) after `:clear` command (supported by evcxr)