### PR TITLE
Up/Down mover: move statements in match arm body

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/mover/RsLineMover.kt
+++ b/src/main/kotlin/org/rust/ide/actions/mover/RsLineMover.kt
@@ -16,6 +16,7 @@ import com.intellij.psi.PsiWhiteSpace
 import org.rust.lang.core.psi.RsElementTypes
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsMatchArm
 import org.rust.lang.core.psi.ext.elementType
 
 abstract class RsLineMover : LineMover() {
@@ -89,6 +90,9 @@ abstract class RsLineMover : LineMover() {
 
         fun isMovingOutOfFunctionBody(sibling: PsiElement, down: Boolean): Boolean =
             isMovingOutOfBraceBlock(sibling, down) && sibling.parent?.parent is RsFunction
+
+        fun isMovingOutOfMatchArmBlock(sibling: PsiElement, down: Boolean): Boolean =
+            isMovingOutOfBraceBlock(sibling, down) && sibling.parent?.parent?.parent is RsMatchArm
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/actions/mover/RsMatchArmUpDownMover.kt
+++ b/src/main/kotlin/org/rust/ide/actions/mover/RsMatchArmUpDownMover.kt
@@ -17,8 +17,10 @@ import org.rust.lang.core.psi.ext.elementType
 import org.rust.lang.core.psi.ext.getPrevNonCommentSibling
 
 class RsMatchArmUpDownMover : RsLineMover() {
-    override fun findMovableAncestor(psi: PsiElement, endpoint: RangeEndpoint): PsiElement? =
-        psi.ancestorOrSelf<RsMatchArm>()
+    override fun findMovableAncestor(psi: PsiElement, endpoint: RangeEndpoint): PsiElement? {
+        if (RsStatementUpDownMover.isMovableElement(psi)) return null
+        return psi.ancestorOrSelf<RsMatchArm>()
+    }
 
     override fun canApply(firstMovableElement: PsiElement, secondMovableElement: PsiElement): Boolean {
         val firstMatchBody = firstMovableElement.ancestorStrict<RsMatchBody>() ?: return false

--- a/src/test/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMoverTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMoverTest.kt
@@ -516,4 +516,108 @@ class RsStatementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
             5;
         }
     """)
+
+    fun `test move up statement in match arm body`() = moveUp("""
+        fn main() {
+             match x {
+                 foo => {
+                     1;
+                 }
+                 bar => {
+                     2;
+                     /*caret*/3;
+                     4;
+                 }
+                 baz => {
+                     5;
+                 }
+             };
+        }
+    """, """
+        fn main() {
+             match x {
+                 foo => {
+                     1;
+                 }
+                 bar => {
+                     /*caret*/3;
+                     2;
+                     4;
+                 }
+                 baz => {
+                     5;
+                 }
+             };
+        }
+    """)
+
+    fun `test move down statement in match arm body`() = moveDown("""
+        fn main() {
+             match x {
+                 foo => {
+                     1;
+                 }
+                 bar => {
+                     2;
+                     3;/*caret*/
+                     4;
+                 }
+                 baz => {
+                     5;
+                 }
+             };
+        }
+    """, """
+        fn main() {
+             match x {
+                 foo => {
+                     1;
+                 }
+                 bar => {
+                     2;
+                     4;
+                     3;/*caret*/
+                 }
+                 baz => {
+                     5;
+                 }
+             };
+        }
+    """)
+
+    fun `test move up first statement in match arm body`() = moveUp("""
+        fn main() {
+             match x {
+                 foo => {
+                     1;
+                 }
+                 bar => {
+                     2;/*caret*/
+                     3;
+                     4;
+                 }
+                 baz => {
+                     5;
+                 }
+             };
+        }
+    """, testmark = UpDownMoverTestMarks.moveOutOfBody)
+
+    fun `test move down last statement in match arm body`() = moveDown("""
+        fn main() {
+             match x {
+                 foo => {
+                     1;
+                 }
+                 bar => {
+                     2;
+                     3;
+                     4;/*caret*/
+                 }
+                 baz => {
+                     5;
+                 }
+             };
+        }
+    """, testmark = UpDownMoverTestMarks.moveOutOfBody)
 }


### PR DESCRIPTION
Fixes #6710

changelog: Do not move the entire `match` arm in [`Move Statement Up/Down`](https://www.jetbrains.com/help/idea/working-with-source-code.html#move-statements) action (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Up</kbd>/<kbd>Down</kbd>) invoked on the statement inside the arm body