### PR TITLE
INSP: check if pattern identifiers are not bound multiple times [E0416]

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -21,6 +21,7 @@ import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.annotator.fixes.*
 import org.rust.ide.presentation.getStubOnlyText
 import org.rust.ide.refactoring.RsNamesValidator.Companion.RESERVED_LIFETIME_NAMES
+import org.rust.ide.refactoring.findBinding
 import org.rust.ide.utils.isCfgUnknown
 import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.*
@@ -106,10 +107,17 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
             override fun visitVariadic(o: RsVariadic) = checkParamAttrs(rsHolder, o)
             override fun visitPatStruct(o: RsPatStruct) = checkRsPatStruct(rsHolder, o)
             override fun visitPatTupleStruct(o: RsPatTupleStruct) = checkRsPatTupleStruct(rsHolder, o)
+            override fun visitPatTup(o: RsPatTup) = checkRsPatTup(rsHolder, o)
             override fun visitStructLiteralField(o: RsStructLiteralField) = checkReferenceIsPublic(o, o, rsHolder)
         }
 
         element.accept(visitor)
+    }
+
+    private fun checkRsPatTup(holder: RsAnnotationHolder, pattern: RsPatTup) {
+        if (pattern.isTopLevel) {
+            checkRepeatedPatIdentifiers(holder, pattern)
+        }
     }
 
     private fun checkOrPat(holder: RsAnnotationHolder, orPat: RsOrPat) {
@@ -128,6 +136,10 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
 
         if (parent !is RsCondition && parent !is RsMatchArm) {
             OR_PATTERNS.check(holder, orPat, "or-patterns syntax")
+        }
+
+        if (orPat.isTopLevel) {
+            orPat.patList.forEach { checkRepeatedPatIdentifiers(holder, it) }
         }
     }
 
@@ -218,6 +230,10 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
 
             checkRepeatedPatStructFields(holder, patStruct.patFieldList)
         }
+
+        if (patStruct.isTopLevel) {
+            checkRepeatedPatIdentifiers(holder, patStruct)
+        }
     }
 
     private fun checkRepeatedPatStructFields(holder: RsAnnotationHolder, pats: List<RsPatField>) {
@@ -240,6 +256,37 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         }
     }
 
+    private fun checkRepeatedPatIdentifiers(holder: RsAnnotationHolder, topPattern: RsPat) {
+        fun check(pattern: RsPat, identifiers: HashSet<String>): HashSet<String> {
+            val visitedIdentifiers = identifiers.toMutableSet()
+            val visitor = object : RsRecursiveVisitor() {
+                override fun visitPatBinding(binding: RsPatBinding) {
+                    val resolved = binding.reference.resolve()
+                    if (resolved == null || resolved is RsNamedFieldDecl) {
+                        val name = binding.identifier.text
+                        if (name in visitedIdentifiers) {
+                            RsDiagnostic.RepeatedIdentifierInPattern(binding, name).addToHolder(holder)
+                        } else {
+                            visitedIdentifiers.add(name)
+                        }
+                    }
+                }
+
+                override fun visitOrPat(pattern: RsOrPat) {
+                    // assumes that all OR branches have the same set of identifiers
+                    val visitedInBranches = mutableSetOf<String>()
+                    for (pat in pattern.patList) {
+                        visitedInBranches += check(pat, visitedIdentifiers.toHashSet())
+                    }
+                    visitedIdentifiers += visitedInBranches
+                }
+            }
+            pattern.accept(visitor)
+            return visitedIdentifiers.toHashSet()
+        }
+        check(topPattern, hashSetOf())
+    }
+
     private fun checkRsPatTupleStruct(holder: RsAnnotationHolder, patTupleStruct: RsPatTupleStruct) {
         val declaration = patTupleStruct.path.reference?.deepResolve() as? RsFieldsOwner ?: return
 
@@ -255,6 +302,10 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         } else if (bodyFieldsAmount > declarationFieldsAmount) {
             RsDiagnostic.ExtraFieldInTupleStructPattern(patTupleStruct, bodyFieldsAmount, declarationFieldsAmount)
                 .addToHolder(holder)
+        }
+
+        if (patTupleStruct.isTopLevel) {
+            checkRepeatedPatIdentifiers(holder, patTupleStruct)
         }
     }
 
@@ -1305,3 +1356,6 @@ private fun RsAttr.isBuiltinWithName(target: String): Boolean {
 
     return !hasInScope(name, MACROS)
 }
+
+private val RsPat.isTopLevel: Boolean
+    get() = findBinding()?.topLevelPattern == this

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -713,6 +713,19 @@ sealed class RsDiagnostic(
         }
     }
 
+    class RepeatedIdentifierInPattern(
+        repeatedIdentifier: RsPatBinding,
+        private val name: String
+    ) : RsDiagnostic(repeatedIdentifier) {
+        override fun prepare(): PreparedAnnotation {
+            return PreparedAnnotation(
+                ERROR,
+                E0416,
+                "Identifier `$name` is bound more than once in the same pattern"
+            )
+        }
+    }
+
     class DuplicateTypeParameterError(
         element: PsiElement,
         private val fieldName: String
@@ -1198,7 +1211,7 @@ sealed class RsDiagnostic(
     }
 
     class RepeatedFieldInStructPattern(
-        private val repeatedField: RsPatField,
+        repeatedField: RsPatField,
         private val name: String
     ) : RsDiagnostic(repeatedField) {
         override fun prepare(): PreparedAnnotation {
@@ -1321,7 +1334,7 @@ enum class RsErrorCode {
     E0106, E0107, E0118, E0120, E0121, E0124, E0132, E0133, E0184, E0185, E0186, E0198, E0199,
     E0200, E0201, E0202, E0252, E0261, E0262, E0263, E0267, E0268, E0277,
     E0308, E0322, E0328, E0364, E0365, E0379, E0384,
-    E0403, E0404, E0407, E0415, E0424, E0426, E0428, E0433, E0435, E0449, E0451, E0463,
+    E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0433, E0435, E0449, E0451, E0463,
     E0517, E0518, E0552, E0562, E0569, E0583, E0586, E0594,
     E0601, E0603, E0614, E0616, E0618, E0624, E0658, E0666, E0667, E0688, E0695,
     E0704, E0732;

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -3722,7 +3722,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         struct Foo { a: i32, b: i32 }
 
         fn foo(x: Foo) {
-            let Foo { a, <error descr="Field `a` bound multiple times in the pattern [E0025]">a</error>, b } = x;
+            let Foo { a, <error descr="Field `a` bound multiple times in the pattern [E0025]"><error descr="Identifier `a` is bound more than once in the same pattern [E0416]">a</error></error>, b } = x;
         }
     """)
 
@@ -3731,6 +3731,128 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
         fn foo(x: Foo) {
             let Foo { a, <error descr="Field `a` bound multiple times in the pattern [E0025]">a: c</error>, b } = x;
+        }
+    """)
+
+    fun `test E0025 struct field bound multiple times in nested pattern`() = checkErrors("""
+        struct Foo { c: i32, b: Bar }
+        struct Bar { a: i32, b: i32 }
+
+        fn foo(x: Foo) {
+            let Foo { c, b: Bar { a, <error descr="Field `a` bound multiple times in the pattern [E0025]"><error descr="Identifier `a` is bound more than once in the same pattern [E0416]">a</error></error>, .. } } = x;
+        }
+    """)
+
+    fun `test E0416 identifier bound multiple times in struct pattern`() = checkErrors("""
+        struct Foo { a: i32, b: i32 }
+
+        fn foo(x: Foo) {
+            let Foo { a, b: <error descr="Identifier `a` is bound more than once in the same pattern [E0416]">a</error> } = x;
+        }
+    """)
+
+    fun `test E0416 identifier bound multiple times in nested struct pattern`() = checkErrors("""
+        struct Foo { a: Bar, b: Bar }
+        struct Bar { a: i32, b: i32 }
+
+        fn foo(x: Foo) {
+            let Foo { a: Bar { a, b }, b: Bar { <error descr="Identifier `a` is bound more than once in the same pattern [E0416]">a</error>, <error descr="Identifier `b` is bound more than once in the same pattern [E0416]">b</error> } } = x;
+        }
+    """)
+
+    fun `test E0416 identifier bound multiple times in nested complex pattern`() = checkErrors("""
+        struct Foo { a: Bar, b: Bar }
+        struct Bar { a: i32, b: (i32, i32) }
+
+        fn foo(x: Foo) {
+            let Foo { a: Bar { a, b }, b: Bar { <error descr="Identifier `a` is bound more than once in the same pattern [E0416]">a</error>, b: (<error descr="Identifier `a` is bound more than once in the same pattern [E0416]">a</error>, <error descr="Identifier `b` is bound more than once in the same pattern [E0416]">b</error>) } } = x;
+        }
+    """)
+
+    fun `test E0416 identifier bound multiple times in tuple pattern`() = checkErrors("""
+        fn foo() {
+            let (a, <error descr="Identifier `a` is bound more than once in the same pattern [E0416]">a</error>) = (0, 0);
+        }
+    """)
+
+    fun `test E0416 identifier bound multiple times in tuple struct pattern`() = checkErrors("""
+        struct Foo(u32, u32);
+
+        fn foo(x: Foo) {
+            let Foo (a, <error descr="Identifier `a` is bound more than once in the same pattern [E0416]">a</error>) = x;
+        }
+    """)
+
+    fun `test E0416 in or pattern branch`() = checkErrors("""
+        enum E {
+            Bar { a: u32, b: u32 },
+            Baz { a: u32 }
+        }
+
+        fn foo(x: E) {
+            match x {
+                E::Bar { a, b: <error descr="Identifier `a` is bound more than once in the same pattern [E0416]">a</error> } | E::Baz { a } => {}
+            }
+        }
+    """)
+
+    fun `test no E0416 on or pattern in distinct or branches`() = checkErrors("""
+        enum E {
+            Bar { a: u32 },
+            Baz { a: u32 }
+        }
+
+        fn foo(x: E) {
+            match x {
+                E::Bar { a } | E::Baz { a } => {}
+            }
+        }
+    """)
+
+    @MockRustcVersion("1.38.0-nightly")
+    fun `test E0416 in nested or pattern branches`() = checkErrors("""
+        #![feature(or_patterns)]
+
+        struct Foo { a: i32, b: E }
+
+        enum E {
+            Bar { a: u32 },
+            Baz { a: u32 }
+        }
+
+        fn foo(x: Foo) {
+            let Foo { a, b: E::Bar { <error descr="Identifier `a` is bound more than once in the same pattern [E0416]">a</error> } | E::Baz { <error descr="Identifier `a` is bound more than once in the same pattern [E0416]">a</error> } } = x;
+        }
+    """)
+
+    @MockRustcVersion("1.38.0-nightly")
+    fun `test E0416 in nested or pattern branches in reverse order`() = checkErrors("""
+        #![feature(or_patterns)]
+
+        struct Foo { a: i32, b: E }
+
+        enum E {
+            Bar { a: u32 },
+            Baz { a: u32 }
+        }
+
+        fn foo(x: Foo) {
+            let Foo { b: E::Bar { a } | E::Baz { a }, <error descr="Identifier `a` is bound more than once in the same pattern [E0416]">a</error> } = x;
+        }
+    """)
+
+    fun `test no E0416 with path pattern`() = checkErrors("""
+        enum Option {
+            None,
+            Some
+        }
+        use Option::*;
+
+        fn foo(x: (Option, Option)) {
+            match x {
+                (None, None) => {},
+                _ => {}
+            }
         }
     """)
 }


### PR DESCRIPTION
Adds support for checking the `E0416` error, which occurs if the same identifier is found more than once in the same pattern.

Related: https://github.com/intellij-rust/intellij-rust/issues/886