### PR TITLE
TOML: add TomlVisitor

### DIFF
--- a/intellij-toml/src/main/kotlin/org/toml/lang/psi/TomlVisitor.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/psi/TomlVisitor.kt
@@ -1,0 +1,68 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.lang.psi
+
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiRecursiveVisitor
+
+open class TomlVisitor : PsiElementVisitor() {
+    open fun visitElement(element: TomlElement) {
+        super.visitElement(element)
+    }
+
+    open fun visitValue(element: TomlValue) {
+        visitElement(element)
+    }
+
+    open fun visitKeyValue(element: TomlKeyValue) {
+        visitElement(element)
+    }
+
+    open fun visitKey(element: TomlKey) {
+        visitElement(element)
+    }
+
+    open fun visitLiteral(element: TomlLiteral) {
+        visitValue(element)
+    }
+
+    open fun visitKeyValueOwner(element: TomlKeyValueOwner) {
+        visitElement(element)
+    }
+
+    open fun visitArray(element: TomlArray) {
+        visitValue(element)
+    }
+
+    open fun visitTable(element: TomlTable) {
+        visitKeyValueOwner(element)
+    }
+
+    open fun visitTableHeader(element: TomlTableHeader) {
+        visitElement(element)
+    }
+
+    open fun visitInlineTable(element: TomlInlineTable) {
+        visitKeyValueOwner(element)
+    }
+
+    open fun visitArrayTable(element: TomlArrayTable) {
+        visitKeyValueOwner(element)
+    }
+}
+
+open class TomlRecursiveVisitor : TomlVisitor(), PsiRecursiveVisitor {
+    override fun visitElement(element: PsiElement) {
+        ProgressManager.checkCanceled()
+        element.acceptChildren(this)
+    }
+
+    override fun visitElement(element: TomlElement) {
+        visitElement(element as PsiElement)
+    }
+}

--- a/intellij-toml/src/main/kotlin/org/toml/lang/psi/impl/Psi.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/psi/impl/Psi.kt
@@ -9,10 +9,7 @@ import com.intellij.ide.projectView.PresentationData
 import com.intellij.lang.ASTFactory
 import com.intellij.lang.psi.SimpleMultiLineTextEscaper
 import com.intellij.navigation.ItemPresentation
-import com.intellij.psi.LiteralTextEscaper
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiLanguageInjectionHost
-import com.intellij.psi.PsiReference
+import com.intellij.psi.*
 import com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry
 import com.intellij.psi.impl.source.tree.CompositeElement
 import com.intellij.psi.impl.source.tree.CompositePsiElement
@@ -27,11 +24,18 @@ class TomlKeyValueImpl(type: IElementType) : CompositePsiElement(type), TomlKeyV
     override val key: TomlKey get() = childOfTypeNotNull()
     override val value: TomlValue? get() = childOfTypeNullable()
     override fun toString(): String = "TomlKeyValue"
+
+    override fun accept(visitor: PsiElementVisitor) {
+        if (visitor is TomlVisitor) {
+            visitor.visitKeyValue(this)
+        } else {
+            super.accept(visitor)
+        }
+    }
 }
 
 class TomlKeyImpl(type: IElementType) : CompositePsiElement(type), TomlKey {
-    override fun getReferences(): Array<PsiReference>
-        = ReferenceProvidersRegistry.getReferencesFromProviders(this)
+    override fun getReferences(): Array<PsiReference> = ReferenceProvidersRegistry.getReferencesFromProviders(this)
 
     override fun getName(): String = text
 
@@ -42,11 +46,18 @@ class TomlKeyImpl(type: IElementType) : CompositePsiElement(type), TomlKey {
     override fun getPresentation(): ItemPresentation = PresentationData(name, null, null, null)
 
     override fun toString(): String = "TomlKey"
+
+    override fun accept(visitor: PsiElementVisitor) {
+        if (visitor is TomlVisitor) {
+            visitor.visitKey(this)
+        } else {
+            super.accept(visitor)
+        }
+    }
 }
 
 class TomlLiteralImpl(type: IElementType) : CompositePsiElement(type), TomlLiteral {
-    override fun getReferences(): Array<PsiReference>
-        = ReferenceProvidersRegistry.getReferencesFromProviders(this)
+    override fun getReferences(): Array<PsiReference> = ReferenceProvidersRegistry.getReferencesFromProviders(this)
 
     override fun toString(): String = "TomlLiteral"
 
@@ -64,34 +75,82 @@ class TomlLiteralImpl(type: IElementType) : CompositePsiElement(type), TomlLiter
         val tokenType = node.findChildByType(TOML_STRING_LITERALS)?.elementType ?: error("$text is not string literal")
         return if (tokenType in TOML_BASIC_STRINGS) TomlLiteralTextEscaper(this) else SimpleMultiLineTextEscaper(this)
     }
+
+    override fun accept(visitor: PsiElementVisitor) {
+        if (visitor is TomlVisitor) {
+            visitor.visitLiteral(this)
+        } else {
+            super.accept(visitor)
+        }
+    }
 }
 
 class TomlArrayImpl(type: IElementType) : CompositePsiElement(type), TomlArray {
     override val elements: List<TomlValue> get() = childrenOfType()
     override fun toString(): String = "TomlArray"
+
+    override fun accept(visitor: PsiElementVisitor) {
+        if (visitor is TomlVisitor) {
+            visitor.visitArray(this)
+        } else {
+            super.accept(visitor)
+        }
+    }
 }
 
 class TomlTableImpl(type: IElementType) : CompositePsiElement(type), TomlTable {
     override val header: TomlTableHeader get() = childOfTypeNotNull()
     override val entries: List<TomlKeyValue> get() = childrenOfType()
     override fun toString(): String = "TomlTable"
+
+    override fun accept(visitor: PsiElementVisitor) {
+        if (visitor is TomlVisitor) {
+            visitor.visitTable(this)
+        } else {
+            super.accept(visitor)
+        }
+    }
 }
 
 class TomlTableHeaderImpl(type: IElementType) : CompositePsiElement(type), TomlTableHeader {
     override val names: List<TomlKey> get() = childrenOfType()
     override fun toString(): String = "TomlTableHeader"
+
+    override fun accept(visitor: PsiElementVisitor) {
+        if (visitor is TomlVisitor) {
+            visitor.visitTableHeader(this)
+        } else {
+            super.accept(visitor)
+        }
+    }
 }
 
 class TomlInlineTableImpl(type: IElementType) : CompositePsiElement(type), TomlInlineTable {
     override val entries: List<TomlKeyValue> get() = childrenOfType()
 
     override fun toString(): String = "TomlInlineTable"
+
+    override fun accept(visitor: PsiElementVisitor) {
+        if (visitor is TomlVisitor) {
+            visitor.visitInlineTable(this)
+        } else {
+            super.accept(visitor)
+        }
+    }
 }
 
 class TomlArrayTableImpl(type: IElementType) : CompositePsiElement(type), TomlArrayTable {
     override val header: TomlTableHeader get() = childOfTypeNotNull()
     override val entries: List<TomlKeyValue> get() = childrenOfType()
     override fun toString(): String = "TomlArrayTable"
+
+    override fun accept(visitor: PsiElementVisitor) {
+        if (visitor is TomlVisitor) {
+            visitor.visitArrayTable(this)
+        } else {
+            super.accept(visitor)
+        }
+    }
 }
 
 class TomlASTFactory : ASTFactory() {

--- a/intellij-toml/src/test/kotlin/org/toml/lang/psi/TomlVisitorTest.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/lang/psi/TomlVisitorTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.lang.psi
+
+import com.intellij.psi.util.parentOfType
+import org.intellij.lang.annotations.Language
+import org.toml.TomlTestBase
+import kotlin.reflect.KClass
+
+class TomlVisitorTest : TomlTestBase() {
+    fun `test visit key`() = doTest<TomlKey>("""
+        <caret>a = 5
+    """, TomlKey::class)
+
+    fun `test visit literal`() = doTest<TomlLiteral>("""
+        a = <caret>5
+    """, TomlLiteral::class, TomlValue::class)
+
+    fun `test visit key value`() = doTest<TomlKeyValue>("""
+        <caret>a = 5
+    """, TomlKeyValue::class)
+
+    fun `test visit array`() = doTest<TomlArray>("""
+        a = <caret>[5]
+    """, TomlArray::class, TomlValue::class)
+
+    fun `test visit table`() = doTest<TomlTable>("""
+        <caret>[foo]
+    """, TomlTable::class, TomlKeyValueOwner::class)
+
+    fun `test visit table header`() = doTest<TomlTableHeader>("""
+        [<caret>foo]
+    """, TomlTableHeader::class)
+
+    fun `test visit inline table`() = doTest<TomlInlineTable>("""
+        a = { b = <caret>5 }
+    """, TomlInlineTable::class, TomlKeyValueOwner::class)
+
+    fun `test visit array table`() = doTest<TomlArrayTable>("""
+        [[<caret>foo]]
+    """, TomlArrayTable::class, TomlKeyValueOwner::class)
+
+    private inline fun <reified T: TomlElement> doTest(
+        @Language("TOML") code: String,
+        vararg expectedVisits: KClass<out TomlElement>
+    ) {
+        InlineFile(code)
+        val element = myFixture.file.findElementAt(myFixture.caretOffset)!!.parentOfType<T>(true)!!
+
+        val visits = mutableListOf<KClass<out TomlElement>>()
+        val visitor = object : TomlVisitor() {
+            override fun visitElement(element: TomlElement) {
+                visits.add(TomlElement::class)
+                super.visitElement(element)
+            }
+
+            override fun visitValue(element: TomlValue) {
+                visits.add(TomlValue::class)
+                super.visitValue(element)
+            }
+
+            override fun visitKeyValue(element: TomlKeyValue) {
+                visits.add(TomlKeyValue::class)
+                super.visitKeyValue(element)
+            }
+
+            override fun visitKey(element: TomlKey) {
+                visits.add(TomlKey::class)
+                super.visitKey(element)
+            }
+
+            override fun visitLiteral(element: TomlLiteral) {
+                visits.add(TomlLiteral::class)
+                super.visitLiteral(element)
+            }
+
+            override fun visitKeyValueOwner(element: TomlKeyValueOwner) {
+                visits.add(TomlKeyValueOwner::class)
+                super.visitKeyValueOwner(element)
+            }
+
+            override fun visitArray(element: TomlArray) {
+                visits.add(TomlArray::class)
+                super.visitArray(element)
+            }
+
+            override fun visitTable(element: TomlTable) {
+                visits.add(TomlTable::class)
+                super.visitTable(element)
+            }
+
+            override fun visitTableHeader(element: TomlTableHeader) {
+                visits.add(TomlTableHeader::class)
+                super.visitTableHeader(element)
+            }
+
+            override fun visitInlineTable(element: TomlInlineTable) {
+                visits.add(TomlInlineTable::class)
+                super.visitInlineTable(element)
+            }
+
+            override fun visitArrayTable(element: TomlArrayTable) {
+                visits.add(TomlArrayTable::class)
+                super.visitArrayTable(element)
+            }
+        }
+        element.accept(visitor)
+        assertEquals(expectedVisits.toList().plus(TomlElement::class), visits)
+    }
+}


### PR DESCRIPTION
This PR adds a simple visitor for TOML elements. I think that it is useful enough to warrant a PR even without a specific usage.
It can be used e.g. in https://github.com/intellij-rust/intellij-rust/pull/6457, https://github.com/intellij-rust/intellij-rust/pull/3787, https://github.com/intellij-rust/intellij-rust/pull/6535 and if it's merged, I suppose that it will be used in many future Cargo.toml inspections, now that the local index is finally working.