### PR TITLE
INSP: extend RsSelfConventionInspection with get, set and with

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/RsSelfConventionInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSelfConventionInspection.kt
@@ -12,15 +12,13 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ImplLookup
 import org.rust.lang.core.types.selfType
 import org.rust.lang.core.types.ty.TyUnknown
-import org.rust.stdext.typeAscription
 
 class RsSelfConventionInspection : RsLocalInspectionTool() {
-
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitFunction(m: RsFunction) {
                 val traitOrImpl = when (val owner = m.owner) {
-                    is RsAbstractableOwner.Trait -> typeAscription<RsTraitOrImpl>(owner.trait)
+                    is RsAbstractableOwner.Trait -> owner.trait
                     is RsAbstractableOwner.Impl -> owner.impl.takeIf { owner.isInherent }
                     else -> null
                 } ?: return
@@ -44,7 +42,10 @@ class RsSelfConventionInspection : RsLocalInspectionTool() {
             SelfConvention("from_", listOf(SelfSignature.NO_SELF)),
             SelfConvention("into_", listOf(SelfSignature.BY_VAL)),
             SelfConvention("is_", listOf(SelfSignature.BY_REF, SelfSignature.NO_SELF)),
-            SelfConvention("to_", listOf(SelfSignature.BY_REF))
+            SelfConvention("to_", listOf(SelfSignature.BY_REF)),
+            SelfConvention("get_", listOf(SelfSignature.BY_REF)),
+            SelfConvention("set_", listOf(SelfSignature.BY_MUT_REF)),
+            SelfConvention("with_", listOf(SelfSignature.BY_VAL, SelfSignature.BY_MUT_REF))
         )
     }
 }

--- a/src/main/kotlin/org/rust/stdext/Utils.kt
+++ b/src/main/kotlin/org/rust/stdext/Utils.kt
@@ -21,12 +21,6 @@ import kotlin.streams.asSequence
 private val LOG = Logger.getInstance("#org.rust.stdext")
 
 /**
- * Just a way to nudge Kotlin's type checker in the right direction
- */
-@Suppress("NOTHING_TO_INLINE")
-inline fun <T> typeAscription(t: T): T = t
-
-/**
  * Just a way to force exhaustiveness analysis for Kotlin's `when` expression.
  *
  * Use it like this:

--- a/src/test/kotlin/org/rust/ide/inspections/RsSelfConventionInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsSelfConventionInspectionTest.kt
@@ -12,8 +12,7 @@ import org.rust.WithStdlibRustProjectDescriptor
  * Tests for Self Convention inspection
  */
 class RsSelfConventionInspectionTest : RsInspectionsTestBase(RsSelfConventionInspection::class) {
-
-    fun testFrom() = checkByText("""
+    fun `test from`() = checkByText("""
         struct Foo;
         impl Foo {
             fn from_nothing(<warning descr="methods called `from_*` usually take no self; consider choosing a less ambiguous name">self</warning>) -> T { T() }
@@ -21,7 +20,7 @@ class RsSelfConventionInspectionTest : RsInspectionsTestBase(RsSelfConventionIns
         }
     """)
 
-    fun testInto() = checkByText("""
+    fun `test into`() = checkByText("""
         struct Foo;
         impl Foo {
             fn into_u32(self) -> u32 { 0 }
@@ -31,7 +30,7 @@ class RsSelfConventionInspectionTest : RsInspectionsTestBase(RsSelfConventionIns
         }
     """)
 
-    fun testTo() = checkByText("""
+    fun `test to`() = checkByText("""
         struct Foo;
         impl Foo {
             fn to_something(<warning descr="methods called `to_*` usually take self by reference; consider choosing a less ambiguous name">self</warning>) -> u32 { 0 }
@@ -39,11 +38,36 @@ class RsSelfConventionInspectionTest : RsInspectionsTestBase(RsSelfConventionIns
         }
     """)
 
-    fun testIs() = checkByText("""
+    fun `test is`() = checkByText("""
         struct Foo;
         impl Foo {
             fn is_awesome(<warning descr="methods called `is_*` usually take self by reference or no self; consider choosing a less ambiguous name">self</warning>) {}
             fn is_awesome_ref(&self) {}
+        }
+    """)
+
+    fun `test get`() = checkByText("""
+        struct Foo;
+        impl Foo {
+            fn get_foo(<warning descr="methods called `get_*` usually take self by reference; consider choosing a less ambiguous name">self</warning>) {}
+            fn get_bar(&self) {}
+        }
+    """)
+
+    fun `test set`() = checkByText("""
+        struct Foo;
+        impl Foo {
+            fn set_foo(<warning descr="methods called `set_*` usually take self by mutable reference; consider choosing a less ambiguous name">&self</warning>) {}
+            fn set_bar(&mut self) {}
+        }
+    """)
+
+    fun `test with`() = checkByText("""
+        struct Foo;
+        impl Foo {
+            fn with_foo(<warning descr="methods called `with_*` usually take self by value or self by mutable reference; consider choosing a less ambiguous name">&self</warning>) {}
+            fn with_bar(&mut self) {}
+            fn with_baz(self) {}
         }
     """)
 


### PR DESCRIPTION
This PR adds more cases to `RsSelfConventionInspection`, useful for getters/setters and the builder pattern.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/1323

changelog: Extend RsSelfConvention inspection with new method prefixes (get, set and with).