### PR TITLE
Provide builtin Clone & Copy impls for TyFunction

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ImplLookup.kt
@@ -365,7 +365,7 @@ class ImplLookup(
      * @see <a href="https://doc.rust-lang.org/std/marker/trait.Copy.html#additional-implementors">Copy additional implementors</a>
      */
     private fun getHardcodedImpls(ty: Ty): Collection<BoundElement<RsTraitItem>> {
-        if (ty is TyTuple || ty is TyArray) {
+        if (ty is TyTuple || ty is TyArray || ty is TyFunction) {
             return listOfNotNull(items.Clone, items.Copy).map { BoundElement(it) }
         }
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/Ty.kt
@@ -186,7 +186,7 @@ tailrec fun Ty.stripReferences(): Ty =
  */
 fun Ty.isMovesByDefault(lookup: ImplLookup): Boolean =
     when (this) {
-        is TyUnknown, is TyReference, is TyPointer, is TyFunction -> false
+        is TyUnknown, is TyReference, is TyPointer -> false
         is TyTuple -> types.any { it.isMovesByDefault(lookup) }
         is TyArray -> base.isMovesByDefault(lookup)
         is TySlice -> elementType.isMovesByDefault(lookup)

--- a/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/borrowck/RsBorrowCheckerMovesTest.kt
@@ -224,6 +224,7 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
         }
     """, checkWarn = false)
 
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test no move error E0382 when closure used twice`() = checkByText("""
         fn main() {
             let f = |x: i32| {};
@@ -754,6 +755,17 @@ class RsBorrowCheckerMovesTest : RsInspectionsTestBase(RsBorrowCheckerInspection
             let s = S;
             #[cfg(not(intellij_rust))] s;
             s;
+        }
+    """, checkWarn = false)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test no move function type parameter`() = checkByText("""
+        #[derive(Copy, Clone)]
+        struct Bar<Fn> { a: Fn }
+
+        fn bar(x: Bar<fn()>) {
+            x;
+            x;
         }
     """, checkWarn = false)
 }


### PR DESCRIPTION
Previously, `TyFunction` was considered as non-Copy and non-Clone type in terms of our type inference. Although there was a special case in `Ty.isMovesByDefault` to handle `TyFunction` properly during move analysis, it did not work in case of `TyFunction` used as a type parameter.
Now `TyFunction` is considered as `Copy` & `Clone` type so the special case in `Ty.isMovesByDefault` has been removed.

More information in Rust docs: [builtin `Clone` impls](https://doc.rust-lang.org/std/clone/trait.Clone.html#additional-implementors) and [builtin `Copy` impls](https://doc.rust-lang.org/std/marker/trait.Copy.html#additional-implementors).

Fixes https://github.com/intellij-rust/intellij-rust/issues/5165

changelog: Fix false-positive move errors on a function pointer type used as a type parameter