### PR TITLE
RES: Fix resolve macro calls inside included file when using new resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -141,7 +141,7 @@ class RsFile(
             return cached.copy(crateRoot = possibleCrateRoot, crate = doctestCrate)
         }
 
-        val includingMod = RsIncludeMacroIndex.getIncludingMod(possibleCrateRoot)
+        val includingMod = RsIncludeMacroIndex.getIncludedFrom(possibleCrateRoot)?.containingMod
         if (includingMod != null) return (includingMod.contextualFile as? RsFile)?.cachedData ?: EMPTY_CACHED_DATA
 
         // This occurs if the file is not included to the project's module structure, i.e. it's
@@ -160,8 +160,8 @@ class RsFile(
 
     override val `super`: RsMod?
         get() {
-            val includingMod = RsIncludeMacroIndex.getIncludingMod(this) ?: return declaration?.containingMod
-            return includingMod.`super`
+            val includedFrom = RsIncludeMacroIndex.getIncludedFrom(this) ?: return declaration?.containingMod
+            return includedFrom.containingMod.`super`
         }
 
     // We can't just return file name here because

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -242,7 +242,7 @@ private fun RsMacroCall.resolveToMacroDefInfo(containingModInfo: RsModInfo): Mac
 private fun getMacroIndex(element: PsiElement, defMap: CrateDefMap): MacroIndex? {
     val itemAndCallExpandedFrom = element.stubAncestors
         .filterIsInstance<RsExpandedElement>()
-        .mapNotNull { it to (it.expandedFrom ?: return@mapNotNull null) }
+        .mapNotNull { it to (it.expandedOrIncludedFrom ?: return@mapNotNull null) }
         .firstOrNull()
     if (itemAndCallExpandedFrom == null) {
         if (element.containingFile is RsCodeFragment) return MacroIndex(intArrayOf(Int.MAX_VALUE))

--- a/src/main/kotlin/org/rust/lang/core/stubs/index/RsIncludeMacroIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/index/RsIncludeMacroIndex.kt
@@ -20,7 +20,6 @@ import com.intellij.util.io.KeyDescriptor
 import org.rust.ide.search.RsWithMacrosProjectScope
 import org.rust.lang.core.macros.macroExpansionManagerIfCreated
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.RsMod
 import org.rust.lang.core.psi.ext.findIncludingFile
 import org.rust.lang.core.psi.ext.macroName
 import org.rust.lang.core.psi.ext.stringValue
@@ -40,8 +39,8 @@ class RsIncludeMacroIndex : AbstractStubIndex<IncludeMacroKey, RsMacroCall>() {
         val KEY : StubIndexKey<IncludeMacroKey, RsMacroCall> =
             StubIndexKey.createIndexKey("org.rust.lang.core.stubs.index.RsIncludeMacroIndex")
 
-        private val INCLUDING_MOD_KEY: Key<CachedValue<RsMod?>> = Key.create("INCLUDING_MOD_KEY")
-        private val INCLUDING_MOD_MACROS_KEY: Key<CachedValue<RsMod?>> = Key.create("INCLUDING_MOD_MACROS_KEY")
+        private val INCLUDING_MOD_KEY: Key<CachedValue<RsMacroCall?>> = Key.create("INCLUDING_MOD_KEY")
+        private val INCLUDING_MOD_MACROS_KEY: Key<CachedValue<RsMacroCall?>> = Key.create("INCLUDING_MOD_MACROS_KEY")
 
         fun index(stub: RsMacroCallStub, indexSink: IndexSink) {
             val key = key(stub.psi) ?: return
@@ -49,9 +48,9 @@ class RsIncludeMacroIndex : AbstractStubIndex<IncludeMacroKey, RsMacroCall>() {
         }
 
         /**
-         * Returns mod item that includes given [file] via `include!()` macro
+         * Returns `include!()` macro call which includes [file]
          */
-        fun getIncludingMod(file: RsFile): RsMod? {
+        fun getIncludedFrom(file: RsFile): RsMacroCall? {
             val originalFile = file.originalFile as? RsFile ?: return null
             val state = file.project.macroExpansionManagerIfCreated?.expansionState
 
@@ -63,36 +62,36 @@ class RsIncludeMacroIndex : AbstractStubIndex<IncludeMacroKey, RsMacroCall>() {
 
             return CachedValuesManager.getCachedValue(originalFile, key) {
                 CachedValueProvider.Result.create(
-                    getIncludingModInternal(originalFile),
+                    getIncludedFromInternal(originalFile),
                     originalFile.rustStructureOrAnyPsiModificationTracker,
                     cacheDependency
                 )
             }
         }
 
-        private fun getIncludingModInternal(file: RsFile): RsMod? {
+        private fun getIncludedFromInternal(file: RsFile): RsMacroCall? {
             return makeIndexLookup(IncludeMacroKey(file.name), file)
                 ?: makeIndexLookup(IncludeMacroKey.UNKNOWN_FILE_NAME, file)
         }
 
-        private fun makeIndexLookup(key: IncludeMacroKey, file: RsFile): RsMod? {
+        private fun makeIndexLookup(key: IncludeMacroKey, file: RsFile): RsMacroCall? {
             return recursionGuard(file, Computable {
                 val project = file.project
                 checkCommitIsNotInProgress(project)
 
-                var parentMod: RsMod? = null
+                var includedFrom: RsMacroCall? = null
                 val scope = project.macroExpansionManagerIfCreated?.expansionState?.expandedSearchScope
                     ?: RsWithMacrosProjectScope(project)
                 StubIndex.getInstance().processElements(KEY, key, project, scope, RsMacroCall::class.java) { macroCall ->
                     val includingFile = macroCall.findIncludingFile()
                     if (includingFile == file) {
-                        parentMod = macroCall.containingMod
+                        includedFrom = macroCall
                         false
                     } else {
                         true
                     }
                 }
-                parentMod
+                includedFrom
             })
         }
 

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsIncludeMacroResolveTest.kt
@@ -191,7 +191,21 @@ class RsIncludeMacroResolveTest : RsResolveTestBase() {
     @UseNewResolve
     @ExpandMacros
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
-    fun `test macro call in included file`() = checkResolve("""
+    fun `test macro call in included file 1`() = checkResolve("""
+    //- main.rs
+        macro_rules! foo {
+            () => {};
+        }
+        include!("foo.rs");
+    //- foo.rs
+        foo!();
+        //^ main.rs
+    """)
+
+    @UseNewResolve
+    @ExpandMacros
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test macro call in included file 2`() = checkResolve("""
     //- main.rs
         macro_rules! gen_use {
             () => { use inner::func; };


### PR DESCRIPTION
E.g.:
```rust
// main.rs
macro_rules! foo {
    () => {};
}
include!("foo.rs");
// foo.rs
foo!();
//^
```

Related: #6236 - [`Token` macro in `syn` crate](https://github.com/dtolnay/syn/blob/133a053fe67d5f360c0ad24370216e0052624dfc/src/token.rs#L882)

changelog: Fix resolve macro calls inside file included by `include!` macro when using new resolve
