### PR TITLE
MACRO: introduce shared persistent cache for macro expansion

### DIFF
--- a/src/202/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
+++ b/src/202/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
@@ -1,0 +1,22 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.psi.stubs.SerializationManagerEx
+import com.intellij.psi.stubs.SerializedStubTreeDataExternalizer
+import com.intellij.psi.stubs.StubForwardIndexExternalizer
+
+@Suppress("UnstableApiUsage")
+fun newSerializedStubTreeDataExternalizer(
+    manager: SerializationManagerEx,
+    externalizer: StubForwardIndexExternalizer<*>,
+): SerializedStubTreeDataExternalizer {
+    return SerializedStubTreeDataExternalizer(
+        /* includeInputs = */ true,
+        manager,
+        externalizer
+    )
+}

--- a/src/203/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
+++ b/src/203/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
@@ -1,0 +1,23 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.psi.stubs.SerializationManagerEx
+import com.intellij.psi.stubs.SerializedStubTreeDataExternalizer
+import com.intellij.psi.stubs.StubForwardIndexExternalizer
+import org.jetbrains.annotations.NotNull
+
+// BACKCOMPAT: 2020.2. Inline it
+@Suppress("UnstableApiUsage")
+fun newSerializedStubTreeDataExternalizer(
+    manager: SerializationManagerEx,
+    externalizer: StubForwardIndexExternalizer<*>,
+): SerializedStubTreeDataExternalizer {
+    return SerializedStubTreeDataExternalizer(
+        manager,
+        externalizer
+    )
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionSharedCache.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionSharedCache.kt
@@ -1,0 +1,263 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.util.registry.RegistryValue
+import com.intellij.openapi.util.registry.RegistryValueListener
+import com.intellij.psi.stubs.*
+import com.intellij.util.indexing.FileContent
+import com.intellij.util.io.*
+import org.rust.lang.core.macros.MacroExpansionSharedCache.Companion.CACHE_ENABLED
+import org.rust.lang.core.psi.RsMacro
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.ext.bodyHash
+import org.rust.lang.core.stubs.RsFileStub
+import org.rust.stdext.HashCode
+import java.io.DataInput
+import java.io.DataOutput
+import java.io.IOException
+import java.nio.file.Path
+import java.util.*
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * A persistent (stored on disk, in the real file system) cache for macro expansion text and stubs.
+ * The cache is shared between different [Project]s (i.e. it's an application service).
+ *
+ * Used in a couple with [MacroExpansionStubsProvider] in order to provide stub cache.
+ * The cache can be invalidated by usual "Invalidate Caches / Restart..." action (handled by
+ * [RsMacroExpansionCachesInvalidator] because the cache is located in [getBaseMacroDir]).
+ *
+ * ## Implementation details
+ *
+ * The implementation is a bit tricky: the persistent cache is accessed via nullable atomic variable [data].
+ * Such design is chosen because any operation with [PersistentHashMap] can lead to [IOException]
+ * (since it's filesystem-based hash map), so this is a way to recover on possible errors.
+ * For now, we just disable the cache (set [data] to `null`) if [IOException] occurs.
+ * Also, the cache can be disabled via [CACHE_ENABLED] registry option.
+ */
+@Suppress("UnstableApiUsage")
+@Service
+class MacroExpansionSharedCache : Disposable {
+    private val sm: SerializationManagerEx = SerializationManagerEx.getInstanceEx()
+    private val ex: StubForwardIndexExternalizer<*> = StubForwardIndexExternalizer.createFileLocalExternalizer()
+
+    private val data: AtomicReference<PersistentCacheData?> =
+        AtomicReference(if (CACHE_ENABLED.asBoolean()) tryCreateData() else null)
+
+    init {
+        // Allows to enable/disable the cache without IDE restart
+        CACHE_ENABLED.addListener(object : RegistryValueListener {
+            override fun afterValueChanged(value: RegistryValue) {
+                if (value.asBoolean()) {
+                    val newData = tryCreateData()
+                    if (newData != null && !data.compareAndSet(null, newData)) {
+                        newData.close()
+                    }
+                } else {
+                    data.compareAndExchange(data.get(), null)?.close()
+                }
+            }
+        }, this)
+    }
+
+    private fun tryCreateData() = PersistentCacheData.tryCreate(getBaseMacroDir().resolve("cache"), sm, ex)
+
+    val isEnabled: Boolean
+        get() = CACHE_ENABLED.asBoolean() && data.get() != null
+
+    override fun dispose() {
+        do {
+            val lastData = data.get()
+            lastData?.close()
+        } while (!data.compareAndSet(lastData, null))
+    }
+
+    fun flush() {
+        data.get()?.flush()
+    }
+
+    private fun <Key, Value : Any> getOrPut(
+        getMap: (PersistentCacheData) -> PersistentHashMap<Key, Value>,
+        key: Key,
+        computeValue: () -> Value?,
+    ): Value? {
+        if (!CACHE_ENABLED.asBoolean()) return computeValue()
+
+        val data = data.get() ?: return computeValue()
+        val map = getMap(data)
+
+        val existingValue = try {
+            map.get(key)
+        } catch (e: IOException) {
+            onError(data, e)
+            return computeValue()
+        }
+
+        return if (existingValue != null) {
+            existingValue
+        } else {
+            val newValue: Value = computeValue() ?: return null
+
+            try {
+                map.put(key, newValue)
+            } catch (e: IOException) {
+                onError(data, e)
+            }
+
+            newValue
+        }
+    }
+
+    private fun onError(lastData: PersistentCacheData, e: IOException) {
+        if (data.compareAndSet(lastData, null)) {
+            lastData.close()
+        }
+        MACRO_LOG.warn(e)
+    }
+
+    fun cachedExpand(expander: MacroExpander, def: RsMacro, call: RsMacroCall): ExpansionResult? {
+        val hash = HashCode.mix(def.bodyHash ?: return null, call.bodyHash ?: return null)
+        return getOrPut(PersistentCacheData::expansions, hash) {
+            val result = expander.expandMacroAsText(def, call) ?: return@getOrPut null
+            ExpansionResult(result.first.toString(), result.second)
+        }
+    }
+
+    fun cachedBuildStub(fileContent: FileContent, hash: HashCode): SerializedStubTree? {
+        return cachedBuildStub(hash) { fileContent }
+    }
+
+    private fun cachedBuildStub(hash: HashCode, fileContent: () -> FileContent?): SerializedStubTree? {
+        return getOrPut(PersistentCacheData::stubs, hash) {
+            val stub = StubTreeBuilder.buildStubTree(fileContent() ?: return@getOrPut null) ?: return@getOrPut null
+            SerializedStubTree.serializeStub(stub, sm, ex)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun getInstance(): MacroExpansionSharedCache = service()
+
+        @JvmStatic
+        private val CACHE_ENABLED = Registry.get("org.rust.lang.macros.persistentCache")
+    }
+}
+
+@Suppress("UnstableApiUsage")
+private class PersistentCacheData(
+    baseDir: Path,
+    sm: SerializationManagerEx,
+    ex: StubForwardIndexExternalizer<*>,
+) {
+    val expansions: PersistentHashMap<HashCode, ExpansionResult> = newPersistentHashMap(
+        baseDir.resolve("expansion-cache"),
+        HashCodeKeyDescriptor,
+        ExpansionResultExternalizer,
+        1 * 1024 * 1024,
+        MacroExpander.EXPANDER_VERSION
+    )
+
+    val stubs: PersistentHashMap<HashCode, SerializedStubTree> = newPersistentHashMap(
+        baseDir.resolve("expansion-stubs-cache"),
+        HashCodeKeyDescriptor,
+        newSerializedStubTreeDataExternalizer(sm, ex),
+        1 * 1024 * 1024,
+        MacroExpander.EXPANDER_VERSION + RsFileStub.Type.stubVersion
+    )
+
+    fun flush() {
+        expansions.force()
+        stubs.force()
+    }
+
+    fun close() {
+        catchAndWarn(expansions::close)
+        catchAndWarn(stubs::close)
+    }
+
+    companion object {
+        @JvmStatic
+        fun tryCreate(
+            baseDir: Path,
+            sm: SerializationManagerEx,
+            ex: StubForwardIndexExternalizer<*>,
+        ): PersistentCacheData? = try {
+            MacroExpansionManager.checkInvalidatedStorage()
+            PersistentCacheData(baseDir, sm, ex)
+        } catch (e: IOException) {
+            MACRO_LOG.warn(e)
+            null
+        }
+
+        @JvmStatic
+        private fun <K, V> newPersistentHashMap(
+            file: Path,
+            keyDescriptor: KeyDescriptor<K>,
+            valueExternalizer: DataExternalizer<V>,
+            initialSize: Int,
+            version: Int,
+        ): PersistentHashMap<K, V> {
+            return IOUtil.openCleanOrResetBroken(
+                { PersistentHashMap(file, keyDescriptor, valueExternalizer, initialSize, version) },
+                file
+            )
+        }
+
+        @JvmStatic
+        private fun catchAndWarn(runnable: () -> Unit) {
+            try {
+                runnable()
+            } catch (e: IOException) {
+                MACRO_LOG.warn(e)
+            }
+        }
+    }
+}
+
+private object HashCodeKeyDescriptor : KeyDescriptor<HashCode>, DifferentSerializableBytesImplyNonEqualityPolicy {
+    override fun getHashCode(value: HashCode): Int {
+        return value.hashCode()
+    }
+
+    override fun isEqual(val1: HashCode?, val2: HashCode?): Boolean {
+        return Objects.equals(val1, val2)
+    }
+
+    override fun save(out: DataOutput, value: HashCode) {
+        out.write(value.toByteArray())
+    }
+
+    override fun read(inp: DataInput): HashCode {
+        val bytes = ByteArray(HashCode.ARRAY_LEN)
+        inp.readFully(bytes)
+        return HashCode.fromByteArray(bytes)
+    }
+}
+
+data class ExpansionResult(
+    val text: String,
+    val ranges: RangeMap,
+)
+
+private object ExpansionResultExternalizer : DataExternalizer<ExpansionResult> {
+    override fun save(out: DataOutput, value: ExpansionResult) {
+        IOUtil.writeUTF(out, value.text)
+        value.ranges.writeTo(out)
+    }
+
+    override fun read(inp: DataInput): ExpansionResult {
+        return ExpansionResult(
+            IOUtil.readUTF(inp),
+            RangeMap.readFrom(inp)
+        )
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionStubsProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionStubsProvider.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.psi.stubs.PrebuiltStubsProvider
+import com.intellij.psi.stubs.SerializedStubTree
+import com.intellij.util.indexing.FileContent
+
+/**
+ * Used in a couple with [MacroExpansionSharedCache] to provide macro expansion cache shared between projects.
+ * This is not a real _prebuilt_ stubs provider. This extension point is used to intercept platform's
+ * stub creation.
+ */
+class MacroExpansionStubsProvider : PrebuiltStubsProvider {
+    @Suppress("UnstableApiUsage")
+    override fun findStub(fileContent: FileContent): SerializedStubTree? {
+        val file = fileContent.file
+        if (!MacroExpansionManager.isExpansionFile(file)) return null
+        if (!MacroExpansionSharedCache.getInstance().isEnabled) return null
+        val hash = file.loadMixHash() ?: return null
+        return MacroExpansionSharedCache.getInstance().cachedBuildStub(fileContent, hash)
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/RangeMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RangeMap.kt
@@ -10,8 +10,8 @@ import com.intellij.util.SmartList
 import org.rust.stdext.optimizeList
 import org.rust.stdext.readVarInt
 import org.rust.stdext.writeVarInt
-import java.io.DataInputStream
-import java.io.DataOutputStream
+import java.io.DataInput
+import java.io.DataOutput
 
 /**
  * Must provide [equals] method because it is used to track changes in the macro expansion mechanism
@@ -55,7 +55,7 @@ data class RangeMap private constructor(val ranges: List<MappedTextRange>) {
         return RangeMap(other.ranges.flatMap(::mapMappedTextRangeFromExpansionToCallBody))
     }
 
-    fun writeTo(data: DataOutputStream) {
+    fun writeTo(data: DataOutput) {
         data.writeInt(ranges.size)
         ranges.forEach {
             data.writeMappedTextRange(it)
@@ -65,7 +65,7 @@ data class RangeMap private constructor(val ranges: List<MappedTextRange>) {
     companion object {
         val EMPTY: RangeMap = RangeMap(emptyList())
 
-        fun readFrom(data: DataInputStream): RangeMap {
+        fun readFrom(data: DataInput): RangeMap {
             val size = data.readInt()
             val ranges = (0 until size).map { data.readMappedTextRange() }
             return RangeMap(ranges)
@@ -77,13 +77,13 @@ data class RangeMap private constructor(val ranges: List<MappedTextRange>) {
     }
 }
 
-private fun DataInputStream.readMappedTextRange(): MappedTextRange = MappedTextRange(
+private fun DataInput.readMappedTextRange(): MappedTextRange = MappedTextRange(
     readVarInt(),
     readVarInt(),
     readVarInt()
 )
 
-private fun DataOutputStream.writeMappedTextRange(range: MappedTextRange) {
+private fun DataOutput.writeMappedTextRange(range: MappedTextRange) {
     writeVarInt(range.srcOffset)
     writeVarInt(range.dstOffset)
     writeVarInt(range.length)

--- a/src/main/kotlin/org/rust/stdext/HashCode.kt
+++ b/src/main/kotlin/org/rust/stdext/HashCode.kt
@@ -7,9 +7,7 @@ package org.rust.stdext
 
 import com.intellij.util.io.DigestUtil
 import org.apache.commons.codec.binary.Hex
-import java.io.DataInput
-import java.io.DataOutput
-import java.io.Serializable
+import java.io.*
 
 /**
  * Abstracts byte array of cryptographic hash to provide appropriate equals/hashCode methods.
@@ -44,6 +42,13 @@ import java.io.Serializable
         fun compute(input: String): HashCode =
             HashCode(SHA1.digest(input.toByteArray()))
 
+        fun mix(hash1: HashCode, hash2: HashCode): HashCode {
+            val md = SHA1
+            md.update(hash1.toByteArray())
+            md.update(hash2.toByteArray())
+            return HashCode(md.digest())
+        }
+
         fun fromByteArray(bytes: ByteArray): HashCode {
             check(bytes.size == ARRAY_LEN)
             return HashCode(bytes)
@@ -53,9 +58,11 @@ import java.io.Serializable
 
 fun HashCode.getLeading64bits(): Long = toByteArray().getLeading64bits()
 
+@Throws(IOException::class)
 fun DataOutput.writeHashCode(hash: HashCode) =
     write(hash.toByteArray())
 
+@Throws(IOException::class, EOFException::class)
 fun DataInput.readHashCode(): HashCode {
     val bytes = ByteArray(HashCode.ARRAY_LEN)
     readFully(bytes)

--- a/src/main/kotlin/org/rust/stdext/path.kt
+++ b/src/main/kotlin/org/rust/stdext/path.kt
@@ -16,22 +16,34 @@ import java.nio.file.attribute.BasicFileAttributes
 import java.util.zip.DeflaterOutputStream
 import java.util.zip.InflaterInputStream
 
-fun Path.cleanDirectory() = Files.walkFileTree(this, object : SimpleFileVisitor<Path>() {
+@Throws(IOException::class)
+fun Path.cleanDirectory(): Path = Files.walkFileTree(this, object : SimpleFileVisitor<Path>() {
+
+    @Throws(IOException::class)
     override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
-        Files.delete(file)
+        try {
+            Files.delete(file)
+        } catch (ignored: IOException) {
+        }
         return FileVisitResult.CONTINUE
     }
 
+    @Throws(IOException::class)
     override fun postVisitDirectory(dir: Path, exc: IOException?): FileVisitResult {
         if (dir != this@cleanDirectory) {
-            Files.delete(dir)
+            try {
+                Files.delete(dir)
+            } catch (ignored: IOException) {
+            }
         }
         return FileVisitResult.CONTINUE
     }
 })
 
+@Throws(IOException::class)
 fun Path.newDeflaterDataOutputStream(): DataOutputStream =
     DataOutputStream(DeflaterOutputStream(Files.newOutputStream(this)))
 
+@Throws(IOException::class)
 fun Path.newInflaterDataInputStream(): DataInputStream =
     DataInputStream(InflaterInputStream(Files.newInputStream(this)))

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -963,6 +963,8 @@
         <virtualFileSystem key="rust_macros" implementationClass="org.rust.lang.core.macros.MacroExpansionFileSystem"/>
         <fileTypeOverrider implementation="org.rust.lang.core.macros.RsFileTypeOverriderForMacroExpansionFileSystem"/>
         <globalIndexFilter implementation="org.rust.lang.core.macros.RsGlobalIndexFilterForMacroExpansionFileSystem"/>
+        <filetype.prebuiltStubsProvider filetype="Rust"
+                                        implementationClass="org.rust.lang.core.macros.MacroExpansionStubsProvider"/>
 
         <!-- REPL Console -->
 
@@ -986,6 +988,8 @@
                      description="Enable Rust cfg attributes support"/>
         <registryKey key="org.rust.lang.highlight.macro.body" defaultValue="true" restartRequired="false"
                      description="Highlight Rust macro call bodies"/>
+        <registryKey key="org.rust.lang.macros.persistentCache" defaultValue="false" restartRequired="false"
+                     description="Use persistent cache for Rust macro expansions"/>
 
         <!-- Move refactoring -->
 


### PR DESCRIPTION
Introduce persistent (stored on disk, in the real file system) cache for macro expansion text and stubs. The cache is shared between different IDEA projects.

The cache is essential for `name resolution 2.0`, but I measured that it doesn't bring significant performance improvements right now (but uses disk storage), so I decided to disable it by default. It can be enabled via `Registry` option `org.rust.lang.macros.persistentCache`. So, the change doesn't affect users for now.