### PR TITLE
ANN: fix false-positive redundant `::` annotation in array types

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -872,10 +872,17 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
         // So we have to use low level ASTNode API to avoid code duplication
         val coloncolon = args.node.findChildByType(RsElementTypes.COLONCOLON)?.psi ?: return
         // `::` is redundant only in types
-        if (PsiTreeUtil.getParentOfType(args, RsTypeReference::class.java, RsTraitRef::class.java) == null) return
+        if (!isTypePart(args)) return
         val annotation = holder.newWeakWarningAnnotation(coloncolon, "Redundant `::`", RemoveElementFix(coloncolon))
             ?: return
         annotation.highlightType(ProblemHighlightType.LIKE_UNUSED_SYMBOL).create()
+    }
+
+    private fun isTypePart(args: RsElement): Boolean {
+        val ancestor = args.ancestors.firstOrNull {
+            PsiTreeUtil.instanceOf(it, RsTypeReference::class.java, RsTraitRef::class.java, RsExpr::class.java)
+        }
+        return ancestor != null && ancestor !is RsExpr
     }
 
     private fun checkValueArgumentList(holder: RsAnnotationHolder, args: RsValueArgumentList) {

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveElementFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/RemoveElementFixTest.kt
@@ -57,6 +57,14 @@ class RemoveElementFixTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         }
     """, checkWeakWarn = true)
 
+    fun `test remove colon colon in array size expr`() = checkFixIsUnavailable("Remove `::`", """
+        use std::mem::size_of;
+
+        fn main() {
+            let b: &[u8; size_of::/*caret*/<i32>()];
+        }
+    """, checkWeakWarn = true)
+
     fun `test derive on function`() = checkFixByText("Remove attribute `derive`","""
         <error descr="`derive` may only be applied to structs, enums and unions">#[derive(Debug)]</error>
         fn foo() { }


### PR DESCRIPTION
Fixes #6883

changelog: Don't show `` Redundant `::` `` warning for expressions inside length of array types
