### PR TITLE
RES&COMP: don't duplicate `Self` while name resolution and completion

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -354,7 +354,24 @@ fun processPathResolveVariants(lookup: ImplLookup?, path: RsPath, isCompletion: 
         typeQual != null ->
             processExplicitTypeQualifiedPathResolveVariants(lookup, path, ns, typeQual, processor)
 
-        else -> processUnqualifiedPathResolveVariants(isCompletion, ns, path, parent, processor)
+        else -> processUnqualifiedPathResolveVariants(isCompletion, ns, path, parent, processor.withIgnoringSecondaryCSelf())
+    }
+}
+
+private fun RsResolveProcessor.withIgnoringSecondaryCSelf(): RsResolveProcessor {
+    var hasSelfItem = false
+
+    return createProcessor {
+        if (it.name == "Self") {
+            if (hasSelfItem) {
+                false
+            } else {
+                hasSelfItem = true
+                this(it)
+            }
+        } else {
+            this(it)
+        }
     }
 }
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -280,6 +280,32 @@ class RsCompletionTest : RsCompletionTestBase() {
         trait T { fn foo() -> Self/*caret*/ }
     """)
 
+    fun `test complete Self type in nested impls`() = doSingleCompletion("""
+        struct A;
+        impl A {
+            fn foo() {
+                struct E {
+                    value: i32
+                }
+                impl E {
+                    fn new() -> Se/*caret*/ {}
+                }
+            }
+        }
+    """, """
+        struct A;
+        impl A {
+            fn foo() {
+                struct E {
+                    value: i32
+                }
+                impl E {
+                    fn new() -> Self/*caret*/ {}
+                }
+            }
+        }
+    """)
+
     fun `test complete self method`() = doSingleCompletion("""
         struct S;
         impl S { fn foo(&se/*caret*/) {}}

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -9,6 +9,7 @@ import org.rust.MockEdition
 import org.rust.MockRustcVersion
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ignoreInNewResolve
+import org.rust.lang.core.psi.RsImplItem
 import org.rust.lang.core.psi.ext.RsFieldDecl
 
 class RsResolveTest : RsResolveTestBase() {
@@ -1431,6 +1432,27 @@ class RsResolveTest : RsResolveTestBase() {
                     //X
             V([usize; AAA]),
                      //^
+        }
+    """)
+
+    fun `test Self with nested impls`() = checkByCodeGeneric<RsImplItem>("""
+        struct A;
+
+        impl A {
+            fn foo() {
+                struct E {
+                    value: i32
+                }
+                impl E {
+                //X
+                    fn new() -> Self {
+                                //^
+                        Self {
+                            value: h
+                        }
+                    }
+                }
+            }
         }
     """)
 }


### PR DESCRIPTION
Previously, the plugin added several `Self` items in nested `impl` blocks that broke name resolution (because of multi resolve) and duplicated items during completion

Fixes #6600 

changelog: Fix name resolution and completion of `Self` keyword for nested structs, enums and `impl` blocks
