### PR TITLE
INSP&COMP: Improve cyclic feature dependencies handling

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlFeatureDependencyCompletionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlFeatureDependencyCompletionProvider.kt
@@ -9,6 +9,7 @@ import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.psi.util.parentOfType
 import com.intellij.util.ProcessingContext
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.toml.StringLiteralInsertionHandler
@@ -16,6 +17,7 @@ import org.rust.toml.findCargoPackageForCargoToml
 import org.rust.toml.getPackageTomlFile
 import org.rust.toml.resolve.allFeatures
 import org.toml.lang.psi.TomlFile
+import org.toml.lang.psi.impl.TomlKeyValueImpl
 
 /**
  *  * Consider `Cargo.toml`:
@@ -32,7 +34,10 @@ class CargoTomlFeatureDependencyCompletionProvider : CompletionProvider<Completi
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
         val element = parameters.position
         val tomlFile = element.containingFile as? TomlFile ?: return
+
+        val parentFeature = element.parentOfType<TomlKeyValueImpl>()?.key ?: return
         for (feature in tomlFile.allFeatures()) {
+            if (feature == parentFeature) continue
             result.addElement(lookupElementForFeature(feature))
         }
 

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CargoTomlCyclicFeatureInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CargoTomlCyclicFeatureInspection.kt
@@ -1,0 +1,51 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import org.rust.cargo.CargoConstants
+import org.rust.toml.isFeatureListHeader
+import org.toml.lang.psi.*
+import org.toml.lang.psi.ext.TomlLiteralKind
+import org.toml.lang.psi.ext.kind
+
+/**
+ *  * Consider `Cargo.toml`:
+ * ```
+ * [features]
+ * foo = ["foo"]
+ *       #^ Shows error that "foo" feature depends on itself
+ * ```
+ */
+class CargoTomlCyclicFeatureInspection : LocalInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+        buildVisitor(holder) ?: super.buildVisitor(holder, isOnTheFly)
+
+    private fun buildVisitor(holder: ProblemsHolder): PsiElementVisitor? {
+        if (holder.file.name != CargoConstants.MANIFEST_FILE) return null
+
+        return object : TomlVisitor() {
+            override fun visitLiteral(element: TomlLiteral) {
+                val parentArray = element.parent as? TomlArray ?: return
+                val parentKeyValue = parentArray.parent as? TomlKeyValue ?: return
+                val parentTable = parentKeyValue.parent as? TomlTable ?: return
+                if (!parentTable.header.isFeatureListHeader) return
+
+                val parentFeatureName = parentKeyValue.key.text ?: return
+                val featureName = (element.kind as? TomlLiteralKind.String)?.value
+
+                if (featureName == parentFeatureName) {
+                    holder.registerProblem(
+                        element,
+                        "Cyclic feature dependency: feature `$parentFeatureName` depends on itself"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -23,6 +23,11 @@
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.toml.inspections.MissingFeaturesInspection"/>
 
+        <localInspection language="TOML" groupName="Rust"
+                         displayName="Cyclic feature dependency"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.rust.toml.inspections.CargoTomlCyclicFeatureInspection"/>
+
         <applicationService serviceImplementation="org.rust.toml.crates.local.CratesLocalIndexService"/>
         <cachesInvalidator implementation="org.rust.toml.crates.local.CratesLocalIndexCachesInvalidator"/>
     </extensions>

--- a/toml/src/main/resources/inspectionDescriptions/CargoTomlCyclicFeature.html
+++ b/toml/src/main/resources/inspectionDescriptions/CargoTomlCyclicFeature.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Detects features depending on themselves
+</body>
+</html>


### PR DESCRIPTION
Closes #6523

<image width="600" src="https://user-images.githubusercontent.com/6342851/103595146-cac3db80-4f0b-11eb-8bad-79f696e6cdb4.png">


changelog: Add inspection to check whether a feature has a cyclic dependency on itself