### PR TITLE
TOML: add CrateVersionInvalidInspection

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt
@@ -15,8 +15,6 @@ import org.rust.ide.icons.RsIcons
 import org.rust.ide.lineMarkers.RsLineMarkerInfoUtils
 import org.rust.lang.core.psi.ext.elementType
 import org.toml.lang.psi.*
-import org.toml.lang.psi.ext.TomlLiteralKind
-import org.toml.lang.psi.ext.kind
 
 class CargoCrateDocLineMarkerProvider : LineMarkerProvider {
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? = null
@@ -81,10 +79,4 @@ private val TomlKeyValue.version: String?
             is TomlInlineTable -> value.entries.find { it.name == "version" }?.value?.stringValue
             else -> null
         }
-    }
-
-private val TomlValue.stringValue: String?
-    get() {
-        val kind = (this as? TomlLiteral)?.kind
-        return (kind as? TomlLiteralKind.String)?.value
     }

--- a/toml/src/main/kotlin/org/rust/toml/Util.kt
+++ b/toml/src/main/kotlin/org/rust/toml/Util.kt
@@ -24,6 +24,8 @@ import org.rust.lang.core.psi.ext.findCargoPackage
 import org.rust.lang.core.psi.ext.isAncestorOf
 import org.rust.openapiext.toPsiFile
 import org.toml.lang.psi.*
+import org.toml.lang.psi.ext.TomlLiteralKind
+import org.toml.lang.psi.ext.kind
 import kotlin.reflect.KProperty
 
 
@@ -180,4 +182,10 @@ val TomlValue.containingDependencyKey: TomlKeySegment?
             // foo = { ... }
             (parentParent.parent as? TomlKeyValue)?.key?.segments?.singleOrNull()
         }
+    }
+
+val TomlValue.stringValue: String?
+    get() {
+        val kind = (this as? TomlLiteral)?.kind
+        return (kind as? TomlLiteralKind.String)?.value
     }

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CrateVersionRequirement.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CrateVersionRequirement.kt
@@ -1,0 +1,74 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.crates.local
+
+import com.vdurmont.semver4j.Requirement
+import com.vdurmont.semver4j.Semver
+import com.vdurmont.semver4j.SemverException
+
+class CrateVersionRequirement private constructor(private val requirements: List<Requirement>) {
+    fun matches(version: Semver): Boolean = requirements.all {
+        it.isSatisfiedBy(version)
+    }
+
+    companion object {
+        fun build(text: String): CrateVersionRequirement? {
+            val requirements = text.split(",").map { it.trim() }
+            if (requirements.size > 1 && requirements.any { it.isEmpty() }) return null
+
+            val parsed = requirements.mapNotNull {
+                try {
+                    Requirement.buildNPM(normalizeVersion(it))
+                } catch (e: Exception) {
+                    return@mapNotNull null
+                }
+            }
+            if (parsed.size != requirements.size) return null
+
+            return CrateVersionRequirement(parsed)
+        }
+    }
+}
+
+/**
+ * Normalizes crate version requirements so that they are compatible with semver4j.
+ *
+ * 1) For exact (=x.y.z) and range-based (>x.y.z, <x.y.z) version requirements, the version requirement is padded by
+ * zeros from the right side.
+ *
+ *      Example:
+ *      - `=1` turns into `=1.0.0`
+ *      - `>2.3` turns into `>2.3.0`
+ *
+ * 2) For "compatible" version requirements (x.y.z) that do not contain a wildcard (*), a caret is added to the
+ * beginning. This matches the behaviour of Cargo.
+ *
+ *      Example:
+ *      - `1.2.3` turns into `^1.2.3`
+ *
+ * See [Cargo Reference](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio).
+ */
+private fun normalizeVersion(version: String): String {
+    if (version.isBlank()) return version
+
+    // Exact and range-based version requirements need to be padded from right by zeros.
+    // Otherwise (if minor and/or patch version is missing), semver4j will match the requirement in a different way
+    // than Cargo.
+    var normalized = version
+    if (normalized[0] in listOf('<', '>', '=')) {
+        while (normalized.count { it == '.' } < 2) {
+            normalized += ".0"
+        }
+    }
+
+    // Cargo treats version requirements like `1.2.3` as if they had a caret at the beginning.
+    // If the version begins with a digit and it does not contain a wildcard, we thus prepend a caret to it.
+    return if (normalized[0].isDigit() && !normalized.contains("*")) {
+        "^$normalized"
+    } else {
+        normalized
+    }
+}

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CargoDependencyCrateVisitor.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CargoDependencyCrateVisitor.kt
@@ -5,6 +5,7 @@
 
 package org.rust.toml.inspections
 
+import org.rust.stdext.intersects
 import org.rust.toml.isDependencyKey
 import org.rust.toml.stringValue
 import org.toml.lang.psi.*
@@ -61,12 +62,7 @@ data class DependencyCrate(
     /**
      * Is this crate from another source than crates.io?
      */
-    fun isForeign(): Boolean {
-        for (property in FOREIGN_PROPERTIES) {
-            if (property in properties) return true
-        }
-        return false
-    }
+    fun isForeign(): Boolean = properties.keys.intersects(FOREIGN_PROPERTIES)
 
     companion object {
         private val FOREIGN_PROPERTIES = listOf("git", "path", "registry")

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CargoDependencyCrateVisitor.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CargoDependencyCrateVisitor.kt
@@ -1,0 +1,126 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import org.rust.toml.isDependencyKey
+import org.rust.toml.stringValue
+import org.toml.lang.psi.*
+import org.toml.lang.psi.ext.TomlLiteralKind
+import org.toml.lang.psi.ext.kind
+import org.toml.lang.psi.ext.name
+
+abstract class CargoDependencyCrateVisitor: TomlVisitor() {
+    abstract fun visitDependency(dependency: DependencyCrate)
+
+    override fun visitKeyValue(element: TomlKeyValue) {
+        val table = element.parent as? TomlTable ?: return
+        val depTable = DependencyTable.fromTomlTable(table) ?: return
+        if (depTable !is DependencyTable.General) return
+
+        val segment = element.key.segments.firstOrNull() ?: return
+        val name = segment.name ?: return
+        val value = element.value ?: return
+        if (value is TomlLiteral && value.kind is TomlLiteralKind.String) {
+            visitDependency(DependencyCrate(name, segment, mapOf("version" to value)))
+        } else if (value is TomlInlineTable) {
+            val pkg = value.getPackageKeyValue()
+            val (originalNameElement, originalName) = when {
+                pkg != null -> pkg.value to pkg.value?.stringValue
+                else -> segment to name
+            }
+            if (originalName != null && originalNameElement != null) {
+                visitDependency(DependencyCrate(originalName, originalNameElement, collectProperties(value)))
+            }
+        }
+    }
+
+    override fun visitTable(element: TomlTable) {
+        val depTable = DependencyTable.fromTomlTable(element) ?: return
+        if (depTable !is DependencyTable.Specific) return
+
+        visitDependency(DependencyCrate(depTable.crateName, depTable.crateNameElement, collectProperties(element)))
+    }
+}
+
+private fun collectProperties(owner: TomlKeyValueOwner): Map<String, TomlValue> {
+    return owner.entries.mapNotNull {
+        val name = it.key.name ?: return@mapNotNull null
+        val value = it.value ?: return@mapNotNull null
+        name to value
+    }.toMap()
+}
+
+data class DependencyCrate(
+    val crateName: String,
+    val crateNameElement: TomlElement,
+    val properties: Map<String, TomlValue>
+) {
+    /**
+     * Is this crate from another source than crates.io?
+     */
+    fun isForeign(): Boolean {
+        for (property in FOREIGN_PROPERTIES) {
+            if (property in properties) return true
+        }
+        return false
+    }
+
+    companion object {
+        private val FOREIGN_PROPERTIES = listOf("git", "path", "registry")
+    }
+}
+
+private sealed class DependencyTable {
+    object General : DependencyTable()
+    data class Specific(val crateName: String, val crateNameElement: TomlElement) : DependencyTable()
+
+    companion object {
+        fun fromTomlTable(table: TomlTable): DependencyTable? {
+            val key = table.header.key ?: return null
+            val segments = key.segments
+            val dependencyNameIndex = segments.indexOfFirst { it.isDependencyKey }
+
+            return when {
+                // [dependencies], [x86.dev-dependencies], etc.
+                dependencyNameIndex == segments.lastIndex -> General
+                // [dependencies.crate]
+                dependencyNameIndex != -1 -> {
+                    val pkg = table.getPackageKeyValue()
+                    val (nameElement, name) = when {
+                        pkg != null -> pkg.value to pkg.value?.stringValue
+                        else -> {
+                            val segment = segments.getOrNull(dependencyNameIndex + 1)
+                            segment to segment?.name
+                        }
+                    }
+
+                    if (nameElement != null && name != null) {
+                        Specific(name, nameElement)
+                    } else {
+                        null
+                    }
+                }
+                else -> null
+            }
+        }
+    }
+}
+
+/**
+ * Return the `package` key from a table, if present.
+ * Example:
+ *
+ * ```
+ * [dependencies.foo]
+ * <selection>package = "bar"</selection>
+ *
+ * [dependencies]
+ * foo = { <selection>package = "bar"</selection> }
+ * ```
+ */
+private fun TomlKeyValueOwner.getPackageKeyValue(): TomlKeyValue? = entries.firstOrNull {
+    it.key.segments.firstOrNull()?.name == "package"
+}

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CargoTomlCyclicFeatureInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CargoTomlCyclicFeatureInspection.kt
@@ -7,7 +7,6 @@ package org.rust.toml.inspections
 
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElementVisitor
-import org.rust.cargo.CargoConstants
 import org.rust.toml.isFeatureListHeader
 import org.toml.lang.psi.*
 import org.toml.lang.psi.ext.TomlLiteralKind
@@ -21,10 +20,8 @@ import org.toml.lang.psi.ext.kind
  *       #^ Shows error that "foo" feature depends on itself
  * ```
  */
-class CargoTomlCyclicFeatureInspection : TomlLocalInspectionToolBase() {
-    override fun buildVisitorInternal(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor? {
-        if (holder.file.name != CargoConstants.MANIFEST_FILE) return null
-
+class CargoTomlCyclicFeatureInspection : CargoTomlInspectionToolBase() {
+    override fun buildCargoTomlVisitor(holder: ProblemsHolder): PsiElementVisitor {
         return object : TomlVisitor() {
             override fun visitLiteral(element: TomlLiteral) {
                 val parentArray = element.parent as? TomlArray ?: return

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CargoTomlCyclicFeatureInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CargoTomlCyclicFeatureInspection.kt
@@ -6,7 +6,6 @@
 package org.rust.toml.inspections
 
 import com.intellij.codeInspection.ProblemsHolder
-import com.intellij.psi.PsiElementVisitor
 import org.rust.toml.isFeatureListHeader
 import org.toml.lang.psi.*
 import org.toml.lang.psi.ext.TomlLiteralKind
@@ -21,7 +20,7 @@ import org.toml.lang.psi.ext.kind
  * ```
  */
 class CargoTomlCyclicFeatureInspection : CargoTomlInspectionToolBase() {
-    override fun buildCargoTomlVisitor(holder: ProblemsHolder): PsiElementVisitor {
+    override fun buildCargoTomlVisitor(holder: ProblemsHolder): TomlVisitor {
         return object : TomlVisitor() {
             override fun visitLiteral(element: TomlLiteral) {
                 val parentArray = element.parent as? TomlArray ?: return

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CargoTomlInspectionToolBase.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CargoTomlInspectionToolBase.kt
@@ -1,0 +1,29 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import org.rust.cargo.CargoConstants
+import org.rust.ide.experiments.RsExperiments
+import org.rust.openapiext.isFeatureEnabled
+
+abstract class CargoTomlInspectionToolBase : TomlLocalInspectionToolBase() {
+    open val requiresLocalCrateIndex: Boolean = false
+
+    abstract fun buildCargoTomlVisitor(holder: ProblemsHolder): PsiElementVisitor?
+
+    override fun buildVisitorInternal(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor? {
+        if (requiresLocalCrateIndex && !isFeatureEnabled(RsExperiments.CRATES_LOCAL_INDEX)) {
+            return super.buildVisitor(holder, isOnTheFly)
+        }
+        return if (holder.file.name != CargoConstants.MANIFEST_FILE) {
+            super.buildVisitor(holder, isOnTheFly)
+        } else {
+            buildCargoTomlVisitor(holder)
+        }
+    }
+}

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CargoTomlInspectionToolBase.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CargoTomlInspectionToolBase.kt
@@ -10,20 +10,18 @@ import com.intellij.psi.PsiElementVisitor
 import org.rust.cargo.CargoConstants
 import org.rust.ide.experiments.RsExperiments
 import org.rust.openapiext.isFeatureEnabled
+import org.toml.lang.psi.TomlVisitor
 
 abstract class CargoTomlInspectionToolBase : TomlLocalInspectionToolBase() {
     open val requiresLocalCrateIndex: Boolean = false
 
-    abstract fun buildCargoTomlVisitor(holder: ProblemsHolder): PsiElementVisitor?
+    abstract fun buildCargoTomlVisitor(holder: ProblemsHolder): TomlVisitor
 
     override fun buildVisitorInternal(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor? {
-        if (requiresLocalCrateIndex && !isFeatureEnabled(RsExperiments.CRATES_LOCAL_INDEX)) {
-            return super.buildVisitor(holder, isOnTheFly)
-        }
-        return if (holder.file.name != CargoConstants.MANIFEST_FILE) {
-            super.buildVisitor(holder, isOnTheFly)
-        } else {
-            buildCargoTomlVisitor(holder)
+        return when {
+            requiresLocalCrateIndex && !isFeatureEnabled(RsExperiments.CRATES_LOCAL_INDEX) -> null
+            holder.file.name != CargoConstants.MANIFEST_FILE -> null
+            else -> buildCargoTomlVisitor(holder)
         }
     }
 }

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CrateNotFoundInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CrateNotFoundInspection.kt
@@ -12,101 +12,24 @@ import org.rust.ide.experiments.RsExperiments
 import org.rust.openapiext.isFeatureEnabled
 import org.rust.toml.crates.local.CratesLocalIndexException
 import org.rust.toml.crates.local.CratesLocalIndexService
-import org.rust.toml.isDependencyKey
-import org.toml.lang.psi.*
-import org.toml.lang.psi.ext.TomlLiteralKind
-import org.toml.lang.psi.ext.kind
-import org.toml.lang.psi.ext.name
 
 class CrateNotFoundInspection : CargoTomlInspectionToolBase() {
-    override val requiresLocalCrateIndex: Boolean = true
+    override val requiresLocalCrateIndex = true
 
-    override fun buildCargoTomlVisitor(holder: ProblemsHolder): PsiElementVisitor = object : TomlVisitor() {
-        override fun visitKeyValue(element: TomlKeyValue) {
-            val table = element.parent as? TomlTable ?: return
-            val depTable = DependencyTable.fromTomlTable(table) ?: return
-            if (depTable !is DependencyTable.General) return
+    override fun buildCargoTomlVisitor(holder: ProblemsHolder): PsiElementVisitor {
+        return object : CargoDependencyCrateVisitor() {
+            override fun visitDependency(dependency: DependencyCrate) {
+                if (dependency.isForeign()) return
 
-            val segment = element.key.segments.getOrNull(0) ?: return
-            val name = segment.name ?: return
-            val value = element.value ?: return
-            if (value is TomlLiteral && value.kind is TomlLiteralKind.String) {
-                handleDependency(DependencyCrate(name, segment, mapOf("version" to value)), holder)
-            } else if (value is TomlInlineTable) {
-                handleDependency(DependencyCrate(name, segment, collectProperties(value)), holder)
-            }
-        }
-
-        override fun visitTable(element: TomlTable) {
-            val depTable = DependencyTable.fromTomlTable(element) ?: return
-            if (depTable !is DependencyTable.Specific) return
-
-            handleDependency(
-                DependencyCrate(depTable.crateName, depTable.crateNameElement, collectProperties(element)), holder
-            )
-        }
-    }
-
-    private fun handleDependency(dependency: DependencyCrate, holder: ProblemsHolder) {
-        // Do not check local, custom or git crates
-        for (property in IGNORED_PROPERTIES) {
-            if (property in dependency.properties) return
-        }
-
-        val crate = try {
-            CratesLocalIndexService.getInstance().getCrate(dependency.crateName)
-        } catch (e: CratesLocalIndexException) {
-            return
-        }
-
-        if (crate == null) {
-            holder.registerProblem(dependency.crateNameElement, "Crate ${dependency.crateName} not found")
-        }
-    }
-
-    companion object {
-        private val IGNORED_PROPERTIES = listOf("git", "path", "registry")
-    }
-}
-
-private fun collectProperties(owner: TomlKeyValueOwner): Map<String, TomlValue> {
-    return owner.entries.mapNotNull {
-        val name = it.key.name ?: return@mapNotNull null
-        val value = it.value ?: return@mapNotNull null
-        name to value
-    }.toMap()
-}
-
-private data class DependencyCrate(
-    val crateName: String,
-    val crateNameElement: TomlKeySegment,
-    val properties: Map<String, TomlValue>
-)
-
-private sealed class DependencyTable {
-    object General : DependencyTable()
-    data class Specific(val crateName: String, val crateNameElement: TomlKeySegment) : DependencyTable()
-
-    companion object {
-        fun fromTomlTable(table: TomlTable): DependencyTable? {
-            val key = table.header.key ?: return null
-            val segments = key.segments
-            val dependencyNameIndex = segments.indexOfFirst { it.isDependencyKey }
-
-            return when {
-                // [dependencies], [x86.dev-dependencies], etc.
-                dependencyNameIndex == segments.lastIndex -> General
-                // [dependencies.crate]
-                dependencyNameIndex != -1 -> {
-                    val crate = segments.getOrNull(dependencyNameIndex + 1)
-                    val crateName = crate?.name
-                    if (crate != null && crateName != null) {
-                        Specific(crateName, crate)
-                    } else {
-                        null
-                    }
+                val crate = try {
+                    CratesLocalIndexService.getInstance().getCrate(dependency.crateName)
+                } catch (e: CratesLocalIndexException) {
+                    return
                 }
-                else -> null
+
+                if (crate == null) {
+                    holder.registerProblem(dependency.crateNameElement, "Crate ${dependency.crateName} not found")
+                }
             }
         }
     }

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CrateNotFoundInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CrateNotFoundInspection.kt
@@ -6,29 +6,27 @@
 package org.rust.toml.inspections
 
 import com.intellij.codeInspection.ProblemsHolder
-import com.intellij.psi.PsiElementVisitor
-import org.rust.cargo.CargoConstants
-import org.rust.ide.experiments.RsExperiments
-import org.rust.openapiext.isFeatureEnabled
 import org.rust.toml.crates.local.CratesLocalIndexException
 import org.rust.toml.crates.local.CratesLocalIndexService
+import org.toml.lang.psi.TomlVisitor
 
 class CrateNotFoundInspection : CargoTomlInspectionToolBase() {
-    override val requiresLocalCrateIndex = true
+    override val requiresLocalCrateIndex: Boolean = true
 
-    override fun buildCargoTomlVisitor(holder: ProblemsHolder): PsiElementVisitor {
+    override fun buildCargoTomlVisitor(holder: ProblemsHolder): TomlVisitor {
         return object : CargoDependencyCrateVisitor() {
             override fun visitDependency(dependency: DependencyCrate) {
                 if (dependency.isForeign()) return
 
+                val crateName = dependency.crateName
                 val crate = try {
-                    CratesLocalIndexService.getInstance().getCrate(dependency.crateName)
+                    CratesLocalIndexService.getInstance().getCrate(crateName)
                 } catch (e: CratesLocalIndexException) {
                     return
                 }
 
                 if (crate == null) {
-                    holder.registerProblem(dependency.crateNameElement, "Crate ${dependency.crateName} not found")
+                    holder.registerProblem(dependency.crateNameElement, "Crate $crateName not found")
                 }
             }
         }

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CrateVersionInvalidInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CrateVersionInvalidInspection.kt
@@ -1,0 +1,56 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import org.rust.toml.crates.local.CrateVersionRequirement
+import org.rust.toml.crates.local.CratesLocalIndexException
+import org.rust.toml.crates.local.CratesLocalIndexService
+import org.rust.toml.stringValue
+import org.toml.lang.psi.TomlVisitor
+
+class CrateVersionInvalidInspection : CargoTomlInspectionToolBase() {
+    override val requiresLocalCrateIndex: Boolean = true
+
+    override fun buildCargoTomlVisitor(holder: ProblemsHolder): TomlVisitor {
+        return object : CargoDependencyCrateVisitor() {
+            override fun visitDependency(dependency: DependencyCrate) {
+                if (dependency.isForeign()) return
+
+                val crate = try {
+                    CratesLocalIndexService.getInstance().getCrate(dependency.crateName) ?: return
+                } catch (e: CratesLocalIndexException) {
+                    return
+                }
+
+                val versionElement = dependency.properties["version"] ?: return
+                val versionText = versionElement.stringValue ?: return
+
+                val versionReq = CrateVersionRequirement.build(versionText)
+                if (versionReq == null) {
+                    holder.registerProblem(
+                        versionElement,
+                        "Invalid version requirement $versionText",
+                        ProblemHighlightType.WEAK_WARNING
+                    )
+                    return
+                }
+
+                val compatibleVersions = crate.versions.filter {
+                    val version = it.semanticVersion ?: return@filter false
+                    versionReq.matches(version)
+                }
+
+                if (compatibleVersions.isEmpty()) {
+                    holder.registerProblem(versionElement, "No version matching $versionText found for crate ${dependency.crateName}")
+                } else if (compatibleVersions.all { it.isYanked }) {
+                    holder.registerProblem(versionElement, "All versions matching $versionText for crate ${dependency.crateName} are yanked")
+                }
+            }
+        }
+    }
+}

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -23,14 +23,27 @@
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.toml.inspections.MissingFeaturesInspection"/>
 
-        <localInspection language="TOML" groupName="Rust"
+        <localInspection language="TOML"
+                         groupPath="Rust"
+                         groupName="Cargo.toml"
                          displayName="Cyclic feature dependency"
-                         enabledByDefault="true" level="ERROR"
+                         enabledByDefault="true"
+                         level="ERROR"
                          implementationClass="org.rust.toml.inspections.CargoTomlCyclicFeatureInspection"/>
-        <localInspection language="TOML" groupName="Rust"
+        <localInspection language="TOML"
                          displayName="Crate not found"
-                         enabledByDefault="true" level="WARNING"
+                         groupPath="Rust"
+                         groupName="Cargo.toml"
+                         enabledByDefault="true"
+                         level="WARNING"
                          implementationClass="org.rust.toml.inspections.CrateNotFoundInspection"/>
+        <localInspection language="TOML"
+                         displayName="Invalid crate version"
+                         groupPath="Rust"
+                         groupName="Cargo.toml"
+                         enabledByDefault="true"
+                         level="WARNING"
+                         implementationClass="org.rust.toml.inspections.CrateVersionInvalidInspection"/>
 
         <applicationService serviceInterface="org.rust.toml.crates.local.CratesLocalIndexService"
                             serviceImplementation="org.rust.toml.crates.local.CratesLocalIndexServiceImpl"

--- a/toml/src/main/resources/inspectionDescriptions/CrateVersionInvalid.html
+++ b/toml/src/main/resources/inspectionDescriptions/CrateVersionInvalid.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Detects dependency crates with invalid versions in Cargo.toml
+</body>
+</html>

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlCrateInspectionTestBase.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlCrateInspectionTestBase.kt
@@ -1,0 +1,39 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import com.intellij.codeInspection.InspectionProfileEntry
+import org.intellij.lang.annotations.Language
+import org.rust.cargo.CargoConstants
+import org.rust.ide.experiments.RsExperiments
+import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.openapiext.runWithEnabledFeatures
+import org.rust.toml.crates.local.CargoRegistryCrate
+import org.rust.toml.crates.local.CargoRegistryCrateVersion
+import org.rust.toml.crates.local.withMockedCrates
+import kotlin.reflect.KClass
+
+abstract class CargoTomlCrateInspectionTestBase(
+    inspectionClass: KClass<out InspectionProfileEntry>
+) : RsInspectionsTestBase(inspectionClass) {
+    protected fun crate(name: String, vararg versions: String): Crate =
+        Crate(name, CargoRegistryCrate(versions.toList().map {
+            CargoRegistryCrateVersion(it, false, listOf())
+        }))
+
+    protected data class Crate(val name: String, val crate: CargoRegistryCrate)
+
+    protected fun doTest(@Language("TOML") code: String, vararg crates: Crate) {
+        val crateMap = crates.toList().associate { it.name to it.crate }
+        myFixture.configureByText(CargoConstants.MANIFEST_FILE, code)
+
+        runWithEnabledFeatures(RsExperiments.CRATES_LOCAL_INDEX) {
+            withMockedCrates(crateMap) {
+                myFixture.checkHighlighting()
+            }
+        }
+    }
+}

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlCrateInspectionTestBase.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlCrateInspectionTestBase.kt
@@ -19,19 +19,11 @@ import kotlin.reflect.KClass
 abstract class CargoTomlCrateInspectionTestBase(
     inspectionClass: KClass<out InspectionProfileEntry>
 ) : RsInspectionsTestBase(inspectionClass) {
-    protected fun crate(name: String, vararg versions: String): Crate =
-        Crate(name, CargoRegistryCrate(versions.toList().map {
-            CargoRegistryCrateVersion(it, false, listOf())
-        }))
-
-    protected data class Crate(val name: String, val crate: CargoRegistryCrate)
-
-    protected fun doTest(@Language("TOML") code: String, vararg crates: Crate) {
-        val crateMap = crates.toList().associate { it.name to it.crate }
+    protected fun doTest(@Language("TOML") code: String, vararg crates: Pair<String, CargoRegistryCrate>) {
         myFixture.configureByText(CargoConstants.MANIFEST_FILE, code)
 
         runWithEnabledFeatures(RsExperiments.CRATES_LOCAL_INDEX) {
-            withMockedCrates(crateMap) {
+            withMockedCrates(crates.toMap()) {
                 myFixture.checkHighlighting()
             }
         }

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CrateNotFoundInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CrateNotFoundInspectionTest.kt
@@ -14,6 +14,7 @@ import org.rust.toml.crates.local.CargoRegistryCrate
 import org.rust.toml.crates.local.withMockedCrates
 
 class CrateNotFoundInspectionTest : RsInspectionsTestBase(CrateNotFoundInspection::class) {
+class CrateNotFoundInspectionTest : CargoTomlCrateInspectionTestBase(CrateNotFoundInspection::class) {
     fun `test missing crate in dependencies`() = doTest("""
         [dependencies]
         <warning descr="Crate foo not found">foo</warning> = "1"

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CrateNotFoundInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CrateNotFoundInspectionTest.kt
@@ -77,6 +77,24 @@ class CrateNotFoundInspectionTest : RsInspectionsTestBase(CrateNotFoundInspectio
         registry = "foo"
     """)
 
+    fun `test renamed package inline`() = doTest("""
+        [dependencies]
+        foo1 = { version = "1", package = "foo" }
+        foo2 = { version = "1", package = <warning descr="Crate bar not found">"bar"</warning> }
+    """,
+        "foo" to CargoRegistryCrate.of("1"),
+    )
+
+    fun `test renamed package table`() = doTest("""
+        [dependencies.foo1]
+        package = "foo"
+
+        [dependencies.foo2]
+        package = <warning descr="Crate bar not found">"bar"</warning>
+    """,
+        "foo" to CargoRegistryCrate.of("1"),
+    )
+
     private fun doTest(@Language("TOML") code: String, vararg crates: Pair<String, CargoRegistryCrate>) {
         myFixture.configureByText(MANIFEST_FILE, code)
 

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CrateNotFoundInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CrateNotFoundInspectionTest.kt
@@ -5,15 +5,8 @@
 
 package org.rust.toml.inspections
 
-import org.intellij.lang.annotations.Language
-import org.rust.cargo.CargoConstants.MANIFEST_FILE
-import org.rust.ide.experiments.RsExperiments
-import org.rust.ide.inspections.RsInspectionsTestBase
-import org.rust.openapiext.runWithEnabledFeatures
 import org.rust.toml.crates.local.CargoRegistryCrate
-import org.rust.toml.crates.local.withMockedCrates
 
-class CrateNotFoundInspectionTest : RsInspectionsTestBase(CrateNotFoundInspection::class) {
 class CrateNotFoundInspectionTest : CargoTomlCrateInspectionTestBase(CrateNotFoundInspection::class) {
     fun `test missing crate in dependencies`() = doTest("""
         [dependencies]
@@ -95,14 +88,4 @@ class CrateNotFoundInspectionTest : CargoTomlCrateInspectionTestBase(CrateNotFou
     """,
         "foo" to CargoRegistryCrate.of("1"),
     )
-
-    private fun doTest(@Language("TOML") code: String, vararg crates: Pair<String, CargoRegistryCrate>) {
-        myFixture.configureByText(MANIFEST_FILE, code)
-
-        runWithEnabledFeatures(RsExperiments.CRATES_LOCAL_INDEX) {
-            withMockedCrates(crates.toMap()) {
-                myFixture.checkHighlighting()
-            }
-        }
-    }
 }

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CrateVersionInvalidInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CrateVersionInvalidInspectionTest.kt
@@ -1,0 +1,316 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import org.rust.toml.crates.local.CargoRegistryCrate
+import org.rust.toml.crates.local.CargoRegistryCrateVersion
+
+class CrateVersionInvalidInspectionTest : CargoTomlCrateInspectionTestBase(CrateVersionInvalidInspection::class) {
+    fun `test do not warn about missing crate`() = doTest("""
+        [dependencies]
+        foo = "1"
+    """)
+
+    fun `test standalone version patch`() = doTest("""
+        [dependencies]
+        foo1 = <warning descr="No version matching 1.2.3 found for crate foo1">"1.2.3"</warning>
+        foo2 = <warning descr="No version matching 1.2.3 found for crate foo2">"1.2.3"</warning>
+        foo3 = <warning descr="No version matching 1.2.3 found for crate foo3">"1.2.3"</warning>
+        foo4 = "1.2.3"
+        foo5 = "1.2.3"
+        foo6 = "1.2.3"
+        foo7 = <warning descr="No version matching 1.2.3 found for crate foo7">"1.2.3"</warning>
+        foo8 = <warning descr="No version matching 0.1.2 found for crate foo8">"0.1.2"</warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("1.0.0"),
+        "foo2" to CargoRegistryCrate.of("1.1.0"),
+        "foo3" to CargoRegistryCrate.of("1.2.2"),
+        "foo4" to CargoRegistryCrate.of("1.2.3"),
+        "foo5" to CargoRegistryCrate.of("1.2.4"),
+        "foo6" to CargoRegistryCrate.of("1.3.0"),
+        "foo7" to CargoRegistryCrate.of("2.0.0"),
+        "foo8" to CargoRegistryCrate.of("0.2.0"),
+    )
+
+    fun `test standalone version minor`() = doTest("""
+        [dependencies]
+        foo1 = <warning descr="No version matching 1.2 found for crate foo1">"1.2"</warning>
+        foo2 = "1.2"
+        foo3 = "1.2"
+        foo4 = "1.2"
+        foo5 = <warning descr="No version matching 1.2 found for crate foo5">"1.2"</warning>
+        foo6 = <warning descr="No version matching 0.2 found for crate foo6">"0.2"</warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("1.0.0"),
+        "foo2" to CargoRegistryCrate.of("1.2.0"),
+        "foo3" to CargoRegistryCrate.of("1.2.3"),
+        "foo4" to CargoRegistryCrate.of("1.3.0"),
+        "foo5" to CargoRegistryCrate.of("2.0.0"),
+        "foo6" to CargoRegistryCrate.of("0.3.0"),
+    )
+
+    fun `test standalone version major`() = doTest("""
+        [dependencies]
+        foo1 = <warning descr="No version matching 1 found for crate foo1">"1"</warning>
+        foo2 = "1"
+        foo3 = "1"
+        foo4 = <warning descr="No version matching 1 found for crate foo4">"1"</warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("0.1.0"),
+        "foo2" to CargoRegistryCrate.of("1.0.0"),
+        "foo3" to CargoRegistryCrate.of("1.2.3"),
+        "foo4" to CargoRegistryCrate.of("2.0.0"),
+    )
+
+    fun `test caret version patch`() = doTest("""
+        [dependencies]
+        foo1 = <warning descr="No version matching ^1.2.3 found for crate foo1">"^1.2.3"</warning>
+        foo2 = <warning descr="No version matching ^1.2.3 found for crate foo2">"^1.2.3"</warning>
+        foo3 = <warning descr="No version matching ^1.2.3 found for crate foo3">"^1.2.3"</warning>
+        foo4 = "^1.2.3"
+        foo5 = "^1.2.3"
+        foo6 = "^1.2.3"
+        foo7 = <warning descr="No version matching ^1.2.3 found for crate foo7">"^1.2.3"</warning>
+        foo8 = <warning descr="No version matching ^0.1.2 found for crate foo8">"^0.1.2"</warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("1.0.0"),
+        "foo2" to CargoRegistryCrate.of("1.1.0"),
+        "foo3" to CargoRegistryCrate.of("1.2.2"),
+        "foo4" to CargoRegistryCrate.of("1.2.3"),
+        "foo5" to CargoRegistryCrate.of("1.2.4"),
+        "foo6" to CargoRegistryCrate.of("1.3.0"),
+        "foo7" to CargoRegistryCrate.of("2.0.0"),
+        "foo8" to CargoRegistryCrate.of("0.2.0"),
+    )
+
+    fun `test caret version minor`() = doTest("""
+        [dependencies]
+        foo1 = <warning descr="No version matching ^1.2 found for crate foo1">"^1.2"</warning>
+        foo2 = "^1.2"
+        foo3 = "^1.2"
+        foo4 = "^1.2"
+        foo5 = <warning descr="No version matching ^1.2 found for crate foo5">"^1.2"</warning>
+        foo6 = <warning descr="No version matching ^0.2 found for crate foo6">"^0.2"</warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("1.0.0"),
+        "foo2" to CargoRegistryCrate.of("1.2.0"),
+        "foo3" to CargoRegistryCrate.of("1.2.3"),
+        "foo4" to CargoRegistryCrate.of("1.3.0"),
+        "foo5" to CargoRegistryCrate.of("2.0.0"),
+        "foo6" to CargoRegistryCrate.of("0.3.0"),
+    )
+
+    fun `test caret version major`() = doTest("""
+        [dependencies]
+        foo1 = <warning descr="No version matching ^1 found for crate foo1">"^1"</warning>
+        foo2 = "^1"
+        foo3 = "^1"
+        foo4 = <warning descr="No version matching ^1 found for crate foo4">"^1"</warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("0.1.0"),
+        "foo2" to CargoRegistryCrate.of("1.0.0"),
+        "foo3" to CargoRegistryCrate.of("1.2.3"),
+        "foo4" to CargoRegistryCrate.of("2.0.0"),
+    )
+
+    fun `test tilde version patch`() = doTest("""
+        [dependencies]
+        foo1 = <warning descr="No version matching ~1.2.3 found for crate foo1">"~1.2.3"</warning>
+        foo2 = "~1.2.3"
+        foo3 = "~1.2.3"
+        foo4 = <warning descr="No version matching ~1.2.3 found for crate foo4">"~1.2.3"</warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("1.2.2"),
+        "foo2" to CargoRegistryCrate.of("1.2.3"),
+        "foo3" to CargoRegistryCrate.of("1.2.4"),
+        "foo4" to CargoRegistryCrate.of("1.3.0"),
+    )
+
+    fun `test tilde version minor`() = doTest("""
+        [dependencies]
+        foo1 = <warning descr="No version matching ~1.2 found for crate foo1">"~1.2"</warning>
+        foo2 = "~1.2"
+        foo3 = "~1.2"
+        foo4 = <warning descr="No version matching ~1.2 found for crate foo4">"~1.2"</warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("1.1.0"),
+        "foo2" to CargoRegistryCrate.of("1.2.0"),
+        "foo3" to CargoRegistryCrate.of("1.2.3"),
+        "foo4" to CargoRegistryCrate.of("1.3.0"),
+    )
+
+    fun `test tilde version major`() = doTest("""
+        [dependencies]
+        foo1 = <warning descr="No version matching ~1 found for crate foo1">"~1"</warning>
+        foo2 = "~1"
+        foo3 = "~1"
+        foo4 = <warning descr="No version matching ~1 found for crate foo4">"~1"</warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("0.1.0"),
+        "foo2" to CargoRegistryCrate.of("1.0.0"),
+        "foo3" to CargoRegistryCrate.of("1.2.3"),
+        "foo4" to CargoRegistryCrate.of("2.0.0"),
+    )
+
+    fun `test wildcard version patch`() = doTest("""
+        [dependencies]
+        foo1 = <warning descr="No version matching 1.2.* found for crate foo1">"1.2.*"</warning>
+        foo2 = "1.2.*"
+        foo3 = "1.2.*"
+        foo4 = <warning descr="No version matching 1.2.* found for crate foo4">"1.2.*"</warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("1.1.0"),
+        "foo2" to CargoRegistryCrate.of("1.2.0"),
+        "foo3" to CargoRegistryCrate.of("1.2.3"),
+        "foo4" to CargoRegistryCrate.of("1.3.0"),
+    )
+
+    fun `test wildcard version minor`() = doTest("""
+        [dependencies]
+        foo1 = <warning descr="No version matching 1.* found for crate foo1">"1.*"</warning>
+        foo2 = "1.*"
+        foo3 = "1.*"
+        foo4 = <warning descr="No version matching 1.* found for crate foo4">"1.*"</warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("0.1.0"),
+        "foo2" to CargoRegistryCrate.of("1.0.0"),
+        "foo2" to CargoRegistryCrate.of("1.1.0"),
+        "foo4" to CargoRegistryCrate.of("2.0.0"),
+    )
+
+    fun `test wildcard version major`() = doTest("""
+        [dependencies]
+        foo1 = "*"
+        foo2 = "*"
+        foo3 = "*"
+    """,
+        "foo1" to CargoRegistryCrate.of("0.1.0"),
+        "foo2" to CargoRegistryCrate.of("1.0.0"),
+        "foo3" to CargoRegistryCrate.of("2.3.4"),
+    )
+
+    fun `test empty version`() = doTest("""
+        [dependencies]
+        foo1 = ""
+        foo2 = ""
+        foo3 = ""
+    """,
+        "foo1" to CargoRegistryCrate.of("0.1.0"),
+        "foo2" to CargoRegistryCrate.of("1.0.0"),
+        "foo3" to CargoRegistryCrate.of("2.3.4"),
+    )
+
+    fun `test exact version patch`() = doTest("""
+        [dependencies]
+        foo1 = <warning descr="No version matching =1.2.3 found for crate foo1">"=1.2.3"</warning>
+        foo2 = "=1.2.3"
+        foo3 = <warning descr="No version matching =1.2.3 found for crate foo3">"=1.2.3"</warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("1.2.2"),
+        "foo2" to CargoRegistryCrate.of("1.2.3"),
+        "foo3" to CargoRegistryCrate.of("1.2.4"),
+    )
+
+    fun `test search all versions`() = doTest("""
+        [dependencies]
+        foo1 = "=1.2.3"
+    """,
+        "foo1" to CargoRegistryCrate.of("0.1.2", "1.2.2", "1.2.3","3.4.5"),
+    )
+
+    fun `test version range`() = doTest("""
+        [dependencies]
+        foo1 = <warning descr="No version matching >=1.2.0 found for crate foo1">">=1.2.0"</warning>
+        foo2 = <warning descr="No version matching >=1.2 found for crate foo2">">=1.2"</warning>
+        foo3 = ">=1.2"
+        foo4 = ">=1.2"
+        foo5 = "<2"
+        foo6 = <warning descr="No version matching <2 found for crate foo6">"<2"</warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("1.1.2"),
+        "foo2" to CargoRegistryCrate.of("1.1.2"),
+        "foo3" to CargoRegistryCrate.of("1.2.3"),
+        "foo4" to CargoRegistryCrate.of("2.3.4"),
+        "foo5" to CargoRegistryCrate.of("1.3.4"),
+        "foo6" to CargoRegistryCrate.of("2.3.4"),
+    )
+
+    fun `test multiple version requirements`() = doTest("""
+        [dependencies]
+        foo1 = <warning descr="No version matching >=1.2.0, <1.4.3 found for crate foo1">">=1.2.0, <1.4.3"</warning>
+        foo2 = ">=1.2.0, <1.4.3"
+        foo3 = ">=1.2.0, <1.4.3"
+        foo4 = ">=1.2.0, <1.4.3"
+        foo5 = <warning descr="No version matching >=1.2.0, <1.4.3 found for crate foo5">">=1.2.0, <1.4.3"</warning>
+        foo6 = <warning descr="No version matching >=1.2.0, <1.4.3 found for crate foo6">">=1.2.0, <1.4.3"</warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("1.1.2"),
+        "foo2" to CargoRegistryCrate.of("1.2.0"),
+        "foo3" to CargoRegistryCrate.of("1.3.5"),
+        "foo4" to CargoRegistryCrate.of("1.4.2"),
+        "foo5" to CargoRegistryCrate.of("1.4.3"),
+        "foo6" to CargoRegistryCrate.of("1.5"),
+    )
+
+    fun `test matching versions not yanked`() = doTest("""
+        [dependencies]
+        foo1 = ">=1.2.0"
+    """,
+        "foo1" to CargoRegistryCrate(listOf(
+            CargoRegistryCrateVersion("1.2.2", true, listOf()),
+            CargoRegistryCrateVersion("1.2.3", true, listOf()),
+            CargoRegistryCrateVersion("1.3.0", false, listOf())
+        ))
+    )
+
+    fun `test matching versions yanked`() = doTest("""
+        [dependencies]
+        foo1 = <warning descr="All versions matching >=1.2.0 for crate foo1 are yanked">">=1.2.0"</warning>
+    """,
+        "foo1" to CargoRegistryCrate(listOf(
+            CargoRegistryCrateVersion("1.1.0", false, listOf()),
+            CargoRegistryCrateVersion("1.2.2", true, listOf()),
+            CargoRegistryCrateVersion("1.2.3", true, listOf()),
+            CargoRegistryCrateVersion("1.3.0", true, listOf())
+        ))
+    )
+
+    fun `test dependency inline table`() = doTest("""
+        [dependencies]
+        foo = { version = <warning descr="No version matching =1.2.0 found for crate foo">"=1.2.0"</warning> }
+    """,
+        "foo" to CargoRegistryCrate.of("1.1.0")
+    )
+
+    fun `test dependency specific table`() = doTest("""
+        [dependencies.foo]
+        version = <warning descr="No version matching =1.2.0 found for crate foo">"=1.2.0"</warning>
+    """,
+        "foo" to CargoRegistryCrate.of("1.1.0")
+    )
+
+    fun `test renamed package`() = doTest("""
+        [dependencies]
+        foo1 = { version = "=1.2.0", package = "bar" }
+        foo2 = { version = <warning descr="No version matching =1.2.0 found for crate baz">"=1.2.0"</warning>, package = "baz" }
+    """,
+        "bar" to CargoRegistryCrate.of("1.2.0"),
+        "baz" to CargoRegistryCrate.of("1.3.0")
+    )
+
+    fun `test invalid version`() = doTest("""
+        [dependencies]
+        foo1 = <weak_warning descr="Invalid version requirement 0.4.0-rc--3-42=34=-23=-42=">"0.4.0-rc--3-42=34=-23=-42="</weak_warning>
+        foo2 = <weak_warning descr="Invalid version requirement ---### aqwe58768">"---### aqwe58768"</weak_warning>
+        foo3 = <weak_warning descr="Invalid version requirement 1.2.||?8">"1.2.||?8"</weak_warning>
+        foo4 = <weak_warning descr="Invalid version requirement *,">"*,"</weak_warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("1.0.0"),
+        "foo2" to CargoRegistryCrate.of("1.0.0"),
+        "foo3" to CargoRegistryCrate.of("1.0.0"),
+        "foo4" to CargoRegistryCrate.of("1.0.0"),
+    )
+}


### PR DESCRIPTION
This PR adds a TOML inspection that checks if dependency version requirements match any known versions. It can also possibly detect yanked versions (or it could be in a separate inspection).

Since this is the second "crate-level" inspection (after https://github.com/intellij-rust/intellij-rust/pull/6591), I separated the crate dependency visitor and introduced shared abstractions for Cargo.toml inspections (and their tests) in separate commits.

For parsing the version requirements, I use the same library as in https://github.com/intellij-rust/intellij-rust/pull/6599. I created a lot of basic tests to check that it works correctly. It mostly seems to work, but sadly, there are (at least) two cases where its behaviour differs from Cargo:
```
1.2.*
Cargo does not accept 1.3.0
Semver4J accepts 1.3.0

>=1.2
Cargo does not accept 1.1.2
Semver4J accepts 1.1.2
```
The second case can be "fixed" if we add patch version to the requirement (`>=1.2.0`), I don't know how to fix the first one.

Possible workarounds for this:
1) Implement some workarounds for wildcard and range version requirements to make them work in Semver4J
2) Don't do anything (Semver4J matches more versions than Cargo, so it should not produce false positives in this case).
3) Implement version matching from scratch (:disappointed:).

(Probably) blocked on: https://github.com/intellij-rust/intellij-rust/pull/6599
Closes: https://github.com/intellij-rust/intellij-rust/pull/3785
Related issue: https://github.com/intellij-rust/intellij-rust/issues/6463

changelog: Add inspection that checks crate dependency version requirements in Cargo.toml that do not match any known crate version.