### PR TITLE
CI: remove deprecated ::set-env command

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,17 +98,17 @@ jobs:
               if: matrix.rust-version == '1.32.0'
               # see https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
               run: |
-                  echo "::set-env name=ORG_GRADLE_PROJECT_ideaVersion::IU-2020.2"
-                  echo "::set-env name=ORG_GRADLE_PROJECT_clionVersion::CL-2020.2"
-                  echo "::set-env name=ORG_GRADLE_PROJECT_nativeDebugPluginVersion::202.6397.20"
-                  echo "::set-env name=ORG_GRADLE_PROJECT_graziePluginVersion::202.6397.11"
+                  echo "ORG_GRADLE_PROJECT_ideaVersion=IU-2020.2" >> $GITHUB_ENV
+                  echo "ORG_GRADLE_PROJECT_clionVersion=CL-2020.2" >> $GITHUB_ENV
+                  echo "ORG_GRADLE_PROJECT_nativeDebugPluginVersion=202.6397.20" >> $GITHUB_ENV
+                  echo "ORG_GRADLE_PROJECT_graziePluginVersion=202.6397.11" >> $GITHUB_ENV
 
             - name: Set up env variable for new resolve
               if: matrix.resolve-engine == 'resolve-new'
               run: echo "INTELLIJ_RUST_FORCE_USE_NEW_RESOLVE=" >> $GITHUB_ENV
 
             - name: Set up test env variables
-              run: echo "::set-env name=RUST_SRC_WITH_SYMLINK::$HOME/.rust-src"
+              run: echo "RUST_SRC_WITH_SYMLINK=$HOME/.rust-src" >> $GITHUB_ENV
 
             - name: Create symlink for Rust stdlib Unix
               if: matrix.os != 'windows-latest'

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -17,14 +17,14 @@ jobs:
             # to calculate difference only for branch changes
             - name: Calculate base commit for workflow_dispatch event
               if: github.event_name == 'workflow_dispatch'
-              run: echo "::set-env name=BASE_COMMIT::$(git merge-base origin/master ${{ github.sha }})"
+              run: echo "BASE_COMMIT=$(git merge-base origin/master ${{ github.sha }})" >> $GITHUB_ENV
 
             # For pull request event, GitHub produces additional merge commit with `master` branch and PR branch as parents
             # In this case, we want to check difference between master branch and merge commit
             # so emit hash of `origin/master` branch itself as base commit
             - name: Calculate base commit for pull_request event
               if: github.event_name == 'pull_request'
-              run: echo "::set-env name=BASE_COMMIT::$(git rev-parse origin/master)"
+              run: echo "BASE_COMMIT=$(git rev-parse origin/master)" >> $GITHUB_ENV
 
             - name: Emit base commit
               id: base-commit


### PR DESCRIPTION
Fixes the removal of `set-env` (https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).

CI was broken because of `set-env` usage: https://github.com/intellij-rust/intellij-rust/pull/6372/checks?check_run_id=1408230162