### PR TITLE
REF(MOVE): Use unqualified path for references to target mod if possible

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
@@ -231,6 +231,15 @@ class RsMoveCommonProcessor(
     ): RsMoveReferenceInfo? {
         val path = convertFromPathOriginal(pathOriginal, codeFragmentFactory)
 
+        // after move both `path` and its target will belong to `targetMod`
+        // so we can refer to item in `targetMod` just with its name
+        if (path.containingMod == sourceMod && target.containingModStrict == targetMod) {
+            val pathNew = target.name?.toRsPath(psiFactory)
+            if (pathNew != null) {
+                return RsMoveReferenceInfo(path, pathOriginal, pathNew, pathNew, target, forceReplaceDirectly = true)
+            }
+        }
+
         if (path.isAbsolute()) {
             // when moving from binary to library crate, we should change path `library_crate::...` to `crate::...`
             // when moving from one library crate to another, we should change path `crate::...` to `first_library::...`

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
@@ -61,7 +61,8 @@ class RsMoveReferenceInfo(
      * == `pathOld.reference.resolve()`
      * mutable because it can be inside moved elements, so after move we have to change it
      */
-    var target: RsQualifiedNamedElement
+    var target: RsQualifiedNamedElement,
+    val forceReplaceDirectly: Boolean = false,
 ) {
     val pathNew: RsPath? get() = pathNewAccessible ?: pathNewFallback
     val isInsideUseDirective: Boolean get() = pathOldOriginal.ancestorStrict<RsUseItem>() != null


### PR DESCRIPTION
E.g. when moving `fn foo() { crate::mod2::bar(); }` to `mod2`, we can replace absolute path `crate::mod2::bar` with just `bar`

changelog: Use unqualified path for references to target mod in move items refactoring