### PR TITLE
RES: Add method to RsPathReference to resolve only public items

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
@@ -80,7 +80,7 @@ inline val RsEnumVariantStub.namespaces: Set<Namespace> get() = if (blockFields 
 val RsUseSpeck.namespaces: Set<Namespace>
     get() = path
         ?.reference
-        ?.multiResolve()
+        ?.multiResolveIfVisible()
         ?.asSequence()
         ?.filterIsInstance<RsNamedElement>()
         ?.flatMap { it.namespaces.asSequence() }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReference.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReference.kt
@@ -12,6 +12,10 @@ import org.rust.lang.core.types.BoundElement
 interface RsPathReference : RsReference {
     override fun getElement(): RsPath
 
+    fun resolveIfVisible(): RsElement? = multiResolveIfVisible().singleOrNull()
+
+    fun multiResolveIfVisible(): List<RsElement> = multiResolve()
+
     fun advancedResolve(): BoundElement<RsElement>? =
         resolve()?.let { BoundElement(it) }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
@@ -66,3 +66,17 @@ val BoundElement<RsGenericDeclaration>.positionalTypeArguments: List<Ty>
 
 val BoundElement<RsGenericDeclaration>.positionalConstArguments: List<Const>
     get() = element.constParameters.map { subst[it] ?: CtConstParameter(it) }
+
+data class BoundElementWithVisibility<T : RsElement>(
+    val inner: BoundElement<T>,
+    val isVisible: Boolean,
+) {
+    override fun toString(): String {
+        val visibility = if (isVisible) "public" else "private"
+        return "$visibility $inner"
+    }
+}
+
+fun <T : RsElement> BoundElementWithVisibility<T>.map(
+    f: (BoundElement<T>) -> BoundElement<T>
+): BoundElementWithVisibility<T> = BoundElementWithVisibility(f(inner), isVisible)

--- a/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/PatternMatching.kt
@@ -26,7 +26,7 @@ fun RsPat.extractBindings(fcx: RsTypeInferenceWalker, type: Ty, defBm: RsBinding
             val expr = expr
             val expected = when {
                 expr is RsLitExpr && expr.kind is RsLiteralKind.String -> type
-                expr is RsPathExpr && resolvePath(expr.path).singleOrNull()?.element is RsConstant -> type
+                expr is RsPathExpr && resolvePath(expr.path).singleOrNull()?.inner?.element is RsConstant -> type
                 else -> type.stripReferences(defBm).first
             }
             fcx.writePatTy(this, expected)

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInference.kt
@@ -967,7 +967,7 @@ fun <T> TyWithObligations<T>.withObligations(addObligations: List<Obligation>) =
 sealed class ResolvedPath {
     abstract val element: RsElement
 
-    class Item(override val element: RsElement) : ResolvedPath()
+    class Item(override val element: RsElement, val isVisible: Boolean) : ResolvedPath()
 
     class AssocItem(
         override val element: RsAbstractable,
@@ -975,11 +975,14 @@ sealed class ResolvedPath {
     ) : ResolvedPath()
 
     companion object {
-        fun from(entry: ScopeEntry): ResolvedPath? {
+        fun from(entry: ScopeEntry, context: RsElement): ResolvedPath? {
             return if (entry is AssocItemScopeEntry) {
                 AssocItem(entry.element, entry.source)
             } else {
-                entry.element?.let { Item(it) }
+                entry.element?.let {
+                    val isVisible = entry.isVisibleFrom(context.containingMod)
+                    Item(it, isVisible)
+                }
             }
         }
 

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -357,7 +357,7 @@ class RsTypeInferenceWalker(
             resolveVariants
         }
 
-        ctx.writePath(expr, filteredVariants.mapNotNull { ResolvedPath.from(it) })
+        ctx.writePath(expr, filteredVariants.mapNotNull { ResolvedPath.from(it, expr) })
 
         val first = filteredVariants.singleOrNull() ?: return TyUnknown
         return instantiatePath(first.element ?: return TyUnknown, first, expr)

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -920,6 +920,21 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         macro_rules! foo { () => {} }
     """)
 
+    @UseNewResolve
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test no duplicates with import E0252 private item`() = checkErrors("""
+        mod mod1 {
+            fn foo() {}
+            pub struct foo {}
+        }
+        mod mod2 {
+            pub fn foo() {}
+        }
+
+        use mod1::foo;
+        use mod2::foo;
+    """)
+
     fun `test unnecessary pub E0449`() = checkErrors("""
         <error descr="Unnecessary visibility qualifier [E0449]">pub</error> extern "C" { }
 


### PR DESCRIPTION
Adds methods `resolveIfVisible` and `multiResolveIfVisible` to `RsPathReference` class (works only with new resolve; with old resolve they are equivalent to `resolve` and `multiResolve`). They can be used in refactorings and intentions, e.g. to fix "A second item with name ... imported" false-positive:

```rust
mod mod1 {
    fn foo() {}
    pub struct foo {}
}
mod mod2 {
    pub fn foo() {}
}

use mod1::foo;  // foo func is private, so no conflict with `mod2::foo`
use mod2::foo;
```

changelog: Fix false-positive [E0252](https://doc.rust-lang.org/error-index.html#E0252) "A second item with name ... imported" error for private items