### PR TITLE
Disable checkFeaturesInference

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -7,7 +7,6 @@ package org.rust.cargo.project.workspace
 
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
-import com.intellij.openapiext.isInternal
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.util.text.SemVer
 import org.jetbrains.annotations.TestOnly
@@ -395,7 +394,7 @@ private class WorkspaceImpl(
 
     /** A kind of test for [inferFeatureState]: check that our features inference works the same way as Cargo's */
     private fun checkFeaturesInference() {
-        if (!isUnitTestMode && !isInternal) return
+        if (!isUnitTestMode) return
         val enabledByCargo = packages.flatMap { pkg ->
             pkg.cargoEnabledFeatures.map { PackageFeature(pkg, it) }
         }


### PR DESCRIPTION
Fixes work with https://github.com/rust-lang/rust repo. The bug was introduced in (#5189 not released yet).
The real problem is that we don't take into account real stdlib packages (hence their dependencies and features) in rust-lang/rust. We should fix this later

bors r+