### PR TITLE
ANN: Support const generics in E0107 inspection

### DIFF
--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -480,9 +480,9 @@
                          implementationClass="org.rust.ide.inspections.RsVariableMutableInspection"/>
 
         <localInspection language="Rust" groupName="Rust"
-                         displayName="Wrong type arguments number"
+                         displayName="Wrong generic arguments number"
                          enabledByDefault="true" level="ERROR"
-                         implementationClass="org.rust.ide.inspections.RsWrongTypeArgumentsNumberInspection"/>
+                         implementationClass="org.rust.ide.inspections.RsWrongGenericArgumentsNumberInspection"/>
 
         <localInspection language="Rust" groupName="Rust"
                          displayName="Wrong lifetime parameters number"

--- a/src/main/resources/inspectionDescriptions/RsWrongGenericArgumentsNumber.html
+++ b/src/main/resources/inspectionDescriptions/RsWrongGenericArgumentsNumber.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-Checks if the right number of type arguments was used for a type, trait, function call or method call.
+Checks if the right number of generic arguments was used for a type, trait, function call or method call.
 <br/>
 Corresponds to the <a href="https://doc.rust-lang.org/error-index.html#E0107">E0107</a> Rust error.
 </body>


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/5753.

changelog: Support const generics in [E0107](https://doc.rust-lang.org/error-index.html#E0107) inspection
