### PR TITLE
TY&MACRO: Support macro types

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsExpandedElement.kt
@@ -68,6 +68,16 @@ fun PsiElement.findMacroCallExpandedFrom(): RsMacroCall? {
     return found?.findMacroCallExpandedFrom() ?: found
 }
 
+fun PsiElement.calculateMacroExpansionDepth(): Int {
+    var macroCall = findMacroCallExpandedFromNonRecursive() ?: return 0
+    var counter = 1
+    while (true) {
+        macroCall = macroCall.findMacroCallExpandedFromNonRecursive() ?: break
+        counter++
+    }
+    return counter
+}
+
 fun PsiElement.findMacroCallExpandedFromNonRecursive(): RsMacroCall? {
     return stubAncestors
         .filterIsInstance<RsExpandedElement>()

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -1543,4 +1543,24 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
           //^ S
         }
     """)
+
+    fun `test macro type`() = testExpr("""
+        fn main() {
+          macro_rules! i32_ty {
+                () => { i32 }
+            }
+            let a: i32_ty!() = unresolved();
+            a;
+        } //^ i32
+    """)
+
+    fun `test infinite macro type`() = testExpr("""
+        fn main() {
+          macro_rules! infinite {
+                () => { infinite!() }
+            }
+            let a: infinite!() = unresolved();
+            a;
+        } //^ <unknown>
+    """)
 }


### PR DESCRIPTION
Works for `let a: foo!() = ...`
Fixes #6290