### PR TITLE
RUN: Initial support for Run Targets

### DIFF
--- a/clion/src/main/kotlin/org/rust/clion/profiler/legacy/RsProfilerRunnerLegacy.kt
+++ b/clion/src/main/kotlin/org/rust/clion/profiler/legacy/RsProfilerRunnerLegacy.kt
@@ -7,7 +7,7 @@ package org.rust.clion.profiler.legacy
 
 import com.intellij.execution.configurations.RunProfile
 import com.intellij.profiler.clion.ProfilerExecutor
-import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowEnabled
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowAvailable
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.runconfig.legacy.RsAsyncRunner
 import org.rust.clion.profiler.dtrace.RsDTraceConfigurationExtension
@@ -16,7 +16,7 @@ import org.rust.clion.profiler.perf.RsPerfConfigurationExtension
 private const val ERROR_MESSAGE_TITLE: String = "Unable to run profiler"
 
 /**
- * This runner is used if [isBuildToolWindowEnabled] is false.
+ * This runner is used if [isBuildToolWindowAvailable] is false.
  */
 class RsProfilerRunnerLegacy : RsAsyncRunner(ProfilerExecutor.EXECUTOR_ID, ERROR_MESSAGE_TITLE) {
     override fun getRunnerId(): String = RUNNER_ID

--- a/clion/src/main/kotlin/org/rust/clion/valgrind/legacy/RsValgrindRunnerLegacy.kt
+++ b/clion/src/main/kotlin/org/rust/clion/valgrind/legacy/RsValgrindRunnerLegacy.kt
@@ -8,13 +8,13 @@ package org.rust.clion.valgrind.legacy
 import com.intellij.execution.configurations.RunProfile
 import com.intellij.openapi.util.SystemInfo
 import com.jetbrains.cidr.cpp.valgrind.ValgrindExecutor
-import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowEnabled
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowAvailable
 import org.rust.cargo.runconfig.legacy.RsAsyncRunner
 
 private const val ERROR_MESSAGE_TITLE: String = "Unable to run Valgrind"
 
 /**
- * This runner is used if [isBuildToolWindowEnabled] is false.
+ * This runner is used if [isBuildToolWindowAvailable] is false.
  */
 class RsValgrindRunnerLegacy : RsAsyncRunner(ValgrindExecutor.EXECUTOR_ID, ERROR_MESSAGE_TITLE) {
     override fun getRunnerId(): String = RUNNER_ID

--- a/coverage/src/main/kotlin/org/rust/coverage/GrcovRunner.kt
+++ b/coverage/src/main/kotlin/org/rust/coverage/GrcovRunner.kt
@@ -33,6 +33,7 @@ import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildConfiguration
 import org.rust.cargo.runconfig.buildtool.CargoPatch
 import org.rust.cargo.runconfig.buildtool.cargoPatches
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.runconfig.command.hasRemoteTarget
 import org.rust.cargo.toolchain.RsToolchainBase.Companion.RUSTC_BOOTSTRAP
 import org.rust.cargo.toolchain.tools.Cargo.Companion.checkNeedInstallGrcov
 import org.rust.cargo.toolchain.tools.grcov
@@ -45,7 +46,7 @@ class GrcovRunner : RsDefaultProgramRunnerBase() {
     override fun canRun(executorId: String, profile: RunProfile): Boolean {
         if (executorId != CoverageExecutor.EXECUTOR_ID || profile !is CargoCommandConfiguration ||
             profile.clean() !is CargoCommandConfiguration.CleanConfiguration.Ok) return false
-        return !isBuildConfiguration(profile) && getBuildConfiguration(profile) != null
+        return !profile.hasRemoteTarget && !isBuildConfiguration(profile) && getBuildConfiguration(profile) != null
     }
 
     override fun createConfigurationData(settingsProvider: ConfigurationInfoProvider): RunnerSettings {

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/legacy/RsDebugRunnerLegacyBase.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/legacy/RsDebugRunnerLegacyBase.kt
@@ -13,14 +13,14 @@ import com.intellij.openapi.project.Project
 import org.jetbrains.concurrency.AsyncPromise
 import org.rust.cargo.runconfig.BuildResult.ToolchainError
 import org.rust.cargo.runconfig.CargoRunStateBase
-import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowEnabled
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowAvailable
 import org.rust.cargo.runconfig.legacy.RsAsyncRunner
 import org.rust.cargo.runconfig.legacy.RsAsyncRunner.Companion.Binary
 import org.rust.debugger.runconfig.RsDebugRunnerUtils
 import org.rust.debugger.runconfig.RsDebugRunnerUtils.ERROR_MESSAGE_TITLE
 
 /**
- * This runner is used if [isBuildToolWindowEnabled] is false.
+ * This runner is used if [isBuildToolWindowAvailable] is false.
  */
 abstract class RsDebugRunnerLegacyBase : RsAsyncRunner(DefaultDebugExecutor.EXECUTOR_ID, ERROR_MESSAGE_TITLE) {
     override fun getRunnerId(): String = RUNNER_ID

--- a/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/RsAdditionalLibraryRootsProvider.kt
@@ -19,7 +19,6 @@ import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.PackageOrigin.*
 import org.rust.cargo.toolchain.impl.RustcVersion
 import org.rust.ide.icons.RsIcons
-import org.rust.openapiext.checkReadAccessAllowed
 import org.rust.stdext.buildList
 import org.rust.stdext.exhaustive
 import javax.swing.Icon
@@ -65,11 +64,8 @@ class GeneratedCodeFakeLibrary(private val sourceRoots: Set<VirtualFile>) : Synt
 }
 
 class RsAdditionalLibraryRootsProvider : AdditionalLibraryRootsProvider() {
-    override fun getAdditionalProjectLibraries(project: Project): Collection<SyntheticLibrary> {
-        checkReadAccessAllowed()
-        return project.cargoProjects.allProjects
-            .smartFlatMap { it.ideaLibraries }
-    }
+    override fun getAdditionalProjectLibraries(project: Project): Collection<SyntheticLibrary> =
+        project.cargoProjects.allProjects.smartFlatMap { it.ideaLibraries }
 
     override fun getRootsToWatch(project: Project): Collection<VirtualFile> =
         getAdditionalProjectLibraries(project).flatMap { it.sourceRoots }

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoCommandRunner.kt
@@ -12,8 +12,9 @@ import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.ui.RunContentDescriptor
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.getBuildConfiguration
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildConfiguration
-import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowEnabled
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowAvailable
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.runconfig.command.hasRemoteTarget
 
 open class CargoCommandRunner : RsDefaultProgramRunnerBase() {
     override fun getRunnerId(): String = RUNNER_ID
@@ -21,15 +22,17 @@ open class CargoCommandRunner : RsDefaultProgramRunnerBase() {
     override fun canRun(executorId: String, profile: RunProfile): Boolean {
         if (executorId != DefaultRunExecutor.EXECUTOR_ID || profile !is CargoCommandConfiguration) return false
         val cleaned = profile.clean().ok ?: return false
-        return profile.isBuildToolWindowEnabled ||
-            cleaned.cmd.command != "test" ||
-            getBuildConfiguration(profile) == null
+        val isLocalRun = !profile.hasRemoteTarget || profile.buildTarget.isRemote
+        val isLegacyTestRun = !profile.isBuildToolWindowAvailable &&
+            cleaned.cmd.command == "test" &&
+            getBuildConfiguration(profile) != null
+        return isLocalRun && !isLegacyTestRun
     }
 
     override fun doExecute(state: RunProfileState, environment: ExecutionEnvironment): RunContentDescriptor? {
         val configuration = environment.runProfile
         return if (configuration is CargoCommandConfiguration &&
-            !(isBuildConfiguration(configuration) && configuration.isBuildToolWindowEnabled)) {
+            !(isBuildConfiguration(configuration) && configuration.isBuildToolWindowAvailable)) {
             super.doExecute(state, environment)
         } else {
             null

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunState.kt
@@ -16,8 +16,8 @@ class CargoRunState(
     config: CargoCommandConfiguration.CleanConfiguration.Ok
 ) : CargoRunStateBase(environment, runConfiguration, config) {
     init {
-        val scope = ExecutionSearchScopes.executionScope(environment.project, environment.runProfile)
-        consoleBuilder = CargoConsoleBuilder(environment.project, scope)
+        val scope = ExecutionSearchScopes.executionScope(project, environment.runProfile)
+        consoleBuilder = CargoConsoleBuilder(project, scope)
         createFilters(cargoProject).forEach { consoleBuilder.addFilter(it) }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoTestCommandRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoTestCommandRunner.kt
@@ -20,9 +20,10 @@ import com.intellij.openapi.application.invokeLater
 import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.getBuildConfiguration
-import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowEnabled
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowAvailable
 import org.rust.cargo.runconfig.buildtool.isActivateToolWindowBeforeRun
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.runconfig.command.hasRemoteTarget
 import org.rust.openapiext.isUnitTestMode
 import org.rust.openapiext.saveAllDocuments
 
@@ -32,9 +33,11 @@ class CargoTestCommandRunner : AsyncProgramRunner<RunnerSettings>() {
     override fun canRun(executorId: String, profile: RunProfile): Boolean {
         if (executorId != DefaultRunExecutor.EXECUTOR_ID || profile !is CargoCommandConfiguration) return false
         val cleaned = profile.clean().ok ?: return false
-        return !profile.isBuildToolWindowEnabled &&
+        val isLocalRun = !profile.hasRemoteTarget || profile.buildTarget.isRemote
+        val isLegacyTestRun = !profile.isBuildToolWindowAvailable &&
             cleaned.cmd.command == "test" &&
             getBuildConfiguration(profile) != null
+        return isLocalRun && isLegacyTestRun
     }
 
     override fun execute(environment: ExecutionEnvironment, state: RunProfileState): Promise<RunContentDescriptor?> {

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoTestRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoTestRunState.kt
@@ -30,7 +30,6 @@ class CargoTestRunState(
     runConfiguration: CargoCommandConfiguration,
     config: CargoCommandConfiguration.CleanConfiguration.Ok
 ) : CargoRunStateBase(environment, runConfiguration, config) {
-
     private val cargoTestPatch: CargoPatch = { commandLine ->
         val rustcVer = cargoProject?.rustcInfo?.version
         // TODO: always pass `withSudo` when `com.intellij.execution.process.ElevationService` supports error stream redirection
@@ -41,7 +40,7 @@ class CargoTestRunState(
             } else {
                 RsBundle.message("notification.run.tests.as.root.unix")
             }
-            environment.project.showBalloon(message, NotificationType.WARNING)
+            project.showBalloon(message, NotificationType.WARNING)
         }
         commandLine.copy(additionalArguments = patchArgs(commandLine, rustcVer), withSudo = false)
     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsCommandConfiguration.kt
@@ -24,7 +24,11 @@ abstract class RsCommandConfiguration(
     RunConfigurationWithSuppressedDefaultDebugAction {
     abstract var command: String
 
-    var workingDirectory: Path? = project.cargoProjects.allProjects.firstOrNull()?.workingDirectory
+    var workingDirectory: Path? = if (!project.isDefault) {
+        project.cargoProjects.allProjects.firstOrNull()?.workingDirectory
+    } else {
+        null
+    }
 
     override fun suggestedName(): String = command.substringBefore(' ').capitalize()
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
@@ -20,9 +20,10 @@ import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.getBuildConfiguration
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildConfiguration
-import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowEnabled
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowAvailable
 import org.rust.cargo.runconfig.buildtool.cargoPatches
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.runconfig.command.hasRemoteTarget
 import org.rust.cargo.toolchain.impl.CompilerArtifactMessage
 import org.rust.cargo.toolchain.tools.Cargo.Companion.getCargoCommonPatch
 import org.rust.cargo.util.CargoArgsParser.Companion.parseArgs
@@ -31,13 +32,14 @@ import org.rust.stdext.toPath
 import java.util.concurrent.CompletableFuture
 
 abstract class RsExecutableRunner(
-    private val executorId: String,
+    protected val executorId: String,
     private val errorMessageTitle: String
 ) : RsDefaultProgramRunnerBase() {
     override fun canRun(executorId: String, profile: RunProfile): Boolean {
-        if (executorId != this.executorId || profile !is CargoCommandConfiguration ||
-            profile.clean() !is CargoCommandConfiguration.CleanConfiguration.Ok) return false
-        return profile.isBuildToolWindowEnabled &&
+        if (executorId != this.executorId || profile !is CargoCommandConfiguration) return false
+        if (profile.clean().ok == null) return false
+        return !profile.hasRemoteTarget &&
+            profile.isBuildToolWindowAvailable &&
             !isBuildConfiguration(profile) &&
             getBuildConfiguration(profile) != null
     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsProcessHandler.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsProcessHandler.kt
@@ -9,15 +9,26 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.AnsiEscapeDecoder
 import com.intellij.execution.process.KillableProcessHandler
 import com.intellij.openapi.util.Key
+import java.nio.charset.Charset
 
 /**
  * Same as [com.intellij.execution.process.KillableColoredProcessHandler], but uses [RsAnsiEscapeDecoder].
  */
-class RsProcessHandler(
-    commandLine: GeneralCommandLine,
-    processColors: Boolean = true
-) : KillableProcessHandler(commandLine), AnsiEscapeDecoder.ColoredTextAcceptor {
-    private val decoder: AnsiEscapeDecoder? = if (processColors) RsAnsiEscapeDecoder() else null
+class RsProcessHandler : KillableProcessHandler, AnsiEscapeDecoder.ColoredTextAcceptor {
+    private val decoder: AnsiEscapeDecoder?
+
+    constructor(commandLine: GeneralCommandLine, processColors: Boolean = true) : super(commandLine) {
+        decoder = if (processColors) RsAnsiEscapeDecoder() else null
+    }
+
+    constructor(
+        process: Process,
+        commandRepresentation: String,
+        charset: Charset,
+        processColors: Boolean = true
+    ) : super(process, commandRepresentation, charset) {
+        decoder = if (processColors) RsAnsiEscapeDecoder() else null
+    }
 
     init {
         setShouldDestroyProcessRecursively(true)

--- a/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
@@ -11,7 +11,6 @@ import com.intellij.execution.RunManager
 import com.intellij.execution.RunnerAndConfigurationSettings
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.filters.Filter
-import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.ui.RunContentManager
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -26,6 +25,8 @@ import org.rust.cargo.project.toolwindow.CargoToolWindow
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.runconfig.command.CargoCommandConfigurationType
 import org.rust.cargo.runconfig.filters.*
+import org.rust.cargo.runconfig.target.startProcess
+import org.rust.cargo.runconfig.target.targetEnvironment
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.toolchain.tools.cargo
 import org.rust.openapiext.checkIsDispatchThread
@@ -189,15 +190,13 @@ fun CargoRunStateBase.executeCommandLine(
     environment: ExecutionEnvironment
 ): DefaultExecutionResult {
     val runConfiguration = runConfiguration
+    val targetEnvironment = runConfiguration.targetEnvironment
     val context = ConfigurationExtensionContext()
 
     val extensionManager = RsRunConfigurationExtensionManager.getInstance()
     extensionManager.patchCommandLine(runConfiguration, environment, commandLine, context)
     extensionManager.patchCommandLineState(runConfiguration, environment, this, context)
-
-    val handler = RsProcessHandler(commandLine)
-    ProcessTerminatedListener.attach(handler) // shows exit code upon termination
-
+    val handler = commandLine.startProcess(environment.project, targetEnvironment, processColors = true, uploadExecutable = true)
     extensionManager.attachExtensionsToProcess(runConfiguration, handler, environment, context)
 
     val console = consoleBuilder.console

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildConfiguration.kt
@@ -9,7 +9,7 @@ import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.roots.ProjectModelBuildableElement
 import com.intellij.openapi.roots.ProjectModelExternalSource
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildConfiguration
-import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowEnabled
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowAvailable
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 
 @Suppress("UnstableApiUsage")
@@ -17,7 +17,7 @@ open class CargoBuildConfiguration(
     val configuration: CargoCommandConfiguration,
     val environment: ExecutionEnvironment
 ) : ProjectModelBuildableElement {
-    open val enabled: Boolean get() = configuration.isBuildToolWindowEnabled
+    open val enabled: Boolean get() = configuration.isBuildToolWindowAvailable
 
     init {
         require(isBuildConfiguration(configuration))

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildTaskRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildTaskRunner.kt
@@ -33,8 +33,9 @@ import org.rust.cargo.runconfig.CargoCommandRunner
 import org.rust.cargo.runconfig.buildProject
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.createBuildEnvironment
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.getBuildConfiguration
-import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowEnabled
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowAvailable
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.runconfig.command.hasRemoteTarget
 import org.rust.cargo.runconfig.createCargoCommandRunConfiguration
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.toolchain.tools.cargo
@@ -62,7 +63,8 @@ class CargoBuildTaskRunner : ProjectTaskRunner() {
             return rejectedPromise(RsBundle.message("untrusted.project.notification.execution.error"))
         }
 
-        if (!project.isBuildToolWindowEnabled) {
+        val configuration = context.runConfiguration as? CargoCommandConfiguration
+        if (configuration?.hasRemoteTarget == true || !project.isBuildToolWindowAvailable) {
             invokeLater { project.buildProject() }
             return rejectedPromise()
         }

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -10,6 +10,9 @@ import com.intellij.execution.InputRedirectAware
 import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.configurations.*
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.execution.target.LanguageRuntimeType
+import com.intellij.execution.target.TargetEnvironmentAwareRunProfile
+import com.intellij.execution.target.TargetEnvironmentConfiguration
 import com.intellij.execution.testframework.actions.ConsolePropertiesProvider
 import com.intellij.execution.testframework.sm.runner.SMTRunnerConsoleProperties
 import com.intellij.execution.util.ProgramParametersUtil
@@ -28,6 +31,9 @@ import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.runconfig.*
+import org.rust.cargo.runconfig.target.BuildTarget
+import org.rust.cargo.runconfig.target.RsLanguageRuntimeConfiguration
+import org.rust.cargo.runconfig.target.RsLanguageRuntimeType
 import org.rust.cargo.runconfig.test.CargoTestConsoleProperties
 import org.rust.cargo.runconfig.ui.CargoCommandConfigurationEditor
 import org.rust.cargo.toolchain.BacktraceMode
@@ -42,23 +48,29 @@ import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
 
+val CargoCommandConfiguration.hasRemoteTarget: Boolean
+    get() = defaultTargetName != null
+
 /**
  * This class describes a Run Configuration.
  * It is basically a bunch of values which are persisted to .xml files inside .idea,
  * or displayed in the GUI form. It has to be mutable to satisfy various IDE's APIs.
  */
-open class CargoCommandConfiguration(
+class CargoCommandConfiguration(
     project: Project,
     name: String,
     factory: ConfigurationFactory
 ) : RsCommandConfiguration(project, name, factory),
-    InputRedirectAware.InputRedirectOptions, ConsolePropertiesProvider {
+    InputRedirectAware.InputRedirectOptions,
+    ConsolePropertiesProvider,
+    TargetEnvironmentAwareRunProfile {
     override var command: String = "run"
     var channel: RustChannel = RustChannel.DEFAULT
     var requiredFeatures: Boolean = true
     var allFeatures: Boolean = false
     var emulateTerminal: Boolean = false
     var withSudo: Boolean = false
+    var buildTarget: BuildTarget = BuildTarget.REMOTE
     var backtrace: BacktraceMode = BacktraceMode.SHORT
     var env: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
 
@@ -88,6 +100,22 @@ open class CargoCommandConfiguration(
         redirectInputPath = value
     }
 
+    override fun canRunOn(target: TargetEnvironmentConfiguration): Boolean {
+        return target.runtimes.findByType(RsLanguageRuntimeConfiguration::class.java) != null
+    }
+
+    override fun getDefaultLanguageRuntimeType(): LanguageRuntimeType<*>? {
+        return LanguageRuntimeType.EXTENSION_NAME.findExtension(RsLanguageRuntimeType::class.java)
+    }
+
+    override fun getDefaultTargetName(): String? {
+        return options.remoteTarget
+    }
+
+    override fun setDefaultTargetName(targetName: String?) {
+        options.remoteTarget = targetName
+    }
+
     override fun writeExternal(element: Element) {
         super.writeExternal(element)
         element.writeEnum("channel", channel)
@@ -95,6 +123,7 @@ open class CargoCommandConfiguration(
         element.writeBool("allFeatures", allFeatures)
         element.writeBool("emulateTerminal", emulateTerminal)
         element.writeBool("withSudo", withSudo)
+        element.writeEnum("buildTarget", buildTarget)
         element.writeEnum("backtrace", backtrace)
         env.writeExternal(element)
         element.writeBool("isRedirectInput", isRedirectInput)
@@ -112,6 +141,7 @@ open class CargoCommandConfiguration(
         element.readBool("allFeatures")?.let { allFeatures = it }
         element.readBool("emulateTerminal")?.let { emulateTerminal = it }
         element.readBool("withSudo")?.let { withSudo = it }
+        element.readEnum<BuildTarget>("buildTarget")?.let { buildTarget = it }
         element.readEnum<BacktraceMode>("backtrace")?.let { backtrace = it }
         env = EnvironmentVariablesData.readExternal(element)
         element.readBool("isRedirectInput")?.let { isRedirectInput = it }
@@ -173,12 +203,13 @@ open class CargoCommandConfiguration(
         }
     }
 
-    private fun showTestToolWindow(commandLine: CargoCommandLine): Boolean =
-        commandLine.command == "test" &&
-            isFeatureEnabled(RsExperiments.TEST_TOOL_WINDOW) &&
-            !Cargo.TEST_NOCAPTURE_ENABLED_KEY.asBoolean() &&
-            "--nocapture" !in commandLine.additionalArguments
-
+    private fun showTestToolWindow(commandLine: CargoCommandLine): Boolean = when {
+        !isFeatureEnabled(RsExperiments.TEST_TOOL_WINDOW) -> false
+        commandLine.command != "test" -> false
+        "--nocapture" in commandLine.additionalArguments -> false
+        Cargo.TEST_NOCAPTURE_ENABLED_KEY.asBoolean() -> false
+        else -> !hasRemoteTarget
+    }
 
     override fun createTestConsoleProperties(executor: Executor): SMTRunnerConsoleProperties? {
         val config = clean().ok ?: return null

--- a/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
@@ -31,8 +31,10 @@ import org.jetbrains.concurrency.Promise
 import org.rust.cargo.runconfig.*
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.getBuildConfiguration
 import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildConfiguration
-import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowEnabled
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowAvailable
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.runconfig.command.hasRemoteTarget
+import org.rust.cargo.runconfig.target.localBuildArgsForRemoteRun
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.toolchain.impl.CargoMetadata
 import org.rust.cargo.toolchain.impl.CompilerArtifactMessage
@@ -46,7 +48,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 /**
- * This runner is used if [isBuildToolWindowEnabled] is false.
+ * This runner is used if [isBuildToolWindowAvailable] is false.
  */
 abstract class RsAsyncRunner(
     private val executorId: String,
@@ -55,7 +57,8 @@ abstract class RsAsyncRunner(
     override fun canRun(executorId: String, profile: RunProfile): Boolean {
         if (executorId != this.executorId || profile !is CargoCommandConfiguration ||
             profile.clean() !is CargoCommandConfiguration.CleanConfiguration.Ok) return false
-        return !profile.isBuildToolWindowEnabled &&
+        return !profile.hasRemoteTarget &&
+            !profile.isBuildToolWindowAvailable &&
             !isBuildConfiguration(profile) &&
             getBuildConfiguration(profile) != null
     }
@@ -67,13 +70,14 @@ abstract class RsAsyncRunner(
 
         val commandLine = state.prepareCommandLine(getCargoCommonPatch(environment.project))
         val (commandArguments, executableArguments) = parseArgs(commandLine.command, commandLine.additionalArguments)
+        val additionalBuildArgs = state.runConfiguration.localBuildArgsForRemoteRun
 
         val isTestRun = commandLine.command == "test"
         val cmdHasNoRun = "--no-run" in commandLine.additionalArguments
         val buildCommand = if (isTestRun) {
             if (cmdHasNoRun) commandLine else commandLine.prependArgument("--no-run")
         } else {
-            commandLine.copy(command = "build", additionalArguments = commandArguments)
+            commandLine.copy(command = "build", additionalArguments = commandArguments + additionalBuildArgs)
         }.copy(emulateTerminal = false, withSudo = false) // building does not require root privileges
 
         val getRunCommand = { executablePath: Path ->

--- a/src/main/kotlin/org/rust/cargo/runconfig/target/RsCommandLineSetup.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/target/RsCommandLineSetup.kt
@@ -1,0 +1,119 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.target
+
+import com.intellij.execution.target.LanguageRuntimeType.VolumeDescriptor
+import com.intellij.execution.target.TargetEnvironment
+import com.intellij.execution.target.TargetEnvironment.TargetPath.Temporary
+import com.intellij.execution.target.TargetEnvironmentRequest
+import com.intellij.execution.target.TargetProgressIndicator
+import com.intellij.execution.target.local.LocalTargetEnvironment
+import com.intellij.execution.target.value.DeferredTargetValue
+import com.intellij.execution.target.value.TargetValue
+import com.intellij.execution.target.value.getUploadRootForLocalPath
+import com.intellij.lang.LangCoreBundle
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.util.io.isDirectory
+import org.jetbrains.concurrency.AsyncPromise
+import org.jetbrains.concurrency.Promise
+import org.rust.stdext.toPath
+import java.nio.file.Path
+import java.nio.file.Paths
+
+@Suppress("UnstableApiUsage")
+class RsCommandLineSetup(val request: TargetEnvironmentRequest) {
+    private val languageRuntime: RsLanguageRuntimeConfiguration? = request.configuration?.languageRuntime
+    private val environmentPromise = AsyncPromise<Pair<TargetEnvironment, TargetProgressIndicator>>()
+    private val dependingOnEnvironmentPromise: MutableList<Promise<Unit>> = mutableListOf()
+    private val uploads: MutableList<Upload> = mutableListOf()
+    private val projectHomeOnTarget: VolumeDescriptor = VolumeDescriptor(
+        RsCommandLineSetup::class.java.simpleName + ":projectHomeOnTarget",
+        "",
+        "",
+        "",
+        request.projectPathOnTarget
+    )
+
+    fun requestUploadIntoTarget(uploadPathString: String): TargetValue<String> {
+        val uploadPath = FileUtil.toSystemDependentName(uploadPathString).toPath()
+        val isDir = uploadPath.isDirectory()
+        val localRootPath = if (isDir) uploadPath else (uploadPath.parent ?: Paths.get("."))
+        val (uploadRoot, pathToRoot) = request.getUploadRootForLocalPath(localRootPath.toString())
+            ?: createUploadRoot(projectHomeOnTarget, localRootPath).let { uploadRoot ->
+                request.uploadVolumes += uploadRoot
+                uploadRoot to "."
+            }
+        val result = DeferredTargetValue(uploadPathString)
+        dependingOnEnvironmentPromise += environmentPromise.then { (environment, targetProgressIndicator) ->
+            if (targetProgressIndicator.isCanceled || targetProgressIndicator.isStopped) {
+                result.stopProceeding()
+                return@then
+            }
+            val volume = environment.uploadVolumes.getValue(uploadRoot)
+            try {
+                val relativePath = if (isDir) {
+                    pathToRoot
+                } else {
+                    uploadPath.fileName.toString()
+                        .let { if (pathToRoot == ".") it else joinPath(pathToRoot, it) }
+                }
+                val resolvedTargetPath = volume.resolveTargetPath(relativePath)
+                uploads.add(Upload(volume, relativePath))
+                result.resolve(resolvedTargetPath)
+            } catch (t: Throwable) {
+                LOG.warn(t)
+                targetProgressIndicator.stopWithErrorMessage(
+                    LangCoreBundle.message(
+                        "progress.message.failed.to.resolve.0.1",
+                        volume.localRoot, t.localizedMessage
+                    )
+                )
+                result.resolveFailure(t)
+            }
+        }
+        return result
+    }
+
+    private fun createUploadRoot(
+        volumeDescriptor: VolumeDescriptor,
+        localRootPath: Path
+    ): TargetEnvironment.UploadRoot =
+        languageRuntime?.createUploadRoot(volumeDescriptor, localRootPath)
+            ?: TargetEnvironment.UploadRoot(localRootPath, Temporary())
+
+    private fun joinPath(vararg segments: String): String =
+        segments.joinToString(request.targetPlatform.platform.fileSeparator.toString())
+
+    fun provideEnvironment(environment: TargetEnvironment, targetProgressIndicator: TargetProgressIndicator) {
+        val application = ApplicationManager.getApplication()
+        LOG.assertTrue(
+            environment is LocalTargetEnvironment ||
+                uploads.isEmpty() ||
+                !application.isDispatchThread ||
+                application.isUnitTestMode,
+            "Preparation of environment shouldn't be performed on EDT."
+        )
+        environmentPromise.setResult(environment to targetProgressIndicator)
+        uploads.asSequence()
+            .sortedBy { it.relativePath.length }
+            .groupBy({ it.volume }, { it.relativePath })
+            .forEach { (volume, relativePaths) ->
+                volume.upload(relativePaths.first(), targetProgressIndicator)
+            }
+        for (promise in dependingOnEnvironmentPromise) {
+            promise.blockingGet(0) // Just rethrows errors
+        }
+    }
+
+    private class Upload(val volume: TargetEnvironment.UploadableVolume, val relativePath: String)
+
+    companion object {
+        private val LOG: Logger = logger<RsCommandLineSetup>()
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/target/RsLanguageRuntimeConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/target/RsLanguageRuntimeConfigurable.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.target
+
+import com.intellij.execution.target.getRuntimeType
+import com.intellij.openapi.options.BoundConfigurable
+import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.layout.panel
+import com.intellij.ui.layout.titledRow
+import org.rust.RsBundle
+
+class RsLanguageRuntimeConfigurable(val config: RsLanguageRuntimeConfiguration) :
+    BoundConfigurable(config.displayName, config.getRuntimeType().helpTopic) {
+
+    override fun createPanel(): DialogPanel = panel {
+        titledRow()
+
+        row(RsBundle.message("run.target.rustc.executable.path.label")) {
+            textField(config::rustcPath)
+        }
+        row(RsBundle.message("run.target.rustc.executable.version.label")) {
+            textField(config::rustcVersion).enabled(false)
+        }
+
+        row(RsBundle.message("run.target.cargo.executable.path.label")) {
+            textField(config::cargoPath)
+        }
+        row(RsBundle.message("run.target.cargo.executable.version.label")) {
+            textField(config::cargoVersion).enabled(false)
+        }
+
+        row(RsBundle.message("run.target.build.arguments.label")) {
+            textField(config::localBuildArgs)
+                .comment(RsBundle.message("run.target.build.arguments.comment"))
+                .apply { component.emptyText.text = "e.g. --target=x86_64-unknown-linux-gnu" }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/target/RsLanguageRuntimeConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/target/RsLanguageRuntimeConfiguration.kt
@@ -1,0 +1,51 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.target
+
+import com.intellij.execution.target.LanguageRuntimeConfiguration
+import com.intellij.openapi.components.BaseState
+import com.intellij.openapi.components.PersistentStateComponent
+
+class RsLanguageRuntimeConfiguration : LanguageRuntimeConfiguration(RsLanguageRuntimeType.TYPE_ID),
+                                       PersistentStateComponent<RsLanguageRuntimeConfiguration.MyState> {
+    var rustcPath: String = ""
+    var rustcVersion: String = ""
+
+    var cargoPath: String = ""
+    var cargoVersion: String = ""
+
+    var localBuildArgs: String = ""
+
+    override fun getState() = MyState().also {
+        it.rustcPath = this.rustcPath
+        it.rustcVersion = this.rustcVersion
+
+        it.cargoPath = this.cargoPath
+        it.cargoVersion = this.cargoVersion
+
+        it.localBuildArgs = this.localBuildArgs
+    }
+
+    override fun loadState(state: MyState) {
+        this.rustcPath = state.rustcPath.orEmpty()
+        this.rustcVersion = state.rustcVersion.orEmpty()
+
+        this.cargoPath = state.cargoPath.orEmpty()
+        this.cargoVersion = state.cargoVersion.orEmpty()
+
+        this.localBuildArgs = state.localBuildArgs.orEmpty()
+    }
+
+    class MyState : BaseState() {
+        var rustcPath by string()
+        var rustcVersion by string()
+
+        var cargoPath by string()
+        var cargoVersion by string()
+
+        var localBuildArgs by string()
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/target/RsLanguageRuntimeIntrospector.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/target/RsLanguageRuntimeIntrospector.kt
@@ -1,0 +1,62 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.target
+
+import com.intellij.execution.target.LanguageRuntimeType
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.util.text.nullize
+import java.util.concurrent.CompletableFuture
+
+class RsLanguageRuntimeIntrospector(val config: RsLanguageRuntimeConfiguration) :
+    LanguageRuntimeType.Introspector<RsLanguageRuntimeConfiguration> {
+
+    override fun introspect(
+        subject: LanguageRuntimeType.Introspectable
+    ): CompletableFuture<RsLanguageRuntimeConfiguration> {
+        val rustcPathPromise = if (config.rustcPath.isBlank()) {
+            subject.promiseOneLineScript("/usr/bin/which rustc").thenApply { output ->
+                output?.trim()?.nullize()?.also { config.rustcPath = it }
+            }
+        } else {
+            CompletableFuture.completedFuture(config.rustcPath)
+        }
+
+        val rustcVersionPromise = rustcPathPromise.thenCompose { rustcPath ->
+            if (rustcPath == null) return@thenCompose LanguageRuntimeType.Introspector.DONE
+            subject.promiseOneLineScript("$rustcPath --version").thenApply { output ->
+                output?.removePrefix("rustc")?.trim()?.nullize()?.also {
+                    config.rustcVersion = it
+                }
+            }
+        }
+
+        val cargoPathPromise = if (config.cargoPath.isBlank()) {
+            subject.promiseOneLineScript("/usr/bin/which cargo").thenApply { output ->
+                output?.trim()?.nullize()?.also { config.cargoPath = it }
+            }
+        } else {
+            CompletableFuture.completedFuture(config.cargoPath)
+        }
+
+        val cargoVersionPromise = cargoPathPromise.thenCompose { cargoPath ->
+            if (cargoPath == null) return@thenCompose LanguageRuntimeType.Introspector.DONE
+            subject.promiseOneLineScript("$cargoPath --version").thenApply { output ->
+                output?.removePrefix("cargo")?.trim()?.nullize()?.also {
+                    config.cargoVersion = it
+                }
+            }
+        }
+
+        return CompletableFuture.allOf(rustcVersionPromise, cargoVersionPromise).thenApply { config }
+    }
+
+    companion object {
+        private fun LanguageRuntimeType.Introspectable.promiseOneLineScript(
+            script: String
+        ): CompletableFuture<String?> = promiseExecuteScript(script)
+            .thenApply { it?.let { StringUtil.splitByLines(it, true) }?.firstOrNull() }
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/target/RsLanguageRuntimeType.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/target/RsLanguageRuntimeType.kt
@@ -1,0 +1,58 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.target
+
+import com.intellij.execution.RunnerAndConfigurationSettings
+import com.intellij.execution.target.LanguageRuntimeType
+import com.intellij.execution.target.TargetEnvironmentConfiguration
+import com.intellij.execution.target.TargetEnvironmentType
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.project.Project
+import org.rust.cargo.runconfig.RsCommandConfiguration
+import org.rust.ide.icons.RsIcons
+import java.util.function.Supplier
+import javax.swing.Icon
+
+class RsLanguageRuntimeType : LanguageRuntimeType<RsLanguageRuntimeConfiguration>(TYPE_ID) {
+    override val displayName: String = "Rust"
+    override val icon: Icon = RsIcons.RUST
+    override val configurableDescription: String = "Rust Configuration"
+    override val launchDescription: String = "Run Rust Command"
+
+    override fun createSerializer(config: RsLanguageRuntimeConfiguration): PersistentStateComponent<*> = config
+
+    override fun createDefaultConfig(): RsLanguageRuntimeConfiguration = RsLanguageRuntimeConfiguration()
+
+    override fun duplicateConfig(config: RsLanguageRuntimeConfiguration): RsLanguageRuntimeConfiguration {
+        return duplicatePersistentComponent(this, config)
+    }
+
+    override fun createIntrospector(config: RsLanguageRuntimeConfiguration): Introspector<RsLanguageRuntimeConfiguration>? {
+        if (config.rustcPath.isNotBlank() && config.rustcVersion.isNotBlank() &&
+            config.cargoPath.isNotBlank() && config.cargoVersion.isNotBlank()) return null
+        return RsLanguageRuntimeIntrospector(config)
+    }
+
+    override fun createConfigurable(
+        project: Project,
+        config: RsLanguageRuntimeConfiguration,
+        targetEnvironmentType: TargetEnvironmentType<*>,
+        targetSupplier: Supplier<TargetEnvironmentConfiguration>
+    ): Configurable = RsLanguageRuntimeConfigurable(config)
+
+    override fun findLanguageRuntime(target: TargetEnvironmentConfiguration): RsLanguageRuntimeConfiguration? {
+        return target.runtimes.findByType()
+    }
+
+    override fun isApplicableTo(runConfig: RunnerAndConfigurationSettings): Boolean {
+        return runConfig.configuration is RsCommandConfiguration
+    }
+
+    companion object {
+        const val TYPE_ID: String = "RsLanguageRuntime"
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/target/RsLocalBuildForTargetRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/target/RsLocalBuildForTargetRunner.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.target
+
+import com.intellij.execution.configurations.RunProfile
+import com.intellij.execution.executors.DefaultRunExecutor
+import org.rust.cargo.runconfig.RsExecutableRunner
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowAvailable
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.runconfig.command.hasRemoteTarget
+
+private const val ERROR_MESSAGE_TITLE: String = "Unable to build"
+
+/**
+ * This runner is used for remote targets if [isBuildToolWindowAvailable] is true.
+ */
+class RsLocalBuildForTargetRunner : RsExecutableRunner(DefaultRunExecutor.EXECUTOR_ID, ERROR_MESSAGE_TITLE) {
+    override fun getRunnerId(): String = RUNNER_ID
+
+    override fun canRun(executorId: String, profile: RunProfile): Boolean {
+        if (executorId != DefaultRunExecutor.EXECUTOR_ID ||
+            profile !is CargoCommandConfiguration ||
+            profile.clean() !is CargoCommandConfiguration.CleanConfiguration.Ok) return false
+        return profile.hasRemoteTarget &&
+            profile.buildTarget.isLocal &&
+            profile.isBuildToolWindowAvailable
+    }
+
+    companion object {
+        const val RUNNER_ID: String = "RsLocalBuildForTargetRunner"
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/target/RsLocalBuildForTargetRunnerLegacy.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/target/RsLocalBuildForTargetRunnerLegacy.kt
@@ -1,0 +1,33 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.runconfig.target
+
+import com.intellij.execution.configurations.RunProfile
+import com.intellij.execution.executors.DefaultRunExecutor
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowAvailable
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.runconfig.command.hasRemoteTarget
+import org.rust.cargo.runconfig.legacy.RsAsyncRunner
+
+private const val ERROR_MESSAGE_TITLE: String = "Unable to build"
+
+/**
+ * This runner is used for remote targets if [isBuildToolWindowAvailable] is false.
+ */
+class RsLocalBuildForTargetRunnerLegacy : RsAsyncRunner(DefaultRunExecutor.EXECUTOR_ID, ERROR_MESSAGE_TITLE) {
+    override fun getRunnerId(): String = RUNNER_ID
+
+    override fun canRun(executorId: String, profile: RunProfile): Boolean {
+        if (executorId != DefaultRunExecutor.EXECUTOR_ID ||
+            profile !is CargoCommandConfiguration ||
+            profile.clean() !is CargoCommandConfiguration.CleanConfiguration.Ok) return false
+        return profile.hasRemoteTarget && profile.buildTarget.isLocal && !profile.isBuildToolWindowAvailable
+    }
+
+    companion object {
+        const val RUNNER_ID: String = "RsLocalBuildForTargetRunnerLegacy"
+    }
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/target/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/target/Utils.kt
@@ -1,0 +1,144 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+package org.rust.cargo.runconfig.target
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.process.ProcessTerminatedListener
+import com.intellij.execution.target.*
+import com.intellij.execution.target.value.TargetValue
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.EmptyProgressIndicator
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.util.execution.ParametersListUtil
+import com.intellij.util.text.nullize
+import org.rust.cargo.runconfig.RsProcessHandler
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.runconfig.command.hasRemoteTarget
+import org.rust.openapiext.computeWithCancelableProgress
+
+private val LOG: Logger = Logger.getInstance("org.rust.cargo.runconfig.target.Utils")
+
+
+enum class BuildTarget {
+    LOCAL, REMOTE;
+
+    val isLocal: Boolean get() = this == LOCAL
+    val isRemote: Boolean get() = this == REMOTE
+}
+
+val CargoCommandConfiguration.targetEnvironment: TargetEnvironmentConfiguration?
+    get() {
+        if (!RunTargetsEnabled.get()) return null
+        val targetName = defaultTargetName ?: return null
+        return TargetEnvironmentsManager.getInstance(project).targets.findByName(targetName)
+    }
+
+val CargoCommandConfiguration.localBuildArgsForRemoteRun: List<String>
+    get() = if (hasRemoteTarget && buildTarget.isLocal) {
+        ParametersListUtil.parse(targetEnvironment?.languageRuntime?.localBuildArgs.orEmpty())
+    } else {
+        emptyList()
+    }
+
+val TargetEnvironmentConfiguration.languageRuntime: RsLanguageRuntimeConfiguration?
+    get() = runtimes.findByType()
+
+fun GeneralCommandLine.startProcess(
+    project: Project,
+    config: TargetEnvironmentConfiguration?,
+    processColors: Boolean,
+    uploadExecutable: Boolean
+): ProcessHandler {
+    if (config == null) {
+        val handler = RsProcessHandler(this)
+        ProcessTerminatedListener.attach(handler)
+        return handler
+    }
+
+    val request = config.createEnvironmentRequest(project)
+    val setup = RsCommandLineSetup(request)
+    val targetCommandLine = toTargeted(setup, uploadExecutable)
+    val progressIndicator = ProgressManager.getInstance().progressIndicator ?: EmptyProgressIndicator()
+    val environment = project.computeWithCancelableProgress("Preparing remote environment...") {
+        request.prepareEnvironment(setup, progressIndicator)
+    }
+    val process = environment.createProcess(targetCommandLine, progressIndicator)
+
+    val commandRepresentation = targetCommandLine.getCommandPresentation(environment)
+    LOG.debug("Executing command: `$commandRepresentation`")
+
+    val handler = RsProcessHandler(process, commandRepresentation, targetCommandLine.charset, processColors)
+    ProcessTerminatedListener.attach(handler)
+    return handler
+}
+
+private fun GeneralCommandLine.toTargeted(
+    setup: RsCommandLineSetup,
+    uploadExecutable: Boolean
+): TargetedCommandLine {
+    val commandLineBuilder = TargetedCommandLineBuilder(setup.request)
+    commandLineBuilder.setCharset(charset)
+
+    val targetedExePath = if (uploadExecutable) setup.requestUploadIntoTarget(exePath) else TargetValue.fixed(exePath)
+    commandLineBuilder.setExePath(targetedExePath)
+
+    val workDirectory = workDirectory
+    if (workDirectory != null) {
+        val targetWorkingDirectory = setup.requestUploadIntoTarget(workDirectory.absolutePath)
+        commandLineBuilder.setWorkingDirectory(targetWorkingDirectory)
+    }
+
+    val inputFile = inputFile
+    if (inputFile != null) {
+        val targetInput = setup.requestUploadIntoTarget(inputFile.absolutePath)
+        commandLineBuilder.setInputFile(targetInput)
+    }
+
+    commandLineBuilder.addParameters(parametersList.parameters)
+
+    for ((key, value) in environment.entries) {
+        commandLineBuilder.addEnvironmentVariable(key, value)
+    }
+
+    val runtime = setup.request.configuration?.languageRuntime
+    commandLineBuilder.addEnvironmentVariable("RUSTC", runtime?.rustcPath?.nullize(true))
+    commandLineBuilder.addEnvironmentVariable("CARGO", runtime?.cargoPath?.nullize(true))
+
+    return commandLineBuilder.build()
+}
+
+private fun TargetEnvironmentRequest.prepareEnvironment(
+    setup: RsCommandLineSetup,
+    progressIndicator: ProgressIndicator
+): TargetEnvironment {
+    val targetProgressIndicator = object : TargetProgressIndicator {
+        override fun isCanceled(): Boolean = progressIndicator.isCanceled
+        override fun stop() = progressIndicator.cancel()
+        override fun isStopped(): Boolean = isCanceled
+        override fun addText(text: String, key: Key<*>) {
+            progressIndicator.text2 = text.trim()
+        }
+    }
+
+    return try {
+        val environment = prepareEnvironment(targetProgressIndicator)
+        setup.provideEnvironment(environment, targetProgressIndicator)
+        environment
+    } catch (e: ProcessCanceledException) {
+        throw e
+    } catch (e: Exception) {
+        throw ExecutionException("Failed to prepare remote environment: ${e.localizedMessage}", e)
+    }
+}
+

--- a/src/main/kotlin/org/rust/cargo/toolchain/RustChannel.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RustChannel.kt
@@ -15,6 +15,15 @@ enum class RustChannel(val index: Int, val channel: String?) {
     override fun toString(): String = channel ?: "[default]"
 
     companion object {
+
         fun fromIndex(index: Int): RustChannel = values().find { it.index == index } ?: DEFAULT
+
+        fun fromPreRelease(releaseSuffix: String): RustChannel = when {
+            releaseSuffix.isEmpty() -> STABLE
+            releaseSuffix.startsWith("beta") -> BETA
+            releaseSuffix.startsWith("nightly") -> NIGHTLY
+            releaseSuffix.startsWith("dev") -> DEV
+            else -> DEFAULT
+        }
     }
 }

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/RustcVersion.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/RustcVersion.kt
@@ -8,6 +8,7 @@ package org.rust.cargo.toolchain.impl
 import com.google.common.annotations.VisibleForTesting
 import com.intellij.util.text.SemVer
 import org.rust.cargo.toolchain.RustChannel
+import org.rust.cargo.toolchain.RustChannel.Companion.fromPreRelease
 import java.time.LocalDate
 import java.time.format.DateTimeParseException
 
@@ -48,13 +49,7 @@ fun parseRustcVersion(lines: List<String>): RustcVersion? {
     }
 
     val semVer = SemVer.parseFromText(versionText) ?: return null
-    val releaseSuffix = semVer.preRelease.orEmpty()
-    val channel = when {
-        releaseSuffix.isEmpty() -> RustChannel.STABLE
-        releaseSuffix.startsWith("beta") -> RustChannel.BETA
-        releaseSuffix.startsWith("nightly") -> RustChannel.NIGHTLY
-        releaseSuffix.startsWith("dev") -> RustChannel.DEV
-        else -> RustChannel.DEFAULT
-    }
+    val preRelease = semVer.preRelease.orEmpty()
+    val channel = fromPreRelease(preRelease)
     return RustcVersion(semVer, hostText, channel, commitHash, commitDate)
 }

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -34,7 +34,7 @@ import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.cargo.project.workspace.PackageId
-import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowEnabled
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowAvailable
 import org.rust.cargo.runconfig.buildtool.CargoPatch
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration.Companion.findCargoPackage
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration.Companion.findCargoProject
@@ -414,7 +414,7 @@ class Cargo(
                 emulateTerminal,
                 // TODO: always pass `withSudo` when `com.intellij.execution.process.ElevationService` supports error stream redirection
                 // https://github.com/intellij-rust/intellij-rust/issues/7320
-                if (project.isBuildToolWindowEnabled) withSudo else false,
+                if (project.isBuildToolWindowAvailable) withSudo else false,
                 http = http
             ).withEnvironment("RUSTC", rustcExecutable)
         }

--- a/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
+++ b/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
@@ -22,6 +22,7 @@ import com.intellij.openapi.util.NlsContexts.DialogMessage
 import com.intellij.util.PlatformUtils.*
 import org.rust.cargo.runconfig.RsDefaultProgramRunnerBase
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.cargo.runconfig.command.hasRemoteTarget
 import org.rust.debugger.NATIVE_DEBUGGING_SUPPORT_PLUGIN_ID
 import org.rust.debugger.nativeDebuggingSupportPlugin
 import org.rust.openapiext.isUnitTestMode
@@ -33,6 +34,7 @@ class RsDebugAdvertisingRunner : RsDefaultProgramRunnerBase() {
         if (executorId != DefaultDebugExecutor.EXECUTOR_ID) return false
         if (profile !is CargoCommandConfiguration) return false
         if (!isSupportedPlatform()) return false
+        if (profile.hasRemoteTarget) return false
         val plugin = nativeDebuggingSupportPlugin() ?: return true
         val loadedPlugins = PluginManagerCore.getLoadedPlugins()
         return plugin !in loadedPlugins || !plugin.isEnabled

--- a/src/main/kotlin/org/rust/ide/actions/RsBuildAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsBuildAction.kt
@@ -12,7 +12,7 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.task.ProjectTaskManager
 import com.intellij.util.PlatformUtils
 import org.rust.cargo.runconfig.buildProject
-import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowEnabled
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowAvailable
 import org.rust.cargo.runconfig.hasCargoProject
 import org.rust.openapiext.project
 
@@ -25,7 +25,7 @@ class RsBuildAction : AnAction() {
     @VisibleForTesting
     fun performForContext(e: DataContext) {
         val project = e.project ?: return
-        if (project.isBuildToolWindowEnabled) {
+        if (project.isBuildToolWindowAvailable) {
             ProjectTaskManager.getInstance(project).buildAllModules()
         } else {
             project.buildProject()

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -996,6 +996,13 @@
 
         <projectTaskRunner implementation="org.rust.cargo.runconfig.buildtool.CargoBuildTaskRunner"/>
 
+        <!-- Run Targets -->
+
+        <executionTargetLanguageRuntimeType implementation="org.rust.cargo.runconfig.target.RsLanguageRuntimeType"/>
+
+        <programRunner implementation="org.rust.cargo.runconfig.target.RsLocalBuildForTargetRunner"/>
+        <programRunner implementation="org.rust.cargo.runconfig.target.RsLocalBuildForTargetRunnerLegacy"/>
+
         <!-- Cargo -->
 
         <projectConfigurable instance="org.rust.cargo.project.configurable.RsProjectConfigurable"

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -93,6 +93,13 @@ refactoring.change.signature.visibility.conflict=The function will not be visibl
 rust.external.linter.cargo.check.item=Cargo Check
 rust.external.linter.clippy.item=Clippy
 
+run.target.build.arguments.comment=Additional arguments to pass to <b>cargo build</b> command in case of <b>Build on target</b> option is disabled
+run.target.build.arguments.label=Additional build arguments:
+run.target.cargo.executable.path.label=Cargo executable:
+run.target.cargo.executable.version.label=Cargo version:
+run.target.rustc.executable.path.label=Rustc executable:
+run.target.rustc.executable.version.label=Rustc version:
+
 settings.rust.auto.import.on.completion=Import out-of-scope items on completion
 settings.rust.auto.import.show.popup=Show import popup
 settings.rust.auto.import.title=Rust

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/BenchRunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/BenchRunConfigurationProducerTest.kt
@@ -7,6 +7,7 @@ package org.rust.cargo.runconfig.producers
 
 import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.psi.PsiElement
+import org.rust.cargo.runconfig.target.BuildTarget
 import org.rust.cargo.runconfig.test.CargoBenchRunConfigurationProducer
 import org.rust.cargo.toolchain.BacktraceMode
 import org.rust.cargo.toolchain.RustChannel
@@ -205,6 +206,7 @@ class BenchRunConfigurationProducerTest : RunConfigurationProducerTestBase() {
             allFeatures = true
             emulateTerminal = true
             withSudo = true
+            buildTarget = BuildTarget.LOCAL
             isRedirectInput = true
             backtrace = BacktraceMode.FULL
             env = EnvironmentVariablesData.create(mapOf("FOO" to "BAR"), true)

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/ExecutableRunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/ExecutableRunConfigurationProducerTest.kt
@@ -7,6 +7,7 @@ package org.rust.cargo.runconfig.producers
 
 import com.intellij.execution.configuration.EnvironmentVariablesData
 import org.rust.cargo.runconfig.command.CargoExecutableRunConfigurationProducer
+import org.rust.cargo.runconfig.target.BuildTarget
 import org.rust.cargo.toolchain.BacktraceMode
 import org.rust.cargo.toolchain.RustChannel
 import org.rust.lang.core.psi.RsFile
@@ -57,6 +58,7 @@ class ExecutableRunConfigurationProducerTest : RunConfigurationProducerTestBase(
             allFeatures = true
             emulateTerminal = true
             withSudo = true
+            buildTarget = BuildTarget.LOCAL
             isRedirectInput = true
             backtrace = BacktraceMode.FULL
             env = EnvironmentVariablesData.create(mapOf("FOO" to "BAR"), true)

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/TestRunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/TestRunConfigurationProducerTest.kt
@@ -7,6 +7,7 @@ package org.rust.cargo.runconfig.producers
 
 import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.psi.PsiElement
+import org.rust.cargo.runconfig.target.BuildTarget
 import org.rust.cargo.runconfig.test.CargoTestRunConfigurationProducer
 import org.rust.cargo.toolchain.BacktraceMode
 import org.rust.cargo.toolchain.RustChannel
@@ -223,6 +224,7 @@ class TestRunConfigurationProducerTest : RunConfigurationProducerTestBase() {
             allFeatures = true
             emulateTerminal = true
             withSudo = true
+            buildTarget = BuildTarget.LOCAL
             isRedirectInput = true
             backtrace = BacktraceMode.FULL
             env = EnvironmentVariablesData.create(mapOf("FOO" to "BAR"), true)

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_configuration_uses_default_environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_configuration_uses_default_environment.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="true" />
     <option name="emulateTerminal" value="true" />
     <option name="withSudo" value="true" />
+    <option name="buildTarget" value="LOCAL" />
     <option name="backtrace" value="FULL" />
     <envs>
       <env name="FOO" value="BAR" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_fn_is_more_specific_than_main_or_test_mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_fn_is_more_specific_than_main_or_test_mod.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_adds_bin_name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_adds_bin_name.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_ignores_selected_files_that_contain_no_benches.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_ignores_selected_files_that_contain_no_benches.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_uses_complete_function_path.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_uses_complete_function_path.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_annotated_functions.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_annotated_functions.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_benches_source_root.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_benches_source_root.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_directories_inside_benches_source_root.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_directories_inside_benches_source_root.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_files.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_module_declarations.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_module_declarations.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_modules.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_modules.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_multiple_files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_multiple_files.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_nested_modules_1.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_nested_modules_1.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_nested_modules_2.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_nested_modules_2.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_root_module.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_root_module.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executable_configuration_uses_default_environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executable_configuration_uses_default_environment.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="true" />
     <option name="emulateTerminal" value="true" />
     <option name="withSudo" value="true" />
+    <option name="buildTarget" value="LOCAL" />
     <option name="backtrace" value="FULL" />
     <envs>
       <env name="FOO" value="BAR" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executable_producer_works_for_bin.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executable_producer_works_for_bin.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executable_producer_works_for_example.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executable_producer_works_for_example.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/hyphen_in_name_works.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/hyphen_in_name_works.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ignored_test_is_run_with_ignored_option.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ignored_test_is_run_with_ignored_option.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_bench_fn.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_bench_fn.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_bench_mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_bench_mod.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_test_fn.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_test_fn.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_test_mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_test_mod.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_mod_is_more_specific_than_test_mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_mod_is_more_specific_than_test_mod.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/meaningful_bench_configuration_name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/meaningful_bench_configuration_name.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/meaningful_test_configuration_name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/meaningful_test_configuration_name.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/take_into_account_path_attribute.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/take_into_account_path_attribute.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_configuration_uses_default_environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_configuration_uses_default_environment.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="true" />
     <option name="emulateTerminal" value="true" />
     <option name="withSudo" value="true" />
+    <option name="buildTarget" value="LOCAL" />
     <option name="backtrace" value="FULL" />
     <envs>
       <env name="FOO" value="BAR" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_fn_is_more_specific_than_main_mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_fn_is_more_specific_than_main_mod.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_mod_decl_is_more_specific_than_main_mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_mod_decl_is_more_specific_than_main_mod.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_mod_is_more_specific_than_bench_mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_mod_is_more_specific_than_bench_mod.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_adds_bin_name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_adds_bin_name.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_ignores_selected_files_that_contain_no_tests.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_ignores_selected_files_that_contain_no_tests.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_uses_complete_function_path.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_uses_complete_function_path.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_annotated_functions.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_annotated_functions.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_directories_inside_tests_source_root.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_directories_inside_tests_source_root.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_files.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_module_declarations.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_module_declarations.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_modules.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_modules.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_multiple_files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_multiple_files.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_nested_modules_1.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_nested_modules_1.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_nested_modules_2.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_nested_modules_2.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_project_root.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_project_root.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_root_module.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_root_module.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_tests_source_root.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_tests_source_root.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/use_raw_identifier_for_module_named_with_keyword.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/use_raw_identifier_for_module_named_with_keyword.xml
@@ -7,6 +7,7 @@
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
     <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />


### PR DESCRIPTION
Closes https://github.com/intellij-rust/intellij-rust/issues/4651.
Closes https://github.com/intellij-rust/intellij-rust/issues/3152.
Closes https://github.com/intellij-rust/intellij-rust/issues/1926.

changelog: Initial support for [Run Targets](https://blog.jetbrains.com/idea/2021/01/run-targets-run-and-debug-your-app-in-the-desired-environment/). Ran Targets allow you to run the applications you’re developing in Docker containers or on remote machines.

<img width="1040" alt="Screenshot 2021-09-27 at 01 18 18" src="https://user-images.githubusercontent.com/6079006/134826028-35c76f2c-6602-4b04-a11f-c55b96913fca.png">

Target API doesn't support:
- "Redirect input from" feature for remote targets
- Stderr to stdin redirection, which is necessary for Build/Test Tool Window
- Debugging/profiling

Also:
- It will be available in CLion 2021.3
- Connecting to Windows via SSH doesn't work (should be fixed on the platform side)
- "Docker via SSH" doesn't work (should be fixed on the platform side)

TODO:
- Improve error messages
- Support `Run with Coverage`
- Get rid of modal windows