### PR TITLE
INT: Compare with zero instead when casting numerical to bool

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/CompareWithZeroFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/CompareWithZeroFix.kt
@@ -1,0 +1,33 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RsCastExpr
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.types.ty.TyNumeric
+import org.rust.lang.core.types.type
+
+class CompareWithZeroFix private constructor(expr: RsCastExpr) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
+    override fun getFamilyName(): String = "Compare with zero"
+
+    override fun getText(): String = familyName
+
+    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
+        if (startElement !is RsCastExpr) return
+        startElement.replace(RsPsiFactory(project).createExpression("${startElement.expr.text} != 0"))
+    }
+
+    companion object {
+        fun createIfCompatible(expression: RsCastExpr): CompareWithZeroFix? {
+            return if (expression.expr.type is TyNumeric) CompareWithZeroFix(expression) else null
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -518,11 +518,12 @@ sealed class RsDiagnostic(
         }
     }
 
-    class CastAsBoolError(element: PsiElement) : RsDiagnostic(element) {
+    class CastAsBoolError(val castExpr: RsCastExpr) : RsDiagnostic(castExpr) {
         override fun prepare() = PreparedAnnotation(
             ERROR,
             E0054,
-            "It is not allowed to cast to a bool."
+            "It is not allowed to cast to a bool.",
+            fixes = listOfNotNull(CompareWithZeroFix.createIfCompatible(castExpr))
         )
     }
 

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/CompareWithZeroFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/CompareWithZeroFixTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.rust.ide.inspections.RsCastToBoolInspection
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class CompareWithZeroFixTest : RsInspectionsTestBase(RsCastToBoolInspection::class) {
+
+    fun `test fix numeric cast to bool`() = checkFixByText("Compare with zero", """
+        fn main() {
+            <error descr="It is not allowed to cast to a bool. [E0054]">5 as bool</error>/*caret*/;
+        }
+    """, """
+        fn main() {
+            5 != 0/*caret*/;
+        }
+    """)
+
+    fun `test fix numeric cast to bool in expression`() = checkFixByText("Compare with zero", """
+        fn main() {
+            let _ = !(<error descr="It is not allowed to cast to a bool. [E0054]">5 as bool</error>/*caret*/);
+        }
+    """, """
+        fn main() {
+            let _ = !(5 != 0/*caret*/);
+        }
+    """)
+
+    // The compare with zero fix does not apply to casts from types that can not be compared with zero.
+    fun `test absent fix nonnumerical cast to bool`() = checkFixIsUnavailable("Compare with zero", """
+        fn main() {
+            <error descr="It is not allowed to cast to a bool. [E0054]">'a' as bool</error>/*caret*/;
+        }
+    """)
+
+}


### PR DESCRIPTION
Builds on #6318.

This PR adds a fix to *Compare with zero instead* when a cast of a numerical type to bool is attempted.

Part of #886 