### PR TITLE
ANN: Support E0116 for impls for trait objects

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -817,8 +817,12 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     private fun checkInherentImplSameCrate(holder: RsAnnotationHolder, impl: RsImplItem) {
         if (impl.traitRef != null) return  // checked in [checkTraitImplOrphanRules]
         val typeReference = impl.typeReference ?: return
-        val struct = (typeReference.type as? TyAdt)?.item ?: return
-        if (impl.containingCrate != struct.containingCrate) {
+        val element = when (val type = typeReference.type) {
+            is TyAdt -> type.item
+            is TyTraitObject -> type.traits.first().element
+            else -> return
+        }
+        if (impl.containingCrate != element.containingCrate) {
             RsDiagnostic.InherentImplDifferentCrateError(typeReference).addToHolder(holder)
         }
     }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -4014,11 +4014,13 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
     fun `test E0116 inherent impls should be in same crate`() = checkByFileTree("""
     //- lib.rs
         pub struct ForeignStruct {}
+        pub trait ForeignTrait {}
     //- main.rs
         /*caret*/
-        use test_package::ForeignStruct;
+        use test_package::{ForeignStruct, ForeignTrait};
 
         struct LocalStruct {}
+        trait LocalTrait {}
         type ForeignStructAlias = ForeignStruct;
         type LocalStructAlias = LocalStruct;
 
@@ -4026,6 +4028,9 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         impl <error descr="Cannot define inherent `impl` for a type outside of the crate where the type is defined [E0116]">ForeignStructAlias</error> {}
         impl LocalStruct {}
         impl LocalStructAlias {}
+
+        impl dyn LocalTrait {}
+        impl <error descr="Cannot define inherent `impl` for a type outside of the crate where the type is defined [E0116]">dyn ForeignTrait</error> {}
     """)
 
     @MinRustcVersion("1.33.0")  // for Pin


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/pull/6776#discussion_r570127570

Produces [E0116](https://doc.rust-lang.org/error-index.html#E0116) in code like:

```rust
impl dyn ForeignTrait {}
```

changelog: Support detecting [E0116](https://doc.rust-lang.org/error-index.html#E0116) for impls for trait objects