### PR TITLE
TOML: add TomlUnresolvedReferenceInspection

### DIFF
--- a/intellij-toml/src/main/kotlin/org/toml/ide/inspections/TomlUnresolvedReferenceInspection.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/ide/inspections/TomlUnresolvedReferenceInspection.kt
@@ -1,0 +1,33 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.ide.inspections
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import org.toml.lang.psi.TomlLiteral
+import org.toml.lang.psi.TomlVisitor
+import org.toml.lang.psi.ext.TomlLiteralKind
+import org.toml.lang.psi.ext.kind
+
+class TomlUnresolvedReferenceInspection : LocalInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : TomlVisitor() {
+            override fun visitLiteral(element: TomlLiteral) {
+                if (element.kind !is TomlLiteralKind.String) return
+                checkReference(element, holder)
+            }
+        }
+    }
+
+    private fun checkReference(element: PsiElement, holder: ProblemsHolder) {
+        element.references
+            .filter { it.resolve() == null }
+            .forEach { holder.registerProblem(it, ProblemsHolder.unresolvedReferenceMessage(it), ProblemHighlightType.LIKE_UNKNOWN_SYMBOL) }
+    }
+}

--- a/intellij-toml/src/main/resources/META-INF/plugin.xml
+++ b/intellij-toml/src/main/resources/META-INF/plugin.xml
@@ -50,5 +50,11 @@
         <annotator language="TOML" implementationClass="org.toml.ide.annotator.TomlAnnotator"/>
         <annotator language="TOML" implementationClass="org.toml.ide.annotator.TomlHighlightingAnnotator"/>
         <extendWordSelectionHandler implementation="org.toml.ide.wordSelection.TomlStringLiteralSelectionHandler"/>
+
+        <localInspection language="TOML"
+                         groupName="TOML"
+                         displayName="Unresolved reference"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.toml.ide.inspections.TomlUnresolvedReferenceInspection"/>
     </extensions>
 </idea-plugin>

--- a/intellij-toml/src/main/resources/inspectionDescriptions/TomlUnresolvedReference.html
+++ b/intellij-toml/src/main/resources/inspectionDescriptions/TomlUnresolvedReference.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Reports unresolved references in TOML files.
+</body>
+</html>

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlUnresolvedPathReferenceInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlUnresolvedPathReferenceInspectionTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+import org.toml.ide.inspections.TomlUnresolvedReferenceInspection
+
+class CargoTomlUnresolvedPathReferenceInspectionTest : RsInspectionsTestBase(TomlUnresolvedReferenceInspection::class) {
+    fun `test build script found`() = checkByFileTree("""
+        //- main.rs
+        fn main() {}
+
+        //- foo.rs
+        fn foo() {}
+
+        //- Cargo.toml
+        [package]
+        name = "example"
+        build = "foo.rs"/*caret*/
+    """)
+
+    fun `test build script not found`() = checkByFileTree("""
+        //- main.rs
+        fn main() {}
+
+        //- Cargo.toml
+        [package]
+        name = "example"
+        build = "<warning descr="Cannot resolve file 'foo.rs'">foo.rs</warning>"/*caret*/
+    """)
+
+    fun `test build script directory`() = checkByFileTree("""
+        //- main.rs
+        fn main() {}
+
+        //- bar/foo.rs
+        fn foo() {}
+
+        //- Cargo.toml
+        [package]
+        name = "example"
+        build = "bar"/*caret*/
+    """)
+
+    fun `test workspace member found`() = checkByFileTree("""
+        //- foo/Cargo.toml
+        [package]
+        name = "foo"
+
+        //- Cargo.toml
+        [workspace]
+        members = [
+            "foo"/*caret*/
+        ]
+    """)
+
+    fun `test workspace member not found`() = checkByFileTree("""
+        //- Cargo.toml
+        [workspace]
+        members = [
+            "<warning descr="Cannot resolve file 'foo'">foo</warning>"/*caret*/
+        ]
+    """)
+
+    fun `test workspace member file`() = checkByFileTree("""
+        //- foo.rs
+        fn foo() {}
+
+        //- Cargo.toml
+        [workspace]
+        members = [
+            "foo.rs"/*caret*/
+        ]
+    """)
+
+    fun `test dependency member found`() = checkByFileTree("""
+        //- foo/Cargo.toml
+        [package]
+        name = "foo"
+
+        //- Cargo.toml
+        [dependencies]
+        foo = { path = "foo" }/*caret*/
+    """)
+
+    fun `test dependency member not found`() = checkByFileTree("""
+        //- Cargo.toml
+        [dependencies]
+        foo = { path = "<warning descr="Cannot resolve file 'foo'">foo</warning>" }/*caret*/
+    """)
+
+    fun `test dependency member file`() = checkByFileTree("""
+        //- foo.rs
+        fn foo() {}
+
+        //- Cargo.toml
+        [dependencies]
+        foo = { path = "foo.rs" }/*caret*/
+    """)
+}


### PR DESCRIPTION
This PR adds an inspection for annotating unresolved references in `TOML` files.

![2021-03-23 20 49 54](https://user-images.githubusercontent.com/2539310/112193848-58fd5300-8c19-11eb-8b60-9124e80b6ea9.gif)

Closes: https://github.com/intellij-rust/intellij-rust/pull/5439
Fixes: https://github.com/intellij-rust/intellij-rust/issues/4144

changelog: Add inspection that annotates invalid references in `TOML` string literals. The inspection can be extended by other plugins. For example, Rust plugin provides file references to local dependency, build script and workspace paths in `Cargo.toml` as well as references to Cargo [features](https://doc.rust-lang.org/cargo/reference/features.html) and the inspection highlights all unresolved ones. Additionally, it provides a quick-fix to create a non-existent file from the corresponding file reference.


