### PR TITLE
CARGO: basic support for rustup override

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -70,6 +70,15 @@ jobs:
                   components: rust-src, rustfmt, clippy
                   default: true
 
+            # Requires for tests with overridden toolchain
+            - name: Set up nightly Rust
+              uses: actions-rs/toolchain@v1
+              with:
+                  profile: minimal
+                  toolchain: nightly
+                  components: rust-src
+                  default: false
+
             - name: Cache evcxr
               uses: actions/cache@v2
               with:

--- a/coverage/src/main/kotlin/org/rust/coverage/GrcovRunner.kt
+++ b/coverage/src/main/kotlin/org/rust/coverage/GrcovRunner.kt
@@ -141,7 +141,7 @@ class GrcovRunner : RsDefaultProgramRunnerBase() {
             var channel: RustChannel? = config.cmd.channel
             if (channel == RustChannel.DEFAULT) {
                 channel = project.computeWithCancelableProgress("Fetching rustc version...") {
-                    config.toolchain.rustc().queryVersion()?.channel
+                    config.toolchain.rustc().queryVersion(config.cmd.workingDirectory)?.channel
                 }
             }
             if (channel == RustChannel.NIGHTLY) return true

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
@@ -189,10 +189,11 @@ private fun fetchRustcInfo(context: CargoSyncTask.SyncContext): TaskResult<Rustc
             return@runWithChildProgress TaskResult.Err("Invalid Rust toolchain ${childContext.toolchain.presentableLocation}")
         }
 
-        val sysroot = childContext.toolchain.rustc().getSysroot(childContext.oldCargoProject.workingDirectory)
+        val workingDirectory = childContext.oldCargoProject.workingDirectory
+        val sysroot = childContext.toolchain.rustc().getSysroot(workingDirectory)
             ?: return@runWithChildProgress TaskResult.Err("failed to get project sysroot")
 
-        val rustcVersion = childContext.toolchain.rustc().queryVersion()
+        val rustcVersion = childContext.toolchain.rustc().queryVersion(workingDirectory)
 
         TaskResult.Ok(RustcInfo(sysroot, rustcVersion))
     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunStateBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunStateBase.kt
@@ -45,7 +45,7 @@ abstract class CargoRunStateBase(
 
     fun cargo(): Cargo = toolchain.cargoOrWrapper(workingDirectory)
 
-    fun rustVersion(): RustcVersion? = toolchain.rustc().queryVersion()
+    fun rustVersion(): RustcVersion? = toolchain.rustc().queryVersion(workingDirectory)
 
     fun prepareCommandLine(vararg additionalPatches: CargoPatch): CargoCommandLine {
         var commandLine = commandLine

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustc.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustc.kt
@@ -22,11 +22,13 @@ fun RsToolchain.rustc(): Rustc = Rustc(this)
 
 class Rustc(toolchain: RsToolchain) : RustupComponent(NAME, toolchain) {
 
-    fun queryVersion(): RustcVersion? {
+    fun queryVersion(workingDirectory: Path? = null): RustcVersion? {
         if (!isUnitTestMode) {
             checkIsBackgroundThread()
         }
-        val lines = createBaseCommandLine("--version", "--verbose").execute()?.stdoutLines
+        val lines = createBaseCommandLine("--version", "--verbose", workingDirectory = workingDirectory)
+            .execute()
+            ?.stdoutLines
         return lines?.let { parseRustcVersion(it) }
     }
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustc.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustc.kt
@@ -44,10 +44,15 @@ class Rustc(toolchain: RsToolchain) : RustupComponent(NAME, toolchain) {
         return if (output?.isSuccess == true) output.stdout.trim() else null
     }
 
-    fun getStdlibFromSysroot(projectDirectory: Path): VirtualFile? {
+    fun getStdlibPathFromSysroot(projectDirectory: Path): String? {
         val sysroot = getSysroot(projectDirectory) ?: return null
+        return FileUtil.join(sysroot, "lib/rustlib/src/rust")
+    }
+
+    fun getStdlibFromSysroot(projectDirectory: Path): VirtualFile? {
+        val stdlibPath = getStdlibPathFromSysroot(projectDirectory) ?: return null
         val fs = LocalFileSystem.getInstance()
-        return fs.refreshAndFindFileByPath(FileUtil.join(sysroot, "lib/rustlib/src/rust"))
+        return fs.refreshAndFindFileByPath(stdlibPath)
     }
 
     private fun getRawCfgOption(projectDirectory: Path?): List<String>? {

--- a/src/test/kotlin/org/rust/FileTree.kt
+++ b/src/test/kotlin/org/rust/FileTree.kt
@@ -243,7 +243,7 @@ private class FileTreeBuilderImpl(val directory: MutableMap<String, Entry> = mut
     }
 
     override fun file(name: String, code: String) {
-        check('/' !in name && '.' in name) { "Bad file name `$name`" }
+        check('/' !in name) { "Bad file name `$name`" }
         directory[name] = Entry.File(code.trimIndent())
     }
 

--- a/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
@@ -7,10 +7,12 @@ package org.rust.cargo
 
 import com.intellij.openapi.util.RecursionManager
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
 import com.intellij.util.ui.UIUtil
 import org.rust.*
 import org.rust.cargo.project.model.impl.testCargoProjects
 import org.rust.cargo.toolchain.tools.rustc
+import org.rust.openapiext.pathAsPath
 
 /**
  * This class allows executing real Cargo during the tests.
@@ -30,6 +32,11 @@ abstract class RsWithToolchainTestBase : RsWithToolchainPlatformTestBase() {
 
     protected fun FileTree.create(): TestProject =
         create(project, cargoProjectDirectory).apply {
+            rustupFixture.toolchain
+                ?.rustc()
+                ?.getStdlibPathFromSysroot(cargoProjectDirectory.pathAsPath)
+                ?.let { VfsRootAccess.allowRootAccess(testRootDisposable, it) }
+
             refreshWorkspace()
         }
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorWithToolchainOverrideTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorWithToolchainOverrideTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator
+
+class RsErrorAnnotatorWithToolchainOverrideTest : RsWithToolchainAnnotatorTestBase<Unit>(RsErrorAnnotator::class) {
+
+    fun `test do not highlight box syntax as experimental with nightly toolchain`() = check {
+        toml("rust-toolchain", """
+            [toolchain]
+            channel = "nightly"
+        """)
+        toml("Cargo.toml", """
+            [package]
+            name = "hello"
+            version = "0.1.0"
+            authors = []
+        """)
+
+        dir("src") {
+            rust("main.rs", """
+                #![feature(box_syntax)]
+
+                /*caret*/
+                fn main() {
+                    let world = box "world";
+                    println!("Hello, {}!", world);
+                }
+            """)
+        }
+    }
+}

--- a/src/test/kotlin/org/rustSlowTests/cargo/RustupOverrideTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/RustupOverrideTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rustSlowTests.cargo
+
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.toolchain.RustChannel
+import org.rust.singleProject
+
+class RustupOverrideTest : RsWithToolchainTestBase() {
+
+    fun test() {
+        buildProject {
+            toml("rust-toolchain", """
+                [toolchain]
+                channel = "nightly"
+            """)
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+            """)
+            dir("src") {
+                rust("main.rs", """
+                    fn main() {}
+                """)
+            }
+        }
+        assertEquals(RustChannel.NIGHTLY, project.cargoProjects.singleProject().rustcInfo?.version?.channel)
+    }
+}


### PR DESCRIPTION
Previously, we didn't specify the working directory during fetching `rustc` version. As a result, the plugin always got version of default toolchain.
But a user can [override](https://rust-lang.github.io/rustup/overrides.html) toolchain via `rustup` for a specific toolchain for a specific directory. And the plugin didn't handle such overrides

Now we pass the working directory and can get the proper toolchain version even it's overridden

Project with `nightly` as overridden toolchains and 1.48 as default toolchain:

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2539310/103315101-b24c5080-4a35-11eb-957d-e925a0f90aca.png) | ![](https://user-images.githubusercontent.com/2539310/103315092-abbdd900-4a35-11eb-90dd-1c57067e3b82.png) |

Fixes #5560
Fixes #6561
Should fix #4930 as well

changelog: Add basic support for [overridden](https://rust-lang.github.io/rustup/overrides.html) toolchains. Note, different overridden toolchains in a single project are still unsupported
