### PR TITLE
INT: Introduce extract dependency in a separate table intention

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/intentions/ExtractDependencySpecificationIntention.kt
+++ b/toml/src/main/kotlin/org/rust/toml/intentions/ExtractDependencySpecificationIntention.kt
@@ -1,0 +1,64 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiParserFacade
+import com.intellij.psi.util.parentOfType
+import com.intellij.psi.util.parentsOfType
+import org.rust.cargo.CargoConstants
+import org.rust.lang.core.psi.ext.endOffset
+import org.rust.toml.isDependencyListHeader
+import org.toml.lang.psi.TomlInlineTable
+import org.toml.lang.psi.TomlKeyValue
+import org.toml.lang.psi.TomlPsiFactory
+import org.toml.lang.psi.TomlTable
+
+class ExtractDependencySpecificationIntention : TomlElementBaseIntentionAction<TomlKeyValue>() {
+    override fun getText() = "Extract dependency specification"
+    override fun getFamilyName(): String = text
+
+    override fun findApplicableContextInternal(project: Project, editor: Editor, element: PsiElement): TomlKeyValue? {
+        if (element.containingFile.name != CargoConstants.MANIFEST_FILE) return null
+
+        val dependencyTable = element.parentOfType<TomlTable>()
+            ?.takeIf { it.header.isDependencyListHeader }
+            ?: return null
+
+        val dependency = element.parentsOfType<TomlKeyValue>()
+            .firstOrNull { it.parent == dependencyTable }
+
+        return dependency?.takeIf { it.value is TomlInlineTable }
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: TomlKeyValue) {
+        val inlineTable = ctx.value as? TomlInlineTable ?: return
+        val table = ctx.parent as? TomlTable ?: return
+        val dependencyTableName = table.header.key?.text.orEmpty()
+        val crateName = ctx.key.text
+        val newTable = TomlPsiFactory(project).createTable("$dependencyTableName.$crateName")
+
+        val psiParserFacade = PsiParserFacade.SERVICE.getInstance(project)
+        for (keyValue in inlineTable.entries) {
+            newTable.add(psiParserFacade.createWhiteSpaceFromText("\n"))
+            newTable.add(keyValue)
+        }
+
+        val newTableOffset = if (table.entries.size == 1) {
+            table.replace(newTable).endOffset
+        } else {
+            ctx.delete()
+            val whitespace = psiParserFacade.createWhiteSpaceFromText("\n\n")
+
+            val addedTable = table.parent.addAfter(newTable, table)
+            table.parent.addAfter(whitespace, table)
+            addedTable.endOffset
+        }
+        editor.caretModel.moveToOffset(newTableOffset)
+    }
+}

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -37,6 +37,11 @@
             <category>Rust/Cargo.toml</category>
         </intentionAction>
 
+        <intentionAction>
+            <className>org.rust.toml.intentions.ExtractDependencySpecificationIntention</className>
+            <category>Rust/Cargo.toml</category>
+        </intentionAction>
+
         <applicationService serviceInterface="org.rust.toml.crates.local.CratesLocalIndexService"
                             serviceImplementation="org.rust.toml.crates.local.CratesLocalIndexServiceImpl"
                             testServiceImplementation="org.rust.toml.crates.local.TestCratesLocalIndexServiceImpl"/>

--- a/toml/src/main/resources/intentionDescriptions/ExtractDependencySpecificationIntention/after.rs.template
+++ b/toml/src/main/resources/intentionDescriptions/ExtractDependencySpecificationIntention/after.rs.template
@@ -1,0 +1,3 @@
+[dependencies.foo]
+version = "1.0.0"
+features = ["bar"]

--- a/toml/src/main/resources/intentionDescriptions/ExtractDependencySpecificationIntention/before.rs.template
+++ b/toml/src/main/resources/intentionDescriptions/ExtractDependencySpecificationIntention/before.rs.template
@@ -1,0 +1,2 @@
+[dependencies]
+foo = { version = "1.0.0", features = ["bar"] }

--- a/toml/src/main/resources/intentionDescriptions/ExtractDependencySpecificationIntention/description.html
+++ b/toml/src/main/resources/intentionDescriptions/ExtractDependencySpecificationIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Extracts dependency specification to a separate table in Cargo.toml.
+</body>
+</html>

--- a/toml/src/test/kotlin/org/rust/toml/intentions/CargoTomlIntentionTestBase.kt
+++ b/toml/src/test/kotlin/org/rust/toml/intentions/CargoTomlIntentionTestBase.kt
@@ -11,7 +11,6 @@ import org.rust.ide.intentions.RsIntentionTestBase
 import kotlin.reflect.KClass
 
 abstract class CargoTomlIntentionTestBase(intentionClass: KClass<out IntentionAction>) : RsIntentionTestBase(intentionClass) {
-    @Suppress("SameParameterValue")
     protected fun doAvailableTest(
         @Language("TOML") before: String,
         @Language("TOML") after: String
@@ -20,7 +19,6 @@ abstract class CargoTomlIntentionTestBase(intentionClass: KClass<out IntentionAc
     protected fun doUnavailableTest(@Language("TOML") before: String) =
         doUnavailableTest(before, "Cargo.toml")
 
-    @Suppress("SameParameterValue")
     protected fun checkAvailableInSelectionOnly(@Language("TOML") code: String) =
         checkAvailableInSelectionOnly(code, "Cargo.toml")
 }

--- a/toml/src/test/kotlin/org/rust/toml/intentions/ExtractDependencySpecificationIntentionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/intentions/ExtractDependencySpecificationIntentionTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.intentions
+
+class ExtractDependencySpecificationIntentionTest : CargoTomlIntentionTestBase(ExtractDependencySpecificationIntention::class) {
+    fun `test availability range`() = checkAvailableInSelectionOnly("""
+        [dependencies]
+        <selection>foo = { version = "0.1.0", features = ["bar"] }</selection>
+    """)
+
+    fun `test unavailable in dependencies table`() = doUnavailableTest("""
+        [dependencies]
+        foo = "0.1.0"/*caret*/
+    """)
+
+    fun `test unavailable for deps tables`() = doUnavailableTest("""
+        [dependencies.foo]
+        version = "0.1.0"/*caret*/
+        features = ["bar"]
+    """)
+
+    fun `test replace from name`() = doAvailableTest("""
+        [dependencies]
+        /*caret*/foo = { version = "0.1.0", features = ["bar"] }
+    """, """
+        [dependencies.foo]
+        version = "0.1.0"
+        features = ["bar"]/*caret*/
+    """)
+
+    fun `test replace simple`() = doAvailableTest("""
+        [dependencies]
+        foo = { version = "0.1.0" }/*caret*/
+    """, """
+        [dependencies.foo]
+        version = "0.1.0"/*caret*/
+    """)
+
+    fun `test replace from value`() = doAvailableTest("""
+        [dependencies]
+        foo = { version = "0.1.0", features = ["bar"] }/*caret*/
+    """, """
+        [dependencies.foo]
+        version = "0.1.0"
+        features = ["bar"]/*caret*/
+    """)
+
+    fun `test replace from inside keyvalue`() = doAvailableTest("""
+        [dependencies]
+        foo = { version = "0.1.0", features = ["bar"/*caret*/] }
+    """, """
+        [dependencies.foo]
+        version = "0.1.0"
+        features = ["bar"]/*caret*/
+    """)
+
+    fun `test replace with platform-specific table`() = doAvailableTest("""
+        [target.'cfg(unix)'.dependencies]
+        foo = { version = "0.1.0", features = ["bar"] }/*caret*/
+    """, """
+        [target.'cfg(unix)'.dependencies.foo]
+        version = "0.1.0"
+        features = ["bar"]/*caret*/
+    """)
+
+    fun `test replace in the middle`() = doAvailableTest("""
+        [dependencies]
+        baz = "0.1.0"
+        foo = { version = "0.1.0", features = ["bar"] }/*caret*/
+        bar = { version = "0.2.0" }
+    """, """
+        [dependencies]
+        baz = "0.1.0"
+        bar = { version = "0.2.0" }
+
+        [dependencies.foo]
+        version = "0.1.0"
+        features = ["bar"]/*caret*/
+    """)
+
+    fun `test replace with another block`() = doAvailableTest("""
+        [dependencies]
+        foo = { version = "0.1.0", features = ["bar"] }/*caret*/
+
+        [features]
+        something = []
+    """, """
+        [dependencies.foo]
+        version = "0.1.0"
+        features = ["bar"]/*caret*/
+
+        [features]
+        something = []
+    """)
+
+    fun `test replace in the middle with another block`() = doAvailableTest("""
+        [dependencies]
+        foo = { version = "0.0.1" }
+        bar = { version = "0.0.2" }/*caret*/
+        baz = { version = "0.0.3" }
+
+        [dependencies.quux]
+        version = "0.0.4"
+    """, """
+        [dependencies]
+        foo = { version = "0.0.1" }
+        baz = { version = "0.0.3" }
+
+        [dependencies.bar]
+        version = "0.0.2"
+
+        [dependencies.quux]
+        version = "0.0.4"
+    """)
+}


### PR DESCRIPTION
Depends on #6960
Part of #4869

Introduces intention to extract dependency specification written as an inline table to a separate table below. 

### TODO
- [x] Fix tests by providing a correct intention test base for TOML

changelog: Add intention to extract dependency specification in a separate table in `Cargo.toml`
