### PR TITLE
ANN: gray out disabled cfg_attr attributes

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotator.kt
@@ -11,20 +11,38 @@ import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
 import org.rust.ide.colors.RsColor
+import org.rust.ide.utils.isDisabledCfgAttrAttribute
+import org.rust.lang.core.psi.ext.RsAttr
 import org.rust.lang.core.psi.ext.RsDocAndAttributeOwner
 import org.rust.lang.core.psi.ext.isEnabledByCfgSelf
+import org.rust.lang.core.psi.ext.owner
 
 class RsCfgDisabledCodeAnnotator : AnnotatorBase() {
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         if (holder.isBatchMode) return
 
         if (element is RsDocAndAttributeOwner && !element.isEnabledByCfgSelf) {
-            val color = RsColor.CFG_DISABLED_CODE
-            val severity = if (isUnitTestMode) color.testSeverity else HighlightSeverity.INFORMATION
-
-            holder.newAnnotation(severity, "Conditionally disabled code")
-                .textAttributes(color.textAttributesKey)
-                .create()
+            holder.createCondDisabledAnnotation()
         }
+
+        if (element is RsAttr && element.isDisabledCfgAttrAttribute && element.owner?.isEnabledByCfgSelf == true) {
+            holder.createCondDisabledAnnotation()
+        }
+    }
+
+    private fun AnnotationHolder.createCondDisabledAnnotation() {
+        val color = RsColor.CFG_DISABLED_CODE
+        val severity = if (isUnitTestMode) color.testSeverity else CONDITIONALLY_DISABLED_CODE_SEVERITY
+
+        newAnnotation(severity, "Conditionally disabled code")
+            .textAttributes(color.textAttributesKey)
+            .create()
+    }
+
+    companion object {
+        private val CONDITIONALLY_DISABLED_CODE_SEVERITY = HighlightSeverity(
+            "CONDITIONALLY_DISABLED_CODE",
+            HighlightSeverity.INFORMATION.myVal + 3
+        )
     }
 }

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -19,6 +19,7 @@ import com.intellij.psi.search.PsiTodoSearchHelper
 import org.rust.ide.colors.RsColor
 import org.rust.ide.highlight.RsHighlighter
 import org.rust.ide.todo.isTodoPattern
+import org.rust.ide.utils.isDisabledCfgAttrAttribute
 import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.*
@@ -37,6 +38,7 @@ class RsHighlightingAnnotator : AnnotatorBase() {
         } ?: return
 
         if (!element.isEnabledByCfg) return
+        if (element.ancestors.any { it is RsAttr && it.isDisabledCfgAttrAttribute }) return
 
         val severity = if (isUnitTestMode) color.testSeverity else HighlightSeverity.INFORMATION
 

--- a/src/main/kotlin/org/rust/ide/utils/CfgUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/CfgUtils.kt
@@ -6,13 +6,22 @@
 package org.rust.ide.utils
 
 import com.intellij.psi.PsiElement
-import org.rust.lang.core.psi.ext.RsDocAndAttributeOwner
-import org.rust.lang.core.psi.ext.ancestors
-import org.rust.lang.core.psi.ext.isCfgUnknownSelf
-import org.rust.lang.core.psi.ext.isEnabledByCfgSelf
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.utils.evaluation.CfgEvaluator
+import org.rust.lang.utils.evaluation.ThreeValuedLogic
 
 val PsiElement.isEnabledByCfg: Boolean
     get() = ancestors.filterIsInstance<RsDocAndAttributeOwner>().all { it.isEnabledByCfgSelf }
 
 val PsiElement.isCfgUnknown: Boolean
     get() = ancestors.filterIsInstance<RsDocAndAttributeOwner>().any { it.isCfgUnknownSelf }
+
+/** Returns `true` if this attribute is `#[cfg_attr()]` and it is disabled */
+val RsAttr.isDisabledCfgAttrAttribute: Boolean
+    get() {
+        val metaItem = metaItem
+        if (metaItem.name != "cfg_attr") return false
+        val condition = metaItem.metaItemArgs?.metaItemList?.firstOrNull() ?: return false
+        val crate = containingCrate ?: return false
+        return CfgEvaluator.forCrate(crate).evaluateCondition(condition) == ThreeValuedLogic.False
+    }

--- a/src/test/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsCfgDisabledCodeAnnotatorTest.kt
@@ -86,4 +86,21 @@ class RsCfgDisabledCodeAnnotatorTest : RsAnnotatorTestBase(RsCfgDisabledCodeAnno
             let x = 1;
         }
     """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test disabled cfg_attr`() = checkHighlighting("""
+        <CFG_DISABLED_CODE descr="Conditionally disabled code">#[cfg_attr(not(intellij_rust), deny(unused_variables))]</CFG_DISABLED_CODE>
+        fn foo() {
+            let x = 1;
+        }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test disabled cfg_attr annotation is not duplicated if the item is disabled`() = checkHighlighting("""
+        <CFG_DISABLED_CODE descr="Conditionally disabled code">#[cfg(not(intellij_rust))]
+        #[cfg_attr(not(intellij_rust), deny(unused_variables))]
+        fn foo() {
+            let x = 1;
+        }</CFG_DISABLED_CODE>
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -21,7 +21,7 @@ class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator:
     }
 
     fun `test attributes`() = checkHighlighting("""
-        <ATTRIBUTE>#[cfg_attr(foo)]</ATTRIBUTE>
+        <ATTRIBUTE>#[foo(foo)]</ATTRIBUTE>
         <ATTRIBUTE>#[foo(<STRING>"bar"</STRING>)]</ATTRIBUTE>
         fn <FUNCTION>main</FUNCTION>() {
             <ATTRIBUTE>#![crate_type = <STRING>"lib"</STRING>]</ATTRIBUTE>

--- a/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPassTest.kt
@@ -16,7 +16,7 @@ import org.rust.ide.colors.RsColor
 class RsMacroExpansionHighlightingPassTest : RsAnnotationTestBase() {
 
     fun `test attributes inside macro call`() = checkHighlightingInsideMacro("""
-        <ATTRIBUTE>#</ATTRIBUTE><ATTRIBUTE>[cfg_attr(foo)]</ATTRIBUTE>
+        <ATTRIBUTE>#</ATTRIBUTE><ATTRIBUTE>[foo(foo)]</ATTRIBUTE>
         fn <FUNCTION>main</FUNCTION>() {
             <ATTRIBUTE>#![crate_type = <STRING>"lib"</STRING>]</ATTRIBUTE>
         }


### PR DESCRIPTION
A little improvement for #6497: highlight disabled `cfg_attr`s as conditionally disabled code:

![image](https://user-images.githubusercontent.com/3221931/103457877-e82e5500-4d13-11eb-893d-2cff982c35db.png)

Nested `cfg_attr`s (e.g. `#[cfg_attr(foo, cfg_attr(bar, foobar))]`) are not highlighted (and why someone needs to write them?)

changelog: Gray out disabled `#[cfg_attr()]` attributes