### PR TITLE
Support for get cargo path in `CARGO_HOME` env

### DIFF
--- a/src/test/kotlin/org/rust/cargo/RustupTestFixture.kt
+++ b/src/test/kotlin/org/rust/cargo/RustupTestFixture.kt
@@ -45,7 +45,9 @@ open class RustupTestFixture(
     }
 
     private fun addCargoHomeToAllowedRoots() {
-        val cargoHome = Paths.get(FileUtil.expandUserHome("~/.cargo"))
+        val cargoHome = Paths.get(
+            System.getenv("CARGO_HOME") ?: FileUtil.expandUserHome("~/.cargo")
+        )
         VfsRootAccess.allowRootAccess(testRootDisposable, cargoHome.toString())
         // actions-rs/toolchain on CI creates symlink at `~/.cargo` while setting up of Rust toolchain
         val canonicalCargoHome = cargoHome.toRealPath()


### PR DESCRIPTION
This is helpful if you do not use the default installation path locally, but need to do tests.