### PR TITLE
CI: Skip already removed maintainer

### DIFF
--- a/scripts/make_next_milestone.py
+++ b/scripts/make_next_milestone.py
@@ -47,7 +47,10 @@ def main():
         desc = m["description"]
         res = re.search(RELEASE_MANAGER_RE, desc)
         if res is not None:
-            maintainers.remove(res.group(1))
+            try:
+                maintainers.remove(res.group(1))
+            except ValueError:
+                pass
 
     description = f"Release manager: @{maintainers[0]}"
     create_milestone(repo, args.token, milestone_version, description=description, due_on=due_on)


### PR DESCRIPTION
If during the last 5 milestones (= number of maintainers - 1) someone was a release manager twice or more times - `make_next_milestone.py` will raise `ValueError` [trying to remove](https://github.com/intellij-rust/intellij-rust/blob/e420b1949879e3e2a1ea9b05c3e243ceb1986f5d/scripts/make_next_milestone.py#L50) this person from the list of maintainers multiple times.

I guess it might happen when the release manager for a given release was manually altered (as the default assignee was sick, on vacation, etc.).

The fix should also cover the case when the release manager is someone outside of the regular `maintainers` list. That's probably would be a rare usecase if ever, but still.

Feel free to discard (or request changes) if `try / except` is not an ideal solution or you think the denoted situations won't happen in the real life.