### PR TITLE
REF: Omit unchanged default type parameters of return type in ExtractFunction

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionConfig.kt
@@ -181,7 +181,7 @@ class RsExtractFunctionConfig private constructor(
         }
         append("fn $name$typeParametersText(${if (isOriginal) originalParametersText else parametersText})")
         if (returnValue != null && returnValue.type !is TyUnit) {
-            append(" -> ${returnValue.type.renderInsertionSafe()}")
+            append(" -> ${returnValue.type.renderInsertionSafe(skipUnchangedDefaultTypeArguments = true)}")
         }
         append(whereClausesText)
     }

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -1115,7 +1115,7 @@ class RsExtractFunctionTest : RsTestBase() {
 
         fn main() {
             let s: S<u32> = S(1u32, 2u32);
-            <selection>println!(s)</selection>;
+            <selection>s</selection>;
         }
     """, """
         struct S<R, T=u32>(R, T);
@@ -1125,8 +1125,8 @@ class RsExtractFunctionTest : RsTestBase() {
             foo(s);
         }
 
-        fn foo(s: S<u32>) {
-            println!(s)
+        fn foo(s: S<u32>) -> S<u32> {
+            s
         }
     """,
         false,
@@ -1137,7 +1137,7 @@ class RsExtractFunctionTest : RsTestBase() {
 
         fn main() {
             let s: S<u32, bool> = S(1u32, true);
-            <selection>println!(s)</selection>;
+            <selection>s</selection>;
         }
     """, """
         struct S<R, T=u32>(R, T);
@@ -1147,8 +1147,8 @@ class RsExtractFunctionTest : RsTestBase() {
             foo(s);
         }
 
-        fn foo(s: S<u32, bool>) {
-            println!(s)
+        fn foo(s: S<u32, bool>) -> S<u32, bool> {
+            s
         }
     """,
         false,
@@ -1159,7 +1159,7 @@ class RsExtractFunctionTest : RsTestBase() {
 
         fn main() {
             let s: S<u32, i32> = S(1u32, 2i32);
-            <selection>println!(s)</selection>;
+            <selection>s</selection>;
         }
     """, """
         struct S<R=u32, T=u32>(R, T);
@@ -1169,8 +1169,8 @@ class RsExtractFunctionTest : RsTestBase() {
             foo(s);
         }
 
-        fn foo(s: S<u32, i32>) {
-            println!(s)
+        fn foo(s: S<u32, i32>) -> S<u32, i32> {
+            s
         }
     """,
         false,


### PR DESCRIPTION
<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

Also, please write a short description explaining your change in the following format: `changelog: %description%`
This description will help a lot to create release changelog. 
Drop these lines for internal only changes

:)
-->

changelog: Omit unchanged default type parameters of return type in `Extract Function` refactoring
