### PR TITLE
ANN: improve fill function arguments fix

### DIFF
--- a/src/test/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFixTest.kt
@@ -136,4 +136,40 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
             S(0, 0);
         }
     """)
+
+    fun `test closure known parameter`() = checkFixByText("Fill missing arguments", """
+        fn main() {
+            let closure = |x: i32| (x);
+            closure(<error>/*caret*/)</error>;
+        }
+    """, """
+        fn main() {
+            let closure = |x: i32| (x);
+            closure(0);
+        }
+    """)
+
+    fun `test closure unknown parameter`() = checkFixByText("Fill missing arguments", """
+        fn main() {
+            let closure = |x| (x);
+            closure(<error>/*caret*/)</error>;
+        }
+    """, """
+        fn main() {
+            let closure = |x| (x);
+            closure(());
+        }
+    """)
+
+    fun `test generic parameter turbofish`() = checkFixByText("Fill missing arguments", """
+        fn foo<T>(a: T) {}
+        fn main() {
+            foo::<bool>(<error>/*caret*/)</error>;
+        }
+    """, """
+        fn foo<T>(a: T) {}
+        fn main() {
+            foo::<bool>(false);
+        }
+    """)
 }


### PR DESCRIPTION
This PR adds basic support for closures to `FillFunctionArgumentsFix` (introduced in https://github.com/intellij-rust/intellij-rust/pull/5644) and also resolves function types with substituted types.

The substitution doesn't yet work properly for method calls (see https://github.com/intellij-rust/intellij-rust/pull/5644#discussion_r555034800). 

Fixes: https://github.com/intellij-rust/intellij-rust/issues/6612
Fixes: https://github.com/intellij-rust/intellij-rust/issues/6645

changelog: Enable the new "Fill function arguments" quick-fix for closures and take generic arguments into consideration when filling default values.