### PR TITLE
INT: Introduce expand dependency specification intention

### DIFF
--- a/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
@@ -38,8 +38,12 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
     private fun checkFileExists(path: Path): String = getResourceAsString(path.toString())
         ?: error("No ${path.fileName} found for $intentionClass ($path)")
 
-    protected fun doAvailableTest(@Language("Rust") before: String, @Language("Rust") after: String) {
-        InlineFile(before.trimIndent()).withCaret()
+    protected fun doAvailableTest(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String,
+        fileName: String = "main.rs"
+    ) {
+        InlineFile(before.trimIndent(), fileName).withCaret()
         launchAction()
         myFixture.checkResult(replaceCaretMarker(after.trimIndent()))
     }
@@ -74,8 +78,8 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
         testmark: Testmark
     ) = testmark.checkHit { doAvailableTest(before, after) }
 
-    protected fun doUnavailableTest(@Language("Rust") before: String) {
-        InlineFile(before).withCaret()
+    protected fun doUnavailableTest(@Language("Rust") before: String, fileName: String = "main.rs") {
+        InlineFile(before, fileName).withCaret()
         val intention = findIntention()
         check(intention == null) {
             "\"${intentionClass.simpleName}\" should not be available"
@@ -89,8 +93,8 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
         }
     }
 
-    protected fun checkAvailableInSelectionOnly(@Language("Rust") code: String) {
-        InlineFile(code.replace("<selection>", "<selection><caret>"))
+    protected fun checkAvailableInSelectionOnly(@Language("Rust") code: String, fileName: String = "main.rs") {
+        InlineFile(code.replace("<selection>", "<selection><caret>"), fileName)
         val selections = myFixture.editor.selectionModel.let { model ->
             model.blockSelectionStarts.zip(model.blockSelectionEnds)
                 .map { TextRange(it.first, it.second + 1) }

--- a/toml/src/main/kotlin/org/rust/toml/intentions/ExpandDependencySpecificationIntention.kt
+++ b/toml/src/main/kotlin/org/rust/toml/intentions/ExpandDependencySpecificationIntention.kt
@@ -1,0 +1,46 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import org.rust.cargo.CargoConstants
+import org.rust.lang.core.psi.ext.endOffset
+import org.rust.toml.isDependencyListHeader
+import org.toml.lang.psi.TomlKeyValue
+import org.toml.lang.psi.TomlLiteral
+import org.toml.lang.psi.TomlPsiFactory
+import org.toml.lang.psi.TomlTable
+import org.toml.lang.psi.ext.TomlLiteralKind
+import org.toml.lang.psi.ext.kind
+
+class ExpandDependencySpecificationIntention : TomlElementBaseIntentionAction<TomlKeyValue>() {
+    override fun getText() = "Expand dependency specification"
+    override fun getFamilyName(): String = text
+
+    override fun findApplicableContextInternal(project: Project, editor: Editor, element: PsiElement): TomlKeyValue? {
+        if (element.containingFile.name != CargoConstants.MANIFEST_FILE) return null
+
+        val keyValue = element.parentOfType<TomlKeyValue>() ?: return null
+        val table = keyValue.parent as? TomlTable ?: return null
+        if (!table.header.isDependencyListHeader) return null
+
+        val value = keyValue.value
+        if (value !is TomlLiteral || value.kind !is TomlLiteralKind.String) return null
+
+        return keyValue
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: TomlKeyValue) {
+        val crateName = ctx.key.text
+        val crateVersion = ctx.value?.text ?: "\"\""
+        val newKeyValue = TomlPsiFactory(project).createKeyValue("$crateName = { version = $crateVersion }")
+        val newKeyValueOffset = ctx.replace(newKeyValue).endOffset
+        editor.caretModel.moveToOffset(newKeyValueOffset)
+    }
+}

--- a/toml/src/main/kotlin/org/rust/toml/intentions/TomlElementBaseIntentionAction.kt
+++ b/toml/src/main/kotlin/org/rust/toml/intentions/TomlElementBaseIntentionAction.kt
@@ -1,0 +1,21 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.rust.ide.intentions.RsElementBaseIntentionAction
+import org.rust.toml.tomlPluginIsAbiCompatible
+
+abstract class TomlElementBaseIntentionAction<Ctx> : RsElementBaseIntentionAction<Ctx>() {
+    final override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Ctx? {
+        if (!tomlPluginIsAbiCompatible()) return null
+        return findApplicableContextInternal(project, editor, element)
+    }
+
+    protected abstract fun findApplicableContextInternal(project: Project, editor: Editor, element: PsiElement): Ctx?
+}

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -32,6 +32,11 @@
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.toml.inspections.CrateNotFoundInspection"/>
 
+        <intentionAction>
+            <className>org.rust.toml.intentions.ExpandDependencySpecificationIntention</className>
+            <category>Rust/Cargo.toml</category>
+        </intentionAction>
+
         <applicationService serviceInterface="org.rust.toml.crates.local.CratesLocalIndexService"
                             serviceImplementation="org.rust.toml.crates.local.CratesLocalIndexServiceImpl"
                             testServiceImplementation="org.rust.toml.crates.local.TestCratesLocalIndexServiceImpl"/>

--- a/toml/src/main/resources/intentionDescriptions/ExpandDependencySpecificationIntention/after.rs.template
+++ b/toml/src/main/resources/intentionDescriptions/ExpandDependencySpecificationIntention/after.rs.template
@@ -1,0 +1,2 @@
+[dependencies]
+foo = { version = "1.0.0" }

--- a/toml/src/main/resources/intentionDescriptions/ExpandDependencySpecificationIntention/before.rs.template
+++ b/toml/src/main/resources/intentionDescriptions/ExpandDependencySpecificationIntention/before.rs.template
@@ -1,0 +1,2 @@
+[dependencies]
+foo = "1.0.0"

--- a/toml/src/main/resources/intentionDescriptions/ExpandDependencySpecificationIntention/description.html
+++ b/toml/src/main/resources/intentionDescriptions/ExpandDependencySpecificationIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Expands dependency specification in Cargo.toml.
+</body>
+</html>

--- a/toml/src/test/kotlin/org/rust/toml/intentions/CargoTomlIntentionTestBase.kt
+++ b/toml/src/test/kotlin/org/rust/toml/intentions/CargoTomlIntentionTestBase.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.intentions
+
+import com.intellij.codeInsight.intention.IntentionAction
+import org.intellij.lang.annotations.Language
+import org.rust.ide.intentions.RsIntentionTestBase
+import kotlin.reflect.KClass
+
+abstract class CargoTomlIntentionTestBase(intentionClass: KClass<out IntentionAction>) : RsIntentionTestBase(intentionClass) {
+    @Suppress("SameParameterValue")
+    protected fun doAvailableTest(
+        @Language("TOML") before: String,
+        @Language("TOML") after: String
+    ) = doAvailableTest(before, after, "Cargo.toml")
+
+    protected fun doUnavailableTest(@Language("TOML") before: String) =
+        doUnavailableTest(before, "Cargo.toml")
+
+    @Suppress("SameParameterValue")
+    protected fun checkAvailableInSelectionOnly(@Language("TOML") code: String) =
+        checkAvailableInSelectionOnly(code, "Cargo.toml")
+}

--- a/toml/src/test/kotlin/org/rust/toml/intentions/ExpandDependencySpecificationIntentionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/intentions/ExpandDependencySpecificationIntentionTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.intentions
+
+class ExpandDependencySpecificationIntentionTest : CargoTomlIntentionTestBase(ExpandDependencySpecificationIntention::class) {
+    fun `test availability range`() = checkAvailableInSelectionOnly("""
+        [dependencies]
+        <selection>foo = "0.1.0"</selection>
+    """)
+
+    fun `test unavailable for already expanded deps`() = doUnavailableTest("""
+        [dependencies]
+        foo = { version = "0.1.0" }<caret>
+    """)
+
+    fun `test unavailable in table specifications`() = doUnavailableTest("""
+        [dependencies.foo]
+        version = "0.1.0"<caret>
+    """)
+
+    fun `test replace from name`() = doAvailableTest("""
+        [dependencies]
+        <caret>foo = "0.1.0"
+    """, """
+        [dependencies]
+        foo = { version = "0.1.0" }<caret>
+    """)
+
+    fun `test replace from version`() = doAvailableTest("""
+        [dependencies]
+        foo = "0.1.0"<caret>
+    """, """
+        [dependencies]
+        foo = { version = "0.1.0" }<caret>
+    """)
+}


### PR DESCRIPTION
Related to #4869

<img width="400" src="https://user-images.githubusercontent.com/6342851/111069568-b76e5700-84de-11eb-931c-25126f832d37.gif">

### TODO
- [x] Provide TOML intention test-base to perform tests correctly

changelog: Add intention to expand dependency specification in `Cargo.toml`