### PR TITLE
DBG: make NonZero printers compatible with Rust 1.48+

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
@@ -170,7 +170,7 @@ class RsDebugProcessConfigurationHelper(
             "^(core::([a-z_]+::)+)Ref<.+>$",
             "^(core::([a-z_]+::)+)RefMut<.+>$",
             "^(core::([a-z_]+::)+)RefCell<.+>$",
-            "^core::num::NonZero.+$"
+            "^core::num::([a-z_]+::)*NonZero.+$"
         )
     }
 }

--- a/prettyPrinters/rust_types.py
+++ b/prettyPrinters/rust_types.py
@@ -49,7 +49,7 @@ STD_CELL_REGEX = re.compile(r"^(core::([a-z_]+::)+)Cell<.+>$")
 STD_REF_REGEX = re.compile(r"^(core::([a-z_]+::)+)Ref<.+>$")
 STD_REF_MUT_REGEX = re.compile(r"^(core::([a-z_]+::)+)RefMut<.+>$")
 STD_REF_CELL_REGEX = re.compile(r"^(core::([a-z_]+::)+)RefCell<.+>$")
-STD_NONZERO_NUMBER_REGEX = re.compile(r"^core::num::NonZero.+$")
+STD_NONZERO_NUMBER_REGEX = re.compile(r"^core::num::([a-z_]+::)*NonZero.+$")
 
 TUPLE_ITEM_REGEX = re.compile(r"__\d+$")
 

--- a/pretty_printers_tests/tests/nonzero.rs
+++ b/pretty_printers_tests/tests/nonzero.rs
@@ -1,6 +1,4 @@
 // min-version: 1.34.0
-// https://github.com/intellij-rust/intellij-rust/issues/6200
-// max-version: 1.47.0
 
 // === LLDB TESTS ==================================================================================
 


### PR DESCRIPTION
The `NonZero` types moved from `core::num` to `core::num::nonzero` in Rust `1.48`, this change makes the regexes compatible with both the old and the new versions.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/6200