### PR TITLE
INT: add intention to create a struct

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateStructIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateStructIntention.kt
@@ -1,0 +1,95 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions.createFromUsage
+
+import com.intellij.ide.DataManager
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import org.rust.ide.intentions.RsElementBaseIntentionAction
+import org.rust.ide.presentation.renderInsertionSafe
+import org.rust.ide.refactoring.RsMultipleVariableRenamer
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.ty.TyUnknown
+import org.rust.lang.core.types.type
+import org.rust.openapiext.createSmartPointer
+
+class CreateStructIntention : RsElementBaseIntentionAction<CreateStructIntention.Context>() {
+    override fun getFamilyName() = "Create struct"
+
+    class Context(val name: String, val literalElement: RsStructLiteral, val target: RsMod) {}
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val path = element.parentOfType<RsPath>()
+        val structLiteral = path?.parentOfType<RsStructLiteral>()
+        if (structLiteral != null) {
+            if (structLiteral.path != path) return null
+            if (path.resolveStatus != PathResolveStatus.UNRESOLVED) return null
+
+            val target = getTargetModForStruct(path) ?: return null
+            val name = path.referenceName ?: return null
+
+            text = "Create struct `$name`"
+            return Context(name, structLiteral, target)
+        }
+        return null
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val struct = buildStruct(project, ctx) ?: return
+        val function = ctx.literalElement.parentOfType<RsFunction>() ?: return
+        val inserted = insertStruct(ctx.target, struct, function)
+
+        PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
+
+        val fields = inserted.blockFields?.namedFieldDeclList.orEmpty()
+        if (inserted.containingFile == function.containingFile && fields.isNotEmpty()) {
+            editor.caretModel.moveToOffset(fields[0].textOffset)
+            RsMultipleVariableRenamer(fields.map { it.createSmartPointer() })
+                .doRename(fields[0], editor, DataManager.getInstance().getDataContext(editor.component))
+        } else {
+            inserted.navigate(true)
+        }
+    }
+
+    private fun buildStruct(project: Project, ctx: Context): RsStructItem? {
+        val factory = RsPsiFactory(project)
+        val fieldList = ctx.literalElement.structLiteralBody.structLiteralFieldList
+        val visibility = getVisibility(ctx.target, ctx.literalElement.containingMod)
+
+        val fieldsJoined = fieldList.joinToString(separator = ",\n") {
+            val name = it.referenceName
+            val expr = it.expr
+            val type = when {
+                expr != null -> expr.type
+                else -> it.resolveToBinding()?.type ?: TyUnknown
+            }
+
+            "$visibility$name: ${type.renderInsertionSafe(includeLifetimeArguments = true)}"
+        }
+        val suffix = when {
+            fieldsJoined.isEmpty() -> ";"
+            else -> " {\n$fieldsJoined\n}"
+        }
+
+        return factory.tryCreateStruct("${visibility}struct ${ctx.name}$suffix")
+    }
+
+    private fun insertStruct(targetModule: RsMod, struct: RsStructItem, sourceFunction: RsElement): RsStructItem {
+        if (targetModule == sourceFunction.containingMod) {
+            return sourceFunction.parent.addBefore(struct, sourceFunction) as RsStructItem
+        }
+        return addToModule(targetModule, struct)
+    }
+}
+
+private fun getTargetModForStruct(path: RsPath): RsMod? = when {
+    path.qualifier != null -> getWritablePathTarget(path) as? RsMod
+    else -> path.containingMod
+}

--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/utils.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/utils.kt
@@ -1,0 +1,39 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions.createFromUsage
+
+import com.intellij.openapiext.isUnitTestMode
+import com.intellij.psi.PsiElement
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.lang.core.psi.RsModItem
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.ext.*
+
+@Suppress("UNCHECKED_CAST")
+fun <T : PsiElement> addToModule(targetModule: RsMod, element: T): T {
+    return if (targetModule is RsModItem) {
+        targetModule.addBefore(element, targetModule.rbrace)
+    } else {
+        if (targetModule.lastChild == null) {
+            targetModule.add(element)
+        } else {
+            targetModule.addAfter(element, targetModule.lastChild)
+        }
+    } as T
+}
+
+fun getVisibility(target: RsMod, source: RsMod): String = when {
+    source.containingCrate != target.containingCrate -> "pub "
+    source != target -> "pub(crate) "
+    else -> ""
+}
+
+fun getWritablePathTarget(path: RsPath): RsQualifiedNamedElement? {
+    val item = path.qualifier?.reference?.resolve() as? RsQualifiedNamedElement
+    if (item?.containingCargoPackage?.origin != PackageOrigin.WORKSPACE) return null
+    if (!isUnitTestMode && !item.isWritable) return null
+    return item
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -189,8 +189,10 @@ class RsPsiFactory(
             ?: error("Failed to create enum from text: `$text`")
 
     fun createStruct(text: String): RsStructItem =
-        createFromText(text)
+        tryCreateStruct(text)
             ?: error("Failed to create struct from text: `$text`")
+
+    fun tryCreateStruct(text: String): RsStructItem? = createFromText(text)
 
     fun createStatement(text: String): RsStmt =
         createFromText("fn main() { $text 92; }")

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -858,7 +858,7 @@
             <category>Rust</category>
         </intentionAction>
         <intentionAction>
-            <className>org.rust.ide.intentions.CreateFunctionIntention</className>
+            <className>org.rust.ide.intentions.createFromUsage.CreateFunctionIntention</className>
             <category>Rust</category>
         </intentionAction>
         <intentionAction>
@@ -887,6 +887,10 @@
         </intentionAction>
         <intentionAction>
             <className>org.rust.ide.intentions.ToggleFeatureIntention</className>
+            <category>Rust</category>
+        </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.createFromUsage.CreateStructIntention</className>
             <category>Rust</category>
         </intentionAction>
 

--- a/src/main/resources/intentionDescriptions/CreateStructIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/CreateStructIntention/after.rs.template
@@ -1,0 +1,8 @@
+struct Foo {
+    a: i32,
+    b: bool
+}
+
+fn bar() {
+    let x = Foo { a: 0, b: true };
+}

--- a/src/main/resources/intentionDescriptions/CreateStructIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/CreateStructIntention/before.rs.template
@@ -1,0 +1,3 @@
+fn bar() {
+    let x = <spot>Foo</spot> { a: 0, b: true };
+}

--- a/src/main/resources/intentionDescriptions/CreateStructIntention/description.html
+++ b/src/main/resources/intentionDescriptions/CreateStructIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention creates a struct from an unresolved struct literal.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
@@ -9,6 +9,7 @@ import org.rust.MockEdition
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ide.intentions.createFromUsage.CreateFunctionIntention
 
 class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention::class) {
     fun `test function availability range`() = checkAvailableInSelectionOnly("""

--- a/src/test/kotlin/org/rust/ide/intentions/CreateStructIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateStructIntentionTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import org.rust.ide.intentions.createFromUsage.CreateStructIntention
+
+class CreateStructIntentionTest : RsIntentionTestBase(CreateStructIntention::class) {
+    fun `test struct availability range`() = checkAvailableInSelectionOnly("""
+        fn main() {
+            <selection>Foo</selection> { a: 0 };
+        }
+    """)
+
+    fun `test simple`() = doAvailableTest("""
+        fn main() {
+            Foo/*caret*/ { a: 0 };
+        }
+    """, """
+        struct Foo {
+            a: i32
+        }
+
+        fn main() {
+            Foo { a: 0 };
+        }
+    """)
+
+    fun `test shorthand field`() = doAvailableTest("""
+        fn main() {
+            let a = 1;
+            Foo/*caret*/ { a };
+        }
+    """, """
+        struct Foo {
+            a: i32
+        }
+
+        fn main() {
+            let a = 1;
+            Foo { a };
+        }
+    """)
+
+    fun `test no fields`() = doAvailableTest("""
+        fn main() {
+            Foo/*caret*/ {};
+        }
+    """, """
+        struct Foo;
+
+        fn main() {
+            Foo {};
+        }
+    """)
+
+    fun `test multiple fields`() = doAvailableTest("""
+        fn main() {
+            Foo/*caret*/ { a: true, b: "foo" };
+        }
+    """, """
+        struct Foo {
+            a: bool,
+            b: &'static str
+        }
+
+        fn main() {
+            Foo { a: true, b: "foo" };
+        }
+    """)
+
+    fun `test unknown type`() = doAvailableTest("""
+        fn main() {
+            Foo/*caret*/ { a: Bar };
+        }
+    """, """
+        struct Foo {
+            a: _
+        }
+
+        fn main() {
+            Foo { a: Bar };
+        }
+    """)
+
+    fun `test create in a module`() = doAvailableTest("""
+        mod foo {}
+
+        fn main() {
+            foo::Foo/*caret*/ { a: 0 };
+        }
+    """, """
+        mod foo {
+            pub(crate) struct Foo {
+                pub(crate) a: i32
+            }
+        }
+
+        fn main() {
+            foo::Foo { a: 0 };
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds an intention to create a struct from an unresolved struct literal (similar to https://github.com/intellij-rust/intellij-rust/pull/5505).

![create-struct](https://user-images.githubusercontent.com/4539057/107833586-06b45100-6d94-11eb-9736-c60084172c30.gif)

I'm not sure what template to offer the user after the struct is created. In the intention for creating functions, we create a template builder that allows the user to change the name and type of each parameter. However, here a template builder is not good enough, because if the user decides to rename the field, the usage from which the struct was created would suddenly contain an invalid field name. Therefore, I borrowed `RsMultipleVariableRenamer` from https://github.com/intellij-rust/intellij-rust/pull/5650 to propagate the field name changes to the struct literal. But with this, it doesn't allow the user to change the field type.

Should I also add support for creating tuples structs in this PR? It could probably share a lot of code from `CreateFunctionIntention`.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/2576

changelog: Add an intention to create a struct from an unresolved struct literal usage.