### PR TITLE
RES: Disable type aliases threshold in new resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsTypeAliasIndex.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/indexes/RsTypeAliasIndex.kt
@@ -17,6 +17,7 @@ import org.rust.ide.search.RsWithMacrosProjectScope
 import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.resolve.RsCachedTypeAlias
 import org.rust.lang.core.resolve.RsProcessor
+import org.rust.lang.core.resolve2.isNewResolveEnabled
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.lang.core.stubs.RsTypeAliasStub
 import org.rust.lang.core.types.TyFingerprint
@@ -42,7 +43,7 @@ class RsTypeAliasIndex : AbstractStubIndex<TyFingerprint, RsTypeAlias>() {
             // This is basically a hack to make some crates (winapi 0.2) work in a reasonable amount of time.
             // If the number of aliases exceeds the threshold, we prefer ones from stdlib and a workspace over
             // aliases from dependencies
-            val threshold = ALIAS_COUNT_THRESHOLD.asInteger()
+            val threshold = getThreshold(project)
             val filteredAliases = if (aliases.size <= threshold) {
                 aliases
             } else {
@@ -75,7 +76,16 @@ class RsTypeAliasIndex : AbstractStubIndex<TyFingerprint, RsTypeAlias>() {
                 .forEach { sink.occurrence(KEY, it) }
         }
 
-        private val ALIAS_COUNT_THRESHOLD: RegistryValue = Registry.get("org.rust.lang.type.alias.threshold")
+        private fun getThreshold(project: Project): Int {
+            return if (project.isNewResolveEnabled) {
+                ALIAS_COUNT_THRESHOLD_NEW_RESOLVE.asInteger()
+            } else {
+                ALIAS_COUNT_THRESHOLD_OLD_RESOLVE.asInteger()
+            }
+        }
+
+        private val ALIAS_COUNT_THRESHOLD_OLD_RESOLVE: RegistryValue = Registry.get("org.rust.lang.type.alias.threshold")
+        private val ALIAS_COUNT_THRESHOLD_NEW_RESOLVE: RegistryValue = Registry.get("org.rust.lang.type.alias.threshold.new.resolve")
         private val KEY: StubIndexKey<TyFingerprint, RsTypeAlias> =
             StubIndexKey.createIndexKey("org.rust.lang.core.stubs.index.RsTypeAliasIndex")
     }

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1024,7 +1024,9 @@
         <!-- Registry keys -->
 
         <registryKey key="org.rust.lang.type.alias.threshold" defaultValue="10" restartRequired="false"
-                     description="Maximum number of type aliases to take into account during `impl`s search"/>
+                     description="Maximum number of type aliases to take into account during `impl`s search (old resolve)"/>
+        <registryKey key="org.rust.lang.type.alias.threshold.new.resolve" defaultValue="2147483647" restartRequired="false"
+                     description="Maximum number of type aliases to take into account during `impl`s search (new resolve)"/>
         <registryKey key="org.rust.lang.cfg.attributes" defaultValue="true" restartRequired="false"
                      description="Enable Rust cfg attributes support"/>
         <registryKey key="org.rust.lang.highlight.macro.body" defaultValue="true" restartRequired="false"


### PR DESCRIPTION
Here is comparison of resolve times (all references in all files of crate) for different crates:


**New resolve**:
project | default threshold | no threshold | difference
-- | -- | -- | --
juniper | 22312 | 22147 | -0.01
diesel | 17459 | 17548 | 0.01
mysql_async | 4298 | 4368 | 0.02
amethyst | 1850 | 2110 | 0.14
tokio | 7198 | 7548 | 0.05
xi_editor | 311 | 414 | 0.33
Cargo | 11356 | 12068 | 0.06
clap | 4744 | 5010 | 0.06
nalgebra | 25836 | 29719 | 0.15
winapi | 4754 | 5260 | 0.11

**Old resolve**:
project | default threshold | no threshold | difference
-- | -- | -- | --
juniper | 22064 | 23433 | 0.06
diesel | 17263 | 17663 | 0.02
mysql_async | 4472 | 5018 | 0.12
amethyst | 1924 | 3218 | 0.67
tokio | 7983 | 8371 | 0.05
xi_editor | 397 | 884 | 1.23
Cargo | 12763 | 13134 | 0.03
clap | 4856 | 5257 | 0.08
nalgebra | 25076 | 28384 | 0.13
winapi | 6716 | 6704 | 0


With new resolve biggest difference is about 15% for `amethyst`, `nalgebra` and `winapi` crates. With old resolve biggest difference is 67% for `amethyst` crate. So I think it is reasonable to disable threshold only with new resolve, where performance regression is not that big.

changelog: Find all possible impls for type alises when using new resolve
