### PR TITLE
 GRAM: simplify syntax error messages on incorrect paths

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
@@ -287,8 +287,7 @@ object RustParserUtil : GeneratedParserUtilBase() {
             }
             else -> {
                 // error message
-                val consumed = consumeToken(b, IDENTIFIER) || consumeToken(b, SELF) ||
-                    consumeToken(b, SUPER) || consumeToken(b, CSELF) || consumeToken(b, CRATE)
+                val consumed = consumeToken(b, IDENTIFIER)
                 check(!consumed)
                 false
             }

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -188,12 +188,12 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
     """)
 
     fun `test no unresolved reference for a path after incomplete path 1`() = checkByText("""
-        use <error descr="Unresolved reference: `foo`">foo</error>::<error descr="Self, crate, identifier, self or super expected, got '::'">:</error>:bar;
+        use <error descr="Unresolved reference: `foo`">foo</error>::<error descr="identifier expected, got '::'">:</error>:bar;
     """, false)
 
     fun `test no unresolved reference for a path after incomplete path 2`() = checkByText("""
         mod foo {}
-        use foo::<error descr="Self, crate, identifier, self or super expected, got '::'">:</error>:bar;
+        use foo::<error descr="identifier expected, got '::'">:</error>:bar;
     """, false)
 
     private fun checkByText(@Language("Rust") text: String, ignoreWithoutQuickFix: Boolean) {

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/partial/paths.txt
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/partial/paths.txt
@@ -5,7 +5,7 @@ FILE
     RsUseSpeckImpl(USE_SPECK)
       RsPathImpl(PATH)
         PsiElement(::)('::')
-        PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+        PsiErrorElement:identifier expected, got ';'
           <empty list>
     PsiElement(;)(';')
   PsiWhiteSpace('\n')
@@ -16,10 +16,10 @@ FILE
       RsPathImpl(PATH)
         RsPathImpl(PATH)
           PsiElement(::)('::')
-          PsiErrorElement:Self, crate, identifier, self or super expected, got '::'
+          PsiErrorElement:identifier expected, got '::'
             <empty list>
         PsiElement(::)('::')
-        PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+        PsiErrorElement:identifier expected, got ';'
           <empty list>
     PsiElement(;)(';')
   PsiWhiteSpace('\n')
@@ -31,7 +31,7 @@ FILE
         RsPathImpl(PATH)
           PsiElement(identifier)('foo')
         PsiElement(::)('::')
-        PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+        PsiErrorElement:identifier expected, got ';'
           <empty list>
     PsiElement(;)(';')
   PsiWhiteSpace('\n')
@@ -44,10 +44,10 @@ FILE
           RsPathImpl(PATH)
             PsiElement(identifier)('foo')
           PsiElement(::)('::')
-          PsiErrorElement:Self, crate, identifier, self or super expected, got '::'
+          PsiErrorElement:identifier expected, got '::'
             <empty list>
         PsiElement(::)('::')
-        PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+        PsiErrorElement:identifier expected, got ';'
           <empty list>
     PsiElement(;)(';')
   PsiWhiteSpace('\n')
@@ -60,7 +60,7 @@ FILE
           RsPathImpl(PATH)
             PsiElement(identifier)('foo')
           PsiElement(::)('::')
-          PsiErrorElement:Self, crate, identifier, self or super expected, got '::'
+          PsiErrorElement:identifier expected, got '::'
             <empty list>
         PsiElement(::)('::')
         PsiElement(identifier)('bar')
@@ -77,7 +77,7 @@ FILE
           PsiElement(::)('::')
           PsiElement(identifier)('bar')
         PsiElement(::)('::')
-        PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+        PsiErrorElement:identifier expected, got ';'
           <empty list>
     PsiElement(;)(';')
   PsiWhiteSpace('\n\n')
@@ -96,7 +96,7 @@ FILE
         RsPathExprImpl(PATH_EXPR)
           RsPathImpl(PATH)
             PsiElement(::)('::')
-            PsiErrorElement:'!', '::', Self, crate, identifier, self, super or '{' expected, got ';'
+            PsiErrorElement:'!', '::', identifier or '{' expected, got ';'
               <empty list>
         PsiElement(;)(';')
       PsiWhiteSpace('\n    ')
@@ -105,10 +105,10 @@ FILE
           RsPathImpl(PATH)
             RsPathImpl(PATH)
               PsiElement(::)('::')
-              PsiErrorElement:'::', <, Self, crate, identifier, self or super expected, got '::'
+              PsiErrorElement:'::', < or identifier expected, got '::'
                 <empty list>
             PsiElement(::)('::')
-            PsiErrorElement:'!', '::', <, Self, crate, identifier, self, super or '{' expected, got ';'
+            PsiErrorElement:'!', '::', <, identifier or '{' expected, got ';'
               <empty list>
         PsiElement(;)(';')
       PsiWhiteSpace('\n    ')
@@ -118,7 +118,7 @@ FILE
             RsPathImpl(PATH)
               PsiElement(identifier)('Foo')
             PsiElement(::)('::')
-            PsiErrorElement:'!', '::', <, Self, crate, identifier, self, super or '{' expected, got ';'
+            PsiErrorElement:'!', '::', <, identifier or '{' expected, got ';'
               <empty list>
         PsiElement(;)(';')
       PsiWhiteSpace('\n    ')
@@ -129,10 +129,10 @@ FILE
               RsPathImpl(PATH)
                 PsiElement(identifier)('Foo')
               PsiElement(::)('::')
-              PsiErrorElement:'::', <, Self, crate, identifier, self or super expected, got '::'
+              PsiErrorElement:'::', < or identifier expected, got '::'
                 <empty list>
             PsiElement(::)('::')
-            PsiErrorElement:'!', '::', <, Self, crate, identifier, self, super or '{' expected, got ';'
+            PsiErrorElement:'!', '::', <, identifier or '{' expected, got ';'
               <empty list>
         PsiElement(;)(';')
       PsiWhiteSpace('\n    ')
@@ -143,7 +143,7 @@ FILE
               RsPathImpl(PATH)
                 PsiElement(identifier)('Foo')
               PsiElement(::)('::')
-              PsiErrorElement:'::', <, Self, crate, identifier, self or super expected, got '::'
+              PsiErrorElement:'::', < or identifier expected, got '::'
                 <empty list>
             PsiElement(::)('::')
             PsiElement(identifier)('bar')
@@ -158,7 +158,7 @@ FILE
               PsiElement(::)('::')
               PsiElement(identifier)('bar')
             PsiElement(::)('::')
-            PsiErrorElement:'!', '::', <, Self, crate, identifier, self, super or '{' expected, got ';'
+            PsiErrorElement:'!', '::', <, identifier or '{' expected, got ';'
               <empty list>
         PsiElement(;)(';')
       PsiWhiteSpace('\n    ')
@@ -175,7 +175,7 @@ FILE
                     PsiElement(identifier)('bar')
                 PsiElement(>)('>')
             PsiElement(::)('::')
-            PsiErrorElement:'::', Self, crate, identifier, self, super or '{' expected, got ';'
+            PsiErrorElement:'::', identifier or '{' expected, got ';'
               <empty list>
         PsiElement(;)(';')
       PsiWhiteSpace('\n    ')
@@ -192,7 +192,7 @@ FILE
                     RsPathImpl(PATH)
                       PsiElement(identifier)('bar')
                     PsiElement(::)('::')
-                    PsiErrorElement:'!', '(', '+', ',', '::', <, <path parameters>, <type argument list>, '>', Self, crate, identifier, self or super expected, got '>'
+                    PsiErrorElement:'!', '(', '+', ',', '::', <, <path parameters>, <type argument list>, '>' or identifier expected, got '>'
                       <empty list>
                 PsiElement(>)('>')
             PsiElement(::)('::')
@@ -215,7 +215,7 @@ FILE
                   PsiElement(identifier)('Bar')
               PsiElement(>)('>')
               PsiElement(::)('::')
-            PsiErrorElement:Self, crate, identifier, self or super expected, got ';'
+            PsiErrorElement:identifier expected, got ';'
               <empty list>
         PsiElement(;)(';')
       PsiWhiteSpace('\n')

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/partial/shifts.txt
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/partial/shifts.txt
@@ -93,7 +93,7 @@ FILE
             PsiWhiteSpace(' ')
             RsBinaryOpImpl(BINARY_OP)
               PsiElement(<)('<')
-            PsiErrorElement:'#', '::', <, <block expr>, <expr>, <for expr>, <loop expr>, <macro call>, <struct literal>, <while expr>, Self, crate, identifier, self, super or '|' expected, got '<'
+            PsiErrorElement:'#', '::', <, <block expr>, <expr>, <for expr>, <loop expr>, <macro call>, <struct literal>, <while expr>, identifier or '|' expected, got '<'
               <empty list>
           PsiWhiteSpace(' ')
           RsBinaryOpImpl(BINARY_OP)
@@ -131,7 +131,7 @@ FILE
             PsiWhiteSpace(' ')
             RsBinaryOpImpl(BINARY_OP)
               PsiElement(<)('<')
-            PsiErrorElement:'#', '::', <, <block expr>, <expr>, <for expr>, <loop expr>, <macro call>, <struct literal>, <while expr>, Self, crate, identifier, self, super or '|' expected, got '<'
+            PsiErrorElement:'#', '::', <, <block expr>, <expr>, <for expr>, <loop expr>, <macro call>, <struct literal>, <while expr>, identifier or '|' expected, got '<'
               <empty list>
           PsiWhiteSpace(' ')
           RsBinaryOpImpl(BINARY_OP)


### PR DESCRIPTION
In addition to #6541 let's show `identifier expected, got ';'` message instead of `Self, crate, identifier, self or super expected, got ';'`. This is a bit closer to `rustc`'s messages

#### Before:
![image](https://user-images.githubusercontent.com/3221931/102892159-872f9300-4470-11eb-86f1-f5bae745f39d.png)

#### After:
![image](https://user-images.githubusercontent.com/3221931/102892340-c78f1100-4470-11eb-9bbe-1c36fd47a297.png)


#### Rustc:
![image](https://user-images.githubusercontent.com/3221931/102892218-99113600-4470-11eb-964c-9ffc29c34e10.png)


changelog: Improve syntax error messages in the case of incomplete paths
