### PR TITLE
T: Add additional resolve tests

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefMapService.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefMapService.kt
@@ -12,10 +12,12 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.ModificationTracker
 import com.intellij.openapi.vfs.VirtualFileWithId
+import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiTreeChangeEvent
+import org.jetbrains.annotations.TestOnly
 import org.rust.RsTask.TaskType.*
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.CargoProjectsService
@@ -276,6 +278,20 @@ class DefMapService(val project: Project) : Disposable {
                     }
                 }
                 else -> Unit
+            }
+        }
+    }
+
+    companion object {
+        var forceUseNewResolve: Boolean = false
+            private set
+
+        @TestOnly
+        fun setUseNewResolve(): Disposable {
+            check(isUnitTestMode)
+            forceUseNewResolve = true
+            return Disposable {
+                forceUseNewResolve = false
             }
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -27,6 +27,7 @@ import org.rust.openapiext.toPsiFile
 
 val isNewResolveEnabled: Boolean
     get() = isFeatureEnabled(RsExperiments.RESOLVE_NEW_ENGINE)
+        || DefMapService.forceUseNewResolve
 
 /** null return value means that new resolve can't be used */
 fun processItemDeclarations2(

--- a/src/test/kotlin/org/rust/NewResolve.kt
+++ b/src/test/kotlin/org/rust/NewResolve.kt
@@ -1,0 +1,10 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class UseNewResolve

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -40,6 +40,7 @@ import org.rust.cargo.toolchain.impl.RustcVersion
 import org.rust.lang.core.macros.findExpansionElements
 import org.rust.lang.core.macros.macroExpansionManager
 import org.rust.lang.core.psi.ext.startOffset
+import org.rust.lang.core.resolve2.DefMapService
 import org.rust.openapiext.saveAllDocuments
 import org.rust.stdext.BothEditions
 import kotlin.reflect.KMutableProperty0
@@ -72,6 +73,10 @@ abstract class RsTestBase : RsPlatformTestBase() {
         setupMockCfgOptions()
         findAnnotationInstance<ExpandMacros>()?.let {
             val disposable = project.macroExpansionManager.setUnitTestExpansionModeAndDirectory(it.mode, it.cache)
+            Disposer.register(testRootDisposable, disposable)
+        }
+        findAnnotationInstance<UseNewResolve>()?.let {
+            val disposable = DefMapService.setUseNewResolve()
             Disposer.register(testRootDisposable, disposable)
         }
         RecursionManager.disableMissedCacheAssertions(testRootDisposable)

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
@@ -7,6 +7,9 @@ package org.rust.lang.core.resolve
 
 import org.intellij.lang.annotations.Language
 import org.rust.ExpandMacros
+import org.rust.MockEdition
+import org.rust.UseNewResolve
+import org.rust.cargo.project.workspace.CargoWorkspace
 
 class RsIncludeMacroResolveTest : RsResolveTestBase() {
 
@@ -183,6 +186,27 @@ class RsIncludeMacroResolveTest : RsResolveTestBase() {
                           //^ bar.rs
     //- bar.rs
         pub struct Foo;
+    """)
+
+    @UseNewResolve
+    @ExpandMacros
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test macro call in included file`() = checkResolve("""
+    //- main.rs
+        macro_rules! gen_use {
+            () => { use inner::func; };
+        }
+
+        mod inner {
+            pub fn func() {}
+        }        //X
+        include!("foo.rs");
+
+        fn main() {
+            func();
+        } //^ main.rs
+    //- foo.rs
+        gen_use!();
     """)
 
     fun `test concat in include 1`() = checkResolve("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
@@ -6,8 +6,8 @@
 package org.rust.lang.core.resolve
 
 import org.intellij.lang.annotations.Language
+import org.rust.UseNewResolve
 import org.rust.lang.core.psi.ext.RsReferenceElement
-
 
 class RsMultiResolveTest : RsResolveTestBase() {
     fun `test struct expr`() = doTest("""
@@ -35,14 +35,59 @@ class RsMultiResolveTest : RsResolveTestBase() {
         }
     """)
 
-    fun `test use multi reference`() = doTest("""
+    fun `test use multi reference, function and mod`() = doTest("""
         use m::foo;
               //^
 
         mod m {
-            fn foo() {}
-            mod foo {}
+            pub fn foo() {}
+            pub mod foo {}
         }
+    """)
+
+    @UseNewResolve
+    fun `test use multi reference, duplicated function`() = doTest("""
+        mod m {
+            pub fn foo() {}
+            pub fn foo() {}
+        }
+        use m::foo;
+        fn main() {
+            foo();
+        } //^
+    """)
+
+    @UseNewResolve
+    fun `test use multi reference, duplicated struct`() = doTest("""
+        mod m {
+            pub struct Foo {}
+            pub struct Foo {}
+        }
+        use m::Foo;
+        fn main() {
+            let _ = Foo {};
+        }         //^
+    """)
+
+    @UseNewResolve
+    fun `test use multi reference, duplicated unit struct`() = doTest("""
+        mod m {
+            pub struct Foo;
+            pub struct Foo;
+        }
+        use m::Foo;
+        fn main() {
+            let _ = Foo;
+        }         //^
+    """)
+
+    @UseNewResolve
+    fun `test use multi reference, duplicated enum variant`() = doTest("""
+        enum E { A, A }
+        use E::A;
+        fn main() {
+            let _ = A;
+        }         //^
     """)
 
     fun `test other mod trait bound method`() = doTest("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -5,10 +5,7 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.ExpandMacros
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.WithStdlibWithSymlinkRustProjectDescriptor
+import org.rust.*
 import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.types.infer.TypeInferenceMarks
 import org.rust.stdext.BothEditions
@@ -256,6 +253,16 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         fn main() {
             println!("Hello, World!");
         }   //^ ...libstd/macros.rs|...std/src/macros.rs
+    """)
+
+    fun `test println macro inside doctest injection`() = stubOnlyResolve("""
+    //- lib.rs
+        /// ```
+        /// fn main() {
+        ///     println!("Hello, World!");
+        /// }   //^ ...libstd/macros.rs|...std/src/macros.rs
+        /// ```
+        pub fn foo() {}
     """)
 
     fun `test assert_eq macro`() = stubOnlyResolve("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.resolve
 
 import org.rust.MockEdition
+import org.rust.UseNewResolve
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.stdext.BothEditions
 
@@ -254,6 +255,16 @@ class RsUseResolveTest : RsResolveTestBase() {
           //X
         mod inner {
             use ::*;
+            fn main() { foo(); }
+        }              //^
+    """)
+
+    // https://github.com/sfackler/rust-openssl/blob/0a0da84f939090f72980c77f40199fc76245d289/openssl-sys/src/asn1.rs#L3
+    fun `test wildcard without any path`() = checkByCode("""
+        mod inner {
+            use *;
+            fn foo() {}
+             //X
             fn main() { foo(); }
         }              //^
     """)
@@ -740,5 +751,106 @@ class RsUseResolveTest : RsResolveTestBase() {
             // here we just check that incomplete path doesn't cause exceptions
             func();
         } //^
+    """)
+
+    @UseNewResolve
+    @MockEdition(Edition.EDITION_2018)
+    fun `test complex cyclic chain with glob imports and aliases`() = checkByCode("""
+        mod a {
+            pub use crate::b::*;
+            pub use foo as foo1;
+            pub use foo2 as foo3;
+            pub use foo4::*;
+        }
+        mod b {
+            pub use crate::a::*;
+            pub use foo1 as foo2;
+            pub use foo3 as foo4;
+            pub mod foo {
+                pub struct S;
+            }            //X
+            type T = S;
+        }          //^
+    """)
+
+    @MockEdition(Edition.EDITION_2018)
+    fun `test usual import overrides glob import`() = checkByCode("""
+        mod foo1 {
+            pub mod bar {
+                pub fn func() {}
+            }
+        }
+
+        mod inner {
+            pub mod foo2 {
+                pub mod bar {
+                    pub fn func() {}
+                          //X
+                }
+            }
+        }
+
+        use foo1::*;    // adds `bar`
+        use bar::func;  // uses `foo1::bar` to resolve func
+
+        use inner::*;
+        use foo2::bar;  // unresolved when we resolve `bar::func` (because we haven't processed `use inner::*;` yet)
+
+        fn main() {
+            func();
+           //^
+        }
+    """)
+
+    // based on https://github.com/rust-lang/cargo/blob/875e0123259b0b6299903fe4aea0a12ecde9324f/src/cargo/util/mod.rs#L23
+    @MockEdition(Edition.EDITION_2018)
+    fun `test import adds same name as existing 1`() = checkByCode("""
+        use foo::foo;
+        mod foo {
+            pub fn foo() {}
+        }        //X
+        mod inner {
+            use crate::foo;
+            fn main() {
+                foo();
+            } //^
+        }
+    """)
+
+    // based on https://github.com/rust-lang/cargo/blob/875e0123259b0b6299903fe4aea0a12ecde9324f/src/cargo/util/mod.rs#L23
+    @MockEdition(Edition.EDITION_2018)
+    fun `test import adds same name as existing 2`() = checkByCode("""
+        use foo::foo;
+        mod foo {
+            pub use inner::*;
+            pub mod inner {
+                pub fn foo() {}
+            }        //X
+        }
+        mod test {
+            use crate::foo;
+            fn main() {
+                foo();
+            } //^
+        }
+    """)
+
+    @UseNewResolve
+    @MockEdition(Edition.EDITION_2018)
+    fun `test two usual imports with same name in different namespaces`() = checkByCode("""
+        mod a {
+            pub mod foo {}
+            fn foo() {}
+        }
+        mod b {
+            pub fn foo() {}
+                  //X
+        }
+        use a::foo;  // type only
+        use b::foo;  // value
+        fn main() {
+            foo();
+           //^
+        }
     """)
 }


### PR DESCRIPTION
Continuation of #6079

Also add special annotation `@UseNewResolve` to mark tests which are expected to work only with [new resolve](https://github.com/intellij-rust/intellij-rust/issues/6217)