### PR TITLE
ANN: add quick fix to add function parameter from function call

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFix.kt
@@ -1,0 +1,252 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInsight.intention.PriorityAction
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.ide.annotator.getFunctionCallContext
+import org.rust.ide.presentation.renderInsertionSafe
+import org.rust.ide.refactoring.changeSignature.*
+import org.rust.ide.refactoring.suggestedNames
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.isMethod
+import org.rust.lang.core.psi.ext.valueParameters
+import org.rust.lang.core.types.implLookup
+import org.rust.lang.core.types.ty.Ty
+import org.rust.lang.core.types.ty.TyUnknown
+import org.rust.lang.core.types.type
+
+/**
+ * Requires that the number of arguments is larger than the number of parameters.
+ */
+class ChangeFunctionSignatureFix private constructor(
+    arguments: RsValueArgumentList,
+    function: RsFunction,
+    private val direction: ArgumentScanDirection,
+) : LocalQuickFixAndIntentionActionOnPsiElement(arguments), PriorityAction {
+    private val fixText: String = run {
+        val signature = calculateSignature(function, arguments, direction)
+        val argumentInsertions = signature.withIndex().filter { (_, item) -> item is SignatureMember.Argument }
+
+        val callableType = if (function.isMethod) "method" else "function"
+        val name = function.name
+        if (argumentInsertions.size == 1) {
+            val index = argumentInsertions[0].index + 1
+            val argument = argumentInsertions[0].value as SignatureMember.Argument
+
+            val ordinal = "${index}${suffix(index)}"
+            "Add `${renderType(argument.expr.type)}` as `$ordinal` parameter to $callableType `$name`"
+        } else {
+            val signatureText = signature.joinToString(", ") {
+                when (it) {
+                    is SignatureMember.Argument -> "<b>${renderType(it.expr.type)}</b>"
+                    is SignatureMember.Parameter -> it.parameter.typeReference?.text.orEmpty()
+                }
+            }
+
+            "<html>Change signature of $name($signatureText)</html>"
+        }
+    }
+
+    override fun getText(): String = fixText
+    override fun getFamilyName(): String = "Add parameter to function"
+
+    override fun startInWriteAction(): Boolean = false
+
+    override fun getPriority(): PriorityAction.Priority = when (direction) {
+        ArgumentScanDirection.Forward -> PriorityAction.Priority.HIGH
+        ArgumentScanDirection.Backward -> PriorityAction.Priority.NORMAL
+    }
+
+    override fun invoke(
+        project: Project,
+        file: PsiFile,
+        editor: Editor?,
+        startElement: PsiElement,
+        endElement: PsiElement
+    ) {
+        val args = startElement as? RsValueArgumentList ?: return
+        val context = when (val parent = args.parent) {
+            is RsCallExpr -> parent.getFunctionCallContext()
+            is RsMethodCall -> parent.getFunctionCallContext()
+            else -> null
+        } ?: return
+        val function = context.function ?: return
+
+        val usedNames = mutableSetOf<String>()
+        getExistingParameterNames(usedNames, function)
+
+        val config = RsChangeFunctionSignatureConfig.create(function)
+        val signature = calculateSignature(function, args, direction)
+        val factory = RsPsiFactory(project)
+
+        for ((index, item) in signature.withIndex()) {
+            if (item is SignatureMember.Argument) {
+                val expr = item.expr
+                val typeText = renderType(expr.type)
+                val fragment = RsTypeReferenceCodeFragment(project, typeText, context = args)
+                val typeReference = fragment.typeReference ?: factory.createType("()")
+                val name = generateName(suggestName(expr), usedNames)
+
+                config.parameters.add(index, Parameter(factory, name, ParameterProperty.fromItem(typeReference)))
+                config.additionalTypesToImport.add(expr.type)
+            }
+        }
+
+        runChangeSignatureRefactoring(config)
+    }
+
+    companion object {
+        fun createIfCompatible(
+            arguments: RsValueArgumentList,
+            function: RsFunction,
+            direction: ArgumentScanDirection
+        ): ChangeFunctionSignatureFix? {
+            if (function.containingCrate?.origin != PackageOrigin.WORKSPACE) return null
+
+            val signature = calculateSignature(function, arguments, direction)
+            val parameterInsertions = signature.filterIsInstance<SignatureMember.Parameter>()
+
+            // There are parameters that were not matched by any argument
+            if (function.valueParameters.size < parameterInsertions.size) {
+                return null
+            }
+
+            return ChangeFunctionSignatureFix(arguments, function, direction)
+        }
+    }
+
+    sealed class ArgumentScanDirection {
+        open fun <T> map(iterable: Iterable<T>): Iterable<T> = iterable
+
+        object Forward : ArgumentScanDirection()
+        object Backward : ArgumentScanDirection() {
+            override fun <T> map(iterable: Iterable<T>): Iterable<T> = iterable.reversed()
+        }
+    }
+}
+
+private fun suggestName(expr: RsExpr): String {
+    if (expr is RsPathExpr) {
+        val reference = expr.path.reference?.resolve()
+        val name = (reference as? RsPatBinding)?.name
+
+        if (name != null) {
+            return name
+        }
+    }
+
+    return expr.suggestedNames().default
+}
+
+private fun generateName(defaultName: String, usedNames: MutableSet<String>): String {
+    var name = defaultName
+    var index = 0
+    while (name in usedNames) {
+        name = "${defaultName}$index"
+        index += 1
+    }
+    usedNames.add(name)
+    return name
+}
+
+/**
+ * Calculates a possible new signature in the specified direction.
+ * Assumes that there are more arguments than parameters.
+ */
+private fun calculateSignature(
+    function: RsFunction,
+    argumentList: RsValueArgumentList,
+    direction: ChangeFunctionSignatureFix.ArgumentScanDirection
+): List<SignatureMember> {
+    val parameters = function.valueParameters
+    val arguments = argumentList.exprList
+
+    if (parameters.isEmpty()) {
+        return arguments.map { SignatureMember.Argument(it) }
+    }
+
+    val ctx = function.implLookup.ctx
+
+    fun <T> createIterator(items: List<T>): PeekableIterator<T> = PeekableIterator(direction.map(items).iterator())
+
+    val parameterIterator = createIterator(parameters)
+    val argumentIterator = createIterator(arguments)
+
+    val insertions = mutableListOf<SignatureMember>()
+    while (true) {
+        val parameter = parameterIterator.value
+        val argument = argumentIterator.value ?: break
+
+        if (parameter != null && ctx.combineTypes(parameter.typeReference?.type ?: TyUnknown, argument.type).isOk) {
+            insertions.add(SignatureMember.Parameter(parameter))
+            parameterIterator.advance()
+            argumentIterator.advance()
+        } else {
+            insertions.add(SignatureMember.Argument(argument))
+            argumentIterator.advance()
+        }
+    }
+
+    return direction.map(insertions).toList()
+}
+
+private class PeekableIterator<T>(private val iterator: Iterator<T>) {
+    var value: T? = null
+
+    init {
+        if (iterator.hasNext()) {
+            value = iterator.next()
+        }
+    }
+
+    fun advance() {
+        value = if (iterator.hasNext()) {
+            iterator.next()
+        } else {
+            null
+        }
+    }
+}
+
+private sealed class SignatureMember {
+    data class Parameter(val parameter: RsValueParameter) : SignatureMember()
+    data class Argument(val expr: RsExpr) : SignatureMember()
+}
+
+private fun suffix(number: Int): String {
+    if ((number % 100) in 11..13) {
+        return "th"
+    }
+    return when (number % 10) {
+        1 -> "st"
+        2 -> "nd"
+        3 -> "rd"
+        else -> "th"
+    }
+}
+
+private fun renderType(ty: Ty): String =
+    ty.renderInsertionSafe(
+        skipUnchangedDefaultTypeArguments = true,
+        useAliasNames = true,
+        includeLifetimeArguments = true
+    )
+
+private fun getExistingParameterNames(usedNames: MutableSet<String>, function: RsFunction) {
+    val visitor = object : RsRecursiveVisitor() {
+        override fun visitPatBinding(o: RsPatBinding) {
+            val name = o.identifier.text
+            usedNames.add(name)
+        }
+    }
+    function.valueParameterList?.acceptChildren(visitor)
+}

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFix.kt
@@ -11,7 +11,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.parentOfType
-import org.rust.ide.annotator.expectedParamsCount
+import org.rust.ide.annotator.getFunctionCallContext
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.knownItems
@@ -37,8 +37,8 @@ class FillFunctionArgumentsFix(element: PsiElement) : LocalQuickFixAndIntentionA
 
         val parameters = getParameterTypes(parent) ?: return
         val requiredParameterCount = when (parent) {
-            is RsCallExpr -> parent.expectedParamsCount()?.first
-            is RsMethodCall -> parent.expectedParamsCount()?.first
+            is RsCallExpr -> parent.getFunctionCallContext()?.expectedParameterCount
+            is RsMethodCall -> parent.getFunctionCallContext()?.expectedParameterCount
             else -> null
         } ?: return
 

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/RemoveRedundantFunctionArgumentsFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/RemoveRedundantFunctionArgumentsFix.kt
@@ -10,11 +10,14 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import org.rust.lang.core.psi.ext.RsElement
-import org.rust.lang.core.psi.ext.deleteWithSurroundingComma
+import org.rust.lang.core.psi.RsValueArgumentList
+import org.rust.lang.core.psi.ext.deleteWithSurroundingCommaAndWhitespace
 
-class RemoveFunctionArgumentFix(element: RsElement) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
-    override fun getText(): String = "Remove argument"
+class RemoveRedundantFunctionArgumentsFix(
+    element: RsValueArgumentList,
+    private val expectedCount: Int
+) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
+    override fun getText(): String = "Remove redundant arguments"
     override fun getFamilyName(): String = text
     override fun invoke(
         project: Project,
@@ -23,7 +26,10 @@ class RemoveFunctionArgumentFix(element: RsElement) : LocalQuickFixAndIntentionA
         startElement: PsiElement,
         endElement: PsiElement
     ) {
-        val element = startElement as? RsElement ?: return
-        element.deleteWithSurroundingComma()
+        val args = startElement as? RsValueArgumentList ?: return
+        val extraArgs = args.exprList.drop(expectedCount)
+        for (arg in extraArgs) {
+            arg.deleteWithSurroundingCommaAndWhitespace()
+        }
     }
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
@@ -99,7 +99,8 @@ class RsChangeFunctionSignatureConfig private constructor(
     var returnTypeDisplay: RsTypeReference?,
     var visibility: RsVis? = null,
     var isAsync: Boolean = false,
-    var isUnsafe: Boolean = false
+    var isUnsafe: Boolean = false,
+    val additionalTypesToImport: MutableList<Ty> = mutableListOf()
 ) : RsFunctionSignatureConfig(function) {
     override fun typeParameters(): List<RsTypeParameter> = function.typeParameters
 

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureDialog.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureDialog.kt
@@ -49,7 +49,7 @@ fun showChangeFunctionSignatureDialog(
     if (isUnitTestMode) {
         val mock = MOCK ?: error("You should set mock UI via `withMockChangeFunctionSignature`")
         mock(config)
-        RsChangeSignatureProcessor(project, config.createChangeInfo()).run()
+        runChangeSignatureRefactoring(config)
     } else {
         ChangeSignatureDialog(project, SignatureDescriptor(config)).show()
     }

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureProcessor.kt
@@ -28,3 +28,7 @@ class RsChangeSignatureProcessor(project: Project, changeInfo: ChangeInfo) : Cha
         return showConflicts(conflicts, refUsages.get())
     }
 }
+
+fun runChangeSignatureRefactoring(config: RsChangeFunctionSignatureConfig) {
+    RsChangeSignatureProcessor(config.function.project, config.createChangeInfo()).run()
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
@@ -78,6 +78,10 @@ fun processFunction(
     changeParameters(factory, function, config)
     changeAsync(factory, function, config)
     changeUnsafe(factory, function, config)
+
+    for (type in config.additionalTypesToImport) {
+        RsImportHelper.importTypeReferencesFromTy(function, type, useAliases = true)
+    }
 }
 
 private fun rename(factory: RsPsiFactory, function: RsFunction, config: RsChangeFunctionSignatureConfig) {

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -13,6 +13,7 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.util.text.StringUtil.pluralize
@@ -543,13 +544,15 @@ sealed class RsDiagnostic(
         private val expectedCount: Int,
         private val realCount: Int,
         private val functionType: FunctionType = FunctionType.FUNCTION,
-        private val fixes: List<LocalQuickFix> = emptyList()
+        private val fixes: List<LocalQuickFix> = emptyList(),
+        private val textAttributes: TextAttributesKey? = null
     ) : RsDiagnostic(element) {
         override fun prepare() = PreparedAnnotation(
             ERROR,
             functionType.errorCode,
             errorText(),
-            fixes = fixes
+            fixes = fixes,
+            textAttributes = textAttributes
         )
 
         private fun errorText(): String {
@@ -1414,7 +1417,8 @@ class PreparedAnnotation(
     val errorCode: RsErrorCode?,
     val header: String,
     val description: String = "",
-    val fixes: List<LocalQuickFix> = emptyList()
+    val fixes: List<LocalQuickFix> = emptyList(),
+    val textAttributes: TextAttributesKey? = null
 )
 
 fun RsDiagnostic.addToHolder(holder: RsAnnotationHolder, checkExistsAfterExpansion: Boolean = true) {
@@ -1441,6 +1445,10 @@ fun RsDiagnostic.addToHolder(holder: AnnotationHolder) {
         .tooltip(prepared.fullDescription)
         .range(textRange)
         .highlightType(prepared.severity.toProblemHighlightType())
+
+    if (prepared.textAttributes != null) {
+        annotationBuilder.textAttributes(prepared.textAttributes)
+    }
 
     for (fix in prepared.fixes) {
         if (fix is IntentionAction) {

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -230,7 +230,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             let closure_2 = |x, y| (x, y);
 
             closure_0();
-            closure_0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0057]">42</error>);
+            closure_0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0057]">(<error>42</error>)</error>;
             closure_1(<error descr="This function takes 1 parameter but 0 parameters were supplied [E0057]">)</error>;
             closure_1(42);
             closure_2(<error descr="This function takes 2 parameters but 0 parameters were supplied [E0057]">)</error>;
@@ -270,11 +270,11 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             par_0_cfg();
             par_1_cfg(1);
 
-            par_0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
+            par_0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>4</error>)</error>;
             par_1(<error descr="This function takes 1 parameter but 0 parameters were supplied [E0061]">)</error>;
-            par_1(true, <error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">false</error>);
+            par_1<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(true, <error>false</error>)</error>;
             par_3(5, 1.0<error descr="This function takes 3 parameters but 2 parameters were supplied [E0061]">)</error>;
-            par_0_cfg(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
+            par_0_cfg<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>4</error>)</error>;
             par_1_cfg(<error descr="This function takes 1 parameter but 0 parameters were supplied [E0061]">)</error>;
         }
     """)
@@ -290,8 +290,8 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             Foo::par_0();
             Foo::par_2(12, 7.1);
 
-            Foo::par_0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
-            Foo::par_2(5, 1.0, <error descr="This function takes 2 parameters but 3 parameters were supplied [E0061]">"three"</error>);
+            Foo::par_0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>4</error>)</error>;
+            Foo::par_2<error descr="This function takes 2 parameters but 3 parameters were supplied [E0061]">(5, 1.0, <error>"three"</error>)</error>;
         }
     """)
 
@@ -307,8 +307,8 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             foo.par_0();
             foo.par_2(12, 7.1);
 
-            foo.par_0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
-            foo.par_2(5, 1.0, <error descr="This function takes 2 parameters but 3 parameters were supplied [E0061]">"three"</error>);
+            foo.par_0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>4</error>)</error>;
+            foo.par_2<error descr="This function takes 2 parameters but 3 parameters were supplied [E0061]">(5, 1.0, <error>"three"</error>)</error>;
             foo.par_2(<error descr="This function takes 2 parameters but 0 parameters were supplied [E0061]">)</error>;
         }
     """)
@@ -320,8 +320,8 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             let _ = Foo0();
             let _ = Foo1(1);
 
-            let _ = Foo0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
-            let _ = Foo1(10, <error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">false</error>);
+            let _ = Foo0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>4</error>)</error>;
+            let _ = Foo1<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(10, <error>false</error>)</error>;
         }
     """)
 
@@ -334,8 +334,8 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
             let _ = Foo::VAR0();
             let _ = Foo::VAR1(1);
 
-            let _ = Foo::VAR0(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">4</error>);
-            let _ = Foo::VAR1(10, <error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">false</error>);
+            let _ = Foo::VAR0<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>4</error>)</error>;
+            let _ = Foo::VAR1<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(10, <error>false</error>)</error>;
         }
     """)
 
@@ -349,7 +349,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
         fn main() {
             let foo = Foo;
-            foo.bar(<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">10</error>);
+            foo.bar<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>10</error>)</error>;
             foo.bar();
         }
     """)
@@ -1074,7 +1074,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
             fn main() {
                 unsafe { foo(1, 2, 3); }
-                bar(<error>92</error>);
+                bar<error>(<error>92</error>)</error>;
                 let _ = S {};
             }  //^
 

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFixTest.kt
@@ -1,0 +1,225 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.rust.ide.annotator.RsAnnotatorTestBase
+import org.rust.ide.annotator.RsErrorAnnotator
+
+class ChangeFunctionSignatureFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
+    fun `test unavailable with unmatched parameters`() = checkFixIsUnavailable("Add `i32`", """
+        fn foo(a: bool) {}
+
+        fn main() {
+            foo<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(1, <error>2/*caret*/</error>)</error>;
+        }
+    """)
+
+    fun `test no parameters add one parameter`() = checkFixByText("Add `i32` as `1st` parameter to function `foo`", """
+        fn foo() {}
+
+        fn main() {
+            foo<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>1/*caret*/</error>)</error>;
+        }
+    """, """
+        fn foo(i: i32) {}
+
+        fn main() {
+            foo(1);
+        }
+    """)
+
+    fun `test no parameters add multiple parameters`() = checkFixByText("<html>Change signature of foo(<b>i32</b>, <b>bool</b>)</html>", """
+        fn foo() {}
+
+        fn main() {
+            foo<error descr="This function takes 0 parameters but 2 parameters were supplied [E0061]">(<error>1/*caret*/</error>, <error>false</error>)</error>;
+        }
+    """, """
+        fn foo(i: i32, x: bool) {}
+
+        fn main() {
+            foo(1, false);
+        }
+    """)
+
+    fun `test add additional parameter same type forward`() = checkFixByText("Add `i32` as `1st` parameter to function `foo`", """
+        fn foo(a: i32) {}
+
+        fn main() {
+            foo<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(0, <error>1/*caret*/</error>)</error>;
+            foo(5);
+        }
+    """, """
+        fn foo(i: i32, a: i32) {}
+
+        fn main() {
+            foo(0, 1);
+            foo(, 5);
+        }
+    """)
+
+    fun `test add additional parameter same type backward`() = checkFixByText("Add `i32` as `2nd` parameter to function `foo`", """
+        fn foo(a: i32) {}
+
+        fn main() {
+            foo<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(0, <error>1/*caret*/</error>)</error>;
+            foo(5,);
+        }
+    """, """
+        fn foo(a: i32, i: i32) {}
+
+        fn main() {
+            foo(0, 1);
+            foo(5, );
+        }
+    """)
+
+    fun `test add additional parameter different type`() = checkFixByText("Add `bool` as `2nd` parameter to function `foo`", """
+        fn foo(a: i32) {}
+
+        fn main() {
+            foo<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(0, <error>false/*caret*/</error>)</error>;
+            foo(5);
+        }
+    """, """
+        fn foo(a: i32, x: bool) {}
+
+        fn main() {
+            foo(0, false);
+            foo(5, );
+        }
+    """)
+
+    fun `test add multiple additional parameters forward`() = checkFixByText("<html>Change signature of foo(i32, <b>bool</b>, i32, <b>i32</b>)</html>", """
+        fn foo(a: i32, b: i32) {}
+
+        fn main() {
+            foo<error descr="This function takes 2 parameters but 4 parameters were supplied [E0061]">(0, false, <error>3/*caret*/</error>, <error>4</error>)</error>;
+            foo(0, 1);
+        }
+    """, """
+        fn foo(a: i32, b0: bool, b: i32, i: i32) {}
+
+        fn main() {
+            foo(0, false, 3, 4);
+            foo(0, , 1, );
+        }
+    """)
+
+    fun `test add multiple additional parameters backward`() = checkFixByText("<html>Change signature of foo(<b>i32</b>, <b>bool</b>, i32, i32)</html>", """
+        fn foo(a: i32, b: i32) {}
+
+        fn main() {
+            foo<error descr="This function takes 2 parameters but 4 parameters were supplied [E0061]">(0, false, <error>3/*caret*/</error>, <error>4</error>)</error>;
+            foo(0, 1);
+        }
+    """, """
+        fn foo(i: i32, b0: bool, a: i32, b: i32) {}
+
+        fn main() {
+            foo(0, false, 3, 4);
+            foo(, , 0, 1);
+        }
+    """)
+
+    fun `test add parameter to method`() = checkFixByText("Add `i32` as `1st` parameter to method `foo`", """
+        struct S;
+        impl S {
+            fn foo(&self) {}
+        }
+
+        fn bar(s: S) {
+            s.foo<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>0/*caret*/</error>)</error>;
+        }
+    """, """
+        struct S;
+        impl S {
+            fn foo(&self, i: i32) {}
+        }
+
+        fn bar(s: S) {
+            s.foo(0);
+        }
+    """)
+
+    fun `test add unknown type`() = checkFixByText("Add `_` as `1st` parameter to function `foo`", """
+        fn foo() {}
+
+        fn main() {
+            foo<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>Unknown/*caret*/</error>)</error>;
+        }
+    """, """
+        fn foo(x: _) {}
+
+        fn main() {
+            foo(Unknown);
+        }
+    """)
+
+    fun `test import argument type`() = checkFixByText("Add `S` as `1st` parameter to function `bar`", """
+        mod foo {
+            pub fn bar() {}
+        }
+
+        pub struct S;
+
+        fn main() {
+            let s = S;
+            foo::bar<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>s/*caret*/</error>)</error>;
+        }
+    """, """
+        mod foo {
+            use S;
+
+            pub fn bar(s: S) {}
+        }
+
+        pub struct S;
+
+        fn main() {
+            let s = S;
+            foo::bar(s);
+        }
+    """)
+
+    fun `test do not offer on tuple struct constructors`() = checkFixIsUnavailable("Add", """
+        struct S(u32);
+
+        fn main() {
+            let s = S<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(0, <error>1/*caret*/</error>)</error>;
+        }
+    """)
+
+    fun `test suggest parameter name`() = checkFixByText("Add `i32` as `1st` parameter to function `foo`", """
+        fn foo() {}
+
+        fn main() {
+            let x = 5;
+            foo<error descr="This function takes 0 parameters but 1 parameter was supplied [E0061]">(<error>x/*caret*/</error>)</error>;
+        }
+    """, """
+        fn foo(x: i32) {}
+
+        fn main() {
+            let x = 5;
+            foo(x);
+        }
+    """)
+
+    fun `test skip existing parameter name`() = checkFixByText("Add `i32` as `2nd` parameter to function `foo`", """
+        fn foo(i: i32) {}
+
+        fn main() {
+            foo<error descr="This function takes 1 parameter but 2 parameters were supplied [E0061]">(1/*caret*/, <error>2</error>)</error>;
+        }
+    """, """
+        fn foo(i: i32, i0: i32) {}
+
+        fn main() {
+            foo(1, 2);
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveFunctionArgumentFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveFunctionArgumentFixTest.kt
@@ -8,12 +8,12 @@ package org.rust.ide.annotator.fixes
 import org.rust.ide.annotator.RsAnnotatorTestBase
 import org.rust.ide.annotator.RsErrorAnnotator
 
-class RemoveFunctionArgumentFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
-    fun `test no parameters`() = checkFixByText("Remove argument", """
+class RemoveRedundantFunctionArgumentsFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
+    fun `test no parameters`() = checkFixByText("Remove redundant arguments", """
         fn foo() {}
 
         fn main() {
-            foo(<error>1/*caret*/</error>);
+            foo<error>(<error>1/*caret*/</error>)</error>;
         }
     """, """
         fn foo() {}
@@ -23,11 +23,11 @@ class RemoveFunctionArgumentFixTest : RsAnnotatorTestBase(RsErrorAnnotator::clas
         }
     """)
 
-    fun `test single parameter`() = checkFixByText("Remove argument", """
+    fun `test single parameter`() = checkFixByText("Remove redundant arguments", """
         fn foo(a: u32) {}
 
         fn main() {
-            foo(1, <error>2/*caret*/</error>);
+            foo<error>(1, <error>2/*caret*/</error>)</error>;
         }
     """, """
         fn foo(a: u32) {}
@@ -37,42 +37,42 @@ class RemoveFunctionArgumentFixTest : RsAnnotatorTestBase(RsErrorAnnotator::clas
         }
     """)
 
-    fun `test multiple redundant arguments`() = checkFixByText("Remove argument", """
+    fun `test multiple redundant arguments 1`() = checkFixByText("Remove redundant arguments", """
         fn foo() {}
 
         fn main() {
-            foo(<error>1/*caret*/</error>, <error>2</error>);
+            foo<error>(<error>1/*caret*/</error>, <error>2</error>)</error>;
         }
     """, """
         fn foo() {}
 
         fn main() {
-            foo(2);
+            foo();
         }
     """)
 
-    fun `test keep whitespace and comments`() = checkFixByText("Remove argument", """
-        fn foo() {}
+    fun `test multiple redundant arguments 2`() = checkFixByText("Remove redundant arguments", """
+        fn foo(a: u32) {}
 
         fn main() {
-            foo(<error>1/*caret*/</error> /* there is a comment here */ );
+            foo<error>(0, <error>1/*caret*/</error>, <error>2</error>)</error>;
         }
     """, """
-        fn foo() {}
+        fn foo(a: u32) {}
 
         fn main() {
-            foo(/* there is a comment here */ );
+            foo(0);
         }
     """)
 
-    fun `test method call`() = checkFixByText("Remove argument", """
+    fun `test method call`() = checkFixByText("Remove redundant arguments", """
         struct S;
         impl S {
             fn foo(&self) {}
         }
 
         fn foo(s: S) {
-            s.foo(<error>1/*caret*/</error>);
+            s.foo<error>(<error>1/*caret*/</error>)</error>;
         }
     """, """
         struct S;
@@ -85,10 +85,10 @@ class RemoveFunctionArgumentFixTest : RsAnnotatorTestBase(RsErrorAnnotator::clas
         }
     """)
 
-    fun `test lambda`() = checkFixByText("Remove argument", """
+    fun `test lambda`() = checkFixByText("Remove redundant arguments", """
         fn main() {
             let foo = |x| x + 1;
-            foo(0, <error>1/*caret*/</error>);
+            foo<error>(0, <error>1/*caret*/</error>)</error>;
         }
     """, """
         fn main() {


### PR DESCRIPTION
This PR adds a quick fix that lets the user add new function parameters to a function from a function call, using the new Change signature refactoring. So far it only works for function and method calls and not tuple struct constructors. The behaviour of the fix is heavily inspired by a similar fix in the Kotlin plugin.
![add-parameters](https://user-images.githubusercontent.com/4539057/106059839-964ed400-60f3-11eb-973b-983495cc76fd.gif)

There are two TODOs in the code, which I'm not sure how to resolve:
- How to name parameters? `p0`, `p1`, etc.? Or continue counting from the existing parameter count? Also the fix should probably make sure that it doesn't generate collisions in parameter binding names.
- How to get the correct type reference from the argument expression type? That is especially important for import to work. I tried to use a type reference fragment, that sort-of works, but it imports the type with a wrong path. I need to somehow get from `Ty` to `RsTypeReference` that exists in the context of the target function.

Related issue: https://github.com/intellij-rust/intellij-rust/issues/6744
Fixes: https://github.com/intellij-rust/intellij-rust/issues/3582

changelog: Add quick fix to add a parameter to a function from a function call.