### PR TITLE
Fix 2020.3 compatibility

### DIFF
--- a/src/202/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
+++ b/src/202/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.macros
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.FileAttributes
 import com.intellij.psi.stubs.SerializationManagerEx
 import com.intellij.psi.stubs.SerializedStubTreeDataExternalizer
 import com.intellij.psi.stubs.StubForwardIndexExternalizer
@@ -28,3 +29,6 @@ fun newSerializedStubTreeDataExternalizer(
 @Suppress("UnstableApiUsage")
 fun createFileContent(project: Project, file: ReadOnlyLightVirtualFile, fileContent: String): FileContent =
     FileContentImpl(file, fileContent, file.modificationStamp).also { it.project = project }
+
+fun createFileAttributes(isDir: Boolean, length: Long, lastModified: Long): FileAttributes =
+    FileAttributes(isDir, false, false, false, length, lastModified, true)

--- a/src/203/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
+++ b/src/203/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
@@ -6,6 +6,8 @@
 package org.rust.lang.core.macros
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.FileAttributes
+import com.intellij.openapi.util.io.FileAttributes.CaseSensitivity
 import com.intellij.psi.stubs.SerializationManagerEx
 import com.intellij.psi.stubs.SerializedStubTreeDataExternalizer
 import com.intellij.psi.stubs.StubForwardIndexExternalizer
@@ -29,3 +31,9 @@ fun newSerializedStubTreeDataExternalizer(
 @Suppress("UnstableApiUsage")
 fun createFileContent(project: Project, file: ReadOnlyLightVirtualFile, fileContent: String): FileContent =
     FileContentImpl.createByText(file, fileContent).also { (it as FileContentImpl).project = project }
+
+// BACKCOMPAT: 2020.2. Inline it
+fun createFileAttributes(isDir: Boolean, length: Long, lastModified: Long): FileAttributes {
+    val caseSensitivity = if (isDir) CaseSensitivity.SENSITIVE else CaseSensitivity.UNKNOWN
+    return FileAttributes(isDir, false, false, false, length, lastModified, true, caseSensitivity)
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystem.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystem.kt
@@ -203,7 +203,7 @@ class MacroExpansionFileSystem : NewVirtualFileSystem() {
     override fun getAttributes(file: VirtualFile): FileAttributes? {
         val item = convert(file) ?: return null
         val length = ((item as? FSFile)?.length ?: 0).toLong()
-        return FileAttributes(item is FSDir, false, false, false, length, item.timestamp, true)
+        return createFileAttributes(item is FSDir, length, item.timestamp)
     }
 
     sealed class FSItem {


### PR DESCRIPTION
`FileAttributes` has `caseSensitivity` property on 203.
Default value `CaseSensitivity.UNKNOWN` leads to errors in logs