### PR TITLE
RES: Fix that cfg-enabled glob import overrides cfg-disabled named import

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateDefMap.kt
@@ -295,8 +295,8 @@ class ModData(
     }
 
     /** Returns true if [visibleItems] were changed */
-    fun addVisibleItem(name: String, def: PerNs): Boolean =
-        pushResolutionFromImport(this, name, def, ImportType.NAMED)
+    fun addVisibleItem(name: String, def: PerNs, visibility: Visibility): Boolean =
+        pushResolutionFromImport(this, name, def, ImportType.NAMED, visibility)
 
     fun asVisItem(): VisItem {
         val parent = parent ?: error("Use CrateDefMap.rootAsPerNs for root ModData")
@@ -480,6 +480,14 @@ sealed class Visibility {
         }
     }
 
+    val type: VisibilityType
+        get() = when (this) {
+            Public -> VisibilityType.Normal
+            is Restricted -> VisibilityType.Normal
+            Invisible -> VisibilityType.Invisible
+            CfgDisabled -> VisibilityType.CfgDisabled
+        }
+
     val isInvisible: Boolean get() = this == Invisible || this == CfgDisabled
 
     override fun toString(): String =
@@ -489,6 +497,14 @@ sealed class Visibility {
             Invisible -> "Invisible"
             CfgDisabled -> "CfgDisabled"
         }
+}
+
+enum class VisibilityType {
+    CfgDisabled,
+    Invisible,
+    Normal;
+
+    fun isWider(other: VisibilityType): Boolean = ordinal > other.ordinal
 }
 
 /** Path to a module or an item in module */

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -249,44 +249,6 @@ class DefCollector(
         return changed
     }
 
-    private fun pushResolutionFromImport(modData: ModData, name: String, def: PerNs, importType: ImportType): Boolean {
-        check(!def.isEmpty)
-
-        // optimization: fast path
-        val defExisting = modData.visibleItems.putIfAbsent(name, def) ?: return true
-
-        return mergeResolutionFromImport(modData, name, def, defExisting, importType)
-    }
-
-    private fun mergeResolutionFromImport(
-        modData: ModData,
-        name: String,
-        def: PerNs,
-        defExisting: PerNs,
-        importType: ImportType
-    ): Boolean {
-        val (typesExisting, valuesExisting, macrosExisting) = defExisting
-        val typesNew = mergeResolutionOneNs(def.types, defExisting.types, importType)
-        val valuesNew = mergeResolutionOneNs(def.values, defExisting.values, importType)
-        val macrosNew = mergeResolutionOneNs(def.macros, defExisting.macros, importType)
-        if (typesExisting === typesNew && valuesExisting === valuesNew && macrosExisting === macrosNew) return false
-        modData.visibleItems[name] = PerNs(typesNew, valuesNew, macrosNew)
-        return true
-    }
-
-    private fun mergeResolutionOneNs(visItem: VisItem?, visItemExisting: VisItem?, importType: ImportType): VisItem? {
-        if (visItem == null) return visItemExisting
-        if (visItemExisting == null) return visItem
-
-        val importTypeExisting = if (visItemExisting.isFromNamedImport) NAMED else GLOB
-        if (importType == GLOB && importTypeExisting == NAMED) return visItemExisting
-        if (importType == importTypeExisting) {
-            val isStrictlyMorePermissive = visItem.visibility.isStrictlyMorePermissive(visItemExisting.visibility)
-            if (!isStrictlyMorePermissive) return visItemExisting
-        }
-        return visItem
-    }
-
     private fun pushTraitResolutionFromImport(modData: ModData, def: PerNs, visibility: Visibility): Boolean {
         check(!def.isEmpty)
         val trait = def.types?.takeIf { !it.isModOrEnum } ?: return false
@@ -472,4 +434,51 @@ private inline fun <T> MutableList<T>.inPlaceRemoveIf(filter: (T) -> Boolean): B
         }
     }
     return removed
+}
+
+fun pushResolutionFromImport(
+    modData: ModData,
+    name: String,
+    def: PerNs,
+    importType: ImportType
+): Boolean {
+    check(!def.isEmpty)
+
+    // optimization: fast path
+    val defExisting = modData.visibleItems.putIfAbsent(name, def) ?: return true
+
+    return mergeResolutionFromImport(modData, name, def, defExisting, importType)
+}
+
+private fun mergeResolutionFromImport(
+    modData: ModData,
+    name: String,
+    def: PerNs,
+    defExisting: PerNs,
+    importType: ImportType
+): Boolean {
+    val (typesExisting, valuesExisting, macrosExisting) = defExisting
+    val typesNew = mergeResolutionOneNs(def.types, defExisting.types, importType)
+    val valuesNew = mergeResolutionOneNs(def.values, defExisting.values, importType)
+    val macrosNew = mergeResolutionOneNs(def.macros, defExisting.macros, importType)
+    if (typesExisting === typesNew && valuesExisting === valuesNew && macrosExisting === macrosNew) return false
+    modData.visibleItems[name] = PerNs(typesNew, valuesNew, macrosNew)
+    return true
+}
+
+private fun mergeResolutionOneNs(
+    visItem: VisItem?,
+    visItemExisting: VisItem?,
+    importType: ImportType
+): VisItem? {
+    if (visItem == null) return visItemExisting
+    if (visItemExisting == null) return visItem
+
+    val importTypeExisting = if (visItemExisting.isFromNamedImport) NAMED else GLOB
+    if (importType == GLOB && importTypeExisting == NAMED) return visItemExisting
+    if (importType == importTypeExisting) {
+        val isStrictlyMorePermissive = visItem.visibility.isStrictlyMorePermissive(visItemExisting.visibility)
+        if (!isStrictlyMorePermissive) return visItemExisting
+    }
+    return visItem
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -924,4 +924,24 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
         #![cfg(intellij_rust)]
         pub fn func() {}
      """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test cfg-enabled glob import overrides cfg-disabled named import`() = checkByCode("""
+        #[cfg(not(intellij_rust))]
+        mod mod1 {
+            pub fn func() {}
+        }
+        mod mod2 {
+            pub fn func() {}
+        }        //X
+
+        #[cfg(not(intellij_rust))]
+        use mod1::func;
+        use mod2::*;
+
+        fn main() {
+            func();
+        } //^
+     """)
 }


### PR DESCRIPTION
Fix cases like:

```rust
#[cfg(not(intellij_rust))]
mod mod1 {
    pub fn func() {}
}
mod mod2 {
    pub fn func() {}
}        //X

#[cfg(not(intellij_rust))]
use mod1::func;
use mod2::*;

fn main() {
    func();
} //^
```

changelog: Fix that cfg-enabled glob import should override cfg-disabled named import when using new name resolution engine
