### PR TITLE
CI: drop builds for 202 platform and start building for 211 by release workflow

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -171,7 +171,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                platform-version: [ 202, 203 ]
+                platform-version: [ 203, 211 ]
         env:
             ORG_GRADLE_PROJECT_buildNumber: ${{ needs.generate-build-number.outputs.build_number }}
             ORG_GRADLE_PROJECT_platformVersion: ${{ matrix.platform-version }}


### PR DESCRIPTION
bors r+