### PR TITLE
ANN: substitute generic method arguments in FillFunctionArgumentsFix

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFix.kt
@@ -15,6 +15,10 @@ import org.rust.ide.annotator.getFunctionCallContext
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.knownItems
+import org.rust.lang.core.types.emptySubstitution
+import org.rust.lang.core.types.infer.substitute
+import org.rust.lang.core.types.infer.type
+import org.rust.lang.core.types.inference
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyFunction
 import org.rust.lang.core.types.type
@@ -64,9 +68,7 @@ class FillFunctionArgumentsFix(element: PsiElement) : LocalQuickFixAndIntentionA
 private fun getParameterTypes(element: PsiElement): List<Ty?>? {
     return when (element) {
         is RsCallExpr -> (element.expr.type as? TyFunction)?.paramTypes
-        is RsMethodCall -> (element.reference.resolve() as? RsFunction)?.valueParameterList?.valueParameterList?.map {
-            it.typeReference?.type
-        }
+        is RsMethodCall -> element.inference?.getResolvedMethodType(element)?.paramTypes?.drop(1)
         else -> null
     }
 }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFixTest.kt
@@ -172,4 +172,24 @@ class FillFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class
             foo::<bool>(false);
         }
     """)
+
+    fun `test generic parameter method call`() = checkFixByText("Fill missing arguments", """
+        struct S<T>(T);
+
+        impl<R> S<R> {
+            fn foo(&self, a: R) {}
+        }
+        fn foo(s: S<u32>) {
+            s.foo(<error>/*caret*/)</error>;
+        }
+    """, """
+        struct S<T>(T);
+
+        impl<R> S<R> {
+            fn foo(&self, a: R) {}
+        }
+        fn foo(s: S<u32>) {
+            s.foo(0);
+        }
+    """)
 }


### PR DESCRIPTION
Improves https://github.com/intellij-rust/intellij-rust/pull/6613, as discussed [here](https://github.com/intellij-rust/intellij-rust/pull/5644#discussion_r555088815).

Changelog: Correctly resolve generic types when invoking "Fill function arguments fix" on generic methods.