### PR TITLE
TOML: unify toml key parsing

### DIFF
--- a/intellij-toml/src/main/grammars/TomlParser.bnf
+++ b/intellij-toml/src/main/grammars/TomlParser.bnf
@@ -42,16 +42,14 @@ private FileForm_recover ::=
   !<<atNewLine (BARE_KEY | BARE_KEY_OR_NUMBER | BARE_KEY_OR_DATE | BASIC_STRING | LITERAL_STRING | '[')>>
 private EatUntilNextLine_recover ::= !<<atNewLine <<any>>>>
 
-KeyValue ::= LongKey '=' <<atSameLine Value>> { pin = 1 }
+KeyValue ::= Key '=' <<atSameLine Value>> { pin = 1 }
 NewLineKeyValue ::= <<atNewLine KeyValue>> {
     elementType = KeyValue
     recoverWhile = EatUntilNextLine_recover
 }
 
-fake Key ::= BasicKey ('.' BasicKey)*
-LongKey ::= BasicKey ('.' BasicKey)* { elementType = Key }
-ShortKey ::= BasicKey { elementType = Key }
-private BasicKey ::= BareKey | BASIC_STRING | LITERAL_STRING
+Key ::= KeySegment ('.' KeySegment)*
+KeySegment ::= BareKey | BASIC_STRING | LITERAL_STRING
 private BareKey ::= BARE_KEY
   | <<remap 'BARE_KEY_OR_NUMBER' 'BARE_KEY'>>
   | <<remap 'BARE_KEY_OR_DATE' 'BARE_KEY'>>
@@ -80,13 +78,13 @@ private ArrayElement ::= !']' Value (','|&']') {
 private ArrayElement_recover ::= !(']' | Value_first) { consumeTokenMethod = "consumeTokenFast" }
 
 Table ::= TableHeader NewLineKeyValue*
-TableHeader ::= '[' ShortKey ('.' ShortKey)* ']' {
+TableHeader ::= '[' Key ']' {
   pin = 1
   recoverWhile = EatUntilNextLine_recover
 }
 
 ArrayTable ::= ArrayTableHeader NewLineKeyValue*
-ArrayTableHeader ::= '[''[' ShortKey ('.' ShortKey)* ']'']' {
+ArrayTableHeader ::= '[''[' Key ']'']' {
   pin = 2
   elementType = TableHeader
   recoverWhile = EatUntilNextLine_recover

--- a/intellij-toml/src/main/kotlin/org/toml/lang/psi/Psi.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/psi/Psi.kt
@@ -30,9 +30,13 @@ interface TomlKeyValue : TomlElement {
 
 /**
  * It's possible to use [PsiReferenceContributor] to inject references
- * into [TomlKey] from third-party plugins.
+ * into [TomlKeySegment] from third-party plugins.
  */
-interface TomlKey : TomlElement, ContributedReferenceHost, PsiNamedElement, NavigatablePsiElement
+interface TomlKeySegment : TomlElement, ContributedReferenceHost, PsiNamedElement, NavigatablePsiElement
+
+interface TomlKey : TomlElement {
+    val segments: List<TomlKeySegment>
+}
 
 /**
  * It's possible to use [PsiReferenceContributor] to inject references
@@ -49,6 +53,6 @@ interface TomlArrayTable : TomlKeyValueOwner, TomlHeaderOwner
 interface TomlInlineTable : TomlKeyValueOwner, TomlValue
 
 interface TomlTableHeader : TomlElement {
-    val names: List<TomlKey>
+    val key: TomlKey?
 }
 

--- a/intellij-toml/src/main/kotlin/org/toml/lang/psi/TomlPsiFactory.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/psi/TomlPsiFactory.kt
@@ -35,6 +35,9 @@ class TomlPsiFactory(private val project: Project, private val markGenerated: Bo
         // contains the quote in the beginning and the end. E.g.: `createValue("\"1.0.90\"")`
         createFromText("dummy = $value") ?: error("Failed to create TomlLiteral")
 
+    fun createKeySegment(key: String): TomlKeySegment =
+        createFromText("$key = \"dummy\"") ?: error("Failed to create TomlKeySegment")
+
     fun createKey(key: String): TomlKey =
         createFromText("$key = \"dummy\"") ?: error("Failed to create TomlKey")
 

--- a/intellij-toml/src/main/kotlin/org/toml/lang/psi/TomlVisitor.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/psi/TomlVisitor.kt
@@ -23,6 +23,10 @@ open class TomlVisitor : PsiElementVisitor() {
         visitElement(element)
     }
 
+    open fun visitKeySegment(element: TomlKeySegment) {
+        visitElement(element)
+    }
+
     open fun visitKey(element: TomlKey) {
         visitElement(element)
     }

--- a/intellij-toml/src/main/kotlin/org/toml/lang/psi/ext/TomlKey.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/psi/ext/TomlKey.kt
@@ -1,0 +1,15 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.toml.lang.psi.ext
+
+import org.toml.lang.psi.TomlKey
+import org.toml.lang.psi.TomlKeySegment
+
+/**
+ * If key consists of single [TomlKeySegment], returns its name.
+ * Otherwise, returns `null`
+ */
+val TomlKey.name: String? get() = segments.singleOrNull()?.name

--- a/intellij-toml/src/main/kotlin/org/toml/lang/psi/impl/Psi.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/psi/impl/Psi.kt
@@ -46,6 +46,14 @@ class TomlKeySegmentImpl(type: IElementType) : CompositePsiElement(type), TomlKe
 
     override fun toString(): String = "TomlKeySegment"
     override fun getReferences(): Array<PsiReference> = ReferenceProvidersRegistry.getReferencesFromProviders(this)
+
+    override fun accept(visitor: PsiElementVisitor) {
+        if (visitor is TomlVisitor) {
+            visitor.visitKeySegment(this)
+        } else {
+            super.accept(visitor)
+        }
+    }
 }
 
 class TomlKeyImpl(type: IElementType) : CompositePsiElement(type), TomlKey {

--- a/intellij-toml/src/main/kotlin/org/toml/lang/psi/impl/Psi.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/psi/impl/Psi.kt
@@ -34,16 +34,22 @@ class TomlKeyValueImpl(type: IElementType) : CompositePsiElement(type), TomlKeyV
     }
 }
 
-class TomlKeyImpl(type: IElementType) : CompositePsiElement(type), TomlKey {
-    override fun getReferences(): Array<PsiReference> = ReferenceProvidersRegistry.getReferencesFromProviders(this)
+class TomlKeySegmentImpl(type: IElementType) : CompositePsiElement(type), TomlKeySegment {
 
     override fun getName(): String = text
 
     override fun setName(name: String): PsiElement {
-        return replace(TomlPsiFactory(project).createKey(name))
+        return replace(TomlPsiFactory(project).createKeySegment(name))
     }
 
     override fun getPresentation(): ItemPresentation = PresentationData(name, null, null, null)
+
+    override fun toString(): String = "TomlKeySegment"
+    override fun getReferences(): Array<PsiReference> = ReferenceProvidersRegistry.getReferencesFromProviders(this)
+}
+
+class TomlKeyImpl(type: IElementType) : CompositePsiElement(type), TomlKey {
+    override val segments: List<TomlKeySegment> get() = childrenOfType()
 
     override fun toString(): String = "TomlKey"
 
@@ -113,7 +119,7 @@ class TomlTableImpl(type: IElementType) : CompositePsiElement(type), TomlTable {
 }
 
 class TomlTableHeaderImpl(type: IElementType) : CompositePsiElement(type), TomlTableHeader {
-    override val names: List<TomlKey> get() = childrenOfType()
+    override val key: TomlKey? get() = childOfTypeNullable()
     override fun toString(): String = "TomlTableHeader"
 
     override fun accept(visitor: PsiElementVisitor) {
@@ -154,8 +160,9 @@ class TomlArrayTableImpl(type: IElementType) : CompositePsiElement(type), TomlAr
 }
 
 class TomlASTFactory : ASTFactory() {
-    override fun createComposite(type: IElementType): CompositeElement? = when (type) {
+    override fun createComposite(type: IElementType): CompositeElement = when (type) {
         KEY_VALUE -> TomlKeyValueImpl(type)
+        KEY_SEGMENT -> TomlKeySegmentImpl(type)
         KEY -> TomlKeyImpl(type)
         LITERAL -> TomlLiteralImpl(type)
         ARRAY -> TomlArrayImpl(type)

--- a/intellij-toml/src/test/kotlin/org/toml/lang/psi/TomlPsiFactoryTest.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/lang/psi/TomlPsiFactoryTest.kt
@@ -15,6 +15,11 @@ class TomlPsiFactoryTest : TomlTestBase() {
         assertEquals("\"value\"", literal.text)
     }
 
+    fun `test create key segment`() {
+        val keySegment = factory.createKeySegment("segment")
+        assertEquals("segment", keySegment.name)
+    }
+
     fun `test create key`() {
         val key = factory.createKey("key")
         assertEquals("key", key.text)
@@ -39,7 +44,7 @@ class TomlPsiFactoryTest : TomlTestBase() {
     fun `test create table header`() {
         val tableHeader = factory.createTableHeader("key1.key2")
         assertEquals("[key1.key2]", tableHeader.text)
-        assertEquals(listOf("key1", "key2"), tableHeader.names.map { it.text })
+        assertEquals(listOf("key1", "key2"), tableHeader.key?.segments.orEmpty().map { it.text })
     }
 
     fun `test create array`() {

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/arrayTables.txt
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/arrayTables.txt
@@ -4,13 +4,15 @@ TOML File
       PsiElement([)('[')
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('products')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('products')
       PsiElement(])(']')
       PsiElement(])(']')
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('name')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('name')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -19,7 +21,8 @@ TOML File
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('sku')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('sku')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -31,7 +34,8 @@ TOML File
       PsiElement([)('[')
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('products')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('products')
       PsiElement(])(']')
       PsiElement(])(']')
   PsiWhiteSpace('\n\n')
@@ -40,13 +44,15 @@ TOML File
       PsiElement([)('[')
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('products')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('products')
       PsiElement(])(']')
       PsiElement(])(']')
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('name')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('name')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -55,7 +61,8 @@ TOML File
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('sku')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('sku')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -64,7 +71,8 @@ TOML File
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('color')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('color')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -76,13 +84,15 @@ TOML File
       PsiElement([)('[')
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('fruit')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('fruit')
       PsiElement(])(']')
       PsiElement(])(']')
     PsiWhiteSpace('\n  ')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('name')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('name')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -93,15 +103,17 @@ TOML File
     TomlTableHeader
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('fruit')
-      PsiElement(.)('.')
-      TomlKey
-        PsiElement(BARE_KEY)('physical')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('fruit')
+        PsiElement(.)('.')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('physical')
       PsiElement(])(']')
     PsiWhiteSpace('\n    ')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('color')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('color')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -110,7 +122,8 @@ TOML File
     PsiWhiteSpace('\n    ')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('shape')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('shape')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -122,16 +135,18 @@ TOML File
       PsiElement([)('[')
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('fruit')
-      PsiElement(.)('.')
-      TomlKey
-        PsiElement(BARE_KEY)('variety')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('fruit')
+        PsiElement(.)('.')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('variety')
       PsiElement(])(']')
       PsiElement(])(']')
     PsiWhiteSpace('\n    ')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('name')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('name')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -143,16 +158,18 @@ TOML File
       PsiElement([)('[')
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('fruit')
-      PsiElement(.)('.')
-      TomlKey
-        PsiElement(BARE_KEY)('variety')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('fruit')
+        PsiElement(.)('.')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('variety')
       PsiElement(])(']')
       PsiElement(])(']')
     PsiWhiteSpace('\n    ')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('name')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('name')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -164,13 +181,15 @@ TOML File
       PsiElement([)('[')
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('fruit')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('fruit')
       PsiElement(])(']')
       PsiElement(])(']')
     PsiWhiteSpace('\n  ')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('name')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('name')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -182,16 +201,18 @@ TOML File
       PsiElement([)('[')
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('fruit')
-      PsiElement(.)('.')
-      TomlKey
-        PsiElement(BARE_KEY)('variety')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('fruit')
+        PsiElement(.)('.')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('variety')
       PsiElement(])(']')
       PsiElement(])(']')
     PsiWhiteSpace('\n    ')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('name')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('name')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -200,7 +221,8 @@ TOML File
     PsiWhiteSpace('\n\n\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('points')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('points')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -212,7 +234,8 @@ TOML File
           PsiWhiteSpace(' ')
           TomlKeyValue
             TomlKey
-              PsiElement(BARE_KEY)('x')
+              TomlKeySegment
+                PsiElement(BARE_KEY)('x')
             PsiWhiteSpace(' ')
             PsiElement(=)('=')
             PsiWhiteSpace(' ')
@@ -222,7 +245,8 @@ TOML File
           PsiWhiteSpace(' ')
           TomlKeyValue
             TomlKey
-              PsiElement(BARE_KEY)('y')
+              TomlKeySegment
+                PsiElement(BARE_KEY)('y')
             PsiWhiteSpace(' ')
             PsiElement(=)('=')
             PsiWhiteSpace(' ')
@@ -232,7 +256,8 @@ TOML File
           PsiWhiteSpace(' ')
           TomlKeyValue
             TomlKey
-              PsiElement(BARE_KEY)('z')
+              TomlKeySegment
+                PsiElement(BARE_KEY)('z')
             PsiWhiteSpace(' ')
             PsiElement(=)('=')
             PsiWhiteSpace(' ')
@@ -247,7 +272,8 @@ TOML File
           PsiWhiteSpace(' ')
           TomlKeyValue
             TomlKey
-              PsiElement(BARE_KEY)('x')
+              TomlKeySegment
+                PsiElement(BARE_KEY)('x')
             PsiWhiteSpace(' ')
             PsiElement(=)('=')
             PsiWhiteSpace(' ')
@@ -257,7 +283,8 @@ TOML File
           PsiWhiteSpace(' ')
           TomlKeyValue
             TomlKey
-              PsiElement(BARE_KEY)('y')
+              TomlKeySegment
+                PsiElement(BARE_KEY)('y')
             PsiWhiteSpace(' ')
             PsiElement(=)('=')
             PsiWhiteSpace(' ')
@@ -267,7 +294,8 @@ TOML File
           PsiWhiteSpace(' ')
           TomlKeyValue
             TomlKey
-              PsiElement(BARE_KEY)('z')
+              TomlKeySegment
+                PsiElement(BARE_KEY)('z')
             PsiWhiteSpace(' ')
             PsiElement(=)('=')
             PsiWhiteSpace(' ')
@@ -282,7 +310,8 @@ TOML File
           PsiWhiteSpace(' ')
           TomlKeyValue
             TomlKey
-              PsiElement(BARE_KEY)('x')
+              TomlKeySegment
+                PsiElement(BARE_KEY)('x')
             PsiWhiteSpace(' ')
             PsiElement(=)('=')
             PsiWhiteSpace(' ')
@@ -292,7 +321,8 @@ TOML File
           PsiWhiteSpace(' ')
           TomlKeyValue
             TomlKey
-              PsiElement(BARE_KEY)('y')
+              TomlKeySegment
+                PsiElement(BARE_KEY)('y')
             PsiWhiteSpace(' ')
             PsiElement(=)('=')
             PsiWhiteSpace(' ')
@@ -302,7 +332,8 @@ TOML File
           PsiWhiteSpace(' ')
           TomlKeyValue
             TomlKey
-              PsiElement(BARE_KEY)('z')
+              TomlKeySegment
+                PsiElement(BARE_KEY)('z')
             PsiWhiteSpace(' ')
             PsiElement(=)('=')
             PsiWhiteSpace(' ')

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/arrays.txt
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/arrays.txt
@@ -1,7 +1,8 @@
 TOML File
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('arr1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('arr1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -23,7 +24,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('arr2')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('arr2')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -45,7 +47,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('arr3')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('arr3')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -83,7 +86,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('arr4')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('arr4')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -108,7 +112,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('arr5')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('arr5')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -146,7 +151,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('arr6')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('arr6')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -166,7 +172,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('arr7')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('arr7')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -188,7 +195,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('arr8')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('arr8')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/boolean.txt
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/boolean.txt
@@ -1,7 +1,8 @@
 TOML File
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('bool1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('bool1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -10,7 +11,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('bool2')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('bool2')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/inlineTables.txt
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/inlineTables.txt
@@ -1,7 +1,8 @@
 TOML File
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('name')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('name')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -10,7 +11,8 @@ TOML File
       PsiWhiteSpace(' ')
       TomlKeyValue
         TomlKey
-          PsiElement(BARE_KEY)('first')
+          TomlKeySegment
+            PsiElement(BARE_KEY)('first')
         PsiWhiteSpace(' ')
         PsiElement(=)('=')
         PsiWhiteSpace(' ')
@@ -20,7 +22,8 @@ TOML File
       PsiWhiteSpace(' ')
       TomlKeyValue
         TomlKey
-          PsiElement(BARE_KEY)('last')
+          TomlKeySegment
+            PsiElement(BARE_KEY)('last')
         PsiWhiteSpace(' ')
         PsiElement(=)('=')
         PsiWhiteSpace(' ')
@@ -31,7 +34,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('point')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('point')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -40,7 +44,8 @@ TOML File
       PsiWhiteSpace(' ')
       TomlKeyValue
         TomlKey
-          PsiElement(BARE_KEY)('x')
+          TomlKeySegment
+            PsiElement(BARE_KEY)('x')
         PsiWhiteSpace(' ')
         PsiElement(=)('=')
         PsiWhiteSpace(' ')
@@ -50,7 +55,8 @@ TOML File
       PsiWhiteSpace(' ')
       TomlKeyValue
         TomlKey
-          PsiElement(BARE_KEY)('y')
+          TomlKeySegment
+            PsiElement(BARE_KEY)('y')
         PsiWhiteSpace(' ')
         PsiElement(=)('=')
         PsiWhiteSpace(' ')

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/invalid.txt
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/invalid.txt
@@ -1,7 +1,8 @@
 TOML File
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key11')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key11')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -13,7 +14,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key12')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key12')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -25,7 +27,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key13')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key13')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiErrorElement:<literal>, '[' or '{' expected, got 'foo'
@@ -37,7 +40,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key14')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key14')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -49,7 +53,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key21')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key21')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -63,7 +68,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key22')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key22')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -72,7 +78,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key31')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key31')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -85,7 +92,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key32')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key32')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -102,7 +110,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key33')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key33')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -122,7 +131,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key34')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key34')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -142,7 +152,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key35')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key35')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -159,7 +170,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key36')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key36')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -174,7 +186,8 @@ TOML File
         PsiElement({)('{')
         TomlKeyValue
           TomlKey
-            PsiElement(BARE_KEY)('valid')
+            TomlKeySegment
+              PsiElement(BARE_KEY)('valid')
           PsiWhiteSpace(' ')
           PsiElement(=)('=')
           PsiWhiteSpace(' ')
@@ -187,7 +200,8 @@ TOML File
     TomlTableHeader
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('header1')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('header1')
       PsiElement(])(']')
       PsiWhiteSpace(' ')
       PsiErrorElement:'invalid' unexpected
@@ -199,7 +213,8 @@ TOML File
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('key')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('key')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -210,12 +225,14 @@ TOML File
     TomlTableHeader
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('header2')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('header2')
       PsiElement(])(']')
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('key1')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('key1')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -231,7 +248,8 @@ TOML File
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('key2')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('key2')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -243,7 +261,8 @@ TOML File
       PsiElement([)('[')
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('header3')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('header3')
       PsiElement(])(']')
       PsiElement(])(']')
       PsiWhiteSpace(' ')
@@ -256,7 +275,8 @@ TOML File
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('key')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('key')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/keys.txt
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/keys.txt
@@ -1,7 +1,8 @@
 TOML File
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -10,7 +11,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('bare_key')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('bare_key')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -19,7 +21,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('bare-key')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('bare-key')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -28,7 +31,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('1234')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('1234')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -37,7 +41,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('2018-04-01')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('2018-04-01')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -46,7 +51,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('2018-04-01Z')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('2018-04-01Z')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -55,7 +61,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BASIC_STRING)('"127.0.0.1"')
+      TomlKeySegment
+        PsiElement(BASIC_STRING)('"127.0.0.1"')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -64,7 +71,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BASIC_STRING)('"character encoding"')
+      TomlKeySegment
+        PsiElement(BASIC_STRING)('"character encoding"')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -73,7 +81,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BASIC_STRING)('"ʎǝʞ"')
+      TomlKeySegment
+        PsiElement(BASIC_STRING)('"ʎǝʞ"')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -82,7 +91,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(LITERAL_STRING)(''key2'')
+      TomlKeySegment
+        PsiElement(LITERAL_STRING)(''key2'')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -91,7 +101,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(LITERAL_STRING)(''quoted "value"'')
+      TomlKeySegment
+        PsiElement(LITERAL_STRING)(''quoted "value"'')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -100,7 +111,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BASIC_STRING)('""')
+      TomlKeySegment
+        PsiElement(BASIC_STRING)('""')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -109,7 +121,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(LITERAL_STRING)('''')
+      TomlKeySegment
+        PsiElement(LITERAL_STRING)('''')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -118,7 +131,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('name')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('name')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -127,9 +141,11 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('physical')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('physical')
       PsiElement(.)('.')
-      PsiElement(BARE_KEY)('color')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('color')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -138,9 +154,11 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('physical')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('physical')
       PsiElement(.)('.')
-      PsiElement(BARE_KEY)('shape')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('shape')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -149,9 +167,11 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('site')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('site')
       PsiElement(.)('.')
-      PsiElement(BASIC_STRING)('"google.com"')
+      TomlKeySegment
+        PsiElement(BASIC_STRING)('"google.com"')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -160,11 +180,14 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('a')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('a')
       PsiElement(.)('.')
-      PsiElement(BARE_KEY)('b')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('b')
       PsiElement(.)('.')
-      PsiElement(BARE_KEY)('c')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('c')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -173,9 +196,11 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('a')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('a')
       PsiElement(.)('.')
-      PsiElement(BARE_KEY)('d')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('d')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -186,10 +211,11 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('a')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('a')
     PsiElement(.)('.')
     PsiWhiteSpace(' ')
-    PsiErrorElement:BARE_KEY, BASIC_STRING or LITERAL_STRING expected, got '='
+    PsiErrorElement:<key segment> expected, got '='
       PsiElement(=)('=')
     PsiWhiteSpace(' ')
     PsiElement(BASIC_STRING)('""')
@@ -206,7 +232,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiErrorElement:VALUE expected, got '"key2"'
@@ -214,7 +241,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BASIC_STRING)('"key2"')
+      TomlKeySegment
+        PsiElement(BASIC_STRING)('"key2"')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -223,7 +251,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key3')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key3')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiErrorElement:VALUE expected, got 'key4'
@@ -231,7 +260,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key4')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key4')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -242,7 +272,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiErrorElement:<literal>, '[' or '{' expected, got 'IntellijIdeaRulezzz'
@@ -251,7 +282,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('key2')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('key2')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiErrorElement:<literal>, '[' or '{' expected, got 'IntellijIdeaRulezzz'

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/numbers.txt
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/numbers.txt
@@ -1,7 +1,8 @@
 TOML File
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('int1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('int1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -10,7 +11,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('int2')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('int2')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -19,7 +21,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('int3')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('int3')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -28,7 +31,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('int4')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('int4')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -37,7 +41,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('int5')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('int5')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -46,7 +51,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('int6')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('int6')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -55,7 +61,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('int7')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('int7')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -64,7 +71,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('hex1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('hex1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -73,7 +81,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('hex2')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('hex2')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -82,7 +91,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('hex3')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('hex3')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -91,7 +101,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('oct1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('oct1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -100,7 +111,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('oct2')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('oct2')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -109,7 +121,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('bin1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('bin1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -118,7 +131,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('flt1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('flt1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -127,7 +141,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('flt2')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('flt2')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -136,7 +151,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('flt3')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('flt3')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -145,7 +161,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('flt4')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('flt4')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -154,7 +171,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('flt5')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('flt5')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -163,7 +181,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('flt6')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('flt6')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -172,7 +191,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('flt7')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('flt7')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -181,7 +201,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('flt8')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('flt8')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -190,7 +211,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('sf1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('sf1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -199,7 +221,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('sf2')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('sf2')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -208,7 +231,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('sf3')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('sf3')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -217,7 +241,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('sf4')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('sf4')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -226,7 +251,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('sf5')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('sf5')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -235,7 +261,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('sf6')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('sf6')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/strings.txt
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/strings.txt
@@ -1,7 +1,8 @@
 TOML File
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('str')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('str')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -10,7 +11,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('str1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('str1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -19,7 +21,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('str2')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('str2')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -28,7 +31,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('str3')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('str3')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -37,7 +41,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('str1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('str1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -46,7 +51,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('str2')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('str2')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -55,7 +61,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('str3')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('str3')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -64,7 +71,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('winpath')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('winpath')
     PsiWhiteSpace('  ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -73,7 +81,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('winpath2')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('winpath2')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -82,7 +91,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('quoted')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('quoted')
     PsiWhiteSpace('   ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -91,7 +101,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('regex')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('regex')
     PsiWhiteSpace('    ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -100,7 +111,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('regex2')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('regex2')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -109,7 +121,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('lines')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('lines')
     PsiWhiteSpace('  ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/tables.txt
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/tables.txt
@@ -3,19 +3,22 @@ TOML File
     TomlTableHeader
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('table')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('table')
       PsiElement(])(']')
   PsiWhiteSpace('\n\n')
   TomlTable
     TomlTableHeader
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('table-1')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('table-1')
       PsiElement(])(']')
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('key1')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('key1')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -24,7 +27,8 @@ TOML File
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('key2')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('key2')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -35,12 +39,14 @@ TOML File
     TomlTableHeader
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('table-2')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('table-2')
       PsiElement(])(']')
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('key1')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('key1')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -49,7 +55,8 @@ TOML File
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('key2')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('key2')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -60,15 +67,17 @@ TOML File
     TomlTableHeader
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('dog')
-      PsiElement(.)('.')
-      TomlKey
-        PsiElement(BASIC_STRING)('"tater.man"')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('dog')
+        PsiElement(.)('.')
+        TomlKeySegment
+          PsiElement(BASIC_STRING)('"tater.man"')
       PsiElement(])(']')
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('type')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('type')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -79,13 +88,14 @@ TOML File
     TomlTableHeader
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('a')
-      PsiElement(.)('.')
-      TomlKey
-        PsiElement(BARE_KEY)('b')
-      PsiElement(.)('.')
-      TomlKey
-        PsiElement(BARE_KEY)('c')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('a')
+        PsiElement(.)('.')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('b')
+        PsiElement(.)('.')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('c')
       PsiElement(])(']')
   PsiWhiteSpace('            ')
   PsiComment(COMMENT)('# this is best practice')
@@ -95,13 +105,14 @@ TOML File
       PsiElement([)('[')
       PsiWhiteSpace(' ')
       TomlKey
-        PsiElement(BARE_KEY)('d')
-      PsiElement(.)('.')
-      TomlKey
-        PsiElement(BARE_KEY)('e')
-      PsiElement(.)('.')
-      TomlKey
-        PsiElement(BARE_KEY)('f')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('d')
+        PsiElement(.)('.')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('e')
+        PsiElement(.)('.')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('f')
       PsiWhiteSpace(' ')
       PsiElement(])(']')
   PsiWhiteSpace('          ')
@@ -112,17 +123,18 @@ TOML File
       PsiElement([)('[')
       PsiWhiteSpace(' ')
       TomlKey
-        PsiElement(BARE_KEY)('g')
-      PsiWhiteSpace(' ')
-      PsiElement(.)('.')
-      PsiWhiteSpace('  ')
-      TomlKey
-        PsiElement(BARE_KEY)('h')
-      PsiWhiteSpace('  ')
-      PsiElement(.)('.')
-      PsiWhiteSpace(' ')
-      TomlKey
-        PsiElement(BARE_KEY)('i')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('g')
+        PsiWhiteSpace(' ')
+        PsiElement(.)('.')
+        PsiWhiteSpace('  ')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('h')
+        PsiWhiteSpace('  ')
+        PsiElement(.)('.')
+        PsiWhiteSpace(' ')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('i')
       PsiWhiteSpace(' ')
       PsiElement(])(']')
   PsiWhiteSpace('    ')
@@ -133,17 +145,18 @@ TOML File
       PsiElement([)('[')
       PsiWhiteSpace(' ')
       TomlKey
-        PsiElement(BARE_KEY)('j')
-      PsiWhiteSpace(' ')
-      PsiElement(.)('.')
-      PsiWhiteSpace(' ')
-      TomlKey
-        PsiElement(BASIC_STRING)('"ʞ"')
-      PsiWhiteSpace(' ')
-      PsiElement(.)('.')
-      PsiWhiteSpace(' ')
-      TomlKey
-        PsiElement(LITERAL_STRING)(''l'')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('j')
+        PsiWhiteSpace(' ')
+        PsiElement(.)('.')
+        PsiWhiteSpace(' ')
+        TomlKeySegment
+          PsiElement(BASIC_STRING)('"ʞ"')
+        PsiWhiteSpace(' ')
+        PsiElement(.)('.')
+        PsiWhiteSpace(' ')
+        TomlKeySegment
+          PsiElement(LITERAL_STRING)(''l'')
       PsiWhiteSpace(' ')
       PsiElement(])(']')
   PsiWhiteSpace('  ')
@@ -159,16 +172,17 @@ TOML File
     TomlTableHeader
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('x')
-      PsiElement(.)('.')
-      TomlKey
-        PsiElement(BARE_KEY)('y')
-      PsiElement(.)('.')
-      TomlKey
-        PsiElement(BARE_KEY)('z')
-      PsiElement(.)('.')
-      TomlKey
-        PsiElement(BARE_KEY)('w')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('x')
+        PsiElement(.)('.')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('y')
+        PsiElement(.)('.')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('z')
+        PsiElement(.)('.')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('w')
       PsiElement(])(']')
   PsiWhiteSpace(' ')
   PsiComment(COMMENT)('# for this to work')
@@ -177,15 +191,17 @@ TOML File
     TomlTableHeader
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('a')
-      PsiElement(.)('.')
-      TomlKey
-        PsiElement(BARE_KEY)('b')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('a')
+        PsiElement(.)('.')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('b')
       PsiElement(])(']')
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('c')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('c')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -196,12 +212,14 @@ TOML File
     TomlTableHeader
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('a')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('a')
       PsiElement(])(']')
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('d')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('d')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiWhiteSpace(' ')
@@ -214,12 +232,14 @@ TOML File
     TomlTableHeader
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('table-a')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('table-a')
       PsiElement(])(']')
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('key')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('key')
       PsiErrorElement:'.' or '=' expected, got '['
         <empty list>
   PsiWhiteSpace('\n')
@@ -227,19 +247,22 @@ TOML File
     TomlTableHeader
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('table-b')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('table-b')
       PsiElement(])(']')
   PsiWhiteSpace('\n\n')
   TomlTable
     TomlTableHeader
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('table-c')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('table-c')
       PsiElement(])(']')
     PsiWhiteSpace('\n')
     TomlKeyValue
       TomlKey
-        PsiElement(BARE_KEY)('key')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('key')
       PsiWhiteSpace(' ')
       PsiElement(=)('=')
       PsiErrorElement:VALUE expected, got '['
@@ -249,5 +272,6 @@ TOML File
     TomlTableHeader
       PsiElement([)('[')
       TomlKey
-        PsiElement(BARE_KEY)('table-d')
+        TomlKeySegment
+          PsiElement(BARE_KEY)('table-d')
       PsiElement(])(']')

--- a/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/time.txt
+++ b/intellij-toml/src/test/resources/org/toml/lang/parse/fixtures/time.txt
@@ -1,7 +1,8 @@
 TOML File
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('odt1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('odt1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -10,7 +11,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('odt2')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('odt2')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -19,7 +21,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('odt3')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('odt3')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -28,7 +31,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('ldt1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('ldt1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -37,7 +41,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('ldt2')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('ldt2')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -46,7 +51,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('ld1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('ld1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -55,7 +61,8 @@ TOML File
   PsiWhiteSpace('\n\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('lt1')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('lt1')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')
@@ -64,7 +71,8 @@ TOML File
   PsiWhiteSpace('\n')
   TomlKeyValue
     TomlKey
-      PsiElement(BARE_KEY)('lt2')
+      TomlKeySegment
+        PsiElement(BARE_KEY)('lt2')
     PsiWhiteSpace(' ')
     PsiElement(=)('=')
     PsiWhiteSpace(' ')

--- a/toml/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt
@@ -28,18 +28,17 @@ class CargoCrateDocLineMarkerProvider : LineMarkerProvider {
 
         loop@ for (element in elements) {
             val parent = element.parent
-            if (parent is TomlKey) {
-                val key = parent
-                val keyValue = key.parent as? TomlKeyValue ?: continue@loop
+            if (parent is TomlKeySegment) {
+                val keyValue = parent.parent?.parent as? TomlKeyValue ?: continue@loop
                 val table = keyValue.parent as? TomlTable ?: continue@loop
                 if (!table.header.isDependencyListHeader) continue@loop
-                if (key.firstChild?.nextSibling != null) continue@loop
+                if (parent.firstChild?.nextSibling != null) continue@loop
                 val pkgName = keyValue.crateName
                 val pkgVersion = keyValue.version ?: continue@loop
                 result += genLineMarkerInfo(element, pkgName, pkgVersion)
             } else if (element.elementType == TomlElementTypes.L_BRACKET) {
                 val header = parent as? TomlTableHeader ?: continue@loop
-                val names = header.names
+                val names = header.key?.segments.orEmpty()
                 if (names.getOrNull(names.size - 2)?.isDependencyKey != true) continue@loop
                 val table = parent.parent as? TomlTable ?: continue@loop
                 val version = table.entries.find { it.name == "version" }?.value?.stringValue ?: continue@loop

--- a/toml/src/main/kotlin/org/rust/toml/CargoFeatureLineMarkerProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoFeatureLineMarkerProvider.kt
@@ -56,15 +56,14 @@ class CargoFeatureLineMarkerProvider : LineMarkerProvider {
 
         loop@ for (element in elements) {
             val parent = element.parent
-            if (parent is TomlKey) {
-                val key = parent
-                val isFeatureKey = key.isFeatureKey
-                if (!isFeatureKey && !key.isDependencyName) continue@loop
-                val featureName = key.text
+            if (parent is TomlKeySegment) {
+                val isFeatureKey = parent.isFeatureKey
+                if (!isFeatureKey && !parent.isDependencyName) continue@loop
+                val featureName = parent.text
                 if ("." in featureName) continue@loop
                 if (!isFeatureKey && featureName !in features) continue@loop
                 result += genFeatureLineMarkerInfo(
-                    key,
+                    parent,
                     featureName,
                     features[featureName],
                     cargoPackage
@@ -83,15 +82,15 @@ class CargoFeatureLineMarkerProvider : LineMarkerProvider {
         get() = CargoTomlPsiPattern.onDependencyKey.accepts(this) ||
             CargoTomlPsiPattern.onSpecificDependencyHeaderKey.accepts(this)
 
-    private val TomlKey.isFeatureKey: Boolean
+    private val TomlKeySegment.isFeatureKey: Boolean
         get() {
-            val keyValue = parent as? TomlKeyValue ?: return false
+            val keyValue = parent?.parent as? TomlKeyValue ?: return false
             val table = keyValue.parent as? TomlTable ?: return false
             return table.header.isFeatureListHeader
         }
 
     private fun genFeatureLineMarkerInfo(
-        element: TomlKey,
+        element: TomlKeySegment,
         name: String,
         featureState: FeatureState?,
         cargoPackage: CargoWorkspace.Package

--- a/toml/src/main/kotlin/org/rust/toml/CargoTomlElementDescriptionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoTomlElementDescriptionProvider.kt
@@ -9,17 +9,15 @@ import com.intellij.codeInsight.highlighting.HighlightUsagesDescriptionLocation
 import com.intellij.psi.ElementDescriptionLocation
 import com.intellij.psi.ElementDescriptionProvider
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiNamedElement
 import com.intellij.usageView.UsageViewLongNameLocation
 import com.intellij.usageView.UsageViewNodeTextLocation
 import com.intellij.usageView.UsageViewShortNameLocation
 import com.intellij.usageView.UsageViewTypeLocation
-import org.toml.lang.psi.TomlKey
+import org.toml.lang.psi.TomlKeySegment
 
 class CargoTomlElementDescriptionProvider : ElementDescriptionProvider {
     override fun getElementDescription(element: PsiElement, location: ElementDescriptionLocation): String? {
-        @Suppress("USELESS_IS_CHECK") // The check is needed for older TOML plugin versions
-        return if (element is TomlKey && element is PsiNamedElement) {
+        return if (element is TomlKeySegment) {
             if (element.isFeatureDef) {
                 when (location) {
                     is UsageViewShortNameLocation -> element.name

--- a/toml/src/main/kotlin/org/rust/toml/Util.kt
+++ b/toml/src/main/kotlin/org/rust/toml/Util.kt
@@ -57,35 +57,35 @@ private fun load(p: KProperty<*>): String = p.name
 
 val PsiFile.isCargoToml: Boolean get() = virtualFile?.name == CargoConstants.MANIFEST_FILE
 
-val TomlKey.isDependencyKey: Boolean
+val TomlKeySegment.isDependencyKey: Boolean
     get() {
-        val text = text
-        return text == "dependencies" || text == "dev-dependencies" || text == "build-dependencies"
+        val name = name
+        return name == "dependencies" || name == "dev-dependencies" || name == "build-dependencies"
     }
 
-val TomlKey.isFeaturesKey: Boolean
+val TomlKeySegment.isFeaturesKey: Boolean
     get() {
-        val text = text
-        return text == "features"
+        val name = name
+        return name == "features"
     }
 
-val TomlKey.isFeatureDef: Boolean
+val TomlKeySegment.isFeatureDef: Boolean
     get() {
-        val table = (parent as? TomlKeyValue)?.parent as? TomlTable ?: return false
+        val table = (parent?.parent as? TomlKeyValue)?.parent as? TomlTable ?: return false
         return table.header.isFeatureListHeader && table.containingFile.isCargoToml
     }
 
 val TomlTableHeader.isDependencyListHeader: Boolean
-    get() = names.lastOrNull()?.isDependencyKey == true
+    get() = key?.segments?.lastOrNull()?.isDependencyKey == true
 
 val TomlTableHeader.isSpecificDependencyTableHeader: Boolean
     get() {
-        val names = names
+        val names = key?.segments.orEmpty()
         return names.getOrNull(names.size - 2)?.isDependencyKey == true
     }
 
 val TomlTableHeader.isFeatureListHeader: Boolean
-    get() = names.lastOrNull()?.isFeaturesKey == true
+    get() = key?.segments?.lastOrNull()?.isFeaturesKey == true
 
 /** Inserts `=` between key and value if missed and wraps inserted string with quotes if needed */
 class StringValueInsertionHandler(private val keyValue: TomlKeyValue) : InsertHandler<LookupElement> {
@@ -177,15 +177,15 @@ fun findDependencyTomlFile(element: TomlElement, depName: String): TomlFile? =
  *
  * @see [org.rust.toml.resolve.CargoTomlDependencyFeaturesReferenceProvider]
  */
-val TomlValue.containingDependencyKey: TomlKey?
+val TomlValue.containingDependencyKey: TomlKeySegment?
     get() {
         val parentParent = parent?.parent as? TomlElement ?: return null
         return if (parentParent is TomlTable) {
             // [dependencies.foo]
-            parentParent.header.names.lastOrNull()
+            parentParent.header.key?.segments?.lastOrNull()
         } else {
             // [dependencies]
             // foo = { ... }
-            (parentParent.parent as? TomlKeyValue)?.key
+            (parentParent.parent as? TomlKeyValue)?.key?.segments?.singleOrNull()
         }
     }

--- a/toml/src/main/kotlin/org/rust/toml/Util.kt
+++ b/toml/src/main/kotlin/org/rust/toml/Util.kt
@@ -13,7 +13,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.tree.IElementType
 import org.rust.cargo.CargoConstants
 import org.rust.cargo.project.workspace.CargoWorkspace
@@ -25,8 +24,6 @@ import org.rust.lang.core.psi.ext.findCargoPackage
 import org.rust.lang.core.psi.ext.isAncestorOf
 import org.rust.openapiext.toPsiFile
 import org.toml.lang.psi.*
-import org.toml.lang.psi.ext.TomlLiteralKind
-import org.toml.lang.psi.ext.kind
 import kotlin.reflect.KProperty
 
 
@@ -34,14 +31,7 @@ fun tomlPluginIsAbiCompatible(): Boolean = computeOnce
 
 private val computeOnce: Boolean by lazy {
     try {
-        load<TomlLiteralKind>()
-        load(TomlLiteral::kind)
-        if (!PsiNamedElement::class.java.isAssignableFrom(TomlKey::class.java)) {
-            showBalloonWithoutProject(
-                "Incompatible TOML plugin version, \"Find Usages\" for cargo features is not available.",
-                NotificationType.WARNING
-            )
-        }
+        load<TomlKeySegment>()
         true
     } catch (e: LinkageError) {
         showBalloonWithoutProject(

--- a/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlLookupElements.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlLookupElements.kt
@@ -7,9 +7,9 @@ package org.rust.toml.completion
 
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import org.rust.toml.StringLiteralInsertionHandler
-import org.toml.lang.psi.TomlKey
+import org.toml.lang.psi.TomlKeySegment
 
-fun lookupElementForFeature(feature: TomlKey): LookupElementBuilder {
+fun lookupElementForFeature(feature: TomlKeySegment): LookupElementBuilder {
     return LookupElementBuilder
         .createWithSmartPointer(feature.text, feature)
         .withInsertHandler(StringLiteralInsertionHandler())

--- a/toml/src/main/kotlin/org/rust/toml/completion/CratesIoApi.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/CratesIoApi.kt
@@ -17,7 +17,7 @@ import com.intellij.util.io.HttpRequests
 import org.jetbrains.annotations.TestOnly
 import org.rust.ide.notifications.showBalloon
 import org.rust.openapiext.runWithCheckCanceled
-import org.toml.lang.psi.TomlKey
+import org.toml.lang.psi.TomlKeySegment
 import java.io.IOException
 
 data class SearchResult(val crates: List<CrateDescription>)
@@ -33,7 +33,7 @@ data class CrateDescription(
 val CrateDescription.dependencyLine: String
     get() = "$name = \"$maxVersion\""
 
-fun searchCrate(key: TomlKey): Collection<CrateDescription> {
+fun searchCrate(key: TomlKeySegment): Collection<CrateDescription> {
     if (isUnitTestMode) return MOCK!!
 
     val name = CompletionUtil.getOriginalElement(key)?.text ?: ""
@@ -43,7 +43,7 @@ fun searchCrate(key: TomlKey): Collection<CrateDescription> {
     return response.crates
 }
 
-fun getCrateLastVersion(key: TomlKey): String? {
+fun getCrateLastVersion(key: TomlKeySegment): String? {
     if (isUnitTestMode) return MOCK!!.first().maxVersion
 
     val name = CompletionUtil.getOriginalElement(key)?.text ?: ""

--- a/toml/src/main/kotlin/org/rust/toml/completion/RsCfgFeatureCompletionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/RsCfgFeatureCompletionProvider.kt
@@ -25,7 +25,7 @@ import org.rust.lang.core.psi.ext.containingCargoPackage
 import org.rust.lang.core.psi.ext.elementType
 import org.rust.toml.getPackageTomlFile
 import org.rust.toml.resolve.allFeatures
-import org.toml.lang.psi.TomlKey
+import org.toml.lang.psi.TomlKeySegment
 
 /**
  * Provides completion for cargo features in Rust cfg attributes:
@@ -50,7 +50,7 @@ object RsCfgFeatureCompletionProvider : RsCompletionProvider() {
         get() = RsPsiPattern.insideAnyCfgFeature
 }
 
-private fun rustLookupElementForFeature(feature: TomlKey): LookupElementBuilder {
+private fun rustLookupElementForFeature(feature: TomlKeySegment): LookupElementBuilder {
     return LookupElementBuilder
         .createWithSmartPointer(feature.text, feature)
         .withInsertHandler(RustStringLiteralInsertionHandler())

--- a/toml/src/main/kotlin/org/rust/toml/completion/TomlKeyValueCompletionProviderBase.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/TomlKeyValueCompletionProviderBase.kt
@@ -10,14 +10,14 @@ import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.util.ProcessingContext
 import org.rust.toml.getClosestKeyValueAncestor
-import org.toml.lang.psi.TomlKey
 import org.toml.lang.psi.TomlKeyValue
+import org.toml.lang.psi.TomlKeySegment
 
 abstract class TomlKeyValueCompletionProviderBase : CompletionProvider<CompletionParameters>() {
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
         val parent = parameters.position.parent ?: return
-        if (parent is TomlKey) {
-            val keyValue = parent.parent as? TomlKeyValue
+        if (parent is TomlKeySegment) {
+            val keyValue = parent.parent?.parent as? TomlKeyValue
                 ?: error("PsiElementPattern must not allow keys outside of TomlKeyValues")
             completeKey(keyValue, result)
         } else {

--- a/toml/src/main/kotlin/org/rust/toml/completion/TomlSchema.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/TomlSchema.kt
@@ -40,8 +40,8 @@ class TomlSchema private constructor(
 private val TomlKeyValueOwner.schema: TomlTableSchema?
     get() {
         val (name, isArray) = when (this) {
-            is TomlTable -> header.names.firstOrNull()?.text to false
-            is TomlArrayTable -> header.names.firstOrNull()?.text to true
+            is TomlTable -> header.key?.segments?.firstOrNull()?.name to false
+            is TomlArrayTable -> header.key?.segments?.firstOrNull()?.name to true
             else -> return null
         }
         if (name == null) return null

--- a/toml/src/main/kotlin/org/rust/toml/resolve/CargoDependencyReferenceProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/resolve/CargoDependencyReferenceProvider.kt
@@ -15,17 +15,17 @@ import com.intellij.util.ProcessingContext
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.lang.core.psi.RsFile
 import org.rust.openapiext.toPsiFile
-import org.toml.lang.psi.TomlKey
+import org.toml.lang.psi.TomlKeySegment
 
 class CargoDependencyReferenceProvider : PsiReferenceProvider() {
 
     override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> {
-        if (element !is TomlKey) return emptyArray()
+        if (element !is TomlKeySegment) return emptyArray()
         return arrayOf(CargoDependencyReferenceImpl(element))
     }
 }
 
-private class CargoDependencyReferenceImpl(key: TomlKey) : PsiReferenceBase<TomlKey>(key) {
+private class CargoDependencyReferenceImpl(key: TomlKeySegment) : PsiReferenceBase<TomlKeySegment>(key) {
 
     override fun resolve(): PsiElement? {
         val project = element.project

--- a/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlFileReferenceProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlFileReferenceProvider.kt
@@ -23,6 +23,7 @@ import org.toml.lang.psi.TomlHeaderOwner
 import org.toml.lang.psi.TomlLiteral
 import org.toml.lang.psi.ext.TomlLiteralKind
 import org.toml.lang.psi.ext.kind
+import org.toml.lang.psi.ext.name
 
 class CargoTomlFileReferenceProvider(private val patternType: PathPatternType) : PsiReferenceProvider() {
     override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<FileReference> {
@@ -31,7 +32,7 @@ class CargoTomlFileReferenceProvider(private val patternType: PathPatternType) :
             WORKSPACE -> true to false
             GENERAL -> {
                 val table = element.ancestorStrict<TomlHeaderOwner>()
-                val completeRustFiles = table != null && table.header.names.singleOrNull()?.text in TARGET_TABLE_NAMES
+                val completeRustFiles = table != null && table.header.key?.name in TARGET_TABLE_NAMES
                 true to completeRustFiles
             }
             BUILD -> false to true

--- a/toml/src/main/kotlin/org/rust/toml/search/CargoTomlFindUsagesHandlerFactory.kt
+++ b/toml/src/main/kotlin/org/rust/toml/search/CargoTomlFindUsagesHandlerFactory.kt
@@ -9,11 +9,11 @@ import com.intellij.find.findUsages.FindUsagesHandler
 import com.intellij.find.findUsages.FindUsagesHandlerFactory
 import com.intellij.psi.PsiElement
 import org.rust.toml.isFeatureDef
-import org.toml.lang.psi.TomlKey
+import org.toml.lang.psi.TomlKeySegment
 
 class CargoTomlFindUsagesHandlerFactory : FindUsagesHandlerFactory() {
     override fun canFindUsages(element: PsiElement): Boolean {
-        return element is TomlKey && element.isFeatureDef
+        return element is TomlKeySegment && element.isFeatureDef
     }
 
     override fun createFindUsagesHandler(element: PsiElement, forHighlightUsages: Boolean): FindUsagesHandler =

--- a/toml/src/test/kotlin/org/rust/toml/resolve/CargoTomlFeatureDependencyReferenceProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/resolve/CargoTomlFeatureDependencyReferenceProviderTest.kt
@@ -8,8 +8,8 @@ package org.rust.toml.resolve
 import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
-import org.toml.lang.psi.TomlKey
 import org.toml.lang.psi.TomlLiteral
+import org.toml.lang.psi.TomlKeySegment
 
 class CargoTomlFeatureDependencyReferenceProviderTest : CargoTomlResolveTestBase() {
     fun `test feature in the same package 1`() = checkResolve("""
@@ -139,5 +139,5 @@ class CargoTomlFeatureDependencyReferenceProviderTest : CargoTomlResolveTestBase
         }
     }
 
-    private fun checkResolve(@Language("TOML") code: String) = checkByCodeToml<TomlLiteral, TomlKey>(code)
+    private fun checkResolve(@Language("TOML") code: String) = checkByCodeToml<TomlLiteral, TomlKeySegment>(code)
 }

--- a/toml/src/test/kotlin/org/rust/toml/resolve/CargoTomlKeyResolveTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/resolve/CargoTomlKeyResolveTest.kt
@@ -8,7 +8,7 @@ package org.rust.toml.resolve
 import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
 import org.rust.WithDependencyRustProjectDescriptor
-import org.toml.lang.psi.TomlKey
+import org.toml.lang.psi.TomlKeySegment
 
 @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
 class CargoTomlKeyResolveTest : CargoTomlResolveTestBase() {
@@ -46,7 +46,7 @@ class CargoTomlKeyResolveTest : CargoTomlResolveTestBase() {
 
     """)
 
-    private fun checkResolve(@Language("TOML") code: String) = doResolveTest<TomlKey> {
+    private fun checkResolve(@Language("TOML") code: String) = doResolveTest<TomlKeySegment> {
         toml("Cargo.toml", code)
     }
 }


### PR DESCRIPTION
Previously, we parsed [dotted keys](https://toml.io/en/v1.0.0-rc.3#keys) in `key1.key2=value` and `[key1.key2]` differently that was quite confusing. Now they are parsed in the same way

changelog: unify toml key parsing 
