### PR TITLE
ACT: support `Move Element Right/Left` actions for const generic parameters

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/RsMoveLeftRightHandler.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RsMoveLeftRightHandler.kt
@@ -9,6 +9,7 @@ import com.intellij.codeInsight.editorActions.moveLeftRight.MoveElementLeftRight
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.arrayElements
+import org.rust.lang.core.psi.ext.genericParameterList
 
 class RsMoveLeftRightHandler : MoveElementLeftRightHandler() {
 
@@ -24,7 +25,7 @@ class RsMoveLeftRightHandler : MoveElementLeftRightHandler() {
             is RsTupleType -> element.typeReferenceList
             is RsTupleFields -> element.tupleFieldDeclList
             is RsTypeParamBounds -> element.polyboundList
-            is RsTypeParameterList -> element.lifetimeParameterList + element.typeParameterList
+            is RsTypeParameterList -> element.genericParameterList
             is RsUseGroup -> element.useSpeckList
             is RsValueArgumentList -> element.exprList
             is RsValueParameterList -> element.valueParameterList

--- a/src/test/kotlin/org/rust/ide/actions/RsMoveLeftRightHandlerTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/RsMoveLeftRightHandlerTest.kt
@@ -49,10 +49,28 @@ class RsMoveLeftRightHandlerTest : RsTestBase() {
         fn foo<'b, 'a/*caret*/>(p1: &'a str, p2: &'b str) {}
     """)
 
-    fun `test lifetime and type parameters`() = doMoveRightTest("""
-        fn foo<'a/*caret*/, T>(p1: &'a str, p2: T) {}
+    fun `test const parameters`() = doRightLeftTest("""
+        fn foo<const C1/*caret*/: i32, const C2: usize>() {}
     """, """
-        fn foo<T, 'a/*caret*/>(p1: &'a str, p2: T) {}
+        fn foo<const C2: usize, const C1/*caret*/: i32>() {}
+    """)
+
+    fun `test generic parameters 1`() = doMoveRightTest("""
+        fn foo<'a/*caret*/, T, const C: usize>(p1: &'a str, p2: T, p3: [T; C]) {}
+    """, """
+        fn foo<T, 'a/*caret*/, const C: usize>(p1: &'a str, p2: T, p3: [T; C]) {}
+    """)
+
+    fun `test generic parameters 2`() = doMoveRightTest("""
+        fn foo<T, 'a/*caret*/, const C: usize>(p1: &'a str, p2: T, p3: [T; C]) {}
+    """, """
+        fn foo<T, const C: usize, 'a/*caret*/>(p1: &'a str, p2: T, p3: [T; C]) {}
+    """)
+
+    fun `test generic parameters 3`() = doMoveRightTest("""
+        fn foo<'a, T/*caret*/, const C: usize>(p1: &'a str, p2: T, p3: [T; C]) {}
+    """, """
+        fn foo<'a, const C: usize, T/*caret*/>(p1: &'a str, p2: T, p3: [T; C]) {}
     """)
 
     fun `test type param bounds`() = doRightLeftTest("""


### PR DESCRIPTION
Part of #3985

changelog: support `Move Element Right/Left` actions for const generic parameters
