### PR TITLE
ANN: Check E0116 "Inherent impls should be in same crate"

### DIFF
--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1350,11 +1350,19 @@ sealed class RsDiagnostic(
             fixes = listOf(createAddOrReplaceFeatureFix(typeReference, CONST_GENERICS, MIN_CONST_GENERICS))
         )
     }
+
+    class InherentImplDifferentCrateError(element: PsiElement) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            E0116,
+            "Cannot define inherent `impl` for a type outside of the crate where the type is defined"
+        )
+    }
 }
 
 enum class RsErrorCode {
     E0004, E0015, E0023, E0025, E0026, E0027, E0040, E0046, E0050, E0054, E0057, E0060, E0061, E0069, E0081, E0084,
-    E0106, E0107, E0118, E0120, E0121, E0124, E0132, E0133, E0184, E0185, E0186, E0198, E0199,
+    E0106, E0107, E0116, E0118, E0120, E0121, E0124, E0132, E0133, E0184, E0185, E0186, E0198, E0199,
     E0200, E0201, E0202, E0252, E0261, E0262, E0263, E0267, E0268, E0277,
     E0308, E0322, E0328, E0364, E0365, E0379, E0384,
     E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0433, E0435, E0449, E0451, E0463,

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -4009,4 +4009,22 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
 
         fn foo() -> impl FooBar {}
     """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test E0116 inherent impls should be in same crate`() = checkByFileTree("""
+    //- lib.rs
+        pub struct ForeignStruct {}
+    //- main.rs
+        /*caret*/
+        use test_package::ForeignStruct;
+
+        struct LocalStruct {}
+        type ForeignStructAlias = ForeignStruct;
+        type LocalStructAlias = LocalStruct;
+
+        impl <error descr="Cannot define inherent `impl` for a type outside of the crate where the type is defined [E0116]">ForeignStruct</error> {}
+        impl <error descr="Cannot define inherent `impl` for a type outside of the crate where the type is defined [E0116]">ForeignStructAlias</error> {}
+        impl LocalStruct {}
+        impl LocalStructAlias {}
+    """)
 }


### PR DESCRIPTION
Related: #6308, #6777, #886

changelog: Detect [E0116](https://doc.rust-lang.org/error-index.html#E0116) compiler error
