### PR TITLE
Fix `RustParserDefinition.getStringLiteralElements`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
@@ -23,7 +23,6 @@ import org.rust.ide.console.RsConsoleView
 import org.rust.lang.RsDebugInjectionListener
 import org.rust.lang.core.lexer.RsLexer
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.RsElementTypes.STRING_LITERAL
 import org.rust.lang.core.stubs.RsFileStub
 
 class RustParserDefinition : ParserDefinition {
@@ -63,8 +62,7 @@ class RustParserDefinition : ParserDefinition {
 
     override fun getFileNodeType(): IFileElementType = RsFileStub.Type
 
-    override fun getStringLiteralElements(): TokenSet =
-        TokenSet.create(STRING_LITERAL)
+    override fun getStringLiteralElements(): TokenSet = RS_ALL_STRING_LITERALS
 
     override fun getWhitespaceTokens(): TokenSet =
         TokenSet.create(TokenType.WHITE_SPACE)


### PR DESCRIPTION
Return a token set containing all possible rust string literals (raw string literals, byte-literals).
I'm not sure what behavior this actually fixes or how it affects a user. One thing that I know is that typing inside string literals skips some complex stuff in `TypedHandler`, so this could be considered as performance improvement