### PR TITLE
RES: Use new resolve for not top level macro calls

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsDoctestInjectionResolveTest.kt
@@ -5,9 +5,11 @@
 
 package org.rust.lang.core.resolve
 
+import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
 import org.rust.WithStdlibAndDependencyRustProjectDescriptor
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
 class RsDoctestInjectionResolveTest : RsResolveTestBase() {
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
@@ -75,5 +77,21 @@ class RsDoctestInjectionResolveTest : RsResolveTestBase() {
         /// }
         /// ```
         pub fn foo() {}
+    """)
+
+    @MockEdition(Edition.EDITION_2018)
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test qualified macro call inside function`() = stubOnlyResolve("""
+    //- lib.rs
+        /// ```
+        /// fn test() {
+        ///     dep_lib_target::bar!();
+        /// }                 //^ dep-lib/lib.rs
+        /// ```
+        pub fn foo() {}
+    //- dep-lib/lib.rs
+        #[macro_export]
+        macro_rules! bar { () => {}; }
+                   //X
     """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -443,21 +443,32 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    // TODO
-    fun `test import macro by qualified path with aliased extern crate`() = expect<IllegalStateException> {
-        stubOnlyResolve("""
-        //- lib.rs
-            extern crate dep_lib_target as aliased;
-            fn bar() {
-                aliased::foo!();
-            }          //^ dep-lib/lib.rs
-        //- dep-lib/lib.rs
-            #[macro_export]
-            macro_rules! foo {
-                () => {};
-            }
-        """)
-    }
+    @UseNewResolve
+    fun `test import macro by qualified path with aliased extern crate`() = stubOnlyResolve("""
+    //- lib.rs
+        extern crate dep_lib_target as aliased;
+        fn bar() {
+            aliased::foo!();
+        }          //^ dep-lib/lib.rs
+    //- dep-lib/lib.rs
+        #[macro_export]
+        macro_rules! foo {
+            () => {};
+        }
+    """)
+
+    @UseNewResolve
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test import macro 2 by qualified path`() = stubOnlyResolve("""
+    //- lib.rs
+        fn bar() {
+            dep_lib_target::foo!();
+        }                 //^ dep-lib/lib.rs
+    //- dep-lib/lib.rs
+        #[macro_export]
+        macro_rules! foo_ { () => {}; }
+        pub use foo_ as foo;
+    """)
 
     fun `test import from crate root without 'pub' vis`() = stubOnlyResolve("""
     //- lib.rs


### PR DESCRIPTION
Fixes resolve of qualified macro calls inside items in some cases, e.g.:
```
fn main() {
    futures::join!();
}
```

changelog: Fixes resolve of qualified macro calls inside items in some cases when using new resolve
