### PR TITLE
RUN: Allow to build different projects simultaneously

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildSessionsQueueManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildSessionsQueueManager.kt
@@ -1,0 +1,20 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.buildtool
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.progress.BackgroundTaskQueue
+import com.intellij.openapi.project.Project
+
+@Service
+class CargoBuildSessionsQueueManager(project: Project) {
+    val buildSessionsQueue: BackgroundTaskQueue = BackgroundTaskQueue(project, "Building...")
+
+    companion object {
+        fun getInstance(project: Project): CargoBuildSessionsQueueManager = project.service()
+    }
+}


### PR DESCRIPTION
Currently, if you are using the new Build View and try to build a second project while building the first project, the second build will hang with the "Waiting for another build to finish" message.

changelog: Allow building different projects simultaneously
