### PR TITLE
Improve CratesLocalIndexService internals

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexServiceImpl.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexServiceImpl.kt
@@ -250,7 +250,7 @@ class CratesLocalIndexServiceImpl
         }
 
         override fun onSuccess() {
-            state.indexedCommitHash = newHead
+            state = CratesLocalIndexState(newHead)
         }
 
         override fun onFinished() {
@@ -259,7 +259,7 @@ class CratesLocalIndexServiceImpl
     }
 
     companion object {
-        data class CratesLocalIndexState(var indexedCommitHash: String = "")
+        data class CratesLocalIndexState(val indexedCommitHash: String = "")
 
         private val corruptionMarkerFile: Path
             get() = baseCratesLocalRegistryDir.resolve(CORRUPTION_MARKER_NAME)


### PR DESCRIPTION
Based on the comments in #6390.

1. Made `CratesLocalIndexState`'s field immutable
2. Clarified `isReady` by a doc comment, not sure what's the better name for it can be