### PR TITLE
Make native helper binary executable

### DIFF
--- a/src/main/kotlin/org/rust/openapiext/RsPathManager.kt
+++ b/src/main/kotlin/org/rust/openapiext/RsPathManager.kt
@@ -29,7 +29,12 @@ object RsPathManager {
             else -> return null
         }
 
-        return pluginDir().resolve("bin/$os/$arch/$binaryName").takeIf { Files.exists(it) }
+        val nativeHelperPath = pluginDir().resolve("bin/$os/$arch/$binaryName").takeIf { Files.exists(it) } ?: return null
+        return if (Files.isExecutable(nativeHelperPath) || nativeHelperPath.toFile().setExecutable(true)) {
+            nativeHelperPath
+        } else {
+            null
+        }
     }
 
     fun pluginDirInSystem(): Path = Paths.get(PathManager.getSystemPath()).resolve("intellij-rust")


### PR DESCRIPTION
Found out all binaries of native-helper lose executable permissions in two places: during uploading/downloading artifacts on CI and during unzipping plugin archive. As a result, all features that may use native helper (fetching info about items generated by build scripts and future proc macro support #6564) don't work

These changes restore executable permissions manually.

changelog: Fix fetching info about items generated by build scripts. Note, the corresponding feature work only when `org.rust.cargo.evaluate.build.scripts` experimental feature is enabled
