### PR TITLE
Add an extension point for toolchain path suggestion

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/RsToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsToolchain.kt
@@ -9,22 +9,21 @@ import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.util.io.exists
 import com.intellij.util.text.SemVer
+import org.rust.cargo.toolchain.flavors.RsToolchainFlavor
 import org.rust.cargo.toolchain.tools.Cargo
-import org.rust.cargo.toolchain.tools.Rustc
+import org.rust.cargo.util.hasExecutable
+import org.rust.cargo.util.pathToExecutable
+import org.rust.stdext.isExecutable
 import java.io.File
-import java.nio.file.Files
 import java.nio.file.Path
 
 open class RsToolchain(val location: Path) {
     val presentableLocation: String = pathToExecutable(Cargo.NAME).toString()
 
-    fun looksLikeValidToolchain(): Boolean = hasExecutable(Cargo.NAME) && hasExecutable(Rustc.NAME)
+    fun looksLikeValidToolchain(): Boolean = RsToolchainFlavor.getFlavor(location) != null
 
     // for executables from toolchain
-    fun pathToExecutable(toolName: String): Path {
-        val exeName = if (SystemInfo.isWindows) "$toolName.exe" else toolName
-        return location.resolve(exeName).toAbsolutePath()
-    }
+    fun pathToExecutable(toolName: String): Path = location.pathToExecutable(toolName)
 
     // for executables installed using `cargo install`
     fun pathToCargoExecutable(toolName: String): Path {
@@ -39,9 +38,9 @@ open class RsToolchain(val location: Path) {
         return cargoBinPath.resolve(exeName).toAbsolutePath()
     }
 
-    fun hasExecutable(exec: String): Boolean = Files.isExecutable(pathToExecutable(exec))
+    fun hasExecutable(exec: String): Boolean = location.hasExecutable(exec)
 
-    fun hasCargoExecutable(exec: String): Boolean = Files.isExecutable(pathToCargoExecutable(exec))
+    fun hasCargoExecutable(exec: String): Boolean = pathToCargoExecutable(exec).isExecutable()
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -64,62 +63,11 @@ open class RsToolchain(val location: Path) {
     companion object {
         val MIN_SUPPORTED_TOOLCHAIN = SemVer.parseFromText("1.32.0")!!
 
-        fun suggest(): RsToolchain? = Suggestions.all().mapNotNull {
-            val candidate = RsToolchain(it.toPath().toAbsolutePath())
-            if (candidate.looksLikeValidToolchain()) candidate else null
-        }.firstOrNull()
-    }
-}
-
-private object Suggestions {
-    fun all() = sequenceOf(
-        fromRustup(),
-        fromPath(),
-        forMac(),
-        forUnix(),
-        forWindows()
-    ).flatten()
-
-    private fun fromRustup(): Sequence<File> {
-        val file = File(FileUtil.expandUserHome("~/.cargo/bin"))
-        return if (file.isDirectory) {
-            sequenceOf(file)
-        } else {
-            emptySequence()
-        }
-    }
-
-    private fun fromPath(): Sequence<File> = System.getenv("PATH").orEmpty()
-        .split(File.pathSeparator)
-        .asSequence()
-        .filter { !it.isEmpty() }
-        .map(::File)
-        .filter { it.isDirectory }
-
-    private fun forUnix(): Sequence<File> {
-        if (!SystemInfo.isUnix) return emptySequence()
-
-        return sequenceOf(File("/usr/local/bin"))
-    }
-
-    private fun forMac(): Sequence<File> {
-        if (!SystemInfo.isMac) return emptySequence()
-
-        return sequenceOf(File("/usr/local/Cellar/rust/bin"))
-    }
-
-    private fun forWindows(): Sequence<File> {
-        if (!SystemInfo.isWindows) return emptySequence()
-        val fromHome = File(System.getProperty("user.home") ?: "", ".cargo/bin")
-
-        val programFiles = File(System.getenv("ProgramFiles") ?: "")
-        val fromProgramFiles = if (!programFiles.exists() || !programFiles.isDirectory)
-            emptySequence()
-        else
-            programFiles.listFiles { file -> file.isDirectory }.asSequence()
-                .filter { it.nameWithoutExtension.toLowerCase().startsWith("rust") }
-                .map { File(it, "bin") }
-
-        return sequenceOf(fromHome) + fromProgramFiles
+        fun suggest(): RsToolchain? =
+            RsToolchainFlavor.getFlavors()
+                .asSequence()
+                .flatMap { it.suggestHomePaths().asSequence() }
+                .map { RsToolchain(it.toAbsolutePath()) }
+                .firstOrNull()
     }
 }

--- a/src/main/kotlin/org/rust/cargo/toolchain/flavors/RsMacToolchainFlavor.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/flavors/RsMacToolchainFlavor.kt
@@ -1,0 +1,21 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.toolchain.flavors
+
+import com.intellij.util.io.isDirectory
+import org.rust.stdext.toPath
+import java.nio.file.Path
+
+object RsMacToolchainFlavor : RsToolchainFlavor() {
+    override fun getHomePathCandidates(): List<Path> {
+        val path = "/usr/local/Cellar/rust/bin".toPath()
+        return if (path.isDirectory()) {
+            listOf(path)
+        } else {
+            emptyList()
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/toolchain/flavors/RsSysPathToolchainFlavor.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/flavors/RsSysPathToolchainFlavor.kt
@@ -1,0 +1,21 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.toolchain.flavors
+
+import com.intellij.util.io.isDirectory
+import org.rust.stdext.toPath
+import java.io.File
+import java.nio.file.Path
+
+object RsSysPathToolchainFlavor : RsToolchainFlavor() {
+    override fun getHomePathCandidates(): List<Path> =
+        System.getenv("PATH")
+            .orEmpty()
+            .split(File.pathSeparator)
+            .filter { it.isNotEmpty() }
+            .map { it.toPath() }
+            .filter { it.isDirectory() }
+}

--- a/src/main/kotlin/org/rust/cargo/toolchain/flavors/RsToolchainFlavor.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/flavors/RsToolchainFlavor.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.toolchain.flavors
+
+import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.util.io.isDirectory
+import org.rust.cargo.toolchain.tools.Cargo
+import org.rust.cargo.toolchain.tools.Rustc
+import org.rust.cargo.util.hasExecutable
+import java.nio.file.Path
+
+abstract class RsToolchainFlavor {
+
+    fun suggestHomePaths(): List<Path> = getHomePathCandidates().distinct().filter { isValidToolchainPath(it) }
+
+    protected abstract fun getHomePathCandidates(): List<Path>
+
+    /**
+     * Checks if the path is the name of a Rust toolchain of this flavor.
+     *
+     * @param path path to check.
+     * @return true if paths points to a valid home.
+     */
+    protected open fun isValidToolchainPath(path: Path): Boolean {
+        return path.isDirectory()
+            && path.hasExecutable(Rustc.NAME)
+            && path.hasExecutable(Cargo.NAME)
+    }
+
+    companion object {
+        private val EP_NAME: ExtensionPointName<RsToolchainFlavor> = ExtensionPointName.create("org.rust.toolchainFlavor")
+
+        fun getFlavors(): List<RsToolchainFlavor> = EP_NAME.extensionList
+
+        fun getFlavor(path: Path): RsToolchainFlavor? =
+            getFlavors().find { flavor -> flavor.isValidToolchainPath(path) }
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/toolchain/flavors/RsUnixToolchainFlavor.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/flavors/RsUnixToolchainFlavor.kt
@@ -1,0 +1,17 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.toolchain.flavors
+
+import com.intellij.util.io.isDirectory
+import org.rust.stdext.toPath
+import java.nio.file.Path
+
+object RsUnixToolchainFlavor : RsToolchainFlavor() {
+    override fun getHomePathCandidates(): List<Path> =
+        listOf("/usr/local/bin", "/usr/bin")
+            .map { it.toPath() }
+            .filter { it.isDirectory() }
+}

--- a/src/main/kotlin/org/rust/cargo/toolchain/flavors/RsWinToolchainFlavor.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/flavors/RsWinToolchainFlavor.kt
@@ -1,0 +1,29 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.toolchain.flavors
+
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.util.io.exists
+import com.intellij.util.io.isDirectory
+import org.rust.stdext.list
+import org.rust.stdext.toPath
+import java.nio.file.Path
+
+object RsWinToolchainFlavor : RsToolchainFlavor() {
+    override fun getHomePathCandidates(): List<Path> {
+        val programFiles = System.getenv("ProgramFiles")?.toPath() ?: return emptyList()
+        if (!programFiles.exists() || !programFiles.isDirectory()) return emptyList()
+        return programFiles.list()
+            .filter { it.isDirectory() }
+            .filter {
+                val name = FileUtil.getNameWithoutExtension(it.fileName.toString())
+                name.toLowerCase().startsWith("rust")
+            }
+            .map { it.resolve("bin") }
+            .filter { it.isDirectory() }
+            .toList()
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/toolchain/flavors/RustupToolchainFlavor.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/flavors/RustupToolchainFlavor.kt
@@ -1,0 +1,28 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.toolchain.flavors
+
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.util.io.isDirectory
+import org.rust.cargo.toolchain.tools.Rustup
+import org.rust.cargo.util.hasExecutable
+import org.rust.stdext.toPath
+import java.nio.file.Path
+
+object RustupToolchainFlavor : RsToolchainFlavor() {
+
+    override fun getHomePathCandidates(): List<Path> {
+        val path = FileUtil.expandUserHome("~/.cargo/bin").toPath()
+        return if (path.isDirectory()) {
+            listOf(path)
+        } else {
+            emptyList()
+        }
+    }
+
+    override fun isValidToolchainPath(path: Path): Boolean =
+        super.isValidToolchainPath(path) && path.hasExecutable(Rustup.NAME)
+}

--- a/src/main/kotlin/org/rust/cargo/util/ToolchainUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/ToolchainUtil.kt
@@ -1,0 +1,17 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.util
+
+import com.intellij.openapi.util.SystemInfo
+import org.rust.stdext.isExecutable
+import java.nio.file.Path
+
+fun Path.hasExecutable(toolName: String): Boolean = pathToExecutable(toolName).isExecutable()
+
+fun Path.pathToExecutable(toolName: String): Path {
+    val exeName = if (SystemInfo.isWindows) "$toolName.exe" else toolName
+    return resolve(exeName).toAbsolutePath()
+}

--- a/src/main/kotlin/org/rust/stdext/Utils.kt
+++ b/src/main/kotlin/org/rust/stdext/Utils.kt
@@ -11,8 +11,10 @@ import com.intellij.openapi.vfs.VirtualFile
 import org.apache.commons.lang.RandomStringUtils
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.streams.asSequence
 
 /**
  * Just a way to nudge Kotlin's type checker in the right direction
@@ -39,6 +41,10 @@ inline fun <T> VirtualFile.applyWithSymlink(f: (VirtualFile) -> T?): T? {
 }
 
 fun String.toPath(): Path = Paths.get(this)
+
+fun Path.isExecutable(): Boolean = Files.isExecutable(this)
+
+fun Path.list(): Sequence<Path> = Files.list(this).asSequence()
 
 fun String.pluralize(): String = StringUtil.pluralize(this)
 

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1038,9 +1038,37 @@
 
     </extensions>
 
+    <extensions defaultExtensionNs="org.rust">
+
+        <!-- Toolchain flavors -->
+
+        <toolchainFlavor id="rust.rustupToolchainFlavor"
+                         implementation="org.rust.cargo.toolchain.flavors.RustupToolchainFlavor"
+                         order="first"/>
+
+        <toolchainFlavor id="rust.sysPathToolchainFlavor"
+                         implementation="org.rust.cargo.toolchain.flavors.RsSysPathToolchainFlavor"/>
+
+        <toolchainFlavor id="rust.unixToolchainFlavor"
+                         implementation="org.rust.cargo.toolchain.flavors.RsUnixToolchainFlavor"
+                         os="unix"/>
+
+        <toolchainFlavor id="rust.macToolchainFlavor"
+                         implementation="org.rust.cargo.toolchain.flavors.RsMacToolchainFlavor"
+                         os="mac"/>
+
+        <toolchainFlavor id="rust.winToolchainFlavor"
+                         implementation="org.rust.cargo.toolchain.flavors.RsWinToolchainFlavor"
+                         os="windows"/>
+
+    </extensions>
+
     <extensionPoints>
         <extensionPoint qualifiedName="org.rust.runConfigurationExtension"
                         interface="org.rust.cargo.runconfig.CargoCommandConfigurationExtension"
+                        dynamic="true"/>
+        <extensionPoint qualifiedName="org.rust.toolchainFlavor"
+                        interface="org.rust.cargo.toolchain.flavors.RsToolchainFlavor"
                         dynamic="true"/>
     </extensionPoints>
 


### PR DESCRIPTION
This can be useful for integration with a plugin that can suggest toolchain paths. For example, WSL integration would suggest something like this:
```
\\wsl$\Ubuntu\home\misha\.cargo\bin
```

Part of https://github.com/intellij-rust/intellij-rust/pull/5529.