### PR TITLE
Run tests with new resolve on CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,12 +34,19 @@ jobs:
                 rust-version: [ 1.47.0, nightly-2020-10-04 ]
                 base-ide: [ idea, clion ]
                 platform-version: [ 202, 203 ]
+                resolve-engine: [ resolve-stable ]
                 include:
                     - os: ubuntu-latest
                       # Don't forget to update condition in `Set up additional env variables` step
                       rust-version: 1.32.0
                       base-ide: idea
                       platform-version: 202
+                      resolve-engine: resolve-stable
+                    - os: ubuntu-latest
+                      rust-version: 1.47.0
+                      base-ide: idea
+                      platform-version: 203
+                      resolve-engine: resolve-new
 
         runs-on: ${{ matrix.os }}
         timeout-minutes: 60
@@ -95,6 +102,10 @@ jobs:
                   echo "::set-env name=ORG_GRADLE_PROJECT_clionVersion::CL-2020.2"
                   echo "::set-env name=ORG_GRADLE_PROJECT_nativeDebugPluginVersion::202.6397.20"
                   echo "::set-env name=ORG_GRADLE_PROJECT_graziePluginVersion::202.6397.11"
+
+            - name: Set up env variable for new resolve
+              if: matrix.resolve-engine == 'resolve-new'
+              run: echo "INTELLIJ_RUST_FORCE_USE_NEW_RESOLVE=" >> $GITHUB_ENV
 
             - name: Set up test env variables
               run: echo "::set-env name=RUST_SRC_WITH_SYMLINK::$HOME/.rust-src"

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -53,10 +53,6 @@ jobs:
                       path: tokio
                       repository: tokio-rs/tokio
                       exclude_paths: ""
-                    - name: amethyst
-                      path: amethyst
-                      repository: amethyst/amethyst
-                      exclude_paths: ""
         env:
             PROJECT_PATH: ${{ matrix.project.path }}
             PROJECT_URL: https://github.com/${{ matrix.project.url }}

--- a/common/src/main/kotlin/com/intellij/openapiext/Testmark.kt
+++ b/common/src/main/kotlin/com/intellij/openapiext/Testmark.kt
@@ -68,7 +68,7 @@ class Testmark(val name: String): TestmarkPred {
     override fun <T> checkHit(f: () -> T): T = checkHit(TestmarkState.HIT, f)
 
     @TestOnly
-    fun <T> checkNotHit(f: () -> T): T = checkHit(TestmarkState.NOT_HIT, f)
+    override fun <T> checkNotHit(f: () -> T): T = checkHit(TestmarkState.NOT_HIT, f)
 
     @TestOnly
     private fun <T> checkHit(expected: TestmarkState, f: () -> T): T {
@@ -102,9 +102,13 @@ fun Testmark.hitOnFalse(b: Boolean): Boolean {
 interface TestmarkPred {
     @TestOnly
     fun <T> checkHit(f: () -> T): T
+
+    @TestOnly
+    fun <T> checkNotHit(f: () -> T): T
 }
 
 @TestOnly
 operator fun Testmark.not(): TestmarkPred = object : TestmarkPred {
-    override fun <T> checkHit(f: () -> T): T = checkNotHit(f)
+    override fun <T> checkHit(f: () -> T): T = this@not.checkNotHit(f)
+    override fun <T> checkNotHit(f: () -> T): T = this@not.checkHit(f)
 }

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleCodeFragmentContext.kt
@@ -13,7 +13,7 @@ import org.rust.cargo.project.model.cargoProjects
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.block
 import org.rust.lang.core.psi.ext.childOfType
-import org.rust.lang.core.resolve.TYPES
+import org.rust.lang.core.resolve.TYPES_N_VALUES_N_MACROS
 import org.rust.lang.core.resolve.createProcessor
 import org.rust.lang.core.resolve.findPrelude
 import org.rust.lang.core.resolve.processNestedScopesUpwards
@@ -46,7 +46,7 @@ class RsConsoleCodeFragmentContext(codeFragment: RsReplCodeFragment?) {
             preludeItemsNames += it.name
             false
         }
-        processNestedScopesUpwards(prelude, TYPES, processor)
+        processNestedScopesUpwards(prelude, TYPES_N_VALUES_N_MACROS, processor)
         itemsNames += preludeItemsNames
         hasAddedNamesFromPrelude = true
     }

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.resolve2
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
+import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.experiments.RsExperiments
 import org.rust.ide.utils.isEnabledByCfg
@@ -26,8 +27,13 @@ import org.rust.openapiext.isFeatureEnabled
 import org.rust.openapiext.toPsiFile
 
 val isNewResolveEnabled: Boolean
-    get() = isFeatureEnabled(RsExperiments.RESOLVE_NEW_ENGINE)
-        || DefMapService.forceUseNewResolve
+    get() {
+        if (isUnitTestMode) {
+            if (DefMapService.forceUseNewResolve) return true
+            if (System.getenv("INTELLIJ_RUST_FORCE_USE_NEW_RESOLVE") != null) return true
+        }
+        return isFeatureEnabled(RsExperiments.RESOLVE_NEW_ENGINE)
+    }
 
 /** null return value means that new resolve can't be used */
 fun processItemDeclarations2(

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeUpdateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeUpdateDefMap.kt
@@ -44,11 +44,15 @@ fun DefMapService.getOrUpdateIfNeeded(crate: CratePersistentId): CrateDefMap? {
         if (holder.hasLatestStamp()) return@withLockAndCheckingCancelled holder.defMap
 
         val pool = Executors.newWorkStealingPool()
-        val indicator = ProgressManager.getGlobalProgressIndicator() ?: EmptyProgressIndicator()
-        // TODO: Invoke outside of read action ?
-        DefMapUpdater(crate, this, pool, indicator, multithread = true).run()
-        if (holder.defMap != null) holder.checkHasLatestStamp()
-        holder.defMap
+        try {
+            val indicator = ProgressManager.getGlobalProgressIndicator() ?: EmptyProgressIndicator()
+            // TODO: Invoke outside of read action ?
+            DefMapUpdater(crate, this, pool, indicator, multithread = true).run()
+            if (holder.defMap != null) holder.checkHasLatestStamp()
+            holder.defMap
+        } finally {
+            pool.shutdown()
+        }
     }
 }
 

--- a/src/test/kotlin/org/rust/NewResolve.kt
+++ b/src/test/kotlin/org/rust/NewResolve.kt
@@ -5,6 +5,22 @@
 
 package org.rust
 
+import com.intellij.openapiext.TestmarkPred
+import org.rust.lang.core.resolve2.isNewResolveEnabled
+
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class UseNewResolve
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class IgnoreInNewResolve
+
+fun TestmarkPred.ignoreInNewResolve(): TestmarkPred {
+    if (!isNewResolveEnabled) return this
+    return object : TestmarkPred {
+        override fun <T> checkHit(f: () -> T): T = f()
+
+        override fun <T> checkNotHit(f: () -> T): T = f()
+    }
+}

--- a/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
@@ -38,7 +38,7 @@ abstract class RsWithToolchainTestBase : RsWithToolchainPlatformTestBase() {
     }
 
     override fun runTestInternal(context: TestContext) {
-        val skipReason = rustupFixture.skipTestReason
+        val skipReason = rustupFixture.skipTestReason ?: getIgnoredInNewResolveReason()
         if (skipReason != null) {
             System.err.println("SKIP \"$name\": $skipReason")
             return

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -3564,6 +3564,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         struct Test(i32);
     """)
 
+    @IgnoreInNewResolve
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test custom repr proc macro attr`() = checkByFileTree("""
     //- dep-proc-macro/lib.rs
@@ -3582,6 +3583,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         type Foo = i32;
     """)
 
+    @IgnoreInNewResolve
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test custom start proc macro attr`() = checkByFileTree("""
     //- dep-proc-macro/lib.rs
@@ -3600,6 +3602,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         type Foo = i32;
     """)
 
+    @IgnoreInNewResolve
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test custom inline proc macro attr`() = checkByFileTree("""
     //- dep-proc-macro/lib.rs

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -934,12 +934,14 @@ class RsCompletionTest : RsCompletionTestBase() {
         }
     """)
 
+    @IgnoreInNewResolve
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test private extern crate`() = checkNoCompletion("""
         mod foo { extern crate std; }
         pub use foo::st/*caret*/
     """)
 
+    @IgnoreInNewResolve
     @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
     fun `test no std completion`() = checkNoCompletion("""
         extern crate dep_lib_target;

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallReferenceDelegationTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallReferenceDelegationTest.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.macros
 
 import org.rust.ExpandMacros
+import org.rust.IgnoreInNewResolve
 import org.rust.lang.core.resolve.RsResolveTestBase
 import org.rust.lang.core.resolve.ref.RsMacroBodyReferenceDelegateImpl.Testmarks
 
@@ -40,6 +41,7 @@ class RsMacroCallReferenceDelegationTest : RsResolveTestBase() {
         }              //^
     """, Testmarks.touched)
 
+    @IgnoreInNewResolve
     fun `test type context`() = checkByCode("""
         struct X;
              //X

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.lang.core.resolve
 
+import org.rust.ignoreInNewResolve
+
 class RsMacroResolveTest : RsResolveTestBase() {
     fun `test resolve simple matching with multiple pattern definition`() = checkByCode("""
         macro_rules! test {
@@ -153,7 +155,7 @@ class RsMacroResolveTest : RsResolveTestBase() {
             foo_bar!();
             //^ unresolved
         }
-    """, NameResolutionTestmarks.missingMacroUse)
+    """, NameResolutionTestmarks.missingMacroUse.ignoreInNewResolve())
 
     fun `test macro_export macro is visible in the same crate without macro_use`() = checkByCode("""
         // #[macro_use] is not needed here
@@ -165,7 +167,7 @@ class RsMacroResolveTest : RsResolveTestBase() {
             foo_bar!();
             //^
         }
-    """, NameResolutionTestmarks.processSelfCrateExportedMacros)
+    """, NameResolutionTestmarks.processSelfCrateExportedMacros.ignoreInNewResolve())
 
     fun `test resolve macro missing macro_use mod`() = checkByCode("""
         // Missing #[macro_use] here
@@ -178,7 +180,7 @@ class RsMacroResolveTest : RsResolveTestBase() {
                 //^ unresolved
             }
         }
-    """, NameResolutionTestmarks.missingMacroUse)
+    """, NameResolutionTestmarks.missingMacroUse.ignoreInNewResolve())
 
     fun `test raw identifier 1`() = checkByCode("""
         macro_rules! r#match { () => () }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -5,10 +5,7 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.MockEdition
-import org.rust.ProjectDescriptor
-import org.rust.WithDependencyRustProjectDescriptor
-import org.rust.WithStdlibAndDependencyRustProjectDescriptor
+import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
 
 @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
@@ -74,6 +71,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @IgnoreInNewResolve
     fun `test duplicated macro_export macro`() = stubOnlyResolve("""
     //- main.rs
         #[macro_use]
@@ -113,7 +111,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
     //- lib.rs
         #[macro_export]
         macro_rules! foo_bar { () => {} }
-    """, NameResolutionTestmarks.missingMacroUse)
+    """, NameResolutionTestmarks.missingMacroUse.ignoreInNewResolve())
 
     fun `test macro rules in mod 1`() = stubOnlyResolve("""
     //- main.rs
@@ -240,7 +238,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         macro_rules! foo {
             () => {};
         }
-    """, NameResolutionTestmarks.missingMacroUse)
+    """, NameResolutionTestmarks.missingMacroUse.ignoreInNewResolve())
 
     fun `test import macro by use item wildcard`() = stubOnlyResolve("""
     //- lib.rs
@@ -254,7 +252,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         macro_rules! foo {
             () => {};
         }
-    """, NameResolutionTestmarks.missingMacroUse)
+    """, NameResolutionTestmarks.missingMacroUse.ignoreInNewResolve())
 
     fun `test import macro by use item without extern crate`() = stubOnlyResolve("""
     //- lib.rs
@@ -640,6 +638,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @IgnoreInNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test ambiguity of extern crate alias and other item with the same name`() {
         stubOnlyResolve("""
@@ -681,7 +680,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         use dep_lib_target;
         use dep_lib_target::Foo;
                           //^ dep-lib/lib.rs
-    """, ItemResolutionTestmarks.extraAtomUse)
+    """, ItemResolutionTestmarks.extraAtomUse.ignoreInNewResolve())
 
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test "extra use of crate name 1" with alias`() = stubOnlyResolve("""
@@ -701,7 +700,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         use dep_lib_target::{self};
         use dep_lib_target::Foo;
                           //^ dep-lib/lib.rs
-    """, ItemResolutionTestmarks.extraAtomUse)
+    """, ItemResolutionTestmarks.extraAtomUse.ignoreInNewResolve())
 
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import the same name as a crate name`() = stubOnlyResolve("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
@@ -5,11 +5,13 @@
 
 package org.rust.lang.core.resolve
 
+import org.rust.IgnoreInNewResolve
 import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace
 
+@IgnoreInNewResolve
 @MockEdition(CargoWorkspace.Edition.EDITION_2018)
 @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
 class RsProcMacroResolveTest : RsResolveTestBase() {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -5,9 +5,11 @@
 
 package org.rust.lang.core.resolve
 
+import org.rust.IgnoreInNewResolve
 import org.rust.MockEdition
 import org.rust.MockRustcVersion
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ignoreInNewResolve
 import org.rust.lang.core.psi.ext.RsFieldDecl
 
 class RsResolveTest : RsResolveTestBase() {
@@ -1399,7 +1401,7 @@ class RsResolveTest : RsResolveTestBase() {
 
         use self::Foo;
                 //^
-    """, ItemResolutionTestmarks.externCrateSelfWithoutAlias)
+    """, ItemResolutionTestmarks.externCrateSelfWithoutAlias.ignoreInNewResolve())
 
     fun `test const generic in fn`() = checkByCode("""
         fn f<const AAA: usize>() {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTestBase.kt
@@ -7,7 +7,7 @@ package org.rust.lang.core.resolve
 
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileFilter
-import com.intellij.openapiext.Testmark
+import com.intellij.openapiext.TestmarkPred
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
@@ -62,7 +62,7 @@ abstract class RsResolveTestBase : RsTestBase() {
         }
     }
 
-    protected fun checkByCode(@Language("Rust") code: String, mark: Testmark) =
+    protected fun checkByCode(@Language("Rust") code: String, mark: TestmarkPred) =
         mark.checkHit { checkByCode(code) }
 
     protected fun stubOnlyResolve(
@@ -72,7 +72,7 @@ abstract class RsResolveTestBase : RsTestBase() {
 
     protected fun stubOnlyResolve(
         @Language("Rust") code: String,
-        mark: Testmark,
+        mark: TestmarkPred,
         resolveFileProducer: (PsiElement) -> VirtualFile = this::getActualResolveFile
     ) = mark.checkHit { stubOnlyResolve(code, resolveFileProducer) }
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2018.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTestEdition2018.kt
@@ -9,6 +9,7 @@ import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ignoreInNewResolve
 
 @MockEdition(CargoWorkspace.Edition.EDITION_2018)
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
@@ -26,5 +27,5 @@ class RsStdlibResolveTestEdition2018 : RsResolveTestBase() {
         fn main() {
             let a = Vec::<i32>::new();
         }         //^ .../vec.rs
-    """, ItemResolutionTestmarks.extraAtomUse)
+    """, ItemResolutionTestmarks.extraAtomUse.ignoreInNewResolve())
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.resolve
 
+import org.rust.IgnoreInNewResolve
 import org.rust.MockEdition
 import org.rust.UseNewResolve
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
@@ -224,6 +225,7 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @IgnoreInNewResolve
     fun `test wildcard`() = checkByCode("""
         mod a {
             fn foo() {}
@@ -500,6 +502,7 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @IgnoreInNewResolve
     fun `test star imports do not leak`() = checkByCode("""
         fn foo() {}
         mod m {
@@ -773,6 +776,7 @@ class RsUseResolveTest : RsResolveTestBase() {
         }          //^
     """)
 
+    @IgnoreInNewResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test usual import overrides glob import`() = checkByCode("""
         mod foo1 {

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoGeneratedItemsResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoGeneratedItemsResolveTest.kt
@@ -7,6 +7,7 @@ package org.rustSlowTests.lang.resolve
 
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl
+import org.rust.IgnoreInNewResolve
 import org.rust.MinRustcVersion
 import org.rust.cargo.toolchain.tools.Cargo
 import org.rust.fileTree
@@ -15,6 +16,7 @@ import org.rust.lang.core.psi.RsPath
 import org.rust.openapiext.runWithEnabledFeature
 import org.rustSlowTests.cargo.runconfig.RunConfigurationTestBase
 
+@IgnoreInNewResolve
 class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
 
     private val tempDirFixture = TempDirTestFixtureImpl()

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoProjectResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoProjectResolveTest.kt
@@ -16,6 +16,7 @@ import org.rust.MinRustcVersion
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.model.impl.testCargoProjects
 import org.rust.fileTree
+import org.rust.ignoreInNewResolve
 import org.rust.lang.core.crate.impl.CrateGraphTestmarks
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.resolve.NameResolutionTestmarks
@@ -91,7 +92,7 @@ class CargoProjectResolveTest : RsWithToolchainTestBase() {
                 }
             }
         }
-        NameResolutionTestmarks.shadowingStdCrates.checkHit {
+        NameResolutionTestmarks.shadowingStdCrates.ignoreInNewResolve().checkHit {
             testProject.checkReferenceIsResolved<RsPath>("foo/src/lib.rs")
         }
     }


### PR DESCRIPTION
Add another job into `check` workflow to run tests with [new resolve](https://github.com/intellij-rust/intellij-rust/issues/6217) enabled.

Also add annotation `@IgnoreInNewResolve` to temporary disable few tests if running with new resolve.