### PR TITLE
RES: Fix resolve of macros inside imports and reexported macros when using new resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -47,10 +47,7 @@ import org.rust.lang.core.resolve.NameResolutionTestmarks.selfInGroup
 import org.rust.lang.core.resolve.indexes.RsLangItemIndex
 import org.rust.lang.core.resolve.indexes.RsMacroIndex
 import org.rust.lang.core.resolve.ref.*
-import org.rust.lang.core.resolve2.isNewResolveEnabled
-import org.rust.lang.core.resolve2.processMacros
-import org.rust.lang.core.resolve2.resolveToMacroAndGetContainingCrate
-import org.rust.lang.core.resolve2.resolveToMacroAndProcessLocalInnerMacros
+import org.rust.lang.core.resolve2.*
 import org.rust.lang.core.stubs.index.RsNamedElementIndex
 import org.rust.lang.core.types.*
 import org.rust.lang.core.types.consts.CtInferVar
@@ -395,9 +392,13 @@ private fun processQualifiedPathResolveVariants(
         if (result) return true
 
         val containingMod = path.containingMod
-        if (Namespace.Macros in ns && base is RsFile && base.isCrateRoot &&
-            containingMod is RsFile && containingMod.isCrateRoot) {
-            if (processAllScopeEntries(exportedMacrosAsScopeEntries(base), processor)) return true
+        if (Namespace.Macros in ns) {
+            val resultWithNewResolve = processMacros(base, processor)
+            if (resultWithNewResolve == true) return true
+            if (resultWithNewResolve == null && base is RsFile && base.isCrateRoot &&
+                containingMod is RsFile && containingMod.isCrateRoot) {
+                if (processAllScopeEntries(exportedMacrosAsScopeEntries(base), processor)) return true
+            }
         }
 
         // Proc macro crates are not allowed to export anything but procedural macros,

--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -144,14 +144,17 @@ fun <T : ScopeEntry> collectResolveVariantsAsScopeEntries(
     return result
 }
 
-fun pickFirstResolveVariant(referenceName: String?, f: (RsResolveProcessor) -> Unit): RsElement? {
+fun pickFirstResolveVariant(referenceName: String?, f: (RsResolveProcessor) -> Unit): RsElement? =
+    pickFirstResolveEntry(referenceName, f)?.element
+
+fun pickFirstResolveEntry(referenceName: String?, f: (RsResolveProcessor) -> Unit): ScopeEntry? {
     if (referenceName == null) return null
-    var result: RsElement? = null
+    var result: ScopeEntry? = null
     val processor = createProcessor(referenceName) { e ->
         if (e.name == referenceName) {
             val element = e.element
             if (element != null && (element !is RsDocAndAttributeOwner || element.isEnabledByCfgSelf)) {
-                result = element
+                result = e
                 return@createProcessor true
             }
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -117,6 +117,15 @@ private fun ModData.processMacros(processor: RsResolveProcessor, defMap: CrateDe
     return false
 }
 
+fun RsMacroCall.resolveToMacroUsingNewResolve(): RsMacro? =
+    resolveToMacroAndThen(
+        withNewResolve = { defInfo, info ->
+            val visItem = VisItem(defInfo.path, Visibility.Public)
+            visItem.toPsi(info.defMap, project, Namespace.Macros).singleOrNull() as RsMacro?
+        },
+        withoutNewResolve = { it }
+    )
+
 /**
  * Resolve without PSI is needed to prevent caching incomplete result in [expandedItemsCached].
  * Consider:

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -83,28 +83,35 @@ fun processItemDeclarations2(
  * We need to get [ModData] to check if we can use new resolve, which is not fast,
  * so we unite check and actual resolve as an optimization.
  */
-fun processMacros(scope: RsMod, processor: RsResolveProcessor, runBeforeResolve: () -> Boolean): Boolean? {
+fun processMacros(
+    scope: RsMod,
+    processor: RsResolveProcessor,
+    runBeforeResolve: (() -> Boolean)? = null
+): Boolean? {
     val (project, defMap, modData) = when (val info = getModInfo(scope)) {
         is CantUseNewResolve -> return null
         InfoNotFound -> return false
         is RsModInfo -> info
     }
-    if (runBeforeResolve()) return true
+    if (runBeforeResolve != null && runBeforeResolve()) return true
 
     return modData.processMacros(processor, defMap, project)
 }
 
 private fun ModData.processMacros(processor: RsResolveProcessor, defMap: CrateDefMap, project: Project): Boolean {
+    val processedMacros = hashSetOf<RsNamedElement>()
     for ((name, macroInfo) in legacyMacros.entriesWithName(processor.name)) {
         val visItem = VisItem(macroInfo.path, Visibility.Public)
-        val macros = visItem.toPsi(defMap, project, Namespace.Macros).singleOrNull() ?: continue
-        processor(name, macros) && return true
+        val macro = visItem.toPsi(defMap, project, Namespace.Macros).singleOrNull() ?: continue
+        processedMacros += macro
+        if (processor(name, macro)) return true
     }
 
     for ((name, perNs) in visibleItems.entriesWithName(processor.name)) {
         val visItem = perNs.macros ?: continue
-        val macros = visItem.toPsi(defMap, project, Namespace.Macros).singleOrNull() ?: continue
-        processor(name, macros) && return true
+        val macro = visItem.toPsi(defMap, project, Namespace.Macros).singleOrNull() ?: continue
+        if (macro in processedMacros) continue  // TODO: Possible optimization - somehow do check before calling [toPsi]
+        if (processor(name, macro)) return true
     }
 
     return false

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionRangeMappingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionRangeMappingTest.kt
@@ -112,10 +112,10 @@ class RsMacroExpansionRangeMappingTest : RsTestBase() {
     """)
 
     fun `test expression`() = checkOffset("""
-        macro_rules! foo {
-            ($ e:expr) => { fn foo() { $ e } };
+        macro_rules! gen_foo {
+            ($ e:expr) => { fn foo() { $ e; } };
         }
-        foo! {
+        gen_foo! {
             /*caret*/2 + 2
         }
         use self::foo;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
@@ -5,6 +5,9 @@
 
 package org.rust.lang.core.resolve
 
+import org.rust.MockEdition
+import org.rust.UseNewResolve
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.ignoreInNewResolve
 
 class RsMacroResolveTest : RsResolveTestBase() {
@@ -211,5 +214,110 @@ class RsMacroResolveTest : RsResolveTestBase() {
               //^ unresolved
     """)
 
-    // More macro tests in [RsPackageLibraryResolveTest] and [RsStubOnlyResolveTest]
+    // TODO
+    @UseNewResolve
+    @MockEdition(Edition.EDITION_2018)
+    fun `test legacy textual macro reexported as macro 2 in nested mod (reexport)`() = expect<IllegalStateException> {
+        checkByCode("""
+            mod inner {
+                #[macro_export]
+                macro_rules! foo_ {
+                           //X
+                    () => {}
+                }
+                pub use foo_ as foo;
+                      //^
+            }
+        """)
+    }
+
+    @UseNewResolve
+    @MockEdition(Edition.EDITION_2018)
+    fun `test legacy textual macro reexported as macro 2 in nested mod (import)`() = checkByCode("""
+        mod inner {
+            #[macro_export]
+            macro_rules! foo_ {
+                       //X
+                () => {}
+            }
+            pub use foo_ as foo;
+        }
+        mod test {
+            use crate::inner::foo;
+                            //^
+        }
+    """)
+
+    @UseNewResolve
+    @MockEdition(Edition.EDITION_2018)
+    fun `test legacy textual macro reexported as macro 2 in nested mod (macro call)`() = checkByCode("""
+        mod inner {
+            #[macro_export]
+            macro_rules! foo_ {
+                       //X
+                () => {}
+            }
+            pub use foo_ as foo;
+        }
+
+        inner::foo! {}
+             //^
+    """)
+
+    @UseNewResolve
+    @MockEdition(Edition.EDITION_2018)
+    fun `test legacy textual macro reexported as macro 2 in crate root (reexport)`() = checkByCode("""
+        #[macro_export]
+        macro_rules! foo_ {
+                   //X
+            () => {}
+        }
+        pub use foo_ as foo;
+              //^
+    """)
+
+    @UseNewResolve
+    @MockEdition(Edition.EDITION_2018)
+    fun `test legacy textual macro reexported as macro 2 in crate root (import)`() = checkByCode("""
+        #[macro_export]
+        macro_rules! foo_ {
+                   //X
+            () => {}
+        }
+        pub use foo_ as foo;
+        mod test {
+            use crate::foo;
+                     //^
+        }
+    """)
+
+    @UseNewResolve
+    @MockEdition(Edition.EDITION_2018)
+    fun `test legacy textual macro reexported as macro 2 in crate root (macro call fqn)`() = checkByCode("""
+        #[macro_export]
+        macro_rules! foo_ {
+                   //X
+            () => {}
+        }
+        pub use foo_ as foo;
+
+        crate::foo! {}
+             //^
+    """)
+
+    @UseNewResolve
+    @MockEdition(Edition.EDITION_2018)
+    fun `test legacy textual macro reexported as macro 2 in crate root (macro call)`() = checkByCode("""
+        #[macro_export]
+        macro_rules! foo_ {
+                   //X
+            () => {}
+        }
+        pub use foo_ as foo;
+
+        foo! {}
+        //^
+    """)
+
+    /** More macro tests in [RsPackageLibraryResolveTest] and [RsStubOnlyResolveTest] */
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -226,6 +226,56 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test macro inside import 1`() = stubOnlyResolve("""
+    //- main.rs
+        use test_package::foo;
+                        //^ lib.rs
+    //- lib.rs
+        #[macro_export]
+        macro_rules! foo { () => {} }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test macro inside import 2`() = stubOnlyResolve("""
+    //- main.rs
+        use test_package::foo;
+                        //^ lib.rs
+    //- lib.rs
+        mod inner {
+            #[macro_export]
+            macro_rules! foo { () => {} }
+        }
+    """)
+
+    @UseNewResolve
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test macro inside import 3`() = stubOnlyResolve("""
+    //- main.rs
+        mod inner {
+            use test_package::foo;
+                            //^ lib.rs
+        }
+    //- lib.rs
+        #[macro_export]
+        macro_rules! foo { () => {} }
+    """)
+
+    @UseNewResolve
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test macro inside import 4`() = stubOnlyResolve("""
+    //- main.rs
+        mod inner1 {
+            use test_package::foo;
+                            //^ lib.rs
+        }
+    //- lib.rs
+        mod inner2 {
+            #[macro_export]
+            macro_rules! foo { () => {} }
+        }
+    """)
+
     fun `test import macro by use item`() = stubOnlyResolve("""
     //- lib.rs
         extern crate dep_lib_target;

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
@@ -115,6 +115,7 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
     """)
     }
 
+    @IgnoreInNewResolve
     fun `test resolve custom derive proc macro in use item`() = stubOnlyResolve("""
     //- dep-proc-macro/lib.rs
         #[proc_macro_derive(ProcMacroName)]
@@ -176,6 +177,7 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
                     //^ dep-proc-macro/lib.rs
     """)
 
+    @IgnoreInNewResolve
     fun `test resolve custom derive proc macro reexported from lib to main from use item`() = stubOnlyResolve("""
     //- lib.rs
         extern crate dep_proc_macro;


### PR DESCRIPTION
Macro resolution impovements in [new resolve](https://github.com/intellij-rust/intellij-rust/issues/6217):
* Fix resolve of macros inside imports when using new resolve
* Fix resolve of macro reexported as macro 2 when using new resolve. It doesn't affect macro expansion, where we use different code to resolve macro call, and it already works