### PR TITLE
CARGO: Use semver to sort crate versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -450,6 +450,7 @@ project(":toml") {
         implementation(project(":"))
         implementation(project(":common"))
         implementation("org.eclipse.jgit:org.eclipse.jgit:5.9.0.202009080501-r") { exclude("org.slf4j") }
+        implementation("com.vdurmont:semver4j:3.1.0")
         testImplementation(project(":", "testOutput"))
         testImplementation(project(":common", "testOutput"))
     }

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexService.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexService.kt
@@ -6,6 +6,8 @@
 package org.rust.toml.crates.local
 
 import com.intellij.openapi.components.service
+import com.vdurmont.semver4j.Semver
+import com.vdurmont.semver4j.SemverException
 import org.jetbrains.annotations.TestOnly
 
 interface CratesLocalIndexService {
@@ -18,6 +20,9 @@ interface CratesLocalIndexService {
 }
 
 data class CargoRegistryCrate(val versions: List<CargoRegistryCrateVersion>) {
+    val sortedVersions: List<CargoRegistryCrateVersion>
+        get() = versions.sortedBy { it.semanticVersion }
+
     companion object {
         @TestOnly
         fun of(vararg versions: String): CargoRegistryCrate =
@@ -27,4 +32,11 @@ data class CargoRegistryCrate(val versions: List<CargoRegistryCrateVersion>) {
     }
 }
 
-data class CargoRegistryCrateVersion(val version: String, val isYanked: Boolean, val features: List<String>)
+data class CargoRegistryCrateVersion(val version: String, val isYanked: Boolean, val features: List<String>) {
+    val semanticVersion: Semver?
+        get() = try {
+            Semver(version, Semver.SemverType.NPM)
+        } catch (e: SemverException) {
+            null
+        }
+}

--- a/toml/src/test/kotlin/org/rust/toml/completion/LocalCargoTomlCompletionTestBase.kt
+++ b/toml/src/test/kotlin/org/rust/toml/completion/LocalCargoTomlCompletionTestBase.kt
@@ -35,4 +35,32 @@ abstract class LocalCargoTomlCompletionTestBase : CargoTomlCompletionTestBase() 
             }
         }
     }
+
+    @Suppress("SameParameterValue")
+    protected fun doFirstCompletion(
+        @Language("TOML") before: String,
+        @Language("TOML") after: String,
+        vararg crates: Pair<String, CargoRegistryCrate>
+    ) {
+        runWithEnabledFeatures(RsExperiments.CRATES_LOCAL_INDEX) {
+            withMockedCrates(crates.toMap()) {
+                completionFixture.doFirstCompletion(before, after)
+            }
+        }
+    }
+
+    @Suppress("SameParameterValue")
+    protected fun completeBasic(
+        @Language("TOML") code: String,
+        expected: List<String>,
+        vararg crates: Pair<String, CargoRegistryCrate>
+    ) {
+        runWithEnabledFeatures(RsExperiments.CRATES_LOCAL_INDEX) {
+            withMockedCrates(crates.toMap()) {
+                myFixture.configureByText("Cargo.toml", code)
+                val actual = myFixture.completeBasic().map { it.lookupString }
+                assertEquals(expected, actual)
+            }
+        }
+    }
 }

--- a/toml/src/test/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyVersionCompletionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyVersionCompletionTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.completion
+
+import org.rust.toml.crates.local.CargoRegistryCrate
+
+class LocalCargoTomlDependencyVersionCompletionTest : LocalCargoTomlCompletionTestBase() {
+    fun `test complete version`() = doFirstCompletion("""
+        [dependencies]
+        foo = "<caret>"
+    """, """
+        [dependencies]
+        foo = "0.1.0<caret>"
+    """, "foo" to CargoRegistryCrate.of("0.1.0")
+    )
+
+    fun `test complete highest by semver version`() = doFirstCompletion("""
+        [dependencies]
+        foo = "<caret>"
+    """, """
+        [dependencies]
+        foo = "1.0.0<caret>"
+    """, "foo" to CargoRegistryCrate.of("0.0.1", "1.0.0", "0.1.0")
+    )
+
+    fun `test complete sorted by semver versions`() = completeBasic(
+        """
+        [dependencies]
+        foo = "<caret>"
+        """,
+        listOf("0.4.7", "0.4.6", "0.4.5", "0.4.4", "0.4.3", "0.4.2", "0.4.1", "0.4.0", "0.4.0-rc.2", "0.4.0-rc.1", "0.4.0-rc", "0.3.17", "0.3.16", "0.3.15", "0.3.14", "0.3.13", "0.3.12", "0.3.11", "0.3.10", "0.3.9", "0.3.8", "0.3.7", "0.3.6", "0.3.5", "0.3.4", "0.3.3", "0.3.2", "0.3.1", "0.3.0", "0.2.11", "0.2.10", "0.2.9", "0.2.8", "0.2.7", "0.2.6", "0.2.5", "0.2.4", "0.2.3", "0.2.2", "0.2.1", "0.2.0", "0.1.6", "0.1.5", "0.1.4", "0.1.3", "0.1.2", "0.1.1", "0.1.0"),
+        "foo" to CargoRegistryCrate.of("0.1.4", "0.4.3", "0.3.0", "0.1.1", "0.4.0", "0.3.5", "0.4.0-rc.1", "0.1.0", "0.4.2", "0.3.3", "0.3.4", "0.2.0", "0.1.3", "0.2.5", "0.3.8", "0.2.6", "0.4.6", "0.1.5", "0.2.11", "0.2.2", "0.4.5", "0.2.1", "0.3.1", "0.3.16", "0.3.6", "0.2.10", "0.4.4", "0.3.12", "0.2.9", "0.3.10", "0.1.6", "0.3.14", "0.2.4", "0.3.2", "0.1.2", "0.3.17", "0.3.9", "0.4.0-rc.2", "0.4.1", "0.3.15", "0.3.7", "0.4.0-rc", "0.2.7", "0.2.3", "0.4.7", "0.3.11", "0.2.8", "0.3.13"),
+    )
+}


### PR DESCRIPTION
Gives the ability to compare crate versions using semantic versioning and sort them this way instead of the default in index version uploading date order. That's useful for completion and inspections in the future.

Related: #6463

changelog: Use semantic versioning to improve version sorting in dependencies when using experimental local crates index