### PR TITLE
DBG: advertise native debugging support plugin in PyCharm Pro

### DIFF
--- a/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
+++ b/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
@@ -69,7 +69,7 @@ class RsDebugAdvertisingRunner : RsDefaultProgramRunnerBase() {
     private fun isSupportedPlatform(): Boolean {
         return when {
             isIdeaUltimate() || isRubyMine() -> true
-            ApplicationInfo.getInstance().build >= BUILD_211 && isGoIde() -> true
+            ApplicationInfo.getInstance().build >= BUILD_211 && (isGoIde() || isPyCharmPro()) -> true
             else -> false
         }
     }


### PR DESCRIPTION
The recent version of PyCharm Pro 2021.1 supports Rust debugging via [Native Debugging Support](https://plugins.jetbrains.com/plugin/12775-native-debugging-support) plugin so let's suggest installing it

changelog: Advertise [Native Debugging Support](https://plugins.jetbrains.com/plugin/12775-native-debugging-support) plugin in PyCharm Pro
