### PR TITLE
INSP: It is not allowed to cast to a bool. (E0054)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -127,5 +127,6 @@ vlad20012
 vlad9486
 webdesus
 winger
+zeroeightysix
 zinoviy23
 zjhmale

--- a/src/main/kotlin/org/rust/ide/inspections/RsCastToBoolInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsCastToBoolInspection.kt
@@ -1,0 +1,32 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import org.rust.lang.core.psi.RsCastExpr
+import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.types.ty.TyBool
+import org.rust.lang.core.types.ty.TyPrimitive
+import org.rust.lang.core.types.ty.TyUnit
+import org.rust.lang.core.types.type
+import org.rust.lang.utils.RsDiagnostic
+import org.rust.lang.utils.addToHolder
+
+class RsCastToBoolInspection : RsLocalInspectionTool() {
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+        override fun visitCastExpr(castExpr: RsCastExpr) {
+            // It is allowed to cast a bool to a bool, so if the expression's type is of bool, ignore this cast.
+            // Casts from non primitive types (and the unit type) emit another error, so we ignore those as well.
+            val exprType = castExpr.expr.type
+            if (exprType === TyBool || exprType !is TyPrimitive || exprType === TyUnit) return
+
+            if (castExpr.typeReference.type === TyBool) {
+                RsDiagnostic.CastAsBoolError(castExpr).addToHolder(holder)
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -518,6 +518,14 @@ sealed class RsDiagnostic(
         }
     }
 
+    class CastAsBoolError(element: PsiElement) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            E0054,
+            "It is not allowed to cast to a bool."
+        )
+    }
+
     class IncorrectFunctionArgumentCountError(
         element: PsiElement,
         private val expectedCount: Int,
@@ -1296,7 +1304,7 @@ sealed class RsDiagnostic(
 }
 
 enum class RsErrorCode {
-    E0004, E0015, E0023, E0025, E0026, E0027, E0040, E0046, E0050, E0060, E0061, E0069, E0081, E0084,
+    E0004, E0015, E0023, E0025, E0026, E0027, E0040, E0046, E0050, E0054, E0060, E0061, E0069, E0081, E0084,
     E0106, E0107, E0118, E0120, E0121, E0124, E0132, E0133, E0184, E0185, E0186, E0198, E0199,
     E0200, E0201, E0202, E0252, E0261, E0262, E0263, E0267, E0268, E0277,
     E0308, E0322, E0328, E0379, E0384,

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -524,6 +524,11 @@
                          enabledByDefault="true" level="ERROR"
                          implementationClass="org.rust.ide.inspections.RsTraitImplementationInspection"/>
 
+        <localInspection language="Rust" groupName="Rust"
+                         displayName="Cast to bool"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.rust.ide.inspections.RsCastToBoolInspection"/>
+
         <localInspection language="Rust" groupPath="Rust" groupName="Lints"
                          displayName="Unreachable patterns"
                          enabledByDefault="true" level="WARNING"

--- a/src/main/resources/inspectionDescriptions/RsCastToBool.html
+++ b/src/main/resources/inspectionDescriptions/RsCastToBool.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+Detects invalid casts to a bool.
+
+Corresponds to <a href="https://doc.rust-lang.org/error-index.html#E0054">E0054</a> Rust error.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/RsCastToBoolInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsCastToBoolInspectionTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+class RsCastToBoolInspectionTest : RsInspectionsTestBase(RsCastToBoolInspection::class) {
+
+    fun `test cast number to bool`() = checkErrors("""
+        fn main() {
+            <error descr="It is not allowed to cast to a bool. [E0054]">5 as bool</error>;
+        }
+    """)
+
+    fun `test cast bool to bool`() = checkErrors("""
+        fn main() {
+            true as bool;
+        }
+    """)
+
+    fun `test cast to bool in expression`() = checkErrors("""
+        fn main() {
+            let a = (<error descr="It is not allowed to cast to a bool. [E0054]">5 as bool</error>) == false;
+        }
+    """)
+
+    // Casts from types that are not primitive emit other errors than E0054.
+    fun `test cast from non primitive type`() = checkErrors("""
+        fn main() {
+            struct S;
+            S as bool;
+        }
+    """)
+
+    // Casts from unit to bool emit E0605 instead of E0054.
+    fun `test cast from unit to bool`() = checkErrors("""
+        fn main() {
+            () as bool;
+        }
+    """)
+
+}


### PR DESCRIPTION
This PR aims to implement an inspection for rust error [E0054](https://doc.rust-lang.org/error-index.html#E0054) *It is not allowed to cast to a bool.*

If this is merged, I am also interested in implementing an intent to "compare with zero instead", as the error index (and compiler) suggests.

Part of #886