### PR TITLE
Support file level cfg attributes in new resolve

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/CfgUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/CfgUtils.kt
@@ -6,12 +6,16 @@
 package org.rust.ide.utils
 
 import com.intellij.psi.PsiElement
+import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.utils.evaluation.CfgEvaluator
 import org.rust.lang.utils.evaluation.ThreeValuedLogic
 
 val PsiElement.isEnabledByCfg: Boolean
     get() = ancestors.filterIsInstance<RsDocAndAttributeOwner>().all { it.isEnabledByCfgSelf }
+
+fun PsiElement.isEnabledByCfg(crate: Crate): Boolean =
+    ancestors.filterIsInstance<RsDocAndAttributeOwner>().all { it.isEnabledByCfgSelf(crate) }
 
 val PsiElement.isCfgUnknown: Boolean
     get() = ancestors.filterIsInstance<RsDocAndAttributeOwner>().any { it.isCfgUnknownSelf }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -201,7 +201,7 @@ class RsFile(
     fun getStdlibAttributes(crate: Crate?): Attributes {
         val stub = greenStub as RsFileStub?
         if (stub?.mayHaveStdlibAttributes == false) return Attributes.NONE
-        val attributes = getQueryAttributes(crate)
+        val attributes = getQueryAttributes(crate, stub)
         if (attributes.hasAtomAttribute("no_core")) return Attributes.NO_CORE
         if (attributes.hasAtomAttribute("no_std")) return Attributes.NO_STD
         return Attributes.NONE
@@ -211,7 +211,7 @@ class RsFile(
     fun hasMacroUseInner(crate: Crate?): Boolean {
         val stub = greenStub as RsFileStub?
         if (stub?.mayHaveMacroUse == false) return false
-        return getQueryAttributes(crate).hasAtomAttribute("macro_use")
+        return getQueryAttributes(crate, stub).hasAtomAttribute("macro_use")
     }
 
     val declaration: RsModDeclItem? get() = declarations.firstOrNull()

--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -118,7 +118,10 @@ class RsFile(
             if (declaration != null) {
                 val (file, isEnabledByCfg) = declaration.contextualFileAndIsEnabledByCfgOnThisWay()
                 val parentCachedData = (file as? RsFile)?.cachedData ?: return EMPTY_CACHED_DATA
-                return parentCachedData.copy(isDeeplyEnabledByCfg = parentCachedData.isDeeplyEnabledByCfg && isEnabledByCfg)
+                val isEnabledByCfgInner = parentCachedData.crate?.let { file.isEnabledByCfgSelf(it) } ?: true
+                val isDeeplyEnabledByCfg = parentCachedData.isDeeplyEnabledByCfg
+                    && isEnabledByCfg && isEnabledByCfgInner
+                return parentCachedData.copy(isDeeplyEnabledByCfg = isDeeplyEnabledByCfg)
             }
         }
 
@@ -128,7 +131,8 @@ class RsFile(
         val crate = project.crateGraph.findCrateByRootMod(crateRootVFile)
         if (crate != null) {
             // `possibleCrateRoot` is a "real" crate root only if we're able to find a `crate` for it
-            return CachedData(crate.cargoProject, crate.cargoWorkspace, possibleCrateRoot, crate)
+            val isEnabledByCfg = possibleCrateRoot.isEnabledByCfgSelf(crate)
+            return CachedData(crate.cargoProject, crate.cargoWorkspace, possibleCrateRoot, crate, isEnabledByCfg)
         }
 
         val injectedFromFile = crateRootVFile.getInjectedFromIfDoctestInjection(project)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -77,7 +77,11 @@ data class Attribute(val name: String, val argText: String? = null) {
 }
 
 inline val RsDocAndAttributeOwner.attributeStub: RsAttributeOwnerStub?
-    get() = (this as? StubBasedPsiElementBase<*>)?.greenStub as? RsAttributeOwnerStub
+    get() = when (this) {
+        is StubBasedPsiElementBase<*> -> greenStub
+        is RsFile -> greenStub
+        else -> null
+    } as? RsAttributeOwnerStub
 
 /**
  * Returns [QueryAttributes] for given PSI element after `#[cfg_attr()]` expansion

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -307,6 +307,9 @@ class QueryAttributes(
 val RsDocAndAttributeOwner.isEnabledByCfgSelf: Boolean
     get() = evaluateCfg() != ThreeValuedLogic.False
 
+fun RsDocAndAttributeOwner.isEnabledByCfgSelf(crate: Crate): Boolean =
+    evaluateCfg(crate) != ThreeValuedLogic.False
+
 val RsDocAndAttributeOwner.isCfgUnknownSelf: Boolean
     get() = evaluateCfg() == ThreeValuedLogic.Unknown
 
@@ -322,9 +325,12 @@ fun RsAttributeOwnerStub.isEnabledByCfgSelf(crate: Crate): Boolean {
 private fun RsDocAndAttributeOwner.evaluateCfg(crateOrNull: Crate? = null): ThreeValuedLogic {
     if (!CFG_ATTRIBUTES_ENABLED_KEY.asBoolean()) return ThreeValuedLogic.True
 
-    // TODO: add cfg to RsFile's stub and remove this line
-    if (this is RsFile) return ThreeValuedLogic.True
+    // We return true because otherwise we have recursion cycle:
+    // [RsFile.crate] -> [RsFile.cachedData] -> [RsFile.declaration] ->
+    //  -> [RsModDeclItem.resolve] -> [RsFile.isEnabledByCfg] -> [RsFile.crate]
+    if (crateOrNull == null && this is RsFile) return ThreeValuedLogic.True
 
+    val attributeStub = attributeStub
     if (attributeStub?.mayHaveCfg == false) return ThreeValuedLogic.True
 
     val crate = crateOrNull ?: containingCrate ?: return ThreeValuedLogic.True // TODO: maybe unknown?

--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
@@ -217,7 +217,16 @@ class ModData(
     val crate: CratePersistentId,
     val path: ModPath,
     val macroIndex: MacroIndex,
-    val isDeeplyEnabledByCfg: Boolean,
+    /**
+     * For [RsMod]:
+     * - [isEnabledByCfgInner] is always true
+     * - [isDeeplyEnabledByCfgOuter] equals to [isDeeplyEnabledByCfg]
+     * For [RsFile]:
+     * - [isEnabledByCfgInner] corresponds to file level cfg attributes - `#![cfg(...)]`
+     * - [isDeeplyEnabledByCfgOuter] corresponds to `parent.isDeeplyEnabledByCfg` plus cfg attributes on mod declaration
+     */
+    val isDeeplyEnabledByCfgOuter: Boolean,
+    val isEnabledByCfgInner: Boolean,
     /** id of containing file */
     val fileId: FileId,
     // TODO: Possible optimization - store as Array<String>
@@ -234,6 +243,7 @@ class ModData(
     val isRsFile: Boolean get() = fileRelativePath.isEmpty()
     val isCrateRoot: Boolean get() = parent == null
     val name: String get() = path.name
+    val isDeeplyEnabledByCfg: Boolean get() = isDeeplyEnabledByCfgOuter && isEnabledByCfgInner
     val parents: Sequence<ModData> get() = generateSequence(this) { it.parent }
     private val rootModData: ModData = parent?.rootModData ?: this
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeBuildDefMap.kt
@@ -11,6 +11,7 @@ import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.crate.CratePersistentId
 import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.ext.isEnabledByCfgSelf
 import org.rust.lang.core.psi.shouldIndexFile
 import org.rust.openapiext.checkReadAccessAllowed
 import org.rust.openapiext.fileId
@@ -68,7 +69,8 @@ private fun buildDefMapContainingExplicitItems(
         crate = crateId,
         path = ModPath(crateId, emptyArray()),
         macroIndex = MacroIndex(intArrayOf(rootModMacroIndex)),
-        isDeeplyEnabledByCfg = true,
+        isDeeplyEnabledByCfgOuter = true,
+        isEnabledByCfgInner = crateRoot.isEnabledByCfgSelf(crate),
         fileId = crateRoot.virtualFile.fileId,
         fileRelativePath = "",
         ownedDirectoryId = crateRootOwnedDirectory.fileId,

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -345,7 +345,7 @@ private fun getModInfo(scope: RsMod): RsModInfoBase {
     val defMap = project.getDefMap(crate) ?: return InfoNotFound
     val modData = defMap.getModData(scope) ?: return InfoNotFound
 
-    if (isModShadowedByOtherMod(scope, modData)) return CantUseNewResolve("mod shadowed by other mod")
+    if (isModShadowedByOtherMod(scope, modData, crate)) return CantUseNewResolve("mod shadowed by other mod")
 
     return RsModInfo(project, defMap, modData)
 }
@@ -365,8 +365,8 @@ private val RsMod.isLocal: Boolean
     get() = ancestorStrict<RsBlock>() != null
 
 /** "shadowed by other mod" means that [ModData] is not accessible from [CrateDefMap.root] through [ModData.childModules] */
-private fun isModShadowedByOtherMod(mod: RsMod, modData: ModData): Boolean {
-    val isDeeplyEnabledByCfg = (mod.containingFile as RsFile).isDeeplyEnabledByCfg && mod.isEnabledByCfg
+private fun isModShadowedByOtherMod(mod: RsMod, modData: ModData, crate: Crate): Boolean {
+    val isDeeplyEnabledByCfg = (mod.containingFile as RsFile).isDeeplyEnabledByCfg && mod.isEnabledByCfg(crate)
     val isShadowedByOtherInlineMod = isDeeplyEnabledByCfg != modData.isDeeplyEnabledByCfg
 
     return modData.isShadowedByOtherFile || isShadowedByOtherInlineMod

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -871,4 +871,44 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
             dep_lib_target::foo::bar();
         }                      //^ dep-lib/not_test.rs
      """)
+
+    @UseNewResolve
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test file level cfg attribute 1`() = stubOnlyResolve("""
+    //- main.rs
+        #[path="foo1.rs"]
+        mod foo;
+        #[path="foo2.rs"]
+        mod foo;
+        fn main() {
+            foo::func();
+        }      //^ foo1.rs
+    //- foo1.rs
+        #![cfg(intellij_rust)]
+        pub fn func() {}
+    //- foo2.rs
+        #![cfg(not(intellij_rust))]
+        pub fn func() {}
+     """)
+
+    @UseNewResolve
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test file level cfg attribute 2`() = stubOnlyResolve("""
+    //- main.rs
+        #[path="foo1.rs"]
+        mod foo;
+        #[path="foo2.rs"]
+        mod foo;
+        fn main() {
+            foo::func();
+        }      //^ foo2.rs
+    //- foo1.rs
+        #![cfg(not(intellij_rust))]
+        pub fn func() {}
+    //- foo2.rs
+        #![cfg(intellij_rust)]
+        pub fn func() {}
+     """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateChangeSingleFileTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateChangeSingleFileTest.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.psi.PsiDocumentManager
 import org.intellij.lang.annotations.Language
 import org.rust.ExpandMacros
+import org.rust.MockAdditionalCfgOptions
 import org.rust.UseNewResolve
 
 /** Tests whether or not [CrateDefMap] should be updated after file modification */
@@ -322,6 +323,12 @@ class RsDefMapUpdateChangeSingleFileTest : RsDefMapUpdateTestBase() {
         macro_rules! foo {
             () => {};
         }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test add file level cfg attribute`() = doTestChanged("""
+    """, """
+        #![cfg(not(intellij_rust))]
     """)
 
     private fun type(text: String = "a"): () -> Unit = {


### PR DESCRIPTION
E.g. now such macro will not be expanded in new resolve (we don't expand cfg-disabled macros):
```rust
#![cfg(false)]
...
some_macro!();
```

Potentially this should slightly speed up [winapi crate](https://github.com/retep998/winapi-rs/blob/2f76bdea3a79817ccfab496fbd1786d5a697387b/src/lib.rs#L6)

changelog: Support file level cfg attributes in new resolve
