### PR TITLE
Name resolution 2.0

### DIFF
--- a/src/202/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
+++ b/src/202/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
@@ -5,9 +5,13 @@
 
 package org.rust.lang.core.macros
 
+import com.intellij.openapi.project.Project
 import com.intellij.psi.stubs.SerializationManagerEx
 import com.intellij.psi.stubs.SerializedStubTreeDataExternalizer
 import com.intellij.psi.stubs.StubForwardIndexExternalizer
+import com.intellij.testFramework.ReadOnlyLightVirtualFile
+import com.intellij.util.indexing.FileContent
+import com.intellij.util.indexing.FileContentImpl
 
 @Suppress("UnstableApiUsage")
 fun newSerializedStubTreeDataExternalizer(
@@ -20,3 +24,7 @@ fun newSerializedStubTreeDataExternalizer(
         externalizer
     )
 }
+
+@Suppress("UnstableApiUsage")
+fun createFileContent(project: Project, file: ReadOnlyLightVirtualFile, fileContent: String): FileContent =
+    FileContentImpl(file, fileContent, file.modificationStamp).also { it.project = project }

--- a/src/203/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
+++ b/src/203/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
@@ -5,10 +5,13 @@
 
 package org.rust.lang.core.macros
 
+import com.intellij.openapi.project.Project
 import com.intellij.psi.stubs.SerializationManagerEx
 import com.intellij.psi.stubs.SerializedStubTreeDataExternalizer
 import com.intellij.psi.stubs.StubForwardIndexExternalizer
-import org.jetbrains.annotations.NotNull
+import com.intellij.testFramework.ReadOnlyLightVirtualFile
+import com.intellij.util.indexing.FileContent
+import com.intellij.util.indexing.FileContentImpl
 
 // BACKCOMPAT: 2020.2. Inline it
 @Suppress("UnstableApiUsage")
@@ -21,3 +24,8 @@ fun newSerializedStubTreeDataExternalizer(
         externalizer
     )
 }
+
+// BACKCOMPAT: 2020.2. Inline it
+@Suppress("UnstableApiUsage")
+fun createFileContent(project: Project, file: ReadOnlyLightVirtualFile, fileContent: String): FileContent =
+    FileContentImpl.createByText(file, fileContent).also { (it as FileContentImpl).project = project }

--- a/src/main/kotlin/org/rust/cargo/CfgOptions.kt
+++ b/src/main/kotlin/org/rust/cargo/CfgOptions.kt
@@ -7,7 +7,7 @@ package org.rust.cargo
 
 import org.jetbrains.annotations.TestOnly
 
-class CfgOptions(
+data class CfgOptions(
     val keyValueOptions: Map<String, Set<String>>,
     val nameOptions: Set<String>
 ) {

--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -12,4 +12,5 @@ object RsExperiments {
     const val EVALUATE_BUILD_SCRIPTS = "org.rust.cargo.evaluate.build.scripts"
     const val CARGO_FEATURES_SETTINGS_GUTTER = "org.rust.cargo.features.settings.gutter"
     const val MACROS_NEW_ENGINE = "org.rust.macros.new.engine"
+    const val RESOLVE_NEW_ENGINE = "org.rust.resolve.new.engine"
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveConflictsDetector.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveConflictsDetector.kt
@@ -91,7 +91,7 @@ class RsMoveConflictsDetector(
         // because if something in inner mod is private, then it was not accessible before move.
         if (elementsToMove.none { (it as? ItemToMove)?.item == item }) return
 
-        val tempMod = RsPsiFactory(sourceMod.project).createModItem("__tmp__", "")
+        val tempMod = RsPsiFactory(sourceMod.project).createModItem(TMP_MOD_NAME, "")
         tempMod.setContext(targetMod)
 
         target.putCopyableUserData(RS_ELEMENT_FOR_CHECK_INSIDE_REFERENCES_VISIBILITY, target)

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
@@ -70,7 +70,7 @@ object RsMoveUtil {
         psiFactory: RsPsiFactory,
         context: RsMod
     ): RsPath? {
-        val mod = psiFactory.createModItem("__tmp__", "")
+        val mod = psiFactory.createModItem(TMP_MOD_NAME, "")
         mod.setContext(context)
         return toRsPath(codeFragmentFactory, mod)
     }

--- a/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.crate
 
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.CargoProject
@@ -86,6 +87,8 @@ interface Crate {
 
         val crate: Crate
     )
+
+    val project: Project get() = cargoProject.project
 }
 
 fun Crate.findDependency(normName: String): Crate? =

--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -10,10 +10,8 @@ import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileDocumentManager
-import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.ModificationTracker
 import com.intellij.openapi.util.SimpleModificationTracker
@@ -36,6 +34,7 @@ import org.rust.lang.core.psi.ext.bodyHash
 import org.rust.lang.core.psi.ext.containingCrate
 import org.rust.lang.core.psi.ext.resolveToMacro
 import org.rust.lang.core.psi.ext.stubDescendantsOfTypeStrict
+import org.rust.lang.core.psi.shouldIndexFile
 import org.rust.lang.core.resolve.DEFAULT_RECURSION_LIMIT
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.openapiext.*
@@ -498,14 +497,6 @@ class SourceFile(
         }
 
         return extract(calls)
-    }
-
-    private fun shouldIndexFile(project: Project, file: VirtualFile): Boolean {
-        val index = ProjectFileIndex.getInstance(project)
-        if (!(index.isInContent(file) || index.isInLibrary(file))) {
-            return false
-        }
-        return !FileTypeManager.getInstance().isFileIgnored(file)
     }
 
     private fun extract(calls: List<RsMacroCall>?): List<Pipeline.Stage1ResolveAndExpand>? {

--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -28,14 +28,13 @@ import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.RsFileType
 import org.rust.lang.core.macros.MacroExpansionManagerImpl.Testmarks
 import org.rust.lang.core.psi.RsFile
-import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.ext.bodyHash
 import org.rust.lang.core.psi.ext.containingCrate
-import org.rust.lang.core.psi.ext.resolveToMacro
 import org.rust.lang.core.psi.ext.stubDescendantsOfTypeStrict
 import org.rust.lang.core.psi.shouldIndexFile
 import org.rust.lang.core.resolve.DEFAULT_RECURSION_LIMIT
+import org.rust.lang.core.resolve2.resolveToMacroWithoutPsi
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.openapiext.*
 import org.rust.stdext.*
@@ -583,7 +582,7 @@ class SourceFile(
         val orphans = mutableListOf<RsMacroCall>()
         val bindList = mutableListOf<Pair<ExpandedMacroInfoImpl, Int>>()
         for (call in calls) {
-            val info = unboundInfos.find { it.isUpToDate(call, call.resolveToMacro()) }
+            val info = unboundInfos.find { it.isUpToDate(call, call.resolveToMacroWithoutPsi()) }
             if (info != null) {
                 Testmarks.refsRecoverExactHit.hit()
                 unboundInfos.remove(info)
@@ -836,7 +835,7 @@ interface ExpandedMacroInfo {
     val expansionFile: VirtualFile?
     val expansionFileHash: Long
     fun getMacroCall(): RsMacroCall?
-    fun isUpToDate(call: RsMacroCall, def: RsMacro?): Boolean
+    fun isUpToDate(call: RsMacroCall, def: RsMacroDataWithHash?): Boolean
     fun getExpansion(): MacroExpansion?
 }
 
@@ -855,7 +854,7 @@ class ExpandedMacroInfoImpl(
     override fun getMacroCall(): RsMacroCall? =
         sourceFile.getCallForInfo(this)
 
-    override fun isUpToDate(call: RsMacroCall, def: RsMacro?): Boolean =
+    override fun isUpToDate(call: RsMacroCall, def: RsMacroDataWithHash?): Boolean =
         callHash == call.bodyHash && def?.bodyHash == defHash
 
     override fun getExpansion(): MacroExpansion? {

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -131,8 +131,7 @@ class RsMacroCallData(val macroBody: String?) {
 }
 
 class MacroExpander(val project: Project) {
-    fun expandMacroAsText(def: RsMacro, call: RsMacroCall): Pair<CharSequence, RangeMap>? {
-        val defData = RsMacroData(def)
+    fun expandMacroAsText(defData: RsMacroData, call: RsMacroCall): Pair<CharSequence, RangeMap>? {
         val callData = RsMacroCallData(call)
         return expandMacroAsText(defData, callData)
     }

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -397,6 +397,7 @@ class MacroExpander(val project: Project) {
  * DON'T TRY THIS AT HOME
  */
 const val MACRO_DOLLAR_CRATE_IDENTIFIER: String = "IntellijRustDollarCrate"
+val MACRO_DOLLAR_CRATE_IDENTIFIER_REGEX: Regex = Regex(MACRO_DOLLAR_CRATE_IDENTIFIER)
 
 class MacroPattern private constructor(
     val pattern: Sequence<ASTNode>

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -122,8 +122,22 @@ private class NestingState(
     var atTheEnd: Boolean = false
 )
 
+class RsMacroData(val macroBody: Lazy<RsMacroBody?>) {
+    constructor(def: RsMacro) : this(lazy(LazyThreadSafetyMode.PUBLICATION) { def.macroBodyStubbed })
+}
+
+class RsMacroCallData(val macroBody: String?) {
+    constructor(call: RsMacroCall) : this(call.macroBody)
+}
+
 class MacroExpander(val project: Project) {
     fun expandMacroAsText(def: RsMacro, call: RsMacroCall): Pair<CharSequence, RangeMap>? {
+        val defData = RsMacroData(def)
+        val callData = RsMacroCallData(call)
+        return expandMacroAsText(defData, callData)
+    }
+
+    fun expandMacroAsText(def: RsMacroData, call: RsMacroCallData): Pair<CharSequence, RangeMap>? {
         val (case, subst, loweringRanges) = findMatchingPattern(def, call) ?: return null
         val macroExpansion = case.macroExpansion?.macroExpansionContents ?: return null
 
@@ -141,13 +155,13 @@ class MacroExpander(val project: Project) {
     }
 
     private fun findMatchingPattern(
-        def: RsMacro,
-        call: RsMacroCall
+        def: RsMacroData,
+        call: RsMacroCallData
     ): Triple<RsMacroCase, MacroSubstitution, RangeMap>? {
         val (macroCallBody, ranges) = project.createAdaptedRustPsiBuilder(call.macroBody ?: return null).lowerDocComments()
         macroCallBody.eof() // skip whitespace
         var start = macroCallBody.mark()
-        val macroCaseList = def.macroBodyStubbed?.macroCaseList ?: return null
+        val macroCaseList = def.macroBody.value?.macroCaseList ?: return null
 
         for (case in macroCaseList) {
             val subst = case.pattern.match(macroCallBody)
@@ -319,7 +333,7 @@ class MacroExpander(val project: Project) {
         }
     }
 
-    private fun checkRanges(call: RsMacroCall, expandedText: CharSequence, ranges: RangeMap) {
+    private fun checkRanges(call: RsMacroCallData, expandedText: CharSequence, ranges: RangeMap) {
         if (!isUnitTestMode) return
         val callBody = call.macroBody ?: return
 

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
@@ -115,7 +115,7 @@ fun getExpansionFromExpandedFile(context: MacroExpansionContext, expandedFile: R
 }
 
 fun MacroExpander.expandMacro(
-    def: RsMacro,
+    def: RsMacroData,
     call: RsMacroCall,
     factory: RsPsiFactory,
     storeRangeMap: Boolean

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -52,6 +52,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsPsiTreeChangeEvent.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.indexes.RsMacroCallIndex
+import org.rust.lang.core.resolve2.defMapService
 import org.rust.openapiext.*
 import org.rust.stdext.*
 import org.rust.taskQueue
@@ -785,6 +786,7 @@ private class MacroExpansionServiceImplInner(
             if (shouldScheduleUpdate && file is RsFile) {
                 val isWorkspace = file.isWorkspaceMember()
                 scheduleChangedMacrosUpdate(isWorkspace)
+                project.defMapService.onFileChanged(file)
             }
         }
 

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -53,6 +53,7 @@ import org.rust.lang.core.psi.RsPsiTreeChangeEvent.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.indexes.RsMacroCallIndex
 import org.rust.lang.core.resolve2.defMapService
+import org.rust.lang.core.resolve2.resolveToMacroWithoutPsi
 import org.rust.openapiext.*
 import org.rust.stdext.*
 import org.rust.taskQueue
@@ -1061,10 +1062,10 @@ private fun expandMacroOld(call: RsMacroCall): CachedValueProvider.Result<MacroE
 
 private fun expandMacroToMemoryFile(call: RsMacroCall, storeRangeMap: Boolean): CachedValueProvider.Result<MacroExpansion?> {
     val context = call.context as? RsElement ?: return nullExpansionResult(call)
-    val def = call.resolveToMacro() ?: return nullExpansionResult(call)
+    val def = call.resolveToMacroWithoutPsi() ?: return nullExpansionResult(call)
     val project = call.project
     val result = MacroExpander(project).expandMacro(
-        def,
+        def.data,
         call,
         RsPsiFactory(project, markGenerated = false),
         storeRangeMap

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionSharedCache.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionSharedCache.kt
@@ -126,11 +126,10 @@ class MacroExpansionSharedCache : Disposable {
         MACRO_LOG.warn(e)
     }
 
-    fun cachedExpand(expander: MacroExpander, def: RsMacro, call: RsMacroCall): ExpansionResult? {
-        val defData = RsMacroData(def)
+    fun cachedExpand(expander: MacroExpander, def: RsMacroDataWithHash, call: RsMacroCall): ExpansionResult? {
         val callData = RsMacroCallData(call)
         val hash = HashCode.mix(def.bodyHash ?: return null, call.bodyHash ?: return null)
-        return cachedExpand(expander, defData, callData, hash)
+        return cachedExpand(expander, def.data, callData, hash)
     }
 
     private fun cachedExpand(

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -29,11 +29,11 @@ import org.rust.lang.core.psi.RsMembers
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.bodyHash
 import org.rust.lang.core.psi.ext.macroBody
-import org.rust.lang.core.psi.ext.resolveToMacro
 import org.rust.lang.core.resolve.DEFAULT_RECURSION_LIMIT
 import org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl
 import org.rust.lang.core.resolve.ref.RsResolveCache
 import org.rust.lang.core.resolve2.RESOLVE_LOG
+import org.rust.lang.core.resolve2.resolveToMacroWithoutPsi
 import org.rust.lang.core.resolve2.updateDefMapForAllCrates
 import org.rust.openapiext.*
 import org.rust.stdext.HashCode
@@ -415,7 +415,7 @@ object ExpansionPipeline {
 
             if (oldExpansionFile != null && !oldExpansionFile.isValid) throw CorruptedExpansionStorageException()
 
-            val def = RsMacroPathReferenceImpl.resolveInBatchMode { call.resolveToMacro() }
+            val def = RsMacroPathReferenceImpl.resolveInBatchMode { call.resolveToMacroWithoutPsi() }
                 ?: return if (oldExpansionFile == null) EmptyPipeline else nextStageFail(callHash, null)
 
             val defHash = def.bodyHash

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -33,6 +33,8 @@ import org.rust.lang.core.psi.ext.resolveToMacro
 import org.rust.lang.core.resolve.DEFAULT_RECURSION_LIMIT
 import org.rust.lang.core.resolve.ref.RsMacroPathReferenceImpl
 import org.rust.lang.core.resolve.ref.RsResolveCache
+import org.rust.lang.core.resolve2.RESOLVE_LOG
+import org.rust.lang.core.resolve2.updateDefMapForAllCrates
 import org.rust.openapiext.*
 import org.rust.stdext.HashCode
 import org.rust.stdext.getLeading64bits
@@ -78,8 +80,6 @@ abstract class MacroExpansionTaskBase(
         indicator.isIndeterminate = false
         realTaskIndicator = indicator
 
-        expansionSteps = getMacrosToExpand(dumbService).iterator()
-
         if (indicator is ProgressIndicatorEx) {
             // [indicator] can be an instance of [BackgroundableProcessIndicator] class, which is thread
             // sensitive and its `checkCanceled` method should be used only from a single thread
@@ -91,6 +91,18 @@ abstract class MacroExpansionTaskBase(
         } else {
             subTaskIndicator = indicator
         }
+
+        try {
+            realTaskIndicator.text = "Preparing resolve data"
+            updateDefMapForAllCrates(project, pool, subTaskIndicator)
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: Exception) {
+            // Exceptions in new resolve should not break macro expansion
+            RESOLVE_LOG.error(e)
+        }
+
+        expansionSteps = getMacrosToExpand(dumbService).iterator()
 
         indicator.checkCanceled()
         var heavyProcessToken: AccessToken? = null

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragmentFactory.kt
@@ -48,7 +48,7 @@ class RsCodeFragmentFactory(val project: Project) {
         } else {
             "" to "use $usePath;"
         }
-        val mod = psiFactory.createModItem("__tmp__", """
+        val mod = psiFactory.createModItem(TMP_MOD_NAME, """
             $externCrateItem
             use super::*;
             $useItem
@@ -57,3 +57,5 @@ class RsCodeFragmentFactory(val project: Project) {
         return createPath(importingPathName, mod, mode, ns)
     }
 }
+
+const val TMP_MOD_NAME: String = "__tmp__"

--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -8,7 +8,9 @@ package org.rust.lang.core.psi
 import com.intellij.extapi.psi.PsiFileBase
 import com.intellij.injected.editor.VirtualFileWindow
 import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.ModificationTracker
@@ -263,3 +265,9 @@ val RsElement.isValidProjectMember: Boolean
         if (file !is RsFile) return true
         return isEnabledByCfg && file.isDeeplyEnabledByCfg && file.crateRoot != null
     }
+
+fun shouldIndexFile(project: Project, file: VirtualFile): Boolean {
+    val index = ProjectFileIndex.getInstance(project)
+    return (index.isInContent(file) || index.isInLibrary(file))
+        && !FileTypeManager.getInstance().isFileIgnored(file)
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiTreeChangeListener.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiTreeChangeListener.kt
@@ -119,16 +119,29 @@ sealed class RsPsiTreeChangeEvent {
         val propertyName: String,
         val oldValue: Any?,
         val newValue: Any?,
-        val element: PsiElement?
+        val element: PsiElement?,
+        val child: PsiElement?,
     ) : RsPsiTreeChangeEvent() {
-        class Before(propertyName: String, oldValue: Any?, newValue: Any?, element: PsiElement?) : PropertyChange(propertyName, oldValue, newValue, element)
-        class After(propertyName: String, oldValue: Any?, newValue: Any?, element: PsiElement?) : PropertyChange(propertyName, oldValue, newValue, element)
+        class Before(
+            propertyName: String,
+            oldValue: Any?,
+            newValue: Any?,
+            element: PsiElement?,
+            child: PsiElement?
+        ) : PropertyChange(propertyName, oldValue, newValue, element, child)
+        class After(
+            propertyName: String,
+            oldValue: Any?,
+            newValue: Any?,
+            element: PsiElement?,
+            child: PsiElement?
+        ) : PropertyChange(propertyName, oldValue, newValue, element, child)
 
         override fun toString(): String {
             val oldValue = if (oldValue is Array<*>) Arrays.toString(oldValue) else oldValue
             val newValue = if (newValue is Array<*>) Arrays.toString(newValue) else newValue
             return "PropertyChange.${javaClass.simpleName}(propertyName='$propertyName', " +
-                "oldValue=$oldValue, newValue=$newValue, element=$element)"
+                "oldValue=$oldValue, newValue=$newValue, element=$element, child=$child)"
         }
     }
 }
@@ -142,7 +155,8 @@ abstract class RsPsiTreeChangeAdapter : PsiTreeChangeListener {
             event.propertyName,
             event.oldValue,
             event.newValue,
-            event.element
+            event.element,
+            event.child
         ))
     }
 
@@ -151,7 +165,8 @@ abstract class RsPsiTreeChangeAdapter : PsiTreeChangeListener {
             event.propertyName,
             event.oldValue,
             event.newValue,
-            event.element
+            event.element,
+            event.child
         ))
     }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -17,6 +17,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ref.RsReference
 import org.rust.lang.core.resolve.ref.advancedDeepResolve
+import org.rust.lang.core.resolve2.processItemDeclarations2
 import org.rust.openapiext.recursionGuard
 import org.rust.stdext.intersects
 import java.util.*
@@ -65,6 +66,10 @@ fun processItemDeclarations(
     originalProcessor: RsResolveProcessor,
     ipm: ItemProcessingMode
 ): Boolean {
+    if (scope is RsMod) {
+        processItemDeclarations2(scope, ns, originalProcessor, ipm)?.let { return it }
+    }
+
     val withPrivateImports = ipm != ItemProcessingMode.WITHOUT_PRIVATE_IMPORTS
 
     val directlyDeclaredNames = HashMap<String, Set<Namespace>>()

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -47,6 +47,8 @@ import org.rust.lang.core.resolve.NameResolutionTestmarks.selfInGroup
 import org.rust.lang.core.resolve.indexes.RsLangItemIndex
 import org.rust.lang.core.resolve.indexes.RsMacroIndex
 import org.rust.lang.core.resolve.ref.*
+import org.rust.lang.core.resolve2.isNewResolveEnabled
+import org.rust.lang.core.resolve2.processMacros
 import org.rust.lang.core.stubs.index.RsNamedElementIndex
 import org.rust.lang.core.types.*
 import org.rust.lang.core.types.consts.CtInferVar
@@ -839,8 +841,8 @@ private fun processMacrosExportedByCrate(crateRoot: RsFile, processor: RsResolve
 }
 
 fun processMacroCallVariantsInScope(context: PsiElement, processor: RsResolveProcessor): Boolean {
-    val result = MacroResolver.processMacrosInLexicalOrderUpward(context, processor)
-    if (result) return true
+    val (result, usedNewResolve) = MacroResolver.processMacrosInLexicalOrderUpward(context, processor)
+    if (result || usedNewResolve) return result
 
     val element = context.contextOrSelf<RsElement>() ?: return false
     val crateRoot = element.crateRoot as? RsFile ?: return false
@@ -848,19 +850,26 @@ fun processMacroCallVariantsInScope(context: PsiElement, processor: RsResolvePro
     return processAllScopeEntries(exportedMacrosAsScopeEntries(prelude), processor)
 }
 
+private data class MacroResolveResult(val result: Boolean, val usedNewResolve: Boolean = false) {
+    companion object {
+        val True: MacroResolveResult = MacroResolveResult(result = true)
+        val False: MacroResolveResult = MacroResolveResult(result = false)
+    }
+}
+
 private class MacroResolver private constructor(private val processor: RsResolveProcessor) : RsVisitor() {
     private val visitor = MacroResolvingVisitor(reverse = true) { processor(it) }
 
-    private fun processMacrosInLexicalOrderUpward(startElement: PsiElement): Boolean {
-        if (processScopesInLexicalOrderUpward(startElement)) {
-            return true
-        }
+    private fun processMacrosInLexicalOrderUpward(startElement: PsiElement): MacroResolveResult {
+        val result = processScopesInLexicalOrderUpward(startElement)
+        if (result.result || result.usedNewResolve) return result
 
-        if (processRemainedExportedMacros()) return true
+        if (processRemainedExportedMacros()) return MacroResolveResult.True
 
-        val crateRoot = startElement.contextOrSelf<RsElement>()?.crateRoot as? RsFile ?: return false
+        val crateRoot = startElement.contextOrSelf<RsElement>()?.crateRoot as? RsFile
+            ?: return MacroResolveResult.False
         NameResolutionTestmarks.processSelfCrateExportedMacros.hit()
-        return processAllScopeEntries(exportedMacrosAsScopeEntries(crateRoot), processor)
+        return processAllScopeEntries(exportedMacrosAsScopeEntries(crateRoot), processor).toResult()
     }
 
     /**
@@ -868,7 +877,7 @@ private class MacroResolver private constructor(private val processor: RsResolve
      * until root (file), then it goes up to module declaration of the file (`mod foo;`) and processes its
      * siblings, and so on until crate root
      */
-    private fun processScopesInLexicalOrderUpward(startElement: PsiElement): Boolean {
+    private fun processScopesInLexicalOrderUpward(startElement: PsiElement): MacroResolveResult {
         val stub = (startElement as? StubBasedPsiElement<*>)?.greenStub
         return if (stub != null) {
             stubBasedProcessScopesInLexicalOrderUpward(stub)
@@ -877,9 +886,11 @@ private class MacroResolver private constructor(private val processor: RsResolve
         }
     }
 
-    private tailrec fun psiBasedProcessScopesInLexicalOrderUpward(element: PsiElement): Boolean {
+    private tailrec fun psiBasedProcessScopesInLexicalOrderUpward(element: PsiElement): MacroResolveResult {
+        tryProcessAllMacrosUsingNewResolve(element)?.let { return it }
+
         for (e in element.leftSiblings) {
-            if (visitor.processMacros(e)) return true
+            if (visitor.processMacros(e)) return MacroResolveResult.True
         }
 
         // ```
@@ -892,31 +903,39 @@ private class MacroResolver private constructor(private val processor: RsResolve
         // But we want to process macro definition before `bar!` macro call, so we have to use
         // a macro call as a "parent"
         val expandedFrom = (element as? RsExpandedElement)?.expandedFrom
-        if (expandedFrom != null && processExpandedFrom(expandedFrom)) return true
-        val context = expandedFrom ?: element.context ?: return false
+        if (expandedFrom != null && processExpandedFrom(expandedFrom)) return MacroResolveResult.True
+        val context = expandedFrom ?: element.context ?: return MacroResolveResult.False
         return when {
-            context is RsFile -> processScopesInLexicalOrderUpward(context.declaration ?: return false)
+            context is RsFile -> {
+                val declaration = context.declaration ?: return MacroResolveResult.False
+                processScopesInLexicalOrderUpward(declaration)
+            }
             // Optimization. Let this function be tailrec if go up by real parent (in the same file)
             context != element.parent -> processScopesInLexicalOrderUpward(context)
             else -> psiBasedProcessScopesInLexicalOrderUpward(context)
         }
     }
 
-    private tailrec fun stubBasedProcessScopesInLexicalOrderUpward(element: StubElement<*>): Boolean {
-        val parentStub = element.parentStub ?: return false
+    private tailrec fun stubBasedProcessScopesInLexicalOrderUpward(element: StubElement<*>): MacroResolveResult {
+        tryProcessAllMacrosUsingNewResolve(element.psi)?.let { return it }
+
+        val parentStub = element.parentStub ?: return MacroResolveResult.False
         val siblings = parentStub.childrenStubs
         val index = siblings.indexOf(element)
         check(index != -1) { "Can't find stub index" }
         val leftSiblings = siblings.subList(0, index)
         for (it in leftSiblings) {
-            if (visitor.processMacros(it.psi)) return true
+            if (visitor.processMacros(it.psi)) return MacroResolveResult.True
         }
         // See comment in psiBasedProcessScopesInLexicalOrderUpward
         val expandedFrom = (element.psi as? RsExpandedElement)?.expandedFrom
-        if (expandedFrom != null && processExpandedFrom(expandedFrom)) return true
+        if (expandedFrom != null && processExpandedFrom(expandedFrom)) return MacroResolveResult.True
         val parentPsi = expandedFrom ?: parentStub.psi
         return when {
-            parentPsi is RsFile -> processScopesInLexicalOrderUpward(parentPsi.declaration ?: return false)
+            parentPsi is RsFile -> {
+                val declaration = parentPsi.declaration ?: return MacroResolveResult.False
+                processScopesInLexicalOrderUpward(declaration)
+            }
             // Optimization. Let this function be tailrec if go up by stub parent
             parentPsi != parentStub.psi -> processScopesInLexicalOrderUpward(parentPsi)
             else -> stubBasedProcessScopesInLexicalOrderUpward(parentStub)
@@ -940,6 +959,20 @@ private class MacroResolver private constructor(private val processor: RsResolve
         return false
     }
 
+    /** Try using new resolve if [element] is top-level item or expanded from top-level macro call. */
+    private fun tryProcessAllMacrosUsingNewResolve(element: PsiElement): MacroResolveResult? {
+        if (!isNewResolveEnabled) return null
+        if (element !is RsElement) return null
+        if (element.parent !is RsMod) return null  // we are interested only in top-level elements
+
+        val expandedFrom = (element as? RsExpandedElement)?.expandedFromRecursively
+        val item = expandedFrom ?: element
+        val scope = item.parent as? RsMod ?: return null
+        /** [processRemainedExportedMacros] processes local imports */
+        return processMacros(scope, processor, ::processRemainedExportedMacros)
+            ?.toResult(usedNewResolve = true)
+    }
+
     private fun processRemainedExportedMacros(): Boolean {
         return visitor.useItems.any { useItem ->
             processAllScopeEntries(collectMacrosImportedWithUseItem(useItem, visitor.exportingMacrosCrates), processor)
@@ -947,8 +980,11 @@ private class MacroResolver private constructor(private val processor: RsResolve
     }
 
     companion object {
-        fun processMacrosInLexicalOrderUpward(startElement: PsiElement, processor: RsResolveProcessor): Boolean =
+        fun processMacrosInLexicalOrderUpward(startElement: PsiElement, processor: RsResolveProcessor): MacroResolveResult =
             MacroResolver(processor).processMacrosInLexicalOrderUpward(startElement)
+
+        private fun Boolean.toResult(usedNewResolve: Boolean = false): MacroResolveResult =
+            MacroResolveResult(this, usedNewResolve)
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroPathReferenceImpl.kt
@@ -60,9 +60,6 @@ class RsMacroPathReferenceImpl(
             .getCached(element, cacheDep) as? RsNamedElement
     }
 
-    private val cacheDep: ResolveCacheDependency
-        get() = if (isBatchMode) ResolveCacheDependency.MACRO else ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE
-
     private object Resolver : (RsPath) -> RsNamedElement? {
         override fun invoke(element: RsPath): RsNamedElement? {
             return pickFirstResolveVariant(element.referenceName) {
@@ -72,6 +69,9 @@ class RsMacroPathReferenceImpl(
     }
 
     companion object {
+        val cacheDep: ResolveCacheDependency
+            get() = if (isBatchMode) ResolveCacheDependency.MACRO else ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE
+
         var isBatchMode by ThreadLocalDelegate { false }
 
         /** @see ResolveCacheDependency.MACRO */

--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
@@ -1,0 +1,447 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.google.common.annotations.VisibleForTesting
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileWithId
+import com.intellij.psi.FileViewProvider
+import com.intellij.psi.PsiFile
+import gnu.trove.THashMap
+import org.rust.lang.core.crate.CratePersistentId
+import org.rust.lang.core.psi.RsEnumVariant
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.resolve.Namespace
+import org.rust.lang.core.resolve2.Visibility.*
+import org.rust.openapiext.fileId
+import org.rust.openapiext.testAssert
+import org.rust.stdext.HashCode
+import java.nio.file.Path
+
+class CrateDefMap(
+    val crate: CratePersistentId,
+    val root: ModData,
+
+    // TODO: Not used after [CrateDefMap] was built, probably it is worth to move it to [CollectorContext]
+    /** Used only by `extern crate crate_name;` declarations */
+    val directDependenciesDefMaps: Map<String, CrateDefMap>,
+    private val allDependenciesDefMaps: Map<CratePersistentId, CrateDefMap>,
+    /**
+     * The prelude module for this crate. This either comes from an import
+     * marked with the `prelude_import` attribute, or (in the normal case) from
+     * a dependency (`std` or `core`).
+     */
+    var prelude: ModData?,
+    val metaData: CrateMetaData,
+    /** Only for debug */
+    val crateDescription: String,
+) {
+    /** It is needed at least to handle `extern crate name as alias;` */
+    val externPrelude: MutableMap<String, CrateDefMap> = directDependenciesDefMaps.toMap(hashMapOf())
+
+    /**
+     * File included via `include!` macro has same [FileInfo.modData] as main file,
+     * but different [FileInfo.hash] and [FileInfo.modificationStamp]
+     */
+    val fileInfos: MutableMap<FileId, FileInfo> = hashMapOf()
+
+    /**
+     * Files which currently do not exist, but could affect resolve if created:
+     * - for unresolved mod declarations - `.../name.rs` and `.../name/mod.rs`
+     * - for unresolved `include!` macro - corresponding file
+     *
+     * Note: [missedFiles] should be empty if compilation is successful.
+     */
+    val missedFiles: MutableList<Path> = mutableListOf()
+
+    @VisibleForTesting
+    val timestamp: Long = System.nanoTime()
+
+    /** Stored as memory optimization */
+    val rootAsPerNs: PerNs = PerNs(types = VisItem(root.path, Public, true))
+
+    fun getDefMap(crate: CratePersistentId): CrateDefMap? =
+        if (crate == this.crate) this else allDependenciesDefMaps[crate]
+
+    fun getModData(path: ModPath): ModData? {
+        val defMap = getDefMap(path.crate) ?: error("Can't find ModData for path $path")
+        return defMap.doGetModData(path)
+    }
+
+    private fun doGetModData(path: ModPath): ModData? {
+        check(crate == path.crate)
+        return path.segments
+            .fold(root as ModData?) { modData, segment -> modData?.childModules?.get(segment) }
+            .also { testAssert({ it != null }, { "Can't find ModData for $path in crate $crateDescription" }) }
+    }
+
+    // TODO: Possible optimization - store in [CrateDefMap] map from [String] (mod path) to [ModData]
+    fun tryCastToModData(types: VisItem): ModData? {
+        if (!types.isModOrEnum) return null
+        return getModData(types.path)
+    }
+
+    fun getModData(mod: RsMod): ModData? {
+        if (mod is RsFile) {
+            val virtualFile = mod.originalFile.virtualFile ?: return null
+            val fileInfo = fileInfos[virtualFile.fileId]
+            // TODO: Exception here does not fail [RsBuildDefMapTest]
+            // Note: we don't expand cfg-disabled macros (it can contain mod declaration)
+            testAssert { fileInfo != null || !mod.isDeeplyEnabledByCfg }
+            return fileInfo?.modData
+        }
+        val parentMod = mod.`super` ?: return null
+        val parentModData = getModData(parentMod) ?: return null
+        return parentModData.childModules[mod.modName]
+    }
+
+    fun getMacroInfo(macroDef: VisItem): MacroDefInfo {
+        val defMap = getDefMap(macroDef.crate) ?: error("Can't find DefMap for macro $macroDef")
+        return defMap.doGetMacroInfo(macroDef)
+    }
+
+    // TODO: [RsMacro2]
+    private fun doGetMacroInfo(macroDef: VisItem): MacroDefInfo {
+        val containingMod = getModData(macroDef.containingMod) ?: error("Can't find ModData for macro $macroDef")
+        return containingMod.legacyMacros[macroDef.name] ?: error("Can't find definition for macro $macroDef")
+    }
+
+    /**
+     * Import all exported macros from another crate.
+     *
+     * Exported macros are just all macros in the root module scope.
+     * Note that it contains not only all ```#[macro_export]``` macros, but also all aliases
+     * created by `use` in the root module, ignoring the visibility of `use`.
+     */
+    fun importAllMacrosExported(from: CrateDefMap) {
+        for ((name, def) in from.root.visibleItems) {
+            val macroDef = def.macros ?: continue
+            // `macro_use` only bring things into legacy scope.
+            root.legacyMacros[name] = from.getMacroInfo(macroDef)
+        }
+    }
+
+    fun addVisitedFile(file: RsFile, modData: ModData, fileHash: HashCode) {
+        val fileId = file.virtualFile.fileId
+        // TODO: File included in module tree multiple times ?
+        // testAssert { fileId !in fileInfos }
+        fileInfos[fileId] = FileInfo(file.modificationStampForResolve, modData, fileHash)
+    }
+
+    override fun toString(): String = crateDescription
+}
+
+/** Refers to [VirtualFileWithId.getId] */
+typealias FileId = Int
+
+class FileInfo(
+    /**
+     * Result of [FileViewProvider.getModificationStamp].
+     *
+     * Here are possible (other) methods to use:
+     * - [PsiFile.getModificationStamp]
+     * - [FileViewProvider.getModificationStamp]
+     * - [VirtualFile.getModificationStamp]
+     * - [VirtualFile.getModificationCount]
+     * - [Document.getModificationStamp]
+     *
+     * Notes:
+     * - [VirtualFile] methods value is updated only after file is saved to disk
+     * - Only [VirtualFile.getModificationCount] survives IDE restart
+     */
+    val modificationStamp: Long,
+    /** Optimization for [CrateDefMap.getModData] */
+    val modData: ModData,
+    val hash: HashCode,
+)
+
+class ModData(
+    val parent: ModData?,
+    val crate: CratePersistentId,
+    val path: ModPath,
+    val isDeeplyEnabledByCfg: Boolean,
+    /** id of containing file */
+    val fileId: FileId,
+    // TODO: Possible optimization - store as Array<String>
+    /** Starts with :: */
+    val fileRelativePath: String,
+    /** `fileId` of owning directory */
+    val ownedDirectoryId: FileId?,
+    val isEnum: Boolean = false,
+    /** Only for debug */
+    val crateDescription: String,
+) {
+    /** `true` if the module is a separate `.rs` file (not an inline module) */
+    val isRsFile: Boolean get() = fileRelativePath.isEmpty()
+    val isCrateRoot: Boolean get() = parent == null
+    val name: String get() = path.name
+    val parents: Sequence<ModData> get() = generateSequence(this) { it.parent }
+
+    // TODO: Compare with storing three maps
+    val visibleItems: MutableMap<String, PerNs> = THashMap()
+
+    val childModules: MutableMap<String, ModData> = hashMapOf()
+
+    /**
+     * Macros visible in current module in legacy textual scope.
+     * Module scoped macros will be inserted into [visibleItems] instead of here.
+     * Currently stores only cfg-enabled macros.
+     */
+    val legacyMacros: MutableMap<String, MacroDefInfo> = THashMap()
+
+    /** Traits imported via `use Trait as _;` */
+    val unnamedTraitImports: MutableMap<ModPath, Visibility> = THashMap()
+
+    /**
+     * Make sense only for files ([isRsFile] == true).
+     * Value `false` means that `this` is not accessible from [CrateDefMap.root] through [ModData.childModules],
+     * but can be accessible using [CrateDefMap.fileInfos].
+     * It could happen when two mod declarations with same path has different cfg-attributes.
+     */
+    var isShadowedByOtherFile: Boolean = true
+
+    /**
+     * Records names which come from glob-imports
+     * to determine whether we can override them (usual imports overrides glob-imports).
+     * Used only in [DefCollector], but stored in [ModData] as an optimization.
+     * null after DefMap was built.
+     */
+    var fromGlobImport: PerNsGlobImports? = PerNsGlobImports()
+
+    fun getVisibleItem(name: String): PerNs = visibleItems.getOrDefault(name, PerNs.Empty)
+
+    fun getVisibleItems(filterVisibility: (Visibility) -> Boolean): List<Pair<String, PerNs>> {
+        val usualItems = visibleItems.entries
+            .map { (name, visItem) -> name to visItem.filterVisibility(filterVisibility) }
+            .filterNot { (_, visItem) -> visItem.isEmpty }
+        if (unnamedTraitImports.isEmpty()) return usualItems
+
+        val traitItems = unnamedTraitImports
+            .mapNotNull { (path, visibility) ->
+                if (!filterVisibility(visibility)) return@mapNotNull null
+                val trait = VisItem(path, visibility, isModOrEnum = false)
+                "_" to PerNs(types = trait)
+            }
+        return usualItems + traitItems
+    }
+
+    fun addVisibleItem(name: String, def: PerNs) {
+        val defExisting = visibleItems.putIfAbsent(name, def) ?: return
+        defExisting.update(def)
+    }
+
+    fun asVisItem(): VisItem {
+        val parent = parent ?: error("Use CrateDefMap.rootAsPerNs for root ModData")
+        return parent.visibleItems[name]?.types?.takeIf { it.isModOrEnum }
+            ?: error("Inconsistent `visibleItems` and `childModules` in parent of $this")
+    }
+
+    fun asPerNs(): PerNs = PerNs(types = asVisItem())
+
+    fun getNthParent(n: Int): ModData? {
+        check(n >= 0)
+        var current = this
+        repeat(n) {
+            current = current.parent ?: return null
+        }
+        return current
+    }
+
+    override fun toString(): String = "ModData($path, crate=$crateDescription)"
+}
+
+data class PerNs(
+    var types: VisItem? = null,
+    var values: VisItem? = null,
+    var macros: VisItem? = null,
+) {
+    val isEmpty: Boolean get() = types == null && values == null && macros == null
+
+    constructor(visItem: VisItem, ns: Set<Namespace>) :
+        this(
+            visItem.takeIf { Namespace.Types in ns },
+            visItem.takeIf { Namespace.Values in ns },
+            visItem.takeIf { Namespace.Macros in ns }
+        )
+
+    fun withVisibility(visibility: Visibility): PerNs =
+        PerNs(
+            types?.withVisibility(visibility),
+            values?.withVisibility(visibility),
+            macros?.withVisibility(visibility)
+        )
+
+    fun filterVisibility(filter: (Visibility) -> Boolean): PerNs =
+        PerNs(
+            types?.takeIf { filter(it.visibility) },
+            values?.takeIf { filter(it.visibility) },
+            macros?.takeIf { filter(it.visibility) }
+        )
+
+    // TODO: Consider unite with [DefCollector#pushResolutionFromImport]
+    fun update(other: PerNs) {
+        fun merge(existing: VisItem?, new: VisItem?): VisItem? {
+            if (existing == null) return new
+            if (new == null) return existing
+            return if (new.visibility.isStrictlyMorePermissive(existing.visibility)) new else existing
+        }
+        types = merge(types, other.types)
+        values = merge(values, other.values)
+        macros = merge(macros, other.macros)
+    }
+
+    fun or(other: PerNs): PerNs {
+        if (isEmpty) return other
+        if (other.isEmpty) return this
+        return PerNs(
+            types.or(other.types),
+            values.or(other.values),
+            macros.or(other.macros)
+        )
+    }
+
+    private fun VisItem?.or(other: VisItem?): VisItem? {
+        if (this == null) return other
+        if (other == null) return this
+        if (visibility == CfgDisabled && other.visibility != CfgDisabled) return other
+        if (visibility == Invisible && !other.visibility.isInvisible) return other
+        return this
+    }
+
+    fun mapItems(f: (VisItem) -> VisItem): PerNs =
+        PerNs(
+            types?.let { f(it) },
+            values?.let { f(it) },
+            macros?.let { f(it) }
+        )
+
+    companion object {
+        val Empty: PerNs = PerNs()
+    }
+}
+
+/**
+ * The item which can be visible in the module (either directly declared or imported)
+ * Could be [RsEnumVariant] (because it can be imported)
+ */
+data class VisItem(
+    // TODO:
+    //  Measure memory usage caused by [path]
+    //  Probably it is better to store [containingMod] and [name] separately
+    /**
+     * Full path to item, including its name.
+     * Note: Can't store [containingMod] and [name] separately, because [VisItem] could be used for crate root
+     */
+    val path: ModPath,
+    val visibility: Visibility,
+    val isModOrEnum: Boolean = false,
+) {
+    init {
+        check(isModOrEnum || path.segments.isNotEmpty())
+    }
+
+    /** Mod where item is explicitly declared */
+    val containingMod: ModPath get() = path.parent
+    val name: String get() = path.name
+    val crate: CratePersistentId get() = path.crate
+
+    fun withVisibility(visibilityNew: Visibility): VisItem =
+        if (visibility == visibilityNew || visibility.isInvisible) this else copy(visibility = visibilityNew)
+
+    override fun toString(): String = "$visibility $path"
+}
+
+sealed class Visibility {
+    object Public : Visibility()
+
+    /** includes private */
+    data class Restricted(val inMod: ModData) : Visibility()
+
+    /**
+     * Means that we have import to private item
+     * So normally we should ignore such [VisItem] (it is not accessible)
+     * But we record it for completion, etc
+     */
+    object Invisible : Visibility()
+
+    object CfgDisabled : Visibility()
+
+    fun isVisibleFromOtherCrate(): Boolean = this == Public
+
+    fun isVisibleFromMod(mod: ModData): Boolean {
+        return when (this) {
+            Public -> true
+            // Alternative realization: `mod.parents.contains(inMod)`
+            is Restricted -> inMod.path.isSubPathOf(mod.path)
+            Invisible, CfgDisabled -> false
+        }
+    }
+
+    fun isStrictlyMorePermissive(other: Visibility): Boolean {
+        return if (this is Restricted && other is Restricted) {
+            inMod.crate == other.inMod.crate
+                && inMod != other.inMod
+                && other.inMod.parents.contains(inMod)
+        } else {
+            when (this) {
+                Public -> other !is Public
+                is Restricted -> other == Invisible || other == CfgDisabled
+                Invisible -> other == CfgDisabled
+                CfgDisabled -> false
+            }
+        }
+    }
+
+    val isInvisible: Boolean get() = this == Invisible || this == CfgDisabled
+
+    override fun toString(): String =
+        when (this) {
+            Public -> "Public"
+            is Restricted -> "Restricted(in ${inMod.path})"
+            Invisible -> "Invisible"
+            CfgDisabled -> "CfgDisabled"
+        }
+}
+
+/** Path to a module or an item in module */
+class ModPath(
+    val crate: CratePersistentId,
+    val segments: Array<String>,
+    // val fileId: FileId,  // id of containing file
+    // val fileRelativePath: String  // empty for pathRsFile
+) {
+    val name: String get() = segments.last()
+    val parent: ModPath get() = ModPath(crate, segments.copyOfRange(0, segments.size - 1))
+
+    fun append(segment: String): ModPath = ModPath(crate, segments + segment)
+
+    /** `mod1::mod2` isSubPathOf `mod1::mod2::mod3` */
+    fun isSubPathOf(other: ModPath): Boolean {
+        if (crate != other.crate) return false
+
+        if (segments.size > other.segments.size) return false
+        for (index in segments.indices) {
+            if (segments[index] != other.segments[index]) return false
+        }
+        return true
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as ModPath
+        return crate == other.crate && segments.contentEquals(other.segments)
+    }
+
+    override fun hashCode(): Int = 31 * crate + segments.contentHashCode()
+
+    override fun toString(): String = segments.joinToString("::").ifEmpty { "crate" }
+}
+
+val RESOLVE_LOG = Logger.getInstance("org.rust.resolve2")

--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateModificationTracker.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateModificationTracker.kt
@@ -1,0 +1,116 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
+import org.rust.cargo.CfgOptions
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.project.workspace.FeatureState
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.crate.CratePersistentId
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.rustFile
+import org.rust.lang.core.psi.shouldIndexFile
+import org.rust.openapiext.checkReadAccessAllowed
+import org.rust.openapiext.testAssert
+import org.rust.openapiext.toPsiFile
+import org.rust.stdext.mapNotNullToSet
+
+/**
+ * Calculates new value of [DefMapHolder.shouldRebuild] field.
+ * Also clears [DefMapHolder.shouldRecheck] and [DefMapHolder.changedFiles].
+ */
+fun DefMapHolder.getShouldRebuild(crate: Crate): Boolean {
+    checkReadAccessAllowed()
+    if (shouldRebuild) return true
+    if (!shouldRecheck && changedFiles.isEmpty()) return false
+    // If `shouldRebuild == false` then `defMap` was built at least once
+    // If `defMap` is `null` then [crate] is weird (e.g. with null `id` or `rootMod`) and can be ignored
+    val defMap = defMap ?: return false
+
+    // We can just add all crate files to [changedFiles] if [shouldRecheck],
+    // but getting all crate files can be slow
+    val changedFilesCopy = if (shouldRecheck) changedFiles.toSet() else emptySet()
+    processChangedFiles(crate, defMap) && return true
+
+    if (shouldRecheck) {
+        if (isCrateChanged(crate, defMap)) return true
+        changedFiles += defMap.getAllChangedFiles(crate.project, ignoredFiles = changedFilesCopy) ?: return true
+        shouldRecheck = false
+
+        processChangedFiles(crate, defMap) && return true
+    }
+    return false
+}
+
+private fun CrateDefMap.getAllChangedFiles(project: Project, ignoredFiles: Set<RsFile>): List<RsFile>? {
+    val persistentFS = PersistentFS.getInstance()
+    return fileInfos.mapNotNull { (fileId, fileInfo) ->
+        val file = persistentFS
+            .findFileById(fileId)
+            ?.toPsiFile(project)
+            ?.rustFile
+            ?: return null  // file was deleted - should rebuilt DefMap
+        file.takeIf {
+            it !in ignoredFiles
+                && it.modificationStampForResolve == fileInfo.modificationStamp
+        }
+    }
+}
+
+private fun DefMapHolder.processChangedFiles(crate: Crate, defMap: CrateDefMap): Boolean {
+    // We are in read action, and [changedFiles] are modified only in write action
+    val iterator = changedFiles.iterator()
+    /** We use iterator in order to not lose progress if [isFileChanged] throws [ProcessCanceledException] */
+    while (iterator.hasNext()) {
+        ProgressManager.checkCanceled()
+        val file = iterator.next()
+        if (isFileChanged(file, defMap, crate)) {
+            return true
+        } else {
+            iterator.remove()
+        }
+    }
+    return false
+}
+
+data class CrateMetaData(
+    val edition: CargoWorkspace.Edition,
+    private val features: Map<String, FeatureState>,
+    private val cfgOptions: CfgOptions,
+    private val env: Map<String, String>,
+    // TODO: Probably we need to store modificationStamp of DefMap for each dependency
+    private val dependencies: Set<CratePersistentId>,
+) {
+    constructor(crate: Crate) : this(
+        edition = crate.edition,
+        features = crate.features,
+        cfgOptions = crate.cfgOptions,
+        env = crate.env,
+        dependencies = crate.flatDependencies.mapNotNullToSet { it.id }
+    )
+}
+
+fun isCrateChanged(crate: Crate, defMap: CrateDefMap): Boolean {
+    ProgressManager.checkCanceled()
+
+    val crateRootFile = crate.rootModFile ?: return false
+    testAssert(
+        { shouldIndexFile(crate.project, crateRootFile) },
+        { "isCrateChanged should not be called for crates which are not indexed" }
+    )
+
+    return defMap.metaData != CrateMetaData(crate) || defMap.hasAnyMissedFileCreated()
+}
+
+private fun CrateDefMap.hasAnyMissedFileCreated(): Boolean {
+    val fileManager = VirtualFileManager.getInstance()
+    return missedFiles.any { fileManager.findFileByNioPath(it) != null }
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -1,0 +1,477 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
+import com.intellij.openapiext.isUnitTestMode
+import org.rust.lang.core.crate.CratePersistentId
+import org.rust.lang.core.macros.*
+import org.rust.lang.core.psi.RsMacroBody
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.ext.body
+import org.rust.lang.core.psi.rustFile
+import org.rust.lang.core.resolve.DEFAULT_RECURSION_LIMIT
+import org.rust.lang.core.resolve2.ImportType.GLOB
+import org.rust.lang.core.resolve2.ImportType.NAMED
+import org.rust.lang.core.resolve2.PartialResolvedImport.*
+import org.rust.lang.core.resolve2.util.processDollarCrate
+import org.rust.openapiext.findFileByMaybeRelativePath
+import org.rust.openapiext.pathAsPath
+import org.rust.openapiext.toPsiFile
+import org.rust.stdext.HashCode
+
+private const val CONSIDER_INDETERMINATE_IMPORTS_AS_RESOLVED: Boolean = false
+
+/** Resolves all imports and expands macros (new items are added to [defMap]) using fixed point iteration algorithm */
+class DefCollector(
+    private val project: Project,
+    private val defMap: CrateDefMap,
+    private val context: CollectorContext,
+) {
+
+    private data class GlobImportInfo(val containingMod: ModData, val visibility: Visibility)
+
+    /**
+     * Reversed glob-imports graph, that is
+     * for each module (`targetMod`) store all modules which contain glob import to `targetMod`
+     */
+    private val globImports: MutableMap<ModData /* target mod */, MutableList<GlobImportInfo>> = hashMapOf()
+    private val unresolvedImports: MutableList<Import> = context.imports
+    private val resolvedImports: MutableList<Import> = mutableListOf()
+
+    private val macroCallsToExpand: MutableList<MacroCallInfo> = context.macroCalls
+
+    /** Created once as optimization */
+    private val macroExpander: MacroExpander = MacroExpander(project)
+    private val macroExpanderShared: MacroExpansionSharedCache = MacroExpansionSharedCache.getInstance()
+
+    fun collect() {
+        do {
+            resolveImports()
+            val changed = expandMacros()
+        } while (changed)
+    }
+
+    /**
+     * Import resolution
+     *
+     * This is a fixed point algorithm. We resolve imports until no forward progress in resolving imports is made
+     */
+    private fun resolveImports() {
+        do {
+            var hasChangedIndeterminateImports = false
+            val hasResolvedImports = unresolvedImports.inPlaceRemoveIf { import ->
+                ProgressManager.checkCanceled()
+                when (val status = resolveImport(import)) {
+                    is Indeterminate -> {
+                        if (import.status is Indeterminate && import.status == status) return@inPlaceRemoveIf false
+
+                        import.status = status
+                        val changed = recordResolvedImport(import)
+                        if (changed) hasChangedIndeterminateImports = true
+                        if (CONSIDER_INDETERMINATE_IMPORTS_AS_RESOLVED) {
+                            resolvedImports.add(import)
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    is Resolved -> {
+                        import.status = status
+                        recordResolvedImport(import)
+                        resolvedImports.add(import)
+                        true
+                    }
+                    Unresolved -> false
+                }
+            }
+        } while (hasResolvedImports || hasChangedIndeterminateImports)
+    }
+
+    private fun resolveImport(import: Import): PartialResolvedImport {
+        if (import.isExternCrate) {
+            val externCrateName = import.usePath.single()
+            val externCrateDefMap = defMap.resolveExternCrateAsDefMap(externCrateName) ?: return Unresolved
+            val def = externCrateDefMap.rootAsPerNs.withVisibility(import.visibility)
+            return Resolved(def)
+        }
+
+        val result = defMap.resolvePathFp(
+            import.containingMod,
+            import.usePath,
+            ResolveMode.IMPORT,
+            withInvisibleItems = import.visibility.isInvisible
+        )
+        val perNs = result.resolvedDef
+
+        if (!result.reachedFixedPoint || perNs.isEmpty) return Unresolved
+
+        // for path `mod1::mod2::mod3::foo`
+        // if any of `mod1`, ... , `mod3` is from other crate
+        // then it means that defMap for that crate is already completely filled
+        if (result.visitedOtherCrate) return Resolved(perNs)
+
+        val isResolvedInAllNamespaces = perNs.types != null && perNs.values != null && perNs.macros != null
+        val isResolvedGlobImport = import.isGlob && perNs.types != null
+        return if (isResolvedInAllNamespaces || isResolvedGlobImport) {
+            Resolved(perNs)
+        } else {
+            Indeterminate(perNs)
+        }
+    }
+
+    private fun recordResolvedImport(import: Import): Boolean {
+        val def = when (val status = import.status) {
+            is Resolved -> status.perNs
+            is Indeterminate -> status.perNs
+            Unresolved -> error("expected resoled import")
+        }
+
+        return if (import.isGlob) {
+            recordResolvedGlobImport(import, def)
+        } else {
+            recordResolvedNamedImport(import, def)
+        }
+    }
+
+    private fun recordResolvedGlobImport(import: Import, def: PerNs): Boolean {
+        val types = def.types ?: run {
+            if (isUnitTestMode) error("Glob import didn't resolve as type: $import")
+            return false
+        }
+        if (!types.isModOrEnum) {
+            if (isUnitTestMode) error("Glob import from not module or enum: $import")
+            return false
+        }
+        val targetMod = defMap.tryCastToModData(types) ?: return false
+        val containingMod = import.containingMod
+        when {
+            import.isPrelude -> {
+                defMap.prelude = targetMod
+                return true
+            }
+            targetMod.crate == defMap.crate -> {
+                // glob import from same crate => we do an initial import,
+                // and then need to propagate any further additions
+                val items = targetMod.getVisibleItems { it.isVisibleFromMod(containingMod) }
+                val changed = update(containingMod, items, import.visibility, GLOB)
+
+                // record the glob import in case we add further items
+                val globImports = globImports.computeIfAbsent(targetMod) { mutableListOf() }
+                // TODO: If there are two glob imports, we should choose with widest visibility
+                if (globImports.none { (mod, _) -> mod == containingMod }) {
+                    globImports += GlobImportInfo(containingMod, import.visibility)
+                }
+                return changed
+            }
+            else -> {
+                // glob import from other crate => we can just import everything once
+                val items = targetMod.getVisibleItems { it.isVisibleFromOtherCrate() }
+                return update(containingMod, items, import.visibility, GLOB)
+            }
+        }
+    }
+
+    private fun recordResolvedNamedImport(import: Import, def: PerNs): Boolean {
+        val containingMod = import.containingMod
+        val name = import.nameInScope
+
+        // extern crates in the crate root are special-cased to insert entries into the extern prelude
+        // https://github.com/rust-lang/rust/pull/54658
+        if (import.isExternCrate && containingMod.isCrateRoot && name != "_") {
+            val types = def.types ?: error("null PerNs.types for extern crate import")
+            val externCrateDefMap = defMap.getDefMap(types.path.crate)
+            externCrateDefMap?.let { defMap.externPrelude[name] = it }
+        }
+
+        val defWithAdjustedVisible = def.mapItems {
+            if (it.visibility.isInvisible || it.visibility.isVisibleFromMod(containingMod)) {
+                it
+            } else {
+                it.copy(visibility = Visibility.Invisible)
+            }
+        }
+        return update(containingMod, listOf(name to defWithAdjustedVisible), import.visibility, NAMED)
+    }
+
+    /**
+     * [resolutions] were added (imported or expanded from macro) to [modData] with [visibility].
+     * We update [ModData.visibleItems] and propagate [resolutions] to modules which have glob import from [modData].
+     */
+    private fun update(
+        modData: ModData,
+        resolutions: List<Pair<String, PerNs>>,
+        visibility: Visibility,
+        importType: ImportType
+    ): Boolean = updateRecursive(modData, resolutions, visibility, importType, depth = 0)
+
+    private fun updateRecursive(
+        modData: ModData,
+        resolutions: List<Pair<String, PerNs>>,
+        // All resolutions are imported with this visibility,
+        // the visibilities in the `PerNs` values are ignored and overwritten
+        visibility: Visibility,
+        importType: ImportType,
+        depth: Int
+    ): Boolean {
+        check(depth <= 100) { "infinite recursion in glob imports!" }
+
+        var changed = false
+        for ((name, def) in resolutions) {
+            val changedCurrent = if (name != "_") {
+                pushResolutionFromImport(modData, name, def.withVisibility(visibility), importType)
+            } else {
+                // TODO: What if `def` is not trait?
+                pushTraitResolutionFromImport(modData, def, visibility)
+            }
+
+            if (changedCurrent) changed = true
+        }
+        if (!changed) return changed
+
+        val globImports = globImports[modData] ?: return changed
+        for ((globImportingMod, globImportVis) in globImports) {
+            // we know all resolutions have the same `visibility`, so we just need to check that once
+            if (!visibility.isVisibleFromMod(globImportingMod)) continue
+            updateRecursive(globImportingMod, resolutions, globImportVis, GLOB, depth + 1)
+        }
+        return changed
+    }
+
+    private fun pushResolutionFromImport(modData: ModData, name: String, def: PerNs, importType: ImportType): Boolean {
+        check(!def.isEmpty)
+
+        // optimization: fast path
+        val defExisting = modData.visibleItems.putIfAbsent(name, def)
+        if (defExisting == null) {
+            if (importType == GLOB) {
+                val fromGlobImport = modData.fromGlobImport ?: error("fromGlobImport is null during collect")
+                if (def.types != null) fromGlobImport.types += name
+                if (def.values != null) fromGlobImport.values += name
+                if (def.macros != null) fromGlobImport.macros += name
+            }
+            return true
+        }
+
+        return mergeResolutionFromImport(modData, name, def, defExisting, importType)
+    }
+
+    private fun mergeResolutionFromImport(
+        modData: ModData,
+        name: String,
+        def: PerNs,
+        defExisting: PerNs,
+        importType: ImportType
+    ): Boolean {
+        fun mergeResolutionOneNs(
+            visItem: VisItem?,
+            visItemExisting: VisItem?,
+            fromGlobImport: MutableSet<String>
+        ): VisItem? {
+            if (visItem == null) return visItemExisting
+            if (visItemExisting == null) {
+                if (importType == GLOB) fromGlobImport.add(name)
+                return visItem
+            }
+
+            val importTypeExisting = if (fromGlobImport.contains(name)) GLOB else NAMED
+            if (importType == GLOB && importTypeExisting == NAMED) return visItemExisting
+            if (importType == importTypeExisting) {
+                val isStrictlyMorePermissive = visItem.visibility.isStrictlyMorePermissive(visItemExisting.visibility)
+                if (!isStrictlyMorePermissive) return visItemExisting
+            }
+            if (importType == NAMED && importTypeExisting == GLOB) fromGlobImport.remove(name)
+            return visItem
+        }
+
+        val (typesExisting, valuesExisting, macrosExisting) = defExisting
+        val fromGlobImport = modData.fromGlobImport ?: error("fromGlobImport is null during collect")
+        defExisting.types = mergeResolutionOneNs(def.types, defExisting.types, fromGlobImport.types)
+        defExisting.values = mergeResolutionOneNs(def.values, defExisting.values, fromGlobImport.values)
+        defExisting.macros = mergeResolutionOneNs(def.macros, defExisting.macros, fromGlobImport.macros)
+        return typesExisting !== defExisting.types
+            || valuesExisting !== defExisting.values
+            || macrosExisting !== defExisting.macros
+    }
+
+    private fun pushTraitResolutionFromImport(modData: ModData, def: PerNs, visibility: Visibility): Boolean {
+        check(!def.isEmpty)
+        val trait = def.types?.takeIf { !it.isModOrEnum } ?: return false
+        val oldVisibility = modData.unnamedTraitImports[trait.path]
+        if (oldVisibility == null || visibility.isStrictlyMorePermissive(oldVisibility)) {
+            modData.unnamedTraitImports[trait.path] = visibility
+            return true
+        }
+        return false
+    }
+
+    private fun expandMacros(): Boolean {
+        return macroCallsToExpand.inPlaceRemoveIf { call ->
+            ProgressManager.checkCanceled()
+            // TODO: Actually resolve macro instead of name check
+            if (call.path.last() == "include") {
+                expandIncludeMacroCall(call)
+                return@inPlaceRemoveIf true
+            }
+            tryExpandMacroCall(call)
+        }
+    }
+
+    private fun tryExpandMacroCall(call: MacroCallInfo): Boolean {
+        val legacyMacroDef = call.macroDef
+        val def = legacyMacroDef
+            ?: defMap.resolveMacroCallToMacroDefInfo(call.containingMod, call.path)
+            ?: return false
+        val defData = RsMacroDataWithHash(RsMacroData(def.body), def.bodyHash)
+        val callData = RsMacroCallDataWithHash(RsMacroCallData(call.body), call.bodyHash)
+        val (expandedFile, expansion) =
+            macroExpanderShared.createExpansionStub(project, macroExpander, defData, callData) ?: return true
+
+        processDollarCrate(call, def, expandedFile, expansion)
+
+        val context = getModCollectorContextForExpandedElements(call) ?: return true
+        collectExpandedElements(expandedFile, call.containingMod, context)
+        return true
+    }
+
+    private fun expandIncludeMacroCall(call: MacroCallInfo) {
+        val modData = call.containingMod
+        val containingFile = PersistentFS.getInstance().findFileById(modData.fileId) ?: return
+        val includePath = call.body
+        val parentDirectory = containingFile.parent
+        val includingFile = parentDirectory
+            .findFileByMaybeRelativePath(includePath)
+            ?.toPsiFile(project)
+            ?.rustFile
+        if (includingFile != null) {
+            val context = getModCollectorContextForExpandedElements(call) ?: return
+            collectFileAndCalculateHash(includingFile, call.containingMod, context)
+        } else {
+            val filePath = parentDirectory.pathAsPath.resolve(includePath)
+            defMap.missedFiles.add(filePath)
+        }
+    }
+
+    private fun getModCollectorContextForExpandedElements(call: MacroCallInfo): ModCollectorContext? {
+        if (call.depth >= DEFAULT_RECURSION_LIMIT) return null
+        return ModCollectorContext(
+            defMap = defMap,
+            crateRoot = defMap.root,
+            context = context,
+            macroDepth = call.depth + 1,
+            onAddItem = ::onAddItem
+        )
+    }
+
+    private fun onAddItem(modData: ModData, name: String, perNs: PerNs) {
+        val visibility = (perNs.types ?: perNs.values ?: perNs.macros)!!.visibility
+        update(modData, listOf(name to perNs), visibility, GLOB)
+    }
+}
+
+/** See [ModData.fromGlobImport]. */
+class PerNsGlobImports {
+    /** Stores names added to current scope by glob imports. */
+    val types: MutableSet<String> = hashSetOf()
+    val values: MutableSet<String> = hashSetOf()
+    val macros: MutableSet<String> = hashSetOf()
+}
+
+class Import(
+    val containingMod: ModData,
+    val usePath: Array<String>,
+    val nameInScope: String,
+    val visibility: Visibility,
+    val isGlob: Boolean = false,
+    val isExternCrate: Boolean = false,
+    val isPrelude: Boolean = false,  // #[prelude_import]
+) {
+    var status: PartialResolvedImport = Unresolved
+
+    override fun toString(): String {
+        val visibility = when (visibility) {
+            Visibility.Public -> "pub "
+            is Visibility.Restricted -> when {
+                visibility.inMod == containingMod -> ""
+                visibility.inMod.isCrateRoot -> "pub(crate) "
+                else -> "pub(in ${visibility.inMod}) "
+            }
+            Visibility.Invisible -> "invisible "
+            Visibility.CfgDisabled -> "#[cfg(false)] "
+        }
+        val use = if (isExternCrate) "extern crate" else "use"
+        val glob = if (isGlob) "::*" else ""
+        val alias = if (usePath.last() == nameInScope || isGlob) "" else " as $nameInScope"
+        return "`${visibility}$use ${usePath.joinToString("::")}$glob$alias;` in ${containingMod.path}"
+    }
+}
+
+enum class ImportType { NAMED, GLOB }
+
+sealed class PartialResolvedImport {
+    /** None of any namespaces is resolved */
+    object Unresolved : PartialResolvedImport()
+
+    /** One of namespaces is resolved */
+    data class Indeterminate(val perNs: PerNs) : PartialResolvedImport()
+
+    /** All namespaces are resolved, OR it is came from other crate */
+    data class Resolved(val perNs: PerNs) : PartialResolvedImport()
+}
+
+class MacroDefInfo(
+    val crate: CratePersistentId,
+    val path: ModPath,
+    private val bodyText: String,
+    val bodyHash: HashCode,
+    val hasMacroExport: Boolean,
+    val hasLocalInnerMacros: Boolean,
+    project: Project,
+) {
+    /** Lazy because usually it should not be used (thanks to macro expansion cache) */
+    val body: Lazy<RsMacroBody?> = lazy(LazyThreadSafetyMode.PUBLICATION) {
+        val psiFactory = RsPsiFactory(project, markGenerated = false)
+        psiFactory.createMacroBody(bodyText)
+    }
+}
+
+class MacroCallInfo(
+    val containingMod: ModData,
+    val path: Array<String>,
+    val body: String,
+    val bodyHash: HashCode?,  // null for `include!` macro
+    val depth: Int,
+    val macroDef: MacroDefInfo?,  // for textual scoped macros
+    /**
+     * `srcOffset` - [CratePersistentId]
+     * `dstOffset` - index of [MACRO_DOLLAR_CRATE_IDENTIFIER] in [body]
+     */
+    val dollarCrateMap: RangeMap = RangeMap.EMPTY,
+) {
+    override fun toString(): String = "${containingMod.path}:  ${path.joinToString("::")}! { $body }"
+}
+
+/**
+ * Faster alternative to [java.util.Collection.removeIf] that doesn't preserve element order.
+ * [filter] is allowed to append to [this].
+ * return true if any elements were removed.
+ */
+private inline fun <T> MutableList<T>.inPlaceRemoveIf(filter: (T) -> Boolean): Boolean {
+    var removed = false
+    var i = 0
+    while (i < size) {
+        if (filter(this[i])) {
+            removed = true
+            this[i] = last()
+            removeAt(lastIndex)
+        } else {
+            ++i
+        }
+    }
+    return removed
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefMapService.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefMapService.kt
@@ -1,0 +1,285 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.injected.editor.VirtualFileWindow
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.ModificationTracker
+import com.intellij.openapi.vfs.VirtualFileWithId
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiTreeChangeEvent
+import org.rust.RsTask.TaskType.*
+import org.rust.cargo.project.model.CargoProject
+import org.rust.cargo.project.model.CargoProjectsService
+import org.rust.cargo.project.model.CargoProjectsService.CargoProjectsListener
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.crate.CratePersistentId
+import org.rust.lang.core.macros.MacroExpansionMode
+import org.rust.lang.core.macros.macroExpansionManager
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsPsiTreeChangeEvent.*
+import org.rust.openapiext.checkWriteAccessAllowed
+import org.rust.openapiext.pathAsPath
+import org.rust.stdext.mapToSet
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.locks.ReentrantLock
+
+/** Stores [CrateDefMap] and data needed to determine whether [defMap] is up-to-date. */
+class DefMapHolder(private val structureModificationTracker: ModificationTracker) {
+
+    /**
+     * Write access requires read action with [DefMapService.defMapsBuildLock] or write action.
+     * Read access requires only read action (needed for fast path in [DefMapService.getOrUpdateIfNeeded]).
+     */
+    @Volatile
+    var defMap: CrateDefMap? = null
+        private set
+
+    /**
+     * Value of [rustStructureModificationTracker] at the time when [defMap] started to built.
+     * Write access requires read action with [DefMapService.defMapsBuildLock] or write action.
+     * Read access requires only read action (needed for fast path in [DefMapService.getOrUpdateIfNeeded]).
+     */
+    private val defMapStamp: AtomicLong = AtomicLong(-1)
+
+    fun hasLatestStamp(): Boolean = defMapStamp.get() == structureModificationTracker.modificationCount
+
+    private fun setLatestStamp() {
+        defMapStamp.set(structureModificationTracker.modificationCount)
+    }
+
+    fun checkHasLatestStamp() {
+        if (!hasLatestStamp()) {
+            RESOLVE_LOG.error(
+                "DefMapHolder must have latest stamp right after DefMap($defMap) was updated. " +
+                    "$defMapStamp vs ${structureModificationTracker.modificationCount}"
+            )
+        }
+    }
+
+    /**
+     * If true then we should rebuild [defMap], regardless of [shouldRecheck] or [changedFiles] values.
+     * Any access requires read action with [DefMapService.defMapsBuildLock] or write action.
+     */
+    @Volatile
+    var shouldRebuild: Boolean = true
+        set(value) {
+            field = value
+            if (value) {
+                defMapStamp.decrementAndGet()
+                shouldRecheck = false
+                changedFiles.clear()
+            }
+        }
+
+    /**
+     * If true then we should check for possible modification every file of the crate
+     * (using [FileInfo.modificationStamp] or [HashCalculator]).
+     * Any access requires read action with [DefMapService.defMapsBuildLock] or write action.
+     */
+    @Volatile
+    var shouldRecheck: Boolean = false
+        set(value) {
+            field = value
+            if (value) {
+                defMapStamp.decrementAndGet()
+            }
+        }
+
+    /** Any access requires read action with [DefMapService.defMapsBuildLock] or write action. */
+    val changedFiles: MutableSet<RsFile> = hashSetOf()
+    fun addChangedFile(file: RsFile) {
+        changedFiles += file
+        defMapStamp.decrementAndGet()
+    }
+
+    fun setDefMap(defMap: CrateDefMap?) {
+        this.defMap = defMap
+        shouldRebuild = false
+        setLatestStamp()
+    }
+
+    fun updateShouldRebuild(crate: Crate): Boolean {
+        val shouldRebuild = getShouldRebuild(crate)
+        if (shouldRebuild) {
+            this.shouldRebuild = true
+        } else {
+            setLatestStamp()
+        }
+        return shouldRebuild
+    }
+
+    override fun toString(): String = "DefMapHolder($defMap, stamp=$defMapStamp)"
+}
+
+@Service
+class DefMapService(val project: Project) : Disposable {
+
+    /** Concurrent because [DefMapsBuilder] uses multiple threads */
+    private val defMaps: ConcurrentHashMap<CratePersistentId, DefMapHolder> = ConcurrentHashMap()
+    val defMapsBuildLock: ReentrantLock = ReentrantLock()
+
+    private val fileIdToCrateId: ConcurrentHashMap<FileId, CratePersistentId> = ConcurrentHashMap()
+
+    /** Merged map of [CrateDefMap.missedFiles] for all crates */
+    private val missedFiles: ConcurrentHashMap<Path, CratePersistentId> = ConcurrentHashMap()
+
+    private val structureModificationTracker: ModificationTracker =
+        project.rustPsiManager.rustStructureModificationTracker
+
+    init {
+        setupListeners()
+    }
+
+    /**
+     * Possible modifications:
+     * - After IDE restart: full recheck (for each crate compare [CrateMetaData] and `modificationStamp` of each file).
+     *   Tasks [CARGO_SYNC] and [MACROS_UNPROCESSED] are executed.
+     * - File changed: calculate hash and compare with hash stored in [CrateDefMap.fileInfos].
+     *   Task [MACROS_WORKSPACE] is executed.
+     * - File added: check whether [missedFiles] contains file path
+     * - File deleted: check whether [fileIdToCrateId] contains this file
+     * - Crate workspace changed: full recheck
+     *   Tasks [CARGO_SYNC] and [MACROS_UNPROCESSED] are executed.
+     */
+    private fun setupListeners() {
+        PsiManager.getInstance(project).addPsiTreeChangeListener(DefMapPsiTreeChangeListener(), this)
+
+        val connection = project.messageBus.connect()
+
+        project.rustPsiManager.subscribeRustPsiChange(connection, object : RustPsiChangeListener {
+            override fun rustPsiChanged(file: PsiFile, element: PsiElement, isStructureModification: Boolean) {
+                /** When macro expansion is enabled, file modification is handled in `ChangedMacroUpdater.rustPsiChanged` */
+                if (file is RsFile && project.macroExpansionManager.macroExpansionMode !is MacroExpansionMode.New) {
+                    onFileChanged(file)
+                }
+            }
+        })
+
+        connection.subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsListener {
+            override fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>) {
+                scheduleRecheckAllDefMaps()
+            }
+        })
+    }
+
+    fun getDefMapHolder(crate: CratePersistentId): DefMapHolder {
+        return defMaps.computeIfAbsent(crate) { DefMapHolder(structureModificationTracker) }
+    }
+
+    fun setDefMap(crate: CratePersistentId, defMap: CrateDefMap?) {
+        updateFilesMaps(crate, defMap)
+
+        val holder = getDefMapHolder(crate)
+        holder.setDefMap(defMap)
+    }
+
+    private fun updateFilesMaps(crate: CratePersistentId, defMap: CrateDefMap?) {
+        fileIdToCrateId.values.remove(crate)
+        missedFiles.values.remove(crate)
+        if (defMap != null) {
+            for (fileId in defMap.fileInfos.keys) {
+                fileIdToCrateId[fileId] = crate
+            }
+            for (missedFile in defMap.missedFiles) {
+                missedFiles[missedFile] = crate
+            }
+        }
+    }
+
+    private fun onFileAdded(file: RsFile) {
+        checkWriteAccessAllowed()
+        val path = file.virtualFile.pathAsPath
+        val crate = missedFiles[path] ?: return
+        getDefMapHolder(crate).shouldRebuild = true
+    }
+
+    private fun onFileRemoved(file: RsFile) {
+        checkWriteAccessAllowed()
+        val crate = findCrate(file) ?: return
+        getDefMapHolder(crate).shouldRebuild = true
+    }
+
+    fun onFileChanged(file: RsFile) {
+        if (!isNewResolveEnabled) return
+        checkWriteAccessAllowed()
+        val crate = findCrate(file) ?: return
+        getDefMapHolder(crate).addChangedFile(file)
+    }
+
+    /** Note: we can't use [RsFile.crate], because it can trigger resolve */
+    private fun findCrate(file: RsFile): CratePersistentId? {
+        /** Virtual file can be [VirtualFileWindow] if it is doctest injection */
+        val virtualFile = file.virtualFile as? VirtualFileWithId ?: return null
+        return fileIdToCrateId[virtualFile.id]
+    }
+
+    private fun scheduleRecheckAllDefMaps() {
+        checkWriteAccessAllowed()
+        for (defMapHolder in defMaps.values) {
+            defMapHolder.shouldRecheck = true
+        }
+    }
+
+    /** Removes DefMaps for crates not in crate graph */
+    fun removeStaleDefMaps(allCrates: List<Crate>) {
+        val allCrateIds = allCrates.mapToSet { it.id }
+        val staleCrates = mutableListOf<CratePersistentId>()
+        defMaps.keys.removeIf { crate ->
+            val isStale = crate !in allCrateIds
+            if (isStale) staleCrates += crate
+            isStale
+        }
+        for (staleCrate in staleCrates) {
+            fileIdToCrateId.values.remove(staleCrate)
+            missedFiles.values.remove(staleCrate)
+        }
+    }
+
+    override fun dispose() {}
+
+    private inner class DefMapPsiTreeChangeListener : RsPsiTreeChangeAdapter() {
+        override fun handleEvent(event: RsPsiTreeChangeEvent) {
+            if (!isNewResolveEnabled) return
+            // events for file addition/deletion have null `event.file` and not-null `event.child`
+            if (event.file != null) return
+            when (event) {
+                is ChildAddition.After -> {
+                    val file = event.child as? RsFile ?: return
+                    onFileAdded(file)
+                }
+                is ChildRemoval.Before -> {
+                    val file = event.child as? RsFile ?: return
+                    onFileRemoved(file)
+                }
+                is PropertyChange.Before -> {  // before rename
+                    if (event.propertyName == PsiTreeChangeEvent.PROP_FILE_NAME) {
+                        val file = event.child as? RsFile ?: return
+                        onFileRemoved(file)
+                    }
+                }
+                is PropertyChange.After -> {  // after rename
+                    if (event.propertyName == PsiTreeChangeEvent.PROP_FILE_NAME) {
+                        val file = event.element as? RsFile ?: return
+                        onFileAdded(file)
+                        return
+                    }
+                }
+                else -> Unit
+            }
+        }
+    }
+}
+
+val Project.defMapService: DefMapService
+    get() = service()

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefMapsBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefMapsBuilder.kt
@@ -1,0 +1,146 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.concurrency.SensitiveProgressWrapper
+import com.intellij.openapi.progress.ProgressIndicator
+import org.rust.lang.core.crate.Crate
+import org.rust.openapiext.computeInReadActionWithWriteActionPriority
+import org.rust.stdext.getWithRethrow
+import java.util.concurrent.*
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.system.measureTimeMillis
+
+/** Builds [CrateDefMap] for [crates] in parallel using [pool] and with respect to dependency graph */
+class DefMapsBuilder(
+    private val defMapService: DefMapService,
+    private val crates: List<Crate>,  // should be top sorted
+    defMaps: Map<Crate, CrateDefMap>,
+    private val indicator: ProgressIndicator,
+    private val pool: Executor,
+) {
+
+    init {
+        check(crates.isNotEmpty())
+    }
+
+    /** Values - number of dependencies for which [CrateDefMap] is not build yet */
+    private val remainingDependenciesCounts: Map<Crate, AtomicInteger> = run {
+        val cratesSet = crates.toSet()
+        crates.associateWithTo(hashMapOf()) {
+            val remainingDependencies = it.dependencies
+                .filter { dep -> dep.crate in cratesSet }
+                .size
+            AtomicInteger(remainingDependencies)
+        }
+    }
+    private val builtDefMaps: MutableMap<Crate, CrateDefMap> = ConcurrentHashMap(defMaps)
+
+    /** We don't use [CountDownLatch] because [CompletableFuture] allows easier exception handling */
+    private val remainingNumberCrates: AtomicInteger = AtomicInteger(crates.size)
+    private val completableFuture: CompletableFuture<Unit> = CompletableFuture()
+
+    /** Only for profiling */
+    private val tasksTimes: MutableMap<Crate, Long> = ConcurrentHashMap()
+
+    fun build() {
+        val wallTime = measureTimeMillis {
+            if (pool is SameThreadExecutor) {
+                buildSync()
+            } else {
+                buildAsync()
+            }
+        }
+
+        printTimeStatistics(wallTime)
+    }
+
+    private fun buildAsync() {
+        val cratesWithoutDependencies = remainingDependenciesCounts
+            .filterValues { it.get() == 0 }
+            .keys
+        // task scheduling must be after all `it.get() == 0` checks
+        for (crate in cratesWithoutDependencies) {
+            buildDefMapAsync(crate)
+        }
+        completableFuture.getWithRethrow()
+    }
+
+    private fun buildSync() {
+        for (crate in crates) {
+            tasksTimes[crate] = measureTimeMillis {
+                doBuildDefMap(crate)
+            }
+        }
+    }
+
+    private fun buildDefMapAsync(crate: Crate) {
+        pool.execute {
+            try {
+                check(crate !in tasksTimes)
+                tasksTimes[crate] = measureTimeMillis {
+                    computeInReadActionWithWriteActionPriority(SensitiveProgressWrapper(indicator)) {
+                        doBuildDefMap(crate)
+                    }
+                }
+            } catch (e: Throwable) {
+                completableFuture.completeExceptionally(e)
+                return@execute
+            }
+            onCrateFinished(crate)
+        }
+    }
+
+    private fun doBuildDefMap(crate: Crate) {
+        val crateId = crate.id ?: return
+        val allDependenciesDefMaps = crate.flatDependencies
+            .mapNotNull {
+                // it can be null e.g. if dependency has null id
+                val dependencyDefMap = builtDefMaps[it] ?: return@mapNotNull null
+                it to dependencyDefMap
+            }
+            .toMap(hashMapOf())
+        val defMap = buildDefMap(crate, allDependenciesDefMaps)
+        defMapService.setDefMap(crateId, defMap)
+        if (defMap != null) {
+            builtDefMaps[crate] = defMap
+        }
+    }
+
+    private fun onCrateFinished(crate: Crate) {
+        if (completableFuture.isCompletedExceptionally) return
+
+        crate.reverseDependencies.forEach { onDependencyCrateFinished(it) }
+        if (remainingNumberCrates.decrementAndGet() == 0) {
+            completableFuture.complete(Unit)
+        }
+    }
+
+    private fun onDependencyCrateFinished(crate: Crate) {
+        val count = remainingDependenciesCounts[crate] ?: return
+        if (count.decrementAndGet() == 0) {
+            buildDefMapAsync(crate)
+        }
+    }
+
+    private fun printTimeStatistics(wallTime: Long) {
+        if (!RESOLVE_LOG.isDebugEnabled) return
+        check(tasksTimes.size == crates.size)
+        val totalTime = tasksTimes.values.sum()
+        val top5crates = tasksTimes.entries
+            .sortedByDescending { (_, time) -> time }
+            .take(5)
+            .joinToString { (crate, time) -> "$crate ${time}ms" }
+        val multithread = pool !is SameThreadExecutor
+        if (multithread) {
+            RESOLVE_LOG.debug("wallTime: $wallTime, totalTime: $totalTime, " +
+                "parallelism coefficient: ${"%.2f".format((totalTime.toDouble() / wallTime))}.    " +
+                "Top 5 crates: $top5crates")
+        } else {
+            RESOLVE_LOG.debug("wallTime: $wallTime.    Top 5 crates: $top5crates")
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
@@ -1,0 +1,206 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.openapi.project.Project
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.cargo.util.AutoInjectedCrates
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.crate.CratePersistentId
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.ext.edition
+import org.rust.lang.core.psi.shouldIndexFile
+import org.rust.openapiext.checkReadAccessAllowed
+import org.rust.openapiext.fileId
+import org.rust.openapiext.testAssert
+import org.rust.stdext.mapToSet
+
+/**
+ * Returns `null` if [crate] has null `id` or `rootMod`,
+ * or if crate should not be indexed (e.g. test/bench non-workspace crate)
+ */
+fun buildDefMap(crate: Crate, allDependenciesDefMaps: Map<Crate, CrateDefMap>): CrateDefMap? {
+    checkReadAccessAllowed()
+    val project = crate.project
+    check(isNewResolveEnabled)
+    val context = CollectorContext(crate, project)
+    val defMap = buildDefMapContainingExplicitItems(context, allDependenciesDefMaps) ?: return null
+    DefCollector(project, defMap, context).collect()
+    defMap.afterBuilt()
+    testAssert({ !isCrateChanged(crate, defMap) }, { "DefMap $defMap should be up-to-date just after built" })
+    return defMap
+}
+
+/** Context for [ModCollector] and [DefCollector] */
+class CollectorContext(
+    val crate: Crate,
+    val project: Project
+) {
+    /** All imports (including expanded from macros - filled in [DefCollector]) */
+    val imports: MutableList<Import> = mutableListOf()
+
+    /** All macro calls */
+    val macroCalls: MutableList<MacroCallInfo> = mutableListOf()
+}
+
+private fun buildDefMapContainingExplicitItems(
+    context: CollectorContext,
+    allDependenciesDefMaps: Map<Crate, CrateDefMap>
+): CrateDefMap? {
+    val crate = context.crate
+    val crateId = crate.id ?: return null
+    val crateRoot = crate.rootMod ?: return null
+
+    val crateRootFile = crate.rootModFile ?: return null
+    if (!shouldIndexFile(context.project, crateRootFile)) return null
+
+    val (directDependenciesDefMaps, allDependenciesDefMapsById) =
+        getDirectAndAllDependencies(crate, allDependenciesDefMaps)
+
+    val crateRootOwnedDirectory = crateRoot.virtualFile?.parent
+        ?: error("Can't find parent directory for crate root of $crate crate")
+    val crateDescription = crate.toString()
+    val crateRootData = ModData(
+        parent = null,
+        crate = crateId,
+        path = ModPath(crateId, emptyArray()),
+        isDeeplyEnabledByCfg = true,
+        fileId = crateRoot.virtualFile.fileId,
+        fileRelativePath = "",
+        ownedDirectoryId = crateRootOwnedDirectory.fileId,
+        crateDescription = crateDescription
+    )
+    val defMap = CrateDefMap(
+        crate = crateId,
+        root = crateRootData,
+        directDependenciesDefMaps = directDependenciesDefMaps,
+        allDependenciesDefMaps = allDependenciesDefMapsById,
+        prelude = findPrelude(crate, allDependenciesDefMaps),
+        metaData = CrateMetaData(crate),
+        crateDescription = crateDescription
+    )
+
+    createExternCrateStdImport(crateRoot, crateRootData)?.let {
+        context.imports += it
+        defMap.importExternCrateMacros(it.usePath.single())
+    }
+    val modCollectorContext = ModCollectorContext(defMap, crateRootData, context)
+    collectFileAndCalculateHash(crateRoot, crateRootData, modCollectorContext)
+
+    removeInvalidImportsAndMacroCalls(defMap, context)
+    sortImports(context.imports)
+    return defMap
+}
+
+private data class DependenciesDefMaps(
+    val directDependenciesDefMaps: Map<String, CrateDefMap>,
+    val allDependenciesDefMaps: Map<CratePersistentId, CrateDefMap>,
+)
+
+private fun getDirectAndAllDependencies(
+    crate: Crate,
+    allDependenciesDefMaps: Map<Crate, CrateDefMap>
+): DependenciesDefMaps {
+    val allDependenciesDefMapsById = allDependenciesDefMaps
+        .filterKeys { it.id != null }
+        .mapKeysTo(hashMapOf()) { it.key.id!! }
+    val directDependenciesDefMaps = crate.dependencies
+        .mapNotNull {
+            val id = it.crate.id ?: return@mapNotNull null
+            val defMap = allDependenciesDefMapsById[id] ?: return@mapNotNull null
+            it.normName to defMap
+        }
+        .toMap(hashMapOf())
+    return DependenciesDefMaps(directDependenciesDefMaps, allDependenciesDefMapsById)
+}
+
+/**
+ * Look for the prelude.
+ * If the dependency defines a prelude, we overwrite an already defined prelude.
+ * This is necessary to import the "std" prelude if a crate depends on both "core" and "std".
+ */
+private fun findPrelude(crate: Crate, allDependenciesDefMaps: Map<Crate, CrateDefMap>): ModData? {
+    /**
+     * Correct prelude is always selected (core vs std), because [Crate.flatDependencies] is top sorted.
+     * And we peek prelude from latest dependency.
+     */
+    val dependencies = crate.dependencies.mapToSet { it.crate }
+    val dependenciesTopSorted = crate.flatDependencies.filter { it in dependencies }
+    return dependenciesTopSorted
+        .asReversed()
+        .asSequence()
+        .mapNotNull { allDependenciesDefMaps[it]?.prelude }
+        .firstOrNull()
+}
+
+private fun createExternCrateStdImport(crateRoot: RsFile, crateRootData: ModData): Import? {
+    // Rust injects implicit `extern crate std` in every crate root module unless it is
+    // a `#![no_std]` crate, in which case `extern crate core` is injected. However, if
+    // there is a (unstable?) `#![no_core]` attribute, nothing is injected.
+    //
+    // https://doc.rust-lang.org/book/using-rust-without-the-standard-library.html
+    // The stdlib lib itself is `#![no_std]`, and the core is `#![no_core]`
+    val name = when (crateRoot.attributes) {
+        RsFile.Attributes.NONE -> AutoInjectedCrates.STD
+        RsFile.Attributes.NO_STD -> AutoInjectedCrates.CORE
+        RsFile.Attributes.NO_CORE -> return null
+    }
+    return Import(
+        crateRootData,
+        arrayOf(name),
+        nameInScope = if (crateRoot.edition == CargoWorkspace.Edition.EDITION_2015) name else "_",
+        visibility = Visibility.Restricted(crateRootData),
+        isExternCrate = true
+    )
+}
+
+/**
+ * "Invalid" means it belongs to [ModData] which is no longer accessible from `defMap.root` using [ModData.childModules]
+ * It could happen if there is cfg-disabled module, which we collect first (with its imports)
+ * And then cfg-enabled module overrides previously created [ModData]
+ */
+private fun removeInvalidImportsAndMacroCalls(defMap: CrateDefMap, context: CollectorContext) {
+    fun ModData.descendantsMods(): Sequence<ModData> =
+        sequenceOf(this) + childModules.values.asSequence().flatMap { it.descendantsMods() }
+
+    val allMods = defMap.root.descendantsMods().toSet()
+    context.imports.removeIf { it.containingMod !in allMods }
+    context.macroCalls.removeIf { it.containingMod !in allMods }
+}
+
+/**
+ * This is a workaround for some real-project cases. See:
+ * - [RsUseResolveTest.`test import adds same name as existing`]
+ * - https://github.com/rust-lang/cargo/blob/875e0123259b0b6299903fe4aea0a12ecde9324f/src/cargo/util/mod.rs#L23
+ */
+private fun sortImports(imports: MutableList<Import>) {
+    imports.sortWith(
+        // TODO: Profile & optimize
+        compareByDescending<Import> { it.nameInScope in it.containingMod.visibleItems }
+            .thenBy { it.isGlob }
+            .thenByDescending { it.containingMod.path.segments.size }  // imports from nested modules first
+    )
+}
+
+private fun CrateDefMap.afterBuilt() {
+    root.visitDescendants {
+        it.isShadowedByOtherFile = false
+        it.fromGlobImport = null
+    }
+    for (fileInfo in fileInfos.values) {
+        fileInfo.modData.fromGlobImport = null
+    }
+
+    // TODO: uncomment when #[cfg_attr] will be supported
+    // testAssert { missedFiles.isEmpty() }
+}
+
+private fun ModData.visitDescendants(visitor: (ModData) -> Unit) {
+    visitor(this)
+    for (childMod in childModules.values) {
+        childMod.visitDescendants(visitor)
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -1,0 +1,236 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
+import com.intellij.psi.util.PsiTreeUtil
+import org.rust.ide.experiments.RsExperiments
+import org.rust.ide.utils.isEnabledByCfg
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.crate.impl.CargoBasedCrate
+import org.rust.lang.core.crate.impl.DoctestCrate
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve.*
+import org.rust.lang.core.resolve.ItemProcessingMode.WITHOUT_PRIVATE_IMPORTS
+import org.rust.lang.core.resolve2.RsModInfoBase.*
+import org.rust.openapiext.isFeatureEnabled
+import org.rust.openapiext.toPsiFile
+
+val isNewResolveEnabled: Boolean
+    get() = isFeatureEnabled(RsExperiments.RESOLVE_NEW_ENGINE)
+
+/** null return value means that new resolve can't be used */
+fun processItemDeclarations2(
+    scope: RsMod,
+    ns: Set<Namespace>,
+    processor: RsResolveProcessor,
+    ipm: ItemProcessingMode
+): Boolean? {
+    val (project, defMap, modData) = when (val info = getModInfo(scope)) {
+        is CantUseNewResolve -> return null
+        InfoNotFound -> return false
+        is RsModInfo -> info
+    }
+
+    for ((name, perNs) in modData.visibleItems.entriesWithName(processor.name)) {
+        val visItems = arrayOf(
+            perNs.types to Namespace.Types,
+            perNs.values to Namespace.Values,
+            perNs.macros to Namespace.Macros,
+        )
+        // We need a `Set` here because item could belong to multiple namespaces (e.g. unit struct)
+        // Also we need to distinguish unit struct and e.g. mod and function with same name in one module
+        val elements = hashSetOf<RsNamedElement>()
+        for ((visItem, namespace) in visItems) {
+            if (visItem == null || namespace !in ns) continue
+            if (ipm == WITHOUT_PRIVATE_IMPORTS && visItem.visibility == Visibility.Invisible) continue
+            elements += visItem.toPsi(defMap, project, namespace)
+        }
+        elements.any { processor(name, it) } && return true
+    }
+
+    if (processor.name == null && Namespace.Types in ns) {
+        for ((traitPath, traitVisibility) in modData.unnamedTraitImports) {
+            val trait = VisItem(traitPath, traitVisibility)
+            val traitPsi = trait.toPsi(defMap, project, Namespace.Types)
+            traitPsi.any { processor("_", it) } && return true
+        }
+    }
+
+    if (ipm.withExternCrates && Namespace.Types in ns) {
+        for ((name, externCrateDefMap) in defMap.externPrelude.entriesWithName(processor.name)) {
+            if (modData.visibleItems[name]?.types != null) continue
+            val externCrateRoot = externCrateDefMap.root.toRsMod(project) ?: continue
+            processor(name, externCrateRoot) && return true
+        }
+    }
+
+    return false
+}
+
+private sealed class RsModInfoBase {
+    /** [reason] is only for debug */
+    class CantUseNewResolve(val reason: String) : RsModInfoBase()
+    object InfoNotFound : RsModInfoBase()
+    data class RsModInfo(val project: Project, val defMap: CrateDefMap, val modData: ModData) : RsModInfoBase()
+}
+
+private fun getModInfo(scope: RsMod): RsModInfoBase {
+    val project = scope.project
+    if (!isNewResolveEnabled) return CantUseNewResolve("not enabled")
+    if (scope.modName == TMP_MOD_NAME) return CantUseNewResolve("__tmp__ mod")
+    if (scope.isLocal) return CantUseNewResolve("local mod")
+    val crate = scope.containingCrate as? CargoBasedCrate ?: return CantUseNewResolve("not CargoBasedCrate")
+
+    val defMap = project.getDefMap(crate) ?: return InfoNotFound
+    val modData = defMap.getModData(scope) ?: return InfoNotFound
+
+    if (isModShadowedByOtherMod(scope, modData)) return CantUseNewResolve("mod shadowed by other mod")
+
+    return RsModInfo(project, defMap, modData)
+}
+
+private fun Project.getDefMap(crate: Crate): CrateDefMap? {
+    check(crate !is DoctestCrate) { "doc test crates are not supported by CrateDefMap" }
+    val crateId = crate.id ?: return null
+    val defMap = defMapService.getOrUpdateIfNeeded(crateId)
+    if (defMap == null) RESOLVE_LOG.error("DefMap is null for $crate during resolve")
+    return defMap
+}
+
+/** E.g. `fn func() { mod foo { ... } }` */
+private val RsMod.isLocal: Boolean
+    get() = ancestorStrict<RsBlock>() != null
+
+/** "shadowed by other mod" means that [ModData] is not accessible from [CrateDefMap.root] through [ModData.childModules] */
+private fun isModShadowedByOtherMod(mod: RsMod, modData: ModData): Boolean {
+    val isDeeplyEnabledByCfg = (mod.containingFile as RsFile).isDeeplyEnabledByCfg && mod.isEnabledByCfg
+    val isShadowedByOtherInlineMod = isDeeplyEnabledByCfg != modData.isDeeplyEnabledByCfg
+
+    return modData.isShadowedByOtherFile || isShadowedByOtherInlineMod
+}
+
+private fun <T> Map<String, T>.entriesWithName(name: String?): Map<String, T> {
+    if (name == null) {
+        return this
+    } else {
+        val value = this[name] ?: return emptyMap()
+        return mapOf(name to value)
+    }
+}
+
+private fun VisItem.toPsi(defMap: CrateDefMap, project: Project, ns: Namespace): List<RsNamedElement> {
+    if (isModOrEnum) return path.toRsModOrEnum(defMap, project)
+    val containingModOrEnum = containingMod.toRsModOrEnum(defMap, project).singleOrNull() ?: return emptyList()
+    return when (containingModOrEnum) {
+        is RsMod -> {
+            if (ns == Namespace.Macros) {
+                // TODO: expandedItemsIncludingMacros
+                val macros = containingModOrEnum.itemsAndMacros
+                    .filterIsInstance<RsNamedElement>()
+                    .filter {
+                        (it is RsMacro || it is RsMacro2) && it.name == name && matchesIsEnabledByCfg(it, this)
+                    }
+                // TODO: Multiresolve for macro 2.0
+                val macro = macros.lastOrNull()
+                listOfNotNull(macro)
+            } else {
+                containingModOrEnum
+                    .getExpandedItemsWithName<RsNamedElement>(name)
+                    .filter { ns in it.namespaces && matchesIsEnabledByCfg(it, this) }
+            }
+        }
+        is RsEnumItem -> {
+            containingModOrEnum.variants
+                .filter { it.name == name && ns in it.namespaces && matchesIsEnabledByCfg(it, this) }
+        }
+        else -> error("Expected mod or enum, got: $containingModOrEnum")
+    }
+}
+
+private fun matchesIsEnabledByCfg(itemPsi: RsNamedElement, item: VisItem): Boolean =
+    if (item.isEnabledByCfg) {
+        itemPsi.isEnabledByCfg
+    } else {
+        // If inside cfg-disabled module we have import to cfg-enabled item,
+        // then this item will be imported with CfgDisabled visibility
+        true
+    }
+
+private val VisItem.isEnabledByCfg: Boolean get() = visibility != Visibility.CfgDisabled
+
+private fun ModPath.toRsModOrEnum(defMap: CrateDefMap, project: Project): List<RsNamedElement /* RsMod or RsEnumItem */> {
+    val modData = defMap.getModData(this) ?: return emptyList()
+    return if (modData.isEnum) {
+        modData.toRsEnum(project)
+    } else {
+        val mod = modData.toRsMod(project)
+        listOfNotNull(mod)
+    }
+}
+
+private fun ModData.toRsEnum(project: Project): List<RsEnumItem> {
+    if (!isEnum) return emptyList()
+    val containingMod = parent?.toRsMod(project) ?: return emptyList()
+    val visItem = asVisItem()
+    return containingMod
+        .getExpandedItemsWithName<RsEnumItem>(name)
+        .filter { matchesIsEnabledByCfg(it, visItem) }
+}
+
+private fun ModData.toRsMod(project: Project): RsMod? = toRsModNullable(project)
+    ?: run {
+        RESOLVE_LOG.warn("Can't find RsMod for $this")
+        null
+    }
+
+private fun ModData.toRsModNullable(project: Project): RsMod? {
+    if (isEnum) return null
+    val file = PersistentFS.getInstance().findFileById(fileId)
+        ?.toPsiFile(project) as? RsFile
+        ?: return null
+    val fileRelativeSegments = fileRelativePath.split("::")
+    return fileRelativeSegments
+        .subList(1, fileRelativeSegments.size)
+        .fold(file as RsMod) { mod, segment ->
+            mod
+                .getExpandedItemsWithName<RsModItem>(segment)
+                .singleOrCfgEnabled()
+                ?: return null
+        }
+}
+
+// TODO: Multiresolve
+private inline fun <reified T : RsElement> List<T>.singleOrCfgEnabled(): T? =
+    singleOrNull() ?: singleOrNull { it.isEnabledByCfg }
+
+private inline fun <reified T : RsNamedElement> RsItemsOwner.getExpandedItemsWithName(name: String): List<T> =
+    getExpandedItemsWithName(name, T::class.java)
+
+/** [expandedItemsExceptImplsAndUses] with addition of items from [RsForeignModItem]s */
+private fun <T : RsNamedElement> RsItemsOwner.getExpandedItemsWithName(
+    name: String,
+    psiClass: Class<T>
+): List<T> {
+    val result = arrayListOf<T>()
+    for (item in expandedItemsExceptImplsAndUses) {
+        if (item is RsForeignModItem) {
+            for (itemInner in PsiTreeUtil.getStubChildrenOfTypeAsList(item, psiClass)) {
+                if (itemInner.name == name) {
+                    result.add(itemInner)
+                }
+            }
+        } else {
+            if (item.name == name && psiClass.isInstance(item)) {
+                @Suppress("UNCHECKED_CAST")
+                result.add(item as T)
+            }
+        }
+    }
+    return result
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeUpdateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeUpdateDefMap.kt
@@ -1,0 +1,232 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.concurrency.SensitiveProgressWrapper
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.EmptyProgressIndicator
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.util.ProgressIndicatorUtils
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import org.rust.RsTask.TaskType.*
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.crate.CratePersistentId
+import org.rust.lang.core.crate.crateGraph
+import org.rust.openapiext.*
+import org.rust.stdext.getWithRethrow
+import java.util.concurrent.*
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.Lock
+import kotlin.system.measureTimeMillis
+
+/**
+ * Returns defMap stored in [DefMapHolder] if it is up-to-date.
+ * Otherwise rebuilds if needed [CrateDefMap] for [crate] and all its dependencies.
+ * If process is cancelled ([ProcessCanceledException]), then only part of defMaps could be updated,
+ * other defMaps will be updated in next call to [getOrUpdateIfNeeded].
+ */
+fun DefMapService.getOrUpdateIfNeeded(crate: CratePersistentId): CrateDefMap? {
+    check(isNewResolveEnabled)
+    val holder = getDefMapHolder(crate)
+
+    if (holder.hasLatestStamp()) return holder.defMap
+
+    checkReadAccessAllowed()
+    checkIsSmartMode(project)
+    return defMapsBuildLock.withLockAndCheckingCancelled {
+        check(defMapsBuildLock.holdCount == 1)
+        if (holder.hasLatestStamp()) return@withLockAndCheckingCancelled holder.defMap
+
+        val pool = Executors.newWorkStealingPool()
+        val indicator = ProgressManager.getGlobalProgressIndicator() ?: EmptyProgressIndicator()
+        // TODO: Invoke outside of read action ?
+        DefMapUpdater(crate, this, pool, indicator, multithread = true).run()
+        if (holder.defMap != null) holder.checkHasLatestStamp()
+        holder.defMap
+    }
+}
+
+/** Called from macro expansion task */
+fun updateDefMapForAllCrates(project: Project, pool: Executor, indicator: ProgressIndicator, multithread: Boolean = true) {
+    if (!isNewResolveEnabled) return
+    val dumbService = DumbService.getInstance(project)
+    val defMapService = project.defMapService
+
+    executeUnderProgressWithWriteActionPriorityWithRetries(indicator) {
+        runReadActionInSmartMode(dumbService) {
+            defMapService.defMapsBuildLock.withLockAndCheckingCancelled {
+                check(defMapService.defMapsBuildLock.holdCount == 1)
+                DefMapUpdater(rootCrateId = null, defMapService, pool, indicator, multithread).run()
+            }
+        }
+    }
+}
+
+private class DefMapUpdater(
+    /**
+     * If null, DefMap is updated for all crates.
+     * Otherwise for [rootCrateId] and all it dependencies.
+     */
+    rootCrateId: CratePersistentId?,
+    private val defMapService: DefMapService,
+    private val pool: Executor,
+    private val indicator: ProgressIndicator,
+    multithread: Boolean,
+) {
+    // Note: we can use only current thread if we are inside write action
+    // (read action will not be started in other threads)
+    private val multithread: Boolean = multithread && !ApplicationManager.getApplication().isWriteAccessAllowed
+    private val topSortedCrates: List<Crate> = defMapService.project.crateGraph.topSortedCrates
+
+    /** Crates to check for update */
+    private val crates: Collection<Crate> = run {
+        val rootCrate = rootCrateId?.let { id -> topSortedCrates.find { it.id == id } }
+        if (rootCrate != null) rootCrate.flatDependencies + rootCrate else topSortedCrates
+    }
+    private var numberUpdatedCrates: Int = 0
+
+    fun run() {
+        checkReadAccessAllowed()
+        val time = measureTimeMillis {
+            executeUnderProgress(indicator) {
+                doRun()
+            }
+        }
+        if (numberUpdatedCrates > 0) {
+            val cratesCount = if (numberUpdatedCrates == topSortedCrates.size) "all" else numberUpdatedCrates.toString()
+            RESOLVE_LOG.info("Updated $cratesCount DefMaps in $time ms")
+        }
+    }
+
+    private fun doRun() {
+        check(isNewResolveEnabled)
+        if (crates.isEmpty()) return
+        indicator.checkCanceled()
+
+        val cratesToCheck = findCratesToCheck()
+        if (cratesToCheck.isEmpty()) return
+
+        val cratesToUpdate = findCratesToUpdate(cratesToCheck)
+        if (cratesToUpdate.isEmpty()) return
+
+        defMapService.removeStaleDefMaps(topSortedCrates)
+
+        val cratesToUpdateAll = getCratesToUpdateWithReversedDependencies(cratesToUpdate)
+        val builtDefMaps = getBuiltDefMaps(cratesToUpdateAll)
+
+        val cratesToUpdateAllSorted = cratesToUpdateAll.topSort(topSortedCrates)
+        val pool = getPool(cratesToUpdateAllSorted.size)
+        numberUpdatedCrates = cratesToUpdateAllSorted.size
+        DefMapsBuilder(defMapService, cratesToUpdateAllSorted, builtDefMaps, indicator, pool).build()
+    }
+
+    private fun findCratesToCheck(): List<Pair<Crate, DefMapHolder>> {
+        checkReadAccessAllowed()
+        val cratesToCheck = mutableListOf<Pair<Crate, DefMapHolder>>()
+        for (crate in crates) {
+            val crateId = crate.id ?: continue
+            val holder = defMapService.getDefMapHolder(crateId)
+            if (!holder.hasLatestStamp()) {
+                cratesToCheck += Pair(crate, holder)
+            }
+        }
+        return cratesToCheck
+    }
+
+    private fun findCratesToUpdate(cratesToCheck: List<Pair<Crate, DefMapHolder>>): List<Crate> {
+        val pool = getPool(cratesToCheck.size)
+        val cratesToUpdate = if (pool is SameThreadExecutor) {
+            cratesToCheck.filter { (crate, holder) ->
+                holder.updateShouldRebuild(crate)
+            }
+        } else {
+            cratesToCheck.filterAsync(pool) { (crate, holder) ->
+                computeInReadActionWithWriteActionPriority(SensitiveProgressWrapper(indicator)) {
+                    holder.updateShouldRebuild(crate)
+                }
+            }
+        }
+        return cratesToUpdate.map { it.first }
+    }
+
+    private fun getCratesToUpdateWithReversedDependencies(cratesToUpdate: List<Crate>): HashSet<Crate> {
+        val cratesToUpdateWithReversedDependencies = cratesToUpdate.withReversedDependencies()
+        for (crate in cratesToUpdateWithReversedDependencies) {
+            val holder = defMapService.getDefMapHolder(crate.id ?: continue)
+            // schedule rebuild for reverse dependencies of [cratesToUpdate],
+            // so if current process is cancelled, they will be rebuilt next time
+            holder.shouldRebuild = true
+        }
+        // Crates from [cratesToUpdateWithReversedDependencies] not in [crates] will be updated in future
+        return crates.filterTo(hashSetOf()) { it in cratesToUpdateWithReversedDependencies }
+    }
+
+    private fun getBuiltDefMaps(cratesToUpdateAll: Set<Crate>): Map<Crate, CrateDefMap> {
+        return crates
+            .filter { it !in cratesToUpdateAll }
+            .mapNotNull {
+                val crateId = it.id ?: return@mapNotNull null
+                val defMap = defMapService.getDefMapHolder(crateId).defMap ?: return@mapNotNull null
+                it to defMap
+            }
+            .toMap(hashMapOf())
+    }
+
+    private fun getPool(size: Int) = if (multithread && size > 1) pool else SameThreadExecutor()
+}
+
+private fun List<Crate>.withReversedDependencies(): Set<Crate> {
+    val result = hashSetOf<Crate>()
+    fun processCrate(crate: Crate) {
+        if (crate.id == null || !result.add(crate)) return
+        for (reverseDependency in crate.reverseDependencies) {
+            processCrate(reverseDependency)
+        }
+    }
+    for (crate in this) {
+        processCrate(crate)
+    }
+    return result
+}
+
+private fun Set<Crate>.topSort(topSortedCrates: List<Crate>): List<Crate> =
+    topSortedCrates.filter { it in this }
+
+class SameThreadExecutor : Executor {
+    override fun execute(action: Runnable) = action.run()
+}
+
+/** Does not persist order of elements */
+private fun <T> Collection<T>.filterAsync(pool: Executor, predicate: (T) -> Boolean): List<T> {
+    val result = ConcurrentLinkedQueue<T>()
+    val future = CompletableFuture<Unit>()
+    val remainingCount = AtomicInteger(size)
+
+    for (element in this) {
+        pool.execute {
+            if (future.isCompletedExceptionally) return@execute
+            try {
+                if (predicate(element)) {
+                    result += element
+                }
+                if (remainingCount.decrementAndGet() == 0) {
+                    future.complete(Unit)
+                }
+            } catch (e: Throwable) {
+                future.completeExceptionally(e)
+            }
+        }
+    }
+
+    future.getWithRethrow()
+    return result.toList()
+}
+
+private fun <T> Lock.withLockAndCheckingCancelled(timeoutMilliseconds: Int = 10, action: () -> T): T =
+    ProgressIndicatorUtils.computeWithLockAndCheckingCanceled<T, Exception>(this, timeoutMilliseconds, TimeUnit.MILLISECONDS, action)

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FileModificationTracker.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FileModificationTracker.kt
@@ -1,0 +1,157 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.openapiext.isUnitTestMode
+import com.intellij.util.io.DigestUtil
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.stubs.RsMacroCallStub
+import org.rust.lang.core.stubs.RsModItemStub
+import org.rust.lang.core.stubs.RsNamedStub
+import org.rust.openapiext.fileId
+import org.rust.stdext.HashCode
+import java.io.DataOutput
+import java.io.DataOutputStream
+import java.io.OutputStream
+import java.security.DigestOutputStream
+import java.util.*
+
+interface Writeable {
+    fun writeTo(data: DataOutput)
+}
+
+val RsFile.modificationStampForResolve: Long get() = viewProvider.modificationStamp
+
+fun isFileChanged(file: RsFile, defMap: CrateDefMap, crate: Crate): Boolean {
+    val fileInfo = defMap.fileInfos[file.virtualFile.fileId] ?: run {
+        if (isUnitTestMode) error("Can't find fileInfo for ${file.virtualFile} in $defMap")
+        return false
+    }
+
+    val hashCalculator = HashCalculator()
+    // Don't use `file.isDeeplyEnabledByCfg` - it can trigger resolve (and cause infinite recursion)
+    val isDeeplyEnabledByCfg = fileInfo.modData.isDeeplyEnabledByCfg
+    val visitor = ModLightCollector(
+        crate,
+        hashCalculator,
+        fileRelativePath = "",
+        collectChildModules = true
+    )
+    val fileStub = file.getOrBuildStub() ?: return false
+    ModCollectorBase.collectMod(fileStub, isDeeplyEnabledByCfg, visitor, crate)
+    if (file.virtualFile == crate.rootModFile) {
+        visitor.modData.attributes = file.attributes
+    }
+    return hashCalculator.getFileHash() != fileInfo.hash
+}
+
+private fun calculateModHash(modData: ModDataLight): HashCode {
+    val digest = DigestUtil.sha1()
+    val data = DataOutputStream(DigestOutputStream(OutputStream.nullOutputStream(), digest))
+
+    fun writeElements(elements: List<Writeable>) {
+        for (element in elements) {
+            element.writeTo(data)
+        }
+        data.writeByte(0)  // delimiter
+    }
+
+    modData.sort()
+    writeElements(modData.items)
+    writeElements(modData.imports)
+    writeElements(modData.macroCalls)
+    writeElements(modData.macroDefs)
+    data.writeByte(modData.attributes?.ordinal ?: RsFile.Attributes.values().size)
+
+    return HashCode.fromByteArray(digest.digest())
+}
+
+private class ModDataLight {
+    val items: MutableList<ItemLight> = mutableListOf()
+    val imports: MutableList<ImportLight> = mutableListOf()
+    val macroCalls: MutableList<MacroCallLight> = mutableListOf()
+    val macroDefs: MutableList<MacroDefLight> = mutableListOf()
+    var attributes: RsFile.Attributes? = null  // not null only for crate root
+
+    fun sort() {
+        items.sortBy { it.name }
+        imports.sortWith(compareBy(Arrays::compare) { it.usePath })
+        // TODO: Smart sort for macro calls & defs
+    }
+}
+
+/** Calculates hash of single file (including all inline modules) */
+class HashCalculator {
+    // We can't use `Map<String /* fileRelativePath */, HashCode>`,
+    // because two modules with different cfg attributes can have same `fileRelativePath`
+    private val modulesHash: MutableList<ModHash> = mutableListOf()
+
+    private data class ModHash(val fileRelativePath: String, val hash: HashCode)
+
+    fun getVisitor(crate: Crate, fileRelativePath: String): ModVisitor =
+        ModLightCollector(crate, this, fileRelativePath)
+
+    fun onCollectMod(fileRelativePath: String, hash: HashCode) {
+        modulesHash += ModHash(fileRelativePath, hash)
+    }
+
+    /** Called after visiting all inline submodules */
+    fun getFileHash(): HashCode {
+        modulesHash.sortBy { it.fileRelativePath }
+        val digest = DigestUtil.sha1()
+        for ((fileRelativePath, modHash) in modulesHash) {
+            digest.update(fileRelativePath.toByteArray())
+            digest.update(modHash.toByteArray())
+        }
+        return HashCode.fromByteArray(digest.digest())
+    }
+}
+
+private class ModLightCollector(
+    private val crate: Crate,
+    private val hashCalculator: HashCalculator,
+    private val fileRelativePath: String,
+    private val collectChildModules: Boolean = false,
+) : ModVisitor {
+
+    val modData: ModDataLight = ModDataLight()
+
+    override fun collectItem(item: ItemLight, stub: RsNamedStub) {
+        modData.items += item
+        if (collectChildModules && stub is RsModItemStub) {
+            collectMod(stub, item.name, item.isDeeplyEnabledByCfg)
+        }
+    }
+
+    override fun collectImport(import: ImportLight) {
+        modData.imports += import
+    }
+
+    override fun collectMacroCall(call: MacroCallLight, stub: RsMacroCallStub) {
+        modData.macroCalls += call
+    }
+
+    override fun collectMacroDef(def: MacroDefLight) {
+        modData.macroDefs += def
+    }
+
+    override fun afterCollectMod() {
+        val fileHash = calculateModHash(modData)
+        hashCalculator.onCollectMod(fileRelativePath, fileHash)
+    }
+
+    private fun collectMod(mod: RsModItemStub, modName: String, isDeeplyEnabledByCfg: Boolean) {
+        val fileRelativePath = "$fileRelativePath::$modName"
+        val visitor = ModLightCollector(
+            crate,
+            hashCalculator,
+            fileRelativePath,
+            collectChildModules = true
+        )
+        ModCollectorBase.collectMod(mod, isDeeplyEnabledByCfg, visitor, crate)
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
@@ -1,0 +1,368 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
+import com.intellij.openapiext.isUnitTestMode
+import com.intellij.psi.stubs.StubElement
+import com.intellij.psi.stubs.StubTreeLoader
+import org.rust.lang.RsConstants
+import org.rust.lang.RsFileType
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.macros.RangeMap
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.ext.RsItemElement
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.isEnabledByCfgSelf
+import org.rust.lang.core.psi.ext.variants
+import org.rust.lang.core.resolve.namespaces
+import org.rust.lang.core.resolve.processModDeclResolveVariants
+import org.rust.lang.core.resolve2.util.RESOLVE_RANGE_MAP_KEY
+import org.rust.lang.core.stubs.*
+import org.rust.openapiext.fileId
+import org.rust.openapiext.findFileByMaybeRelativePath
+import org.rust.openapiext.pathAsPath
+import org.rust.openapiext.toPsiFile
+
+class ModCollectorContext(
+    val defMap: CrateDefMap,
+    val crateRoot: ModData,
+    val context: CollectorContext,
+    val macroDepth: Int = 0,
+    /**
+     * called when new [RsItemElement] is found
+     * default behaviour: just add it to [ModData.visibleItems]
+     * behaviour when processing expanded items:
+     * add it to [ModData.visibleItems] and propagate to modules which have glob import from [ModData]
+     */
+    val onAddItem: (ModData, String, PerNs) -> Unit =
+        { containingMod, name, perNs -> containingMod.addVisibleItem(name, perNs) }
+)
+
+fun collectFileAndCalculateHash(file: RsFile, modData: ModData, context: ModCollectorContext) {
+    val hashCalculator = HashCalculator()
+    val collector = ModCollector(modData, context, hashCalculator)
+    collector.collectMod(file.getOrBuildStub() ?: return)
+    val fileHash = hashCalculator.getFileHash()
+    context.defMap.addVisitedFile(file, modData, fileHash)
+}
+
+fun collectExpandedElements(expandedFile: RsFileStub, modData: ModData, context: ModCollectorContext) {
+    val collector = ModCollector(modData, context, hashCalculator = null)
+    collector.collectMod(expandedFile)
+}
+
+/**
+ * Collects explicitly declared items in all modules of crate.
+ * Also populates [CollectorContext.imports] and [CollectorContext.macroCalls] in [context].
+ */
+private class ModCollector(
+    private val modData: ModData,
+    private val context: ModCollectorContext,
+    private val hashCalculator: HashCalculator?,
+) : ModVisitor {
+
+    private val defMap: CrateDefMap = context.defMap
+    private val crateRoot: ModData = context.crateRoot
+    private val macroDepth: Int = context.macroDepth
+    private val onAddItem: (ModData, String, PerNs) -> Unit = context.onAddItem
+    private val crate: Crate = context.context.crate
+    private val project: Project = context.context.project
+
+    fun collectMod(mod: StubElement<out RsMod>) {
+        val visitor = if (hashCalculator != null) {
+            val hashVisitor = hashCalculator.getVisitor(crate, modData.fileRelativePath)
+            CompositeModVisitor(hashVisitor, this)
+        } else {
+            this
+        }
+        ModCollectorBase.collectMod(mod, modData.isDeeplyEnabledByCfg, visitor, crate)
+        if (isUnitTestMode) {
+            modData.checkChildModulesAndVisibleItemsConsistency()
+        }
+    }
+
+    override fun collectImport(import: ImportLight) {
+        context.context.imports += Import(
+            containingMod = modData,
+            usePath = import.usePath,
+            nameInScope = import.nameInScope,
+            visibility = convertVisibility(import.visibility, import.isDeeplyEnabledByCfg),
+            isGlob = import.isGlob,
+            isExternCrate = import.isExternCrate,
+            isPrelude = import.isPrelude
+        )
+
+        if (import.isDeeplyEnabledByCfg && import.isExternCrate && import.isMacroUse) {
+            defMap.importExternCrateMacros(import.usePath.single())
+        }
+    }
+
+    override fun collectItem(item: ItemLight, stub: RsNamedStub) {
+        val name = item.name
+
+        // could be null if `.resolve()` on `RsModDeclItem` returns null
+        val childModData = tryCollectChildModule(item, stub)
+
+        val visItem = convertToVisItem(item, stub)
+        if (visItem.isModOrEnum && childModData == null) return
+        val perNs = PerNs(visItem, item.namespaces)
+        onAddItem(modData, name, perNs)
+
+        // we have to check `modData[name]` to be sure that `childModules` and `visibleItems` are consistent
+        if (childModData != null && perNs.types === modData.getVisibleItem(name).types) {
+            modData.childModules[name] = childModData
+        }
+    }
+
+    private fun convertToVisItem(item: ItemLight, stub: RsNamedStub): VisItem {
+        val visibility = convertVisibility(item.visibility, item.isDeeplyEnabledByCfg)
+        val itemPath = modData.path.append(item.name)
+        val isModOrEnum = stub is RsModItemStub || stub is RsModDeclItemStub || stub is RsEnumItemStub
+        return VisItem(itemPath, visibility, isModOrEnum)
+    }
+
+    private fun tryCollectChildModule(item: ItemLight, stub: RsNamedStub): ModData? {
+        if (stub is RsEnumItemStub) return collectEnumAsModData(item, stub)
+
+        val childMod = when (stub) {
+            is RsModItemStub -> ChildMod.Inline(stub, item.name)
+            is RsModDeclItemStub -> {
+                val childModPsi = resolveModDecl(item.name, item.pathAttribute) ?: return null
+                ChildMod.File(childModPsi, item.name)
+            }
+            else -> return null
+        }
+        val isDeeplyEnabledByCfg = item.isDeeplyEnabledByCfg
+        val childModData = collectChildModule(childMod, isDeeplyEnabledByCfg, item.pathAttribute)
+        if (item.hasMacroUse && isDeeplyEnabledByCfg) modData.legacyMacros += childModData.legacyMacros
+        return childModData
+    }
+
+    private fun collectChildModule(
+        childMod: ChildMod,
+        isDeeplyEnabledByCfg: Boolean,
+        pathAttribute: String?
+    ): ModData {
+        ProgressManager.checkCanceled()
+        val childModPath = modData.path.append(childMod.name)
+        val (fileId, fileRelativePath) = when (childMod) {
+            is ChildMod.File -> childMod.file.virtualFile.fileId to ""
+            is ChildMod.Inline -> modData.fileId to "${modData.fileRelativePath}::${childMod.name}"
+        }
+        val childModData = ModData(
+            parent = modData,
+            crate = modData.crate,
+            path = childModPath,
+            isDeeplyEnabledByCfg = isDeeplyEnabledByCfg,
+            fileId = fileId,
+            fileRelativePath = fileRelativePath,
+            ownedDirectoryId = childMod.getOwnedDirectory(modData, pathAttribute)?.fileId,
+            crateDescription = defMap.crateDescription
+        )
+        childModData.legacyMacros += modData.legacyMacros
+
+        when (childMod) {
+            is ChildMod.Inline -> {
+                val collector = ModCollector(childModData, context, hashCalculator)
+                collector.collectMod(childMod.mod)
+            }
+            is ChildMod.File -> collectFileAndCalculateHash(childMod.file, childModData, context)
+        }
+        return childModData
+    }
+
+    private fun collectEnumAsModData(enum: ItemLight, enumStub: RsEnumItemStub): ModData {
+        val enumName = enum.name
+        val enumPath = modData.path.append(enumName)
+        val enumData = ModData(
+            parent = modData,
+            crate = modData.crate,
+            path = enumPath,
+            isDeeplyEnabledByCfg = enum.isDeeplyEnabledByCfg,
+            fileId = modData.fileId,
+            fileRelativePath = "${modData.fileRelativePath}::$enumName",
+            ownedDirectoryId = modData.ownedDirectoryId,  // actually can use any value here
+            isEnum = true,
+            crateDescription = defMap.crateDescription
+        )
+        for (variantPsi in enumStub.variants) {
+            val variantName = variantPsi.name ?: continue
+            val variantPath = enumPath.append(variantName)
+            val isVariantDeeplyEnabledByCfg = enumData.isDeeplyEnabledByCfg && variantPsi.isEnabledByCfgSelf(crate)
+            val variantVisibility = if (isVariantDeeplyEnabledByCfg) Visibility.Public else Visibility.CfgDisabled
+            val variant = VisItem(variantPath, variantVisibility)
+            val variantPerNs = PerNs(variant, variantPsi.namespaces)
+            enumData.addVisibleItem(variantName, variantPerNs)
+        }
+        return enumData
+    }
+
+    override fun collectMacroCall(call: MacroCallLight, stub: RsMacroCallStub) {
+        check(modData.isDeeplyEnabledByCfg) { "for performance reasons cfg-disabled macros should not be collected" }
+        val bodyHash = call.bodyHash
+        if (bodyHash == null && call.path.last() != "include") return
+        val macroDef = call.path.singleOrNull()?.let { modData.legacyMacros[it] }
+        val dollarCrateMap = stub.getUserData(RESOLVE_RANGE_MAP_KEY) ?: RangeMap.EMPTY
+        context.context.macroCalls += MacroCallInfo(modData, call.path, call.body, bodyHash, macroDepth, macroDef, dollarCrateMap)
+    }
+
+    override fun collectMacroDef(def: MacroDefLight) {
+        val bodyHash = def.bodyHash ?: return
+        val macroPath = modData.path.append(def.name)
+
+        val defInfo = MacroDefInfo(
+            modData.crate,
+            macroPath,
+            def.body,
+            bodyHash,
+            def.hasMacroExport,
+            def.hasLocalInnerMacros,
+            project
+        )
+        modData.legacyMacros[def.name] = defInfo
+
+        if (def.hasMacroExport) {
+            val visItem = VisItem(macroPath, Visibility.Public)
+            val perNs = PerNs(macros = visItem)
+            onAddItem(crateRoot, def.name, perNs)
+        }
+    }
+
+    private fun convertVisibility(visibility: VisibilityLight, isDeeplyEnabledByCfg: Boolean): Visibility {
+        if (!isDeeplyEnabledByCfg) return Visibility.CfgDisabled
+        return when (visibility) {
+            VisibilityLight.Public -> Visibility.Public
+            // TODO: Optimization - create Visibility.Crate and Visibility.Private to reduce allocations
+            VisibilityLight.RestrictedCrate -> Visibility.Restricted(crateRoot)
+            VisibilityLight.Private -> Visibility.Restricted(modData)
+            is VisibilityLight.Restricted -> resolveRestrictedVisibility(visibility.inPath, crateRoot, modData)
+        }
+    }
+
+    /** See also [processModDeclResolveVariants] */
+    private fun resolveModDecl(name: String, pathAttribute: String?): RsFile? {
+        val (parentDirectory, fileNames) = if (pathAttribute == null) {
+            val parentDirectory = modData.getOwnedDirectory() ?: return null
+            val fileNames = arrayOf("$name.rs", "$name/mod.rs")
+            parentDirectory to fileNames
+        } else {
+            // https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute
+            val parentDirectory = if (modData.isRsFile) {
+                // For path attributes on modules not inside inline module blocks,
+                // the file path is relative to the directory the source file is located.
+                val containingFile = modData.asVirtualFile() ?: return null
+                containingFile.parent
+            } else {
+                // Paths for path attributes inside inline module blocks are relative to
+                // the directory of file including the inline module components as directories.
+                modData.getOwnedDirectory()
+            } ?: return null
+            val explicitPath = FileUtil.toSystemIndependentName(pathAttribute)
+            parentDirectory to arrayOf(explicitPath)
+        }
+
+        val virtualFiles = fileNames.mapNotNull { parentDirectory.findFileByMaybeRelativePath(it) }
+        // Note: It is possible that [virtualFiles] is not empty,
+        // but result is null, when e.g. file is too big (thus will be [PsiFile] and not [RsFile])
+        if (virtualFiles.isEmpty()) {
+            for (fileName in fileNames) {
+                val path = parentDirectory.pathAsPath.resolve(fileName)
+                defMap.missedFiles.add(path)
+            }
+        }
+        return virtualFiles.singleOrNull()?.toPsiFile(project) as? RsFile
+    }
+}
+
+fun RsFile.getOrBuildStub(): RsFileStub? {
+    val stubTree = greenStubTree ?: StubTreeLoader.getInstance().readOrBuild(project, virtualFile, this)
+    val stub = stubTree?.root as? RsFileStub
+    if (stub == null) RESOLVE_LOG.error("No stub for file ${virtualFile.path}")
+    return stub
+}
+
+// `#[macro_use] extern crate <name>;` - import macros
+fun CrateDefMap.importExternCrateMacros(externCrateName: String) {
+    val externCrateDefMap = resolveExternCrateAsDefMap(externCrateName) ?: return
+    importAllMacrosExported(externCrateDefMap)
+}
+
+// https://doc.rust-lang.org/reference/visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself
+private fun resolveRestrictedVisibility(
+    path: Array<String>,
+    crateRoot: ModData,
+    containingMod: ModData
+): Visibility.Restricted {
+    val initialModData = when (path.first()) {
+        "super", "self" -> containingMod
+        else -> crateRoot
+    }
+    val pathTarget = path
+        .fold(initialModData) { modData, segment ->
+            val nextModData = when (segment) {
+                "self" -> modData
+                "super" -> modData.parent
+                else -> modData.childModules[segment]
+            }
+            nextModData ?: return Visibility.Restricted(crateRoot)
+        }
+    return Visibility.Restricted(pathTarget)
+}
+
+private fun ModData.checkChildModulesAndVisibleItemsConsistency() {
+    for ((name, childMod) in childModules) {
+        check(name == childMod.name) { "Inconsistent name of $childMod" }
+        check(visibleItems[name]?.types?.isModOrEnum == true)
+        { "Inconsistent `visibleItems` and `childModules` in $this for name $name" }
+    }
+}
+
+private fun ModData.getOwnedDirectory(): VirtualFile? {
+    val ownedDirectoryId = ownedDirectoryId ?: return null
+    return PersistentFS.getInstance().findFileById(ownedDirectoryId)
+}
+
+private fun ModData.asVirtualFile(): VirtualFile? {
+    check(isRsFile)
+    return PersistentFS.getInstance().findFileById(fileId)
+        ?: run {
+            RESOLVE_LOG.error("Can't find VirtualFile for $this")
+            return null
+        }
+}
+
+private sealed class ChildMod(val name: String) {
+    class Inline(val mod: RsModItemStub, name: String) : ChildMod(name)
+    class File(val file: RsFile, name: String) : ChildMod(name)
+}
+
+/**
+ * Have to pass [pathAttribute], because [RsFile.pathAttribute] triggers resolve.
+ * See also: [RsMod.getOwnedDirectory]
+ */
+private fun ChildMod.getOwnedDirectory(parentMod: ModData, pathAttribute: String?): VirtualFile? {
+    if (this is ChildMod.File && name == RsConstants.MOD_RS_FILE) return file.virtualFile.parent
+
+    val (parentDirectory, path) = if (pathAttribute != null) {
+        when {
+            this is ChildMod.File -> return file.virtualFile.parent
+            parentMod.isRsFile -> parentMod.asVirtualFile()?.parent to pathAttribute
+            else -> parentMod.getOwnedDirectory() to pathAttribute
+        }
+    } else {
+        parentMod.getOwnedDirectory() to name
+    }
+    if (parentDirectory == null) return null
+
+    // Don't use `FileUtil#getNameWithoutExtension` to correctly process relative paths like `./foo`
+    val directoryPath = FileUtil.toSystemIndependentName(path).removeSuffix(".${RsFileType.defaultExtension}")
+    return parentDirectory.findFileByMaybeRelativePath(directoryPath)
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
@@ -1,0 +1,363 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.StubElement
+import com.intellij.util.io.IOUtil
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.psi.RsForeignModItem
+import org.rust.lang.core.psi.RsModDeclItem
+import org.rust.lang.core.psi.RsModItem
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve.Namespace
+import org.rust.lang.core.resolve.namespaces
+import org.rust.lang.core.resolve2.util.forEachLeafSpeck
+import org.rust.lang.core.resolve2.util.getPathWithAdjustedDollarCrate
+import org.rust.lang.core.resolve2.util.getRestrictedPath
+import org.rust.lang.core.stubs.*
+import org.rust.stdext.HashCode
+import org.rust.stdext.exhaustive
+import org.rust.stdext.makeBitMask
+import org.rust.stdext.writeHashCodeNullable
+import java.io.DataOutput
+
+/**
+ * This class is used:
+ * - When collecting explicit items: filling ModData + calculating hash
+ * - When collecting expanded items: filling ModData
+ * - When checking if file was changed: calculating hash
+ */
+class ModCollectorBase private constructor(
+    private val visitor: ModVisitor,
+    private val crate: Crate,
+    private val isDeeplyEnabledByCfg: Boolean,
+) {
+
+    /** [itemsOwner] - [RsMod] or [RsForeignModItem] */
+    private fun collectElements(itemsOwner: StubElement<out RsElement>) {
+        val items = itemsOwner.childrenStubs
+
+        // This should be processed eagerly instead of deferred to resolving.
+        // `#[macro_use] extern crate` is hoisted to import macros before collecting any other items.
+        for (item in items) {
+            if (item is RsExternCrateItemStub) {
+                collectExternCrate(item)
+            }
+        }
+        for (item in items) {
+            if (item !is RsExternCrateItemStub) {
+                collectElement(item)
+            }
+        }
+    }
+
+    private fun collectElement(element: StubElement<out PsiElement>) {
+        when (element) {
+            // impls are not named elements, so we don't need them for name resolution
+            is RsImplItemStub -> Unit
+
+            is RsForeignModStub -> collectElements(element)
+
+            is RsUseItemStub -> collectUseItem(element)
+            is RsExternCrateItemStub -> error("extern crates are processed eagerly")
+
+            is RsMacroCallStub -> collectMacroCall(element)
+            is RsMacroStub -> collectMacroDef(element)
+
+            // Should be after macro stubs (they are [RsNamedStub])
+            is RsNamedStub -> collectItem(element)
+
+            // `RsOuterAttr`, `RsInnerAttr` or `RsVis` when `itemsOwner` is `RsModItem`
+            // `RsExternAbi` when `itemsOwner` is `RsForeignModItem`
+            // etc
+            else -> Unit
+        }
+    }
+
+    private fun collectUseItem(useItem: RsUseItemStub) {
+        val visibility = VisibilityLight.from(useItem)
+        val hasPreludeImport = useItem.hasPreludeImport
+        useItem.forEachLeafSpeck { usePath, alias, isStarImport ->
+            // Ignore `use self;`
+            if (alias == null && usePath.singleOrNull() == "self") return@forEachLeafSpeck
+
+            val import = ImportLight(
+                usePath = usePath,
+                nameInScope = alias ?: usePath.last(),
+                visibility = visibility,
+                isDeeplyEnabledByCfg = isDeeplyEnabledByCfg && useItem.isEnabledByCfgSelf(crate),
+                isGlob = isStarImport,
+                isPrelude = hasPreludeImport
+            )
+            visitor.collectImport(import)
+        }
+    }
+
+    private fun collectExternCrate(externCrate: RsExternCrateItemStub) {
+        val import = ImportLight(
+            usePath = arrayOf(externCrate.name),
+            nameInScope = externCrate.nameWithAlias,
+            visibility = VisibilityLight.from(externCrate),
+            isDeeplyEnabledByCfg = isDeeplyEnabledByCfg && externCrate.isEnabledByCfgSelf(crate),
+            isExternCrate = true,
+            isMacroUse = externCrate.hasMacroUse
+        )
+        if (externCrate.name == "self" && import.nameInScope == "self") return
+        visitor.collectImport(import)
+    }
+
+    private fun collectItem(item: RsNamedStub) {
+        val name = item.name ?: return
+        if (item !is RsAttributeOwnerStub) return
+        if (item is RsFunctionStub && item.isProcMacroDef) return  // TODO: Support proc macros
+
+        val (hasMacroUse, pathAttribute) = when (item) {
+            is RsModItemStub -> item.hasMacroUse to item.pathAttribute
+            is RsModDeclItemStub -> item.hasMacroUse to item.pathAttribute
+            else -> false to null
+        }
+        @Suppress("UNCHECKED_CAST")
+        val itemLight = ItemLight(
+            name = name,
+            visibility = VisibilityLight.from(item as StubElement<out RsVisibilityOwner>),
+            isDeeplyEnabledByCfg = isDeeplyEnabledByCfg && item.isEnabledByCfgSelf(crate),
+            namespaces = item.namespaces,
+            isModItem = item is RsModItemStub,
+            isModDecl = item is RsModDeclItemStub,
+            hasMacroUse = hasMacroUse,
+            pathAttribute = pathAttribute
+        )
+        visitor.collectItem(itemLight, item)
+    }
+
+    private fun collectMacroCall(call: RsMacroCallStub) {
+        val isCallDeeplyEnabledByCfg = isDeeplyEnabledByCfg && call.isEnabledByCfgSelf(crate)
+        if (!isCallDeeplyEnabledByCfg) return
+        val body = call.getIncludeMacroArgument(crate) ?: call.macroBody ?: return
+        val path = call.getPathWithAdjustedDollarCrate()
+        val callLight = MacroCallLight(path, body, call.bodyHash)
+        visitor.collectMacroCall(callLight, call)
+    }
+
+    private fun collectMacroDef(def: RsMacroStub) {
+        val isDefDeeplyEnabledByCfg = isDeeplyEnabledByCfg && def.isEnabledByCfgSelf(crate)
+        if (!isDefDeeplyEnabledByCfg) return
+        val defLight = MacroDefLight(
+            name = def.name ?: return,
+            body = def.macroBody ?: return,
+            bodyHash = def.bodyHash,
+            hasMacroExport = def.hasMacroExport,
+            hasLocalInnerMacros = def.hasMacroExportLocalInnerMacros
+        )
+        visitor.collectMacroDef(defLight)
+    }
+
+    companion object {
+        fun collectMod(mod: StubElement<out RsMod>, isDeeplyEnabledByCfg: Boolean, visitor: ModVisitor, crate: Crate) {
+            val collector = ModCollectorBase(visitor, crate, isDeeplyEnabledByCfg)
+            collector.collectElements(mod)
+            collector.visitor.afterCollectMod()
+        }
+    }
+}
+
+interface ModVisitor {
+    fun collectItem(item: ItemLight, stub: RsNamedStub)
+    fun collectImport(import: ImportLight)
+    fun collectMacroCall(call: MacroCallLight, stub: RsMacroCallStub)
+    fun collectMacroDef(def: MacroDefLight)
+    fun afterCollectMod() {}
+}
+
+class CompositeModVisitor(
+    private val visitor1: ModVisitor,
+    private val visitor2: ModVisitor,
+) : ModVisitor {
+    override fun collectItem(item: ItemLight, stub: RsNamedStub) {
+        visitor1.collectItem(item, stub)
+        visitor2.collectItem(item, stub)
+    }
+
+    override fun collectImport(import: ImportLight) {
+        visitor1.collectImport(import)
+        visitor2.collectImport(import)
+    }
+
+    override fun collectMacroCall(call: MacroCallLight, stub: RsMacroCallStub) {
+        visitor1.collectMacroCall(call, stub)
+        visitor2.collectMacroCall(call, stub)
+    }
+
+    override fun collectMacroDef(def: MacroDefLight) {
+        visitor1.collectMacroDef(def)
+        visitor2.collectMacroDef(def)
+    }
+
+    override fun afterCollectMod() {
+        visitor1.afterCollectMod()
+        visitor2.afterCollectMod()
+    }
+}
+
+sealed class VisibilityLight : Writeable {
+    object Public : VisibilityLight()
+
+    /** `pub(crate)` */
+    object RestrictedCrate : VisibilityLight()
+
+    class Restricted(val inPath: Array<String>) : VisibilityLight()
+
+    object Private : VisibilityLight()
+
+    override fun writeTo(data: DataOutput) {
+        when (this) {
+            Public -> data.writeByte(0)
+            RestrictedCrate -> data.writeByte(1)
+            Private -> data.writeByte(2)
+            is Restricted -> {
+                data.writeByte(3)
+                data.writePath(inPath)
+            }
+        }.exhaustive
+    }
+
+    companion object {
+        fun from(item: StubElement<out RsVisibilityOwner>): VisibilityLight {
+            val vis = item.findChildStubByType(RsVisStub.Type) ?: return Private
+            return when (vis.kind) {
+                RsVisStubKind.PUB -> Public
+                RsVisStubKind.CRATE -> RestrictedCrate
+                RsVisStubKind.RESTRICTED -> {
+                    val path = vis.getRestrictedPath()
+                    val pathSingle = path.singleOrNull()
+                    if (path.isEmpty() || pathSingle == "crate") return RestrictedCrate
+                    if (pathSingle == "self") return Private
+                    Restricted(path)
+                }
+            }
+        }
+    }
+}
+
+data class ItemLight(
+    val name: String,
+    val visibility: VisibilityLight,
+    val isDeeplyEnabledByCfg: Boolean,
+    val namespaces: Set<Namespace>,
+
+    val isModItem: Boolean,
+    val isModDecl: Boolean,
+    /** Only for [RsModItem] or [RsModDeclItem] */
+    val hasMacroUse: Boolean,
+    val pathAttribute: String?,
+) : Writeable {
+    override fun writeTo(data: DataOutput) {
+        IOUtil.writeUTF(data, name)
+        visibility.writeTo(data)
+
+        var flags = 0
+        if (Namespace.Types in namespaces) flags += NAMESPACE_TYPES_MASK
+        if (Namespace.Values in namespaces) flags += NAMESPACE_VALUES_MASK
+        if (Namespace.Macros in namespaces) flags += NAMESPACE_MACROS_MASK
+        if (isDeeplyEnabledByCfg) flags += IS_DEEPLY_ENABLED_BY_CFG_MASK
+        if (isModItem) flags += IS_MOD_ITEM_MASK
+        if (isModDecl) flags += IS_MOD_DECL_MASK
+        if (hasMacroUse) flags += HAS_MACRO_USE_MASK
+        if (pathAttribute != null) flags += PATH_ATTRIBUTE_MASK
+        data.writeByte(flags)
+
+        if (pathAttribute != null) data.writeUTF(pathAttribute)
+    }
+
+    companion object {
+        private val NAMESPACE_TYPES_MASK: Int = makeBitMask(0)
+        private val NAMESPACE_VALUES_MASK: Int = makeBitMask(1)
+        private val NAMESPACE_MACROS_MASK: Int = makeBitMask(2)
+        private val IS_DEEPLY_ENABLED_BY_CFG_MASK: Int = makeBitMask(3)
+        private val IS_MOD_ITEM_MASK: Int = makeBitMask(4)
+        private val IS_MOD_DECL_MASK: Int = makeBitMask(5)
+        private val HAS_MACRO_USE_MASK: Int = makeBitMask(6)
+        private val PATH_ATTRIBUTE_MASK: Int = makeBitMask(7)
+    }
+}
+
+class ImportLight(
+    val usePath: Array<String>,
+    val nameInScope: String,
+    val visibility: VisibilityLight,
+    val isDeeplyEnabledByCfg: Boolean,
+    val isGlob: Boolean = false,
+    val isExternCrate: Boolean = false,
+    val isMacroUse: Boolean = false,
+    val isPrelude: Boolean = false,  // #[prelude_import]
+) : Writeable {
+
+    override fun writeTo(data: DataOutput) {
+        data.writePath(usePath)
+        IOUtil.writeUTF(data, nameInScope)
+        visibility.writeTo(data)
+
+        var flags = 0
+        if (isDeeplyEnabledByCfg) flags += IS_DEEPLY_ENABLED_BY_CFG_MASK
+        if (isGlob) flags += IS_GLOB_MASK
+        if (isExternCrate) flags += IS_EXTERN_CRATE_MASK
+        if (isMacroUse) flags += IS_MACRO_USE_MASK
+        if (isPrelude) flags += IS_PRELUDE_MASK
+        data.writeByte(flags)
+    }
+
+    companion object {
+        private val IS_DEEPLY_ENABLED_BY_CFG_MASK: Int = makeBitMask(0)
+        private val IS_GLOB_MASK: Int = makeBitMask(1)
+        private val IS_EXTERN_CRATE_MASK: Int = makeBitMask(2)
+        private val IS_MACRO_USE_MASK: Int = makeBitMask(3)
+        private val IS_PRELUDE_MASK: Int = makeBitMask(4)
+    }
+}
+
+class MacroCallLight(
+    val path: Array<String>,
+    val body: String,
+    val bodyHash: HashCode?,
+) : Writeable {
+
+    override fun writeTo(data: DataOutput) {
+        data.writePath(path)
+        data.writeHashCodeNullable(bodyHash)
+    }
+}
+
+data class MacroDefLight(
+    val name: String,
+    val body: String,
+    val bodyHash: HashCode?,
+    val hasMacroExport: Boolean,
+    val hasLocalInnerMacros: Boolean,
+) : Writeable {
+
+    override fun writeTo(data: DataOutput) {
+        IOUtil.writeUTF(data, name)
+        data.writeHashCodeNullable(bodyHash)
+
+        var flags = 0
+        if (hasMacroExport) flags += HAS_MACRO_EXPORT_MASK
+        if (hasLocalInnerMacros) flags += HAS_LOCAL_INNER_MACROS_MASK
+        data.writeByte(flags)
+    }
+
+    companion object {
+        private val HAS_MACRO_EXPORT_MASK: Int = makeBitMask(0)
+        private val HAS_LOCAL_INNER_MACROS_MASK: Int = makeBitMask(1)
+    }
+}
+
+private fun DataOutput.writePath(path: Array<String>) {
+    for (segment in path) {
+        IOUtil.writeUTF(this, segment)
+        writeChar(':'.toInt())
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve2/PathResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/PathResolution.kt
@@ -1,0 +1,200 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.lang.core.crate.CratePersistentId
+import org.rust.lang.core.macros.MACRO_DOLLAR_CRATE_IDENTIFIER
+
+enum class ResolveMode { IMPORT, OTHER }
+
+/** Returns `reachedFixedPoint=true` if we are sure that additions to [ModData.visibleItems] wouldn't change the result */
+fun CrateDefMap.resolvePathFp(
+    containingMod: ModData,
+    path: Array<String>,
+    mode: ResolveMode,
+    withInvisibleItems: Boolean
+): ResolvePathResult {
+    var (pathKind, firstSegmentIndex) = getPathKind(path)
+    // we use PerNs and not ModData for first segment,
+    // because path could be one-segment: `use crate as foo;` and `use func as func2;`
+    //                                         ~~~~~ path              ~~~~ path
+    val firstSegmentPerNs = when {
+        pathKind is PathKind.DollarCrate -> {
+            val defMap = getDefMap(pathKind.crateId) ?: error("Can't find DefMap for path ${path.joinToString("::")}")
+            defMap.rootAsPerNs
+        }
+        pathKind == PathKind.Crate -> rootAsPerNs
+        pathKind is PathKind.Super -> {
+            val modData = containingMod.getNthParent(pathKind.level)
+                ?: return ResolvePathResult.empty(reachedFixedPoint = true)
+            if (modData == root) rootAsPerNs else modData.asPerNs()
+        }
+        // plain import or absolute path in 2015:
+        // crate-relative with fallback to extern prelude
+        // (with the simplification in https://github.com/rust-lang/rust/issues/57745)
+        metaData.edition == CargoWorkspace.Edition.EDITION_2015
+            && (pathKind is PathKind.Absolute || pathKind is PathKind.Plain && mode == ResolveMode.IMPORT) -> {
+            val firstSegment = path[firstSegmentIndex++]
+            resolveNameInCrateRootOrExternPrelude(firstSegment)
+        }
+        pathKind == PathKind.Absolute -> {
+            val crateName = path[firstSegmentIndex++]
+            externPrelude[crateName]?.rootAsPerNs
+            // extern crate declarations can add to the extern prelude
+                ?: return ResolvePathResult.empty(reachedFixedPoint = false)
+        }
+        pathKind == PathKind.Plain -> {
+            val firstSegment = path[firstSegmentIndex++]
+            resolveNameInModule(containingMod, firstSegment)
+        }
+        else -> error("unreachable")
+    }
+
+    var currentPerNs = firstSegmentPerNs
+    var visitedOtherCrate = false
+    for (segmentIndex in firstSegmentIndex until path.size) {
+        // we still have path segments left, but the path so far
+        // didn't resolve in the types namespace => no resolution
+        val currentModAsVisItem = currentPerNs.types
+            // TODO: It is not enough - we should also check that `it.visibility` is visible inside `sourceMod`
+            ?.takeIf { withInvisibleItems || !it.visibility.isInvisible }
+            ?: return ResolvePathResult.empty(reachedFixedPoint = false)
+
+        val currentModData = tryCastToModData(currentModAsVisItem)
+        // could be an inherent method call in UFCS form
+        // (`Struct::method`), or some other kind of associated item
+            ?: return ResolvePathResult.empty(reachedFixedPoint = true)
+        if (currentModData.crate != crate) visitedOtherCrate = true
+
+        val segment = path[segmentIndex]
+        currentPerNs = currentModData.getVisibleItem(segment)
+    }
+    val resultPerNs = if (withInvisibleItems) currentPerNs else currentPerNs.filterVisibility { !it.isInvisible }
+    return ResolvePathResult(resultPerNs, reachedFixedPoint = true, visitedOtherCrate = visitedOtherCrate)
+}
+
+fun CrateDefMap.resolveMacroCallToMacroDefInfo(containingMod: ModData, macroPath: Array<String>): MacroDefInfo? {
+    val perNs = resolvePathFp(
+        containingMod,
+        macroPath,
+        ResolveMode.OTHER,
+        withInvisibleItems = false  // because we expand only cfg-enabled macros
+    )
+    val defItem = perNs.resolvedDef.macros ?: return null
+    return getMacroInfo(defItem)
+}
+
+private fun CrateDefMap.resolveNameInExternPrelude(name: String): PerNs {
+    val defMap = externPrelude[name] ?: return PerNs.Empty
+    return defMap.rootAsPerNs
+}
+
+// only when resolving `name` in `extern crate name;`
+//                                             ~~~~
+fun CrateDefMap.resolveExternCrateAsDefMap(name: String): CrateDefMap? =
+    if (name == "self") this else directDependenciesDefMaps[name]
+
+/**
+ * Resolve in:
+ * - legacy scope of macro (needed e.g. for `use name_ as name;`)
+ * - current module / scope
+ * - extern prelude
+ * - std prelude
+ */
+private fun CrateDefMap.resolveNameInModule(modData: ModData, name: String): PerNs {
+    val fromLegacyMacro = modData.legacyMacros[name]
+        ?.let {
+            val visibility = if (it.hasMacroExport) Visibility.Public else Visibility.Restricted(modData)
+            val visItem = VisItem(modData.path.append(name), visibility)
+            PerNs(macros = visItem)
+        } ?: PerNs.Empty
+    val fromScope = modData.getVisibleItem(name)
+    val fromExternPrelude = resolveNameInExternPrelude(name)
+    val fromPrelude = resolveNameInPrelude(name)
+    return fromLegacyMacro.or(fromScope).or(fromExternPrelude).or(fromPrelude)
+}
+
+private fun CrateDefMap.resolveNameInCrateRootOrExternPrelude(name: String): PerNs {
+    val fromCrateRoot = root.getVisibleItem(name)
+    val fromExternPrelude = resolveNameInExternPrelude(name)
+
+    return fromCrateRoot.or(fromExternPrelude)
+}
+
+private fun CrateDefMap.resolveNameInPrelude(name: String): PerNs {
+    val prelude = prelude ?: return PerNs.Empty
+    return prelude.getVisibleItem(name)
+}
+
+private sealed class PathKind {
+    object Plain : PathKind()
+
+    /** `self` is `Super(0)` */
+    class Super(val level: Int) : PathKind()
+
+    /** Starts with crate */
+    object Crate : PathKind()
+
+    /** Starts with :: */
+    object Absolute : PathKind()
+
+    /** `$crate` from macro expansion */
+    class DollarCrate(val crateId: CratePersistentId) : PathKind()
+}
+
+private data class PathInfo(
+    val kind: PathKind,
+    /** number of segments represented by [kind]. */
+    val segmentsToSkip: Int,
+)
+
+/**
+ * Examples:
+ * - For path               'foo::bar' returns `PathKindInfo([PathKind.Plain], 0)`
+ * - For path        'super::foo::bar' returns `PathKindInfo([PathKind.Super], 1)`
+ * - For path 'super::super::foo::bar' returns `PathKindInfo([PathKind.Super], 2)`
+ */
+private fun getPathKind(path: Array<String>): PathInfo {
+    return when (path.first()) {
+        MACRO_DOLLAR_CRATE_IDENTIFIER -> {
+            val crateId = path.getOrNull(1)?.toIntOrNull()
+            if (crateId != null) {
+                PathInfo(PathKind.DollarCrate(crateId), 2)
+            } else {
+                RESOLVE_LOG.warn("Invalid path starting with dollar crate: '${path.contentToString()}'")
+                PathInfo(PathKind.Plain, 0)
+            }
+        }
+        "crate" -> PathInfo(PathKind.Crate, 1)
+        "super" -> {
+            var level = 0
+            while (path.getOrNull(level) == "super") ++level
+            PathInfo(PathKind.Super(level), level)
+        }
+        "self" -> {
+            if (path.getOrNull(1) == "super") {
+                val kind = getPathKind(path.copyOfRange(1, path.size))
+                kind.copy(segmentsToSkip = kind.segmentsToSkip + 1)
+            } else {
+                PathInfo(PathKind.Super(0), 1)
+            }
+        }
+        "" -> PathInfo(PathKind.Absolute, 1)
+        else -> PathInfo(PathKind.Plain, 0)
+    }
+}
+
+data class ResolvePathResult(
+    val resolvedDef: PerNs,
+    val reachedFixedPoint: Boolean,
+    val visitedOtherCrate: Boolean,
+) {
+    companion object {
+        fun empty(reachedFixedPoint: Boolean): ResolvePathResult =
+            ResolvePathResult(PerNs.Empty, reachedFixedPoint, false)
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve2/util/DollarCrateUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/util/DollarCrateUtil.kt
@@ -1,0 +1,181 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2.util
+
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.stubs.StubElement
+import com.intellij.util.SmartList
+import org.rust.lang.core.crate.CratePersistentId
+import org.rust.lang.core.macros.*
+import org.rust.lang.core.psi.RsMacro
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.RsUseItem
+import org.rust.lang.core.psi.ext.basePath
+import org.rust.lang.core.psi.ext.bodyTextRange
+import org.rust.lang.core.resolve2.MacroCallInfo
+import org.rust.lang.core.resolve2.MacroDefInfo
+import org.rust.lang.core.resolve2.RESOLVE_LOG
+import org.rust.lang.core.stubs.*
+import org.rust.openapiext.testAssert
+
+/**
+ * For each expanded [RsMacroCall] we store [RangeMap] - see [MacroCallInfo.dollarCrateMap]
+ */
+val RESOLVE_RANGE_MAP_KEY: Key<RangeMap> = Key("RESOLVE_RANGE_MAP_KEY")
+
+/**
+ * For [RsUseItem] and [RsMacroCall] we store `crateId`,
+ * if `path` (path to macro or use path) starts with [MACRO_DOLLAR_CRATE_IDENTIFIER]
+ */
+val RESOLVE_DOLLAR_CRATE_ID_KEY: Key<CratePersistentId> = Key("RESOLVE_DOLLAR_CRATE_ID_KEY")
+
+/**
+ * If [RsMacroCall] is expanded from macro with ```#[macro_export(local_inner_macros)]``` attribute,
+ * then we store `crateId` of macro definition
+ */
+val RESOLVE_LOCAL_INNER_MACROS_CRATE_ID_KEY: Key<CratePersistentId> = Key("RESOLVE_LOCAL_INNER_MACROS_CRATE_ID_KEY")
+
+/**
+ * Algorithm: for each [MacroDefInfo] and [MacroCallInfo] maintain map
+ * from index of [MACRO_DOLLAR_CRATE_IDENTIFIER] occurrence in text to corresponding [CratePersistentId].
+ * When expand macro call, we want for each occurrence
+ * of [MACRO_DOLLAR_CRATE_IDENTIFIER] in `expansion.text` to find corresponding [CratePersistentId].
+ * [MACRO_DOLLAR_CRATE_IDENTIFIER] could come from:
+ * - '$crate' from macro itself (macro_rules) - use [MacroDefInfo.crate]
+ * - [MACRO_DOLLAR_CRATE_IDENTIFIER] from macro itself (macro_rules) - use map from [MacroDefInfo]
+ * - [MACRO_DOLLAR_CRATE_IDENTIFIER] from macro call - use map from [MacroCallInfo]
+ */
+fun processDollarCrate(
+    call: MacroCallInfo,
+    def: MacroDefInfo,
+    file: RsFileStub,
+    expansion: ExpansionResult
+) {
+    val rangesInFile = findCrateIdForEachDollarCrate(expansion, call, def)
+    if (rangesInFile.isEmpty() && !def.hasLocalInnerMacros) return
+
+    val ranges = expansion.ranges  // between `call.body` and `expandedText`
+    // TODO: Possible optimization - [mapOffsetFromExpansionToCallBody] works in O(N), probably it can be optimized to O(log N)
+    file.forEachTopLevelElement { element ->
+        if (rangesInFile.isNotEmpty()) {
+            processDollarCrateInsideExpandedElement(element, rangesInFile)
+        }
+
+        if (def.hasLocalInnerMacros && element is RsMacroCallStub) {
+            val pathOffsetInExpansion = element.path.startOffset
+            val pathOffsetInCall = ranges.mapOffsetFromExpansionToCallBody(pathOffsetInExpansion)
+            val isExpandedFromDef = pathOffsetInCall == null
+            if (isExpandedFromDef) {
+                element.putUserData(RESOLVE_LOCAL_INNER_MACROS_CRATE_ID_KEY, def.crate)
+            }
+        }
+    }
+}
+
+/**
+ * Entry `(index, crateId)` in returning map means that
+ * `expansion.text` starting from `index` contains [MACRO_DOLLAR_CRATE_IDENTIFIER] which corresponds to `crateId`
+ */
+private fun findCrateIdForEachDollarCrate(
+    expansion: ExpansionResult,
+    call: MacroCallInfo,
+    def: MacroDefInfo
+): Map<Int, CratePersistentId> {
+    val ranges = expansion.ranges  // between `call.body` and `expandedText`
+    return MACRO_DOLLAR_CRATE_IDENTIFIER_REGEX.findAll(expansion.text)
+        .map { it.range.first }
+        .mapNotNull { indexInExpandedText ->
+            val indexInCallBody = ranges.mapOffsetFromExpansionToCallBody(indexInExpandedText)
+            val crateId: CratePersistentId = if (indexInCallBody != null) {
+                testAssert {
+                    val fragmentInCallBody = call.body
+                        .subSequence(indexInCallBody, indexInCallBody + MACRO_DOLLAR_CRATE_IDENTIFIER.length)
+                    fragmentInCallBody == MACRO_DOLLAR_CRATE_IDENTIFIER
+                }
+                call.dollarCrateMap.mapOffsetFromExpansionToCallBody(indexInCallBody)
+                    ?: run {
+                        RESOLVE_LOG.error("Unexpected macro expansion. Macro call: '$call', expansion: '${expansion.text}'")
+                        return@mapNotNull null
+                    }
+            } else {
+                // TODO: We should use [RangeMap] between `expansion.text` and macro body (macro_rules),
+                //  because there can be [MACRO_DOLLAR_CRATE_IDENTIFIER] in macro body (and not only '$crate')
+                def.crate
+            }
+            indexInExpandedText to crateId
+        }
+        .toMap(hashMapOf())
+}
+
+/**
+ * We are interested in these elements:
+ * - [RsUseItem] - if path starts with [MACRO_DOLLAR_CRATE_IDENTIFIER]
+ * - [RsMacroCall] - if path starts with [MACRO_DOLLAR_CRATE_IDENTIFIER] or if body contains [MACRO_DOLLAR_CRATE_IDENTIFIER]
+ * - [RsMacro] - if body contains [MACRO_DOLLAR_CRATE_IDENTIFIER]
+ */
+private fun processDollarCrateInsideExpandedElement(
+    element: StubElement<*>,
+    rangesInFile: Map<Int, CratePersistentId>
+) {
+    fun filterRangesInside(range: TextRange): Map<Int, CratePersistentId> =
+        rangesInFile.filterKeys { indexInFile ->
+            val rangeInFile = TextRange(indexInFile, indexInFile + MACRO_DOLLAR_CRATE_IDENTIFIER.length)
+            range.contains(rangeInFile)
+        }
+
+    when (element) {
+        is RsUseItemStub -> {
+            // expandedText = 'use $crate::foo;'
+            val useSpeck = element.useSpeck ?: return
+            useSpeck.forEachTopLevelPath {
+                val crateId = rangesInFile[it.startOffset] ?: return@forEachTopLevelPath
+                it.basePath().putUserData(RESOLVE_DOLLAR_CRATE_ID_KEY, crateId)
+            }
+        }
+        is RsMacroCallStub -> {
+            // expandedText = 'foo! { ... $crate ... }'
+            run {
+                val macroRangeInFile = element.bodyTextRange ?: return@run
+                val rangesInMacro = filterRangesInside(macroRangeInFile)
+                    .map { (indexInFile, crateId) ->
+                        val indexInMacro = indexInFile - macroRangeInFile.startOffset
+                        MappedTextRange(crateId, indexInMacro, MACRO_DOLLAR_CRATE_IDENTIFIER.length)
+                    }
+                if (rangesInMacro.isEmpty()) return@run
+                element.putUserData(RESOLVE_RANGE_MAP_KEY, RangeMap.from(SmartList(rangesInMacro)))
+            }
+
+            // expandedText = '$crate::foo! { ... }'
+            run {
+                val path = element.path
+                val crateId = rangesInFile[path.startOffset] ?: return@run
+                path.basePath().putUserData(RESOLVE_DOLLAR_CRATE_ID_KEY, crateId)
+            }
+        }
+    }
+}
+
+private fun StubElement<*>.forEachTopLevelElement(action: (StubElement<*>) -> Unit) {
+    for (childStub in childrenStubs) {
+        action(childStub)
+        if (childStub is RsModItemStub || childStub is RsForeignModStub) {
+            childStub.forEachTopLevelElement(action)
+        }
+    }
+}
+
+private fun RsUseSpeckStub.forEachTopLevelPath(consumer: (RsPathStub) -> Unit) {
+    val path = path
+    if (path != null) {
+        consumer(path)
+    } else {
+        val useGroup = useGroup ?: return
+        for (speck in useGroup.childrenStubs) {
+            (speck as RsUseSpeckStub).forEachTopLevelPath(consumer)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/resolve2/util/PathUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/util/PathUtil.kt
@@ -1,0 +1,94 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2.util
+
+import org.rust.lang.core.macros.MACRO_DOLLAR_CRATE_IDENTIFIER
+import org.rust.lang.core.resolve2.RESOLVE_LOG
+import org.rust.lang.core.stubs.*
+
+fun interface RsLeafUseSpeckConsumer {
+    fun consume(usePath: Array<String>, alias: String?, isStarImport: Boolean)
+}
+
+fun RsUseItemStub.forEachLeafSpeck(consumer: RsLeafUseSpeckConsumer) {
+    val rootUseSpeck = findChildStubByType(RsUseSpeckStub.Type) ?: return
+    val segments = arrayListOf<String>()
+    rootUseSpeck.forEachLeafSpeck(consumer, segments, isRootSpeck = true)
+}
+
+private fun RsUseSpeckStub.forEachLeafSpeck(consumer: RsLeafUseSpeckConsumer, segments: ArrayList<String>, isRootSpeck: Boolean) {
+    val path = path
+    val useGroup = useGroup
+    val isStarImport = isStarImport
+
+    if (path == null && isRootSpeck) {
+        // e.g. `use ::*;` and `use ::{aaa, bbb};`
+        if (hasColonColon) segments += "crate"
+        // We ignore `use *;` - https://github.com/sfackler/rust-openssl/blob/0a0da84f939090f72980c77f40199fc76245d289/openssl-sys/src/asn1.rs#L3
+        // Note that `use ::*;` is correct in 2015 edition
+        if (!hasColonColon && useGroup == null) return
+    }
+
+    val numberSegments = segments.size
+    if (path != null) addPathSegments(path, segments)
+
+    if (useGroup == null) {
+        if (!isStarImport && segments.size > 1 && segments.last() == "self") segments.removeAt(segments.lastIndex)
+        val alias = if (isStarImport) "_" else alias?.name
+        consumer.consume(segments.toTypedArray(), alias, isStarImport)
+    } else {
+        for (childSpeck in useGroup.childrenStubs) {
+            (childSpeck as RsUseSpeckStub).forEachLeafSpeck(consumer, segments, isRootSpeck = false)
+        }
+    }
+
+    while (segments.size > numberSegments) {
+        segments.removeAt(segments.lastIndex)
+    }
+}
+
+private fun addPathSegments(path: RsPathStub, segments: ArrayList<String>) {
+    val subpath = path.path
+    if (subpath != null) {
+        addPathSegments(subpath, segments)
+    } else if (path.hasColonColon) {
+        // absolute path: `::foo::bar`
+        //                 ~~~~~ this
+        segments += ""
+    }
+
+    val segment = path.referenceName
+    segments += segment
+    if (subpath == null && segment == MACRO_DOLLAR_CRATE_IDENTIFIER) {
+        val crateId = path.getUserData(RESOLVE_DOLLAR_CRATE_ID_KEY)
+        if (crateId != null) {
+            segments += crateId.toString()
+        } else {
+            RESOLVE_LOG.error("Can't find crate for path starting with \$crate")
+        }
+    }
+}
+
+fun RsMacroCallStub.getPathWithAdjustedDollarCrate(): Array<String> {
+    val segments = arrayListOf<String>()
+
+    val crateIdFromLocalInnerMacros = getUserData(RESOLVE_LOCAL_INNER_MACROS_CRATE_ID_KEY)
+    if (crateIdFromLocalInnerMacros != null) {
+        segments += MACRO_DOLLAR_CRATE_IDENTIFIER
+        segments += crateIdFromLocalInnerMacros.toString()
+    }
+
+    addPathSegments(path, segments)
+    return segments.toTypedArray()
+}
+
+fun RsVisStub.getRestrictedPath(): Array<String> {
+    val path = visRestrictionPath ?: error("no visibility restriction")
+    val segments = arrayListOf<String>()
+    addPathSegments(path, segments)
+    if (segments.first().isEmpty()) segments.removeAt(0)
+    return segments.toTypedArray()
+}

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -296,6 +296,18 @@ fun <T : Any> executeUnderProgressWithWriteActionPriorityWithRetries(indicator: 
 fun runWithWriteActionPriority(indicator: ProgressIndicator, action: () -> Unit): Boolean =
     ProgressIndicatorUtils.runWithWriteActionPriority(action, indicator)
 
+fun runInReadActionWithWriteActionPriority(indicator: ProgressIndicator, action: () -> Unit): Boolean =
+    ProgressIndicatorUtils.runInReadActionWithWriteActionPriority(action, indicator)
+
+fun <T: Any> computeInReadActionWithWriteActionPriority(indicator: ProgressIndicator, action: () -> T): T {
+    lateinit var result: T
+    val success = runInReadActionWithWriteActionPriority(indicator) {
+        result = action()
+    }
+    if (!success) throw ProcessCanceledException()
+    return result
+}
+
 fun <T> executeUnderProgress(indicator: ProgressIndicator, action: () -> T): T {
     var result: T? = null
     ProgressManager.getInstance().executeProcessUnderProgress({ result = action() }, indicator)

--- a/src/main/kotlin/org/rust/stdext/CompletableFuture.kt
+++ b/src/main/kotlin/org/rust/stdext/CompletableFuture.kt
@@ -6,6 +6,7 @@
 package org.rust.stdext
 
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executor
 import java.util.function.Supplier
 
@@ -16,3 +17,11 @@ fun <T> List<CompletableFuture<T>>.joinAll(): CompletableFuture<List<T>> =
 
 fun <T> supplyAsync(executor: Executor, supplier: () -> T): CompletableFuture<T> =
     CompletableFuture.supplyAsync(Supplier { supplier() }, executor)
+
+fun <T> CompletableFuture<T>.getWithRethrow(): T {
+    try {
+        return get()
+    } catch (e: ExecutionException) {
+        throw e.cause ?: e
+    }
+}

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -15,5 +15,8 @@
         <experimentalFeature id="org.rust.macros.new.engine" percentOfUsers="100">
             <description>Enables new macro expansion engine by default</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.resolve.new.engine" percentOfUsers="0">
+            <description>Enables experimental resolve engine</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -15,5 +15,8 @@
         <experimentalFeature id="org.rust.macros.new.engine" percentOfUsers="100">
             <description>Enables new macro expansion engine by default</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.resolve.new.engine" percentOfUsers="0">
+            <description>Enables experimental resolve engine</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Name resolution 2.0 implementaion. Please see [meta issue](https://github.com/intellij-rust/intellij-rust/issues/6217) for details.

The new name resolution is disabled by default.

Please, note that the new resolve engine is in an experimental state and has known regressions. It is intended for internal use. If you wish to give a try:
1. Ensure you have at lease `-Xmx1500m` in `Help | Edit custom VM Options`
2. Enable `org.rust.resolve.new.engine` registry key
3. Enable `org.rust.lang.macros.persistentCache` registry key