### PR TITLE
REF: Check impls in move refactoring when moving to other crate

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
@@ -165,6 +165,7 @@ class RsMoveCommonProcessor(
                     conflictsDetector = RsMoveConflictsDetector(conflicts, elementsToMove, sourceMod, targetMod)
                     conflictsDetector.detectOutsideReferencesVisibilityProblems(outsideReferences)
                     conflictsDetector.detectInsideReferencesVisibilityProblems(insideReferences)
+                    conflictsDetector.checkImpls()
                 }
             }
             true

--- a/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/KnownItems.kt
@@ -136,6 +136,7 @@ class KnownItems(
     // In this case, fully qualified name search is used
     val Debug: RsTraitItem? get() = findLangItem("debug_trait") ?: findItem("core::fmt::Debug")
     val Box: RsStructOrEnumItemElement? get() = findLangItem("owned_box", "alloc")
+    val Pin: RsStructOrEnumItemElement? get() = findLangItem("pin", "core")
 
     val drop: RsFunction? get() = findItem("core::mem::drop")
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveTopLevelItemsTest.kt
@@ -506,6 +506,185 @@ class RsMoveTopLevelItemsTest : RsMoveTopLevelItemsTestBase() {
         }
     """)
 
+    fun `test move inherent impl without struct to different crate 1`() = doTestConflictsError("""
+    //- lib.rs
+        pub struct Foo {}
+        impl Foo/*caret*/ {}
+    //- main.rs
+        pub mod mod2/*target*/ {}
+    """)
+
+    fun `test move inherent impl without struct to different crate 2`() = doTestConflictsError("""
+    //- lib.rs
+        pub mod foo1 {
+            pub struct Foo {}
+        }
+        pub mod foo2/*caret*/ {
+            use crate::foo1::Foo;
+            impl Foo {}
+        }
+    //- main.rs
+        pub mod mod2/*target*/ {}
+    """)
+
+    fun `test move inherent impl without struct to same crate`() = doTest("""
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo {}
+            impl Foo/*caret*/ {}
+        }
+        mod mod2/*target*/ {}
+    """, """
+    //- lib.rs
+        mod mod1 {
+            pub struct Foo {}
+        }
+        mod mod2 {
+            use crate::mod1::Foo;
+
+            impl Foo {}
+        }
+    """)
+
+    fun `test move inherent impl together with struct`() = doTest("""
+    //- lib.rs
+        mod mod1 {
+            struct Foo/*caret*/ {}
+            impl/*caret*/ Foo {}
+        }
+        mod mod2/*target*/ {}
+    """, """
+    //- lib.rs
+        mod mod1 {}
+        mod mod2 {
+            struct Foo {}
+
+            impl Foo {}
+        }
+    """)
+
+    fun `test move struct without inherent impl to different crate 1`() = doTestConflictsError("""
+    //- main.rs
+        pub struct Foo/*caret*/ {}
+        impl Foo {}
+    //- lib.rs
+        pub mod mod2/*target*/ {}
+    """)
+
+    fun `test move struct without inherent impl to different crate 2`() = doTestConflictsError("""
+    //- main.rs
+        pub mod foo1/*caret*/ {
+            pub struct Foo {}
+        }
+        pub mod foo2 {
+            use crate::foo1::Foo;
+            impl Foo {}
+        }
+    //- lib.rs
+        pub mod mod2/*target*/ {}
+    """)
+
+    fun `test move struct without inherent impl to same crate`() = doTest("""
+    //- lib.rs
+        mod mod1 {
+            struct Foo/*caret*/ {}
+            impl Foo {}
+        }
+        mod mod2/*target*/ {}
+    """, """
+    //- lib.rs
+        mod mod1 {
+            use crate::mod2::Foo;
+
+            impl Foo {}
+        }
+        mod mod2 {
+            pub struct Foo {}
+        }
+    """)
+
+    fun `test move struct with inherent impl to different crate`() = doTest("""
+    //- main.rs
+        mod mod1 {
+            struct Foo/*caret*/ {}
+            impl Foo/*caret*/ {}
+        }
+    //- lib.rs
+        mod mod2/*target*/ {}
+    """, """
+    //- main.rs
+        mod mod1 {}
+    //- lib.rs
+        mod mod2 {
+            struct Foo {}
+
+            impl Foo {}
+        }
+    """)
+
+    fun `test move trait impl without trait to different crate 1`() = doTestConflictsError("""
+    //- lib.rs
+        pub trait Foo {}
+        impl Foo for ()/*caret*/ {}
+    //- main.rs
+        pub mod mod2/*target*/ {}
+    """)
+
+    fun `test move trait impl without trait to different crate 2`() = doTestConflictsError("""
+    //- lib.rs
+        pub mod mod1 {
+            pub trait Foo {}
+            impl Foo for Bar/*caret*/ {}
+            pub struct Bar {}
+        }
+    //- main.rs
+        pub mod mod2/*target*/ {}
+    """)
+
+    fun `test move trait impl without trait to different crate 3`() = doTestConflictsError("""
+    //- lib.rs
+        pub mod mod1 {
+            pub trait Foo<T> {}
+            impl Foo<Bar2> for Bar1/*caret*/ {}
+            pub struct Bar1 {}
+            pub struct Bar2 {}
+        }
+    //- main.rs
+        pub mod mod2/*target*/ {}
+    """)
+
+    fun `test move trait impl with implementing type to different crate 1`() = doTestNoConflicts("""
+    //- lib.rs
+        pub mod mod1 {
+            pub trait Foo {}
+            impl Foo for Bar/*caret*/ {}
+            pub struct Bar/*caret*/ {}
+        }
+    //- main.rs
+        pub mod mod2/*target*/ {}
+    """)
+
+    fun `test move trait impl with implementing type to different crate 2`() = doTestNoConflicts("""
+    //- lib.rs
+        pub mod mod1 {
+            pub trait Foo<T> {}
+            impl Foo<Bar> for ()/*caret*/ {}
+            pub struct Bar/*caret*/ {}
+        }
+    //- main.rs
+        pub mod mod2/*target*/ {}
+    """)
+
+    fun `test move trait with trait impl to different crate`() = doTestNoConflicts("""
+    //- lib.rs
+        pub mod mod1 {
+            pub trait Foo/*caret*/ {}
+            impl Foo for ()/*caret*/ {}
+        }
+    //- main.rs
+        pub mod mod2/*target*/ {}
+    """)
+
     fun `test spaces 1`() = doTest("""
     //- lib.rs
         mod mod1 {


### PR DESCRIPTION
### Rules for inherent impls:
- An implementing type must be defined within the same crate as the original type definition
- https://doc.rust-lang.org/reference/items/implementations.html#inherent-implementations
- https://doc.rust-lang.org/error-index.html#E0116

We should check:
- When moving inherent impl: check that implementing type is also moved
- When moving struct/enum: check that all inherent impls are also moved

### Rules for trait impls:
- Orphan rules: https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
- https://doc.rust-lang.org/error-index.html#E0117

We should check (denote impls as `impl<P1..=Pn> Trait<T1..=Tn> for T0`):
- When moving trait impl:
    - either implemented trait is in target crate
    - or at least one of the types `T0..=Tn` is a local type
- When moving trait: for each impl of this trait which remains in source crate:
    - at least one of the types `T0..=Tn` is a local type
- Uncovering is not checking, because it is complicated