### PR TITLE
RES: Store fromGlobImport flag inside VisItem in new resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
@@ -172,10 +172,6 @@ private fun sortImports(imports: MutableList<Import>) {
 private fun CrateDefMap.afterBuilt() {
     root.visitDescendants {
         it.isShadowedByOtherFile = false
-        it.fromGlobImport = null
-    }
-    for (fileInfo in fileInfos.values) {
-        fileInfo.modData.fromGlobImport = null
     }
 
     // TODO: uncomment when #[cfg_attr] will be supported


### PR DESCRIPTION
This reduces memory needed during building CrateDefMap (up to 100MB on big crates like amethyst)

changelog: Reduce memory consumption when using new name resolution engine