### PR TITLE
COMP: complete continue and break in expression context inside loops

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributor.kt
@@ -127,8 +127,11 @@ class RsKeywordCompletionContributor : CompletionContributor(), DumbAware {
     private fun letPattern(): PsiElementPattern.Capture<PsiElement> =
         baseCodeStatementPattern().and(statementBeginningPattern("let"))
 
-    private fun loopFlowCommandPattern(): PsiElementPattern.Capture<PsiElement> =
-        RsPsiPattern.inAnyLoop.and(newCodeStatementPattern())
+    private fun loopFlowCommandPattern(): PsiElementPattern.Capture<PsiElement>
+        = RsPsiPattern.inAnyLoop.and(
+            newCodeStatementPattern() or
+            pathExpressionPattern()
+        )
 
     private fun baseDeclarationPattern(): PsiElementPattern.Capture<PsiElement> =
         psiElement()

--- a/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
@@ -127,6 +127,26 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         }
     """)
 
+    fun `test continue expression`() = checkCompletion("continue", """
+        fn foo() {
+            loop {
+                let x = cont/*caret*/;
+            }
+        }
+    """, """
+        fn foo() {
+            loop {
+                let x = continue/*caret*/;
+            }
+        }
+    """)
+
+    fun `test continue expression outside loop`() = checkNoCompletion("""
+        fn foo() {
+            let x = cont/*caret*/;
+        }
+    """)
+
     fun `test const`() = checkCompletion("const", """
         con/*caret*/
     """, """

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPsiPatternTest.kt
@@ -302,6 +302,22 @@ class RsPsiPatternTest : RsTestBase() {
         }
     """, RsPsiPattern.inAnyLoop)
 
+    fun `test in any loop expression`() = testPattern("""
+        fn foo(x: u32) {
+            loop {
+                let x = ;
+                     //^
+            }
+        }
+    """, RsPsiPattern.inAnyLoop)
+
+    fun `test in any loop negative expression outside of loop`() = testPatternNegative("""
+        fn foo(x: u32) {
+            let x = ;
+                 //^
+        }
+    """, RsPsiPattern.inAnyLoop)
+
     fun `test in any loop negative before block`() = testPatternNegative("""
         fn foo() {
             for _ in 1..5 {}


### PR DESCRIPTION
Both `continue` and `break` are expressions, so they should be completed in expression contexts. I'm not too sure about the "expression location" pattern that I have used, but it seems to work.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/6524

changelog: Complete `continue` and `break` statements inside expression contexts in loops.