### PR TITLE
RES: resolve cargo features in conditional attributes under `cfg_attr`

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
@@ -340,43 +340,68 @@ class RsPsiPatternTest : RsTestBase() {
     fun `test cfg feature`() = testPattern("""
         #[cfg(feature = "foo")]
         fn foo() {}   //^
-    """, RsPsiPattern.onCfgOrAttrFeature)
+    """, RsPsiPattern.onAnyCfgFeature)
 
     fun `test inner attribute cfg feature`() = testPattern("""
         fn foo() {
             #![cfg(feature = "foo")]
         }                   //^
-    """, RsPsiPattern.onCfgOrAttrFeature)
+    """, RsPsiPattern.onAnyCfgFeature)
 
     fun `test nested cfg feature`() = testPattern("""
         #[cfg(not(feature = "foo"))]
         fn foo() {}        //^
-    """, RsPsiPattern.onCfgOrAttrFeature)
+    """, RsPsiPattern.onAnyCfgFeature)
 
     fun `test not a cfg feature`() = testPatternNegative("""
         #[zfg(feature = "foo")]
         fn foo() {}    //^
-    """, RsPsiPattern.onCfgOrAttrFeature)
+    """, RsPsiPattern.onAnyCfgFeature)
 
     fun `test cfg not a feature`() = testPatternNegative("""
         #[cfg(not_a_feature = "foo")]
         fn foo() {}          //^
-    """, RsPsiPattern.onCfgOrAttrFeature)
+    """, RsPsiPattern.onAnyCfgFeature)
 
     fun `test cfg_attr feature`() = testPattern("""
-        #[cfg_attr(feature = "foo")]
+        #[cfg_attr(feature = "foo", allow(all))]
         fn foo() {}          //^
-    """, RsPsiPattern.onCfgOrAttrFeature)
+    """, RsPsiPattern.onAnyCfgFeature)
 
-    fun `test not right part of cfg_attr`() = testPatternNegative("""
+    fun `test not right part of cfg_attr 1`() = testPatternNegative("""
         #[cfg_attr(windows, foo(feature = "foo"))]
         fn foo() {}                      //^
-    """, RsPsiPattern.onCfgOrAttrFeature)
+    """, RsPsiPattern.onAnyCfgFeature)
+
+    fun `test not right part of cfg_attr 2`() = testPatternNegative("""
+        #[cfg_attr(windows, foo(cfg(feature = "foo")))]
+        fn foo() {}                          //^
+    """, RsPsiPattern.onAnyCfgFeature)
+
+    fun `test cfg at right part of cfg_attr`() = testPattern("""
+        #[cfg_attr(windows, cfg(feature = "foo"))]
+        fn foo() {}                      //^
+    """, RsPsiPattern.onAnyCfgFeature)
+
+    fun `test nested cfg_attr feature`() = testPattern("""
+        #[cfg_attr(windows, cfg_attr(feature = "foo", allow(all)))]
+        fn foo() {}                           //^
+    """, RsPsiPattern.onAnyCfgFeature)
+
+    fun `test nested cfg_attr cfg feature`() = testPattern("""
+        #[cfg_attr(windows, cfg_attr(foobar, cfg(feature = "foo")))]
+        fn foo() {}                                       //^
+    """, RsPsiPattern.onAnyCfgFeature)
 
     fun `test doc cfg`() = testPattern("""
         #[doc(cfg(feature = "foo"))]
         fn foo() {}        //^
-    """, RsPsiPattern.onCfgOrAttrFeature)
+    """, RsPsiPattern.onAnyCfgFeature)
+
+    fun `test doc cfg at right part of cfg_attr`() = testPattern("""
+        #[cfg_attr(windows, doc(cfg(feature = "foo")))]
+        fn foo() {}                          //^
+    """, RsPsiPattern.onAnyCfgFeature)
 
     private inline fun <reified T : PsiElement> testPattern(@Language("Rust") code: String, pattern: ElementPattern<T>) {
         InlineFile(code)

--- a/toml/src/main/kotlin/org/rust/toml/resolve/RsCargoTomlIntegrationReferenceContributor.kt
+++ b/toml/src/main/kotlin/org/rust/toml/resolve/RsCargoTomlIntegrationReferenceContributor.kt
@@ -12,6 +12,6 @@ import org.rust.lang.core.RsPsiPattern
 /** Provides references (that point to TOML elements) for Rust elements in Rust files */
 class RsCargoTomlIntegrationReferenceContributor : PsiReferenceContributor() {
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
-        registrar.registerReferenceProvider(RsPsiPattern.onCfgOrAttrFeature, RsCfgFeatureReferenceProvider())
+        registrar.registerReferenceProvider(RsPsiPattern.onAnyCfgFeature, RsCfgFeatureReferenceProvider())
     }
 }

--- a/toml/src/test/kotlin/org/rust/toml/resolve/RsCfgFeatureReferenceProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/resolve/RsCfgFeatureReferenceProviderTest.kt
@@ -89,6 +89,50 @@ class RsCfgFeatureReferenceProviderTest : RsResolveTestBase() {
         """)
     }
 
+    fun `test cfg in cfg_attr`() = doResolveTest {
+        toml("Cargo.toml", """
+            [features]
+            foo = []
+        """)
+        rust("main.rs", """
+            #[cfg_attr(windows, cfg(feature = "foo"))]
+            fn foo() {}                      //^ Cargo.toml
+        """)
+    }
+
+    fun `test cfg_attr in cfg_attr`() = doResolveTest {
+        toml("Cargo.toml", """
+            [features]
+            foo = []
+        """)
+        rust("main.rs", """
+            #[cfg_attr(windows, cfg_attr(feature = "foo", deny(all)))]
+            fn foo() {}                           //^ Cargo.toml
+        """)
+    }
+
+    fun `test cfg in cfg_attr nested`() = doResolveTest {
+        toml("Cargo.toml", """
+            [features]
+            foo = []
+        """)
+        rust("main.rs", """
+            #[cfg_attr(windows, cfg_attr(foobar, cfg(feature = "foo")))]
+            fn foo() {}                                       //^ Cargo.toml
+        """)
+    }
+
+    fun `test doc cfg in cfg_attr`() = doResolveTest {
+        toml("Cargo.toml", """
+            [features]
+            foo = []
+        """)
+        rust("main.rs", """
+            #[cfg_attr(windows, doc(cfg(feature = "foo")))]
+            fn foo() {}                          //^ Cargo.toml
+        """)
+    }
+
     private fun doResolveTest(builder: FileTreeBuilder.() -> Unit) {
         val fileTree = fileTree(builder)
         resolveByFileTree<RsLitExpr>(fileTree, resolveFileProducer = this::getActualResolveFile)


### PR DESCRIPTION
Real world example is tokio's
```rust
#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
fn foo() {}
```
here "macros" will be resolved as a cargo feature.

This works for any `cfg_attr` nesting, e.g. for
```rust
#[cfg_attr(windows, cfg_attr(foobar, cfg(feature = "foo")))]
fn foo() {}
```

Continuation of #6432, related to #4693

changelog: Provide name resolution for cargo features in conditional attributes like `#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]`