### PR TITLE
Complete and suggest to install target in cargo run configuration

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -114,7 +114,7 @@ interface CargoProject : UserDataHolderEx {
     }
 }
 
-data class RustcInfo(val sysroot: String, val version: RustcVersion?)
+data class RustcInfo(val sysroot: String, val version: RustcVersion?, val targets: List<String>? = null)
 
 fun guessAndSetupRustProject(project: Project, explicitRequest: Boolean = false): Boolean {
     if (!explicitRequest) {

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -57,8 +57,14 @@ import org.rust.cargo.util.AutoInjectedCrates
 import org.rust.ide.notifications.showBalloon
 import org.rust.lang.RsFileType
 import org.rust.lang.core.macros.macroExpansionManager
-import org.rust.openapiext.*
-import org.rust.stdext.*
+import org.rust.openapiext.CachedVirtualFile
+import org.rust.openapiext.TaskResult
+import org.rust.openapiext.modules
+import org.rust.openapiext.pathAsPath
+import org.rust.stdext.AsyncValue
+import org.rust.stdext.applyWithSymlink
+import org.rust.stdext.exhaustive
+import org.rust.stdext.mapNotNullToSet
 import org.rust.taskQueue
 import java.nio.file.Path
 import java.nio.file.Paths

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
@@ -197,8 +197,9 @@ private fun fetchRustcInfo(context: CargoSyncTask.SyncContext): TaskResult<Rustc
             ?: return@runWithChildProgress TaskResult.Err("failed to get project sysroot")
 
         val rustcVersion = childContext.toolchain.rustc().queryVersion(workingDirectory)
+        val rustcTargets = childContext.toolchain.rustc().getTargets(workingDirectory)
 
-        TaskResult.Ok(RustcInfo(sysroot, rustcVersion))
+        TaskResult.Ok(RustcInfo(sysroot, rustcVersion, rustcTargets))
     }
 }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildTaskProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildTaskProvider.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.util.Key
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.getBuildConfiguration
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.toolchain.tools.Rustup
 
 class CargoBuildTaskProvider : RsBuildTaskProvider<CargoBuildTaskProvider.BuildTask>() {
     override fun getId(): Key<BuildTask> = ID
@@ -26,6 +27,15 @@ class CargoBuildTaskProvider : RsBuildTaskProvider<CargoBuildTaskProvider.BuildT
     ): Boolean {
         if (configuration !is CargoCommandConfiguration) return false
         val buildConfiguration = getBuildConfiguration(configuration) ?: return true
+
+        val projectDirectory = configuration.workingDirectory ?: return false
+
+        val configArgs = configuration.command.split(' ')
+        val targetFlagIdx = configArgs.indexOf("--target")
+        val targetTriple = if (targetFlagIdx != -1) configArgs.getOrNull(targetFlagIdx + 1).orEmpty() else ""
+
+        if (Rustup.checkNeedInstallTarget(configuration.project, projectDirectory, targetTriple)) return false
+
         return doExecuteTask(buildConfiguration, environment)
     }
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustc.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustc.kt
@@ -76,6 +76,18 @@ class Rustc(toolchain: RsToolchain) : RustupComponent(NAME, toolchain) {
         return CfgOptions.parse(rawCfgOptions)
     }
 
+    fun getTargets(projectDirectory: Path?): List<String>? {
+        if (!isUnitTestMode) {
+            checkIsBackgroundThread()
+        }
+        val timeoutMs = 10000
+        val output = createBaseCommandLine(
+            "--print", "target-list",
+            workingDirectory = projectDirectory
+        ).execute(timeoutMs)
+        return if (output?.isSuccess == true) output.stdout.trim().lines() else null
+    }
+
     companion object {
         const val NAME: String = "rustc"
     }

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustup.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustup.kt
@@ -175,8 +175,7 @@ class Rustup(toolchain: RsToolchain, private val projectDirectory: Path) : RsToo
             return needInstall
         }
 
-        @Suppress("SameParameterValue")
-        private fun checkNeedInstallTarget(
+        fun checkNeedInstallTarget(
             project: Project,
             cargoProjectDirectory: Path,
             targetName: String

--- a/src/main/kotlin/org/rust/cargo/util/CargoCommandCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/util/CargoCommandCompletionProvider.kt
@@ -62,7 +62,15 @@ private fun getCompleterForOption(name: String): ArgCompleter? = when (name) {
     "bench" -> targetCompleter(CargoWorkspace.TargetKind.Bench)
     "package" -> { ctx -> ctx.currentWorkspace?.packages.orEmpty().map { it.lookupElement } }
     "manifest-path" -> { ctx -> ctx.projects.map { it.lookupElement } }
+    "target" -> { ctx -> getTargetTripleCompletions(ctx) }
     else -> null
+}
+
+private fun getTargetTripleCompletions(ctx: Context): List<LookupElement> {
+    val cargoProject = ctx.projects.firstOrNull() ?: return emptyList()
+    val targets = cargoProject.rustcInfo?.targets ?: return emptyList()
+
+    return targets.map { LookupElementBuilder.create(it) }
 }
 
 private val CargoProject.lookupElement: LookupElement

--- a/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/cargo/util/CargoCommandCompletionProviderTest.kt
@@ -8,6 +8,7 @@ package org.rust.cargo.util
 import com.intellij.codeInsight.completion.PlainPrefixMatcher
 import org.rust.RsTestBase
 import org.rust.cargo.CfgOptions
+import org.rust.cargo.project.model.CargoProjectsService
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspace.*
@@ -131,12 +132,8 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
         text: String,
         expectedCompletions: List<String>
     ) {
+        val actual = complete(text, project.cargoProjects, testWorkspace)
 
-        val provider = CargoCommandCompletionProvider(project.cargoProjects, testWorkspace)
-        val (ctx, prefix) = provider.splitContextPrefix(text)
-        val matcher = PlainPrefixMatcher(prefix)
-
-        val actual = provider.complete(ctx).filter { matcher.isStartMatch(it) }.map { it.lookupString }
         check(actual == expectedCompletions) {
             "\nExpected:\n$expectedCompletions\n\nActual:\n$actual"
         }
@@ -194,5 +191,15 @@ class CargoCommandCompletionProviderTest : RsTestBase() {
             ),
             CfgOptions.DEFAULT
         )
+    }
+
+    companion object {
+        fun complete(text: String, cargoProjects: CargoProjectsService, testWorkspace: CargoWorkspace?): List<String> {
+            val provider = CargoCommandCompletionProvider(cargoProjects, testWorkspace)
+            val (ctx, prefix) = provider.splitContextPrefix(text)
+            val matcher = PlainPrefixMatcher(prefix)
+
+            return provider.complete(ctx).filter { matcher.isStartMatch(it) }.map { it.lookupString }
+        }
     }
 }

--- a/src/test/kotlin/org/rust/cargo/util/CargoWithToolchainCommandCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/cargo/util/CargoWithToolchainCommandCompletionProviderTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.util
+
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.cargo.project.model.cargoProjects
+
+class CargoWithToolchainCommandCompletionProviderTest : RsWithToolchainTestBase() {
+    fun `test target triple completion includes popular targets`() {
+        val testProject = buildProject {
+            toml("Cargo.toml", """
+                [package]
+                name = "hello"
+                version = "0.1.0"
+                authors = []
+            """)
+
+            dir("src") {
+                rust("main.rs", """
+                    fn main() {}
+                """)
+            }
+        }
+
+        val cargoProjects = testProject.psiFile("src/main.rs").project.cargoProjects
+        val cargoProject = cargoProjects.allProjects.first()
+        val completions = CargoCommandCompletionProviderTest.complete("build --target ", cargoProjects, cargoProject.workspace)
+
+        assertContainsElements(
+            completions,
+            // Tier 1
+            "aarch64-unknown-linux-gnu",
+            "i686-pc-windows-gnu",
+            "i686-pc-windows-msvc",
+            "i686-pc-windows-msvc",
+            "x86_64-apple-darwin",
+            "x86_64-pc-windows-gnu",
+            "x86_64-pc-windows-msvc",
+            "x86_64-pc-windows-gnu",
+            // Other popular
+            "wasm32-unknown-unknown",
+            "wasm32-wasi"
+        )
+    }
+}


### PR DESCRIPTION
Adds completion for the `--target` flag in cargo run configuration and run anything action.

<img src="https://user-images.githubusercontent.com/6342851/114849041-08c47b80-9de8-11eb-950e-a9ddb3ad9cc8.png" width="500">

If a user will try to run the configuration without chosen target installed, there will be a prompt to install it.

<img src="https://user-images.githubusercontent.com/6342851/107682598-96350380-6cb1-11eb-831f-288f14a283d6.png" width="400">

### TODO:
- [x] Move target list retrieving into `rustcInfo` in `CargoSyncTask`
- [x] Add tests

changelog: Suggest target triples in command for Cargo run configuration and run anything dialog. Suggest installing the target if it is not yet installed
