### PR TITLE
REF(MOVE): Change references in use groups

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/RsImportOptimizer.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsImportOptimizer.kt
@@ -39,7 +39,7 @@ class RsImportOptimizer : ImportOptimizer {
         externCrateItems.forEach { it.delete() }
     }
 
-    private fun executeForUseItem(mod: RsMod) {
+    fun executeForUseItem(mod: RsMod) {
         val uses = mod.childrenOfType<RsUseItem>()
         if (uses.isNotEmpty()) {
             replaceOrderOfUseItems(mod, uses)
@@ -51,7 +51,7 @@ class RsImportOptimizer : ImportOptimizer {
     companion object {
 
         /** Returns false if [useSpeck] is empty and should be removed */
-        private fun optimizeUseSpeck(psiFactory: RsPsiFactory, useSpeck: RsUseSpeck): Boolean {
+        fun optimizeUseSpeck(psiFactory: RsPsiFactory, useSpeck: RsUseSpeck): Boolean {
             val useGroup = useSpeck.useGroup ?: return true
             useGroup.useSpeckList.forEach { optimizeUseSpeck(psiFactory, it) }
             if (removeUseSpeckIfEmpty(useSpeck)) return false

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveCommonProcessor.kt
@@ -137,10 +137,6 @@ class RsMoveCommonProcessor(
         val element = reference.element
         val target = reference.resolve() ?: return null
 
-        // `use path1::{path2, path3}`
-        //              ~~~~~  ~~~~~ TODO: don't ignore such paths
-        if (element.ancestorStrict<RsUseGroup>() != null) return null
-
         return when {
             element is RsModDeclItem && target is RsFile -> RsModDeclUsageInfo(element, target)
             element is RsPath && target is RsQualifiedNamedElement -> RsPathUsageInfo(element, reference, target)
@@ -376,6 +372,7 @@ class RsMoveCommonProcessor(
             .map { it.referenceInfo }
         updateInsideReferenceInfosIfNeeded(insideReferences)
         retargetReferencesProcessor.retargetReferences(insideReferences)
+        retargetReferencesProcessor.optimizeImports()
     }
 
     private fun updateOutsideReferencesInVisRestrictions() {

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileReexportTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileReexportTest.kt
@@ -26,10 +26,10 @@ class RsMoveFileReexportTest : RsMoveFileTestBase() {
         mod mod1;
         mod mod2;
     //- mod1/mod.rs
+        pub use mod1_inner::mod1_func;
         mod mod1_inner {  // private
             pub fn mod1_func() {}
         }
-        pub use mod1_inner::mod1_func;
 
         mod foo;
     //- mod2/mod.rs
@@ -42,10 +42,11 @@ class RsMoveFileReexportTest : RsMoveFileTestBase() {
         mod mod1;
         mod mod2;
     //- mod1/mod.rs
+        pub use mod1_inner::mod1_func;
+
         mod mod1_inner {  // private
             pub fn mod1_func() {}
         }
-        pub use mod1_inner::mod1_func;
     //- mod2/mod.rs
         mod foo;
     //- mod2/foo.rs

--- a/src/test/resources/org/rust/ide/refactoring/move/fixtures/rename_outside_references/after/mod2/foo.rs
+++ b/src/test/resources/org/rust/ide/refactoring/move/fixtures/rename_outside_references/after/mod2/foo.rs
@@ -22,8 +22,8 @@ fn test3() {
 }
 
 mod foo_inner1 {
-    use crate::mod1::mod1_inner;
     use crate::mod1;
+    use crate::mod1::mod1_inner;
 
     pub fn foo_inner1_func() {}
 
@@ -38,8 +38,8 @@ mod foo_inner1 {
     }
 
     pub mod foo_inner2 {
-        use crate::mod1::mod1_inner;
         use crate::mod1;
+        use crate::mod1::mod1_inner;
 
         pub fn foo_inner2_func() {}
 


### PR DESCRIPTION
E.g. when moving `foo` from `mod1` to `mod2`, changing `use mod1::{foo, bar};` to `use mod2::foo; use mod1::bar;` is now supported.

changelog: Support changing references in use groups in `Move` refactoring (<kbd>F6</kbd>)