### PR TITLE
CI: fix next milestone creation

### DIFF
--- a/scripts/github.py
+++ b/scripts/github.py
@@ -7,7 +7,7 @@ from common import get_patch_version
 
 
 def get_current_milestone(repo: str, patch_version: Optional[int] = None) -> Dict:
-    milestones = get_all_milestones(repo)
+    milestones = get_latest_milestones(repo)
     if patch_version is None:
         patch_version = get_patch_version()
     milestone_version = f"v{patch_version}"
@@ -25,8 +25,8 @@ def set_milestone(token: str, repo: str, issue_number: int, milestone_number: in
     urlopen(request)
 
 
-def get_all_milestones(repo: str, state: str = "open") -> List[Dict]:
-    response = urlopen(f"https://api.github.com/repos/{repo}/milestones?state={state}")
+def get_latest_milestones(repo: str, state: str = "open") -> List[Dict]:
+    response = urlopen(f"https://api.github.com/repos/{repo}/milestones?state={state}&sort=due_on&direction=desc")
     return json.load(response)
 
 

--- a/scripts/make_next_milestone.py
+++ b/scripts/make_next_milestone.py
@@ -3,7 +3,7 @@ import re
 from datetime import datetime, timedelta
 
 from common import env, get_patch_version
-from github import get_all_milestones, create_milestone
+from github import get_latest_milestones, create_milestone
 
 RELEASE_MANAGER_RE = re.compile("Release manager: @(\\w+)")
 
@@ -15,7 +15,7 @@ def main():
     args = parser.parse_args()
 
     repo = env("GITHUB_REPOSITORY")
-    milestones = get_all_milestones(repo, state="all")
+    milestones = get_latest_milestones(repo, state="all")
     milestones.sort(key=lambda milestone: milestone["title"], reverse=True)
 
     patch_version = get_patch_version()


### PR DESCRIPTION
Previously, to get collect the latest milestones, we didn't specify `sort` and `direction` query params.
And GitHub API had might return milestones without the latest one (since GitHub uses pagination).
And as a result, "make next milestone" step on CI had might create next milestone without due_on date and with an incorrect release manager

Now both parameters are specified to make GitHub return the latest milestones by `due_on` property