### PR TITLE
IDE: add support for navbar breadcrumbs

### DIFF
--- a/src/main/kotlin/org/rust/ide/navigationToolbar/RsNavBarModelExtension.kt
+++ b/src/main/kotlin/org/rust/ide/navigationToolbar/RsNavBarModelExtension.kt
@@ -1,0 +1,30 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.navigationToolbar
+
+import com.intellij.ide.navigationToolbar.StructureAwareNavBarModelExtension
+import com.intellij.lang.Language
+import org.rust.ide.miscExtensions.RsBreadcrumbsInfoProvider
+import org.rust.lang.RsLanguage
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.ext.RsElement
+
+class RsNavBarModelExtension : StructureAwareNavBarModelExtension() {
+    override val language: Language = RsLanguage
+
+    override fun getPresentableText(item: Any?): String? {
+        val element = item as? RsElement ?: return null
+        if (element is RsFile) {
+            return element.name
+        }
+
+        val provider = RsBreadcrumbsInfoProvider()
+        if (provider.acceptElement(element)) {
+            return provider.getElementInfo(element)
+        }
+        return null
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -253,6 +253,8 @@
         <elementDescriptionProvider implementation="org.rust.ide.presentation.RsDescriptionProvider"/>
         <breadcrumbsInfoProvider implementation="org.rust.ide.miscExtensions.RsBreadcrumbsInfoProvider"/>
 
+        <navbar implementation="org.rust.ide.navigationToolbar.RsNavBarModelExtension" order="first"/>
+
         <!-- Spell-checker -->
 
         <spellchecker.support language="Rust" implementationClass="org.rust.ide.spelling.RsSpellcheckingStrategy"/>


### PR DESCRIPTION
While working on something else, I noticed that IDEA has these cool new breadcrumbs directly inside the navigation bar. So I looked at the Kotlin to find inspiration and implemented it also for the Rust plugin, by reusing the implementation of the breadcrumbs provider.

![navbar](https://user-images.githubusercontent.com/4539057/103312409-39d99580-4a1d-11eb-9cfc-22d6a480bc4c.gif)
![navbar2](https://user-images.githubusercontent.com/4539057/103312522-a359a400-4a1d-11eb-9d70-6e167ef1e8ba.gif)

The Kotlin plugin [disables](https://github.com/JetBrains/kotlin/blob/master/idea/src/org/jetbrains/kotlin/idea/codeInsight/BreadcrumbsProviderCompatBase.kt#L14) classic breadcrumbs when the navigation bar model is enabled, but I suppose it doesn't hurt to show both?

changelog: Introduce navigation bar breadcrumbs.