### PR TITLE
T: Replace `@IgnoreInNewResolve` with `@UseOldResolve`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefMapService.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefMapService.kt
@@ -321,10 +321,10 @@ class DefMapService(val project: Project) : Disposable {
 
     companion object {
         @TestOnly
-        fun setUseNewResolve(project: Project, disposable: Disposable) {
+        fun setNewResolveEnabled(project: Project, disposable: Disposable, value: Boolean) {
             check(isUnitTestMode)
             project.rustSettings.modifyTemporary(disposable) {
-                it.newResolveEnabled = true
+                it.newResolveEnabled = value
             }
         }
     }

--- a/src/test/kotlin/org/rust/NewResolve.kt
+++ b/src/test/kotlin/org/rust/NewResolve.kt
@@ -5,8 +5,12 @@
 
 package org.rust
 
+import com.intellij.findAnnotationInstance
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import com.intellij.openapiext.TestmarkPred
+import junit.framework.TestCase
+import org.rust.lang.core.resolve2.DefMapService
 import org.rust.lang.core.resolve2.isNewResolveEnabled
 
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
@@ -15,7 +19,7 @@ annotation class UseNewResolve
 
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class IgnoreInNewResolve
+annotation class UseOldResolve
 
 fun TestmarkPred.ignoreInNewResolve(project: Project): TestmarkPred {
     if (!project.isNewResolveEnabled) return this
@@ -23,5 +27,14 @@ fun TestmarkPred.ignoreInNewResolve(project: Project): TestmarkPred {
         override fun <T> checkHit(f: () -> T): T = f()
 
         override fun <T> checkNotHit(f: () -> T): T = f()
+    }
+}
+
+fun TestCase.setupResolveEngine(project: Project, testRootDisposable: Disposable) {
+    findAnnotationInstance<UseNewResolve>()?.let {
+        DefMapService.setNewResolveEnabled(project, testRootDisposable, true)
+    }
+    findAnnotationInstance<UseOldResolve>()?.let {
+        DefMapService.setNewResolveEnabled(project, testRootDisposable, false)
     }
 }

--- a/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
+++ b/src/test/kotlin/org/rust/cargo/RsWithToolchainTestBase.kt
@@ -48,7 +48,7 @@ abstract class RsWithToolchainTestBase : CodeInsightFixtureTestCase<ModuleFixtur
     }
 
     override fun runTestRunnable(testRunnable: ThrowableRunnable<Throwable>) {
-        val skipReason = rustupFixture.skipTestReason ?: getIgnoredInNewResolveReason(project)
+        val skipReason = rustupFixture.skipTestReason
         if (skipReason != null) {
             System.err.println("SKIP \"$name\": $skipReason")
             return
@@ -77,6 +77,7 @@ abstract class RsWithToolchainTestBase : CodeInsightFixtureTestCase<ModuleFixtur
         if (disableMissedCacheAssertions) {
             RecursionManager.disableMissedCacheAssertions(testRootDisposable)
         }
+        setupResolveEngine(project, testRootDisposable)
     }
 
     override fun tearDown() {

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -3765,7 +3765,7 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         type Foo = i32;
     """)
 
-    @IgnoreInNewResolve
+    @UseOldResolve
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test custom inline proc macro attr and disable cfg`() = checkByFileTree("""
     //- dep-proc-macro/lib.rs

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -989,7 +989,6 @@ class RsCompletionTest : RsCompletionTestBase() {
         pub use foo::st/*caret*/
     """)
 
-    @IgnoreInNewResolve
     @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
     fun `test no std completion`() = checkNoCompletion("""
         extern crate dep_lib_target;

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallReferenceDelegationTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallReferenceDelegationTest.kt
@@ -6,7 +6,7 @@
 package org.rust.lang.core.macros
 
 import org.rust.ExpandMacros
-import org.rust.IgnoreInNewResolve
+import org.rust.UseOldResolve
 import org.rust.lang.core.resolve.RsResolveTestBase
 import org.rust.lang.core.resolve.ref.RsMacroBodyReferenceDelegateImpl.Testmarks
 
@@ -41,7 +41,7 @@ class RsMacroCallReferenceDelegationTest : RsResolveTestBase() {
         }              //^
     """, Testmarks.touched)
 
-    @IgnoreInNewResolve
+    @UseOldResolve
     fun `test type context`() = checkByCode("""
         struct X;
              //X

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -71,7 +71,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @IgnoreInNewResolve
+    @UseOldResolve
     fun `test duplicated macro_export macro`() = stubOnlyResolve("""
     //- main.rs
         #[macro_use]
@@ -742,7 +742,7 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @IgnoreInNewResolve
+    @UseOldResolve
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test ambiguity of extern crate alias and other item with the same name`() {
         stubOnlyResolve("""

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsUseResolveTest.kt
@@ -5,9 +5,9 @@
 
 package org.rust.lang.core.resolve
 
-import org.rust.IgnoreInNewResolve
 import org.rust.MockEdition
 import org.rust.UseNewResolve
+import org.rust.UseOldResolve
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.stdext.BothEditions
 
@@ -225,12 +225,11 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @IgnoreInNewResolve
     fun `test wildcard`() = checkByCode("""
         mod a {
-            fn foo() {}
-              //X
-            fn bar() {}
+            pub fn foo() {}
+                 //X
+            pub fn bar() {}
         }
 
         mod b {
@@ -502,7 +501,7 @@ class RsUseResolveTest : RsResolveTestBase() {
         }
     """)
 
-    @IgnoreInNewResolve
+    @UseOldResolve
     fun `test star imports do not leak`() = checkByCode("""
         fn foo() {}
         mod m {
@@ -776,7 +775,7 @@ class RsUseResolveTest : RsResolveTestBase() {
         }          //^
     """)
 
-    @IgnoreInNewResolve
+    @UseOldResolve
     @MockEdition(Edition.EDITION_2018)
     fun `test usual import overrides glob import`() = checkByCode("""
         mod foo1 {

--- a/src/test/kotlin/org/rustPerformanceTests/RsProfileBuildDefMapTest.kt
+++ b/src/test/kotlin/org/rustPerformanceTests/RsProfileBuildDefMapTest.kt
@@ -5,9 +5,10 @@
 
 package org.rustPerformanceTests
 
-import org.rust.lang.core.resolve2.DefMapService
+import org.rust.UseNewResolve
 import org.rust.lang.core.resolve2.forceRebuildDefMapForAllCrates
 
+@UseNewResolve
 class RsProfileBuildDefMapTest : RsPerformanceTestBase() {
 
     fun `test rustc`() = doTest(RUSTC)
@@ -23,7 +24,6 @@ class RsProfileBuildDefMapTest : RsPerformanceTestBase() {
     fun `test juniper`() = doTest(JUNIPER)
 
     private fun doTest(info: RealProjectInfo) {
-        DefMapService.setUseNewResolve(project, testRootDisposable)
         openProject(info)
         profile("buildDefMap") {
             project.forceRebuildDefMapForAllCrates(multithread = false)

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoGeneratedItemsResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoGeneratedItemsResolveTest.kt
@@ -8,8 +8,8 @@ package org.rustSlowTests.lang.resolve
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl
-import org.rust.IgnoreInNewResolve
 import org.rust.MinRustcVersion
+import org.rust.UseOldResolve
 import org.rust.cargo.toolchain.tools.Cargo
 import org.rust.fileTree
 import org.rust.ide.experiments.RsExperiments
@@ -17,7 +17,6 @@ import org.rust.lang.core.psi.RsPath
 import org.rust.openapiext.runWithEnabledFeature
 import org.rustSlowTests.cargo.runconfig.RunConfigurationTestBase
 
-@IgnoreInNewResolve
 class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
 
     private val tempDirFixture = TempDirTestFixtureImpl()
@@ -36,6 +35,7 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
     // because it leads to too long path and compilation of test rust project fails on Windows
     override fun shouldContainTempFiles(): Boolean = false
 
+    @UseOldResolve
     @MinRustcVersion("1.48.0")
     fun `test include in workspace project`() = withEnabledFetchOutDirFeature {
         val testProject = buildProject {
@@ -82,6 +82,7 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
     }
 
     // https://github.com/intellij-rust/intellij-rust/issues/4579
+    @UseOldResolve
     @MinRustcVersion("1.48.0")
     fun `test do not overflow stack 1`() = withEnabledFetchOutDirFeature {
         val testProject = buildProject {
@@ -128,6 +129,7 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
     }
 
     // https://github.com/intellij-rust/intellij-rust/issues/4579
+    @UseOldResolve
     @MinRustcVersion("1.48.0")
     fun `test do not overflow stack 2`() = withEnabledFetchOutDirFeature {
         val testProject = buildProject {
@@ -207,6 +209,7 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
         }
     }
 
+    @UseOldResolve
     @MinRustcVersion("1.48.0")
     fun `test include in dependency`() = withEnabledFetchOutDirFeature {
         val testProject = buildProject {


### PR DESCRIPTION
As a consequence of #6731, [new resolve](https://github.com/intellij-rust/intellij-rust/issues/6217) was enabled by default on CI and for local development. There are few tests which are currently not supported by new resolve, so it makes sense to force use old resolve for them (instead of ignoring them in new resolve)