### PR TITLE
COMP: complete more attributes, don't complete outdated ones

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
@@ -147,13 +147,6 @@ object RsPsiPattern {
 
     val onTrait: PsiElementPattern.Capture<PsiElement> = onItem<RsTraitItem>()
 
-    val onDropFn: PsiElementPattern.Capture<PsiElement> = onItem(
-        psiElement<RsFunction>().withSuperParent(
-            2,
-            psiElement<RsImplItem>().withChild(psiElement<RsTraitRef>().withText("Drop"))
-        )
-    )
-
     val onTestFn: PsiElementPattern.Capture<PsiElement> = onItem(psiElement<RsFunction>()
         .withChild(psiElement<RsOuterAttr>().withText("#[test]")))
 

--- a/src/main/kotlin/org/rust/lang/core/completion/RsAttributeCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsAttributeCompletionProvider.kt
@@ -18,7 +18,6 @@ import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.RsPsiPattern.META_ITEM_ATTR
 import org.rust.lang.core.RsPsiPattern.onAnyItem
 import org.rust.lang.core.RsPsiPattern.onCrate
-import org.rust.lang.core.RsPsiPattern.onDropFn
 import org.rust.lang.core.RsPsiPattern.onEnum
 import org.rust.lang.core.RsPsiPattern.onExternBlock
 import org.rust.lang.core.RsPsiPattern.onExternBlockDecl
@@ -47,11 +46,11 @@ object RsAttributeCompletionProvider : RsCompletionProvider() {
     private data class RustAttribute(val name: String, val appliesTo: ElementPattern<PsiElement>)
 
     private val attributes = mapOf(
-        onCrate to "crate_name crate_type feature() no_builtins no_main no_start no_std plugin recursion_limit " +
+        onCrate to "crate_name crate_type feature() no_builtins no_main no_start no_std recursion_limit " +
             "type_length_limit windows_subsystem",
-        onExternCrate to "macro_use macro_reexport no_link",
+        onExternCrate to "macro_use no_link",
         onMod to "no_implicit_prelude path macro_use",
-        onFn to "main plugin_registrar start test cold naked export_name link_section lang inline track_caller " +
+        onFn to "main start test cold naked export_name link_section lang inline track_caller " +
             "panic_handler must_use",
         onTestFn to "should_panic ignore",
         onStaticMut to "thread_local",
@@ -59,12 +58,11 @@ object RsAttributeCompletionProvider : RsCompletionProvider() {
         onExternBlockDecl to "link_name linkage",
         onStruct to "repr() unsafe_no_drop_flags derive() must_use",
         onEnum to "repr() derive() must_use",
-        onTrait to "rustc_on_unimplemented must_use",
+        onTrait to "must_use",
         onMacro to "macro_export",
         onStatic to "export_name link_section used global_allocator",
         onAnyItem to "no_mangle doc cfg() cfg_attr() allow() warn() forbid() deny() deprecated",
         onTupleStruct to "simd",
-        onDropFn to "unsafe_destructor_blind_to_params",
         onStructLike to "non_exhaustive"
     ).flatMap { entry -> entry.value.split(' ').map { attrName -> RustAttribute(attrName, entry.key) } }
 

--- a/src/main/kotlin/org/rust/lang/core/completion/RsAttributeCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsAttributeCompletionProvider.kt
@@ -47,19 +47,21 @@ object RsAttributeCompletionProvider : RsCompletionProvider() {
     private data class RustAttribute(val name: String, val appliesTo: ElementPattern<PsiElement>)
 
     private val attributes = mapOf(
-        onCrate to "crate_name crate_type feature() no_builtins no_main no_start no_std plugin recursion_limit",
+        onCrate to "crate_name crate_type feature() no_builtins no_main no_start no_std plugin recursion_limit " +
+            "type_length_limit windows_subsystem",
         onExternCrate to "macro_use macro_reexport no_link",
         onMod to "no_implicit_prelude path macro_use",
-        onFn to "main plugin_registrar start test cold naked export_name link_section lang inline track_caller",
-        onTestFn to "should_panic",
+        onFn to "main plugin_registrar start test cold naked export_name link_section lang inline track_caller " +
+            "panic_handler must_use",
+        onTestFn to "should_panic ignore",
         onStaticMut to "thread_local",
         onExternBlock to "link_args link() linked_from",
         onExternBlockDecl to "link_name linkage",
-        onStruct to "repr() unsafe_no_drop_flags derive()",
-        onEnum to "repr() derive()",
-        onTrait to "rustc_on_unimplemented",
+        onStruct to "repr() unsafe_no_drop_flags derive() must_use",
+        onEnum to "repr() derive() must_use",
+        onTrait to "rustc_on_unimplemented must_use",
         onMacro to "macro_export",
-        onStatic to "export_name link_section",
+        onStatic to "export_name link_section used global_allocator",
         onAnyItem to "no_mangle doc cfg() cfg_attr() allow() warn() forbid() deny() deprecated",
         onTupleStruct to "simd",
         onDropFn to "unsafe_destructor_blind_to_params",

--- a/src/test/kotlin/org/rust/lang/core/completion/RsAttributeCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsAttributeCompletionTest.kt
@@ -56,11 +56,11 @@ class RsAttributeCompletionTest : RsAttributeCompletionTestBase() {
         struct Bar(u8, u8);
     """)
 
-    fun `test allow on static`() = doSingleAttributeCompletion("""
-        #[allo/*caret*/]
+    fun `test forbid on static`() = doSingleAttributeCompletion("""
+        #[forb/*caret*/]
         static BAR: u8 = 1;
     """, """
-        #[allow(/*caret*/)]
+        #[forbid(/*caret*/)]
         static BAR: u8 = 1;
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
@@ -106,18 +106,6 @@ class RsPsiPatternTest : RsTestBase() {
         struct Foo(u8, u8);
     """, RsPsiPattern.onCrate)
 
-    fun `test on drop fn attr`() = testAttributePattern("""
-        struct HasDrop;
-
-        impl Drop for HasDrop {
-            #[foo]
-            //^
-            fn drop(&mut self) {
-                println!("Dropping!");
-            }
-        }
-    """, RsPsiPattern.onDropFn)
-
     fun `test on enum attr`() = testAttributePattern("""
         #[foo]
         //^


### PR DESCRIPTION
Complete: `type_length_limit`, `windows_subsystem`, `panic_handler`, `must_use` `ignore`, `used`, `global_allocator`

Don't complete: `plugin`, `macro_reexport`, `plugin_registrar`, `rustc_on_unimplemented`, `unsafe_destructor_blind_to_params`

See [built-in attributes index](https://doc.rust-lang.org/reference/attributes.html#built-in-attributes-index)

changelog: Provide completion for more attributes: `type_length_limit`, `windows_subsystem`, `panic_handler`, `must_use` `ignore`, `used`, `global_allocator`