### PR TITLE
Fix cargo features inference with renamed packages

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/Util.kt
+++ b/toml/src/main/kotlin/org/rust/toml/Util.kt
@@ -152,8 +152,8 @@ fun PsiElement.findCargoPackageForCargoToml(): CargoWorkspace.Package? {
     return containingFile.findCargoPackage()?.takeIf { it.getPackageTomlFile(containingFile.project) == containingFile }
 }
 
-fun CargoWorkspace.Package.findDependencyByPackageName(pkgName: String): CargoWorkspace.Package? =
-    dependencies.find { it.pkg.name == pkgName }?.pkg
+private fun CargoWorkspace.Package.findDependencyByPackageName(pkgName: String): CargoWorkspace.Package? =
+    dependencies.find { it.cargoFeatureDependencyPackageName == pkgName }?.pkg
 
 fun findDependencyTomlFile(element: TomlElement, depName: String): TomlFile? =
     element.findCargoPackageForCargoToml()

--- a/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlFeatureDependencyReferenceProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlFeatureDependencyReferenceProvider.kt
@@ -43,7 +43,6 @@ private class CargoTomlFeatureDependencyReference(element: TomlLiteral) : PsiPol
                 .takeIf { it.size == 2 }
                 ?: return ResolveResult.EMPTY_ARRAY
 
-            // Features are linked by a `Package` name, not by dependency name
             val depToml = findDependencyTomlFile(element, depName) ?: return ResolveResult.EMPTY_ARRAY
             depToml.resolveFeature(featureName)
         } else {


### PR DESCRIPTION


changelog: Fix cargo features inference with renamed packages
