### PR TITLE
REF: allow choosing default values for new parameters in ChangeSignature

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
@@ -124,6 +124,10 @@ private fun changeArguments(
         is RsFunctionUsage.MethodCall -> usage.call.valueArgumentList
         else -> error("unreachable")
     }
+    for (parameter in config.parameters) {
+        val defaultValue = parameter.defaultValue.item ?: continue
+        RsImportHelper.importTypeReferencesFromElements(arguments, setOf(defaultValue), useAliases = true)
+    }
     val argumentsCopy = arguments.copy() as RsValueArgumentList
     val argumentsList = argumentsCopy.exprList
     val isUFCS = isMethod && usage is RsFunctionUsage.FunctionCall
@@ -134,7 +138,7 @@ private fun changeArguments(
         if (isUFCS) argumentsList.first() else null,
         if (isUFCS) argumentsList.drop(1) else argumentsList,
         config
-    ) { null }
+    ) { it.defaultValue.item }
 }
 
 private fun changeParameters(factory: RsPsiFactory, function: RsFunction, config: RsChangeFunctionSignatureConfig) {

--- a/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
@@ -7,9 +7,7 @@ package org.rust.ide.utils.import
 
 import org.rust.ide.settings.RsCodeInsightSettings
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.RsElement
-import org.rust.lang.core.psi.ext.RsMod
-import org.rust.lang.core.psi.ext.RsQualifiedNamedElement
+import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.TYPES
 import org.rust.lang.core.resolve.createProcessor
 import org.rust.lang.core.resolve.processNestedScopesUpwards
@@ -100,6 +98,17 @@ object RsImportHelper {
         useAliases: Boolean
     ) {
         context.accept(object : RsVisitor() {
+            override fun visitPath(path: RsPath) {
+                val qualifier = path.path
+                if (qualifier == null) {
+                    val item = path.reference?.resolve() as? RsQualifiedNamedElement
+                    if (item != null) {
+                        result += item
+                    }
+                }
+                super.visitPath(path)
+            }
+
             override fun visitTypeReference(reference: RsTypeReference) =
                 collectImportSubjectsFromTy(reference.type, subst, result, useAliases)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsCodeFragment.kt
@@ -115,8 +115,8 @@ class RsExpressionCodeFragment : RsCodeFragment, RsInferenceContextOwner {
     constructor(fileViewProvider: FileViewProvider, context: RsElement)
         : super(fileViewProvider, RsCodeFragmentElementType.EXPR, context)
 
-    constructor(project: Project, text: CharSequence, context: RsElement)
-        : super(project, text, RsCodeFragmentElementType.EXPR, context)
+    constructor(project: Project, text: CharSequence, context: RsElement, importTarget: RsItemsOwner? = null)
+        : super(project, text, RsCodeFragmentElementType.EXPR, context, importTarget = importTarget)
 
     val expr: RsExpr? get() = childOfType()
 }


### PR DESCRIPTION
I started working on suggested refactoring for functions using the new change signature refactoring, but I realized that it's not that useful without default value parameters, so first I'll begin with this PR.

Unresolved questions:
1) What about error checking? Should we somehow check that the default value expression's type is compatible with the parameter type? Or just do a basic sanity check that the expression should be parsed?
2) What to do about importing types from the default value expression? The trick with storing the type reference from the parameter type code fragment no longer works here, because the type reference created in the dialog has its context set to the refactored function. We need a type reference with a context set to each specific function call for it to work, and that is not available during refactoring. Maybe we can just automatically invoke the import quick fix on the inserted argument expression?

Btw @dima74 your refactored function for fixing parameters/arguments was really pleasant to use here, I just had to modify a single line of code to get default values working :+1:.

Related issue: https://github.com/intellij-rust/intellij-rust/issues/6744

changelog: The Change Signature refactoring now allows you to choose a default value for new parameters.