### PR TITLE
Make CargoCommandConfiguration open

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -113,6 +113,7 @@ stigger
 Stzx
 t-kameyama
 tamird
+telezhnaya
 ThoseGrapefruits
 tov
 ttaomae

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -41,7 +41,7 @@ import kotlin.run
  * It is basically a bunch of values which are persisted to .xml files inside .idea,
  * or displayed in the GUI form. It has to be mutable to satisfy various IDE's APIs.
  */
-class CargoCommandConfiguration(
+open class CargoCommandConfiguration(
     project: Project,
     name: String,
     factory: ConfigurationFactory


### PR DESCRIPTION
We need to inherit from this configuration in EduTools plugin.
That will allow us to create configurations with redirecting input,
it is useful for some cases, e.g. Codeforces support.

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

Also, please write a short description explaining your change in the following format: `changelog: %description%`
This description will help a lot to create release changelog. 
Drop these lines for internal only changes

:)

