### PR TITLE
Fix rust structure modification increment after remove a PSI element

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiManager.kt
@@ -124,6 +124,7 @@ class RsPsiManagerImpl(val project: Project) : RsPsiManager, Disposable {
         override fun handleEvent(event: RsPsiTreeChangeEvent) {
             val element = when (event) {
                 is ChildRemoval.Before -> event.child
+                is ChildRemoval.After -> event.parent
                 is ChildReplacement.Before -> event.oldChild
                 is ChildReplacement.After -> event.newChild
                 is ChildAddition.After -> event.child
@@ -163,7 +164,7 @@ class RsPsiManagerImpl(val project: Project) : RsPsiManager, Disposable {
                 // Most of events means that some element *itself* is changed, but ChildrenChange means
                 // that changed some of element's children, not the element itself. In this case
                 // we should look up for ModificationTrackerOwner a bit differently
-                val isChildrenChange = event is ChildrenChange
+                val isChildrenChange = event is ChildrenChange || event is ChildRemoval.After
 
                 updateModificationCount(file, element, isChildrenChange, isWhitespaceOrComment)
             }

--- a/src/test/kotlin/org/rust/lang/core/psi/RsRustStructureModificationTrackerTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsRustStructureModificationTrackerTest.kt
@@ -14,6 +14,8 @@ import org.rust.RsTestBase
 import org.rust.fileTreeFromText
 import org.rust.lang.core.psi.RsRustStructureModificationTrackerTest.TestAction.INC
 import org.rust.lang.core.psi.RsRustStructureModificationTrackerTest.TestAction.NOT_INC
+import org.rust.lang.core.psi.ext.childOfType
+import org.rust.openapiext.runWriteCommandAction
 
 class RsRustStructureModificationTrackerTest : RsTestBase() {
     private enum class TestAction(val function: (Long, Long) -> Boolean, val comment: String) {
@@ -249,4 +251,16 @@ class RsRustStructureModificationTrackerTest : RsTestBase() {
     fun `test replace expr with block with call`() = doTest(NOT_INC, """
         fn foo() { 2/*caret*/; }
     """, "\b{ foo!() }")
+
+    fun `test delete use item via PSI`() {
+        InlineFile("""
+            use foo::bar;
+        """)
+
+        checkModCount(INC) {
+            project.runWriteCommandAction {
+                myFixture.file.childOfType<RsUseItem>()!!.delete()
+            }
+        }
+    }
 }


### PR DESCRIPTION
This fixes potential `PsiInvalidAccessException` exceptions or not updated highlighting (or similar problems like "IDE doesn't see my change") after applying some actions that delete PSI elements

changelog: can be omitted in the changelog
