### PR TITLE
Fix cargo features state inference on renamed packages

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -255,7 +255,7 @@ private class WorkspaceImpl(
 
                             if (name in dep.pkg.rawFeatures) {
                                 if (dep.isOptional) {
-                                    listOf(PackageFeature(pkg, dep.pkg.name), PackageFeature(dep.pkg, name))
+                                    listOf(PackageFeature(pkg, dep.cargoFeatureDependencyPackageName), PackageFeature(dep.pkg, name))
                                 } else {
                                     listOf(PackageFeature(dep.pkg, name))
                                 }

--- a/src/main/kotlin/org/rust/cargo/project/workspace/FeatureGraph.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/FeatureGraph.kt
@@ -5,6 +5,7 @@
 
 package org.rust.cargo.project.workspace
 
+import com.intellij.openapiext.isUnitTestMode
 import org.rust.lang.utils.Node
 import org.rust.lang.utils.PresentableGraph
 
@@ -93,11 +94,11 @@ class FeatureGraph private constructor(
 
             // Add edges
             for ((feature, dependencies) in features) {
+                val targetNode = featureToNode[feature]
+                    ?: if (isUnitTestMode) error("Unknown feature $feature") else continue
                 for (dependency in dependencies) {
-                    addFeatureIfNeeded(feature)
-                    addFeatureIfNeeded(dependency)
-                    val sourceNode = featureToNode[dependency]!!
-                    val targetNode = featureToNode[feature]!!
+                    val sourceNode = featureToNode[dependency]
+                        ?: if (isUnitTestMode) error("Unknown feature $dependency (dependency of $feature)") else continue
                     graph.addEdge(sourceNode, targetNode, Unit)
                 }
             }

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -130,6 +130,7 @@ object CargoMetadata {
     data class RawDependency(
         /** A `package` name (non-normalized) of the dependency */
         val name: String,
+        val rename: String?,
         val kind: String?,
         val target: String?,
         val optional: Boolean,
@@ -350,8 +351,9 @@ object CargoMetadata {
 
         // Optional dependencies are features implicitly
         for (dependency in dependencies) {
-            if (dependency.optional && dependency.name !in features) {
-                features[dependency.name] = emptyList()
+            val featureName = dependency.rename ?: dependency.name
+            if (dependency.optional && featureName !in features) {
+                features[featureName] = emptyList()
             }
         }
 


### PR DESCRIPTION
This also fixes `regressions-1` CI workflow.

changelog: Fix cargo features state inference on renamed packages
