### PR TITLE
Refresh inlay hints when modifying cargo features

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -29,6 +29,8 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapiext.isUnitTestMode
+import com.intellij.psi.PsiManager
+import com.intellij.psi.impl.PsiModificationTrackerImpl
 import com.intellij.ui.GuiUtils
 import com.intellij.util.Consumer
 import com.intellij.util.indexing.LightDirectoryIndex
@@ -343,6 +345,7 @@ open class CargoProjectsServiceImpl(
                         directoryIndex.resetIndex()
                         project.messageBus.syncPublisher(CargoProjectsService.CARGO_PROJECTS_TOPIC)
                             .cargoProjectsUpdated(this, projects)
+                        (PsiManager.getInstance(project).modificationTracker as PsiModificationTrackerImpl).incCounter()
                         DaemonCodeAnalyzer.getInstance(project).restart()
                     }
                 }


### PR DESCRIPTION
Previously, when cargo features was modified (#5189),
inlay hints was not updated, so some old state remained
in en editor

bors r+