### PR TITLE
ANN: allow removing redundant type arguments from types with lifetimes

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveTypeArguments.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveTypeArguments.kt
@@ -10,6 +10,8 @@ import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.openapi.project.Project
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.deleteWithSurroundingComma
+import org.rust.lang.core.psi.ext.getNextNonCommentSibling
 
 class RemoveTypeArguments(
     private val startIndex: Int,
@@ -32,14 +34,13 @@ class RemoveTypeArguments(
     }
 
     private fun RsTypeArgumentList.removeTypeParameters() {
-        if (lifetimeList.size > 0) return
-
-        if (startIndex == 0) delete()
-        else {
-            val startElement = typeReferenceList[startIndex - 1].nextSibling
-            val endElement = typeReferenceList[endIndex - 1]
-
-            deleteChildRange(startElement, endElement)
+        val count = endIndex - startIndex
+        for (i in 0 until count) {
+            typeReferenceList[startIndex].deleteWithSurroundingComma()
+        }
+        // If the type argument list is empty, delete it
+        if (lt.getNextNonCommentSibling() == gt) {
+            delete()
         }
     }
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsWrongTypeArgumentsNumberInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsWrongTypeArgumentsNumberInspectionTest.kt
@@ -391,4 +391,32 @@ class RsWrongTypeArgumentsNumberInspectionTest : RsInspectionsTestBase(RsWrongTy
             let x: foo::   S<T>;
         }
     """)
+
+    fun `test remove type arguments with lifetime 1`() = checkFixByText("Remove redundant type arguments", """
+        struct B<'a, T>(&'a T);
+
+        struct C<'a> {
+            a: <error descr="Wrong number of type arguments: expected 1, found 2 [E0107]">B<'a, u32, i32>/*caret*/</error>
+        }
+    """, """
+        struct B<'a, T>(&'a T);
+
+        struct C<'a> {
+            a: B<'a, u32>
+        }
+    """)
+
+    fun `test remove type arguments with lifetime 2`() = checkFixByText("Remove redundant type arguments", """
+        struct B<'a>(&'a u32);
+
+        struct C<'a> {
+            a: <error descr="Wrong number of type arguments: expected 0, found 1 [E0107]">B<'a, i32>/*caret*/</error>
+        }
+    """, """
+        struct B<'a>(&'a u32);
+
+        struct C<'a> {
+            a: B<'a>
+        }
+    """)
 }


### PR DESCRIPTION
The `RemoveTypeArguments` fix was introduced in https://github.com/intellij-rust/intellij-rust/pull/1305 and for some reason it ignored types with lifetimes (I hadn't found why in the PR description. @farodin91 do you recall? :D ). I suppose that it shouldn't be a problem, so I removed the condition to fix https://github.com/intellij-rust/intellij-rust/issues/6620. If you are aware of any issues that might arise from this, let me know.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/6620

changelog: Allow removing redundant type arguments from types with lifetimes