### PR TITLE
RES: Enable new name resolution engine on nightly by default

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,19 +34,19 @@ jobs:
                 rust-version: [ 1.48.0, nightly-2020-10-04 ]
                 base-ide: [ idea, clion ]
                 platform-version: [ 203, 211 ]
-                resolve-engine: [ resolve-stable ]
+                resolve-engine: [ resolve-new ]
                 include:
                     - os: ubuntu-latest
                       # Don't forget to update condition in `Set up additional env variables` step
                       rust-version: 1.32.0
                       base-ide: idea
                       platform-version: 203
-                      resolve-engine: resolve-stable
+                      resolve-engine: resolve-old
                     - os: ubuntu-latest
                       rust-version: 1.48.0
                       base-ide: idea
                       platform-version: 203
-                      resolve-engine: resolve-new
+                      resolve-engine: resolve-old
 
         runs-on: ${{ matrix.os }}
         timeout-minutes: 60
@@ -114,9 +114,9 @@ jobs:
                   echo "ORG_GRADLE_PROJECT_graziePluginVersion=203.7148.20" >> $GITHUB_ENV
                   echo "ORG_GRADLE_PROJECT_compileNativeCode=false" >> $GITHUB_ENV
 
-            - name: Set up env variable for new resolve
-              if: matrix.resolve-engine == 'resolve-new'
-              run: echo "INTELLIJ_RUST_FORCE_USE_NEW_RESOLVE=" >> $GITHUB_ENV
+            - name: Set up env variable for old resolve
+              if: matrix.resolve-engine == 'resolve-old'
+              run: echo "INTELLIJ_RUST_FORCE_USE_OLD_RESOLVE=" >> $GITHUB_ENV
 
             - name: Set up test env variables
               run: echo "RUST_SRC_WITH_SYMLINK=$HOME/.rust-src" >> $GITHUB_ENV

--- a/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/settings/RustProjectSettingsService.kt
@@ -46,7 +46,7 @@ interface RustProjectSettingsService {
         var macroExpansionEngine: MacroExpansionEngine = defaultMacroExpansionEngine,
         @AffectsHighlighting
         var newResolveEnabled: Boolean = isFeatureEnabled(RsExperiments.RESOLVE_NEW_ENGINE)
-            || System.getenv("INTELLIJ_RUST_FORCE_USE_NEW_RESOLVE") != null,
+            && System.getenv("INTELLIJ_RUST_FORCE_USE_OLD_RESOLVE") == null,
         @AffectsHighlighting
         var doctestInjectionEnabled: Boolean = true,
         var useRustfmt: Boolean = false,

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -15,7 +15,7 @@
         <experimentalFeature id="org.rust.macros.new.engine" percentOfUsers="100">
             <description>Enables new macro expansion engine by default</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.resolve.new.engine" percentOfUsers="0">
+        <experimentalFeature id="org.rust.resolve.new.engine" percentOfUsers="100">
             <description>Enables experimental resolve engine</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="0">


### PR DESCRIPTION
This allows us to gather more feedback and find potential issues

Should be merged after #6719

changelog: Enable new name resolution engine on the nightly plugin channel by default
