### PR TITLE
RES: Fix exception when resolve is called during building CrateDefMap

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
@@ -11,7 +11,6 @@ import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.CratePersistentId
 import org.rust.lang.core.psi.RsFile
-import org.rust.lang.core.psi.ext.edition
 import org.rust.lang.core.psi.shouldIndexFile
 import org.rust.openapiext.checkReadAccessAllowed
 import org.rust.openapiext.fileId
@@ -83,7 +82,7 @@ private fun buildDefMapContainingExplicitItems(
         crateDescription = crateDescription
     )
 
-    createExternCrateStdImport(crateRoot, crateRootData)?.let {
+    createExternCrateStdImport(crate, crateRoot, crateRootData)?.let {
         context.imports += it
         defMap.importExternCrateMacros(it.usePath.single())
     }
@@ -135,7 +134,7 @@ private fun findPrelude(crate: Crate, allDependenciesDefMaps: Map<Crate, CrateDe
         .firstOrNull()
 }
 
-private fun createExternCrateStdImport(crateRoot: RsFile, crateRootData: ModData): Import? {
+private fun createExternCrateStdImport(crate: Crate, crateRoot: RsFile, crateRootData: ModData): Import? {
     // Rust injects implicit `extern crate std` in every crate root module unless it is
     // a `#![no_std]` crate, in which case `extern crate core` is injected. However, if
     // there is a (unstable?) `#![no_core]` attribute, nothing is injected.
@@ -150,7 +149,7 @@ private fun createExternCrateStdImport(crateRoot: RsFile, crateRootData: ModData
     return Import(
         crateRootData,
         arrayOf(name),
-        nameInScope = if (crateRoot.edition == CargoWorkspace.Edition.EDITION_2015) name else "_",
+        nameInScope = if (crate.edition == CargoWorkspace.Edition.EDITION_2015) name else "_",
         visibility = crateRootData.visibilityInSelf,
         isExternCrate = true
     )

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeUpdateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeUpdateDefMap.kt
@@ -41,7 +41,7 @@ fun DefMapService.getOrUpdateIfNeeded(crate: CratePersistentId): CrateDefMap? {
     checkReadAccessAllowed()
     checkIsSmartMode(project)
     return defMapsBuildLock.withLockAndCheckingCancelled {
-        check(defMapsBuildLock.holdCount == 1)
+        check(defMapsBuildLock.holdCount == 1) { "Can't use resolve while building CrateDefMap" }
         if (holder.hasLatestStamp()) return@withLockAndCheckingCancelled holder.defMap
 
         val pool = Executors.newWorkStealingPool()


### PR DESCRIPTION
Replaces call of `RsFile.edition` to `Crate.edition`

<details>

```
Caused by: java.lang.IllegalStateException: Check failed.
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt$getOrUpdateIfNeeded$1.invoke(FacadeUpdateDefMap.kt:44)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt$getOrUpdateIfNeeded$1.invoke(FacadeUpdateDefMap.kt)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt$sam$com_intellij_openapi_util_ThrowableComputable$0.compute(FacadeUpdateDefMap.kt)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.computeWithLockAndCheckingCanceled(ProgressIndicatorUtils.java:326)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt.withLockAndCheckingCancelled(FacadeUpdateDefMap.kt:249)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt.withLockAndCheckingCancelled$default(FacadeUpdateDefMap.kt:248)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt.getOrUpdateIfNeeded(FacadeUpdateDefMap.kt:43)
	at org.rust.lang.core.resolve2.FacadeResolveKt.findModDataFor(FacadeResolve.kt:444)
	at org.rust.lang.core.psi.RsFile.doGetCachedData(RsFile.kt:110)
	at org.rust.lang.core.psi.RsFile.access$doGetCachedData(RsFile.kt:72)
	at org.rust.lang.core.psi.RsFile$cachedData$1$value$1.compute(RsFile.kt:97)
	at org.rust.lang.core.psi.RsFile$cachedData$1$value$1.compute(RsFile.kt:72)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:42)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at org.rust.openapiext.UtilsKt.recursionGuard(utils.kt:69)
	at org.rust.openapiext.UtilsKt.recursionGuard$default(utils.kt:68)
	at org.rust.lang.core.psi.RsFile$cachedData$1.compute(RsFile.kt:97)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:153)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:54)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$1(CachedValueBase.java:235)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:42)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:236)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:43)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:78)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:150)
	at org.rust.lang.core.psi.RsFile.getCachedData(RsFile.kt:96)
	at org.rust.lang.core.psi.RsFile.getCrate(RsFile.kt:80)
	at org.rust.lang.core.psi.ext.RsElementKt.getContainingCrate(RsElement.kt:60)
	at org.rust.lang.core.psi.ext.RsElementKt.getEdition(RsElement.kt:142)
	at org.rust.lang.core.resolve2.FacadeBuildDefMapKt.createExternCrateStdImport(FacadeBuildDefMap.kt:154)
	at org.rust.lang.core.resolve2.FacadeBuildDefMapKt.buildDefMapContainingExplicitItems(FacadeBuildDefMap.kt:86)
	at org.rust.lang.core.resolve2.FacadeBuildDefMapKt.buildDefMap(FacadeBuildDefMap.kt:30)
	at org.rust.lang.core.resolve2.DefMapsBuilder.doBuildDefMap(DefMapsBuilder.kt:106)
	at org.rust.lang.core.resolve2.DefMapsBuilder.buildSync(DefMapsBuilder.kt:75)
	at org.rust.lang.core.resolve2.DefMapsBuilder.build(DefMapsBuilder.kt:52)
	at org.rust.lang.core.resolve2.DefMapUpdater.doRun(FacadeUpdateDefMap.kt:143)
	at org.rust.lang.core.resolve2.DefMapUpdater.runWithStrongReferencesToDefMapHolders(FacadeUpdateDefMap.kt:119)
	at org.rust.lang.core.resolve2.DefMapUpdater.access$runWithStrongReferencesToDefMapHolders(FacadeUpdateDefMap.kt:77)
	at org.rust.lang.core.resolve2.DefMapUpdater$run$$inlined$measureTimeMillis$lambda$1.invoke(FacadeUpdateDefMap.kt:104)
	at org.rust.lang.core.resolve2.DefMapUpdater$run$$inlined$measureTimeMillis$lambda$1.invoke(FacadeUpdateDefMap.kt:77)
	at org.rust.openapiext.UtilsKt$executeUnderProgress$1.run(utils.kt:313)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:617)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:65)
	at org.rust.openapiext.UtilsKt.executeUnderProgress(utils.kt:313)
	at org.rust.lang.core.resolve2.DefMapUpdater.run(FacadeUpdateDefMap.kt:103)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt$getOrUpdateIfNeeded$1.invoke(FacadeUpdateDefMap.kt:51)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt$getOrUpdateIfNeeded$1.invoke(FacadeUpdateDefMap.kt)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt$sam$com_intellij_openapi_util_ThrowableComputable$0.compute(FacadeUpdateDefMap.kt)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.computeWithLockAndCheckingCanceled(ProgressIndicatorUtils.java:326)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt.withLockAndCheckingCancelled(FacadeUpdateDefMap.kt:249)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt.withLockAndCheckingCancelled$default(FacadeUpdateDefMap.kt:248)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt.getOrUpdateIfNeeded(FacadeUpdateDefMap.kt:43)
	at org.rust.lang.core.resolve2.FacadeResolveKt.findModDataFor(FacadeResolve.kt:444)
	at org.rust.lang.core.psi.RsFile.doGetCachedData(RsFile.kt:110)
	at org.rust.lang.core.psi.RsFile.access$doGetCachedData(RsFile.kt:72)
	at org.rust.lang.core.psi.RsFile$cachedData$1$value$1.compute(RsFile.kt:97)
	at org.rust.lang.core.psi.RsFile$cachedData$1$value$1.compute(RsFile.kt:72)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:42)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at org.rust.openapiext.UtilsKt.recursionGuard(utils.kt:69)
	at org.rust.openapiext.UtilsKt.recursionGuard$default(utils.kt:68)
	at org.rust.lang.core.psi.RsFile$cachedData$1.compute(RsFile.kt:97)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:153)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:54)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$1(CachedValueBase.java:235)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:42)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:236)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:43)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:78)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:150)
	at org.rust.lang.core.psi.RsFile.getCachedData(RsFile.kt:96)
	at org.rust.lang.core.psi.RsFile.getCrateRoot(RsFile.kt:81)
	at org.rust.lang.core.macros.SourceFile.extract(ExpandedMacroStorage.kt:525)
	at org.rust.lang.core.macros.SourceFile.extract(ExpandedMacroStorage.kt:498)
	at org.rust.lang.core.macros.Extractable.extract(MacroExpansionTask.kt:341)
	at org.rust.lang.core.macros.MacroExpansionTaskBase$submitExpansionTask$1$stages1$1$result$1$1.invoke(MacroExpansionTask.kt:203)
	at org.rust.lang.core.macros.MacroExpansionTaskBase$submitExpansionTask$1$stages1$1$result$1$1.invoke(MacroExpansionTask.kt:50)
	at org.rust.openapiext.UtilsKt$runReadActionInSmartMode$1.compute(utils.kt:275)
	at com.intellij.openapi.project.DumbService.lambda$runReadActionInSmartMode$0(DumbService.java:103)
	at com.intellij.openapi.project.DumbService.lambda$runReadActionInSmartMode$1(DumbService.java:147)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:889)
	at com.intellij.openapi.application.ReadAction.compute(ReadAction.java:61)
	at com.intellij.openapi.project.DumbService.runReadActionInSmartMode(DumbService.java:140)
	at com.intellij.openapi.project.DumbService.runReadActionInSmartMode(DumbService.java:103)
	at org.rust.openapiext.UtilsKt.runReadActionInSmartMode(utils.kt:273)
	at org.rust.lang.core.macros.MacroExpansionTaskBase$submitExpansionTask$1$stages1$1$result$1.invoke(MacroExpansionTask.kt:200)
	at org.rust.lang.core.macros.MacroExpansionTaskBase$submitExpansionTask$1$stages1$1$result$1.invoke(MacroExpansionTask.kt:50)
	at org.rust.openapiext.UtilsKt$executeUnderProgressWithWriteActionPriorityWithRetries$success$1.invoke(utils.kt:285)
	at org.rust.openapiext.UtilsKt$executeUnderProgressWithWriteActionPriorityWithRetries$success$1.invoke(utils.kt)
	at org.rust.openapiext.UtilsKt$sam$java_lang_Runnable$0.run(utils.kt)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runActionAndCancelBeforeWrite(ProgressIndicatorUtils.java:152)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.lambda$runWithWriteActionPriority$1(ProgressIndicatorUtils.java:113)
	at com.intellij.openapi.progress.ProgressManager.lambda$runProcess$0(ProgressManager.java:59)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:178)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:658)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:610)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:65)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:165)
	at com.intellij.openapi.progress.ProgressManager.runProcess(ProgressManager.java:59)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runWithWriteActionPriority(ProgressIndicatorUtils.java:110)
	at org.rust.openapiext.UtilsKt.runWithWriteActionPriority(utils.kt:297)
	at org.rust.openapiext.UtilsKt.executeUnderProgressWithWriteActionPriorityWithRetries(utils.kt:284)
	at org.rust.lang.core.macros.MacroExpansionTaskBase$submitExpansionTask$1$stages1$1.apply(MacroExpansionTask.kt:198)
	at org.rust.lang.core.macros.MacroExpansionTaskBase$submitExpansionTask$1$stages1$1.apply(MacroExpansionTask.kt:50)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:271)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:952)
	at java.base/java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:926)
	at java.base/java.util.stream.AbstractTask.compute(AbstractTask.java:327)
	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:746)
	... 5 more
```

</details>