### PR TITLE
INSP: add QualifyPathFix

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/QualifyPathFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/QualifyPathFix.kt
@@ -1,0 +1,34 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.RsPsiFactory
+
+
+/**
+ * Fix that qualifies a path.
+ */
+class QualifyPathFix(
+    path: RsPath,
+    private val qualifiedPath: String
+) : LocalQuickFixOnPsiElement(path) {
+    private val _text: String = "Qualify path to `$qualifiedPath`"
+
+    override fun getText() = _text
+    override fun getFamilyName() = "Qualify path"
+
+    override fun invoke(project: Project, file: PsiFile, expr: PsiElement, endElement: PsiElement) {
+        val path = expr as? RsPath ?: return
+        val fullPath = "$qualifiedPath${path.typeArgumentList?.text.orEmpty()}"
+        val newPath = RsPsiFactory(project).tryCreatePath(fullPath) ?: return
+        path.replace(newPath)
+    }
+}

--- a/src/test/kotlin/org/rust/ide/inspections/fixes/QualifyPathFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/fixes/QualifyPathFixTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.RsUnresolvedReferenceInspection
+
+class QualifyPathFixTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection::class) {
+    fun `test function call`() = checkFixByText("Qualify path to `foo::bar`", """
+        mod foo {
+            pub fn bar() {}
+        }
+        fn main() {
+            <error descr="Unresolved reference: `bar`">bar/*caret*/</error>();
+        }
+    """, """
+        mod foo {
+            pub fn bar() {}
+        }
+        fn main() {
+            foo::bar();
+        }
+    """)
+
+    fun `test struct type`() = checkFixByText("Qualify path to `foo::S`", """
+        mod foo {
+            pub struct S;
+        }
+        fn main() {
+            let x: <error descr="Unresolved reference: `S`">S/*caret*/</error>;
+        }
+    """, """
+        mod foo {
+            pub struct S;
+        }
+        fn main() {
+            let x: foo::S;
+        }
+    """)
+
+    fun `test generic struct type`() = checkFixByText("Qualify path to `foo::S`", """
+        mod foo {
+            pub struct S<T>(T);
+        }
+        fn main() {
+            let x: <error descr="Unresolved reference: `S`">S/*caret*/</error><u32>;
+        }
+    """, """
+        mod foo {
+            pub struct S<T>(T);
+        }
+        fn main() {
+            let x: foo::S<u32>;
+        }
+    """)
+
+    fun `test struct associated method call`() = checkFixByText("Qualify path to `foo::S`", """
+        mod foo {
+            pub struct S;
+            impl S {
+                pub fn bar() {}
+            }
+        }
+        fn main() {
+            let x = <error descr="Unresolved reference: `S`">S/*caret*/</error>::bar();
+        }
+    """, """
+        mod foo {
+            pub struct S;
+            impl S {
+                pub fn bar() {}
+            }
+        }
+        fn main() {
+            let x = foo::S::bar();
+        }
+    """)
+
+    fun `test generic struct associated method call`() = checkFixByText("Qualify path to `foo::S`", """
+        mod foo {
+            pub struct S<T>(T);
+            impl<T> S<T> {
+                pub fn bar() {}
+            }
+        }
+        fn main() {
+            let x = <error descr="Unresolved reference: `S`">S/*caret*/</error>::<u32>::bar();
+        }
+    """, """
+        mod foo {
+            pub struct S<T>(T);
+            impl<T> S<T> {
+                pub fn bar() {}
+            }
+        }
+        fn main() {
+            let x = foo::S::<u32>::bar();
+        }
+    """)
+
+    fun `test multiple candidates`() = checkFixIsUnavailable("Qualify path", """
+        mod foo {
+            pub fn bar() {}
+        }
+        mod baz {
+            pub fn bar() {}
+        }
+        fn main() {
+            <error descr="Unresolved reference: `bar`">bar/*caret*/</error>();
+        }
+    """)
+
+    fun `test associated constant`() = checkFixIsUnavailable("Qualify path", """
+        mod foo {
+            pub trait Foo {
+                const C: i32;
+            }
+
+            impl<T> Foo for T {
+                const C: i32 = 0;
+            }
+        }
+
+        fn main() {
+            let x = i32::<error descr="Unresolved reference: `C`">C/*caret*/</error>(123);
+        }
+    """)
+
+    fun `test trait impl`() = checkFixIsUnavailable("Qualify path", """
+        mod foo {
+            pub trait Foo {
+                fn foo(&self) {}
+            }
+
+            impl<T> Foo for T {}
+        }
+
+        fn main() {
+            let x = i32::<error descr="Unresolved reference: `foo`">foo/*caret*/</error>(123);
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds a quick fix to `RsUnresolvedReferenceInspection` that qualifies an unresolved path (instead of importing it). It was inspired by https://github.com/rust-analyzer/rust-analyzer/pull/6172.

![qualify](https://user-images.githubusercontent.com/4539057/97704536-daa9e400-1ab2-11eb-9d0c-7f88dea56ae4.gif)

Currently it is only offered when there is one import candidate. We can also create a separate quick fix for each candidate.
If you think that this is OK, I'll also add an intention that will enable this fix even on resolved paths (to fully qualify them).