### PR TITLE
INSP: do not remove function references in remove parameter quick fix

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveParameterFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveParameterFix.kt
@@ -38,12 +38,11 @@ class RemoveParameterFix(binding: RsPatBinding, private val bindingName: String)
 }
 
 private fun removeArguments(function: RsFunction, parameterIndex: Int) {
-    ReferencesSearch.search(function).forEach {
-        val call = it.element.parentOfTypes(RsCallExpr::class, RsDotExpr::class) ?: return@forEach
-
+    val calls = function.findFunctionCalls() + function.findMethodCalls()
+    calls.forEach { call ->
         val arguments = when (call) {
             is RsCallExpr -> call.valueArgumentList
-            is RsDotExpr -> call.methodCall?.valueArgumentList ?: return@forEach
+            is RsMethodCall -> call.valueArgumentList
             else -> return@forEach
         }
         val isMethod = function.hasSelfParameters

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -8,9 +8,12 @@ package org.rust.lang.core.psi.ext
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReference
 import com.intellij.psi.search.SearchScope
+import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.Query
 import org.rust.ide.icons.RsIcons
 import org.rust.ide.icons.addTestMark
 import org.rust.lang.core.macros.RsExpandedElement
@@ -184,6 +187,31 @@ val QueryAttributes.isProcMacroDef
         "proc_macro_attribute",
         "proc_macro_derive"
     )
+
+fun RsFunction.findFunctionCalls(scope: SearchScope? = null): Sequence<RsCallExpr> {
+    return searchReferences(scope)
+        .asSequence()
+        .mapNotNull {
+            val path = it.element
+            val pathExpr = path.parent
+            pathExpr.parent as? RsCallExpr
+        }
+}
+
+fun RsFunction.findMethodCalls(scope: SearchScope? = null): Sequence<RsMethodCall> {
+    return searchReferences(scope)
+        .asSequence()
+        .map { it.element }
+        .filterIsInstance<RsMethodCall>()
+}
+
+private fun RsElement.searchReferences(scope: SearchScope? = null): Query<PsiReference> {
+    return if (scope == null) {
+        ReferencesSearch.search(this)
+    } else {
+        ReferencesSearch.search(this, scope)
+    }
+}
 
 abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, RsFunction, RsModificationTrackerOwner {
 

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsLivenessInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsLivenessInspectionTest.kt
@@ -739,6 +739,23 @@ class RsLivenessInspectionTest : RsInspectionsTestBase(RsLivenessInspection::cla
         }
     """)
 
+    // https://github.com/intellij-rust/intellij-rust/issues/6513
+    fun `test remove function argument when function is used as an argument`() = checkFixByText("Remove parameter `x`", """
+        fn foo(<warning>x/*caret*/</warning>: i32) {}
+        fn id<T>(<warning>t</warning>: T) {}
+
+        fn main() {
+            id(foo);
+        }
+    """, """
+        fn foo() {}
+        fn id<T>(t: T) {}
+
+        fn main() {
+            id(foo);
+        }
+    """)
+
     fun `test remove method argument UFCS`() = checkFixByText("Remove parameter `a`", """
         struct S;
         impl S {


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/6513

changelog: RemoveParameter quick fix no longer removes some references of the modified function.
