### PR TITLE
INSP: Implement unreachable code detection

### DIFF
--- a/.idea/dictionaries/intellij_rust.xml
+++ b/.idea/dictionaries/intellij_rust.xml
@@ -82,6 +82,7 @@
       <w>simd</w>
       <w>staticlib</w>
       <w>stmts</w>
+      <w>straightline</w>
       <w>subcommand</w>
       <w>subcommands</w>
       <w>submatrix</w>
@@ -97,6 +98,7 @@
       <w>turbofish</w>
       <w>uncached</w>
       <w>unescape</w>
+      <w>unexecuted</w>
       <w>unsafety</w>
       <w>valobj</w>
       <w>wasm</w>

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -55,6 +55,14 @@ enum class RsLint(
 
     UnreachablePattern("unreachable_patterns", listOf("unused")),
 
+    UnreachableCode("unreachable_code") {
+        override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
+            when (level) {
+                WARN -> ProblemHighlightType.LIKE_UNUSED_SYMBOL
+                else -> super.toHighlightingType(level)
+            }
+    },
+
     BareTraitObjects("bare_trait_objects", listOf("rust_2018_idioms"));
 
     protected open fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnreachableCodeInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnreachableCodeInspection.kt
@@ -1,0 +1,82 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.openapi.util.Segment
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.refactoring.suggested.stripWhitespace
+import org.rust.ide.injected.isDoctestInjection
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.fixes.SubstituteTextFix
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.ext.rangeWithPrevSpace
+import org.rust.lang.core.psi.ext.startOffset
+import org.rust.lang.core.types.controlFlowGraph
+import org.rust.openapiext.document
+import org.rust.stdext.mapToMutableList
+import java.util.*
+
+class RsUnreachableCodeInspection : RsLintInspection() {
+    override fun getDisplayName(): String = "Unreachable code"
+
+    override fun getLint(element: PsiElement): RsLint = RsLint.UnreachableCode
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
+        override fun visitFunction(func: RsFunction) {
+            if (func.isDoctestInjection) return
+            val controlFlowGraph = func.controlFlowGraph ?: return
+
+            val elementsToReport = controlFlowGraph
+                .unreachableElements
+                .takeIf { it.isNotEmpty() }
+                ?: return
+
+            // Collect text ranges of unreachable elements and merge them in order to highlight
+            // most enclosing ranges entirely, instead of highlighting each element separately
+            val sortedRanges = elementsToReport
+                .filter { it.isPhysical }
+                .mapToMutableList { it.rangeWithPrevSpace }
+                .apply { sortWith(Segment.BY_START_OFFSET_THEN_END_OFFSET) }
+                .takeIf { it.isNotEmpty() }
+                ?: return
+
+            val mergedRanges = mergeRanges(sortedRanges)
+            for (range in mergedRanges) {
+                registerUnreachableProblem(holder, func, range)
+            }
+        }
+    }
+
+    /** Merges intersecting (including adjacent) text ranges into one */
+    private fun mergeRanges(sortedRanges: List<TextRange>): Collection<TextRange> {
+        val mergedRanges = ArrayDeque<TextRange>()
+        mergedRanges.add(sortedRanges[0])
+        for (range in sortedRanges.drop(1)) {
+            val leftNeighbour = mergedRanges.peek()
+            if (leftNeighbour.intersects(range)) {
+                mergedRanges.pop()
+                mergedRanges.push(leftNeighbour.union(range))
+            } else {
+                mergedRanges.push(range)
+            }
+        }
+        return mergedRanges
+    }
+
+    private fun registerUnreachableProblem(holder: RsProblemsHolder, func: RsFunction, range: TextRange) {
+        val chars = func.containingFile.document?.immutableCharSequence ?: return
+        val strippedRangeInFunction = range.stripWhitespace(chars).shiftLeft(func.startOffset)
+
+        holder.registerLintProblem(
+            func,
+            "Unreachable code",
+            strippedRangeInFunction,
+            SubstituteTextFix.delete("Remove unreachable code", func.containingFile, range)
+        )
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/dfa/CFGBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/CFGBuilder.kt
@@ -583,8 +583,9 @@ class CFGBuilder(
         }
     }
 
-    override fun visitLitExpr(litExpr: RsLitExpr) =
-        finishWith { straightLine(litExpr, pred, emptyList()) }
+    override fun visitLitExpr(litExpr: RsLitExpr) = finishWithAstNode(litExpr, pred)
+
+    override fun visitUnitExpr(unitExpr: RsUnitExpr) = finishWithAstNode(unitExpr, pred)
 
     override fun visitMatchExpr(matchExpr: RsMatchExpr) {
         fun processGuard(guard: RsMatchArmGuard, prevGuards: ArrayDeque<CFGNode>, guardStart: CFGNode): CFGNode {

--- a/src/main/kotlin/org/rust/lang/core/dfa/ControlFlowGraph.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/ControlFlowGraph.kt
@@ -40,7 +40,7 @@ sealed class CFGNodeData(val element: RsElement? = null) : PresentableNodeData {
 
     override val text: String
         get() = when (this) {
-            is AST -> element?.cfgText()?.trim() ?: "AST"
+            is AST -> element!!.cfgText().trim()
             Entry -> "Entry"
             Exit -> "Exit"
             Termination -> "Termination"
@@ -56,6 +56,7 @@ sealed class CFGNodeData(val element: RsElement? = null) : PresentableNodeData {
             is RsLoopExpr -> "LOOP"
             is RsForExpr -> "FOR"
             is RsMatchExpr -> "MATCH"
+            is RsLambdaExpr -> "CLOSURE"
             is RsExprStmt -> expr.cfgText() + ";"
             else -> this.text
         }
@@ -64,10 +65,11 @@ sealed class CFGNodeData(val element: RsElement? = null) : PresentableNodeData {
 class CFGEdgeData(val exitingScopes: List<RsElement>)
 
 typealias CFGNode = Node<CFGNodeData, CFGEdgeData>
+typealias CFGGraph = PresentableGraph<CFGNodeData, CFGEdgeData>
 
 class ControlFlowGraph private constructor(
     val owner: RsElement,
-    val graph: PresentableGraph<CFGNodeData, CFGEdgeData>,
+    val graph: CFGGraph,
     val body: RsBlock,
     val regionScopeTree: ScopeTree,
     val entry: CFGNode,
@@ -97,7 +99,7 @@ class ControlFlowGraph private constructor(
          *
          * Only collects [RsExprStmt]s, [RsLetDecl]s and tail expressions, ignoring conditionally disabled.
          */
-        private fun collectUnreachableElements(graph: PresentableGraph<CFGNodeData, CFGEdgeData>, entry: CFGNode): Set<RsElement> {
+        private fun collectUnreachableElements(graph: CFGGraph, entry: CFGNode): Set<RsElement> {
             /**
              * In terms of our control-flow graph, a [RsElement]'s node is not reachable if it cannot be fully executed,
              * since [CFGBuilder] processes elements in post-order.

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -589,6 +589,11 @@
                          enabledByDefault="true" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.RsDuplicatedTraitMethodBindingInspection"/>
 
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
+                         displayName="Unreachable code"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.lints.RsUnreachableCodeInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsUnreachableCode.html
+++ b/src/main/resources/inspectionDescriptions/RsUnreachableCode.html
@@ -1,0 +1,1 @@
+Reports unreachable code.

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnreachableCodeInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnreachableCodeInspectionTest.kt
@@ -1,0 +1,232 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import org.rust.MockAdditionalCfgOptions
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class RsUnreachableCodeInspectionTest : RsInspectionsTestBase(RsUnreachableCodeInspection::class) {
+    fun `test straightline with return`() = checkByText("""
+        fn main() {
+            let x = 1;
+            return;
+            <warning descr="Unreachable code">let y = 2;
+            let z = 3;</warning>
+        }
+    """)
+
+    fun `test complex code after return`() = checkByText("""
+        fn foo(flag: bool, bar: bool) {
+            let x = 1;
+            return;
+            <warning descr="Unreachable code">let y = 2;
+            if foo {
+                1;
+            }
+            2;
+            if bar {
+                2;
+            }</warning>
+        }
+    """)
+
+    fun `test return tail expr`() = checkByText("""
+        fn main() {
+            return;
+        }
+    """)
+
+    fun `test unreachable tail expr`() = checkByText("""
+        fn foo() -> i32 {
+            return 42;
+            <warning descr="Unreachable code">123</warning>
+        }
+    """)
+
+    fun `test code after loop`() = checkByText("""
+        fn main() {
+            loop {
+                1;
+            }
+            <warning descr="Unreachable code">2;</warning>
+        }
+    """)
+
+    fun `test loop with break`() = checkByText("""
+        fn foo(flag: bool) {
+            loop {
+                1;
+                if flag {
+                    break;
+                }
+                2;
+            }
+            3;
+        }
+    """)
+
+    fun `test complex loop with break`() = checkByText("""
+        enum E { A, B }
+        fn foo(e: E, flag: bool) {
+            loop {
+                1;
+                match e {
+                    E::A => {
+                        2;
+                        if flag {
+                            break;
+                        }
+                    }
+                    E::B => {
+                        3;
+                    }
+                }
+                4;
+            }
+            5;
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test unreachable in closure call`() = checkByText("""
+        fn foo(f: fn(i32)) {}
+        fn main() {
+            foo(|x| {
+                if x > 0 {
+                    panic!();
+                    <warning descr="Unreachable code">1;</warning>
+                }
+            });
+            2;
+        }
+    """)
+
+    fun `test closure call with loop`() = checkByText("""
+        fn foo(f: fn(i32)) {}
+        fn main() {
+            foo(|x| {
+                1;
+                loop {
+                    2;
+                }
+                <warning descr="Unreachable code">3;</warning>
+            });
+            4;
+        }
+    """)
+
+    fun `test if else stmt unconditional return`() = checkByText("""
+        fn main() {
+            if a {
+                1;
+                return;
+                <warning descr="Unreachable code">2;
+                3;</warning>
+            } else {
+                4;
+                return;
+                <warning descr="Unreachable code">5;</warning>
+            }
+            <warning descr="Unreachable code">6;</warning>
+        }
+    """)
+
+    fun `test if else tail expr unconditional return`() = checkByText("""
+        fn foo(flag: bool) {
+            if flag {
+                1;
+                return;
+                <warning descr="Unreachable code">2;
+                3;</warning>
+            } else {
+                4;
+                return;
+                <warning descr="Unreachable code">5;</warning>
+            }
+        }
+    """)
+
+    fun `test let declaration with unreachable init`() = checkByText("""
+        fn main() {
+            let x = return;
+        }
+    """)
+
+    fun `test multiple return`() = checkByText("""
+        fn main() {
+            return;
+            <warning descr="Unreachable code">1;
+            return;
+            2;
+            return;</warning>
+        }
+    """)
+
+    fun `test remove unreachable code fix`() = checkFixByText("Remove unreachable code", """
+        fn main() {
+            1;
+            if flag1 {
+                2;
+                return;
+                <warning descr="Unreachable code">3;/*caret*/
+                if flag2 {
+                    4;
+                }</warning>
+            }
+            5;
+        }
+    """, """
+        fn main() {
+            1;
+            if flag1 {
+                2;
+                return;
+            }
+            5;
+        }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test ignore conditionally disabled unreachable code`() = checkByText("""
+        fn foo() -> i32 {
+            return 1;
+            #[cfg(not(intellij_rust))] return 2;
+        }
+    """)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test annotate conditionally enabled unreachable code`() = checkByText("""
+        fn foo() -> i32 {
+            return 1;
+            <warning descr="Unreachable code">#[cfg(intellij_rust)]
+            return 2;</warning>
+        }
+    """)
+
+    fun `test allow unreachable_code`() = checkByText("""
+        #[allow(unreachable_code)]
+        fn foo() -> i32 {
+            return 1;
+            return 2;
+        }
+    """)
+
+    fun `test tail macro expr`() = checkByText("""
+        fn main() {
+            return;
+            <warning descr="Unreachable code">foo!()</warning>
+        }
+    """)
+
+    fun `test tail unit expr`() = checkByText("""
+        fn main() {
+            return;
+            <warning descr="Unreachable code">()</warning>
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/lang/core/dfa/RsControlFlowGraphTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/dfa/RsControlFlowGraphTest.kt
@@ -867,7 +867,7 @@ class RsControlFlowGraphTest : RsTestBase() {
         x + 1
         BLOCK
         BLOCK
-        |x: i32| { x + 1 }
+        CLOSURE
         f
         f
         let f = |x: i32| { x + 1 };
@@ -950,7 +950,7 @@ class RsControlFlowGraphTest : RsTestBase() {
         Entry
         panic!()
         Termination
-        || { panic!() }
+        CLOSURE
         f
         f
         let f = || { panic!() };
@@ -1098,6 +1098,6 @@ class RsControlFlowGraphTest : RsTestBase() {
         val cfg = ControlFlowGraph.buildFor(function.block!!, getRegionScopeTree(function))
         val expected = expectedIndented.trimIndent()
         val actual = cfg.graph.depthFirstTraversalTrace(cfg.entry)
-        check(actual == expected) { throw ComparisonFailure("Comparision failed", expected, actual) }
+        check(actual == expected) { throw ComparisonFailure("Comparison failed", expected, actual) }
     }
 }


### PR DESCRIPTION
This PR introduces `Unreachable code` inspection to detect and remove unreachable code.

![unreachable_code](https://user-images.githubusercontent.com/4854600/107639621-2ce9cc00-6c82-11eb-8a06-114953a733ab.gif)

Note that now it might produce some false-positive warnings due to https://github.com/intellij-rust/intellij-rust/issues/6749 and https://github.com/intellij-rust/intellij-rust/issues/6797, so probably it's better to try fixing these issues before merging this. 

Some implementation details:
* Based on the control-flow graph which is already used for several inspections (move analysis, liveness analysis)
* Found unreachable elements are cached by `org.rust.lang.core.types.ExtensionsKt#CONTROL_FLOW_KEY` as well as the  graph itself
* Does not highlight each unreachable element separately, but merges their text ranges instead in order to highlight the widest range

Part of https://github.com/intellij-rust/intellij-rust/issues/1612.

changelog: Add `Unreachable code` inspection and quick-fix