### PR TITLE
Disable `cfg(test)` in external dependencies if there is `cfg(not(test))`

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -5,6 +5,8 @@
 
 package org.rust.cargo.project.workspace
 
+import com.intellij.openapi.util.UserDataHolderBase
+import com.intellij.openapi.util.UserDataHolderEx
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.openapiext.isUnitTestMode
@@ -61,7 +63,7 @@ interface CargoWorkspace {
     fun withCfgOptions(cfgOptions: CfgOptions): CargoWorkspace
 
     /** See docs for [CargoProjectsService] */
-    interface Package {
+    interface Package : UserDataHolderEx {
         val contentRoot: VirtualFile?
         val rootDirectory: Path
 
@@ -519,7 +521,7 @@ private class PackageImpl(
     val cargoEnabledFeatures: Set<FeatureName>,
     override val env: Map<String, String>,
     val outDirUrl: String?
-) : CargoWorkspace.Package {
+) : UserDataHolderBase(), CargoWorkspace.Package {
     override val targets = targetsData.map {
         TargetImpl(
             this,

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -49,7 +49,7 @@ class RsFileStub(
     override fun getType() = Type
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
-        private const val STUB_VERSION = 205
+        private const val STUB_VERSION = 206
 
         // Bump this number if Stub structure changes
         override fun getStubVersion(): Int = RustParserDefinition.PARSER_VERSION + STUB_VERSION
@@ -1506,6 +1506,10 @@ class RsMetaItemStub(
 
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): RsMetaItemStub =
             RsMetaItemStub(parentStub, this, dataStream.readBoolean())
+
+        override fun indexStub(stub: RsMetaItemStub, sink: IndexSink) {
+            sink.indexMetaItem(stub)
+        }
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubIndexing.kt
@@ -100,6 +100,10 @@ fun IndexSink.indexInnerAttr(stub: RsInnerAttrStub) {
     RsFeatureIndex.index(stub, this)
 }
 
+fun IndexSink.indexMetaItem(stub: RsMetaItemStub) {
+    RsCfgNotTestIndex.index(stub, this)
+}
+
 private fun IndexSink.indexNamedStub(stub: RsNamedStub) {
     stub.name?.let {
         occurrence(RsNamedElementIndex.KEY, it)

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsCfgNotTestIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsCfgNotTestIndex.kt
@@ -1,0 +1,80 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.stubs.index
+
+import com.google.common.annotations.VisibleForTesting
+import com.intellij.openapi.project.Project
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.GlobalSearchScopesCore
+import com.intellij.psi.stubs.IndexSink
+import com.intellij.psi.stubs.StringStubIndexExtension
+import com.intellij.psi.stubs.StubIndex
+import com.intellij.psi.stubs.StubIndexKey
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.lang.core.RsPsiPattern
+import org.rust.lang.core.psi.RsMetaItem
+import org.rust.lang.core.psi.RsMetaItemArgs
+import org.rust.lang.core.psi.ext.ancestors
+import org.rust.lang.core.psi.ext.name
+import org.rust.lang.core.psi.rustStructureModificationTracker
+import org.rust.lang.core.stubs.RsFileStub
+import org.rust.lang.core.stubs.RsMetaItemStub
+import org.rust.openapiext.checkCommitIsNotInProgress
+
+/**
+ * An index for `test` cfg options in any negative context like
+ * `#[cfg(not(test))]` or `#[cfg(not(and(or(test, ...), ...)))]`
+ */
+class RsCfgNotTestIndex : StringStubIndexExtension<RsMetaItem>() {
+    override fun getKey(): StubIndexKey<String, RsMetaItem> = KEY
+    override fun getVersion(): Int = RsFileStub.Type.stubVersion
+
+    companion object {
+        private val KEY: StubIndexKey<String, RsMetaItem> =
+            StubIndexKey.createIndexKey("org.rust.lang.core.stubs.index.RsCfgIndex")
+
+        private const val NOT_TEST: String = "#"
+
+        fun index(stub: RsMetaItemStub, sink: IndexSink) {
+            if (isCfgNotTest(stub.psi)) {
+                sink.occurrence(KEY, NOT_TEST)
+            }
+        }
+
+        // `#[cfg(not(test))]`
+        fun hasCfgNotTest(project: Project, pkg: CargoWorkspace.Package): Boolean {
+            return CachedValuesManager.getManager(project).getCachedValue(pkg) {
+                val contentRoot = pkg.contentRoot
+                val result = if (contentRoot != null) {
+                    hasCfgNotTest(project, GlobalSearchScopesCore.DirectoryScope(project, contentRoot, true))
+                } else {
+                    false
+                }
+                CachedValueProvider.Result.create(
+                    result,
+                    project.rustStructureModificationTracker
+                )
+            }
+        }
+
+        private fun hasCfgNotTest(project: Project, scope: GlobalSearchScope): Boolean {
+            checkCommitIsNotInProgress(project)
+            return !StubIndex.getInstance().processElements(KEY, NOT_TEST, project, scope, RsMetaItem::class.java) {
+                false
+            }
+        }
+
+        @VisibleForTesting
+        fun isCfgNotTest(psi: RsMetaItem): Boolean {
+            if (psi.name != "test") return false
+            val parent = psi.parent as? RsMetaItemArgs ?: return false
+            val not = parent.ancestors.find { it is RsMetaItem && it.name == "not" } ?: return false
+            return not.ancestors.any { it is RsMetaItem && RsPsiPattern.anyCfgCondition.accepts(it) }
+        }
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -930,6 +930,7 @@
         <stubIndex implementation="org.rust.lang.core.stubs.index.RsReexportIndex"/>
         <stubIndex implementation="org.rust.lang.core.stubs.index.RsExternCrateReexportIndex"/>
         <stubIndex implementation="org.rust.lang.core.stubs.index.RsFeatureIndex"/>
+        <stubIndex implementation="org.rust.lang.core.stubs.index.RsCfgNotTestIndex"/>
         <stubIndex implementation="org.rust.lang.core.stubs.index.RsIncludeMacroIndex"/>
 
         <stubIndex implementation="org.rust.lang.core.resolve.indexes.RsImplIndex"/>

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -851,4 +851,24 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
           //^
         }
     """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test resolve to 'cfg(not(test))' in external dependencies`() = stubOnlyResolve("""
+    //- dep-lib/lib.rs
+        #[cfg(test)]
+        #[path = "test.rs"]
+        mod foo;
+        #[cfg(not(test))]
+        #[path = "not_test.rs"]
+        mod foo;
+    //- dep-lib/test.rs
+        pub fn bar() {}
+    //- dep-lib/not_test.rs
+        pub fn bar() {}
+    //- lib.rs
+        fn main() {
+            dep_lib_target::foo::bar();
+        }                      //^ dep-lib/not_test.rs
+     """)
 }

--- a/src/test/kotlin/org/rust/lang/core/stubs/index/RsCfgNotTestIndexTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/stubs/index/RsCfgNotTestIndexTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.stubs.index
+
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+import org.rust.lang.core.psi.RsMetaItem
+
+class RsCfgNotTestIndexTest : RsTestBase() {
+    fun `test simple cfg test`() = doTest("""
+        #[cfg(test)]
+            //^ false
+        fn foo() {}
+    """)
+
+    fun `test simple cfg not test`() = doTest("""
+        #[cfg(not(test))]
+                //^ true
+        fn foo() {}
+    """)
+
+    fun `test cfg test in complex condition`() = doTest("""
+        #[cfg(and(windows, test))]
+                         //^ false
+        fn foo() {}
+    """)
+
+    fun `test cfg not test in complex condition`() = doTest("""
+        #[cfg(not(and(windows, test)))]
+                             //^ true
+        fn foo() {}
+    """)
+
+    fun `test simple cfg_attr test`() = doTest("""
+        #[cfg_attr(test, foo(bar))]
+                 //^ false
+        fn foo() {}
+    """)
+
+    fun `test simple cfg_attr not test`() = doTest("""
+        #[cfg_attr(not(test), foo(bar))]
+                     //^ true
+        fn foo() {}
+    """)
+
+    fun `test cfg in cfg_attr test`() = doTest("""
+        #[cfg_attr(windows, cfg(test))]
+                              //^ false
+        fn foo() {}
+    """)
+
+    fun `test cfg in cfg_attr not test`() = doTest("""
+        #[cfg_attr(windows, cfg(not(test)))]
+                                  //^ true
+        fn foo() {}
+    """)
+
+    private fun doTest(@Language("Rust") code: String) {
+        InlineFile(code)
+        val (item, data) = findElementAndDataInEditor<RsMetaItem>()
+        assertEquals(data.toBoolean(), RsCfgNotTestIndex.isCfgNotTest(item))
+    }
+}


### PR DESCRIPTION
Consider a code under `#[cfg(test)]` disabled in external dependencies (I.e. outside of a cargo workspace). Previously it was considered "enabled and disabled simultaneously", i.e. a code under `#[cfg(test)]` and `#[cfg(not(test))]` both was enabled.

The issue is that `#[cfg(test)]` sometimes used to mock something for testing:
```rust
#[cfg(test)]
mod foo {
    // Some mocks here
}
#[cfg(not(test))]
use foobar::foo; // Import the production variant of `foo`
```
So, we need `cfg(test)` to be disabled in order to provide correct name resolution.

But more often `cfg(test)` is used placed on test modules like this:
```rust
#[cfg(test)]
mod test {
    #[test]
    fn some_test() {}
}
```
So, if we disable `cfg(test)`, we make all tests grayed out!

The question "what to do with `cfg(test)`" was discussed for a long time. This PR starts with disabling `cfg(test)` in external dependency if that dependency has `not(test)` cfg condition in any context (like simple `#[cfg(not(test))]` or more complex `#[cfg(and(or(not(test), not(bar)), baz))]`). Yes, it makes it harder to read the test code in such dependencies. But firstly, this affects a minority of crates. Secondly, why usually someone reads tests in external dependencies? I think it's because they want to find examples of some library functionality. And there are doctests for this case, and we support doctests very well! So we decided that disabling `cfg(test)` in external dependencies should not be a real problem for our users.

The question "what to do with `cfg(test)` in workspace packages" is not answered yet. We think there should be some UI for enabling/disabling `cfg(test)` _in workspace packages_ like cargo features, but we don't imagine such UI yet.

changelog: Consider a code under `#[cfg(test)]` disabled in external dependencies (I.e. outside of a cargo workspace) that have `cfg(not(test))` cfg conditions. Previously it was considered "enabled and disabled simultaneously", i.e. a code under `#[cfg(test)]` and `#[cfg(not(test))]` both was enabled.
