### PR TITLE
COMP: Improve dependency completion when using crates local index

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyCompletionProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyCompletionProvider.kt
@@ -5,17 +5,16 @@
 
 package org.rust.toml.completion
 
+import com.intellij.codeInsight.AutoPopupController
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.CompletionUtil
 import com.intellij.codeInsight.completion.PrioritizedLookupElement
-import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
-import com.intellij.codeInsight.lookup.LookupElementPresentation
-import com.intellij.codeInsight.lookup.LookupElementRenderer
 import com.intellij.icons.AllIcons
+import com.intellij.openapi.editor.EditorModificationUtil
+import org.rust.lang.core.completion.nextCharIs
 import org.rust.toml.StringValueInsertionHandler
 import org.rust.toml.crates.local.CratesLocalIndexService
-import org.rust.toml.crates.local.lastVersion
 import org.toml.lang.psi.TomlKeyValue
 
 class LocalCargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProviderBase() {
@@ -26,22 +25,23 @@ class LocalCargoTomlDependencyCompletionProvider : TomlKeyValueCompletionProvide
 
         val crateNames = indexService.getAllCrateNames()
         val elements = crateNames.mapNotNull { crateName ->
-            val crate = indexService.getCrate(crateName) ?: return@mapNotNull null
-
             PrioritizedLookupElement.withPriority(
                 LookupElementBuilder
                     .create(crateName)
                     .withIcon(AllIcons.Nodes.PpLib)
-                    .withExpensiveRenderer(object : LookupElementRenderer<LookupElement>() {
-                        override fun renderElement(element: LookupElement, presentation: LookupElementPresentation) {
-                            presentation.itemText = "$crateName = \"${crate.lastVersion.orEmpty()}\""
+                    .withInsertHandler { ctx, _ ->
+                        val alreadyHasValue = ctx.nextCharIs('=')
+
+                        if (!alreadyHasValue) {
+                            ctx.document.insertString(ctx.selectionEndOffset, " = \"\"")
                         }
-                    })
-                    .withInsertHandler { context, _ ->
-                        context.document.insertString(context.tailOffset, " = \"${crate.lastVersion}\"")
-                        val endLineOffset = context.editor.caretModel.visualLineEnd
-                        // TODO: Currently moves caret to the next line
-                        context.editor.caretModel.moveToOffset(endLineOffset)
+
+                        EditorModificationUtil.moveCaretRelatively(ctx.editor, 4)
+
+                        if (!alreadyHasValue) {
+                            // Triggers dependency version completion
+                            AutoPopupController.getInstance(ctx.project).scheduleAutoPopup(ctx.editor)
+                        }
                     },
                 (-crateName.length).toDouble()
             )

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexServiceImpl.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexServiceImpl.kt
@@ -283,11 +283,6 @@ class CratesLocalIndexServiceImpl
 private fun VFileEvent.pathEndsWith(suffix: String): Boolean =
     path.endsWith(suffix) || (this is VFilePropertyChangeEvent && oldPath.endsWith(suffix))
 
-val CargoRegistryCrate.lastVersion: String?
-    // TODO: Last version sometimes can differ from latest major
-    //  (e.g. if developer uploaded a patch to previous major)
-    get() = versions.lastOrNull()?.version
-
 private object CrateExternalizer : DataExternalizer<CargoRegistryCrate> {
     override fun save(out: DataOutput, value: CargoRegistryCrate) {
         out.writeInt(value.versions.size)

--- a/toml/src/test/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyCompletionProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/completion/LocalCargoTomlDependencyCompletionProviderTest.kt
@@ -13,7 +13,7 @@ class LocalCargoTomlDependencyCompletionProviderTest : LocalCargoTomlCompletionT
         fo<caret>
     """, """
         [dependencies]
-        foo = "1.0.0"<caret>
+        foo = "<caret>"
     """,
         "foo" to CargoRegistryCrate.of("1.0.0"),
         "bar" to CargoRegistryCrate.of("1.0.0")
@@ -24,20 +24,12 @@ class LocalCargoTomlDependencyCompletionProviderTest : LocalCargoTomlCompletionT
         fo<caret>
     """, "bar" to CargoRegistryCrate.of("1.0.0"))
 
-    fun `test complete last version`() = doSingleCompletion("""
-        [dependencies]
-        f<caret>
-    """, """
-        [dependencies]
-        foo = "1.0.0"<caret>
-    """, "foo" to CargoRegistryCrate.of("0.0.1", "1.0.0"))
-
     fun `test complete with hyphen-underscore disambiguation`() = doSingleCompletion("""
         [dependencies]
         foo-<caret>
     """, """
         [dependencies]
-        foo_bar = "1.0.0"<caret>
+        foo_bar = "<caret>"
     """, "foo_bar" to CargoRegistryCrate.of("1.0.0"))
 
     fun `test complete by subwords`() = doSingleCompletion("""
@@ -45,6 +37,6 @@ class LocalCargoTomlDependencyCompletionProviderTest : LocalCargoTomlCompletionT
         f-ba<caret>
     """, """
         [dependencies]
-        foo_bar = "1.0.0"<caret>
+        foo_bar = "<caret>"
     """, "foo_bar" to CargoRegistryCrate.of("1.0.0"))
 }


### PR DESCRIPTION
<img width="400" src="https://user-images.githubusercontent.com/6342851/111127949-6c5b4f00-8585-11eb-8a1f-e1284d32009d.gif">

changelog: Make dependencies completion in `Cargo.toml` more intuitive and faster when using crates local index. Note, this feature is disabled by default for now. To use it, enable `org.rust.crates.local.index` experimental feature