### PR TITLE
MACRO: fix float literals in macros

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/FragmentKind.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/FragmentKind.kt
@@ -12,7 +12,6 @@ import org.rust.lang.core.parser.RustParser
 import org.rust.lang.core.parser.RustParserUtil
 import org.rust.lang.core.parser.clearFrame
 import org.rust.lang.core.psi.RS_KEYWORDS
-import org.rust.lang.core.psi.RS_LITERALS
 import org.rust.lang.core.psi.RsElementTypes
 import org.rust.lang.core.psi.RsElementTypes.QUOTE_IDENTIFIER
 import org.rust.lang.core.psi.RsElementTypes.TT
@@ -66,7 +65,9 @@ enum class FragmentKind(private val kind: String) {
         return RustParserUtil.unpairedToken(b, 0) || RustParserUtil.parseTokenTreeLazy(b, 0, TT)
     }
 
-    private fun parseLiteral(b: PsiBuilder): Boolean = b.consumeToken(RS_LITERALS)
+    private fun parseLiteral(b: PsiBuilder): Boolean {
+        return RustParser.LitExprWithoutAttrs(b, 0)
+    }
 
     private fun PsiBuilder.consumeToken(tokenSet: TokenSet): Boolean {
         return if (tokenType in tokenSet) {

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.macros
 import com.intellij.lang.ASTNode
 import com.intellij.lang.PsiBuilder
 import com.intellij.lang.PsiBuilderUtil
+import com.intellij.lang.parser.GeneratedParserUtilBase
 import com.intellij.lang.parser.rawLookupText
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
@@ -332,7 +333,7 @@ class MacroExpander(val project: Project) {
     }
 
     companion object {
-        const val EXPANDER_VERSION = 10
+        const val EXPANDER_VERSION = 11
         private val USELESS_PARENS_EXPRS = tokenSetOf(
             LIT_EXPR, MACRO_EXPR, PATH_EXPR, PAREN_EXPR, TUPLE_EXPR, ARRAY_EXPR, UNIT_EXPR
         )
@@ -538,7 +539,8 @@ private val COMPARE_BY_TEXT_TOKES = TokenSet.orSet(tokenSetOf(IDENTIFIER, QUOTE_
 
 fun PsiBuilder.isSameToken(node: ASTNode): Boolean {
     val (elementType, size) = collapsedTokenType(this) ?: (tokenType to 1)
-    val result = node.elementType == elementType && (elementType !in COMPARE_BY_TEXT_TOKES || node.chars == tokenText)
+    val result = node.elementType == elementType
+        && (elementType !in COMPARE_BY_TEXT_TOKES || GeneratedParserUtilBase.nextTokenIsFast(this, node.text, true) == size)
     if (result) {
         PsiBuilderUtil.advance(this, size)
     }

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -332,7 +332,7 @@ class MacroExpander(val project: Project) {
     }
 
     companion object {
-        const val EXPANDER_VERSION = 9
+        const val EXPANDER_VERSION = 10
         private val USELESS_PARENS_EXPRS = tokenSetOf(
             LIT_EXPR, MACRO_EXPR, PATH_EXPR, PAREN_EXPR, TUPLE_EXPR, ARRAY_EXPR, UNIT_EXPR
         )

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
@@ -94,6 +94,6 @@ class RustParserDefinition : ParserDefinition {
         /**
          * Should be increased after any change of parser rules
          */
-        const val PARSER_VERSION: Int = LEXER_VERSION + 12
+        const val PARSER_VERSION: Int = LEXER_VERSION + 13
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
@@ -606,6 +606,15 @@ object RustParserUtil : GeneratedParserUtilBase() {
                 AND -> ANDAND to 2
                 else -> null
             }
+            // See `parseFloatLiteral`
+            INTEGER_LITERAL -> when (b.rawLookup(1)) {
+                DOT -> when (b.rawLookup(2)) {
+                    INTEGER_LITERAL, FLOAT_LITERAL -> FLOAT_LITERAL to 3
+                    IDENTIFIER -> null
+                    else -> FLOAT_LITERAL to 2
+                }
+                else -> null
+            }
             else -> null
         }
     }

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -325,7 +325,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
 
     fun `test match complex pattern`() = doTest("""
         macro_rules! foo {
-            (=/ $ i1:item #%*=> $ i2:item) => (
+            (=/ $ i1:item #%*=> $ i2:item 0.0) => (
                 $ i1
                 $ i2
             )
@@ -335,6 +335,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
             fn foo() {}
             #%*=>
             fn bar() {}
+            0.0
         }
     """, """
         fn foo() {}

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -179,6 +179,24 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         fn foo() { true && false; }
     """)
 
+    fun `test tt collapsed token 2`() = doTest("""
+        macro_rules! foo {
+            ($ i:tt) => { fn foo() { $ i; } }
+        }
+        foo! { 0.0 }
+        foo! { 0. }
+        foo! { 0.0f32 }
+        foo! { 0.1e-3f32 }
+    """, """
+        fn foo() { 0.0; }
+    """, """
+        fn foo() { 0.; }
+    """, """
+        fn foo() { 0.0f32; }
+    """, """
+        fn foo() { 0.1e-3f32; }
+    """)
+
     fun `test vis matcher`() = doTest("""
         macro_rules! foo {
             ($ vis:vis $ name:ident) => { $ vis fn $ name() {}};

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -233,10 +233,22 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         }
         foo!(u8 0);
         foo!(&'static str "value");
+        foo!(f64 0.0);
+        foo!(f64 0.);
+        foo!(f32 0.0f32);
+        foo!(f32 0.1e-3f32);
     """, """
         const VALUE: u8 = 0;
     """, """
         const VALUE: &'static str = "value";
+    """, """
+        const VALUE: f64 = 0.0;
+    """, """
+        const VALUE: f64 = 0.;
+    """, """
+        const VALUE: f32 = 0.0f32;
+    """, """
+        const VALUE: f32 = 0.1e-3f32;
     """)
 
     fun `test tt group`() = doTest("""


### PR DESCRIPTION
The bug(s) was introduced in #6177 (not released yet)