### PR TITLE
CI: set milestone properly from CI

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -11,7 +11,11 @@ PATCH_VERSION_RE: str = r"patchVersion=(\d+)"
 def __get_patch_version() -> Tuple[str, int]:
     with open(GRADLE_PROPERTIES) as properties:
         text = properties.read()
-    return text, int(re.search(PATCH_VERSION_RE, text).group(1))
+    return text, get_patch_version_from_text(text)
+
+
+def get_patch_version_from_text(text: str) -> int:
+    return int(re.search(PATCH_VERSION_RE, text).group(1))
 
 
 def get_patch_version() -> int:

--- a/scripts/github.py
+++ b/scripts/github.py
@@ -1,15 +1,17 @@
 # TODO: think about using library for GitHub API
 import json
-from typing import Dict
+from typing import Dict, Optional
 from urllib.request import Request, urlopen
 
 from common import get_patch_version
 
 
-def get_current_milestone(repo: str) -> Dict:
+def get_current_milestone(repo: str, patch_version: Optional[int] = None) -> Dict:
     response = urlopen(f"https://api.github.com/repos/{repo}/milestones")
     milestones = json.load(response)
-    milestone_version = f"v{get_patch_version()}"
+    if patch_version is None:
+        patch_version = get_patch_version()
+    milestone_version = f"v{patch_version}"
     result = next((milestone for milestone in milestones if milestone["title"] == milestone_version), None)
     if result is None:
         raise AssertionError(f"Milestone `{milestone_version}` doesn't exist")

--- a/scripts/set_milestone.py
+++ b/scripts/set_milestone.py
@@ -1,6 +1,7 @@
 import argparse
+from urllib.request import urlopen
 
-from common import env
+from common import env, get_patch_version_from_text
 from github import get_current_milestone, set_milestone
 
 if __name__ == '__main__':
@@ -11,6 +12,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     repo = env("GITHUB_REPOSITORY")
-    milestone = get_current_milestone(repo)
+    text = urlopen(f"https://github.com/{repo}/raw/master/gradle.properties").read().decode("utf-8")
+    patch_version = get_patch_version_from_text(text)
+    milestone = get_current_milestone(repo, patch_version)
 
     set_milestone(args.token, repo, args.pull_request, milestone["number"])


### PR DESCRIPTION
#6538 changed event when milestone workflow triggered. Most important part of this change is that now we use base commit of each PR to determine milestone.
It allows us to launch the workflow for any PR (even from forks) but at the same time it works incorrectly because now the workflow look on old version of `gradle.properties` files to get proper milestone version.

These changes get actual content of `gradle.properties` via downloading it via http instead of using potentially outdated local version

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

Also, please write a short description explaining your change in the following format: `changelog: %description%`
This description will help a lot to create release changelog. 
Drop these lines for internal only changes

:)
-->
