### PR TITLE
MACRO: fix doc comments lowering

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/decl/DeclMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/decl/DeclMacroExpander.kt
@@ -284,7 +284,7 @@ class DeclMacroExpander(val project: Project): MacroExpander<RsDeclMacroData, De
     }
 
     companion object {
-        const val EXPANDER_VERSION = 13
+        const val EXPANDER_VERSION = 14
         private val USELESS_PARENS_EXPRS = tokenSetOf(
             LIT_EXPR, MACRO_EXPR, PATH_EXPR, PAREN_EXPR, TUPLE_EXPR, ARRAY_EXPR, UNIT_EXPR
         )

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
@@ -67,6 +67,6 @@ class ProcMacroExpander(
     }
 
     companion object {
-        const val EXPANDER_VERSION: Int = 0
+        const val EXPANDER_VERSION: Int = 1
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/macros/DocsLoweringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/DocsLoweringTest.kt
@@ -1,0 +1,183 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import junit.framework.ComparisonFailure
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+import org.rust.lang.core.parser.createRustPsiBuilder
+
+class DocsLoweringTest : RsTestBase() {
+    fun `test EOL doc 0 spaces`() = doTest("""
+        ///foo
+    """, """
+        #[doc="foo"]
+    """)
+
+    fun `test EOL doc 1 space`() = doTest("""
+        /// foo
+    """, """
+        #[doc=" foo"]
+    """)
+
+    fun `test EOL doc 2 spaces`() = doTest("""
+        ///  foo
+    """, """
+        #[doc="  foo"]
+    """)
+
+    fun `test 2 EOL comments`() = doTest("""
+        /// foo
+        /// bar
+    """, """
+        #[doc=" foo"]
+        #[doc=" bar"]
+    """)
+
+    fun `test 2 EOL comments with different indent`() = doTest("""
+        /// foo
+            /// bar
+    """, """
+        #[doc=" foo"]
+        #[doc=" bar"]
+    """)
+
+    fun `test empty EOL comment`() = doTest("""
+        ///
+        /// foo
+    """, """
+        #[doc=""]
+        #[doc=" foo"]
+    """)
+
+    fun `test one-line block comment`() = doTest("""
+        /**foo*/
+    """, """
+        #[doc="foo"]
+    """)
+
+    fun `test one-line block comment with space before`() = doTest("""
+        /** foo*/
+    """, """
+        #[doc=" foo"]
+    """)
+
+    fun `test one-line block comment with space before and after`() = doTest("""
+        /** foo */
+    """, """
+        #[doc=" foo "]
+    """)
+
+    fun `test one-line block comment with extra asterisk`() = doTest("""
+        /**foo**/
+    """, """
+        #[doc="foo*"]
+    """)
+
+    fun `test block comment`() = doTest("""
+        /**
+         * foo
+         */
+    """, """
+        #[doc="\n * foo\n "]
+    """)
+
+    fun `test block comment with extra asterisk`() = doTest("""
+        /**
+         * foo
+         **/
+    """, """
+        #[doc="\n * foo\n *"]
+    """)
+
+    fun `test block comment 2 lines`() = doTest("""
+        /**
+         * foo
+         * bar
+         */
+    """, """
+        #[doc="\n * foo\n * bar\n "]
+    """)
+
+    fun `test block comment with docs on the first line`() = doTest("""
+        /** foo
+         *  bar
+         *  baz
+         */
+    """, """
+        #[doc=" foo\n *  bar\n *  baz\n "]
+    """)
+
+    fun `test block comment 2 lines with docs on the last line`() = doTest("""
+        /**
+         * foo
+         * bar */
+    """, """
+        #[doc="\n * foo\n * bar "]
+    """)
+
+    fun `test block comment without infix`() = doTest("""
+        /**
+         foo
+         */
+    """, """
+        #[doc="\n foo\n "]
+    """)
+
+    fun `test quote escaping`() = doTest("""
+        /// "foo"
+    """, """
+        #[doc=" \"foo\""]
+    """)
+
+    fun `test apostrophe escaping`() = doTest("""
+        /// 'foo'
+    """, """
+        #[doc=" \'foo\'"]
+    """)
+
+    fun `test simple emoji is not escaped`() = doTest("""
+        /// ❤
+    """, """
+        #[doc=" ❤"]
+    """)
+
+    // TODO We should find a way to detect Grapheme_Extend characters in Java
+    fun `test character from Grapheme_Extend`() = expect<ComparisonFailure> {
+    doTest("""
+        /// ${0x981.toChar()}
+    """, """
+        #[doc=" \u{981}"]
+    """)
+    }
+
+    fun `test non-printable character`() = doTest("""
+        /// ${1.toChar()}
+    """, """
+        #[doc=" \u{1}"]
+    """)
+
+    fun `test inner EOL doc`() = doTest("""
+        //! foo
+    """, """
+        #![doc=" foo"]
+    """)
+
+    fun `test inner block doc`() = doTest("""
+        /*! foo */
+    """, """
+        #![doc=" foo "]
+    """)
+
+    private fun doTest(
+        @Language("Rust") code: String,
+        @Language("Rust", suffix = "fn foo() {}") expected: String
+    ) {
+        val (expanded, _) = project.createRustPsiBuilder(code.trimIndent()).lowerDocComments()
+            ?: error("No doc comments in the source")
+        assertEquals(expected.trimIndent() + "\n", expanded.toString())
+    }
+}

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsErrorChainMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsErrorChainMacroExpansionTest.kt
@@ -1023,10 +1023,10 @@ class RsErrorChainMacroExpansionTest : RsMacroExpansionTestBase() {
                 &self.0
             }
         }
-        #[doc = r###"The kind of an error."###]
+        #[doc = " The kind of an error."]
         #[derive(Debug)]
         pub enum ErrorKind {
-            #[doc = r###"A convenient variant for String."###]
+            #[doc = " A convenient variant for String."]
             Msg(String),
             #[cfg(unix)]
             Another(other_error::ErrorKind),
@@ -1045,7 +1045,7 @@ class RsErrorChainMacroExpansionTest : RsMacroExpansionTestBase() {
                    -> ::std::fmt::Result
             {
                 match *self {
-                    #[doc = r###"A convenient variant for String."###]
+                    #[doc = " A convenient variant for String."]
                     ErrorKind::Msg(ref s) => {
                         let display_fn = |_, f: &mut ::std::fmt::Formatter| { write!(f, "{}", s) };
 
@@ -1088,7 +1088,7 @@ class RsErrorChainMacroExpansionTest : RsMacroExpansionTestBase() {
             /// A string describing the error kind.
             pub fn description(&self) -> &str {
                 match *self {
-                    #[doc = r###"A convenient variant for String."###]
+                    #[doc = " A convenient variant for String."]
                     ErrorKind::Msg(ref s) => {
                         (&s)
                     }

--- a/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/decl/RsMacroExpansionTest.kt
@@ -1023,7 +1023,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
             fn foo() {}
         }
     """, """
-        #[doc = r###"Some docs"###]
+        #[doc = " Some docs"]
         fn foo() {}
     """ to MacroExpansionMarks.docsLowering)
 
@@ -1038,7 +1038,7 @@ class RsMacroExpansionTest : RsMacroExpansionTestBase() {
             /// Some docs
         }
     """, """
-        #[doc = r###"Some docs"###]
+        #[doc = " Some docs"]
         fn foo() {}
     """ to MacroExpansionMarks.docsLowering)
 

--- a/src/test/kotlin/org/rust/lang/doc/RsDocRemoveDecorationTest.kt
+++ b/src/test/kotlin/org/rust/lang/doc/RsDocRemoveDecorationTest.kt
@@ -21,15 +21,15 @@ class RsDocRemoveDecorationTest(
 ) {
     @Test
     fun test() {
-        val commentNorm = StringUtil.convertLineSeparators(comment).trim()
-        val contentNorm = StringUtil.convertLineSeparators(content).trim()
+        val commentNorm = StringUtil.convertLineSeparators(comment)
+        val contentNorm = StringUtil.convertLineSeparators(content)
 
         assertEquals(contentNorm,
             kind.removeDecoration(commentNorm.splitToSequence('\n')).joinToString("\n").trim())
     }
 
     companion object {
-        @Parameterized.Parameters(name = "{index}: \"{0}\" → \"{1}\"")
+        @Parameterized.Parameters(name = "{index}: {0} \"{1}\" → \"{2}\"")
         @JvmStatic fun data(): Collection<Array<Any>> = listOf(
             arrayOf(InnerEol, "//! foo", "foo"),
             arrayOf(OuterEol, "/// foo", "foo"),
@@ -140,7 +140,16 @@ code {
                    |*/""".trimMargin(),
                 "foo\nbar * bar"),
 
-            arrayOf(Attr, "foo\nbar", "foo\nbar")
+            arrayOf(Attr, "foo\nbar", "foo\nbar"),
+            arrayOf(Attr, " *foo1", "*foo1"),
+            arrayOf(Attr, "\n * foo2\n", "foo2"),
+            arrayOf(Attr, "\n * foo3\n * foo4\n ", "foo3\nfoo4"),
+            arrayOf(Attr, "\n  * foo5\n  * foo6\n  ", "foo5\nfoo6"),
+            arrayOf(Attr, "\n   * foo7\n * foo8\n ", "* foo7\n* foo8"),
+            arrayOf(Attr, "\n  * foo9\n \n  *\n  *", "* foo9\n\n*\n*"),
+            arrayOf(Attr, "\n  * foo10\na\n  *\n  *", "* foo10\na\n*\n*"),
+            arrayOf(Attr, "\n \n foo11\n", "foo11"),
+            arrayOf(Attr, "\n foo12\n ", "foo12"),
         )
     }
 }

--- a/src/test/kotlin/org/rust/lang/utils/RsEscapesUtilsTest.kt
+++ b/src/test/kotlin/org/rust/lang/utils/RsEscapesUtilsTest.kt
@@ -107,3 +107,31 @@ class UnescapeRsWithOffsetsTest(
         )
     }
 }
+
+@RunWith(Parameterized::class)
+class EscapeRsTest(
+    private val input: String,
+    private val expected: String,
+    private val escapeNonPrintable: Boolean,
+) {
+    @Test
+    fun test() = assertEquals(expected, input.escapeRust(escapeNonPrintable))
+
+    companion object {
+        private const val STX = 2.toChar().toString()
+
+        @Parameters(name = "{index}: \"{0}\" → \"{1}\" P:{2}")
+        @JvmStatic fun data(): Collection<Array<Any>> = listOf(
+            arrayOf("aaa", "aaa", true),
+            arrayOf("aaa", "aaa", false),
+            arrayOf("\"", "\\\"", true),
+            arrayOf("\'", "\\\'", true),
+            arrayOf("\n", "\\n", true),
+            arrayOf("\r", "\\r", true),
+            arrayOf("\t", "\\t", true),
+            arrayOf("\u0000", "\\0", true),
+            arrayOf(STX, "\\u{2}", true),
+            arrayOf(STX, STX, false),
+        )
+    }
+}


### PR DESCRIPTION
Rustc replaces doc comments like `/// foo` to attributes `#[doc = "foo"]` before macro expansion. We did it a bit wrongly, but it was not a problem because we were able to generate quick docs from them ourselves. But recently we started to support proc macros, and proc macros can see these lowered docs. This sometimes leads to expansion failures because a proc macro can expect some specific lowering. Now we lower docs correctly, I hope.

Also, I tweaked docs undecoraing so that it understands such lowering.

This should not appear in changelog if it merged into the same release as proc macro.