### PR TITLE
TYPE: auto-indent line when typing <enter> inside an array literal

### DIFF
--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -266,6 +266,9 @@
         <enterHandlerDelegate implementation="org.rust.ide.typing.RsEnterInStringLiteralHandler"
                               id="RustEnterInStringLiterals"/>
 
+        <enterBetweenBracesDelegate language="Rust"
+                                    implementationClass="com.intellij.codeInsight.editorActions.enter.EnterBetweenBracesAndBracketsDelegate"/>
+
         <typedHandler implementation="org.rust.ide.typing.RsRawLiteralHashesInserter"
                       id="RsRawLiteralHashesInserter"/>
         <typedHandler implementation="org.rust.ide.typing.RsAngleBraceTypedHandler"

--- a/src/test/kotlin/org/rust/ide/formatter/RsAutoIndentTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsAutoIndentTest.kt
@@ -259,4 +259,17 @@ class RsAutoIndentTest : RsTypingTestBase() {
             /*caret*/
         }
     """)
+
+    // A test for `enterBetweenBracesDelegate` extension point
+    fun `test array literal`() = doTestByText("""
+        fn main() {
+            let _ = [/*caret*/];
+        }
+    """, """
+        fn main() {
+            let _ = [
+                /*caret*/
+            ];
+        }
+    """)
 }


### PR DESCRIPTION
Initial:

```rust
fn main() {
    let a = [/*caret*/];
}
```

<enter> typed, before this PR:

```rust
fn main() {
    let a = [
    /*caret*/];
}
```

<enter> typed, now:

```rust
fn main() {
    let a = [
        /*caret*/
    ];
}
```

changelog: auto-indent line when typing <enter> inside an array literal
