### PR TITLE
MACRO: fix MacroExpansionSharedCache

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeUpdateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeUpdateDefMap.kt
@@ -18,6 +18,7 @@ import org.rust.RsTask.TaskType.*
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.CratePersistentId
 import org.rust.lang.core.crate.crateGraph
+import org.rust.lang.core.macros.MacroExpansionSharedCache
 import org.rust.openapiext.*
 import org.rust.stdext.getWithRethrow
 import java.util.concurrent.*
@@ -52,6 +53,7 @@ fun DefMapService.getOrUpdateIfNeeded(crate: CratePersistentId): CrateDefMap? {
             holder.defMap
         } finally {
             pool.shutdown()
+            MacroExpansionSharedCache.getInstance().flush()
         }
     }
 }


### PR DESCRIPTION
The bug was introduced in #6212, but the cache was not enabled by default, so this bug most likely affects nobody. 

The stub cache must be consistent with SerializationManager.
Otherwise it leads to exceptions like this:

```
java.lang.IllegalArgumentException: Argument for @NotNull parameter 'root' of com/intellij/psi/stubs/StubSerializationUtil.brokenStubFormat must not be null
at com.intellij.psi.stubs.StubSerializationUtil.$$$reportNull$$$0(StubSerializationUtil.java)
at com.intellij.psi.stubs.StubSerializationUtil.brokenStubFormat(StubSerializationUtil.java)
at com.intellij.psi.stubs.StubSerializationHelper.reportMissingSerializer(StubSerializationHelper.java:390)
at com.intellij.psi.stubs.StubSerializationHelper.instantiateSerializer(StubSerializationHelper.java:379)
at com.intellij.psi.stubs.StubSerializationHelper.getClassById(StubSerializationHelper.java:369)
at com.intellij.psi.stubs.StubSerializationHelper.deserializeRoot(StubSerializationHelper.java:212)
at com.intellij.psi.stubs.StubSerializationHelper.deserialize(StubSerializationHelper.java:187)
at com.intellij.psi.stubs.SerializationManagerImpl.deserialize(SerializationManagerImpl.java:193)
at com.intellij.psi.stubs.SerializedStubTree.getStub(SerializedStubTree.java:144)
at org.rust.lang.core.macros.MacroExpansionSharedCache.createExpansionStub(MacroExpansionSharedCache.kt:171)
...
```