### PR TITLE
INT: Remove empty use groups in import optimizer

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveParameterFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveParameterFix.kt
@@ -13,7 +13,6 @@ import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.parentOfType
 import com.intellij.psi.util.parentOfTypes
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.RsElementTypes.COMMA
 import org.rust.lang.core.psi.ext.*
 
 
@@ -33,7 +32,7 @@ class RemoveParameterFix(binding: RsPatBinding, private val bindingName: String)
         val parameterIndex = function.valueParameterList?.valueParameterList?.indexOf(parameter) ?: -1
         if (parameterIndex == -1) return
 
-        parameter.deleteElementWithCommas()
+        parameter.deleteWithSurroundingComma()
         removeArguments(function, parameterIndex)
     }
 }
@@ -52,20 +51,6 @@ private fun removeArguments(function: RsFunction, parameterIndex: Int) {
             isMethod && call is RsCallExpr -> parameterIndex + 1 // UFCS
             else -> parameterIndex
         }
-        arguments.exprList.getOrNull(argumentIndex)?.deleteElementWithCommas()
+        arguments.exprList.getOrNull(argumentIndex)?.deleteWithSurroundingComma()
     }
-}
-
-private fun RsElement.deleteElementWithCommas() {
-    val followingComma = getNextNonCommentSibling()
-    if (followingComma?.elementType == COMMA) {
-        followingComma?.delete()
-    } else {
-        val precedingComma = getPrevNonCommentSibling()
-        if (precedingComma?.elementType == COMMA) {
-            precedingComma?.delete()
-        }
-    }
-
-    delete()
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -20,6 +20,7 @@ import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.findDependency
 import org.rust.lang.core.macros.findNavigationTargetIfMacroExpansion
 import org.rust.lang.core.psi.RsConstant
+import org.rust.lang.core.psi.RsElementTypes
 import org.rust.lang.core.psi.RsEnumVariant
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.resolve.Namespace
@@ -138,3 +139,24 @@ fun RsElement.findInScope(name: String, ns: Set<Namespace>): PsiElement? {
 
 fun RsElement.hasInScope(name: String, ns: Set<Namespace>): Boolean =
     findInScope(name, ns) != null
+
+/**
+ * Delete the element along with a neighbour comma.
+ * If a comma follow the element, it will be deleted.
+ * Else if a comma precedes the element, it will be deleted.
+ *
+ * It is useful to remove elements that are parts of comma separated lists (parameters, arguments, use specks, ...).
+ */
+fun RsElement.deleteWithSurroundingComma() {
+    val followingComma = getNextNonCommentSibling()
+    if (followingComma?.elementType == RsElementTypes.COMMA) {
+        followingComma?.delete()
+    } else {
+        val precedingComma = getPrevNonCommentSibling()
+        if (precedingComma?.elementType == RsElementTypes.COMMA) {
+            precedingComma?.delete()
+        }
+    }
+
+    delete()
+}

--- a/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsImportOptimizerTest.kt
@@ -346,6 +346,50 @@ class RsImportOptimizerTest: RsTestBase() {
         fn main() {}
     """)
 
+    fun `test remove empty use item 1`() = doTest("""
+        use foo::{};
+
+        fn main() {}
+    """, """
+        fn main() {}
+    """)
+
+    fun `test remove empty use item 2`() = doTest("""
+        use aaa::foo;
+        use bbb::{};
+        use ccc::foo;
+
+        fn main() {}
+    """, """
+        use aaa::foo;
+        use ccc::foo;
+
+        fn main() {}
+    """)
+
+    fun `test remove empty use group`() = doTest("""
+        use aaa1::{zzz::{}};
+        use aaa2::{zzz::{{}}};
+        use aaa3::{zzz::{}, bbb};
+        use aaa4::{bbb, zzz::{}};
+        use aaa5::{bbb, zzz::{}, ccc};
+        use aaa6::{bbb, yyy::{}, zzz::{}, ccc};
+        use aaa7::{bbb, yyy::{}, ccc, zzz::{}, ddd};
+        use aaa8::{bbb::{ccc::{}, ddd::{{}}}, zzz, eee::{}};
+        use aaa9::{bbb::{ccc::{}, ddd::{{}}}, eee::{}};
+
+        fn main() {}
+    """, """
+        use aaa3::bbb;
+        use aaa4::bbb;
+        use aaa5::{bbb, ccc};
+        use aaa6::{bbb, ccc};
+        use aaa7::{bbb, ccc, ddd};
+        use aaa8::zzz;
+
+        fn main() {}
+    """)
+
     fun `test do not move use items from test mod`() = doTest("""
         use std::io::Read;
 


### PR DESCRIPTION
It is needed for better imports handling in move refactoring.

changelog: Remove empty use groups when optimizing imports
