### PR TITLE
ANN: add quick fix to remove redundant function call arguments

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -869,7 +869,9 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
             )).addToHolder(holder)
         } else if (!functionType.variadic && realCount > expectedCount) {
             args.exprList.drop(expectedCount).forEach {
-                RsDiagnostic.IncorrectFunctionArgumentCountError(it, expectedCount, realCount, functionType).addToHolder(holder)
+                RsDiagnostic.IncorrectFunctionArgumentCountError(it, expectedCount, realCount, functionType, listOf(
+                    RemoveFunctionArgumentFix(it)
+                )).addToHolder(holder)
             }
         }
     }

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/RemoveFunctionArgumentFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/RemoveFunctionArgumentFix.kt
@@ -1,0 +1,29 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.deleteWithSurroundingComma
+
+class RemoveFunctionArgumentFix(element: RsElement) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+    override fun getText(): String = "Remove argument"
+    override fun getFamilyName(): String = text
+    override fun invoke(
+        project: Project,
+        file: PsiFile,
+        editor: Editor?,
+        startElement: PsiElement,
+        endElement: PsiElement
+    ) {
+        val element = startElement as? RsElement ?: return
+        element.deleteWithSurroundingComma()
+    }
+}

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveFunctionArgumentFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveFunctionArgumentFixTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.rust.ide.annotator.RsAnnotatorTestBase
+import org.rust.ide.annotator.RsErrorAnnotator
+
+class RemoveFunctionArgumentFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
+    fun `test no parameters`() = checkFixByText("Remove argument", """
+        fn foo() {}
+
+        fn main() {
+            foo(<error>1/*caret*/</error>);
+        }
+    """, """
+        fn foo() {}
+
+        fn main() {
+            foo();
+        }
+    """)
+
+    fun `test single parameter`() = checkFixByText("Remove argument", """
+        fn foo(a: u32) {}
+
+        fn main() {
+            foo(1, <error>2/*caret*/</error>);
+        }
+    """, """
+        fn foo(a: u32) {}
+
+        fn main() {
+            foo(1);
+        }
+    """)
+
+    fun `test multiple redundant arguments`() = checkFixByText("Remove argument", """
+        fn foo() {}
+
+        fn main() {
+            foo(<error>1/*caret*/</error>, <error>2</error>);
+        }
+    """, """
+        fn foo() {}
+
+        fn main() {
+            foo(2);
+        }
+    """)
+
+    fun `test keep whitespace and comments`() = checkFixByText("Remove argument", """
+        fn foo() {}
+
+        fn main() {
+            foo(<error>1/*caret*/</error> /* there is a comment here */ );
+        }
+    """, """
+        fn foo() {}
+
+        fn main() {
+            foo(/* there is a comment here */ );
+        }
+    """)
+
+    fun `test method call`() = checkFixByText("Remove argument", """
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+
+        fn foo(s: S) {
+            s.foo(<error>1/*caret*/</error>);
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+
+        fn foo(s: S) {
+            s.foo();
+        }
+    """)
+
+    fun `test lambda`() = checkFixByText("Remove argument", """
+        fn main() {
+            let foo = |x| x + 1;
+            foo(0, <error>1/*caret*/</error>);
+        }
+    """, """
+        fn main() {
+            let foo = |x| x + 1;
+            foo(0);
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds a quick fix that lets the user quickly remove a redundant function argument. This fix is inspired by a similar one that exists for Kotlin (and probably also for other languages).

![remove-argument](https://user-images.githubusercontent.com/4539057/103584893-77896300-4ee2-11eb-9e8a-39242a4692f1.gif)

I wanted to implement this right after https://github.com/intellij-rust/intellij-rust/pull/5612, but I kind of forgot about it. Another option (instead of removing the argument) is to add a new parameter, but that is blocked on https://github.com/intellij-rust/intellij-rust/pull/5944.

I didn't inherit from `RemoveElementFix`, because I would have to override all of its functions anyway. Currently, whitespace/comments next to the removed argument are preserved, not removed, I'm not sure which is better.

changelog: Add a quick fix to remove redundant function call arguments.