### PR TITLE
GRD: update 2020.3 IDE and plugin dependencies

### DIFF
--- a/clion/src/202/main/kotlin/org/rust/clion/cargo/CidrBuildConfigurationProvider.kt
+++ b/clion/src/202/main/kotlin/org/rust/clion/cargo/CidrBuildConfigurationProvider.kt
@@ -1,0 +1,8 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.cargo
+
+typealias CidrBuildConfigurationProvider = com.jetbrains.cidr.cpp.execution.build.CLionBuildConfigurationProvider

--- a/clion/src/202/main/resources/META-INF/platform-clion-only.xml
+++ b/clion/src/202/main/resources/META-INF/platform-clion-only.xml
@@ -1,2 +1,5 @@
 <idea-plugin>
+    <extensions defaultExtensionNs="clion">
+        <buildConfigurationProvider implementation="org.rust.clion.cargo.CargoBuildConfigurationProvider"/>
+    </extensions>
 </idea-plugin>

--- a/clion/src/203/main/kotlin/org/rust/clion/cargo/CidrBuildConfigurationProvider.kt
+++ b/clion/src/203/main/kotlin/org/rust/clion/cargo/CidrBuildConfigurationProvider.kt
@@ -1,0 +1,8 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.cargo
+
+typealias CidrBuildConfigurationProvider = com.jetbrains.cidr.execution.build.CidrBuildConfigurationProvider

--- a/clion/src/203/main/resources/META-INF/platform-clion-only.xml
+++ b/clion/src/203/main/resources/META-INF/platform-clion-only.xml
@@ -1,4 +1,8 @@
 <idea-plugin>
     <depends>com.intellij.cidr.base</depends>
     <depends>com.intellij.clion</depends>
+
+    <extensions defaultExtensionNs="cidr">
+        <buildConfigurationProvider implementation="org.rust.clion.cargo.CargoBuildConfigurationProvider"/>
+    </extensions>
 </idea-plugin>

--- a/clion/src/main/kotlin/org/rust/clion/cargo/CargoBuildConfigurationProvider.kt
+++ b/clion/src/main/kotlin/org/rust/clion/cargo/CargoBuildConfigurationProvider.kt
@@ -8,12 +8,11 @@ package org.rust.clion.cargo
 import com.intellij.execution.RunManager
 import com.intellij.execution.impl.RunManagerImpl
 import com.intellij.openapi.project.Project
-import com.jetbrains.cidr.cpp.execution.build.CLionBuildConfigurationProvider
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.createBuildEnvironment
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.getBuildConfiguration
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 
-class CargoBuildConfigurationProvider : CLionBuildConfigurationProvider {
+class CargoBuildConfigurationProvider : CidrBuildConfigurationProvider {
     override fun getBuildableConfigurations(project: Project): List<CLionCargoBuildConfiguration> {
         val runManager = RunManager.getInstance(project) as? RunManagerImpl ?: return emptyList()
         val configuration = runManager.selectedConfiguration?.configuration as? CargoCommandConfiguration

--- a/clion/src/main/resources/META-INF/clion-only.xml
+++ b/clion/src/main/resources/META-INF/clion-only.xml
@@ -2,10 +2,6 @@
     <xi:include href="/META-INF/platform-clion-only.xml" xpointer="xpointer(/idea-plugin/*)"/>
     <xi:include href="/META-INF/core-debugger-only.xml" xpointer="xpointer(/idea-plugin/*)"/>
 
-    <extensions defaultExtensionNs="clion">
-        <buildConfigurationProvider implementation="org.rust.clion.cargo.CargoBuildConfigurationProvider"/>
-    </extensions>
-
     <extensions defaultExtensionNs="com.intellij">
         <programRunner implementation="org.rust.clion.debugger.runconfig.RsCLionDebugRunner"/>
         <programRunner implementation="org.rust.clion.debugger.runconfig.legacy.RsCLionDebugRunnerLegacy"/>

--- a/gradle-203.properties
+++ b/gradle-203.properties
@@ -1,13 +1,13 @@
 # Existent IDE versions can be found in the following repos:
 # https://www.jetbrains.com/intellij-repository/releases/
 # https://www.jetbrains.com/intellij-repository/snapshots/
-ideaVersion=IU-2020.3.1
-clionVersion=CL-2020.3.1
+ideaVersion=IU-2020.3.2
+clionVersion=CL-2020.3.2
 
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions
-nativeDebugPluginVersion=203.6682.168
+nativeDebugPluginVersion=203.7148.57
 # https://plugins.jetbrains.com/plugin/12175-grazie/versions
-graziePluginVersion=203.5981.152
+graziePluginVersion=203.7148.20
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions
 psiViewerPluginVersion=203-SNAPSHOT
 

--- a/gradle-203.properties
+++ b/gradle-203.properties
@@ -12,5 +12,5 @@ graziePluginVersion=203.7148.20
 psiViewerPluginVersion=203-SNAPSHOT
 
 # please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
-sinceBuild=203.5784
+sinceBuild=203.7148
 untilBuild=211.*


### PR DESCRIPTION
Fixes #6752

changelog: fix `Build` action in CLion 2020.3.2