### PR TITLE
Improve popup of `Has implementations` gutter icon

### DIFF
--- a/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
@@ -5,13 +5,21 @@
 
 package org.rust.ide.lineMarkers
 
+import com.intellij.codeInsight.CodeInsightBundle
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
+import com.intellij.codeInsight.daemon.impl.PsiElementListNavigator
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
+import com.intellij.codeInsight.navigation.NavigationGutterIconRenderer
 import com.intellij.ide.util.DefaultPsiElementCellRenderer
+import com.intellij.ide.util.PsiElementListCellRenderer
+import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.Condition
 import com.intellij.openapi.util.NotNullLazyValue
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.NavigatablePsiElement
 import com.intellij.psi.PsiElement
+import com.intellij.psi.SmartPsiElementPointer
 import com.intellij.util.Query
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.psi.RsEnumItem
@@ -20,6 +28,9 @@ import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.filterQuery
 import org.rust.openapiext.mapQuery
+import java.awt.event.MouseEvent
+import java.util.*
+import javax.swing.Icon
 
 /**
  * Annotates trait declaration with an icon on the gutter that allows to jump to
@@ -39,15 +50,69 @@ class RsImplsLineMarkerProvider : LineMarkerProvider {
             // if (query.isEmptyQuery) return null
             val query = implsQuery(el) ?: continue
             val targets: NotNullLazyValue<Collection<PsiElement>> = NotNullLazyValue.createValue { query.findAll() }
-            val info = NavigationGutterIconBuilder
-                .create(RsIcons.IMPLEMENTED)
+            val info = ImplsGutterIconBuilder(RsIcons.IMPLEMENTED)
                 .setTargets(targets)
-                .setPopupTitle("Go to implementation of ${el.text}")
                 .setTooltipText("Has implementations")
                 .setCellRenderer(GoToImplRenderer())
                 .createLineMarkerInfo(el)
 
             result.add(info)
+        }
+    }
+
+    private class ImplsGutterIconBuilder(icon: Icon) :
+        NavigationGutterIconBuilder<PsiElement>(icon, DEFAULT_PSI_CONVERTOR, PSI_GOTO_RELATED_ITEM_PROVIDER) {
+
+        override fun createGutterIconRenderer(
+            pointers: NotNullLazyValue<List<SmartPsiElementPointer<*>>>,
+            renderer: Computable<PsiElementListCellRenderer<*>>,
+            empty: Boolean
+        ): NavigationGutterIconRenderer {
+            return ImplsNavigationGutterIconRenderer(
+                popupTitle = myPopupTitle,
+                emptyText = myEmptyText,
+                pointers = pointers,
+                cellRenderer = renderer,
+                alignment = myAlignment,
+                icon = myIcon,
+                tooltipText = myTooltipText,
+                empty = empty
+            )
+        }
+    }
+
+    private class ImplsNavigationGutterIconRenderer(
+        popupTitle: String?,
+        emptyText: String?,
+        pointers: NotNullLazyValue<List<SmartPsiElementPointer<*>>>,
+        cellRenderer: Computable<PsiElementListCellRenderer<*>>,
+        private val alignment: Alignment,
+        private val icon: Icon,
+        private val tooltipText: String?,
+        private val empty: Boolean
+    ) : NavigationGutterIconRenderer(popupTitle, emptyText, cellRenderer, pointers) {
+        override fun isNavigateAction(): Boolean = !empty
+        override fun getIcon(): Icon = icon
+        override fun getTooltipText(): String? = tooltipText
+        override fun getAlignment(): Alignment = alignment
+
+        override fun navigate(event: MouseEvent?, elt: PsiElement?) {
+            if (event == null || elt == null) return
+
+            val targets = targetElements.filterIsInstance<NavigatablePsiElement>().toTypedArray()
+            val renderer = myCellRenderer.compute()
+
+            Arrays.sort(targets, Comparator.comparing(renderer::getComparingObject))
+
+            val escapedName = StringUtil.escapeXmlEntities(elt.text)
+            @Suppress("DialogTitleCapitalization")
+            PsiElementListNavigator.openTargets(
+                event,
+                targets,
+                CodeInsightBundle.message("goto.implementation.chooserTitle", escapedName, targets.size, ""),
+                CodeInsightBundle.message("goto.implementation.findUsages.title", escapedName, targets.size),
+                renderer
+            )
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
+++ b/src/main/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProvider.kt
@@ -14,7 +14,6 @@ import com.intellij.codeInsight.navigation.NavigationGutterIconRenderer
 import com.intellij.ide.util.DefaultPsiElementCellRenderer
 import com.intellij.ide.util.PsiElementListCellRenderer
 import com.intellij.openapi.util.Computable
-import com.intellij.openapi.util.Condition
 import com.intellij.openapi.util.NotNullLazyValue
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.NavigatablePsiElement
@@ -149,7 +148,7 @@ class RsImplsLineMarkerProvider : LineMarkerProvider {
                     parent.owner is RsAbstractableOwner.Trait -> parent.searchForImplementations().mapQuery { it }
                 else -> return null
             }
-            return query.filterQuery(Condition { it != null })
+            return query.filterQuery { it != null }
         }
     }
 }

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt
@@ -19,13 +19,13 @@ class RsImplsLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
         trait Foo {} // - Has implementations
     """)
 
-    fun testOneImpl() = doTestByText("""
+    fun `test one impl`() = doTestByText("""
         trait Foo {}  // - Has implementations
         struct Bar {} // - Has implementations
         impl Foo for Bar {}
     """)
 
-    fun testMultipleImpl() = doTestByText("""
+    fun `test multiple impls`() = doTestByText("""
         trait Foo {}  // - Has implementations
         mod bar {
             use super::Foo;
@@ -39,7 +39,7 @@ class RsImplsLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
         }
     """)
 
-    fun testIconPosition() = doTestByText("""
+    fun `test icon position`() = doTestByText("""
         ///
         /// Documentation
         ///


### PR DESCRIPTION
Fixes #6508

| Before | After |
| - | - |
| <img src="https://user-images.githubusercontent.com/2539310/102648855-4c301580-4179-11eb-8432-c127817758e8.png"> | <img src="https://user-images.githubusercontent.com/2539310/102648848-476b6180-4179-11eb-9080-e6895a48d497.png"> |

changelog: Improve popup of `Has implementations` gutter icon by items sorting and allowing to open results in `Find` tool window
