### PR TITLE
Fix passing item name through RsResolveProcessor

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -359,9 +359,12 @@ fun processPathResolveVariants(lookup: ImplLookup?, path: RsPath, isCompletion: 
 }
 
 private fun RsResolveProcessor.withIgnoringSecondaryCSelf(): RsResolveProcessor {
+    val name = name
+    if (name != null && name != "Self") return this
+
     var hasSelfItem = false
 
-    return createProcessor {
+    return createProcessor(name) {
         if (it.name == "Self") {
             if (hasSelfItem) {
                 false

--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -74,6 +74,7 @@ fun <T : ScopeEntry> createProcessorGeneric(
     return object : RsResolveProcessorBase<T> {
         override fun invoke(entry: T): Boolean = processor(entry)
         override val name: String? = name
+        override fun toString(): String = "Processor(name=$name)"
     }
 }
 


### PR DESCRIPTION
Please see #5955 for details why `name` is needed

changelog: Fix performance regression in name resolution for large modules