### PR TITLE
GRD: use 211 as default platform for development

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 propertiesPluginEnvironmentNameProperty=platformVersion
 # Supported platforms: 203, 211
-platformVersion=203
+platformVersion=211
 # Supported IDEs: idea, clion
 baseIDE=idea
 


### PR DESCRIPTION
changelog: Use 2021.1 platform as a default for development
