### PR TITLE
RES: Use old resolve in test/bench non-workspace crates

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -291,6 +291,7 @@ val RsElement.isValidProjectMember: Boolean
         return isEnabledByCfg && file.isDeeplyEnabledByCfg && file.crateRoot != null
     }
 
+/** Usually used to filter out test/bench non-workspace crates */
 fun shouldIndexFile(project: Project, file: VirtualFile): Boolean {
     val index = ProjectFileIndex.getInstance(project)
     return (index.isInContent(file) || index.isInLibrary(file))

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -341,6 +341,9 @@ private fun getModInfo(scope: RsMod): RsModInfoBase {
     if (scope is RsModItem && scope.modName == TMP_MOD_NAME) return CantUseNewResolve("__tmp__ mod")
     if (scope.isLocal) return CantUseNewResolve("local mod")
     val crate = scope.containingCrate as? CargoBasedCrate ?: return CantUseNewResolve("not CargoBasedCrate")
+    if (crate.rootModFile != null && !shouldIndexFile(project, crate.rootModFile)) {
+        return CantUseNewResolve("crate root isn't indexed")
+    }
 
     val defMap = project.getDefMap(crate) ?: return InfoNotFound
     val modData = defMap.getModData(scope) ?: return InfoNotFound


### PR DESCRIPTION
Because currently we don't build [DefMaps](https://github.com/intellij-rust/intellij-rust/issues/6217) for such crates in new resolve (for performance reasons)

changelog: Use old resolve in test/bench non-workspace crates
