### PR TITLE
Adjust multiline functions code style

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -2,6 +2,10 @@
   <code_scheme name="Project" version="173">
     <codeStyleSettings language="kotlin">
       <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
+      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>


### PR DESCRIPTION
Some time ago intention "Put parameters on separate lines" converted this function:
```kt
fun function1(parameter1: Int, parameter2: Int, parameter3: Int) {}
```
into this:
```kt
fun function1(
    parameter1: Int,
    parameter2: Int,
    parameter3: Int
) {}
```

Recently this intention started to instead convert function to
```kt
fun function1(parameter1: Int,
              parameter2: Int,
              parameter3: Int) {}
```

Since all our code use first variant, I guess it makes sense to adjust code style settings to continue using it (for consistency purpose)