### PR TITLE
COMP: switch dependency completion provider for Cargo.toml on the fly

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlCompletionContributor.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlCompletionContributor.kt
@@ -16,7 +16,6 @@ import org.rust.toml.CargoTomlPsiPattern.inKey
 import org.rust.toml.CargoTomlPsiPattern.inSpecificDependencyHeaderKey
 import org.rust.toml.CargoTomlPsiPattern.inSpecificDependencyKeyValue
 import org.rust.toml.CargoTomlPsiPattern.inValueWithKey
-import org.rust.toml.crates.local.completion.DependencyCratesLocalCompletionProvider
 import org.rust.toml.tomlPluginIsAbiCompatible
 
 class CargoTomlCompletionContributor : CompletionContributor() {
@@ -24,16 +23,16 @@ class CargoTomlCompletionContributor : CompletionContributor() {
         val isCratesLocalIndexEnabled = isFeatureEnabled(RsExperiments.CRATES_LOCAL_INDEX)
 
         val dependencyCompletionProvider = if (isCratesLocalIndexEnabled) {
-            DependencyCratesLocalCompletionProvider()
+            LocalCargoTomlDependencyCompletionProvider()
         } else {
-            CargoTomlDependencyCompletionProvider()
+            CratesIoCargoTomlDependencyCompletionProvider()
         }
 
         if (tomlPluginIsAbiCompatible()) {
             extend(BASIC, inKey, CargoTomlKeysCompletionProvider())
             extend(BASIC, inValueWithKey("edition"), CargoTomlKnownValuesCompletionProvider(listOf("2015", "2018")))
-            extend(BASIC, inSpecificDependencyHeaderKey, CargoTomlSpecificDependencyHeaderCompletionProvider())
-            extend(BASIC, inSpecificDependencyKeyValue, CargoTomlSpecificDependencyVersionCompletionProvider())
+            extend(BASIC, inSpecificDependencyHeaderKey, CratesIoCargoTomlSpecificDependencyHeaderCompletionProvider())
+            extend(BASIC, inSpecificDependencyKeyValue, CratesIoCargoTomlSpecificDependencyVersionCompletionProvider())
             extend(BASIC, inFeatureDependencyArray, CargoTomlFeatureDependencyCompletionProvider())
             extend(BASIC, inDependencyPackageFeatureArray, CargoTomlDependencyFeaturesCompletionProvider())
 

--- a/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlCompletionContributor.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlCompletionContributor.kt
@@ -7,8 +7,6 @@ package org.rust.toml.completion
 
 import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionType.BASIC
-import org.rust.ide.experiments.RsExperiments
-import org.rust.openapiext.isFeatureEnabled
 import org.rust.toml.CargoTomlPsiPattern.inDependencyKeyValue
 import org.rust.toml.CargoTomlPsiPattern.inDependencyPackageFeatureArray
 import org.rust.toml.CargoTomlPsiPattern.inFeatureDependencyArray
@@ -20,14 +18,6 @@ import org.rust.toml.tomlPluginIsAbiCompatible
 
 class CargoTomlCompletionContributor : CompletionContributor() {
     init {
-        val isCratesLocalIndexEnabled = isFeatureEnabled(RsExperiments.CRATES_LOCAL_INDEX)
-
-        val dependencyCompletionProvider = if (isCratesLocalIndexEnabled) {
-            LocalCargoTomlDependencyCompletionProvider()
-        } else {
-            CratesIoCargoTomlDependencyCompletionProvider()
-        }
-
         if (tomlPluginIsAbiCompatible()) {
             extend(BASIC, inKey, CargoTomlKeysCompletionProvider())
             extend(BASIC, inValueWithKey("edition"), CargoTomlKnownValuesCompletionProvider(listOf("2015", "2018")))
@@ -36,7 +26,7 @@ class CargoTomlCompletionContributor : CompletionContributor() {
             extend(BASIC, inFeatureDependencyArray, CargoTomlFeatureDependencyCompletionProvider())
             extend(BASIC, inDependencyPackageFeatureArray, CargoTomlDependencyFeaturesCompletionProvider())
 
-            extend(BASIC, inDependencyKeyValue, dependencyCompletionProvider)
+            extend(BASIC, inDependencyKeyValue, CargoTomlDependencyCompletionProvider())
         }
     }
 }

--- a/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlDependencyCompletionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlDependencyCompletionProvider.kt
@@ -1,0 +1,32 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.util.ProcessingContext
+import org.rust.ide.experiments.RsExperiments
+import org.rust.openapiext.isFeatureEnabled
+
+class CargoTomlDependencyCompletionProvider : CompletionProvider<CompletionParameters>() {
+
+    private val localCompletionProvider = LocalCargoTomlDependencyCompletionProvider()
+    private val cratesIoCompletionProvider = CratesIoCargoTomlDependencyCompletionProvider()
+
+    private val delegate: TomlKeyValueCompletionProviderBase
+        get() {
+            return if (isFeatureEnabled(RsExperiments.CRATES_LOCAL_INDEX)) {
+                localCompletionProvider
+            } else {
+                cratesIoCompletionProvider
+            }
+        }
+
+    override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+        delegate.addCompletionVariants(parameters, context, result)
+    }
+}

--- a/toml/src/main/kotlin/org/rust/toml/completion/CratesIoCargoTomlDependencyCompletionProviders.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/CratesIoCargoTomlDependencyCompletionProviders.kt
@@ -11,32 +11,14 @@ import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.util.ProcessingContext
 import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.toml.CargoTomlPsiPattern
 import org.rust.toml.StringValueInsertionHandler
-import org.rust.toml.getClosestKeyValueAncestor
 import org.toml.lang.psi.TomlKey
 import org.toml.lang.psi.TomlKeyValue
 import org.toml.lang.psi.TomlTable
 
-abstract class TomlKeyValueCompletionProviderBase : CompletionProvider<CompletionParameters>() {
-    override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
-        val parent = parameters.position.parent ?: return
-        if (parent is TomlKey) {
-            val keyValue = parent.parent as? TomlKeyValue
-                ?: error("PsiElementPattern must not allow keys outside of TomlKeyValues")
-            completeKey(keyValue, result)
-        } else {
-            val keyValue = getClosestKeyValueAncestor(parameters.position) ?: return
-            completeValue(keyValue, result)
-        }
-    }
-
-    protected abstract fun completeKey(keyValue: TomlKeyValue, result: CompletionResultSet)
-
-    protected abstract fun completeValue(keyValue: TomlKeyValue, result: CompletionResultSet)
-}
-
 /** @see CargoTomlPsiPattern.inDependencyKeyValue */
-class CargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProviderBase() {
+class CratesIoCargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProviderBase() {
     override fun completeKey(keyValue: TomlKeyValue, result: CompletionResultSet) {
         val variants = searchCrate(keyValue.key).map { it.dependencyLine }
         result.addAllElements(variants.map(LookupElementBuilder::create))
@@ -53,7 +35,7 @@ class CargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProviderBase
 }
 
 /** @see CargoTomlPsiPattern.inSpecificDependencyHeaderKey */
-class CargoTomlSpecificDependencyHeaderCompletionProvider : CompletionProvider<CompletionParameters>() {
+class CratesIoCargoTomlSpecificDependencyHeaderCompletionProvider : CompletionProvider<CompletionParameters>() {
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
         val key = parameters.position.parent as? TomlKey ?: return
         val variants = searchCrate(key)
@@ -77,7 +59,7 @@ class CargoTomlSpecificDependencyHeaderCompletionProvider : CompletionProvider<C
 }
 
 /** @see CargoTomlPsiPattern.inSpecificDependencyKeyValue */
-class CargoTomlSpecificDependencyVersionCompletionProvider : TomlKeyValueCompletionProviderBase() {
+class CratesIoCargoTomlSpecificDependencyVersionCompletionProvider : TomlKeyValueCompletionProviderBase() {
     override fun completeKey(keyValue: TomlKeyValue, result: CompletionResultSet) {
         val dependencyNameKey = getDependencyKeyFromTableHeader(keyValue)
 

--- a/toml/src/main/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyCompletionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyCompletionProvider.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.toml.crates.local.completion
+package org.rust.toml.completion
 
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.CompletionUtil
@@ -15,13 +15,11 @@ import com.intellij.codeInsight.lookup.LookupElementRenderer
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.components.service
 import org.rust.toml.StringValueInsertionHandler
-import org.rust.toml.completion.CargoNormalizedNamesPrefixMatcher
-import org.rust.toml.completion.TomlKeyValueCompletionProviderBase
 import org.rust.toml.crates.local.CratesLocalIndexService
 import org.rust.toml.crates.local.lastVersion
 import org.toml.lang.psi.TomlKeyValue
 
-class DependencyCratesLocalCompletionProvider : TomlKeyValueCompletionProviderBase() {
+class LocalCargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProviderBase() {
     override fun completeKey(keyValue: TomlKeyValue, result: CompletionResultSet) {
         val prefix = CompletionUtil.getOriginalElement(keyValue.key)?.text ?: return
 

--- a/toml/src/main/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyCompletionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyCompletionProvider.kt
@@ -13,7 +13,6 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.codeInsight.lookup.LookupElementPresentation
 import com.intellij.codeInsight.lookup.LookupElementRenderer
 import com.intellij.icons.AllIcons
-import com.intellij.openapi.components.service
 import org.rust.toml.StringValueInsertionHandler
 import org.rust.toml.crates.local.CratesLocalIndexService
 import org.rust.toml.crates.local.lastVersion
@@ -23,7 +22,7 @@ class LocalCargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProvide
     override fun completeKey(keyValue: TomlKeyValue, result: CompletionResultSet) {
         val prefix = CompletionUtil.getOriginalElement(keyValue.key)?.text ?: return
 
-        val indexService = service<CratesLocalIndexService>()
+        val indexService = CratesLocalIndexService.getInstance()
         if (!indexService.isReady()) return
 
         val crateNames = indexService.getAllCrateNames()
@@ -54,7 +53,7 @@ class LocalCargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProvide
     override fun completeValue(keyValue: TomlKeyValue, result: CompletionResultSet) {
         val name = CompletionUtil.getOriginalElement(keyValue.key)?.text ?: return
 
-        val indexService = service<CratesLocalIndexService>()
+        val indexService = CratesLocalIndexService.getInstance()
         if (!indexService.isReady()) return
 
         val versions = indexService.getCrate(name)?.versions ?: return

--- a/toml/src/main/kotlin/org/rust/toml/completion/TomlKeyValueCompletionProviderBase.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/TomlKeyValueCompletionProviderBase.kt
@@ -1,0 +1,32 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.util.ProcessingContext
+import org.rust.toml.getClosestKeyValueAncestor
+import org.toml.lang.psi.TomlKey
+import org.toml.lang.psi.TomlKeyValue
+
+abstract class TomlKeyValueCompletionProviderBase : CompletionProvider<CompletionParameters>() {
+    override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+        val parent = parameters.position.parent ?: return
+        if (parent is TomlKey) {
+            val keyValue = parent.parent as? TomlKeyValue
+                ?: error("PsiElementPattern must not allow keys outside of TomlKeyValues")
+            completeKey(keyValue, result)
+        } else {
+            val keyValue = getClosestKeyValueAncestor(parameters.position) ?: return
+            completeValue(keyValue, result)
+        }
+    }
+
+    protected abstract fun completeKey(keyValue: TomlKeyValue, result: CompletionResultSet)
+
+    protected abstract fun completeValue(keyValue: TomlKeyValue, result: CompletionResultSet)
+}

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexCachesInvalidator.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexCachesInvalidator.kt
@@ -6,10 +6,9 @@
 package org.rust.toml.crates.local
 
 import com.intellij.ide.caches.CachesInvalidator
-import com.intellij.openapi.components.service
 
 class CratesLocalIndexCachesInvalidator : CachesInvalidator() {
     override fun invalidateCaches() {
-        service<CratesLocalIndexService>().invalidateCaches()
+        CratesLocalIndexService.getInstance().invalidateCaches()
     }
 }

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexService.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexService.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProgressIndicator
@@ -211,6 +212,8 @@ class CratesLocalIndexService : PersistentStateComponent<CratesLocalIndexState>,
         private const val INVALID_COMMIT_HASH: String = "<invalid>"
         private const val CRATES_INDEX_VERSION: Int = 0
         private val LOG: Logger = logger<CratesLocalIndexService>()
+
+        fun getInstance(): CratesLocalIndexService = service()
     }
 }
 


### PR DESCRIPTION
Previously, we set up dependency completion providers (via local registry index or via crates.io API) in `CargoTomlCompletionContributor`'s constructor based on `RsExperiments.CRATES_LOCAL_INDEX` feature value.
But the platform creates a single object of `CargoTomlCompletionContributor` on plugin loading and doesn't recreate it on `RsExperiments.CRATES_LOCAL_INDEX` feature changes. So it wasn't possible to switch completion provider without IDE restart

These changes register new completion provider that can switch a completion way dynamically (i.e. without IDE restart)