### PR TITLE
INT: add intention to toggle feature state from cfg attribute

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/ToggleFeatureIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ToggleFeatureIntention.kt
@@ -1,0 +1,61 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import org.rust.RsBundle
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.lang.core.RsPsiPattern.insideAnyCfgFeature
+import org.rust.lang.core.psi.RsLitExpr
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.cargoProject
+import org.rust.lang.core.psi.ext.containingCargoPackage
+import org.rust.lang.core.psi.ext.stringValue
+
+class ToggleFeatureIntention : RsElementBaseIntentionAction<ToggleFeatureIntention.Context>() {
+    private val matcher = insideAnyCfgFeature
+
+    data class Context(val featureName: String, val element: RsElement)
+
+    override fun getFamilyName() = RsBundle.message("intention.Rust.ToggleFeatureIntention.family.name")
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        if (!matcher.accepts(element)) return null
+
+        val context = element.parentOfType<RsLitExpr>() ?: return null
+        val featureName = context.stringValue ?: return null
+        val isEnabled = isFeatureEnabled(context, featureName) ?: return null
+
+        text = if (isEnabled) {
+            RsBundle.message("intention.Rust.ToggleFeatureIntention.disable", featureName)
+        } else {
+            RsBundle.message("intention.Rust.ToggleFeatureIntention.enable", featureName)
+        }
+
+        return Context(featureName, context)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val element = ctx.element
+        val cargoProject = element.cargoProject ?: return
+        val pkg = element.containingCargoPackage ?: return
+
+        val feature = pkg.features.find { it.name == ctx.featureName } ?: return
+        val state = pkg.featureState[ctx.featureName] ?: return
+        project.cargoProjects.modifyFeatures(cargoProject, setOf(feature), !state)
+    }
+}
+private fun isFeatureEnabled(element: RsElement, name: String): Boolean? {
+    val pkg = element.containingCargoPackage ?: return null
+    if (pkg.origin != PackageOrigin.WORKSPACE) return null
+
+    val state = pkg.featureState[name] ?: return null
+    return state.isEnabled
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -883,6 +883,10 @@
             <className>org.rust.ide.intentions.ShareInPlaygroundIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.ToggleFeatureIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 

--- a/src/main/resources/intentionDescriptions/ToggleFeatureIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/ToggleFeatureIntention/after.rs.template
@@ -1,0 +1,2 @@
+#[cfg(feature = "foo")]
+fn foo() {}

--- a/src/main/resources/intentionDescriptions/ToggleFeatureIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/ToggleFeatureIntention/before.rs.template
@@ -1,0 +1,2 @@
+#[cfg(feature = <spot>"foo"</spot>)]
+fn foo() {}

--- a/src/main/resources/intentionDescriptions/ToggleFeatureIntention/description.html
+++ b/src/main/resources/intentionDescriptions/ToggleFeatureIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Toggles Cargo feature state from a cfg attribute.
+</body>
+</html>

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -69,3 +69,7 @@ refactoring.change.signature.name.conflict=The name {0} conflicts with an existi
 refactoring.change.signature.name=Change Signature
 refactoring.change.signature.refactor.super.function=Method {0} implements base method of trait {1}.\nDo you want to refactor the base method?
 refactoring.change.signature.visibility.conflict=The function will not be visible from {0} after the refactoring
+
+intention.Rust.ToggleFeatureIntention.enable=Enable feature `{0}`
+intention.Rust.ToggleFeatureIntention.disable=Disable feature `{0}`
+intention.Rust.ToggleFeatureIntention.family.name=Toggle feature state

--- a/src/test/kotlin/org/rust/ide/intentions/ToggleFeatureIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ToggleFeatureIntentionTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import org.intellij.lang.annotations.Language
+import org.rust.MockCargoFeatures
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.workspace.FeatureState
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.singleProject
+import org.rust.workspaceOrFail
+
+class ToggleFeatureIntentionTest : RsIntentionTestBase(ToggleFeatureIntention::class) {
+    fun `test unknown feature`() = doUnavailableTest(
+        """
+        #[cfg(feature = "bar"/*caret*/)]
+        fn foo() {}
+    """
+    )
+
+    @MockCargoFeatures("foo")
+    fun `test enable`() = doTest(
+        """
+        #[cfg(feature = "foo"/*caret*/)]
+        fn foo() {}
+    """, "foo", FeatureState.Disabled
+    )
+
+    @MockCargoFeatures("foo")
+    fun `test disable`() = doTest(
+        """
+        #[cfg(feature = "foo"/*caret*/)]
+        fn foo() {}
+    """, "foo", FeatureState.Enabled
+    )
+
+    private fun doTest(@Language("Rust") code: String, featureName: String, initialState: FeatureState) {
+        val cargoProject = project.cargoProjects.singleProject()
+        val pkg = cargoProject.workspaceOrFail().packages.single { it.origin == PackageOrigin.WORKSPACE }
+        val feature = pkg.features.find { it.name == featureName } ?: error("Feature $featureName not found in test")
+        project.cargoProjects.modifyFeatures(cargoProject, setOf(feature), initialState)
+
+        InlineFile(code.trimIndent()).withCaret()
+        launchAction()
+
+        val cargoProjectRefreshed = project.cargoProjects.singleProject()
+        val pkgRefreshed = cargoProjectRefreshed.workspaceOrFail().packages.single { it.origin == PackageOrigin.WORKSPACE }
+
+        assertEquals(!initialState, pkgRefreshed.featureState[featureName])
+    }
+}


### PR DESCRIPTION
This PR adds a simple intention that toggles feature state. It can be invoked from `cfg` feature attributes.

I needed an intention test with a toolchain, so the test inherits from `RsWithToolchainTestBase` and reimplements a small amount of logic from `RsIntentionTestBase`.

Related issue: https://github.com/intellij-rust/intellij-rust/issues/4693

changelog: Add intention that toggles feature state from a cfg attribute