### PR TITLE
CARGO: Implement crates local index based on cargo registry index

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,7 @@ allprojects {
         mavenCentral()
         jcenter()
         maven("https://dl.bintray.com/jetbrains/markdown")
+        maven("http://download.eclipse.org/jgit/maven")
     }
 
     idea {
@@ -376,6 +377,7 @@ project(":toml") {
     dependencies {
         implementation(project(":"))
         implementation(project(":common"))
+        implementation("org.eclipse.jgit:org.eclipse.jgit:5.9.0.202009080501-r") { exclude("org.slf4j") }
         testImplementation(project(":", "testOutput"))
         testImplementation(project(":common", "testOutput"))
     }

--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -14,4 +14,5 @@ object RsExperiments {
     const val MACROS_NEW_ENGINE = "org.rust.macros.new.engine"
     const val RESOLVE_NEW_ENGINE = "org.rust.resolve.new.engine"
     const val FETCH_ACTUAL_STDLIB_METADATA = "org.rust.cargo.fetch.actual.stdlib.metadata"
+    const val CRATES_LOCAL_INDEX = "org.rust.crates.local.index"
 }

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -18,5 +18,8 @@
         <experimentalFeature id="org.rust.resolve.new.engine" percentOfUsers="0">
             <description>Enables experimental resolve engine</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="0">
+            <description>Enables crates local index</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -18,5 +18,8 @@
         <experimentalFeature id="org.rust.resolve.new.engine" percentOfUsers="0">
             <description>Enables experimental resolve engine</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="0">
+            <description>Enables crates local index</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>

--- a/toml/src/main/kotlin/org/rust/toml/completion/CargoNormalizedNamesPrefixMatcher.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/CargoNormalizedNamesPrefixMatcher.kt
@@ -1,0 +1,16 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.completion
+
+import com.intellij.codeInsight.completion.PrefixMatcher
+
+class CargoNormalizedNamesPrefixMatcher(prefix: String): PrefixMatcher(prefix) {
+    override fun prefixMatches(name: String): Boolean =
+        name.replace('-', '_').startsWith(prefix.replace('-', '_'))
+
+    override fun cloneWithPrefix(prefix: String): PrefixMatcher =
+        CargoNormalizedNamesPrefixMatcher(prefix)
+}

--- a/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlCompletionContributor.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlCompletionContributor.kt
@@ -7,6 +7,8 @@ package org.rust.toml.completion
 
 import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionType.BASIC
+import org.rust.ide.experiments.RsExperiments
+import org.rust.openapiext.isFeatureEnabled
 import org.rust.toml.CargoTomlPsiPattern.inDependencyKeyValue
 import org.rust.toml.CargoTomlPsiPattern.inDependencyPackageFeatureArray
 import org.rust.toml.CargoTomlPsiPattern.inFeatureDependencyArray
@@ -14,18 +16,28 @@ import org.rust.toml.CargoTomlPsiPattern.inKey
 import org.rust.toml.CargoTomlPsiPattern.inSpecificDependencyHeaderKey
 import org.rust.toml.CargoTomlPsiPattern.inSpecificDependencyKeyValue
 import org.rust.toml.CargoTomlPsiPattern.inValueWithKey
+import org.rust.toml.crates.local.completion.DependencyCratesLocalCompletionProvider
 import org.rust.toml.tomlPluginIsAbiCompatible
 
 class CargoTomlCompletionContributor : CompletionContributor() {
     init {
+        val isCratesLocalIndexEnabled = isFeatureEnabled(RsExperiments.CRATES_LOCAL_INDEX)
+
+        val dependencyCompletionProvider = if (isCratesLocalIndexEnabled) {
+            DependencyCratesLocalCompletionProvider()
+        } else {
+            CargoTomlDependencyCompletionProvider()
+        }
+
         if (tomlPluginIsAbiCompatible()) {
             extend(BASIC, inKey, CargoTomlKeysCompletionProvider())
             extend(BASIC, inValueWithKey("edition"), CargoTomlKnownValuesCompletionProvider(listOf("2015", "2018")))
-            extend(BASIC, inDependencyKeyValue, CargoTomlDependencyCompletionProvider())
             extend(BASIC, inSpecificDependencyHeaderKey, CargoTomlSpecificDependencyHeaderCompletionProvider())
             extend(BASIC, inSpecificDependencyKeyValue, CargoTomlSpecificDependencyVersionCompletionProvider())
             extend(BASIC, inFeatureDependencyArray, CargoTomlFeatureDependencyCompletionProvider())
             extend(BASIC, inDependencyPackageFeatureArray, CargoTomlDependencyFeaturesCompletionProvider())
+
+            extend(BASIC, inDependencyKeyValue, dependencyCompletionProvider)
         }
     }
 }

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexCachesInvalidator.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexCachesInvalidator.kt
@@ -1,0 +1,15 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.crates.local
+
+import com.intellij.ide.caches.CachesInvalidator
+import com.intellij.openapi.components.service
+
+class CratesLocalIndexCachesInvalidator : CachesInvalidator() {
+    override fun invalidateCaches() {
+        service<CratesLocalIndexService>().invalidateCaches()
+    }
+}

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexService.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexService.kt
@@ -1,0 +1,274 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.crates.local
+
+import com.google.gson.Gson
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
+import com.intellij.util.io.*
+import org.eclipse.jgit.lib.ObjectId
+import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.revwalk.RevTree
+import org.eclipse.jgit.revwalk.RevWalk
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder
+import org.eclipse.jgit.treewalk.TreeWalk
+import org.rust.openapiext.pluginDirInSystem
+import org.rust.stdext.cleanDirectory
+import org.rust.toml.crates.local.CratesLocalIndexService.Companion.CratesLocalIndexState
+import java.io.*
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Crates local index, created from user cargo registry index on host machine.
+ * Used for dependency code insight in project's `Cargo.toml`.
+ * Stores crates info in [crates] persistent hash map and hash for commit which has been used for index load in
+ * persistent state [CratesLocalIndexState].
+ */
+@State(name = "CratesLocalIndexState", storages = [Storage("rust.crateslocalindex.xml")])
+class CratesLocalIndexService : PersistentStateComponent<CratesLocalIndexState>, Disposable {
+    private val userCargoIndexDir: Path
+        get() = Paths.get(System.getProperty("user.home"), CARGO_REGISTRY_INDEX_LOCATION)
+
+    // TODO: handle RepositoryNotFoundException
+    private val repository: Repository = FileRepositoryBuilder()
+        .setGitDir(userCargoIndexDir.toFile())
+        .build()
+
+    private val registryHeadCommitHash: String = repository.resolve("origin/master")?.name ?: run {
+        LOG.error("Git revision string cannot be resolved to any object id")
+        INVALID_COMMIT_HASH
+    }
+
+    private val crates: PersistentHashMap<String, CargoRegistryCrate>? = run {
+        resetIndexIfNeeded()
+
+        val file = baseCratesLocalRegistryDir.resolve("crates-local-index")
+        try {
+            IOUtil.openCleanOrResetBroken({
+                PersistentHashMap(
+                    file,
+                    EnumeratorStringDescriptor.INSTANCE,
+                    CrateExternalizer,
+                    4 * 1024,
+                    CRATES_INDEX_VERSION
+                )
+            }, file)
+        } catch (e: IOException) {
+            LOG.error("Cannot open or create PersistentHashMap in $file", e)
+            null
+        }
+    }
+
+    @Volatile
+    private var state: CratesLocalIndexState = CratesLocalIndexState()
+
+    private val isReady: AtomicBoolean = AtomicBoolean(true)
+
+    override fun getState(): CratesLocalIndexState = state
+    override fun loadState(state: CratesLocalIndexState) {
+        this.state = state
+    }
+
+    fun isReady(): Boolean = isReady.get()
+
+    fun getCrate(crateName: String): CargoRegistryCrate? {
+        updateIfNeeded()
+        if (crates == null) return null
+
+        return try {
+            crates.get(crateName)
+        } catch (e: IOException) {
+            LOG.error("Failed to get crate $crateName", e)
+            null
+        }
+    }
+
+    fun getAllCrateNames(): List<String> {
+        updateIfNeeded()
+        if (crates == null) return emptyList()
+
+        val crateNames = mutableListOf<String>()
+
+        try {
+            crates.processKeys { name ->
+                crateNames.add(name)
+            }
+        } catch (e: IOException) {
+            LOG.error("Failed to get crate names", e)
+        }
+
+        return crateNames
+    }
+
+    private fun updateIfNeeded() {
+        if (state.indexedCommitHash != registryHeadCommitHash && isReady.compareAndSet(true, false)) {
+            CratesLocalIndexUpdateTask().queue()
+        }
+    }
+
+    private fun resetIndexIfNeeded() {
+        if (corruptionMarkerFile.exists()) {
+            baseCratesLocalRegistryDir.cleanDirectory()
+        }
+    }
+
+    fun invalidateCaches() {
+        corruptionMarkerFile.apply {
+            parent?.createDirectories()
+            Files.createFile(this)
+            state = CratesLocalIndexState(INVALID_COMMIT_HASH)
+        }
+    }
+
+    private fun reloadCrates(revTree: RevTree) {
+        TreeWalk(repository).use { treeWalk ->
+            treeWalk.addTree(revTree)
+            treeWalk.isRecursive = true
+            treeWalk.isPostOrderTraversal = false
+
+            while (treeWalk.next()) {
+                if (treeWalk.pathString == "config.json") continue
+
+                val objectId = treeWalk.getObjectId(0)
+                val loader = repository.open(objectId)
+                val versions = mutableListOf<CargoRegistryCrateVersion>()
+                val reader = BufferedReader(InputStreamReader(loader.openStream()))
+
+                reader.forEachLine { line ->
+                    if (line.isBlank()) return@forEachLine
+
+                    try {
+                        versions.add(CargoRegistryCrateVersion.fromJson(line))
+                    } catch (e: Exception) {
+                        LOG.warn("Failed to parse JSON from ${treeWalk.pathString}, line ${line}: ${e.message}")
+                    }
+                }
+
+                try {
+                    crates?.put(treeWalk.nameString, CargoRegistryCrate(versions))
+                } catch (e: IOException) {
+                    LOG.error("Failed to put crate `${treeWalk.nameString}` into local index", e)
+                }
+            }
+        }
+
+        // Force to save everything on the disk
+        try {
+            crates?.force()
+        } catch (e: IOException) {
+            LOG.warn(e)
+        }
+    }
+
+    override fun dispose() {
+        try {
+            crates?.close()
+        } catch (e: IOException) {
+            LOG.warn(e)
+        }
+    }
+
+    private inner class CratesLocalIndexUpdateTask : Task.Backgroundable(null, "Loading cargo registry index", false) {
+        override fun run(indicator: ProgressIndicator) {
+            val branch = repository.resolve("origin/master") ?: return
+            val revCommit = RevWalk(repository).parseCommit(ObjectId.fromString(branch.name))
+            reloadCrates(revCommit.tree)
+        }
+
+        override fun onSuccess() {
+            state = CratesLocalIndexState(registryHeadCommitHash)
+        }
+
+        override fun onFinished() {
+            isReady.set(true)
+        }
+    }
+
+    companion object {
+        data class CratesLocalIndexState(var indexedCommitHash: String = "")
+
+        private val corruptionMarkerFile: Path
+            get() = baseCratesLocalRegistryDir.resolve(CORRUPTION_MARKER_NAME)
+
+        private val baseCratesLocalRegistryDir: Path
+            get() = pluginDirInSystem().resolve("crates-local-index")
+
+        // TODO: Determine how path to index is created
+        private const val CARGO_REGISTRY_INDEX_LOCATION: String = ".cargo/registry/index/github.com-1ecc6299db9ec823/.git/"
+        private const val CORRUPTION_MARKER_NAME: String = "corruption.marker"
+        private const val INVALID_COMMIT_HASH: String = "<invalid>"
+        private const val CRATES_INDEX_VERSION: Int = 0
+        private val LOG: Logger = logger<CratesLocalIndexService>()
+    }
+}
+
+data class CargoRegistryCrate(val versions: List<CargoRegistryCrateVersion>)
+data class CargoRegistryCrateVersion(val version: String, val isYanked: Boolean, val features: List<String>) {
+    companion object {
+        private data class ParsedVersion(
+            val name: String,
+            val vers: String,
+            val yanked: Boolean,
+            val features: HashMap<String, List<String>>
+        )
+
+        fun fromJson(json: String): CargoRegistryCrateVersion {
+            val parsedVersion = Gson().fromJson(json, ParsedVersion::class.java)
+
+            return CargoRegistryCrateVersion(
+                parsedVersion.vers,
+                parsedVersion.yanked,
+                parsedVersion.features.map { it.key }
+            )
+        }
+    }
+}
+
+val CargoRegistryCrate.lastVersion: String?
+    // TODO: Last version sometimes can differ from latest major
+    //  (e.g. if developer uploaded a patch to previous major)
+    get() = versions.lastOrNull()?.version
+
+private object CrateExternalizer : DataExternalizer<CargoRegistryCrate> {
+    override fun save(out: DataOutput, value: CargoRegistryCrate) {
+        out.writeInt(value.versions.size)
+        value.versions.forEach { version ->
+            out.writeUTF(version.version)
+            out.writeBoolean(version.isYanked)
+
+            out.writeInt(version.features.size)
+            version.features.forEach { feature ->
+                out.writeUTF(feature)
+            }
+        }
+    }
+
+    override fun read(inp: DataInput): CargoRegistryCrate {
+        val versions = mutableListOf<CargoRegistryCrateVersion>()
+        val versionsSize = inp.readInt()
+        repeat(versionsSize) {
+            val version = inp.readUTF()
+            val yanked = inp.readBoolean()
+
+            val features = mutableListOf<String>()
+            val featuresSize = inp.readInt()
+            repeat(featuresSize) {
+                features.add(inp.readUTF())
+            }
+            versions.add(CargoRegistryCrateVersion(version, yanked, features))
+        }
+        return CargoRegistryCrate(versions)
+    }
+}

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/completion/DependencyCratesLocalCompletionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/completion/DependencyCratesLocalCompletionProvider.kt
@@ -1,0 +1,75 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.crates.local.completion
+
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.CompletionUtil
+import com.intellij.codeInsight.completion.PrioritizedLookupElement
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.codeInsight.lookup.LookupElementPresentation
+import com.intellij.codeInsight.lookup.LookupElementRenderer
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.components.service
+import org.rust.toml.StringValueInsertionHandler
+import org.rust.toml.completion.CargoNormalizedNamesPrefixMatcher
+import org.rust.toml.completion.TomlKeyValueCompletionProviderBase
+import org.rust.toml.crates.local.CratesLocalIndexService
+import org.rust.toml.crates.local.lastVersion
+import org.toml.lang.psi.TomlKeyValue
+
+class DependencyCratesLocalCompletionProvider : TomlKeyValueCompletionProviderBase() {
+    override fun completeKey(keyValue: TomlKeyValue, result: CompletionResultSet) {
+        val prefix = CompletionUtil.getOriginalElement(keyValue.key)?.text ?: return
+
+        val indexService = service<CratesLocalIndexService>()
+        if (!indexService.isReady()) return
+
+        val crateNames = indexService.getAllCrateNames()
+        val elements = crateNames.mapNotNull { crateName ->
+            val crate = indexService.getCrate(crateName) ?: return@mapNotNull null
+
+            PrioritizedLookupElement.withPriority(
+                LookupElementBuilder
+                    .create(crateName)
+                    .withIcon(AllIcons.Nodes.PpLib)
+                    .withExpensiveRenderer(object : LookupElementRenderer<LookupElement>() {
+                        override fun renderElement(element: LookupElement, presentation: LookupElementPresentation) {
+                            presentation.itemText = "$crateName = \"${crate.lastVersion.orEmpty()}\""
+                        }
+                    })
+                    .withInsertHandler { context, _ ->
+                        context.document.insertString(context.tailOffset, " = \"${crate.lastVersion}\"")
+                        val endLineOffset = context.editor.caretModel.visualLineEnd
+                        // TODO: Currently moves caret to the next line
+                        context.editor.caretModel.moveToOffset(endLineOffset)
+                    },
+                (-crateName.length).toDouble()
+            )
+        }
+        result.withPrefixMatcher(CargoNormalizedNamesPrefixMatcher(prefix)).addAllElements(elements)
+    }
+
+    override fun completeValue(keyValue: TomlKeyValue, result: CompletionResultSet) {
+        val name = CompletionUtil.getOriginalElement(keyValue.key)?.text ?: return
+
+        val indexService = service<CratesLocalIndexService>()
+        if (!indexService.isReady()) return
+
+        val versions = indexService.getCrate(name)?.versions ?: return
+        val elements = versions.mapIndexed { index, variant ->
+            val lookupElement = LookupElementBuilder.create(variant.version)
+                .withInsertHandler(StringValueInsertionHandler(keyValue))
+                .withTailText(if (variant.isYanked) " yanked" else null)
+
+            PrioritizedLookupElement.withPriority(
+                lookupElement,
+                index.toDouble()
+            )
+        }
+        result.addAllElements(elements)
+    }
+}

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -22,5 +22,8 @@
                          displayName="Missing features"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.toml.inspections.CargoTomlMissingFeaturesInspection"/>
+
+        <applicationService serviceImplementation="org.rust.toml.crates.local.CratesLocalIndexService"/>
+        <cachesInvalidator implementation="org.rust.toml.crates.local.CratesLocalIndexCachesInvalidator"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Initial implementation of crates local index inside the plugin.

It gives the ability to retrieve crate names, versions, and features right from the crates index stored on disk and generated from the local cargo registry index. This way code analysis can be performed faster and with better quality and more complete results.

<img src="https://user-images.githubusercontent.com/6342851/100945858-2963f700-3513-11eb-81f2-fca166985780.gif" width="400">

changelog: Added experimental `Cargo.toml` dependency completion based on local cargo registry index. It can be enabled with `org.rust.crates.local.index` experimental flag