### PR TITLE
RES&COMP: resolve and complete derive attributes under `cfg_attr`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
+++ b/src/main/kotlin/org/rust/lang/core/RsPsiPattern.kt
@@ -175,9 +175,10 @@ object RsPsiPattern {
     val derivedTraitMetaItem: PsiElementPattern.Capture<RsMetaItem> =
         psiElement<RsMetaItem>().withSuperParent(
             2,
-            psiElement()
-                .withSuperParent<RsStructOrEnumItemElement>(2)
-                .with("deriveCondition") { e -> e is RsMetaItem && e.name == "derive" }
+            rootMetaItem("derive").with("item") { _, context ->
+                val attr = context?.get(META_ITEM_ATTR) ?: return@with false
+                attr.owner is RsStructOrEnumItemElement
+            }
         )
 
     /**
@@ -284,9 +285,9 @@ object RsPsiPattern {
     }
 
     private fun metaItem(key: String): PsiElementPattern.Capture<RsMetaItem> =
-        psiElement<RsMetaItem>().withChild(
-            psiElement<RsPath>().withText(key)
-        )
+        psiElement<RsMetaItem>().with("MetaItemName") { item, _ ->
+            item.name == key
+        }
 
     /** @see RsMetaItem.isRootMetaItem */
     private fun rootMetaItem(key: String): PsiElementPattern.Capture<RsMetaItem> =

--- a/src/test/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProviderTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.lang.core.completion
 
+import org.rust.MockAdditionalCfgOptions
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.core.resolve.KnownDerivableTrait
@@ -128,4 +129,27 @@ class RsDeriveCompletionProviderTest : RsCompletionTestBase() {
         #[derive(std::marker::Clo/*caret*/)]
         struct S;
     """)
+
+    fun `test complete in cfg_attr`() = doSingleCompletion("""
+        #[cfg_attr(windows, derive(Debu/*caret*/))]
+        struct Test {
+            foo: u8
+        }
+    """, """
+        #[cfg_attr(windows, derive(Debug/*caret*/))]
+        struct Test {
+            foo: u8
+        }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test no completion if already derived under cfg_attr`() = expect<IllegalStateException> {
+    checkNoCompletion("""
+        #[cfg_attr(intellij_rust, derive(Debug))]
+        #[cfg_attr(intellij_rust, derive(Debu/*caret*/))]
+        struct Test {
+            foo: u8
+        }
+    """)
+    }
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
@@ -341,6 +341,12 @@ class RsPsiPatternTest : RsTestBase() {
         struct Foo(i32);
     """, RsPsiPattern.derivedTraitMetaItem)
 
+    fun `test derived trait meta item in cfg_attr`() = testPattern("""
+        #[cfg_attr(unix, derive(Debug))]
+                                //^
+        struct Foo(i32);
+    """, RsPsiPattern.derivedTraitMetaItem)
+
     fun `test literal in include macro`() = testPattern("""
         include!("foo.rs");
                   //^

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -5,7 +5,10 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.*
+import org.rust.ExpandMacros
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.WithStdlibWithSymlinkRustProjectDescriptor
 import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.types.infer.TypeInferenceMarks
 import org.rust.stdext.BothEditions
@@ -429,6 +432,13 @@ class RsStdlibResolveTest : RsResolveTestBase() {
     //- main.rs
         #[derive(r#Debug)]
                  //^ ...libcore/fmt/mod.rs|...core/src/fmt/mod.rs
+        struct Foo;
+    """)
+
+    fun `test derive trait in cfg_attr`() = stubOnlyResolve("""
+    //- main.rs
+        #[cfg_attr(unix, derive(Debug))]
+                              //^ ...libcore/fmt/mod.rs|...core/src/fmt/mod.rs
         struct Foo;
     """)
 


### PR DESCRIPTION
Make resolve and complete works for `derive()` inside `cfg_attr`: `#[cfg_attr(foobar, derive(...))]`