### PR TITLE
RES: Support file level macro_use attribute in new resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -207,6 +207,13 @@ class RsFile(
         return Attributes.NONE
     }
 
+    /** ```#![macro_use]``` inside file (in contrast to ```#[macro_use]``` on mod declaration) */
+    fun hasMacroUseInner(crate: Crate?): Boolean {
+        val stub = greenStub as RsFileStub?
+        if (stub?.mayHaveMacroUse == false) return false
+        return getQueryAttributes(crate).hasAtomAttribute("macro_use")
+    }
+
     val declaration: RsModDeclItem? get() = declarations.firstOrNull()
 
     val declarations: List<RsModDeclItem> get() {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroResolveTest.kt
@@ -85,6 +85,20 @@ class RsMacroResolveTest : RsResolveTestBase() {
         }
     """)
 
+    fun `test resolve macro mod inner macro_use`() = checkByCode("""
+        mod a {
+            #![macro_use]
+            macro_rules! foo_bar { () => () }
+            //X
+        }
+        mod b {
+            fn main() {
+                foo_bar!();
+                //^
+            }
+        }
+    """)
+
     // Macros are scoped by lexical order
     // see https://github.com/intellij-rust/intellij-rust/issues/1474
     fun `test resolve macro mod wrong order`() = checkByCode("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStubOnlyResolveTest.kt
@@ -5,6 +5,8 @@
 
 package org.rust.lang.core.resolve
 
+import org.rust.UseNewResolve
+
 class RsStubOnlyResolveTest : RsResolveTestBase() {
     fun `test child mod`() = stubOnlyResolve("""
     //- main.rs
@@ -548,6 +550,19 @@ class RsStubOnlyResolveTest : RsResolveTestBase() {
     //- main.rs
         #[macro_use]
         mod b;
+    """)
+
+    @UseNewResolve
+    fun `test resolve macro multi file 4`() = stubOnlyResolve("""
+    //- b.rs
+        #![macro_use]
+        macro_rules! foo_bar { () => () }
+    //- lib.rs
+        mod b;
+        mod c {
+            foo_bar!();
+            //^ b.rs
+        }
     """)
 
     fun `test resolve crate keyword in path to crate root mod`() = stubOnlyResolve("""


### PR DESCRIPTION
Fixes <!----> #6136 and #6486 with [new resolve](https://github.com/intellij-rust/intellij-rust/issues/6217)

changelog: Support `#![macro_use]` attribute at file level when using new name resolution engine