### PR TITLE
QDOC: show documentation for keyword like elements

### DIFF
--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -142,15 +142,15 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
     }
 
     override fun getDocumentationElementForLink(psiManager: PsiManager, link: String, context: PsiElement): PsiElement? {
-        if (context !is RsElement) return null
+        val element = context as? RsElement ?: context.parent as? RsElement ?: return null
         val qualifiedName = RsQualifiedName.from(link)
         return if (qualifiedName == null) {
             RsCodeFragmentFactory(context.project)
-                .createPath(link, context)
+                .createPath(link, element)
                 ?.reference
                 ?.resolve()
         } else {
-            qualifiedName.findPsiElement(psiManager, context)
+            qualifiedName.findPsiElement(psiManager, element)
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/docs/RsDocumentationProvider.kt
@@ -8,6 +8,7 @@ package org.rust.ide.docs
 import com.intellij.codeInsight.documentation.DocumentationManagerUtil
 import com.intellij.lang.documentation.AbstractDocumentationProvider
 import com.intellij.lang.documentation.DocumentationMarkup
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapiext.Testmark
 import com.intellij.openapiext.hitOnFalse
@@ -38,7 +39,7 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
             is RsDocAndAttributeOwner -> generateDoc(element, buffer)
             is RsPatBinding -> definition(buffer) { generateDoc(element, it) }
             is RsPath -> generateDoc(element, buffer)
-            else -> return null
+            else -> generateCustomDoc(element, buffer)
         }
         return if (buffer.isEmpty()) null else buffer.toString()
     }
@@ -122,6 +123,24 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
         content(buffer) { it += mod.documentationAsHtml(element) }
     }
 
+    private fun generateCustomDoc(element: PsiElement, buffer: StringBuilder) {
+        if (element.isKeywordLike()) {
+            val keywordDocs = element.project.findFileInStdCrate("keyword_docs.rs") ?: return
+            val keywordName = element.text
+            val mod = keywordDocs.childrenOfType<RsModItem>().find {
+                it.queryAttributes.hasAttributeWithKeyValue("doc", "keyword", keywordName)
+            } ?: return
+
+            definition(buffer) {
+                it += STD
+                it += "\n"
+                it += "keyword "
+                it.b { it += keywordName }
+            }
+            content(buffer) { it += mod.documentationAsHtml(element) }
+        }
+    }
+
     override fun getDocumentationElementForLink(psiManager: PsiManager, link: String, context: PsiElement): PsiElement? {
         if (context !is RsElement) return null
         val qualifiedName = RsQualifiedName.from(link)
@@ -136,14 +155,15 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
     }
 
     override fun getUrlFor(element: PsiElement, originalElement: PsiElement?): List<String> {
-        val (qualifiedName, origin) = if (element is RsPath) {
-            (RsQualifiedName.from(element) ?: return emptyList()) to STDLIB
-        } else {
-            if (element !is RsDocAndAttributeOwner ||
-                element !is RsQualifiedNamedElement ||
-                !element.hasExternalDocumentation) return emptyList()
-            val origin = element.containingCrate?.origin
-            RsQualifiedName.from(element) to origin
+        val (qualifiedName, origin) = when {
+            element is RsDocAndAttributeOwner && element is RsQualifiedNamedElement && element.hasExternalDocumentation -> {
+                val origin = element.containingCrate?.origin
+                RsQualifiedName.from(element) to origin
+            }
+            else -> {
+                val qualifiedName = RsQualifiedName.from(element) ?: return emptyList()
+                qualifiedName to STDLIB
+            }
         }
 
         val pagePrefix = when (origin) {
@@ -165,6 +185,18 @@ class RsDocumentationProvider : AbstractDocumentationProvider() {
 
         val pagePath = qualifiedName?.toUrlPath() ?: return emptyList()
         return listOf("$pagePrefix/$pagePath")
+    }
+
+    override fun getCustomDocumentationElement(
+        editor: Editor,
+        file: PsiFile,
+        contextElement: PsiElement?,
+        targetOffset: Int
+    ): PsiElement? {
+        // Don't show documentation for keywords like `self`, `super`, etc. when they are part of path.
+        // We want to show documentation for the corresponding item that path references to
+        if (contextElement?.isKeywordLike() == true && contextElement.parent !is RsPath) return contextElement
+        return null
     }
 
     @Suppress("UnstableApiUsage")

--- a/src/main/kotlin/org/rust/lang/core/psi/RsTokenType.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsTokenType.kt
@@ -22,10 +22,10 @@ open class RsTokenType(debugName: String) : IElementType(debugName, RsLanguage)
 fun tokenSetOf(vararg tokens: IElementType) = TokenSet.create(*tokens)
 
 val RS_KEYWORDS = tokenSetOf(
-    AS,
+    AS, ASYNC, AUTO,
     BOX, BREAK,
     CONST, CONTINUE, CRATE, CSELF,
-    DEFAULT,
+    DEFAULT, DYN,
     ELSE, ENUM, EXTERN,
     FN, FOR,
     IF, IMPL, IN,
@@ -33,7 +33,7 @@ val RS_KEYWORDS = tokenSetOf(
     LET, LOOP,
     MATCH, MOD, MOVE, MUT,
     PUB,
-    REF, RETURN,
+    RAW, REF, RETURN,
     SELF, STATIC, STRUCT, SUPER,
     TRAIT, TYPE_KW,
     UNION, UNSAFE, USE,

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -16,8 +16,8 @@ import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.PsiUtilCore
 import com.intellij.util.SmartList
-import org.rust.lang.core.psi.RsFile
-import org.rust.lang.core.psi.RsReplCodeFragment
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.openapiext.document
 import org.rust.openapiext.findDescendantsWithMacrosOfAnyType
@@ -285,3 +285,16 @@ fun PsiWhiteSpace.isMultiLine(): Boolean = getLineCount() > 1
 @Suppress("UNCHECKED_CAST")
 inline val <T : StubElement<*>> StubBasedPsiElement<T>.greenStub: T?
     get() = (this as? StubBasedPsiElementBase<T>)?.greenStub
+
+fun PsiElement.isKeywordLike(): Boolean {
+    return when (elementType) {
+        in RS_KEYWORDS,
+        RsElementTypes.BOOL_LITERAL -> true
+        RsElementTypes.IDENTIFIER -> {
+            val parent = parent as? RsFieldLookup ?: return false
+            if (parent.edition == CargoWorkspace.Edition.EDITION_2015) return false
+            text == "await"
+        }
+        else -> false
+    }
+}

--- a/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlStdTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsExternalDocUrlStdTest.kt
@@ -6,8 +6,10 @@
 package org.rust.ide.docs
 
 import junit.framework.AssertionFailedError
+import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.cargo.project.workspace.CargoWorkspace
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsExternalDocUrlStdTest : RsDocumentationProviderTest() {
@@ -105,4 +107,24 @@ class RsExternalDocUrlStdTest : RsDocumentationProviderTest() {
         fn foo() -> bool {}
                    //^
     """, "https://doc.rust-lang.org/std/primitive.bool.html")
+
+    fun `test keyword`() = doUrlTestByText("""
+        struct Foo;
+          //^
+    """, "https://doc.rust-lang.org/std/keyword.struct.html")
+
+    fun `test boolean value`() = doUrlTestByText("""
+        fn main() {
+            let a = true;
+                   //^
+        }
+    """, "https://doc.rust-lang.org/std/keyword.true.html")
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test await`() = doUrlTestByText("""
+        fn main() {
+            foo().await;
+                 //^
+        }
+    """, "https://doc.rust-lang.org/std/keyword.await.html")
 }

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -1105,6 +1105,26 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         keyword <b>enum</b></pre></div><div class='content'><p>.+</p></div>
     """)
 
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test async keyword doc`() = doTestRegex("""
+        async fn foo() {}
+        //^
+    """, """
+        <div class='definition'><pre>std
+        keyword <b>async</b></pre></div><div class='content'><p>.+</p></div>
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test dyn keyword doc`() = doTestRegex("""
+        trait Foo {}
+        fn foo(x: &dyn Foo) {}
+                 //^
+    """, """
+        <div class='definition'><pre>std
+        keyword <b>dyn</b></pre></div><div class='content'><p>.+</p></div>
+    """)
+
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test boolean value doc`() = doTestRegex("""
         fn main() {

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -7,10 +7,7 @@ package org.rust.ide.docs
 
 import com.intellij.psi.PsiElement
 import org.intellij.lang.annotations.Language
-import org.rust.ExpandMacros
-import org.rust.MockEdition
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.lang.core.psi.RsBaseType
 import org.rust.lang.core.psi.RsConstant
@@ -1105,6 +1102,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         keyword <b>enum</b></pre></div><div class='content'><p>.+</p></div>
     """)
 
+    @MinRustcVersion("1.36.0")
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test async keyword doc`() = doTestRegex("""
@@ -1115,6 +1113,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         keyword <b>async</b></pre></div><div class='content'><p>.+</p></div>
     """)
 
+    @MinRustcVersion("1.36.0")
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test dyn keyword doc`() = doTestRegex("""
         trait Foo {}
@@ -1125,6 +1124,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         keyword <b>dyn</b></pre></div><div class='content'><p>.+</p></div>
     """)
 
+    @MinRustcVersion("1.36.0")
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test boolean value doc`() = doTestRegex("""
         fn main() {
@@ -1145,6 +1145,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         }
     """, null)
 
+    @MinRustcVersion("1.36.0")
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test await doc 2`() = doTestRegex("""

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -8,8 +8,10 @@ package org.rust.ide.docs
 import com.intellij.psi.PsiElement
 import org.intellij.lang.annotations.Language
 import org.rust.ExpandMacros
+import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.lang.core.psi.RsBaseType
 import org.rust.lang.core.psi.RsConstant
 import org.rust.lang.core.psi.ext.RsElement
@@ -1094,6 +1096,63 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         originalElement to originalElement.textOffset
     }
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test keyword doc`() = doTestRegex("""
+        enum Foo { V1 }
+        //^
+    """, """
+        <div class='definition'><pre>std
+        keyword <b>enum</b></pre></div><div class='content'><p>.+</p></div>
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test boolean value doc`() = doTestRegex("""
+        fn main() {
+            let a = false;
+                    //^
+        }
+    """, """
+        <div class='definition'><pre>std
+        keyword <b>false</b></pre></div><div class='content'><p>.+</p></div>
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2015)
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test await doc 1`() = doTest("""
+        fn main() {
+            foo().await;
+                  //^
+        }
+    """, null)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test await doc 2`() = doTestRegex("""
+        fn main() {
+            foo().await;
+                  //^
+        }
+    """, """
+        <div class='definition'><pre>std
+        keyword <b>await</b></pre></div><div class='content'><p>.+</p></div>
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test keyword doc in stdlib`() = doTestRegex("""
+        const C: u32 = std::f64::DIGITS;
+                                //^
+    """, """
+        <div class='definition'><pre>std
+        keyword <b>const</b></pre></div><div class='content'><p>.+</p></div>
+    """) {
+        val element = findElementWithDataAndOffsetInEditor<RsElement>().first
+        val const = element.reference?.resolve() as? RsConstant ?: error("Failed to resolve `${element.text}`")
+        val originalElement = const.const!!
+
+        myFixture.openFileInEditor(const.containingFile.virtualFile)
+        originalElement to originalElement.textOffset
+    }
+
     @ExpandMacros
     fun `test documentation provided via macro definition 1`() = doTest("""
         macro_rules! foobar {
@@ -1167,12 +1226,12 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
     """)
 
 
-    private fun doTest(@Language("Rust") code: String, @Language("Html") expected: String)
+    private fun doTest(@Language("Rust") code: String, @Language("Html") expected: String?)
         = doTest(code, expected, block = RsDocumentationProvider::generateDoc)
 
     private fun doTestRegex(
         @Language("Rust") code: String,
         @Language("Html") expected: String,
         findElement: () -> Pair<PsiElement, Int> = { findElementAndOffsetInEditor() }
-    ) = doTest(code, Regex(expected.trimIndent(), RegexOption.MULTILINE), findElement, RsDocumentationProvider::generateDoc)
+    ) = doTest(code, Regex(expected.trimIndent(), setOf(RegexOption.MULTILINE, RegexOption.DOT_MATCHES_ALL)), findElement, RsDocumentationProvider::generateDoc)
 }


### PR DESCRIPTION
Current changes allow opening quick documentation for [keyword](https://doc.rust-lang.org/stable/std/#keywords) like elements.
But for `self`, `super`, `crate` and `Self` documentation won't be shown if they are part of a path. I suppose documentation for the referenced element is more important than documentation about keywords in such cases

Note, currently, if documentation contains a link to a keyword, the plugin can't open the corresponding quick doc. Will be fixed in separate PR.

changelog: show [quick documentation](https://www.jetbrains.com/help/idea/viewing-reference-information.html#inline-quick-documentation) for [keyword](https://doc.rust-lang.org/stable/std/#keywords) like elements like `fn`, `enum`, `async`, etc.