### PR TITLE
Simplify rustc version parsing

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt
@@ -17,7 +17,6 @@ import org.rust.cargo.icons.CargoIcons
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.PackageOrigin.*
-import org.rust.cargo.toolchain.RustChannel
 import org.rust.cargo.toolchain.impl.RustcVersion
 import org.rust.ide.icons.RsIcons
 import org.rust.openapiext.checkReadAccessAllowed
@@ -102,15 +101,8 @@ private fun makeStdlibLibrary(packages: List<CargoWorkspace.Package>, rustcVersi
         excludedRoots += listOfNotNull(root.findChild("tests"), root.findChild("benches"))
     }
 
-    val version = rustcVersion?.stdlibVersion()
+    val version = rustcVersion?.semver?.parsedVersion
     return CargoLibrary("stdlib", sourceRoots, excludedRoots, RsIcons.RUST, version)
-}
-
-private fun RustcVersion.stdlibVersion(): String = buildString {
-    append(semver)
-    if (channel > RustChannel.STABLE) {
-        channel.channel?.let { append("-$it") }
-    }
 }
 
 private fun CargoWorkspace.Package.toCargoLibrary(): CargoLibrary? {

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/RustcVersion.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/RustcVersion.kt
@@ -31,7 +31,7 @@ fun parseRustcVersion(lines: List<String>): RustcVersion? {
     //  host: x86_64-unknown-linux-gnu
     //  release: 1.8.0-beta.1
     //  ```
-    val releaseRe = """release: (\d+\.\d+\.\d+)(.*)""".toRegex()
+    val releaseRe = """release: (\d+\.\d+\.\d+.*)""".toRegex()
     val hostRe = "host: (.*)".toRegex()
     val commitHashRe = "commit-hash: ([A-Fa-f0-9]{40})".toRegex()
     val commitDateRe = """commit-date: (\d{4}-\d{2}-\d{2})""".toRegex()
@@ -48,12 +48,12 @@ fun parseRustcVersion(lines: List<String>): RustcVersion? {
     }
 
     val semVer = SemVer.parseFromText(versionText) ?: return null
-    val releaseSuffix = releaseMatch.groups[2]?.value.orEmpty()
+    val releaseSuffix = semVer.preRelease.orEmpty()
     val channel = when {
         releaseSuffix.isEmpty() -> RustChannel.STABLE
-        releaseSuffix.startsWith("-beta") -> RustChannel.BETA
-        releaseSuffix.startsWith("-nightly") -> RustChannel.NIGHTLY
-        releaseSuffix.startsWith("-dev") -> RustChannel.DEV
+        releaseSuffix.startsWith("beta") -> RustChannel.BETA
+        releaseSuffix.startsWith("nightly") -> RustChannel.NIGHTLY
+        releaseSuffix.startsWith("dev") -> RustChannel.DEV
         else -> RustChannel.DEFAULT
     }
     return RustcVersion(semVer, hostText, channel, commitHash, commitDate)

--- a/src/test/kotlin/org/rust/cargo/toolchain/RustcVersionParsingTest.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/RustcVersionParsingTest.kt
@@ -54,7 +54,7 @@ class RustcVersionParsingTest(
                 release: 1.39.0-nightly
                 LLVM version: 9.0     
             """, RustcVersion(
-                parseFromText("1.39.0")!!,
+                parseFromText("1.39.0-nightly")!!,
                 "x86_64-unknown-linux-gnu",
                 NIGHTLY,
                 "9af17757be1cc3f672928ecf06c40a662c5ec26d",
@@ -69,7 +69,7 @@ class RustcVersionParsingTest(
                 release: 1.38.0-beta.2
                 LLVM version: 9.0                
             """, RustcVersion(
-                parseFromText("1.38.0")!!,
+                parseFromText("1.38.0-beta.2")!!,
                 "x86_64-apple-darwin",
                 BETA,
                 "641586c1a54f1b1740f8dd796d7501e34c044da2",


### PR DESCRIPTION
It also fixes stdlib's version string in `External Libraries`:

![image](https://user-images.githubusercontent.com/6079006/95896006-417d8c80-0d94-11eb-872d-d6481febdc42.png)

(`beta.2` instead of just `beta`)`