### PR TITLE
ANN: Take into account const generics in inspections about generic parameters/arguments ordering

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
@@ -313,7 +313,7 @@ private enum class TypeArgumentKind(private val elementClass: KClass<*>, val arg
         get() = StringUtil.capitalize(argumentName)
 
     fun canStandAfter(prevArgument: TypeArgumentKind): Boolean =
-        ordinal >= prevArgument.ordinal
+        this !== LIFETIME || prevArgument === LIFETIME
 
     companion object {
         private val VALUES = values()

--- a/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
@@ -11,7 +11,6 @@ import com.intellij.ide.annotator.AnnotatorBase
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.util.TextRange
-import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.annotator.fixes.AddTypeFix
@@ -25,7 +24,6 @@ import org.rust.lang.utils.addToHolder
 import org.rust.openapiext.forEachChild
 import org.rust.stdext.pluralize
 import java.lang.Integer.max
-import kotlin.reflect.KClass
 
 class RsSyntaxErrorsAnnotator : AnnotatorBase() {
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
@@ -263,9 +261,10 @@ private fun checkTypeParameterList(holder: AnnotationHolder, element: RsTypePara
         element.typeParameterList
             .mapNotNull { it.typeReference }
             .forEach {
-                holder.newAnnotation(HighlightSeverity.ERROR,
-                    "Defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions")
-                    .range(it).create()
+                holder.newAnnotation(
+                    HighlightSeverity.ERROR,
+                    "Defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions"
+                ).range(it).create()
             }
     } else {
         val lastNotDefaultIndex = max(element.typeParameterList.indexOfLast { it.typeReference == null }, 0)
@@ -278,69 +277,55 @@ private fun checkTypeParameterList(holder: AnnotationHolder, element: RsTypePara
             }
     }
 
-    var kind = TypeParameterKind.LIFETIME
-    element.forEachChild { child ->
-        val newKind = TypeParameterKind.forType(child) ?: return@forEachChild
-        if (newKind.canStandAfter(kind)) {
-            kind = newKind
-        } else {
-            val newStateName = newKind.parameterNameCapitalized
-
-            holder.newAnnotation(HighlightSeverity.ERROR, "$newStateName must be declared prior to ${kind.parameterName}")
-                .range(child).create()
-        }
-    }
-}
-
-private enum class TypeParameterKind(private val elementClass: KClass<*>, val parameterName: String) {
-    LIFETIME(RsLifetimeParameter::class, "lifetime parameters"),
-    TYPE(RsTypeParameter::class, "type parameters"),
-    CONST(RsConstParameter::class, "const parameters");
-
-    val parameterNameCapitalized: String
-        get() = StringUtil.capitalize(parameterName)
-
-    fun canStandAfter(prevArgument: TypeParameterKind): Boolean =
-        this !== LIFETIME || prevArgument === LIFETIME
-
-    companion object {
-        private val VALUES = values()
-        fun forType(seekingElement: PsiElement): TypeParameterKind? =
-            VALUES.find { it.elementClass.isInstance(seekingElement) }
-    }
+    checkTypeList(element, "parameters", holder)
 }
 
 private fun checkTypeArgumentList(holder: AnnotationHolder, args: RsTypeArgumentList) {
-    var kind = TypeArgumentKind.LIFETIME
-    args.forEachChild { child ->
-        val newKind = TypeArgumentKind.forType(child) ?: return@forEachChild
-        if (newKind.canStandAfter(kind)) {
-            kind = newKind
-        } else {
-            val newStateName = newKind.argumentNameCapitalized
+    checkTypeList(args, "arguments", holder)
 
-            holder.newAnnotation(HighlightSeverity.ERROR, "$newStateName must be declared prior to ${kind.argumentName}")
-                .range(child).create()
+    val startOfAssocTypeBindings = args.assocTypeBindingList.firstOrNull()?.textOffset ?: return
+    for (generic in args.lifetimeList + args.typeReferenceList + args.exprList) {
+        if (generic.textOffset > startOfAssocTypeBindings) {
+            holder.newAnnotation(HighlightSeverity.ERROR, "Generic arguments must come before the first constraint")
+                .range(generic).create()
         }
     }
 }
 
-private enum class TypeArgumentKind(private val elementClass: KClass<*>, val argumentName: String) {
-    LIFETIME(RsLifetime::class, "lifetime arguments"),
-    TYPE(RsTypeReference::class, "type arguments"),
-    CONST(RsExpr::class, "const arguments"),
-    ASSOC(RsAssocTypeBinding::class, "associated type bindings");
+private fun checkTypeList(typeList: PsiElement, elementsName: String, holder: AnnotationHolder) {
+    var kind = TypeKind.LIFETIME
+    typeList.forEachChild { child ->
+        val newKind = TypeKind.forType(child) ?: return@forEachChild
+        if (newKind.canStandAfter(kind)) {
+            kind = newKind
+        } else {
+            val newStateName = newKind.presentableName.capitalize()
+            holder.newAnnotation(
+                HighlightSeverity.ERROR,
+                "$newStateName $elementsName must be declared prior to ${kind.presentableName} $elementsName"
+            ).range(child).create()
+        }
+    }
+}
 
-    val argumentNameCapitalized: String
-        get() = StringUtil.capitalize(argumentName)
+private enum class TypeKind {
+    LIFETIME,
+    TYPE,
+    CONST;
 
-    fun canStandAfter(prevArgument: TypeArgumentKind): Boolean =
-        this !== LIFETIME || prevArgument === LIFETIME
+    val presentableName: String get() = name.toLowerCase()
+
+    fun canStandAfter(prev: TypeKind): Boolean =
+        this !== LIFETIME || prev === LIFETIME
 
     companion object {
-        private val VALUES = values()
-        fun forType(seekingElement: PsiElement): TypeArgumentKind? =
-            VALUES.find { it.elementClass.isInstance(seekingElement) }
+        fun forType(seekingElement: PsiElement): TypeKind? =
+            when (seekingElement) {
+                is RsLifetimeParameter, is RsLifetime -> LIFETIME
+                is RsTypeParameter, is RsTypeReference -> TYPE
+                is RsConstParameter, is RsExpr -> CONST
+                else -> null
+            }
     }
 }
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
@@ -270,6 +270,23 @@ class RsSyntaxErrorsAnnotatorTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator:
         type A7 = B<0, C, <error descr="Lifetime arguments must be declared prior to type arguments">'d</error>>;
     """)
 
+    fun `test generic arguments after constraints`() = checkErrors("""
+        type A1 = B<C=D, <error descr="Generic arguments must come before the first constraint">E</error>>;
+
+        type A2 = B<C=D, <error descr="Generic arguments must come before the first constraint">E</error>,
+                         <error descr="Generic arguments must come before the first constraint">F</error>>;
+
+        type A3 = B<C=D, <error descr="Generic arguments must come before the first constraint">'e</error>>;
+
+        type A4 = B<C=D, <error descr="Generic arguments must come before the first constraint">'e</error>,
+                         <error descr="Generic arguments must come before the first constraint">'f</error>>;
+
+        type A5 = B<C=D, <error descr="Generic arguments must come before the first constraint">1</error>>;
+
+        type A6 = B<C=D, <error descr="Generic arguments must come before the first constraint">1</error>,
+                         <error descr="Generic arguments must come before the first constraint">2</error>>;
+    """)
+
     fun `test default type parameters in impl`() = checkErrors("""
         struct S<T=String>{ f: T }
         impl<T=<error descr="Defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions">String</error>> S<T> {}

--- a/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
@@ -244,6 +244,14 @@ class RsSyntaxErrorsAnnotatorTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator:
         fn foo<T, <error descr="Lifetime parameters must be declared prior to type parameters">'a</error>>(bar: &'a T) {}
     """)
 
+    fun `test lifetime params after const params`() = checkErrors("""
+        fn foo<const C: usize, <error descr="Lifetime parameters must be declared prior to const parameters">'a</error>>(bar: &'a usize) {}
+    """)
+
+    fun `test type params after const params`() = checkErrors("""
+        fn foo<const C: usize, T>(bar: T) {}
+    """)
+
     fun `test type arguments order`() = checkErrors("""
         type A1 = B<C, <error descr="Lifetime arguments must be declared prior to type arguments">'d</error>>;
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
@@ -256,20 +256,18 @@ class RsSyntaxErrorsAnnotatorTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator:
         type A1 = B<C, <error descr="Lifetime arguments must be declared prior to type arguments">'d</error>>;
 
         type A2 = B<C, <error descr="Lifetime arguments must be declared prior to type arguments">'d</error>,
-                      <error descr="Lifetime arguments must be declared prior to type arguments">'e</error>>;
+                       <error descr="Lifetime arguments must be declared prior to type arguments">'e</error>>;
 
-        type A3 = B<C=D, <error descr="Type arguments must be declared prior to associated type bindings">E</error>>;
+        type A3 = B<0, <error descr="Lifetime arguments must be declared prior to const arguments">'d</error>>;
 
-        type A4 = B<C=D, <error descr="Type arguments must be declared prior to associated type bindings">E</error>,
-                         <error descr="Type arguments must be declared prior to associated type bindings">F</error>>;
+        type A4 = B<0, <error descr="Lifetime arguments must be declared prior to const arguments">'d</error>,
+                       <error descr="Lifetime arguments must be declared prior to const arguments">'e</error>>;
 
-        type A3 = B<C=D, <error descr="Lifetime arguments must be declared prior to associated type bindings">'e</error>>;
+        type A4 = B<C, 0, 1>;
+        type A5 = B<0, C1, C2>;
 
-        type A4 = B<C=D, <error descr="Lifetime arguments must be declared prior to associated type bindings">'e</error>,
-                         <error descr="Lifetime arguments must be declared prior to associated type bindings">'f</error>>;
-
-        type A5 = B<1, <error descr="Type arguments must be declared prior to const arguments">C</error>,
-                         <error descr="Lifetime arguments must be declared prior to const arguments">'d</error>>;
+        type A6 = B<C, 0, <error descr="Lifetime arguments must be declared prior to const arguments">'d</error>>;
+        type A7 = B<0, C, <error descr="Lifetime arguments must be declared prior to type arguments">'d</error>>;
     """)
 
     fun `test default type parameters in impl`() = checkErrors("""

--- a/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt
@@ -56,14 +56,14 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
     fun `test const generic in path (explicit)`() = stubOnlyTypeInfer("""
     //- foo.rs
         #![feature(const_generics)]
-        
+
         pub struct S<const N1: usize>;
-        
+
         pub fn foo<const N2: usize>() -> S<{ N2 }> { S }
-        
+
     //- main.rs
         mod foo;
-        
+
         fn main() {
             let x = foo::foo::<0>();
             x;
@@ -74,16 +74,16 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
     fun `test const generic in path (implicit)`() = stubOnlyTypeInfer("""
     //- foo.rs
         #![feature(const_generics)]
-        
+
         #[derive(Clone, Copy)]
         pub struct S<const N1: usize>;
-        
+
         pub fn foo<const N2: usize>() -> S<{ N2 }> { S }
         pub fn bar<const N3: usize>(s: S<{ N3 }>) -> S<{ N3 }> { s }
-        
+
     //- main.rs
         mod foo;
-        
+
         fn main() {
             let x = foo::foo();
             let y: foo::S<0> = foo::bar(x);
@@ -95,16 +95,16 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
     fun `test const generic in path (not inferred)`() = stubOnlyTypeInfer("""
     //- foo.rs
         #![feature(const_generics)]
-        
+
         #[derive(Clone, Copy)]
         pub struct S<const N1: usize>;
-        
+
         pub fn foo<const N2: usize>() -> S<{ N2 }> { S }
         pub fn bar<const N3: usize>(s: S<{ N3 }>) -> S<{ N3 }> { s }
-        
+
     //- main.rs
         mod foo;
-        
+
         fn main() {
             let x = foo::foo();
             let y = foo::bar(x);
@@ -113,15 +113,33 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test const generic in path (wrong arguments order)`() = stubOnlyTypeInfer("""
+    //- foo.rs
+        #![feature(const_generics)]
+
+        pub struct S<T1, const N1: usize>;
+
+        pub fn foo<T2, const N2: usize>() -> S<{ N2 }, T2> { S }
+
+    //- main.rs
+        mod foo;
+
+        fn main() {
+            let x = foo::foo::<0, usize>();
+            x;
+          //^ S<usize, 0>
+        }
+    """)
+
     fun `test const generic (block expr) 1`() = stubOnlyTypeInfer("""
     //- foo.rs
         #![feature(const_generics)]
-        
+
         pub struct S<const N: usize>;
-        
+
     //- main.rs
         mod foo;
-        
+
         fn main() {
             let x = foo::S::<{ 0 }>;
             x;
@@ -132,12 +150,12 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
     fun `test const generic (block expr) 2`() = stubOnlyTypeInfer("""
     //- foo.rs
         #![feature(const_generics)]
-        
+
         pub struct S<const N: usize>;
-        
+
     //- main.rs
         mod foo;
-        
+
         fn main() {
             let x = foo::S::<{ 1 + 1 }>;
             x;
@@ -148,14 +166,14 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
     fun `test const generic (block expr) 3`() = stubOnlyTypeInfer("""
     //- foo.rs
         #![feature(const_generics)]
-        
+
         pub struct S<const N: usize>;
-        
+
         pub fn add1<const N: usize>() -> S<{ N + 1 }> { S }
-        
+
     //- main.rs
         mod foo;
-        
+
         fn main() {
             let x = foo::add1::<1>();
             x;
@@ -166,17 +184,17 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
     fun `test const generic in method call (explicit)`() = stubOnlyTypeInfer("""
     //- foo.rs
         #![feature(const_generics)]
-        
+
         pub struct S1<const N1: usize>;
         pub struct S2<const N2: usize, const M2: usize>;
-        
+
         impl<const N3: usize> S1<{ N3 }> {
             pub fn foo<const M3: usize>(&self) -> S2<{ N3 }, { M3 }> { S2 }
         }
-        
+
     //- main.rs
         mod foo;
-        
+
         fn main() {
             let x = foo::S1::<0>.foo::<1usize>();
             x;
@@ -187,21 +205,21 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
     fun `test const generic in method call (implicit)`() = stubOnlyTypeInfer("""
     //- foo.rs
         #![feature(const_generics)]
-        
+
         pub struct S1<const N1: usize>;
-        
+
         #[derive(Clone, Copy)]
         pub struct S2<const N2: usize, const M2: usize>;
-        
+
         impl<const N3: usize> S1<{ N3 }> {
             pub fn foo<const M3: usize>(&self) -> S2<{ N3 }, { M3 }> { S2 }
         }
-        
+
         pub fn bar<const N4: usize, const M4: usize>(s: S2<{ N4 }, { M4 }>) -> S2<{ N4 }, { M4 }> { s }
-        
+
     //- main.rs
         mod foo;
-        
+
         fn main() {
             let x = foo::S1.foo();
             let y: foo::S2<0, 1> = foo::bar(x);
@@ -213,12 +231,12 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
     fun `test const generic in base type`() = stubOnlyTypeInfer("""
     //- foo.rs
         #![feature(const_generics)]
-        
+
         pub struct S<const N1: usize>;
-        
+
     //- mod.rs
         mod foo;
-        
+
         fn bar<const N2: usize>() -> foo::S<{ N2 }> { foo::S }
                                              //^ usize
     """)
@@ -226,14 +244,14 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
     fun `test const generic in trait ref`() = stubOnlyTypeInfer("""
     //- foo.rs
         #![feature(const_generics)]
-        
+
         pub struct S;
-        
+
         pub trait T<const N1: usize> {}
-        
+
     //- mod.rs
         mod foo;
-        
+
         impl <const N2: usize> foo::T<{ N2 }> for foo::S {}
                                        //^ usize
     """)


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/6454.
Relates to https://github.com/intellij-rust/intellij-rust/issues/3985.

changelog: Take into account const generics in inspections about generic parameters/arguments ordering
