### PR TITLE
RES: resolve cargo features in `#[doc(cfg(feature = "foo"))]` attributes

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
@@ -216,12 +216,17 @@ object RsPsiPattern {
         }
 
     /** `#[cfg()]` */
-    private val onCfgAttribute: PsiElementPattern.Capture<RsAttr> = psiElement<RsAttr>()
-        .withChild(metaItem("cfg"))
+    private val onCfgAttributeMeta: PsiElementPattern.Capture<RsMetaItem> = metaItem("cfg")
+        .withParent(RsAttr::class.java)
 
     /** `#[cfg_attr()]` */
-    private val onCfgAttrAttribute: PsiElementPattern.Capture<RsAttr> = psiElement<RsAttr>()
-        .withChild(metaItem("cfg_attr"))
+    private val onCfgAttrAttributeMeta: PsiElementPattern.Capture<RsMetaItem> = metaItem("cfg_attr")
+        .withParent(RsAttr::class.java)
+
+    /** `#[doc(cfg())]` */
+    private val onDocCfgAttributeMeta: PsiElementPattern.Capture<RsMetaItem> = metaItem("cfg")
+        .withSuperParent(2, metaItem("doc"))
+        .withSuperParent(3, RsAttr::class.java)
 
     /**
      * ```
@@ -230,12 +235,12 @@ object RsPsiPattern {
      * ```
      */
     private val onCfgAttrCondition: PsiElementPattern.Capture<RsMetaItem> = psiElement<RsMetaItem>()
-        .withSuperParent(3, onCfgAttrAttribute)
+        .withSuperParent(2, onCfgAttrAttributeMeta)
         .with("firstItem") { it, _ -> (it.parent as? RsMetaItemArgs)?.metaItemList?.firstOrNull() == it }
 
     val onCfgOrAttrFeature: PsiElementPattern.Capture<RsLitExpr> = psiElement<RsLitExpr>()
         .withParent(metaItem("feature"))
-        .inside(onCfgAttribute or onCfgAttrCondition)
+        .inside(onCfgAttributeMeta or onCfgAttrCondition or onDocCfgAttributeMeta)
 
     private inline fun <reified I : RsDocAndAttributeOwner> onItem(): PsiElementPattern.Capture<PsiElement> {
         return psiElement().withSuperParent<I>(META_ITEM_IDENTIFIER_DEPTH)

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
@@ -373,6 +373,11 @@ class RsPsiPatternTest : RsTestBase() {
         fn foo() {}                      //^
     """, RsPsiPattern.onCfgOrAttrFeature)
 
+    fun `test doc cfg`() = testPattern("""
+        #[doc(cfg(feature = "foo"))]
+        fn foo() {}        //^
+    """, RsPsiPattern.onCfgOrAttrFeature)
+
     private inline fun <reified T : PsiElement> testPattern(@Language("Rust") code: String, pattern: ElementPattern<T>) {
         InlineFile(code)
         val element = findElementInEditor<T>()

--- a/toml/src/test/kotlin/org/rust/toml/resolve/RsCfgFeatureReferenceProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/resolve/RsCfgFeatureReferenceProviderTest.kt
@@ -33,6 +33,17 @@ class RsCfgFeatureReferenceProviderTest : RsResolveTestBase() {
         """)
     }
 
+    fun `test doc cfg simple`() = doResolveTest {
+        toml("Cargo.toml", """
+            [features]
+            foo = []
+        """)
+        rust("main.rs", """
+            #[doc(cfg(feature = "foo"))]
+            fn foo() {}        //^ Cargo.toml
+        """)
+    }
+
     fun `test not resolved`() = doResolveTest {
         toml("Cargo.toml", """
             [features]


### PR DESCRIPTION
Resolve cargo features in [`#[doc(cfg())]`](https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html) attributes. They are used e.g. in `tokio`.

```rust
#[doc(cfg(feature = "foo"))]
fn foo() {}        //^ Cargo.toml
```

Continuation of #6276, related to #4693

changelog: Provide name resolution for cargo features in [`#[doc(cfg())]`](https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html) attributes
