### PR TITLE
REF: don't import default type parameters by `Extract Function` refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractFunction/RsExtractFunctionHandler.kt
@@ -46,7 +46,7 @@ class RsExtractFunctionHandler : RefactoringActionHandler {
             val parameters = config.valueParameters.filter { it.isSelected }
             renameFunctionParameters(extractedFunction, parameters.map { it.name })
             val types = (parameters.map { it.type } + config.returnValue?.type).filterNotNull()
-            importTypeReferencesFromTys(extractedFunction, types, useAliases = true)
+            importTypeReferencesFromTys(extractedFunction, types, useAliases = true, skipUnchangedDefaultTypeArguments = true)
         }
     }
 

--- a/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
@@ -30,13 +30,28 @@ object RsImportHelper {
         importElements(context, toImport)
     }
 
-    fun importTypeReferencesFromTys(context: RsElement, tys: Collection<Ty>, useAliases: Boolean = false) {
-        val (toImport, _) = getTypeReferencesInfoFromTys(context, *tys.toTypedArray(), useAliases = useAliases)
+    fun importTypeReferencesFromTys(
+        context: RsElement,
+        tys: Collection<Ty>,
+        useAliases: Boolean = false,
+        skipUnchangedDefaultTypeArguments: Boolean = false
+    ) {
+        val (toImport, _) = getTypeReferencesInfoFromTys(
+            context,
+            *tys.toTypedArray(),
+            useAliases = useAliases,
+            skipUnchangedDefaultTypeArguments = skipUnchangedDefaultTypeArguments
+        )
         importElements(context, toImport)
     }
 
-    fun importTypeReferencesFromTy(context: RsElement, ty: Ty, useAliases: Boolean = false) {
-        importTypeReferencesFromTys(context, listOf(ty), useAliases)
+    fun importTypeReferencesFromTy(
+        context: RsElement,
+        ty: Ty,
+        useAliases: Boolean = false,
+        skipUnchangedDefaultTypeArguments: Boolean = false
+    ) {
+        importTypeReferencesFromTys(context, listOf(ty), useAliases, skipUnchangedDefaultTypeArguments)
     }
 
     fun importElements(context: RsElement, elements: Set<RsQualifiedNamedElement>) {

--- a/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsExtractFunctionTest.kt
@@ -1134,7 +1134,7 @@ class RsExtractFunctionTest : RsTestBase() {
     """, "foo")
 
     fun `test import parameter types`() = doTest("""
-        use a::{S, foo};
+        use a::foo;
 
         mod a {
             pub struct A;
@@ -1146,7 +1146,7 @@ class RsExtractFunctionTest : RsTestBase() {
             <selection>s;</selection>
         }
     """, """
-        use a::{S, foo, A};
+        use a::{foo, A};
 
         mod a {
             pub struct A;
@@ -1164,7 +1164,7 @@ class RsExtractFunctionTest : RsTestBase() {
     """, "bar")
 
     fun `test import return type`() = doTest("""
-        use a::{S, foo};
+        use a::foo;
 
         mod a {
             pub struct A;
@@ -1175,7 +1175,7 @@ class RsExtractFunctionTest : RsTestBase() {
             <selection>foo()</selection>;
         }
     """, """
-        use a::{S, foo, A};
+        use a::{foo, A};
 
         mod a {
             pub struct A;
@@ -1187,6 +1187,68 @@ class RsExtractFunctionTest : RsTestBase() {
         }
 
         fn bar() -> A {
+            foo()
+        }
+    """, "bar")
+
+    fun `test do not import default types`() = doTest("""
+        use a::foo;
+
+        mod a {
+            pub struct S;
+            pub struct A<T = S>(T);
+            pub fn foo() -> A { unimplemented!() }
+        }
+
+        fn main() {
+            <selection>foo()</selection>;
+        }
+    """, """
+        use a::{foo, A};
+
+        mod a {
+            pub struct S;
+            pub struct A<T = S>(T);
+            pub fn foo() -> A { unimplemented!() }
+        }
+
+        fn main() {
+            bar();
+        }
+
+        fn bar() -> A {
+            foo()
+        }
+    """, "bar")
+
+    fun `test import non default types`() = doTest("""
+        use a::foo;
+
+        mod a {
+            pub struct S1;
+            pub struct S2;
+            pub struct A<T = S1>(T);
+            pub fn foo() -> A<S2> { unimplemented!() }
+        }
+
+        fn main() {
+            <selection>foo()</selection>;
+        }
+    """, """
+        use a::{foo, A, S2};
+
+        mod a {
+            pub struct S1;
+            pub struct S2;
+            pub struct A<T = S1>(T);
+            pub fn foo() -> A<S2> { unimplemented!() }
+        }
+
+        fn main() {
+            bar();
+        }
+
+        fn bar() -> A<S2> {
             foo()
         }
     """, "bar")


### PR DESCRIPTION
changelog: Don't import default type parameters by `Extract Function` refactoring (`Refactor | Extract | Method` or <kbd>Cmd</kbd> + <kbd>Alt</kbd> + <kbd>M</kbd>)
