### PR TITLE
Introduce EDITION_2021

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -201,7 +201,9 @@ interface CargoWorkspace {
     }
 
     enum class Edition(val presentation: String) {
-        EDITION_2015("2015"), EDITION_2018("2018")
+        EDITION_2015("2015"),
+        EDITION_2018("2018"),
+        EDITION_2021("2021")
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/impl/CargoMetadata.kt
@@ -515,6 +515,7 @@ object CargoMetadata {
     private fun String?.cleanEdition(): Edition = when (this) {
         Edition.EDITION_2015.presentation -> Edition.EDITION_2015
         Edition.EDITION_2018.presentation -> Edition.EDITION_2018
+        Edition.EDITION_2021.presentation -> Edition.EDITION_2021
         else -> Edition.EDITION_2015
     }
 

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -116,7 +116,7 @@ class RsHighlightingAnnotator : AnnotatorBase() {
             isPrimitiveType -> RsColor.PRIMITIVE_TYPE
             parent is RsMacroCall -> if (shouldHighlightMacroCall(parent, holder)) RsColor.MACRO else null
             element is RsMethodCall -> RsColor.METHOD_CALL
-            element is RsFieldLookup && element.identifier?.text == "await" && element.isEdition2018 -> RsColor.KEYWORD
+            element is RsFieldLookup && element.identifier?.text == "await" && element.isAtLeastEdition2018 -> RsColor.KEYWORD
             element is RsPath && element.isCall() -> {
                 val ref = reference?.resolve() ?: return null
                 if (ref is RsFunction) {

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AttachFileToModuleFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AttachFileToModuleFix.kt
@@ -91,7 +91,7 @@ class AttachFileToModuleFix(
                 modules.addIfNotNull(findModule(file, project, directory.findFileByRelativePath(RsConstants.MOD_RS_FILE)))
 
                 // module file in parent directory
-                if (pkg.edition == CargoWorkspace.Edition.EDITION_2018) {
+                if (pkg.edition >= CargoWorkspace.Edition.EDITION_2018) {
                     modules.addIfNotNull(findModule(file, project, directory.parent?.findFileByRelativePath("${directory.name}.rs")))
                 }
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspection.kt
@@ -12,7 +12,7 @@ import com.intellij.psi.PsiElement
 import org.rust.ide.inspections.RsProblemsHolder
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.dyn
-import org.rust.lang.core.psi.ext.isEdition2018
+import org.rust.lang.core.psi.ext.isAtLeastEdition2018
 import org.rust.lang.core.psi.ext.skipParens
 import org.rust.lang.core.resolve.ref.deepResolve
 
@@ -22,7 +22,7 @@ class RsBareTraitObjectsInspection : RsLintInspection() {
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
         object : RsVisitor() {
             override fun visitTypeReference(typeReference: RsTypeReference) {
-                if (!typeReference.isEdition2018) return
+                if (!typeReference.isAtLeastEdition2018) return
 
                 val traitType = typeReference.skipParens() as? RsTraitType
                 val baseTypePath = (typeReference.skipParens() as? RsBaseType)?.path

--- a/src/main/kotlin/org/rust/ide/intentions/CreateFunctionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/CreateFunctionIntention.kt
@@ -38,7 +38,7 @@ class CreateFunctionIntention : RsElementBaseIntentionAction<CreateFunctionInten
 
     sealed class Context(val name: String, val callElement: PsiElement) {
         abstract val visibility: String
-        open val isAsync: Boolean = callElement.isEdition2018
+        open val isAsync: Boolean = callElement.isAtLeastEdition2018
         abstract val arguments: RsValueArgumentList
         abstract val returnType: Ty?
         open val implItem: RsImplItem? = null

--- a/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/RsMoveFilesOrDirectoriesHandler.kt
@@ -20,7 +20,7 @@ import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectori
 import com.intellij.refactoring.util.CommonRefactoringUtil
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.RsFile
-import org.rust.lang.core.psi.ext.isEdition2018
+import org.rust.lang.core.psi.ext.isAtLeastEdition2018
 import org.rust.stdext.mapToSet
 
 class RsMoveFilesOrDirectoriesHandler : MoveFilesOrDirectoriesHandler() {
@@ -118,5 +118,5 @@ private fun RsFile.canBeMoved(): Boolean =
         && crateRoot != null
         && crateRelativePath != null
         && !isCrateRoot
-        && isEdition2018  // TODO: support 2015 edition
+        && isAtLeastEdition2018  // TODO: support 2015 edition
         && pathAttribute == null  // TODO: support path attribute on mod declaration

--- a/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector.kt
@@ -191,7 +191,7 @@ object ImportCandidatesCollector {
             ourSuperMods to importInfo
         } else {
             val targetMod = superMods.first()
-            val relativePath = if (targetMod.isEdition2018) {
+            val relativePath = if (targetMod.isAtLeastEdition2018) {
                 "crate::$crateRelativePath"
             } else {
                 crateRelativePath

--- a/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
@@ -25,7 +25,7 @@ fun ImportCandidate.import(context: RsElement) {
     // we uses this info to create correct relative use item path if needed
     var relativeDepth: Int? = null
 
-    val isEdition2018 = context.isEdition2018
+    val isAtLeastEdition2018 = context.isAtLeastEdition2018
     val info = info
     // if crate of importing element differs from current crate
     // we need to add new extern crate item
@@ -42,7 +42,7 @@ fun ImportCandidate.import(context: RsElement) {
             // we don't add corresponding extern crate item manually for the same reason
             attributes == RsFile.Attributes.NO_STD && crate.isCore -> Testmarks.autoInjectedCoreCrate.hit()
             else -> {
-                if (info.needInsertExternCrateItem && !isEdition2018) {
+                if (info.needInsertExternCrateItem && !isAtLeastEdition2018) {
                     crateRoot?.insertExternCrateItem(psiFactory, info.externCrateName)
                 } else {
                     if (info.depth != null) {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsAwaitCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsAwaitCompletionProvider.kt
@@ -17,7 +17,7 @@ import com.intellij.util.ProcessingContext
 import org.rust.lang.core.psi.RsElementTypes
 import org.rust.lang.core.psi.RsFieldLookup
 import org.rust.lang.core.psi.ext.findAssociatedType
-import org.rust.lang.core.psi.ext.isEdition2018
+import org.rust.lang.core.psi.ext.isAtLeastEdition2018
 import org.rust.lang.core.psi.ext.receiver
 import org.rust.lang.core.psi.ext.withSubst
 import org.rust.lang.core.psiElement
@@ -36,7 +36,7 @@ object RsAwaitCompletionProvider : RsCompletionProvider() {
             val parent = psiElement<RsFieldLookup>()
                 .with(object : PatternCondition<RsFieldLookup>("RsPostfixAwait") {
                     override fun accepts(t: RsFieldLookup, context: ProcessingContext?): Boolean {
-                        if (context == null || !t.isEdition2018) return false
+                        if (context == null || !t.isAtLeastEdition2018) return false
                         val receiver = t.receiver.safeGetOriginalOrSelf()
                         val lookup = ImplLookup.relativeTo(receiver)
                         val awaitTy = receiver.type.lookupFutureOutputTy(lookup)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsElement.kt
@@ -65,8 +65,11 @@ val RsElement.containingCargoPackage: CargoWorkspace.Package? get() = containing
 val PsiElement.edition: CargoWorkspace.Edition?
     get() = contextOrSelf<RsElement>()?.containingCrate?.edition
 
-val PsiElement.isEdition2018: Boolean
-    get() = edition == CargoWorkspace.Edition.EDITION_2018
+val PsiElement.isAtLeastEdition2018: Boolean
+    get() {
+        val edition = edition ?: return false
+        return edition >= CargoWorkspace.Edition.EDITION_2018
+    }
 
 /**
  * It is possible to match value with constant-like element, e.g.

--- a/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ItemResolution.kt
@@ -110,12 +110,12 @@ fun processItemDeclarations(
         }
     }
 
-    val isEdition2018 = scope.isEdition2018
+    val isAtLeastEdition2018 = scope.isAtLeastEdition2018
     for ((isPublic, path, name, isAtom) in cachedItems.namedImports) {
         if (!(isPublic || withPrivateImports)) continue
 
-        if (isEdition2018 && isAtom) {
-            // Use items like `use foo;` or `use foo::{self}` are meaningful on 2018 edition
+        if (isAtLeastEdition2018 && isAtom) {
+            // Use items like `use foo;` or `use foo::{self}` are meaningful since 2018 edition
             // only if `foo` is a crate, and it is `pub use` item. Otherwise,
             // we should ignore it or it breaks resolve of such `foo` in other places.
             ItemResolutionTestmarks.extraAtomUse.hit()
@@ -131,7 +131,7 @@ fun processItemDeclarations(
         }
     }
 
-    if (withPrivateImports && Namespace.Types in ns && scope is RsFile && !isEdition2018 && scope.isCrateRoot) {
+    if (withPrivateImports && Namespace.Types in ns && scope is RsFile && !isAtLeastEdition2018 && scope.isCrateRoot) {
         // Rust injects implicit `extern crate std` in every crate root module unless it is
         // a `#![no_std]` crate, in which case `extern crate core` is injected. However, if
         // there is a (unstable?) `#![no_core]` attribute, nothing is injected.
@@ -154,7 +154,7 @@ fun processItemDeclarations(
     }
 
     if (ipm.withExternCrates && Namespace.Types in ns && scope is RsMod) {
-        if (isEdition2018 && !scope.isCrateRoot) {
+        if (isAtLeastEdition2018 && !scope.isCrateRoot) {
             val crateRoot = scope.crateRoot
             if (crateRoot != null) {
                 val result = processWithShadowingAndUpdateScope(directlyDeclaredNames, originalProcessor) { shadowingProcessor ->

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -554,7 +554,7 @@ private fun processUnqualifiedPathResolveVariants(
         }
     }
 
-    val isEdition2018 = (crateRoot ?: containingMod).isEdition2018
+    val isAtLeastEdition2018 = (crateRoot ?: containingMod).isAtLeastEdition2018
 
     // In 2015 edition a path is crate-relative (global) if it's inside use item,
     // inside "visibility restriction" or if it starts with `::`
@@ -564,13 +564,13 @@ private fun processUnqualifiedPathResolveVariants(
     // pub(in foo::bar) fn baz() {}
     //       //^ crate-relative path too
     // ```
-    // In 2018 edition a path is crate-relative if it starts with `crate::` (handled above)
-    // or if it's inside "visibility restriction". `::`-qualified path on 2018 edition means that
+    // Starting 2018 edition a path is crate-relative if it starts with `crate::` (handled above)
+    // or if it's inside "visibility restriction". `::`-qualified path since 2018 edition means that
     // such path is a name of some dependency crate (that should be resolved without `extern crate`)
-    val isCrateRelative = !isEdition2018 && (hasColonColon || path.rootPath().parent is RsUseSpeck)
+    val isCrateRelative = !isAtLeastEdition2018 && (hasColonColon || path.rootPath().parent is RsUseSpeck)
         || path.rootPath().parent is RsVisRestriction
     // see https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html#the-crate-keyword-refers-to-the-current-crate
-    val isExternCrate = isEdition2018 && hasColonColon
+    val isExternCrate = isAtLeastEdition2018 && hasColonColon
     return when {
         isCrateRelative -> if (crateRoot != null) {
             processItemOrEnumVariantDeclarations(crateRoot, ns, processor, withPrivateImports = { true })

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -123,7 +123,7 @@ class RsPathReferenceImpl(
     }
 
     private fun bindToMod(target: RsMod): PsiElement? {
-        if (!element.isEdition2018) return null
+        if (!element.isAtLeastEdition2018) return null
         var targetPath = target.qualifiedNameRelativeTo(element.containingMod) ?: return null
 
         // consider old target (`element.reference.resolve()`) was `bar1::bar2::bar3::bar4::foo`

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -792,7 +792,7 @@ class RsTypeInferenceWalker(
     }
 
     private fun inferFieldExprType(receiver: Ty, fieldLookup: RsFieldLookup): Ty {
-        if (fieldLookup.identifier?.text == "await" && fieldLookup.isEdition2018) {
+        if (fieldLookup.identifier?.text == "await" && fieldLookup.isAtLeastEdition2018) {
             return receiver.lookupFutureOutputTy(lookup)
         }
 


### PR DESCRIPTION
Initial preparation for 2021 edition. It should only support parsing `2021` edition from cargo metadata. All user-visible features should be the same as for `2018` edition

Part of #6902 

changelog: Introduce `2021` edition variant in the plugin and adjust the corresponding code
