### PR TITLE
INSP: Add error for `repr` without parentheses

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -909,7 +909,14 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
 
         val owner = attr.owner ?: return
 
-        val reprArgs = attr.metaItem.metaItemArgs?.metaItemList.orEmpty()
+        val metaItem = attr.metaItem
+        val metaItemArgs = metaItem.metaItemArgs
+
+        if (metaItemArgs == null) {
+            RsDiagnostic.NoAttrParentheses(metaItem, "repr").addToHolder(holder)
+        }
+
+        val reprArgs = metaItemArgs?.metaItemList.orEmpty()
 
         check@ for (reprArg in reprArgs) {
             val reprName = reprArg.name ?: continue

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddAttrParenthesesFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddAttrParenthesesFix.kt
@@ -1,0 +1,31 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.ide.util.PsiNavigationSupport
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.RsMetaItem
+import org.rust.lang.core.psi.RsPsiFactory
+
+class AddAttrParenthesesFix(element: RsMetaItem, private val attrName: String) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+    override fun getFamilyName(): String = "Add parentheses"
+    override fun getText(): String = "Add parentheses to `$attrName`"
+
+    override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
+        if (startElement !is RsMetaItem) return
+
+        val newItem = RsPsiFactory(project).createOuterAttr("$attrName()").metaItem
+        val replaced = startElement.replace(newItem) as? RsMetaItem ?: return
+
+        // Place caret between parentheses, so the user can immediately start typing
+        val offset = replaced.metaItemArgs?.lparen?.textOffset ?: return
+        PsiNavigationSupport.getInstance().createNavigatable(project, file.virtualFile, offset + 1).navigate(true)
+    }
+}

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1284,6 +1284,15 @@ sealed class RsDiagnostic(
         )
     }
 
+    class NoAttrParentheses(element: RsMetaItem, private val attrName: String) : RsDiagnostic(element) {
+        override fun prepare(): PreparedAnnotation = PreparedAnnotation(
+            ERROR,
+            null,
+            "Malformed `$attrName` attribute input: missing parentheses",
+            fixes = listOf(AddAttrParenthesesFix(element as RsMetaItem, attrName))
+        )
+    }
+
     class ReprAttrUnsupportedItem(element: PsiElement,
                                   private val errorText: String
     ) : RsDiagnostic(element) {

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -2133,6 +2133,13 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
+    fun `test enum with repr annotation without parentheses`() = checkErrors("""
+        #[<error descr="Malformed `repr` attribute input: missing parentheses">repr</error>]
+        enum Bad {
+            X = -1
+        }
+    """)
+
     fun `test duplicate enum discriminant repr type invalid range E0081`() = checkErrors("""
         #[repr(u8)]
         enum Good {

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddAttrParenthesesFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddAttrParenthesesFixTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.rust.ide.annotator.RsAnnotatorTestBase
+import org.rust.ide.annotator.RsErrorAnnotator
+
+class AddAttrParenthesesFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
+
+    // Note: this tests both the fix and it moving the caret to the parentheses.
+    fun `test fix repr without parentheses`() = checkFixByText("Add parentheses to `repr`", """
+        #[<error descr="Malformed `repr` attribute input: missing parentheses">re/*caret*/pr</error>]
+        enum E {
+            V
+        }
+    """, """
+        #[repr(/*caret*/)]
+        enum E {
+            V
+        }
+    """)
+
+}


### PR DESCRIPTION
Adds a new error for when a `repr` attribute does not have `RsMetaItemArgs` (thus, no pair of parentheses)

![image](https://user-images.githubusercontent.com/27009727/98054741-1559a680-1e3c-11eb-8a25-17dbb0bc6e2c.png)

Fixes #6336

changelog: Show error if `repr` attribute doesn't have parentheses and provide quick-fix to add them