### PR TITLE
INSP: Extend function argument count check to work for closures (E0057)

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -43,6 +43,7 @@ import org.rust.lang.core.types.infer.containsTyOfClass
 import org.rust.lang.core.types.infer.substitute
 import org.rust.lang.core.types.ty.*
 import org.rust.lang.utils.RsDiagnostic
+import org.rust.lang.utils.RsDiagnostic.IncorrectFunctionArgumentCountError.FunctionType
 import org.rust.lang.utils.RsErrorCode
 import org.rust.lang.utils.addToHolder
 import org.rust.lang.utils.evaluation.evaluate
@@ -793,18 +794,19 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     }
 
     private fun checkValueArgumentList(holder: RsAnnotationHolder, args: RsValueArgumentList) {
-        val (expectedCount, variadic) = when (val parent = args.parent) {
+        val (expectedCount, functionType) = when (val parent = args.parent) {
             is RsCallExpr -> parent.expectedParamsCount()
             is RsMethodCall -> parent.expectedParamsCount()
             else -> null
         } ?: return
+
         val realCount = args.exprList.size
         if (realCount < expectedCount) {
             val target = args.rparen ?: args
-            RsDiagnostic.IncorrectFunctionArgumentCountError(target, expectedCount, realCount, variadic).addToHolder(holder)
-        } else if (!variadic && realCount > expectedCount) {
+            RsDiagnostic.IncorrectFunctionArgumentCountError(target, expectedCount, realCount, functionType).addToHolder(holder)
+        } else if (!functionType.variadic && realCount > expectedCount) {
             args.exprList.drop(expectedCount).forEach {
-                RsDiagnostic.IncorrectFunctionArgumentCountError(it, expectedCount, realCount).addToHolder(holder)
+                RsDiagnostic.IncorrectFunctionArgumentCountError(it, expectedCount, realCount, functionType).addToHolder(holder)
             }
         }
     }
@@ -1244,27 +1246,43 @@ private fun AnnotationSession.fileDuplicatesMap(): MutableMap<PsiElement, Map<Na
     return map
 }
 
-
-private fun RsCallExpr.expectedParamsCount(): Pair<Int, Boolean>? {
+private fun RsCallExpr.expectedParamsCount(): Pair<Int, FunctionType>? {
     val path = (expr as? RsPathExpr)?.path ?: return null
     val el = path.reference?.resolve()
     return when (el) {
-        is RsFieldsOwner -> Pair(el.fields.size, false)
+        is RsFieldsOwner -> Pair(el.fields.size, FunctionType.FUNCTION)
         is RsFunction -> {
             val owner = el.owner
             if (owner.isTraitImpl) return null
             val count = el.valueParameterList?.valueParameterList?.size ?: return null
             val s = if (el.selfParameter != null) 1 else 0
-            Pair(count + s, el.isVariadic)
+            val functionType = if (el.isVariadic) {
+                FunctionType.VARIADIC_FUNCTION
+            } else {
+                FunctionType.FUNCTION
+            }
+            Pair(count + s, functionType)
+        }
+        is RsPatBinding -> {
+            val type = el.type.stripReferences()
+            // TODO: replace with more generic solution
+            // when https://github.com/intellij-rust/intellij-rust/issues/6391 will be implemented
+            if (type is TyFunction) {
+                val letDecl = el.parent?.parent as? RsLetDecl
+                if (letDecl?.expr is RsLambdaExpr) type.paramTypes.size to FunctionType.CLOSURE else null
+            } else {
+                null
+            }
         }
         else -> null
     }
 }
 
-private fun RsMethodCall.expectedParamsCount(): Pair<Int, Boolean>? {
+private fun RsMethodCall.expectedParamsCount(): Pair<Int, FunctionType>? {
     val fn = reference.resolve() as? RsFunction ?: return null
-    return fn.valueParameterList?.valueParameterList?.size?.let { Pair(it, fn.isVariadic) }
-        .takeIf { fn.owner.isInherentImpl }
+    return fn.valueParameterList?.valueParameterList?.size?.let {
+        Pair(it, if (fn.isVariadic) FunctionType.VARIADIC_FUNCTION else FunctionType.FUNCTION)
+    }.takeIf { fn.owner.isInherentImpl }
 }
 
 private fun isValidSelfSuperPrefix(path: RsPath): Boolean {

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -531,19 +531,25 @@ sealed class RsDiagnostic(
         element: PsiElement,
         private val expectedCount: Int,
         private val realCount: Int,
-        private val variadic: Boolean = false
+        private val functionType: FunctionType = FunctionType.FUNCTION
     ) : RsDiagnostic(element) {
         override fun prepare() = PreparedAnnotation(
             ERROR,
-            if (variadic) E0060 else E0061,
+            functionType.errorCode,
             errorText()
         )
 
         private fun errorText(): String {
-            return "This function takes${if (variadic) " at least" else ""}" +
+            return "This function takes${if (functionType.variadic) " at least" else ""}" +
                 " $expectedCount ${pluralise(expectedCount, "parameter", "parameters")}" +
                 " but $realCount ${pluralise(realCount, "parameter", "parameters")}" +
                 " ${pluralise(realCount, "was", "were")} supplied"
+        }
+
+        enum class FunctionType(val variadic: Boolean, val errorCode: RsErrorCode) {
+            VARIADIC_FUNCTION(true, E0060),
+            FUNCTION(false, E0061),
+            CLOSURE(false, E0057)
         }
     }
 
@@ -1321,7 +1327,7 @@ sealed class RsDiagnostic(
 }
 
 enum class RsErrorCode {
-    E0004, E0015, E0023, E0025, E0026, E0027, E0040, E0046, E0050, E0054, E0060, E0061, E0069, E0081, E0084,
+    E0004, E0015, E0023, E0025, E0026, E0027, E0040, E0046, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
     E0106, E0107, E0118, E0120, E0121, E0124, E0132, E0133, E0184, E0185, E0186, E0198, E0199,
     E0200, E0201, E0202, E0252, E0261, E0262, E0263, E0267, E0268, E0277,
     E0308, E0322, E0328, E0364, E0365, E0379, E0384,

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -223,6 +223,22 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         impl T for S { impl_foo!(); }
     """)
 
+    fun `test invalid parameters number in closures E0057`() = checkErrors("""
+        fn main() {
+            let closure_0 = || ();
+            let closure_1 = |x| x;
+            let closure_2 = |x, y| (x, y);
+
+            closure_0();
+            closure_0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0057]">42</error>);
+            closure_1(<error descr="This function takes 1 parameter but 0 parameters were supplied [E0057]">)</error>;
+            closure_1(42);
+            closure_2(<error descr="This function takes 2 parameters but 0 parameters were supplied [E0057]">)</error>;
+            closure_2(42<error descr="This function takes 2 parameters but 1 parameter was supplied [E0057]">)</error>;
+            closure_2(42, 43);
+        }
+    """)
+
     fun `test invalid parameters number in variadic functions E0060`() = checkErrors("""
         extern {
             fn variadic_1(p1: u32, ...);


### PR DESCRIPTION
This PR extends the inspection for fixing an incorrect amount of arguments passed to a function to work for closures as well. This corresponds to rust error [E0057](https://doc.rust-lang.org/error-index.html#E0057).

This PR might clash with #6318 as both modify the same enum, on the same line.

Part of #886

changelog: Detect [E0057](https://doc.rust-lang.org/error-index.html#E0057) in some cases