### PR TITLE
STUB: create stubs for lifetime parameters only if needed

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -52,7 +52,7 @@ class RsFileStub : PsiFileStubImpl<RsFile> {
     override fun getType() = Type
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
-        private const val STUB_VERSION = 202
+        private const val STUB_VERSION = 203
 
         // Bump this number if Stub structure changes
         override fun getStubVersion(): Int = RustParserDefinition.PARSER_VERSION + STUB_VERSION
@@ -1297,6 +1297,9 @@ class RsLifetimeParameterStub(
     RsNamedStub {
 
     object Type : RsStubElementType<RsLifetimeParameterStub, RsLifetimeParameter>("LIFETIME_PARAMETER") {
+
+        override fun shouldCreateStub(node: ASTNode): Boolean = createStubIfParentIsStub(node)
+
         override fun createPsi(stub: RsLifetimeParameterStub) =
             RsLifetimeParameterImpl(stub, this)
 

--- a/src/test/kotlin/org/rust/lang/core/stubs/RsLazyBlockStubCreationTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/stubs/RsLazyBlockStubCreationTest.kt
@@ -18,6 +18,14 @@ class RsLazyBlockStubCreationTest : RsLazyBlockStubCreationTestBase() {
         }
     """)
 
+    fun `test lifetime parameter in function body`() = doTest("""
+    //- main.rs
+        struct S<'a, T: ?Sized>(&'a T);
+        fn main() {
+            let lambda: &dyn for<'b> Fn(&'b str) -> S<'b, str> = &|s| S(s);
+        }
+    """)
+
     private fun doTest(@Language("Rust") fileTreeText: String) {
         fileTreeFromText(fileTreeText).create()
         checkRustFiles(myFixture.findFileInTempDir("."), emptyList())

--- a/src/test/kotlin/org/rust/lang/core/stubs/RsLazyBlockStubCreationTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/stubs/RsLazyBlockStubCreationTestBase.kt
@@ -30,12 +30,18 @@ abstract class RsLazyBlockStubCreationTestBase : RsTestBase() {
 
     protected fun checkRustFiles(directory: VirtualFile, ignored: Collection<String>) {
         val files = collectRustFiles(directory, ignored)
-            .mapNotNull { it.toInMemoryPsiFile() as? RsFile }
 
         var numBlocks = 0
         var numParsedBlocks = 0
 
-        for (psi in files) {
+        for (file in files) {
+            fun check(value: Boolean, lazyMessage: () -> Any) {
+                kotlin.check(value) {
+                    "file: $file\n${lazyMessage()}"
+                }
+            }
+
+            val psi = file.toInMemoryPsiFile() as? RsFile ?: continue
             parseFile(psi)
             val blocks = SyntaxTraverser.psiTraverser(psi).expand { it !is RsBlock }.filterIsInstance<RsBlock>()
 


### PR DESCRIPTION
Original issue was found in [gimli](https://github.com/gimli-rs/gimli/blob/d36fcf11c878c8ebfb4da4cad300773869b5b5e4/examples/simple.rs#L38-L41) project that now is part of stdlib sources (stdlib dependency).

Also, print file url in `RsLazyBlockStubCreationTestBase` tests. It may help to find file with problem code and even open it in your IDE if it's located in local file system.

Fix the corresponding test in #6374 and #6417