### PR TITLE
GRD: update 2020.3 EAPs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -262,6 +262,13 @@ project(":") {
         }
     }
 
+    intellij {
+        // TODO: drop it when CLion move `navigation.class.hierarchy` property from c-plugin to CLion resources
+        if (baseIDE == "clion" && platformVersion >= 203) {
+            setPlugins("c-plugin")
+        }
+    }
+
     val testOutput = configurations.create("testOutput")
 
     dependencies {
@@ -359,7 +366,12 @@ project(":debugger") {
 
 project(":toml") {
     intellij {
-        setPlugins(project(":intellij-toml"))
+        val plugins = mutableListOf<Any>(project(":intellij-toml"))
+        // TODO: drop it when CLion move `navigation.class.hierarchy` property from c-plugin to CLion resources
+        if (baseIDE == "clion" && platformVersion >= 203) {
+            plugins += "c-plugin"
+        }
+        setPlugins(*plugins.toTypedArray())
     }
     dependencies {
         implementation(project(":"))
@@ -438,6 +450,12 @@ project(":js") {
 
 project(":intellij-toml") {
     version = "0.2.$patchVersion.${prop("buildNumber")}$versionSuffix"
+    intellij {
+        // TODO: drop it when CLion move `navigation.class.hierarchy` property from c-plugin to CLion resources
+        if (baseIDE == "clion" && platformVersion >= 203) {
+            setPlugins("c-plugin")
+        }
+    }
 
     dependencies {
         implementation(project(":common"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,8 @@ val baseVersion = when (baseIDE) {
 
 val nativeDebugPlugin = "com.intellij.nativeDebug:${prop("nativeDebugPluginVersion")}"
 val graziePlugin = if (baseIDE == "idea") "grazie" else "tanvd.grazi:${prop("graziePluginVersion")}"
+// BACKCOMPAT: 2020.2
+val clionPlugins = if (platformVersion < 203) emptyList() else listOf("cidr-base", "clion")
 val psiViewerPlugin = "PsiViewer:${prop("psiViewerPluginVersion")}"
 
 plugins {
@@ -321,6 +323,7 @@ project(":idea") {
 project(":clion") {
     intellij {
         version = clionVersion
+        setPlugins(*clionPlugins.toTypedArray())
     }
     dependencies {
         implementation(project(":"))
@@ -337,6 +340,7 @@ project(":debugger") {
             setPlugins(nativeDebugPlugin)
         } else {
             version = clionVersion
+            setPlugins(*clionPlugins.toTypedArray())
         }
     }
     dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,10 +35,16 @@ val baseVersion = when (baseIDE) {
 }
 
 val nativeDebugPlugin = "com.intellij.nativeDebug:${prop("nativeDebugPluginVersion")}"
-val graziePlugin = if (baseIDE == "idea") "grazie" else "tanvd.grazi:${prop("graziePluginVersion")}"
-// BACKCOMPAT: 2020.2
-val clionPlugins = if (platformVersion < 203) emptyList() else listOf("cidr-base", "clion")
+val graziePlugin = if (baseIDE == "idea") "tanvd.grazi" else "tanvd.grazi:${prop("graziePluginVersion")}"
 val psiViewerPlugin = "PsiViewer:${prop("psiViewerPluginVersion")}"
+val intelliLangPlugin = "org.intellij.intelliLang"
+val copyrightPlugin = "com.intellij.copyright"
+// We can't use `com.intellij.java` here because of
+// https://github.com/JetBrains/gradle-intellij-plugin/issues/565
+val javaPlugin = "java"
+val javaScriptPlugin = "JavaScript"
+// BACKCOMPAT: 2020.2
+val clionPlugins = if (platformVersion < 203) emptyList() else listOf("com.intellij.cidr.base", "com.intellij.clion")
 
 plugins {
     idea
@@ -182,15 +188,15 @@ project(":plugin") {
         pluginName = "intellij-rust"
         val plugins = mutableListOf(
             project(":intellij-toml"),
-            "IntelliLang",
+            intelliLangPlugin,
             graziePlugin,
             psiViewerPlugin,
-            "JavaScriptLanguage"
+            javaScriptPlugin
         )
         if (baseIDE == "idea") {
             plugins += listOf(
-                "copyright",
-                "java",
+                copyrightPlugin,
+                javaPlugin,
                 nativeDebugPlugin
             )
         }
@@ -310,7 +316,7 @@ project(":") {
 project(":idea") {
     intellij {
         version = ideaVersion
-        setPlugins("java")
+        setPlugins(javaPlugin)
     }
     dependencies {
         implementation(project(":"))
@@ -365,7 +371,7 @@ project(":toml") {
 
 project(":intelliLang") {
     intellij {
-        setPlugins("IntelliLang")
+        setPlugins(intelliLangPlugin)
     }
     dependencies {
         implementation(project(":"))
@@ -378,7 +384,7 @@ project(":intelliLang") {
 project(":copyright") {
     intellij {
         version = ideaVersion
-        setPlugins("copyright")
+        setPlugins(copyrightPlugin)
     }
     dependencies {
         implementation(project(":"))
@@ -420,7 +426,7 @@ project(":grazie") {
 
 project(":js") {
     intellij {
-        setPlugins("JavaScriptLanguage")
+        setPlugins(javaScriptPlugin)
     }
     dependencies {
         implementation(project(":"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ val psiViewerPlugin = "PsiViewer:${prop("psiViewerPluginVersion")}"
 plugins {
     idea
     kotlin("jvm") version "1.4.10"
-    id("org.jetbrains.intellij") version "0.5.0"
+    id("org.jetbrains.intellij") version "0.6.3"
     id("org.jetbrains.grammarkit") version "2020.2.1"
     id("net.saliman.properties") version "1.5.1"
 }

--- a/clion/src/202/main/resources/META-INF/platform-clion-only.xml
+++ b/clion/src/202/main/resources/META-INF/platform-clion-only.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/clion/src/203/main/resources/META-INF/platform-clion-only.xml
+++ b/clion/src/203/main/resources/META-INF/platform-clion-only.xml
@@ -1,0 +1,4 @@
+<idea-plugin>
+    <depends>com.intellij.cidr.base</depends>
+    <depends>com.intellij.clion</depends>
+</idea-plugin>

--- a/clion/src/main/resources/META-INF/clion-only.xml
+++ b/clion/src/main/resources/META-INF/clion-only.xml
@@ -1,4 +1,5 @@
 <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude" allow-bundled-update="true">
+    <xi:include href="/META-INF/platform-clion-only.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/core-debugger-only.xml" xpointer="xpointer(/idea-plugin/*)"/>
 
     <extensions defaultExtensionNs="clion">

--- a/gradle-203.properties
+++ b/gradle-203.properties
@@ -1,16 +1,16 @@
 # Existent IDE versions can be found in the following repos:
 # https://www.jetbrains.com/intellij-repository/releases/
 # https://www.jetbrains.com/intellij-repository/snapshots/
-ideaVersion=IU-203.4818-EAP-CANDIDATE-SNAPSHOT
-clionVersion=CL-203.4818-EAP-CANDIDATE-SNAPSHOT
+ideaVersion=IU-203.5784-EAP-CANDIDATE-SNAPSHOT
+clionVersion=CL-203.5784-EAP-CANDIDATE-SNAPSHOT
 
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions
-nativeDebugPluginVersion=203.4818.26
+nativeDebugPluginVersion=203.5784.10
 # https://plugins.jetbrains.com/plugin/12175-grazie/versions
-graziePluginVersion=203.4818.9
+graziePluginVersion=203.5784.12
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions
 psiViewerPluginVersion=203-SNAPSHOT
 
 # please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
-sinceBuild=203.4449
+sinceBuild=203.5784
 untilBuild=211.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 propertiesPluginEnvironmentNameProperty=platformVersion
 # Supported platforms: 202, 203
-platformVersion=202
+platformVersion=203
 # Supported IDEs: idea, clion
 baseIDE=idea
 


### PR DESCRIPTION
Also makes 203 platform default for development

changelog: 2020.3 platform is default for development now