### PR TITLE
Fix trait inner attributes and `RsAttr.owner`

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -822,6 +822,7 @@ upper TraitItem ::= unsafe? auto? trait identifier TypeParameterList? TypeParamB
                  "org.rust.lang.core.psi.ext.RsItemElement"
                  "org.rust.lang.core.psi.ext.RsNameIdentifierOwner"
                  "org.rust.lang.core.psi.ext.RsUnsafetyOwner"
+                 "org.rust.lang.core.psi.ext.RsInnerAttributeOwner"
                  "org.rust.lang.core.psi.ext.RsTypeDeclarationElement" ]
   mixin = "org.rust.lang.core.psi.ext.RsTraitItemImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsTraitItemStub"

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAttr.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAttr.kt
@@ -5,9 +5,7 @@
 
 package org.rust.lang.core.psi.ext
 
-import org.rust.lang.core.psi.RsInnerAttr
-import org.rust.lang.core.psi.RsMetaItem
-import org.rust.lang.core.psi.RsOuterAttr
+import org.rust.lang.core.psi.*
 
 interface RsAttr : RsElement {
     val metaItem: RsMetaItem
@@ -15,8 +13,15 @@ interface RsAttr : RsElement {
 
 val RsAttr.owner: RsDocAndAttributeOwner?
     get() = when (this) {
-        is RsInnerAttr -> parent?.parent as? RsDocAndAttributeOwner
         is RsOuterAttr -> parent as? RsDocAndAttributeOwner
+        is RsInnerAttr -> when (val parent = parent) {
+            is RsMembers -> parent.parent as? RsDocAndAttributeOwner
+            is RsBlock -> when (val parentParent = parent.parent) {
+                is RsFunction -> parentParent
+                else -> parent as? RsDocAndAttributeOwner
+            }
+            else -> parent as? RsDocAndAttributeOwner
+        }
         // Throw exception so that any problems with this property aren't silent and are instead easily findable
         else -> error("Unsupported attribute type: $this")
     }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -144,6 +144,9 @@ abstract class RsTraitItemImplMixin : RsStubbedNamedElementImpl<RsTraitItemStub>
     override val associatedTypesTransitively: Collection<RsTypeAlias>
         get() = BoundElement(this).associatedTypesTransitively
 
+    override val innerAttrList: List<RsInnerAttr>
+        get() = members?.innerAttrList ?: emptyList()
+
     override val isUnsafe: Boolean get() {
         val stub = greenStub
         return stub?.isUnsafe ?: (unsafe != null)

--- a/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
@@ -28,6 +28,9 @@ class RsAttributeTest : RsTestBase() {
             Inner -> check(isInner && !isOuter)
             Outer -> check(!isInner && isOuter)
         }
+
+        check(element !is RsOuterAttributeOwner || element.outerAttrList.all { it.owner == element })
+        check(element !is RsInnerAttributeOwner || element.innerAttrList.all { it.owner == element })
     }
 
     private fun doTest(@Language("Rust") code: String, type: AttributeType) {

--- a/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/psi/RsAttributeTest.kt
@@ -89,7 +89,7 @@ class RsAttributeTest : RsTestBase() {
         //^
             #![inner]
         }
-    """, Outer)
+    """, Both)
 
     fun `test struct`() = doTest("""
         #[outer]


### PR DESCRIPTION
The change about `RsAttr.owner` most likely doesn't affect users because today it is used exactly in the cases where it works perfectly.

Take into account trait inner attributes like
```rust
trait Foo {
    #![allow(deprecated)]
}
```