### PR TITLE
CARGO: fetch actual info about stdlb

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
@@ -219,14 +219,7 @@ private fun fetchCargoWorkspace(context: CargoSyncTask.SyncContext): TaskResult<
             })
             val manifestPath = projectDirectory.resolve("Cargo.toml")
 
-            // Running "cargo rustc -- --print cfg" causes an error when run in a project with multiple targets
-            // error: extra arguments to `rustc` can only be passed to one target, consider filtering
-            // the package by passing e.g. `--lib` or `--bin NAME` to specify a single target
-            // Running "cargo rustc --bin=projectname  -- --print cfg" we can get around this
-            // but it also compiles the whole project, which is probably not wanted
-            // TODO: This does not query the target specific cfg flags during cross compilation :-(
-            val rawCfgOptions = toolchain.rustc().getCfgOptions(projectDirectory) ?: emptyList()
-            val cfgOptions = CfgOptions.parse(rawCfgOptions)
+            val cfgOptions = toolchain.rustc().getCfgOptions(projectDirectory)
             val ws = CargoWorkspace.deserialize(manifestPath, projectDescriptionData, cfgOptions)
             TaskResult.Ok(ws)
         } catch (e: ExecutionException) {

--- a/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/StandardLibrary.kt
@@ -5,44 +5,46 @@
 
 package org.rust.cargo.project.workspace
 
+import com.intellij.execution.ExecutionException
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.io.exists
+import com.intellij.util.text.SemVer
+import org.rust.cargo.CargoConstants
+import org.rust.cargo.CfgOptions
+import org.rust.cargo.project.model.RustcInfo
+import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.toolchain.impl.CargoMetadata
+import org.rust.cargo.toolchain.tools.Cargo
+import org.rust.cargo.toolchain.tools.cargo
 import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.cargo.util.StdLibType
+import org.rust.ide.experiments.RsExperiments
+import org.rust.openapiext.isFeatureEnabled
+import org.rust.openapiext.pathAsPath
+import org.rust.stdext.toPath
+import java.nio.file.Path
 
-class StandardLibrary private constructor(
-    val crates: List<StdCrate>,
+data class StandardLibrary(
+    val crates: List<CargoWorkspaceData.Package>,
+    val dependencies: Map<PackageId, Set<CargoWorkspaceData.Dependency>>,
+    val isHardcoded: Boolean,
     val isPartOfCargoProject: Boolean = false
 ) {
-
-    data class StdCrate(
-        val name: String,
-        val type: StdLibType,
-        val crateRootUrl: String,
-        val packageRootUrl: String,
-        val dependencies: Collection<String>,
-        val id: PackageId = "(stdlib) $name"
-    )
-
-    fun asPartOfCargoProject(): StandardLibrary = StandardLibrary(crates, true)
-
     companion object {
+        private val LOG: Logger = logger<StandardLibrary>()
+
         private val SRC_ROOTS: List<String> = listOf("library", "src")
         private val LIB_PATHS: List<String> = listOf("src/lib.rs", "lib.rs")
 
-        fun fromPath(path: String): StandardLibrary? =
-            LocalFileSystem.getInstance().findFileByPath(path)?.let { fromFile(it) }
+        fun fromPath(project: Project, path: String, isPartOfCargoProject: Boolean = false): StandardLibrary? =
+            LocalFileSystem.getInstance().findFileByPath(path)?.let { fromFile(project, it, isPartOfCargoProject) }
 
-        fun fromFile(sources: VirtualFile): StandardLibrary? {
+        fun fromFile(project: Project, sources: VirtualFile, isPartOfCargoProject: Boolean = false): StandardLibrary? {
             if (!sources.isDirectory) return null
-
-            fun VirtualFile.findFirstFileByRelativePaths(paths: List<String>): VirtualFile? {
-                for (path in paths) {
-                    val file = findFileByRelativePath(path)
-                    if (file != null) return file
-                }
-                return null
-            }
 
             val srcDir = if (sources.name in SRC_ROOTS) {
                 sources
@@ -50,17 +52,242 @@ class StandardLibrary private constructor(
                 sources.findFirstFileByRelativePaths(SRC_ROOTS) ?: sources
             }
 
-            val stdlib = AutoInjectedCrates.stdlibCrates.mapNotNull { libInfo ->
+            val stdlib = if (isFeatureEnabled(RsExperiments.FETCH_ACTUAL_STDLIB_METADATA) && !isPartOfCargoProject) {
+                fetchRealStdlib(project, srcDir)
+            } else {
+                fetchHardcodedStdlib(srcDir)
+            }
+
+            return stdlib?.copy(isPartOfCargoProject = isPartOfCargoProject)
+        }
+
+        private fun fetchRealStdlib(project: Project, srcDir: VirtualFile): StandardLibrary? {
+            val cargo = project.toolchain?.cargo() ?: return null
+
+            val testPackageSrcPaths = listOf(AutoInjectedCrates.TEST, "lib${AutoInjectedCrates.TEST}")
+            val testPackageSrcDir = srcDir.findFirstFileByRelativePaths(testPackageSrcPaths)?.canonicalFile
+                ?: return null
+            val stdlibDependenciesDir = findStdlibDependencyDirectory(project, cargo, srcDir, testPackageSrcDir)
+                ?: return null
+
+            val workspaceMembers = mutableListOf<PackageId>()
+            val visitedPackages = mutableSetOf<PackageId>()
+
+            val allPackages = mutableListOf<CargoMetadata.Package>()
+            val allNodes = mutableListOf<CargoMetadata.ResolveNode>()
+
+            fun String.remapPath(libName: String, version: String): String {
+                val path = toPath()
+                for (i in path.nameCount - 1 downTo 0) {
+                    val fileName = path.getName(i).fileName.toString()
+                    if (fileName.startsWith(libName) && fileName.endsWith(version)) {
+                        val subpath = path.subpath(i + 1, path.nameCount)
+                        return stdlibDependenciesDir.resolve(libName).resolve(subpath).toString()
+                    }
+                }
+                error("Failed to remap `$this`")
+            }
+
+            fun CargoMetadata.Project.walk(id: PackageId, root: Boolean) {
+                if (id in visitedPackages) return
+                val stdlibId = id.toStdlibId()
+
+                if (root) {
+                    workspaceMembers += stdlibId
+                }
+
+                visitedPackages += id
+
+                val pkg = packages.first { it.id == id }
+
+                val pkgNode = resolve.nodes.first { it.id == id }
+                val nodeDeps = mutableListOf<CargoMetadata.Dep>()
+                val nodeDependencies = mutableListOf<PackageId>()
+
+                for (dep in pkgNode.deps.orEmpty()) {
+                    val depKinds = dep.dep_kinds?.filter { it.kind == null }.orEmpty()
+                    if (depKinds.isNotEmpty()) {
+                        nodeDependencies += dep.pkg.toStdlibId()
+                        nodeDeps += dep.copy(pkg = dep.pkg.toStdlibId(), dep_kinds = depKinds)
+                        walk(dep.pkg, false)
+                    }
+                }
+
+                allNodes += pkgNode.copy(id = stdlibId, dependencies = nodeDependencies, deps = nodeDeps)
+
+                val (newManifestPath, newTargets) = if (pkg.source != null) {
+                    val newTargets = pkg.targets.map { it.copy(src_path = it.src_path.remapPath(pkg.name, pkg.version)) }
+                    pkg.manifest_path.remapPath(pkg.name, pkg.version) to newTargets
+                } else {
+                    pkg.manifest_path to pkg.targets
+                }
+
+                val newPkg = pkg.copy(
+                    id = stdlibId,
+                    manifest_path = newManifestPath,
+                    targets = newTargets,
+                    dependencies = pkg.dependencies.filter { it.kind == null }
+                )
+
+                allPackages += newPkg
+            }
+
+            fun VirtualFile.collectPackageMetadata() {
+                val metadataProject = try {
+                    cargo.fetchMetadata(project, pathAsPath)
+                } catch (e: ExecutionException) {
+                    LOG.error(e)
+                    return
+                }
+
+                val rootPackageId = metadataProject.workspace_members.first()
+                metadataProject.walk(rootPackageId, true)
+            }
+
+            // `test` package depends on all other stdlib packages from `AutoInjectedCrates` (at least on moment of writing)
+            // so let's collect its metadata first to avoid redundant calls of `cargo metadata`
+            testPackageSrcDir.collectPackageMetadata()
+            // if there is a package that is not in dependencies of `test` package,
+            // collect its metadata manually
+            val rootStdlibCrates = AutoInjectedCrates.stdlibCrates.filter { it.type != StdLibType.DEPENDENCY }
+            for (libInfo in rootStdlibCrates) {
+                val packageSrcPaths = listOf(libInfo.name, "lib${libInfo.name}")
+                val packageSrcDir = srcDir.findFirstFileByRelativePaths(packageSrcPaths)?.canonicalFile ?: continue
+
+                val packageManifestPath = packageSrcDir.pathAsPath.resolve(CargoConstants.MANIFEST_FILE).toString()
+                val pkg = allPackages.find { it.manifest_path == packageManifestPath }
+                if (pkg == null) {
+                    packageSrcDir.collectPackageMetadata()
+                } else {
+                    workspaceMembers += pkg.id
+                }
+            }
+
+            val stdlibMetadataProject = CargoMetadata.Project(
+                allPackages,
+                CargoMetadata.Resolve(allNodes),
+                1,
+                workspaceMembers,
+                srcDir.path
+            )
+            val stdlibWorkspaceData = CargoMetadata.clean(stdlibMetadataProject)
+            val stdlibPackages = stdlibWorkspaceData.packages.map {
+                // TODO: introduce PackageOrigin.STDLIB_DEPENDENCY
+                if (it.source == null) it.copy(origin = PackageOrigin.STDLIB) else it
+            }
+            return StandardLibrary(stdlibPackages, stdlibWorkspaceData.dependencies, isHardcoded = false)
+        }
+
+        private fun findStdlibDependencyDirectory(
+            project: Project,
+            cargo: Cargo,
+            srcDir: VirtualFile,
+            testPackageSrcDir: VirtualFile
+        ): Path? {
+            val stdlibDependenciesDir = srcDir.pathAsPath.resolve("../vendor").normalize()
+
+            if (!stdlibDependenciesDir.exists()) {
+                try {
+                    // `test` package depends on all other stdlib packages,
+                    // at least before 1.49 when `vendor` became a part of `rust-src`.
+                    // So it's enough to vendor only its dependencies
+                    cargo.vendorDependencies(project, testPackageSrcDir.pathAsPath, stdlibDependenciesDir)
+                } catch (e: ExecutionException) {
+                    LOG.error(e)
+                    return null
+                }
+            }
+            return stdlibDependenciesDir
+        }
+
+        private fun fetchHardcodedStdlib(srcDir: VirtualFile): StandardLibrary? {
+            val crates = mutableMapOf<PackageId, CargoWorkspaceData.Package>()
+
+            for (libInfo in AutoInjectedCrates.stdlibCrates) {
                 val packageSrcPaths = listOf(libInfo.name, "lib${libInfo.name}")
                 val packageSrcDir = srcDir.findFirstFileByRelativePaths(packageSrcPaths)?.canonicalFile
                 val libFile = packageSrcDir?.findFirstFileByRelativePaths(LIB_PATHS)
-                if (packageSrcDir != null && libFile != null)
-                    StdCrate(libInfo.name, libInfo.type, libFile.url, packageSrcDir.url, libInfo.dependencies)
-                else
-                    null
+                if (packageSrcDir != null && libFile != null) {
+                    val cratePkg = CargoWorkspaceData.Package(
+                        id = libInfo.name.toStdlibId(),
+                        contentRootUrl = packageSrcDir.url,
+                        name = libInfo.name,
+                        version = "",
+                        targets = listOf(CargoWorkspaceData.Target(
+                            crateRootUrl = libFile.url,
+                            name = libInfo.name,
+                            kind = CargoWorkspace.TargetKind.Lib(CargoWorkspace.LibKind.LIB),
+                            edition = CargoWorkspace.Edition.EDITION_2015,
+                            doctest = true,
+                            requiredFeatures = emptyList()
+                        )),
+                        source = null,
+                        origin = PackageOrigin.STDLIB,
+                        edition = CargoWorkspace.Edition.EDITION_2015,
+                        features = emptyMap(),
+                        enabledFeatures = emptySet(),
+                        cfgOptions = CfgOptions.EMPTY,
+                        env = emptyMap(),
+                        outDirUrl = null
+                    )
+                    crates[cratePkg.id] = cratePkg
+                }
             }
-            if (stdlib.isEmpty()) return null
-            return StandardLibrary(stdlib)
+
+            val dependencies = mutableMapOf<PackageId, MutableSet<CargoWorkspaceData.Dependency>>()
+            val depKinds = listOf(CargoWorkspace.DepKindInfo(CargoWorkspace.DepKind.Stdlib))
+
+            for (libInfo in AutoInjectedCrates.stdlibCrates) {
+                val pkgId = libInfo.name.toStdlibId()
+                if (crates[pkgId] == null) continue
+
+                for (dependency in libInfo.dependencies) {
+                    val dependencyId = dependency.toStdlibId()
+                    if (crates[dependencyId] != null) {
+                        dependencies.getOrPut(pkgId, ::mutableSetOf) += CargoWorkspaceData.Dependency(dependencyId, depKinds = depKinds)
+                    }
+                }
+            }
+
+            if (crates.isEmpty()) return null
+            return StandardLibrary(crates.values.toList(), dependencies, isHardcoded = true)
         }
+
+        private fun VirtualFile.findFirstFileByRelativePaths(paths: List<String>): VirtualFile? {
+            for (path in paths) {
+                val file = findFileByRelativePath(path)
+                if (file != null) return file
+            }
+            return null
+        }
+
+        private fun PackageId.toStdlibId(): String = "(stdlib) $this"
     }
 }
+
+fun StandardLibrary.asPackageData(rustcInfo: RustcInfo?): List<CargoWorkspaceData.Package> {
+    if (!isHardcoded) return crates
+    return crates.map { it.withProperEdition(rustcInfo) }
+}
+
+private fun CargoWorkspaceData.Package.withProperEdition(rustcInfo: RustcInfo?): CargoWorkspaceData.Package {
+    val firstVersionWithEdition2018 = when (name) {
+        AutoInjectedCrates.CORE -> RUST_1_36
+        AutoInjectedCrates.STD -> RUST_1_35
+        else -> RUST_1_34
+    }
+
+    val currentRustcVersion = rustcInfo?.version?.semver
+    val edition = if (currentRustcVersion == null || currentRustcVersion < firstVersionWithEdition2018) {
+        CargoWorkspace.Edition.EDITION_2015
+    } else {
+        CargoWorkspace.Edition.EDITION_2018
+    }
+
+    val newTargets = targets.map { it.copy(edition = edition) }
+    return copy(targets = newTargets, edition = edition)
+}
+
+private val RUST_1_34: SemVer = SemVer.parseFromText("1.34.0")!!
+private val RUST_1_35: SemVer = SemVer.parseFromText("1.35.0")!!
+private val RUST_1_36: SemVer = SemVer.parseFromText("1.36.0")!!

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -48,7 +48,7 @@ object CargoMetadata {
         /**
          * Ids of packages that are members of the cargo workspace
          */
-        val workspace_members: List<String>?,
+        val workspace_members: List<String>,
 
         /**
          * Path to workspace root folder. Can be null for old cargo version
@@ -326,10 +326,6 @@ object CargoMetadata {
     ): CargoWorkspaceData {
         val fs = LocalFileSystem.getInstance()
         val members = project.workspace_members
-            ?: error(
-                "No `workspace_members` key in the `cargo metadata` output.\n" +
-                    "Your version of Cargo is no longer supported, please upgrade Cargo."
-            )
         val variables = PackageVariables.from(buildPlan)
         val packageIdToNode = project.resolve.nodes.associateBy { it.id }
         return CargoWorkspaceData(

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -321,8 +321,8 @@ object CargoMetadata {
 
     fun clean(
         project: Project,
-        buildScriptsInfo: BuildScriptsInfo?,
-        buildPlan: CargoBuildPlan?
+        buildScriptsInfo: BuildScriptsInfo? = null,
+        buildPlan: CargoBuildPlan? = null
     ): CargoWorkspaceData {
         val fs = LocalFileSystem.getInstance()
         val members = project.workspace_members

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -134,10 +134,10 @@ open class Cargo(toolchain: RsToolchain, useWrapper: Boolean = false)
     }
 
     @Throws(ExecutionException::class)
-    private fun fetchMetadata(
+    fun fetchMetadata(
         owner: Project,
         projectDirectory: Path,
-        listener: ProcessListener?
+        listener: ProcessListener? = null
     ): CargoMetadata.Project {
         val additionalArgs = mutableListOf("--verbose", "--format-version", "1", "--all-features")
         val json = CargoCommandLine("metadata", projectDirectory, additionalArgs)
@@ -149,6 +149,16 @@ open class Cargo(toolchain: RsToolchain, useWrapper: Boolean = false)
         } catch (e: JsonSyntaxException) {
             throw ExecutionException(e)
         }
+    }
+
+    @Throws(ExecutionException::class)
+    fun vendorDependencies(
+        owner: Project,
+        projectDirectory: Path,
+        dstPath: Path
+    ) {
+        val commandLine = CargoCommandLine("vendor", projectDirectory, listOf(dstPath.toString()))
+        commandLine.execute(owner)
     }
 
     private fun fetchBuildScriptsInfo(

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustc.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustc.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapiext.isUnitTestMode
+import org.rust.cargo.CfgOptions
 import org.rust.cargo.toolchain.RsToolchain
 import org.rust.cargo.toolchain.impl.RustcVersion
 import org.rust.cargo.toolchain.impl.parseRustcVersion
@@ -47,13 +48,24 @@ class Rustc(toolchain: RsToolchain) : RustupComponent(NAME, toolchain) {
         return fs.refreshAndFindFileByPath(FileUtil.join(sysroot, "lib/rustlib/src/rust"))
     }
 
-    fun getCfgOptions(projectDirectory: Path): List<String>? {
+    private fun getRawCfgOption(projectDirectory: Path?): List<String>? {
         val timeoutMs = 10000
         val output = createBaseCommandLine(
             "--print", "cfg",
             workingDirectory = projectDirectory
         ).execute(timeoutMs)
         return if (output?.isSuccess == true) output.stdoutLines else null
+    }
+
+    fun getCfgOptions(projectDirectory: Path?): CfgOptions {
+        // Running "cargo rustc -- --print cfg" causes an error when run in a project with multiple targets
+        // error: extra arguments to `rustc` can only be passed to one target, consider filtering
+        // the package by passing e.g. `--lib` or `--bin NAME` to specify a single target
+        // Running "cargo rustc --bin=projectname  -- --print cfg" we can get around this
+        // but it also compiles the whole project, which is probably not wanted
+        // TODO: This does not query the target specific cfg flags during cross compilation :-(
+        val rawCfgOptions = getRawCfgOption(projectDirectory) ?: emptyList()
+        return CfgOptions.parse(rawCfgOptions)
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
+++ b/src/main/kotlin/org/rust/cargo/util/RustCrateUtil.kt
@@ -36,6 +36,7 @@ data class StdLibInfo(
 object AutoInjectedCrates {
     const val STD: String = "std"
     const val CORE: String = "core"
+    const val TEST: String = "test"
     val stdlibCrates = listOf(
         // Roots
         StdLibInfo(CORE, StdLibType.ROOT),
@@ -43,7 +44,7 @@ object AutoInjectedCrates {
             CORE, "libc", "compiler_builtins", "profiler_builtins", "unwind")),
         StdLibInfo("alloc", StdLibType.ROOT, dependencies = listOf(CORE, "compiler_builtins")),
         StdLibInfo("proc_macro", type = StdLibType.ROOT, dependencies = listOf(STD)),
-        StdLibInfo("test", type = StdLibType.ROOT, dependencies = listOf(STD, CORE, "libc", "getopts", "term")),
+        StdLibInfo(TEST, type = StdLibType.ROOT, dependencies = listOf(STD, CORE, "libc", "getopts", "term")),
         // Feature gated
         StdLibInfo("libc", StdLibType.FEATURE_GATED),
         StdLibInfo("panic_unwind", type = StdLibType.FEATURE_GATED, dependencies = listOf(CORE, "libc", "alloc",

--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -13,4 +13,5 @@ object RsExperiments {
     const val CARGO_FEATURES_SETTINGS_GUTTER = "org.rust.cargo.features.settings.gutter"
     const val MACROS_NEW_ENGINE = "org.rust.macros.new.engine"
     const val RESOLVE_NEW_ENGINE = "org.rust.resolve.new.engine"
+    const val FETCH_ACTUAL_STDLIB_METADATA = "org.rust.cargo.fetch.actual.stdlib.metadata"
 }

--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -76,7 +76,7 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
             // If rustup is not null, the WorkspaceService will use it
             // to add stdlib automatically. This happens asynchronously,
             // so we can't reliably say here if that succeeded or not.
-            if (!toolchain.isRustupAvailable) return createLibraryAttachingPanel(file)
+            if (!toolchain.isRustupAvailable) return createLibraryAttachingPanel(project, file)
         }
 
         return null
@@ -94,16 +94,16 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
             }
         }
 
-    private fun createLibraryAttachingPanel(file: VirtualFile): RsEditorNotificationPanel =
+    private fun createLibraryAttachingPanel(project: Project, file: VirtualFile): RsEditorNotificationPanel =
         RsEditorNotificationPanel(NO_ATTACHED_STDLIB).apply {
             setText("Can not attach stdlib sources automatically without rustup.")
             createActionLabel("Attach manually") {
                 val descriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
-                val stdlib = FileChooser.chooseFile(descriptor, this, project, null) ?: return@createActionLabel
-                if (StandardLibrary.fromFile(stdlib) != null) {
-                    project.rustSettings.modify { it.explicitPathToStdlib = stdlib.path }
+                val stdlib = FileChooser.chooseFile(descriptor, this, this@MissingToolchainNotificationProvider.project, null) ?: return@createActionLabel
+                if (StandardLibrary.fromFile(project, stdlib) != null) {
+                    this@MissingToolchainNotificationProvider.project.rustSettings.modify { it.explicitPathToStdlib = stdlib.path }
                 } else {
-                    project.showBalloon(
+                    this@MissingToolchainNotificationProvider.project.showBalloon(
                         "Invalid Rust standard library source path: `${stdlib.presentableUrl}`",
                         NotificationType.ERROR
                     )

--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -71,12 +71,13 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
 
         if (!cargoProjects.initialized) return null
 
-        val workspace = cargoProjects.findProjectForFile(file)?.workspace ?: return null
+        val cargoProject = cargoProjects.findProjectForFile(file) ?: return null
+        val workspace = cargoProject.workspace ?: return null
         if (!workspace.hasStandardLibrary) {
             // If rustup is not null, the WorkspaceService will use it
             // to add stdlib automatically. This happens asynchronously,
             // so we can't reliably say here if that succeeded or not.
-            if (!toolchain.isRustupAvailable) return createLibraryAttachingPanel(project, file)
+            if (!toolchain.isRustupAvailable) return createLibraryAttachingPanel(project, file, cargoProject.rustcInfo)
         }
 
         return null
@@ -94,13 +95,13 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
             }
         }
 
-    private fun createLibraryAttachingPanel(project: Project, file: VirtualFile): RsEditorNotificationPanel =
+    private fun createLibraryAttachingPanel(project: Project, file: VirtualFile, rustcInfo: RustcInfo?): RsEditorNotificationPanel =
         RsEditorNotificationPanel(NO_ATTACHED_STDLIB).apply {
             setText("Can not attach stdlib sources automatically without rustup.")
             createActionLabel("Attach manually") {
                 val descriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
                 val stdlib = FileChooser.chooseFile(descriptor, this, this@MissingToolchainNotificationProvider.project, null) ?: return@createActionLabel
-                if (StandardLibrary.fromFile(project, stdlib) != null) {
+                if (StandardLibrary.fromFile(project, stdlib, rustcInfo) != null) {
                     this@MissingToolchainNotificationProvider.project.rustSettings.modify { it.explicitPathToStdlib = stdlib.path }
                 } else {
                     this@MissingToolchainNotificationProvider.project.showBalloon(

--- a/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
+++ b/src/main/kotlin/org/rust/lang/utils/evaluation/CfgEvaluator.kt
@@ -95,7 +95,7 @@ class CfgEvaluator(
         name in packageOptions.nameOptions -> True
         // TODO: convert whitelist to blacklist and merge options with packageOption
         name in SUPPORTED_NAME_OPTIONS -> ThreeValuedLogic.fromBoolean(options.isNameEnabled(name))
-        (name == "test" || name == "bootstrap") && origin == PackageOrigin.STDLIB -> False
+        (name == "test" || name == "bootstrap" || name == "doc") && origin == PackageOrigin.STDLIB -> False
         name == CfgOptions.TEST && isUnitTestMode -> ThreeValuedLogic.fromBoolean(options.isNameEnabled(name))
         else -> Unknown
     }

--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -338,10 +338,10 @@ val DataContext.elementUnderCaretInEditor: PsiElement?
 fun isFeatureEnabled(featureId: String): Boolean = Experiments.getInstance().isFeatureEnabled(featureId)
 fun setFeatureEnabled(featureId: String, enabled: Boolean) = Experiments.getInstance().setFeatureEnabled(featureId, enabled)
 
-fun runWithEnabledFeature(featureId: String, action: () -> Unit) {
+fun <T> runWithEnabledFeature(featureId: String, action: () -> T): T {
     val currentValue = isFeatureEnabled(featureId)
     setFeatureEnabled(featureId, true)
-    try {
+    return try {
         action()
     } finally {
         setFeatureEnabled(featureId, currentValue)

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1035,6 +1035,9 @@
         <experimentalFeature id="org.rust.cargo.features.settings.gutter" percentOfUsers="0">
             <description>Show settings gutter icon near [features] section in `Cargo.toml` where you can enable or disable all features</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.cargo.fetch.actual.stdlib.metadata" percentOfUsers="0">
+            <description>Fetch metadata of actual stdlib crates instead of using hardcoded data</description>
+        </experimentalFeature>
 
     </extensions>
 

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -140,7 +140,8 @@ open class WithRustup(private val delegate: RustProjectDescriptorBase) : RustPro
             it.toolchain = toolchain
         }
         try {
-            val stdlib = StandardLibrary.fromFile(module.project, stdlib!!)!!
+            val rustcInfo = rustcInfo
+            val stdlib = StandardLibrary.fromFile(module.project, stdlib!!, rustcInfo)!!
             return delegate.testCargoProject(module, contentRoot).withStdlib(stdlib, CfgOptions.DEFAULT, rustcInfo)
         } finally {
             Disposer.dispose(disposable)
@@ -170,7 +171,7 @@ open class WithCustomStdlibRustProjectDescriptor(
         }
 
     override fun testCargoProject(module: Module, contentRoot: String): CargoWorkspace {
-        val stdlib = StandardLibrary.fromPath(module.project, explicitStdlibPath()!!)!!
+        val stdlib = StandardLibrary.fromPath(module.project, explicitStdlibPath()!!, rustcInfo)!!
         return delegate.testCargoProject(module, contentRoot).withStdlib(stdlib, CfgOptions.DEFAULT)
     }
 

--- a/src/test/kotlin/org/rust/RustProjectDescriptors.kt
+++ b/src/test/kotlin/org/rust/RustProjectDescriptors.kt
@@ -118,6 +118,10 @@ open class WithRustup(private val delegate: RustProjectDescriptorBase) : RustPro
     private val rustup by lazy { toolchain?.rustup(Paths.get(".")) }
     val stdlib by lazy { (rustup?.downloadStdlib() as? DownloadResult.Ok)?.value }
 
+    private val cfgOptions by lazy {
+        toolchain?.rustc()?.getCfgOptions(null)
+    }
+
     override val skipTestReason: String?
         get() {
             if (rustup == null) return "No rustup"
@@ -142,7 +146,8 @@ open class WithRustup(private val delegate: RustProjectDescriptorBase) : RustPro
         try {
             val rustcInfo = rustcInfo
             val stdlib = StandardLibrary.fromFile(module.project, stdlib!!, rustcInfo)!!
-            return delegate.testCargoProject(module, contentRoot).withStdlib(stdlib, CfgOptions.DEFAULT, rustcInfo)
+            val cfgOptions = cfgOptions!!
+            return delegate.testCargoProject(module, contentRoot).withStdlib(stdlib, cfgOptions, rustcInfo)
         } finally {
             Disposer.dispose(disposable)
         }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
@@ -5,10 +5,10 @@
 
 package org.rust.lang.core.completion
 
-import org.rust.MockEdition
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibRustProjectDescriptor
+import com.intellij.openapi.util.SystemInfo
+import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.lang.core.macros.MacroExpansionScope
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsStdlibCompletionTest : RsCompletionTestBase() {
@@ -88,5 +88,29 @@ class RsStdlibCompletionTest : RsCompletionTestBase() {
     fun `test complete all in std in 'use' in crate root`() = checkContainsCompletion("vec", """
         use std::/*caret*/;
     """)
+
+    @MinRustcVersion("1.41.0")
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
+    @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
+    fun `test complete items from 'os' module unix`() {
+        if (!SystemInfo.isUnix) return
+        doSingleCompletion("""
+            use std::os::uni/*caret*/
+        """, """
+            use std::os::unix/*caret*/
+        """)
+    }
+
+    @MinRustcVersion("1.41.0")
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
+    @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
+    fun `test complete items from 'os' module windows`() {
+        if (!SystemInfo.isWindows) return
+        doSingleCompletion("""
+            use std::os::win/*caret*/
+        """, """
+            use std::os::windows/*caret*/
+        """)
+    }
 }
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -5,10 +5,8 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.ExpandMacros
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibRustProjectDescriptor
-import org.rust.WithStdlibWithSymlinkRustProjectDescriptor
+import com.intellij.openapi.util.SystemInfo
+import org.rust.*
 import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.types.infer.TypeInferenceMarks
 import org.rust.stdext.BothEditions
@@ -715,4 +713,28 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
                         //^ ...libstd/macros.rs|...libcore/macros.rs|...libcore/macros/mod.rs|...core/src/macros/mod.rs
     """)
+
+    @MinRustcVersion("1.41.0")
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
+    @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
+    fun `test resolve in os module unix`() {
+        if (!SystemInfo.isUnix) return
+        stubOnlyResolve("""
+            //- main.rs
+            use std::os::unix;
+                        //^ ...libstd/sys/unix/ext/mod.rs|...std/src/sys/unix/ext/mod.rs
+        """)
+    }
+
+    @MinRustcVersion("1.41.0")
+    @ExpandMacros(MacroExpansionScope.ALL, "std")
+    @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
+    fun `test resolve in os module windows`() {
+        if (!SystemInfo.isWindows) return
+        stubOnlyResolve("""
+            //- main.rs
+            use std::os::windows;
+                        //^ ...libstd/sys/windows/ext/mod.rs|...std/src/sys/windows/ext/mod.rs
+        """)
+    }
 }


### PR DESCRIPTION
Previously, we always used hardcoded info about stdlib: its packages and their relationships.
But it prevented us from getting actual info about stdlib packages: dependencies, edition, features, etc.
As a result, some code in stdlib that depends on third-party crates (like `cfg-if`) cannot be properly taken into account while name resolution and type inference.

These changes introduce an option (as an experimental feature for now) to fetch actual info about stdlib packages.
Due to the fact that stdlib sources contain `Cargo.toml`, it's possible just to run `cargo metadata` to get all necessary info.
It allows us to get proper info about:
- edition. When stdlib started to use `2018` edition, plugin name resolution was broken in some places because of it. See #3835. We solved this issue by hardcoded edition for root stdlib packages depending on `rustc` version. Actual info about edition allows avoiding similar issues for future editions like edition 2021.
- dependencies. It fixes name resolution in cases when third-party libraries are used in stdlib packages. The most known case is the usage of `cfg-if` lib in `std::os` module that provides different API for different operating systems. Now name resolution and completion for child modules of `std::os` should work as expected.
- features. They also are taken into account while name resolution

![2020-11-20 13 41 58](https://user-images.githubusercontent.com/2539310/99798555-44615f00-2b42-11eb-8811-368c1a381ea6.gif)



Restrictions:
- works since 1.41.0
- the plugin calls `cargo vendor` to collect stdlib dependencies before rustc 1.49. Since https://github.com/rust-lang/rust/pull/78790 `rust-src` component already contains `vendor` directory with the corresponding libraries

Known issues and future improvements:
- There isn't UI option to enable it. Currently, the feature can be enabled via `org.rust.cargo.fetch.actual.stdlib.metadata` experimental feature
- stdlib dependencies are shown as project dependencies. They should be part of `stdlib` node 
  <image src='https://user-images.githubusercontent.com/2539310/99792714-884f6680-2b38-11eb-94c6-e58112f45bf0.png' width='200px'/>
- Progress is not shown in `Sync` tool window
- Name resolution doesn't work properly for stdlib items inside stdlib dependencies because of [rustc-std-workspace-core](https://github.com/rust-lang/rust/tree/master/library/rustc-std-workspace-core) dependency and its friends. Not sure that we want to fix it


Closes #3864

Main step to fix the following issues: #3957 #4960 #5881 #6081
Part of #6104

changelog: TODO