### PR TITLE
CI: change publish order of TOML and Rust plugins

### DIFF
--- a/.github/workflows/rust-nightly.yml
+++ b/.github/workflows/rust-nightly.yml
@@ -144,16 +144,16 @@ jobs:
                   name: macos-x86-64
                   path: bin/macos/x86-64
 
-            - name: Publish rust plugin
-              uses: eskatos/gradle-command-action@v1
-              with:
-                  arguments: ":plugin:publishPlugin"
-
             - name: Publish toml plugin
               if: needs.fetch-latest-changes.outputs.toml-commit != needs.fetch-latest-changes.outputs.toml-nightly
               uses: eskatos/gradle-command-action@v1
               with:
                   arguments: ":intellij-toml:publishPlugin"
+
+            - name: Publish rust plugin
+              uses: eskatos/gradle-command-action@v1
+              with:
+                  arguments: ":plugin:publishPlugin"
 
     save-commit:
         needs: [ build, fetch-latest-changes ]

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -209,16 +209,16 @@ jobs:
                   name: macos-x86-64
                   path: bin/macos/x86-64
 
-            - name: Publish rust plugin
-              uses: eskatos/gradle-command-action@v1
-              with:
-                  arguments: ":plugin:publishPlugin"
-
             - name: Publish toml plugin
               if: needs.fetch-latest-changes.outputs.toml-commit != needs.fetch-latest-changes.outputs.toml-release
               uses: eskatos/gradle-command-action@v1
               with:
                   arguments: ":intellij-toml:publishPlugin"
+
+            - name: Publish rust plugin
+              uses: eskatos/gradle-command-action@v1
+              with:
+                  arguments: ":plugin:publishPlugin"
 
     save-commit:
         needs: [ get-channel, fetch-latest-changes, build ]


### PR DESCRIPTION
Previously, we Rust plugin was published before TOML plugin. As a result, Marketplace launched its compatibility verification task for Rust plugin with old TOML plugin and had might produce false positive warnings in case of incompatible changes in TOML plugin and the corresponding changes in Rust plugin.
For example, for 140 release Marketplace produces the following:
![image](https://user-images.githubusercontent.com/2539310/108605567-d38e4500-73c5-11eb-8909-67845cf02e3d.png)

Now, TOML plugin is published before Rust one to avoid such situations
