### PR TITLE
Support `Find Usages` action for Cargo features

### DIFF
--- a/intellij-toml/src/main/kotlin/org/toml/ide/search/TomlFindUsagesProvider.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/search/TomlFindUsagesProvider.kt
@@ -1,0 +1,31 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.search
+
+import com.intellij.lang.HelpID
+import com.intellij.lang.cacheBuilder.WordsScanner
+import com.intellij.lang.findUsages.FindUsagesProvider
+import com.intellij.psi.PsiElement
+
+/**
+ * This basic provider just enables `Find Usages` action for TOML language. Implement
+ * [com.intellij.find.findUsages.FindUsagesHandlerFactory],
+ * [com.intellij.psi.ElementDescriptionProvider] and
+ * [com.intellij.usages.impl.rules.UsageTypeProviderEx]
+ * in your plugin to make find usages for your TOML use-case.
+ */
+class TomlFindUsagesProvider : FindUsagesProvider {
+    /** If null, use default [com.intellij.lang.cacheBuilder.SimpleWordsScanner] here */
+    override fun getWordsScanner(): WordsScanner? = null
+
+    override fun canFindUsagesFor(element: PsiElement): Boolean = false
+
+    override fun getHelpId(element: PsiElement): String = HelpID.FIND_OTHER_USAGES
+
+    override fun getType(element: PsiElement): String = ""
+    override fun getDescriptiveName(element: PsiElement): String = ""
+    override fun getNodeText(element: PsiElement, useFullName: Boolean): String = ""
+}

--- a/intellij-toml/src/main/kotlin/org/toml/lang/psi/Psi.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/psi/Psi.kt
@@ -5,10 +5,7 @@
 
 package org.toml.lang.psi
 
-import com.intellij.psi.ContributedReferenceHost
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiLanguageInjectionHost
-import com.intellij.psi.PsiReferenceContributor
+import com.intellij.psi.*
 
 interface TomlElement : PsiElement
 
@@ -35,7 +32,7 @@ interface TomlKeyValue : TomlElement {
  * It's possible to use [PsiReferenceContributor] to inject references
  * into [TomlKey] from third-party plugins.
  */
-interface TomlKey : TomlElement, ContributedReferenceHost
+interface TomlKey : TomlElement, ContributedReferenceHost, PsiNamedElement, NavigatablePsiElement
 
 /**
  * It's possible to use [PsiReferenceContributor] to inject references

--- a/intellij-toml/src/main/kotlin/org/toml/lang/psi/impl/Psi.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/psi/impl/Psi.kt
@@ -5,9 +5,12 @@
 
 package org.toml.lang.psi.impl
 
+import com.intellij.ide.projectView.PresentationData
 import com.intellij.lang.ASTFactory
 import com.intellij.lang.psi.SimpleMultiLineTextEscaper
+import com.intellij.navigation.ItemPresentation
 import com.intellij.psi.LiteralTextEscaper
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiLanguageInjectionHost
 import com.intellij.psi.PsiReference
 import com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry
@@ -29,6 +32,14 @@ class TomlKeyValueImpl(type: IElementType) : CompositePsiElement(type), TomlKeyV
 class TomlKeyImpl(type: IElementType) : CompositePsiElement(type), TomlKey {
     override fun getReferences(): Array<PsiReference>
         = ReferenceProvidersRegistry.getReferencesFromProviders(this)
+
+    override fun getName(): String = text
+
+    override fun setName(name: String): PsiElement {
+        return replace(TomlPsiFactory(project).createKey(name))
+    }
+
+    override fun getPresentation(): ItemPresentation = PresentationData(name, null, null, null)
 
     override fun toString(): String = "TomlKey"
 }

--- a/intellij-toml/src/main/resources/META-INF/plugin.xml
+++ b/intellij-toml/src/main/resources/META-INF/plugin.xml
@@ -34,6 +34,8 @@
         <lang.elementManipulator forClass="org.toml.lang.psi.TomlLiteral"
                                  implementationClass="org.toml.lang.psi.TomlStringLiteralManipulator"/>
 
+        <lang.findUsagesProvider language="TOML" implementationClass="org.toml.ide.search.TomlFindUsagesProvider"/>
+
         <!-- Formatting -->
         <lang.formatter language="TOML" implementationClass="org.toml.ide.formatter.TomlFormattingModelBuilder"/>
         <langCodeStyleSettingsProvider

--- a/src/main/kotlin/org/rust/ide/search/RsWordScanner.kt
+++ b/src/main/kotlin/org/rust/ide/search/RsWordScanner.kt
@@ -9,14 +9,24 @@ import com.intellij.lang.cacheBuilder.DefaultWordsScanner
 import com.intellij.psi.tree.TokenSet
 import org.rust.lang.core.lexer.RsLexer
 import org.rust.lang.core.parser.RustParserDefinition
+import org.rust.lang.core.psi.RS_ALL_STRING_LITERALS
 import org.rust.lang.core.psi.RS_COMMENTS
-import org.rust.lang.core.psi.RsElementTypes.*
+import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
 
 class RsWordScanner : DefaultWordsScanner(
     RsLexer(),
     TokenSet.create(IDENTIFIER),
     RS_COMMENTS,
-    TokenSet.create(STRING_LITERAL)
+    RS_ALL_STRING_LITERALS
 ) {
-    override fun getVersion(): Int = RustParserDefinition.LEXER_VERSION
+    init {
+        // This actually means that it's possible to do language injections into Rust string literals
+        setMayHaveFileRefsInLiterals(true)
+    }
+
+    override fun getVersion(): Int = RustParserDefinition.LEXER_VERSION + VERSION
+
+    companion object {
+        private const val VERSION = 1
+    }
 }

--- a/toml/src/main/kotlin/org/rust/toml/CargoTomlElementDescriptionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoTomlElementDescriptionProvider.kt
@@ -1,0 +1,47 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml
+
+import com.intellij.codeInsight.highlighting.HighlightUsagesDescriptionLocation
+import com.intellij.psi.ElementDescriptionLocation
+import com.intellij.psi.ElementDescriptionProvider
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
+import com.intellij.usageView.UsageViewLongNameLocation
+import com.intellij.usageView.UsageViewNodeTextLocation
+import com.intellij.usageView.UsageViewShortNameLocation
+import com.intellij.usageView.UsageViewTypeLocation
+import org.toml.lang.psi.TomlKey
+
+class CargoTomlElementDescriptionProvider : ElementDescriptionProvider {
+    override fun getElementDescription(element: PsiElement, location: ElementDescriptionLocation): String? {
+        @Suppress("USELESS_IS_CHECK") // The check is needed for older TOML plugin versions
+        return if (element is TomlKey && element is PsiNamedElement) {
+            if (element.isFeatureDef) {
+                when (location) {
+                    is UsageViewShortNameLocation -> element.name
+
+                    is UsageViewNodeTextLocation,
+                    is UsageViewLongNameLocation,
+                    is HighlightUsagesDescriptionLocation -> {
+                        "Cargo feature \"${element.name}\""
+                    }
+
+                    is UsageViewTypeLocation -> "Cargo feature"
+                    else -> null
+                }
+            } else {
+                if (location is UsageViewTypeLocation) {
+                    "Toml key"
+                } else {
+                    null
+                }
+            }
+        } else {
+            null
+        }
+    }
+}

--- a/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlFeatureDependencyReferenceProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlFeatureDependencyReferenceProvider.kt
@@ -5,6 +5,7 @@
 
 package org.rust.toml.resolve
 
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.*
 import com.intellij.util.ProcessingContext
 import org.rust.toml.findDependencyTomlFile
@@ -49,5 +50,18 @@ private class CargoTomlFeatureDependencyReference(element: TomlLiteral) : PsiPol
             val tomlFile = element.containingFile as? TomlFile ?: return ResolveResult.EMPTY_ARRAY
             tomlFile.resolveFeature(literalValue)
         }
+    }
+
+    override fun handleElementRename(newElementName: String): PsiElement {
+        val valueRange = rangeInElement
+        val unescapedLiteralValue = valueRange.substring(element.node.text)
+        val separatorIndex = unescapedLiteralValue.indexOf("/")
+        val range = if (separatorIndex != -1) {
+            TextRange(valueRange.startOffset + separatorIndex + 1, valueRange.endOffset)
+        } else {
+            rangeInElement
+        }
+        return ElementManipulators.getManipulator(element)!!
+            .handleContentChange(myElement, range, newElementName)!!
     }
 }

--- a/toml/src/main/kotlin/org/rust/toml/search/CargoTomlFindUsagesHandlerFactory.kt
+++ b/toml/src/main/kotlin/org/rust/toml/search/CargoTomlFindUsagesHandlerFactory.kt
@@ -1,0 +1,21 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.search
+
+import com.intellij.find.findUsages.FindUsagesHandler
+import com.intellij.find.findUsages.FindUsagesHandlerFactory
+import com.intellij.psi.PsiElement
+import org.rust.toml.isFeatureDef
+import org.toml.lang.psi.TomlKey
+
+class CargoTomlFindUsagesHandlerFactory : FindUsagesHandlerFactory() {
+    override fun canFindUsages(element: PsiElement): Boolean {
+        return element is TomlKey && element.isFeatureDef
+    }
+
+    override fun createFindUsagesHandler(element: PsiElement, forHighlightUsages: Boolean): FindUsagesHandler =
+        object : FindUsagesHandler(element) {}
+}

--- a/toml/src/main/kotlin/org/rust/toml/search/CargoTomlUsageTypeProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/search/CargoTomlUsageTypeProvider.kt
@@ -1,0 +1,33 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.search
+
+import com.intellij.psi.PsiElement
+import com.intellij.usages.UsageTarget
+import com.intellij.usages.impl.rules.UsageType
+import com.intellij.usages.impl.rules.UsageTypeProviderEx
+import org.rust.lang.core.RsPsiPattern.anyCfgFeature
+import org.rust.lang.core.psi.RsLitExpr
+import org.rust.toml.CargoTomlPsiPattern.onFeatureDependencyLiteral
+import org.toml.lang.psi.TomlLiteral
+
+class CargoTomlUsageTypeProvider : UsageTypeProviderEx {
+    override fun getUsageType(element: PsiElement?): UsageType? = getUsageType(element, UsageTarget.EMPTY_ARRAY)
+
+    override fun getUsageType(element: PsiElement?, targets: Array<out UsageTarget>): UsageType? {
+        return when (element) {
+            is TomlLiteral -> if (onFeatureDependencyLiteral.accepts(element)) FEATURE_DEPENDENCY else DEPENDENCY_FEATURE
+            is RsLitExpr -> if (anyCfgFeature.accepts(element)) CFG_FEATURE else null
+            else -> null
+        }
+    }
+
+    companion object {
+        private val FEATURE_DEPENDENCY = UsageType { "Cargo feature dependency" }
+        private val DEPENDENCY_FEATURE = UsageType { "Package dependency" }
+        private val CFG_FEATURE = UsageType { "Cfg attribute" }
+    }
+}

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -14,6 +14,10 @@
                                         implementationClass="org.rust.toml.CargoFeatureLineMarkerProvider"/>
         <codeInsight.gotoSuper language="TOML" implementationClass="org.rust.toml.CargoTomlGotoSuperHandler"/>
 
+        <findUsagesHandlerFactory implementation="org.rust.toml.search.CargoTomlFindUsagesHandlerFactory"/>
+        <usageTypeProvider implementation="org.rust.toml.search.CargoTomlUsageTypeProvider"/>
+        <elementDescriptionProvider implementation="org.rust.toml.CargoTomlElementDescriptionProvider"/>
+
         <localInspection language="TOML" groupName="Rust"
                          displayName="Missing features"
                          enabledByDefault="true" level="WARNING"

--- a/toml/src/test/kotlin/org/rust/toml/search/CargoTomlFindUsagesTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/search/CargoTomlFindUsagesTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.search
+
+import com.intellij.codeInsight.TargetElementUtil
+import com.intellij.lang.LanguageCommenters
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
+import org.rust.FileTreeBuilder
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.lang.core.psi.ext.startOffset
+import org.rust.openapiext.document
+import org.rust.openapiext.toPsiFile
+
+class CargoTomlFindUsagesTest : RsWithToolchainTestBase() {
+
+    fun test() = doTest {
+        toml("Cargo.toml", """
+            [package]
+            name = "hello"
+            version = "0.1.0"
+            authors = []
+
+            [features]
+            foo = ["dep_pkg/feature_bar"] # - Cargo feature dependency
+
+            [dependencies]
+            dep_pkg = { path = "./dep_pkg", features = ["feature_bar"] } # - Package dependency
+        """)
+
+        dir("src") {
+            rust("main.rs", """
+                fn main() {}
+            """)
+        }
+
+        dir("dep_pkg") {
+            toml("Cargo.toml", """
+                [package]
+                name = "dep_pkg"
+                version = "0.1.0"
+                authors = []
+
+                [features]
+                feature_foo = ["feature_bar"] # - Cargo feature dependency
+                feature_bar = []
+                #^
+            """)
+
+            dir("src") {
+                rust("lib.rs", """
+                    #[cfg(feature = "feature_bar")] // - Cfg attribute
+                    #[cfg_attr(feature = "feature_bar", allow(all))] // - Cfg attribute
+                    fn foobar() {}
+                """)
+            }
+        }
+    }
+
+    private fun doTest(fileTree: FileTreeBuilder.() -> Unit) {
+        val testProject = buildProject(fileTree)
+
+        assertNotNull(project.cargoProjects.allProjects.single().workspace)
+        val allFiles = mutableListOf<VirtualFile>()
+        VfsUtilCore.iterateChildrenRecursively(testProject.root, null) {
+            if (!it.isDirectory) {
+                allFiles += it
+            }
+            true
+        }
+        val vFile = testProject.root.findFileByRelativePath(testProject.fileWithCaret)
+        val psiFile = vFile!!.toPsiFile(project)!!
+
+        myFixture.openFileInEditor(vFile)
+
+        val markerOffset = psiFile.text.indexOf("^")
+        check(markerOffset != -1) { "No `^` in \n${psiFile.text}" }
+
+        val doc = psiFile.document!!
+        val markerLine = doc.getLineNumber(markerOffset)
+        val makerColumn = markerOffset - doc.getLineStartOffset(markerLine)
+        val elementOffset = doc.getLineStartOffset(markerLine - 1) + makerColumn
+
+        val source = TargetElementUtil.getInstance().findTargetElement(
+            myFixture.editor,
+            TargetElementUtil.ELEMENT_NAME_ACCEPTED,
+            elementOffset
+        ) as? PsiNamedElement ?: error("Element not found")
+
+        val markersActual = myFixture.findUsages(source)
+            .mapNotNull { it.element }
+            .groupBy { it.containingFile.virtualFile!! }
+            .mapValues { (_, v) ->
+                v.map { Pair(it.line ?: -1, CargoTomlUsageTypeProvider().getUsageType(it).toString()) }
+                    .sortedBy { it.first }
+            }
+            .toMutableMap()
+
+        val expectedMarkers = allFiles.mapNotNull { file ->
+            markersFrom(file).takeIf { it.isNotEmpty() }?.let { file to it }
+        }.toMap()
+
+        for ((file, expected) in expectedMarkers) {
+            val actual = markersActual.remove(file) ?: error("Expected usages in $file, but found 0 usages")
+            assertEquals(expected.joinToString("\n"), actual.joinToString("\n"))
+        }
+
+        if (markersActual.isNotEmpty()) {
+            error("Extra usages in $markersActual")
+        }
+    }
+
+    private fun markersFrom(file: VirtualFile): List<Pair<Int, String>> {
+        val text = VfsUtil.loadText(file)
+        val commentPrefix = LanguageCommenters.INSTANCE.forLanguage(file.toPsiFile(project)!!.language).lineCommentPrefix ?: "//"
+        val marker = "$commentPrefix - "
+        return text.split('\n')
+            .withIndex()
+            .filter { it.value.contains(marker) }
+            .map { Pair(it.index, it.value.substring(it.value.indexOf(marker) + marker.length).trim()) }
+    }
+
+    private val PsiElement.line: Int? get() = containingFile.viewProvider.document?.getLineNumber(startOffset)
+}


### PR DESCRIPTION
Usage search works for Rust and TOML code. Related to #4693

With `ctrl + B`:
![image](https://user-images.githubusercontent.com/3221931/99973781-306f6480-2db1-11eb-94c4-2794a69f78c0.png)

With `alt + F7`:
![image](https://user-images.githubusercontent.com/3221931/99974329-d15e1f80-2db1-11eb-98f1-3da537ac2c15.png)

Usage highlighting:
![Peek 2020-11-23 17-27](https://user-images.githubusercontent.com/3221931/99974001-6e6c8880-2db1-11eb-99c1-a00d7abcc03a.gif)

There is a **bug** with usage highlighting - now any key in any TOML file is highlighted as some definition when under the caret. But I've checked that YAML plugin has the same bug (or a feature?), so I don't think it's critical. I also found that this bug (feature?) can be fixed with a new `Symbol` API that is available on 2020.3 platform.

![Peek 2020-11-23 17-53](https://user-images.githubusercontent.com/3221931/99976642-c5279180-2db4-11eb-9a3e-38ed6a26946e.gif)

