### PR TITLE
Properly render Refresh Cargo Projects action in Sync view

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
@@ -18,6 +18,7 @@ import com.intellij.execution.ExecutionException
 import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProcessCanceledException
@@ -42,7 +43,6 @@ import org.rust.cargo.toolchain.tools.cargoOrWrapper
 import org.rust.cargo.toolchain.tools.rustc
 import org.rust.cargo.toolchain.tools.rustup
 import org.rust.cargo.util.DownloadResult
-import org.rust.ide.actions.RefreshCargoProjectsAction
 import org.rust.openapiext.TaskResult
 import java.util.concurrent.CompletableFuture
 import javax.swing.JComponent
@@ -124,9 +124,10 @@ class CargoSyncTask(
         val buildContentDescriptor = BuildContentDescriptor(null, null, object : JComponent() {}, "Cargo")
         buildContentDescriptor.isActivateToolWindowWhenFailed = true
         buildContentDescriptor.isActivateToolWindowWhenAdded = false
+        val refreshAction = ActionManager.getInstance().getAction("Cargo.RefreshCargoProject")
         val descriptor = DefaultBuildDescriptor("Cargo", "Cargo", project.basePath!!, System.currentTimeMillis())
             .withContentDescriptor { buildContentDescriptor }
-            .withRestartAction(RefreshCargoProjectsAction())
+            .withRestartAction(refreshAction)
             .withRestartAction(StopAction(progress))
         return object : BuildProgressDescriptor {
             override fun getTitle(): String = descriptor.title

--- a/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
+++ b/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
@@ -12,17 +12,14 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
 import com.intellij.psi.codeStyle.CodeStyleManager
-import com.intellij.testFramework.MapDataContext
-import com.intellij.testFramework.TestActionEvent
 import org.intellij.lang.annotations.Language
 import org.rust.FileTreeBuilder
 import org.rust.MinRustcVersion
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.fileTree
-import org.rust.ide.actions.RustfmtCargoProjectAction
-import org.rust.ide.actions.RustfmtFileAction
 import org.rust.ide.formatter.RustfmtExternalFormatProcessor
+import org.rust.launchAction
 import org.rust.openapiext.saveAllDocuments
 
 class RustfmtTest : RsWithToolchainTestBase() {
@@ -324,32 +321,11 @@ class RustfmtTest : RsWithToolchainTestBase() {
     }
 
     private fun reformatFile(editor: Editor) {
-        val dataContext = MapDataContext(mapOf(
-            CommonDataKeys.PROJECT to project,
-            CommonDataKeys.EDITOR_EVEN_IF_INACTIVE to editor
-        ))
-        val action = RustfmtFileAction()
-        val e = TestActionEvent(dataContext, action)
-        action.beforeActionPerformedUpdate(e)
-        check(e.presentation.isEnabledAndVisible) {
-            "Failed to run `${RustfmtFileAction::class.java.simpleName}` action"
-        }
-
-        action.actionPerformed(e)
+        myFixture.launchAction("Cargo.RustfmtFile", CommonDataKeys.EDITOR_EVEN_IF_INACTIVE to editor)
     }
 
     private fun reformatCargoProject() {
-        val dataContext = MapDataContext(mapOf(
-            CommonDataKeys.PROJECT to project
-        ))
-        val action = RustfmtCargoProjectAction()
-        val e = TestActionEvent(dataContext, action)
-        action.beforeActionPerformedUpdate(e)
-        check(e.presentation.isEnabledAndVisible) {
-            "Failed to run `${RustfmtCargoProjectAction::class.java.simpleName}` action"
-        }
-
-        action.actionPerformed(e)
+        myFixture.launchAction("Cargo.RustfmtCargoProject")
     }
 
     /**

--- a/src/test/kotlin/org/rust/cargo/project/model/AttachCargoProjectActionTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/AttachCargoProjectActionTest.kt
@@ -5,6 +5,7 @@
 
 package org.rust.cargo.project.model
 
+import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionPlaces
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.PlatformDataKeys
@@ -142,7 +143,7 @@ class AttachCargoProjectActionTest : RsWithToolchainTestBase() {
             put(AttachCargoProjectAction.MOCK_CHOSEN_FILE_KEY, mockChosenFile)
         }
         val testEvent = TestActionEvent(context, place)
-        val action = AttachCargoProjectAction()
+        val action = ActionManager.getInstance().getAction("Cargo.AttachCargoProject")
         action.beforeActionPerformedUpdate(testEvent)
         assertEquals(shouldBeEnabled, testEvent.presentation.isEnabledAndVisible)
         if (shouldBeEnabled) {

--- a/src/test/kotlin/org/rust/cargo/project/model/impl/SyncToolWindowTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/impl/SyncToolWindowTest.kt
@@ -7,13 +7,11 @@ package org.rust.cargo.project.model.impl
 
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.testFramework.MapDataContext
 import com.intellij.testFramework.PlatformTestUtil
-import com.intellij.testFramework.TestActionEvent
 import com.intellij.testFramework.fixtures.BuildViewTestFixture
 import org.rust.cargo.RsWithToolchainTestBase
-import org.rust.cargo.project.model.AttachCargoProjectAction
 import org.rust.cargo.project.model.cargoProjects
+import org.rust.launchAction
 
 class SyncToolWindowTest : RsWithToolchainTestBase() {
 
@@ -176,14 +174,7 @@ class SyncToolWindowTest : RsWithToolchainTestBase() {
     }
 
     private fun attachCargoProject(cargoProjectRoot: VirtualFile) {
-        val context = MapDataContext().apply {
-            put(PlatformDataKeys.PROJECT, project)
-            put(PlatformDataKeys.VIRTUAL_FILE, cargoProjectRoot)
-        }
-        val testEvent = TestActionEvent(context)
-        val action = AttachCargoProjectAction()
-        action.beforeActionPerformedUpdate(testEvent)
-        action.actionPerformed(testEvent)
+        myFixture.launchAction("Cargo.AttachCargoProject", PlatformDataKeys.VIRTUAL_FILE to cargoProjectRoot)
     }
 
     private fun checkSyncViewTree(expected: String) {

--- a/src/test/kotlin/org/rust/common.kt
+++ b/src/test/kotlin/org/rust/common.kt
@@ -5,6 +5,12 @@
 
 package org.rust
 
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.DataKey
+import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.testFramework.TestApplicationManager
+import com.intellij.testFramework.TestDataProvider
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.CargoProjectsService
 import org.rust.cargo.project.model.impl.CargoProjectImpl
@@ -52,3 +58,27 @@ fun CargoProject.workspaceOrFail(): CargoWorkspace {
 }
 
 fun CargoProjectsService.singleWorkspace(): CargoWorkspace = singleProject().workspaceOrFail()
+
+fun CodeInsightTestFixture.launchAction(
+    actionId: String,
+    vararg context: Pair<DataKey<*>, *>,
+    shouldBeEnabled: Boolean = true
+): Presentation {
+    TestApplicationManager.getInstance().setDataProvider(object : TestDataProvider(project) {
+        override fun getData(dataId: String): Any? {
+            for ((key, value) in context) {
+                if (key.`is`(dataId)) return value
+            }
+            return super.getData(dataId)
+        }
+    }, testRootDisposable)
+
+    val action = ActionManager.getInstance().getAction(actionId) ?: error("Failed to find action by `$actionId` id")
+    val presentation = testAction(action)
+    if (shouldBeEnabled) {
+        check(presentation.isEnabledAndVisible) { "Failed to run `${action.javaClass.simpleName}` action" }
+    } else {
+        check(!presentation.isEnabledAndVisible) { "`${action.javaClass.simpleName}` action shouldn't be enabled"}
+    }
+    return presentation
+}

--- a/src/test/kotlin/org/rust/ide/actions/RsCreateCrateActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/RsCreateCrateActionTest.kt
@@ -7,14 +7,13 @@ package org.rust.ide.actions
 
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.testFramework.MapDataContext
-import com.intellij.testFramework.TestActionEvent
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.fileTree
 import org.rust.ide.actions.ui.CargoNewCrateSettings
 import org.rust.ide.actions.ui.CargoNewCrateUI
 import org.rust.ide.actions.ui.withMockCargoNewCrateUi
+import org.rust.launchAction
 
 class RsCreateCrateActionTest : RsWithToolchainTestBase() {
     fun `test create with file context`() {
@@ -35,24 +34,12 @@ class RsCreateCrateActionTest : RsWithToolchainTestBase() {
     }
 
     private fun createCrate(file: VirtualFile, name: String, binary: Boolean = true) {
-        val action = RsCreateCrateAction()
-
-        val dataContext = MapDataContext(mapOf(
-            CommonDataKeys.PROJECT to project,
-            CommonDataKeys.VIRTUAL_FILE to file
-        ))
-        val e = TestActionEvent(dataContext, action)
-        action.beforeActionPerformedUpdate(e)
-        check(e.presentation.isEnabledAndVisible) {
-            "Failed to run `${RsCreateCrateAction::class.java.simpleName}` action"
-        }
-
         withMockCargoNewCrateUi(object : CargoNewCrateUI {
-            override fun selectCargoCrateSettings(): CargoNewCrateSettings? {
+            override fun selectCargoCrateSettings(): CargoNewCrateSettings {
                 return CargoNewCrateSettings(binary, name)
             }
         }) {
-            action.actionPerformed(e)
+            myFixture.launchAction("Rust.NewCargoCrate", CommonDataKeys.VIRTUAL_FILE to file)
         }
 
         val src = if (binary) "main" else "lib"

--- a/src/test/kotlin/org/rust/ide/refactoring/ConvertToNamedFieldsRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/ConvertToNamedFieldsRefactoringTest.kt
@@ -7,7 +7,7 @@ package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
-import org.rust.ide.refactoring.convertStruct.RsConvertToNamedFieldsAction
+import org.rust.launchAction
 
 class ConvertToNamedFieldsRefactoringTest : RsTestBase() {
 
@@ -184,7 +184,7 @@ class ConvertToNamedFieldsRefactoringTest : RsTestBase() {
 
     private fun doAvailableTest(@Language("Rust") before: String, @Language("Rust") after: String) {
         InlineFile(before.trimIndent()).withCaret()
-        myFixture.testAction(RsConvertToNamedFieldsAction())
+        myFixture.launchAction("Rust.RsConvertToNamedFields")
         myFixture.checkResult(replaceCaretMarker(after.trimIndent()))
     }
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/ConvertToTupleRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/ConvertToTupleRefactoringTest.kt
@@ -7,7 +7,7 @@ package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
-import org.rust.ide.refactoring.convertStruct.RsConvertToTupleAction
+import org.rust.launchAction
 
 class ConvertToTupleRefactoringTest : RsTestBase() {
 
@@ -144,7 +144,7 @@ class ConvertToTupleRefactoringTest : RsTestBase() {
 
     private fun doAvailableTest(@Language("Rust") before: String, @Language("Rust") after: String) {
         InlineFile(before.trimIndent()).withCaret()
-        myFixture.testAction(RsConvertToTupleAction())
+        myFixture.launchAction("Rust.RsConvertToTuple")
         myFixture.checkResult(replaceCaretMarker(after.trimIndent()))
     }
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsDowngradeModuleToFileTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsDowngradeModuleToFileTest.kt
@@ -5,13 +5,12 @@
 
 package org.rust.ide.refactoring
 
-import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.psi.PsiElement
-import com.intellij.testFramework.TestApplicationManager
-import com.intellij.testFramework.TestDataProvider
 import org.rust.FileTree
 import org.rust.RsTestBase
 import org.rust.fileTree
+import org.rust.launchAction
 
 class RsDowngradeModuleToFileTest : RsTestBase() {
     fun `test works on file`() = checkAvailable(
@@ -60,24 +59,22 @@ class RsDowngradeModuleToFileTest : RsTestBase() {
         }
     )
 
-    fun checkAvailable(target: String, before: FileTree, after: FileTree) {
+    private fun checkAvailable(target: String, before: FileTree, after: FileTree) {
         val file = before.create().psiFile(target)
-        testActionOnElement(file)
+        testActionOnElement(file, shouldBeEnabled = true)
         after.assertEquals(myFixture.findFileInTempDir("."))
     }
 
-    fun checkNotAvailable(target: String, before: FileTree) {
+    private fun checkNotAvailable(target: String, before: FileTree) {
         val file = before.create().psiFile(target)
-        val presentation = testActionOnElement(file)
-        check(!presentation.isEnabled)
+        testActionOnElement(file, shouldBeEnabled = false)
     }
 
-    private fun testActionOnElement(element: PsiElement): Presentation {
-        TestApplicationManager.getInstance().setDataProvider(object : TestDataProvider(project) {
-            override fun getData(dataId: String): Any? =
-                if (com.intellij.openapi.actionSystem.CommonDataKeys.PSI_ELEMENT.`is`(dataId)) element else super.getData(dataId)
-        }, testRootDisposable)
-
-        return myFixture.testAction(RsDowngradeModuleToFile())
+    private fun testActionOnElement(element: PsiElement, shouldBeEnabled: Boolean) {
+        myFixture.launchAction(
+            "Rust.RsDowngradeModuleToFile",
+            CommonDataKeys.PSI_ELEMENT to element,
+            shouldBeEnabled = shouldBeEnabled
+        )
     }
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractEnumVariantTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractEnumVariantTest.kt
@@ -7,7 +7,7 @@ package org.rust.ide.refactoring
 
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
-import org.rust.ide.refactoring.extractEnumVariant.RsExtractEnumVariantAction
+import org.rust.launchAction
 
 class RsExtractEnumVariantTest : RsTestBase() {
     fun `test not available on empty variant`() = doUnavailableTest("""
@@ -601,6 +601,6 @@ class RsExtractEnumVariantTest : RsTestBase() {
 
     private fun doUnavailableTest(@Language("Rust") code: String) {
         InlineFile(code.trimIndent()).withCaret()
-        check(!myFixture.testAction(RsExtractEnumVariantAction()).isEnabled)
+        myFixture.launchAction("Rust.RsExtractEnumVariant", shouldBeEnabled = false)
     }
 }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsPromoteModuleToDirectoryActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsPromoteModuleToDirectoryActionTest.kt
@@ -6,13 +6,11 @@
 package org.rust.ide.refactoring
 
 import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.psi.PsiElement
-import com.intellij.testFramework.TestApplicationManager
-import com.intellij.testFramework.TestDataProvider
 import org.rust.FileTree
 import org.rust.RsTestBase
 import org.rust.fileTree
+import org.rust.launchAction
 
 class RsPromoteModuleToDirectoryActionTest : RsTestBase() {
     fun `test works on file`() = checkAvailable(
@@ -38,22 +36,20 @@ class RsPromoteModuleToDirectoryActionTest : RsTestBase() {
 
     private fun checkAvailable(target: String, before: FileTree, after: FileTree) {
         val file = before.create().psiFile(target)
-        testActionOnElement(file)
+        testActionOnElement(file, shouldBeEnabled = true)
         after.assertEquals(myFixture.findFileInTempDir("."))
     }
 
     private fun checkNotAvailable(target: String, before: FileTree) {
         val file = before.create().psiFile(target)
-        val presentation = testActionOnElement(file)
-        check(!presentation.isEnabled)
+        testActionOnElement(file, shouldBeEnabled = false)
     }
 
-    private fun testActionOnElement(element: PsiElement): Presentation {
-        TestApplicationManager.getInstance().setDataProvider(object : TestDataProvider(project) {
-            override fun getData(dataId: String): Any? =
-                if (CommonDataKeys.PSI_ELEMENT.`is`(dataId)) element else super.getData(dataId)
-        }, testRootDisposable)
-
-        return myFixture.testAction(RsPromoteModuleToDirectoryAction())
+    private fun testActionOnElement(element: PsiElement, shouldBeEnabled: Boolean) {
+        myFixture.launchAction(
+            "Rust.RsPromoteModuleToDirectoryAction",
+            CommonDataKeys.PSI_ELEMENT to element,
+            shouldBeEnabled = shouldBeEnabled
+        )
     }
 }

--- a/src/test/kotlin/org/rustSlowTests/ide/actions/RsBuildActionTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/ide/actions/RsBuildActionTest.kt
@@ -10,7 +10,7 @@ package org.rustSlowTests.ide.actions
 import com.intellij.build.events.impl.SuccessResultImpl
 import com.intellij.execution.RunManager
 import com.intellij.execution.impl.RunManagerImpl
-import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.testFramework.TestDataProvider
 import org.rust.MinRustcVersion
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.lastBuildCommandLine
@@ -71,7 +71,7 @@ class RsBuildActionTest : CargoBuildTest() {
         }.create()
 
         setUpSelectedConfigurationFromContext(testProject.fileWithCaret)
-        RsBuildAction().performForContext(dataContext)
+        performBuildAction()
         mockBuildProgressListener!!.waitFinished()
 
         val actualCommandLine = lastBuildCommandLine!!
@@ -143,7 +143,7 @@ class RsBuildActionTest : CargoBuildTest() {
         }.create()
 
         setUpSelectedConfigurationFromContext(testProject.fileWithCaret)
-        RsBuildAction().performForContext(dataContext)
+        performBuildAction()
         mockBuildProgressListener!!.waitFinished()
 
         val actualCommandLine = lastBuildCommandLine!!
@@ -217,7 +217,7 @@ class RsBuildActionTest : CargoBuildTest() {
             }
         }.create()
 
-        RsBuildAction().performForContext(dataContext)
+        performBuildAction()
         mockBuildProgressListener!!.waitFinished()
 
         val actualCommandLine = lastBuildCommandLine!!
@@ -258,8 +258,10 @@ class RsBuildActionTest : CargoBuildTest() {
         )
     }
 
-    private val dataContext: DataContext
-        get() = TestDataProvider(project)
+    private fun performBuildAction() {
+        val action = ActionManager.getInstance().getAction("Rust.Build") as RsBuildAction
+        action.performForContext(TestDataProvider(project))
+    }
 
     private fun setUpSelectedConfigurationFromContext(fileWithCaret: String) {
         val runManager = RunManager.getInstance(project) as RunManagerImpl


### PR DESCRIPTION
Also, search all actions in tests via ids instead of creating action objects manually. It should check that tested actions are registered in `plugin.xml`

Fixes #6565