### PR TITLE
Fix control flow of break/continue inside block expression

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/dfa/CFGBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/CFGBuilder.kt
@@ -28,7 +28,7 @@ class CFGBuilder(
 ) : RsVisitor() {
     data class BlockScope(val blockExpr: RsBlockExpr, val breakNode: CFGNode)
 
-    data class LoopScope(val loop: RsLabeledExpression, val continueNode: CFGNode, val breakNode: CFGNode)
+    data class LoopScope(val loop: RsLooplikeExpr, val continueNode: CFGNode, val breakNode: CFGNode)
 
     enum class ScopeCFKind {
         Break, Continue;
@@ -135,7 +135,7 @@ class CFGBuilder(
             }
         } else {
             // otherwise, try to find the corresponding loop
-            val exprBlock = expr.ancestors.filterIsInstance<RsLabeledExpression>().firstOrNull()?.block
+            val exprBlock = expr.ancestors.filterIsInstance<RsLooplikeExpr>().firstOrNull()?.block
 
             for ((loop, continueNode, breakNode) in loopScopes) {
                 if (loop.block == exprBlock) {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsLivenessInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsLivenessInspectionTest.kt
@@ -803,4 +803,16 @@ class RsLivenessInspectionTest : RsInspectionsTestBase(RsLivenessInspection::cla
             a;
         }
     """)
+
+    fun `test use after loop with break inside block expr`() = checkByText("""
+        fn main() {
+            let x = 1;
+            loop {
+                {
+                    break;
+                }
+            }
+            x;
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/dfa/RsControlFlowGraphTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/dfa/RsControlFlowGraphTest.kt
@@ -998,6 +998,28 @@ class RsControlFlowGraphTest : RsTestBase() {
         Exit
     """)
 
+    fun `test loop with break inside block expr`() = testCFG("""
+        fn main() {
+            loop {
+                {
+                    break;
+                }
+            }
+            1;
+        }
+    """, """
+        Entry
+        Dummy
+        break
+        LOOP
+        LOOP;
+        1
+        1;
+        BLOCK
+        Exit
+        Termination
+    """)
+
     private fun testCFG(@Language("Rust") code: String, expectedIndented: String) {
         InlineFile(code)
         val function = myFixture.file.descendantsOfType<RsFunction>().firstOrNull() ?: return


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/6781

changelog: Fix processing of `break`/`continue` inside block expression during control-flow analysis