### PR TITLE
RUN: Suggest to install wasm32 target in wasm-pack configuration

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackBuildTaskProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/wasmpack/WasmPackBuildTaskProvider.kt
@@ -13,6 +13,7 @@ import com.intellij.util.execution.ParametersListUtil
 import org.rust.cargo.runconfig.buildtool.RsBuildTaskProvider
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.runconfig.command.CargoCommandConfigurationType
+import org.rust.cargo.toolchain.tools.Rustup
 import org.rust.cargo.util.splitOnDoubleDash
 import org.rust.openapiext.project
 import org.rust.stdext.buildList
@@ -32,6 +33,9 @@ class WasmPackBuildTaskProvider : RsBuildTaskProvider<WasmPackBuildTaskProvider.
         if (configuration !is WasmPackCommandConfiguration) return false
 
         val project = context.project ?: return false
+        val cargoProjectDirectory = configuration.workingDirectory ?: return false
+        if (Rustup.checkNeedInstallWasmTarget(project, cargoProjectDirectory)) return false
+
         val configurationArgs = ParametersListUtil.parse(configuration.command)
         val (preArgs, postArgs) = splitOnDoubleDash(configurationArgs)
         val configurationCommand = configurationArgs.firstOrNull() ?: return false
@@ -70,6 +74,6 @@ class WasmPackBuildTaskProvider : RsBuildTaskProvider<WasmPackBuildTaskProvider.
     companion object {
         val ID: Key<BuildTask> = Key.create("WASM_PACK.BUILD_TASK_PROVIDER")
 
-        private const val WASM_TARGET: String = "wasm32-unknown-unknown"
+        const val WASM_TARGET: String = "wasm32-unknown-unknown"
     }
 }

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustup.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustup.kt
@@ -13,9 +13,11 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.runconfig.wasmpack.WasmPackBuildTaskProvider.Companion.WASM_TARGET
 import org.rust.cargo.toolchain.RsToolchain
 import org.rust.cargo.util.DownloadResult
 import org.rust.ide.actions.InstallComponentAction
+import org.rust.ide.actions.InstallTargetAction
 import org.rust.ide.notifications.showBalloon
 import org.rust.openapiext.execute
 import org.rust.openapiext.fullyRefreshDirectory
@@ -43,11 +45,27 @@ class Rustup(toolchain: RsToolchain, private val projectDirectory: Path) : RsToo
         }
     }
 
+    data class Target(val name: String, val isInstalled: Boolean) {
+        companion object {
+            fun from(line: String): Target {
+                val name = line.substringBefore(' ')
+                val isInstalled = line.substringAfter(' ') in listOf("(installed)", "(default)")
+                return Target(name, isInstalled)
+            }
+        }
+    }
+
     fun listComponents(): List<Component> =
         createBaseCommandLine(
             "component", "list",
             workingDirectory = projectDirectory
         ).execute()?.stdoutLines?.map { Component.from(it) }.orEmpty()
+
+    private fun listTargets(): List<Target> =
+        createBaseCommandLine(
+            "target", "list",
+            workingDirectory = projectDirectory
+        ).execute()?.stdoutLines?.map { Target.from(it) }.orEmpty()
 
     fun downloadStdlib(owner: Disposable? = null, listener: ProcessListener? = null): DownloadResult<VirtualFile> {
         // Sometimes we have stdlib but don't have write access to install it (for example, github workflow)
@@ -90,9 +108,31 @@ class Rustup(toolchain: RsToolchain, private val projectDirectory: Path) : RsToo
             DownloadResult.Err(message)
         }
 
+    fun downloadTarget(owner: Disposable, targetName: String): DownloadResult<Unit> =
+        try {
+            createBaseCommandLine(
+                "target", "add", targetName,
+                workingDirectory = projectDirectory
+            ).execute(owner, false)
+            DownloadResult.Ok(Unit)
+        } catch (e: ExecutionException) {
+            val message = "rustup failed: ${e.message}"
+            LOG.warn(message)
+            DownloadResult.Err(message)
+        }
+
     private fun needInstallComponent(componentName: String): Boolean {
         val isInstalled = listComponents()
             .find { (name, _) -> name.startsWith(componentName) }
+            ?.isInstalled
+            ?: return false
+
+        return !isInstalled
+    }
+
+    private fun needInstallTarget(targetName: String): Boolean {
+        val isInstalled = listTargets()
+            .find { it.name == targetName }
             ?.isInstalled
             ?: return false
 
@@ -107,6 +147,9 @@ class Rustup(toolchain: RsToolchain, private val projectDirectory: Path) : RsToo
 
         fun checkNeedInstallRustfmt(project: Project, cargoProjectDirectory: Path): Boolean =
             checkNeedInstallComponent(project, cargoProjectDirectory, "rustfmt")
+
+        fun checkNeedInstallWasmTarget(project: Project, cargoProjectDirectory: Path): Boolean =
+            checkNeedInstallTarget(project, cargoProjectDirectory, WASM_TARGET)
 
         // We don't want to install the component if:
         // 1. It is already installed
@@ -125,6 +168,26 @@ class Rustup(toolchain: RsToolchain, private val projectDirectory: Path) : RsToo
                     "${componentName.capitalize()} is not installed",
                     NotificationType.ERROR,
                     InstallComponentAction(cargoProjectDirectory, componentName)
+                )
+            }
+
+            return needInstall
+        }
+
+        @Suppress("SameParameterValue")
+        private fun checkNeedInstallTarget(
+            project: Project,
+            cargoProjectDirectory: Path,
+            targetName: String
+        ): Boolean {
+            val rustup = project.toolchain?.rustup(cargoProjectDirectory) ?: return false
+            val needInstall = rustup.needInstallTarget(targetName)
+
+            if (needInstall) {
+                project.showBalloon(
+                    "$targetName target is not installed",
+                    NotificationType.ERROR,
+                    InstallTargetAction(cargoProjectDirectory, targetName)
                 )
             }
 

--- a/src/main/kotlin/org/rust/ide/actions/InstallTargetAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/InstallTargetAction.kt
@@ -1,0 +1,42 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.actions
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.DumbAwareAction
+import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.toolchain.tools.rustup
+import org.rust.cargo.util.DownloadResult
+import org.rust.ide.notifications.showBalloon
+import java.nio.file.Path
+
+class InstallTargetAction(
+    private val projectDirectory: Path,
+    private val targetName: String
+) : DumbAwareAction("Install") {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val rustup = project.toolchain?.rustup(projectDirectory) ?: return
+
+        Notification.get(e).expire()
+
+        object : Task.Backgroundable(project, "Installing $targetName...") {
+            override fun shouldStartInBackground(): Boolean = false
+
+            override fun run(indicator: ProgressIndicator) {
+                val result = rustup.downloadTarget(myProject, targetName)
+
+                if (result is DownloadResult.Err) {
+                    myProject.showBalloon(result.error, NotificationType.ERROR)
+                }
+            }
+        }.queue()
+    }
+}


### PR DESCRIPTION
Fixes #6714

In wasm-pack configuration before launch Build step checks if `wasm32-unknown-unknown` target is installed and suggests installing it if It is not.

<img width="400" src="https://user-images.githubusercontent.com/6342851/105644956-aecbae00-5ea9-11eb-9315-6a3779e8ea82.png">
