### PR TITLE
GRD: update gradle-intellij plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ val compileNativeCodeTaskName = "compileNativeCode"
 plugins {
     idea
     kotlin("jvm") version "1.4.10"
-    id("org.jetbrains.intellij") version "0.6.5"
+    id("org.jetbrains.intellij") version "0.7.2"
     id("org.jetbrains.grammarkit") version "2020.3.2"
     id("net.saliman.properties") version "1.5.1"
     id("org.gradle.test-retry") version "1.2.0"


### PR DESCRIPTION
It should also fix jbr loading by `runIde` gradle task for 211 platform

bors r+