### PR TITLE
T: Fix "test import to mod shadowed by expanded mod"

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -753,6 +753,7 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
 
     // We check that there are no exceptions during building CrateDefMap (actual resolve result is not important)
     @ExpandMacros
+    @UseNewResolve
     @MockAdditionalCfgOptions("intellij_rust")
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test import to mod shadowed by expanded mod`() = checkByCode("""


### PR DESCRIPTION
This test was changed in #6721 and actually since then it should fail with old resolve (at least it fails if I try locally). Not sure why it started to fail on CI only now. This test was originally created for new resolve only, so lets run this test only with new resolve.