### PR TITLE
ANN: Fix E0252 false-positive for scoped vs textual macros

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1318,9 +1318,11 @@ private fun AnnotationSession.duplicatesByNamespace(
         ?.asSequence()
         ?.mapNotNull { it.path.parent as? RsUseSpeck }
         .orEmpty()
+    val namedChildren = owner
+        .namedChildren(recursively, stopAt = RsFnPointerType::class.java)
+        .filter { it !is RsMacro }
     val duplicates: Map<Namespace, Set<PsiElement>> =
-        (owner.namedChildren(recursively, stopAt = RsFnPointerType::class.java)
-            + importedNames)
+        (namedChildren + importedNames)
             .filter { it !is RsExternCrateItem } // extern crates can have aliases.
             .filter {
                 val name = it.nameOrImportedName()

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -910,6 +910,16 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """)
 
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test no duplicates with import E0252 textual-scoped macros`() = checkDontTouchAstInOtherFiles("""
+    //- main.rs
+        use test_package::foo;
+        macro_rules! foo { () => {} }
+    //- lib.rs
+        #[macro_export]
+        macro_rules! foo { () => {} }
+    """)
+
     fun `test unnecessary pub E0449`() = checkErrors("""
         <error descr="Unnecessary visibility qualifier [E0449]">pub</error> extern "C" { }
 


### PR DESCRIPTION
Fixes #6774

changelog: Fix false-positive [E0252](https://doc.rust-lang.org/error-index.html#E0252) "A second item with name ... imported" error for textual vs scoped macro