### PR TITLE
Fix crashes on 2021.1 when proc macros are enabled

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -132,6 +132,7 @@ class ExpandedMacroStorage(val project: Project) {
         oldInfo: ExpandedMacroInfo,
         callHash: HashCode?,
         defHash: HashCode?,
+        mixHash: HashCode?,
         expansionFile: VirtualFile?,
         ranges: RangeMap?,
         expansionTextHash: Long
@@ -167,8 +168,8 @@ class ExpandedMacroStorage(val project: Project) {
             newInfo.expansionFile.writeRangeMap(ranges)
         }
 
-        if (newInfo.expansionFile != null && defHash != null && callHash != null) {
-            newInfo.expansionFile.writeMixHash(HashCode.mix(defHash, callHash))
+        if (newInfo.expansionFile != null && mixHash != null) {
+            newInfo.expansionFile.writeMixHash(mixHash)
         }
 
         return newInfo

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionSharedCache.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionSharedCache.kt
@@ -23,7 +23,6 @@ import org.rust.lang.core.macros.MacroExpansionSharedCache.Companion.CACHE_ENABL
 import org.rust.lang.core.macros.decl.*
 import org.rust.lang.core.macros.proc.ProcMacroExpander
 import org.rust.lang.core.parser.RustParserDefinition
-import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.stubs.RsFileStub
 import org.rust.stdext.HashCode
@@ -133,13 +132,7 @@ class MacroExpansionSharedCache : Disposable {
         MACRO_LOG.warn(e)
     }
 
-    fun <T : RsMacroData> cachedExpand(expander: MacroExpander<T, *>, def: RsMacroDataWithHash<T>, call: RsMacroCall): ExpansionResult? {
-        val callData = RsMacroCallData.fromPsi(call)
-        val hash = def.mixHash(RsMacroCallDataWithHash(callData, call.bodyHash)) ?: return null
-        return cachedExpand(expander, def.data, callData, hash)
-    }
-
-    private fun <T : RsMacroData> cachedExpand(
+    fun <T : RsMacroData> cachedExpand(
         expander: MacroExpander<T, *>,
         def: T,
         call: RsMacroCallData,


### PR DESCRIPTION
Store correct `mixHash` for proc macros

changelog: should not be mentioned in changelog if merged into release-143