### PR TITLE
REF: Fix types auto import in change signature dialog with new resolve

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureDialog.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureDialog.kt
@@ -26,6 +26,7 @@ import net.miginfocom.swing.MigLayout
 import org.jetbrains.annotations.TestOnly
 import org.rust.ide.refactoring.isValidRustVariableIdentifier
 import org.rust.lang.RsFileType
+import org.rust.lang.core.macros.setContext
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.openapiext.document
@@ -356,14 +357,14 @@ private fun createTypeCodeFragment(
     context: RsElement,
     type: RsTypeReference?
 ): PsiCodeFragment {
-    val freshFile = RsPsiFactory(context.project).createFile("fn main() {}")
-    freshFile.originalFile = context.containingFile as RsFile
+    val freshMod = RsPsiFactory(context.project).createModItem(TMP_MOD_NAME, "")
+    freshMod.setContext(context.containingFile as RsFile)
 
     val fragment = RsTypeReferenceCodeFragment(
         context.project,
         type?.text.orEmpty(),
-        context = freshFile,
-        importTarget = freshFile
+        context = freshMod,
+        importTarget = freshMod
     )
     val document = fragment.document!!
     document.addDocumentListener(object : DocumentListener {

--- a/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
@@ -99,7 +99,8 @@ fun RsItemsOwner.insertUseItem(psiFactory: RsPsiFactory, usePath: String) {
             addBefore(psiFactory.createNewline(), insertedUseItem)
         }
     } else {
-        addBefore(useItem, firstItem)
+        // `if` is needed to support adding import to empty inline mod (see `RsCodeFragment#importTarget`)
+        addBefore(useItem, if (this is RsModItem && itemsAndMacros.none()) rbrace else firstItem)
         addAfter(psiFactory.createNewline(), firstItem)
     }
 }


### PR DESCRIPTION
E.g. try changing function return type to `FooStruct`:
```rust
mod mod1 {
    pub struct FooStruct {}
}

fn foo() {}
```

changelog: Fix auto-import in change signature refactoring dialog when using new resolve
