### PR TITLE
CARGO: Make crates local index updates incremental

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyCompletionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyCompletionProvider.kt
@@ -23,7 +23,6 @@ class LocalCargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProvide
         val prefix = CompletionUtil.getOriginalElement(keyValue.key)?.text ?: return
 
         val indexService = CratesLocalIndexService.getInstance()
-        if (!indexService.isReady()) return
 
         val crateNames = indexService.getAllCrateNames()
         val elements = crateNames.mapNotNull { crateName ->
@@ -54,7 +53,6 @@ class LocalCargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProvide
         val name = CompletionUtil.getOriginalElement(keyValue.key)?.text ?: return
 
         val indexService = CratesLocalIndexService.getInstance()
-        if (!indexService.isReady()) return
 
         val versions = indexService.getCrate(name)?.versions ?: return
         val elements = versions.mapIndexed { index, variant ->


### PR DESCRIPTION
Implements incremental updates of crates local index on `Cargo.toml` changes.

To incrementally update the crates local index, it gets the previous indexed commit from the state and finds the changed files with the current head in the cargo registry repo. Then, the changed files are getting reloaded from the head state.

In a case when there is no previous indexed commit or it hasn't been found, it refreshes the index with all changes.

Part of https://github.com/intellij-rust/intellij-rust/issues/6463

changelog: Update experimental [local crates index](https://github.com/intellij-rust/intellij-rust/pull/6390) incrementally. This speeds up the experimental `Cargo.toml` dependency completion and will affect other new code insight based on this index in the future. Note, the corresponding feature is disabled by default for now. You can enable it via `org.rust.crates.local.index` option in `Experimental Feature` dialog (`Help | Find Action` and type `Experimental features` to open the dialog)