### PR TITLE
TY: fix unification with `!` in match arms

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -1340,12 +1340,15 @@ class RsTypeInferenceWalker(
     }
 
     // TODO should be replaced with coerceMany
-    private fun getMoreCompleteType(ty1: Ty, ty2: Ty): Ty = when (ty1) {
-        is TyNever -> ty2
-        is TyUnknown -> if (ty2 !is TyNever) ty2 else TyUnknown
-        else -> {
-            ctx.combineTypes(ty1, ty2)
-            ty1
+    private fun getMoreCompleteType(ty1: Ty, ty2: Ty): Ty {
+        return when {
+            ty1 is TyNever -> ty2
+            ty2 is TyNever -> ty1
+            ty1 is TyUnknown -> if (ty2 !is TyNever) ty2 else TyUnknown
+            else -> {
+                ctx.combineTypes(ty1, ty2)
+                ty1
+            }
         }
     }
 

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -827,4 +827,19 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
             b;
         } //^ S
     """)
+
+    // Issue https://github.com/intellij-rust/intellij-rust/issues/6749
+    fun `test diverging and non-diverging match arm`() = stubOnlyTypeInfer("""
+    //- main.rs
+        fn foo(x: i32) {}
+
+        fn main() {
+            let num2 = match "42".parse() {
+                Ok(v) => v,
+                Err(e) => panic!(),
+            }; // type of `num2` should be `i32`, not `!`
+            foo(num2);
+            num2;
+        } //^ i32
+    """)
 }


### PR DESCRIPTION
Fixes #6749
