### PR TITLE
COMP: Repr attribute layouts

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
@@ -269,7 +269,7 @@ object RsPsiPattern {
      * @see RsMetaItem.isRootMetaItem
      * @see RsAttr.owner
      */
-    private fun rootMetaItem(
+    fun rootMetaItem(
         key: String? = null,
         ownerPattern: ElementPattern<out RsDocAndAttributeOwner>? = null
     ): PsiElementPattern.Capture<RsMetaItem> {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
@@ -37,6 +37,7 @@ class RsCompletionContributor : CompletionContributor() {
         extend(CompletionType.BASIC, RsLambdaExprCompletionProvider)
         extend(CompletionType.BASIC, RsPsiPattern.fieldVisibility, RsVisibilityCompletionProvider())
         extend(CompletionType.BASIC, declarationPattern() or inherentImplDeclarationPattern(), RsVisibilityCompletionProvider())
+        extend(CompletionType.BASIC, RsReprCompletionProvider)
     }
 
     fun extend(type: CompletionType?, provider: RsCompletionProvider) {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsReprCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsReprCompletionProvider.kt
@@ -14,6 +14,7 @@ import com.intellij.patterns.PlatformPatterns
 import com.intellij.psi.PsiElement
 import com.intellij.util.ProcessingContext
 import org.rust.lang.RsLanguage
+import org.rust.lang.core.RsPsiPattern
 import org.rust.lang.core.psi.RsEnumItem
 import org.rust.lang.core.psi.RsMetaItem
 import org.rust.lang.core.psi.RsPath
@@ -22,19 +23,20 @@ import org.rust.lang.core.psi.ext.RsStructOrEnumItemElement
 import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psiElement
 import org.rust.lang.core.types.ty.TyInteger
-import org.rust.lang.core.withSuperParent
 
 object RsReprCompletionProvider : RsCompletionProvider() {
     override val elementPattern: ElementPattern<out PsiElement>
         get() = PlatformPatterns.psiElement()
             .withLanguage(RsLanguage)
-            .withParent(psiElement<RsPath>()
-                .withParent(psiElement<RsMetaItem>()
-                    .withSuperParent(2,
-                        psiElement<PsiElement>()
-                            .withSuperParent<RsStructOrEnumItemElement>(2)
+            .withParent(
+                psiElement<RsPath>()
+                    .withParent(
+                        psiElement<RsMetaItem>()
+                            .withSuperParent(
+                                2,
+                                RsPsiPattern.rootMetaItem("repr", psiElement<RsStructOrEnumItemElement>())
+                            )
                     )
-                )
             )
 
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsReprCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsReprCompletionProvider.kt
@@ -1,0 +1,71 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.editor.EditorModificationUtil
+import com.intellij.patterns.ElementPattern
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.PsiElement
+import com.intellij.util.ProcessingContext
+import org.rust.lang.RsLanguage
+import org.rust.lang.core.psi.RsEnumItem
+import org.rust.lang.core.psi.RsMetaItem
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.RsStructItem
+import org.rust.lang.core.psi.ext.RsStructOrEnumItemElement
+import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psiElement
+import org.rust.lang.core.types.ty.TyInteger
+import org.rust.lang.core.withSuperParent
+
+object RsReprCompletionProvider : RsCompletionProvider() {
+    override val elementPattern: ElementPattern<out PsiElement>
+        get() = PlatformPatterns.psiElement()
+            .withLanguage(RsLanguage)
+            .withParent(psiElement<RsPath>()
+                .withParent(psiElement<RsMetaItem>()
+                    .withSuperParent(2,
+                        psiElement<PsiElement>()
+                            .withSuperParent<RsStructOrEnumItemElement>(2)
+                    )
+                )
+            )
+
+    override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+        val owner = parameters.position.ancestorStrict<RsStructOrEnumItemElement>()
+            ?: return
+
+        fun Sequence<String>.addToResults() = forEach {
+            val element = LookupElementBuilder.create(it).run {
+                if (it.endsWith("()")) {
+                    // If the attribute name ends in parentheses, put the caret in-between those parentheses.
+                    this.withInsertHandler { ctx, _ ->
+                        EditorModificationUtil.moveCaretRelatively(ctx.editor, -1)
+                    }
+                } else this
+            }
+            result.addElement(element.withPriority(DEFAULT_PRIORITY))
+        }
+
+        // Layouts common to struct, enum and union
+        if (owner is RsStructItem || owner is RsEnumItem) {
+            sequenceOf("C", "transparent", "align()").addToResults()
+        }
+
+        // Layouts specific to enum
+        if (owner is RsEnumItem) {
+            TyInteger.NAMES.asSequence().addToResults()
+        }
+
+        // Layouts specific to struct or union
+        if (owner is RsStructItem) {
+            sequenceOf("packed", "packed()", "simd").addToResults()
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/lang/core/completion/RsReprCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsReprCompletionProviderTest.kt
@@ -5,13 +5,38 @@
 
 package org.rust.lang.core.completion
 
+import org.rust.lang.core.types.ty.TyInteger
+
 class RsReprCompletionProviderTest : RsCompletionTestBase() {
 
-    fun `test complete on enum`() = doSingleCompletion("""
+    fun `test complete on enum`() = checkContainsCompletion(listOf("C", "transparent", "align()") + TyInteger.NAMES, """
+        #[repr(/*caret*/)]
+        enum E { A }
+    """)
+
+    fun `test complete on struct`() = checkContainsCompletion(listOf("C", "transparent", "align()", "packed", "packed()", "simd"), """
+        #[repr(/*caret*/)]
+        struct S { f: i32 }
+    """)
+
+    fun `test complete 'transparent' on enum`() = doSingleCompletion("""
         #[repr(trans/*caret*/)]
-        enum E {}
+        enum E { A }
     """, """
         #[repr(transparent/*caret*/)]
+        enum E { A }
+    """)
+
+    fun `test complete attr under cfg_attr`() = doSingleCompletion("""
+        #[cfg_attr(unix, repr(trans/*caret*/))]
+        enum E { A }
+    """, """
+        #[cfg_attr(unix, repr(transparent/*caret*/))]
+        enum E { A }
+    """)
+
+    fun `test no packed layout inside another attribute`() = checkNotContainsCompletion("packed", """
+        #[foo(trans/*caret*/)]
         enum E {}
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsReprCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsReprCompletionProviderTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+class RsReprCompletionProviderTest : RsCompletionTestBase() {
+
+    fun `test complete on enum`() = doSingleCompletion("""
+        #[repr(trans/*caret*/)]
+        enum E {}
+    """, """
+        #[repr(transparent/*caret*/)]
+        enum E {}
+    """)
+
+    // The packed layout is applicable only to struct and union.
+    fun `test no packed layout on enum`() = checkNotContainsCompletion("packed", """
+        #[repr(pack/*caret*/)]
+        enum E {}
+    """)
+
+    // Primitive representations are only applicable to enumerations.
+    fun `test no primitive repr on struct`() = checkNotContainsCompletion("isize", """
+        #[repr("isi/*caret*/")]
+        struct S {}
+    """)
+
+}


### PR DESCRIPTION
Closes #6365 

* [X] Completion for layouts applicable to the item the repr attribute it on
* [x] Proper completion for `align`, which requires a power of two in parentheses (eg `align(8)`).
* [ ] Proper completion for `packed`, which optionally requires parentheses.

changelog:
Add completion for layouts in `repr` attributes.