### PR TITLE
RES: Fix restricted visibility in new resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/util/PathUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/util/PathUtil.kt
@@ -93,6 +93,6 @@ fun RsVisStub.getRestrictedPath(): Array<String>? {
     val path = visRestrictionPath ?: error("no visibility restriction")
     val segments = arrayListOf<String>()
     if (!addPathSegments(path, segments)) return null
-    if (segments.first().isEmpty()) segments.removeAt(0)
+    if (segments.first().let { it.isEmpty() || it == "crate" }) segments.removeAt(0)
     return segments.toTypedArray()
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.completion
 
 import org.rust.MockEdition
 import org.rust.ProjectDescriptor
+import org.rust.UseNewResolve
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 
@@ -161,6 +162,34 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
         }
         fn bar(s: S) {
             s.f/*caret*/
+        }
+    """)
+
+    @UseNewResolve
+    @MockEdition(Edition.EDITION_2018)
+    fun `test public item reexported with restricted visibility 1`() = checkNoCompletion("""
+        pub mod inner1 {
+            pub mod inner2 {
+                pub fn foo() {}
+                pub(in crate::inner1) use foo as bar;
+            }
+        }
+        fn main() {
+            crate::inner1::inner2::ba/*caret*/
+        }
+    """)
+
+    @UseNewResolve
+    @MockEdition(Edition.EDITION_2018)
+    fun `test public item reexported with restricted visibility 2`() = checkContainsCompletion("bar2", """
+        pub mod inner1 {
+            pub mod inner2 {
+                pub fn bar1() {}
+                pub(in crate::inner1) use bar1 as bar2;
+            }
+            fn main() {
+                crate::inner1::inner2::ba/*caret*/
+            }
         }
     """)
 


### PR DESCRIPTION
Fix handling restricted visibility with path from crate root in [new resolve](https://github.com/intellij-rust/intellij-rust/issues/6217). E.g.:
```rust
mod inner1 {
    mod inner2 {
        mod inner3 {
            pub(in crate::inner1) fn foo1() {}
            pub(in crate::inner1::inner2) fn foo2() {}
        }
    }
}
```

Previously items with such visibility were considered as `pub(crate)`

changelog: Fix handling items with restricted visibility with absolute path in new resolve
