### PR TITLE
CI: set milestone automatically for PRs from forks

### DIFF
--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -1,7 +1,7 @@
 name: milestones
 
 on:
-    pull_request:
+    pull_request_target:
         types: [ closed ]
 
 jobs:


### PR DESCRIPTION
Allows setting a milestone for merged PR even if PR was made from fork.

Previously, it didn't work for PRs from forks because of read-only permissions that Github grant to workflow with `pull_request` event not to execute arbitrary code with write permissions in our repo. But `pull_request_target` event allows us to have a token with write permissions even in fork PR because everything is executed in context of the base of the pull request. See more details [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target)

Continuation of #6051.

changelog: Set milestone automatically for pull requests from forks. Previously, it worked only for pull requests in original repository
