### PR TITLE
TY: hotfix array indexing on Rust 1.50.0

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -1115,7 +1115,10 @@ class RsTypeInferenceWalker(
             if (!isArrayToSlice(prevType, type)) derefCount++
 
             val outputType = lookup.findIndexOutputType(type, indexType)
-            if (outputType != null) {
+            if (outputType != null
+                // TODO fix resolve in `impl<T, I, const N: usize> Index<I> for [T; N]` and remove this line
+                && (outputType.value != TyUnknown || type !is TyArray)
+            ) {
                 result = outputType.register()
                 break
             }


### PR DESCRIPTION
Fixes #7009

changelog: fix array indexing on Rust 1.50.0