### PR TITLE
COMP: add completion for cargo features in cfg attributes

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProvider.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.completion
 
 import com.intellij.codeInsight.completion.CompletionParameters
-import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.InsertionContext
 import com.intellij.codeInsight.lookup.LookupElementBuilder
@@ -16,9 +15,10 @@ import com.intellij.patterns.PatternCondition
 import com.intellij.patterns.PlatformPatterns.psiElement
 import com.intellij.psi.PsiElement
 import com.intellij.util.ProcessingContext
-import org.rust.lang.RsLanguage
+import org.rust.lang.core.psi.RsElementTypes
 import org.rust.lang.core.psi.RsMetaItem
 import org.rust.lang.core.psi.RsMetaItemArgs
+import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.ext.name
 import org.rust.lang.core.psiElement
 
@@ -79,7 +79,7 @@ object RsCfgAttributeCompletionProvider : RsCompletionProvider() {
     private val InsertionContext.alreadyHasValue: Boolean
         get() = nextCharIs('=')
 
-    override val elementPattern: ElementPattern<PsiElement>
+    override val elementPattern: ElementPattern<out PsiElement>
         get() {
             val cfgAttr = psiElement<RsMetaItem>()
                 .with(object : PatternCondition<RsMetaItem>("cfg") {
@@ -93,8 +93,10 @@ object RsCfgAttributeCompletionProvider : RsCompletionProvider() {
                         .withParent(cfgAttr)
                 )
 
-            return psiElement()
-                .withLanguage(RsLanguage)
-                .inside(cfgOption)
+            return psiElement(RsElementTypes.IDENTIFIER)
+                .withParent(
+                    psiElement<RsPath>()
+                        .inside(cfgOption)
+                )
         }
 }

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProvider.kt
@@ -22,6 +22,7 @@ import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.ext.name
 import org.rust.lang.core.psiElement
 
+/** See also `RsCfgFeatureCompletionProvider` */
 object RsCfgAttributeCompletionProvider : RsCompletionProvider() {
 
     private val NAME_OPTIONS: List<String> = listOf(

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProviderTest.kt
@@ -61,4 +61,14 @@ class RsCfgAttributeCompletionProviderTest : RsCompletionTestBase() {
         #[cfg(not(and(unix, target_endian = "/*caret*/")))]
         fn foo() {}
     """)
+
+    fun `test no completion in feature names 1`() = checkNoCompletion("""
+        #[cfg(feature = "/*caret*/")]
+        fn foo() {}
+    """)
+
+    fun `test no completion in feature names 2`() = checkNoCompletion("""
+        #[cfg(feature = /*caret*/)]
+        fn foo() {}
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
@@ -55,11 +55,13 @@ abstract class RsCompletionTestFixtureBase<IN>(
     fun doSingleCompletionByFileTree(before: String, after: String) =
         doSingleCompletionByFileTree(fileTreeFromText(before), after)
 
-    fun doSingleCompletionByFileTree(fileTree: FileTree, after: String) {
+    fun doSingleCompletionByFileTree(fileTree: FileTree, after: String, forbidAstLoading: Boolean = true) {
         val testProject = fileTree.createAndOpenFileWithCaretMarker(myFixture)
-        checkAstNotLoaded(VirtualFileFilter { file ->
-            !file.path.endsWith(testProject.fileWithCaret)
-        })
+        if (forbidAstLoading) {
+            checkAstNotLoaded(VirtualFileFilter { file ->
+                !file.path.endsWith(testProject.fileWithCaret)
+            })
+        }
         executeSoloCompletion()
         myFixture.checkResult(replaceCaretMarker(after.trimIndent()))
     }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
@@ -403,6 +403,21 @@ class RsPsiPatternTest : RsTestBase() {
         fn foo() {}                          //^
     """, RsPsiPattern.onAnyCfgFeature)
 
+    fun `test in cfg feature`() = testPattern("""
+        #[cfg(feature = "foo")]
+        fn foo() {}    //^
+    """, RsPsiPattern.insideAnyCfgFeature)
+
+    fun `test in cfg feature without literal`() = testPattern("""
+        #[cfg(feature = foo)]
+        fn foo() {}    //^
+    """, RsPsiPattern.insideAnyCfgFeature)
+
+    fun `test not in cfg feature without literal`() = testPatternNegative("""
+        #[cfg( f = foo)]
+        fn foo() {}//^
+    """, RsPsiPattern.insideAnyCfgFeature)
+
     private inline fun <reified T : PsiElement> testPattern(@Language("Rust") code: String, pattern: ElementPattern<T>) {
         InlineFile(code)
         val element = findElementInEditor<T>()

--- a/toml/src/main/kotlin/org/rust/toml/completion/RsCargoTomlIntegrationCompletionContributor.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/RsCargoTomlIntegrationCompletionContributor.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.completion
+
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.completion.CompletionType.BASIC
+import org.rust.lang.core.completion.RsCompletionProvider
+import org.rust.toml.tomlPluginIsAbiCompatible
+
+/** Provides completion in **Rust** files for elements that points to TOML elements, e.g. for cargo features */
+class RsCargoTomlIntegrationCompletionContributor : CompletionContributor() {
+    init {
+        if (tomlPluginIsAbiCompatible()) {
+            extend(BASIC, RsCfgFeatureCompletionProvider)
+        }
+    }
+
+    @Suppress("SameParameterValue")
+    private fun extend(type: CompletionType?, provider: RsCompletionProvider) {
+        extend(type, provider.elementPattern, provider)
+    }
+}

--- a/toml/src/main/kotlin/org/rust/toml/completion/RsCfgFeatureCompletionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/RsCfgFeatureCompletionProvider.kt
@@ -1,0 +1,69 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.InsertHandler
+import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.patterns.ElementPattern
+import com.intellij.psi.PsiElement
+import com.intellij.util.ProcessingContext
+import org.rust.lang.core.RsPsiPattern
+import org.rust.lang.core.completion.RsCompletionProvider
+import org.rust.lang.core.completion.getElementOfType
+import org.rust.lang.core.psi.RS_ALL_STRING_LITERALS
+import org.rust.lang.core.psi.RsLitExpr
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.rust.lang.core.psi.ext.containingCargoPackage
+import org.rust.lang.core.psi.ext.elementType
+import org.rust.toml.getPackageTomlFile
+import org.rust.toml.resolve.allFeatures
+import org.toml.lang.psi.TomlKey
+
+/**
+ * Provides completion for cargo features in Rust cfg attributes:
+ * ```
+ * #[cfg(feature = "<caret>")]
+ * fn foo() {}    //^ Provides completion here
+ * ```
+ *
+ * @see org.rust.toml.resolve.RsCfgFeatureReferenceProvider
+ */
+object RsCfgFeatureCompletionProvider : RsCompletionProvider() {
+    override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+        val pkg = parameters.position.ancestorOrSelf<RsElement>()?.containingCargoPackage ?: return
+        val pkgToml = pkg.getPackageTomlFile(parameters.originalFile.project) ?: return
+
+        for (feature in pkgToml.allFeatures()) {
+            result.addElement(rustLookupElementForFeature(feature))
+        }
+    }
+
+    override val elementPattern: ElementPattern<out PsiElement>
+        get() = RsPsiPattern.insideAnyCfgFeature
+}
+
+private fun rustLookupElementForFeature(feature: TomlKey): LookupElementBuilder {
+    return LookupElementBuilder
+        .createWithSmartPointer(feature.text, feature)
+        .withInsertHandler(RustStringLiteralInsertionHandler())
+}
+
+private class RustStringLiteralInsertionHandler : InsertHandler<LookupElement> {
+    override fun handleInsert(context: InsertionContext, item: LookupElement) {
+        val leaf = context.getElementOfType<PsiElement>() ?: return
+        val hasQuotes = leaf.parent is RsLitExpr && leaf.elementType in RS_ALL_STRING_LITERALS
+
+        if (!hasQuotes) {
+            context.document.insertString(context.startOffset, "\"")
+            context.document.insertString(context.selectionEndOffset, "\"")
+        }
+    }
+}

--- a/toml/src/main/kotlin/org/rust/toml/resolve/RsCargoTomlIntegrationReferenceContributor.kt
+++ b/toml/src/main/kotlin/org/rust/toml/resolve/RsCargoTomlIntegrationReferenceContributor.kt
@@ -8,10 +8,13 @@ package org.rust.toml.resolve
 import com.intellij.psi.PsiReferenceContributor
 import com.intellij.psi.PsiReferenceRegistrar
 import org.rust.lang.core.RsPsiPattern
+import org.rust.toml.tomlPluginIsAbiCompatible
 
 /** Provides references (that point to TOML elements) for Rust elements in Rust files */
 class RsCargoTomlIntegrationReferenceContributor : PsiReferenceContributor() {
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
-        registrar.registerReferenceProvider(RsPsiPattern.onAnyCfgFeature, RsCfgFeatureReferenceProvider())
+        if (tomlPluginIsAbiCompatible()) {
+            registrar.registerReferenceProvider(RsPsiPattern.onAnyCfgFeature, RsCfgFeatureReferenceProvider())
+        }
     }
 }

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -6,6 +6,8 @@
                                   implementation="org.rust.toml.resolve.RsCargoTomlIntegrationReferenceContributor"/>
         <completion.contributor language="TOML"
                                 implementationClass="org.rust.toml.completion.CargoTomlCompletionContributor"/>
+        <completion.contributor language="Rust"
+                                implementationClass="org.rust.toml.completion.RsCargoTomlIntegrationCompletionContributor"/>
         <codeInsight.lineMarkerProvider language="TOML"
                                         implementationClass="org.rust.toml.CargoCrateDocLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="TOML"

--- a/toml/src/test/kotlin/org/rust/toml/completion/RsCfgFeatureCompletionProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/completion/RsCfgFeatureCompletionProviderTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.completion
+
+import org.intellij.lang.annotations.Language
+import org.rust.FileTreeBuilder
+import org.rust.fileTree
+import org.rust.lang.core.completion.RsCompletionTestBase
+
+class RsCfgFeatureCompletionProviderTest : RsCompletionTestBase() {
+    fun `test simple in literal`() = doSingleCompletionByFileTree({
+        toml("Cargo.toml", """
+            [features]
+            foo = []
+        """)
+        rust("main.rs", """
+            #[cfg(feature = "/*caret*/")]
+            fn foo() {}
+        """)
+    }, """
+        #[cfg(feature = "foo")]
+        fn foo() {}
+    """)
+
+    fun `test simple without literal`() = doSingleCompletionByFileTree({
+        toml("Cargo.toml", """
+            [features]
+            foo = []
+        """)
+        rust("main.rs", """
+            #[cfg(feature = /*caret*/)]
+            fn foo() {}
+        """)
+    }, """
+        #[cfg(feature = "foo")]
+        fn foo() {}
+    """)
+
+    fun `test complex in literal`() = doSingleCompletionByFileTree({
+        toml("Cargo.toml", """
+            [features]
+            foo = []
+            bar = []
+            qux = []
+        """)
+        rust("main.rs", """
+            #[cfg(any(feature = "foo", feature = "b/*caret*/", feature = "qux"))]
+            fn foo() {}
+        """)
+    }, """
+        #[cfg(any(feature = "foo", feature = "bar", feature = "qux"))]
+        fn foo() {}
+    """)
+
+    fun `test complex without literal`() = doSingleCompletionByFileTree({
+        toml("Cargo.toml", """
+            [features]
+            foo = []
+            bar = []
+            qux = []
+        """)
+        rust("main.rs", """
+            #[cfg(any(feature = "foo", feature = b/*caret*/, feature = "qux"))]
+            fn foo() {}
+        """)
+    }, """
+        #[cfg(any(feature = "foo", feature = "bar", feature = "qux"))]
+        fn foo() {}
+    """)
+
+    private fun doSingleCompletionByFileTree(builder: FileTreeBuilder.() -> Unit, @Language("Rust") after: String) {
+        completionFixture.doSingleCompletionByFileTree(fileTree(builder), after, forbidAstLoading = false)
+    }
+}


### PR DESCRIPTION
![Peek 2020-11-25 18-55](https://user-images.githubusercontent.com/3221931/100251683-15872680-2f50-11eb-88fa-28ebddc2baed.gif)


Related to #4693

changelog: Provide completion for cargo features in `#[cfg()]` attributes