### PR TITLE
Update CratesIoApi.kt

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/completion/CratesIoApi.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/CratesIoApi.kt
@@ -39,7 +39,7 @@ fun searchCrate(key: TomlKeySegment): Collection<CrateDescription> {
     val name = CompletionUtil.getOriginalElement(key)?.text ?: ""
     if (name.isEmpty()) return emptyList()
 
-    val response = requestCratesIo<SearchResult>(key, "crates?page=1&per_page=20&q=$name&sort=") ?: return emptyList()
+    val response = requestCratesIo<SearchResult>(key, "crates?page=1&per_page=100&q=$name") ?: return emptyList()
     return response.crates
 }
 


### PR DESCRIPTION
Fixes issues with irrelevant search results due to empty $sort: https://github.com/rust-lang/crates.io/blob/master/src/controllers/krate/search.rs#L65

Fore more details see https://github.com/rust-lang/crates.io/issues/3187

Ideally plugin should narrow the search results even further using `startsWith` on `crates.io` response since not all of the results are really relevant.