### PR TITLE
MACRO: enable macro expansion cache by default

### DIFF
--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1003,7 +1003,7 @@
                      description="Enable Rust cfg attributes support"/>
         <registryKey key="org.rust.lang.highlight.macro.body" defaultValue="true" restartRequired="false"
                      description="Highlight Rust macro call bodies"/>
-        <registryKey key="org.rust.lang.macros.persistentCache" defaultValue="false" restartRequired="false"
+        <registryKey key="org.rust.lang.macros.persistentCache" defaultValue="true" restartRequired="false"
                      description="Use persistent cache for Rust macro expansions"/>
 
         <!-- Move refactoring -->


### PR DESCRIPTION
Enable the cache from #6212 by default.

The cache is essential for [`name resolution 2.0`](https://github.com/intellij-rust/intellij-rust/issues/6217).
Right now it brings slightly (about 20%) macro expansion speedup in the case of a second expansion of the same macros (e.g. when you open a second project that shares the same libraries).
It still can be disabled using `org.rust.lang.macros.persistentCache` registry key.