### PR TITLE
DBG: support debugging on Windows outside of CLion

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The plugin is compatible with all IntelliJ-based IDEs starting from the version 
 
 \** Requires the
 [Native Debugging Support](https://plugins.jetbrains.com/plugin/12775-native-debugging-support) plugin. 
-Available on macOS and Linux, LLDB only.
+LLDB only.
 
 ## TOML
 

--- a/debugger/src/main/kotlin/org/rust/debugger/RsDebuggerToolchainService.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/RsDebuggerToolchainService.kt
@@ -40,10 +40,7 @@ class RsDebuggerToolchainService {
         val (frameworkPath, frontendPath) = when {
             SystemInfo.isMac -> "LLDB.framework" to "LLDBFrontend"
             SystemInfo.isUnix -> "lib/liblldb.so" to "bin/LLDBFrontend"
-            SystemInfo.isWindows -> {
-                val binaryDir = "${if (SystemInfo.is32Bit) "x86" else "x64"}/bin"
-                "$binaryDir/liblldb.dll" to "$binaryDir/LLDBFrontend.exe"
-            }
+            SystemInfo.isWindows -> "bin/liblldb.dll" to "bin/LLDBFrontend.exe"
             else -> return LLDBStatus.Unavailable
         }
 

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunner.kt
@@ -5,16 +5,13 @@
 
 package org.rust.debugger.runconfig
 
-import com.intellij.execution.configurations.RunProfile
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.SystemInfo
+import org.rust.cargo.runconfig.BuildResult
 
 class RsDebugRunner : RsDebugRunnerBase() {
 
-    override fun canRun(executorId: String, profile: RunProfile): Boolean {
-        if (!super.canRun(executorId, profile)) return false
-        return SystemInfo.isMac || SystemInfo.isLinux
-    }
+    override fun checkToolchainSupported(host: String): BuildResult.ToolchainError? =
+        RsDebugRunnerUtils.checkToolchainSupported(host)
 
     override fun checkToolchainConfigured(project: Project): Boolean =
         RsDebugRunnerUtils.checkToolchainConfigured(project)

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtils.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtils.kt
@@ -12,11 +12,13 @@ import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.util.SystemInfo
 import com.intellij.xdebugger.XDebugProcess
 import com.intellij.xdebugger.XDebugSession
 import com.intellij.xdebugger.XDebuggerManager
 import com.intellij.xdebugger.impl.XDebugProcessConfiguratorStarter
 import com.intellij.xdebugger.impl.ui.XDebugSessionData
+import org.rust.cargo.runconfig.BuildResult
 import org.rust.cargo.runconfig.CargoRunStateBase
 import org.rust.debugger.RsDebuggerToolchainService
 import org.rust.debugger.settings.RsDebuggerSettings
@@ -43,6 +45,16 @@ object RsDebugRunnerUtils {
                 override fun configure(data: XDebugSessionData?) {}
             })
             .runContentDescriptor
+    }
+
+    fun checkToolchainSupported(host: String): BuildResult.ToolchainError? {
+        if (SystemInfo.isWindows) {
+            val isGNURustToolchain = "gnu" in host
+            if (isGNURustToolchain) {
+                return BuildResult.ToolchainError.UnsupportedGNU
+            }
+        }
+        return null
     }
 
     fun checkToolchainConfigured(project: Project): Boolean {

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/legacy/RsDebugRunnerLegacy.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/legacy/RsDebugRunnerLegacy.kt
@@ -5,17 +5,14 @@
 
 package org.rust.debugger.runconfig.legacy
 
-import com.intellij.execution.configurations.RunProfile
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.SystemInfo
+import org.rust.cargo.runconfig.BuildResult
 import org.rust.debugger.runconfig.RsDebugRunnerUtils
 
 class RsDebugRunnerLegacy : RsDebugRunnerLegacyBase() {
 
-    override fun canRun(executorId: String, profile: RunProfile): Boolean {
-        if (!super.canRun(executorId, profile)) return false
-        return SystemInfo.isMac || SystemInfo.isLinux
-    }
+    override fun checkToolchainSupported(host: String): BuildResult.ToolchainError? =
+        RsDebugRunnerUtils.checkToolchainSupported(host)
 
     override fun checkToolchainConfigured(project: Project): Boolean =
         RsDebugRunnerUtils.checkToolchainConfigured(project)

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/legacy/RsDebugRunnerLegacyBase.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/legacy/RsDebugRunnerLegacyBase.kt
@@ -10,10 +10,8 @@ import com.intellij.execution.executors.DefaultDebugExecutor
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.SystemInfo
 import org.jetbrains.concurrency.AsyncPromise
 import org.rust.cargo.runconfig.BuildResult.ToolchainError
-import org.rust.cargo.runconfig.BuildResult.ToolchainError.UnsupportedMSVC
 import org.rust.cargo.runconfig.CargoRunStateBase
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowEnabled
 import org.rust.cargo.runconfig.legacy.RsAsyncRunner
@@ -40,11 +38,6 @@ abstract class RsDebugRunnerLegacyBase : RsAsyncRunner(DefaultDebugExecutor.EXEC
     ) {
         project.showErrorDialog(toolchainError.message)
         promise.setResult(null)
-    }
-
-    override fun checkToolchainSupported(host: String): ToolchainError? = when {
-        SystemInfo.isWindows && "msvc" in host -> UnsupportedMSVC
-        else -> null
     }
 
     companion object {

--- a/debugger/src/test/kotlin/org/rust/debugger/RsDebuggerToolchainServiceTest.kt
+++ b/debugger/src/test/kotlin/org/rust/debugger/RsDebuggerToolchainServiceTest.kt
@@ -5,7 +5,6 @@
 
 package org.rust.debugger
 
-import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.PlatformUtils
 import org.rust.RsTestBase
 import org.rust.TestContext
@@ -17,7 +16,7 @@ class RsDebuggerToolchainServiceTest : RsTestBase() {
     private var lldbDir: File? = null
 
     override fun runTestInternal(context: TestContext) {
-        if (PlatformUtils.isIdeaUltimate() && !SystemInfo.isWindows) {
+        if (PlatformUtils.isIdeaUltimate()) {
             super.runTestInternal(context)
         }
     }

--- a/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
+++ b/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
@@ -17,7 +17,6 @@ import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.updateSettings.impl.pluginsAdvertisement.PluginsAdvertiser
-import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.PlatformUtils
 import org.rust.cargo.runconfig.RsDefaultProgramRunnerBase
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
@@ -27,7 +26,6 @@ class RsDebugAdvertisingRunner : RsDefaultProgramRunnerBase() {
     override fun canRun(executorId: String, profile: RunProfile): Boolean {
         if (executorId != DefaultDebugExecutor.EXECUTOR_ID) return false
         if (profile !is CargoCommandConfiguration) return false
-        if (!(SystemInfo.isMac || SystemInfo.isLinux)) return false
         if (!(PlatformUtils.isIdeaUltimate() || PlatformUtils.isRubyMine())) return false
         val id = PluginId.getId(NATIVE_DEBUG_PLUGIN_ID)
         val plugin = PluginManagerCore.getPlugin(id)


### PR DESCRIPTION
Continuation of #5200 and #5535

Restrictions:
* supported IDEs: IDEA Ultimate and RubyMine
* requires [Native Debugging Support](https://plugins.jetbrains.com/plugin/12775-native-debugging-support) plugin for IDEA Ultimate
* only LLDB
* only Rust MSVC toolchain
* debugger is not bundled and has to be downloaded. Also, debugger binaries should be updated after IDE/[Native Debugging Support](https://plugins.jetbrains.com/plugin/12775-native-debugging-support) plugin update

See #5632 for details about the status of MSVC LLDB support/restrictions 

Fixes #5610