### PR TITLE
Fix enum rendering while debugging with GDB in CLion 2021.1

### DIFF
--- a/prettyPrinters/gdb_lookup.py
+++ b/prettyPrinters/gdb_lookup.py
@@ -12,18 +12,11 @@ def is_hashbrown_hashmap(hash_map):
     return len(hash_map.type.fields()) == 1
 
 
-def classify_rust_type(type):
-    type_class = type.code
-    if type_class == gdb.TYPE_CODE_STRUCT:
-        return classify_struct(type.tag, type.fields())
-    if type_class == gdb.TYPE_CODE_UNION:
-        return classify_union(type.fields())
-
-    return RustType.OTHER
-
-
-def check_enum_discriminant(valobj):
+# Enum representation in gdb <= 9.1
+def is_old_enum(valobj):
     content = valobj[valobj.type.fields()[0]]
+    if content.type.code != gdb.TYPE_CODE_UNION:
+        return False
     fields = content.type.fields()
     if len(fields) > 1:
         discriminant = int(content[fields[0]]) + 1
@@ -31,6 +24,29 @@ def check_enum_discriminant(valobj):
             # invalid discriminant
             return False
     return True
+
+
+# Enum representation in gdb >= 10.1
+# Introduced in https://github.com/bminor/binutils-gdb/commit/9c6a1327ad9a92b8584f0501dd25bf8ba9e84ac6
+def is_new_enum(type):
+    fields = type.fields()
+    if len(fields) > 1:
+        field0 = fields[0]
+        if field0.artificial and field0.name is None and field0.type.code == gdb.TYPE_CODE_INT:
+            return True
+    return False
+
+
+def classify_rust_type(type):
+    type_class = type.code
+    if type_class == gdb.TYPE_CODE_STRUCT:
+        if is_new_enum(type):
+            return RustType.ENUM
+        return classify_struct(type.tag, type.fields())
+    if type_class == gdb.TYPE_CODE_UNION:
+        return classify_union(type.fields())
+
+    return RustType.OTHER
 
 
 def lookup(valobj):
@@ -41,8 +57,10 @@ def lookup(valobj):
     if rust_type == RustType.TUPLE:
         return TupleProvider(valobj)
     if rust_type == RustType.ENUM:
-        if check_enum_discriminant(valobj):
-            return EnumProvider(valobj)
+        if is_old_enum(valobj):
+            return OldEnumProvider(valobj)
+        elif is_new_enum(valobj.type):
+            return NewEnumProvider(valobj)
 
     if rust_type == RustType.STD_STRING:
         return StdStringProvider(valobj)

--- a/pretty_printers_tests/tests/enum.rs
+++ b/pretty_printers_tests/tests/enum.rs
@@ -1,14 +1,11 @@
 // min-version: 1.30.0
-// Temporarily disable this test because it fails on 2021.1
-// https://github.com/intellij-rust/intellij-rust/issues/6746
-// max-version: 1.30.0
 
 // === GDB TESTS ===================================================================================
 
 // gdb-command:run
 
 // gdb-command:print a
-// gdbg-check:[...]$1 = enum::EnumA::Var3 = {Var3 = enum::EnumA::Var3 = {a = 5, b = enum::TestEnumB::Var2 = {Var2 = enum::TestEnumB::Var2 = {a = 5, b = "hello", c = enum::EnumC::Var1 = {Var1 = size=1 = {8}}}}}}
+// gdbg-check:[...]$1 = enum::EnumA::Var3 = {Var3 = enum::EnumA::Var3 = {a = 5, b = enum::TestEnumB::Var2 = {Var2 = enum::TestEnumB::Var2 = {a = 5, b = "hello", c = enum::EnumC[...] = {Var1 = size=1 = {8}}}}}}
 
 // gdb-command:print d
 // gdbg-check:[...]$2 = enum::EnumD


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/6746

The new enum representation was introduced in https://github.com/bminor/binutils-gdb/commit/9c6a1327ad9a92b8584f0501dd25bf8ba9e84ac6

To test:
- [x] CLion 2020.3 on Linux
- [x] CLion 2021.1 on Linux
- [ ]  CLion 2020.3 with MinGW on Windows
- [ ]  CLion 2021.1 with MinGW on Windows

changelog: Fix enum rendering while debugging with GDB in CLion 2021.1