### PR TITLE
Fix macro calls under cfg

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -455,7 +455,11 @@ data class CargoProjectImpl(
 
     override val workspace: CargoWorkspace? by lazy(LazyThreadSafetyMode.PUBLICATION) {
         val rawWorkspace = rawWorkspace ?: return@lazy null
-        val stdlib = stdlib ?: return@lazy rawWorkspace
+        val stdlib = stdlib ?: return@lazy if (!userDisabledFeatures.isEmpty() && isUnitTestMode) {
+            rawWorkspace.withDisabledFeatures(userDisabledFeatures)
+        } else {
+            rawWorkspace
+        }
         rawWorkspace.withStdlib(stdlib, rawWorkspace.cfgOptions, rustcInfo)
             .withDisabledFeatures(userDisabledFeatures)
     }
@@ -476,7 +480,7 @@ data class CargoProjectImpl(
             return file
         }
 
-    override val workspaceRootDir: VirtualFile? by CachedVirtualFile(workspace?.workspaceRootPath?.toUri()?.toString())
+    override val workspaceRootDir: VirtualFile? by CachedVirtualFile(rawWorkspace?.workspaceRootPath?.toUri()?.toString())
 
     @TestOnly
     fun setRootDir(dir: VirtualFile) = rootDirCache.set(dir)

--- a/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/ExpandedMacroStorage.kt
@@ -24,7 +24,6 @@ import com.intellij.psi.StubBasedPsiElement
 import com.intellij.psi.impl.source.StubbedSpine
 import gnu.trove.TIntObjectHashMap
 import org.rust.cargo.project.workspace.PackageOrigin
-import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.RsFileType
 import org.rust.lang.core.macros.MacroExpansionManagerImpl.Testmarks
 import org.rust.lang.core.macros.decl.DeclMacroExpander
@@ -559,11 +558,9 @@ class SourceFile(
     private fun freshExtractMacros(prefetchedCalls: List<RsMacroCall>?) {
         val psi = loadPsi() ?: return
         val calls = prefetchedCalls ?: psi.stubDescendantsOfTypeStrict<RsMacroCall>().filter { it.isTopLevelExpansion }
-        val newInfos = calls
-            .filter { it.isEnabledByCfg }
-            .map { call ->
-                ExpandedMacroInfoImpl.newStubLinked(this, call)
-            }
+        val newInfos = calls.map { call ->
+            ExpandedMacroInfoImpl.newStubLinked(this, call)
+        }
         switchToStubRefsInReadAction(RefKind.FRESH) { infos ->
             check(infos.isEmpty())
             infos.addAll(newInfos)
@@ -873,7 +870,7 @@ class ExpandedMacroInfoImpl(
     }
 
     fun makePipeline(call: RsMacroCall?): Pipeline.Stage1ResolveAndExpand {
-        return if (call != null && call.isEnabledByCfg) {
+        return if (call != null) {
             ExpansionPipeline.Stage1(call, this)
         } else {
             InvalidationPipeline.Stage1(this)

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionTask.kt
@@ -24,6 +24,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.containers.ContainerUtil
 import com.intellij.util.io.storage.HeavyProcessLatch
 import org.rust.RsTask
+import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.RsMembers
 import org.rust.lang.core.psi.ext.RsMod
@@ -414,6 +415,8 @@ object ExpansionPipeline {
             val oldExpansionFile = info.expansionFile
 
             if (oldExpansionFile != null && !oldExpansionFile.isValid) throw CorruptedExpansionStorageException()
+
+            if (!call.isEnabledByCfg) return nextStageFail(callHash, null)
 
             val def = RsMacroPathReferenceImpl.resolveInBatchMode { call.resolveToMacroWithoutPsi() }
                 ?: return if (oldExpansionFile == null) EmptyPipeline else nextStageFail(callHash, null)

--- a/src/test/kotlin/org/rust/MockCargoFeatures.kt
+++ b/src/test/kotlin/org/rust/MockCargoFeatures.kt
@@ -1,0 +1,21 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust
+
+import java.lang.annotation.Inherited
+
+/**
+ * Allows setting cargo features for a specific test ([RsTestBase]).
+ *
+ * Use it like `@MockCargoFeatures("package_name/feature_name")`.
+ * `package_name` can be omitted. In this case "test-package" assumed.
+ *
+ * @see RsTestBase.setupMockCfgOptions
+ */
+@Inherited
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MockCargoFeatures(vararg val features: String)

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallUnderCfgTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroCallUnderCfgTest.kt
@@ -1,0 +1,208 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.intellij.lang.annotations.Language
+import org.rust.*
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.workspace.FeatureState
+import org.rust.cargo.project.workspace.PackageFeature
+import org.rust.lang.core.psi.RsFile
+import org.rust.lang.core.psi.RsMacroCall
+import org.rust.lang.core.psi.RsModDeclItem
+import org.rust.lang.core.psi.ext.RsReferenceElement
+import org.rust.lang.core.psi.ext.expansion
+
+@ExpandMacros
+class RsMacroCallUnderCfgTest : RsTestBase() {
+    @MockCargoFeatures("feature_foo")
+    fun `test simple`() = checkResolvedOnlyWhenFeatureIsEnabled("feature_foo", """
+        macro_rules! foo {
+            () => {
+                fn foobar() {}
+            };
+        }
+
+        #[cfg(feature = "feature_foo")]
+        foo! {}
+
+        fn main() {
+            foobar();
+            //^
+        }
+    """)
+
+    @MockCargoFeatures("feature_foo")
+    fun `test nested macro call`() = checkResolvedOnlyWhenFeatureIsEnabled("feature_foo", """
+        macro_rules! foo {
+            () => {
+                fn foobar() {}
+            };
+        }
+
+        macro_rules! bar {
+            () => {
+                #[cfg(feature = "feature_foo")]
+                foo! {}
+            };
+        }
+
+        bar! {}
+
+        fn main() {
+            foobar();
+            //^
+        }
+    """)
+
+    @MockCargoFeatures("feature_foo")
+    fun `test nested inline mod`() = checkResolvedOnlyWhenFeatureIsEnabled("feature_foo", """
+        macro_rules! foo {
+            () => {
+                pub fn foobar() {}
+            };
+        }
+
+        macro_rules! bar {
+            () => {
+                #[cfg(feature = "feature_foo")]
+                mod foo {
+                    foo! {}
+                }
+            };
+        }
+
+        bar! {}
+
+        fn main() {
+            foo::foobar();
+               //^
+        }
+    """)
+
+    @UseNewResolve
+    @MockCargoFeatures("feature_foo")
+    fun `test macro call in cfg disabled nested mod`() = checkResolvedOnlyWhenFeatureIsEnabledByTree("feature_foo", """
+    //- foo.rs
+        foo! {}
+    //- main.rs
+        macro_rules! foo {
+            () => {
+                pub fn foobar() {}
+            };
+        }
+
+        macro_rules! bar {
+            () => {
+                #[cfg(feature = "feature_foo")]
+                mod foo;
+            };
+        }
+
+        bar! {}
+
+        fn main() {
+            foo::foobar();
+               //^
+        }
+    """)
+
+    @MockCargoFeatures("feature_foo")
+    fun `test nested macro call in cfg disabled mod`() = checkResolvedOnlyWhenFeatureIsEnabledByTree("feature_foo", """
+    //- foo.rs
+        bar! {}
+    //- main.rs
+        macro_rules! foo {
+            () => {
+                pub fn foobar() {}
+            };
+        }
+
+        macro_rules! bar {
+            () => {
+                foo! {}
+            };
+        }
+
+        #[cfg(feature = "feature_foo")]
+        mod foo;
+
+        fn main() {
+            foo::foobar();
+               //^
+        }
+    """)
+
+    private fun checkResolvedOnlyWhenFeatureIsEnabled(feature: String, @Language("Rust") code: String) {
+        checkResolvedOnlyWhenFeatureIsEnabledInner(feature) {
+            InlineFile(code)
+        }
+    }
+
+    private fun checkResolvedOnlyWhenFeatureIsEnabledByTree(feature: String, @Language("Rust") code: String) {
+        checkResolvedOnlyWhenFeatureIsEnabledInner(feature) {
+            fileTreeFromText(code).createAndOpenFileWithCaretMarker()
+        }
+    }
+
+    private fun checkResolvedOnlyWhenFeatureIsEnabledInner(
+        feature: String,
+        init: () -> Unit
+    ) {
+        init()
+
+        // Enabled -> Disabled -> Enabled
+        run {
+            val (refElement, _, _) = findElementWithDataAndOffsetInEditor<RsReferenceElement>("^")
+            val resolved = { refElement.reference!!.resolve() != null }
+
+            check(resolved())
+
+            setCargoFeature(feature, FeatureState.Disabled)
+            check(!resolved())
+            check(collectMacroCallsRecursively(myFixture.file).any { it.expansion == null })
+
+            setCargoFeature(feature, FeatureState.Enabled)
+            check(resolved())
+        }
+
+        runWriteAction { myFixture.tempDirFixture.getFile(".")!!.children.forEach { it.delete(null) } }
+        setCargoFeature(feature, FeatureState.Disabled)
+        init()
+        runWriteAction { project.macroExpansionManager.reexpand() }
+
+        // Disabled -> Enabled
+        run {
+            val (refElement, _, _) = findElementWithDataAndOffsetInEditor<RsReferenceElement>("^")
+            val resolved = { refElement.reference!!.resolve() != null }
+
+            check(!resolved())
+            check(collectMacroCallsRecursively(myFixture.file).any { it.expansion == null })
+
+            setCargoFeature(feature, FeatureState.Enabled)
+            check(resolved())
+        }
+    }
+
+    private fun collectMacroCallsRecursively(psi: PsiElement): List<RsMacroCall> {
+        return PsiTreeUtil.findChildrenOfAnyType(psi, RsMacroCall::class.java, RsModDeclItem::class.java)
+            .flatMap {
+                when (it) {
+                    is RsMacroCall -> listOf(it) + (it.expansion?.let { collectMacroCallsRecursively(it.file) } ?: emptyList())
+                    is RsModDeclItem -> (it.reference.resolve() as? RsFile)?.let { collectMacroCallsRecursively(it) } ?: emptyList()
+                    else -> error("impossible")
+                }
+            }
+    }
+
+    private fun setCargoFeature(feature: String, newState: FeatureState) {
+        val pkg = project.cargoProjects.singleWorkspace().packages.single()
+        project.cargoProjects.modifyFeatures(project.cargoProjects.singleProject(), setOf(PackageFeature(pkg, feature)), newState)
+    }
+}


### PR DESCRIPTION
Fixes a bug: when a nested cfg-disabled macro calls becomes cfg-enabled (for example, when a user enables some Cargo feature that previously was disabled), the macro call remains unexpanded (disabled)