### PR TITLE
MACRO: fix macro group matching

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -346,7 +346,7 @@ class MacroExpander(val project: Project) {
     }
 
     companion object {
-        const val EXPANDER_VERSION = 12
+        const val EXPANDER_VERSION = 13
         private val USELESS_PARENS_EXPRS = tokenSetOf(
             LIT_EXPR, MACRO_EXPR, PATH_EXPR, PAREN_EXPR, TUPLE_EXPR, ARRAY_EXPR, UNIT_EXPR
         )
@@ -467,13 +467,13 @@ class MacroPattern private constructor(
         return MacroSubstitution(map)
     }
 
-
     private fun matchGroup(group: RsMacroBindingGroup, macroCallBody: PsiBuilder): List<MacroSubstitution>? {
         val groups = mutableListOf<MacroSubstitution>()
         val pattern = MacroPattern.valueOf(group.macroPatternContents ?: return null)
         if (pattern.isEmpty()) return null
         val separator = group.macroBindingGroupSeparator?.node?.firstChildNode
-        var mark: PsiBuilder.Marker? = null
+        macroCallBody.eof() // skip whitespace
+        var mark: PsiBuilder.Marker? = macroCallBody.mark()
 
         while (true) {
             if (macroCallBody.eof()) {

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -883,6 +883,28 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         foo!(a);
     """ to MacroExpansionMarks.groupMatchedEmptyTT)
 
+    fun `test two sequential groups starting with the same token`() = doTest("""
+        macro_rules! foobar {
+            (
+                $(: foo)?
+                $(: bar)?
+                $ name:ident
+            ) => {
+                fn $ name(){}
+            }
+        }
+
+        foobar!(: foo a);
+        foobar!(: bar b);
+        foobar!(c);
+    """, """
+        fn a(){}
+    """, """
+        fn b(){}
+    """, """
+        fn c(){}
+    """)
+
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     @BothEditions
     fun `test local_inner_macros 1`() = checkSingleMacroByTree("""


### PR DESCRIPTION
Works for sequential groups starting with the same token, e.g. `$(: foo)? $(: bar)?`

Fixes #6379
