### PR TITLE
PERF: Optimize backtrace filter and folding when using new resolve

### DIFF
--- a/src/main/kotlin/org/rust/ide/console/RsConsoleFolding.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleFolding.kt
@@ -15,7 +15,7 @@ import org.rust.cargo.runconfig.filters.FilterUtils
 import org.rust.cargo.runconfig.filters.RegexpFileLinkFilter
 import org.rust.cargo.runconfig.filters.RsBacktraceFilter
 import org.rust.cargo.runconfig.filters.RsBacktraceItemFilter
-import org.rust.lang.core.resolve.resolveStringPath
+import org.rust.lang.core.resolve.splitAbsolutePath
 
 /**
  * Folds backtrace items (function names and source code locations) that do not belong to the
@@ -37,7 +37,8 @@ class RsConsoleFolding : ConsoleFolding() {
             val functionName = RsBacktraceItemFilter.parseBacktraceRecord(line)?.functionName ?: return@any false
             val func = FilterUtils.normalizeFunctionPath(functionName)
             val workspace = it.workspace ?: return@any false
-            val (_, pkg) = resolveStringPath(func, workspace, project) ?: return@any true
+            val (pkgName, _) = splitAbsolutePath(func) ?: return@any true
+            val pkg = workspace.findPackageByName(pkgName) ?: return@any true
 
             pkg.origin != PackageOrigin.WORKSPACE
         }

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -359,7 +359,9 @@ private fun Project.getDefMap(crate: Crate): CrateDefMap? {
     check(crate !is DoctestCrate) { "doc test crates are not supported by CrateDefMap" }
     val crateId = crate.id ?: return null
     val defMap = defMapService.getOrUpdateIfNeeded(crateId)
-    if (defMap == null) RESOLVE_LOG.error("DefMap is null for $crate during resolve")
+    if (defMap == null) {
+        RESOLVE_LOG.warn("DefMap is null for $crate during resolve")
+    }
     return defMap
 }
 


### PR DESCRIPTION
Fix #6607

From issue:
> When a test is unsuccessful, the whole IDE becomes unresponsive temporarily.

When test is unsuccessful, there is backtrace, and we process backtrace in `RsConsoleFolding` and `RsBacktraceFilter`. Both services try to resolve absolute paths from backtrace for *each* crate, including e.g. test/bench dependencies crates. We do not currently build DefMap for such crates, and log error message in new resolve if we try to use resolve in such crates. That's the cause of issue: error message was logged too many times (and e.g. each time it has to calculate java stacktrace). Btw `RsConsoleFolding` runs on EDT (so IDE freezes) and `RsBacktraceFilter` runs in background.

This PR:
* Optimizes error message logging by replacing `LOG.error` to `LOG.warn`
* Removes resolve from `RsConsoleFolding` since it is actually not needed there
* Ignores test/bench dependencies crates in `RsBacktraceFilter`

changelog: Fix freeze after running test when using new resolve
