### PR TITLE
CI: Retry failed tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,7 @@ plugins {
     id("org.jetbrains.intellij") version "0.6.3"
     id("org.jetbrains.grammarkit") version "2020.2.1"
     id("net.saliman.properties") version "1.5.1"
+    id("org.gradle.test-retry") version "1.2.0"
 }
 
 idea {
@@ -67,6 +68,7 @@ allprojects {
         plugin("kotlin")
         plugin("org.jetbrains.grammarkit")
         plugin("org.jetbrains.intellij")
+        plugin("org.gradle.test-retry")
     }
 
     repositories {
@@ -113,6 +115,12 @@ allprojects {
 
         test {
             testLogging.showStandardStreams = prop("showStandardStreams").toBoolean()
+            if (CI) {
+                retry {
+                    maxRetries.set(3)
+                    maxFailures.set(5)
+                }
+            }
         }
 
         val compileNativeCode = task<Exec>("compileNativeCode") {


### PR DESCRIPTION
Failed test will be retried at most 3 times. This is needed to mitigate flaky tests. If there are more then 20 failed test, no test will be retried. Implemented by [`test-retry-gradle-plugin`](https://github.com/gradle/test-retry-gradle-plugin).