### PR TITLE
TOML: improve parser recovery on errors

### DIFF
--- a/intellij-toml/src/main/kotlin/org/toml/ide/TomlBraceMatcher.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/TomlBraceMatcher.kt
@@ -9,6 +9,7 @@ import com.intellij.lang.BracePair
 import com.intellij.lang.PairedBraceMatcher
 import com.intellij.psi.PsiFile
 import com.intellij.psi.tree.IElementType
+import org.toml.lang.TomlLanguage
 import org.toml.lang.psi.TomlElementTypes.*
 
 class TomlBraceMatcher : PairedBraceMatcher {
@@ -21,6 +22,9 @@ class TomlBraceMatcher : PairedBraceMatcher {
 
     companion object {
         private val PAIRS: Array<BracePair> = arrayOf(
+            // Grammar Kit hack - ignore braces in recovery
+            BracePair(IElementType("FAKE_L_BRACE", TomlLanguage), IElementType("FAKE_L_BRACE", TomlLanguage), false),
+
             BracePair(L_CURLY, R_CURLY, false),
             BracePair(L_BRACKET, R_BRACKET, false)
         )

--- a/intellij-toml/src/test/kotlin/org/toml/lang/TomlParserTest.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/lang/TomlParserTest.kt
@@ -6,7 +6,9 @@
 package org.toml.lang
 
 import com.intellij.lang.LanguageASTFactory
+import com.intellij.lang.LanguageBraceMatching
 import com.intellij.testFramework.ParsingTestCase
+import org.toml.ide.TomlBraceMatcher
 import org.toml.lang.parse.TomlParserDefinition
 import org.toml.lang.psi.impl.TomlASTFactory
 
@@ -30,6 +32,7 @@ class TomlParserTest
     override fun setUp() {
         super.setUp()
         addExplicitExtension(LanguageASTFactory.INSTANCE, myLanguage, TomlASTFactory())
+        addExplicitExtension(LanguageBraceMatching.INSTANCE, myLanguage, TomlBraceMatcher())
     }
 
     private fun doTest() = doTest(true)

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/invalid.toml
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/invalid.toml
@@ -11,6 +11,7 @@ key32 = [invalid, "valid"]
 key33 = ["valid", invalid, "valid"]
 key34 = [invalid, ["valid"]]
 key35 = [invalid, 42]
+key36 = [invalid, {valid = 2}]
 
 [header1] invalid = ""
 key = ""

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/invalid.txt
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/invalid.txt
@@ -156,6 +156,32 @@ TOML File
       TomlLiteral
         PsiElement(NUMBER)('42')
       PsiElement(])(']')
+  PsiWhiteSpace('\n')
+  TomlKeyValue
+    TomlKey
+      PsiElement(BARE_KEY)('key36')
+    PsiWhiteSpace(' ')
+    PsiElement(=)('=')
+    PsiWhiteSpace(' ')
+    TomlArray
+      PsiElement([)('[')
+      PsiErrorElement:<literal>, '[' or '{' expected, got 'invalid'
+        <empty list>
+      PsiElement(BARE_KEY)('invalid')
+      PsiElement(,)(',')
+      PsiWhiteSpace(' ')
+      TomlInlineTable
+        PsiElement({)('{')
+        TomlKeyValue
+          TomlKey
+            PsiElement(BARE_KEY)('valid')
+          PsiWhiteSpace(' ')
+          PsiElement(=)('=')
+          PsiWhiteSpace(' ')
+          TomlLiteral
+            PsiElement(NUMBER)('2')
+        PsiElement(})('}')
+      PsiElement(])(']')
   PsiWhiteSpace('\n\n')
   TomlTable
     TomlTableHeader


### PR DESCRIPTION
A continuation of #6202

1. Fix TOML parser tests (was needed to manually register `TomlBraceMatcher` in the parser test)
2. Recover on `key = [invalid, {valid = 2}]` case