### PR TITLE
Fix endless go-to-declaration for invalid self-containing structs

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -630,6 +630,18 @@ class RsResolveTest : RsResolveTestBase() {
                                         //^
     """)
 
+    fun `test enum Self in impl block for invalid self-containing struct`() = checkByCodeGeneric<RsImplItem>("""
+        struct E {
+            value: Self
+        }
+        impl E {
+           //X
+            fn new() -> Self {
+                Self
+            } //^
+        }
+    """)
+
     fun `test enum variant 2`() = checkByCode("""
         enum E { X, Y(X) }
                     //^ unresolved

--- a/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsImplicitTraitsTest.kt
@@ -174,6 +174,23 @@ class RsImplicitTraitsTest : RsTypificationTestBase() {
                //^ !Copy
     """)
 
+    fun `test invalid self-containing struct 1`() = doTest("""
+        struct S {
+            field: Self
+        }
+        type T = S;
+               //^ Sized
+    """)
+
+    fun `test invalid self-containing struct 2`() = doTest("""
+        struct Rc<T>(T);
+        struct S {
+            field: Rc<Self>
+        }
+        type T = S;
+               //^ Sized
+    """)
+
     private fun checkPrimitiveTypes(traitName: String) {
         val allIntegers = TyInteger.VALUES.toTypedArray()
         val allFloats = TyFloat.VALUES.toTypedArray()


### PR DESCRIPTION
Fixes #6605

changelog: Fix endless go-to-declaration for invalid self-containing structs