### PR TITLE
TY: infer type of default type parameters for known stdlib items

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
@@ -98,7 +98,7 @@ fun RsPat.extractBindings(fcx: RsTypeInferenceWalker, type: Ty, defBm: RsBinding
                     }
                     is RsPatFieldKind.Shorthand -> {
                         val bindingType = if (fieldType is TyAdt && kind.isBox) {
-                            fieldType.typeArguments.singleOrNull() ?: return
+                            fieldType.typeArguments.firstOrNull() ?: return
                         } else {
                             fieldType
                         }
@@ -116,7 +116,7 @@ fun RsPat.extractBindings(fcx: RsTypeInferenceWalker, type: Ty, defBm: RsBinding
             val (expected, bm) = type.stripReferences(defBm)
             fcx.writePatTy(this, expected)
             if (expected is TyAdt && expected.isBox) {
-                val boxed = expected.typeArguments.singleOrNull() ?: return
+                val boxed = expected.typeArguments.firstOrNull() ?: return
                 pat.extractBindings(fcx, boxed, bm)
             }
         }


### PR DESCRIPTION
Recent implementations of `Box` (since 1.49) and `Vec` (latest nightly) provide new allocator API.
So now these items contain additional type parameter for allocator type with some default value.

Previously, we didn't infer type of allocator type parameter for `box` patterns and `vec!` macro.
Now it works as expected

Note, I haven't added any new test since all necessary cases are covered with existing tests. So this PR fixes some failed test with new Rust versions (see #6604)

changelog: Adjust type inference to infer type of allocator type parameter for `Box` and `Vec` items. See the corresponding [RFC](https://rust-lang.github.io/rfcs/1398-kinds-of-allocators.html) about allocator API
