### PR TITLE
Initialize crates local index service on startup

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexStartupActivity.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexStartupActivity.kt
@@ -1,0 +1,28 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.crates.local
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+import com.intellij.openapiext.isUnitTestMode
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.ide.experiments.RsExperiments
+import org.rust.openapiext.isFeatureEnabled
+
+/**
+ * [CratesLocalIndexService] initializer.
+ * Only tries to get service instance, without any updates to its crates index.
+ */
+class CratesLocalIndexStartupActivity : StartupActivity.Background {
+    override fun runActivity(project: Project) {
+        if (isUnitTestMode) return
+        if (!project.cargoProjects.hasAtLeastOneValidProject) return
+
+        if (isFeatureEnabled(RsExperiments.CRATES_LOCAL_INDEX)) {
+            CratesLocalIndexService.getInstance()
+        }
+    }
+}

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -29,6 +29,7 @@
                          implementationClass="org.rust.toml.inspections.CargoTomlCyclicFeatureInspection"/>
 
         <applicationService serviceImplementation="org.rust.toml.crates.local.CratesLocalIndexService"/>
+        <backgroundPostStartupActivity implementation="org.rust.toml.crates.local.CratesLocalIndexStartupActivity"/>
         <cachesInvalidator implementation="org.rust.toml.crates.local.CratesLocalIndexCachesInvalidator"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
After opening a project, `CratesLocalIndexStartupActivity` tries to get an instance of the service. This initializes the service's `Cargo.toml` watcher and PersistentHashMap before performing any inspection or completion.