### PR TITLE
ANN: improve "Item is private" annotation and "Make public" fix

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -401,6 +401,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
 
     private fun checkReferenceIsPublic(ref: RsReferenceElement, o: RsElement, holder: RsAnnotationHolder) {
         val reference = ref.reference ?: return
+        val highlightedElement = ref.referenceNameElement ?: return
         val referenceName = ref.referenceName ?: return
         val resolvedElement = reference.resolve() as? RsVisible ?: return
         val oMod = o.contextStrict<RsMod>() ?: return
@@ -416,12 +417,12 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
             element is RsNamedFieldDecl -> {
                 val structName = element.ancestorStrict<RsStructItem>()?.crateRelativePath?.removePrefix("::") ?: ""
                 RsDiagnostic.StructFieldAccessError(
-                    ref, referenceName, structName,
+                    highlightedElement, referenceName, structName,
                     MakePublicFix.createIfCompatible(element, element.name, withinOneCrate)
                 )
             }
             ref is RsMethodCall -> RsDiagnostic.AccessError(
-                ref.identifier, RsErrorCode.E0624, "Method",
+                highlightedElement, RsErrorCode.E0624, "Method",
                 MakePublicFix.createIfCompatible(element, referenceName, withinOneCrate)
             )
             else -> {
@@ -431,7 +432,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
                 }
 
                 RsDiagnostic.AccessError(
-                    ref, RsErrorCode.E0603, itemType,
+                    highlightedElement, RsErrorCode.E0603, itemType,
                     MakePublicFix.createIfCompatible(element, referenceName, withinOneCrate)
                 )
             }

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/MakePublicFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/MakePublicFix.kt
@@ -14,8 +14,8 @@ import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 
-class MakePublicFix(
-    element: RsVisible,
+class MakePublicFix private constructor(
+    element: RsVisibilityOwner,
     elementName: String?,
     private val withinOneCrate: Boolean
 ) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
@@ -65,7 +65,11 @@ class MakePublicFix(
     }
 
     companion object {
-        fun createIfCompatible(visible: RsVisible, elementName: String?, withinOneCrate: Boolean): MakePublicFix? {
+        fun createIfCompatible(
+            visible: RsVisibilityOwner,
+            elementName: String?,
+            withinOneCrate: Boolean
+        ): MakePublicFix? {
             return when {
                 // TODO: Allow this fix for pub-restricted elements too
                 visible.visibility is RsVisibility.Private

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/MakePublicFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/MakePublicFix.kt
@@ -53,11 +53,6 @@ class MakePublicFix(
             startElement.addBefore(RsPsiFactory(project).createPub(), anchor)
         } else {
             startElement.addBefore(RsPsiFactory(project).createPubCrateRestricted(), anchor)
-            // External functions and struct fields are special case when inserting pub(crate)
-            // so we have to insert space after `pub(crate)` manually
-            if (anchor is RsExternAbi || anchor?.parent is RsNamedFieldDecl) {
-                startElement.addBefore(RsPsiFactory(project).createPubCrateRestricted().nextSibling, anchor)
-            }
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/MakePublicFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/MakePublicFix.kt
@@ -33,26 +33,31 @@ class MakePublicFix private constructor(
         startElement: PsiElement,
         endElement: PsiElement
     ) {
-        var anchor = getAnchor(startElement)
-        // Check if there are any elements between `pub` and type keyword like
-        // `extern "C"`, `unsafe`, `const`, `async` etc.
-        // If prevNonCommentSibling is an attribute or null, then
-        // there are no extra words, listed above, and we can
-        // freely insert `pub` element right before keyword element.
-        // Otherwise, there are some of these words and we roll anchor back to
-        // insert `pub` element before them.
-        while (true) {
-            val prevNonCommentSibling = anchor.getPrevNonCommentSibling()
-            if (!(prevNonCommentSibling is RsOuterAttr || prevNonCommentSibling == null)) {
-                anchor = prevNonCommentSibling
-            } else {
-                break
-            }
-        }
-        if (!withinOneCrate) {
-            startElement.addBefore(RsPsiFactory(project).createPub(), anchor)
+        if (startElement !is RsVisibilityOwner) return
+        val psiFactory = RsPsiFactory(project)
+        val newVis = if (withinOneCrate) psiFactory.createPubCrateRestricted() else psiFactory.createPub()
+
+        val currentVis = startElement.vis
+        if (currentVis != null) {
+            currentVis.replace(newVis)
         } else {
-            startElement.addBefore(RsPsiFactory(project).createPubCrateRestricted(), anchor)
+            var anchor = getAnchor(startElement)
+            // Check if there are any elements between `pub` and type keyword like
+            // `extern "C"`, `unsafe`, `const`, `async` etc.
+            // If prevNonCommentSibling is an attribute or null, then
+            // there are no extra words, listed above, and we can
+            // freely insert `pub` element right before keyword element.
+            // Otherwise, there are some of these words and we roll anchor back to
+            // insert `pub` element before them.
+            while (true) {
+                val prevNonCommentSibling = anchor.getPrevNonCommentSibling()
+                if (!(prevNonCommentSibling is RsOuterAttr || prevNonCommentSibling == null)) {
+                    anchor = prevNonCommentSibling
+                } else {
+                    break
+                }
+            }
+            startElement.addBefore(newVis, anchor)
         }
     }
 
@@ -70,15 +75,10 @@ class MakePublicFix private constructor(
             elementName: String?,
             withinOneCrate: Boolean
         ): MakePublicFix? {
-            return when {
-                // TODO: Allow this fix for pub-restricted elements too
-                visible.visibility is RsVisibility.Private
-                    && visible !is RsEnumVariant
-                    && visible.parent.parent !is RsTraitItem
-                    && visible.containingCrate?.origin == PackageOrigin.WORKSPACE
-                -> MakePublicFix(visible, elementName, withinOneCrate)
-                else -> null
-            }
+            if (visible is RsEnumVariant ||
+                visible.parent.parent is RsTraitItem ||
+                visible.containingCrate?.origin != PackageOrigin.WORKSPACE) return null
+            return MakePublicFix(visible, elementName, withinOneCrate)
         }
     }
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
@@ -438,8 +438,8 @@ class RsMoveCommonProcessor(
                         LOG.error("Unexpected item to make public: $item")
                         return
                     }
-                    MakePublicFix(item, itemName, withinOneCrate = false)
-                        .invoke(project, null, containingFile)
+                    MakePublicFix.createIfCompatible(item, itemName, withinOneCrate = false)
+                        ?.invoke(project, null, containingFile)
                 }
             }
             is RsVisibility.Restricted -> run {

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1331,7 +1331,7 @@ sealed class RsDiagnostic(
             ERROR,
             if (exportedItem is RsMod) E0365 else E0364,
             "`$name` is private, and cannot be re-exported",
-            fixes = listOf(MakePublicFix(exportedItem, exportedItem.name, false))
+            fixes = listOfNotNull(MakePublicFix.createIfCompatible(exportedItem, exportedItem.name, false))
         )
     }
 }

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -290,7 +290,7 @@ sealed class RsDiagnostic(
     ) : RsDiagnostic(element) {
         override fun prepare() = PreparedAnnotation(
             ERROR,
-            if (element is RsStructLiteralField) E0451 else E0616,
+            if (element.parent is RsStructLiteralField) E0451 else E0616,
             "Field `${escapeString(fieldName)}` of struct `${escapeString(structName)}` is private",
             fixes = listOfNotNull(fix)
         )

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -1114,7 +1114,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             }
         }
         fn main() {
-            let f = some_module::Foo { <error descr="Field `x` of struct `some_module::Foo` is private [E0451]">x: 0</error> };
+            let f = some_module::Foo { <error descr="Field `x` of struct `some_module::Foo` is private [E0451]">x</error>: 0 };
         }
     """)
 
@@ -1217,7 +1217,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             const BAR: u32 = 0x_a_bad_1dea_u32;
         }
 
-        use <error descr="Constant `foo::BAR` is private [E0603]">foo::BAR</error>;
+        use foo::<error descr="Constant `BAR` is private [E0603]">BAR</error>;
     """)
 
     fun `test not const outside scope E0603`() = checkErrors("""
@@ -1233,7 +1233,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             fn bar() {}
         }
 
-        use <error descr="Function `foo::bar` is private [E0603]">foo::bar</error>;
+        use foo::<error descr="Function `bar` is private [E0603]">bar</error>;
     """)
 
     fun `test not fn outside scope E0603`() = checkErrors("""
@@ -1249,7 +1249,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             struct Bar;
         }
 
-        use <error descr="Struct `foo::Bar` is private [E0603]">foo::Bar</error>;
+        use foo::<error descr="Struct `Bar` is private [E0603]">Bar</error>;
     """)
 
     fun `test struct fn outside scope E0603`() = checkErrors("""
@@ -1268,7 +1268,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         //- main.rs
             mod foo;
 
-            use <error descr="Module `foo::bar` is private [E0603]">foo::bar</error>::Foo;
+            use foo::<error descr="Module `bar` is private [E0603]">bar</error>::Foo;
     """)
 
     fun `test module is public E0603`() = checkDontTouchAstInOtherFiles("""
@@ -1332,7 +1332,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
         mod bar {
             mod baz {
-                use <error descr="Module `foo::qwe` is private [E0603]">foo::qwe</error>::Foo;
+                use foo::<error descr="Module `qwe` is private [E0603]">qwe</error>::Foo;
             }
         }
     """)
@@ -1348,7 +1348,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         //- bar/mod.rs
             mod baz;
         //- bar/baz.rs
-            use <error descr="Module `foo::qwe` is private [E0603]">foo::qwe</error>::Foo;
+            use foo::<error descr="Module `qwe` is private [E0603]">qwe</error>::Foo;
     """, filePath = "bar/baz.rs")
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
@@ -1359,8 +1359,8 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             pub(crate) fn bar() {}
         //- main.rs
             extern crate test_package;
-            use <error descr="Function `test_package::foo` is private [E0603]">test_package::foo</error>; /*caret*/
-            use <error descr="Function `test_package::bar` is private [E0603]">test_package::bar</error>; /*caret*/
+            use test_package::<error descr="Function `foo` is private [E0603]">foo</error>; /*caret*/
+            use test_package::<error descr="Function `bar` is private [E0603]">bar</error>;
     """, checkWarn = false)
 
     fun `test item with crate visibility is visible in the same crate E0603`() = checkErrors("""
@@ -1382,13 +1382,13 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
                 pub(super) fn spam() {}
                 pub(in foo) fn eggs() {}
             }
-            use <error descr="Function `self::bar::quux` is private [E0603]">self::bar::quux</error>;
+            use self::bar::<error descr="Function `quux` is private [E0603]">quux</error>;
             use self::bar::spam;
             use self::bar::eggs;
         }
-        use <error descr="Function `foo::bar::quux` is private [E0603]">foo::bar::quux</error>;
-        use <error descr="Function `foo::bar::spam` is private [E0603]">foo::bar::spam</error>;
-        use <error descr="Function `foo::bar::eggs` is private [E0603]">foo::bar::eggs</error>;
+        use foo::bar::<error descr="Function `quux` is private [E0603]">quux</error>;
+        use foo::bar::<error descr="Function `spam` is private [E0603]">spam</error>;
+        use foo::bar::<error descr="Function `eggs` is private [E0603]">eggs</error>;
     """)
 
     // Issue https://github.com/intellij-rust/intellij-rust/issues/3558
@@ -1413,7 +1413,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         mod foo {
             pub(in foo) trait Bar { fn baz(&self); }
         }
-        fn quux(a: &<error descr="Trait `foo::Bar` is private [E0603]">foo::Bar</error>) {
+        fn quux(a: &foo::<error descr="Trait `Bar` is private [E0603]">Bar</error>) {
             a.<error descr="Method `baz` is private [E0624]">baz</error>();
         }
     """)

--- a/src/test/kotlin/org/rust/ide/annotator/RsInvalidReexportErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsInvalidReexportErrorAnnotatorTest.kt
@@ -205,10 +205,15 @@ class RsInvalidReexportErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator
         }
     """)
 
-    fun `test make public fix for item with restricted visibility`() = checkFixIsUnavailable("Make `bar` public", """
+    fun `test make public fix for item with restricted visibility`() = checkFixByText("Make `bar` public", """
         pub mod foo {
             pub(crate) mod bar {}
             pub use <error>bar/*caret*/</error> as baz;
+        }
+    """, """
+        pub mod foo {
+            pub mod bar {}
+            pub use bar/*caret*/ as baz;
         }
     """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsInvalidReexportErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsInvalidReexportErrorAnnotatorTest.kt
@@ -26,7 +26,7 @@ class RsInvalidReexportErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator
             mod bar {
                 mod baz {}
             }
-            pub use <error descr="Module `bar::baz` is private [E0603]">bar::baz</error>;
+            pub use bar::<error descr="Module `baz` is private [E0603]">baz</error>;
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsInvalidReexportErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsInvalidReexportErrorAnnotatorTest.kt
@@ -204,4 +204,11 @@ class RsInvalidReexportErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator
             pub use bar/*caret*/ as baz;
         }
     """)
+
+    fun `test make public fix for item with restricted visibility`() = checkFixIsUnavailable("Make `bar` public", """
+        pub mod foo {
+            pub(crate) mod bar {}
+            pub use <error>bar/*caret*/</error> as baz;
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsInvalidReexportErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsInvalidReexportErrorAnnotatorTest.kt
@@ -192,4 +192,16 @@ class RsInvalidReexportErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator
             use bar as baz;
         }
     """)
+
+    fun `test make public fix`() = checkFixByText("Make `bar` public", """
+        pub mod foo {
+            mod bar {}
+            pub use <error>bar/*caret*/</error> as baz;
+        }
+    """, """
+        pub mod foo {
+            pub mod bar {}
+            pub use bar/*caret*/ as baz;
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/MakePublicFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/MakePublicFixTest.kt
@@ -16,7 +16,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             const BAR: i32 = 10;
         }
         fn main() {
-            <error>foo::BAR/*caret*/</error>;
+            foo::<error>BAR/*caret*/</error>;
         }
     """, """
         mod foo {
@@ -33,7 +33,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             const BAR: i32 = 10;
         }
         fn main() {
-            <error>foo::BAR/*caret*/</error>;
+            foo::<error>BAR/*caret*/</error>;
         }
     """, """
         mod foo {
@@ -51,7 +51,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             const BAR: i32 = 10;
         }
         fn main() {
-            <error>foo::BAR/*caret*/</error>;
+            foo::<error>BAR/*caret*/</error>;
         }
     """, """
         mod foo {
@@ -70,7 +70,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             const BAR: i32 = 10;
         }
         fn main() {
-            <error>foo::BAR/*caret*/</error>;
+            foo::<error>BAR/*caret*/</error>;
         }
     """, """
         mod foo {
@@ -90,7 +90,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             static BAR: i32 = 10;
         }
         fn main() {
-            &<error>foo::BAR/*caret*/</error>;
+            &foo::<error>BAR/*caret*/</error>;
         }
     """, """
         mod foo {
@@ -110,7 +110,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             static mut BAR: i32 = 10;
         }
         fn main() {
-            unsafe { &<error>foo::BAR/*caret*/</error> };
+            unsafe { &foo::<error>BAR/*caret*/</error> };
         }
     """, """
         mod foo {
@@ -128,7 +128,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             fn bar() {}
         }
         fn main() {
-            <error>foo::bar</error>/*caret*/();
+            foo::<error>bar</error>/*caret*/();
         }
     """, """
         mod foo {
@@ -144,7 +144,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             async fn bar() {}
         }
         fn main() {
-            <error>foo::bar</error>/*caret*/();
+            foo::<error>bar/*caret*/</error>();
         }
     """, """
         mod foo {
@@ -160,7 +160,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             unsafe fn bar() {}
         }
         fn main() {
-            unsafe { <error>foo::bar</error>/*caret*/(); };
+            unsafe { foo::<error>bar</error>/*caret*/(); };
         }
     """, """
         mod foo {
@@ -176,7 +176,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             const fn bar() {}
         }
         fn main() {
-            <error>foo::bar</error>/*caret*/();
+            foo::<error>bar/*caret*/</error>();
         }
     """, """
         mod foo {
@@ -192,7 +192,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             extern "C" fn bar() {}
         }
         fn main() {
-            <error>foo::bar</error>/*caret*/();
+            foo::<error>bar/*caret*/</error>();
         }
     """, """
         mod foo {
@@ -209,7 +209,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             fn bar() {}
         }
         fn main() {
-            <error>foo::bar</error>/*caret*/();
+            foo::<error>bar</error>/*caret*/();
         }
     """, """
         mod foo {
@@ -228,7 +228,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             async fn bar() {}
         }
         fn main() {
-            <error>foo::bar</error>/*caret*/();
+            foo::<error>bar/*caret*/</error>();
         }
     """, """
         mod foo {
@@ -247,7 +247,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             unsafe fn bar() {}
         }
         fn main() {
-            unsafe { <error>foo::bar</error>/*caret*/(); };
+            unsafe { foo::<error>bar</error>/*caret*/(); };
         }
     """, """
         mod foo {
@@ -265,7 +265,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             const fn bar() {}
         }
         fn main() {
-            <error>foo::bar</error>/*caret*/();
+            foo::<error>bar</error>/*caret*/();
         }
     """, """
         mod foo {
@@ -284,7 +284,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             extern "C" fn bar() {}
         }
         fn main() {
-            <error>foo::bar</error>/*caret*/();
+            foo::<error>bar/*caret*/</error>();
         }
     """, """
         mod foo {
@@ -304,7 +304,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             }
         }
         fn main() {
-            <error>foo::bar::quux</error>/*caret*/();
+            foo::bar::<error>quux/*caret*/</error>();
         }
     """, """
         mod foo {
@@ -325,7 +325,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             }
         }
         fn main() {
-            <error>foo::bar::quux</error>/*caret*/();
+            foo::bar::<error>quux</error>/*caret*/();
         }
     """, """
         mod foo {
@@ -345,7 +345,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             struct Bar;
         }
         fn main() {
-            <error>foo::Bar/*caret*/</error>;
+            foo::<error>Bar/*caret*/</error>;
         }
     """, """
         mod foo {
@@ -362,7 +362,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             // Some simple trait
             trait Bar {}
         }
-        fn quux<T: <error>foo::Bar/*caret*/</error>>() {}
+        fn quux<T: foo::<error>Bar/*caret*/</error>>() {}
     """, """
         mod foo {
             // Some simple trait
@@ -376,7 +376,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             // Some unsafe trait
             unsafe trait Bar {}
         }
-        fn quux<T: <error>foo::Bar/*caret*/</error>>() {}
+        fn quux<T: foo::<error>Bar/*caret*/</error>>() {}
     """, """
         mod foo {
             // Some unsafe trait
@@ -390,7 +390,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             // Some auto trait
             auto trait Bar {}
         }
-        fn quux<T: <error>foo::Bar/*caret*/</error>>() {}
+        fn quux<T: foo::<error>Bar/*caret*/</error>>() {}
     """, """
         mod foo {
             // Some auto trait
@@ -405,7 +405,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             #[doc(hidden)]
             unsafe auto trait Bar {}
         }
-        fn quux<T: <error>foo::Bar/*caret*/</error>>() {}
+        fn quux<T: foo::<error>Bar/*caret*/</error>>() {}
     """, """
         mod foo {
             // Some unsafe auto trait
@@ -422,7 +422,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             enum Bar { Baz }
         }
         fn main() {
-            <error><error>foo::Bar/*caret*/</error>::Baz</error>;
+            foo::<error>Bar/*caret*/</error>::<error>Baz</error>;
         }
     """, """
         mod foo {
@@ -464,7 +464,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             pub(crate) struct Bar { baz: i32 }
         }
         fn main() {
-            let foo = foo::Bar { <error>baz/*caret*/: 1</error> };
+            let foo = foo::Bar { <error>baz/*caret*/</error>: 1 };
         }
     """, """
         mod foo {
@@ -504,7 +504,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             type Bar = i32;
         }
         fn main() {
-            let foo : <error>foo::Bar/*caret*/</error> = 1;
+            let foo : foo::<error>Bar/*caret*/</error> = 1;
         }
     """, """
         mod foo {
@@ -523,7 +523,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             }
         }
         fn main() {
-            <error>foo::bar/*caret*/</error>::quux();
+            foo::<error>bar/*caret*/</error>::quux();
         }
     """, """
         mod foo {
@@ -542,7 +542,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
     //- main.rs
         extern crate test_package;
         fn main() {
-            <error>test_package::foo::bar/*caret*/</error>();
+            test_package::foo::<error>bar/*caret*/</error>();
         }
     //- lib.rs
         pub mod foo {
@@ -566,7 +566,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             mod bar;
         }
         fn main() {
-            <error>foo::bar/*caret*/</error>::baz();
+            foo::<error>bar/*caret*/</error>::baz();
         }
     //- foo/bar.rs
         pub fn baz() {}
@@ -588,7 +588,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
 
         fn main() {
-            <error>foo::A/*caret*/</error>;
+            foo::<error>A/*caret*/</error>;
         }
     """, """
         pub mod foo {
@@ -608,7 +608,7 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
     //- main.rs
         extern crate test_package;
         fn main() {
-            <error>test_package::foo::A/*caret*/</error>;
+            test_package::foo::<error>A/*caret*/</error>;
         }
     """, """
     //- lib.rs

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/MakePublicFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/MakePublicFixTest.kt
@@ -582,13 +582,43 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         pub fn baz() {}
     """, stubOnly = false)
 
-    fun `test make public fix for restricted visibility`() = checkFixIsUnavailable("Make `A` public", """
+    fun `test make public fix for restricted visibility 1`() = checkFixByText("Make `A` public", """
         pub mod foo {
             pub(self) struct A;
         }
 
         fn main() {
             <error>foo::A/*caret*/</error>;
+        }
+    """, """
+        pub mod foo {
+            pub(crate) struct A;
+        }
+
+        fn main() {
+            foo::A/*caret*/;
+        }
+    """)
+
+    fun `test make public fix for restricted visibility 2`() = checkFixByFileTree("Make `A` public", """
+    //- lib.rs
+        pub mod foo {
+            pub(self) struct A;
+        }
+    //- main.rs
+        extern crate test_package;
+        fn main() {
+            <error>test_package::foo::A/*caret*/</error>;
+        }
+    """, """
+    //- lib.rs
+        pub mod foo {
+            pub struct A;
+        }
+    //- main.rs
+        extern crate test_package;
+        fn main() {
+            test_package::foo::A/*caret*/;
         }
     """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/MakePublicFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/MakePublicFixTest.kt
@@ -581,4 +581,14 @@ class MakePublicFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
     //- foo/bar.rs
         pub fn baz() {}
     """, stubOnly = false)
+
+    fun `test make public fix for restricted visibility`() = checkFixIsUnavailable("Make `A` public", """
+        pub mod foo {
+            pub(self) struct A;
+        }
+
+        fn main() {
+            <error>foo::A/*caret*/</error>;
+        }
+    """)
 }


### PR DESCRIPTION
These changes:
- make range of `Item is private` annotation narrower
- provide `Make public` quick-fix available for items with restricted visibility in case of `Item is private` error
- fix `Make public` quick-fix for items with restricted visibility in case of `Item is private, and cannot be re-exported` error
- don't allow providing `Make public` quick-fix for unsupported cases


changelog: Make `Item is private` error highlighting more precisely; Provide `Make public` quick-fix for items with [restricted visibility](https://doc.rust-lang.org/reference/visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself) like `pub(crate)` 
