### PR TITLE
T: Fix propagate expanded macro test

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
@@ -948,6 +948,7 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
         } //^
     """)
 
+    @UseNewResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test propagate expanded macro def to grandparent mod`() = checkByCode("""
         mod inner {


### PR DESCRIPTION
Fixup for #6558. For some reason, bors has merged commit, even though tests [don't pass](https://github.com/intellij-rust/intellij-rust/pull/6558#issuecomment-751242039)