### PR TITLE
REF: Support import aliases in Move refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveRetargetReferencesProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveRetargetReferencesProcessor.kt
@@ -81,8 +81,13 @@ class RsMoveRetargetReferencesProcessor(
             .take(pathNewSegments.size - pathNewShortNumberSegments + 1)
             .joinToString("::")
 
+        val alias = reference.pathOld
+            .takeIf { it.coloncolon == null && pathNewShortNumberSegments == 1 }
+            ?.referenceName
+            ?.takeIf { it != pathNewShortText }
+
         val containingMod = reference.pathOldOriginal.containingMod
-        val pathNewShort = pathNewShortText.toRsPath(codeFragmentFactory, containingMod) ?: return false
+        val pathNewShort = (alias ?: pathNewShortText).toRsPath(codeFragmentFactory, containingMod) ?: return false
         val containingModHasSameNameInScope = pathNewShort.basePath().reference?.resolve()
             .let {
                 val elementToImport = usePath.toRsPath(codeFragmentFactory, containingMod)?.reference?.resolve()
@@ -95,8 +100,7 @@ class RsMoveRetargetReferencesProcessor(
                 pathNewShortNumberSegments + 1
             )
         }
-
-        addImport(reference.pathOldOriginal, usePath)
+        addImport(reference.pathOldOriginal, usePath, alias)
         replacePathOld(reference, pathNewShort)
         return true
     }
@@ -238,8 +242,8 @@ class RsMoveRetargetReferencesProcessor(
         filesToOptimizeImports.add(containingMod.containingFile as RsFile)
     }
 
-    private fun addImport(context: RsElement, usePath: String) {
-        addImport(psiFactory, context, usePath)
+    private fun addImport(context: RsElement, usePath: String, alias: String?) {
+        addImport(psiFactory, context, usePath, alias)
         filesToOptimizeImports.add(context.containingFile as RsFile)
     }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/move/common/RsMoveUtil.kt
@@ -286,10 +286,11 @@ fun RsVisRestriction.updateScopeIfNecessary(psiFactory: RsPsiFactory, newParent:
     }
 }
 
-fun addImport(psiFactory: RsPsiFactory, context: RsElement, usePath: String) {
+fun addImport(psiFactory: RsPsiFactory, context: RsElement, usePath: String, alias: String? = null) {
     if (!usePath.contains("::")) return
     val blockScope = context.ancestors.find { it is RsBlock && it.childOfType<RsUseItem>() != null } as RsBlock?
     check(context !is RsMod)
     val scope = blockScope ?: context.containingMod
-    scope.insertUseItem(psiFactory, usePath)
+    val useItem = psiFactory.createUseItem(usePath, alias = alias)
+    scope.insertUseItem(psiFactory, useItem)
 }

--- a/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/importUtils.kt
@@ -89,6 +89,10 @@ private fun RsMod.insertExternCrateItem(psiFactory: RsPsiFactory, crateName: Str
 
 fun RsItemsOwner.insertUseItem(psiFactory: RsPsiFactory, usePath: String) {
     val useItem = psiFactory.createUseItem(usePath)
+    insertUseItem(psiFactory, useItem)
+}
+
+fun RsItemsOwner.insertUseItem(psiFactory: RsPsiFactory, useItem: RsUseItem) {
     if (tryGroupWithOtherUseItems(psiFactory, useItem)) return
     val anchor = childrenOfType<RsUseItem>().lastElement ?: childrenOfType<RsExternCrateItem>().lastElement
     if (anchor != null) {

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -220,9 +220,11 @@ class RsPsiFactory(
     fun tryCreateModDeclItem(modName: String): RsModDeclItem? =
         createFromText("mod $modName;")
 
-    fun createUseItem(text: String, visibility: String = ""): RsUseItem =
-        createFromText("$visibility use $text;")
+    fun createUseItem(text: String, visibility: String = "", alias: String? = null): RsUseItem {
+        val aliasText = if (!alias.isNullOrEmpty()) " as $alias" else ""
+        return createFromText("$visibility use $text$aliasText;")
             ?: error("Failed to create use item from text: `$text`")
+    }
 
     fun createUseSpeck(text: String): RsUseSpeck =
         createFromText("use $text;")


### PR DESCRIPTION
Fixes #5952

changelog: Support import aliases in Move refactoring (<kbd>F6</kbd> or `Refactor | Move`)
