### PR TITLE
T: Add tests for updating CrateDefMap in new resolve

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateChangeSingleFileTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateChangeSingleFileTest.kt
@@ -1,0 +1,333 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.psi.PsiDocumentManager
+import org.intellij.lang.annotations.Language
+import org.rust.ExpandMacros
+import org.rust.UseNewResolve
+
+/** Tests whether or not [CrateDefMap] should be updated after file modification */
+@UseNewResolve
+@ExpandMacros  // needed to enable precise modification tracker
+class RsDefMapUpdateChangeSingleFileTest : RsDefMapUpdateTestBase() {
+
+    fun `test edit function body`() = doTestNotChanged(type(), """
+        fn foo() {/*caret*/}
+    """)
+
+    fun `test edit function name`() = doTestChanged(type(), """
+        fn foo/*caret*/(x: i32) {}
+    """)
+
+    fun `test edit function arg name`() = doTestNotChanged(type(), """
+        fn foo(x/*caret*/: i32) {}
+    """)
+
+    fun `test edit function arg type`() = doTestNotChanged(type(), """
+        fn foo(x: /*caret*/i32) {}
+    """)
+
+    fun `test add function in empty file`() = doTestChanged("""
+
+    """, """
+        fn bar() {}
+    """)
+
+    fun `test add function to end of file`() = doTestChanged("""
+        fn foo() {}
+    """, """
+        fn foo() {}
+        fn bar() {}
+    """)
+
+    fun `test add function to beginning of file`() = doTestChanged("""
+        fn foo() {}
+    """, """
+        fn bar() {}
+        fn foo() {}
+    """)
+
+    fun `test swap functions`() = doTestNotChanged("""
+        fn foo() {}
+        fn bar() {}
+    """, """
+        fn bar() {}
+        fn foo() {}
+    """)
+
+    fun `test change item visibility`() = doTestChanged("""
+        fn foo() {}
+    """, """
+        pub fn foo() {}
+    """)
+
+    fun `test change item visibility 2`() = doTestChanged("""
+        pub fn foo() {}
+    """, """
+        pub(crate) fn foo() {}
+    """)
+
+    fun `test change item visibility 3`() = doTestNotChanged("""
+        pub(crate) fn foo() {}
+    """, """
+        pub(in crate) fn foo() {}
+    """)
+
+    fun `test change item visibility 4`() = doTestNotChanged("""
+        fn foo() {}
+    """, """
+        pub(self) fn foo() {}
+    """)
+
+    fun `test add item with same name in different namespace`() = doTestChanged("""
+        fn foo() {}
+    """, """
+        fn foo() {}
+        mod foo {}
+    """)
+
+    fun `test change import 1`() = doTestChanged("""
+        use aaa::bbb;
+    """, """
+        use aaa::ccc;
+    """)
+
+    fun `test change import 2`() = doTestChanged("""
+        use aaa::{bbb, ccc};
+    """, """
+        use aaa::{bbb, ddd};
+    """)
+
+    fun `test swap imports`() = doTestNotChanged("""
+        use aaa::bbb;
+        use aaa::ccc;
+    """, """
+        use aaa::ccc;
+        use aaa::bbb;
+    """)
+
+    fun `test swap paths in use group`() = doTestNotChanged("""
+        use aaa::{bbb, ccc};
+    """, """
+        use aaa::{ccc, bbb};
+    """)
+
+    fun `test change import visibility`() = doTestChanged("""
+        use aaa::bbb;
+    """, """
+        pub use aaa::bbb;
+    """)
+
+    fun `test change extern crate 1`() = doTestChanged("""
+        extern crate foo;
+    """, """
+        extern crate bar;
+    """)
+
+    fun `test change extern crate 2`() = doTestChanged("""
+        extern crate foo;
+    """, """
+        extern crate foo as bar;
+    """)
+
+    fun `test add macro_use to extern crate`() = doTestChanged("""
+        extern crate foo;
+    """, """
+        #[macro_use]
+        extern crate foo;
+    """)
+
+    fun `test change extern crate visibility`() = doTestChanged("""
+        extern crate foo;
+    """, """
+        pub extern crate foo;
+    """)
+
+    fun `test change mod item to mod decl`() = doTestChanged("""
+        mod foo {}
+    """, """
+        mod foo;
+    """)
+
+    fun `test add macro_use to mod item`() = doTestChanged("""
+        mod foo {}
+    """, """
+        #[macro_use]
+        mod foo {}
+    """)
+
+    fun `test add path attribute to mod item`() = doTestChanged("""
+        mod foo {}
+    """, """
+        #[path = "bar.rs"]
+        mod foo {}
+    """)
+
+    fun `test change path attribute of mod item`() = doTestChanged("""
+        #[path = "bar1.rs"]
+        mod foo {}
+    """, """
+        #[path = "bar2.rs"]
+        mod foo {}
+    """)
+
+    fun `test add macro_use to mod decl`() = doTestChanged("""
+        mod foo;
+    """, """
+        #[macro_use]
+        mod foo;
+    """)
+
+    fun `test add path attribute to mod decl`() = doTestChanged("""
+        mod foo;
+    """, """
+        #[path = "bar.rs"]
+        mod foo;
+    """)
+
+    fun `test change path attribute of mod decl`() = doTestChanged("""
+        #[path = "bar1.rs"]
+        mod foo;
+    """, """
+        #[path = "bar2.rs"]
+        mod foo;
+    """)
+
+    fun `test change macro call path`() = doTestChanged("""
+        foo!();
+    """, """
+        bar!();
+    """)
+
+    fun `test change macro call content`() = doTestChanged("""
+        foo!();
+    """, """
+        foo!(bar);
+    """)
+
+    fun `test change macro call content spaces`() = doTestChanged("""
+        foo!();
+    """, """
+        foo!( );
+    """)
+
+    fun `test swap macro calls`() = doTestChanged("""
+        foo1!();
+        foo2!();
+    """, """
+        foo2!();
+        foo1!();
+    """)
+
+    fun `test change macro call path inside item`() = doTestNotChanged("""
+        fn func() {
+            foo!();
+        }
+    """, """
+        fn func() {
+            bar!();
+        }
+    """)
+
+    fun `test change macro call content inside item`() = doTestNotChanged("""
+        fn func() {
+            foo!();
+        }
+    """, """
+        fn func() {
+            foo!(bar);
+        }
+    """)
+
+    fun `test change macro def name`() = doTestChanged("""
+        macro_rules! foo {
+            () => {};
+        }
+    """, """
+        macro_rules! bar {
+            () => {};
+        }
+    """)
+
+    fun `test change macro def content 1`() = doTestChanged("""
+        macro_rules! foo {
+            () => {};
+        }
+    """, """
+        macro_rules! foo {
+            () => { fn func() {} };
+        }
+    """)
+
+    fun `test add macro_export to macro def`() = doTestChanged("""
+        macro_rules! foo {
+            () => {};
+        }
+    """, """
+        #[macro_export]
+        macro_rules! foo {
+            () => {};
+        }
+    """)
+
+    fun `test add local_inner_macros to macro def`() = doTestChanged("""
+        #[macro_export]
+        macro_rules! foo {
+            () => {};
+        }
+    """, """
+        #[macro_export(local_inner_macros)]
+        macro_rules! foo {
+            () => {};
+        }
+    """)
+
+    private fun type(text: String = "a"): () -> Unit = {
+        myFixture.type(text)
+        PsiDocumentManager.getInstance(project).commitAllDocuments()
+    }
+
+    private fun replaceFileContent(after: String): () -> Unit = {
+        val virtualFile = myFixture.file.virtualFile
+        runWriteAction {
+            VfsUtil.saveText(virtualFile, after)
+        }
+        PsiDocumentManager.getInstance(project).commitAllDocuments()
+    }
+
+    private fun doTestChanged(action: () -> Unit, @Language("Rust") code: String) {
+        InlineFile(code).withCaret()
+        doTest(action, shouldChange = true)
+    }
+
+    private fun doTestNotChanged(action: () -> Unit, @Language("Rust") code: String) {
+        InlineFile(code).withCaret()
+        doTest(action, shouldChange = false)
+    }
+
+    private fun doTest(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String,
+        shouldChange: Boolean
+    ) {
+        InlineFile(before)
+        doTest(replaceFileContent(after), shouldChange)
+        doTest(replaceFileContent(before), shouldChange)
+    }
+
+    private fun doTestChanged(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String
+    ) = doTest(before, after, shouldChange = true)
+
+    private fun doTestNotChanged(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String
+    ) = doTest(before, after, shouldChange = false)
+}

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateCreateNewFileTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateCreateNewFileTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.psi.PsiDirectory
+import org.intellij.lang.annotations.Language
+import org.rust.ExpandMacros
+import org.rust.UseNewResolve
+import org.rust.fileTreeFromText
+import org.rust.openapiext.toPsiDirectory
+
+/** Tests whether or not [CrateDefMap] should be updated after creation of new file */
+@UseNewResolve
+@ExpandMacros
+class RsDefMapUpdateCreateNewFileTest : RsDefMapUpdateTestBase() {
+
+    private fun createFile(parent: PsiDirectory, fileToCreate: String): () -> Unit = {
+        runWriteAction {
+            parent.createFile(fileToCreate)
+        }
+    }
+
+    private fun doTest(
+        fileToCreate: String,
+        @Language("Rust") before: String,
+        shouldChange: Boolean = true
+    ) {
+        val testProject = fileTreeFromText(before).create()
+        val root = testProject.root.toPsiDirectory(myFixture.project)!!
+        doTest(createFile(root, fileToCreate), shouldChange)
+    }
+
+    fun `test create file for mod decl`() = doTest("foo.rs", """
+    //- main.rs
+        mod foo;
+    """)
+
+    fun `test create file for include! macro`() = doTest("foo.rs", """
+    //- main.rs
+        include!("foo.rs");
+    """)
+
+    fun `test create non relevant file`() = doTest("foo.rs", """
+    //- main.rs
+        fn main() {}
+    """, shouldChange = false)
+}

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateTestBase.kt
@@ -1,0 +1,28 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import org.rust.RsTestBase
+import org.rust.lang.core.psi.RsFile
+import org.rust.openapiext.toPsiFile
+
+abstract class RsDefMapUpdateTestBase : RsTestBase() {
+
+    protected fun doTest(action: () -> Unit, shouldChange: Boolean) {
+        val crateRoot = myFixture.findFileInTempDir("main.rs").toPsiFile(myFixture.project) as RsFile
+        // Note: crate can change after `action`
+        val getTimestamp = {
+            val crateId = crateRoot.crate!!.id!!
+            val defMap = project.defMapService.getOrUpdateIfNeeded(crateId)!!
+            defMap.timestamp
+        }
+        val oldStamp = getTimestamp()
+        action()
+        val newStamp = getTimestamp()
+        val changed = newStamp != oldStamp
+        check(changed == shouldChange) { "DefMap should ${if (shouldChange) "" else "not "}rebuilt" }
+    }
+}

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsMultipleDefMapsUpdateTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsMultipleDefMapsUpdateTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.openapi.command.WriteCommandAction.runWriteCommandAction
+import org.junit.Assert
+import org.rust.*
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.crate.crateGraph
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.ext.containingCrate
+import org.rust.lang.core.psi.rustStructureModificationTracker
+import org.rust.lang.core.resolve2.CrateInfo.*
+import org.rust.openapiext.toPsiFile
+
+/** Tests which exactly [CrateDefMap]s are updated when we modify some crate and then run resolve in some other crate */
+@UseNewResolve
+@ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+class RsMultipleDefMapsUpdateTest : RsTestBase() {
+
+    override fun setUp() {
+        super.setUp()
+        fileTreeFromText(codeAllCrates).create()
+        for (crate in project.crateGraph.topSortedCrates) {
+            project.defMapService.getOrUpdateIfNeeded(crate.id ?: continue)
+        }
+    }
+
+    private fun modifyCrates(vararg crates: CrateInfo) {
+        runWriteCommandAction(project) {
+            for (crateToModify in crates) {
+                val file = crateToModify.crate.rootMod!!
+                val modificationCount = project.rustStructureModificationTracker.modificationCount
+                file.add(RsPsiFactory(project).createFunction("pub fn foo$modificationCount() {}"))
+            }
+        }
+    }
+
+    private fun getDefMap(crateInfo: CrateInfo, cratesUpdatedExpected: Array<CrateInfo>) {
+        val crates = project.crateGraph.topSortedCrates
+        val crateIds = crates.mapNotNull { it.id }
+
+        val getDefMapStamps = {
+            crateIds.associateWith {
+                val holder = project.defMapService.getDefMapHolder(it)
+                holder.defMap!!.timestamp
+            }
+        }
+
+        val defMapStampsOld = getDefMapStamps()
+        project.defMapService.getOrUpdateIfNeeded(crateInfo.crate.id!!)!!
+        val defMapStampsNew = getDefMapStamps()
+
+        val cratesUpdatedActual = crateIds
+            .filter { defMapStampsOld[it] != defMapStampsNew[it] }
+            .map { id -> values().single { it.crate.id == id } }
+            .sorted()
+        Assert.assertEquals(cratesUpdatedExpected.sorted(), cratesUpdatedActual)
+    }
+
+    private val CrateInfo.crate: Crate
+        get() {
+            val crateRoot = myFixture.findFileInTempDir(crateRootPath).toPsiFile(project) as RsFile
+            return crateRoot.containingCrate!!
+        }
+
+    fun `test no modifications`() {
+        getDefMap(BIN, emptyArray())
+        getDefMap(LIB, emptyArray())
+    }
+
+    fun `test modify binary crate`() {
+        modifyCrates(BIN)
+        getDefMap(LIB, emptyArray())
+        getDefMap(BIN, arrayOf(BIN))
+        getDefMap(BIN, emptyArray())
+
+        modifyCrates(BIN)
+        getDefMap(LIB, emptyArray())
+        getDefMap(BIN, arrayOf(BIN))
+    }
+
+    fun `test modify trans-lib and trans-lib-2 crates`() {
+        modifyCrates(TRANS_LIB2)
+        getDefMap(DEP_LIB, arrayOf(DEP_LIB, TRANS_LIB, TRANS_LIB2))
+        modifyCrates(TRANS_LIB)
+        getDefMap(LIB, arrayOf(LIB, DEP_LIB, TRANS_LIB))
+    }
+
+    fun `test modify trans-lib-2 crate 1`() {
+        modifyCrates(TRANS_LIB2)
+        getDefMap(TRANS_LIB2, arrayOf(TRANS_LIB2))
+        getDefMap(TRANS_LIB, arrayOf(TRANS_LIB))
+        getDefMap(DEP_LIB, arrayOf(DEP_LIB))
+        getDefMap(LIB, arrayOf(LIB))
+        getDefMap(BIN, arrayOf(BIN))
+    }
+
+    fun `test modify trans-lib-2 crate 2`() {
+        modifyCrates(TRANS_LIB2)
+        getDefMap(TRANS_LIB, arrayOf(TRANS_LIB, TRANS_LIB2))
+        getDefMap(BIN, arrayOf(BIN, LIB, DEP_LIB))
+    }
+
+    fun `test modify dep-lib-2 and trans-lib-2 crates 1`() {
+        modifyCrates(DEP_LIB2, TRANS_LIB2)
+        getDefMap(DEP_LIB, arrayOf(DEP_LIB, DEP_LIB2, TRANS_LIB, TRANS_LIB2))
+        getDefMap(DEP_LIB, emptyArray())
+    }
+
+    fun `test modify dep-lib-2 and trans-lib-2 crates 2`() {
+        modifyCrates(DEP_LIB2, TRANS_LIB2)
+        getDefMap(DEP_LIB2, arrayOf(DEP_LIB2))
+        getDefMap(TRANS_LIB, arrayOf(TRANS_LIB, TRANS_LIB2))
+        getDefMap(DEP_LIB, arrayOf(DEP_LIB))
+        getDefMap(DEP_LIB, emptyArray())
+    }
+}
+
+/**
+ * See [WithDependencyRustProjectDescriptor.testCargoProject]
+ *
+ * BIN -> LIB -> DEP_LIB -> TRANS_LIB -> TRANS_LIB2
+ *                  |
+ *                  +-----> DEP_LIB2
+ */
+private enum class CrateInfo(val crateRootPath: String) {
+    BIN("main.rs"),
+    LIB("lib.rs"),
+    DEP_LIB("dep-lib/lib.rs"),
+    DEP_LIB2("dep-lib-new/lib.rs"),
+    TRANS_LIB("trans-lib/lib.rs"),
+    TRANS_LIB2("trans-lib-2/lib.rs"),
+}
+
+// crate roots are empty files
+private const val codeAllCrates: String = """
+//- main.rs
+//- lib.rs
+//- dep-lib/lib.rs
+//- dep-lib-new/lib.rs
+//- trans-lib/lib.rs
+//- trans-lib-2/lib.rs
+"""


### PR DESCRIPTION
Add tests for updating `CrateDefMap` in [new resolve](https://github.com/intellij-rust/intellij-rust/issues/6217):

* `RsDefMapUpdateChangeSingleFileTest` - tests whether or not `CrateDefMap` should be updated after file modification
* `RsDefMapUpdateCreateNewFileTest` - tests whether or not `CrateDefMap` should be updated after creation of new file
* `RsMultipleDefMapsUpdateTest` - tests which exactly `CrateDefMap`s are updated when we modify some crate and then run resolve in some other crate