### PR TITLE
Simplify bit flags creation

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/FileModificationTracker.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FileModificationTracker.kt
@@ -17,8 +17,8 @@ import org.rust.lang.core.stubs.RsMacroCallStub
 import org.rust.lang.core.stubs.RsModItemStub
 import org.rust.lang.core.stubs.RsNamedStub
 import org.rust.openapiext.fileId
+import org.rust.stdext.BitFlagsBuilder
 import org.rust.stdext.HashCode
-import org.rust.stdext.makeBitMask
 import org.rust.stdext.writeVarInt
 import java.io.DataOutput
 import java.io.DataOutputStream
@@ -191,9 +191,9 @@ private class EnumVariantLight(
         data.writeByte(flags)
     }
 
-    companion object {
-        private val IS_DEEPLY_ENABLED_BY_CFG_MASK: Int = makeBitMask(0)
-        private val HAS_BLOCK_FIELDS: Int = makeBitMask(1)
+    companion object : BitFlagsBuilder(Limit.BYTE) {
+        private val IS_DEEPLY_ENABLED_BY_CFG_MASK: Int = nextBitMask()
+        private val HAS_BLOCK_FIELDS: Int = nextBitMask()
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
@@ -304,15 +304,15 @@ data class ItemLight(
         if (pathAttribute != null) data.writeUTF(pathAttribute)
     }
 
-    companion object {
-        private val NAMESPACE_TYPES_MASK: Int = makeBitMask(0)
-        private val NAMESPACE_VALUES_MASK: Int = makeBitMask(1)
-        private val NAMESPACE_MACROS_MASK: Int = makeBitMask(2)
-        private val IS_DEEPLY_ENABLED_BY_CFG_MASK: Int = makeBitMask(3)
-        private val IS_MOD_ITEM_MASK: Int = makeBitMask(4)
-        private val IS_MOD_DECL_MASK: Int = makeBitMask(5)
-        private val HAS_MACRO_USE_MASK: Int = makeBitMask(6)
-        private val PATH_ATTRIBUTE_MASK: Int = makeBitMask(7)
+    companion object : BitFlagsBuilder(Limit.BYTE) {
+        private val NAMESPACE_TYPES_MASK: Int = nextBitMask()
+        private val NAMESPACE_VALUES_MASK: Int = nextBitMask()
+        private val NAMESPACE_MACROS_MASK: Int = nextBitMask()
+        private val IS_DEEPLY_ENABLED_BY_CFG_MASK: Int = nextBitMask()
+        private val IS_MOD_ITEM_MASK: Int = nextBitMask()
+        private val IS_MOD_DECL_MASK: Int = nextBitMask()
+        private val HAS_MACRO_USE_MASK: Int = nextBitMask()
+        private val PATH_ATTRIBUTE_MASK: Int = nextBitMask()
     }
 }
 
@@ -341,12 +341,12 @@ class ImportLight(
         data.writeByte(flags)
     }
 
-    companion object {
-        private val IS_DEEPLY_ENABLED_BY_CFG_MASK: Int = makeBitMask(0)
-        private val IS_GLOB_MASK: Int = makeBitMask(1)
-        private val IS_EXTERN_CRATE_MASK: Int = makeBitMask(2)
-        private val IS_MACRO_USE_MASK: Int = makeBitMask(3)
-        private val IS_PRELUDE_MASK: Int = makeBitMask(4)
+    companion object : BitFlagsBuilder(Limit.BYTE) {
+        private val IS_DEEPLY_ENABLED_BY_CFG_MASK: Int = nextBitMask()
+        private val IS_GLOB_MASK: Int = nextBitMask()
+        private val IS_EXTERN_CRATE_MASK: Int = nextBitMask()
+        private val IS_MACRO_USE_MASK: Int = nextBitMask()
+        private val IS_PRELUDE_MASK: Int = nextBitMask()
     }
 }
 
@@ -386,9 +386,9 @@ data class MacroDefLight(
         data.writeByte(flags)
     }
 
-    companion object {
-        private val HAS_MACRO_EXPORT_MASK: Int = makeBitMask(0)
-        private val HAS_LOCAL_INNER_MACROS_MASK: Int = makeBitMask(1)
+    companion object : BitFlagsBuilder(Limit.BYTE) {
+        private val HAS_MACRO_EXPORT_MASK: Int = nextBitMask()
+        private val HAS_LOCAL_INNER_MACROS_MASK: Int = nextBitMask()
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -35,8 +35,10 @@ import org.rust.lang.core.stubs.BlockMayHaveStubsHeuristic.getAndClearCached
 import org.rust.lang.core.types.ty.TyFloat
 import org.rust.lang.core.types.ty.TyInteger
 import org.rust.openapiext.ancestors
+import org.rust.stdext.BitFlagsBuilder
+import org.rust.stdext.BitFlagsBuilder.Limit.BYTE
+import org.rust.stdext.BitFlagsBuilder.Limit.INT
 import org.rust.stdext.HashCode
-import org.rust.stdext.makeBitMask
 import org.rust.stdext.readHashCodeNullable
 import org.rust.stdext.writeHashCodeNullable
 
@@ -120,8 +122,8 @@ class RsFileStub(
 //        }
     }
 
-    companion object {
-        private val MAY_HAVE_STDLIB_ATTRIBUTES_MASK: Int = makeBitMask(RsAttributeOwnerStub.USED_BITS + 0)
+    companion object : BitFlagsBuilder(RsAttributeOwnerStub, BYTE) {
+        private val MAY_HAVE_STDLIB_ATTRIBUTES_MASK: Int = nextBitMask()
     }
 }
 
@@ -402,8 +404,8 @@ class RsUseItemStub(
         }
     }
 
-    companion object {
-        private val HAS_PRELUDE_IMPORT_MASK: Int = makeBitMask(RsAttributeOwnerStub.USED_BITS + 0)
+    companion object : BitFlagsBuilder(RsAttributeOwnerStub, BYTE) {
+        private val HAS_PRELUDE_IMPORT_MASK: Int = nextBitMask()
     }
 }
 
@@ -448,9 +450,9 @@ class RsUseSpeckStub(
         override fun indexStub(stub: RsUseSpeckStub, sink: IndexSink) = sink.indexUseSpeck(stub)
     }
 
-    companion object {
-        private val IS_STAR_IMPORT_MASK: Int = makeBitMask(0)
-        private val HAS_COLON_COLON_MASK: Int = makeBitMask(1)
+    companion object : BitFlagsBuilder(BYTE) {
+        private val IS_STAR_IMPORT_MASK: Int = nextBitMask()
+        private val HAS_COLON_COLON_MASK: Int = nextBitMask()
     }
 }
 
@@ -488,12 +490,11 @@ class RsStructItemStub(
             return RsStructItemStub(parentStub, this, psi.name, flags)
         }
 
-
         override fun indexStub(stub: RsStructItemStub, sink: IndexSink) = sink.indexStructItem(stub)
     }
 
-    companion object {
-        private val IS_UNION_MASK: Int = makeBitMask(RsAttributeOwnerStub.USED_BITS + 0)
+    companion object : BitFlagsBuilder(RsAttributeOwnerStub, BYTE) {
+        private val IS_UNION_MASK: Int = nextBitMask()
     }
 }
 
@@ -674,9 +675,9 @@ class RsTraitItemStub(
         override fun indexStub(stub: RsTraitItemStub, sink: IndexSink) = sink.indexTraitItem(stub)
     }
 
-    companion object {
-        private val UNSAFE_MASK: Int = makeBitMask(RsAttributeOwnerStub.USED_BITS + 0)
-        private val AUTO_MASK: Int =   makeBitMask(RsAttributeOwnerStub.USED_BITS + 1)
+    companion object : BitFlagsBuilder(RsAttributeOwnerStub, BYTE) {
+        private val UNSAFE_MASK: Int = nextBitMask()
+        private val AUTO_MASK: Int = nextBitMask()
     }
 }
 
@@ -710,8 +711,8 @@ class RsImplItemStub(
         override fun indexStub(stub: RsImplItemStub, sink: IndexSink) = sink.indexImplItem(stub)
     }
 
-    companion object {
-        private val NEGATIVE_IMPL_MASK: Int = makeBitMask(RsAttributeOwnerStub.USED_BITS + 0)
+    companion object : BitFlagsBuilder(RsAttributeOwnerStub, BYTE) {
+        private val NEGATIVE_IMPL_MASK: Int = nextBitMask()
     }
 }
 
@@ -816,15 +817,15 @@ class RsFunctionStub(
         override fun indexStub(stub: RsFunctionStub, sink: IndexSink) = sink.indexFunction(stub)
     }
 
-    companion object {
-        private val ABSTRACT_MASK: Int =           makeBitMask(RsAttributeOwnerStub.USED_BITS + 0)
-        private val CONST_MASK: Int =              makeBitMask(RsAttributeOwnerStub.USED_BITS + 1)
-        private val UNSAFE_MASK: Int =             makeBitMask(RsAttributeOwnerStub.USED_BITS + 2)
-        private val EXTERN_MASK: Int =             makeBitMask(RsAttributeOwnerStub.USED_BITS + 3)
-        private val VARIADIC_MASK: Int =           makeBitMask(RsAttributeOwnerStub.USED_BITS + 4)
-        private val ASYNC_MASK: Int =              makeBitMask(RsAttributeOwnerStub.USED_BITS + 5)
-        private val HAS_SELF_PARAMETER_MASK: Int = makeBitMask(RsAttributeOwnerStub.USED_BITS + 6)
-        private val IS_PROC_MACRO_DEF: Int =       makeBitMask(RsAttributeOwnerStub.USED_BITS + 7)
+    companion object : BitFlagsBuilder(RsAttributeOwnerStub, INT) {
+        private val ABSTRACT_MASK: Int = nextBitMask()
+        private val CONST_MASK: Int = nextBitMask()
+        private val UNSAFE_MASK: Int = nextBitMask()
+        private val EXTERN_MASK: Int = nextBitMask()
+        private val VARIADIC_MASK: Int = nextBitMask()
+        private val ASYNC_MASK: Int = nextBitMask()
+        private val HAS_SELF_PARAMETER_MASK: Int = nextBitMask()
+        private val IS_PROC_MACRO_DEF: Int = nextBitMask()
     }
 }
 
@@ -867,9 +868,9 @@ class RsConstantStub(
         override fun indexStub(stub: RsConstantStub, sink: IndexSink) = sink.indexConstant(stub)
     }
 
-    companion object {
-        private val IS_MUT_MASK: Int =   makeBitMask(RsAttributeOwnerStub.USED_BITS + 0)
-        private val IS_CONST_MASK: Int = makeBitMask(RsAttributeOwnerStub.USED_BITS + 1)
+    companion object : BitFlagsBuilder(RsAttributeOwnerStub, BYTE) {
+        private val IS_MUT_MASK: Int = nextBitMask()
+        private val IS_CONST_MASK: Int = nextBitMask()
     }
 }
 
@@ -1058,8 +1059,8 @@ class RsTypeParameterStub(
         }
     }
 
-    companion object {
-        private val IS_SIZED_MASK: Int = makeBitMask(RsAttributeOwnerStub.USED_BITS + 0)
+    companion object : BitFlagsBuilder(RsAttributeOwnerStub, BYTE) {
+        private val IS_SIZED_MASK: Int = nextBitMask()
     }
 }
 
@@ -1154,10 +1155,10 @@ class RsSelfParameterStub(
         }
     }
 
-    companion object {
-        private val IS_MUT_MASK: Int =           makeBitMask(RsAttributeOwnerStub.USED_BITS + 0)
-        private val IS_REF_MASK: Int =           makeBitMask(RsAttributeOwnerStub.USED_BITS + 1)
-        private val IS_EXPLICIT_TYPE_MASK: Int = makeBitMask(RsAttributeOwnerStub.USED_BITS + 2)
+    companion object : BitFlagsBuilder(RsAttributeOwnerStub, BYTE) {
+        private val IS_MUT_MASK: Int = nextBitMask()
+        private val IS_REF_MASK: Int = nextBitMask()
+        private val IS_EXPLICIT_TYPE_MASK: Int = nextBitMask()
     }
 }
 
@@ -1388,9 +1389,9 @@ class RsMacroStub(
         override fun indexStub(stub: RsMacroStub, sink: IndexSink) = sink.indexMacro(stub)
     }
 
-    companion object {
-        private val HAS_MACRO_EXPORT: Int = makeBitMask(RsAttributeOwnerStub.USED_BITS + 0)
-        private val HAS_MACRO_EXPORT_LOCAL_INNER_MACROS: Int = makeBitMask(RsAttributeOwnerStub.USED_BITS + 1)
+    companion object : BitFlagsBuilder(RsAttributeOwnerStub, BYTE) {
+        private val HAS_MACRO_EXPORT: Int = nextBitMask()
+        private val HAS_MACRO_EXPORT_LOCAL_INNER_MACROS: Int = nextBitMask()
     }
 }
 
@@ -1672,10 +1673,10 @@ class RsBlockExprStub(
         override fun createPsi(stub: RsBlockExprStub): RsBlockExpr = RsBlockExprImpl(stub, this)
     }
 
-    companion object {
-        private val UNSAFE_MASK: Int = makeBitMask(0)
-        private val ASYNC_MASK: Int = makeBitMask(1)
-        private val TRY_MASK: Int = makeBitMask(2)
+    companion object : BitFlagsBuilder(BYTE) {
+        private val UNSAFE_MASK: Int = nextBitMask()
+        private val ASYNC_MASK: Int = nextBitMask()
+        private val TRY_MASK: Int = nextBitMask()
     }
 }
 

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubInterfaces.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubInterfaces.kt
@@ -10,7 +10,7 @@ import org.rust.lang.core.psi.ext.QueryAttributes
 import org.rust.lang.core.psi.ext.RsDocAndAttributeOwner
 import org.rust.lang.core.psi.ext.getTraversedRawAttributes
 import org.rust.lang.core.psi.ext.name
-import org.rust.stdext.makeBitMask
+import org.rust.stdext.BitFlagsBuilder
 
 interface RsNamedStub {
     val name: String?
@@ -32,12 +32,11 @@ interface RsAttributeOwnerStub {
     // #[macro_use]
     val mayHaveMacroUse: Boolean
 
-    companion object {
-        val ATTRS_MASK: Int = makeBitMask(0)
-        val CFG_MASK: Int = makeBitMask(1)
-        val CFG_ATTR_MASK: Int = makeBitMask(2)
-        val HAS_MACRO_USE_MASK: Int = makeBitMask(3)
-        const val USED_BITS: Int = 4
+    companion object : BitFlagsBuilder(Limit.BYTE) {
+        val ATTRS_MASK: Int = nextBitMask()
+        val CFG_MASK: Int = nextBitMask()
+        val CFG_ATTR_MASK: Int = nextBitMask()
+        val HAS_MACRO_USE_MASK: Int = nextBitMask()
 
         fun extractFlags(element: RsDocAndAttributeOwner): Int =
             extractFlags(element.getTraversedRawAttributes(withCfgAttrAttribute = true))

--- a/src/main/kotlin/org/rust/stdext/BitFlagsBuilder.kt
+++ b/src/main/kotlin/org/rust/stdext/BitFlagsBuilder.kt
@@ -1,0 +1,35 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.stdext
+
+/**
+ * A simple utility for bitmask creation. Use it like this:
+ *
+ * ```
+ * object Foo: BitFlagsBuilder(Limit.BYTE) {
+ *     val BIT_MASK_0 = nextBitMask() // Equivalent to `1 shl 0`
+ *     val BIT_MASK_1 = nextBitMask() // Equivalent to `1 shl 1`
+ *     val BIT_MASK_2 = nextBitMask() // Equivalent to `1 shl 2`
+ *     // ...etc
+ * }
+ * ```
+ */
+abstract class BitFlagsBuilder private constructor(private val limit: Limit, startFromBit: Int) {
+    protected constructor(limit: Limit) : this(limit, 0)
+    protected constructor(prevBuilder: BitFlagsBuilder, limit: Limit) : this(limit, prevBuilder.counter)
+
+    private var counter: Int = startFromBit
+
+    protected fun nextBitMask(): Int {
+        val nextBit = counter++
+        if (nextBit == limit.bits) error("Bitmask index out of $limit limit!")
+        return makeBitMask(nextBit)
+    }
+
+    protected enum class Limit(val bits: Int) {
+        BYTE(8), INT(32)
+    }
+}


### PR DESCRIPTION
Internal. Simplifies bitmask creation and makes it less error-prone. 

How we crated bitmasks before:

```kotlin
companion object {
    private val NAMESPACE_TYPES_MASK: Int = makeBitMask(0)
    private val NAMESPACE_VALUES_MASK: Int = makeBitMask(1)
    private val NAMESPACE_MACROS_MASK: Int = makeBitMask(2)
}
```

And how we can create them now:

```kotlin
companion object : BitFlagsBuilder(Limit.BYTE) {
    private val NAMESPACE_TYPES_MASK: Int = nextBitMask()
    private val NAMESPACE_VALUES_MASK: Int = nextBitMask()
    private val NAMESPACE_MACROS_MASK: Int = nextBitMask()
}
```

Also, it's possible to "extend" another bitmask:

```kotlin
object Foo : BitFlagsBuilder(Limit.BYTE) {
    private val ONE: Int = nextBitMask() // 0
    private val TWO: Int = nextBitMask() // 1
}

object Bar : BitFlagsBuilder(Foo, Limit.BYTE) { // Note `Foo` here!
    private val THREE: Int = nextBitMask() // 2
    private val FOUR: Int = nextBitMask() // 3
}
```