### PR TITLE
Take into account cfg_attr during experimental compiler features annotation

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -111,7 +111,7 @@ private fun RsDocAndAttributeOwner.getExpandedAttributesNoStub(explicitCrate: Cr
     return QueryAttributes(evaluator.expandCfgAttrs(rawMetaItems))
 }
 
-private fun CfgEvaluator.expandCfgAttrs(rawMetaItems: Sequence<RsMetaItem>): Sequence<RsMetaItem> {
+fun CfgEvaluator.expandCfgAttrs(rawMetaItems: Sequence<RsMetaItem>): Sequence<RsMetaItem> {
     return rawMetaItems.flatMap {
         if (it.name == "cfg_attr") {
             val list = it.metaItemArgs?.metaItemList?.iterator() ?: return@flatMap emptySequence()

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -49,7 +49,7 @@ class RsFileStub(
     override fun getType() = Type
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
-        private const val STUB_VERSION = 206
+        private const val STUB_VERSION = 207
 
         // Bump this number if Stub structure changes
         override fun getStubVersion(): Int = RustParserDefinition.PARSER_VERSION + STUB_VERSION

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -1591,6 +1591,30 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
+    @MockAdditionalCfgOptions("intellij_rust")
+    @MockRustcVersion("1.29.0-nightly")
+    fun `test crate visibility feature E0658 under cfg_attr 1`() = checkErrors("""
+        #![cfg_attr(intellij_rust, feature(crate_visibility_modifier))]
+
+        crate struct Foo;
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    @MockRustcVersion("1.29.0-nightly")
+    fun `test crate visibility feature E0658 under cfg_attr 2`() = checkErrors("""
+        #![cfg_attr(not(intellij_rust), feature(crate_visibility_modifier))]
+
+        <error descr="`crate` visibility modifier is experimental [E0658]">crate</error> struct Foo;
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    @MockRustcVersion("1.29.0-nightly")
+    fun `test crate visibility feature E0658 under nested cfg_attr`() = checkErrors("""
+        #![cfg_attr(intellij_rust, cfg_attr(intellij_rust, feature(crate_visibility_modifier)))]
+
+        crate struct Foo;
+    """)
+
     fun `test parenthesized lifetime bounds`() = checkErrors("""
         fn foo<'a, T: <error descr="Parenthesized lifetime bounds are not supported">('a)</error>>(t: T) {
             unimplemented!();
@@ -1711,6 +1735,28 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         struct S;
         fn main() {
             let x = box S;
+        }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    @MockRustcVersion("1.0.0-nightly")
+    fun `test box expression feature E0658 with cfg_attr with several attributes 1`() = checkErrors("""
+        #![cfg_attr(intellij_rust, feature(generators), feature(box_syntax))]
+
+        struct S;
+        fn main() {
+            let x = box S;
+        }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    @MockRustcVersion("1.0.0-nightly")
+    fun `test box expression feature E0658 with cfg_attr with several attributes 2`() = checkErrors("""
+        #![cfg_attr(not(intellij_rust), feature(generators), feature(box_syntax))]
+
+        struct S;
+        fn main() {
+            let x = <error descr="`box` expression syntax is experimental [E0658]">box</error> S;
         }
     """)
 


### PR DESCRIPTION
Previously, the corresponding annotations took into account only top-level `feature` attributes.
Now, they correctly expand `cfg_attr` attribute

Continuation of #6497
Fixes #6631

changelog: Take into account `cfg_attr` attribute during experimental compiler features annotation 
