### PR TITLE
REF: Omit unchanged default type argument only if the next type argument is already ommited

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -219,9 +219,10 @@ private data class TypeRenderer(
         val typeArguments = adt.typeArguments
 
         val typeArgumentNames = if (skipUnchangedDefaultTypeArguments) {
-            adt.item.typeParameters.zip(typeArguments).filter { (param, argument) ->
-                param.typeReference == null || param.typeReference?.type != argument
-            }.map { (_, argument) -> render(argument) }
+            adt.item.typeParameters
+                .zip(typeArguments)
+                .dropLastWhile { (param, argument) -> param.typeReference?.type == argument }
+                .map { (_, argument) -> render(argument) }
         } else {
             typeArguments.map(render)
         }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -1154,6 +1154,28 @@ class RsExtractFunctionTest : RsTestBase() {
         false,
         "foo")
 
+    fun `test extract a function can't skip default type parameter`() = doTest("""
+        struct S<R=u32, T=u32>(R, T);
+
+        fn main() {
+            let s: S<u32, i32> = S(1u32, 2i32);
+            <selection>println!(s)</selection>;
+        }
+    """, """
+        struct S<R=u32, T=u32>(R, T);
+
+        fn main() {
+            let s: S<u32, i32> = S(1u32, 2i32);
+            foo(s);
+        }
+
+        fn foo(s: S<u32, i32>) {
+            println!(s)
+        }
+    """,
+        false,
+        "foo")
+
     fun `test extract set value to mutable`() = doTest("""
         fn main() {
             let a = 1u32;


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/6873.

changelog: TODO
