### PR TITLE
Support function parameters under cfg attributes

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/TestCargoProjectsServiceImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/TestCargoProjectsServiceImpl.kt
@@ -77,7 +77,14 @@ class TestCargoProjectsServiceImpl(project: Project) : CargoProjectsServiceImpl(
     }
 
     @TestOnly
-    fun setCfgOptions(cfgOptions: CfgOptions) {
+    fun setCfgOptions(cfgOptions: CfgOptions, parentDisposable: Disposable) {
+        setCfgOptionsInner(cfgOptions)
+        Disposer.register(parentDisposable, Disposable {
+            setCfgOptionsInner(CfgOptions.DEFAULT)
+        })
+    }
+
+    private fun setCfgOptionsInner(cfgOptions: CfgOptions) {
         modifyProjectsSync { projects ->
             val updatedProjects = projects.map { project ->
                 val ws = project.workspace?.withCfgOptions(cfgOptions)

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1262,7 +1262,7 @@ private fun AnnotationSession.duplicatesByNamespace(
             + importedNames)
             .filter { it !is RsExternCrateItem } // extern crates can have aliases.
             .filter { it.nameOrImportedName() != null }
-            .filter { it !is RsDocAndAttributeOwner || (it.isEnabledByCfg && !it.isCfgUnknown) }
+            .filter { it.isEnabledByCfg && !it.isCfgUnknown }
             .flatMap { it.namespaced() }
             .groupBy { it.first }       // Group by namespace
             .map { entry ->
@@ -1315,7 +1315,7 @@ private fun RsCallExpr.expectedParamsCount(): Pair<Int, FunctionType>? {
         is RsFunction -> {
             val owner = el.owner
             if (owner.isTraitImpl) return null
-            val count = el.valueParameterList?.valueParameterList?.size ?: return null
+            val count = el.valueParameters.size
             val s = if (el.selfParameter != null) 1 else 0
             val functionType = if (el.isVariadic) {
                 FunctionType.VARIADIC_FUNCTION

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddSelfFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddSelfFix.kt
@@ -12,7 +12,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsPsiFactory
-import org.rust.lang.core.psi.ext.valueParameters
+import org.rust.lang.core.psi.ext.rawValueParameters
 
 class AddSelfFix(function: RsFunction) : LocalQuickFixAndIntentionActionOnPsiElement(function) {
     override fun getFamilyName() = "Add self to function"
@@ -21,7 +21,7 @@ class AddSelfFix(function: RsFunction) : LocalQuickFixAndIntentionActionOnPsiEle
 
     override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
         val function = startElement as RsFunction
-        val hasParameters = function.valueParameters.isNotEmpty()
+        val hasParameters = function.rawValueParameters.isNotEmpty()
         val psiFactory = RsPsiFactory(project)
 
         val valueParameterList = function.valueParameterList

--- a/src/main/kotlin/org/rust/ide/intentions/CreateFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/CreateFunctionIntention.kt
@@ -87,7 +87,7 @@ class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionInten
         val inserted = insertCallable(ctx, function) ?: return
 
         if (inserted.containingFile == ctx.callElement.containingFile) {
-            val toBeReplaced = inserted.valueParameters.flatMap { listOfNotNull(it.pat, it.typeReference) } +
+            val toBeReplaced = inserted.rawValueParameters.flatMap { listOfNotNull(it.pat, it.typeReference) } +
                 listOfNotNull(inserted.block?.expr)
             editor.buildAndRunTemplate(inserted, toBeReplaced.map { it.createSmartPointer() })
         } else {

--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
@@ -76,7 +76,7 @@ class RsExtractFunctionHandler : RefactoringActionHandler {
      * Then it is necessary to change the names of original parameters to the real (renamed) parameters' names.
      */
     private fun renameFunctionParameters(function: RsFunction, newNames: List<String>) {
-        val parameters = function.valueParameters
+        val parameters = function.rawValueParameters
             .map { it.pat }
             .filterIsInstance(RsPatIdent::class.java)
             .map { it.patBinding }

--- a/src/main/kotlin/org/rust/ide/refactoring/introduceParameter/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/introduceParameter/impl.kt
@@ -170,7 +170,7 @@ private class ParamIntroducer(
     }
 
     private fun introduceParam(func: RsFunction, name: String, typeRef: RsTypeReference): PsiElement? {
-        val params = func.valueParameters
+        val params = func.rawValueParameters
         val parent = func.valueParameterList ?: return null
         val newParam = createParam(name, typeRef)
         return if (params.isEmpty()) {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -73,7 +73,20 @@ val RsFunction.abiName: String?
         return stub?.abiName ?: abi?.stringLiteral?.text
     }
 
+/**
+ * Those function parameters that are not disabled by cfg attributes.
+ *
+ * Should be used in code analysis: name resolution, type inference, inspections, annotations, etc.
+ */
 val RsFunction.valueParameters: List<RsValueParameter>
+    get() = rawValueParameters.filter { it.isEnabledByCfgSelf }
+
+/**
+ * All function parameters.
+ *
+ * Should be used in code (PSI) manipulations: intentions, quick-fixes, refactorings, code generation, etc.
+ */
+val RsFunction.rawValueParameters: List<RsValueParameter>
     get() = valueParameterList?.valueParameterList.orEmpty()
 
 val RsFunction.selfParameter: RsSelfParameter?

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -119,7 +119,7 @@ abstract class RsTestBase : RsPlatformTestBase() {
             CfgOptions.DEFAULT.keyValueOptions,
             CfgOptions.DEFAULT.nameOptions + additionalOptions
         )
-        project.testCargoProjects.setCfgOptions(allOptions)
+        project.testCargoProjects.setCfgOptions(allOptions, testRootDisposable)
     }
 
     private fun parse(version: String): Pair<SemVer, RustChannel> {

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/AddSelfTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/AddSelfTest.kt
@@ -44,4 +44,22 @@ class AddSelfTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             }
         }
     """)
+
+    fun `test has parameters under cfg`() = checkFixByText("Add self to function", """
+        struct S;
+
+        impl S {
+            fn foo(#[cfg(intellij_rust)] a: i32) {
+                <error>self/*caret*/</error>;
+            }
+        }
+    """, """
+        struct S;
+
+        impl S {
+            fn foo(&self, #[cfg(intellij_rust)] a: i32) {
+                self/*caret*/;
+            }
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHintsProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHintsProviderTest.kt
@@ -8,6 +8,7 @@ package org.rust.ide.hints.parameter
 import com.intellij.codeInsight.daemon.impl.HintRenderer
 import com.intellij.openapi.vfs.VirtualFileFilter
 import org.intellij.lang.annotations.Language
+import org.rust.MockAdditionalCfgOptions
 import org.rust.RsTestBase
 import org.rust.fileTreeFromText
 import org.rust.lang.core.psi.RsMethodCall
@@ -21,6 +22,16 @@ class RsInlayParameterHintsProviderTest : RsTestBase() {
     fun `test arg out of bounds`() = checkByText("""
         fn foo(arg: u32) {}
         fn main() { foo(/*hint text="arg:"*/0, 1); }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test fn args with cfg`() = checkByText("""
+        fn foo(
+            #[cfg(not(intellij_rust))] arg1: u16,
+            #[cfg(intellij_rust)]      arg2: u32,
+            arg3: u64,
+        ) {}
+        fn main() { foo(/*hint text="arg2:"*/0, /*hint text="arg3:"*/1); }
     """)
 
     fun `test method args`() = checkByText("""

--- a/src/test/kotlin/org/rust/ide/inspections/RsTraitImplementationInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsTraitImplementationInspectionTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.ide.inspections
 
+import org.rust.MockAdditionalCfgOptions
+
 class RsTraitImplementationInspectionTest : RsInspectionsTestBase(RsTraitImplementationInspection::class) {
 
     fun `test self in trait not in impl E0186`() = checkErrors("""
@@ -64,6 +66,30 @@ class RsTraitImplementationInspectionTest : RsInspectionsTestBase(RsTraitImpleme
             fn bar<error descr="Method `bar` has 2 parameters but the declaration in trait `T` has 1 [E0050]">(a: u32, b: bool)</error> {}
             fn baz<error descr="Method `baz` has 0 parameters but the declaration in trait `T` has 3 [E0050]">()</error> {}
             fn boo<error descr="Method `boo` has 2 parameters but the declaration in trait `T` has 1 [E0050]">(&self, o: isize, x: f16)</error> {}
+        }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test incorrect params number in trait impl E0050 with cfg attributes`() = checkErrors("""
+        trait T {
+            fn foo(#[cfg(intellij_rust)] a: i32);
+            fn bar(#[cfg(not(intellij_rust))] a: i32);
+            fn baz(#[cfg(intellij_rust)] a: i32, #[cfg(not(intellij_rust))] a: u32);
+            fn quux(#[cfg(not(intellij_rust))] a: i32, #[cfg(intellij_rust)] a: u32);
+        }
+        struct S1;
+        impl T for S1 {
+            fn foo(a: i32) {}
+            fn bar() {}
+            fn baz(a: i32);
+            fn quux(a: u32);
+        }
+        struct S2;
+        impl T for S2 {
+            fn foo(#[cfg(intellij_rust)] a: i32) {}
+            fn bar(#[cfg(not(intellij_rust))] a: i32) {}
+            fn baz(#[cfg(intellij_rust)] a: i32, #[cfg(not(intellij_rust))] a: i32) {}
+            fn quux(#[cfg(not(intellij_rust))] a: i32, #[cfg(intellij_rust)] a: u32);
         }
     """)
 

--- a/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/UnElideLifetimesIntentionTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.ide.intentions
 
+import org.rust.MockAdditionalCfgOptions
+
 class UnElideLifetimesIntentionTest : RsIntentionTestBase(UnElideLifetimesIntention::class) {
     fun `test unavailable without references`() = doUnavailableTest("""
         fn bar/*caret*/(x: i32) -> i32 {}
@@ -27,6 +29,11 @@ class UnElideLifetimesIntentionTest : RsIntentionTestBase(UnElideLifetimesIntent
 
     fun `test unavailable with explicit lifetime`() = doUnavailableTest("""
         fn bar<'a>(x: &'a /*caret*/ i32) {}
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test unavailable if there are parameters under cfg attributes`() = doUnavailableTest("""
+        fn foo(#[cfg(intellij_rust)] p: &/*caret*/ i32, #[cfg(not(intellij_rust))] p: &/*caret*/ u32) -> & i32 { p }
     """)
 
     fun `test simple`() = doAvailableTest("""

--- a/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceParameterTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsIntroduceParameterTest.kt
@@ -5,6 +5,7 @@
 package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
+import org.rust.MockAdditionalCfgOptions
 import org.rust.RsTestBase
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsFunction
@@ -27,6 +28,17 @@ class RsIntroduceParameterTest : RsTestBase() {
     """, listOf("10", "param + 10"), 0, 0, """
         fn hello(param: i32, /*caret*/i: i32) {
             let result = param + i;
+        }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test function with a cfg disabled params`() = doTest("""
+        fn hello(#[cfg(not(intellij_rust))] param: i32) {
+            foo(5 + /*caret*/10);
+        }
+    """, listOf("10", "5 + 10", "foo(5 + 10)"), 0, 0, """
+        fn hello(#[cfg(not(intellij_rust))] param: i32, /*caret*/i: i32) {
+            foo(5 + i);
         }
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/type/RsCfgAttrTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsCfgAttrTypeInferenceTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.type
+
+import org.rust.MockAdditionalCfgOptions
+
+class RsCfgAttrTypeInferenceTest : RsTypificationTestBase() {
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test function parameter under cfg 1`() = testExpr("""
+        fn foo(
+            #[cfg(intellij_rust)]      a: u8,
+            #[cfg(not(intellij_rust))] a: i8,
+        ) {}
+        fn main() {
+            let a = 0;
+            foo(a);
+            a;
+        } //^ u8
+    """)
+
+    fun `test function parameter under cfg 2`() = testExpr("""
+        fn foo(
+            #[cfg(intellij_rust)]      a: u8,
+            #[cfg(not(intellij_rust))] a: i8,
+        ) {}
+        fn main() {
+            let a = 0;
+            foo(a);
+            a;
+        } //^ i8
+    """)
+}


### PR DESCRIPTION
Fixes #6148

Correctly handle function parameters under `cfg` attributes in type inference and annotators. Works for:

```rust
fn foo(
    #[cfg(foo)]      a: u8,
    #[cfg(not(foo))] a: i8,
) {}
```

Note that it doesn't works `implement members` quick fix/action because it doesn't support any attributes at all. it should be fixed separately.

`self` parameter can also be under cfg. This case is not covered.

### Implementation details

There is `RsFunction.valueParameters` that resturns function parameter list after `cfg` evaluation and  should be used in type inference/inspections/annotatos/etc, and there is `RsFunction.rawValueParameters` that resturns function parameter list **without** `cfg` evaluation and should be used in PSI manipulations

changelog: Support function parameters under `#[cfg()]` attributes