### PR TITLE
GRD: exclude kotlin-stdlib-common jar from the plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -319,6 +319,7 @@ project(":") {
         implementation("org.jetbrains:markdown:0.2.0") {
             exclude(module = "kotlin-runtime")
             exclude(module = "kotlin-stdlib")
+            exclude(module = "kotlin-stdlib-common")
         }
         testImplementation(project(":common", "testOutput"))
         testImplementation("com.squareup.okhttp3:mockwebserver:4.9.0")


### PR DESCRIPTION
It was included into plugin archive by accident in #6847.
Note, we shouldn't include kotlin stdlib jar files into the plugin because the platform already contains all necessary kotlin runtime and own kotlin stdlib libs can conflict with platform ones

bors r+