### PR TITLE
INSP: Ignore expanded members in `Trait implementation` inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsTraitImplementationInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsTraitImplementationInspection.kt
@@ -33,11 +33,17 @@ class RsTraitImplementationInspection : RsLocalInspectionTool() {
             }
 
             for (member in implInfo.nonExistentInTrait) {
+                // ignore members expanded from macros
+                if (member.containingFile != impl.containingFile) continue
+
                 RsDiagnostic.UnknownMethodInTraitError(member.nameIdentifier!!, member, traitName)
                     .addToHolder(holder)
             }
 
             for ((imp, dec) in implInfo.implementationToDeclaration) {
+                // ignore members expanded from macros
+                if (imp.containingFile != impl.containingFile) continue
+
                 if (imp is RsFunction && dec is RsFunction) {
                     checkTraitFnImplParams(holder, imp, dec, traitName)
                 }


### PR DESCRIPTION
Fixes exception in `RsRealProjectAnalysisTest#test analyze juniper`:

<details>

```
com.intellij.diagnostic.PluginException: Reported element PsiElement(identifier) is not from the file '/src/main.rs' the inspection 'RsTraitImplementation' (class org.rust.ide.inspections.RsTraitImplementationInspection) was invoked for. Message: '<html>Method `bar` is not a member of trait `T` [<a href='https://doc.rust-lang.org/error-index.html#E0407'>E0407</a>]<br></html>'.
Element containing file: FILE
Inspection invoked for file: FILE

	at com.intellij.ide.plugins.PluginManagerCore.createPluginException(PluginManagerCore.java:335)
	at com.intellij.diagnostic.PluginProblemReporterImpl.createPluginExceptionByClass(PluginProblemReporterImpl.java:12)
	at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:59)
	at com.intellij.diagnostic.PluginException.logPluginError(PluginException.java:76)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.createHighlightsForDescriptor(LocalInspectionsPass.java:570)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.createHighlightsForDescriptor(LocalInspectionsPass.java:527)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.addHighlightsFromResults(LocalInspectionsPass.java:496)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.inspect(LocalInspectionsPass.java:202)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.collectInformationWithProgress(LocalInspectionsPass.java:115)
	at com.intellij.codeInsight.daemon.impl.ProgressableTextEditorHighlightingPass.doCollectInformation(ProgressableTextEditorHighlightingPass.java:84)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:56)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$1(PassExecutorService.java:400)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1137)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:393)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:658)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:610)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:65)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:392)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:368)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:172)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:183)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:366)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:188)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1016)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1665)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1598)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```

</details>

changelog: Fix `Trait implementation` inspection on impls with expanded members
