### PR TITLE
ANN: Enable by default "Simplify boolean expression" inspection

### DIFF
--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -468,7 +468,7 @@
 
         <localInspection language="Rust" groupName="Rust"
                          displayName="Simplify boolean expression"
-                         enabledByDefault="false" level="WARNING"
+                         enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.RsSimplifyBooleanExpressionInspection"/>
 
         <localInspection language="Rust" groupName="Rust"


### PR DESCRIPTION
There are `RsSimplifyBooleanExpressionInspection` and `SimplifyBooleanExpressionIntention`. Inspection is offered only for pure expressions, and intention is always offered. Inspection was disabled in e0962ec008e9ed9f8031ecd3d12ca57be1b20fbb because of bug which however was fixed in #1001

changelog: Enable by default "Simplify boolean expression" inspection