### PR TITLE
INT: Convert from lambdas to local named functions

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -88,6 +88,7 @@ msmorgan
 netvl
 nicholastmosher
 ninjabear
+nschoellhorn
 oistein
 oleg-semenov
 ondralukes

--- a/src/main/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionIntention.kt
@@ -1,0 +1,135 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.SmartPsiElementPointer
+import org.rust.ide.presentation.render
+import org.rust.ide.refactoring.isValidRustVariableIdentifier
+import org.rust.ide.utils.template.buildAndRunTemplate
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.ty.TyUnit
+import org.rust.lang.core.types.ty.TyUnknown
+import org.rust.lang.core.types.type
+import org.rust.openapiext.createSmartPointer
+
+class ConvertClosureToFunctionIntention : RsElementBaseIntentionAction<ConvertClosureToFunctionIntention.Context>() {
+
+    override fun getText(): String = "Convert closure to function"
+    override fun getFamilyName(): String = "Convert between local function and closure"
+
+    data class Context(
+        val assignment: RsLetDecl,
+        val lambda: RsLambdaExpr,
+    )
+
+    private fun getLetDeclarationForElementInSignature(element: PsiElement): RsLetDecl? {
+        if (element.text == ";") {
+            return null
+        }
+
+        for (el in element.ancestors) {
+            return when (el) {
+                is RsLetDecl -> el
+                is RsValueArgumentList -> el.ancestorStrict()
+                is RsBlock -> return null
+                else -> continue
+            }
+        }
+
+        return null
+    }
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        // We try to find a let declaration
+        val possibleTarget = element.ancestorStrict<RsLetDecl>() ?: return null
+
+        // The assignment of the let declaration should be a lambda to be a valid target
+        if (possibleTarget.expr !is RsLambdaExpr) {
+            return null
+        }
+
+        val signatureTarget = getLetDeclarationForElementInSignature(element) ?: return null
+
+        return Context(signatureTarget, signatureTarget.expr as RsLambdaExpr)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val factory = RsPsiFactory(project)
+
+        var targetName = ctx.assignment.pat?.text
+
+        var isTemplate = if (targetName == null || !isValidRustVariableIdentifier(targetName)) {
+            targetName = "func"
+
+            true
+        } else {
+            false
+        }
+
+        val valueParameters = ctx.lambda.valueParameters
+        val (parametersText, parameterPlaceholders) = this.createParameterList(factory, valueParameters)
+        if (parameterPlaceholders.isNotEmpty()) {
+            isTemplate = true
+        }
+        val lambdaExpr = ctx.lambda.expr
+        val returnText = if (ctx.lambda.retType != null) {
+            ctx.lambda.retType!!.text
+        } else if (lambdaExpr != null && lambdaExpr.type != TyUnknown && lambdaExpr.type !is TyUnit){
+            "-> ${lambdaExpr.type.render()}"
+        } else {
+            ""
+        }
+
+        val body = if (lambdaExpr is RsBlockExpr) {
+            lambdaExpr.text
+        } else {
+            "{ ${lambdaExpr?.text} }"
+        }
+
+        val function = factory.createFunction("fn $targetName($parametersText) $returnText $body")
+        val replaced = ctx.assignment.replace(function) as RsFunction
+
+        val identifier = replaced.identifier
+
+        // in case we auto-generated a function name, we encourage the user to change it by running a template on the replacement
+        if (isTemplate) {
+            val placeholderElements = mutableListOf<SmartPsiElementPointer<PsiElement>>()
+            if (targetName == "func") {
+                placeholderElements.add(identifier.createSmartPointer())
+            }
+            placeholderElements.addAll(replaced.descendantsOfType<RsTypeReference>().filter {
+                it.type is TyUnit
+            }.map { it.createSmartPointer() })
+                editor.buildAndRunTemplate(replaced, placeholderElements)
+
+        } else {
+            editor.caretModel.moveToOffset(replaced.endOffset)
+        }
+    }
+
+    private fun createParameterList(factory: RsPsiFactory, valueParameters: List<RsValueParameter>): Pair<String, List<RsTypeReference>> {
+        val placeholders = mutableListOf<RsTypeReference>()
+        val newParams = valueParameters.map { param ->
+            if (param.typeReference == null) {
+                val colon = param.addAfter(factory.createColon(), param.pat)
+                val placeholder = param.addAfter(factory.createType("()"), colon) as RsTypeReference
+                placeholders.add(placeholder)
+
+                param
+            } else {
+                param
+            }
+        }.joinToString(", ") {
+            it.text
+        }
+
+        return Pair(newParams, placeholders)
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -880,6 +880,10 @@
             <category>Rust</category>
         </intentionAction>
         <intentionAction>
+            <className>org.rust.ide.intentions.ConvertClosureToFunctionIntention</className>
+            <category>Rust</category>
+        </intentionAction>
+        <intentionAction>
             <className>org.rust.ide.intentions.AddRemainingArmsIntention</className>
             <category>Rust</category>
         </intentionAction>

--- a/src/main/resources/intentionDescriptions/ConvertClosureToFunctionIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/ConvertClosureToFunctionIntention/after.rs.template
@@ -1,0 +1,3 @@
+fn main() {
+    fn foo(x: i32) -> i32 { x + 1 }
+}

--- a/src/main/resources/intentionDescriptions/ConvertClosureToFunctionIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/ConvertClosureToFunctionIntention/before.rs.template
@@ -1,0 +1,3 @@
+fn main() {
+    let foo = |x: i32| -> i32 { x + 1 };
+}

--- a/src/main/resources/intentionDescriptions/ConvertClosureToFunctionIntention/description.html
+++ b/src/main/resources/intentionDescriptions/ConvertClosureToFunctionIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention converts an anonymous closure to a local function.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionIntentionTest.kt
@@ -8,7 +8,13 @@ package org.rust.ide.intentions
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 
-class ConvertClosureToFunctionTest : RsIntentionTestBase(ConvertClosureToFunctionIntention::class) {
+class ConvertClosureToFunctionIntentionTest : RsIntentionTestBase(ConvertClosureToFunctionIntention::class) {
+
+    fun `test intention is only available on variable name and argument list`() = checkAvailableInSelectionOnly("""
+        fn main() {
+            <selection>let foo = |x: i32| -> i32</selection> { x + 1 };
+        }
+    """)
 
     fun `test conversion from closure to function`() = doAvailableTest("""
         fn main() {
@@ -27,12 +33,6 @@ class ConvertClosureToFunctionTest : RsIntentionTestBase(ConvertClosureToFunctio
     """, """
         fn main() {
             fn func/*caret*/(x: i32) -> i32 { x + 1 }
-        }
-    """)
-
-    fun `test intention is only available on variable name and argument list`() = checkAvailableInSelectionOnly("""
-        fn main() {
-            <selection>let foo = |x: i32| -> i32 </selection>{ x + 1 };
         }
     """)
 
@@ -67,4 +67,23 @@ class ConvertClosureToFunctionTest : RsIntentionTestBase(ConvertClosureToFunctio
         }
     """)
 
+    fun `test raw identifier`() = doAvailableTest("""
+        fn main() {
+            let r#match = |x: i32/*caret*/| -> i32 { x + 1 };
+        }
+    """, """
+        fn main() {
+            fn r#match(x: i32) -> i32 { x + 1 }/*caret*/
+        }
+    """)
+
+    fun `test inferred types`() = doAvailableTest("""
+        fn main() {
+            let foo: fn(i32) -> i32 = |x/*caret*/| { x + 1 };
+        }
+    """, """
+        fn main() {
+            fn foo(x: i32) -> i32 { x + 1 }/*caret*/
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ConvertClosureToFunctionTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+
+class ConvertClosureToFunctionTest : RsIntentionTestBase(ConvertClosureToFunctionIntention::class) {
+
+    fun `test conversion from closure to function`() = doAvailableTest("""
+        fn main() {
+            let foo = |x: i32/*caret*/| -> i32 { x + 1 };
+        }
+    """, """
+        fn main() {
+            fn foo(x: i32) -> i32 { x + 1 }/*caret*/
+        }
+    """)
+
+    fun `test conversion auto-generates function name for wildcard binding`() = doAvailableTest("""
+        fn main() {
+            let _ = |x: i32/*caret*/| -> i32 { x + 1 };
+        }
+    """, """
+        fn main() {
+            fn func/*caret*/(x: i32) -> i32 { x + 1 }
+        }
+    """)
+
+    fun `test intention is only available on variable name and argument list`() = checkAvailableInSelectionOnly("""
+        fn main() {
+            <selection>let foo = |x: i32| -> i32 </selection>{ x + 1 };
+        }
+    """)
+
+    fun `test intention adds function body when closure doesnt have one`() = doAvailableTest("""
+        fn main() {
+            let foo = |x: i32/*caret*/| -> i32 x + 1;
+        }
+    """, """
+        fn main() {
+            fn foo(x: i32) -> i32 { x + 1 }/*caret*/
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test intention adds return type to function when closure doesnt have one`() = doAvailableTest("""
+        fn main() {
+            let foo = |x: i32/*caret*/| x + 1;
+        }
+    """, """
+        fn main() {
+            fn foo(x: i32) -> i32 { x + 1 }/*caret*/
+        }
+    """)
+
+    fun `test intention does not add unit return type explicitly`() = doAvailableTest("""
+        fn main() {
+            let foo = |x: i32/*caret*/| println!(x);
+        }
+    """, """
+        fn main() {
+            fn foo(x: i32) { println!(x) }/*caret*/
+        }
+    """)
+
+}


### PR DESCRIPTION
Since this is my first PR on this project, I'd be very grateful for detailed feedback on how I approached this issue.
One thing I'm still not sure about is the way I'm generating the context in `findApplicableContext()`. The way it currently checks whether the intention is applicable, is pretty broad. The caret could be somewhere in the lambda/function body as well and the intention would still be available. I didn't find any general guidelines on how intention availability is defined, would appreciate directions here. 

Also, regarding tests: I am not sure what I can test here exactly. I added tests for the basic "positive" cases and also a test for the edge case that the lambda is bound to `let _`, which would result in an invalid function name. Any other good test case hints would be very appreciated as well! :)

Closes #6711 

changelog: Added intentions to convert from lambdas to named local functions and vice versa