### PR TITLE
T: improve error messages in `RsMacroExpansionTest`

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/macroExpansion/MacroExpansionViewUtils.kt
+++ b/src/main/kotlin/org/rust/ide/actions/macroExpansion/MacroExpansionViewUtils.kt
@@ -97,7 +97,7 @@ private fun getMacroExpansions(macroToExpand: RsMacroCall, expandRecursively: Bo
     }
 
     val expansionText = if (expandRecursively) {
-        macroToExpand.expandAllMacrosRecursively(replaceDollarCrate = true)
+        macroToExpand.expandMacrosRecursively(replaceDollarCrate = true)
     } else {
         macroToExpand.expandMacrosRecursively(depthLimit = 1, replaceDollarCrate = true)
     }

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionError.kt
@@ -1,0 +1,51 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.PsiBuilder
+import com.intellij.psi.tree.IElementType
+
+sealed class MacroExpansionAndParsingError {
+    data class ExpansionError(val error: MacroExpansionError) : MacroExpansionAndParsingError()
+    class ParsingError(val expansionText: CharSequence, val context: MacroExpansionContext) : MacroExpansionAndParsingError()
+}
+
+sealed class MacroExpansionError {
+    data class Matching(val errors: List<MacroMatchingError>) : MacroExpansionError()
+    object DefSyntax : MacroExpansionError()
+}
+
+sealed class MacroMatchingError(macroCallBody: PsiBuilder) {
+    val offsetInCallBody: Int = macroCallBody.currentOffset
+
+    class PatternSyntax(macroCallBody: PsiBuilder): MacroMatchingError(macroCallBody) {
+        override fun toString(): String = "PatternSyntax"
+    }
+    class ExtraInput(macroCallBody: PsiBuilder): MacroMatchingError(macroCallBody) {
+        override fun toString(): String = "ExtraInput"
+    }
+    class UnmatchedToken(macroCallBody: PsiBuilder, node: ASTNode): MacroMatchingError(macroCallBody) {
+        val expectedToken: IElementType = node.elementType
+        val expectedText: String = node.text
+        val actualToken: IElementType? = macroCallBody.tokenType
+        val actualText: String? = macroCallBody.tokenText
+
+        override fun toString(): String = "UnmatchedToken($expectedToken(`$expectedText`) != $actualToken(`$actualText`))"
+    }
+    class FragmentNotParsed(macroCallBody: PsiBuilder, val kind: FragmentKind): MacroMatchingError(macroCallBody) {
+        override fun toString(): String = "FragmentNotParsed($kind)"
+    }
+    class EmptyGroup(macroCallBody: PsiBuilder): MacroMatchingError(macroCallBody) {
+        override fun toString(): String = "EmptyGroup"
+    }
+    class TooFewGroupElements(macroCallBody: PsiBuilder): MacroMatchingError(macroCallBody) {
+        override fun toString(): String = "TooFewGroupElements"
+    }
+    class Nesting(macroCallBody: PsiBuilder, val variableName: String): MacroMatchingError(macroCallBody) {
+        override fun toString(): String = "Nesting($variableName)"
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.macros
 
+import com.google.common.annotations.VisibleForTesting
 import com.intellij.codeInsight.template.TemplateManager
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.*
@@ -1071,7 +1072,7 @@ private fun expandMacroToMemoryFile(call: RsMacroCall, storeRangeMap: Boolean): 
         call,
         RsPsiFactory(project, markGenerated = false),
         storeRangeMap
-    )
+    ).ok()
     result?.elements?.forEach {
         it.setContext(context)
         it.setExpandedFrom(call)

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -1090,7 +1090,8 @@ private fun nullExpansionResult(call: RsMacroCall): CachedValueProvider.Result<M
 
 private val RS_EXPANSION_MACRO_CALL = Key.create<RsMacroCall>("org.rust.lang.core.psi.RS_EXPANSION_MACRO_CALL")
 
-private fun RsExpandedElement.setExpandedFrom(call: RsMacroCall) {
+@VisibleForTesting
+fun RsExpandedElement.setExpandedFrom(call: RsMacroCall) {
     putUserData(RS_EXPANSION_MACRO_CALL, call)
 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -173,10 +173,11 @@ val RsMacroCall.expansionFlatten: List<RsExpandedElement>
         return list
     }
 
-fun RsMacroCall.expandAllMacrosRecursively(replaceDollarCrate: Boolean): String =
-    expandMacrosRecursively(DEFAULT_RECURSION_LIMIT, replaceDollarCrate)
-
-fun RsMacroCall.expandMacrosRecursively(depthLimit: Int, replaceDollarCrate: Boolean): String {
+fun RsMacroCall.expandMacrosRecursively(
+    depthLimit: Int = DEFAULT_RECURSION_LIMIT,
+    replaceDollarCrate: Boolean = true,
+    expander: (RsMacroCall) -> MacroExpansion? = RsMacroCall::expansion
+): String {
     if (depthLimit == 0) return text
 
     fun toExpandedText(element: PsiElement): String =
@@ -193,7 +194,7 @@ fun RsMacroCall.expandMacrosRecursively(depthLimit: Int, replaceDollarCrate: Boo
             else -> element.text
         }
 
-    return expansion?.elements?.joinToString(" ") { toExpandedText(it) } ?: text
+    return expander(this)?.elements?.joinToString(" ") { toExpandedText(it) } ?: text
 }
 
 fun RsMacroCall.processExpansionRecursively(processor: (RsExpandedElement) -> Boolean): Boolean =

--- a/src/main/kotlin/org/rust/stdext/RsResult.kt
+++ b/src/main/kotlin/org/rust/stdext/RsResult.kt
@@ -1,0 +1,34 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.stdext
+
+sealed class RsResult<T, E> {
+    data class Ok<T, E>(val ok: T) : RsResult<T, E>()
+    data class Err<T, E>(val err: E) : RsResult<T, E>()
+
+    val isOk: Boolean get() = this is Ok
+    val isErr: Boolean get() = this is Err
+
+    fun ok(): T? = when (this) {
+        is Ok -> ok
+        is Err -> null
+    }
+
+    inline fun <U> map(mapper: (T) -> U): RsResult<U, E> = when (this) {
+        is Ok -> Ok(mapper(ok))
+        is Err -> Err(err)
+    }
+
+    inline fun <U> andThen(action: (T) -> RsResult<U, E>): RsResult<U, E> = when (this) {
+        is Ok -> action(ok)
+        is Err -> Err(err)
+    }
+
+    inline fun unwrapOrElse(op: (E) -> T): T = when (this) {
+        is Ok -> ok
+        is Err -> op(err)
+    }
+}

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
@@ -873,15 +873,14 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
         fn foo() {}
     """ to NameResolutionTestmarks.dollarCrateMagicIdentifier)
 
-    fun `test incorrect "vis" group does not cause OOM`() = doTest("""
+    fun `test incorrect "vis" group does not cause OOM`() = doErrorTest("""
         // error: repetition matches empty token tree
         macro_rules! foo {
             ($($ p:vis)*) => {}
         }
         foo!(a);
-    """, """
-        foo!(a);
-    """ to MacroExpansionMarks.groupMatchedEmptyTT)
+        //^
+    """, MacroExpansionMarks.groupMatchedEmptyTT)
 
     fun `test two sequential groups starting with the same token`() = doTest("""
         macro_rules! foobar {


### PR DESCRIPTION
`MacroExpander.expandMacroAsText`  returned a nullable value for a long time. I made something like Rust's `Result` and return some kind of `Err(MacroExpansionError(...))` instead of `null`. This simplifies `MacroExpander` debugging (e.g. #6380)