### PR TITLE
INT: add intention to extract fields from a struct into a new struct

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/ExtractStructFieldsIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ExtractStructFieldsIntention.kt
@@ -1,0 +1,18 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import org.rust.RsBundle
+import org.rust.ide.refactoring.RsBaseEditorRefactoringAction
+import org.rust.ide.refactoring.extractStructFields.RsExtractStructFieldsAction
+
+class ExtractStructFieldsIntention : RsRefactoringAdaptorIntention() {
+    override fun getText(): String = RsBundle.message("action.Rust.RsExtractStructFields.intention.text")
+    override fun getFamilyName(): String = text
+
+    override val refactoringAction: RsBaseEditorRefactoringAction
+        get() = RsExtractStructFieldsAction()
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/extractEnumVariant/RsExtractEnumVariantProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractEnumVariant/RsExtractEnumVariantProcessor.kt
@@ -17,6 +17,7 @@ import com.intellij.usageView.BaseUsageViewDescriptor
 import com.intellij.usageView.UsageInfo
 import com.intellij.usageView.UsageViewDescriptor
 import org.rust.ide.refactoring.RsInPlaceVariableIntroducer
+import org.rust.ide.refactoring.findTransitiveAttributes
 import org.rust.ide.utils.import.RsImportHelper
 import org.rust.ide.utils.GenericConstraints
 import org.rust.lang.core.psi.*
@@ -249,6 +250,3 @@ private fun createElement(variant: RsEnumVariant, factory: RsPsiFactory): Varian
         else -> error("unreachable")
     }
 }
-
-private fun findTransitiveAttributes(enum: RsEnumItem, supportedAttributes: Set<String>): List<RsOuterAttr> =
-    enum.outerAttrList.filter { it.metaItem.name in supportedAttributes }

--- a/src/main/kotlin/org/rust/ide/refactoring/extractStructFields/RsExtractStructFieldsAction.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractStructFields/RsExtractStructFieldsAction.kt
@@ -1,0 +1,63 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.extractStructFields
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.RsBundle
+import org.rust.ide.refactoring.RsBaseEditorRefactoringAction
+import org.rust.ide.refactoring.generate.StructMember
+import org.rust.ide.refactoring.generate.showStructMemberChooserDialog
+import org.rust.lang.core.psi.RsStructItem
+import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.rust.lang.core.psi.ext.isTupleStruct
+import org.rust.lang.core.types.emptySubstitution
+
+class RsExtractStructFieldsAction : RsBaseEditorRefactoringAction() {
+    override fun isAvailableOnElementInEditorAndFile(
+        element: PsiElement,
+        editor: Editor,
+        file: PsiFile,
+        context: DataContext
+    ): Boolean = findApplicableContext(editor, file) != null
+
+    override fun invoke(project: Project, editor: Editor, file: PsiFile, dataContext: DataContext?) {
+        val struct = findApplicableContext(editor, file) ?: return
+
+        val fields = StructMember.fromStruct(struct, emptySubstitution)
+        val chosenFields = showStructMemberChooserDialog(
+            project,
+            struct,
+            fields,
+            RsBundle.message("action.Rust.RsExtractStructFields.choose.fields.title")
+        ) ?: return
+        if (chosenFields.isEmpty()) return
+
+        val name = showExtractStructFieldsDialog(project) ?: return
+
+        val ctx = ExtractStructFieldsContext(struct, chosenFields, name)
+        val processor = RsExtractStructFieldsProcessor(project, editor, ctx)
+        processor.setPreviewUsages(false)
+        processor.run()
+    }
+
+    companion object {
+        private fun findApplicableContext(editor: Editor, file: PsiFile): RsStructItem? {
+            val offset = editor.caretModel.offset
+            val struct = file.findElementAt(offset)?.ancestorOrSelf<RsStructItem>() ?: return null
+
+            if (struct.isTupleStruct) return null
+            if (struct.blockFields?.namedFieldDeclList?.isEmpty() != false) return null
+
+            return struct
+        }
+    }
+}
+
+data class ExtractStructFieldsContext(val struct: RsStructItem, val fields: List<StructMember>, val name: String)

--- a/src/main/kotlin/org/rust/ide/refactoring/extractStructFields/RsExtractStructFieldsProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractStructFields/RsExtractStructFieldsProcessor.kt
@@ -1,0 +1,331 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.extractStructFields
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.psi.util.elementType
+import com.intellij.psi.util.parentOfType
+import com.intellij.refactoring.BaseRefactoringProcessor
+import com.intellij.usageView.BaseUsageViewDescriptor
+import com.intellij.usageView.UsageInfo
+import com.intellij.usageView.UsageViewDescriptor
+import org.rust.RsBundle
+import org.rust.ide.inspections.lints.toSnakeCase
+import org.rust.ide.presentation.renderInsertionSafe
+import org.rust.ide.refactoring.RsInPlaceVariableIntroducer
+import org.rust.ide.refactoring.findTransitiveAttributes
+import org.rust.ide.refactoring.generate.StructMember
+import org.rust.ide.refactoring.suggestedNames
+import org.rust.ide.utils.GenericConstraints
+import org.rust.ide.utils.import.RsImportHelper
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsElementTypes.RBRACE
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.ty.Ty
+
+private sealed class StructUsage(usage: RsElement) : UsageInfo(usage) {
+    data class LiteralUsage(val literal: RsStructLiteral) : StructUsage(literal)
+    data class PatUsage(val pat: RsPatStruct) : StructUsage(pat)
+    data class FieldUsage(val fieldLookup: RsFieldLookup) : StructUsage(fieldLookup)
+}
+
+class RsExtractStructFieldsProcessor(
+    project: Project,
+    private val editor: Editor,
+    private val ctx: ExtractStructFieldsContext
+) : BaseRefactoringProcessor(project) {
+    override fun findUsages(): Array<UsageInfo> {
+        val structUsages = ReferencesSearch.search(ctx.struct).mapNotNull {
+            val element = it.element
+            when (val parent = element.parent) {
+                is RsStructLiteral -> StructUsage.LiteralUsage(parent)
+                is RsPatStruct -> StructUsage.PatUsage(parent)
+                else -> null
+            }
+        }
+        val fieldUsages = ctx.fields.flatMap {
+            ReferencesSearch.search(it.field).mapNotNull { fieldUsage ->
+                val lookup = fieldUsage.element as? RsFieldLookup ?: return@mapNotNull null
+                StructUsage.FieldUsage(lookup)
+            }
+        }
+        return (structUsages + fieldUsages).toTypedArray()
+    }
+
+    override fun performRefactoring(usages: Array<out UsageInfo>) {
+        val struct = ctx.struct
+        val project = struct.project
+        val factory = RsPsiFactory(project)
+
+        val newStruct = createStruct(factory, ctx)
+        val inserted = struct.parent.addBefore(newStruct, struct) as RsStructItem
+        val type = inserted.declaredType
+
+        val newField = replaceFields(factory, ctx.name, struct, ctx.fields, type)
+        val newFieldName = newField.name ?: return
+
+        val fieldMap = ctx.fields.mapNotNull {
+            val field = it.field as? RsNamedFieldDecl ?: return@mapNotNull null
+            val name = field.name ?: return@mapNotNull null
+            name to field
+        }.toMap()
+
+        val occurrences = mutableListOf<RsReferenceElement>()
+        for (usage in usages) {
+            val structUsage = usage as? StructUsage ?: continue
+            val occurrence = replaceUsage(factory, structUsage, newFieldName, ctx.name, fieldMap) ?: continue
+            occurrences.add(occurrence)
+        }
+
+        for (occurrence in occurrences) {
+            if (occurrence.reference?.resolve() == null) {
+                RsImportHelper.importElements(occurrence, setOf(inserted))
+            }
+        }
+
+        PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
+
+        editor.caretModel.moveToOffset(newField.identifier.startOffset)
+        RsInPlaceVariableIntroducer(newField, editor, project, "choose field name").performInplaceRefactoring(null)
+    }
+
+    override fun getCommandName(): String = RsBundle.message("action.Rust.RsExtractStructFields.command.name")
+
+    override fun createUsageViewDescriptor(usages: Array<out UsageInfo>): UsageViewDescriptor =
+        BaseUsageViewDescriptor(ctx.struct)
+
+    override fun getRefactoringId(): String = "refactoring.extractStructFields"
+
+    private fun replaceFields(
+        factory: RsPsiFactory,
+        name: String,
+        struct: RsStructItem,
+        replacedFields: List<StructMember>,
+        type: Ty
+    ): RsNamedFieldDecl {
+        val visibility = getBroadestVisibility(factory, replacedFields)
+        val visibilityText = if (visibility != null) {
+            "${visibility.text} "
+        } else ""
+        val fieldName = generateName(struct, name)
+        val text = "$visibilityText${fieldName}: ${type.renderInsertionSafe(includeLifetimeArguments = true)}"
+
+        val newField = factory.createStructNamedField(text)
+        val firstField = replacedFields[0].field
+        val insertedField = firstField.parent.addBefore(newField, firstField) as RsNamedFieldDecl
+        insertedField.parent.addAfter(factory.createComma(), insertedField)
+
+        replacedFields.forEach {
+            it.field.deleteWithSurroundingCommaAndWhitespace()
+        }
+        return insertedField
+    }
+
+    private fun generateName(struct: RsStructItem, structName: String): String {
+        val fieldName = structName.toSnakeCase(false)
+        var name = fieldName
+        var index = 0
+        val fieldMap = struct.blockFields?.namedFieldDeclList?.map { it.name }?.toSet().orEmpty()
+        while (name in fieldMap) {
+            name = "$fieldName${index}"
+            index += 1
+        }
+        return name
+    }
+
+    private fun createStruct(factory: RsPsiFactory, ctx: ExtractStructFieldsContext): RsStructItem {
+        val struct = ctx.struct
+        val vis = struct.vis?.text
+        val formattedVis = if (vis == null) "" else "$vis "
+        val fieldsText = ctx.fields.joinToString(separator = ",\n") {
+            it.field.text
+        }
+        val attributes = findTransitiveAttributes(struct, TRANSITIVE_ATTRIBUTES)
+
+        val fieldTypeReferences = ctx.fields.mapNotNull { it.field.typeReference }
+        val genericConstraints = GenericConstraints.create(struct)
+            .filterByTypeReferences(fieldTypeReferences)
+
+        val typeParameters = genericConstraints.buildTypeParameters()
+        val whereClause = genericConstraints.buildWhereClause()
+
+        val text = "${formattedVis}struct ${ctx.name}$typeParameters$whereClause {\n$fieldsText\n}"
+        val attributesText = if (attributes.isNotEmpty()) {
+            attributes.joinToString(separator = "\n", postfix = "\n") { it.text }
+        } else ""
+        return factory.createStruct("$attributesText$text")
+    }
+
+    companion object {
+        val TRANSITIVE_ATTRIBUTES = setOf("derive", "repr")
+    }
+}
+
+/**
+ * Find the visibility for the field containing the newly extracted struct.
+ * If any of the extracted fields were pub, use pub.
+ * Otherwise, if any of the extracted fields were pub(crate), use pub(crate).
+ * Otherwise, find the ancestor module that encompasses all of the extracted fields.
+ */
+private fun getBroadestVisibility(factory: RsPsiFactory, replacedFields: List<StructMember>): RsVis? {
+    val visibilities = replacedFields.mapNotNull { it.field.vis }
+    val pubVis = visibilities.find { it.visibility == RsVisibility.Public }
+    if (pubVis != null) return pubVis
+
+    val crateVis = visibilities.find {
+        val visibility = it.visibility
+        visibility is RsVisibility.Restricted && visibility.inMod.isCrateRoot
+    }
+    if (crateVis != null) return crateVis
+
+    var broadest: RsMod? = null
+    for (vis in visibilities) {
+        val visibility = vis.visibility
+        if (visibility is RsVisibility.Restricted) {
+            val module = visibility.inMod
+            broadest = if (broadest == null) {
+                module
+            } else {
+                commonParentMod(broadest, module) ?: return factory.createVis("pub(crate)")
+            }
+        }
+    }
+    if (broadest != null) {
+        return factory.createVis("pub(in ${broadest.qualifiedName})")
+    }
+    return null
+}
+
+private fun replaceUsage(
+    factory: RsPsiFactory,
+    usage: StructUsage,
+    fieldName: String,
+    structName: String,
+    fields: Map<String, RsFieldDecl>
+): RsReferenceElement? {
+    return when (usage) {
+        is StructUsage.LiteralUsage -> replaceLiteralUsage(factory, usage.literal, fieldName, structName, fields)
+        is StructUsage.PatUsage -> replacePatUsage(factory, usage.pat, fieldName, structName, fields)
+        is StructUsage.FieldUsage -> replaceFieldUsage(factory, usage.fieldLookup, fieldName)
+    }
+}
+
+private fun replaceLiteralUsage(
+    factory: RsPsiFactory,
+    literal: RsStructLiteral,
+    fieldName: String,
+    structName: String,
+    fields: Map<String, RsFieldDecl>
+): RsReferenceElement {
+    val foundFields = mutableSetOf<String>()
+    val fieldExprs = mutableListOf<RsStructLiteralField>()
+    val body = literal.structLiteralBody
+    for (field in body.structLiteralFieldList) {
+        val name = field.identifier?.text ?: continue
+        if (name in fields) {
+            fieldExprs.add(field)
+            foundFields.add(name)
+        }
+    }
+    if (fieldExprs.size < fields.size) {
+        // Some fields were not found, try to map them from ..
+        val expr = body.expr
+        val dotdot = body.dotdot
+        if (dotdot != null && expr != null) {
+            val extractedExpr = extractDotDotExpr(factory, literal, expr)
+            val missingKeys = fields.keys - foundFields
+            for (key in missingKeys) {
+                // Access the field through the new substruct
+                val literalField = factory.createStructLiteralField(key, "${extractedExpr.text}.$fieldName.$key")
+                fieldExprs.add(literalField)
+            }
+            expr.replace(extractedExpr)
+        }
+    }
+
+    val newLiteral = factory.createStructLiteral(structName, "{ ${fieldExprs.joinToString(", ") { it.text }} }")
+    val newField = factory.createStructLiteralField(fieldName, newLiteral)
+    val anchor = fieldExprs.firstOrNull { it.isPhysical } ?: body.dotdot ?: body.expr ?: body.rbrace
+    val inserted = body.addBefore(newField, anchor) as RsStructLiteralField
+
+    fieldExprs.forEach {
+        it.deleteWithSurroundingCommaAndWhitespace()
+    }
+
+    if (inserted.getNextNonCommentSibling()?.elementType != RBRACE) {
+        inserted.parent.addAfter(factory.createComma(), inserted)
+    }
+
+    return (inserted.expr as RsStructLiteral).path
+}
+
+private fun replacePatUsage(
+    factory: RsPsiFactory,
+    pat: RsPatStruct,
+    fieldName: String,
+    structName: String,
+    fields: Map<String, RsFieldDecl>
+): RsReferenceElement {
+    val fieldPats = pat.patFieldList.filter {
+        val patFieldFull = it.patFieldFull
+        val patBinding = it.patBinding
+        val name = when {
+            patFieldFull != null -> patFieldFull.identifier?.text.orEmpty()
+            patBinding != null -> patBinding.identifier.text
+            else -> return@filter false
+        }
+        name in fields
+    }
+    val rest = if (fieldPats.size < fields.size) {
+        factory.createPatRest()
+    } else {
+        null
+    }
+
+    val newStructPat = factory.createPatStruct(structName, fieldPats, rest)
+    val newFieldPat = factory.createPatFieldFull(fieldName, newStructPat.text)
+    val anchor = fieldPats.firstOrNull() ?: pat.patRest ?: pat.rbrace
+    val inserted = pat.addBefore(newFieldPat, anchor) as RsPatFieldFull
+
+    fieldPats.forEach {
+        it.deleteWithSurroundingCommaAndWhitespace()
+    }
+
+    if (inserted.getNextNonCommentSibling()?.elementType != RBRACE) {
+        inserted.parent.addAfter(factory.createComma(), inserted)
+    }
+
+    return (inserted.pat as RsPatStruct).path
+}
+
+private fun replaceFieldUsage(
+    factory: RsPsiFactory,
+    fieldLookup: RsFieldLookup,
+    fieldName: String
+): RsReferenceElement? {
+    val dotExpr = fieldLookup.parentDotExpr
+    val newDotExpr = factory.createExpression("${dotExpr.expr.text}.$fieldName")
+    dotExpr.expr.replace(newDotExpr)
+    return null
+}
+
+/**
+ * Either return the dotdot expression directly or extract it into a local variable and return a reference to it.
+ */
+fun extractDotDotExpr(factory: RsPsiFactory, literal: RsStructLiteral, expr: RsExpr): RsExpr {
+    // Do not create a new variable if the expression already refers to one
+    if (expr is RsPathExpr) return expr
+
+    val name = expr.suggestedNames().default
+    val variable = factory.createLetDeclaration(name, expr)
+
+    val anchor = literal.parentOfType<RsStmt>() ?: literal
+    anchor.parent.addBefore(variable, anchor)
+    return factory.createExpression(name)
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/extractStructFields/ui.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractStructFields/ui.kt
@@ -1,0 +1,73 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.extractStructFields
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.openapiext.isUnitTestMode
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.layout.panel
+import org.jetbrains.annotations.TestOnly
+import org.rust.RsBundle
+import org.rust.ide.refactoring.isValidRustVariableIdentifier
+import javax.swing.JComponent
+
+private var MOCK: ExtractFieldsUi? = null
+
+fun showExtractStructFieldsDialog(project: Project): String? {
+    val chooser = if (isUnitTestMode) {
+        MOCK ?: error("You should set mock ui via `withMockExtractFieldsUi`")
+    } else {
+        ExtractFieldsDialog(project)
+    }
+    return chooser.selectStructName(project)
+}
+
+@TestOnly
+fun withMockExtractFieldsUi(mockUi: ExtractFieldsUi, action: () -> Unit) {
+    MOCK = mockUi
+    try {
+        action()
+    } finally {
+        MOCK = null
+    }
+}
+
+interface ExtractFieldsUi {
+    fun selectStructName(project: Project): String?
+}
+
+private class ExtractFieldsDialog(project: Project) : DialogWrapper(project, false), ExtractFieldsUi {
+    private val input = JBTextField()
+
+    init {
+        super.init()
+        title = RsBundle.message("action.Rust.RsExtractStructFields.choose.name.dialog.title")
+    }
+
+    override fun doValidate(): ValidationInfo? {
+        if (!isValidRustVariableIdentifier(input.text)) {
+            return ValidationInfo(RsBundle.message("action.Rust.RsExtractStructFields.choose.name.dialog.invalid.name"), input)
+        }
+        return null
+    }
+
+    override fun createCenterPanel(): JComponent {
+        return panel {
+            row {
+                input().focused()
+            }
+        }
+    }
+
+    override fun selectStructName(project: Project): String? {
+        if (this.showAndGet()) {
+            return input.text
+        }
+        return null
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/extractSubsetUtils.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractSubsetUtils.kt
@@ -1,0 +1,13 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring
+
+import org.rust.lang.core.psi.RsOuterAttr
+import org.rust.lang.core.psi.ext.RsOuterAttributeOwner
+import org.rust.lang.core.psi.ext.name
+
+fun findTransitiveAttributes(enum: RsOuterAttributeOwner, supportedAttributes: Set<String>): List<RsOuterAttr> =
+    enum.outerAttrList.filter { it.metaItem.name in supportedAttributes }

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -163,6 +163,9 @@ class RsPsiFactory(
         return structLiteralField
     }
 
+    fun createStructNamedField(text: String): RsNamedFieldDecl =
+        createFromText("struct S { $text }") ?: error("Failed to create block fields")
+
     data class BlockField(val name: String, val type: Ty, val addPub: Boolean)
 
     data class TupleField(val type: Ty, val addPub: Boolean)

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -871,6 +871,10 @@
             <className>org.rust.ide.intentions.visibility.MakePrivateIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.ExtractStructFieldsIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 
@@ -1153,6 +1157,11 @@
         <action id="Rust.RsExtractEnumVariant"
                 class="org.rust.ide.refactoring.extractEnumVariant.RsExtractEnumVariantAction">
             <add-to-group group-id="IntroduceActionsGroup" anchor="after" relative-to-action="ExtractMethod"/>
+        </action>
+
+        <action id="Rust.RsExtractStructFields"
+                class="org.rust.ide.refactoring.extractStructFields.RsExtractStructFieldsAction">
+            <add-to-group group-id="IntroduceActionsGroup" anchor="after" relative-to-action="Rust.RsExtractEnumVariant"/>
         </action>
 
         <action id="Rust.ShowSingleStepMacroExpansionAction"

--- a/src/main/resources/intentionDescriptions/ExtractStructFieldsIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/ExtractStructFieldsIntention/after.rs.template
@@ -1,0 +1,8 @@
+struct Foo {
+    a: u32
+}
+
+struct A {
+    foo: Foo,
+    b: u32
+}

--- a/src/main/resources/intentionDescriptions/ExtractStructFieldsIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/ExtractStructFieldsIntention/before.rs.template
@@ -1,0 +1,4 @@
+struct A {
+    <spot>a</spot>: u32,
+    b: u32
+}

--- a/src/main/resources/intentionDescriptions/ExtractStructFieldsIntention/description.html
+++ b/src/main/resources/intentionDescriptions/ExtractStructFieldsIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention extracts selected struct fields into a standalone struct.
+</body>
+</html>

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -46,6 +46,13 @@ action.Rust.ShareInPlayground.notification.text=File shared in the Rust Playgrou
 action.Rust.ShareInPlayground.notification.title=Share in Rust Playground
 action.Rust.ShareInPlayground.progress.title=Posting code to Rust Playground
 action.Rust.ShareInPlayground.text=Share in Playground
+action.Rust.RsExtractStructFields.description=Extract selected struct fields into a separate struct
+action.Rust.RsExtractStructFields.text=Extract Struct Fields
+action.Rust.RsExtractStructFields.intention.text=Extract struct fields
+action.Rust.RsExtractStructFields.choose.fields.title=Choose Fields to Extract
+action.Rust.RsExtractStructFields.choose.name.dialog.title=Enter Name For the New Struct
+action.Rust.RsExtractStructFields.choose.name.dialog.invalid.name=Invalid struct name
+action.Rust.RsExtractStructFields.command.name=Extracting Struct Fields
 
 action.Rust.ShowRecursiveMacroExpansionAction.text=Show Recursively Expanded Macro
 action.Rust.ShowSingleStepMacroExpansionAction.text=Show Expanded Macro

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractStructFieldsTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractStructFieldsTest.kt
@@ -1,0 +1,612 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring
+
+import com.intellij.openapi.project.Project
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+import org.rust.ide.refactoring.generate.RsStructMemberChooserObject
+import org.rust.ide.refactoring.generate.StructMemberChooserUi
+import org.rust.ide.refactoring.extractStructFields.ExtractFieldsUi
+import org.rust.ide.refactoring.extractStructFields.withMockExtractFieldsUi
+import org.rust.ide.refactoring.generate.withMockStructMemberChooserUi
+import org.rust.launchAction
+
+class RsExtractStructFieldsTest : RsTestBase() {
+    fun `test unavailable on tuple struct`() = doUnavailableTest("""
+        struct A(u32, u32/*caret*/);
+    """)
+
+    fun `test unavailable on unit struct`() = doUnavailableTest("""
+        struct A/*caret*/;
+    """)
+
+    fun `test unavailable on empty block struct`() = doUnavailableTest("""
+        struct A { /*caret*/ }
+    """)
+
+    fun `test unavailable on impl`() = doUnavailableTest("""
+        struct A {
+            a: u32
+        }
+
+        impl A {
+            /*caret*/
+        }
+    """)
+
+    fun `test simple`() = doAvailableTest("""
+        struct A {
+            a: u32/*caret*/
+        }
+    """, "S1", listOf("a"), """
+        struct S1 {
+            a: u32
+        }
+
+        struct A {
+            s1: S1
+        }
+    """)
+
+    fun `test keep existing fields`() = doAvailableTest("""
+        struct A {
+            a: u32,/*caret*/
+            b: i32,
+            c: bool
+        }
+    """, "S1", listOf("b"), """
+        struct S1 {
+            b: i32
+        }
+
+        struct A {
+            a: u32,
+            s1: S1,
+            c: bool
+        }
+    """)
+
+    fun `test field with same name`() = doAvailableTest("""
+        struct A {
+            a: u32,/*caret*/
+            b: u32,
+        }
+    """, "B", listOf("a"), """
+        struct B {
+            a: u32
+        }
+
+        struct A {
+            b0: B,
+            b: u32,
+        }
+    """)
+
+    fun `test multiple fields`() = doAvailableTest("""
+        struct A {
+            a: u32,/*caret*/
+            b: i32,
+            c: bool,
+            d: u32
+        }
+    """, "S1", listOf("b", "c"), """
+        struct S1 {
+            b: i32,
+            c: bool
+        }
+
+        struct A {
+            a: u32,
+            s1: S1,
+            d: u32
+        }
+    """)
+
+    fun `test keep supported attributes`() = doAvailableTest("""
+        #[derive(Debug, Clone)]
+        #[repr(C)]
+        struct A {
+            a: u32/*caret*/
+        }
+    """, "S1", listOf("a"), """
+        #[derive(Debug, Clone)]
+        #[repr(C)]
+        struct S1 {
+            a: u32
+        }
+
+        #[derive(Debug, Clone)]
+        #[repr(C)]
+        struct A {
+            s1: S1
+        }
+    """)
+
+    fun `test filter generic parameters`() = doAvailableTest("""
+        struct A<T, R> {
+            a: T,/*caret*/
+            b: R
+        }
+    """, "S1", listOf("a"), """
+        struct S1<T> {
+            a: T
+        }
+
+        struct A<T, R> {
+            s1: S1<T>,
+            b: R
+        }
+    """)
+
+    fun `test filter lifetimes`() = doAvailableTest("""
+        struct A<'a, 'b> {
+            a: &'a u32,/*caret*/
+            b: &'b u32
+        }
+    """, "S1", listOf("a"), """
+        struct S1<'a> {
+            a: &'a u32
+        }
+
+        struct A<'a, 'b> {
+            s1: S1<'a>,
+            b: &'b u32
+        }
+    """)
+
+    fun `test where clause`() = doAvailableTest("""
+        trait Trait<S> {}
+        struct A<T, R> where T: Trait<R> {
+            a: T,/*caret*/
+            b: R
+        }
+    """, "S1", listOf("a"), """
+        trait Trait<S> {}
+
+        struct S1<T, R> where T: Trait<R> {
+            a: T
+        }
+
+        struct A<T, R> where T: Trait<R> {
+            s1: S1<T, R>,
+            b: R
+        }
+    """)
+
+    fun `test visibility pub`() = doAvailableTest("""
+        struct A {
+            pub a: u32,/*caret*/
+            pub(crate) b: u32
+        }
+    """, "S1", listOf("a", "b"), """
+        struct S1 {
+            pub a: u32,
+            pub(crate) b: u32
+        }
+
+        struct A {
+            pub s1: S1
+        }
+    """)
+
+    fun `test visibility pub(crate)`() = doAvailableTest("""
+        struct A {
+            pub(crate) a: u32,/*caret*/
+            b: u32
+        }
+    """, "S1", listOf("a", "b"), """
+        struct S1 {
+            pub(crate) a: u32,
+            b: u32
+        }
+
+        struct A {
+            pub(crate) s1: S1
+        }
+    """)
+
+    fun `test visibility broadest module`() = doAvailableTest("""
+        mod foo {
+            mod bar {
+                struct A {
+                    pub(in crate::foo) a: u32,/*caret*/
+                    pub(in crate::foo::bar) b: u32
+                }
+            }
+        }
+    """, "S1", listOf("a", "b"), """
+        mod foo {
+            mod bar {
+                struct S1 {
+                    pub(in crate::foo) a: u32,
+                    pub(in crate::foo::bar) b: u32
+                }
+
+                struct A {
+                    pub(in test_package::foo) s1: S1
+                }
+            }
+        }
+    """)
+
+    fun `test replace literal usage`() = doAvailableTest("""
+        struct A {
+            a: u32,/*caret*/
+            b: u32,
+            c: u32,
+            d: bool
+        }
+        fn foo() -> A {
+            A { a: 0, b: 1, c: 2, d: true }
+        }
+    """, "S1", listOf("b", "c"), """
+        struct S1 {
+            b: u32,
+            c: u32
+        }
+
+        struct A {
+            a: u32,
+            s1: S1,
+            d: bool
+        }
+        fn foo() -> A {
+            A { a: 0, s1: S1 { b: 1, c: 2 }, d: true }
+        }
+    """)
+
+    fun `test replace literal usage last literal field`() = doAvailableTest("""
+        struct A {
+            a: u32,/*caret*/
+            b: u32
+        }
+        fn foo() -> A {
+            A { a: 0, b: 1 }
+        }
+    """, "S1", listOf("a", "b"), """
+        struct S1 {
+            a: u32,
+            b: u32
+        }
+
+        struct A {
+            s1: S1
+        }
+        fn foo() -> A {
+            A { s1: S1 { a: 0, b: 1 } }
+        }
+    """)
+
+    fun `test replace literal usage with shorthand`() = doAvailableTest("""
+        struct A {
+            a: u32,/*caret*/
+            b: u32,
+            c: u32,
+            d: bool
+        }
+        fn foo() -> A {
+            let b = 5;
+            A { a: 0, b, c: 2, d: true }
+        }
+    """, "S1", listOf("b", "c"), """
+        struct S1 {
+            b: u32,
+            c: u32
+        }
+
+        struct A {
+            a: u32,
+            s1: S1,
+            d: bool
+        }
+        fn foo() -> A {
+            let b = 5;
+            A { a: 0, s1: S1 { b, c: 2 }, d: true }
+        }
+    """)
+
+    fun `test replace literal usage import new struct`() = doAvailableTest("""
+        mod foo {
+            pub struct A {
+                pub a: u32,/*caret*/
+            }
+        }
+        fn bar() -> foo::A {
+            foo::A { a: 0 }
+        }
+    """, "S1", listOf("a"), """
+        use foo::S1;
+
+        mod foo {
+            pub struct S1 {
+                pub a: u32
+            }
+
+            pub struct A {
+                pub s1: S1,
+            }
+        }
+        fn bar() -> foo::A {
+            foo::A { s1: S1 { a: 0 } }
+        }
+    """)
+
+    fun `test replace literal usage dotdot all fields`() = doAvailableTest("""
+        struct A {
+            a: u32,/*caret*/
+            b: u32
+        }
+        fn foo() -> A { unimplemented!() }
+        fn bar() -> A {
+            A { ..foo() }
+        }
+    """, "S1", listOf("a", "b"), """
+        struct S1 {
+            a: u32,
+            b: u32
+        }
+
+        struct A {
+            s1: S1
+        }
+        fn foo() -> A { unimplemented!() }
+        fn bar() -> A {
+            let a = foo();
+            A { s1: S1 { a: a.s1.a, b: a.s1.b }, ..a }
+        }
+    """)
+
+    fun `test replace literal usage dotdot let decl`() = doAvailableTest("""
+        struct A {
+            a: u32,/*caret*/
+            b: u32
+        }
+        fn foo() -> A { unimplemented!() }
+        fn bar() -> A {
+            let x = A { ..foo() };
+        }
+    """, "S1", listOf("a", "b"), """
+        struct S1 {
+            a: u32,
+            b: u32
+        }
+
+        struct A {
+            s1: S1
+        }
+        fn foo() -> A { unimplemented!() }
+        fn bar() -> A {
+            let a = foo();
+            let x = A { s1: S1 { a: a.s1.a, b: a.s1.b }, ..a };
+        }
+    """)
+
+    fun `test replace literal usage dotdot subset of fields`() = doAvailableTest("""
+        struct A {
+            a: u32,/*caret*/
+            b: u32
+        }
+        fn foo() -> A { unimplemented!() }
+        fn bar() -> A {
+            A { ..foo() }
+        }
+    """, "S1", listOf("a"), """
+        struct S1 {
+            a: u32
+        }
+
+        struct A {
+            s1: S1,
+            b: u32
+        }
+        fn foo() -> A { unimplemented!() }
+        fn bar() -> A {
+            let a = foo();
+            A { s1: S1 { a: a.s1.a }, ..a }
+        }
+    """)
+
+    fun `test replace literal usage dotdot path expr`() = doAvailableTest("""
+        struct A {
+            a: u32,/*caret*/
+            b: u32
+        }
+        fn bar(a: A) -> A {
+            A { ..a }
+        }
+    """, "S1", listOf("a"), """
+        struct S1 {
+            a: u32
+        }
+
+        struct A {
+            s1: S1,
+            b: u32
+        }
+        fn bar(a: A) -> A {
+            A { s1: S1 { a: a.s1.a }, ..a }
+        }
+    """)
+
+    fun `test replace pat literal usage all fields`() = doAvailableTest("""
+        struct A {
+            a: u32,/*caret*/
+            b: u32
+        }
+        fn foo(x: A) {
+            let A { a, b } = x;
+        }
+    """, "S1", listOf("a", "b"), """
+        struct S1 {
+            a: u32,
+            b: u32
+        }
+
+        struct A {
+            s1: S1
+        }
+        fn foo(x: A) {
+            let A { s1: S1 { a, b } } = x;
+        }
+    """)
+
+    fun `test replace pat literal usage subset of fields`() = doAvailableTest("""
+        struct A {
+            a: u32,/*caret*/
+            b: u32,
+            c: u32
+        }
+        fn foo(x: A) {
+            let A { a, b, c } = x;
+        }
+    """, "S1", listOf("a", "b"), """
+        struct S1 {
+            a: u32,
+            b: u32
+        }
+
+        struct A {
+            s1: S1,
+            c: u32
+        }
+        fn foo(x: A) {
+            let A { s1: S1 { a, b }, c } = x;
+        }
+    """)
+
+    fun `test replace pat literal usage full rest pat`() = doAvailableTest("""
+        struct A {
+            a: u32,/*caret*/
+            b: u32,
+            c: u32
+        }
+        fn foo(x: A) {
+            let A { .. } = x;
+        }
+    """, "S1", listOf("a", "b"), """
+        struct S1 {
+            a: u32,
+            b: u32
+        }
+
+        struct A {
+            s1: S1,
+            c: u32
+        }
+        fn foo(x: A) {
+            let A { s1: S1 { .. }, .. } = x;
+        }
+    """)
+
+    fun `test replace pat literal usage partial rest pat`() = doAvailableTest("""
+        struct A {
+            a: u32,/*caret*/
+            b: u32,
+            c: u32
+        }
+        fn foo(x: A) {
+            let A { a: foo, .. } = x;
+        }
+    """, "S1", listOf("a", "b"), """
+        struct S1 {
+            a: u32,
+            b: u32
+        }
+
+        struct A {
+            s1: S1,
+            c: u32
+        }
+        fn foo(x: A) {
+            let A { s1: S1 { a: foo, .. }, .. } = x;
+        }
+    """)
+
+    fun `test replace field usage`() = doAvailableTest("""
+        struct A {
+            a: u32,/*caret*/
+            b: u32,
+            c: u32
+        }
+        fn foo(a: A) {
+            let x = a.a;
+            let y = a.b;
+        }
+    """, "S1", listOf("a", "b"), """
+        struct S1 {
+            a: u32,
+            b: u32
+        }
+
+        struct A {
+            s1: S1,
+            c: u32
+        }
+        fn foo(a: A) {
+            let x = a.s1.a;
+            let y = a.s1.b;
+        }
+    """)
+
+    fun `test replace nested field usage`() = doAvailableTest("""
+        struct B {
+            x: u32
+        }
+        struct A {
+            a: u32,/*caret*/
+            b: B,
+            c: u32
+        }
+        fn foo(a: A) {
+            let x = a.b.x;
+        }
+    """, "Foo", listOf("a", "b"), """
+        struct B {
+            x: u32
+        }
+
+        struct Foo {
+            a: u32,
+            b: B
+        }
+
+        struct A {
+            foo: Foo,
+            c: u32
+        }
+        fn foo(a: A) {
+            let x = a.foo.b.x;
+        }
+    """)
+
+    private fun doAvailableTest(
+        @Language("Rust") before: String,
+        structName: String,
+        selected: List<String>,
+        @Language("Rust") after: String
+    ) {
+        withMockStructMemberChooserUi(object : StructMemberChooserUi {
+            override fun selectMembers(
+                project: Project,
+                all: List<RsStructMemberChooserObject>
+            ): List<RsStructMemberChooserObject> {
+                return all.filter { it.member.argumentIdentifier in selected }
+            }
+        }) {
+            withMockExtractFieldsUi(object : ExtractFieldsUi {
+                override fun selectStructName(project: Project): String = structName
+            }) {
+                checkEditorAction(before, after, "Rust.RsExtractStructFields")
+            }
+        }
+    }
+
+    private fun doUnavailableTest(@Language("Rust") code: String) {
+        InlineFile(code.trimIndent()).withCaret()
+        myFixture.launchAction("Rust.RsExtractStructFields", shouldBeEnabled = false)
+    }
+}


### PR DESCRIPTION
This PR adds a refactoring that extracts selected struct fields into a new struct. It is similar to the ExtractEnumVariant refactoring (https://github.com/intellij-rust/intellij-rust/pull/5037). It only works for block structs currently.

![extract-struct](https://user-images.githubusercontent.com/4539057/107858836-901c5f80-6e36-11eb-8522-6834822d2c14.gif)

Fixes: https://github.com/intellij-rust/intellij-rust/issues/1336

changelog: Add a refactoring and an intention to extract selected struct fields into a separate struct.