### PR TITLE
RES: Fix name of option in settings to enable new resolve

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
@@ -41,7 +41,7 @@ class RsProjectConfigurable(
             )
         }
         row {
-            checkBox("Use experimental name resolution engine:", state::newResolveEnabled)
+            checkBox("Use experimental name resolution engine", state::newResolveEnabled)
         }
         row {
             checkBox("Inject Rust language into documentation comments", state::doctestInjectionEnabled)


### PR DESCRIPTION
Fix name of [option to enable new resolve](https://github.com/intellij-rust/intellij-rust/pull/6378)

bors r+