### PR TITLE
GRD: update IDE dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,8 @@ val ideaVersion = prop("ideaVersion")
 val clionVersion = prop("clionVersion")
 val baseVersion = when (baseIDE) {
     "idea" -> ideaVersion
-    "clion" -> clionVersion
+    // FIXME: 203.4203. use clionVersion
+    "clion" -> if (platformVersion == 203) ideaVersion else clionVersion
     else -> error("Unexpected IDE name: `$baseIDE`")
 }
 
@@ -183,7 +184,8 @@ project(":plugin") {
             graziePlugin,
             psiViewerPlugin
         )
-        if (baseIDE == "idea") {
+        // FIXME: 203.4203. use `baseIDE == "idea"`
+        if (baseVersion == ideaVersion) {
             plugins += listOf(
                 "copyright",
                 "java",

--- a/gradle-202.properties
+++ b/gradle-202.properties
@@ -1,11 +1,11 @@
 # Existent IDE versions can be found in the following repos:
 # https://www.jetbrains.com/intellij-repository/releases/
 # https://www.jetbrains.com/intellij-repository/snapshots/
-ideaVersion=IU-2020.2.2
-clionVersion=CL-2020.2.2
+ideaVersion=IU-2020.2.3
+clionVersion=CL-2020.2.4
 
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions
-nativeDebugPluginVersion=202.7319.45
+nativeDebugPluginVersion=202.7660.3
 # https://plugins.jetbrains.com/plugin/12175-grazie/versions
 graziePluginVersion=202.6948.45
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions

--- a/gradle-203.properties
+++ b/gradle-203.properties
@@ -1,16 +1,17 @@
 # Existent IDE versions can be found in the following repos:
 # https://www.jetbrains.com/intellij-repository/releases/
 # https://www.jetbrains.com/intellij-repository/snapshots/
-ideaVersion=IU-203.4203-EAP-CANDIDATE-SNAPSHOT
+ideaVersion=IU-203.4449-EAP-CANDIDATE-SNAPSHOT
+# TODO: fix all "FIXME: 203.4203." comments in `build.gradle.kts`
 clionVersion=CL-203.4203-EAP-CANDIDATE-SNAPSHOT
 
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions
-nativeDebugPluginVersion=203.4203.26
+nativeDebugPluginVersion=203.4449.2
 # https://plugins.jetbrains.com/plugin/12175-grazie/versions
-graziePluginVersion=203.4203.24
+graziePluginVersion=203.4449.8
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions
 psiViewerPluginVersion=203-SNAPSHOT
 
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
-sinceBuild=203.3645
+sinceBuild=203.4449
 untilBuild=211.*

--- a/src/202/main/kotlin/org/rust/lang/core/resolve/ref/compatUtils.kt
+++ b/src/202/main/kotlin/org/rust/lang/core/resolve/ref/compatUtils.kt
@@ -1,0 +1,11 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve.ref
+
+import com.intellij.util.containers.ContainerUtil
+import gnu.trove.TObjectHashingStrategy
+
+fun <T> canonicalStrategy(): TObjectHashingStrategy<T> = ContainerUtil.canonicalStrategy()

--- a/src/203/main/kotlin/org/rust/lang/core/resolve/ref/compatUtils.kt
+++ b/src/203/main/kotlin/org/rust/lang/core/resolve/ref/compatUtils.kt
@@ -1,0 +1,11 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve.ref
+
+import com.intellij.util.containers.HashingStrategy
+
+@Suppress("UnstableApiUsage")
+fun <T> canonicalStrategy(): HashingStrategy<T> = HashingStrategy.canonical()

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsResolveCache.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsResolveCache.kt
@@ -26,7 +26,6 @@ import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiUtilCore
 import com.intellij.util.containers.ConcurrentWeakKeySoftValueHashMap
-import com.intellij.util.containers.ContainerUtil
 import org.rust.lang.core.macros.MacroExpansionManager
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsModificationTrackerOwner
@@ -271,7 +270,7 @@ private fun <K, V> createWeakMap(): ConcurrentMap<K, V> {
         100,
         0.75f,
         Runtime.getRuntime().availableProcessors(),
-        ContainerUtil.canonicalStrategy()
+        canonicalStrategy()
     ) {
         override fun createValueReference(
             value: V,


### PR DESCRIPTION
* Updates IDE dependencies for 2020.3 EAPs. Makes plugin compatible with 203.4449 EAPs, e.g. fixes `java.lang.NoSuchMethodError: 'void com.intellij.util.containers.ConcurrentWeakKeySoftValueHashMap.<init>(int, float, int, gnu.trove.TObjectHashingStrategy)'`
* Update IDE dependencies for 2020.2

Fixes #6225