### PR TITLE
RES: Store CrateDefMap under soft reference

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeUpdateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeUpdateDefMap.kt
@@ -99,13 +99,24 @@ private class DefMapUpdater(
         checkReadAccessAllowed()
         val time = measureTimeMillis {
             executeUnderProgress(indicator) {
-                doRun()
+                runWithStrongReferencesToDefMapHolders()
             }
         }
         if (numberUpdatedCrates > 0) {
             val cratesCount = if (numberUpdatedCrates == topSortedCrates.size) "all" else numberUpdatedCrates.toString()
             RESOLVE_LOG.info("Updated $cratesCount DefMaps in $time ms")
         }
+    }
+
+    private fun runWithStrongReferencesToDefMapHolders() {
+        /**
+         * Strong references to all [DefMapHolder]s we need,
+         * so they will not be garbage collected ([DefMapService.defMaps] stores values as soft references)
+         */
+        val holders = crates.mapNotNull { defMapService.getDefMapHolder(it.id ?: return@mapNotNull null) }
+        doRun()
+        /** Pretend we are using `crateHolders`, so it will not be optimized out */
+        check(holders.size <= crates.size)
     }
 
     private fun doRun() {

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/RsDefMapSoftReferenceTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/RsDefMapSoftReferenceTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rustSlowTests.lang.resolve
+
+import org.intellij.lang.annotations.Language
+import org.rust.UseNewResolve
+import org.rust.lang.core.psi.ext.RsNamedElement
+import org.rust.lang.core.psi.ext.RsReferenceElement
+import org.rust.lang.core.resolve.RsResolveTestBase
+import org.rust.lang.core.resolve2.DefMapHolder
+import org.rust.lang.core.resolve2.DefMapService
+import org.rust.lang.core.resolve2.defMapService
+
+/** See [DefMapService.defMaps] for details */
+@UseNewResolve
+class RsDefMapSoftReferenceTest : RsResolveTestBase() {
+
+    fun test() = doTest("""
+        fn foo() {}
+         //X
+        fn main() {
+            foo();
+        } //^
+    """)
+
+    fun doTest(@Language("Rust") code: String) {
+        InlineFile(code)
+        val element = findElementInEditor<RsReferenceElement>()
+        val reference = element.reference ?: error("Failed to get reference for `${element.text}`")
+        val target = findElementInEditor<RsNamedElement>("X")
+
+        check(reference.resolve() == target)
+
+        /** [DefMapHolder] is stored under soft reference */
+        project.defMapService.forceClearSoftReferences()
+        check(reference.resolve() == target)
+    }
+}


### PR DESCRIPTION
Memory optimization for [new resolve](https://github.com/intellij-rust/intellij-rust/issues/6217): store `CrateDefMap`s under soft references, so they will be cleared if IDE is low on memory. If `CrateDefMap` is cleared, then it will be rebuild next time it is needed.
