### PR TITLE
CARGO: improve project opening

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/CargoProjectOpenProcessor.kt
+++ b/src/main/kotlin/org/rust/cargo/project/CargoProjectOpenProcessor.kt
@@ -17,10 +17,13 @@ import org.rust.cargo.project.model.guessAndSetupRustProject
 import javax.swing.Icon
 
 class CargoProjectOpenProcessor : ProjectOpenProcessor() {
-    override fun getIcon(): Icon? = CargoIcons.ICON
+    override fun getIcon(): Icon = CargoIcons.ICON
     override fun getName(): String = "Cargo"
 
-    override fun canOpenProject(file: VirtualFile): Boolean = FileUtil.namesEqual(file.name, CargoConstants.MANIFEST_FILE)
+    override fun canOpenProject(file: VirtualFile): Boolean {
+        return FileUtil.namesEqual(file.name, CargoConstants.MANIFEST_FILE) ||
+            file.isDirectory && file.findChild(CargoConstants.MANIFEST_FILE) != null
+    }
 
     override fun doOpenProject(virtualFile: VirtualFile, projectToClose: Project?, forceNewFrame: Boolean): Project? {
         val basedir = if (virtualFile.isDirectory) virtualFile else virtualFile.parent

--- a/src/test/kotlin/org/rust/FileTree.kt
+++ b/src/test/kotlin/org/rust/FileTree.kt
@@ -216,17 +216,19 @@ class TestProject(
     }
 
     fun doFindElementInFile(path: String): PsiElement {
-        val vFile = root.findFileByRelativePath(path)
-            ?: error("No `$path` file in test project")
+        val vFile = file(path)
         val file = vFile.toPsiFile(project)!!
         return findElementInFile(file, "^")
     }
 
     fun psiFile(path: String): PsiFileSystemItem {
-        val vFile = root.findFileByRelativePath(path)
-            ?: error("Can't find `$path`")
+        val vFile = file(path)
         val psiManager = PsiManager.getInstance(project)
         return if (vFile.isDirectory) psiManager.findDirectory(vFile)!! else psiManager.findFile(vFile)!!
+    }
+
+    fun file(path: String): VirtualFile {
+        return root.findFileByRelativePath(path) ?: error("Can't find `$path`")
     }
 }
 

--- a/src/test/kotlin/org/rust/cargo/project/CargoProjectOpenProcessorTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/CargoProjectOpenProcessorTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.project
+
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.projectImport.ProjectOpenProcessor
+import com.intellij.testFramework.LightPlatformTestCase
+import org.rust.RsTestBase
+import org.rust.fileTree
+
+class CargoProjectOpenProcessorTest : RsTestBase() {
+
+    fun `test open project via Cargo toml file`() {
+        val testDir = fileTree {
+            dir("crate") {
+                toml("Cargo.toml", "")
+                dir("src") {
+                    rust("lib.rs", "")
+                }
+            }
+        }.create(project, LightPlatformTestCase.getSourceRoot())
+
+        val crateDir = testDir.file("crate/Cargo.toml")
+        checkFileCanBeOpenedAsProject(crateDir)
+    }
+
+    fun `test open project via directory with Cargo toml file`() {
+        val testDir = fileTree {
+            dir("crate") {
+                toml("Cargo.toml", "")
+                dir("src") {
+                    rust("lib.rs", "")
+                }
+            }
+        }.create(project, LightPlatformTestCase.getSourceRoot())
+
+        val crateDir = testDir.file("crate")
+        checkFileCanBeOpenedAsProject(crateDir)
+    }
+
+    private fun checkFileCanBeOpenedAsProject(file: VirtualFile) {
+        val processor = ProjectOpenProcessor.EXTENSION_POINT_NAME.extensionList.find { it is CargoProjectOpenProcessor }
+            ?: error("CargoProjectOpenProcessor is not registered in plugin.xml")
+        check(processor.canOpenProject(file)) {
+            "Cargo project cannot be opened via `$file`"
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/cargo/project/model/AttachCargoProjectActionTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/AttachCargoProjectActionTest.kt
@@ -59,7 +59,7 @@ class AttachCargoProjectActionTest : RsWithToolchainTestBase() {
             dir("dir", cargoProjectSupplier)
         }
 
-        val rootDir = testProject.root.findChild("dir")!!
+        val rootDir = testProject.file("dir")
         testAction(ActionPlaces.PROJECT_VIEW_POPUP, true, contextFile = rootDir)
         val cargoProject = project.cargoProjects.allProjects.find { it.rootDir == rootDir }
         assertNotNull("Failed to attach project in `$rootDir`", cargoProject)
@@ -70,7 +70,7 @@ class AttachCargoProjectActionTest : RsWithToolchainTestBase() {
             dir("dir", cargoProjectSupplier)
         }
 
-        val cargoToml = testProject.root.findFileByRelativePath("dir/Cargo.toml")!!
+        val cargoToml = testProject.file("dir/Cargo.toml")
         testAction(ActionPlaces.PROJECT_VIEW_POPUP, true, contextFile = cargoToml)
         val cargoProject = project.cargoProjects.allProjects.find { it.manifest == cargoToml.pathAsPath }
         assertNotNull("Failed to attach project via `$cargoToml` file", cargoProject)
@@ -78,7 +78,7 @@ class AttachCargoProjectActionTest : RsWithToolchainTestBase() {
 
     fun `test no action for cargo toml of existing cargo project`() {
         val testProject = buildProject(cargoProjectSupplier)
-        val cargoToml = testProject.root.findFileByRelativePath("Cargo.toml")!!
+        val cargoToml = testProject.file("Cargo.toml")
         testAction(ActionPlaces.PROJECT_VIEW_POPUP, false, contextFile = cargoToml)
     }
 
@@ -92,13 +92,13 @@ class AttachCargoProjectActionTest : RsWithToolchainTestBase() {
             dir("foo", cargoProjectSupplier)
         }
 
-        val cargoToml = testProject.root.findFileByRelativePath("foo/Cargo.toml")!!
+        val cargoToml = testProject.file("foo/Cargo.toml")
         testAction(ActionPlaces.PROJECT_VIEW_POPUP, false, contextFile = cargoToml)
     }
 
     fun `test no action for cargo toml outside of project`() {
         val libraryProject = fileTree(cargoProjectSupplier).create(project, tempDirFixture.getFile("")!!)
-        val cargoToml = libraryProject.root.findFileByRelativePath("Cargo.toml")!!
+        val cargoToml = libraryProject.file("Cargo.toml")
         testAction(ActionPlaces.PROJECT_VIEW_POPUP, false, contextFile = cargoToml)
     }
 
@@ -107,7 +107,7 @@ class AttachCargoProjectActionTest : RsWithToolchainTestBase() {
             dir("dir", cargoProjectSupplier)
         }
 
-        val cargoToml = testProject.root.findFileByRelativePath("dir/Cargo.toml")!!
+        val cargoToml = testProject.file("dir/Cargo.toml")
         testAction(CargoToolWindow.CARGO_TOOLBAR_PLACE, true, contextFile = null, mockChosenFile = cargoToml)
         val cargoProject = project.cargoProjects.allProjects.find { it.manifest == cargoToml.pathAsPath }
         assertNotNull("Failed to attach project via `$cargoToml` file", cargoProject)
@@ -118,8 +118,8 @@ class AttachCargoProjectActionTest : RsWithToolchainTestBase() {
             dir("dir", cargoProjectSupplier)
         }
 
-        val srcFile = testProject.root.findFileByRelativePath("dir/src/main.rs")!!
-        val cargoToml = testProject.root.findFileByRelativePath("dir/Cargo.toml")!!
+        val srcFile = testProject.file("dir/src/main.rs")
+        val cargoToml = testProject.file("dir/Cargo.toml")
         testAction(RsEditorNotificationPanel.NOTIFICATION_PANEL_PLACE, true, contextFile = srcFile, mockChosenFile = cargoToml)
         val cargoProject = project.cargoProjects.allProjects.find { it.manifest == cargoToml.pathAsPath }
         assertNotNull("Failed to attach project via `$srcFile` file", cargoProject)
@@ -130,7 +130,7 @@ class AttachCargoProjectActionTest : RsWithToolchainTestBase() {
             dir("dir", cargoProjectSupplier)
         }
 
-        val cargoToml = testProject.root.findFileByRelativePath("dir/Cargo.toml")!!
+        val cargoToml = testProject.file("dir/Cargo.toml")
         testAction(RsEditorNotificationPanel.NOTIFICATION_PANEL_PLACE, true, contextFile = cargoToml)
         val cargoProject = project.cargoProjects.allProjects.find { it.manifest == cargoToml.pathAsPath }
         assertNotNull("Failed to attach project via `$cargoToml` file", cargoProject)

--- a/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherIntegrationTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/impl/CargoTomlWatcherIntegrationTest.kt
@@ -61,7 +61,7 @@ class CargoTomlWatcherIntegrationTest : RsWithToolchainTestBase() {
         p.checkReferenceIsResolved<RsPath>("src/main.rs", shouldNotResolve = true)
         project.testCargoProjects.discoverAndRefreshSync()
 
-        val toml = p.root.findFileByRelativePath("Cargo.toml")!!
+        val toml = p.file("Cargo.toml")
         runWriteAction {
             VfsUtil.saveText(toml, VfsUtil.loadText(toml).replace("#", ""))
         }

--- a/src/test/kotlin/org/rust/cargo/project/model/impl/SyncToolWindowTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/impl/SyncToolWindowTest.kt
@@ -85,7 +85,7 @@ class SyncToolWindowTest : RsWithToolchainTestBase() {
             }
         }
 
-        attachCargoProject(project.root.findChild("crate2")!!)
+        attachCargoProject(project.file("crate2"))
 
         checkSyncViewTree("""
             -
@@ -132,8 +132,8 @@ class SyncToolWindowTest : RsWithToolchainTestBase() {
                 }
             }
         }
-        attachCargoProject(project.root.findChild("crate1")!!)
-        attachCargoProject(project.root.findChild("crate2")!!)
+        attachCargoProject(project.file("crate1"))
+        attachCargoProject(project.file("crate2"))
 
         checkSyncViewTree("""
             -
@@ -192,7 +192,7 @@ class SyncToolWindowTest : RsWithToolchainTestBase() {
                 }
             }
         }.create(project, cargoProjectDirectory)
-        val crateRoot = testProject.root.findChild("crate")!!
+        val crateRoot = testProject.file("crate")
         attachCargoProject(crateRoot)
         val cargoProject = project.testCargoProjects.refreshAllProjectsSync().single()
         detachCargoProject(cargoProject)

--- a/src/test/kotlin/org/rust/ide/annotator/RsWithToolchainAnnotationTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsWithToolchainAnnotationTestBase.kt
@@ -47,6 +47,6 @@ abstract class RsWithToolchainAnnotationTestBase<C> : RsWithToolchainTestBase() 
      */
     protected open fun configureProject(fileTree: FileTree, context: C?): VirtualFile {
         val testProject = fileTree.create()
-        return testProject.root.findFileByRelativePath(testProject.fileWithCaret)!!
+        return testProject.file(testProject.fileWithCaret)
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachingTest.kt
@@ -34,12 +34,12 @@ class RsMacroExpansionCachingTest : RsMacroExpansionTestBase() {
     }
 
     private fun touchFile(path: String): (TestProject) -> Unit = { p ->
-        val file = p.root.findFileByRelativePath(path)!!
+        val file = p.file(path)
         VfsUtil.saveText(file, VfsUtil.loadText(file) + " ")
     }
 
     private fun replaceInFile(path: String, find: String, replace: String): (TestProject) -> Unit = { p ->
-        val file = p.root.findFileByRelativePath(path)!!
+        val file = p.file(path)
         runWriteAction {
             VfsUtil.saveText(file, VfsUtil.loadText(file).replace(find, replace))
         }
@@ -92,7 +92,7 @@ class RsMacroExpansionCachingTest : RsMacroExpansionTestBase() {
         names: List<String>
     ) {
         val p = fileTreeFromText(code).create()
-        val file = p.root.findChild("main.rs")!!.toPsiFile(project)!! as RsFile
+        val file = p.psiFile("main.rs") as RsFile
         checkAstNotLoaded()
         val oldStamps = file.collectMacros().collectStamps()
         action(p)

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachingToolchainTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachingToolchainTest.kt
@@ -59,13 +59,13 @@ class RsMacroExpansionCachingToolchainTest : RsWithToolchainTestBase() {
 
     private fun doNothing(): (p: TestProject) -> Unit = {}
     private fun touchFile(path: String): (p: TestProject) -> Unit = { p ->
-        val file = p.root.findFileByRelativePath(path)!!
+        val file = p.file(path)
         runWriteAction {
             VfsUtil.saveText(file, VfsUtil.loadText(file) + " ")
         }
     }
     private fun replaceInFile(path: String, find: String, replace: String): (p: TestProject) -> Unit = { p ->
-        val file = p.root.findFileByRelativePath(path)!!
+        val file = p.file(path)
         runWriteAction {
             VfsUtil.saveText(file, VfsUtil.loadText(file).replace(find, replace))
         }
@@ -90,7 +90,7 @@ class RsMacroExpansionCachingToolchainTest : RsWithToolchainTestBase() {
         }.create(project, dirFixture.getFile(".")!!)
 
         attachCargoProjectAndExpandMacros(p)
-        myFixture.openFileInEditor(p.root.findFileByRelativePath("src/main.rs")!!)
+        myFixture.openFileInEditor(p.file("src/main.rs"))
         val oldStamps = myFixture.file.childrenOfType<RsMacroCall>().collectStamps()
 
         macroExpansionServiceDisposable?.let { Disposer.dispose(it) } // also save
@@ -100,7 +100,7 @@ class RsMacroExpansionCachingToolchainTest : RsWithToolchainTestBase() {
         super.setUp()
 
         attachCargoProjectAndExpandMacros(p)
-        myFixture.openFileInEditor(p.root.findFileByRelativePath("src/main.rs")!!)
+        myFixture.openFileInEditor(p.file("src/main.rs"))
         val changed = myFixture.file.childrenOfType<RsMacroCall>().collectStamps().entries
             .filter { oldStamps[it.key] != it.value }
             .map { it.key }
@@ -117,7 +117,7 @@ class RsMacroExpansionCachingToolchainTest : RsWithToolchainTestBase() {
 
     private fun attachCargoProjectAndExpandMacros(p: TestProject) {
         macroExpansionServiceDisposable = project.macroExpansionManager.setUnitTestExpansionModeAndDirectory(MacroExpansionScope.WORKSPACE, "mocked")
-        check(project.cargoProjects.attachCargoProject(p.root.findFileByRelativePath("Cargo.toml")!!.pathAsPath))
+        check(project.cargoProjects.attachCargoProject(p.file("Cargo.toml").pathAsPath))
         val future = project.cargoProjects.refreshAllProjects()
         while (!future.isDone) {
             Thread.sleep(10)

--- a/src/test/kotlin/org/rustSlowTests/CargoProjectServiceTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/CargoProjectServiceTest.kt
@@ -82,7 +82,7 @@ class CargoProjectServiceTest : RsWithToolchainTestBase() {
         }
 
         fun checkFile(relpath: String, projectName: String?) {
-            val vFile = testProject.root.findFileByRelativePath(relpath)!!
+            val vFile = testProject.file(relpath)
             val project = projects.findProjectForFile(vFile)
             if (project?.presentableName != projectName) {
                 error("Expected $projectName, found $project for $relpath")

--- a/src/test/kotlin/org/rustSlowTests/RsContentRootsTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsContentRootsTest.kt
@@ -7,7 +7,6 @@ package org.rustSlowTests
 
 import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.vfs.VirtualFile
-import org.rust.TestProject
 import org.rust.cargo.RsWithToolchainTestBase
 
 class RsContentRootsTest : RsWithToolchainTestBase() {
@@ -49,16 +48,16 @@ class RsContentRootsTest : RsWithToolchainTestBase() {
         }
 
         val projectFolders = listOf(
-            ProjectFolder.Source(project.findFile("src"), false),
-            ProjectFolder.Source(project.findFile("examples"), false),
-            ProjectFolder.Source(project.findFile("tests"), true),
-            ProjectFolder.Source(project.findFile("benches"), true),
-            ProjectFolder.Excluded(project.findFile("target")),
-            ProjectFolder.Source(project.findFile("subproject/src"), false),
-            ProjectFolder.Source(project.findFile("subproject/examples"), false),
-            ProjectFolder.Source(project.findFile("subproject/tests"), true),
-            ProjectFolder.Source(project.findFile("subproject/benches"), true),
-            ProjectFolder.Excluded(project.findFile("subproject/target"))
+            ProjectFolder.Source(project.file("src"), false),
+            ProjectFolder.Source(project.file("examples"), false),
+            ProjectFolder.Source(project.file("tests"), true),
+            ProjectFolder.Source(project.file("benches"), true),
+            ProjectFolder.Excluded(project.file("target")),
+            ProjectFolder.Source(project.file("subproject/src"), false),
+            ProjectFolder.Source(project.file("subproject/examples"), false),
+            ProjectFolder.Source(project.file("subproject/tests"), true),
+            ProjectFolder.Source(project.file("subproject/benches"), true),
+            ProjectFolder.Excluded(project.file("subproject/target"))
         )
 
         check(projectFolders)
@@ -80,9 +79,9 @@ class RsContentRootsTest : RsWithToolchainTestBase() {
         }
 
         val projectFolders = listOf(
-            ProjectFolder.Source(project.findFile("src"), false),
-            ProjectFolder.Source(project.findFile("tests"), true),
-            ProjectFolder.Excluded(project.findFile("target"))
+            ProjectFolder.Source(project.file("src"), false),
+            ProjectFolder.Source(project.file("tests"), true),
+            ProjectFolder.Excluded(project.file("target"))
         )
 
         check(projectFolders)
@@ -130,19 +129,19 @@ class RsContentRootsTest : RsWithToolchainTestBase() {
         }
 
         val projectFolders = listOf(
-            ProjectFolder.Excluded(project.findFile("target")),
+            ProjectFolder.Excluded(project.file("target")),
 
-            ProjectFolder.Source(project.findFile("package1/src"), false),
-            ProjectFolder.Source(project.findFile("package1/examples"), false),
-            ProjectFolder.Source(project.findFile("package1/tests"), true),
-            ProjectFolder.Source(project.findFile("package1/benches"), true),
-            ProjectFolder.Excluded(project.findFile("package1/target")),
+            ProjectFolder.Source(project.file("package1/src"), false),
+            ProjectFolder.Source(project.file("package1/examples"), false),
+            ProjectFolder.Source(project.file("package1/tests"), true),
+            ProjectFolder.Source(project.file("package1/benches"), true),
+            ProjectFolder.Excluded(project.file("package1/target")),
 
-            ProjectFolder.Source(project.findFile("package2/src"), false),
-            ProjectFolder.Source(project.findFile("package2/examples"), false),
-            ProjectFolder.Source(project.findFile("package2/tests"), true),
-            ProjectFolder.Source(project.findFile("package2/benches"), true),
-            ProjectFolder.Excluded(project.findFile("package2/target"))
+            ProjectFolder.Source(project.file("package2/src"), false),
+            ProjectFolder.Source(project.file("package2/examples"), false),
+            ProjectFolder.Source(project.file("package2/tests"), true),
+            ProjectFolder.Source(project.file("package2/benches"), true),
+            ProjectFolder.Excluded(project.file("package2/target"))
         )
 
         check(projectFolders)
@@ -175,9 +174,6 @@ class RsContentRootsTest : RsWithToolchainTestBase() {
             }
         }
     }
-
-    private fun TestProject.findFile(path: String): VirtualFile =
-        root.findFileByRelativePath(path) ?: error("Can't find `$path` in `$root`")
 
     private sealed class ProjectFolder {
         data class Source(val file: VirtualFile, val isTest: Boolean) : ProjectFolder()

--- a/toml/src/test/kotlin/org/rust/toml/inspections/MissingFeaturesInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/MissingFeaturesInspectionTest.kt
@@ -159,7 +159,7 @@ class MissingFeaturesInspectionTest : RsWithToolchainInspectionTestBase<Context>
             ?: error("Package ${context.pkgWithFeature} not found")
 
         project.cargoProjects.modifyFeatures(cargoProject, setOf(PackageFeature(pkg, context.featureName)), FeatureState.Disabled)
-        return testProject.root.findFileByRelativePath(context.fileToCheck)!!
+        return testProject.file(context.fileToCheck)
     }
 
     private fun doTest(

--- a/toml/src/test/kotlin/org/rust/toml/search/CargoTomlFindUsagesTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/search/CargoTomlFindUsagesTest.kt
@@ -75,8 +75,8 @@ class CargoTomlFindUsagesTest : RsWithToolchainTestBase() {
             }
             true
         }
-        val vFile = testProject.root.findFileByRelativePath(testProject.fileWithCaret)
-        val psiFile = vFile!!.toPsiFile(project)!!
+        val vFile = testProject.file(testProject.fileWithCaret)
+        val psiFile = vFile.toPsiFile(project)!!
 
         myFixture.openFileInEditor(vFile)
 


### PR DESCRIPTION
Now, `Open` action properly sets up Cargo project if the selected file is a directory contained `Cargo.toml`.
Previously, you had to open Cargo tool window to detect top-level `Cargo.toml` and load project structure

Also, in the case of several variants how to open a project, IDE suggests choosing the desired type of project a user.
Fixes https://youtrack.jetbrains.com/issue/CPP-23725

changelog: improve `File | Open` action to set up project structure of Cargo project if a project is opened via directory with `Cargo.toml`
