### PR TITLE
RUN: Ignore environment variables when comparing Cargo run configurations

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CompositeCargoRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CompositeCargoRunConfigurationProducer.kt
@@ -113,7 +113,6 @@ class CompositeCargoRunConfigurationProducer : CargoRunConfigurationProducer() {
             command != other.command -> false
             backtrace != other.backtrace -> false
             workingDirectory != other.workingDirectory -> false
-            env != other.env -> false
             else -> true
         }
 }


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/6646.