### PR TITLE
INT: Don't show "Add wildcard pattern" for empty match

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/AddWildcardArmIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddWildcardArmIntention.kt
@@ -5,14 +5,22 @@
 
 package org.rust.ide.intentions
 
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
 import org.rust.ide.inspections.fixes.AddRemainingArmsFix
 import org.rust.ide.inspections.fixes.AddWildcardArmFix
 import org.rust.ide.utils.checkMatch.Pattern
 import org.rust.lang.core.psi.RsMatchExpr
+import org.rust.lang.core.psi.ext.arms
 
 class AddWildcardArmIntention : AddRemainingArmsIntention() {
 
     override fun getText(): String = AddWildcardArmFix.NAME
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? =
+        super.findApplicableContext(project, editor, element)
+            ?.takeIf { it.matchExpr.arms.isNotEmpty() }
 
     override fun createQuickFix(matchExpr: RsMatchExpr, patterns: List<Pattern>): AddRemainingArmsFix {
         return AddWildcardArmFix(matchExpr)

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1090,7 +1090,10 @@ sealed class RsDiagnostic(
             ERROR,
             E0004,
             "Match must be exhaustive",
-            fixes = listOf(AddRemainingArmsFix(matchExpr, patterns), AddWildcardArmFix(matchExpr))
+            fixes = listOfNotNull(
+                AddRemainingArmsFix(matchExpr, patterns),
+                AddWildcardArmFix(matchExpr).takeIf { matchExpr.arms.isNotEmpty() }
+            )
         )
     }
 

--- a/src/test/kotlin/org/rust/ide/inspections/match/RsNonExhaustiveMatchInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/match/RsNonExhaustiveMatchInspectionTest.kt
@@ -464,6 +464,13 @@ class RsNonExhaustiveMatchInspectionTest : RsInspectionsTestBase(RsNonExhaustive
         }
     """)
 
+    fun `test no add _ pattern for empty match`() = checkFixIsUnavailable("Add _ pattern", """
+        fn main() {
+            let test = true;
+            <error descr="Match must be exhaustive [E0004]">match/*caret*/</error> test {}
+        }
+    """)
+
     fun `test add _ pattern for no expression in match`() = checkFixByText("Add _ pattern", """
         fn main() {
             let test = true;

--- a/src/test/kotlin/org/rust/ide/intentions/AddWildcardArmIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddWildcardArmIntentionTest.kt
@@ -10,20 +10,12 @@ package org.rust.ide.intentions
  */
 class AddWildcardArmIntentionTest : RsIntentionTestBase(AddWildcardArmIntention::class) {
 
-    fun `test empty match`() = doAvailableTest("""
+    fun `test empty match`() = doUnavailableTest("""
         enum E { A, B, C }
         fn main() {
             let a = E::A;
             match a {
                 /*caret*/
-            }
-        }
-    """, """
-        enum E { A, B, C }
-        fn main() {
-            let a = E::A;
-            match a {
-                _ => {}
             }
         }
     """)


### PR DESCRIPTION
Shows "Add wildcard pattern" intention only if `match` is not empty. I think it is not reasonable to use "Add wildcard pattern" intention on empty `match` because resulting code will be similar to `if true { ... }`.

| Before | After |
| ------- | ----- |
| ![image](https://user-images.githubusercontent.com/6505554/95209940-99941c00-07f3-11eb-956f-aedcd78a1425.png) | ![image](https://user-images.githubusercontent.com/6505554/95210724-774ece00-07f4-11eb-8fa9-185c87881e81.png) |
