### PR TITLE
COMP: Don't suggest postfix templates inside string literals

### DIFF
--- a/src/main/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplate.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplate.kt
@@ -13,8 +13,6 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.knownItems
 import org.rust.lang.core.types.TraitRef
 import org.rust.lang.core.types.implLookup
-import org.rust.lang.core.types.ty.TyReference
-import org.rust.lang.core.types.ty.TyStr
 import org.rust.lang.core.types.ty.TyUnit
 import org.rust.lang.core.types.type
 
@@ -23,7 +21,7 @@ class PrintlnPostfixTemplate(provider: RsPostfixTemplateProvider, private val ma
         null,
         macroName,
         "$macroName!(\"{:?}\", expr);",
-        RsTopMostInScopeSelector { it.isNotIgnored && (it.isDebug || it.isDisplay) },
+        RsExprParentsSelector { it.isNotIgnored && (it.isDebug || it.isDisplay) },
         provider
     ) {
 

--- a/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
@@ -55,7 +55,7 @@ class RsPostfixTemplateProvider : PostfixTemplateProvider {
 }
 
 class LetPostfixTemplate(provider: RsPostfixTemplateProvider) :
-    PostfixTemplateWithExpressionSelector(null, "let", "let name = expr;", RsAllParentsSelector(), provider) {
+    PostfixTemplateWithExpressionSelector(null, "let", "let name = expr;", RsExprParentsSelector(), provider) {
     override fun expandForChooseExpression(expression: PsiElement, editor: Editor) {
         if (expression !is RsExpr) return
         extractExpression(editor, expression)

--- a/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/stringBasedPostfixTemplates.kt
@@ -22,7 +22,7 @@ import org.rust.lang.core.types.type
 abstract class AssertPostfixTemplateBase(
     name: String,
     provider: RsPostfixTemplateProvider
-) : StringBasedPostfixTemplate(name, "$name!(exp);", RsTopMostInScopeSelector(RsExpr::isBool), provider) {
+) : StringBasedPostfixTemplate(name, "$name!(exp);", RsExprParentsSelector(RsExpr::isBool), provider) {
 
     override fun getTemplateString(element: PsiElement): String =
         if (element is RsBinaryExpr && element.operatorType == EqualityOp.EQ) {
@@ -46,8 +46,8 @@ abstract class SimpleExprPostfixTemplate(
     name: String,
     example: String,
     provider: RsPostfixTemplateProvider,
-    selector: PostfixTemplateExpressionSelector = RsTopMostInScopeSelector()
-): StringBasedPostfixTemplate(name, example, selector, provider) {
+    selector: PostfixTemplateExpressionSelector = RsExprParentsSelector()
+) : StringBasedPostfixTemplate(name, example, selector, provider) {
 
     init {
         require("expr" in example) {
@@ -71,13 +71,13 @@ class DerefPostfixTemplate(provider: RsPostfixTemplateProvider) :
         "deref",
         "*expr",
         provider,
-        RsTopMostInScopeSelector {
+        RsExprParentsSelector {
             it.type is TyReference || it.type is TyPointer || it.implementsDeref
         }
     )
 
 class MatchPostfixTemplate(provider: RsPostfixTemplateProvider) :
-    StringBasedPostfixTemplate("match", "match expr {...}", RsTopMostInScopeSelector(), provider) {
+    StringBasedPostfixTemplate("match", "match expr {...}", RsExprParentsSelector(), provider) {
 
     override fun getTemplateString(element: PsiElement): String = "match ${element.text} {\n\$PAT\$ => {\$END\$}\n}"
 
@@ -94,7 +94,7 @@ class IterPostfixTemplate(name: String, provider: RsPostfixTemplateProvider) :
     StringBasedPostfixTemplate(
         name,
         "for x in expr",
-        RsTopMostInScopeSelector { it.isIntoIterator },
+        RsExprParentsSelector { it.isIntoIterator },
         provider
     ) {
     override fun getTemplateString(element: PsiElement): String =

--- a/src/main/kotlin/org/rust/ide/template/postfix/surrounderBasedPostfixTemplates.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/surrounderBasedPostfixTemplates.kt
@@ -18,7 +18,7 @@ class IfExpressionPostfixTemplate : SurroundPostfixTemplateBase(
     "if",
     "if exp {}",
     RsPostfixTemplatePsiInfo,
-    RsTopMostInScopeSelector(RsExpr::isBool)
+    RsExprParentsSelector(RsExpr::isBool)
 ) {
     override fun getSurrounder(): Surrounder = RsWithIfExpSurrounder()
 }
@@ -27,7 +27,7 @@ class ElseExpressionPostfixTemplate : SurroundPostfixTemplateBase(
     "else",
     "if !exp {}",
     RsPostfixTemplatePsiInfo,
-    RsTopMostInScopeSelector(RsExpr::isBool)
+    RsExprParentsSelector(RsExpr::isBool)
 ) {
     override fun getSurrounder(): Surrounder = RsWithIfExpSurrounder()
 
@@ -38,7 +38,7 @@ class WhileExpressionPostfixTemplate : SurroundPostfixTemplateBase(
     "while",
     "while exp {}",
     RsPostfixTemplatePsiInfo,
-    RsTopMostInScopeSelector(RsExpr::isBool)
+    RsExprParentsSelector(RsExpr::isBool)
 ) {
     override fun getSurrounder(): Surrounder = RsWithWhileExpSurrounder()
 }
@@ -47,7 +47,7 @@ class WhileNotExpressionPostfixTemplate : SurroundPostfixTemplateBase(
     "whilenot",
     "while !exp {}",
     RsPostfixTemplatePsiInfo,
-    RsTopMostInScopeSelector(RsExpr::isBool)
+    RsExprParentsSelector(RsExpr::isBool)
 ) {
     override fun getSurrounder(): Surrounder = RsWithWhileExpSurrounder()
 
@@ -58,7 +58,7 @@ class ParenPostfixTemplate : SurroundPostfixTemplateBase(
     "par",
     "(expr)",
     RsPostfixTemplatePsiInfo,
-    RsAllParentsSelector()
+    RsExprParentsSelector()
 ) {
     override fun getSurrounder(): Surrounder = RsWithParenthesesSurrounder()
 }

--- a/src/main/kotlin/org/rust/ide/template/postfix/utils.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/utils.kt
@@ -5,17 +5,16 @@
 
 package org.rust.ide.template.postfix
 
-import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateExpressionSelector
+import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateExpressionSelectorBase
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplatePsiInfo
 import com.intellij.openapi.editor.Document
+import com.intellij.openapi.util.Condition
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
-import com.intellij.util.Function
 import org.rust.lang.core.psi.RsBlock
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.ancestors
-import org.rust.lang.core.psi.ext.endOffset
 import org.rust.lang.core.types.ty.TyBool
 import org.rust.lang.core.types.type
 import org.rust.lang.utils.negate
@@ -28,48 +27,26 @@ internal object RsPostfixTemplatePsiInfo : PostfixTemplatePsiInfo() {
         RsPsiFactory(context.project).createExpression("$prefix${context.text}$suffix")
 }
 
-abstract class RsExprParentsSelectorBase(val pred: (RsExpr) -> Boolean) : PostfixTemplateExpressionSelector {
-    override fun getRenderer(): Function<PsiElement, String> = Function { it.text }
+class RsExprParentsSelector(pred: (RsExpr) -> Boolean = { true })
+    : PostfixTemplateExpressionSelectorBase(Condition { it is RsExpr && pred(it) }) {
 
-    final override fun getExpressions(context: PsiElement, document: Document, offset: Int): List<PsiElement> {
-        val expressions = getExpressionsInternal(context, document, offset)
+    override fun getExpressions(context: PsiElement, document: Document, offset: Int): List<PsiElement> {
+        val expressions = super.getExpressions(context, document, offset)
         // `PostfixTemplateWithExpressionSelector#expand` selects only one item from this list in unit tests.
         // But in different platform versions different items are selected (of course, it's very convenient).
         // So let's return the latest item to commit tests behavior with all platform versions
         return if (isUnitTestMode) listOfNotNull(expressions.lastOrNull()) else expressions
     }
 
-    protected abstract fun getExpressionsInternal(context: PsiElement, document: Document, offset: Int): List<PsiElement>
-}
-
-class RsTopMostInScopeSelector(pred: ((RsExpr) -> Boolean) = { true }) : RsExprParentsSelectorBase(pred) {
-    override fun getExpressionsInternal(context: PsiElement, document: Document, offset: Int): List<PsiElement> =
-        context
-            .ancestors
-            .takeWhile { it !is RsBlock && it.endOffset == context.endOffset }
-            .filter { it is RsExpr && pred(it) }
-            .toList()
-
-    override fun hasExpression(context: PsiElement, copyDocument: Document, newOffset: Int): Boolean =
-        context
-            .ancestors
-            .takeWhile { it !is RsBlock }
-            .any { it is RsExpr && pred(it) }
-}
-
-class RsAllParentsSelector(pred: ((RsExpr) -> Boolean) = { true }) : RsExprParentsSelectorBase(pred) {
-    override fun getExpressionsInternal(context: PsiElement, document: Document, offset: Int): List<PsiElement> =
-        context
-            .ancestors
-            .takeWhile { it !is RsBlock }
-            .filter { it is RsExpr && pred(it) }
-            .toList()
-
-    override fun hasExpression(context: PsiElement, copyDocument: Document, newOffset: Int): Boolean =
-        context
-            .ancestors
-            .takeWhile { it !is RsBlock }
-            .any { it is RsExpr && pred(it) }
+    override fun getNonFilteredExpressions(
+        context: PsiElement,
+        document: Document,
+        offset: Int
+    ): List<PsiElement> = context
+        .ancestors
+        .takeWhile { it !is RsBlock }
+        .filter { it is RsExpr }
+        .toList()
 }
 
 fun RsExpr.isBool() = type == TyBool

--- a/src/test/kotlin/org/rust/ide/template/postfix/DerefPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/DerefPostfixTemplateTest.kt
@@ -69,4 +69,28 @@ class DerefPostfixTemplateTest : RsPostfixTemplateTest(DerefPostfixTemplate(RsPo
             assert_eq!(123, 123.deref/*caret*/);
         }
     """)
+
+    fun `test no deref in string literal`() = doTestNotApplicable("""
+        fn main() {
+            "qwe.deref/*caret*/";
+        }
+    """)
+
+    fun `test no deref in raw string literal`() = doTestNotApplicable("""
+        fn main() {
+            r#"qwe.deref/*caret*/"#;
+        }
+    """)
+
+    fun `test no deref in byte string literal`() = doTestNotApplicable("""
+        fn main() {
+            b"qwe.deref/*caret*/";
+        }
+    """)
+
+    fun `test no deref in raw byte string literal`() = doTestNotApplicable("""
+        fn main() {
+            br#"qwe.deref/*caret*/"#;
+        }
+    """)
 }


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/6964.

changelog: Don't suggest postfix templates inside string literals
