### PR TITLE
RES: Fix propagation expanded macro def to grandparent mod

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
@@ -308,7 +308,7 @@ private class ModCollector(
             }
         }
         if (modData.hasMacroUse) {
-            val parent = this.modData.parent ?: return
+            val parent = modData.parent ?: return
             parent.addLegacyMacros(legacyMacros)
             propagateLegacyMacros(parent)
         }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
@@ -947,4 +947,25 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
             func();
         } //^
     """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test propagate expanded macro def to grandparent mod`() = checkByCode("""
+        mod inner {
+            #[macro_use]
+            mod mod1 {
+                #[macro_use]
+                mod mod2 {
+                    macro_rules! gen {
+                        ($ name:ident) => {
+                            macro_rules! $ name { () => {} }
+                        };
+                    }
+                    gen!(foo);
+                       //X
+                }
+            }
+            foo!();
+            //^
+        }
+    """)
 }


### PR DESCRIPTION
Fix `StackOverflowError` in case when both parent and grandparent mod of expanded macro def has `macro_use` attribute (Introduced in #6543)