### PR TITLE
GRAM: parse `::` as an incomplete path

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -195,7 +195,10 @@ private Path_first ::= identifier | self | 'Self' | super | '::' | '<' | crate
 
 private PathImpl ::= PathStart PathSegment*
 
-PathStart ::= ('::' | <<checkTypeQualAllowed>> TypeQual)? PathIdent PathTypeArguments? { elementType = Path }
+PathStart ::= (PathIdent | FQPathStart) PathTypeArguments? { elementType = Path }
+private FQPathStart ::= ('::' | <<checkTypeQualAllowed>> TypeQual) !('{' | '*') PathIdent {
+  pin = 2
+}
 //    <T as Foo>::bar::baz::<i32>
 //    ^~~~~~~~~~~^ TypeQual
 TypeQual ::= '<' TypeReference [ as TraitRef] '>' '::' {

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
@@ -92,6 +92,6 @@ class RustParserDefinition : ParserDefinition {
         /**
          * Should be increased after any change of parser rules
          */
-        const val PARSER_VERSION: Int = LEXER_VERSION + 22
+        const val PARSER_VERSION: Int = LEXER_VERSION + 23
     }
 }

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/partial/paths.rs
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/partial/paths.rs
@@ -14,4 +14,5 @@ fn foo() {
     Foo::bar::;
     Foo::<bar>::;
     Foo::<bar::>::baz;
+    <Foo as Bar>::;
 }

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/partial/paths.txt
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/partial/paths.txt
@@ -1,23 +1,26 @@
 FILE
   RsUseItemImpl(USE_ITEM)
     PsiElement(use)('use')
-  PsiErrorElement:'::' or ';' expected, got '::'
-    <empty list>
-  PsiWhiteSpace(' ')
-  PsiElement(::)('::')
-  PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+    PsiWhiteSpace(' ')
+    RsUseSpeckImpl(USE_SPECK)
+      RsPathImpl(PATH)
+        PsiElement(::)('::')
+        PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+          <empty list>
     PsiElement(;)(';')
   PsiWhiteSpace('\n')
   RsUseItemImpl(USE_ITEM)
     PsiElement(use)('use')
-  PsiErrorElement:'::' or ';' expected, got '::'
-    <empty list>
-  PsiWhiteSpace(' ')
-  PsiElement(::)('::')
-  PsiErrorElement:Self, crate, identifier, self or super expected, got '::'
-    <empty list>
-  PsiElement(::)('::')
-  PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+    PsiWhiteSpace(' ')
+    RsUseSpeckImpl(USE_SPECK)
+      RsPathImpl(PATH)
+        RsPathImpl(PATH)
+          PsiElement(::)('::')
+          PsiErrorElement:Self, crate, identifier, self or super expected, got '::'
+            <empty list>
+        PsiElement(::)('::')
+        PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+          <empty list>
     PsiElement(;)(';')
   PsiWhiteSpace('\n')
   RsUseItemImpl(USE_ITEM)
@@ -89,19 +92,24 @@ FILE
     RsBlockImpl(BLOCK)
       PsiElement({)('{')
       PsiWhiteSpace('\n    ')
-      PsiElement(::)('::')
-      PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
-        <empty list>
-      RsEmptyStmtImpl(EMPTY_STMT)
+      RsExprStmtImpl(EXPR_STMT)
+        RsPathExprImpl(PATH_EXPR)
+          RsPathImpl(PATH)
+            PsiElement(::)('::')
+            PsiErrorElement:'!', '::', Self, crate, identifier, self, super or '{' expected, got ';'
+              <empty list>
         PsiElement(;)(';')
       PsiWhiteSpace('\n    ')
-      PsiElement(::)('::')
-      PsiErrorElement:Self, crate, identifier, self or super expected, got '::'
-        <empty list>
-      PsiElement(::)('::')
-      PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
-        <empty list>
-      RsEmptyStmtImpl(EMPTY_STMT)
+      RsExprStmtImpl(EXPR_STMT)
+        RsPathExprImpl(PATH_EXPR)
+          RsPathImpl(PATH)
+            RsPathImpl(PATH)
+              PsiElement(::)('::')
+              PsiErrorElement:'::', <, Self, crate, identifier, self or super expected, got '::'
+                <empty list>
+            PsiElement(::)('::')
+            PsiErrorElement:'!', '::', <, Self, crate, identifier, self, super or '{' expected, got ';'
+              <empty list>
         PsiElement(;)(';')
       PsiWhiteSpace('\n    ')
       RsExprStmtImpl(EXPR_STMT)
@@ -189,6 +197,26 @@ FILE
                 PsiElement(>)('>')
             PsiElement(::)('::')
             PsiElement(identifier)('baz')
+        PsiElement(;)(';')
+      PsiWhiteSpace('\n    ')
+      RsExprStmtImpl(EXPR_STMT)
+        RsPathExprImpl(PATH_EXPR)
+          RsPathImpl(PATH)
+            RsTypeQualImpl(TYPE_QUAL)
+              PsiElement(<)('<')
+              RsBaseTypeImpl(BASE_TYPE)
+                RsPathImpl(PATH)
+                  PsiElement(identifier)('Foo')
+              PsiWhiteSpace(' ')
+              PsiElement(as)('as')
+              PsiWhiteSpace(' ')
+              RsTraitRefImpl(TRAIT_REF)
+                RsPathImpl(PATH)
+                  PsiElement(identifier)('Bar')
+              PsiElement(>)('>')
+              PsiElement(::)('::')
+            PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+              <empty list>
         PsiElement(;)(';')
       PsiWhiteSpace('\n')
       PsiElement(})('}')


### PR DESCRIPTION
As discussed in https://github.com/intellij-rust/intellij-rust/pull/6404#issuecomment-748450945. Can be considered as a continuation of #6285.

Provides better syntax error messages in the case of an incomplete path like this:
```rust
use ::;
type T = <Foo as Bar>::;
```

c.c. @msmorgan

changelog: Improve parser recovery and syntax error messages in the case of incomplete paths
