### PR TITLE
CI: provide regression testing for stdlib

### DIFF
--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -53,6 +53,9 @@ jobs:
                             repository: tokio-rs/tokio
                           - name: amethyst
                             repository: amethyst/amethyst
+                    - name: regressions-2
+                      projects:
+                          - name: stdlib
         env:
             ORG_GRADLE_PROJECT_showStandardStreams: true
             PROJECTS: ${{ toJSON(matrix.batch.projects) }}

--- a/scripts/fetch_projects.py
+++ b/scripts/fetch_projects.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import subprocess
 from typing import List, Dict
 
 from common import git_command
@@ -13,6 +14,11 @@ if __name__ == '__main__':
 
     for project in projects:
         name = project["name"]
-        repository = project["repository"]
+        path = f"testData/{name}"
 
-        git_command("clone", "--depth", "1", f"https://github.com/{repository}.git", f"testData/{name}")
+        if name == "stdlib":
+            subprocess.run(["cargo", "new", "--name", name, "--bin", "--vcs", "none", path], check=True,
+                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        else:
+            repository = project["repository"]
+            git_command("clone", "--depth", "1", f"https://github.com/{repository}.git", path)

--- a/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
@@ -20,7 +20,7 @@ import org.rust.cargo.toolchain.tools.rustc
  */
 abstract class RsWithToolchainTestBase : RsWithToolchainPlatformTestBase() {
 
-    private lateinit var rustupFixture: RustupTestFixture
+    protected lateinit var rustupFixture: RustupTestFixture
 
     open val dataPath: String = ""
 


### PR DESCRIPTION
Note, I've created a new batch in regression tests workflow because analysis is quite slow currently for `core_arch` module in `std`.
But #6526 should significantly improve the performance (from 17 to 3 minutes on my machine) of stdlib test, so it's probably worth to merge both batches into a single one after #6526

changelog: provide regression testing for stdlib packages on CI
