### PR TITLE
RES: Support resolve multi-segment macro paths in new resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -835,7 +835,6 @@ fun processAssocTypeVariants(trait: RsTraitItem, processor: RsResolveProcessor):
 fun processMacroCallPathResolveVariants(path: RsPath, isCompletion: Boolean, processor: RsResolveProcessor): Boolean {
     // Allowed only 1 or 2-segment paths: `foo!()` or `foo::bar!()`, but not foo::bar::baz!();
     val qualifier = path.qualifier
-    if (qualifier?.path != null) return false
     return if (qualifier == null) {
         if (isCompletion) {
             processMacroCallVariantsInScope(path, processor)
@@ -879,6 +878,7 @@ fun processMacroCallPathResolveVariants(path: RsPath, isCompletion: Boolean, pro
                 ) ?: false
             }
         } else {
+            if (qualifier.path != null) return false
             processMacrosExportedByCratePath(path, qualifier, processor)
         }
     }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -431,11 +431,54 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    fun `test import macro by qualified path without extern crate`() = stubOnlyResolve("""
+    fun `test import macro by qualified path without extern crate 1`() = stubOnlyResolve("""
+    //- lib.rs
+        dep_lib_target::foo!();
+                      //^ dep-lib/lib.rs
+    //- dep-lib/lib.rs
+        #[macro_export]
+        macro_rules! foo {
+            () => {};
+        }
+    """)
+
+    fun `test import macro by qualified path without extern crate 2`() = stubOnlyResolve("""
     //- lib.rs
         fn bar() {
             dep_lib_target::foo!();
         }                 //^ dep-lib/lib.rs
+    //- dep-lib/lib.rs
+        #[macro_export]
+        macro_rules! foo {
+            () => {};
+        }
+    """)
+
+    @UseNewResolve
+    fun `test import macro by multi-segment path without extern crate 1`() = stubOnlyResolve("""
+    //- lib.rs
+        use dep_lib_target;
+        mod inner {
+            crate::dep_lib_target::foo!();
+                                 //^ dep-lib/lib.rs
+        }
+    //- dep-lib/lib.rs
+        #[macro_export]
+        macro_rules! foo {
+            () => {};
+        }
+    """)
+
+    @UseNewResolve
+    fun `test import macro by multi-segment path without extern crate 2`() = stubOnlyResolve("""
+    //- lib.rs
+        use dep_lib_target;
+        mod inner {
+            fn bar() {
+                crate::dep_lib_target::foo!();
+                                     //^ dep-lib/lib.rs
+            }
+        }
     //- dep-lib/lib.rs
         #[macro_export]
         macro_rules! foo {


### PR DESCRIPTION
Support macros with 3 or more segments ([example](https://github.com/amethyst/amethyst/blob/e60f89fe4a08dd43313402b3b04dccfedd9318cc/amethyst_assets/src/loader.rs#L462))

changelog: Support resolve multi-segment macro paths in new resolve
