### PR TITLE
TYPE&FMT: auto-indent line when typing <enter> in macro bodies

### DIFF
--- a/src/main/kotlin/org/rust/ide/formatter/RsFormattingModelBuilder.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/RsFormattingModelBuilder.kt
@@ -17,6 +17,7 @@ import org.rust.ide.formatter.blocks.RsMultilineStringLiteralBlock
 import org.rust.lang.core.psi.RS_RAW_LITERALS
 import org.rust.lang.core.psi.RS_STRING_LITERALS
 import org.rust.lang.core.psi.RsElementTypes.*
+import org.rust.lang.core.psi.tokenSetOf
 
 class RsFormattingModelBuilder : FormattingModelBuilder {
     override fun getRangeAffectingIndent(file: PsiFile?, offset: Int, elementAtOffset: ASTNode?): TextRange? = null
@@ -29,6 +30,13 @@ class RsFormattingModelBuilder : FormattingModelBuilder {
     }
 
     companion object {
+        private val MACRO_COMPOSITE_NODES = tokenSetOf(
+            MACRO_BODY, MACRO_CASE, MACRO_PATTERN, MACRO_PATTERN_CONTENTS, MACRO_BINDING, MACRO_BINDING_GROUP,
+            MACRO_EXPANSION, MACRO_EXPANSION_CONTENTS, MACRO_REFERENCE, MACRO_EXPANSION_REFERENCE_GROUP,
+            MACRO_BINDING_GROUP_SEPARATOR, META_VAR_IDENTIFIER,
+            MACRO_ARGUMENT, MACRO_ARGUMENT_TT
+        )
+
         fun createBlock(
             node: ASTNode,
             alignment: Alignment?,
@@ -38,7 +46,7 @@ class RsFormattingModelBuilder : FormattingModelBuilder {
         ): ASTBlock {
             val type = node.elementType
 
-            if (type == MACRO_BODY || type == MACRO_ARGUMENT) {
+            if (type in MACRO_COMPOSITE_NODES) {
                 return RsMacroArgFmtBlock(node, alignment, indent, wrap, ctx)
             }
 

--- a/src/main/kotlin/org/rust/ide/formatter/blocks/RsMacroArgFmtBlock.kt
+++ b/src/main/kotlin/org/rust/ide/formatter/blocks/RsMacroArgFmtBlock.kt
@@ -8,7 +8,13 @@ package org.rust.ide.formatter.blocks
 import com.intellij.formatting.*
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.TextRange
+import com.intellij.psi.formatter.FormatterUtil
 import org.rust.ide.formatter.RsFmtContext
+import org.rust.ide.formatter.RsFormattingModelBuilder
+import org.rust.ide.formatter.impl.isWhitespaceOrEmpty
+import org.rust.lang.core.psi.MacroBraces
+import org.rust.lang.core.psi.RsElementTypes.*
+import org.rust.lang.core.psi.tokenSetOf
 
 class RsMacroArgFmtBlock(
     private val node: ASTNode,
@@ -23,11 +29,51 @@ class RsMacroArgFmtBlock(
     override fun getIndent(): Indent? = indent
     override fun getWrap(): Wrap? = wrap
 
-    override fun getSubBlocks(): List<Block> = emptyList()
+    override fun getSubBlocks(): List<Block> = mySubBlocks
+    private val mySubBlocks: List<Block> by lazy { buildChildren() }
 
-    override fun getSpacing(child1: Block?, child2: Block): Spacing? = Spacing.getReadOnlySpacing()
-    override fun getChildAttributes(newChildIndex: Int): ChildAttributes = ChildAttributes(null, null)
+    private fun buildChildren(): List<Block> {
+        return node.getChildren(null)
+            .filter { !it.isWhitespaceOrEmpty() }
+            .map { childNode: ASTNode ->
+                RsFormattingModelBuilder.createBlock(
+                    node = childNode,
+                    alignment = null,
+                    indent = computeIndentForChild(childNode),
+                    wrap = null,
+                    ctx = ctx)
+            }
+    }
+
+    override fun getSpacing(child1: Block?, child2: Block): Spacing? {
+        return Spacing.getReadOnlySpacing()
+    }
+
+    override fun getChildAttributes(newChildIndex: Int): ChildAttributes {
+        val indent = when (node.elementType) {
+            in SUBTREES -> Indent.getNormalIndent()
+            else -> Indent.getNoneIndent()
+        }
+        return ChildAttributes(indent, null)
+    }
 
     override fun isLeaf(): Boolean = node.firstChildNode == null
-    override fun isIncomplete(): Boolean = false
+
+    override fun isIncomplete(): Boolean = myIsIncomplete
+    private val myIsIncomplete: Boolean by lazy { FormatterUtil.isIncomplete(node) }
+
+    private fun computeIndentForChild(child: ASTNode): Indent? {
+        return when (node.elementType) {
+            in SUBTREES -> if (MacroBraces.fromToken(child.elementType) == null) {
+                Indent.getNormalIndent()
+            } else {
+                Indent.getNoneIndent()
+            }
+            else -> Indent.getNoneIndent()
+        }
+    }
+
+    companion object {
+        private val SUBTREES = tokenSetOf(MACRO_ARGUMENT, MACRO_ARGUMENT_TT, MACRO_BODY, MACRO_PATTERN, MACRO_EXPANSION)
+    }
 }

--- a/src/test/kotlin/org/rust/ide/formatter/RsAutoIndentMacrosTest.kt
+++ b/src/test/kotlin/org/rust/ide/formatter/RsAutoIndentMacrosTest.kt
@@ -1,0 +1,441 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.formatter
+
+import org.rust.ide.typing.RsTypingTestBase
+
+class RsAutoIndentMacrosTest : RsTypingTestBase() {
+    fun `test macro call argument one line braces`() = doTestByText("""
+        foo! {/*caret*/}
+    """, """
+        foo! {
+            /*caret*/
+        }
+    """)
+
+    fun `test macro call argument one line parens`() = doTestByText("""
+        foo! (/*caret*/);
+    """, """
+        foo! (
+            /*caret*/
+        );
+    """)
+
+    fun `test macro call argument one line brackets`() = doTestByText("""
+        foo! [/*caret*/];
+    """, """
+        foo! [
+            /*caret*/
+        ];
+    """)
+
+    fun `test macro call argument two lines`() = doTestByText("""
+        foo! {/*caret*/
+        }
+    """, """
+        foo! {
+            /*caret*/
+        }
+    """)
+
+    fun `test macro call argument one line with extra token`() = doTestByText("""
+        foo! {/*caret*/foo}
+    """, """
+        foo! {
+            /*caret*/foo}
+    """)
+
+    fun `test macro call argument tt one line braces`() = doTestByText("""
+        foo! {
+            {/*caret*/}
+        }
+    """, """
+        foo! {
+            {
+                /*caret*/
+            }
+        }
+    """)
+
+    fun `test macro call argument tt one line parens`() = doTestByText("""
+        foo! {
+            (/*caret*/)
+        }
+    """, """
+        foo! {
+            (
+                /*caret*/
+            )
+        }
+    """)
+
+    fun `test macro call argument tt one line brackets`() = doTestByText("""
+        foo! {
+            [/*caret*/]
+        }
+    """, """
+        foo! {
+            [
+                /*caret*/
+            ]
+        }
+    """)
+
+    fun `test macro call argument tt one line with extra token`() = doTestByText("""
+        foo! {
+            {/*caret*/foo}
+        }
+    """, """
+        foo! {
+            {
+                /*caret*/foo}
+        }
+    """)
+
+    fun `test macro definition body one line braces`() = doTestByText("""
+        macro_rules! foo {/*caret*/}
+    """, """
+        macro_rules! foo {
+            /*caret*/
+        }
+    """)
+
+    fun `test macro definition body one line parens`() = doTestByText("""
+        macro_rules! foo (/*caret*/);
+    """, """
+        macro_rules! foo (
+            /*caret*/
+        );
+    """)
+
+    fun `test macro definition body one line brackets`() = doTestByText("""
+        macro_rules! foo [/*caret*/];
+    """, """
+        macro_rules! foo [
+            /*caret*/
+        ];
+    """)
+
+    fun `test macro definition body two lines`() = doTestByText("""
+        macro_rules! foo {/*caret*/
+        }
+    """, """
+        macro_rules! foo {
+            /*caret*/
+        }
+    """)
+
+    fun `test macro definition body one line with extra tokens`() = doTestByText("""
+        macro_rules! foo {/*caret*/() => {}}
+    """, """
+        macro_rules! foo {
+            /*caret*/() => {}}
+    """)
+
+    fun `test macro definition case pattern one line parens`() = doTestByText("""
+        macro_rules! foo {
+            (/*caret*/) => {}
+        }
+    """, """
+        macro_rules! foo {
+            (
+                /*caret*/
+            ) => {}
+        }
+    """)
+
+    fun `test macro definition case pattern one line braces`() = doTestByText("""
+        macro_rules! foo {
+            {/*caret*/} => {}
+        }
+    """, """
+        macro_rules! foo {
+            {
+                /*caret*/
+            } => {}
+        }
+    """)
+
+    fun `test macro definition case pattern one line brackets`() = doTestByText("""
+        macro_rules! foo {
+            [/*caret*/] => {}
+        }
+    """, """
+        macro_rules! foo {
+            [
+                /*caret*/
+            ] => {}
+        }
+    """)
+
+    fun `test macro definition case pattern one line with extra token`() = doTestByText("""
+        macro_rules! foo {
+            (/*caret*/foo) => {}
+        }
+    """, """
+        macro_rules! foo {
+            (
+                /*caret*/foo) => {}
+        }
+    """)
+
+    fun `test macro definition case body one line braces`() = doTestByText("""
+        macro_rules! foo {
+            () => {/*caret*/}
+        }
+    """, """
+        macro_rules! foo {
+            () => {
+                /*caret*/
+            }
+        }
+    """)
+
+    fun `test macro definition case body one line parens`() = doTestByText("""
+        macro_rules! foo {
+            () => (/*caret*/)
+        }
+    """, """
+        macro_rules! foo {
+            () => (
+                /*caret*/
+            )
+        }
+    """)
+
+    fun `test macro definition case body one line brackets`() = doTestByText("""
+        macro_rules! foo {
+            () => [/*caret*/]
+        }
+    """, """
+        macro_rules! foo {
+            () => [
+                /*caret*/
+            ]
+        }
+    """)
+
+    fun `test macro definition case body one line with extra token`() = doTestByText("""
+        macro_rules! foo {
+            () => {/*caret*/foo}
+        }
+    """, """
+        macro_rules! foo {
+            () => {
+                /*caret*/foo}
+        }
+    """)
+
+    fun `test macro definition case body tt one line braces`() = doTestByText("""
+        macro_rules! foo {
+            () => {
+                {/*caret*/}
+            }
+        }
+    """, """
+        macro_rules! foo {
+            () => {
+                {
+                    /*caret*/
+                }
+            }
+        }
+    """)
+
+    fun `test macro definition case body tt one line parens`() = doTestByText("""
+        macro_rules! foo {
+            () => {
+                (/*caret*/)
+            }
+        }
+    """, """
+        macro_rules! foo {
+            () => {
+                (
+                    /*caret*/
+                )
+            }
+        }
+    """)
+
+    fun `test macro definition case body tt one line brackets`() = doTestByText("""
+        macro_rules! foo {
+            () => {
+                [/*caret*/]
+            }
+        }
+    """, """
+        macro_rules! foo {
+            () => {
+                [
+                    /*caret*/
+                ]
+            }
+        }
+    """)
+
+    fun `test macro definition case body tt one line with extra token`() = doTestByText("""
+        macro_rules! foo {
+            () => {
+                {/*caret*/foo}
+            }
+        }
+    """, """
+        macro_rules! foo {
+            () => {
+                {
+                    /*caret*/foo}
+            }
+        }
+    """)
+
+    fun `test macro definition case body tt 2 one line braces`() = doTestByText("""
+        macro_rules! foo {
+            () => {
+                {
+                    {/*caret*/}
+                }
+            }
+        }
+    """, """
+        macro_rules! foo {
+            () => {
+                {
+                    {
+                        /*caret*/
+                    }
+                }
+            }
+        }
+    """)
+
+    fun `test macro definition case body tt 2 one line parens`() = doTestByText("""
+        macro_rules! foo {
+            () => {
+                {
+                    (/*caret*/)
+                }
+            }
+        }
+    """, """
+        macro_rules! foo {
+            () => {
+                {
+                    (
+                        /*caret*/
+                    )
+                }
+            }
+        }
+    """)
+
+    fun `test macro definition case body tt 2 one line brackets`() = doTestByText("""
+        macro_rules! foo {
+            () => {
+                {
+                    [/*caret*/]
+                }
+            }
+        }
+    """, """
+        macro_rules! foo {
+            () => {
+                {
+                    [
+                        /*caret*/
+                    ]
+                }
+            }
+        }
+    """)
+
+    fun `test macro definition case body tt 2 one line with extra token`() = doTestByText("""
+        macro_rules! foo {
+            () => {
+                {
+                    {/*caret*/foo}
+                }
+            }
+        }
+    """, """
+        macro_rules! foo {
+            () => {
+                {
+                    {
+                        /*caret*/foo}
+                }
+            }
+        }
+    """)
+
+    fun `test macro definition case pattern between tokens 1`() = doTestByText("""
+        macro_rules! foo {
+            (
+                foo/*caret*/
+                bar
+            ) => {}
+        }
+    """, """
+        macro_rules! foo {
+            (
+                foo
+                /*caret*/
+                bar
+            ) => {}
+        }
+    """)
+
+    fun `test macro definition case pattern between tokens 2`() = doTestByText("""
+        macro_rules! foo {
+            (
+                foo/*caret*/bar
+                baz
+            ) => {}
+        }
+    """, """
+        macro_rules! foo {
+            (
+                foo
+                /*caret*/bar
+                baz
+            ) => {}
+        }
+    """)
+
+    fun `test macro definition case body between tokens 1`() = doTestByText("""
+        macro_rules! foo {
+            () => {
+                foo/*caret*/
+                bar
+            }
+        }
+    """, """
+        macro_rules! foo {
+            () => {
+                foo
+                /*caret*/
+                bar
+            }
+        }
+    """)
+
+    fun `test macro definition case body between tokens 2`() = doTestByText("""
+        macro_rules! foo {
+            () => {
+                foo/*caret*/bar
+                baz
+            }
+        }
+    """, """
+        macro_rules! foo {
+            () => {
+                foo
+                /*caret*/bar
+                baz
+            }
+        }
+    """)
+}


### PR DESCRIPTION
Previously there was absolutely no auto-indentation in macro (call&def) bodies. Now there is a simple syntax tree-based auto-indentation (based on a token tree `{}`/`()`/`[]` nesting).

changelog: auto-indent line when typing `<enter>` in macro bodies
