### PR TITLE
CARGO: doesn't load Cargo project structure twice

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -63,7 +63,7 @@ interface CargoProjectsService {
         )
     }
 
-    interface CargoProjectsListener {
+    fun interface CargoProjectsListener {
         fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>)
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoEventService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoEventService.kt
@@ -1,0 +1,50 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project.model.impl
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import org.rust.cargo.project.model.CargoProjectsService.CargoProjectsListener
+import org.rust.cargo.project.model.CargoProjectsService.Companion.CARGO_PROJECTS_TOPIC
+import org.rust.cargo.runconfig.command.workingDirectory
+import org.rust.stdext.mapToSet
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+
+/**
+ * The plugin uses `cargo metadata` command to retrieve project structure from Cargo point of view.
+ * It may lead to changes in `Cargo.lock` file.
+ * At the same time, the plugin watches changes in `Cargo.lock` to update project structure
+ * because the content of `Cargo.lock` is taken into account by Cargo while `cargo metadata` command.
+ * As a result, the plugin may call `cargo metadata` twice in a row and the second call always redundant.
+ *
+ * This service keeps timestamps of previous `cargo metadata` invocation for each cargo project
+ * to check changes in `Cargo.lock` should be skipped and avoid unnecessary project loading that can be quite long sometimes
+ */
+@Service
+class CargoEventService(project: Project) {
+
+    private val metadataCallTimestamps: ConcurrentMap<Path, Long> = ConcurrentHashMap()
+
+    init {
+        project.messageBus.connect().subscribe(CARGO_PROJECTS_TOPIC, CargoProjectsListener { _, projects ->
+            val projectDirs = projects.mapToSet { it.workingDirectory }
+            metadataCallTimestamps.keys.retainAll(projectDirs)
+        })
+    }
+
+    fun onMetadataCall(projectDirectory: Path) {
+        metadataCallTimestamps[projectDirectory] = System.currentTimeMillis()
+    }
+
+    fun extractTimestamp(projectDirectory: Path): Long? = metadataCallTimestamps.remove(projectDirectory)
+
+    companion object {
+        fun getInstance(project: Project): CargoEventService = project.service()
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -42,6 +42,7 @@ import org.rust.cargo.CargoConstants
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.CargoProject.UpdateStatus
 import org.rust.cargo.project.model.CargoProjectsService
+import org.rust.cargo.project.model.CargoProjectsService.CargoProjectsListener
 import org.rust.cargo.project.model.RustcInfo
 import org.rust.cargo.project.model.setup
 import org.rust.cargo.project.settings.RustProjectSettingsService
@@ -89,13 +90,11 @@ open class CargoProjectsServiceImpl(
                 }
             })
 
-            subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsService.CargoProjectsListener {
-                override fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>) {
-                    StartupManager.getInstance(project).runAfterOpened {
-                        GuiUtils.invokeLaterIfNeeded({
-                            initializeToolWindow(project)
-                        }, ModalityState.NON_MODAL)
-                    }
+            subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, CargoProjectsListener { _, _ ->
+                StartupManager.getInstance(project).runAfterOpened {
+                    GuiUtils.invokeLaterIfNeeded({
+                        initializeToolWindow(project)
+                    }, ModalityState.NON_MODAL)
                 }
             })
         }

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcher.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcher.kt
@@ -6,6 +6,9 @@
 package org.rust.cargo.project.model.impl
 
 import com.google.common.annotations.VisibleForTesting
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.newvfs.BulkFileListener
 import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
@@ -15,6 +18,7 @@ import com.intellij.util.PathUtil
 import org.rust.cargo.CargoConstants
 import org.rust.cargo.project.model.CargoProjectsService
 import org.rust.cargo.project.workspace.PackageOrigin
+import java.nio.file.Paths
 
 /**
  * File changes listener, detecting changes inside the `Cargo.toml` files
@@ -32,7 +36,7 @@ class CargoTomlWatcher(
     }
 
     private fun isInterestingEvent(event: VFileEvent): Boolean {
-        if (!Companion.isInterestingEvent(event)) return false
+        if (!Companion.isInterestingEvent(cargoProjects.project, event)) return false
 
         // Fixes https://github.com/intellij-rust/intellij-rust/issues/5621
         // For some reason, Cargo bumps modification time of `Cargo.toml` of `openid 0.4.0`
@@ -57,20 +61,40 @@ class CargoTomlWatcher(
         )
 
         @VisibleForTesting
-        fun isInterestingEvent(event: VFileEvent): Boolean = when {
-            event.pathEndsWith(CargoConstants.MANIFEST_FILE) || event.pathEndsWith(CargoConstants.LOCK_FILE) -> true
-            event is VFileContentChangeEvent -> false
-            !event.pathEndsWith(".rs") -> false
-            event is VFilePropertyChangeEvent && event.propertyName != VirtualFile.PROP_NAME -> false
-            IMPLICIT_TARGET_FILES.any { event.pathEndsWith(it) } -> true
-            else -> {
-                val parent = PathUtil.getParentPath(event.path)
-                val grandParent = PathUtil.getParentPath(parent)
-                IMPLICIT_TARGET_DIRS.any { parent.endsWith(it) || (event.pathEndsWith("main.rs") && grandParent.endsWith(it)) }
+        fun isInterestingEvent(project: Project, event: VFileEvent): Boolean {
+            return when {
+                event.pathEndsWith(CargoConstants.MANIFEST_FILE) -> true
+                event.pathEndsWith(CargoConstants.LOCK_FILE) -> {
+                    val projectDir = Paths.get(event.path).parent
+                    val timestamp = CargoEventService.getInstance(project).extractTimestamp(projectDir) ?: 0
+                    // Non-null requestor means a change from IDE itself
+                    if (event.requestor != null) return true
+                    val current = System.currentTimeMillis()
+                    val delayThreshold = Registry.intValue("org.rust.cargo.lock.update.delay.threshold")
+                    val delay = current - timestamp
+                    return if (delay > delayThreshold) {
+                        LOG.info("External change in ${event.path}. Previous Cargo metadata call was $delay ms before")
+                        true
+                    } else {
+                        LOG.info("Skip external change for ${event.path}. Previous Cargo metadata call was $delay ms before")
+                        false
+                    }
+                }
+                event is VFileContentChangeEvent -> false
+                !event.pathEndsWith(".rs") -> false
+                event is VFilePropertyChangeEvent && event.propertyName != VirtualFile.PROP_NAME -> false
+                IMPLICIT_TARGET_FILES.any { event.pathEndsWith(it) } -> true
+                else -> {
+                    val parent = PathUtil.getParentPath(event.path)
+                    val grandParent = PathUtil.getParentPath(parent)
+                    IMPLICIT_TARGET_DIRS.any { parent.endsWith(it) || (event.pathEndsWith("main.rs") && grandParent.endsWith(it)) }
+                }
             }
         }
 
         private fun VFileEvent.pathEndsWith(suffix: String): Boolean = path.endsWith(suffix) ||
             this is VFilePropertyChangeEvent && oldPath.endsWith(suffix)
+
+        private val LOG = logger<CargoTomlWatcher>()
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoToolWindow.kt
+++ b/src/main/kotlin/org/rust/cargo/project/toolwindow/CargoToolWindow.kt
@@ -25,6 +25,7 @@ import com.intellij.ui.content.ContentFactory
 import com.intellij.util.ui.UIUtil
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.CargoProjectsService
+import org.rust.cargo.project.model.CargoProjectsService.CargoProjectsListener
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.model.guessAndSetupRustProject
 import org.rust.cargo.runconfig.hasCargoProject
@@ -106,11 +107,9 @@ class CargoToolWindow(
 
     init {
         with(project.messageBus.connect()) {
-            subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsService.CargoProjectsListener {
-                override fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>) {
-                    invokeLater {
-                        projectStructure.updateCargoProjects(projects.toList())
-                    }
+            subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, CargoProjectsListener { _, projects ->
+                invokeLater {
+                    projectStructure.updateCargoProjects(projects.toList())
                 }
             })
         }

--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -16,6 +16,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.ui.EditorNotificationPanel
 import org.rust.cargo.project.model.*
+import org.rust.cargo.project.model.CargoProjectsService.CargoProjectsListener
 import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.settings.RustProjectSettingsService.RustSettingsChangedEvent
 import org.rust.cargo.project.settings.RustProjectSettingsService.RustSettingsListener
@@ -44,10 +45,8 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
                     }
                 })
 
-            subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsService.CargoProjectsListener {
-                override fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>) {
-                    updateAllNotifications()
-                }
+            subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, CargoProjectsListener { _, _ ->
+                updateAllNotifications()
             })
         }
     }

--- a/src/main/kotlin/org/rust/ide/notifications/NoCargoProjectNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/NoCargoProjectNotificationProvider.kt
@@ -13,16 +13,15 @@ import com.intellij.openapiext.isDispatchThread
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.ui.EditorNotificationPanel
 import org.rust.cargo.project.model.*
+import org.rust.cargo.project.model.CargoProjectsService.CargoProjectsListener
 import org.rust.lang.core.psi.isRustFile
 
 class NoCargoProjectNotificationProvider(project: Project) : RsNotificationProvider(project) {
 
     init {
         project.messageBus.connect().apply {
-            subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsService.CargoProjectsListener {
-                override fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>) {
-                    updateAllNotifications()
-                }
+            subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, CargoProjectsListener { _, _ ->
+                updateAllNotifications()
             })
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/CrateGraphServiceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/CrateGraphServiceImpl.kt
@@ -38,10 +38,8 @@ class CrateGraphServiceImpl(val project: Project) : CrateGraphService {
     private val cargoProjectsModTracker = SimpleModificationTracker()
 
     init {
-        project.messageBus.connect().subscribe(CARGO_PROJECTS_TOPIC, object : CargoProjectsListener {
-            override fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>) {
-                cargoProjectsModTracker.incModificationCount()
-            }
+        project.messageBus.connect().subscribe(CARGO_PROJECTS_TOPIC, CargoProjectsListener { _, _ ->
+            cargoProjectsModTracker.incModificationCount()
         })
     }
 

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -44,6 +44,7 @@ import org.jetbrains.annotations.TestOnly
 import org.rust.RsTask
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.CargoProjectsService
+import org.rust.cargo.project.model.CargoProjectsService.CargoProjectsListener
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.RustProjectSettingsService
 import org.rust.cargo.project.settings.rustSettings
@@ -668,10 +669,8 @@ private class MacroExpansionServiceImplInner(
 
         val connect = project.messageBus.connect(disposable)
 
-        connect.subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsService.CargoProjectsListener {
-            override fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>) {
-                settingsChanged()
-            }
+        connect.subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, CargoProjectsListener { _, _ ->
+            settingsChanged()
         })
 
         connect.subscribe(RustProjectSettingsService.RUST_SETTINGS_TOPIC, object : RustProjectSettingsService.RustSettingsListener {
@@ -1043,7 +1042,7 @@ private class MacroExpansionServiceImplInner(
  * [MacroExpansionManager] should be loaded in order to add expansion directory to the index via
  * [RsIndexableSetContributor]
  */
-class MacroExpansionManagerWaker : CargoProjectsService.CargoProjectsListener {
+class MacroExpansionManagerWaker : CargoProjectsListener {
     override fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>) {
         if (projects.isNotEmpty()) {
             service.project.macroExpansionManager

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
@@ -24,8 +24,8 @@ import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.testFramework.LightVirtualFile
 import com.intellij.util.messages.MessageBusConnection
 import com.intellij.util.messages.Topic
-import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.CargoProjectsService
+import org.rust.cargo.project.model.CargoProjectsService.CargoProjectsListener
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.lang.RsFileType
 import org.rust.lang.core.macros.MacroExpansionMode
@@ -113,10 +113,8 @@ class RsPsiManagerImpl(val project: Project) : RsPsiManager, Disposable {
                 incRustStructureModificationCount()
             }
         })
-        project.messageBus.connect().subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsService.CargoProjectsListener {
-            override fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>) {
-                incRustStructureModificationCount()
-            }
+        project.messageBus.connect().subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, CargoProjectsListener { _, _ ->
+            incRustStructureModificationCount()
         })
     }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefMapService.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefMapService.kt
@@ -168,10 +168,8 @@ class DefMapService(val project: Project) : Disposable {
             }
         })
 
-        connection.subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsListener {
-            override fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>) {
-                scheduleRecheckAllDefMaps()
-            }
+        connection.subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, CargoProjectsListener { _, _ ->
+            scheduleRecheckAllDefMaps()
         })
     }
 

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1005,6 +1005,9 @@
                      description="Highlight Rust macro call bodies"/>
         <registryKey key="org.rust.lang.macros.persistentCache" defaultValue="false" restartRequired="false"
                      description="Use persistent cache for Rust macro expansions"/>
+        <registryKey key="org.rust.cargo.lock.update.delay.threshold" defaultValue="5000" restartRequired="false"
+                     description="Delay in ms between Cargo metadata call and changes in Cargo.lock
+                     when automatic project structure reload doesn't occur"/>
 
         <!-- Move refactoring -->
 

--- a/src/test/kotlin/org/rust/cargo/project/model/AttachCargoProjectActionTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/AttachCargoProjectActionTest.kt
@@ -14,6 +14,7 @@ import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl
 import com.intellij.util.ui.UIUtil
 import org.rust.FileTreeBuilder
 import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.cargo.project.model.CargoProjectsService.CargoProjectsListener
 import org.rust.cargo.project.toolwindow.CargoToolWindow
 import org.rust.fileTree
 import org.rust.ide.notifications.RsEditorNotificationPanel
@@ -146,10 +147,8 @@ class AttachCargoProjectActionTest : RsWithToolchainTestBase() {
         assertEquals(shouldBeEnabled, testEvent.presentation.isEnabledAndVisible)
         if (shouldBeEnabled) {
             val latch = CountDownLatch(1)
-            project.messageBus.connect().subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, object : CargoProjectsService.CargoProjectsListener {
-                override fun cargoProjectsUpdated(service: CargoProjectsService, projects: Collection<CargoProject>) {
-                    latch.countDown()
-                }
+            project.messageBus.connect().subscribe(CargoProjectsService.CARGO_PROJECTS_TOPIC, CargoProjectsListener { _, _ ->
+                latch.countDown()
             })
 
             action.actionPerformed(testEvent)


### PR DESCRIPTION
Doesn't trigger the loading of Cargo projects structure on the first external change in `Cargo.lock` file after `cargo metadata` call because this change is performed  `cargo metadata` command itself.
It should reduce the loading of cargo projects. It may be essential if/when loading takes a long time

Part of #6104
