### PR TITLE
Associate `Cargo.toml.orig` files with TOML file type

### DIFF
--- a/intellij-toml/src/main/resources/META-INF/plugin.xml
+++ b/intellij-toml/src/main/resources/META-INF/plugin.xml
@@ -24,7 +24,7 @@
                   implementationClass="org.toml.lang.psi.TomlFileType"
                   fieldName="INSTANCE"
                   extensions="toml"
-                  fileNames="Cargo.lock;Gopkg.lock;Pipfile"/>
+                  fileNames="Cargo.lock;Cargo.toml.orig;Gopkg.lock;Pipfile"/>
         <lang.parserDefinition language="TOML" implementationClass="org.toml.lang.parse.TomlParserDefinition"/>
         <lang.ast.factory language="TOML" implementationClass="org.toml.lang.psi.impl.TomlASTFactory"/>
         <lang.syntaxHighlighter language="TOML" implementationClass="org.toml.ide.TomlHighlighter"/>

--- a/intellij-toml/src/test/kotlin/org/toml/lang/TomlFileTypeTest.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/lang/TomlFileTypeTest.kt
@@ -14,6 +14,7 @@ class TomlFileTypeTest : TomlTestBase() {
 
     fun `test toml file by extension`() = doTest("example.toml")
     fun `test Cargo lock`() = doTest("Cargo.lock")
+    fun `test Cargo toml orig`() = doTest("Cargo.toml.orig")
     fun `test Gopkg lock`() = doTest("Gopkg.lock")
     fun `test Pipfile`() = doTest("Pipfile")
     fun `test Cargo config`() = doTest(".cargo/config")


### PR DESCRIPTION
Fixes #6884

changelog: Toml syntax highlighting is now available in `Cargo.toml.orig` files