### PR TITLE
COMP: complete `feature =""` in `cfg` attributes

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProvider.kt
@@ -37,7 +37,8 @@ object RsCfgAttributeCompletionProvider : RsCompletionProvider() {
         "target_feature",
         "target_os",
         "target_pointer_width",
-        "target_vendor"
+        "target_vendor",
+        "feature"
     )
 
     private val OPERATORS: List<String> = listOf(

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProvider.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.completion
 
+import com.intellij.codeInsight.AutoPopupController
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.InsertionContext
@@ -54,11 +55,16 @@ object RsCfgAttributeCompletionProvider : RsCompletionProvider() {
 
         for (option in NAME_VALUE_OPTIONS) {
             result.addElement(
-                LookupElementBuilder.create(option).withInsertHandler { ctx, _ ->
-                    if (!ctx.alreadyHasValue) {
+                LookupElementBuilder.create(option).withInsertHandler { ctx, element ->
+                    val alreadyHasValue = ctx.alreadyHasValue
+                    if (!alreadyHasValue) {
                         ctx.document.insertString(ctx.selectionEndOffset, " = \"\"")
                     }
                     EditorModificationUtil.moveCaretRelatively(ctx.editor, 4)
+                    if (!alreadyHasValue && element.lookupString == "feature") {
+                        // Triggers `RsCfgFeatureCompletionProvider`
+                        AutoPopupController.getInstance(ctx.project).scheduleAutoPopup(ctx.editor)
+                    }
                 }
             )
         }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProviderTest.kt
@@ -108,4 +108,9 @@ class RsCfgAttributeCompletionProviderTest : RsCompletionTestBase() {
         #[doc(cfg(unix/*caret*/))]
         fn foo() {}
     """)
+
+    fun `test feature`() = checkContainsCompletion("feature", """
+        #[cfg(feat/*caret*/)]
+        fn foo() {}
+    """)
 }


### PR DESCRIPTION
![Peek 2020-11-27 19-19](https://user-images.githubusercontent.com/3221931/100468543-a93e2b80-30e5-11eb-9852-93df4ae378f1.gif)

Improves #4492, a continuation of https://github.com/intellij-rust/intellij-rust/pull/6436#discussion_r530843956, related to #4693

changelog: Complete `feature = ""` in `#[cfg()]` attributes and then invoke autocompletion with available feature list