### PR TITLE
T: Add cyclic feature dependency inspection & completion tests

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlFeatureDependencyCompletionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/CargoTomlFeatureDependencyCompletionProvider.kt
@@ -35,7 +35,7 @@ class CargoTomlFeatureDependencyCompletionProvider : CompletionProvider<Completi
         val element = parameters.position
         val tomlFile = element.containingFile as? TomlFile ?: return
 
-        val parentFeature = element.parentOfType<TomlKeyValueImpl>()?.key ?: return
+        val parentFeature = element.parentOfType<TomlKeyValueImpl>()?.key?.segments?.singleOrNull() ?: return
         for (feature in tomlFile.allFeatures()) {
             if (feature == parentFeature) continue
             result.addElement(lookupElementForFeature(feature))

--- a/toml/src/test/kotlin/org/rust/toml/completion/CargoTomlFeatureDependencyCompletionProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/completion/CargoTomlFeatureDependencyCompletionProviderTest.kt
@@ -42,6 +42,16 @@ class CargoTomlFeatureDependencyCompletionProviderTest : CargoTomlCompletionTest
         baz = ["bar", "foo<caret>"]
     """)
 
+    fun `test feature single completion without itself`() = doSingleCompletion("""
+        [features]
+        foo = []
+        bar = [<caret>]
+    """, """
+        [features]
+        foo = []
+        bar = ["foo<caret>"]
+    """)
+
     // TODO the test should fail because of AST loading
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test feature in another package`() {

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlCyclicFeatureInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlCyclicFeatureInspectionTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import org.intellij.lang.annotations.Language
+import org.rust.cargo.CargoConstants.MANIFEST_FILE
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class CargoTomlCyclicFeatureInspectionTest : RsInspectionsTestBase(CargoTomlCyclicFeatureInspection::class) {
+    fun `test feature depending on itself`() = doTest("""
+        [features]
+        foo = [<error descr="Cyclic feature dependency: feature `foo` depends on itself">"foo"</error>]
+    """)
+
+    fun `test features depending on themselves`() = doTest("""
+        [features]
+        foo = ["bar"]
+        bar = ["foo"]
+    """)
+
+    fun `test features depending acyclically`() = doTest("""
+        [features]
+        foo = []
+        bar = ["foo"]
+    """)
+
+    private fun doTest(@Language("TOML") code: String) {
+        myFixture.configureByText(MANIFEST_FILE, code)
+        myFixture.checkHighlighting()
+    }
+}


### PR DESCRIPTION
Implemented simple test cases for inspection and another one for completion, checking that there is only one suggestion in the scope.

Improvement of #6535
