### PR TITLE
Allow only LMB double-click for `targets` in the cargo tool window

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectsTree.kt
+++ b/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoProjectsTree.kt
@@ -13,6 +13,7 @@ import org.rust.cargo.project.toolwindow.CargoProjectTreeStructure.CargoSimpleNo
 import org.rust.cargo.project.workspace.CargoWorkspace
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
+import javax.swing.SwingUtilities
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.TreeSelectionModel
 
@@ -32,7 +33,7 @@ class CargoProjectsTree : SimpleTree() {
         selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
         addMouseListener(object : MouseAdapter() {
             override fun mouseClicked(e: MouseEvent) {
-                if (e.clickCount < 2) return
+                if (e.clickCount < 2 || !SwingUtilities.isLeftMouseButton(e)) return
                 val tree = e.source as? CargoProjectsTree ?: return
                 val node = tree.selectionModel.selectionPath
                     ?.lastPathComponent as? DefaultMutableTreeNode ?: return


### PR DESCRIPTION
Today it's possible to run `main` target by doubleclicking `main` using any mouse button (e.g. right mouse button):

![image](https://user-images.githubusercontent.com/3221931/95863265-a9b87800-0d6c-11eb-8b7c-36b29bc7567c.png)

Let's allow only the left mouse button