### PR TITLE
INSP: allow duplicate parameter bindings for trait methods without a body [E0415]

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsDuplicatedTraitMethodBindingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDuplicatedTraitMethodBindingInspection.kt
@@ -1,0 +1,46 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import com.intellij.psi.PsiElementVisitor
+import org.rust.ide.refactoring.findBinding
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsPatBinding
+import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.ext.RsAbstractableOwner
+import org.rust.lang.core.psi.ext.owner
+
+class RsDuplicatedTraitMethodBindingInspection : RsLocalInspectionTool() {
+    override fun getDisplayName() = "Duplicated trait method parameter binding"
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+        object : RsVisitor() {
+            override fun visitFunction(function: RsFunction) {
+                if (function.owner !is RsAbstractableOwner.Trait) return
+                if (!function.isAbstract) return
+
+                val parameters = function.valueParameterList ?: return
+                val bindings = mutableMapOf<String, MutableSet<RsPatBinding>>()
+                parameters.valueParameterList.forEach {
+                    val binding = it.pat?.findBinding() ?: return@forEach
+                    val name = binding.name ?: return@forEach
+                    val set = bindings.getOrPut(name) { mutableSetOf() }
+                    set.add(binding)
+                }
+
+                bindings
+                    .filter { it.value.size > 1 }
+                    .forEach { (_, bindings) ->
+                        bindings.forEach { binding ->
+                            holder.registerProblem(
+                                binding,
+                                "Duplicated parameter name `${binding.name}`. Consider renaming it"
+                            )
+                        }
+                    }
+            }
+        }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -564,6 +564,11 @@
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RsMissingFeaturesInspection"/>
 
+        <localInspection language="Rust" groupName="Rust"
+                         displayName="Duplicate trait method parameter name"
+                         enabledByDefault="true" level="WEAK WARNING"
+                         implementationClass="org.rust.ide.inspections.RsDuplicatedTraitMethodBindingInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsDuplicatedTraitMethodBinding.html
+++ b/src/main/resources/inspectionDescriptions/RsDuplicatedTraitMethodBinding.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Checks duplicated parameter names of abstract trait methods.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -618,6 +618,19 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
                   <error>a</error>: f64) {}
         fn tuples(<error>a</error>: u8, (b, (<error>a</error>, c)): (u16, (u32, u64))) {}
         fn fn_ptrs(x: i32, y: fn (x: i32, y: i32), z: fn (x: i32, x: i32)) {}
+
+        trait Foo {
+            fn foo(&self,
+                   <error descr="Identifier `x` is bound more than once in this parameter list [E0415]">x</error>: i32,
+                   <error descr="Identifier `x` is bound more than once in this parameter list [E0415]">x</error>: i32
+            ) {}
+        }
+    """)
+
+    fun `test name duplication in param list of non-default trait methods`() = checkErrors("""
+        trait Foo {
+            fn bar(x: i32, x: i32);
+        }
     """)
 
     fun `test undeclared label E0426`() = checkErrors("""

--- a/src/test/kotlin/org/rust/ide/inspections/RsDuplicatedTraitMethodBindingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsDuplicatedTraitMethodBindingInspectionTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import org.intellij.lang.annotations.Language
+
+class RsDuplicatedTraitMethodBindingInspectionTest : RsInspectionsTestBase(RsDuplicatedTraitMethodBindingInspection::class) {
+    fun `test duplicated`() = doTest("""
+        trait Foo {
+            fn bar(
+                <weak_warning descr="Duplicated parameter name `x`. Consider renaming it">x</weak_warning>: i32,
+                <weak_warning descr="Duplicated parameter name `x`. Consider renaming it">x</weak_warning>: i32
+            );
+        }
+    """)
+
+    fun `test not duplicated`() = doTest("""
+        trait Foo {
+            fn bar(x: i32, y: i32);
+        }
+    """)
+
+    fun `test trait method with body`() = doTest("""
+        trait Foo {
+            fn bar(x: i32, x: i32) {}
+        }
+    """)
+
+    fun `test impl method`() = doTest("""
+        struct S;
+        impl S {
+            fn bar(x: i32, x: i32);
+        }
+    """)
+
+    private fun doTest(@Language("Rust") code: String) = checkByText(code, checkWeakWarn = true)
+}


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/6191