### PR TITLE
Do not expand builtin macros as "{}"

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -6,6 +6,7 @@
 package org.rust.lang.core.macros
 
 import com.intellij.openapi.project.Project
+import org.rust.lang.core.macros.builtin.BuiltinMacroExpander
 import org.rust.lang.core.macros.decl.DeclMacroExpander
 import org.rust.lang.core.macros.proc.ProcMacroExpander
 import org.rust.stdext.RsResult
@@ -21,12 +22,14 @@ abstract class MacroExpander<in T: RsMacroData, out E> {
 /** A macro expander for macro calls like `foo!()` */
 class FunctionLikeMacroExpander(
     private val decl: DeclMacroExpander,
-    private val proc: ProcMacroExpander
+    private val proc: ProcMacroExpander,
+    private val builtin: BuiltinMacroExpander
 ) : MacroExpander<RsMacroData, MacroExpansionError>() {
     override fun expandMacroAsText(def: RsMacroData, call: RsMacroCallData): Pair<CharSequence, RangeMap>? {
         return when (def) {
             is RsDeclMacroData -> decl.expandMacroAsText(def, call)
             is RsProcMacroData -> proc.expandMacroAsText(def, call)
+            is RsBuiltinMacroData -> builtin.expandMacroAsText(def, call)
         }
     }
 
@@ -37,13 +40,15 @@ class FunctionLikeMacroExpander(
         return when (def) {
             is RsDeclMacroData -> decl.expandMacroAsTextWithErr(def, call)
             is RsProcMacroData -> proc.expandMacroAsTextWithErr(def, call)
+            is RsBuiltinMacroData -> builtin.expandMacroAsTextWithErr(def, call)
         }
     }
 
     companion object {
         fun new(project: Project): FunctionLikeMacroExpander = FunctionLikeMacroExpander(
             DeclMacroExpander(project),
-            ProcMacroExpander(project)
+            ProcMacroExpander(project),
+            BuiltinMacroExpander(project)
         )
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/macros/RsMacroData.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsMacroData.kt
@@ -6,9 +6,11 @@
 package org.rust.lang.core.macros
 
 import org.rust.cargo.project.workspace.CargoWorkspaceData
+import org.rust.lang.core.macros.builtin.BuiltinMacroExpander
 import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.RsMacroBody
 import org.rust.lang.core.psi.ext.macroBodyStubbed
+import org.rust.stdext.HashCode
 
 sealed class RsMacroData
 
@@ -17,3 +19,13 @@ class RsDeclMacroData(val macroBody: Lazy<RsMacroBody?>): RsMacroData() {
 }
 
 data class RsProcMacroData(val name: String, val artifact: CargoWorkspaceData.ProcMacroArtifact): RsMacroData()
+
+class RsBuiltinMacroData(val name: String): RsMacroData() {
+
+    fun withHash(): RsMacroDataWithHash<RsBuiltinMacroData> =
+        RsMacroDataWithHash(this, HashCode.mix(HashCode.compute(name), BUILTIN_DEF_HASH))
+
+    companion object {
+        private val BUILTIN_DEF_HASH = HashCode.compute(BuiltinMacroExpander.EXPANDER_VERSION.toString())
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/builtin/BuiltinMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/builtin/BuiltinMacroExpander.kt
@@ -1,0 +1,28 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros.builtin
+
+import com.intellij.openapi.project.Project
+import org.rust.lang.core.macros.*
+import org.rust.stdext.RsResult
+import org.rust.stdext.RsResult.Err
+
+/**
+ * A macro expander for built-in macros like `concat!()` and `stringify!()`
+ */
+class BuiltinMacroExpander(val project: Project) : MacroExpander<RsBuiltinMacroData, DeclMacroExpansionError>() {
+    override fun expandMacroAsTextWithErr(
+        def: RsBuiltinMacroData,
+        call: RsMacroCallData
+    ): RsResult<Pair<CharSequence, RangeMap>, out DeclMacroExpansionError> {
+        val macroCallBodyText = call.macroBody ?: return Err(DeclMacroExpansionError.DefSyntax)
+        return Err(DeclMacroExpansionError.DefSyntax)
+    }
+
+    companion object {
+        const val EXPANDER_VERSION = 0
+    }
+}

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
@@ -58,6 +58,8 @@ val HAS_MACRO_EXPORT_PROP: StubbedAttributeProperty<RsMacro, RsMacroStub> =
     StubbedAttributeProperty(QueryAttributes::hasMacroExport, RsMacroStub::mayHaveMacroExport)
 val HAS_MACRO_EXPORT_LOCAL_INNER_MACROS_PROP: StubbedAttributeProperty<RsMacro, RsMacroStub> =
     StubbedAttributeProperty(QueryAttributes::hasMacroExportLocalInnerMacros, RsMacroStub::mayHaveMacroExportLocalInnerMacros)
+val HAS_RUSTC_BUILTIN_MACRO_PROP: StubbedAttributeProperty<RsMacro, RsMacroStub> =
+    StubbedAttributeProperty(QueryAttributes::hasRustcBuiltinMacro, RsMacroStub::mayHaveRustcBuiltinMacro)
 
 val RsMacro.hasMacroExport: Boolean
     get() = HAS_MACRO_EXPORT_PROP.getByPsi(this)
@@ -71,6 +73,12 @@ val RsMacro.hasMacroExportLocalInnerMacros: Boolean
 
 val QueryAttributes.hasMacroExportLocalInnerMacros: Boolean
     get() = hasAttributeWithArg("macro_export", "local_inner_macros")
+
+val RsMacro.hasRustcBuiltinMacro: Boolean
+    get() = HAS_RUSTC_BUILTIN_MACRO_PROP.getByPsi(this)
+
+val QueryAttributes.hasRustcBuiltinMacro: Boolean
+    get() = hasAttribute("rustc_builtin_macro")
 
 val RsMacro.isRustcDocOnlyMacro: Boolean
     get() = queryAttributes.isRustcDocOnlyMacro

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -388,6 +388,7 @@ class DeclMacroDefInfo(
     val bodyHash: HashCode,
     val hasMacroExport: Boolean,
     val hasLocalInnerMacros: Boolean,
+    val hasRustcBuiltinMacro: Boolean,
     project: Project,
 ): MacroDefInfo() {
     /** Lazy because usually it should not be used (thanks to macro expansion cache) */

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
@@ -288,6 +288,7 @@ private class ModCollector(
             bodyHash,
             def.hasMacroExport,
             def.hasLocalInnerMacros,
+            def.hasRustcBuiltinMacro,
             project
         )
         modData.addLegacyMacro(def.name, defInfo)

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
@@ -154,6 +154,7 @@ class ModCollectorBase private constructor(
             bodyHash = def.bodyHash,
             hasMacroExport = HAS_MACRO_EXPORT_PROP.getByStub(def, crate),
             hasLocalInnerMacros = HAS_MACRO_EXPORT_LOCAL_INNER_MACROS_PROP.getByStub(def, crate),
+            hasRustcBuiltinMacro = HAS_RUSTC_BUILTIN_MACRO_PROP.getByStub(def, crate),
             macroIndexInParent = macroIndexInParent
         )
         visitor.collectMacroDef(defLight)
@@ -371,6 +372,7 @@ data class MacroDefLight(
     val bodyHash: HashCode?,
     val hasMacroExport: Boolean,
     val hasLocalInnerMacros: Boolean,
+    val hasRustcBuiltinMacro: Boolean,
     /** See [MacroIndex] */
     val macroIndexInParent: Int,
 ) : Writeable {
@@ -383,12 +385,14 @@ data class MacroDefLight(
         var flags = 0
         if (hasMacroExport) flags += HAS_MACRO_EXPORT_MASK
         if (hasLocalInnerMacros) flags += HAS_LOCAL_INNER_MACROS_MASK
+        if (hasRustcBuiltinMacro) flags += HAS_RUSTC_BUILTIN_MACRO_MASK
         data.writeByte(flags)
     }
 
     companion object : BitFlagsBuilder(Limit.BYTE) {
         private val HAS_MACRO_EXPORT_MASK: Int = nextBitMask()
         private val HAS_LOCAL_INNER_MACROS_MASK: Int = nextBitMask()
+        private val HAS_RUSTC_BUILTIN_MACRO_MASK: Int = nextBitMask()
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -62,7 +62,7 @@ class RsFileStub(
     override fun getType() = Type
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
-        private const val STUB_VERSION = 209
+        private const val STUB_VERSION = 210
 
         // Bump this number if Stub structure changes
         override fun getStubVersion(): Int = RustParserDefinition.PARSER_VERSION + STUB_VERSION
@@ -1342,9 +1342,14 @@ class RsMacroStub(
     // stored in stub as an optimization
     val mayHaveMacroExport: Boolean
         get() = BitUtil.isSet(flags, HAS_MACRO_EXPORT)
+
     // stored in stub as an optimization
     val mayHaveMacroExportLocalInnerMacros: Boolean
         get() = BitUtil.isSet(flags, HAS_MACRO_EXPORT_LOCAL_INNER_MACROS)
+
+    // stored in stub as an optimization
+    val mayHaveRustcBuiltinMacro: Boolean
+        get() = BitUtil.isSet(flags, HAS_RUSTC_BUILTIN_MACRO)
 
     object Type : RsStubElementType<RsMacroStub, RsMacro>("MACRO") {
         override fun shouldCreateStub(node: ASTNode): Boolean =
@@ -1375,6 +1380,7 @@ class RsMacroStub(
             var flags = RsAttributeOwnerStub.extractFlags(psi)
             flags = BitUtil.set(flags, HAS_MACRO_EXPORT, HAS_MACRO_EXPORT_PROP.getDuringIndexing(psi))
             flags = BitUtil.set(flags, HAS_MACRO_EXPORT_LOCAL_INNER_MACROS, HAS_MACRO_EXPORT_LOCAL_INNER_MACROS_PROP.getDuringIndexing(psi))
+            flags = BitUtil.set(flags, HAS_RUSTC_BUILTIN_MACRO, HAS_RUSTC_BUILTIN_MACRO_PROP.getDuringIndexing(psi))
             return RsMacroStub(
                 parentStub,
                 this,
@@ -1392,6 +1398,7 @@ class RsMacroStub(
     companion object : BitFlagsBuilder(RsAttributeOwnerStub, BYTE) {
         private val HAS_MACRO_EXPORT: Int = nextBitMask()
         private val HAS_MACRO_EXPORT_LOCAL_INNER_MACROS: Int = nextBitMask()
+        private val HAS_RUSTC_BUILTIN_MACRO: Int = nextBitMask()
     }
 }
 

--- a/src/test/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActionsTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActionsTest.kt
@@ -9,7 +9,10 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.project.Project
 import org.intellij.lang.annotations.Language
+import org.rust.MinRustcVersion
+import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.core.macros.RsExpandedElement
 
 class RsShowMacroExpansionActionsTest : RsTestBase() {
@@ -95,6 +98,19 @@ class RsShowMacroExpansionActionsTest : RsTestBase() {
     fun `test that single step expansion of macro without body is just its name`() = testMacroExpansionFail("""
         /*caret*/foo!();
     """, expandRecursively = false)
+
+    @MinRustcVersion("1.37.0")
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test recursive expansion does not expand compile_error!()`() = testRecursiveExpansion("""
+        fn foo() {
+            macro_rules! foo {
+                () => { compile_error!(""); }
+            }
+            /*caret*/foo!();
+        }
+    """, """
+        compile_error!("");
+    """)
 
     private fun testNoExpansionHappens(@Language("Rust") code: String) {
         InlineFile(code)


### PR DESCRIPTION
Initial groundwork for built-in macros support (like `concat!()`).
Now these macros are not expanded as "{}" (as before)

changelog: INTERNAL: Add initial infrastructure for builtin macro expansion, FIX: Do not expand builtin macros as "{}"