### PR TITLE
INT: use template for unknown return type in CreateFunctionIntention

### DIFF
--- a/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateFunctionIntentionTest.kt
@@ -276,6 +276,34 @@ class CreateFunctionIntentionTest : RsIntentionTestBase(CreateFunctionIntention:
         }
     """)
 
+    fun `test guess return unknown type`() = doAvailableTest("""
+        fn foo() {
+            let x: S = bar/*caret*/();
+        }
+    """, """
+        fn foo() {
+            let x: S = bar();
+        }
+
+        fn bar() -> _/*caret*/ {
+            todo!()
+        }
+    """)
+
+    fun `test guess return type empty let decl`() = doAvailableTest("""
+        fn foo() {
+            let x = bar/*caret*/();
+        }
+    """, """
+        fn foo() {
+            let x = bar();
+        }
+
+        fn bar() -> _/*caret*/ {
+            todo!()
+        }
+    """)
+
     fun `test guess return type assignment`() = doAvailableTest("""
         fn foo() {
             let mut x: u32 = 0;


### PR DESCRIPTION
This PR changes how `CreateFunctionIntention` treats function call expressions with unknown expected return types. Previously, it collapsed them to `TyUnit`, so the created function didn't have any return type. This was problematic in scenarios like this:
```rust
let foo = bar(42i8); // missing return type
```
as noted by @lancelote (https://github.com/intellij-rust/intellij-rust/issues/6978).

After inspecting the issue, I realized that this can happen in more cases:
```rust
let foo: UnknownType = bar(); // let decl with unknown type

fn baz(a: UnknownType) {}
baz(bar());  // argument with unknown type
```

In all these cases, the user will most likely want to enter the return type right away. Therefore I created a general heuristic that tries to guess if the user will want to enter the return type or not. Currently, the heuristic works like this:
1) If the return type is known, do not use any template for entering return type and just render it
2) If the return type is unknown:
    a) If the function call is a statement, treat return type as unit, do not display template.
    b) If the function call is an `await` statement (`foo().await;`), treat return type as unit, do not display template.
    c) Otherwise, let the user choose the return type with a template.

Basically it wants to let the user choose the return type if it is unknown, with the exception of "base" calls (and "bare" await calls), which probably are not supposed to have a return type:
```rust
foo();
// v
fn foo() {}

foo().await;
// v
fn foo() {}

let x = foo();
// v
fn foo() -> _/*caret*/ {}

fn bar(a: UnknownType) {}
bar(foo());
// v
fn foo() -> _/*caret*/ {}
```

Fixes: https://github.com/intellij-rust/intellij-rust/issues/6978

changelog: Allow explicitly stating the function return type in CreateFunctionIntention if the inferred return type was unknown.