### PR TITLE
REF: don't throw exception on changing name of local variable during indexing

### DIFF
--- a/src/test/kotlin/org/rust/ide/actions/mover/RsCommaListElementUpDownMoverTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/mover/RsCommaListElementUpDownMoverTest.kt
@@ -5,15 +5,6 @@
 
 package org.rust.ide.actions.mover
 
-import org.rust.UseOldResolve
-
-// These test may implicitly invoke `RsSuggestedRefactoringSupport.isDeclaration` during indexing.
-// `RsSuggestedRefactoringSupport.isDeclaration` may invoke name resolution and in combination with new name resolution engine
-// (which loads stubs itself) lead to "Outdated stub in index" error
-//
-// So force using old name resolution engine here for now.
-// Annotation should be removed when https://github.com/intellij-rust/intellij-rust/issues/6833 will be fixed
-@UseOldResolve
 class RsCommaListElementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
     fun `test function parameter`() = moveDownAndBackUp("""
         fn foo(

--- a/src/test/kotlin/org/rust/ide/refactoring/suggested/RsRenameSuggestedRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/suggested/RsRenameSuggestedRefactoringTest.kt
@@ -56,9 +56,21 @@ class RsRenameSuggestedRefactoringTest : RsSuggestedRefactoringTestBase() {
             let b = a;
         }
     """) {
-            myFixture.performEditorAction(IdeActions.ACTION_EDITOR_DELETE)
-            myFixture.type("5")
+        myFixture.performEditorAction(IdeActions.ACTION_EDITOR_DELETE)
+        myFixture.type("5")
+    }
+
+    fun `test do not rename constant`() = doUnavailableTest("""
+        const C: i32 = 1;
+        fn foo() {
+            match 1 {
+                C/*caret*/ => println!("Oops"),
+                X => println!("{}", X)
+            };
         }
+    """) {
+        myFixture.type("1")
+    }
 
     fun `test rename nested binding`() = doTestRename("""
         fn foo() {

--- a/src/test/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringTest.kt
@@ -11,11 +11,12 @@ import com.intellij.openapi.command.executeCommand
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.impl.source.PostprocessReformattingAspect
 import com.intellij.refactoring.RefactoringBundle
+import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 
 abstract class RsSuggestedRefactoringTestBase : RsTestBase() {
     protected fun doUnavailableTest(
-        initialText: String,
+        @Language("Rust") initialText: String,
         editingAction: () -> Unit
     ) {
         InlineFile(initialText).withCaret()
@@ -28,8 +29,8 @@ abstract class RsSuggestedRefactoringTestBase : RsTestBase() {
     }
 
     protected fun doTestRename(
-        initialText: String,
-        textAfterRefactoring: String,
+        @Language("Rust") initialText: String,
+        @Language("Rust") textAfterRefactoring: String,
         oldName: String,
         newName: String,
         editingAction: () -> Unit


### PR DESCRIPTION
Previously, `RsSuggestedRefactoringSupport.isDeclaration` checked that pat binding is not constant that required name resolution and consequently index info. But `isDeclaration` can be called during indexing that led to `IndexNotReadyException`.

Now, rename refactoring is suppressed by `RsSuggestedRefactoringAvailability` that can perform name resolution

Fixes #6833

changelog: Don't throw an exception on changing name of local variable during indexing
