### PR TITLE
ANN: support fields under `cfg` attribute in E0023 detection

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -223,7 +223,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
             extraFields.forEach { RsDiagnostic.ExtraFieldInStructPattern(it, "struct").addToHolder(holder) }
 
             val bodyFieldNames = bodyFields.map { it.kind.fieldName }
-            val missingFields = declaration.fields.filter { it.name !in bodyFieldNames && !it.queryAttributes.hasCfgAttr() }
+            val missingFields = declaration.fields.filter { it.name !in bodyFieldNames }
 
             if (missingFields.isNotEmpty() && patStruct.patRest == null) {
                 RsDiagnostic.MissingFieldsInStructPattern(patStruct, declaration, missingFields).addToHolder(holder)

--- a/src/main/kotlin/org/rust/ide/utils/StructFieldsExpander.kt
+++ b/src/main/kotlin/org/rust/ide/utils/StructFieldsExpander.kt
@@ -42,7 +42,7 @@ fun expandStructFields(factory: RsPsiFactory, patStruct: RsPatStruct) {
     val existingFields = patStruct.patFieldList
     val bodyFieldNames = existingFields.map { it.kind.fieldName }.toSet()
     val missingFields = declaration.fields
-        .filter { it.name !in bodyFieldNames && !it.queryAttributes.hasCfgAttr() }
+        .filter { it.name !in bodyFieldNames }
         .map { factory.createPatField(it.name!!) }
 
     if (existingFields.isEmpty()) {

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -3225,11 +3225,11 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
-    fun `test no error on missing field with cfg-attribute`() = checkErrors("""
+    fun `test no error on missing field under disabled cfg-attribute`() = checkErrors("""
         struct Foo {
             a: i32,
             b: i32,
-            #[cfg(foo)]
+            #[cfg(intellij_rust)]
             c: i32,
         }
 

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsPatFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddStructFieldsPatFixTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.annotator.fixes
 
+import org.rust.MockAdditionalCfgOptions
 import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsErrorAnnotator
 
@@ -277,6 +278,28 @@ class AddStructFieldsPatFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             match x {
                 Foo::Bar(a, _0/*caret*/, _1) => {}
             }
+        }
+        """
+    )
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test 123`() = checkFixByText("Add missing fields", """
+        struct Foo {
+            a: i32,
+            #[cfg(intellij_rust)]
+            b: i32,
+        }
+        fn main() {
+            let <error>Foo { a }/*caret*/</error> = foo;
+        }
+        """, """
+        struct Foo {
+            a: i32,
+            #[cfg(intellij_rust)]
+            b: i32,
+        }
+        fn main() {
+            let Foo { a, b }/*caret*/ = foo;
         }
         """
     )


### PR DESCRIPTION
... and `Add missing fields` quick fix.

Improves #3996 to better work with fields under `#[cfg]`

changelog: Fix `cfg` attributes support in `E0023` detection and a corresponding quick fix.