### PR TITLE
Properly change state of optional dependencies in Cargo toml

### DIFF
--- a/src/test/kotlin/org/rust/ide/lineMarkers/LineMarkerTestHelper.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/LineMarkerTestHelper.kt
@@ -1,0 +1,62 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.lineMarkers
+
+import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl
+import com.intellij.lang.LanguageCommenters
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+
+class LineMarkerTestHelper(private val fixture: CodeInsightTestFixture) {
+
+    fun doTestByText(fileName: String, source: String) {
+        fixture.configureByText(fileName, source)
+        doTest()
+    }
+
+    fun doTestFromFile(file: VirtualFile) {
+        fixture.configureFromExistingVirtualFile(file)
+        doTest()
+    }
+
+    private fun doTest() {
+        fixture.doHighlighting()
+        val expected = markersFrom(fixture.editor.document.text)
+        val actual = markersFrom(fixture.editor, fixture.project)
+        BasePlatformTestCase.assertEquals(expected.joinToString(COMPARE_SEPARATOR), actual.joinToString(COMPARE_SEPARATOR))
+    }
+
+    private fun markersFrom(text: String): List<Pair<Int, String>> {
+        val commentPrefix = LanguageCommenters.INSTANCE.forLanguage(fixture.file.language).lineCommentPrefix ?: "//"
+        val marker = "$commentPrefix - "
+        return text.split('\n')
+            .withIndex()
+            .filter { it.value.contains(marker) }
+            .flatMap { row ->
+                row.value
+                    .substring(row.value.indexOf(marker) + marker.length)
+                    .trim()
+                    .split(',')
+                    .map { Pair(row.index, it) }
+            }
+            .sortedWith(compareBy({ it.first }, { it.second }))
+    }
+
+    private fun markersFrom(editor: Editor, project: Project): List<Pair<Int, String>> =
+        DaemonCodeAnalyzerImpl.getLineMarkers(editor.document, project)
+            .map {
+                Pair(editor.document.getLineNumber(it.element?.textRange?.startOffset as Int),
+                    it.lineMarkerTooltip ?: "null")
+            }
+            .sortedWith(compareBy({ it.first }, { it.second }))
+
+    private companion object {
+        private const val COMPARE_SEPARATOR = " | "
+    }
+}

--- a/src/test/kotlin/org/rust/ide/lineMarkers/LineMarkerTestHelper.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/LineMarkerTestHelper.kt
@@ -5,13 +5,17 @@
 
 package org.rust.ide.lineMarkers
 
+import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl
 import com.intellij.lang.LanguageCommenters
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import java.awt.event.MouseEvent
+import javax.swing.JLabel
 
 class LineMarkerTestHelper(private val fixture: CodeInsightTestFixture) {
 
@@ -59,4 +63,8 @@ class LineMarkerTestHelper(private val fixture: CodeInsightTestFixture) {
     private companion object {
         private const val COMPARE_SEPARATOR = " | "
     }
+}
+
+fun LineMarkerInfo<PsiElement>.invokeNavigationHandler(element: PsiElement?) {
+    navigationHandler.navigate(MouseEvent(JLabel(), 0, 0, 0, 0, 0, 0, false), element)
 }

--- a/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/rust/ide/lineMarkers/RsImplsLineMarkerProviderTest.kt
@@ -70,7 +70,7 @@ class RsImplsLineMarkerProviderTest : RsLineMarkerProviderTestBase() {
         val element = myFixture.file.findElementAt(myFixture.caretOffset)!!
         @Suppress("UNCHECKED_CAST")
         val markerInfo = (myFixture.findGuttersAtCaret().first() as LineMarkerInfo.LineMarkerGutterIconRenderer<PsiElement>).lineMarkerInfo
-        markerInfo.navigationHandler.navigate(MouseEvent(JLabel(), 0, 0, 0, 0, 0, 0, false), element)
+        markerInfo.invokeNavigationHandler(element)
         val renderedImpls = element.getUserData(RsImplsLineMarkerProvider.RENDERED_IMPLS)!!
         assertEquals(expectedItems.toList(), renderedImpls)
     }

--- a/toml/src/main/kotlin/org/rust/toml/CargoFeatureLineMarkerProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoFeatureLineMarkerProvider.kt
@@ -59,8 +59,7 @@ class CargoFeatureLineMarkerProvider : LineMarkerProvider {
             if (parent is TomlKeySegment) {
                 val isFeatureKey = parent.isFeatureKey
                 if (!isFeatureKey && !parent.isDependencyName) continue@loop
-                val featureName = parent.text
-                if ("." in featureName) continue@loop
+                val featureName = parent.name ?: continue@loop
                 if (!isFeatureKey && featureName !in features) continue@loop
                 result += genFeatureLineMarkerInfo(
                     parent,
@@ -153,7 +152,7 @@ class CargoFeatureLineMarkerProvider : LineMarkerProvider {
 private object ToggleFeatureAction : GutterIconNavigationHandler<PsiElement> {
     override fun navigate(e: MouseEvent, element: PsiElement) {
         val context = getContext(element) ?: return
-        val featureName = element.ancestorStrict<TomlKey>()?.text ?: return
+        val featureName = element.ancestorStrict<TomlKeySegment>()?.name ?: return
         val oldState = context.cargoPackage.featureState.getOrDefault(featureName, FeatureState.Disabled)
         val newState = !oldState
         val tomlDoc = PsiDocumentManager.getInstance(context.cargoProject.project).getDocument(element.containingFile)

--- a/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
@@ -69,5 +69,5 @@ class CargoCrateDocLineMarkerProviderTest : CargoTomlLineMarkerProviderTestBase(
     fun `test exact version`() = doTestByText("""
         [dependencies]
         base64 = "=0.8.0"  # - Open documentation for `base64@=0.8.0`
-    """.trimIndent())
+    """)
 }

--- a/toml/src/test/kotlin/org/rust/toml/CargoFeatureLineMarkerProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoFeatureLineMarkerProviderTest.kt
@@ -5,15 +5,71 @@
 
 package org.rust.toml
 
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibAndDependencyRustProjectDescriptor
+import org.intellij.lang.annotations.Language
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.ide.lineMarkers.LineMarkerTestHelper
 
-@ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
-class CargoFeatureLineMarkerProviderTest : CargoTomlLineMarkerProviderTestBase() {
-    fun `test simple features`() = doTestByText("""
+class CargoFeatureLineMarkerProviderTest : RsWithToolchainTestBase() {
+
+    private lateinit var lineMarkerTestHelper: LineMarkerTestHelper
+
+    override fun setUp() {
+        super.setUp()
+        lineMarkerTestHelper = LineMarkerTestHelper(myFixture)
+    }
+
+    fun `test simple features`() = doTest("""
+        [package]
+        name = "intellij-rust-test"
+        version = "0.1.0"
+        authors = []
+
         [features]
         foo = []   # - Toggle feature `foo`
         bar = []   # - Toggle feature `bar`
         foobar = ["foo", "bar"]  # - Toggle feature `foobar`
     """)
+
+    fun `test optional dependency`() = doTest("""
+        [package]
+        name = "intellij-rust-test"
+        version = "0.1.0"
+        authors = []
+
+        [dependencies.foo] # - Toggle feature `foo`
+        path = "foo"
+        optional = true
+    """)
+
+    fun `test optional dependency inline table`() = doTest("""
+        [package]
+        name = "intellij-rust-test"
+        version = "0.1.0"
+        authors = []
+
+        [dependencies]
+        foo = { path = "foo", optional = true } # - Toggle feature `foo`
+    """)
+
+    private fun doTest(@Language("Toml") source: String) {
+        val testProject = buildProject {
+            toml("Cargo.toml", source)
+            dir("src") {
+                rust("lib.rs", "")
+            }
+            dir("foo") {
+                toml("Cargo.toml", """
+                    [package]
+                    name = "foo"
+                    version = "0.1.0"
+                    authors = []
+                """)
+                dir("src") {
+                    rust("lib.rs", "")
+                }
+            }
+        }
+
+        lineMarkerTestHelper.doTestFromFile(testProject.file("Cargo.toml"))
+    }
 }

--- a/toml/src/test/kotlin/org/rust/toml/CargoTomlLineMarkerProviderTestBase.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoTomlLineMarkerProviderTestBase.kt
@@ -5,39 +5,20 @@
 
 package org.rust.toml
 
-import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.project.Project
 import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
+import org.rust.ide.lineMarkers.LineMarkerTestHelper
 
 abstract class CargoTomlLineMarkerProviderTestBase : RsTestBase() {
-    protected fun doTestByText(@Language("Toml") source: String) {
-        myFixture.configureByText("Cargo.toml", source)
-        myFixture.doHighlighting()
-        val expected = markersFrom(source)
-        val actual = markersFrom(myFixture.editor, myFixture.project)
-        assertEquals(expected.joinToString(COMPARE_SEPARATOR), actual.joinToString(COMPARE_SEPARATOR))
+
+    private lateinit var lineMarkerTestHelper: LineMarkerTestHelper
+
+    override fun setUp() {
+        super.setUp()
+        lineMarkerTestHelper = LineMarkerTestHelper(myFixture)
     }
 
-    private fun markersFrom(text: String): List<Pair<Int, String>> =
-        text.lines()
-            .withIndex()
-            .filter { it.value.contains(MARKER) }
-            .map { (index, line) ->
-                index to line.substringAfter(MARKER).trim()
-            }
-
-    private fun markersFrom(editor: Editor, project: Project): List<Pair<Int, String>> =
-        DaemonCodeAnalyzerImpl.getLineMarkers(editor.document, project)
-            .map {
-                val startOffset = it.element!!.textRange.startOffset
-                editor.document.getLineNumber(startOffset) to it.lineMarkerTooltip!!
-            }
-            .sortedBy { it.first }
-
-    private companion object {
-        const val MARKER = "# - "
-        const val COMPARE_SEPARATOR = " | "
+    protected fun doTestByText(@Language("Toml") source: String) {
+        lineMarkerTestHelper.doTestByText("Cargo.toml", source)
     }
 }


### PR DESCRIPTION
The bug was introduced in #6623.

Also, these changes introduce `LineMarkerTestHelper` to avoid code duplication related to line marker tests

Fixes #6828
