### PR TITLE
INSP: add unused imports inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -192,7 +192,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
 
     private fun checkReexports(holder: RsAnnotationHolder, useSpeck: RsUseSpeck) {
         val item = useSpeck.ancestorStrict<RsUseItem>() ?: return
-        if (item.visibility == RsVisibility.Private) return
+        if (!item.isReexport) return
 
         val path = useSpeck.path ?: return
         val targets = path.reference?.multiResolve()?.filterIsInstance<RsItemElement>() ?: emptyList()

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -37,6 +37,14 @@ enum class RsLint(
             }
     },
 
+    UnusedImports("unused_imports", listOf("unused")) {
+        override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
+            when (level) {
+                WARN -> ProblemHighlightType.LIKE_UNUSED_SYMBOL
+                else -> super.toHighlightingType(level)
+            }
+    },
+
     WhileTrue("while_true") {
         override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
             when (level) {

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsPathUsageAnalysis.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsPathUsageAnalysis.kt
@@ -1,0 +1,116 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.*
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.infer.ResolvedPath
+import org.rust.lang.core.types.inference
+import org.rust.openapiext.processElementsWithMacros
+
+data class PathUsageMap(
+    val pathUsages: Map<String, Set<RsElement>>,
+    val traitUsages: Set<RsTraitItem>
+)
+
+private val PATH_USAGE_KEY: Key<CachedValue<PathUsageMap>> = Key.create("PATH_USAGE_KEY")
+
+val RsItemsOwner.pathUsage: PathUsageMap
+    get() = CachedValuesManager.getCachedValue(this, PATH_USAGE_KEY) {
+        val usages = calculatePathUsages(this)
+        CachedValueProvider.Result.create(usages, PsiModificationTracker.MODIFICATION_COUNT)
+    }
+
+private fun calculatePathUsages(owner: RsItemsOwner): PathUsageMap {
+    val directUsages = hashMapOf<String, MutableSet<RsElement>>()
+    val traitUsages = hashSetOf<RsTraitItem>()
+
+    for (child in owner.children) {
+        processElementsWithMacros(child) { element ->
+            handleElement(element, directUsages, traitUsages)
+        }
+    }
+
+    return PathUsageMap(directUsages, traitUsages)
+}
+
+private fun handleElement(
+    element: PsiElement,
+    directUsages: MutableMap<String, MutableSet<RsElement>>,
+    traitUsages: MutableSet<RsTraitItem>
+): Boolean {
+    fun addItem(name: String, item: RsElement) {
+        directUsages.getOrPut(name) { hashSetOf() }.add(item)
+    }
+
+    if (!element.isEnabledByCfg) return false
+
+    return when (element) {
+        is RsModItem -> false
+        is RsPatIdent -> {
+            val name = element.patBinding.referenceName
+            val targets = element.patBinding.reference.multiResolve()
+            targets.forEach {
+                addItem(name, it)
+            }
+            true
+        }
+        is RsPath -> {
+            if (element.qualifier != null) {
+                val requiredTraits = getAssociatedItemRequiredTraits(element).orEmpty()
+                traitUsages.addAll(requiredTraits)
+            } else {
+                val useSpeck = element.parentOfType<RsUseSpeck>()
+                if (useSpeck == null || useSpeck.isTopLevel) {
+                    val name = element.referenceName ?: return true
+                    if (name in IGNORED_USE_PATHS) return true
+                    val targets = element.reference?.multiResolve().orEmpty()
+                    targets.forEach {
+                        addItem(name, it)
+                    }
+                }
+            }
+            true
+        }
+        is RsMethodCall -> {
+            val requiredTraits = getMethodRequiredTraits(element).orEmpty()
+            traitUsages.addAll(requiredTraits)
+            true
+        }
+        else -> true
+    }
+}
+
+private val IGNORED_USE_PATHS = listOf("crate", "self", "super")
+
+private fun getMethodRequiredTraits(call: RsMethodCall): Set<RsTraitItem>? {
+    val result = call.inference?.getResolvedMethod(call) ?: return null
+    return result.mapNotNull {
+        it.source.implementedTrait?.element
+    }.toSet()
+}
+
+private fun getAssociatedItemRequiredTraits(path: RsPath): Set<RsTraitItem>? {
+    val parent = path.parent as? RsPathExpr ?: return null
+    val resolved = path.inference?.getResolvedPath(parent) ?: return null
+    return resolved.mapNotNull {
+        if (it is ResolvedPath.AssocItem) {
+            it.source.implementedTrait?.element
+        } else null
+    }.toSet()
+}
+
+/**
+ * We should collect paths only from relative use specks,
+ * that is top-level use specks without `::`
+ * E.g. we shouldn't collect such paths: `use ::{foo, bar}`
+ */
+private val RsUseSpeck.isTopLevel: Boolean
+    get() = (path != null || coloncolon == null)
+        && parentOfType<RsUseSpeck>()?.isTopLevel != false

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -1,0 +1,91 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve2.NamedItem
+import org.rust.lang.core.resolve2.exportedItems
+import org.rust.lang.core.resolve2.isNewResolveEnabled
+
+class RsUnusedImportInspection : RsLintInspection() {
+    override fun getLint(element: PsiElement): RsLint = RsLint.UnusedImports
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+        override fun visitUseSpeck(o: RsUseSpeck) {
+            if (!holder.project.isNewResolveEnabled) return
+            val item = o.ancestorStrict<RsUseItem>() ?: return
+            if (item.isReexport) return
+            if (o.path?.resolveStatus != PathResolveStatus.RESOLVED) return
+
+            // Do not check uses if there is a child mod inside the current mod
+            val parentMod = o.containingMod
+            val hasChildMods = parentMod.expandedItemsExceptImplsAndUses.any {
+                it is RsModItem || it is RsModDeclItem
+            }
+            if (o.parentOfType<RsFunction>() == null && hasChildMods) return
+
+            checkUseSpeck(o, holder)
+        }
+    }
+
+    private fun checkUseSpeck(useSpeck: RsUseSpeck, holder: RsProblemsHolder) {
+        if (!useSpeck.isUsed()) {
+            val element = getHighlightElement(useSpeck)
+            holder.registerLintProblem(
+                element,
+                "Unused import: `${useSpeck.text}`"
+            )
+        }
+    }
+}
+
+private fun getHighlightElement(useSpeck: RsUseSpeck): PsiElement {
+    if (useSpeck.parent is RsUseItem) {
+        return useSpeck.parent
+    }
+    return useSpeck
+}
+
+/**
+ * Returns true if this use speck has at least one usage in its containing owner (module or function).
+ * A usage can be either a path that uses the import of the use speck or a method call/associated item available through
+ * a trait that is imported by this use speck.
+ */
+private fun RsUseSpeck.isUsed(): Boolean {
+    val owner = this.parentOfType<RsUseItem>()?.parent as? RsItemsOwner ?: return true
+    val usage = owner.pathUsage
+    return isUseSpeckUsed(this, usage)
+}
+
+private fun isUseSpeckUsed(useSpeck: RsUseSpeck, usage: PathUsageMap): Boolean {
+    // Use speck with an empty group is always unused
+    val useGroup = useSpeck.useGroup
+    if (useGroup != null && useGroup.useSpeckList.isEmpty()) return false
+
+    val items = if (useSpeck.isStarImport) {
+        val module = useSpeck.path?.reference?.resolve() as? RsMod ?: return true
+        module.exportedItems(useSpeck.containingMod)
+    } else {
+        val path = useSpeck.path ?: return true
+        val items = path.reference?.multiResolve() ?: return true
+        val name = useSpeck.itemName(withAlias = true) ?: return true
+        items.filterIsInstance<RsNamedElement>().map { NamedItem(name, it) }
+    }
+
+    // TODO: remove after macros are supported in RsPathUsageAnalysis.kt
+    if (items.any { (_, item) -> item is RsMacro }) {
+        return true
+    }
+
+    return items.any { (name, item) ->
+        item in usage.pathUsages[name].orEmpty()
+            || item in usage.traitUsages
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseItem.kt
@@ -22,3 +22,6 @@ abstract class RsUseItemImplMixin : RsStubbedElementImpl<RsUseItemStub>, RsUseIt
 
 val HAS_PRELUDE_IMPORT_PROP: StubbedAttributeProperty<RsUseItem, RsUseItemStub> =
     StubbedAttributeProperty({ it.hasAttribute("prelude_import") }, RsUseItemStub::mayHavePreludeImport)
+
+val RsUseItem.isReexport: Boolean
+    get() = visibility != RsVisibility.Private

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeMetaInfo.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeMetaInfo.kt
@@ -1,0 +1,33 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve2
+
+import com.intellij.util.containers.map2Array
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.RsNamedElement
+import org.rust.lang.core.resolve.Namespace
+import org.rust.lang.core.resolve2.RsModInfoBase.RsModInfo
+
+data class NamedItem(val name: String, val item: RsNamedElement)
+
+/** List of items added to [context] by glob import to [this] */
+fun RsMod.exportedItems(context: RsMod): List<NamedItem> {
+    val (project, defMap, modData) = getModInfo(this) as? RsModInfo ?: return emptyList()
+    val contextInfo = getModInfo(context) as? RsModInfo ?: return emptyList()
+    return modData
+        .getVisibleItems { it.isVisibleFromMod(contextInfo.modData) }
+        .flatMap { (name, perNs) ->
+            perNs.allVisItems().flatMap { (visItem, namespace) ->
+                val items = visItem.toPsi(defMap, project, namespace)
+                items.map { NamedItem(name, it) }
+            }
+        }
+}
+
+private fun PerNs.allVisItems(): Array<Pair<VisItem, Namespace>> =
+    types.map2Array { it to Namespace.Types } +
+        values.map2Array { it to Namespace.Values } +
+        macros.map2Array { it to Namespace.Macros }

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -400,14 +400,14 @@ private val RsPath.pathSegmentsAdjustedForAttrMacro: List<String>?
         }
     }
 
-private sealed class RsModInfoBase {
+sealed class RsModInfoBase {
     /** [reason] is only for debug */
     class CantUseNewResolve(val reason: String) : RsModInfoBase()
     object InfoNotFound : RsModInfoBase()
     data class RsModInfo(val project: Project, val defMap: CrateDefMap, val modData: ModData) : RsModInfoBase()
 }
 
-private fun getModInfo(scope: RsMod): RsModInfoBase {
+fun getModInfo(scope: RsMod): RsModInfoBase {
     val project = scope.project
     if (!project.isNewResolveEnabled) return CantUseNewResolve("not enabled")
     if (scope is RsModItem && scope.modName == TMP_MOD_NAME) return CantUseNewResolve("__tmp__ mod")
@@ -518,7 +518,7 @@ private fun MacroDefInfo.legacyMacroToPsi(containingMod: RsMod, defMap: CrateDef
     // Note that we can return null, e.g. if old macro engine is enabled and macro definition is itself expanded
 }
 
-private fun VisItem.toPsi(defMap: CrateDefMap, project: Project, ns: Namespace): List<RsNamedElement> {
+fun VisItem.toPsi(defMap: CrateDefMap, project: Project, ns: Namespace): List<RsNamedElement> {
     if (isModOrEnum) return path.toRsModOrEnum(defMap, project)
 
     val containingModData = defMap.getModData(containingMod) ?: return emptyList()

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -608,6 +608,11 @@
                          enabledByDefault="true" level="ERROR"
                          implementationClass="org.rust.ide.inspections.lints.RsUnknownCrateTypesInspection"/>
 
+        <localInspection language="Rust" groupName="Rust"
+                         displayName="Unused import"
+                         enabledByDefault="false" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.lints.RsUnusedImportInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsUnusedImport.html
+++ b/src/main/resources/inspectionDescriptions/RsUnusedImport.html
@@ -1,0 +1,1 @@
+Detects unused <code>use</code> directives.

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
@@ -1,0 +1,619 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import org.rust.*
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+@UseNewResolve
+class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspection::class) {
+    fun `test unused import`() = checkByText("""
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            <warning descr="Unused import: `super::foo::S`">use super::foo::S;</warning>
+        }
+    """)
+
+    fun `test unused import in group`() = checkByText("""
+        mod foo {
+            pub struct S;
+            pub struct T;
+        }
+
+        mod bar {
+            use super::foo::{S, <warning descr="Unused import: `T`">T</warning>};
+
+            fn bar(_: S) {}
+        }
+    """)
+
+    fun `test unused import with nested path in group`() = checkByText("""
+        mod foo {
+            pub struct R;
+            pub mod bar {
+                pub struct S;
+            }
+        }
+
+        mod bar {
+            use super::foo::{R, <warning descr="Unused import: `bar::S`">bar::S</warning>};
+
+            fn bar(_: R) {}
+        }
+    """)
+
+    fun `test import used in type context`() = checkByText("""
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            use super::foo::S;
+
+            fn bar(_: S) {}
+        }
+    """)
+
+    fun `test import used in expr context`() = checkByText("""
+        mod foo {
+            pub struct S;
+            impl S {
+                pub fn foo() {}
+            }
+        }
+
+        mod bar {
+            use super::foo::S;
+
+            fn bar() {
+                S::foo();
+            }
+        }
+    """)
+
+    fun `test ignore reexport`() = checkByText("""
+        pub mod foo {
+            pub struct S {}
+        }
+
+        pub use foo::S;
+        pub(crate) use foo::S;
+    """)
+
+    fun `test shadowed path`() = checkByText("""
+        mod foo {
+            pub struct S {}
+        }
+
+        mod bar {
+            <warning descr="Unused import: `super::foo::S`">use super::foo::S;</warning>
+            fn bar() {
+                let S = 1;
+                let x = S;
+            }
+        }
+    """)
+
+    fun `test path with global import`() = checkByText("""
+        mod foo {
+            pub struct S {}
+        }
+
+        mod bar {
+            <warning descr="Unused import: `super::foo::S`">use super::foo::S;</warning>
+            fn bar(s: crate::foo::S) {}
+        }
+    """)
+
+    fun `test unused multi-resolve import`() = checkByText("""
+        mod foo {
+            pub const S: u32 = 1;
+            pub struct S {}
+        }
+
+        mod bar {
+            <warning descr="Unused import: `super::foo::S`">use super::foo::S;</warning>
+        }
+    """)
+
+    fun `test used multi-resolve import`() = checkByText("""
+        mod foo {
+            pub const S: u32 = 1;
+            pub struct S {}
+        }
+
+        mod bar {
+            use super::foo::S;
+
+            fn bar(_: S) {}
+        }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test cfg-disabled usage`() = checkByText("""
+        mod foo {
+            pub struct S {}
+        }
+
+        mod bar {
+            <warning descr="Unused import: `super::foo::S`">use super::foo::S;</warning>
+
+            #[cfg(not(intellij_rust))]
+            fn bar() {
+                let s: S;
+            }
+        }
+    """)
+
+    fun `test used trait method`() = checkByText("""
+        mod foo {
+            pub trait Trait {
+                fn method(&self);
+            }
+        }
+
+        mod bar {
+            use super::foo::Trait;
+
+            struct S;
+            impl super::foo::Trait for S {
+                fn method(&self) {}
+            }
+
+            fn bar(s: S) {
+                s.method();
+            }
+        }
+    """)
+
+    fun `test used trait associated constant`() = checkByText("""
+        mod foo {
+            pub trait Trait {
+                const FOO: u32;
+            }
+        }
+
+        mod bar {
+            use super::foo::Trait;
+
+            struct S;
+            impl super::foo::Trait for S {
+                const FOO: u32 = 1;
+            }
+
+            fn bar() {
+                let _ = S::FOO;
+            }
+        }
+    """)
+
+    fun `test used trait method with alias`() = checkByText("""
+        mod foo {
+            pub trait Trait {
+                fn method(&self);
+            }
+        }
+
+        mod bar {
+            use super::foo::Trait as T;
+
+            struct S;
+            impl super::foo::Trait for S {
+                fn method(&self) {}
+            }
+
+            fn bar(s: S) {
+                s.method();
+            }
+        }
+    """)
+
+    fun `test unused import with alias`() = checkByText("""
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            <warning descr="Unused import: `super::foo::S as T`">use super::foo::S as T;</warning>
+
+            fn bar(_: S) {}
+        }
+    """)
+
+    fun `test used import with alias`() = checkByText("""
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            use super::foo::S as T;
+
+            fn bar(_: T) {}
+        }
+    """)
+
+    fun `test unused self import`() = checkByText("""
+        mod foo {
+            pub mod bar {
+                pub struct S;
+            }
+        }
+
+        mod bar {
+            use super::foo::bar::{<warning descr="Unused import: `self`">self</warning>};
+        }
+    """)
+
+    fun `test used self import`() = checkByText("""
+        mod foo {
+            pub mod baz {
+                pub struct S;
+            }
+        }
+
+        mod bar {
+            use super::foo::baz::{self};
+
+            fn bar(_: baz::S) {}
+        }
+    """)
+
+    fun `test unused star import`() = checkByText("""
+        mod foo {}
+
+        mod bar {
+            <warning descr="Unused import: `super::foo::*`">use super::foo::*;</warning>
+        }
+    """)
+
+    fun `test used star import`() = checkByText("""
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            use super::foo::*;
+
+            fn bar(_: S) {}
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test star import reexport`() = checkByText("""
+        mod foo {
+            mod bar {
+                pub struct S;
+            }
+            pub use bar::S as T;
+        }
+
+        mod bar {
+            use super::foo::*;
+
+            fn bar(_: T) {}
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test star import star reexport`() = checkByText("""
+        mod foo {
+            mod bar {
+                pub struct S;
+            }
+            pub use bar::*;
+        }
+
+        mod bar {
+            use super::foo::*;
+
+            fn bar(_: S) {}
+        }
+    """)
+
+    fun `test used star import in group`() = checkByText("""
+        mod foo {
+            pub mod bar {
+                pub struct S;
+            }
+        }
+
+        mod bar {
+            use super::foo::{bar::*};
+
+            fn bar(_: S) {}
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test private import used in same module`() = checkByText("""
+       mod foo {
+            mod bar {
+                pub struct S;
+            }
+            mod baz {
+                use super::bar::S;
+                use S as T;
+
+                fn fun(_: T) {}
+            }
+        }
+    """)
+
+    fun `test unused import in function`() = checkByText("""
+        mod foo {
+            pub struct S;
+        }
+
+        fn bar() {
+            <warning descr="Unused import: `foo::S`">use foo::S;</warning>
+        }
+    """)
+
+    fun `test used import in function`() = checkByText("""
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            fn bar() {
+                use super::foo::S;
+                let _: S;
+            }
+        }
+    """)
+
+    fun `test usage inside macro`() = checkByText("""
+        mod foo {
+            pub struct S;
+        }
+        mod bar {
+            use super::foo::S;
+
+            macro_rules! handle {
+                (${"$"}p:path) => {
+                    let _: ${"$"}p;
+                }
+            }
+
+            fn bar() {
+                handle!(S);
+            }
+        }
+    """)
+
+    fun `test deny lint`() = checkByText("""
+        #![deny(unused_imports)]
+
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            <error descr="Unused import: `super::foo::S`">use super::foo::S;</error>
+        }
+    """)
+
+    fun `test deny lint group`() = checkByText("""
+        #![deny(unused)]
+
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            <error descr="Unused import: `super::foo::S`">use super::foo::S;</error>
+        }
+    """)
+
+    fun `test empty group`() = checkByText("""
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            <warning descr="Unused import: `super::foo::{}`">use super::foo::{};</warning>
+        }
+    """)
+
+    fun `test unresolved import`() = checkByText("""
+        mod bar {}
+
+        mod baz {
+            use foo::S;
+            use super::bar::T;
+        }
+    """)
+
+    fun `test use imported item in use speck 1`() = checkByText("""
+        mod bar {
+            pub fn func() {}
+        }
+        mod foo {
+            use crate::bar;
+            use bar::func;
+
+            fn main() {
+                func();
+            }
+        }
+    """)
+
+    fun `test use imported item in use speck 2`() = checkByText("""
+        mod bar {
+            pub fn func() {}
+        }
+        mod foo {
+            use crate::bar;
+            use bar::{func};
+
+            fn main() {
+                func();
+            }
+        }
+    """)
+
+    // TODO: https://github.com/intellij-rust/intellij-rust/issues/7314 needs to be fixed
+    /*@MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test colon colon import`() = checkByText("""
+        mod foo {
+            use ::{std::collections};
+            use collections::HashMap;
+
+            fn bar(_: HashMap<u32, u32>) {}
+        }
+    """)*/
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test use imported item in use speck with alias`() = checkByText("""
+        mod bar {
+            pub fn foo1() {}
+            pub fn foo2() {}
+        }
+        mod foo {
+            use crate::bar::{foo1, foo2};
+            use {foo1 as bar1, foo2 as bar2};
+
+            fn foo() {
+                bar1();
+                bar2();
+            }
+        }
+    """)
+
+    fun `test use imported item in pat ident`() = checkByText("""
+        enum A { A1, A2(u32) }
+
+        mod bar {
+            use crate::A;
+            use crate::A::A1;
+            use crate::A::A2;
+
+            fn main(a: A) {
+                match a {
+                    A1 => {}
+                    A2(_) => {}
+                }
+            }
+        }
+    """)
+
+    fun `test star import name imported multiple times`() = checkByText("""
+        mod mod1 {
+            pub fn foo() {}
+        }
+        mod mod2 {
+            pub use crate::mod1::foo;
+            pub fn bar() {}
+        }
+        mod test {
+            <warning descr="Unused import: `crate::mod2::*`">use crate::mod2::*;</warning>
+            use crate::mod1::foo as bar;
+
+            fn baz() {
+                bar();
+            }
+        }
+    """)
+
+    fun `test used macro`() = checkByText("""
+        mod foo {
+            #[macro_export]
+            macro_rules! mac { () => {} }
+        }
+
+        mod bar {
+            fn baz() {
+                use crate::mac;
+                mac!();
+            }
+        }
+    """)
+
+    /*fun `test unused macro`() = checkByText("""
+        mod foo {
+            #[macro_export]
+            macro_rules! mac { () => {} }
+        }
+
+        mod bar {
+            fn baz() {
+                <warning descr="Unused import: `crate::mac`">use crate::mac;</warning>
+            }
+        }
+    """)*/
+
+    fun `test unresolved use`() = checkByText("""
+        mod bar {
+            use super::foo::Baz;
+
+            fn baz(x: Baz) {}
+        }
+    """)
+
+    /*fun `test redundant use speck`() = checkByText("""
+        mod foo {
+            pub struct S;
+        }
+
+        mod bar {
+            <warning descr="Unused import: `super::foo::S`">use super::foo::S;</warning>
+
+            fn bar() {
+                use super::foo::S;
+                let _: S;
+            }
+        }
+    """)*/
+
+    /*
+    fun `test ignore unresolved usage in child module`() = checkByText("""
+        mod foo {
+            pub struct S {}
+        }
+
+        <warning descr="Unused import: `foo::S`">use foo::S;</warning>
+        mod bar {
+            fn foo() {
+                let x: S;
+            }
+        }
+    """)*/
+
+    /*fun `test ignore resolved usage in child module`() = checkByText("""
+        mod foo {
+            pub struct S {}
+        }
+
+        <warning descr="Unused import: `foo::S`">use foo::S;</warning>
+        mod bar {
+            use super::foo::S;
+
+            fn foo() {
+                let x: S;
+            }
+        }
+    """)*/
+
+    /*@MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test private import used in child module`() = checkByText("""
+       mod foo {
+            mod bar {
+                pub struct S;
+            }
+            use bar::S;
+
+            mod baz {
+                use super::S;
+                fn fun(_: S) {}
+            }
+        }
+    """)*/
+}


### PR DESCRIPTION
This PR adds basic support for detecting unused `use` imports. I did not know which platform machinery should be used to implement this, so I took a little inspiration from the Kotlin plugin and implemented something that made sense to me to get the ball rolling. If it should be implemented in a different way, please let me know.

![unused](https://user-images.githubusercontent.com/4539057/99143896-9cd7be80-2661-11eb-86ef-6971c214b024.gif)

~Currently, the inspection does not seem to run after every code change, I'm not sure what should be changed in the caching implementation, any hints?~

There are currently some false negatives (see last commented test), but these should be rare and I think that we can solve these in a future PR. If this gets merged, I'll add a quick fix to remove the unused use speck and then try to integrate this into the import optimizer to automate the process.

Related issues: https://github.com/intellij-rust/intellij-rust/issues/2158 https://github.com/intellij-rust/intellij-rust/issues/2259

changelog: TODO
