### PR TITLE
REF: correctly extract selected statements inside exprs into a function

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/SearchByOffset.kt
+++ b/src/main/kotlin/org/rust/ide/utils/SearchByOffset.kt
@@ -78,10 +78,8 @@ fun findStatementsOrExprInRange(file: PsiFile, startOffset: Int, endOffset: Int)
     val mostDistantParent = parent.ancestors
         .last { it.textRange == parent.textRange }
 
-    if (mostDistantParent is RsExpr || mostDistantParent is RsStmt)
-    {
-        val isContained = startOffset == mostDistantParent.startOffset && endOffset == mostDistantParent.endOffset
-        if (mostDistantParent !is RsBlockExpr || isContained) {
+    if (mostDistantParent is RsExpr || mostDistantParent is RsStmt) {
+        if (startOffset == mostDistantParent.startOffset && endOffset == mostDistantParent.endOffset) {
             return arrayOf(mostDistantParent)
         }
     }
@@ -116,10 +114,10 @@ private fun findStatementsInRangeUnchecked(element1: PsiElement, element2: PsiEl
     // Finally check if found elements meet requirements, and return result
     elements.forEachIndexed { idx, element ->
         if (!(element is RsStmt
-            || element is RsMacroCall && element.expansionContext == STMT
-            || (idx == elements.size - 1 && element is RsExpr)
-            || element is PsiComment
-            )) return emptyArray()
+                || element is RsMacroCall && element.expansionContext == STMT
+                || (idx == elements.size - 1 && element is RsExpr)
+                || element is PsiComment
+                )) return emptyArray()
     }
 
     return elements

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -1228,7 +1228,7 @@ class RsExtractFunctionTest : RsTestBase() {
         false,
         "foo")
 
-    fun `test selection inside a block`() = doTest("""
+    fun `test selection inside a block expression`() = doTest("""
         fn foo() {
             {
                 <selection>let a = 1;
@@ -1244,6 +1244,37 @@ class RsExtractFunctionTest : RsTestBase() {
 
                 let c = a + b;
             }
+        }
+
+        fn bar() -> (i32, i32) {
+            let a = 1;
+            let b = 2;
+            (a, b)
+        }
+    """,
+        false,
+        "bar")
+
+    fun `test selection inside a block statement`() = doTest("""
+        fn foo() {
+            {
+                <selection>let a = 1;
+                let b = 2;</selection>
+                let c = a + b;
+                ()
+            }
+
+            ()
+        }
+    """, """
+        fn foo() {
+            {
+                let (a, b) = bar();
+                let c = a + b;
+                ()
+            }
+
+            ()
         }
 
         fn bar() -> (i32, i32) {


### PR DESCRIPTION
Continuation of https://github.com/intellij-rust/intellij-rust/pull/6678.

I could special case it for `RsBlockExpr`/`RsExprStmt`, since blocks are probably the only place where this could happen, but I realized that the actually important thing is the containment within an expr/stmt. So I removed the explicit check for `RsBlockExpr`.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/6683