### PR TITLE
Drop using old API

### DIFF
--- a/src/main/kotlin/org/rust/openapiext/utils.kt
+++ b/src/main/kotlin/org/rust/openapiext/utils.kt
@@ -355,6 +355,3 @@ class CachedValueDelegate<T>(provider: () -> CachedValueProvider.Result<T>) {
         return cachedValue.value
     }
 }
-
-// BACKCOMPAT: 2020.1
-val BUILD_202 = BuildNumber.fromString("202")!!


### PR DESCRIPTION
Remove usage of `FileBasedIndex.registerIndexableSet` and `FileBasedIndex.removeIndexableSet`.
We don't actually use it anymore (it was used before 2020.2 because of bug in the platform) and these methods are dropped in 2021.1