### PR TITLE
TY: fix assoc type bounds with supertrait

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsTypeAwareGenericResolveTest.kt
@@ -1108,4 +1108,29 @@ class RsTypeAwareGenericResolveTest : RsResolveTestBase() {
             b.foo();
         }   //^
     """)
+
+    fun `test assoc type bound method 2`() = checkByCode("""
+        trait Foo { type Item: Bar; }
+        trait Bar: Baz {}
+        trait Baz {
+            fn baz(&self) {}
+        }    //X
+
+        fn foobar<T: Foo>(a: T::Item) {
+            a.baz();
+        }   //^
+    """)
+
+    fun `test assoc type bound method 3`() = checkByCode("""
+        trait Foo { type Item: Bar1 + Bar2; }
+        trait Bar1: Baz {}
+        trait Bar2: Baz {}
+        trait Baz {
+            fn baz(&self) {}
+        }    //X
+
+        fn foobar<T: Foo>(a: T::Item) {
+            a.baz();
+        }   //^
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsGenericExpressionTypeInferenceTest.kt
@@ -1817,6 +1817,33 @@ class RsGenericExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ X
     """)
 
+    fun `test assoc type bound selection 5`() = testExpr("""
+        struct X;
+        trait Foo { type Item: Bar; }
+        trait Bar: Baz<X> {}
+        trait Baz<T> {}
+        fn baz<A: Baz<B>, B>(t: A) -> B { unimplemented!() }
+
+        fn foobar<T: Foo>(a: T::Item) {
+            let b = baz(a);
+            b;
+        } //^ X
+    """)
+
+    fun `test assoc type bound selection 6`() = testExpr("""
+        struct X;
+        trait Foo { type Item: Bar1 + Bar2; }
+        trait Bar1: Baz<X> {}
+        trait Bar2: Baz<X> {}
+        trait Baz<T> {}
+        fn baz<A: Baz<B>, B>(t: A) -> B { unimplemented!() }
+
+        fn foobar<T: Foo>(a: T::Item) {
+            let b = baz(a);
+            b;
+        } //^ X
+    """)
+
     fun `test assoc type bound in path selection`() = testExpr("""
         struct X;
         trait Foo<T> {}


### PR DESCRIPTION
Works for
```rust
trait Foo { type Item: Bar; }
trait Bar: Baz {}
trait Baz {
    fn baz(&self) {}
}    //X

fn foobar<T: Foo>(a: T::Item) {
    a.baz();
}   //^
```