### PR TITLE
Increase minimal supported rustc version to 1.41.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -95,7 +95,7 @@ jobs:
                 include:
                     - os: ubuntu-18.04
                       # Don't forget to update condition in `Set up additional env variables` step
-                      rust-version: 1.32.0
+                      rust-version: 1.41.0
                       base-ide: idea
                       platform-version: 203
                       resolve-engine: resolve-old
@@ -149,7 +149,7 @@ jobs:
                       ${{ runner.os }}-cache-evcxr-${{ matrix.rust-version }}-
 
             - name: Install evcxr
-              if: matrix.os != 'windows-latest' && matrix.rust-version >= '1.40.0' # BACKCOMPAT: Rust 1.39.0
+              if: matrix.os != 'windows-latest' && matrix.rust-version >= '1.46.0' # BACKCOMPAT: Rust 1.45.0
               uses: actions-rs/cargo@v1
               with:
                   command: install
@@ -162,7 +162,7 @@ jobs:
                   cargo install --list
 
             - name: Set up additional env variables
-              if: matrix.rust-version == '1.32.0'
+              if: matrix.rust-version == '1.41.0'
               # see https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
               # BACKCOMPAT: 1.45.0. Don't redefine `compileNativeCode` property
               run: |

--- a/prettyPrinters/gdb_lookup.py
+++ b/prettyPrinters/gdb_lookup.py
@@ -9,11 +9,6 @@ def register_printers(objfile):
     objfile.pretty_printers.append(lookup)
 
 
-# BACKCOMPAT: rust 1.35
-def is_hashbrown_hashmap(hash_map):
-    return len(hash_map.type.fields()) == 1
-
-
 # Enum representation in gdb <= 9.1
 def is_old_enum(valobj):
     content = valobj[valobj.type.fields()[0]]
@@ -82,17 +77,9 @@ def lookup(valobj):
     if rust_type == RustType.STD_BTREE_MAP:
         return StdBTreeMapProvider(valobj)
     if rust_type == RustType.STD_HASH_MAP:
-        if is_hashbrown_hashmap(valobj):
-            return StdHashMapProvider(valobj)
-        else:
-            return StdOldHashMapProvider(valobj)
+        return StdHashMapProvider(valobj)
     if rust_type == RustType.STD_HASH_SET:
-        hash_map = valobj[valobj.type.fields()[0]]
-        if is_hashbrown_hashmap(hash_map):
-            return StdHashMapProvider(valobj, show_values=False)
-        else:
-            return StdOldHashMapProvider(hash_map, show_values=False)
-
+        return StdHashMapProvider(valobj, show_values=False)
     if rust_type == RustType.STD_RC:
         return StdRcProvider(valobj)
     if rust_type == RustType.STD_ARC:

--- a/prettyPrinters/lldb_lookup.py
+++ b/prettyPrinters/lldb_lookup.py
@@ -5,11 +5,6 @@ from lldb_providers import *
 from rust_types import RustType, classify_struct, classify_union
 
 
-# BACKCOMPAT: rust 1.35
-def is_hashbrown_hashmap(hash_map):
-    return len(hash_map.type.fields) == 1
-
-
 def classify_rust_type(type):
     # type: (SBType) -> RustType
     type_class = type.GetTypeClass()
@@ -88,17 +83,9 @@ def synthetic_lookup(valobj, dict):
         return StdVecDequeSyntheticProvider(valobj, dict)
 
     if rust_type == RustType.STD_HASH_MAP:
-        if is_hashbrown_hashmap(valobj):
-            return StdHashMapSyntheticProvider(valobj, dict)
-        else:
-            return StdOldHashMapSyntheticProvider(valobj, dict)
+        return StdHashMapSyntheticProvider(valobj, dict)
     if rust_type == RustType.STD_HASH_SET:
-        hash_map = valobj.GetChildAtIndex(0)
-        if is_hashbrown_hashmap(hash_map):
-            return StdHashMapSyntheticProvider(valobj, dict, show_values=False)
-        else:
-            return StdOldHashMapSyntheticProvider(hash_map, dict, show_values=False)
-
+        return StdHashMapSyntheticProvider(valobj, dict, show_values=False)
     if rust_type == RustType.STD_RC:
         return StdRcSyntheticProvider(valobj, dict)
     if rust_type == RustType.STD_ARC:

--- a/pretty_printers_tests/src/main.rs
+++ b/pretty_printers_tests/src/main.rs
@@ -86,7 +86,7 @@ fn test(debugger: Debugger, path: String) -> Result<(), ()> {
 
     for path in src_paths {
         let path = Path::new(&path);
-        let test_runner: Box<TestRunner> = create_test_runner(&config, path);
+        let test_runner: Box<dyn TestRunner> = create_test_runner(&config, path);
         let result = test_runner.run();
         let path_string = path.file_name().unwrap().to_str().unwrap();
 

--- a/pretty_printers_tests/src/test_runner.rs
+++ b/pretty_printers_tests/src/test_runner.rs
@@ -69,7 +69,7 @@ pub enum TestResult {
 pub fn create_test_runner<'test>(
     config: &'test Config,
     src_path: &'test Path,
-) -> Box<TestRunner<'test> + 'test> {
+) -> Box<dyn TestRunner<'test> + 'test> {
     match config {
         Config::LLDB(config) => Box::new(LLDBTestRunner { config, src_path }),
         Config::GDB(config) => Box::new(GDBTestRunner { config, src_path })
@@ -312,7 +312,7 @@ fn parse_debugger_commands(src_path: &Path, debugger_prefixes: &[&str]) -> Debug
         match line {
             Ok(line) => {
                 let line = if line.starts_with("//") {
-                    line[2..].trim_left()
+                    line[2..].trim_start()
                 } else {
                     line.as_str()
                 };
@@ -368,7 +368,7 @@ fn parse_debugger_commands(src_path: &Path, debugger_prefixes: &[&str]) -> Debug
 
 fn parse_rustc_version(line: &str, prefix: &str) -> Result<Option<Version>, SemVerError> {
     if line.starts_with(prefix) {
-        let min_version_str = &line[prefix.len()..].trim_left();
+        let min_version_str = &line[prefix.len()..].trim_start();
         let version = Version::parse(min_version_str)?;
         Ok(Some(version))
     } else {

--- a/src/main/kotlin/org/rust/cargo/toolchain/RsToolchain.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsToolchain.kt
@@ -61,7 +61,7 @@ open class RsToolchain(val location: Path) {
 
 
     companion object {
-        val MIN_SUPPORTED_TOOLCHAIN = SemVer.parseFromText("1.32.0")!!
+        val MIN_SUPPORTED_TOOLCHAIN = SemVer.parseFromText("1.41.0")!!
 
         /** Environment variable to unlock unstable features of rustc and cargo.
          *  It doesn't change real toolchain.

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -43,8 +43,11 @@ import org.rust.cargo.toolchain.RsToolchain
 import org.rust.cargo.toolchain.RsToolchain.Companion.RUSTC_BOOTSTRAP
 import org.rust.cargo.toolchain.RsToolchain.Companion.RUSTC_WRAPPER
 import org.rust.cargo.toolchain.RustChannel
-import org.rust.cargo.toolchain.impl.*
+import org.rust.cargo.toolchain.impl.BuildMessages
+import org.rust.cargo.toolchain.impl.CargoBuildPlan
+import org.rust.cargo.toolchain.impl.CargoMetadata
 import org.rust.cargo.toolchain.impl.CargoMetadata.replacePaths
+import org.rust.cargo.toolchain.impl.CompilerMessage
 import org.rust.cargo.toolchain.tools.Rustup.Companion.checkNeedInstallClippy
 import org.rust.ide.actions.InstallBinaryCrateAction
 import org.rust.ide.experiments.RsExperiments
@@ -380,10 +383,8 @@ open class Cargo(toolchain: RsToolchain, useWrapper: Boolean = false)
                 if (project.rustSettings.useOffline) {
                     val cargoProject = findCargoProject(project, additionalArguments, workingDirectory)
                     val rustcVersion = cargoProject?.rustcInfo?.version?.semver
-                    when {
-                        rustcVersion == null -> Unit
-                        rustcVersion < RUST_1_36 -> add("-Zoffline")
-                        else -> add("--offline")
+                    if (rustcVersion != null) {
+                        add("--offline")
                     }
                 }
                 add(command)
@@ -616,5 +617,3 @@ sealed class CargoCheckArgs {
         }
     }
 }
-
-private val RUST_1_36: SemVer = SemVer.parseFromText("1.36.0")!!

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustfmt.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Rustfmt.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapiext.isUnitTestMode
-import com.intellij.util.text.SemVer
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.CargoWorkspace
@@ -54,7 +53,7 @@ class Rustfmt(toolchain: RsToolchain) : RustupComponent(NAME, toolchain) {
             }
 
             val currentRustcVersion = cargoProject.rustcInfo?.version?.semver
-            if (currentRustcVersion != null && currentRustcVersion >= RUST_1_31) {
+            if (currentRustcVersion != null) {
                 val edition = runReadAction {
                     val psiFile = file.toPsiFile(cargoProject.project)
                     psiFile?.edition ?: CargoWorkspace.Edition.EDITION_2018
@@ -84,8 +83,6 @@ class Rustfmt(toolchain: RsToolchain) : RustupComponent(NAME, toolchain) {
 
     companion object {
         const val NAME: String = "rustfmt"
-
-        private val RUST_1_31: SemVer = SemVer.parseFromText("1.31.0")!!
 
         private val CONFIG_FILES: List<String> = listOf("rustfmt.toml", ".rustfmt.toml")
 

--- a/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
+++ b/src/test/kotlin/org/rust/cargo/commands/RustfmtTest.kt
@@ -14,11 +14,9 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.codeStyle.CodeStyleManager
 import org.intellij.lang.annotations.Language
 import org.rust.FileTreeBuilder
-import org.rust.MinRustcVersion
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.fileTree
-import org.rust.ide.formatter.RustfmtExternalFormatProcessor
 import org.rust.ide.formatter.RustfmtExternalFormatProcessorBase
 import org.rust.launchAction
 import org.rust.openapiext.saveAllDocuments
@@ -100,7 +98,6 @@ class RustfmtTest : RsWithToolchainTestBase() {
         }
     """) { reformatFile(myFixture.editor) }
 
-    @MinRustcVersion("1.31.0")
     fun `test rustfmt file action edition 2018`() = doTest({
         toml("Cargo.toml", """
             [package]

--- a/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt
+++ b/src/test/kotlin/org/rust/cargo/toolchain/CargoTest.kt
@@ -92,17 +92,6 @@ class CargoTest : RsTestBase() {
         """)
     }
 
-    @MockRustcVersion("1.35.0-nightly")
-    fun `test adds -Zoffline`() = withOfflineMode {
-        checkCommandLine(cargo.toColoredCommandLine(project, CargoCommandLine("run", wd, listOf("--release", "--", "foo"))), """
-            cmd: /usr/bin/cargo -Zoffline run --color=always --release -- foo
-            env: RUSTC=/usr/bin/rustc, RUST_BACKTRACE=short, TERM=ansi
-            """, """
-            cmd: C:/usr/bin/cargo.exe -Zoffline run --color=always --release -- foo
-            env: RUSTC=C:/usr/bin/rustc.exe, RUST_BACKTRACE=short, TERM=ansi
-        """)
-    }
-
     private fun withOfflineMode(action: () -> Unit) {
         val oldStatus = project.rustSettings.useOffline
         try {
@@ -120,9 +109,7 @@ class CargoTest : RsTestBase() {
     ) {
         val cleaned = (if (SystemInfo.isWindows) expectedWin else expected).trimIndent()
         val actual = cmd.debug().trim()
-        check(cleaned == actual) {
-            "Expected:\n$cleaned\nActual:\n$actual"
-        }
+        assertEquals(cleaned, actual)
     }
 
     private fun GeneralCommandLine.debug(): String {

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -4058,7 +4058,6 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         impl <error descr="Cannot define inherent `impl` for a type outside of the crate where the type is defined [E0116]">dyn ForeignTrait</error> {}
     """)
 
-    @MinRustcVersion("1.33.0")  // for Pin
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test E0117 trait impls orphan rules`() = checkByFileTree("""

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/ApplySuggestionFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/ApplySuggestionFixTest.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.annotator.fixes
 
 import org.intellij.lang.annotations.Language
-import org.rust.MinRustcVersion
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.toolchain.ExternalLinter
@@ -70,7 +69,6 @@ class ApplySuggestionFixTest : RsWithToolchainTestBase() {
         }
     """)
 
-    @MinRustcVersion("1.29.0")
     fun `test clippy suggestion`() = checkFixByText("""
         pub fn main() {
             <weak_warning>if true { true } else { false }</weak_warning>;

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -7,7 +7,10 @@ package org.rust.ide.docs
 
 import com.intellij.psi.PsiElement
 import org.intellij.lang.annotations.Language
-import org.rust.*
+import org.rust.ExpandMacros
+import org.rust.MockEdition
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.lang.core.psi.RsBaseType
 import org.rust.lang.core.psi.RsConstant
@@ -1118,7 +1121,6 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         keyword <b>enum</b></pre></div><div class='content'><p>.+</p></div>
     """)
 
-    @MinRustcVersion("1.36.0")
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test async keyword doc`() = doTestRegex("""
@@ -1129,7 +1131,6 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         keyword <b>async</b></pre></div><div class='content'><p>.+</p></div>
     """)
 
-    @MinRustcVersion("1.36.0")
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test dyn keyword doc`() = doTestRegex("""
         trait Foo {}
@@ -1140,7 +1141,6 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         keyword <b>dyn</b></pre></div><div class='content'><p>.+</p></div>
     """)
 
-    @MinRustcVersion("1.36.0")
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test boolean value doc`() = doTestRegex("""
         fn main() {
@@ -1161,7 +1161,6 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         }
     """, null)
 
-    @MinRustcVersion("1.36.0")
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test await doc 2`() = doTestRegex("""

--- a/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/implementMembers/ImplementMembersHandlerTest.kt
@@ -8,7 +8,10 @@ package org.rust.ide.refactoring.implementMembers
 import com.intellij.openapi.actionSystem.ex.ActionManagerEx
 import junit.framework.TestCase
 import org.intellij.lang.annotations.Language
-import org.rust.*
+import org.rust.MockAdditionalCfgOptions
+import org.rust.ProjectDescriptor
+import org.rust.RsTestBase
+import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.inspections.RsTraitImplementationInspection
 
 class ImplementMembersHandlerTest : RsTestBase() {
@@ -1138,7 +1141,6 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @MinRustcVersion("1.33.0")
     fun `test Pin self type`() = doTest("""
         use std::pin::Pin;
         struct Foo;
@@ -1166,7 +1168,6 @@ class ImplementMembersHandlerTest : RsTestBase() {
     """)
 
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    @MinRustcVersion("1.33.0")
     fun `test Pin self type with lifetime`() = doTest("""
         use std::pin::Pin;
         struct Foo;

--- a/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
@@ -89,7 +89,6 @@ class RsStdlibCompletionTest : RsCompletionTestBase() {
         use std::/*caret*/;
     """)
 
-    @MinRustcVersion("1.41.0")
     @ExpandMacros(MacroExpansionScope.ALL, "std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test complete items from 'os' module unix`() {
@@ -101,7 +100,6 @@ class RsStdlibCompletionTest : RsCompletionTestBase() {
         """)
     }
 
-    @MinRustcVersion("1.41.0")
     @ExpandMacros(MacroExpansionScope.ALL, "std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test complete items from 'os' module windows`() {

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachingToolchainTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachingToolchainTest.kt
@@ -15,7 +15,6 @@ import com.intellij.testFramework.builders.ModuleFixtureBuilder
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl
 import com.intellij.util.io.delete
 import org.intellij.lang.annotations.Language
-import org.rust.MinRustcVersion
 import org.rust.TestProject
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.model.cargoProjects
@@ -133,7 +132,6 @@ class RsMacroExpansionCachingToolchainTest : RsWithToolchainTestBase() {
         bar!(a);
     """)
 
-    @MinRustcVersion("1.33.0")
     fun `test touch definition at separate file`() = stubBasedRefMatch.checkReExpanded(touchFile("src/foo.rs"), """
         //- foo.rs
         macro_rules! foo { ($ i:ident) => { mod $ i {} } }
@@ -148,7 +146,6 @@ class RsMacroExpansionCachingToolchainTest : RsWithToolchainTestBase() {
         bar!(a);
     """)
 
-    @MinRustcVersion("1.33.0")
     fun `test touch usage at separate file`() = refsRecoverExactHit.checkReExpanded(touchFile("src/main.rs"), """
         //- def.rs
         macro_rules! foo { ($ i:ident) => { mod $ i {} } }
@@ -164,7 +161,6 @@ class RsMacroExpansionCachingToolchainTest : RsWithToolchainTestBase() {
         foo!(aaa);
     """, "foo")
 
-    @MinRustcVersion("1.33.0")
     fun `test edit usage at separate file`() = refsRecoverNotHit.checkReExpanded(replaceInFile("src/main.rs", "aaa", "aab"), """
         //- def.rs
         macro_rules! foo { ($ i:ident) => { mod $ i {} } }
@@ -180,7 +176,6 @@ class RsMacroExpansionCachingToolchainTest : RsWithToolchainTestBase() {
         foo!(a);
     """, "foo")
 
-    @MinRustcVersion("1.33.0")
     fun `test edit definition at separate file`() = stubBasedRefMatch.checkReExpanded(replaceInFile("src/def.rs", "aaa", "aab"), """
         //- def.rs
         macro_rules! foo { ($ i:ident) => { fn $ i() { aaa; } } }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -714,7 +714,6 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                         //^ ...libstd/macros.rs|...libcore/macros.rs|...libcore/macros/mod.rs|...core/src/macros/mod.rs
     """)
 
-    @MinRustcVersion("1.41.0")
     @ExpandMacros(MacroExpansionScope.ALL, "std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test resolve in os module unix`() {
@@ -726,7 +725,6 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         """)
     }
 
-    @MinRustcVersion("1.41.0")
     @ExpandMacros(MacroExpansionScope.ALL, "std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test resolve in os module windows`() {

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -194,58 +194,58 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                        //^ .../f64.rs
     """)
 
-    // BACKCOMPAT: Rust 1.36.0
-    //  Since 1.37.0 common pointer methods moved from `libcore/ptr.rs` to `libcore/ptr/mod.rs`
+    // BACKCOMPAT: Rust 1.41.0
+    //  Since 1.42.0 some pointer methods moved from `libcore/ptr/mod.rs` to `libcore/ptr/const_ptr.rs`
     fun `test inherent impl const ptr 1`() = stubOnlyResolve("""
     //- main.rs
         fn main() {
             let p: *const char;
             p.is_null();
-            //^ ...libcore/ptr.rs|...libcore/ptr/mod.rs|...libcore/ptr/const_ptr.rs|...core/src/ptr/const_ptr.rs
+            //^ ...libcore/ptr/mod.rs|...libcore/ptr/const_ptr.rs|...core/src/ptr/const_ptr.rs
         }
     """)
 
-    // BACKCOMPAT: Rust 1.36.0
-    //  Since 1.37.0 common pointer methods moved from `libcore/ptr.rs` to `libcore/ptr/mod.rs`
+    // BACKCOMPAT: Rust 1.41.0
+    //  Since 1.42.0 some pointer methods moved from `libcore/ptr/mod.rs` to `libcore/ptr/const_ptr.rs`
     fun `test inherent impl const ptr 2`() = stubOnlyResolve("""
     //- main.rs
         fn main() {
             let p: *const char;
             <*const char>::is_null(p);
-                         //^ ...libcore/ptr.rs|...libcore/ptr/mod.rs|...libcore/ptr/const_ptr.rs|...core/src/ptr/const_ptr.rs
+                         //^ ...libcore/ptr/mod.rs|...libcore/ptr/const_ptr.rs|...core/src/ptr/const_ptr.rs
         }
     """)
 
-    // BACKCOMPAT: Rust 1.36.0
-    //  Since 1.37.0 common pointer methods moved from `libcore/ptr.rs` to `libcore/ptr/mod.rs`
+    // BACKCOMPAT: Rust 1.41.0
+    //  Since 1.42.0 some pointer methods moved from `libcore/ptr/mod.rs` to `libcore/ptr/const_ptr.rs`
     fun `test inherent impl const ptr 3`() = stubOnlyResolve("""
     //- main.rs
         fn main() {
             let p: *mut char;
             <*const char>::is_null(p); //Pass a *mut pointer to a *const method
-                         //^ ...libcore/ptr.rs|...libcore/ptr/mod.rs|...libcore/ptr/const_ptr.rs|...core/src/ptr/const_ptr.rs
+                         //^ ...libcore/ptr/mod.rs|...libcore/ptr/const_ptr.rs|...core/src/ptr/const_ptr.rs
         }
     """)
 
-    // BACKCOMPAT: Rust 1.36.0
-    //  Since 1.37.0 common pointer methods moved from `libcore/ptr.rs` to `libcore/ptr/mod.rs`
+    // BACKCOMPAT: Rust 1.41.0
+    //  Since 1.42.0 some pointer methods moved from `libcore/ptr/mod.rs` to `libcore/ptr/mut_ptr.rs`
     fun `test inherent impl mut ptr 1`() = stubOnlyResolve("""
     //- main.rs
         fn main() {
             let p: *mut char;
             p.is_null();
-            //^ ...libcore/ptr.rs|...libcore/ptr/mod.rs|...libcore/ptr/mut_ptr.rs|...core/src/ptr/mut_ptr.rs
+            //^ ...libcore/ptr/mod.rs|...libcore/ptr/mut_ptr.rs|...core/src/ptr/mut_ptr.rs
         }
     """)
 
-    // BACKCOMPAT: Rust 1.36.0
-    //  Since 1.37.0 common pointer methods moved from `libcore/ptr.rs` to `libcore/ptr/mod.rs`
+    // BACKCOMPAT: Rust 1.41.0
+    //  Since 1.42.0 some pointer methods moved from `libcore/ptr/mod.rs` to `libcore/ptr/mut_ptr.rs`
     fun `test inherent impl mut ptr 2`() = stubOnlyResolve("""
     //- main.rs
         fn main() {
             let p: *mut char;
             <*mut char>::is_null(p);
-                       //^ ...libcore/ptr.rs|...libcore/ptr/mod.rs|...libcore/ptr/mut_ptr.rs|...core/src/ptr/mut_ptr.rs
+                       //^ ...libcore/ptr/mod.rs|...libcore/ptr/mut_ptr.rs|...core/src/ptr/mut_ptr.rs
         }
     """)
 
@@ -270,7 +270,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
     //- main.rs
         fn main() {
             assert_eq!("Hello, World!", "");
-        }   //^ ...libcore/macros.rs|...libcore/macros/mod.rs|...core/src/macros/mod.rs
+        }   //^ ...libcore/macros/mod.rs|...core/src/macros/mod.rs
     """)
 
     fun `test iterating a vec`() = stubOnlyResolve("""
@@ -566,7 +566,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
     //- main.rs
         fn main() {
             let _: String = "".into();
-        }                    //^ ...convert.rs|...convert/mod.rs
+        }                    //^ ...convert/mod.rs
     """)
 
     fun `test resolve with no_std attribute`() = stubOnlyResolve("""
@@ -604,7 +604,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
 
         fn foo() {
             panic!("{}");
-            //^ ...libcore/macros.rs|...libcore/macros/mod.rs|...core/src/macros/mod.rs
+            //^ ...libcore/macros/mod.rs|...core/src/macros/mod.rs
         }
     """)
 
@@ -646,14 +646,12 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         }   //^ ...libcore/sync/atomic.rs|...core/src/sync/atomic.rs
     """)
 
-    // BACKCOMPAT: Rust 1.36.0
-    //  Since 1.37.0 common code from `libcore/mem.rs` moved to `libcore/mem/mod.rs`
     fun `test non-absolute std-qualified path in non-root module`() = stubOnlyResolve("""
     //- main.rs
         mod foo {
             fn main() {
                 std::mem::size_of::<i32>();
-            }           //^ ...libcore/mem.rs|...libcore/mem/mod.rs|...core/src/mem/mod.rs
+            }           //^ ...libcore/mem/mod.rs|...core/src/mem/mod.rs
         }
     """)
 
@@ -690,14 +688,14 @@ class RsStdlibResolveTest : RsResolveTestBase() {
     //- main.rs
         fn main() {
             format_args!(true);
-        }   //^ ...libstd/macros.rs|...libcore/macros.rs|...libcore/macros/mod.rs|...core/src/macros/mod.rs
+        }   //^ ...libcore/macros/mod.rs|...core/src/macros/mod.rs
     """)
 
     fun `test rustc doc only macro from std`() = stubOnlyResolve("""
     //- main.rs
         fn main() {
             std::format_args!(true);
-        }        //^ ...libstd/macros.rs|...libcore/macros.rs|...libcore/macros/mod.rs|...core/src/macros/mod.rs
+        }        //^ ...libcore/macros/mod.rs|...core/src/macros/mod.rs
     """)
 
     fun `test f64 INFINITY`() = stubOnlyResolve("""
@@ -711,7 +709,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
     fun `test resolve concat args`() = stubOnlyResolve("""
     //- main.rs
         include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-                        //^ ...libstd/macros.rs|...libcore/macros.rs|...libcore/macros/mod.rs|...core/src/macros/mod.rs
+                        //^ ...libcore/macros/mod.rs|...core/src/macros/mod.rs
     """)
 
     @ExpandMacros(MacroExpansionScope.ALL, "std")

--- a/src/test/kotlin/org/rustSlowTests/RsExternalLinterPassTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/RsExternalLinterPassTest.kt
@@ -7,7 +7,6 @@ package org.rustSlowTests
 
 import com.intellij.lang.annotation.HighlightSeverity
 import org.intellij.lang.annotations.Language
-import org.rust.*
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.rustSettings
@@ -15,7 +14,11 @@ import org.rust.cargo.project.workspace.FeatureState
 import org.rust.cargo.project.workspace.PackageFeature
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.cargo.toolchain.ExternalLinter
+import org.rust.fileTree
 import org.rust.ide.annotator.RsExternalLinterUtils
+import org.rust.singleProject
+import org.rust.singleWorkspace
+import org.rust.workspaceOrFail
 
 class RsExternalLinterPassTest : RsWithToolchainTestBase() {
 
@@ -35,7 +38,6 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
         }
     """)
 
-    @MinRustcVersion("1.32.0")
     fun `test highlights errors from macro`() = doTest("""
         fn main() {
             let mut x = 42;
@@ -54,7 +56,6 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
         }
     """)
 
-    @MinRustcVersion("1.29.0")
     fun `test highlights clippy errors`() = doTest("""
         fn main() {
             <weak_warning descr="${RsExternalLinterUtils.TEST_MESSAGE}">if true { true } else { false }</weak_warning>;
@@ -101,12 +102,6 @@ class RsExternalLinterPassTest : RsWithToolchainTestBase() {
         }
     }
 
-    // https://github.com/intellij-rust/intellij-rust/issues/1497
-    //
-    // We don't want to run this test with rust below 1.30.0
-    // because the corresponding cargo can fail to run `metadata` command
-    // due to `edition` property in `Cargo.toml` in some dependency of `rand` crate
-    @MinRustcVersion("1.30.0")
     fun `test don't try to highlight non project files`() {
         fileTree {
             toml("Cargo.toml", """

--- a/src/test/kotlin/org/rustSlowTests/cargo/runconfig/test/CargoTestNodeInfoTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/cargo/runconfig/test/CargoTestNodeInfoTest.kt
@@ -12,7 +12,6 @@ import com.intellij.execution.testframework.Printer
 import com.intellij.execution.testframework.sm.runner.SMTestProxy
 import com.intellij.execution.ui.ConsoleViewContentType
 import org.intellij.lang.annotations.Language
-import org.rust.MinRustcVersion
 
 class CargoTestNodeInfoTest : CargoTestRunnerTestBase() {
 
@@ -56,12 +55,10 @@ class CargoTestNodeInfoTest : CargoTestRunnerTestBase() {
        assert_eq!("a\\\\b", "a\\b", "`a\\\\b` != `a\\b`");
     """, "`a\\\\b` != `a\\b`", Diff("a\\\\b", "a\\b"))
 
-    @MinRustcVersion("1.39.0")
     fun `test don't unescape test output`() = checkOutput("""
         println!("a\\\\b");
     """, "a\\\\b\n")
 
-    @MinRustcVersion("1.39.0")
     fun `test successful output`() = checkOutput("""
         println!("
                   aaa - bbb");

--- a/src/test/kotlin/org/rustSlowTests/console/RsEvcxrTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/console/RsEvcxrTest.kt
@@ -6,7 +6,6 @@
 package org.rustSlowTests.console
 
 import com.intellij.util.ThrowableRunnable
-import org.rust.MinRustcVersion
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.toolchain.tools.Cargo
@@ -16,7 +15,6 @@ import org.rust.openapiext.pathAsPath
 import java.io.PrintWriter
 import java.util.*
 
-@MinRustcVersion("1.40.0")  // Evcxr supports 1.40 and above
 class RsEvcxrTest : RsWithToolchainTestBase() {
     override fun runTestRunnable(testRunnable: ThrowableRunnable<Throwable>) {
         if (Cargo.checkNeedInstallEvcxr(project)) {

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoGeneratedItemsResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoGeneratedItemsResolveTest.kt
@@ -17,7 +17,6 @@ import org.rust.lang.core.psi.RsPath
 import org.rust.openapiext.runWithEnabledFeatures
 import org.rustSlowTests.cargo.runconfig.RunConfigurationTestBase
 
-@MinRustcVersion("1.41.0")
 class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
 
     private val tempDirFixture = TempDirTestFixtureImpl()
@@ -238,7 +237,6 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
         }
     }
 
-    @MinRustcVersion("1.41.0")
     fun `test include with build script info`() = withEnabledEvaluateBuildScriptsFeature {
         buildProject {
             toml("Cargo.toml", """
@@ -261,7 +259,6 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
         }.checkReferenceIsResolved<RsPath>("src/lib.rs")
     }
 
-    @MinRustcVersion("1.41.0")
     fun `test include with build script info with invalid code`() = withEnabledEvaluateBuildScriptsFeature {
         assertTrue(Registry.`is`("org.rust.cargo.evaluate.build.scripts.wrapper"))
         buildProject {
@@ -286,7 +283,6 @@ class CargoGeneratedItemsResolveTest : RunConfigurationTestBase() {
         }.checkReferenceIsResolved<RsPath>("src/lib.rs")
     }
 
-    @MinRustcVersion("1.41.0")
     fun `test do not run build-plan if build script info is enough`() = withEnabledFetchOutDirFeature {
         withEnabledEvaluateBuildScriptsFeature {
             Cargo.Testmarks.fetchBuildPlan.checkNotHit {

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoProjectResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoProjectResolveTest.kt
@@ -457,7 +457,6 @@ class CargoProjectResolveTest : RsWithToolchainTestBase() {
         checkReferenceIsResolved<RsPath>("bar/src/lib.rs", toCrate = "rand 54.0.0")
     }
 
-    @MinRustcVersion("1.31.0")
     fun `test cargo rename`() = buildProject {
         toml("Cargo.toml", """
             [package]
@@ -478,7 +477,6 @@ class CargoProjectResolveTest : RsWithToolchainTestBase() {
         }
     }.checkReferenceIsResolved<RsPath>("src/main.rs", toCrate = "log 0.4.7")
 
-    @MinRustcVersion("1.31.0")
     fun `test cargo rename of local dependency`() = buildProject {
         toml("Cargo.toml", """
             [package]
@@ -514,7 +512,6 @@ class CargoProjectResolveTest : RsWithToolchainTestBase() {
         }
     }.checkReferenceIsResolved<RsPath>("src/main.rs")
 
-    @MinRustcVersion("1.31.0")
     fun `test cargo rename of local dependency with custom lib target name`() = buildProject {
         toml("Cargo.toml", """
             [package]
@@ -934,7 +931,6 @@ class CargoProjectResolveTest : RsWithToolchainTestBase() {
         }
     }
 
-    @MinRustcVersion("1.41.0") // In this version Cargo starts providing `[build-dependencies]` info
     fun `test build-dependency is resolved in 'build rs' and not resolved in 'main rs'`() = buildProject {
         toml("Cargo.toml", """
             [package]
@@ -976,7 +972,6 @@ class CargoProjectResolveTest : RsWithToolchainTestBase() {
         checkReferenceIsResolved<RsPath>("src/main.rs", shouldNotResolve = true)
     }
 
-    @MinRustcVersion("1.41.0") // In this version Cargo starts providing `[build-dependencies]` info
     fun `test normal dependency is not resolved in 'build rs' and resolved in 'main rs'`() = buildProject {
         toml("Cargo.toml", """
             [package]


### PR DESCRIPTION
And drop all (or almost all) code for rustic below 1.41

changelog: Increase minimal supported rustc version to 1.41.0
