### PR TITLE
QDOC: show quick documentation for primitive types in stdlib

### DIFF
--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -303,6 +303,11 @@ abstract class RsTestBase : RsPlatformTestBase() {
         return element to data
     }
 
+    protected inline fun <reified T : PsiElement> findElementAndOffsetInEditor(marker: String = "^"): Pair<T, Int> {
+        val (element, _, offset) = findElementWithDataAndOffsetInEditor<T>(marker)
+        return element to offset
+    }
+
     protected inline fun <reified T : PsiElement> findElementWithDataAndOffsetInEditor(
         marker: String = "^"
     ): Triple<T, String, Int> {

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickNavigationInfoTest.kt
@@ -730,5 +730,5 @@ class RsQuickNavigationInfoTest : RsDocumentationProviderTest() {
     """)
 
     private fun doTest(@Language("Rust") code: String, @Language("Html") expected: String)
-        = doTest(code, expected, RsDocumentationProvider::getQuickNavigateInfo)
+        = doTest(code, expected, block = RsDocumentationProvider::getQuickNavigateInfo)
 }


### PR DESCRIPTION
Previously, the plugin failed to find file with documentation when you tried to get quick documentation for primitive types from stdlib sources