### PR TITLE
INSP: add inspection that checks non-existent crates

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyCompletionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyCompletionProvider.kt
@@ -14,7 +14,7 @@ import com.intellij.codeInsight.lookup.LookupElementPresentation
 import com.intellij.codeInsight.lookup.LookupElementRenderer
 import com.intellij.icons.AllIcons
 import org.rust.toml.StringValueInsertionHandler
-import org.rust.toml.crates.local.CratesLocalIndexServiceImpl
+import org.rust.toml.crates.local.CratesLocalIndexService
 import org.rust.toml.crates.local.lastVersion
 import org.toml.lang.psi.TomlKeyValue
 
@@ -22,7 +22,7 @@ class LocalCargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProvide
     override fun completeKey(keyValue: TomlKeyValue, result: CompletionResultSet) {
         val prefix = CompletionUtil.getOriginalElement(keyValue.key)?.text ?: return
 
-        val indexService = CratesLocalIndexServiceImpl.getInstance()
+        val indexService = CratesLocalIndexService.getInstance()
 
         val crateNames = indexService.getAllCrateNames()
         val elements = crateNames.mapNotNull { crateName ->
@@ -52,7 +52,7 @@ class LocalCargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProvide
     override fun completeValue(keyValue: TomlKeyValue, result: CompletionResultSet) {
         val name = CompletionUtil.getOriginalElement(keyValue.key)?.text ?: return
 
-        val indexService = CratesLocalIndexServiceImpl.getInstance()
+        val indexService = CratesLocalIndexService.getInstance()
 
         val versions = indexService.getCrate(name)?.versions ?: return
         val elements = versions.mapIndexed { index, variant ->

--- a/toml/src/main/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyCompletionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyCompletionProvider.kt
@@ -14,7 +14,7 @@ import com.intellij.codeInsight.lookup.LookupElementPresentation
 import com.intellij.codeInsight.lookup.LookupElementRenderer
 import com.intellij.icons.AllIcons
 import org.rust.toml.StringValueInsertionHandler
-import org.rust.toml.crates.local.CratesLocalIndexService
+import org.rust.toml.crates.local.CratesLocalIndexServiceImpl
 import org.rust.toml.crates.local.lastVersion
 import org.toml.lang.psi.TomlKeyValue
 
@@ -22,7 +22,7 @@ class LocalCargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProvide
     override fun completeKey(keyValue: TomlKeyValue, result: CompletionResultSet) {
         val prefix = CompletionUtil.getOriginalElement(keyValue.key)?.text ?: return
 
-        val indexService = CratesLocalIndexService.getInstance()
+        val indexService = CratesLocalIndexServiceImpl.getInstance()
 
         val crateNames = indexService.getAllCrateNames()
         val elements = crateNames.mapNotNull { crateName ->
@@ -52,7 +52,7 @@ class LocalCargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProvide
     override fun completeValue(keyValue: TomlKeyValue, result: CompletionResultSet) {
         val name = CompletionUtil.getOriginalElement(keyValue.key)?.text ?: return
 
-        val indexService = CratesLocalIndexService.getInstance()
+        val indexService = CratesLocalIndexServiceImpl.getInstance()
 
         val versions = indexService.getCrate(name)?.versions ?: return
         val elements = versions.mapIndexed { index, variant ->

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexCachesInvalidator.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexCachesInvalidator.kt
@@ -9,6 +9,6 @@ import com.intellij.ide.caches.CachesInvalidator
 
 class CratesLocalIndexCachesInvalidator : CachesInvalidator() {
     override fun invalidateCaches() {
-        CratesLocalIndexServiceImpl.getInstance().invalidateCaches()
+        (CratesLocalIndexService.getInstance() as? CratesLocalIndexServiceImpl)?.invalidateCaches()
     }
 }

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexCachesInvalidator.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexCachesInvalidator.kt
@@ -9,6 +9,6 @@ import com.intellij.ide.caches.CachesInvalidator
 
 class CratesLocalIndexCachesInvalidator : CachesInvalidator() {
     override fun invalidateCaches() {
-        CratesLocalIndexService.getInstance().invalidateCaches()
+        CratesLocalIndexServiceImpl.getInstance().invalidateCaches()
     }
 }

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexService.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexService.kt
@@ -1,0 +1,20 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.crates.local
+
+import com.intellij.openapi.components.service
+
+interface CratesLocalIndexService {
+    fun getCrate(crateName: String): CargoRegistryCrate?
+    fun getAllCrateNames(): List<String>
+
+    companion object {
+        fun getInstance(): CratesLocalIndexService = service()
+    }
+}
+
+data class CargoRegistryCrate(val versions: List<CargoRegistryCrateVersion>)
+data class CargoRegistryCrateVersion(val version: String, val isYanked: Boolean, val features: List<String>)

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexServiceImpl.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexServiceImpl.kt
@@ -35,7 +35,7 @@ import org.eclipse.jgit.treewalk.filter.TreeFilter
 import org.rust.cargo.CargoConstants
 import org.rust.openapiext.RsPathManager
 import org.rust.stdext.cleanDirectory
-import org.rust.toml.crates.local.CratesLocalIndexService.Companion.CratesLocalIndexState
+import org.rust.toml.crates.local.CratesLocalIndexServiceImpl.Companion.CratesLocalIndexState
 import java.io.*
 import java.nio.file.Files
 import java.nio.file.Path
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * persistent state [CratesLocalIndexState].
  */
 @State(name = "CratesLocalIndexState", storages = [Storage("rust.crateslocalindex.xml")])
-class CratesLocalIndexService : PersistentStateComponent<CratesLocalIndexState>, Disposable {
+class CratesLocalIndexServiceImpl : PersistentStateComponent<CratesLocalIndexState>, Disposable {
     private val userCargoIndexDir: Path
         get() = Paths.get(System.getProperty("user.home"), CARGO_REGISTRY_INDEX_LOCATION)
 
@@ -270,9 +270,9 @@ class CratesLocalIndexService : PersistentStateComponent<CratesLocalIndexState>,
         private const val INVALID_COMMIT_HASH: String = "<invalid>"
         private const val CRATES_INDEX_VERSION: Int = 0
 
-        private val LOG: Logger = logger<CratesLocalIndexService>()
+        private val LOG: Logger = logger<CratesLocalIndexServiceImpl>()
 
-        fun getInstance(): CratesLocalIndexService = service()
+        fun getInstance(): CratesLocalIndexServiceImpl = service()
     }
 }
 

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexServiceImpl.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexServiceImpl.kt
@@ -48,7 +48,8 @@ import java.util.concurrent.atomic.AtomicBoolean
  * persistent state [CratesLocalIndexState].
  */
 @State(name = "CratesLocalIndexState", storages = [Storage("rust.crateslocalindex.xml")])
-class CratesLocalIndexServiceImpl : PersistentStateComponent<CratesLocalIndexState>, CratesLocalIndexService, Disposable {
+class CratesLocalIndexServiceImpl
+    : CratesLocalIndexService, PersistentStateComponent<CratesLocalIndexState>, Disposable {
     private val userCargoIndexDir: Path
         get() = Paths.get(System.getProperty("user.home"), CARGO_REGISTRY_INDEX_LOCATION)
 
@@ -313,14 +314,14 @@ private object CrateExternalizer : DataExternalizer<CargoRegistryCrate> {
     }
 }
 
-private data class ParsedVersion(
-    val name: String,
-    val vers: String,
-    val yanked: Boolean,
-    val features: HashMap<String, List<String>>
-)
-
 private fun crateFromJson(json: String): CargoRegistryCrateVersion {
+    data class ParsedVersion(
+        val name: String,
+        val vers: String,
+        val yanked: Boolean,
+        val features: HashMap<String, List<String>>
+    )
+
     val parsedVersion = Gson().fromJson(json, ParsedVersion::class.java)
 
     return CargoRegistryCrateVersion(

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/TestCrateResolverService.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/TestCrateResolverService.kt
@@ -1,0 +1,27 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.crates.local
+
+import org.jetbrains.annotations.TestOnly
+
+class TestCratesLocalIndexServiceImpl : CratesLocalIndexService {
+    var testCrates: Map<String, CargoRegistryCrate> = emptyMap()
+
+    override fun getCrate(crateName: String): CargoRegistryCrate? = testCrates[crateName]
+    override fun getAllCrateNames(): List<String> = testCrates.keys.toList()
+}
+
+@TestOnly
+fun withMockedCrates(crates: Map<String, CargoRegistryCrate>, action: () -> Unit) {
+    val resolver = CratesLocalIndexService.getInstance() as TestCratesLocalIndexServiceImpl
+    val orgCrates = resolver.testCrates
+    try {
+        resolver.testCrates = crates
+        action()
+    } finally {
+        resolver.testCrates = orgCrates
+    }
+}

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CrateNotFoundInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CrateNotFoundInspection.kt
@@ -1,0 +1,112 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import com.intellij.codeInspection.*
+import com.intellij.psi.PsiElementVisitor
+import org.rust.cargo.CargoConstants
+import org.rust.ide.experiments.RsExperiments
+import org.rust.openapiext.isFeatureEnabled
+import org.rust.toml.crates.local.CratesLocalIndexService
+import org.rust.toml.isDependencyKey
+import org.toml.lang.psi.*
+import org.toml.lang.psi.ext.TomlLiteralKind
+import org.toml.lang.psi.ext.kind
+import org.toml.lang.psi.ext.name
+
+class CrateNotFoundInspection : LocalInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+        buildVisitor(holder) ?: super.buildVisitor(holder, isOnTheFly)
+
+    private fun buildVisitor(holder: ProblemsHolder): PsiElementVisitor? {
+        if (!isFeatureEnabled(RsExperiments.CRATES_LOCAL_INDEX)) return null
+        if (holder.file.name != CargoConstants.MANIFEST_FILE) return null
+
+        return object : TomlVisitor() {
+            override fun visitKeyValue(element: TomlKeyValue) {
+                val table = element.parent as? TomlTable ?: return
+                val depTable = DependencyTable.fromTomlTable(table) ?: return
+                if (depTable !is DependencyTable.General) return
+
+                val segment = element.key.segments.getOrNull(0) ?: return
+                val name = segment.name ?: return
+                val value = element.value ?: return
+                if (value is TomlLiteral && value.kind is TomlLiteralKind.String) {
+                    handleDependency(DependencyCrate(name, segment, mapOf("version" to value)), holder)
+                } else if (value is TomlInlineTable) {
+                    handleDependency(DependencyCrate(name, segment, collectProperties(value)), holder)
+                }
+            }
+
+            override fun visitTable(element: TomlTable) {
+                val depTable = DependencyTable.fromTomlTable(element) ?: return
+                if (depTable !is DependencyTable.Specific) return
+
+                handleDependency(
+                    DependencyCrate(depTable.crateName, depTable.crateNameElement, collectProperties(element)), holder
+                )
+            }
+        }
+    }
+
+    private fun handleDependency(dependency: DependencyCrate, holder: ProblemsHolder) {
+        // Do not check local, custom or git crates
+        for (property in IGNORED_PROPERTIES) {
+            if (property in dependency.properties) return
+        }
+
+        if (CratesLocalIndexService.getInstance().getCrate(dependency.crateName) == null) {
+            holder.registerProblem(dependency.crateNameElement, "Crate ${dependency.crateName} not found")
+        }
+    }
+
+    companion object {
+        private val IGNORED_PROPERTIES = listOf("git", "path", "registry")
+    }
+}
+
+private fun collectProperties(owner: TomlKeyValueOwner): Map<String, TomlValue> {
+    return owner.entries.mapNotNull {
+        val name = it.key.name ?: return@mapNotNull null
+        val value = it.value ?: return@mapNotNull null
+        name to value
+    }.toMap()
+}
+
+private data class DependencyCrate(
+    val crateName: String,
+    val crateNameElement: TomlKeySegment,
+    val properties: Map<String, TomlValue>
+)
+
+private sealed class DependencyTable {
+    object General : DependencyTable()
+    data class Specific(val crateName: String, val crateNameElement: TomlKeySegment) : DependencyTable()
+
+    companion object {
+        fun fromTomlTable(table: TomlTable): DependencyTable? {
+            val key = table.header.key ?: return null
+            val segments = key.segments
+            val dependencyNameIndex = segments.indexOfFirst { it.isDependencyKey }
+
+            return when {
+                // [dependencies], [x86.dev-dependencies], etc.
+                dependencyNameIndex == segments.lastIndex -> General
+                // [dependencies.crate]
+                dependencyNameIndex != -1 -> {
+                    val crate = segments.getOrNull(dependencyNameIndex + 1)
+                    val crateName = crate?.name
+                    if (crate != null && crateName != null) {
+                        Specific(crateName, crate)
+                    } else {
+                        null
+                    }
+                }
+                else -> null
+            }
+        }
+    }
+}

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -27,11 +27,15 @@
                          displayName="Cyclic feature dependency"
                          enabledByDefault="true" level="ERROR"
                          implementationClass="org.rust.toml.inspections.CargoTomlCyclicFeatureInspection"/>
+        <localInspection language="TOML" groupName="Rust"
+                         displayName="Crate not found"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.toml.inspections.CrateNotFoundInspection"/>
 
-        <applicationService
-            serviceInterface="org.rust.toml.crates.local.CratesLocalIndexService"
-            serviceImplementation="org.rust.toml.crates.local.CratesLocalIndexServiceImpl"
-            testServiceImplementation="org.rust.toml.crates.local.TestCratesLocalIndexServiceImpl"/>
+        <applicationService serviceInterface="org.rust.toml.crates.local.CratesLocalIndexService"
+                            serviceImplementation="org.rust.toml.crates.local.CratesLocalIndexServiceImpl"
+                            testServiceImplementation="org.rust.toml.crates.local.TestCratesLocalIndexServiceImpl"/>
+
         <backgroundPostStartupActivity implementation="org.rust.toml.crates.local.CratesLocalIndexStartupActivity"/>
         <cachesInvalidator implementation="org.rust.toml.crates.local.CratesLocalIndexCachesInvalidator"/>
     </extensions>

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -28,7 +28,10 @@
                          enabledByDefault="true" level="ERROR"
                          implementationClass="org.rust.toml.inspections.CargoTomlCyclicFeatureInspection"/>
 
-        <applicationService serviceImplementation="org.rust.toml.crates.local.CratesLocalIndexServiceImpl"/>
+        <applicationService
+            serviceInterface="org.rust.toml.crates.local.CratesLocalIndexService"
+            serviceImplementation="org.rust.toml.crates.local.CratesLocalIndexServiceImpl"
+            testServiceImplementation="org.rust.toml.crates.local.TestCratesLocalIndexServiceImpl"/>
         <backgroundPostStartupActivity implementation="org.rust.toml.crates.local.CratesLocalIndexStartupActivity"/>
         <cachesInvalidator implementation="org.rust.toml.crates.local.CratesLocalIndexCachesInvalidator"/>
     </extensions>

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -28,7 +28,7 @@
                          enabledByDefault="true" level="ERROR"
                          implementationClass="org.rust.toml.inspections.CargoTomlCyclicFeatureInspection"/>
 
-        <applicationService serviceImplementation="org.rust.toml.crates.local.CratesLocalIndexService"/>
+        <applicationService serviceImplementation="org.rust.toml.crates.local.CratesLocalIndexServiceImpl"/>
         <backgroundPostStartupActivity implementation="org.rust.toml.crates.local.CratesLocalIndexStartupActivity"/>
         <cachesInvalidator implementation="org.rust.toml.crates.local.CratesLocalIndexCachesInvalidator"/>
     </extensions>

--- a/toml/src/main/resources/inspectionDescriptions/CrateNotFound.html
+++ b/toml/src/main/resources/inspectionDescriptions/CrateNotFound.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Detects unknown dependency crates in Cargo.toml
+</body>
+</html>

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CrateNotFoundInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CrateNotFoundInspectionTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import org.intellij.lang.annotations.Language
+import org.rust.cargo.CargoConstants.MANIFEST_FILE
+import org.rust.ide.experiments.RsExperiments
+import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.openapiext.runWithEnabledFeature
+import org.rust.toml.crates.local.CargoRegistryCrate
+import org.rust.toml.crates.local.CargoRegistryCrateVersion
+import org.rust.toml.crates.local.withMockedCrates
+
+class CrateNotFoundInspectionTest : RsInspectionsTestBase(CrateNotFoundInspection::class) {
+    fun `test missing crate in dependencies`() = doTest("""
+        [dependencies]
+        <warning descr="Crate foo not found">foo</warning> = "1"
+    """)
+
+    fun `test missing crate in dev-dependencies`() = doTest("""
+        [dev-dependencies]
+        <warning descr="Crate foo not found">foo</warning> = "1"
+    """)
+
+    fun `test missing crate complex dependencies`() = doTest("""
+        [x86.dependencies]
+        <warning descr="Crate foo not found">foo</warning> = "1"
+    """)
+
+    fun `test missing crate in specific dependency`() = doTest("""
+        [dependencies.<warning descr="Crate foo not found">foo</warning>]
+    """)
+
+    fun `test existing crate in dependencies`() = doTest("""
+        [dependencies]
+        foo = "1"
+    """, crate("foo", "1"))
+
+    fun `test multiple missing crates`() = doTest("""
+        [dependencies]
+        <warning descr="Crate foo1 not found">foo1</warning> = "1"
+        foo = "1"
+        <warning descr="Crate foo2 not found">foo2</warning> = "2"
+        bar = "1"
+        <warning descr="Crate bar1 not found">bar1</warning> = "1"
+    """, crate("foo", "1"), crate("bar", "1"))
+
+    fun `test dependency inline table`() = doTest("""
+        [dependencies]
+        <warning descr="Crate foo1 not found">foo1</warning> = { version = "1" }
+        foo = { version = "1" }
+    """, crate("foo", "1"))
+
+    fun `test do not check dependencies with local, custom, git property`() = doTest("""
+        [dependencies]
+        foo1 = { version = "1", git = "https://foo.bar" }
+        foo2 = { version = "1", path = "../foo/bar" }
+        foo3 = { version = "1", registry = "foo" }
+    """)
+
+    fun `test do not check specific dependency with local, custom, git property`() = doTest("""
+        [dependencies.foo1]
+        version = "1"
+        git = "https://foo.bar"
+
+        [dependencies.foo2]
+        version = "1"
+        path = "../foo/bar"
+
+        [dependencies.foo3]
+        version = "1"
+        registry = "foo"
+    """)
+
+    private fun crate(name: String, vararg versions: String): Crate =
+        Crate(name, CargoRegistryCrate(versions.toList().map {
+            CargoRegistryCrateVersion(it, false, listOf())
+        }))
+
+    private data class Crate(val name: String, val crate: CargoRegistryCrate)
+
+    private fun doTest(@Language("TOML") code: String, vararg crates: Crate) {
+        val crateMap = crates.toList().associate { it.name to it.crate }
+        myFixture.configureByText(MANIFEST_FILE, code)
+
+        runWithEnabledFeature(RsExperiments.CRATES_LOCAL_INDEX) {
+            withMockedCrates(crateMap) {
+                myFixture.checkHighlighting()
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR add more basic infrastructure to TOML, based on the new local crate index. The first commit introduces a simple inspection which checks crates in `Cargo.toml` that do not exist (=were not found in the index). It uses the new TOML visitor (https://github.com/intellij-rust/intellij-rust/pull/6578) and also the dependency visitor from https://github.com/intellij-rust/intellij-rust/pull/3787. After another inspection is added, this dependency visitor should be extracted into a separate file.

The second commit then introduces tests for the inspection, which however require a lot of new infrastructure. Mainly it adds a service interface and a test implementation for the local crate index (taken from https://github.com/intellij-rust/intellij-rust/pull/5988).

Closes: https://github.com/intellij-rust/intellij-rust/pull/3787
Closes: https://github.com/intellij-rust/intellij-rust/pull/5988
Related: https://github.com/intellij-rust/intellij-rust/issues/6463

changelog: Add inspection that checks non-existent crates in Cargo.toml. Enabled only with the experimental local crate index.