### PR TITLE
ANN: Provides case-checking for non-ascii name

### DIFF
--- a/src/test/kotlin/org/rust/ide/inspections/lints/NamingNotationsTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/NamingNotationsTest.kt
@@ -52,6 +52,7 @@ class CamelCaseNotationTest : NamingNotationTest() {
         testOk("__CamelCaseName")
         testOk("CamelCaseName__")
         testOk("__Cam1elCa2seN3ame__")
+        testOk("测试驼峰")
     }
 
     fun testDefaultSuggestion() {
@@ -94,6 +95,7 @@ class SnakeCaseNotationTest : NamingNotationTest() {
         testOk("'__")
         testOk("'lifetime")
         testOk("'static_lifetime")
+        testOk("测试小写")
     }
 
     fun testDefaultSuggestion() {
@@ -134,6 +136,7 @@ class UpperCaseNotationTest : NamingNotationTest() {
         testOk("__UPPER_CASE_NAME")
         testOk("UPPER_CASE_NAME__")
         testOk("___UPPER___CA3E__2__NAME__")
+        testOk("测试大写")
     }
 
     fun testDefaultSuggestion() {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsArgumentNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsArgumentNamingInspectionTest.kt
@@ -64,4 +64,15 @@ class RsArgumentNamingInspectionTest: RsInspectionsTestBase(RsArgumentNamingInsp
             }
         }
     """)
+
+    fun `test fun argument not support case`() = checkByText("""
+        fn test(名字: &str) { }
+    """)
+
+    fun `test method argument not support case`() = checkByText("""
+        struct Foo {}
+        impl Foo {
+            fn fn_par(名字: &str) { }
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsAssocTypeNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsAssocTypeNamingInspectionTest.kt
@@ -34,4 +34,10 @@ class RsAssocTypeNamingInspectionTest : RsInspectionsTestBase(RsAssocTypeNamingI
             fn bar(foo: &Self::AssocFoo) {}
         }
     """)
+
+    fun `test associated type not support case`() = checkByText("""
+        trait Foo {
+            type 类型;
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsConstNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsConstNamingInspectionTest.kt
@@ -35,4 +35,8 @@ class RsConstNamingInspectionTest : RsInspectionsTestBase(RsConstNamingInspectio
             let a = CONST_FOO;
         }
     """)
+
+    fun `test constant not support case`() = checkByText("""
+        const 常量: u32 = 12;
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsEnumNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsEnumNamingInspectionTest.kt
@@ -30,4 +30,8 @@ class RsEnumNamingInspectionTest : RsInspectionsTestBase(RsEnumNamingInspection:
             let a = EnumFoo::Var;
         }
     """)
+
+    fun `test enum not support case`() = checkByText("""
+        enum 枚举 {}
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsEnumVariantNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsEnumVariantNamingInspectionTest.kt
@@ -38,4 +38,10 @@ class RsEnumVariantNamingInspectionTest : RsInspectionsTestBase(RsEnumVariantNam
             let a = ToFix::VarBar;
         }
     """)
+
+    fun `test enum variant not support case`() = checkByText("""
+        enum EnumVar {
+            枚举变量,
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsFieldNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsFieldNamingInspectionTest.kt
@@ -77,4 +77,19 @@ class RsFieldNamingInspectionTest : RsInspectionsTestBase(RsFieldNamingInspectio
             let a = Foo { is_deleted: false };
         }
     """)
+
+    fun `test enum variant field not support case`() = checkByText("""
+        enum EnumVarField {
+            Variant {
+                字段: u32
+            }
+        }
+        static 静态的: u32 = 12;
+    """)
+
+    fun `test struct field not support case`() = checkByText("""
+        struct Foo {
+            字段: u32
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsFunctionNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsFunctionNamingInspectionTest.kt
@@ -56,4 +56,12 @@ class RsFunctionNamingInspectionTest : RsInspectionsTestBase(RsFunctionNamingIns
         #[no_mangle]
         pub unsafe extern fn Foo() {}
     """)
+
+    fun `test functions not support case`() = checkByText("""
+        fn 函数() {}
+
+        extern "C" {
+            fn 函数();
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsLifetimeNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsLifetimeNamingInspectionTest.kt
@@ -31,4 +31,8 @@ class RsLifetimeNamingInspectionTest : RsInspectionsTestBase(RsLifetimeNamingIns
             'lifetime_foo>(x: &'lifetime_foo u32) {
         }
     """)
+
+    fun `test lifetime not support case`() = checkByText("""
+        fn lifetime<'生命周期>() { }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsMacroNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsMacroNamingInspectionTest.kt
@@ -34,4 +34,9 @@ class RsMacroNamingInspectionTest : RsInspectionsTestBase(RsMacroNamingInspectio
         macro_rules! macro_foo { () => {}; }
         macro_foo!();
     """)
+
+    fun `test macro not support case`() = checkByText("""
+        macro_rules! 宏 { () => {}; }
+        宏!();
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsMethodNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsMethodNamingInspectionTest.kt
@@ -78,4 +78,17 @@ class RsMethodNamingInspectionTest : RsInspectionsTestBase(RsMethodNamingInspect
     //         fn bar_baz() {}
     //     }
     // """)
+
+    fun `test method not support case`() = checkByText("""
+        struct  Foo {}
+        impl Foo {
+            fn 测试函数(&self) { }
+        }
+    """)
+
+    fun `test trait method not support case`() = checkByText("""
+        trait Foo {
+            fn 特质函数(){ }
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsModuleNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsModuleNamingInspectionTest.kt
@@ -53,4 +53,8 @@ class RsModuleNamingInspectionTest : RsInspectionsTestBase(RsModuleNamingInspect
             let a = mod_foo::ONE;
         }
     """)
+
+    fun `test module not support case`() = checkByText("""
+        mod 模块名 {}
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsStaticConstNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsStaticConstNamingInspectionTest.kt
@@ -36,4 +36,8 @@ class RsStaticConstNamingInspectionTest : RsInspectionsTestBase(RsStaticConstNam
             static Bar: i32;
         }
     """)
+
+    fun `test static not support case`() = checkByText("""
+        static 静态的: u32 = 12;
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsStructNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsStructNamingInspectionTest.kt
@@ -42,4 +42,11 @@ class RsStructNamingInspectionTest : RsInspectionsTestBase(RsStructNamingInspect
             let a = FooBar;
         }
     """)
+
+    fun `test struct not support case`() = checkByText("""
+       struct 结构体;
+       struct 結構;
+       struct 구조체;
+       struct 構造体;
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTraitNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTraitNamingInspectionTest.kt
@@ -33,4 +33,10 @@ class RsTraitNamingInspectionTest : RsInspectionsTestBase(RsTraitNamingInspectio
         struct Patch {}
         impl HotFix for Patch {}
     """)
+
+    fun `test trait not support case`() = checkByText("""
+       trait 特质 {}
+       struct 结构体 {}
+       impl 特质 for 结构体 {}
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTypeAliasNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTypeAliasNamingInspectionTest.kt
@@ -26,4 +26,9 @@ class RsTypeAliasNamingInspectionTest : RsInspectionsTestBase(RsTypeAliasNamingI
         type ULong = u64;
         const ZERO: ULong = 0;
     """)
+
+    fun `test type alias not support case`() = checkByText("""
+        type 类型别名 = u64;
+        const ZERO: 类型别名 = 0;
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTypeParameterNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsTypeParameterNamingInspectionTest.kt
@@ -39,4 +39,8 @@ class RsTypeParameterNamingInspectionTest : RsInspectionsTestBase(RsTypeParamete
     """, """
         fn type_params<Base>(b: &Base) where Base: Clone {}
     """)
+
+    fun `test type parameter not support case`() = checkByText("""
+        fn type_params<类型: Clone>() { }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsVariableNamingInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/naming/RsVariableNamingInspectionTest.kt
@@ -86,4 +86,16 @@ class RsVariableNamingInspectionTest : RsInspectionsTestBase(RsVariableNamingIns
             }
         }
     """)
+
+    fun `test variable not support case`() = checkByText("""
+        fn loc_var() {
+            let 变量 = 0;
+        }
+    """)
+
+    fun `test tuple variable not support case`() = checkByText("""
+        fn loc_var() {
+            let (一, 二) = (1, 2);
+        }
+    """)
 }


### PR DESCRIPTION
The PR provides detection for non-ASCII naming and suppresses `CamelCase`, `SnakeCase`, `UpperCase` detection if case is not supported.

CamelCase rules from https://github.com/rust-lang/rust/blob/master/compiler/rustc_lint/src/nonstandard_style.rs

Fixed #6480 