### PR TITLE
FIX: do not offer create method intention on foreign types

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/CreateFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/CreateFunctionIntention.kt
@@ -75,6 +75,7 @@ class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionInten
 
             val name = methodCall.identifier.text
             val type = methodCall.parentDotExpr.expr.type.stripReferences() as? TyAdt ?: return null
+            if (type.item.containingCargoPackage?.origin != PackageOrigin.WORKSPACE) return null
 
             text = "Create method `$name`"
             return Context.Method(methodCall, name, type.item)

--- a/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
@@ -5,6 +5,9 @@
 
 package org.rust.ide.intentions
 
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+
 class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention::class) {
     fun `test function availability range`() = checkAvailableInSelectionOnly("""
         fn main() {
@@ -37,6 +40,21 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
     fun `test unavailable on path argument`() = doUnavailableTest("""
         fn main() {
             foo(bar::baz/*caret*/);
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test create function unavailable on std`() = doUnavailableTest("""
+        fn main() {
+            std::foo/*caret*/();
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test create method unavailable on std`() = doUnavailableTest("""
+        fn main() {
+            let v: Vec<u32> = Vec::new();
+            v.foo/*caret*/();
         }
     """)
 


### PR DESCRIPTION
The `CreateFunctionIntention` checks that the target module is from the user's workspace, but this check was missing for creating methods. This PR fixes that.

changelog: Create method intention is no longer offered for types from external or std crates.
