### PR TITLE
GRAM: better parser recovery for incomplete paths (pin path) 

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -204,7 +204,10 @@ TypeQual ::= '<' TypeReference [ as TraitRef] '>' '::' {
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 
-left PathSegment ::= '::' PathIdent PathTypeArguments? { elementType = Path }
+left PathSegment ::= '::' !('{' | '*') PathIdent PathTypeArguments? {
+  pin = 2
+  elementType = Path
+}
 
 private PathTypeArguments ::= <<isPathMode 'VALUE'>> ColonTypeArgumentList
                             | <<isPathMode 'TYPE'>> ( TypeArgumentList | PathParameters RetType? ) // Fn(i32) -> i32 sugar

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -431,8 +431,9 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     private fun checkPath(holder: RsAnnotationHolder, path: RsPath) {
         val qualifier = path.path
         if ((qualifier == null || isValidSelfSuperPrefix(qualifier)) && !isValidSelfSuperPrefix(path)) {
+            val element = path.referenceNameElement ?: return
             holder.createErrorAnnotation(
-                path.referenceNameElement,
+                element,
                 "Invalid path: self and super are allowed only at the beginning"
             )
             return

--- a/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
@@ -39,7 +39,7 @@ class RsUnsafeExpressionAnnotator : AnnotatorBase() {
         if (expr.isInUnsafeBlockOrFn(/* skip the expression itself*/ 1)) {
             val textRange = when (expr) {
                 is RsCallExpr -> when (val callee = expr.expr) {
-                    is RsPathExpr -> callee.path.textRangeOfLastSegment
+                    is RsPathExpr -> callee.path.textRangeOfLastSegment ?: return
                     else -> callee.textRange
                 }
                 is RsDotExpr -> when (val call = expr.methodCall) {
@@ -62,7 +62,8 @@ class RsUnsafeExpressionAnnotator : AnnotatorBase() {
         }
 
         if (expr.isInUnsafeBlockOrFn()) {
-            holder.holder.createUnsafeAnnotation(expr.path.textRangeOfLastSegment, "Use of unsafe $constantType static")
+            val textRange = expr.path.textRangeOfLastSegment ?: return
+            holder.holder.createUnsafeAnnotation(textRange, "Use of unsafe $constantType static")
         } else {
             RsDiagnostic.UnsafeError(expr, "Use of $constantType static is unsafe and requires unsafe function or block")
                 .addToHolder(holder)

--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -22,11 +22,9 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyPrimitive
 import org.rust.lang.core.types.type
 import org.rust.lang.doc.RsDocRenderMode
-import org.rust.lang.doc.docElements
 import org.rust.lang.doc.documentationAsHtml
 import org.rust.openapiext.escaped
 import org.rust.stdext.joinToWithBuffer
-import java.util.function.Consumer
 
 @Suppress("UnstableApiUsage")
 class RsDocumentationProvider : AbstractDocumentationProvider() {
@@ -429,7 +427,7 @@ private fun generatePathDocumentation(element: RsPath, buffer: StringBuilder) {
     }
     element.typeQual?.generateDocumentation(buffer)
 
-    val name = element.referenceName
+    val name = element.referenceName.orEmpty()
     if (element.isLinkNeeded()) {
         createLink(buffer, element.link(), name)
     } else {
@@ -506,7 +504,7 @@ private fun RsPath.isLinkNeeded(): Boolean {
 private fun RsPath.link(): String {
     val path = path
     val prefix = if (path != null) "${path.text.escaped}::" else typeQual?.text?.escaped
-    return if (prefix != null) "$prefix$referenceName" else referenceName
+    return if (prefix != null) "$prefix${referenceName.orEmpty()}" else referenceName.orEmpty()
 }
 
 private fun createLink(buffer: StringBuilder, refText: String, text: String) {

--- a/src/main/kotlin/org/rust/ide/highlight/RsRainbowVisitor.kt
+++ b/src/main/kotlin/org/rust/ide/highlight/RsRainbowVisitor.kt
@@ -9,7 +9,10 @@ import com.intellij.codeInsight.daemon.RainbowVisitor
 import com.intellij.codeInsight.daemon.impl.HighlightVisitor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsPatBinding
+import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.ext.descendantsOfType
 
 class RsRainbowVisitor : RainbowVisitor() {
@@ -39,7 +42,8 @@ class RsRainbowVisitor : RainbowVisitor() {
         for (path in function.descendantsOfType<RsPath>()) {
             val target = path.reference?.resolve() as? RsPatBinding ?: continue
             val colorTag = bindingToUniqueName[target] ?: return
-            addInfo(path.referenceNameElement, colorTag)
+            val ident = path.referenceNameElement ?: return
+            addInfo(ident, colorTag)
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
@@ -16,10 +16,7 @@ import org.rust.lang.core.psi.RsMetaItem
 import org.rust.lang.core.psi.RsMethodCall
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.RsVisitor
-import org.rust.lang.core.psi.ext.RsReferenceElement
-import org.rust.lang.core.psi.ext.ancestorStrict
-import org.rust.lang.core.psi.ext.isUnresolved
-import org.rust.lang.core.psi.ext.qualifier
+import org.rust.lang.core.psi.ext.*
 import javax.swing.JComponent
 
 class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
@@ -37,7 +34,7 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
                 // Don't show unresolved reference error in attributes for now
                 if (path.ancestorStrict<RsMetaItem>() != null) return
 
-                val isPathUnresolved = path.isUnresolved
+                val isPathUnresolved = path.resolveStatus != PathResolveStatus.RESOLVED
                 val qualifier = path.qualifier
 
                 val context = when {
@@ -45,7 +42,7 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
                     qualifier != null && isPathUnresolved -> {
                         // There is not sense to highlight path as unresolved
                         // if qualifier cannot be resolved as well
-                        if (qualifier.isUnresolved) return
+                        if (qualifier.resolveStatus != PathResolveStatus.RESOLVED) return
                         null
                     }
                     // Despite the fact that path is (multi)resolved by our resolve engine, it can be unresolved from

--- a/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/import/AutoImportFix.kt
@@ -79,7 +79,7 @@ class AutoImportFix(element: RsElement, private val type: Type) : LocalQuickFixO
             if (path.reference == null) return null
 
             val basePath = path.basePath()
-            if (!basePath.isUnresolved) return null
+            if (basePath.resolveStatus != PathResolveStatus.UNRESOLVED) return null
 
             if (path.ancestorStrict<RsUseSpeck>() != null) {
                 // Don't try to import path in use item
@@ -87,7 +87,9 @@ class AutoImportFix(element: RsElement, private val type: Type) : LocalQuickFixO
                 return null
             }
 
-            val isNameInScope = path.hasInScope(basePath.referenceName, TYPES_N_VALUES)
+            val referenceName = basePath.referenceName ?: return null
+
+            val isNameInScope = path.hasInScope(referenceName, TYPES_N_VALUES)
             if (isNameInScope) {
                 // Don't import names that are already in scope but cannot be resolved
                 // because namespace of psi element prevents correct name resolution.
@@ -99,7 +101,7 @@ class AutoImportFix(element: RsElement, private val type: Type) : LocalQuickFixO
             val superPath = path.rootPath()
             val candidates = ImportCandidatesCollector.getImportCandidates(
                 ImportContext.from(project, path, false),
-                basePath.referenceName,
+                referenceName,
                 superPath.text
             ) {
                 superPath != basePath || !(it.item is RsMod || it.item is RsModDeclItem || it.item.parent is RsMembers)

--- a/src/main/kotlin/org/rust/ide/intentions/AddCurlyBracesIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddCurlyBracesIntention.kt
@@ -49,11 +49,11 @@ class AddCurlyBracesIntention : RsElementBaseIntentionAction<AddCurlyBracesInten
     }
 
     override fun invoke(project: Project, editor: Editor, ctx: Context) {
-        val identifier = ctx.path.referenceNameElement
+        val identifier = ctx.path.referenceNameElement?.text ?: ""
 
         // Create a new use item that contains a glob list that we can use.
         // Then extract from it the glob list and the double colon.
-        val newUseSpeck = RsPsiFactory(project).createUseSpeck("dummy::{${identifier.text}}")
+        val newUseSpeck = RsPsiFactory(project).createUseSpeck("dummy::{$identifier}")
         val newGroup = newUseSpeck.useGroup ?: return
         val newColonColon = newUseSpeck.coloncolon ?: return
 

--- a/src/main/kotlin/org/rust/ide/intentions/AddImportIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddImportIntention.kt
@@ -31,7 +31,7 @@ class AddImportIntention : RsElementBaseIntentionAction<AddImportIntention.Conte
         val importablePath = path.findImportablePath() ?: return null
         if (importablePath.kind != PathKind.IDENTIFIER ||
             importablePath.reference == null ||
-            importablePath.isUnresolved) return null
+            importablePath.resolveStatus != PathResolveStatus.RESOLVED) return null
 
         // ignore paths that cannot be shortened
         if (importablePath.path == null) return null
@@ -40,7 +40,7 @@ class AddImportIntention : RsElementBaseIntentionAction<AddImportIntention.Conte
         val namespace = target.namespaces
 
         // check if the name is already in scope in the same namespace
-        val existingItem = importablePath.findInScope(importablePath.referenceName, namespace)
+        val existingItem = importablePath.findInScope(importablePath.referenceName ?: return null, namespace)
         val sameReference = target == existingItem
 
         // if name exists, but is a different type, exit
@@ -117,7 +117,7 @@ private fun RsPath.findImportablePath(): RsPath? {
 }
 
 private fun RsPath.generateUsePath(): String = generateSequence(this) { it.path }
-    .map { it.referenceName }
+    .map { it.referenceName.orEmpty() }
     .toList()
     .asReversed()
     .joinToString("::")

--- a/src/main/kotlin/org/rust/ide/intentions/CreateFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/CreateFunctionIntention.kt
@@ -60,11 +60,11 @@ class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionInten
         val path = element.parentOfType<RsPath>()
         val functionCall = path?.parentOfType<RsCallExpr>()
         if (functionCall != null) {
-            if (!path.isUnresolved) return null
+            if (path.resolveStatus != PathResolveStatus.UNRESOLVED) return null
             if (!functionCall.expr.isAncestorOf(path)) return null
 
             val module = getTargetModuleForFunction(path) ?: return null
-            val name = path.referenceName
+            val name = path.referenceName ?: return null
             text = "Create function `$name`"
             return Context.Function(functionCall, name, module)
         }

--- a/src/main/kotlin/org/rust/ide/intentions/NestUseStatementsIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/NestUseStatementsIntention.kt
@@ -186,8 +186,8 @@ fun getBasePathFromPath(path: RsPath): String {
     val basePathColoncolon = basePath.coloncolon
 
     return if (basePathColoncolon != null) {
-        "::${basePath.referenceName}"
+        "::${basePath.referenceName.orEmpty()}"
     } else {
-        basePath.referenceName
+        basePath.referenceName.orEmpty()
     }
 }

--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRendering.kt
@@ -151,7 +151,7 @@ private fun StringBuilder.appendTypeReference(ref: RsTypeReference, subst: Subst
 }
 
 private fun StringBuilder.appendPath(path: RsPath, subst: Substitution, renderLifetimes: Boolean) {
-    append(path.referenceName)
+    append(path.referenceName.orEmpty())
     val inAngles = path.typeArgumentList // Foo<...>
     val fnSugar = path.valueParameterList // &dyn FnOnce(...) -> i32
     if (inAngles != null) {

--- a/src/main/kotlin/org/rust/ide/refactoring/RsNameSuggestions.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsNameSuggestions.kt
@@ -112,5 +112,11 @@ private fun findNamesInLocalScope(expr: PsiElement): Set<String> {
     // Existing names should not be shadowed.
     // For example, see https://github.com/intellij-rust/intellij-rust/issues/2919
     return PsiTreeUtil.findChildrenOfAnyType(functionScope, RsPatBinding::class.java, RsPath::class.java)
-        .mapNotNullToSet { (it as? RsPath)?.referenceName ?: (it as RsPatBinding).name }
+        .mapNotNullToSet {
+            when (it) {
+                is RsPath -> it.referenceName
+                is RsPatBinding -> it.name
+                else -> null
+            }
+        }
 }

--- a/src/main/kotlin/org/rust/ide/todo/RsTodoSearcher.kt
+++ b/src/main/kotlin/org/rust/ide/todo/RsTodoSearcher.kt
@@ -44,7 +44,7 @@ class RsTodoSearcher : QueryExecutorBase<IndexPatternOccurrence, IndexPatternSea
             override fun visitMacroCall(call: RsMacroCall) {
                 super.visitMacroCall(call)
                 if (call.macroName == "todo") {
-                    val startOffset = call.path.referenceNameElement.startOffset
+                    val startOffset = call.path.referenceNameElement?.startOffset ?: return
                     val endOffset = call.semicolon?.startOffset ?: call.endOffset
                     val range = TextRange(startOffset, endOffset)
                     consumer.process(RsTodoOccurrence(file, range, pattern))

--- a/src/main/kotlin/org/rust/lang/core/completion/lint/RsLintCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/lint/RsLintCompletionProvider.kt
@@ -80,7 +80,7 @@ abstract class RsLintCompletionProvider : RsCompletionProvider() {
 
     protected fun getPathPrefix(path: RsPath): String {
         val qualifier = path.qualifier ?: return ""
-        return "${getPathPrefix(qualifier)}${qualifier.referenceName}::"
+        return "${getPathPrefix(qualifier)}${qualifier.referenceName.orEmpty()}::"
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -426,7 +426,7 @@ object ExpansionPipeline {
 
             val expansion = MacroExpansionSharedCache.getInstance().cachedExpand(expander, def, call)
             if (expansion == null) {
-                MACRO_LOG.debug("Failed to expand macro: `${call.path.referenceName}!(${call.macroBody})`")
+                MACRO_LOG.debug("Failed to expand macro: `${call.path.referenceName.orEmpty()}!(${call.macroBody})`")
                 return nextStageFail(callHash, defHash)
             }
 
@@ -455,7 +455,7 @@ object ExpansionPipeline {
             Stage2Fail(info, callHash, defHash)
 
         override fun toString(): String =
-            "ExpansionPipeline.Stage1(call=${call.path.referenceName}!(${call.macroBody}))"
+            "ExpansionPipeline.Stage1(call=${call.path.referenceName.orEmpty()}!(${call.macroBody}))"
     }
 
     class Stage2Ok(

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
@@ -94,6 +94,6 @@ class RustParserDefinition : ParserDefinition {
         /**
          * Should be increased after any change of parser rules
          */
-        const val PARSER_VERSION: Int = LEXER_VERSION + 17
+        const val PARSER_VERSION: Int = LEXER_VERSION + 18
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -44,7 +44,7 @@ abstract class RsMacroCallImplMixin : RsStubbedElementImpl<RsMacroCallStub>,
 }
 
 val RsMacroCall.macroName: String
-    get() = path.referenceName
+    get() = path.referenceName.orEmpty() // TODO return null if `referenceName` is null
 
 val RsMacroCall.bracesKind: MacroBraces?
     get() = macroArgumentElement?.firstChild?.let { MacroBraces.fromToken(it.elementType) }
@@ -186,7 +186,7 @@ fun RsMacroCall.expandMacrosRecursively(depthLimit: Int, replaceDollarCrate: Boo
                 && element.qualifier == null && element.typeQual == null && !element.hasColonColon) {
                 // Replace `$crate` to a crate name. Note that the name can be incorrect because of crate renames
                 // and the fact that `$crate` can come from a transitive dependency
-                "::" + (element.resolveDollarCrateIdentifier()?.normName ?: element.referenceName)
+                "::" + (element.resolveDollarCrateIdentifier()?.normName ?: element.referenceName.orEmpty())
             } else {
                 element.childrenWithLeaves.joinToString(" ") { toExpandedText(it) }
             }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
@@ -23,7 +23,8 @@ val RsMetaItem.id: String?
         .asIterable()
         .reversed()
         .takeIf { it.isNotEmpty() }
-        ?.joinToString("::") { it.referenceName }
+        ?.map { it.referenceName ?: return null }
+        ?.joinToString("::")
 
 val RsMetaItem.value: String? get() = litExpr?.stringValue
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPathReferenceElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPathReferenceElement.kt
@@ -12,8 +12,8 @@ import org.rust.lang.core.resolve.ref.RsPathReference
 interface RsPathReferenceElement : RsReferenceElement {
     override fun getReference(): RsPathReference?
 
-    override val referenceNameElement: PsiElement
+    override val referenceNameElement: PsiElement?
 
     @JvmDefault
-    override val referenceName: String get() = referenceNameElement.unescapedText
+    override val referenceName: String? get() = referenceNameElement?.unescapedText
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -80,9 +80,10 @@ fun <T : ScopeEntry> createProcessorGeneric(
 typealias RsMethodResolveProcessor = RsResolveProcessorBase<MethodResolveVariant>
 
 fun collectPathResolveVariants(
-    referenceName: String,
+    referenceName: String?,
     f: (RsResolveProcessor) -> Unit
 ): List<BoundElement<RsElement>> {
+    if (referenceName == null) return emptyList()
     val result = SmartList<BoundElement<RsElement>>()
     val processor = createProcessor(referenceName) { e ->
         if ((e == ScopeEvent.STAR_IMPORTS) && result.isNotEmpty()) {
@@ -101,7 +102,8 @@ fun collectPathResolveVariants(
     return result
 }
 
-fun collectResolveVariants(referenceName: String, f: (RsResolveProcessor) -> Unit): List<RsElement> {
+fun collectResolveVariants(referenceName: String?, f: (RsResolveProcessor) -> Unit): List<RsElement> {
+    if (referenceName == null) return emptyList()
     val result = SmartList<RsElement>()
     val processor = createProcessor(referenceName) { e ->
         if (e == ScopeEvent.STAR_IMPORTS && result.isNotEmpty()) return@createProcessor true
@@ -119,9 +121,10 @@ fun collectResolveVariants(referenceName: String, f: (RsResolveProcessor) -> Uni
 }
 
 fun <T : ScopeEntry> collectResolveVariantsAsScopeEntries(
-    referenceName: String,
+    referenceName: String?,
     f: (RsResolveProcessorBase<T>) -> Unit
 ): List<T> {
+    if (referenceName == null) return emptyList()
     val result = mutableListOf<T>()
     val processor = createProcessorGeneric<T>(referenceName) { e ->
         if ((e == ScopeEvent.STAR_IMPORTS) && result.isNotEmpty()) {
@@ -141,7 +144,8 @@ fun <T : ScopeEntry> collectResolveVariantsAsScopeEntries(
     return result
 }
 
-fun pickFirstResolveVariant(referenceName: String, f: (RsResolveProcessor) -> Unit): RsElement? {
+fun pickFirstResolveVariant(referenceName: String?, f: (RsResolveProcessor) -> Unit): RsElement? {
+    if (referenceName == null) return null
     var result: RsElement? = null
     val processor = createProcessor(referenceName) { e ->
         if (e.name == referenceName) {

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsDeriveTraitReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsDeriveTraitReferenceImpl.kt
@@ -19,7 +19,7 @@ class RsDeriveTraitReferenceImpl(
     RsPathReference {
 
     override fun resolveInner(): List<RsElement> {
-        val traitName = element.referenceName
+        val traitName = element.referenceName ?: return emptyList()
         return collectResolveVariants(traitName) { processDeriveTraitResolveVariants(element, traitName, it) }
     }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -186,7 +186,7 @@ private fun RsMacroCall.resolveToMacroDefInfo(containingModInfo: RsModInfo): Mac
 
 private val RsMacroCall.pathSegments: List<String>
     get() = generateSequence(path) { it.path }
-        .map { it.referenceName }
+        .map { it.referenceName.orEmpty() }
         .toMutableList()
         .also { it.reverse() }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
@@ -138,7 +138,7 @@ class ModCollectorBase private constructor(
         val isCallDeeplyEnabledByCfg = isDeeplyEnabledByCfg && call.isEnabledByCfgSelf(crate)
         if (!isCallDeeplyEnabledByCfg) return
         val body = call.getIncludeMacroArgument(crate) ?: call.macroBody ?: return
-        val path = call.getPathWithAdjustedDollarCrate()
+        val path = call.getPathWithAdjustedDollarCrate() ?: return
         val callLight = MacroCallLight(path, body, call.bodyHash)
         visitor.collectMacroCall(callLight, call)
     }
@@ -232,7 +232,7 @@ sealed class VisibilityLight : Writeable {
                 RsVisStubKind.PUB -> Public
                 RsVisStubKind.CRATE -> RestrictedCrate
                 RsVisStubKind.RESTRICTED -> {
-                    val path = vis.getRestrictedPath()
+                    val path = vis.getRestrictedPath() ?: return RestrictedCrate
                     val pathSingle = path.singleOrNull()
                     if (path.isEmpty() || pathSingle == "crate") return RestrictedCrate
                     if (pathSingle == "self") return Private

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -978,7 +978,7 @@ class RsAliasStub(
 
 class RsPathStub(
     parent: StubElement<*>?, elementType: IStubElementType<*, *>,
-    val referenceName: String,
+    val referenceName: String?,
     val hasColonColon: Boolean,
     val kind: PathKind,
     val startOffset: Int
@@ -998,7 +998,7 @@ class RsPathStub(
 
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
             RsPathStub(parentStub, this,
-                dataStream.readName()!!.string,
+                dataStream.readName()?.string,
                 dataStream.readBoolean(),
                 dataStream.readEnum(),
                 dataStream.readVarInt()

--- a/src/main/kotlin/org/rust/lang/core/types/TyFingerprint.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/TyFingerprint.kt
@@ -35,6 +35,7 @@ data class TyFingerprint constructor(
                     RsBaseTypeKind.Never -> TyFingerprint("!")
                     RsBaseTypeKind.Underscore -> return emptyList()
                     is RsBaseTypeKind.Path -> when (val name = kind.path.referenceName) {
+                        null -> return emptyList()
                         in typeParameters -> TYPE_PARAMETER_FINGERPRINT
                         in TyInteger.NAMES -> return listOf(TyFingerprint(name), ANY_INTEGER_FINGERPRINT)
                         in TyFloat.NAMES -> return listOf(TyFingerprint(name), ANY_FLOAT_FINGERPRINT)

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyPrimitive.kt
@@ -22,7 +22,7 @@ abstract class TyPrimitive : Ty() {
     companion object {
         fun fromPath(path: RsPath): TyPrimitive? {
             if (path.hasColonColon) return null
-            val name = path.referenceName
+            val name = path.referenceName ?: return null
 
             TyInteger.fromName(name)?.let { return it }
             TyFloat.fromName(name)?.let { return it }

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -187,6 +187,15 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         }
     """)
 
+    fun `test no unresolved reference for a path after incomplete path 1`() = checkByText("""
+        use <error descr="Unresolved reference: `foo`">foo</error>::<error descr="Self, crate, identifier, self or super expected, got '::'">:</error>:bar;
+    """, false)
+
+    fun `test no unresolved reference for a path after incomplete path 2`() = checkByText("""
+        mod foo {}
+        use foo::<error descr="Self, crate, identifier, self or super expected, got '::'">:</error>:bar;
+    """, false)
+
     private fun checkByText(@Language("Rust") text: String, ignoreWithoutQuickFix: Boolean) {
         val inspection = inspection as RsUnresolvedReferenceInspection
         val defaultValue = inspection.ignoreWithoutQuickFix

--- a/src/test/kotlin/org/rust/ide/intentions/AddCurlyBracesIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddCurlyBracesIntentionTest.kt
@@ -45,4 +45,9 @@ class AddCurlyBracesIntentionTest : RsIntentionTestBase(AddCurlyBracesIntention:
     fun `test not available for star imports`() = doUnavailableTest("""
         use foo::*/*caret*/;
     """)
+
+    fun `test without last path segment`() = doAvailableTest(
+        "use std::/*caret*/;",
+        "use std::{/*caret*/};"
+    )
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
@@ -5,8 +5,10 @@
 
 package org.rust.lang.core.completion
 
+import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.cargo.project.workspace.CargoWorkspace
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsStdlibCompletionTest : RsCompletionTestBase() {
@@ -80,6 +82,11 @@ class RsStdlibCompletionTest : RsCompletionTestBase() {
         fn main() { std::stringif/*caret*/ }
     """, """
         fn main() { std::stringify!(/*caret*/) }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
+    fun `test complete all in std in 'use' in crate root`() = checkContainsCompletion("vec", """
+        use std::/*caret*/;
     """)
 }
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsStubOnlyCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsStubOnlyCompletionTest.kt
@@ -5,6 +5,11 @@
 
 package org.rust.lang.core.completion
 
+import org.rust.MockEdition
+import org.rust.ProjectDescriptor
+import org.rust.WithDependencyRustProjectDescriptor
+import org.rust.cargo.project.workspace.CargoWorkspace
+
 class RsStubOnlyCompletionTest : RsCompletionTestBase() {
     fun `test function`() = doSingleCompletionByFileTree("""
     //- foo.rs
@@ -50,5 +55,18 @@ class RsStubOnlyCompletionTest : RsCompletionTestBase() {
     """, """
         mod foo;
         fn bar(s: foo::S) { s.field/*caret*/ }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test complete all in extern crate in 'use' in crate root`() = doSingleCompletionByFileTree("""
+    //- lib.rs
+        pub fn foo() {}
+    //- main.rs
+        extern crate test_package;
+        use test_package::/*caret*/;
+    """, """
+        extern crate test_package;
+        use test_package::foo/*caret*/;
     """)
 }

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachingTest.kt
@@ -50,10 +50,10 @@ class RsMacroExpansionCachingTest : RsMacroExpansionTestBase() {
 
     private fun List<RsMacroCall>.collectStamps(): Map<String, Long> =
         associate {
-            val expansion = it.expansion ?: error("failed to expand macro ${it.path.referenceName}!")
-            val first = expansion.elements.firstOrNull() ?: error("Macro expanded to empty ${it.path.referenceName}!")
+            val expansion = it.expansion ?: error("failed to expand macro ${it.path.referenceName.orEmpty()}!")
+            val first = expansion.elements.firstOrNull() ?: error("Macro expanded to empty ${it.path.referenceName.orEmpty()}!")
             check(first.isValid)
-            it.path.referenceName to expansion.file.virtualFile.timeStamp
+            it.path.referenceName.orEmpty() to expansion.file.virtualFile.timeStamp
         }
 
     private fun PsiFile.collectMacros(): List<RsMacroCall> {

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachingToolchainTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachingToolchainTest.kt
@@ -73,8 +73,8 @@ class RsMacroExpansionCachingToolchainTest : RsWithToolchainTestBase() {
 
     private fun List<RsMacroCall>.collectStamps(): Map<String, Long> =
         associate {
-            val expansion = it.expansion ?: error("failed to expand macro ${it.path.referenceName}!")
-            it.path.referenceName to expansion.file.virtualFile.timeStamp
+            val expansion = it.expansion ?: error("failed to expand macro ${it.path.referenceName.orEmpty()}!")
+            it.path.referenceName.orEmpty() to expansion.file.virtualFile.timeStamp
         }
 
     private fun checkReExpanded(action: (p: TestProject) -> Unit, @Language("Rust") code: String, vararg names: String) {

--- a/src/test/kotlin/org/rust/lang/core/parser/RsPartialParsingTestCase.kt
+++ b/src/test/kotlin/org/rust/lang/core/parser/RsPartialParsingTestCase.kt
@@ -30,6 +30,7 @@ class RsPartialParsingTestCase : RsParsingTestCaseBase("partial") {
     fun `test macros`() = doTest(true)
     fun `test exprs`() = doTest(true)
     fun `test bounds`() = doTest(true)
+    fun `test paths`() = doTest(true)
 
     override fun checkResult(targetDataName: String, file: PsiFile) {
         check(hasError(file)) {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
@@ -863,4 +863,19 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
             () => { use Foo as Bar; };
         }
     """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test expand macro with incomplete path`() = stubOnlyResolve("""
+    //- main.rs
+        macro_rules! gen_func {
+            () => { fn func() {} };
+        }
+
+        gen_func::!();
+
+        fn main() {
+            // here we just check that incomplete path doesn't cause exceptions
+            func();
+        } //^ unresolved
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -1344,6 +1344,20 @@ class RsResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test 'pub (in incomplete_path)'`() = checkByCode("""
+        mod foo {
+            mod bar {
+                pub(in foo::) fn baz() {}
+                               //X
+                fn main() {
+                    // here we just check that incomplete path doesn't cause exceptions
+                    baz();
+                } //^
+            }
+        }
+    """)
+
     fun `test 'pub (self)'`() = checkByCode("""
         mod bar {
           //X

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
@@ -726,4 +726,19 @@ class RsUseResolveTest : RsResolveTestBase() {
                      //^
         }
     """)
+
+    @MockEdition(Edition.EDITION_2018)
+    fun `test use incomplete path`() = checkByCode("""
+        use foo::;
+        mod foo {
+            pub fn func() {}
+        }
+
+        fn func() {}
+         //X
+        fn main() {
+            // here we just check that incomplete path doesn't cause exceptions
+            func();
+        } //^
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt
@@ -262,6 +262,22 @@ class RsStubTest : RsTestBase() {
               LIT_EXPR:RsLitExprStub
     """)
 
+    fun `test incomplete paths`() = doTest("""
+        use foo::;
+        use foo::::bar;
+    """, """
+        RsFileStub
+          USE_ITEM:RsUseItemStub
+            USE_SPECK:RsUseSpeckStub
+              PATH:RsPathStub
+                PATH:RsPathStub
+          USE_ITEM:RsUseItemStub
+            USE_SPECK:RsUseSpeckStub
+              PATH:RsPathStub
+                PATH:RsPathStub
+                  PATH:RsPathStub
+    """)
+
     private fun doTest(@Language("Rust") code: String, expectedStubText: String) {
         val fileName = "main.rs"
         fileTreeFromText("//- $fileName\n$code").create()

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/partial/paths.rs
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/partial/paths.rs
@@ -1,0 +1,17 @@
+use ::;
+use ::::;
+use foo::;
+use foo::::;
+use foo::::bar;
+use foo::bar::;
+
+fn foo() {
+    ::;
+    ::::;
+    Foo::;
+    Foo::::;
+    Foo::::bar;
+    Foo::bar::;
+    Foo::<bar>::;
+    Foo::<bar::>::baz;
+}

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/partial/paths.txt
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/partial/paths.txt
@@ -19,33 +19,11 @@ FILE
     PsiWhiteSpace(' ')
     RsUseSpeckImpl(USE_SPECK)
       RsPathImpl(PATH)
-        PsiElement(identifier)('foo')
-  PsiElement(::)('::')
-  PsiErrorElement:'*', Self, crate, identifier, self, super or '{' expected, got ';'
-    PsiElement(;)(';')
-  PsiWhiteSpace('\n')
-  RsUseItemImpl(USE_ITEM)
-    PsiElement(use)('use')
-    PsiWhiteSpace(' ')
-    RsUseSpeckImpl(USE_SPECK)
-      RsPathImpl(PATH)
-        PsiElement(identifier)('foo')
-  PsiElement(::)('::')
-  PsiErrorElement:'*', Self, crate, identifier, self, super or '{' expected, got '::'
-    PsiElement(::)('::')
-  PsiElement(;)(';')
-  PsiWhiteSpace('\n')
-  RsUseItemImpl(USE_ITEM)
-    PsiElement(use)('use')
-    PsiWhiteSpace(' ')
-    RsUseSpeckImpl(USE_SPECK)
-      RsPathImpl(PATH)
-        PsiElement(identifier)('foo')
-  PsiElement(::)('::')
-  PsiErrorElement:'*', Self, crate, identifier, self, super or '{' expected, got '::'
-    PsiElement(::)('::')
-  PsiElement(identifier)('bar')
-  PsiErrorElement:'!' or '::' expected, got ';'
+        RsPathImpl(PATH)
+          PsiElement(identifier)('foo')
+        PsiElement(::)('::')
+        PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+          <empty list>
     PsiElement(;)(';')
   PsiWhiteSpace('\n')
   RsUseItemImpl(USE_ITEM)
@@ -54,11 +32,44 @@ FILE
     RsUseSpeckImpl(USE_SPECK)
       RsPathImpl(PATH)
         RsPathImpl(PATH)
-          PsiElement(identifier)('foo')
+          RsPathImpl(PATH)
+            PsiElement(identifier)('foo')
+          PsiElement(::)('::')
+          PsiErrorElement:Self, crate, identifier, self or super expected, got '::'
+            <empty list>
+        PsiElement(::)('::')
+        PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+          <empty list>
+    PsiElement(;)(';')
+  PsiWhiteSpace('\n')
+  RsUseItemImpl(USE_ITEM)
+    PsiElement(use)('use')
+    PsiWhiteSpace(' ')
+    RsUseSpeckImpl(USE_SPECK)
+      RsPathImpl(PATH)
+        RsPathImpl(PATH)
+          RsPathImpl(PATH)
+            PsiElement(identifier)('foo')
+          PsiElement(::)('::')
+          PsiErrorElement:Self, crate, identifier, self or super expected, got '::'
+            <empty list>
         PsiElement(::)('::')
         PsiElement(identifier)('bar')
-  PsiElement(::)('::')
-  PsiErrorElement:'*', Self, crate, identifier, self, super or '{' expected, got ';'
+    PsiElement(;)(';')
+  PsiWhiteSpace('\n')
+  RsUseItemImpl(USE_ITEM)
+    PsiElement(use)('use')
+    PsiWhiteSpace(' ')
+    RsUseSpeckImpl(USE_SPECK)
+      RsPathImpl(PATH)
+        RsPathImpl(PATH)
+          RsPathImpl(PATH)
+            PsiElement(identifier)('foo')
+          PsiElement(::)('::')
+          PsiElement(identifier)('bar')
+        PsiElement(::)('::')
+        PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+          <empty list>
     PsiElement(;)(';')
   PsiWhiteSpace('\n\n')
   RsFunctionImpl(FUNCTION)
@@ -90,42 +101,36 @@ FILE
       RsExprStmtImpl(EXPR_STMT)
         RsPathExprImpl(PATH_EXPR)
           RsPathImpl(PATH)
-            PsiElement(identifier)('Foo')
-        PsiErrorElement:'!', '(', '::', ';', <, <operator>, '[' or '{' expected, got '::'
-          <empty list>
-      PsiElement(::)('::')
-      PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
-        <empty list>
-      RsEmptyStmtImpl(EMPTY_STMT)
+            RsPathImpl(PATH)
+              PsiElement(identifier)('Foo')
+            PsiElement(::)('::')
+            PsiErrorElement:'!', '::', <, Self, crate, identifier, self, super or '{' expected, got ';'
+              <empty list>
         PsiElement(;)(';')
       PsiWhiteSpace('\n    ')
       RsExprStmtImpl(EXPR_STMT)
         RsPathExprImpl(PATH_EXPR)
           RsPathImpl(PATH)
-            PsiElement(identifier)('Foo')
-        PsiErrorElement:'!', '(', '::', ';', <, <operator>, '[' or '{' expected, got '::'
-          <empty list>
-      PsiElement(::)('::')
-      PsiErrorElement:Self, crate, identifier, self or super expected, got '::'
-        <empty list>
-      PsiElement(::)('::')
-      PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
-        <empty list>
-      RsEmptyStmtImpl(EMPTY_STMT)
+            RsPathImpl(PATH)
+              RsPathImpl(PATH)
+                PsiElement(identifier)('Foo')
+              PsiElement(::)('::')
+              PsiErrorElement:'::', <, Self, crate, identifier, self or super expected, got '::'
+                <empty list>
+            PsiElement(::)('::')
+            PsiErrorElement:'!', '::', <, Self, crate, identifier, self, super or '{' expected, got ';'
+              <empty list>
         PsiElement(;)(';')
       PsiWhiteSpace('\n    ')
       RsExprStmtImpl(EXPR_STMT)
         RsPathExprImpl(PATH_EXPR)
           RsPathImpl(PATH)
-            PsiElement(identifier)('Foo')
-        PsiErrorElement:'!', '(', '::', ';', <, <operator>, '[' or '{' expected, got '::'
-          <empty list>
-      PsiElement(::)('::')
-      PsiErrorElement:Self, crate, identifier, self or super expected, got '::'
-        <empty list>
-      RsExprStmtImpl(EXPR_STMT)
-        RsPathExprImpl(PATH_EXPR)
-          RsPathImpl(PATH)
+            RsPathImpl(PATH)
+              RsPathImpl(PATH)
+                PsiElement(identifier)('Foo')
+              PsiElement(::)('::')
+              PsiErrorElement:'::', <, Self, crate, identifier, self or super expected, got '::'
+                <empty list>
             PsiElement(::)('::')
             PsiElement(identifier)('bar')
         PsiElement(;)(';')
@@ -134,54 +139,48 @@ FILE
         RsPathExprImpl(PATH_EXPR)
           RsPathImpl(PATH)
             RsPathImpl(PATH)
-              PsiElement(identifier)('Foo')
+              RsPathImpl(PATH)
+                PsiElement(identifier)('Foo')
+              PsiElement(::)('::')
+              PsiElement(identifier)('bar')
             PsiElement(::)('::')
-            PsiElement(identifier)('bar')
-        PsiErrorElement:'!', '(', '::', ';', <, <operator>, '[' or '{' expected, got '::'
-          <empty list>
-      PsiElement(::)('::')
-      PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
-        <empty list>
-      RsEmptyStmtImpl(EMPTY_STMT)
+            PsiErrorElement:'!', '::', <, Self, crate, identifier, self, super or '{' expected, got ';'
+              <empty list>
         PsiElement(;)(';')
       PsiWhiteSpace('\n    ')
       RsExprStmtImpl(EXPR_STMT)
         RsPathExprImpl(PATH_EXPR)
           RsPathImpl(PATH)
-            PsiElement(identifier)('Foo')
-            RsTypeArgumentListImpl(TYPE_ARGUMENT_LIST)
-              PsiElement(::)('::')
-              PsiElement(<)('<')
-              RsBaseTypeImpl(BASE_TYPE)
-                RsPathImpl(PATH)
-                  PsiElement(identifier)('bar')
-              PsiElement(>)('>')
-        PsiErrorElement:'(', '::', ';', <operator>, '[' or '{' expected, got '::'
-          <empty list>
-      PsiElement(::)('::')
-      PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
-        <empty list>
-      RsEmptyStmtImpl(EMPTY_STMT)
+            RsPathImpl(PATH)
+              PsiElement(identifier)('Foo')
+              RsTypeArgumentListImpl(TYPE_ARGUMENT_LIST)
+                PsiElement(::)('::')
+                PsiElement(<)('<')
+                RsBaseTypeImpl(BASE_TYPE)
+                  RsPathImpl(PATH)
+                    PsiElement(identifier)('bar')
+                PsiElement(>)('>')
+            PsiElement(::)('::')
+            PsiErrorElement:'::', Self, crate, identifier, self, super or '{' expected, got ';'
+              <empty list>
         PsiElement(;)(';')
       PsiWhiteSpace('\n    ')
       RsExprStmtImpl(EXPR_STMT)
         RsPathExprImpl(PATH_EXPR)
           RsPathImpl(PATH)
-            PsiElement(identifier)('Foo')
-            RsTypeArgumentListImpl(TYPE_ARGUMENT_LIST)
-              PsiElement(::)('::')
-              PsiElement(<)('<')
-              RsBaseTypeImpl(BASE_TYPE)
-                RsPathImpl(PATH)
-                  PsiElement(identifier)('bar')
-              PsiErrorElement:'!', '#', '(', '+', ',', '-', ':', '::', <, <block expr>, <fn pointer type>, <path parameters>, <ref like type>, <trivial base type>, <type argument list>, <vis>, '=', '>', '?', QUOTE_IDENTIFIER, '[', for, identifier, impl or '{' expected, got '::'
-                <empty list>
-      PsiElement(::)('::')
-      PsiErrorElement:Self, crate, identifier, self or super expected, got '>'
-        PsiElement(>)('>')
-      RsExprStmtImpl(EXPR_STMT)
-        RsPathExprImpl(PATH_EXPR)
-          RsPathImpl(PATH)
+            RsPathImpl(PATH)
+              PsiElement(identifier)('Foo')
+              RsTypeArgumentListImpl(TYPE_ARGUMENT_LIST)
+                PsiElement(::)('::')
+                PsiElement(<)('<')
+                RsBaseTypeImpl(BASE_TYPE)
+                  RsPathImpl(PATH)
+                    RsPathImpl(PATH)
+                      PsiElement(identifier)('bar')
+                    PsiElement(::)('::')
+                    PsiErrorElement:'!', '(', '+', ',', '::', <, <path parameters>, <type argument list>, '>', Self, crate, identifier, self or super expected, got '>'
+                      <empty list>
+                PsiElement(>)('>')
             PsiElement(::)('::')
             PsiElement(identifier)('baz')
         PsiElement(;)(';')

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/partial/paths.txt
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/partial/paths.txt
@@ -1,0 +1,189 @@
+FILE
+  RsUseItemImpl(USE_ITEM)
+    PsiElement(use)('use')
+  PsiWhiteSpace(' ')
+  PsiElement(::)('::')
+  PsiErrorElement:'*', Self, crate, identifier, self, super or '{' expected, got ';'
+    PsiElement(;)(';')
+  PsiWhiteSpace('\n')
+  RsUseItemImpl(USE_ITEM)
+    PsiElement(use)('use')
+  PsiWhiteSpace(' ')
+  PsiElement(::)('::')
+  PsiErrorElement:'*', Self, crate, identifier, self, super or '{' expected, got '::'
+    PsiElement(::)('::')
+  PsiElement(;)(';')
+  PsiWhiteSpace('\n')
+  RsUseItemImpl(USE_ITEM)
+    PsiElement(use)('use')
+    PsiWhiteSpace(' ')
+    RsUseSpeckImpl(USE_SPECK)
+      RsPathImpl(PATH)
+        PsiElement(identifier)('foo')
+  PsiElement(::)('::')
+  PsiErrorElement:'*', Self, crate, identifier, self, super or '{' expected, got ';'
+    PsiElement(;)(';')
+  PsiWhiteSpace('\n')
+  RsUseItemImpl(USE_ITEM)
+    PsiElement(use)('use')
+    PsiWhiteSpace(' ')
+    RsUseSpeckImpl(USE_SPECK)
+      RsPathImpl(PATH)
+        PsiElement(identifier)('foo')
+  PsiElement(::)('::')
+  PsiErrorElement:'*', Self, crate, identifier, self, super or '{' expected, got '::'
+    PsiElement(::)('::')
+  PsiElement(;)(';')
+  PsiWhiteSpace('\n')
+  RsUseItemImpl(USE_ITEM)
+    PsiElement(use)('use')
+    PsiWhiteSpace(' ')
+    RsUseSpeckImpl(USE_SPECK)
+      RsPathImpl(PATH)
+        PsiElement(identifier)('foo')
+  PsiElement(::)('::')
+  PsiErrorElement:'*', Self, crate, identifier, self, super or '{' expected, got '::'
+    PsiElement(::)('::')
+  PsiElement(identifier)('bar')
+  PsiErrorElement:'!' or '::' expected, got ';'
+    PsiElement(;)(';')
+  PsiWhiteSpace('\n')
+  RsUseItemImpl(USE_ITEM)
+    PsiElement(use)('use')
+    PsiWhiteSpace(' ')
+    RsUseSpeckImpl(USE_SPECK)
+      RsPathImpl(PATH)
+        RsPathImpl(PATH)
+          PsiElement(identifier)('foo')
+        PsiElement(::)('::')
+        PsiElement(identifier)('bar')
+  PsiElement(::)('::')
+  PsiErrorElement:'*', Self, crate, identifier, self, super or '{' expected, got ';'
+    PsiElement(;)(';')
+  PsiWhiteSpace('\n\n')
+  RsFunctionImpl(FUNCTION)
+    PsiElement(fn)('fn')
+    PsiWhiteSpace(' ')
+    PsiElement(identifier)('foo')
+    RsValueParameterListImpl(VALUE_PARAMETER_LIST)
+      PsiElement(()('(')
+      PsiElement())(')')
+    PsiWhiteSpace(' ')
+    RsBlockImpl(BLOCK)
+      PsiElement({)('{')
+      PsiWhiteSpace('\n    ')
+      PsiElement(::)('::')
+      PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+        <empty list>
+      RsEmptyStmtImpl(EMPTY_STMT)
+        PsiElement(;)(';')
+      PsiWhiteSpace('\n    ')
+      PsiElement(::)('::')
+      PsiErrorElement:Self, crate, identifier, self or super expected, got '::'
+        <empty list>
+      PsiElement(::)('::')
+      PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+        <empty list>
+      RsEmptyStmtImpl(EMPTY_STMT)
+        PsiElement(;)(';')
+      PsiWhiteSpace('\n    ')
+      RsExprStmtImpl(EXPR_STMT)
+        RsPathExprImpl(PATH_EXPR)
+          RsPathImpl(PATH)
+            PsiElement(identifier)('Foo')
+        PsiErrorElement:'!', '(', '::', ';', <, <operator>, '[' or '{' expected, got '::'
+          <empty list>
+      PsiElement(::)('::')
+      PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+        <empty list>
+      RsEmptyStmtImpl(EMPTY_STMT)
+        PsiElement(;)(';')
+      PsiWhiteSpace('\n    ')
+      RsExprStmtImpl(EXPR_STMT)
+        RsPathExprImpl(PATH_EXPR)
+          RsPathImpl(PATH)
+            PsiElement(identifier)('Foo')
+        PsiErrorElement:'!', '(', '::', ';', <, <operator>, '[' or '{' expected, got '::'
+          <empty list>
+      PsiElement(::)('::')
+      PsiErrorElement:Self, crate, identifier, self or super expected, got '::'
+        <empty list>
+      PsiElement(::)('::')
+      PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+        <empty list>
+      RsEmptyStmtImpl(EMPTY_STMT)
+        PsiElement(;)(';')
+      PsiWhiteSpace('\n    ')
+      RsExprStmtImpl(EXPR_STMT)
+        RsPathExprImpl(PATH_EXPR)
+          RsPathImpl(PATH)
+            PsiElement(identifier)('Foo')
+        PsiErrorElement:'!', '(', '::', ';', <, <operator>, '[' or '{' expected, got '::'
+          <empty list>
+      PsiElement(::)('::')
+      PsiErrorElement:Self, crate, identifier, self or super expected, got '::'
+        <empty list>
+      RsExprStmtImpl(EXPR_STMT)
+        RsPathExprImpl(PATH_EXPR)
+          RsPathImpl(PATH)
+            PsiElement(::)('::')
+            PsiElement(identifier)('bar')
+        PsiElement(;)(';')
+      PsiWhiteSpace('\n    ')
+      RsExprStmtImpl(EXPR_STMT)
+        RsPathExprImpl(PATH_EXPR)
+          RsPathImpl(PATH)
+            RsPathImpl(PATH)
+              PsiElement(identifier)('Foo')
+            PsiElement(::)('::')
+            PsiElement(identifier)('bar')
+        PsiErrorElement:'!', '(', '::', ';', <, <operator>, '[' or '{' expected, got '::'
+          <empty list>
+      PsiElement(::)('::')
+      PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+        <empty list>
+      RsEmptyStmtImpl(EMPTY_STMT)
+        PsiElement(;)(';')
+      PsiWhiteSpace('\n    ')
+      RsExprStmtImpl(EXPR_STMT)
+        RsPathExprImpl(PATH_EXPR)
+          RsPathImpl(PATH)
+            PsiElement(identifier)('Foo')
+            RsTypeArgumentListImpl(TYPE_ARGUMENT_LIST)
+              PsiElement(::)('::')
+              PsiElement(<)('<')
+              RsBaseTypeImpl(BASE_TYPE)
+                RsPathImpl(PATH)
+                  PsiElement(identifier)('bar')
+              PsiElement(>)('>')
+        PsiErrorElement:'(', '::', ';', <operator>, '[' or '{' expected, got '::'
+          <empty list>
+      PsiElement(::)('::')
+      PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+        <empty list>
+      RsEmptyStmtImpl(EMPTY_STMT)
+        PsiElement(;)(';')
+      PsiWhiteSpace('\n    ')
+      RsExprStmtImpl(EXPR_STMT)
+        RsPathExprImpl(PATH_EXPR)
+          RsPathImpl(PATH)
+            PsiElement(identifier)('Foo')
+            RsTypeArgumentListImpl(TYPE_ARGUMENT_LIST)
+              PsiElement(::)('::')
+              PsiElement(<)('<')
+              RsBaseTypeImpl(BASE_TYPE)
+                RsPathImpl(PATH)
+                  PsiElement(identifier)('bar')
+              PsiErrorElement:'!', '#', '(', '+', ',', '-', ':', '::', <, <block expr>, <fn pointer type>, <path parameters>, <ref like type>, <trivial base type>, <type argument list>, <vis>, '=', '>', '?', QUOTE_IDENTIFIER, '[', for, identifier, impl or '{' expected, got '::'
+                <empty list>
+      PsiElement(::)('::')
+      PsiErrorElement:Self, crate, identifier, self or super expected, got '>'
+        PsiElement(>)('>')
+      RsExprStmtImpl(EXPR_STMT)
+        RsPathExprImpl(PATH_EXPR)
+          RsPathImpl(PATH)
+            PsiElement(::)('::')
+            PsiElement(identifier)('baz')
+        PsiElement(;)(';')
+      PsiWhiteSpace('\n')
+      PsiElement(})('}')


### PR DESCRIPTION
Works in the case of `foo::`.
Previous attempt - #4199