### PR TITLE
RES: Fix resolve inside cfg-disabled inline mod in new resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -507,8 +507,11 @@ private fun ModData.toRsModNullable(project: Project): RsMod? {
 private inline fun <reified T : RsElement> List<T>.singleOrCfgEnabled(): T? =
     singleOrNull() ?: singleOrNull { it.isEnabledByCfg }
 
-private inline fun <reified T : RsNamedElement> RsItemsOwner.getExpandedItemsWithName(name: String): List<T> =
-    expandedItemsCached.named[name]?.filterIsInstance<T>() ?: emptyList()
+private inline fun <reified T : RsNamedElement> RsItemsOwner.getExpandedItemsWithName(name: String): List<T> {
+    val itemsCfgEnabled = expandedItemsCached.named[name]?.filterIsInstance<T>()
+    if (itemsCfgEnabled != null && itemsCfgEnabled.isNotEmpty()) return itemsCfgEnabled
+    return expandedItemsCached.namedCfgDisabled[name]?.filterIsInstance<T>() ?: emptyList()
+}
 
 fun findModDataFor(file: RsFile): ModData? {
     val project = file.project

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -102,6 +102,19 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         }
      """)
 
+    @MockAdditionalCfgOptions("intellij_rust")
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test inline mod with cfg 2`() = checkByCode("""
+        #[cfg(not(intellij_rust))]
+        mod my {
+            fn bar() {}
+             //X
+            fn t() {
+                bar();
+            } //^
+        }
+     """)
+
     // From https://github.com/rust-lang/hashbrown/blob/09e43a8cf97f37b17768b98f28291a24c5767847/src/lib.rs#L52-L68
     @MockAdditionalCfgOptions("intellij_rust")
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)


### PR DESCRIPTION
E.g.
```rust
#[cfg(false)]
mod my {
    fn bar() {}
     //X
    fn t() {
        bar();
    } //^
}
```

changelog: Fix resolve inside cfg-disabled inline mod in new resolve
