### PR TITLE
CI: batch regression tests

### DIFF
--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -39,35 +39,28 @@ jobs:
 
     check:
         needs: [ calculate-base-commit ]
-        name: ${{ matrix.project.name }}
+        name: ${{ matrix.batch.name }}
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
-                project:
-                    - name: cargo
-                      path: cargo
-                      repository: rust-lang/cargo
-                      exclude_paths: ""
-                    - name: tokio
-                      path: tokio
-                      repository: tokio-rs/tokio
-                      exclude_paths: ""
+                batch:
+                    - name: regressions-1
+                      projects:
+                          - name: cargo
+                            repository: rust-lang/cargo
+                          - name: tokio
+                            repository: tokio-rs/tokio
+                          - name: amethyst
+                            repository: amethyst/amethyst
         env:
-            PROJECT_PATH: ${{ matrix.project.path }}
-            PROJECT_URL: https://github.com/${{ matrix.project.url }}
-            PROJECT_EXCLUDE_PATHS: ${{ matrix.project.exclude_paths }}
+            ORG_GRADLE_PROJECT_platformVersion: 203
             ORG_GRADLE_PROJECT_showStandardStreams: true
+            PROJECTS: ${{ toJSON(matrix.batch.projects) }}
         steps:
             - uses: actions/checkout@v2
               with:
                   fetch-depth: 0
-
-            - uses: actions/checkout@v2
-              with:
-                  repository: ${{ matrix.project.repository }}
-                  ref: master
-                  path: testData/${{ matrix.project.name }}
 
             - name: Set up JDK 11
               uses: actions/setup-java@v1
@@ -87,6 +80,9 @@ jobs:
                   components: rust-src
                   default: true
 
+            - name: Checkout projects
+              run: python scripts/fetch_projects.py --projects $'${{ toJSON(matrix.batch.projects) }}'
+
             - name: Download
               uses: eskatos/gradle-command-action@v1
               with:
@@ -95,9 +91,9 @@ jobs:
             - name: Check with changes
               uses: eskatos/gradle-command-action@v1
               env:
-                  PROJECT_NAME: ${{ matrix.project.name }}_with_changes
+                  RESULT_SUFFIX: _with_changes
               with:
-                  arguments: "clean :test --tests \"org.rustPerformanceTests.CustomRealProjectAnalysisTest.test\""
+                  arguments: "clean :test --tests \"org.rustPerformanceTests.CustomRealProjectAnalysisTest\""
 
             - name: Checkout base version
               run: git checkout ${{ needs.calculate-base-commit.outputs.base-commit }}
@@ -105,19 +101,19 @@ jobs:
             - name: Check without changes
               uses: eskatos/gradle-command-action@v1
               env:
-                  PROJECT_NAME: ${{ matrix.project.name }}_without_changes
+                  RESULT_SUFFIX: _without_changes
               with:
-                  arguments: "clean :test --tests \"org.rustPerformanceTests.CustomRealProjectAnalysisTest.test\""
+                  arguments: "clean :test --tests \"org.rustPerformanceTests.CustomRealProjectAnalysisTest\""
 
             - name: Checkout current version
               run: git checkout ${{ github.sha }}
 
             - name: Calculate regressions
-              run: python scripts/calculate_regressions.py --name ${{ matrix.project.name }}
+              run: python scripts/calculate_regressions.py --projects $'${{ toJSON(matrix.batch.projects) }}'
 
             - name: Upload results
               if: ${{ always() }}
               uses: actions/upload-artifact@v2
               with:
-                  name: ${{ matrix.project.name }}
+                  name: ${{ matrix.batch.name }}
                   path: regressions/

--- a/scripts/fetch_projects.py
+++ b/scripts/fetch_projects.py
@@ -1,0 +1,18 @@
+import argparse
+import json
+from typing import List, Dict
+
+from common import git_command
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--projects", type=str, help="Projects info in JSON format", required=True)
+
+    args = parser.parse_args()
+    projects: List[Dict] = json.loads(args.projects)
+
+    for project in projects:
+        name = project["name"]
+        repository = project["repository"]
+
+        git_command("clone", "--depth", "1", f"https://github.com/{repository}.git", f"testData/{name}")

--- a/src/test/kotlin/org/rustPerformanceTests/RsRealProjectTestBase.kt
+++ b/src/test/kotlin/org/rustPerformanceTests/RsRealProjectTestBase.kt
@@ -17,7 +17,7 @@ abstract class RsRealProjectTestBase : RsWithToolchainTestBase() {
         val base = openRealProject("testData/${info.path}", info.exclude)
         if (base == null) {
             val name = info.name
-            println("SKIP $name: git clone ${info.gitUrl} testData/$name")
+            println("SKIP $name: git clone ${info.repository} testData/$name")
             return null
         }
         return base
@@ -53,10 +53,10 @@ abstract class RsRealProjectTestBase : RsWithToolchainTestBase() {
         return cargoProjectDirectory
     }
 
-    class RealProjectInfo(
+    data class RealProjectInfo(
         val name: String,
-        val path: String,
-        val gitUrl: String,
+        val path: String = name,
+        val repository: String = "",
         val exclude: List<String> = emptyList()
     )
 
@@ -64,7 +64,7 @@ abstract class RsRealProjectTestBase : RsWithToolchainTestBase() {
         val RUSTC = RealProjectInfo(
             name = "rust",
             path = "rust",
-            gitUrl = "https://github.com/rust-lang/rust",
+            repository = "https://github.com/rust-lang/rust",
             exclude = listOf(
                 "src/llvm",
                 "src/llvm-emscripten",


### PR DESCRIPTION
It should reduce common overhead for downloading/compilation and reduce numbers of CI instances required to run regression tests. I've checked in my own fork and all three tests took less than 35 min (currently, every single run takes about 17 minutes)

Note, now regression tests use 203 platform because I use junit 4 to generate all necessary tests in runtime and 202 platform is not compatible with junit 4 tests.