### PR TITLE
Support `cfg_attr` attributes

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
@@ -152,7 +152,7 @@ private val RsItemsOwner.firstItem: RsElement get() = itemsAndMacros.first { it 
 val <T : RsElement> List<T>.lastElement: T? get() = maxBy { it.textOffset }
 
 val RsElement.stdlibAttributes: RsFile.Attributes
-    get() = (crateRoot?.containingFile as? RsFile)?.attributes ?: RsFile.Attributes.NONE
+    get() = (crateRoot?.containingFile as? RsFile)?.stdlibAttributes ?: RsFile.Attributes.NONE
 
 val Crate.isStd: Boolean
     get() = origin == PackageOrigin.STDLIB && normName == AutoInjectedCrates.STD

--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -195,14 +195,17 @@ class RsFile(
         return declaration?.isPublic ?: false
     }
 
-    val attributes: Attributes
-        get() {
-            val stub = greenStub as RsFileStub?
-            if (stub != null) return stub.attributes
-            if (queryAttributes.hasAtomAttribute("no_core")) return Attributes.NO_CORE
-            if (queryAttributes.hasAtomAttribute("no_std")) return Attributes.NO_STD
-            return Attributes.NONE
-        }
+    val stdlibAttributes: Attributes
+        get() = getStdlibAttributes(null)
+
+    fun getStdlibAttributes(crate: Crate?): Attributes {
+        val stub = greenStub as RsFileStub?
+        if (stub?.mayHaveStdlibAttributes == false) return Attributes.NONE
+        val attributes = getQueryAttributes(crate)
+        if (attributes.hasAtomAttribute("no_core")) return Attributes.NO_CORE
+        if (attributes.hasAtomAttribute("no_std")) return Attributes.NO_STD
+        return Attributes.NONE
+    }
 
     val declaration: RsModDeclItem? get() = declarations.firstOrNull()
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsExternCrateItem.kt
@@ -20,8 +20,10 @@ import org.rust.lang.core.stubs.RsExternCrateItemStub
 val RsExternCrateItem.nameWithAlias: String get() = alias?.name ?: referenceName
 val RsExternCrateItemStub.nameWithAlias: String get() = alias?.name ?: name
 
-val RsExternCrateItem.hasMacroUse: Boolean get() =
-    greenStub?.hasMacroUse ?: queryAttributes.hasAttribute("macro_use")
+val RsExternCrateItem.hasMacroUse: Boolean get() = EXTERN_CRATE_HAS_MACRO_USE_PROP.getByPsi(this)
+
+val EXTERN_CRATE_HAS_MACRO_USE_PROP: StubbedAttributeProperty<RsExternCrateItem, RsExternCrateItemStub> =
+    StubbedAttributeProperty({ it.hasAttribute("macro_use") }, RsExternCrateItemStub::mayHaveMacroUse)
 
 abstract class RsExternCrateItemImplMixin : RsStubbedNamedElementImpl<RsExternCrateItemStub>,
                                             RsExternCrateItem {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
@@ -54,15 +54,29 @@ val RsMacro.macroRules: PsiElement
 val RsMacro.macroBody: RsMacroBody?
     get() = childOfType()
 
+val HAS_MACRO_EXPORT_PROP: StubbedAttributeProperty<RsMacro, RsMacroStub> =
+    StubbedAttributeProperty(QueryAttributes::hasMacroExport, RsMacroStub::mayHaveMacroExport)
+val HAS_MACRO_EXPORT_LOCAL_INNER_MACROS_PROP: StubbedAttributeProperty<RsMacro, RsMacroStub> =
+    StubbedAttributeProperty(QueryAttributes::hasMacroExportLocalInnerMacros, RsMacroStub::mayHaveMacroExportLocalInnerMacros)
+
 val RsMacro.hasMacroExport: Boolean
-    get() = queryAttributes.hasAttribute("macro_export")
+    get() = HAS_MACRO_EXPORT_PROP.getByPsi(this)
+
+val QueryAttributes.hasMacroExport: Boolean
+    get() = hasAttribute("macro_export")
 
 /** `#[macro_export(local_inner_macros)]` */
 val RsMacro.hasMacroExportLocalInnerMacros: Boolean
-    get() = queryAttributes.hasAttributeWithArg("macro_export", "local_inner_macros")
+    get() = HAS_MACRO_EXPORT_LOCAL_INNER_MACROS_PROP.getByPsi(this)
+
+val QueryAttributes.hasMacroExportLocalInnerMacros: Boolean
+    get() = hasAttributeWithArg("macro_export", "local_inner_macros")
 
 val RsMacro.isRustcDocOnlyMacro: Boolean
-    get() = queryAttributes.hasAttribute("rustc_doc_only_macro")
+    get() = queryAttributes.isRustcDocOnlyMacro
+
+val QueryAttributes.isRustcDocOnlyMacro: Boolean
+    get() = hasAttribute("rustc_doc_only_macro")
 
 val RsMacro.macroBodyStubbed: RsMacroBody?
     get() {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsModDeclItem.kt
@@ -43,8 +43,10 @@ private val RsModDeclItem.implicitPaths: List<String> get() {
 
 val RsModDeclItem.pathAttribute: String? get() = queryAttributes.lookupStringValueForKey("path")
 
-val RsModDeclItem.hasMacroUse: Boolean get() =
-    greenStub?.hasMacroUse ?: queryAttributes.hasAttribute("macro_use")
+val RsModDeclItem.hasMacroUse: Boolean get() = MOD_DECL_HAS_MACRO_USE_PROP.getByPsi(this)
+
+val MOD_DECL_HAS_MACRO_USE_PROP: StubbedAttributeProperty<RsModDeclItem, RsModDeclItemStub> =
+    StubbedAttributeProperty({ it.hasAttribute("macro_use") }, RsModDeclItemStub::mayHaveMacroUse)
 
 abstract class RsModDeclItemImplMixin : RsStubbedNamedElementImpl<RsModDeclItemStub>,
                                         RsModDeclItem {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsModItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsModItem.kt
@@ -17,8 +17,10 @@ import org.rust.lang.core.psi.RsPsiImplUtil
 import org.rust.lang.core.stubs.RsModItemStub
 import javax.swing.Icon
 
-val RsModItem.hasMacroUse: Boolean get() =
-    greenStub?.hasMacroUse ?: queryAttributes.hasAttribute("macro_use")
+val RsModItem.hasMacroUse: Boolean get() = MOD_ITEM_HAS_MACRO_USE_PROP.getByPsi(this)
+
+val MOD_ITEM_HAS_MACRO_USE_PROP: StubbedAttributeProperty<RsModItem, RsModItemStub> =
+    StubbedAttributeProperty({ it.hasAttribute("macro_use") }, RsModItemStub::mayHaveMacroUse)
 
 abstract class RsModItemImplMixin : RsStubbedNamedElementImpl<RsModItemStub>,
                                     RsModItem {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseItem.kt
@@ -20,6 +20,5 @@ abstract class RsUseItemImplMixin : RsStubbedElementImpl<RsUseItemStub>, RsUseIt
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 }
 
-// #[prelude_import]
-val RsUseItem.hasPreludeImport: Boolean
-    get() = greenStub?.hasPreludeImport ?: queryAttributes.hasAttribute("prelude_import")
+val HAS_PRELUDE_IMPORT_PROP: StubbedAttributeProperty<RsUseItem, RsUseItemStub> =
+    StubbedAttributeProperty({ it.hasAttribute("prelude_import") }, RsUseItemStub::mayHavePreludeImport)

--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -141,7 +141,7 @@ fun processItemDeclarations(
         //
         // https://doc.rust-lang.org/book/using-rust-without-the-standard-library.html
         // The stdlib lib itself is `#![no_std]`, and the core is `#![no_core]`
-        when (scope.attributes) {
+        when (scope.stdlibAttributes) {
             RsFile.Attributes.NONE ->
                 if (processor.lazy(STD) { scope.findDependencyCrateRoot(STD) }) return true
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -1637,7 +1637,7 @@ fun findPrelude(element: RsElement): RsFile? {
 
 // Implicit extern crate from stdlib
 private fun implicitStdlibCrate(scope: RsFile): ImplicitStdlibCrate? {
-    val (name, crateRoot) = when (scope.attributes) {
+    val (name, crateRoot) = when (scope.stdlibAttributes) {
         NO_CORE -> return null
         NO_STD -> CORE to scope.findDependencyCrateRoot(CORE)
         NONE -> STD to scope.findDependencyCrateRoot(STD)

--- a/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
@@ -6,7 +6,9 @@
 package org.rust.lang.core.resolve
 
 import com.intellij.psi.stubs.StubElement
+import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.IS_PROC_MACRO_DEF_PROP
 import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.isProcMacroDef
@@ -50,7 +52,7 @@ val RsNamedElement.namespaces: Set<Namespace> get() = when (this) {
     else -> TYPES_N_VALUES
 }
 
-val StubElement<*>.namespaces: Set<Namespace> get() = when (this) {
+fun StubElement<*>.getNamespaces(crate: Crate): Set<Namespace> = when (this) {
     is RsModItemStub,
     is RsModDeclItemStub,
     is RsEnumItemStub,
@@ -59,7 +61,7 @@ val StubElement<*>.namespaces: Set<Namespace> get() = when (this) {
     is RsTypeAliasStub -> TYPES
 
     is RsConstantStub -> VALUES
-    is RsFunctionStub -> if (isProcMacroDef) MACROS else VALUES
+    is RsFunctionStub -> if (IS_PROC_MACRO_DEF_PROP.getByStub(this, crate)) MACROS else VALUES
 
     is RsEnumVariantStub -> namespaces
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsLangItemIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsLangItemIndex.kt
@@ -16,7 +16,7 @@ import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.lang.core.psi.ext.RsItemElement
 import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.psi.ext.containingCrate
-import org.rust.lang.core.psi.ext.queryAttributes
+import org.rust.lang.core.psi.ext.getTraversedRawAttributes
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.openapiext.checkCommitIsNotInProgress
 import org.rust.openapiext.getElements
@@ -42,8 +42,7 @@ class RsLangItemIndex : AbstractStubIndex<String, RsItemElement>() {
         }
 
         fun index(psi: RsItemElement, sink: IndexSink) {
-            val key = psi.queryAttributes.langAttribute
-            if (key != null) {
+            for (key in psi.getTraversedRawAttributes().langAttributes) {
                 sink.occurrence(KEY, key)
             }
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsMacroIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsMacroIndex.kt
@@ -18,6 +18,7 @@ import com.intellij.psi.util.CachedValuesManager
 import org.rust.lang.core.macros.macroExpansionManager
 import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.getTraversedRawAttributes
 import org.rust.lang.core.psi.ext.hasMacroExport
 import org.rust.lang.core.psi.ext.isRustcDocOnlyMacro
 import org.rust.lang.core.psi.isValidProjectMember
@@ -40,7 +41,8 @@ class RsMacroIndex : StringStubIndexExtension<RsMacro>() {
         private const val SINGLE_KEY = "#"
 
         fun index(stub: RsMacroStub, sink: IndexSink) {
-            if (stub.name != null && (stub.psi.hasMacroExport || stub.psi.isRustcDocOnlyMacro)) {
+            val attributes = stub.psi.getTraversedRawAttributes()
+            if (stub.name != null && (attributes.hasMacroExport || attributes.isRustcDocOnlyMacro)) {
                 sink.occurrence(KEY, SINGLE_KEY)
             }
         }
@@ -54,7 +56,7 @@ class RsMacroIndex : StringStubIndexExtension<RsMacro>() {
                 for (key in keys) {
                     val elements = getElements(KEY, key, project, GlobalSearchScope.allScope(project))
                     for (element in elements) {
-                        if (element.isValidProjectMember) {
+                        if (element.isValidProjectMember && (element.hasMacroExport || element.isRustcDocOnlyMacro)) {
                             val crateRoot = element.crateRoot ?: continue
                             result.getOrPut(crateRoot, ::ArrayList) += element
                         }

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
@@ -145,7 +145,7 @@ private fun createExternCrateStdImport(crate: Crate, crateRoot: RsFile, crateRoo
     //
     // https://doc.rust-lang.org/book/using-rust-without-the-standard-library.html
     // The stdlib lib itself is `#![no_std]`, and the core is `#![no_core]`
-    val name = when (crateRoot.attributes) {
+    val name = when (crateRoot.getStdlibAttributes(crate)) {
         RsFile.Attributes.NONE -> AutoInjectedCrates.STD
         RsFile.Attributes.NO_STD -> AutoInjectedCrates.CORE
         RsFile.Attributes.NO_CORE -> return null

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FileModificationTracker.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FileModificationTracker.kt
@@ -50,7 +50,7 @@ fun isFileChanged(file: RsFile, defMap: CrateDefMap, crate: Crate): Boolean {
     val fileStub = file.getOrBuildStub() ?: return false
     ModCollectorBase.collectMod(fileStub, isDeeplyEnabledByCfg, visitor, crate)
     if (file.virtualFile == crate.rootModFile) {
-        visitor.modData.attributes = file.attributes
+        visitor.modData.attributes = file.getStdlibAttributes(crate)
     }
     return hashCalculator.getFileHash() != fileInfo.hash
 }

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubInterfaces.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubInterfaces.kt
@@ -8,8 +8,8 @@ package org.rust.lang.core.stubs
 import com.intellij.util.BitUtil
 import org.rust.lang.core.psi.ext.QueryAttributes
 import org.rust.lang.core.psi.ext.RsDocAndAttributeOwner
+import org.rust.lang.core.psi.ext.getTraversedRawAttributes
 import org.rust.lang.core.psi.ext.name
-import org.rust.lang.core.psi.ext.queryAttributes
 import org.rust.stdext.makeBitMask
 
 interface RsNamedStub {
@@ -24,36 +24,41 @@ interface RsAttributeOwnerStub {
     val hasAttrs: Boolean
 
     // #[cfg()]
-    val hasCfg: Boolean
+    val mayHaveCfg: Boolean
+
+    // #[cfg_attr()]
+    val hasCfgAttr: Boolean
 
     // #[macro_use]
-    val hasMacroUse: Boolean
+    val mayHaveMacroUse: Boolean
 
     companion object {
         val ATTRS_MASK: Int = makeBitMask(0)
         val CFG_MASK: Int = makeBitMask(1)
-        val HAS_MACRO_USE_MASK: Int = makeBitMask(2)
-        const val USED_BITS: Int = 3
+        val CFG_ATTR_MASK: Int = makeBitMask(2)
+        val HAS_MACRO_USE_MASK: Int = makeBitMask(3)
+        const val USED_BITS: Int = 4
 
         fun extractFlags(element: RsDocAndAttributeOwner): Int =
-            extractFlags(element.queryAttributes)
+            extractFlags(element.getTraversedRawAttributes(withCfgAttrAttribute = true))
 
         fun extractFlags(attrs: QueryAttributes): Int {
             var hasAttrs = false
             var hasCfg = false
+            var hasCfgAttr = false
             var hasMacroUse = false
             for (meta in attrs.metaItems) {
                 hasAttrs = true
                 when (meta.name) {
                     "cfg" -> hasCfg = true
+                    "cfg_attr" -> hasCfgAttr = true
                     "macro_use" -> hasMacroUse = true
-                    // TODO cfg_attr
                 }
-                if (hasCfg && hasMacroUse) break
             }
             var flags = 0
             flags = BitUtil.set(flags, ATTRS_MASK, hasAttrs)
             flags = BitUtil.set(flags, CFG_MASK, hasCfg)
+            flags = BitUtil.set(flags, CFG_ATTR_MASK, hasCfgAttr)
             flags = BitUtil.set(flags, HAS_MACRO_USE_MASK, hasMacroUse)
             return flags
         }

--- a/src/test/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotatorTest.kt
@@ -70,4 +70,20 @@ class RsCfgDisabledCodeAnnotatorTest : RsAnnotatorTestBase(RsCfgDisabledCodeAnno
             let x = 1;
         }
     """, ignoreExtraHighlighting = false)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test disabled under cfg_attr function`() = checkHighlighting("""
+        <CFG_DISABLED_CODE descr="Conditionally disabled code">#[cfg_attr(intellij_rust, cfg(not(intellij_rust)))]
+        fn foo() {
+            let x = 1;
+        }</CFG_DISABLED_CODE>
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test enabled under cfg_attr function`() = checkHighlighting("""
+        #[cfg_attr(not(intellij_rust), cfg(not(intellij_rust)))]
+        fn foo() {
+            let x = 1;
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoBenchRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoBenchRunLineMarkerContributorTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.lineMarkers
 
+import org.rust.MockAdditionalCfgOptions
 import org.rust.fileTree
 
 /**
@@ -81,5 +82,13 @@ class CargoBenchRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
             fn has_test_icon() { assert(true) } // - Test module::has_test_icon
             fn no_icon() { assert(true) }
         }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test attribute under cfg_attr`() = doTestByText("""
+        #[cfg_attr(intellij_rust, bench)]
+        fn has_icon() { assert(true) } // - Bench has_icon
+        #[cfg_attr(not(intellij_rust), bench)]
+        fn no_icon() { assert(true) }
     """)
 }

--- a/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/CargoTestRunLineMarkerContributorTest.kt
@@ -7,6 +7,7 @@ package org.rust.ide.lineMarkers
 
 import com.intellij.psi.PsiFileFactory
 import org.intellij.lang.annotations.Language
+import org.rust.MockAdditionalCfgOptions
 import org.rust.cargo.icons.CargoIcons
 import org.rust.fileTree
 import org.rust.lang.RsFileType
@@ -138,6 +139,14 @@ class CargoTestRunLineMarkerContributorTest : RsLineMarkerProviderTestBase() {
     fun `test ignore attributes with irrelevant test 2`() = doTestByText("""
         #[cfg(not(test))]
         fn has_icon() { assert(true) }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test attribute under cfg_attr`() = doTestByText("""
+        #[cfg_attr(intellij_rust, test)]
+        fn has_icon() { assert(true) } // - Test has_icon
+        #[cfg_attr(not(intellij_rust), test)]
+        fn no_icon() { assert(true) }
     """)
 
     private inline fun <reified E : RsElement> checkElement(@Language("Rust") code: String, callback: (E) -> Unit) {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsDeriveCompletionProviderTest.kt
@@ -143,13 +143,11 @@ class RsDeriveCompletionProviderTest : RsCompletionTestBase() {
     """)
 
     @MockAdditionalCfgOptions("intellij_rust")
-    fun `test no completion if already derived under cfg_attr`() = expect<IllegalStateException> {
-    checkNoCompletion("""
+    fun `test no completion if already derived under cfg_attr`() = checkNoCompletion("""
         #[cfg_attr(intellij_rust, derive(Debug))]
         #[cfg_attr(intellij_rust, derive(Debu/*caret*/))]
         struct Test {
             foo: u8
         }
     """)
-    }
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsProcMacroResolveTest.kt
@@ -231,7 +231,6 @@ class RsProcMacroResolveTest : RsResolveTestBase() {
                              //^ dep-proc-macro/lib.rs
     """)
 
-
     fun `test resolve attribute proc macro reexported from lib to main from macro call`() = stubOnlyResolve("""
     //- lib.rs
         extern crate dep_proc_macro;

--- a/src/test/kotlin/org/rust/lang/core/type/RsCfgAttrTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsCfgAttrTypeInferenceTest.kt
@@ -6,6 +6,8 @@
 package org.rust.lang.core.type
 
 import org.rust.MockAdditionalCfgOptions
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 
 class RsCfgAttrTypeInferenceTest : RsTypificationTestBase() {
     @MockAdditionalCfgOptions("intellij_rust")
@@ -31,5 +33,33 @@ class RsCfgAttrTypeInferenceTest : RsTypificationTestBase() {
             foo(a);
             a;
         } //^ i8
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test infer type of derivable trait method call 1`() = stubOnlyTypeInfer("""
+    //- main.rs
+        #[cfg_attr(intellij_rust, derive(Clone))]
+        struct Foo;
+
+        fn bar(foo: Foo) {
+            let foo2 = foo.clone();
+            foo2;
+           //^ Foo
+        }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test infer type of derivable trait method call 2`() = stubOnlyTypeInfer("""
+    //- main.rs
+        #[cfg_attr(not(intellij_rust), derive(Clone))]
+        struct Foo;
+
+        fn bar(foo: Foo) {
+            let foo2 = foo.clone();
+            foo2;
+           //^ <unknown>
+        }
     """)
 }


### PR DESCRIPTION
Now `cfg_attr` is mostly transparent for the plugin. The support includes (but is not limited to) these attributes:
* `derive` (`#[cfg_attr(windows, derive(Clone))]`, #3683 case)
* `path` (`#[cfg_attr(windows, path="win.rs")] mod foo;`, #5458 case)
* `cfg` (yes, `cfg` under `cfg_attr`: `#[cfg_attr(feature = "foo", cfg(feature = "bar"))]`)
* `proc_macro`, `proc_macro_attribute`, `proc_macro_derive`
* `test`, `bench`
* `no_std`, `no_core`
* `macro_use`, `macro_export`
* `no_main`, `may_dangle`, `non_exhaustive`, `doc(hidden)`, `deprecated`
* `lang`, `repr`, `unstable`

Documentation under `cfg_attr` is not supported for now (e.g. `#[cfg_attr(windows, doc = "...")]`).

### Implementation details

`RsDocAndAttributeOwner.queryAttributes` now yields meta items after `cfg_attr` expansion.

We often store attribute values to item PSI Stubs as an optimization (stub field access is much faster than PSI traversing). For example, we have `hasMacroUse` field that means that there is a `#[macro_use]` attribute on the item. The attribute can also be under cfg_attr: `#[cfg_attr(foobar, macro_use)]`. We can't evaluate `cfg` conditions during Stub building, so now we can't strictly say whether there is a `#[macro_use]` attribute or not. Now, instead of storing strict  `hasMacroUse`, we store a more fuzzy  `mayHaveMacroUse` flag. It's `true` when `#[macro_use]` or `#[cfg_attr(foobar, macro_use)]` is mentioned on the item. 

Fixes #5458, fixes #3683
Related to #1191

changelog: Take into account attributes under `#[cfg_attr]` attribute in type inference, name resolution, and the rest analysis.
