### PR TITLE
INSP: improve `AttrWithoutParentheses`: take into account `cfg_attr

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsAttrWithoutParenthesesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsAttrWithoutParenthesesInspection.kt
@@ -7,7 +7,7 @@ package org.rust.ide.inspections
 
 import org.rust.lang.core.psi.RsMetaItem
 import org.rust.lang.core.psi.RsVisitor
-import org.rust.lang.core.psi.ext.RsAttr
+import org.rust.lang.core.psi.ext.isRootMetaItem
 import org.rust.lang.core.psi.ext.name
 import org.rust.lang.utils.RsDiagnostic
 import org.rust.lang.utils.addToHolder
@@ -16,7 +16,7 @@ class RsAttrWithoutParenthesesInspection : RsLocalInspectionTool() {
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
         override fun visitMetaItem(metaItem: RsMetaItem) {
-            if (metaItem.parent !is RsAttr) return
+            if (!metaItem.isRootMetaItem) return
             val name = metaItem.name ?: return
             if (name in ATTRIBUTES_WITH_PARENTHESES && metaItem.metaItemArgs == null) {
                 RsDiagnostic.NoAttrParentheses(metaItem, name).addToHolder(holder)

--- a/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
@@ -215,6 +215,10 @@ object RsPsiPattern {
             return psiElement().withParent(simplePath)
         }
 
+    /** @see RsMetaItem.isRootMetaItem */
+    val rootMetaItem: PsiElementPattern.Capture<RsMetaItem> = psiElement<RsMetaItem>()
+        .with(RootMetaItemCondition)
+
     /** `#[cfg()]` */
     private val onCfgAttributeMeta: PsiElementPattern.Capture<RsMetaItem> = rootMetaItem("cfg")
 
@@ -277,9 +281,9 @@ object RsPsiPattern {
             psiElement<RsPath>().withText(key)
         )
 
-    /** @see OnRootMetaItem */
+    /** @see RsMetaItem.isRootMetaItem */
     private fun rootMetaItem(key: String): PsiElementPattern.Capture<RsMetaItem> =
-        metaItem(key).with(OnRootMetaItem)
+        metaItem(key).with(RootMetaItemCondition)
 
     private class OnStatementBeginning(vararg startWords: String) : PatternCondition<PsiElement>("on statement beginning") {
         val myStartWords = startWords
@@ -293,7 +297,7 @@ object RsPsiPattern {
     }
 
     /** @see RsMetaItem.isRootMetaItem */
-    private object OnRootMetaItem : PatternCondition<RsMetaItem>("rootMetaItem") {
+    private object RootMetaItemCondition : PatternCondition<RsMetaItem>("rootMetaItem") {
         override fun accepts(meta: RsMetaItem, context: ProcessingContext?): Boolean {
             return meta.isRootMetaItem
         }

--- a/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
@@ -220,13 +220,13 @@ object RsPsiPattern {
         .with(RootMetaItemCondition)
 
     /** `#[cfg()]` */
-    private val onCfgAttributeMeta: PsiElementPattern.Capture<RsMetaItem> = rootMetaItem("cfg")
+    private val cfgAttributeMeta: PsiElementPattern.Capture<RsMetaItem> = rootMetaItem("cfg")
 
     /** `#[cfg_attr()]` */
-    private val onCfgAttrAttributeMeta: PsiElementPattern.Capture<RsMetaItem> = rootMetaItem("cfg_attr")
+    private val cfgAttrAttributeMeta: PsiElementPattern.Capture<RsMetaItem> = rootMetaItem("cfg_attr")
 
     /** `#[doc(cfg())]` */
-    private val onDocCfgAttributeMeta: PsiElementPattern.Capture<RsMetaItem> = metaItem("cfg")
+    private val docCfgAttributeMeta: PsiElementPattern.Capture<RsMetaItem> = metaItem("cfg")
         .withSuperParent(2, rootMetaItem("doc"))
 
     /**
@@ -235,31 +235,31 @@ object RsPsiPattern {
      *           //^
      * ```
      */
-    private val onCfgAttrCondition: PsiElementPattern.Capture<RsMetaItem> = psiElement<RsMetaItem>()
-        .withSuperParent(2, onCfgAttrAttributeMeta)
+    private val cfgAttrCondition: PsiElementPattern.Capture<RsMetaItem> = psiElement<RsMetaItem>()
+        .withSuperParent(2, cfgAttrAttributeMeta)
         .with("firstItem") { it, _ -> (it.parent as? RsMetaItemArgs)?.metaItemList?.firstOrNull() == it }
 
-    private val onAnyCfgCondition: PsiElementPattern.Capture<RsMetaItem> =
-        onCfgAttributeMeta or onCfgAttrCondition or onDocCfgAttributeMeta
+    private val anyCfgCondition: PsiElementPattern.Capture<RsMetaItem> =
+        cfgAttributeMeta or cfgAttrCondition or docCfgAttributeMeta
 
-    val onAnyCfgFeature: PsiElementPattern.Capture<RsLitExpr> = psiElement<RsLitExpr>()
+    val anyCfgFeature: PsiElementPattern.Capture<RsLitExpr> = psiElement<RsLitExpr>()
         .withParent(metaItem("feature"))
-        .inside(onAnyCfgCondition)
+        .inside(anyCfgCondition)
 
     /**
-     * A leaf literal inside [onAnyCfgFeature] or an identifier at the same place
+     * A leaf literal inside [anyCfgFeature] or an identifier at the same place
      * ```
      * #[cfg(feature = "foo")] // Works for "foo" (leaf literal)
      * #[cfg(feature = foo)]   // Works for "foo" (leaf identifier)
      * ```
      */
-    val insideAnyCfgFeature: PsiElementPattern.Capture<PsiElement> = psiElement().withParent(onAnyCfgFeature) or
+    val insideAnyCfgFeature: PsiElementPattern.Capture<PsiElement> = psiElement().withParent(anyCfgFeature) or
         psiElement(IDENTIFIER)
             .withParent(
                 psiElement<RsCompactTT>()
                     .withParent(
                         psiElement<RsMetaItem>()
-                            .inside(onAnyCfgCondition)
+                            .inside(anyCfgCondition)
                     )
             )
             .with("feature") { it, _ ->

--- a/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
@@ -235,16 +235,6 @@ object RsPsiPattern {
         .withSuperParent(2, onCfgAttrAttributeMeta)
         .with("firstItem") { it, _ -> (it.parent as? RsMetaItemArgs)?.metaItemList?.firstOrNull() == it }
 
-    /**
-     * ```
-     * #[cfg_attr(condition, attr)]
-     *                     //^
-     * ```
-     */
-    private val onCfgAttrBody: PsiElementPattern.Capture<RsMetaItem> = psiElement<RsMetaItem>()
-        .withSuperParent(2, onCfgAttrAttributeMeta)
-        .with("lastItem") { it, _ -> (it.parent as? RsMetaItemArgs)?.metaItemList?.lastOrNull() == it }
-
     private val onAnyCfgCondition: PsiElementPattern.Capture<RsMetaItem> =
         onCfgAttributeMeta or onCfgAttrCondition or onDocCfgAttributeMeta
 
@@ -302,15 +292,10 @@ object RsPsiPattern {
         }
     }
 
-    /**
-     * In the case of `#[foo(bar)]`, the `foo(bar)` meta item is considered "root", but `bar` is not.
-     * In the case of `#[cfg_attr(windows, foo(bar))]`, the `foo(bar)` is also considered "root" meta item
-     * because after `cfg_attr` expanding the `foo(bar)` will turn into `#[foo(bar)]`.
-     * This also applied to nested `cfg_attr`s, e.g. `#[cfg_attr(windows, cfg_attr(foobar, foo(bar)))]`
-     */
+    /** @see RsMetaItem.isRootMetaItem */
     private object OnRootMetaItem : PatternCondition<RsMetaItem>("rootMetaItem") {
         override fun accepts(meta: RsMetaItem, context: ProcessingContext?): Boolean {
-            return meta.parent is RsAttr || onCfgAttrBody.accepts(meta)
+            return meta.isRootMetaItem
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.psi.ext
 
 import org.rust.lang.core.psi.RsMetaItem
+import org.rust.lang.core.psi.RsMetaItemArgs
 import org.rust.lang.core.psi.RsTraitItem
 
 /**
@@ -32,3 +33,33 @@ val RsMetaItem.hasEq: Boolean get() = greenStub?.hasEq ?: (eq != null)
 
 fun RsMetaItem.resolveToDerivedTrait(): RsTraitItem? =
     path?.reference?.resolve() as? RsTraitItem
+
+/**
+ * In the case of `#[foo(bar)]`, the `foo(bar)` meta item is considered "root" but `bar` is not.
+ * In the case of `#[cfg_attr(windows, foo(bar))]`, the `foo(bar)` is also considered "root" meta item
+ * because after `cfg_attr` expanding the `foo(bar)` will turn into `#[foo(bar)]`.
+ * This also applied to nested `cfg_attr`s, e.g. `#[cfg_attr(windows, cfg_attr(foobar, foo(bar)))]`
+ */
+val RsMetaItem.isRootMetaItem: Boolean
+    get() = parent is RsAttr || isCfgAttrBody
+
+/**
+ * ```
+ * #[cfg_attr(condition, attr)]
+ *                     //^
+ * ```
+ */
+private val RsMetaItem.isCfgAttrBody: Boolean
+    get() {
+        val parent = parent as? RsMetaItemArgs ?: return false
+        val parentMetaItem = parent.parent as? RsMetaItem ?: return false
+
+        if (!parentMetaItem.isCfgAttrMetaItem) return false
+
+        val conditionPart = parent.metaItemList.firstOrNull()
+        return this != conditionPart
+    }
+
+/** `#[cfg_attr()]` */
+private val RsMetaItem.isCfgAttrMetaItem: Boolean
+    get() = name == "cfg_attr" && isRootMetaItem

--- a/src/test/kotlin/org/rust/ide/inspections/RsAttrWithoutParenthesesInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsAttrWithoutParenthesesInspectionTest.kt
@@ -28,9 +28,8 @@ class RsAttrWithoutParenthesesInspectionTest : RsInspectionsTestBase(RsAttrWitho
         struct Foo(i32);
     """)
 
-    // TODO: detect error in `repr` without parentheses inside `cfg_attr` attribute
     fun `test error in cfg attr items`() = checkErrors("""
-        #[cfg_attr(unix, repr)]
+        #[cfg_attr(unix, <error descr="Malformed `repr` attribute input: missing parentheses">repr</error>)]
         struct Foo(u8);
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
@@ -382,68 +382,68 @@ class RsPsiPatternTest : RsTestBase() {
     fun `test cfg feature`() = testPattern("""
         #[cfg(feature = "foo")]
         fn foo() {}   //^
-    """, RsPsiPattern.onAnyCfgFeature)
+    """, RsPsiPattern.anyCfgFeature)
 
     fun `test inner attribute cfg feature`() = testPattern("""
         fn foo() {
             #![cfg(feature = "foo")]
         }                   //^
-    """, RsPsiPattern.onAnyCfgFeature)
+    """, RsPsiPattern.anyCfgFeature)
 
     fun `test nested cfg feature`() = testPattern("""
         #[cfg(not(feature = "foo"))]
         fn foo() {}        //^
-    """, RsPsiPattern.onAnyCfgFeature)
+    """, RsPsiPattern.anyCfgFeature)
 
     fun `test not a cfg feature`() = testPatternNegative("""
         #[zfg(feature = "foo")]
         fn foo() {}    //^
-    """, RsPsiPattern.onAnyCfgFeature)
+    """, RsPsiPattern.anyCfgFeature)
 
     fun `test cfg not a feature`() = testPatternNegative("""
         #[cfg(not_a_feature = "foo")]
         fn foo() {}          //^
-    """, RsPsiPattern.onAnyCfgFeature)
+    """, RsPsiPattern.anyCfgFeature)
 
     fun `test cfg_attr feature`() = testPattern("""
         #[cfg_attr(feature = "foo", allow(all))]
         fn foo() {}          //^
-    """, RsPsiPattern.onAnyCfgFeature)
+    """, RsPsiPattern.anyCfgFeature)
 
     fun `test not right part of cfg_attr 1`() = testPatternNegative("""
         #[cfg_attr(windows, foo(feature = "foo"))]
         fn foo() {}                      //^
-    """, RsPsiPattern.onAnyCfgFeature)
+    """, RsPsiPattern.anyCfgFeature)
 
     fun `test not right part of cfg_attr 2`() = testPatternNegative("""
         #[cfg_attr(windows, foo(cfg(feature = "foo")))]
         fn foo() {}                          //^
-    """, RsPsiPattern.onAnyCfgFeature)
+    """, RsPsiPattern.anyCfgFeature)
 
     fun `test cfg at right part of cfg_attr`() = testPattern("""
         #[cfg_attr(windows, cfg(feature = "foo"))]
         fn foo() {}                      //^
-    """, RsPsiPattern.onAnyCfgFeature)
+    """, RsPsiPattern.anyCfgFeature)
 
     fun `test nested cfg_attr feature`() = testPattern("""
         #[cfg_attr(windows, cfg_attr(feature = "foo", allow(all)))]
         fn foo() {}                           //^
-    """, RsPsiPattern.onAnyCfgFeature)
+    """, RsPsiPattern.anyCfgFeature)
 
     fun `test nested cfg_attr cfg feature`() = testPattern("""
         #[cfg_attr(windows, cfg_attr(foobar, cfg(feature = "foo")))]
         fn foo() {}                                       //^
-    """, RsPsiPattern.onAnyCfgFeature)
+    """, RsPsiPattern.anyCfgFeature)
 
     fun `test doc cfg`() = testPattern("""
         #[doc(cfg(feature = "foo"))]
         fn foo() {}        //^
-    """, RsPsiPattern.onAnyCfgFeature)
+    """, RsPsiPattern.anyCfgFeature)
 
     fun `test doc cfg at right part of cfg_attr`() = testPattern("""
         #[cfg_attr(windows, doc(cfg(feature = "foo")))]
         fn foo() {}                          //^
-    """, RsPsiPattern.onAnyCfgFeature)
+    """, RsPsiPattern.anyCfgFeature)
 
     fun `test in cfg feature`() = testPattern("""
         #[cfg(feature = "foo")]

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
@@ -337,6 +337,48 @@ class RsPsiPatternTest : RsTestBase() {
         mod foo {}
     """, RsPsiPattern.pathAttrLiteral)
 
+    fun `test a root meta item 1`() = testPattern("""
+        #[foo]
+        //^
+        fn foo() {}
+    """, RsPsiPattern.rootMetaItem)
+
+    fun `test a root meta item 2`() = testPattern("""
+        #![foo]
+         //^
+    """, RsPsiPattern.rootMetaItem)
+
+    fun `test a root meta item 3`() = testPattern("""
+        #[cfg_attr(foo, bar)]
+        fn foo() {}   //^
+    """, RsPsiPattern.rootMetaItem)
+
+    fun `test a root meta item 4`() = testPattern("""
+        #[cfg_attr(foo, bar, baz)]
+        fn foo() {}        //^
+    """, RsPsiPattern.rootMetaItem)
+
+    fun `test a root meta item 5`() = testPattern("""
+        #[cfg_attr(foo, cfg_attr(bar, baz))]
+        fn foo() {}                  //^
+    """, RsPsiPattern.rootMetaItem)
+
+    fun `test not a root meta item 1`() = testPatternNegative("""
+        #[cfg_attr(foo, bar)]
+        fn foo() {}//^
+    """, RsPsiPattern.rootMetaItem)
+
+    fun `test not a root meta item 2`() = testPatternNegative("""
+        #[cfg_attr(foo, cfg_attr(bar, baz))]
+        fn foo() {}            //^
+    """, RsPsiPattern.rootMetaItem)
+
+    fun `test not a root meta item 3`() = testPatternNegative("""
+        #[foo(bar())]
+             //^
+        fn foo() {}
+    """, RsPsiPattern.rootMetaItem)
+
     fun `test cfg feature`() = testPattern("""
         #[cfg(feature = "foo")]
         fn foo() {}   //^

--- a/toml/src/main/kotlin/org/rust/toml/resolve/RsCargoTomlIntegrationReferenceContributor.kt
+++ b/toml/src/main/kotlin/org/rust/toml/resolve/RsCargoTomlIntegrationReferenceContributor.kt
@@ -14,7 +14,7 @@ import org.rust.toml.tomlPluginIsAbiCompatible
 class RsCargoTomlIntegrationReferenceContributor : PsiReferenceContributor() {
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
         if (tomlPluginIsAbiCompatible()) {
-            registrar.registerReferenceProvider(RsPsiPattern.onAnyCfgFeature, RsCfgFeatureReferenceProvider())
+            registrar.registerReferenceProvider(RsPsiPattern.anyCfgFeature, RsCfgFeatureReferenceProvider())
         }
     }
 }


### PR DESCRIPTION
An improvement for #6413: take into account attributes in `#[cfg_attr(foobar, ...)]`

c.c. @zeroeightysix

changelog: Detect attributes that require parentheses but have no parentheses, and suggest Add parentheses quick-fix for attributes under #[cfg_attr]