### PR TITLE
Evaluate unknown cfg options to false if no `build.rs` in a package

### DIFF
--- a/src/main/kotlin/org/rust/cargo/CfgOptions.kt
+++ b/src/main/kotlin/org/rust/cargo/CfgOptions.kt
@@ -17,6 +17,9 @@ data class CfgOptions(
     fun isNameValueEnabled(name: String, value: String): Boolean =
         keyValueOptions[name]?.contains(value) ?: false
 
+    operator fun plus(other: CfgOptions): CfgOptions =
+        CfgOptions(keyValueOptions + other.keyValueOptions, nameOptions + other.nameOptions)
+
     companion object {
         fun parse(rawCfgOptions: List<String>): CfgOptions {
             val knownKeyValueOptions = hashMapOf<String, MutableSet<String>>()
@@ -54,8 +57,5 @@ data class CfgOptions(
 
             nameOptions = hashSetOf("debug_assertions", "unix")
         )
-
-        @TestOnly
-        const val TEST: String = "intellij_rust"
     }
 }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -562,7 +562,9 @@ private class TargetImpl(
 
     override val crateRoot: VirtualFile? by CachedVirtualFile(crateRootUrl)
 
-    override val cfgOptions: CfgOptions = pkg.workspace.cfgOptions + (pkg.cfgOptions ?: CfgOptions.EMPTY)
+    override val cfgOptions: CfgOptions = pkg.workspace.cfgOptions + (pkg.cfgOptions ?: CfgOptions.EMPTY) +
+        // https://doc.rust-lang.org/reference/conditional-compilation.html#proc_macro
+        if (kind.isProcMacro) CfgOptions(emptyMap(), setOf("proc_macro")) else CfgOptions.EMPTY
 
     override fun toString(): String = "Target(name='$name', kind=$kind, crateRootUrl='$crateRootUrl')"
 }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspaceData.kt
@@ -55,7 +55,7 @@ data class CargoWorkspaceData(
         val features: Map<FeatureName, List<FeatureDep>>,
         /** Enabled features (from Cargo point of view) */
         val enabledFeatures: Set<FeatureName>,
-        val cfgOptions: CfgOptions,
+        val cfgOptions: CfgOptions?,
         val env: Map<String, String>,
         val outDirUrl: String?
     )

--- a/src/main/kotlin/org/rust/cargo/toolchain/RsToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsToolchain.kt
@@ -63,6 +63,13 @@ open class RsToolchain(val location: Path) {
     companion object {
         val MIN_SUPPORTED_TOOLCHAIN = SemVer.parseFromText("1.32.0")!!
 
+        /** Environment variable to unlock unstable features of rustc and cargo.
+         *  It doesn't change real toolchain.
+         *
+         * @see <a href="https://github.com/rust-lang/cargo/blob/06ddf3557796038fd87743bd3b6530676e12e719/src/cargo/core/features.rs#L447">features.rs</a>
+         */
+        const val RUSTC_BOOTSTRAP: String = "RUSTC_BOOTSTRAP"
+
         fun suggest(): RsToolchain? =
             RsToolchainFlavor.getFlavors()
                 .asSequence()

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -376,7 +376,7 @@ object CargoMetadata {
             }
         }
 
-        val cfgOptions = CfgOptions.parse(buildScriptMessage?.cfgs.orEmpty())
+        val cfgOptions = buildScriptMessage?.cfgs?.let { CfgOptions.parse(it) }
 
         val env = buildScriptMessage?.env.orEmpty()
             .filter { it.size == 2 }

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -37,6 +37,7 @@ import org.rust.cargo.runconfig.command.workingDirectory
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.toolchain.ExternalLinter
 import org.rust.cargo.toolchain.RsToolchain
+import org.rust.cargo.toolchain.RsToolchain.Companion.RUSTC_BOOTSTRAP
 import org.rust.cargo.toolchain.RustChannel
 import org.rust.cargo.toolchain.impl.BuildScriptMessage
 import org.rust.cargo.toolchain.impl.BuildScriptsInfo
@@ -438,13 +439,6 @@ open class Cargo(toolchain: RsToolchain, useWrapper: Boolean = false)
         private val COLOR_ACCEPTING_COMMANDS: List<String> = listOf(
             "bench", "build", "check", "clean", "clippy", "doc", "install", "publish", "run", "rustc", "test", "update"
         )
-
-        /** Environment variable to unlock unstable features of rustc and cargo.
-         *  It doesn't change real toolchain.
-         *
-         * @see <a href="https://github.com/rust-lang/cargo/blob/06ddf3557796038fd87743bd3b6530676e12e719/src/cargo/core/features.rs#L447">features.rs</a>
-         */
-        private const val RUSTC_BOOTSTRAP: String = "RUSTC_BOOTSTRAP"
 
         data class GeneratedFilesHolder(val manifest: VirtualFile, val sourceFiles: List<VirtualFile>)
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustc.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustc.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapiext.isUnitTestMode
 import org.rust.cargo.CfgOptions
 import org.rust.cargo.toolchain.RsToolchain
+import org.rust.cargo.toolchain.RsToolchain.Companion.RUSTC_BOOTSTRAP
 import org.rust.cargo.toolchain.impl.RustcVersion
 import org.rust.cargo.toolchain.impl.parseRustcVersion
 import org.rust.openapiext.checkIsBackgroundThread
@@ -52,8 +53,8 @@ class Rustc(toolchain: RsToolchain) : RustupComponent(NAME, toolchain) {
         val timeoutMs = 10000
         val output = createBaseCommandLine(
             "--print", "cfg",
-            workingDirectory = projectDirectory
-        ).execute(timeoutMs)
+            workingDirectory = projectDirectory,
+        ).withEnvironment(RUSTC_BOOTSTRAP, "1").execute(timeoutMs)
         return if (output?.isSuccess == true) output.stdoutLines else null
     }
 

--- a/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/Crate.kt
@@ -37,6 +37,13 @@ interface Crate {
     val cfgOptions: CfgOptions
     val features: Map<String, FeatureState>
 
+    /**
+     * `true` if there isn't a custom build script (`build.rs`) in the package or if the build script is
+     * successfully evaluated (hence [cfgOptions] is filled). The value affects `#[cfg()]` and `#[cfg_attr()]`
+     * attributes evaluation.
+     */
+    val evaluateUnknownCfgToFalse: Boolean
+
     /** A map of compile-time environment variables, needed for `env!("FOO")` macros expansion */
     val env: Map<String, String>
 

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/CargoBasedCrate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/CargoBasedCrate.kt
@@ -47,7 +47,12 @@ class CargoBasedCrate(
     override val cargoWorkspace: CargoWorkspace get() = cargoTarget.pkg.workspace
     override val kind: CargoWorkspace.TargetKind get() = cargoTarget.kind
 
-    override val cfgOptions: CfgOptions get() = cargoTarget.pkg.cfgOptions
+    override val cfgOptions: CfgOptions get() = cargoTarget.cfgOptions
+
+    override val evaluateUnknownCfgToFalse: Boolean
+        get() = cargoTarget.pkg.cfgOptions != null   // `true` if there is `build.rs` and it is evaluated
+            || !cargoTarget.pkg.hasCustomBuildScript // `true` if there isn't `build.rs`
+
     override val env: Map<String, String> get() = cargoTarget.pkg.env
     override val outDir: VirtualFile? get() = cargoTarget.pkg.outDir
 

--- a/src/main/kotlin/org/rust/lang/core/crate/impl/DoctestCrate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/DoctestCrate.kt
@@ -34,6 +34,7 @@ class DoctestCrate(
 
     override val cfgOptions: CfgOptions get() = CfgOptions.EMPTY
     override val features: Map<String, FeatureState> get() = emptyMap()
+    override val evaluateUnknownCfgToFalse: Boolean get() = true
     override val env: Map<String, String> get() = emptyMap()
     override val outDir: VirtualFile? get() = null
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateModificationTracker.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateModificationTracker.kt
@@ -84,7 +84,7 @@ private fun DefMapHolder.processChangedFiles(crate: Crate, defMap: CrateDefMap):
 data class CrateMetaData(
     val edition: CargoWorkspace.Edition,
     private val features: Map<String, FeatureState>,
-    private val cfgOptions: CfgOptions,
+    private val cfgOptions: CfgOptions?,
     private val env: Map<String, String>,
     // TODO: Probably we need to store modificationStamp of DefMap for each dependency
     private val dependencies: Set<CratePersistentId>,

--- a/src/test/kotlin/org/rust/MockAdditionalCfgOptions.kt
+++ b/src/test/kotlin/org/rust/MockAdditionalCfgOptions.kt
@@ -10,10 +10,6 @@ import java.lang.annotation.Inherited
 /**
  * Allows extending default cfg options ([org.rust.cargo.CfgOptions.DEFAULT]) for a specific test.
  *
- * NB: Only a few cfg options are allowed to be evaluated.
- * You can either use the special test-only [org.rust.cargo.CfgOptions.TEST] option here
- * or one of the supported options from [org.rust.lang.utils.evaluation.CfgEvaluator.SUPPORTED_NAME_OPTIONS].
- *
  * @see RsTestBase.setupMockCfgOptions
  */
 @Inherited

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -825,4 +825,30 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         fn foo(v: Vec) {}
                  //^ ...vec.rs
     """)
+
+    fun `test unknown cfg options are disabled`() = checkByCode("""
+        #[cfg(unknown_cfg_option)]
+        fn foo() {}
+        #[cfg(not(unknown_cfg_option))]
+        fn foo() {}
+         //X
+
+        fn main() {
+            foo();
+          //^
+        }
+    """)
+
+    fun `test unknown cargo features are disabled`() = checkByCode("""
+        #[cfg(feature = "unknown_cargo_feature")]
+        fn foo() {}
+        #[cfg(not(feature = "unknown_cargo_feature"))]
+        fn foo() {}
+         //X
+
+        fn main() {
+            foo();
+          //^
+        }
+    """)
 }

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoProjectResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoProjectResolveTest.kt
@@ -732,7 +732,7 @@ class CargoProjectResolveTest : RsWithToolchainTestBase() {
             """)
             dir("src") {
                 rust("lib.rs", """
-                    #[cfg(feature="foobar")]
+                    #[cfg(feature="bar_feature")]
                     pub fn bar() -> u32 { 42 }
                 """)
             }
@@ -793,7 +793,7 @@ class CargoProjectResolveTest : RsWithToolchainTestBase() {
             """)
             dir("src") {
                 rust("lib.rs", """
-                    #[cfg(feature="foobar")]
+                    #[cfg(feature="bar_feature")]
                     pub fn bar() -> u32 { 42 }
                 """)
             }


### PR DESCRIPTION
For a long time, we did consider _unknown_ `cfg` options and unknown cargo features as enabled and disabled at the same time.
For example, both `foo` were enabled here:
```rust
#[cfg(unknown_cfg_option)]
fn foo() {}
#[cfg(not(unknown_cfg_option))]
fn foo() {}
```

What means "unknown"? Well, we had a list of known `cfg` options. It contained `debug_assertions`, `unix`, `windows` named options and `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_os`, `target_pointer_width`, `target_vendor` key-value options.

In the case of cargo features, we considered as "unknown" features that are not mentioned in `[features]` table of `Cargo.toml`.

Why? Why not just consider these `cfg` options as disabled (just like `rustc` does)?

There are two reasons:
1. We use `rustc --print cfg` command in order to retrieve actual compiler cfg options. But a stable compiler doesn't print unstable options that are used in the stdlib. 
2. Custom build scripts (`build.rs`) can produce custom `cfg` options (`#[cfg(foobar)]`), as well as features that are not mentioned in `Cargo-toml`: `#[cfg(feature = "foobar")]`.

This PR fights the first problem by unsing `RUSTC_BOOTSTRAP=1` environment variable when invoking `rustc --print cfg`. This magic variable makes the compiler think that it is nightly and so print unstable `cfg` options.

The second problem should be eventually solved by honest buildscript evaluation (see #6104), but now we can just apply "honest" behavior for packages without `build.rs` and leave old behavior for packages with build.rs. Also, the "honest" behavior is applied to all packages if experimental buildscript evaluation is enabled.

So finally if a package doesn't have a custom build script (`build.rs`), (almost) all `cfg` conditions are evaluated correctly. But there are two exception:
1. `test` cfg option is still considered enabled and disabled at the same time (`#[cfg(test)]` and `#[cfg(not(test))]` both enabled). #6507 fixes it for external dependencies, but not for workspace packages.
2. An unstable [`panic`](https://doc.rust-lang.org/nightly/unstable-book/language-features/cfg-panic.html) cfg option (`#[cfg(panic = "unwind")]`) is still considered enabled and disabled at the same time, just because I haven't found a way to determine panic strategy for a crate.

changelog: Honestly Evaluate unknown `cfg` options to false if there is no custom build script (`build.rs`) in a package
