### PR TITLE
COMP: add completion for impl trait items

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
@@ -31,6 +31,7 @@ import org.rust.openapiext.checkReadAccessAllowed
 import org.rust.openapiext.checkWriteAccessAllowed
 import org.rust.openapiext.checkWriteAccessNotAllowed
 import kotlin.math.max
+import org.rust.openapiext.selectElement
 
 fun generateTraitMembers(impl: RsImplItem, editor: Editor?) {
     checkWriteAccessNotAllowed()
@@ -163,13 +164,6 @@ private fun simplifyConstExprs(insertedMembers: List<RsAbstractable>) {
             }
         }
     }
-}
-
-private fun selectElement(element: RsElement, editor: Editor) {
-    val start = element.textRange.startOffset
-    editor.caretModel.moveToOffset(start)
-    editor.scrollingModel.scrollToCaret(ScrollType.RELATIVE)
-    editor.selectionModel.setSelection(start, element.textRange.endOffset)
 }
 
 private fun createExtraWhitespacesAroundFunction(left: PsiElement, right: PsiElement): PsiElement {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
@@ -31,6 +31,7 @@ class RsCompletionContributor : CompletionContributor() {
         extend(CompletionType.BASIC, RsStructPatRestCompletionProvider)
         extend(CompletionType.BASIC, RsClippyLintCompletionProvider)
         extend(CompletionType.BASIC, RsRustcLintCompletionProvider)
+        extend(CompletionType.BASIC, RsImplTraitMemberCompletionProvider)
     }
 
     fun extend(type: CompletionType?, provider: RsCompletionProvider) {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProvider.kt
@@ -1,0 +1,153 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.patterns.ElementPattern
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import com.intellij.util.ProcessingContext
+import org.rust.ide.presentation.ImportingPsiRenderer
+import org.rust.ide.presentation.PsiRenderingOptions
+import org.rust.ide.presentation.renderFunctionSignature
+import org.rust.ide.presentation.renderTypeReference
+import org.rust.ide.utils.import.import
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsAbstractable
+import org.rust.lang.core.psi.ext.block
+import org.rust.lang.core.psi.ext.expandedMembers
+import org.rust.lang.core.resolve.knownItems
+import org.rust.lang.core.resolve.ref.pathPsiSubst
+import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.types.RsPsiSubstitution
+import org.rust.lang.core.types.infer.substitute
+import org.rust.lang.core.types.type
+import org.rust.openapiext.selectElement
+
+object RsImplTraitMemberCompletionProvider : RsCompletionProvider() {
+    override val elementPattern: ElementPattern<PsiElement>
+        get() {
+            val contributor = RsKeywordCompletionContributor()
+            return contributor.traitOrImplDeclarationPattern()
+        }
+
+    override fun addCompletions(
+        parameters: CompletionParameters,
+        context: ProcessingContext,
+        result: CompletionResultSet
+    ) {
+        val element = parameters.position
+        val implBlock = element.parentOfType<RsImplItem>() ?: return
+
+        val traitRef = implBlock.traitRef ?: return
+
+        val trait = implBlock.implementedTrait ?: return
+        val subst = pathPsiSubst(traitRef.path, trait.element)
+
+        val members = trait.element.members ?: return
+
+        val parentItems = members.expandedMembers.toMutableSet()
+        for (item in implBlock.expandedMembers) {
+            parentItems.removeIf { it.javaClass == item.javaClass && it.name == item.name }
+        }
+
+        for (item in parentItems) {
+            val lookup = getCompletion(item, trait, implBlock, subst) ?: continue
+            result.addElement(
+                lookup.withPriority(KEYWORD_PRIORITY + 1)
+            )
+        }
+    }
+}
+
+private fun getCompletion(
+    target: RsAbstractable,
+    trait: BoundElement<RsTraitItem>,
+    impl: RsImplItem,
+    substitution: RsPsiSubstitution
+): LookupElementBuilder? {
+    return when (target) {
+        is RsConstant -> completeConstant(target, trait, impl, substitution)
+        is RsTypeAlias -> completeType(target)
+        is RsFunction -> completeFunction(target, impl, substitution)
+        else -> error("unreachable")
+    }
+}
+
+private fun completeConstant(
+    target: RsConstant,
+    trait: BoundElement<RsTraitItem>,
+    impl: RsImplItem,
+    substitution: RsPsiSubstitution
+): LookupElementBuilder? {
+    val renderer = ImportingPsiRenderer(PsiRenderingOptions(renderGenericsAndWhere = true), substitution, impl)
+    val text = buildString {
+        append("const ")
+        append(target.name)
+        val typeRef = target.typeReference ?: return null
+        append(": ")
+        append(renderer.renderTypeReference(typeRef))
+        val builder = RsDefaultValueBuilder(impl.knownItems, target.containingMod, RsPsiFactory(target.project))
+        append(" = ")
+        val type = typeRef.type.substitute(trait.subst)
+        append(builder.buildFor(type, mapOf()).text)
+        append(';')
+    }
+    return LookupElementBuilder.create(text)
+        .withIcon(target.getIcon(0))
+        .withInsertHandler { context, _ ->
+            val element = context.getElementOfType<RsConstant>() ?: return@withInsertHandler
+            for (importCandidate in renderer.itemsToImport) {
+                importCandidate.import(impl)
+            }
+            val expr = element.expr ?: return@withInsertHandler
+            selectElement(expr, context.editor)
+        }
+}
+
+private fun completeType(target: RsTypeAlias): LookupElementBuilder {
+    val text = buildString {
+        append("type ")
+        append(target.name)
+        append(" = ();")
+    }
+    return LookupElementBuilder.create(text)
+        .withIcon(target.getIcon(0))
+        .withInsertHandler { context, _ ->
+            val element = context.getElementOfType<RsTypeAlias>() ?: return@withInsertHandler
+            val typeReference = element.typeReference ?: return@withInsertHandler
+            selectElement(typeReference, context.editor)
+        }
+}
+
+private fun completeFunction(
+    target: RsFunction,
+    impl: RsImplItem,
+    substitution: RsPsiSubstitution
+): LookupElementBuilder {
+    val renderer = ImportingPsiRenderer(PsiRenderingOptions(renderGenericsAndWhere = true), substitution, impl)
+    val shortRenderer = ImportingPsiRenderer(PsiRenderingOptions(renderGenericsAndWhere = false), substitution, impl)
+    val shortSignature = shortRenderer.renderFunctionSignature(target)
+    var signature = renderer.renderFunctionSignature(target)
+    if (!signature.endsWith(" ")) {
+        signature += " "
+    }
+    val text = "$signature{\n        todo!()\n    }"
+    return LookupElementBuilder
+        .create(text)
+        .withIcon(target.getIcon(0))
+        .withInsertHandler { context, _ ->
+            val element = context.getElementOfType<RsFunction>() ?: return@withInsertHandler
+            for (importCandidate in renderer.itemsToImport) {
+                importCandidate.import(impl)
+            }
+            val body = element.block?.expr ?: return@withInsertHandler
+            selectElement(body, context.editor)
+        }
+        .withPresentableText("$shortSignature { ... }")
+}

--- a/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt
@@ -221,7 +221,7 @@ class RsKeywordCompletionContributor : CompletionContributor(), DumbAware {
         )
     }
 
-    private fun traitOrImplDeclarationPattern(): PsiElementPattern.Capture<PsiElement> {
+    fun traitOrImplDeclarationPattern(): PsiElementPattern.Capture<PsiElement> {
         return baseTraitOrImplDeclaration().and(statementBeginningPattern())
     }
 

--- a/src/main/kotlin/org/rust/openapiext/ui.kt
+++ b/src/main/kotlin/org/rust/openapiext/ui.kt
@@ -8,6 +8,8 @@ package org.rust.openapiext
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.invokeLater
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.ScrollType
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.project.Project
@@ -22,6 +24,7 @@ import com.intellij.ui.layout.Row
 import com.intellij.ui.layout.RowBuilder
 import com.intellij.util.Alarm
 import org.rust.lang.RsFileType
+import org.rust.lang.core.psi.ext.RsElement
 import javax.swing.event.DocumentEvent
 import kotlin.reflect.KProperty
 
@@ -117,4 +120,11 @@ fun RowBuilder.row(
     val label = Label(labelText)
     label.toolTipText = toolTip.trimIndent()
     return row(label, separated, init)
+}
+
+fun selectElement(element: RsElement, editor: Editor) {
+    val start = element.textRange.startOffset
+    editor.caretModel.moveToOffset(start)
+    editor.scrollingModel.scrollToCaret(ScrollType.RELATIVE)
+    editor.selectionModel.setSelection(start, element.textRange.endOffset)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
@@ -87,6 +87,11 @@ abstract class RsCompletionTestBase : RsTestBase() {
         render: LookupElement.() -> String = { lookupString }
     ) = completionFixture.checkContainsCompletionByFileTree(code, variants, render)
 
+    protected fun checkContainsCompletionPrefixes(
+        prefixes: List<String>,
+        @Language("Rust") code: String
+    ) = completionFixture.checkContainsCompletionPrefixes(code, prefixes)
+
     protected fun checkCompletion(
         lookupString: String,
         @Language("Rust") before: String,

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
@@ -122,6 +122,20 @@ abstract class RsCompletionTestFixtureBase<IN>(
         }
     }
 
+    fun checkContainsCompletionPrefixes(code: IN, prefixes: List<String>) {
+        prepare(code)
+        val lookups = myFixture.completeBasic()
+
+        checkNotNull(lookups) {
+            "Expected completions that start with $prefixes, but no completions found"
+        }
+        for (prefix in prefixes) {
+            if (lookups.all { it.lookupString.startsWith(prefix) }) {
+                error("Expected completions that start with $prefix, but got ${lookups.map { it.lookupString }}")
+            }
+        }
+    }
+
     protected fun checkByText(code: IN, after: String, action: () -> Unit) {
         prepare(code)
         action()

--- a/src/test/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProviderTest.kt
@@ -1,0 +1,387 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import org.rust.UseNewResolve
+
+@UseNewResolve
+class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
+    fun `test constant`() = doFirstCompletion("""
+        trait Foo {
+            const FOO: u32;
+        }
+
+        impl Foo for () {
+            /*caret*/
+        }
+    """, """
+        trait Foo {
+            const FOO: u32;
+        }
+
+        impl Foo for () {
+            const FOO: u32 = <selection>/*caret*/0</selection>;
+        }
+    """)
+
+    fun `test constant type substitution`() = doFirstCompletion("""
+        struct S<R>(R);
+
+        trait Foo<T> {
+            const FOO: S<T>;
+        }
+
+        impl<X> Foo<X> for () {
+            /*caret*/
+        }
+    """, """
+        struct S<R>(R);
+
+        trait Foo<T> {
+            const FOO: S<T>;
+        }
+
+        impl<X> Foo<X> for () {
+            const FOO: S<X> = <selection>/*caret*/S()</selection>;
+        }
+    """)
+
+    fun `test type alias`() = doFirstCompletion("""
+        trait Foo {
+            type FOO;
+        }
+
+        impl Foo for () {
+            /*caret*/
+        }
+    """, """
+        trait Foo {
+            type FOO;
+        }
+
+        impl Foo for () {
+            type FOO = <selection>/*caret*/()</selection>;
+        }
+    """)
+
+    fun `test function`() = doFirstCompletion("""
+        trait Foo {
+            fn foo(&self, a: u32, b: u32) -> u32;
+        }
+
+        impl Foo for () {
+            /*caret*/
+        }
+    """, """
+        trait Foo {
+            fn foo(&self, a: u32, b: u32) -> u32;
+        }
+
+        impl Foo for () {
+            fn foo(&self, a: u32, b: u32) -> u32 {
+                <selection>/*caret*/todo!()</selection>
+            }
+        }
+    """)
+
+    fun `test multiple constants`() = checkContainsCompletion(
+        listOf("const FOO: u32 = 0;", "const BAR: u32 = 0;", "const BAZ: u32 = 0;"), """
+        trait Foo {
+            const FOO: u32;
+            const BAR: u32;
+            const BAZ: u32;
+        }
+
+        impl Foo for () {
+            /*caret*/
+        }
+    """)
+
+    fun `test multiple types`() = checkContainsCompletion(
+        listOf("type FOO = ();", "type BAR = ();", "type BAZ = ();"), """
+        trait Foo {
+            type FOO;
+            type BAR;
+            type BAZ;
+        }
+
+        impl Foo for () {
+            /*caret*/
+        }
+    """)
+
+    fun `test multiple functions`() = checkContainsCompletionPrefixes(
+        listOf("fn foo", "fn bar", "fn baz"), """
+        trait Foo {
+            fn foo();
+            fn bar();
+            fn baz();
+        }
+
+        impl Foo for () {
+            /*caret*/
+        }
+    """)
+
+    fun `test ignore existing constants`() = checkNotContainsCompletion("const FOO", """
+        trait Foo {
+            const FOO: u32;
+            const BAR: u32;
+            const BAZ: u32;
+        }
+
+        impl Foo for () {
+            const FOO: u32 = 0;
+            /*caret*/
+        }
+    """)
+
+    fun `test ignore existing types`() = checkNotContainsCompletion("type FOO", """
+        trait Foo {
+            type FOO;
+            type BAR;
+            type BAZ;
+        }
+
+        impl Foo for () {
+            type FOO = ();
+            /*caret*/
+        }
+    """)
+
+    fun `test ignore existing functions`() = checkNotContainsCompletion("fn foo", """
+        trait Foo {
+            fn foo();
+            fn bar();
+            fn baz();
+        }
+
+        impl Foo for () {
+            fn foo() {}
+            /*caret*/
+        }
+    """)
+
+    fun `test offer item with different type but same name`() = checkContainsCompletionPrefixes(listOf("fn FOO"), """
+        trait Foo {
+            type FOO: u32;
+            fn FOO();
+        }
+
+        impl Foo for () {
+            type FOO = ();
+            /*caret*/
+        }
+    """)
+
+    fun `test auto import constant type`() = doFirstCompletion("""
+        mod foo {
+            pub struct S;
+
+            pub trait Foo {
+                const FOO: S;
+            }
+        }
+
+        impl foo::Foo for () {
+            /*caret*/
+        }
+    """, """
+        use foo::S;
+
+        mod foo {
+            pub struct S;
+
+            pub trait Foo {
+                const FOO: S;
+            }
+        }
+
+        impl foo::Foo for () {
+            const FOO: S = <selection>/*caret*/S</selection>;
+        }
+    """)
+
+    fun `test auto import constant type with alias`() = doFirstCompletion("""
+        mod foo {
+            pub type ALIAS = u32;
+
+            pub trait Foo {
+                const FOO: ALIAS;
+            }
+        }
+
+        impl foo::Foo for () {
+            /*caret*/
+        }
+    """, """
+        use foo::ALIAS;
+
+        mod foo {
+            pub type ALIAS = u32;
+
+            pub trait Foo {
+                const FOO: ALIAS;
+            }
+        }
+
+        impl foo::Foo for () {
+            const FOO: ALIAS = <selection>/*caret*/0</selection>;
+        }
+    """)
+
+    fun `test auto import function types`() = doFirstCompletion("""
+        mod foo {
+            pub struct S;
+            pub struct T;
+
+            pub trait Foo {
+                fn foo(s: S) -> T;
+            }
+        }
+
+        impl foo::Foo for () {
+            /*caret*/
+        }
+    """, """
+        use foo::{S, T};
+
+        mod foo {
+            pub struct S;
+            pub struct T;
+
+            pub trait Foo {
+                fn foo(s: S) -> T;
+            }
+        }
+
+        impl foo::Foo for () {
+            fn foo(s: S) -> T {
+                <selection>/*caret*/todo!()</selection>
+            }
+        }
+    """)
+
+    fun `test auto import function types with aliases`() = doFirstCompletion("""
+        mod foo {
+            pub type ALIAS1 = u32;
+            pub type ALIAS2 = usize;
+
+            pub trait Foo {
+                fn foo(s: ALIAS1) -> ALIAS2;
+            }
+        }
+
+        impl foo::Foo for () {
+            /*caret*/
+        }
+    """, """
+        use foo::{ALIAS1, ALIAS2};
+
+        mod foo {
+            pub type ALIAS1 = u32;
+            pub type ALIAS2 = usize;
+
+            pub trait Foo {
+                fn foo(s: ALIAS1) -> ALIAS2;
+            }
+        }
+
+        impl foo::Foo for () {
+            fn foo(s: ALIAS1) -> ALIAS2 {
+                <selection>/*caret*/todo!()</selection>
+            }
+        }
+    """)
+
+    fun `test complete full function signature`() = doFirstCompletion("""
+        trait T1 {}
+        trait T2 {
+            fn foo<T>() -> T where T: T1;
+        }
+
+        impl T2 for () {
+            /*caret*/
+        }
+    """, """
+        trait T1 {}
+        trait T2 {
+            fn foo<T>() -> T where T: T1;
+        }
+
+        impl T2 for () {
+            fn foo<T>() -> T where T: T1 {
+                <selection>/*caret*/todo!()</selection>
+            }
+        }
+    """)
+
+    fun `test substitute generic types in function`() = doFirstCompletion("""
+        trait T2<T> {
+            fn foo() -> T;
+        }
+
+        impl T2<u32> for () {
+            /*caret*/
+        }
+    """, """
+        trait T2<T> {
+            fn foo() -> T;
+        }
+
+        impl T2<u32> for () {
+            fn foo() -> u32 {
+                <selection>/*caret*/todo!()</selection>
+            }
+        }
+    """)
+
+    fun `test substitute generic types with alias in function`() = doFirstCompletion("""
+        trait T2<T> {
+            fn foo() -> T;
+        }
+
+        type Alias = u32;
+
+        impl T2<Alias> for () {
+            /*caret*/
+        }
+    """, """
+        trait T2<T> {
+            fn foo() -> T;
+        }
+
+        type Alias = u32;
+
+        impl T2<Alias> for () {
+            fn foo() -> Alias {
+                <selection>/*caret*/todo!()</selection>
+            }
+        }
+    """)
+
+    fun `test substitute generic types with alias in constant`() = doFirstCompletion("""
+        trait T2<T> {
+            const FOO: T;
+        }
+
+        type Alias = u32;
+
+        impl T2<Alias> for () {
+            /*caret*/
+        }
+    """, """
+        trait T2<T> {
+            const FOO: T;
+        }
+
+        type Alias = u32;
+
+        impl T2<Alias> for () {
+            const FOO: Alias = <selection>/*caret*/0</selection>;
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds completion for types, constants and functions in `impl Trait for Foo` blocks.
![complete-impl-items](https://user-images.githubusercontent.com/4539057/102211763-62697780-3ed4-11eb-9769-3ed9a99f7e29.gif)

I'm not sure what should be done with the caret/selection after the completion. Using `RsInPlaceVariableIntroducer` is probably not right in completion? But without it if I select the completed value and the user presses enter, it will be overwritten.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/6282