### PR TITLE
RES: prefer trait methods before private inherent methods

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMultiResolveTest.kt
@@ -110,30 +110,6 @@ class RsMultiResolveTest : RsResolveTestBase() {
         }   //^
     """)
 
-    fun `test trait method and private inherent method`() = doTest("""
-        use foo::{Foo, Trait};
-
-        mod foo {
-            pub struct Foo;
-            impl Foo {
-                fn get(&self) { println!("struct"); }
-            }
-
-            pub trait Trait {
-                fn get(&self);
-            }
-            impl Trait for Foo {
-                fn get(&self) { println!("trait"); }
-            }
-        }
-
-        fn main() {
-            let f = foo::Foo;
-            f.get();
-            //^
-        }
-    """)
-
     private fun doTest(@Language("Rust") code: String) {
         InlineFile(code)
         val element = findElementInEditor<RsReferenceElement>()

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPreciseTraitMatchingTest.kt
@@ -554,4 +554,29 @@ class RsPreciseTraitMatchingTest : RsResolveTestBase() {
             S.foo();
         }      //^
     """)
+
+    fun `test trait method and private inherent method`() = checkByCode("""
+        use foo::{Foo, Trait};
+
+        mod foo {
+            pub struct Foo;
+            impl Foo {
+                // Private
+                fn get(&self) { println!("struct"); }
+            }
+
+            pub trait Trait {
+                fn get(&self);
+            }
+            impl Trait for Foo {
+                fn get(&self) { println!("trait"); }
+            }    //X
+        }
+
+        fn main() {
+            let f = foo::Foo;
+            f.get();
+            //^
+        }
+    """)
 }


### PR DESCRIPTION
Improves the #5661 fix: now resolve it to visible trait impl instead of private inherent impl:

```rust
use foo::{Foo, Trait};

mod foo {
    pub struct Foo;
    impl Foo {
        // Private
        fn get(&self) { println!("struct"); }
    }

    pub trait Trait {
        fn get(&self);
    }
    impl Trait for Foo {
        fn get(&self) { println!("trait"); }
    }    //X
}

fn main() {
    let f = foo::Foo;
    f.get();
    //^
}
```

c.c. @Kobzol 
