### PR TITLE
UI: `Setup toolchain` action shows Rust settings dialog instead of configurable

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/impl/RustProjectSettingsServiceImpl.kt
@@ -88,7 +88,7 @@ class RustProjectSettingsServiceImpl(
     }
 
     override fun configureToolchain() {
-        ShowSettingsUtil.getInstance().editConfigurable(project, RsProjectConfigurable(project))
+        ShowSettingsUtil.getInstance().showSettingsDialog(project, RsProjectConfigurable::class.java)
     }
 
     private fun notifySettingsChanged(oldState: State, newState: State) {


### PR DESCRIPTION
![Peek 2020-10-14 11-16](https://user-images.githubusercontent.com/3221931/95962281-d755fd80-0e0e-11eb-9ca2-3780464f7e66.gif)
