### PR TITLE
COMP: add all remaining arms match postfix template

### DIFF
--- a/src/main/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplate.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplate.kt
@@ -1,0 +1,52 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.template.postfix
+
+import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateWithExpressionSelector
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import org.rust.ide.inspections.fixes.AddRemainingArmsFix
+import org.rust.ide.inspections.fixes.AddWildcardArmFix
+import org.rust.ide.utils.checkMatch.checkExhaustive
+import org.rust.lang.core.psi.*
+
+class MatchPostfixTemplate(provider: RsPostfixTemplateProvider) :
+    PostfixTemplateWithExpressionSelector(
+        null,
+        "match",
+        "match expr {...}",
+        RsExprParentsSelector(),
+        provider
+    ) {
+
+    override fun expandForChooseExpression(expression: PsiElement, editor: Editor) {
+        if (expression !is RsExpr) return
+
+        val project = expression.project
+        val factory = RsPsiFactory(project)
+
+        val exprText = if (expression is RsStructLiteral) "(${expression.text})" else expression.text
+        val emptyMatch = factory.createExpression("match $exprText {}")
+        val matchExpr = expression.replace(emptyMatch) as RsMatchExpr
+
+        PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
+
+        val patterns = matchExpr.checkExhaustive().orEmpty()
+        val fix = if (patterns.isEmpty()) {
+            AddWildcardArmFix(matchExpr)
+        } else {
+            AddRemainingArmsFix(matchExpr, patterns)
+        }
+        fix.invoke(project, matchExpr.containingFile, matchExpr, matchExpr)
+
+        PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
+
+        val arm = matchExpr.matchBody?.matchArmList?.firstOrNull() ?: return
+        val blockExpr = arm.expr as? RsBlockExpr ?: return
+        editor.caretModel.moveToOffset(blockExpr.block.lbrace.textOffset + 1)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
@@ -76,20 +76,6 @@ class DerefPostfixTemplate(provider: RsPostfixTemplateProvider) :
         }
     )
 
-class MatchPostfixTemplate(provider: RsPostfixTemplateProvider) :
-    StringBasedPostfixTemplate("match", "match expr {...}", RsExprParentsSelector(), provider) {
-
-    override fun getTemplateString(element: PsiElement): String = "match ${element.text} {\n\$PAT\$ => {\$END\$}\n}"
-
-    override fun getElementToRemove(expr: PsiElement): PsiElement = expr
-
-    override fun setVariables(template: Template, element: PsiElement) {
-        with(template) {
-            addVariable("PAT", TextExpression("_"), true)
-        }
-    }
-}
-
 class IterPostfixTemplate(name: String, provider: RsPostfixTemplateProvider) :
     StringBasedPostfixTemplate(
         name,

--- a/src/main/resources/postfixTemplates/MatchPostfixTemplate/after.rs.template
+++ b/src/main/resources/postfixTemplates/MatchPostfixTemplate/after.rs.template
@@ -4,6 +4,8 @@ enum Foo {
 
 fn foo(x: Foo) {
     match x {
-        <spot>_</spot> => {}
+        Foo::A => {<spot></spot>}
+        Foo::B => {}
+        Foo::C => {}
     }
 }

--- a/src/test/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplateTest.kt
@@ -29,24 +29,43 @@ class MatchPostfixTemplateTest : RsPostfixTemplateTest(MatchPostfixTemplate(RsPo
         fn process_message() {
             let msg = Message::ChangeColor(255, 255, 255);
             match msg {
-                _ => {}
+                Message::Quit => {/*caret*/}
+                Message::ChangeColor(_, _, _) => {}
+                Message::Move { .. } => {}
+                Message::Write(_) => {}
             }
         }
     """)
 
-    fun `test can match constant`() = doTest("""
+    fun `test constant`() = doTest("""
         const THE_ANSWER: i32 = 42;
 
-        fn check(x: i32) -> bool {
+        fn check(x: i32) {
             x.match/*caret*/
         }
     """, """
         const THE_ANSWER: i32 = 42;
 
-        fn check(x: i32) -> bool {
-            match x {
-                _ => {}
-            }
+        fn check(x: i32) {
+            match x { _ => {/*caret*/} }
+        }
+    """)
+
+    fun `test struct literal`() = doTest("""
+        struct S {
+            a: u32
+        }
+
+        fn foo() {
+            S { a: 0 }.match/*caret*/
+        }
+    """, """
+        struct S {
+            a: u32
+        }
+
+        fn foo() {
+            match (S { a: 0 }) { S { .. } => {/*caret*/} }
         }
     """)
 
@@ -59,11 +78,18 @@ class MatchPostfixTemplateTest : RsPostfixTemplateTest(MatchPostfixTemplate(RsPo
     """, """
         fn main() {
             match a {
-                _ => match b {
-                    _ => {/*caret*/}
-                }
+                _ => match b { _ => {/*caret*/} }
             }
         }
     """)
 
+    fun `test subexpression`() = doTest("""
+        fn main() {
+            let x = 1 + 2.match/*caret*/;
+        }
+    """, """
+        fn main() {
+            let x = match 1 + 2 { _ => {/*caret*/} };
+        }
+    """)
 }


### PR DESCRIPTION
This PR changes `match` postfix template to generate all match arms instead of just a single wildcard.

Currently, no template is used, the caret is just moved after the left brace of the first arm. Should there be some template to rename things from the generated arms? If yes, what should it rename?

Fixes https://github.com/intellij-rust/intellij-rust/issues/6630
Fixes https://github.com/intellij-rust/intellij-rust/issues/4727

changelog: `match` postfix template now generates all missing match arms by default.