### PR TITLE
Reduce availability range of some intentions

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/AddElseIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddElseIntention.kt
@@ -11,6 +11,8 @@ import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.RsIfExpr
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.ancestorStrict
+import org.rust.lang.core.psi.ext.endOffset
+import org.rust.lang.core.psi.ext.startOffset
 
 class AddElseIntention : RsElementBaseIntentionAction<RsIfExpr>() {
     override fun getText() = "Add else branch to this if statement"
@@ -18,7 +20,10 @@ class AddElseIntention : RsElementBaseIntentionAction<RsIfExpr>() {
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsIfExpr? {
         val ifExpr = element.ancestorStrict<RsIfExpr>() ?: return null
-        return if (ifExpr.elseBranch == null) ifExpr else null
+        if (ifExpr.elseBranch != null) return null
+        val block = ifExpr.block ?: return null
+        if (element.startOffset >= block.lbrace.endOffset && element != block.rbrace) return null
+        return ifExpr
     }
 
     override fun invoke(project: Project, editor: Editor, ctx: RsIfExpr) {

--- a/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntention.kt
@@ -14,14 +14,18 @@ import org.rust.lang.core.psi.RsModItem
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.ancestorOrSelf
 import org.rust.lang.core.psi.ext.getOrCreateModuleFile
+import org.rust.lang.core.psi.ext.isAncestorOf
 
 //TODO: make context more precise here
 class ExtractInlineModuleIntention : RsElementBaseIntentionAction<RsModItem>() {
     override fun getFamilyName() = "Extract inline module structure"
     override fun getText() = "Extract inline module"
 
-    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsModItem? =
-        element.ancestorOrSelf()
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsModItem? {
+        val mod = element.ancestorOrSelf<RsModItem>() ?: return null
+        if (element != mod.mod && element != mod.identifier && mod.vis?.isAncestorOf(element) != true) return null
+        return mod
+    }
 
     override fun invoke(project: Project, editor: Editor, ctx: RsModItem) {
         val modName = ctx.name ?: return

--- a/src/main/kotlin/org/rust/ide/intentions/FlipBinaryExpressionIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/FlipBinaryExpressionIntention.kt
@@ -22,6 +22,7 @@ class FlipBinaryExpressionIntention : RsElementBaseIntentionAction<RsBinaryExpr>
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsBinaryExpr? {
         val binaryExpr = element.ancestorStrict<RsBinaryExpr>() ?: return null
+        if (element.parent != binaryExpr.binaryOp) return null
         if (binaryExpr.right == null) return null
         val op = binaryExpr.operator
         val opText = op.text

--- a/src/main/kotlin/org/rust/ide/intentions/IfLetToMatchIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/IfLetToMatchIntention.kt
@@ -35,6 +35,13 @@ class IfLetToMatchIntention : RsElementBaseIntentionAction<IfLetToMatchIntention
         //1) Check that we have an if statement
         var ifStatement = element.ancestorStrict<RsIfExpr>() ?: return null
 
+        // if let Some(value) = x {}
+        // ~~~~~~             ~
+        // ^ available here   ^ and here
+        if (element != ifStatement.`if`
+            && element != ifStatement.condition?.let
+            && element != ifStatement.condition?.eq) return null
+
         // We go up in the tree to detect cases like `... else if let Some(value) = x { ... }`
         // and select the correct if statement
 

--- a/src/main/kotlin/org/rust/ide/intentions/InvertIfIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/InvertIfIntention.kt
@@ -23,6 +23,7 @@ class InvertIfIntention : RsElementBaseIntentionAction<InvertIfIntention.Context
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
         val ifExpr = element.ancestorStrict<RsIfExpr>() ?: return null
+        if (element != ifExpr.`if`) return null
         val condition = getSuitableCondition(ifExpr) ?: return null
         val thenBlock = ifExpr.block ?: return null
         val elseBlock = ifExpr.elseBranch?.block ?: return null

--- a/src/main/kotlin/org/rust/ide/intentions/MatchToIfLetIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/MatchToIfLetIntention.kt
@@ -25,6 +25,7 @@ class MatchToIfLetIntention : RsElementBaseIntentionAction<MatchToIfLetIntention
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
         val matchExpr = element.ancestorStrict<RsMatchExpr>() ?: return null
+        if (element != matchExpr.match) return null
         val matchTarget = matchExpr.expr ?: return null
         val matchBody = matchExpr.matchBody ?: return null
         val matchArmList = matchBody.matchArmList

--- a/src/main/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentions.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentions.kt
@@ -16,14 +16,18 @@ import org.rust.ide.actions.macroExpansion.expandMacroForViewWithProgress
 import org.rust.ide.actions.macroExpansion.showMacroExpansionPopup
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.ext.ancestorOrSelf
+import org.rust.lang.core.psi.ext.isAncestorOf
 
 abstract class RsShowMacroExpansionIntentionBase(private val expandRecursively: Boolean) :
     RsElementBaseIntentionAction<RsMacroCall>() {
 
     override fun getFamilyName() = text
 
-    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsMacroCall? =
-        element.ancestorOrSelf()
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): RsMacroCall? {
+        val macroCall = element.ancestorOrSelf<RsMacroCall>() ?: return null
+        if (!macroCall.path.isAncestorOf(element) && element != macroCall.excl) return null
+        return macroCall
+    }
 
     override fun invoke(project: Project, editor: Editor, ctx: RsMacroCall) {
         val expansionDetails = expandMacroForViewWithProgress(project, ctx, expandRecursively)

--- a/src/main/kotlin/org/rust/ide/intentions/SplitIfIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/SplitIfIntention.kt
@@ -29,7 +29,7 @@ class SplitIfIntention : RsElementBaseIntentionAction<SplitIfIntention.Context>(
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
         val binExpr = element.ancestorStrict<RsBinaryExpr>() ?: return null
         if (binExpr.operatorType !is LogicOp) return null
-
+        if (element.parent != binExpr.binaryOp) return null
         val condition = binExpr.findCondition() ?: return null
         return Context(binExpr.binaryOp, condition)
     }

--- a/src/test/kotlin/org/rust/ide/intentions/AddCurlyBracesIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddCurlyBracesIntentionTest.kt
@@ -50,4 +50,8 @@ class AddCurlyBracesIntentionTest : RsIntentionTestBase(AddCurlyBracesIntention:
         "use std::/*caret*/;",
         "use std::{/*caret*/};"
     )
+
+    fun `test not available if already has braces`() = doUnavailableTest("""
+        use foo::{bar/*caret*/};
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/AddDeriveIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddDeriveIntentionTest.kt
@@ -6,22 +6,36 @@
 package org.rust.ide.intentions
 
 class AddDeriveIntentionTest : RsIntentionTestBase(AddDeriveIntention::class) {
+    fun `test availability range in struct`() = checkAvailableInSelectionOnly("""
+        <selection>struct Test {
+            field: i32
+        }</selection>
+    """)
+
+    fun `test availability range in tuple struct`() = checkAvailableInSelectionOnly("""
+        <selection>struct Test (i32);</selection>
+    """)
+
+    fun `test availability range in enum`() = checkAvailableInSelectionOnly("""
+        <selection>enum Test {
+            Something
+        }</selection>
+    """)
 
     fun `test add derive struct`() = doAvailableTest("""
-        struct Te/*caret*/st {}
+        struct Test/*caret*/ {}
     """, """
         #[derive(/*caret*/)]
         struct Test {}
     """)
 
     fun `test add derive pub struct`() = doAvailableTest("""
-        pub struct Te/*caret*/st {}
+        pub struct Test/*caret*/ {}
     """, """
         #[derive(/*caret*/)]
         pub struct Test {}
     """)
 
-    // FIXME: there is something weird with enum re-formatting, for some reason it adds more indentation
     fun `test add derive enum`() = doAvailableTest("""
         enum Test /*caret*/{
             Something

--- a/src/test/kotlin/org/rust/ide/intentions/AddElseIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddElseIntentionTest.kt
@@ -6,10 +6,23 @@
 package org.rust.ide.intentions
 
 class AddElseIntentionTest : RsIntentionTestBase(AddElseIntention::class) {
+    fun `test availability range`() = checkAvailableInSelectionOnly("""
+        fn main() {
+            <selection>if false {</selection>
 
-    fun test1() = doUnavailableTest("""
+            <selection>}</selection>
+        }
+    """)
+
+    fun `test unavailable without if expression`() = doUnavailableTest("""
         fn main() {
             42/*caret*/;
+        }
+    """)
+
+    fun `test unavailable in incomplete if expression`() = doUnavailableTest("""
+        fn main() {
+            if 1 == 2/*caret*/;
         }
     """)
 
@@ -25,8 +38,8 @@ class AddElseIntentionTest : RsIntentionTestBase(AddElseIntention::class) {
 
     fun `test simple`() = doAvailableTest("""
         fn foo(a: i32, b: i32) {
-            if a == b {
-                println!("Equally");/*caret*/
+            if a == b {/*caret*/
+                println!("Equally");
             }
         }
     """, """
@@ -82,16 +95,16 @@ class AddElseIntentionTest : RsIntentionTestBase(AddElseIntention::class) {
             if true {
                 if true {
                     42
-                }
-            } else {/*caret*/}
+                } else {/*caret*/}
+            }
         }
     """)
 
     fun `test reformat`() = doAvailableTest("""
         fn main() {
             if true {
-            /*caret*/
-            }
+
+            }/*caret*/
         }
     """, """
         fn main() {

--- a/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ExtractInlineModuleIntentionTest.kt
@@ -6,11 +6,17 @@
 package org.rust.ide.intentions
 
 import org.rust.FileTree
-import org.rust.RsTestBase
 import org.rust.fileTree
 
-class ExtractInlineModuleIntentionTest : RsTestBase() {
+class ExtractInlineModuleIntentionTest : RsIntentionTestBase(ExtractInlineModuleIntention::class) {
     override val dataPath = "org/rust/ide/intentions/fixtures/"
+
+    fun `test availability range`() = checkAvailableInSelectionOnly("""
+        #[attr]
+        <selection>pub mod foo</selection> {
+            fn bar() {}
+        }
+    """)
 
     fun `test valid extract inline module`() = doTest(
         fileTree {

--- a/src/test/kotlin/org/rust/ide/intentions/FlipBinaryExpressionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/FlipBinaryExpressionIntentionTest.kt
@@ -8,6 +8,11 @@ package org.rust.ide.intentions
 import org.rust.lang.core.psi.RsElementTypes.*
 
 class FlipBinaryExpressionIntentionTest : RsIntentionTestBase(FlipBinaryExpressionIntention::class) {
+    fun `test availability range`() = checkAvailableInSelectionOnly("""
+        fn test(x: i32, y: i32) {
+            x <selection><</selection> y;
+        }
+    """)
 
     fun `test all available operators`() {
         val operators = FlipBinaryExpressionIntention.COMMUNICATIVE_OPERATORS +

--- a/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/IfLetToMatchIntentionTest.kt
@@ -10,10 +10,19 @@ import org.rust.WithStdlibRustProjectDescriptor
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::class) {
+    fun `test availability range`() = checkAvailableInSelectionOnly("""
+        fn foo() {
+            let x = Some(42);
+            <selection>if let</selection> Some(value) <selection>=</selection> x {
+                println!("some")
+            }
+        }
+    """)
+
     fun `test option with some`() = doAvailableTest("""
         fn main() {
             let x = Some(42);
-            if let Some(value) = x {/*caret*/
+            /*caret*/if let Some(value) = x {
                 println!("some")
             }
         }
@@ -32,7 +41,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test option with refutable some`() = doAvailableTest("""
         fn main() {
             let x = Some(42);
-            if let Some(42) = x {/*caret*/
+            /*caret*/if let Some(42) = x {
                 println!("some")
             }
         }
@@ -51,7 +60,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test option with wild some`() = doAvailableTest("""
         fn main() {
             let x = Some(42);
-            if let Some(_) = x {/*caret*/
+            /*caret*/if let Some(_) = x {
                 println!("some")
             }
         }
@@ -70,7 +79,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test option with range`() = doAvailableTest("""
         fn main() {
             let x = Some(42);
-            if let Some(1..=5) = x {/*caret*/
+            /*caret*/if let Some(1..=5) = x {
                 println!("some")
             }
         }
@@ -89,7 +98,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test option with none`() = doAvailableTest("""
         fn main() {
             let x = Some(42);
-            if let None = x {/*caret*/
+            /*caret*/if let None = x {
                 println!("none")
             }
         }
@@ -108,7 +117,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test option with unnecessary parentheses around pattern`() = doAvailableTest("""
         fn main() {
             let x = Some(42);
-            if let (((None))) = x {/*caret*/
+            /*caret*/if let (((None))) = x {
                 println!("none")
             }
         }
@@ -127,7 +136,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test option full 1`() = doAvailableTest("""
         fn main() {
             let x = Some(42);
-            if let Some(value) = x {/*caret*/
+            /*caret*/if let Some(value) = x {
                 println!("some")
             } else {
                 println!("none")
@@ -150,7 +159,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test option full 2`() = doAvailableTest("""
         fn main() {
             let x = Some(42);
-            if let None = x {/*caret*/
+            /*caret*/if let None = x {
                 println!("none")
             } else {
                 println!("some")
@@ -173,7 +182,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test option full with unnecessary parentheses around pattern`() = doAvailableTest("""
         fn main() {
             let x = Some(42);
-            if let ((((None)))) = x {/*caret*/
+            /*caret*/if let ((((None)))) = x {
                 println!("none")
             } else if let Some(a) = x {
                 println!("some")
@@ -196,7 +205,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test result with ok`() = doAvailableTest("""
         fn main() {
             let x: Result<i32, i32> = Ok(42);
-            if let Ok(value) = x {/*caret*/
+            /*caret*/if let Ok(value) = x {
                 println!("ok")
             }
         }
@@ -215,7 +224,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test result with err`() = doAvailableTest("""
         fn main() {
             let x: Result<i32, i32> = Err(42);
-            if let Err(e) = x {/*caret*/
+            /*caret*/if let Err(e) = x {
                 println!("err")
             }
         }
@@ -234,7 +243,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test result full 1`() = doAvailableTest("""
         fn main() {
             let x: Result<i32, i32> = Ok(42);
-            if let Ok(value) = x {/*caret*/
+            /*caret*/if let Ok(value) = x {
                 println!("ok")
             } else {
                 println!("err")
@@ -257,7 +266,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test result full 2`() = doAvailableTest("""
         fn main() {
             let x: Result<i32, i32> = Ok(42);
-            if let Err(e) = x {/*caret*/
+            /*caret*/if let Err(e) = x {
                 println!("err")
             } else {
                 println!("ok")
@@ -280,9 +289,9 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test simple else`() = doAvailableTest("""
         fn main() {
             let x = Some(42);
-            if let Some(val) = x {
+            /*caret*/if let Some(val) = x {
 
-            } else {/*caret*/
+            } else {
                 println!("it work")
             }
         }
@@ -302,8 +311,8 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
         fn main() {
             if let A(value) = x {
 
-            } else if let B(value) = x {
-                /*caret*/
+            } else /*caret*/if let B(value) = x {
+
             }
         }
     """, """
@@ -319,10 +328,10 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test full option else if`() = doAvailableTest("""
         fn main() {
             let x = Some(42);
-            if let Some(value) = x {
+            /*caret*/if let Some(value) = x {
                 println!("some")
             } else if let None = x {
-                /*caret*/println!("none")
+                println!("none")
             }
         }
     """, """
@@ -342,10 +351,10 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test full result else if`() = doAvailableTest("""
         fn main() {
             let x: Result<i32, i32> = Ok(42);
-            if let Ok(value) = x {
+            /*caret*/if let Ok(value) = x {
                 println!("ok")
             } else if let Err(e) = x {
-                /*caret*/println!("err")
+                println!("err")
             }
         }
     """, """
@@ -364,8 +373,8 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
 
     fun `test else if else`() = doAvailableTest("""
         fn main() {
-            if let A(value) = x {
-                /*caret*/
+            /*caret*/if let A(value) = x {
+
             } else if let B(value) = x {
 
             } else {
@@ -384,10 +393,10 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
 
     fun `test trackback if`() = doAvailableTest("""
         fn main() {
-            if let A(value) = x {
+            /*caret*/if let A(value) = x {
 
             } else if let B(value) = x {
-                /*caret*/
+
             } else {
 
             }
@@ -404,10 +413,10 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
 
     fun `test apply on same target`() = doUnavailableTest("""
         fn main() {
-            if let A(value) = x {
+            /*caret*/if let A(value) = x {
 
             } else if let B(value) = y {
-                /*caret*/
+
             }
         }
     """)
@@ -415,7 +424,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test available with range`() = doAvailableTest("""
         fn main() {
             let e = 4;
-            if let 1..=5 = e {/*caret*/
+            /*caret*/if let 1..=5 = e {
                 println!("got {}", e)
             };
         }
@@ -434,7 +443,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test available with const`() = doAvailableTest("""
         fn main() {
             let e = 4;
-            if let 4 = e {/*caret*/
+            /*caret*/if let 4 = e {
                 println!("got {}", e)
             };
         }
@@ -457,7 +466,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
         }
         fn main() {
             let point = Point { x: false, y: true };
-            if let Point { x: true, .. } = point {/*caret*/
+            /*caret*/if let Point { x: true, .. } = point {
                 println!("42")
             }
         }
@@ -484,7 +493,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
         }
         fn main() {
             let point = Point { x: false, y: true };
-            if let Point { x: true, y: f } = point {/*caret*/
+            /*caret*/if let Point { x: true, y: f } = point {
                 println!("42")
             }
         }
@@ -507,7 +516,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test available pattern with tup`() = doAvailableTest("""
         fn main() {
             let e = Some(32);
-            if let (Some(42)) = e {/*caret*/
+            /*caret*/if let (Some(42)) = e {
                 println!("got {:?}", a)
             }
         }
@@ -526,7 +535,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test available pattern with tup 2`() = doAvailableTest("""
         fn main() {
             let e = (42, 50);
-            if let (a, 50) = e {/*caret*/
+            /*caret*/if let (a, 50) = e {
                 println!("got {:?}", a)
             }
         }
@@ -545,7 +554,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test available with slice`() = doAvailableTest("""
         fn main() {
             let x = [1, 2];
-            if let [1, ..] = x {/*caret*/
+            /*caret*/if let [1, ..] = x {
                 println!("42")
             }
         }
@@ -564,7 +573,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test available with box`() = doAvailableTest("""
         fn main() {
             let x = box 42;
-            if let box 42 = x {/*caret*/
+            /*caret*/if let box 42 = x {
                 println!("42")
             }
         }
@@ -583,7 +592,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test available with ref`() = doAvailableTest("""
         fn main() {
             let x = &42;
-            if let &42 = x {/*caret*/
+            /*caret*/if let &42 = x {
                 println!("42")
             }
         }
@@ -602,7 +611,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test multiple if let pattern`() = doAvailableTest("""
         enum V { V1(i32), V2(i32), V3 }
         fn foo(v: V) {
-            if let V1(x) | V2(x) = v/*caret*/ {
+            /*caret*/if let V1(x) | V2(x) = v {
                 println!("{}", x);
             }
         }
@@ -621,7 +630,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test multiple if let pattern with leading |`() = doAvailableTest("""
         enum V { V1(i32), V2(i32), V3 }
         fn foo(v: V) {
-            if let | V1(x) | V2(x) = v/*caret*/ {
+            /*caret*/if let | V1(x) | V2(x) = v {
                 println!("{}", x);
             }
         }
@@ -641,7 +650,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
         struct Id(u32);
         struct S { a: Id, b: u32 }
         fn foo(s: S) {
-            if let S { a: Id(ref name), .. } = s/*caret*/ {
+            /*caret*/if let S { a: Id(ref name), .. } = s {
                 let _x = name;
             }
         }
@@ -661,7 +670,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
         struct Id(u32);
         struct S { a: Id, b: u32 }
         fn foo(s: S) {
-            if let S { a: Id(ref name), .. } = s/*caret*/ {
+            /*caret*/if let S { a: Id(ref name), .. } = s {
                 let _x = name;
             }
             else {
@@ -686,7 +695,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test irrefutable single variant enum`() = doAvailableTest("""
         enum V { V1 }
         fn foo(v: V) {
-            if let V::V1 = v/*caret*/ {
+            /*caret*/if let V::V1 = v {
                 println!("hello");
             }
         }
@@ -704,7 +713,7 @@ class IfLetToMatchIntentionTest : RsIntentionTestBase(IfLetToMatchIntention::cla
     fun `test irrefutable struct`() = doAvailableTest("""
         struct S;
         fn foo(s: S) {
-            if let S = s/*caret*/ {
+            /*caret*/if let S = s {
                 println!("hello");
             }
         }

--- a/src/test/kotlin/org/rust/ide/intentions/InvertIfIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/InvertIfIntentionTest.kt
@@ -30,6 +30,12 @@ class InvertIfIntentionTest : RsIntentionTestBase(InvertIfIntention::class) {
         }
     """)
 
+    fun `test availability range`() = checkAvailableInSelectionOnly("""
+        fn foo() {
+            <selection>if</selection> 2 == 2 { Ok(()) } else { Err(()) }
+        }
+    """)
+
     fun `test simple inversion`() = doAvailableTest("""
         fn foo() {
             if/*caret*/ 2 == 2 { Ok(()) } else { Err(()) }

--- a/src/test/kotlin/org/rust/ide/intentions/MatchToIfLetIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/MatchToIfLetIntentionTest.kt
@@ -10,6 +10,21 @@ import org.rust.WithStdlibRustProjectDescriptor
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::class) {
+    fun `test availability range`() = checkAvailableInSelectionOnly("""
+        enum MyOption { Some(x) }
+
+        fn main() {
+            let color = MyOption::Some(52);
+
+            <selection>match</selection> color {
+                MyOption::Some(42) => {
+                    let a = x + 1;
+                }
+                _ => {}
+            }
+        }
+    """)
+
     fun `test unavailable all void arms`() = doUnavailableTest("""
         enum MyOption {
             Nothing,
@@ -19,8 +34,8 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
         fn main() {
             let a = MyOption::Some(52);
 
-            match a {
-                MyOption::Some(x) => {}/*caret*/
+            /*caret*/match a {
+                MyOption::Some(x) => {}
                 Nothing => {}
             }
         }
@@ -51,7 +66,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
         fn main() {
             let color = OptionColor::Color(255, 255, 255);
 
-            match color {/*caret*/
+            /*caret*/match color {
                 OptionColor::Color(_, _, _) => {}
                 _ => {print!("No color")}
             };
@@ -77,12 +92,12 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
         fn main() {
             let color = MyOption::Some(52);
 
-            match color {
+            /*caret*/match color {
                 MyOption::Some(42) => {
                     let a = x + 1;
                     let b = x + 2;
                     let c = a + b;
-                }/*caret*/
+                }
                 _ => {}
             }
         }
@@ -111,7 +126,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
         fn main() {
             let color = OptionColor::Color(255, 255, 255);
 
-            match color {/*caret*/
+            /*caret*/match color {
                 OptionColor::Color(255, 255, 255) => print!("White"),
                 OptionColor::Color(_,   _,   _  ) => {}
                 OptionColor::NoColor => {}
@@ -135,7 +150,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test simple with range`() = doAvailableTest("""
         fn main() {
             let e = 4;
-            match e {/*caret*/
+            /*caret*/match e {
                 1..=5 => println!("got {}", e),
                 _ => {}
             };
@@ -152,7 +167,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test simple with const`() = doAvailableTest("""
         fn main() {
             let e = 4;
-            match e {/*caret*/
+            /*caret*/match e {
                 4 => println!("got {}", e),
                 _ => {}
             };
@@ -174,7 +189,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
 
         fn main() {
             let point = Point { x: false, y: true };
-            match point {/*caret*/
+            /*caret*/match point {
                 Point { x: true, .. } => println!("42"),
                 _ => {}
             }
@@ -201,7 +216,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
 
         fn main() {
             let point = Point { x: false, y: true };
-            match point {/*caret*/
+            /*caret*/match point {
                 Point { x: true, y: f } => println!("42"),
                 _ => {}
             }
@@ -228,7 +243,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
 
         fn main() {
             let point = Point { x: false, y: true };
-            match point {/*caret*/
+            /*caret*/match point {
                 Point { x, .. } => println!("42"),
                 _ => {}
             }
@@ -250,7 +265,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test irrefutable pattern with ident`() = doAvailableTest("""
         fn main() {
             let e = Some(32);
-            match e {/*caret*/
+            /*caret*/match e {
                 a => println!("got {}", a.unwrap()),
                 _ => ()
             }
@@ -267,7 +282,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test irrefutable pattern with tup`() = doAvailableTest("""
         fn main() {
             let e = Some(32);
-            match e {/*caret*/
+            /*caret*/match e {
                 (a) => println!("got {:?}", a),
                 _ => ()
             }
@@ -284,7 +299,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test available pattern with tup`() = doAvailableTest("""
         fn main() {
             let e = Some(32);
-            match e {/*caret*/
+            /*caret*/match e {
                 (Some(42)) => println!("got {:?}", a),
                 _ => ()
             }
@@ -301,7 +316,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test available pattern with tup 2`() = doAvailableTest("""
         fn main() {
             let e = (42, 50);
-            match e {/*caret*/
+            /*caret*/match e {
                 (a, 50) => println!("got {:?}", a),
                 _ => ()
             }
@@ -318,7 +333,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test unavailable pattern with guard`() = doUnavailableTest("""
         fn main() {
             let e = 42;
-            match e {/*caret*/
+            /*caret*/match e {
                 a if a < 6 => println!("got {}", a),
                 _ => ()
             }
@@ -328,7 +343,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test unavailable pattern with attr`() = doUnavailableTest("""
         fn main() {
             let e = Some(42);
-            match e {/*caret*/
+            /*caret*/match e {
                 #[cold] Some(a) => println!("got {}", a),
                 _ => ()
             }
@@ -338,7 +353,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test available with slice`() = doAvailableTest("""
         fn main() {
             let x = [1, 2];
-            match x {/*caret*/
+            /*caret*/match x {
                 [f] => println!("42"),
                 _ => {}
             }
@@ -355,7 +370,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test irrefutable pattern with slice 1`() = doAvailableTest("""
         fn main() {
             let x = [1, 2];
-            match x {/*caret*/
+            /*caret*/match x {
                 [..] => println!("42"),
                 _ => {}
             }
@@ -372,7 +387,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test irrefutable pattern with slice 2`() = doAvailableTest("""
         fn main() {
             let x = [1, 2];
-            match x {/*caret*/
+            /*caret*/match x {
                 [f @ ..] => println!("42"),
                 _ => {}
             }
@@ -389,7 +404,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test available with box`() = doAvailableTest("""
         fn main() {
             let x = box 42;
-            match x {/*caret*/
+            /*caret*/match x {
                 box 42 => println!("42"),
                 _ => {}
             }
@@ -406,7 +421,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test irrefutable pattern with box`() = doAvailableTest("""
         fn main() {
             let x = box 42;
-            match x {/*caret*/
+            /*caret*/match x {
                 box a => println!("42"),
                 _ => {}
             }
@@ -423,7 +438,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test available with ref`() = doAvailableTest("""
         fn main() {
             let x = &42;
-            match x {/*caret*/
+            /*caret*/match x {
                 &42 => println!("42"),
                 _ => {}
             }
@@ -440,7 +455,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test irrefutable pattern with ref`() = doAvailableTest("""
         fn main() {
             let x = &42;
-            match x {/*caret*/
+            /*caret*/match x {
                 &a => println!("42"),
                 _ => {}
             }
@@ -457,7 +472,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test available with some`() = doAvailableTest("""
         fn main() {
             let x = Some(42);
-            match x {/*caret*/
+            /*caret*/match x {
                 Some(a) => println!("42"),
                 _ => {}
             }
@@ -474,7 +489,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test available with none`() = doAvailableTest("""
         fn main() {
             let x = Some(42);
-            match x {/*caret*/
+            /*caret*/match x {
                 None => println!("42"),
                 _ => {}
             }
@@ -491,7 +506,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test available with ok`() = doAvailableTest("""
         fn main() {
             let x: Result<i32, i32> = Ok(42);
-            match x {/*caret*/
+            /*caret*/match x {
                 Ok(a) => println!("42"),
                 _ => {}
             }
@@ -508,7 +523,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test available with err`() = doAvailableTest("""
         fn main() {
             let x: Result<i32, i32> = Ok(42);
-            match x {/*caret*/
+            /*caret*/match x {
                 Err(e) => println!("42"),
                 _ => {}
             }
@@ -525,7 +540,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test available with unnecessary parentheses around pattern`() = doAvailableTest("""
         fn main() {
             let x: Result<i32, i32> = Ok(42);
-            match x {/*caret*/
+            /*caret*/match x {
                 (((Err(e)))) => println!("42"),
                 _ => {}
             }
@@ -542,7 +557,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test multiple if let pattern`() = doAvailableTest("""
         enum V { V1(i32), V2(i32), V3 }
         fn foo(v: V) {
-            match v {/*caret*/
+            /*caret*/match v {
                 V1(x) | V2(x) => {
                     println!("{}", x);
                 }
@@ -561,7 +576,7 @@ class MatchToIfLetIntentionTest : RsIntentionTestBase(MatchToIfLetIntention::cla
     fun `test multiple if let pattern with leading |`() = doAvailableTest("""
         enum V { V1(i32), V2(i32), V3 }
         fn foo(v: V) {
-            match v {/*caret*/
+            /*caret*/match v {
                 | V1(x) | V2(x) => {
                     println!("{}", x);
                 }

--- a/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
@@ -7,6 +7,7 @@ package org.rust.ide.intentions
 
 import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.codeInsight.intention.IntentionActionDelegate
+import com.intellij.codeInsight.intention.IntentionManager
 import com.intellij.openapi.util.TextRange
 import com.intellij.openapiext.Testmark
 import com.intellij.util.ui.UIUtil
@@ -16,7 +17,6 @@ import org.rust.fileTreeFromText
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.reflect.KClass
-import kotlin.reflect.full.createInstance
 import kotlin.reflect.full.isSubclassOf
 
 abstract class RsIntentionTestBase(private val intentionClass: KClass<out IntentionAction>) : RsTestBase() {
@@ -93,7 +93,9 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
             model.blockSelectionStarts.zip(model.blockSelectionEnds)
                 .map { TextRange(it.first, it.second + 1) }
         }
-        val intention = intentionClass.createInstance()
+        val intention = IntentionManager.getInstance().intentionActions.find {
+            IntentionActionDelegate.unwrap(it).javaClass == intentionClass.java
+        } ?: error("Intention action with class $intentionClass is not registered")
         for (pos in myFixture.file.text.indices) {
             myFixture.editor.caretModel.moveToOffset(pos)
             val expectAvailable = selections.any { it.contains(pos) }

--- a/src/test/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentionBaseTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsShowMacroExpansionIntentionBaseTest.kt
@@ -22,6 +22,12 @@ class RsShowMacroExpansionIntentionBaseTest : RsIntentionTestBase(RsShowMacroExp
         super.tearDown()
     }
 
+    fun `test availability range`() = checkAvailableInSelectionOnly("""
+        <selection>foo!</selection> {
+            bar baz
+        }
+    """)
+
     fun `test that intention is not available outside of the macros`() = doUnavailableTest("""
         foo!();
         /*caret*/foo();

--- a/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SpecifyTypeExplicitlyIntentionTest.kt
@@ -9,6 +9,19 @@ import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 
 class SpecifyTypeExplicitlyIntentionTest : RsIntentionTestBase(SpecifyTypeExplicitlyIntention::class) {
+    fun `test availability range 1`() = checkAvailableInSelectionOnly("""
+        fn foo() {
+            <selection>let mut a;</selection>
+            a = 1;
+        }
+    """)
+
+    fun `test availability range 2`() = checkAvailableInSelectionOnly("""
+        fn foo() {
+            <selection>let a =</selection> 1;
+        }
+    """)
+
     fun `test inferred type`() = doAvailableTest(
         """ fn main() { let var/*caret*/ = 42; } """,
         """ fn main() { let var: i32 = 42; } """

--- a/src/test/kotlin/org/rust/ide/intentions/SplitIfIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/SplitIfIntentionTest.kt
@@ -19,6 +19,13 @@ class SplitIfIntentionTest : RsIntentionTestBase(SplitIfIntention::class) {
         }
     """)
 
+    fun `test availability range`() = checkAvailableInSelectionOnly("""
+        fn foo() {
+            if true <selection>&&</selection> false {}
+            if true <selection>&&</selection> false <selection>&&</selection> true {}
+        }
+    """)
+
     fun `test simple &&`() = doAvailableTest("""
         fn main() {
             if true &/*caret*/& false {


### PR DESCRIPTION
Reduce availability range of some intentions:
- `AddElseIntention` now is not available inside `if` body
- `InvertIfIntention` is now available only in `if` keyword
- `IfLetToMatchIntention` is now available only in `if let` keywords and `=` token
- `MatchToIfLetIntention` is now available only in `match` keyword
- `SplitIfIntention` is now available only in a binary operator (like `&&`)
- `FlipBinaryExpressionIntention` is now available only in a binary operator (like `&&`)
- `ExtractInlineModuleIntention` is now available only in `mod` keyword, a module name and its visibility (not available in a module body or its attributes)
- `RsShowMacroExpansionIntentionBase` is now available only in a macro call path and `!` token


changelog: Reduce availability range of some intention actions. For example, now "Add else branch to this if statement" should not be suggested in `Alt` + `Enter` menu when the caret is placed inside an `if` body