### PR TITLE
TOML: check TOML plugin compatibility in CrateNotFoundInspection

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/inspections/CargoTomlCyclicFeatureInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CargoTomlCyclicFeatureInspection.kt
@@ -5,12 +5,10 @@
 
 package org.rust.toml.inspections
 
-import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElementVisitor
 import org.rust.cargo.CargoConstants
 import org.rust.toml.isFeatureListHeader
-import org.rust.toml.tomlPluginIsAbiCompatible
 import org.toml.lang.psi.*
 import org.toml.lang.psi.ext.TomlLiteralKind
 import org.toml.lang.psi.ext.kind
@@ -23,13 +21,8 @@ import org.toml.lang.psi.ext.kind
  *       #^ Shows error that "foo" feature depends on itself
  * ```
  */
-class CargoTomlCyclicFeatureInspection : LocalInspectionTool() {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
-        if (!tomlPluginIsAbiCompatible()) return super.buildVisitor(holder, isOnTheFly)
-        return buildVisitor(holder) ?: super.buildVisitor(holder, isOnTheFly)
-    }
-
-    private fun buildVisitor(holder: ProblemsHolder): PsiElementVisitor? {
+class CargoTomlCyclicFeatureInspection : TomlLocalInspectionToolBase() {
+    override fun buildVisitorInternal(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor? {
         if (holder.file.name != CargoConstants.MANIFEST_FILE) return null
 
         return object : TomlVisitor() {

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CrateNotFoundInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CrateNotFoundInspection.kt
@@ -17,11 +17,8 @@ import org.toml.lang.psi.ext.TomlLiteralKind
 import org.toml.lang.psi.ext.kind
 import org.toml.lang.psi.ext.name
 
-class CrateNotFoundInspection : LocalInspectionTool() {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
-        buildVisitor(holder) ?: super.buildVisitor(holder, isOnTheFly)
-
-    private fun buildVisitor(holder: ProblemsHolder): PsiElementVisitor? {
+class CrateNotFoundInspection : TomlLocalInspectionToolBase() {
+    override fun buildVisitorInternal(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor? {
         if (!isFeatureEnabled(RsExperiments.CRATES_LOCAL_INDEX)) return null
         if (holder.file.name != CargoConstants.MANIFEST_FILE) return null
 

--- a/toml/src/main/kotlin/org/rust/toml/inspections/TomlLocalInspectionToolBase.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/TomlLocalInspectionToolBase.kt
@@ -1,0 +1,21 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import org.rust.toml.tomlPluginIsAbiCompatible
+
+abstract class TomlLocalInspectionToolBase : LocalInspectionTool() {
+
+    final override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        if (!tomlPluginIsAbiCompatible()) return super.buildVisitor(holder, isOnTheFly)
+        return buildVisitorInternal(holder, isOnTheFly) ?: super.buildVisitor(holder, isOnTheFly)
+    }
+
+    protected abstract fun buildVisitorInternal(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor?
+}


### PR DESCRIPTION
Otherwise, the inspection may throw exceptions when PSI in TOML plugin is changed

Also, introduce `TomlLocalInspectionToolBase` not to forget to check TOML plugin compatibility.