### PR TITLE
COMP: complete cfg options and operators in `cfg_attr` and `doc(cfg())`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
@@ -239,8 +239,9 @@ object RsPsiPattern {
         .withSuperParent(2, cfgAttrAttributeMeta)
         .with("firstItem") { it, _ -> (it.parent as? RsMetaItemArgs)?.metaItemList?.firstOrNull() == it }
 
-    private val anyCfgCondition: PsiElementPattern.Capture<RsMetaItem> =
-        cfgAttributeMeta or cfgAttrCondition or docCfgAttributeMeta
+    val anyCfgCondition: PsiElementPattern.Capture<RsMetaItem> = cfgAttrCondition or
+        psiElement<RsMetaItem>()
+            .withSuperParent(2, cfgAttributeMeta or docCfgAttributeMeta)
 
     val anyCfgFeature: PsiElementPattern.Capture<RsLitExpr> = psiElement<RsLitExpr>()
         .withParent(metaItem("feature"))

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProvider.kt
@@ -11,15 +11,12 @@ import com.intellij.codeInsight.completion.InsertionContext
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.openapi.editor.EditorModificationUtil
 import com.intellij.patterns.ElementPattern
-import com.intellij.patterns.PatternCondition
 import com.intellij.patterns.PlatformPatterns.psiElement
 import com.intellij.psi.PsiElement
 import com.intellij.util.ProcessingContext
+import org.rust.lang.core.RsPsiPattern
 import org.rust.lang.core.psi.RsElementTypes
-import org.rust.lang.core.psi.RsMetaItem
-import org.rust.lang.core.psi.RsMetaItemArgs
 import org.rust.lang.core.psi.RsPath
-import org.rust.lang.core.psi.ext.name
 import org.rust.lang.core.psiElement
 
 /** See also `RsCfgFeatureCompletionProvider` */
@@ -82,22 +79,10 @@ object RsCfgAttributeCompletionProvider : RsCompletionProvider() {
 
     override val elementPattern: ElementPattern<out PsiElement>
         get() {
-            val cfgAttr = psiElement<RsMetaItem>()
-                .with(object : PatternCondition<RsMetaItem>("cfg") {
-                    override fun accepts(t: RsMetaItem, context: ProcessingContext?): Boolean =
-                        t.name == "cfg"
-                })
-
-            val cfgOption = psiElement<RsMetaItem>()
-                .withParent(
-                    psiElement<RsMetaItemArgs>()
-                        .withParent(cfgAttr)
-                )
-
             return psiElement(RsElementTypes.IDENTIFIER)
                 .withParent(
                     psiElement<RsPath>()
-                        .inside(cfgOption)
+                        .inside(RsPsiPattern.anyCfgCondition)
                 )
         }
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCfgAttributeCompletionProviderTest.kt
@@ -71,4 +71,41 @@ class RsCfgAttributeCompletionProviderTest : RsCompletionTestBase() {
         #[cfg(feature = /*caret*/)]
         fn foo() {}
     """)
+
+    fun `test complete in cfg_attr 1`() = doSingleCompletion("""
+        #[cfg_attr(un/*caret*/)]
+        fn foo() {}
+    """, """
+        #[cfg_attr(unix/*caret*/)]
+        fn foo() {}
+    """)
+
+    fun `test complete in cfg_attr 2`() = doSingleCompletion("""
+        #[cfg_attr(un/*caret*/, foo)]
+        fn foo() {}
+    """, """
+        #[cfg_attr(unix/*caret*/, foo)]
+        fn foo() {}
+    """)
+
+    fun `test complete in cfg_attr 3`() = doSingleCompletion("""
+        #[cfg_attr(foobar, cfg_attr(un/*caret*/, foo))]
+        fn foo() {}
+    """, """
+        #[cfg_attr(foobar, cfg_attr(unix/*caret*/, foo))]
+        fn foo() {}
+    """)
+
+    fun `test no completion in second argument of cfg_attr`() = checkNoCompletion("""
+        #[cfg_attr(unix, window/*caret*/)]
+        fn foo() {}
+    """)
+
+    fun `test complete in doc cfg`() = doSingleCompletion("""
+        #[doc(cfg(un/*caret*/))]
+        fn foo() {}
+    """, """
+        #[doc(cfg(unix/*caret*/))]
+        fn foo() {}
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
@@ -379,6 +379,54 @@ class RsPsiPatternTest : RsTestBase() {
         fn foo() {}
     """, RsPsiPattern.rootMetaItem)
 
+    fun `test cfg condition in cfg`() = testPattern("""
+        #[cfg(foo)]
+            //^
+        fn foo() {}
+    """, RsPsiPattern.anyCfgCondition)
+
+    fun `test cfg condition in cfg_attr`() = testPattern("""
+        #[cfg_attr(foo)]
+                 //^
+        fn foo() {}
+    """, RsPsiPattern.anyCfgCondition)
+
+    fun `test cfg condition in doc cfg`() = testPattern("""
+        #[doc(cfg(foo))]
+                //^
+        fn foo() {}
+    """, RsPsiPattern.anyCfgCondition)
+
+    fun `test cfg condition in cfg in cfg_attr`() = testPattern("""
+        #[cfg_attr(windows, cfg(foo))]
+                              //^
+        fn foo() {}
+    """, RsPsiPattern.anyCfgCondition)
+
+    fun `test not cfg condition 1`() = testPatternNegative("""
+        #[cfg(foo)]
+          //^
+        fn foo() {}
+    """, RsPsiPattern.anyCfgCondition)
+
+    fun `test not cfg condition 2`() = testPatternNegative("""
+        #[cfg_attr(foo)]
+          //^
+        fn foo() {}
+    """, RsPsiPattern.anyCfgCondition)
+
+    fun `test not cfg condition 3`() = testPatternNegative("""
+        #[doc(cfg(foo))]
+             //^
+        fn foo() {}
+    """, RsPsiPattern.anyCfgCondition)
+
+    fun `test not cfg condition 4`() = testPatternNegative("""
+        #[cfg_attr(foo, bar)]
+                       //^
+        fn foo() {}
+    """, RsPsiPattern.anyCfgCondition)
+
     fun `test cfg feature`() = testPattern("""
         #[cfg(feature = "foo")]
         fn foo() {}   //^


### PR DESCRIPTION
Extends #4492 to `#[cfg_attr()]` and `#[doc(cfg())]`

changelog: Add cfg options and operators completion inside `#[cfg_attr()]` and `#[doc(cfg())]` attributes