### PR TITLE
CARGO: resolve URL references in some package and dependency attributes

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/CargoTomlPsiPattern.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoTomlPsiPattern.kt
@@ -20,6 +20,7 @@ import org.toml.lang.psi.ext.kind
 object CargoTomlPsiPattern {
     private const val TOML_KEY_CONTEXT_NAME = "key"
     private const val TOML_KEY_VALUE_CONTEXT_NAME = "keyValue"
+    private val PACKAGE_URL_ATTRIBUTES = setOf("homepage", "repository", "documentation")
 
     private inline fun <reified I : PsiElement> cargoTomlPsiElement(): PsiElementPattern.Capture<I> {
         return psiElement<I>().inVirtualFile(
@@ -284,6 +285,16 @@ object CargoTomlPsiPattern {
     val onDependencyPackageFeature: PsiElementPattern.Capture<TomlLiteral> = cargoTomlStringLiteral()
         .withParent(
             onDependencyPackageFeatureArray
+        )
+
+    val dependencyGitUrl: PsiElementPattern.Capture<TomlLiteral> = cargoTomlStringLiteral()
+        .withParent(dependencyProperty("git"))
+
+    val packageUrl: PsiElementPattern.Capture<TomlLiteral> = cargoTomlStringLiteral()
+        .withParent(
+            psiElement<TomlKeyValue>()
+                .withParent(tomlTable("package"))
+                .with("name") { e, _ -> e.key.name in PACKAGE_URL_ATTRIBUTES }
         )
 
     private fun cargoTomlStringLiteral() = cargoTomlPsiElement<TomlLiteral>()

--- a/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlReferenceContributor.kt
+++ b/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlReferenceContributor.kt
@@ -10,7 +10,9 @@ import com.intellij.psi.PsiReferenceRegistrar
 import org.rust.lang.core.or
 import org.rust.toml.CargoTomlPsiPattern.onDependencyKey
 import org.rust.toml.CargoTomlPsiPattern.onDependencyPackageFeature
+import org.rust.toml.CargoTomlPsiPattern.dependencyGitUrl
 import org.rust.toml.CargoTomlPsiPattern.onFeatureDependencyLiteral
+import org.rust.toml.CargoTomlPsiPattern.packageUrl
 import org.rust.toml.CargoTomlPsiPattern.onSpecificDependencyHeaderKey
 import org.rust.toml.tomlPluginIsAbiCompatible
 
@@ -28,6 +30,7 @@ class CargoTomlReferenceContributor : PsiReferenceContributor() {
             }
             registrar.registerReferenceProvider(onFeatureDependencyLiteral, CargoTomlFeatureDependencyReferenceProvider())
             registrar.registerReferenceProvider(onDependencyPackageFeature, CargoTomlDependencyFeaturesReferenceProvider())
+            registrar.registerReferenceProvider(dependencyGitUrl or packageUrl, CargoTomlUrlReferenceProvider())
         }
     }
 }

--- a/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlUrlReferenceProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlUrlReferenceProvider.kt
@@ -1,0 +1,28 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.resolve
+
+import com.intellij.openapi.paths.WebReference
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceProvider
+import com.intellij.util.ProcessingContext
+import org.toml.lang.psi.TomlLiteral
+import org.toml.lang.psi.ext.TomlLiteralKind
+import org.toml.lang.psi.ext.kind
+
+class CargoTomlUrlReferenceProvider : PsiReferenceProvider() {
+    override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> {
+        val literal = element as? TomlLiteral ?: return emptyArray()
+        val kind = (literal.kind as? TomlLiteralKind.String) ?: return emptyArray()
+        val value = kind.value ?: return emptyArray()
+
+        if (value.startsWith("http://") || value.startsWith("https://")) {
+            return arrayOf(WebReference(element, value))
+        }
+        return emptyArray()
+    }
+}

--- a/toml/src/test/kotlin/org/rust/toml/CargoTomlPsiPatternTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoTomlPsiPatternTest.kt
@@ -185,6 +185,18 @@ class CargoTomlPsiPatternTest : RsTestBase() {
                     #^
     """)
 
+    fun `test dependency key in inline table`() = testPattern(CargoTomlPsiPattern.dependencyProperty("features"), """
+        [dependencies]
+        foo = { features = [] }
+                        #^
+    """)
+
+    fun `test dependency key in specific dependency`() = testPattern(CargoTomlPsiPattern.dependencyProperty("features"), """
+        [dependencies.foo]
+        features = []
+                #^
+    """)
+
     private inline fun <reified T : PsiElement> testPattern(
         pattern: ElementPattern<T>,
         @Language("Toml") code: String,

--- a/toml/src/test/kotlin/org/rust/toml/CargoTomlPsiPatternTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoTomlPsiPatternTest.kt
@@ -16,7 +16,9 @@ import org.rust.toml.CargoTomlPsiPattern.inSpecificDependencyHeaderKey
 import org.rust.toml.CargoTomlPsiPattern.inSpecificDependencyKeyValue
 import org.rust.toml.CargoTomlPsiPattern.onDependencyKey
 import org.rust.toml.CargoTomlPsiPattern.onDependencyPackageFeature
+import org.rust.toml.CargoTomlPsiPattern.dependencyGitUrl
 import org.rust.toml.CargoTomlPsiPattern.onFeatureDependencyLiteral
+import org.rust.toml.CargoTomlPsiPattern.packageUrl
 import org.rust.toml.CargoTomlPsiPattern.onSpecificDependencyHeaderKey
 import org.rust.toml.CargoTomlPsiPattern.packageWorkspacePath
 import org.rust.toml.CargoTomlPsiPattern.path
@@ -195,6 +197,30 @@ class CargoTomlPsiPatternTest : RsTestBase() {
         [dependencies.foo]
         features = []
                 #^
+    """)
+
+    fun `test dependency git url link`() = testPattern(dependencyGitUrl, """
+        [dependencies]
+        foo = { git = "foo" }
+                       #^
+    """)
+
+    fun `test package homepage url link`() = testPattern(packageUrl, """
+        [package]
+        homepage = "foo"
+                    #^
+    """)
+
+    fun `test package repository url link`() = testPattern(packageUrl, """
+        [package]
+        repository = "foo"
+                      #^
+    """)
+
+    fun `test package documentation url link`() = testPattern(packageUrl, """
+        [package]
+        documentation = "foo"
+                         #^
     """)
 
     private inline fun <reified T : PsiElement> testPattern(

--- a/toml/src/test/kotlin/org/rust/toml/resolve/CargoTomlUrlResolveTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/resolve/CargoTomlUrlResolveTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.resolve
+
+import com.intellij.openapi.paths.WebReference
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+
+class CargoTomlUrlResolveTest : RsTestBase() {
+    fun `test no reference for package name`() = checkNoUrlReference("""
+        [package]
+        name = "<caret>https://github.com/foo/bar"
+    """)
+
+    fun `test no reference if literal is not absolute URL`() = checkNoUrlReference("""
+        [package]
+        documentation = "<caret>github.com/foo/bar"
+    """)
+
+    fun `test reference http`() = checkUrlReference("""
+        [package]
+        homepage = "<caret>http://github.com/foo/bar"
+    """, "http://github.com/foo/bar")
+
+    fun `test reference in homepage`() = checkUrlReference("""
+        [package]
+        homepage = "<caret>https://github.com/foo/bar"
+    """, "https://github.com/foo/bar")
+
+    fun `test reference in repository`() = checkUrlReference("""
+        [package]
+        repository = "<caret>https://github.com/foo/bar"
+    """, "https://github.com/foo/bar")
+
+    fun `test reference in documentation`() = checkUrlReference("""
+        [package]
+        homepage = "<caret>https://github.com/foo/bar"
+    """, "https://github.com/foo/bar")
+
+    fun `test reference in dependency git URL`() = checkUrlReference("""
+        [dependencies]
+        foo = { git = "<caret>https://github.com/foo/bar" }
+    """, "https://github.com/foo/bar")
+
+    fun `test reference in specific dependency git URL`() = checkUrlReference("""
+        [dependencies.foo]
+        git = "<caret>https://github.com/foo/bar"
+    """, "https://github.com/foo/bar")
+
+    private fun checkUrlReference(@Language("TOML") code: String, url: String) {
+        InlineFile(code, "Cargo.toml")
+        val reference = myFixture.getReferenceAtCaretPosition()
+        assertInstanceOf(reference, WebReference::class.java)
+        assertEquals(url, (reference as WebReference).url)
+    }
+
+    private fun checkNoUrlReference(@Language("TOML") code: String) {
+        InlineFile(code, "Cargo.toml")
+        assertNull(myFixture.getReferenceAtCaretPosition())
+    }
+}


### PR DESCRIPTION
This PR adds support for resolveing URLs in `git`, `homepage`, `repository` and `documentation` attributes in `Cargo.toml`. I didn't know how to test web references, so I just added tests for their corresponding PSI patterns.

I also refactored the TOML PSI patterns a bit to introduce a method that can be used to find any dependency attribute.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/6552

changelog: Resolve URLs in Cargo.toml (e.g. in dependency `git` links).