### PR TITLE
ANN: take into account workspace features in external linter

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
@@ -31,6 +31,7 @@ import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.runconfig.command.workingDirectory
+import org.rust.cargo.toolchain.tools.CargoCheckArgs
 import org.rust.ide.annotator.RsExternalLinterResult
 import org.rust.ide.annotator.RsExternalLinterUtils
 import org.rust.ide.annotator.createAnnotationsForFile
@@ -128,7 +129,7 @@ class RsExternalLinterInspection : GlobalSimpleInspectionTool() {
                 cargoProject.project,
                 disposable,
                 cargoProject.workingDirectory,
-                null
+                CargoCheckArgs.forCargoProject(cargoProject)
             )
         }
 


### PR DESCRIPTION
Now external linter (`cargo check` or `clippy`) takes into account workspace features configuration (from #5189):

![Peek 2020-10-20 20-57](https://user-images.githubusercontent.com/3221931/96625526-f83eb700-1316-11eb-8194-01af2f5b8398.gif)

I made some changes in external linter invocation mechanics:

1. Pass `--no-default-features` and `--features` options to `cargo check` invocation
2. In a workspace, instead of invoking `cargo check` in a workspace root with `--package foo` option, now we execute `cargo check` in a **package root** without package option. It's needed because it's not possible to pass `--features` option in a workspace root if the workspace consists of multiple packages.
3. Pass concrete `target` to `cargo check` invocation, e.g. `--bin foo`, `--lib`, `--test foo`. This is not strictly needed, but it makes the code simpler, and also it should speed up the linting.