### PR TITLE
ANN: do not annotate unimplemented cfg-disabled trait items

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsAbstractable.kt
@@ -14,7 +14,7 @@ import org.rust.lang.core.psi.*
 import org.rust.openapiext.filterQuery
 import org.rust.openapiext.mapQuery
 
-interface RsAbstractable : RsNameIdentifierOwner, RsExpandedElement, RsVisible {
+interface RsAbstractable : RsNameIdentifierOwner, RsExpandedElement, RsVisible, RsDocAndAttributeOwner {
     val isAbstract: Boolean
 }
 

--- a/src/test/kotlin/org/rust/ide/inspections/RsTraitImplementationInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsTraitImplementationInspectionTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.ide.inspections
 
+import org.rust.MockAdditionalCfgOptions
+
 class RsTraitImplementationInspectionTest : RsInspectionsTestBase(RsTraitImplementationInspection::class) {
 
     fun `test self in trait not in impl E0186`() = checkErrors("""
@@ -96,5 +98,16 @@ class RsTraitImplementationInspectionTest : RsInspectionsTestBase(RsTraitImpleme
         <error descr="Not all trait items implemented, missing: `C` [E0046]">impl A for ()</error> {
             type C = ();
         }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test ignore cfg-disabled item without a default`() = checkErrors("""
+        trait A {
+            #[cfg(intellij_rust)]
+            fn foo() {}
+            #[cfg(not(intellij_rust))]
+            fn foo();
+        }
+        impl A for () {}
     """)
 }


### PR DESCRIPTION
Do not annotate or offer cfg-disabled trait items for [E0046](https://doc.rust-lang.org/error-index.html#E0046) and `Generate members`.
![cfg-impl](https://user-images.githubusercontent.com/4539057/101326901-3a439e00-386e-11eb-92e3-27f4b584e315.gif)

Fixes: https://github.com/intellij-rust/intellij-rust/issues/1470

changelog: Better handle cfg-disabled items when checking [E0046](https://doc.rust-lang.org/error-index.html#E0046).
