### PR TITLE
avoid empty test tool window on the Code With Me client (CWM-2044)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -2,6 +2,7 @@
 # If you are wondering, how to sort lines in IDEA, then the answer is
 # https://plugins.jetbrains.com/plugin/2162
 
+akozlova
 alexeykudinkin
 alexpana
 allengeorge

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoTestRunState.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoTestRunState.kt
@@ -33,7 +33,7 @@ class CargoTestRunState(
     }
 
     init {
-        consoleBuilder = CargoTestConsoleBuilder(environment.runProfile as RsCommandConfiguration, environment.executor)
+        consoleBuilder = CargoTestConsoleBuilder(environment.runProfile as CargoCommandConfiguration, environment.executor)
         commandLinePatches.add(cargoTestPatch)
         createFilters(cargoProject).forEach { consoleBuilder.addFilter(it) }
     }

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsCommandConfiguration.kt
@@ -5,18 +5,14 @@
 
 package org.rust.cargo.runconfig
 
-import com.intellij.execution.Executor
 import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.LocatableConfigurationBase
 import com.intellij.execution.configurations.RunConfigurationWithSuppressedDefaultDebugAction
 import com.intellij.execution.configurations.RunProfileState
-import com.intellij.execution.testframework.sm.runner.SMRunnerConsolePropertiesProvider
-import com.intellij.execution.testframework.sm.runner.SMTRunnerConsoleProperties
 import com.intellij.openapi.project.Project
 import org.jdom.Element
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.runconfig.command.workingDirectory
-import org.rust.cargo.runconfig.test.CargoTestConsoleProperties
 import java.nio.file.Path
 
 
@@ -25,17 +21,12 @@ abstract class RsCommandConfiguration(
     name: String,
     factory: ConfigurationFactory
 ) : LocatableConfigurationBase<RunProfileState>(project, factory, name),
-    RunConfigurationWithSuppressedDefaultDebugAction,
-    SMRunnerConsolePropertiesProvider {
+    RunConfigurationWithSuppressedDefaultDebugAction {
     abstract var command: String
 
     var workingDirectory: Path? = project.cargoProjects.allProjects.firstOrNull()?.workingDirectory
 
     override fun suggestedName(): String = command.substringBefore(' ').capitalize()
-
-    override fun createTestConsoleProperties(executor: Executor): SMTRunnerConsoleProperties {
-        return CargoTestConsoleProperties(this, executor)
-    }
 
     override fun writeExternal(element: Element) {
         super.writeExternal(element)

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -146,7 +146,7 @@ open class CargoCommandConfiguration(
         }
     }
 
-    private fun showTestToolWindow() = command.startsWith("test") &&
+    private fun showTestToolWindow(): Boolean = command.startsWith("test") &&
         isFeatureEnabled(RsExperiments.TEST_TOOL_WINDOW) &&
         !command.contains("--nocapture")
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/console/CargoConsoleBuilder.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/console/CargoConsoleBuilder.kt
@@ -14,6 +14,7 @@ import com.intellij.execution.ui.ConsoleView
 import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import org.rust.cargo.runconfig.RsCommandConfiguration
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.cargo.runconfig.test.CargoTestConsoleProperties.Companion.TEST_FRAMEWORK_NAME
 
 open class CargoConsoleBuilder(project: Project, scope: GlobalSearchScope) : TextConsoleBuilderImpl(project, scope) {
@@ -21,7 +22,7 @@ open class CargoConsoleBuilder(project: Project, scope: GlobalSearchScope) : Tex
 }
 
 class CargoTestConsoleBuilder(
-    private val config: RsCommandConfiguration,
+    private val config: CargoCommandConfiguration,
     private val executor: Executor
 ) : TextConsoleBuilder() {
     private val filters: MutableList<Filter> = mutableListOf()
@@ -34,7 +35,7 @@ class CargoTestConsoleBuilder(
 
     override fun getConsole(): ConsoleView {
         val consoleProperties = config.createTestConsoleProperties(executor)
-        val consoleView = SMTestRunnerConnectionUtil.createConsole(TEST_FRAMEWORK_NAME, consoleProperties)
+        val consoleView = SMTestRunnerConnectionUtil.createConsole(TEST_FRAMEWORK_NAME, consoleProperties!!)
         filters.forEach { consoleView.addMessageFilter(it) }
         return consoleView
     }


### PR DESCRIPTION
changelog: if run configuration returns non-empty `SMTRunnerConsoleProperties`, Code With Me client treats it as tests and reserves test toolwindow for it. The suggested fix ensures that properties are provided only for the case when test toolwindow  is shown on host

https://youtrack.jetbrains.com/issue/CWM-2044