### PR TITLE
Fix wrong resolve of cargo feature in `cfg_attr`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
@@ -230,7 +230,7 @@ object RsPsiPattern {
      * ```
      */
     private val onCfgAttrCondition: PsiElementPattern.Capture<RsMetaItem> = psiElement<RsMetaItem>()
-        .inside(onCfgAttrAttribute)
+        .withSuperParent(3, onCfgAttrAttribute)
         .with("firstItem") { it, _ -> (it.parent as? RsMetaItemArgs)?.metaItemList?.firstOrNull() == it }
 
     val onCfgOrAttrFeature: PsiElementPattern.Capture<RsLitExpr> = psiElement<RsLitExpr>()

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
@@ -379,9 +379,9 @@ class RsPsiPatternTest : RsTestBase() {
         assertTrue(pattern.accepts(element))
     }
 
-    private fun <T> testPatternNegative(@Language("Rust") code: String, pattern: ElementPattern<T>) {
+    private inline fun <reified T : PsiElement> testPatternNegative(@Language("Rust") code: String, pattern: ElementPattern<T>) {
         InlineFile(code)
-        val element = findElementInEditor<PsiElement>()
+        val element = findElementInEditor<T>()
         assertFalse(pattern.accepts(element, null))
     }
 }

--- a/toml/src/test/kotlin/org/rust/toml/CargoTomlPsiPatternTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoTomlPsiPatternTest.kt
@@ -195,9 +195,9 @@ class CargoTomlPsiPatternTest : RsTestBase() {
         assertTrue(pattern.accepts(element))
     }
 
-    private fun <T> testPatternNegative(pattern: ElementPattern<T>, @Language("Toml") code: String) {
+    private inline fun <reified T : PsiElement> testPatternNegative(pattern: ElementPattern<T>, @Language("Toml") code: String) {
         InlineFile(code, "Cargo.toml")
-        val element = findElementInEditor<PsiElement>()
+        val element = findElementInEditor<T>()
         assertFalse(pattern.accepts(element))
     }
 }


### PR DESCRIPTION
This "foo" was resolved as a cargo feature, although it shouldn't:
```
#[cfg_attr(foobar, foobar(feature = "foo"))]
```