### PR TITLE
DBG: debugger support for Rider for Unreal Engine 2021.1

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/RsDebuggerToolchainService.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/RsDebuggerToolchainService.kt
@@ -37,11 +37,15 @@ import java.util.*
 class RsDebuggerToolchainService {
 
     fun getLLDBStatus(): LLDBStatus {
-        val bundledPath = bundledLLDBDirPath()?.toString()
-        val status = getLLDBStatus(bundledPath, checkVersions = false)
+        val status = getBundledLLDBStatus()
         if (status is LLDBStatus.Binaries) return status
 
         return getLLDBStatus(RsDebuggerSettings.getInstance().lldbPath)
+    }
+
+    fun getBundledLLDBStatus(): LLDBStatus {
+        val bundledPath = bundledLLDBDirPath()?.toString()
+        return getLLDBStatus(bundledPath, checkVersions = false)
     }
 
     fun getLLDBStatus(lldbPath: String?, checkVersions: Boolean = true): LLDBStatus {

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtils.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtils.kt
@@ -14,10 +14,9 @@ import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.xdebugger.XDebugProcess
+import com.intellij.xdebugger.XDebugProcessStarter
 import com.intellij.xdebugger.XDebugSession
 import com.intellij.xdebugger.XDebuggerManager
-import com.intellij.xdebugger.impl.XDebugProcessConfiguratorStarter
-import com.intellij.xdebugger.impl.ui.XDebugSessionData
 import org.rust.cargo.runconfig.BuildResult
 import org.rust.cargo.runconfig.CargoRunStateBase
 import org.rust.debugger.RsDebuggerToolchainService
@@ -32,17 +31,15 @@ object RsDebugRunnerUtils {
         state: CargoRunStateBase,
         environment: ExecutionEnvironment,
         runExecutable: GeneralCommandLine
-    ): RunContentDescriptor? {
+    ): RunContentDescriptor {
         val runParameters = RsDebugRunParameters(environment.project, runExecutable, state.cargoProject)
         return XDebuggerManager.getInstance(environment.project)
-            .startSession(environment, object : XDebugProcessConfiguratorStarter() {
+            .startSession(environment, object : XDebugProcessStarter() {
                 override fun start(session: XDebugSession): XDebugProcess =
                     RsLocalDebugProcess(runParameters, session, state.consoleBuilder).apply {
                         ProcessTerminatedListener.attach(processHandler, environment.project)
                         start()
                     }
-
-                override fun configure(data: XDebugSessionData?) {}
             })
             .runContentDescriptor
     }

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettings.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettings.kt
@@ -14,6 +14,7 @@ import com.intellij.xdebugger.settings.DebuggerSettingsCategory
 import com.intellij.xdebugger.settings.XDebuggerSettings
 import org.rust.debugger.GDBRenderers
 import org.rust.debugger.LLDBRenderers
+import org.rust.debugger.RsDebuggerToolchainService
 
 class RsDebuggerSettings : XDebuggerSettings<RsDebuggerSettings>("Rust") {
 
@@ -67,7 +68,11 @@ class RsDebuggerSettings : XDebuggerSettings<RsDebuggerSettings>("Rust") {
 
     private val needToShowToolchainSettings: Boolean
         get() {
-            return !PlatformUtils.isCLion()
+            // CLion has own Toolchain settings
+            if (PlatformUtils.isCLion()) return false
+            val status = RsDebuggerToolchainService.getInstance().getBundledLLDBStatus()
+            // If there is bundled LLDB, no need to show this toolchain settings
+            return status !is RsDebuggerToolchainService.LLDBStatus.Binaries
         }
 
     companion object {

--- a/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
+++ b/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
@@ -22,6 +22,8 @@ import com.intellij.openapi.util.BuildNumber
 import com.intellij.util.PlatformUtils.*
 import org.rust.cargo.runconfig.RsDefaultProgramRunnerBase
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.debugger.NATIVE_DEBUGGING_SUPPORT_PLUGIN_ID
+import org.rust.debugger.nativeDebuggingSupportPlugin
 
 class RsDebugAdvertisingRunner : RsDefaultProgramRunnerBase() {
 
@@ -29,20 +31,18 @@ class RsDebugAdvertisingRunner : RsDefaultProgramRunnerBase() {
         if (executorId != DefaultDebugExecutor.EXECUTOR_ID) return false
         if (profile !is CargoCommandConfiguration) return false
         if (!isSupportedPlatform()) return false
-        val id = PluginId.getId(NATIVE_DEBUG_PLUGIN_ID)
-        val plugin = PluginManagerCore.getPlugin(id)
+        val plugin = nativeDebuggingSupportPlugin()
         val loadedPlugins = PluginManagerCore.getLoadedPlugins()
         return plugin !in loadedPlugins || plugin?.isEnabled != true
     }
 
     override fun execute(environment: ExecutionEnvironment) {
-        val id = PluginId.getId(NATIVE_DEBUG_PLUGIN_ID)
-        val plugin = PluginManagerCore.getPlugin(id)
+        val plugin = nativeDebuggingSupportPlugin()
         val pluginsState = InstalledPluginsState.getInstance()
 
         val action = when {
             // Not installed
-            plugin == null && !pluginsState.wasInstalled(id) -> Action.INSTALL
+            plugin == null && !pluginsState.wasInstalled(NATIVE_DEBUGGING_SUPPORT_PLUGIN_ID) -> Action.INSTALL
             // Disabled
             plugin?.isEnabled == false -> Action.ENABLE
             // Restart required
@@ -60,7 +60,7 @@ class RsDebugAdvertisingRunner : RsDefaultProgramRunnerBase() {
         )
 
         if (options == Messages.OK) {
-            action.doOkAction(project, id)
+            action.doOkAction(project, NATIVE_DEBUGGING_SUPPORT_PLUGIN_ID)
         }
     }
 

--- a/src/main/kotlin/org/rust/debugger/utils.kt
+++ b/src/main/kotlin/org/rust/debugger/utils.kt
@@ -1,0 +1,15 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
+
+val NATIVE_DEBUGGING_SUPPORT_PLUGIN_ID: PluginId = PluginId.getId("com.intellij.nativeDebug")
+
+fun nativeDebuggingSupportPlugin(): IdeaPluginDescriptor? =
+    PluginManagerCore.getPlugin(NATIVE_DEBUGGING_SUPPORT_PLUGIN_ID)


### PR DESCRIPTION
Current restrictions:
- the support works starting 2021.1 EAPs
- only [Rider for Unreal Engine](https://www.jetbrains.com/lp/rider-unreal/) is supported for now
- only LLDB

Part of #5422

changelog: Provide debugging in [Rider for Unreal Engine](https://www.jetbrains.com/lp/rider-unreal/) 2021.1
