### PR TITLE
Fix automatic detection of brew installed Rust toolchain

### DIFF
--- a/src/main/kotlin/org/rust/cargo/toolchain/flavors/RsMacToolchainFlavor.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/flavors/RsMacToolchainFlavor.kt
@@ -11,7 +11,7 @@ import java.nio.file.Path
 
 object RsMacToolchainFlavor : RsToolchainFlavor() {
     override fun getHomePathCandidates(): List<Path> {
-        val path = "/usr/local/Cellar/rust/bin".toPath()
+        val path = "/opt/homebrew/bin".toPath()
         return if (path.isDirectory()) {
             listOf(path)
         } else {


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/6962.

changelog: Automatically detect Rust toolchain installed via Homebrew 3
