### PR TITLE
INSP: Constants cannot refer to statics. (E0013)

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsConstReferStaticInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsConstReferStaticInspection.kt
@@ -1,0 +1,43 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.RsConstContextKind
+import org.rust.lang.core.psi.ext.classifyConstContext
+import org.rust.lang.core.psi.ext.isConst
+import org.rust.lang.utils.RsDiagnostic
+import org.rust.lang.utils.addToHolder
+
+/**
+ * Inspection that detects the E0013 error.
+ */
+class RsConstReferStaticInspection : RsLocalInspectionTool() {
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+        override fun visitPathExpr(pathExpr: RsPathExpr) {
+            val constContext = pathExpr.classifyConstContext
+            if (constContext != null) {
+                checkPathInConstContext(holder, pathExpr.path, constContext)
+            }
+            super.visitPathExpr(pathExpr)
+        }
+
+        override fun visitBaseType(o: RsBaseType) {
+            val path = o.path
+            if (path != null) {
+                checkPathInConstContext(holder, path, RsConstContextKind.ConstGenericArgument)
+            }
+            super.visitBaseType(o)
+        }
+    }
+
+    private fun checkPathInConstContext(holder: RsProblemsHolder, path: RsPath, constContext: RsConstContextKind) {
+        val ref = path.reference?.resolve() as? RsConstant ?: return
+        if (!ref.isConst) {
+            RsDiagnostic.ConstItemReferToStaticError(path, constContext).addToHolder(holder)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -544,6 +544,24 @@ sealed class RsDiagnostic(
         )
     }
 
+    class ConstItemReferToStaticError(element: RsElement, val constContext: RsConstContextKind) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            E0013,
+            when (constContext) {
+                is RsConstContextKind.Constant -> "Const `${constContext.psi.name.orEmpty()}` cannot refer to static " +
+                    "`${element.text}`"
+                is RsConstContextKind.ConstFn -> "Constant function `${constContext.psi.name.orEmpty()}` cannot refer " +
+                    "to static `${element.text}`"
+                is RsConstContextKind.EnumVariantDiscriminant -> "Enum variant `${constContext.psi.name.orEmpty()}`'s " +
+                    "discriminant value cannot refer to static `${element.text}`"
+                RsConstContextKind.ArraySize -> "Array size cannot refer to static `${element.text}`"
+                RsConstContextKind.ConstGenericArgument -> "Const generic argument cannot refer to static " +
+                    "`${element.text}`"
+            }
+        )
+    }
+
     class IncorrectFunctionArgumentCountError(
         element: PsiElement,
         private val expectedCount: Int,
@@ -1465,7 +1483,7 @@ sealed class RsDiagnostic(
 }
 
 enum class RsErrorCode {
-    E0004, E0015, E0023, E0025, E0026, E0027, E0040, E0046, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
+    E0004, E0013, E0015, E0023, E0025, E0026, E0027, E0040, E0046, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
     E0106, E0107, E0116, E0117, E0118, E0120, E0121, E0124, E0132, E0133, E0184, E0185, E0186, E0198, E0199,
     E0200, E0201, E0202, E0252, E0261, E0262, E0263, E0267, E0268, E0277,
     E0308, E0322, E0328, E0364, E0365, E0379, E0384,

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -569,6 +569,11 @@
                          implementationClass="org.rust.ide.inspections.RsCastToBoolInspection"/>
 
         <localInspection language="Rust" groupName="Rust"
+                         displayName="Constant refers to statics"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.rust.ide.inspections.RsConstReferStaticInspection"/>
+
+        <localInspection language="Rust" groupName="Rust"
                          displayName="Attribute without parentheses"
                          enabledByDefault="true" level="ERROR"
                          implementationClass="org.rust.ide.inspections.RsAttrWithoutParenthesesInspection"/>

--- a/src/main/resources/inspectionDescriptions/RsConstReferStatic.html
+++ b/src/main/resources/inspectionDescriptions/RsConstReferStatic.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+Detects constant variables that refer to static variables.
+
+Corresponds to <a href="https://doc.rust-lang.org/error-index.html#E0013">E0013</a> Rust error.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/RsConstReferStaticInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsConstReferStaticInspectionTest.kt
@@ -1,0 +1,171 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections
+
+class RsConstReferStaticInspectionTest : RsInspectionsTestBase(RsConstReferStaticInspection::class) {
+    fun `test const refer to static`() = checkErrors("""
+        static X: usize = 0;
+        const Y: usize = <error descr="Const `Y` cannot refer to static `X` [E0013]">X</error>;
+    """)
+
+    fun `test const refer to static within expression`() = checkErrors("""
+        static X: usize = 0;
+        const Y: usize = <error descr="Const `Y` cannot refer to static `X` [E0013]">X</error> + 5;
+    """)
+
+    fun `test const refer to static within complex expression`() = checkErrors("""
+        static X: usize = 0;
+        const Y: bool = 0 + (<error descr="Const `Y` cannot refer to static `X` [E0013]">X</error> - 42) / 2 == 0;
+    """)
+
+    fun `test const refer to static with extra modifier`() = checkErrors("""
+        pub static X: usize = 0;
+        const Y: usize = <error descr="Const `Y` cannot refer to static `X` [E0013]">X</error>;
+    """)
+
+    fun `test const refer to static within const function call`() = checkErrors("""
+        static X: usize = 0;
+
+        const fn times_five(x: usize) -> usize {
+            x * 5
+        }
+
+        const Y: usize = times_five(<error descr="Const `Y` cannot refer to static `X` [E0013]">X</error>) / 5;
+    """)
+
+    fun `test const refer to static within tuple`() = checkErrors("""
+        static X: usize = 0;
+        const Y: (usize, usize) = (<error descr="Const `Y` cannot refer to static `X` [E0013]">X</error>, 42);
+    """)
+
+    fun `test const refer to static within block expr`() = checkErrors("""
+        static X: usize = 0;
+        const Y: usize = { <error descr="Const `Y` cannot refer to static `X` [E0013]">X</error> };
+    """)
+
+    fun `test const refer to static within array literal`() = checkErrors("""
+        static X: usize = 1;
+        const Y: [usize; 3] = [0, <error descr="Const `Y` cannot refer to static `X` [E0013]">X</error>, 2];
+    """)
+
+    fun `test static reference in const array size`() = checkErrors("""
+        static SIZE: usize = 5;
+
+        fn main() {
+            let _: [usize; <error descr="Array size cannot refer to static `SIZE` [E0013]">SIZE</error>];
+        }
+    """)
+
+    fun `test static reference in expression of const array size`() = checkErrors("""
+        static SIZE: usize = 5;
+
+        fn main() {
+            let _: [usize; 4 + <error descr="Array size cannot refer to static `SIZE` [E0013]">SIZE</error>];
+        }
+    """)
+
+    fun `test static reference in enum discriminant`() = checkErrors("""
+        static X: isize = 5;
+
+        enum Bad {
+            First = <error descr="Enum variant `First`'s discriminant value cannot refer to static `X` [E0013]">X</error>,
+            Second
+        }
+    """)
+
+    fun `test const reference in enum discriminant`() = checkErrors("""
+        const X: isize = 5;
+
+        enum Good {
+            First = X,
+            Second
+        }
+    """)
+
+    // Even though E0015 will be emitted here, E0013 is emitted as well.
+    fun `test const call to non-const fn with static argument`() = checkErrors("""
+        fn times_five(x: usize) -> usize {
+            x * 5
+        }
+
+        static X: usize = 2;
+        const TEN: usize = times_five(<error descr="Const `TEN` cannot refer to static `X` [E0013]">X</error>);
+    """)
+
+    // Valid code: const may refer to const.
+    fun `test const refer to const`() = checkErrors("""
+        const X: usize = 0;
+        const Y: usize = X;
+    """)
+
+    // Valid code: static may refer to static.
+    fun `test static refer to static`() = checkErrors("""
+        static X: usize = 0;
+        static Y: usize = X;
+    """)
+
+    fun `test const array expression length is static`() = checkErrors("""
+        static S: usize = 3;
+
+        fn main() {
+            [isize; <error descr="Array size cannot refer to static `S` [E0013]">S</error>];
+        }
+    """)
+
+    fun `test const generic (expr) is static`() = checkErrors("""
+        static S: usize = 42;
+
+        fn foo<const C: usize>() {}
+
+        fn main() {
+            foo::<{ <error descr="Const generic argument cannot refer to static `S` [E0013]">S</error> }>();
+        }
+    """)
+
+    fun `test const generic (base type) is static`() = checkErrors("""
+        static S: usize = 42;
+
+        fn foo<const C: usize>() {}
+
+        fn main() {
+            foo::<<error descr="Const generic argument cannot refer to static `S` [E0013]">S</error>>();
+        }
+    """)
+
+    fun `test const generic (unit struct)`() = checkErrors("""
+        #![feature(adt_const_params)]
+
+        #[derive(PartialEq, Eq)]
+        struct S;
+
+        fn foo<const C: S>() {}
+
+        fn main() {
+            foo::<{ S }>();
+        }
+    """)
+
+    fun `test const generic (complex path) is static`() = checkErrors("""
+        static A: usize = 42;
+
+        struct S<const N: usize>;
+
+        impl <const N: usize> S<N> {
+            fn foo<const M: usize>(&self) {}
+        }
+
+        fn main() {
+            S::<{ <error descr="Const generic argument cannot refer to static `A` [E0013]">A</error> }>.foo::<{ <error descr="Const generic argument cannot refer to static `A` [E0013]">A</error> }>();
+        }
+    """)
+
+    fun `test const fn refer to static`() = checkErrors("""
+        static X: usize = 0;
+        const fn foo() -> usize {
+            <error descr="Constant function `foo` cannot refer to static `X` [E0013]">X</error>
+        }
+    """)
+}


### PR DESCRIPTION
This PR aims to implement an inspection for rust error [E0013](https://doc.rust-lang.org/error-index.html#E0013) *A const variable cannot refer to a static variable.*

Covering the following [const contexts](https://doc.rust-lang.org/reference/const_eval.html#const-context):
- [X] Constant variables
- [x] Constant size of array
- [x] Constant enum item discriminant

Part of #886 