### PR TITLE
INSP&COMP: Use exceptions to check whether index is updating

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexService.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexService.kt
@@ -11,13 +11,28 @@ import com.vdurmont.semver4j.SemverException
 import org.jetbrains.annotations.TestOnly
 
 interface CratesLocalIndexService {
+    /**
+     * @throws CratesLocalIndexException if index is either being updated, or PersistentHashMap has failed to
+     * initialize and not available.
+     * @return [CargoRegistryCrate] if there is a crate with such [crateName], and `null` if it is not.
+     */
+    @Throws(CratesLocalIndexException::class)
     fun getCrate(crateName: String): CargoRegistryCrate?
+
+    /**
+     * @throws CratesLocalIndexException if index is either being updated, or PersistentHashMap has failed to
+     * initialize and not available.
+     * @return list of crate names in the index.
+     */
+    @Throws(CratesLocalIndexException::class)
     fun getAllCrateNames(): List<String>
 
     companion object {
         fun getInstance(): CratesLocalIndexService = service()
     }
 }
+
+class CratesLocalIndexException(message: String) : Exception(message)
 
 data class CargoRegistryCrate(val versions: List<CargoRegistryCrateVersion>) {
     val sortedVersions: List<CargoRegistryCrateVersion>

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexServiceImpl.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexServiceImpl.kt
@@ -126,7 +126,8 @@ class CratesLocalIndexServiceImpl
     }
 
     override fun getCrate(crateName: String): CargoRegistryCrate? {
-        if (isUpdating.get() || crates == null) return null
+        if (isUpdating.get()) throw CratesLocalIndexException("Index is being updated")
+        if (crates == null) throw CratesLocalIndexException("PersistentHashMap is not available")
 
         return try {
             crates.get(crateName)
@@ -137,7 +138,8 @@ class CratesLocalIndexServiceImpl
     }
 
     override fun getAllCrateNames(): List<String> {
-        if (isUpdating.get() || crates == null) return emptyList()
+        if (isUpdating.get()) throw CratesLocalIndexException("Index is being updated")
+        if (crates == null) throw CratesLocalIndexException("PersistentHashMap is not available")
 
         val crateNames = mutableListOf<String>()
 

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CrateNotFoundInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CrateNotFoundInspection.kt
@@ -5,11 +5,12 @@
 
 package org.rust.toml.inspections
 
-import com.intellij.codeInspection.*
+import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElementVisitor
 import org.rust.cargo.CargoConstants
 import org.rust.ide.experiments.RsExperiments
 import org.rust.openapiext.isFeatureEnabled
+import org.rust.toml.crates.local.CratesLocalIndexException
 import org.rust.toml.crates.local.CratesLocalIndexService
 import org.rust.toml.isDependencyKey
 import org.toml.lang.psi.*
@@ -55,7 +56,13 @@ class CrateNotFoundInspection : TomlLocalInspectionToolBase() {
             if (property in dependency.properties) return
         }
 
-        if (CratesLocalIndexService.getInstance().getCrate(dependency.crateName) == null) {
+        val crate = try {
+            CratesLocalIndexService.getInstance().getCrate(dependency.crateName)
+        } catch (e: CratesLocalIndexException) {
+            return
+        }
+
+        if (crate == null) {
             holder.registerProblem(dependency.crateNameElement, "Crate ${dependency.crateName} not found")
         }
     }


### PR DESCRIPTION
Part of #6463
Fixes #6812

Check for the readiness of the crates local index before performing completions and inspections. This should reduce the number of false-positives happening while the index is not ready yet.

<!--changelog:-->
