### PR TITLE
ANN: Annotate wrong order of const generic parameters without `const_generics` feature

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotator.kt
@@ -15,7 +15,9 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.annotator.fixes.AddTypeFix
 import org.rust.ide.inspections.fixes.SubstituteTextFix
+import org.rust.lang.core.CONST_GENERICS
 import org.rust.lang.core.C_VARIADIC
+import org.rust.lang.core.FeatureAvailability
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.type
@@ -293,10 +295,11 @@ private fun checkTypeArgumentList(holder: AnnotationHolder, args: RsTypeArgument
 }
 
 private fun checkTypeList(typeList: PsiElement, elementsName: String, holder: AnnotationHolder) {
+    val isConstGenericsAvailable = CONST_GENERICS.availability(typeList) == FeatureAvailability.AVAILABLE
     var kind = TypeKind.LIFETIME
     typeList.forEachChild { child ->
         val newKind = TypeKind.forType(child) ?: return@forEachChild
-        if (newKind.canStandAfter(kind)) {
+        if (newKind.canStandAfter(kind, isConstGenericsAvailable)) {
             kind = newKind
         } else {
             val newStateName = newKind.presentableName.capitalize()
@@ -315,8 +318,8 @@ private enum class TypeKind {
 
     val presentableName: String get() = name.toLowerCase()
 
-    fun canStandAfter(prev: TypeKind): Boolean =
-        this !== LIFETIME || prev === LIFETIME
+    fun canStandAfter(prev: TypeKind, isConstGenericsAvailable: Boolean): Boolean =
+        if (isConstGenericsAvailable) this !== LIFETIME || prev === LIFETIME else ordinal >= prev.ordinal
 
     companion object {
         fun forType(seekingElement: PsiElement): TypeKind? =

--- a/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsSyntaxErrorsAnnotatorTest.kt
@@ -248,11 +248,21 @@ class RsSyntaxErrorsAnnotatorTest : RsAnnotatorTestBase(RsSyntaxErrorsAnnotator:
         fn foo<const C: usize, <error descr="Lifetime parameters must be declared prior to const parameters">'a</error>>(bar: &'a usize) {}
     """)
 
-    fun `test type params after const params`() = checkErrors("""
+    @MockRustcVersion("1.51.0-nightly")
+    fun `test type params after const params (old)`() = checkErrors("""
+        #![feature(min_const_generics)]
+        fn foo<const C: usize, <error descr="Type parameters must be declared prior to const parameters">T</error>>(bar: T) {}
+    """)
+
+    @MockRustcVersion("1.34.0-nightly")
+    fun `test type params after const params (new)`() = checkErrors("""
+        #![feature(const_generics)]
         fn foo<const C: usize, T>(bar: T) {}
     """)
 
+    @MockRustcVersion("1.34.0-nightly")
     fun `test type arguments order`() = checkErrors("""
+        #![feature(const_generics)]
         type A1 = B<C, <error descr="Lifetime arguments must be declared prior to type arguments">'d</error>>;
 
         type A2 = B<C, <error descr="Lifetime arguments must be declared prior to type arguments">'d</error>,


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/6942.

changelog: Annotate wrong order of const generic parameters without `const_generics` feature
