### PR TITLE
Improve `Convert to type` quick-fixes

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/fixes/AddAsTyFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/AddAsTyFix.kt
@@ -17,7 +17,7 @@ import org.rust.lang.core.types.ty.Ty
 /**
  * For the given `expr` adds cast to the given type `ty`
  */
-class AddAsTyFix(expr: PsiElement, val ty: Ty) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
+class AddAsTyFix(expr: RsExpr, val ty: Ty) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
 
     override fun getFamilyName(): String = "Add safe cast"
 

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToStrFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToStrFix.kt
@@ -16,7 +16,7 @@ import org.rust.lang.core.psi.RsPsiFactory
  * For the given `expr` adds `as_str()`/`as_mut_str()` method call. Note the fix doesn't attempt to verify that the type
  * of `expr` is `String` and so doesn't check if adding the function call will produce a valid expression.
  */
-abstract class ConvertToStrFix(expr: PsiElement, strTypeName: String, private val strMethodName: String) :
+abstract class ConvertToStrFix(expr: RsExpr, strTypeName: String, private val strMethodName: String) :
     ConvertToTyFix(expr, strTypeName, "`$strMethodName` method") {
 
     override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
@@ -25,5 +25,5 @@ abstract class ConvertToStrFix(expr: PsiElement, strTypeName: String, private va
     }
 }
 
-class ConvertToImmutableStrFix(expr: PsiElement) : ConvertToStrFix(expr, "&str", "as_str")
-class ConvertToMutStrFix(expr: PsiElement) : ConvertToStrFix(expr, "&mut str", "as_mut_str")
+class ConvertToImmutableStrFix(expr: RsExpr) : ConvertToStrFix(expr, "&str", "as_str")
+class ConvertToMutStrFix(expr: RsExpr) : ConvertToStrFix(expr, "&mut str", "as_mut_str")

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToStrFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToStrFix.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.annotator.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
@@ -17,29 +16,14 @@ import org.rust.lang.core.psi.RsPsiFactory
  * For the given `expr` adds `as_str()`/`as_mut_str()` method call. Note the fix doesn't attempt to verify that the type
  * of `expr` is `String` and so doesn't check if adding the function call will produce a valid expression.
  */
-abstract class ConvertToStrFix(expr: PsiElement) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
-
-    override fun getFamilyName(): String = "Convert to type"
-
-    override fun getText(): String = "Convert to ${getStrTypeName()} using `${getStrMethodName()}` method"
+abstract class ConvertToStrFix(expr: PsiElement, strTypeName: String, private val strMethodName: String) :
+    ConvertToTyFix(expr, strTypeName, "`$strMethodName` method") {
 
     override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
         if (startElement !is RsExpr) return
-        startElement.replace(RsPsiFactory(project).createNoArgsMethodCall(startElement, getStrMethodName()))
+        startElement.replace(RsPsiFactory(project).createNoArgsMethodCall(startElement, strMethodName))
     }
-
-    protected abstract fun getStrMethodName(): String
-    protected abstract fun getStrTypeName(): String
 }
 
-class ConvertToImmutableStrFix(expr: PsiElement) : ConvertToStrFix(expr) {
-    override fun getStrMethodName(): String = "as_str"
-
-    override fun getStrTypeName(): String = "&str"
-}
-
-class ConvertToMutStrFix(expr: PsiElement) : ConvertToStrFix(expr) {
-    override fun getStrMethodName(): String = "as_mut_str"
-
-    override fun getStrTypeName(): String = "&mut str"
-}
+class ConvertToImmutableStrFix(expr: PsiElement) : ConvertToStrFix(expr, "&str", "as_str")
+class ConvertToMutStrFix(expr: PsiElement) : ConvertToStrFix(expr, "&mut str", "as_mut_str")

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyFix.kt
@@ -8,6 +8,7 @@ package org.rust.ide.annotator.fixes
 import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.psi.PsiElement
 import org.rust.ide.presentation.render
+import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.types.ty.Ty
 
 abstract class ConvertToTyFix : LocalQuickFixAndIntentionActionOnPsiElement {
@@ -15,12 +16,12 @@ abstract class ConvertToTyFix : LocalQuickFixAndIntentionActionOnPsiElement {
     private val tyName: String
     private val convertSubject: String
 
-    constructor(expr: PsiElement, tyName: String, convertSubject: String): super(expr) {
+    constructor(expr: RsExpr, tyName: String, convertSubject: String): super(expr) {
         this.tyName = tyName
         this.convertSubject = convertSubject
     }
 
-    constructor(expr: PsiElement, ty: Ty, convertSubject: String) :
+    constructor(expr: RsExpr, ty: Ty, convertSubject: String) :
         this(expr, ty.render(skipUnchangedDefaultTypeArguments = true), convertSubject)
 
     override fun getFamilyName(): String = "Convert to type"

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyFix.kt
@@ -7,6 +7,7 @@ package org.rust.ide.annotator.fixes
 
 import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.psi.PsiElement
+import org.rust.ide.presentation.render
 import org.rust.lang.core.types.ty.Ty
 
 abstract class ConvertToTyFix : LocalQuickFixAndIntentionActionOnPsiElement {
@@ -19,7 +20,8 @@ abstract class ConvertToTyFix : LocalQuickFixAndIntentionActionOnPsiElement {
         this.convertSubject = convertSubject
     }
 
-    constructor(expr: PsiElement, ty: Ty, convertSubject: String) : this(expr, ty.toString(), convertSubject)
+    constructor(expr: PsiElement, ty: Ty, convertSubject: String) :
+        this(expr, ty.render(skipUnchangedDefaultTypeArguments = true), convertSubject)
 
     override fun getFamilyName(): String = "Convert to type"
     override fun getText(): String = "Convert to $tyName using $convertSubject"

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyFix.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.types.ty.Ty
+
+abstract class ConvertToTyFix : LocalQuickFixAndIntentionActionOnPsiElement {
+
+    private val tyName: String
+    private val convertSubject: String
+
+    constructor(expr: PsiElement, tyName: String, convertSubject: String): super(expr) {
+        this.tyName = tyName
+        this.convertSubject = convertSubject
+    }
+
+    constructor(expr: PsiElement, ty: Ty, convertSubject: String) : this(expr, ty.toString(), convertSubject)
+
+    override fun getFamilyName(): String = "Convert to type"
+    override fun getText(): String = "Convert to $tyName using $convertSubject"
+}

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFix.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.annotator.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
@@ -18,11 +17,7 @@ import org.rust.lang.core.types.ty.Ty
 /**
  * For the given `expr` converts it to the type `ty` with `ty::from(expr)`
  */
-class ConvertToTyUsingFromTraitFix(expr: PsiElement, val ty: Ty) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
-    override fun getFamilyName(): String = "Convert to type"
-
-    override fun getText(): String = "Convert to $ty using `From` trait"
-
+class ConvertToTyUsingFromTraitFix(expr: PsiElement, val ty: Ty) : ConvertToTyUsingTraitFix(expr, ty, "From") {
     override fun invoke(
         project: Project,
         file: PsiFile,

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingFromTraitFix.kt
@@ -17,7 +17,7 @@ import org.rust.lang.core.types.ty.Ty
 /**
  * For the given `expr` converts it to the type `ty` with `ty::from(expr)`
  */
-class ConvertToTyUsingFromTraitFix(expr: PsiElement, val ty: Ty) : ConvertToTyUsingTraitFix(expr, ty, "From") {
+class ConvertToTyUsingFromTraitFix(expr: RsExpr, val ty: Ty) : ConvertToTyUsingTraitFix(expr, ty, "From") {
     override fun invoke(
         project: Project,
         file: PsiFile,

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTraitFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTraitFix.kt
@@ -14,8 +14,8 @@ import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.types.ty.Ty
 
 abstract class ConvertToTyUsingTraitFix : ConvertToTyFix {
-    constructor(expr: PsiElement, tyName: String, traitName: String) : super(expr, tyName, "`$traitName` trait")
-    constructor(expr: PsiElement, ty: Ty, traitName: String) : super(expr, ty, "`$traitName` trait")
+    constructor(expr: RsExpr, tyName: String, traitName: String) : super(expr, tyName, "`$traitName` trait")
+    constructor(expr: RsExpr, ty: Ty, traitName: String) : super(expr, ty, "`$traitName` trait")
 }
 
 /**
@@ -27,11 +27,11 @@ abstract class ConvertToTyUsingTraitMethodFix : ConvertToTyUsingTraitFix {
 
     private val methodName: String
 
-    constructor(expr: PsiElement, tyName: String, traitName: String, methodName: String) : super(expr, tyName, traitName) {
+    constructor(expr: RsExpr, tyName: String, traitName: String, methodName: String) : super(expr, tyName, traitName) {
         this.methodName = methodName
     }
 
-    constructor(expr: PsiElement, ty: Ty, traitName: String, methodName: String) : super(expr, ty, traitName) {
+    constructor(expr: RsExpr, ty: Ty, traitName: String, methodName: String) : super(expr, ty, traitName) {
         this.methodName = methodName
     }
 
@@ -44,30 +44,30 @@ abstract class ConvertToTyUsingTraitMethodFix : ConvertToTyUsingTraitFix {
 /**
  * For the given `expr` converts it to the borrowed type with `borrow()` method.
  */
-class ConvertToBorrowedTyFix(expr: PsiElement, ty: Ty) : ConvertToTyUsingTraitMethodFix(expr, ty, "Borrow", "borrow")
+class ConvertToBorrowedTyFix(expr: RsExpr, ty: Ty) : ConvertToTyUsingTraitMethodFix(expr, ty, "Borrow", "borrow")
 
 /**
  * For the given `expr` converts it to the borrowed type with `borrow_mut()` method.
  */
-class ConvertToBorrowedTyWithMutFix(expr: PsiElement, ty: Ty) : ConvertToTyUsingTraitMethodFix(expr, ty, "BorrowMut", "borrow_mut")
+class ConvertToBorrowedTyWithMutFix(expr: RsExpr, ty: Ty) : ConvertToTyUsingTraitMethodFix(expr, ty, "BorrowMut", "borrow_mut")
 
 /**
  * For the given `expr` converts it to the borrowed type with `as_mut()` method.
  */
-class ConvertToMutTyFix(expr: PsiElement, ty: Ty) : ConvertToTyUsingTraitMethodFix(expr, ty, "AsMut", "as_mut")
+class ConvertToMutTyFix(expr: RsExpr, ty: Ty) : ConvertToTyUsingTraitMethodFix(expr, ty, "AsMut", "as_mut")
 
 /**
  * For the given `expr` converts it to the reference type with `as_ref()` method.
  */
-class ConvertToRefTyFix(expr: PsiElement, ty: Ty) : ConvertToTyUsingTraitMethodFix(expr, ty, "AsRef", "as_ref")
+class ConvertToRefTyFix(expr: RsExpr, ty: Ty) : ConvertToTyUsingTraitMethodFix(expr, ty, "AsRef", "as_ref")
 
 /**
  * For the given `expr` converts it to the owned type with `to_owned()` method.
  */
-class ConvertToOwnedTyFix(expr: PsiElement, ty: Ty): ConvertToTyUsingTraitMethodFix(expr, ty, "ToOwned", "to_owned")
+class ConvertToOwnedTyFix(expr: RsExpr, ty: Ty): ConvertToTyUsingTraitMethodFix(expr, ty, "ToOwned", "to_owned")
 
 /**
  * For the given `expr` adds `to_string()` call. Note the fix doesn't attempt to check if adding the function call
  * will produce a valid expression.
  */
-class ConvertToStringFix(expr: PsiElement) : ConvertToTyUsingTraitMethodFix(expr, "String", "ToString", "to_string")
+class ConvertToStringFix(expr: RsExpr) : ConvertToTyUsingTraitMethodFix(expr, "String", "ToString", "to_string")

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTraitFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTraitFix.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.annotator.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
@@ -14,22 +13,27 @@ import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.types.ty.Ty
 
+abstract class ConvertToTyUsingTraitFix : ConvertToTyFix {
+    constructor(expr: PsiElement, tyName: String, traitName: String) : super(expr, tyName, "`$traitName` trait")
+    constructor(expr: PsiElement, ty: Ty, traitName: String) : super(expr, ty, "`$traitName` trait")
+}
+
 /**
  * For the given `expr` adds method call defined by [methodName]. Note the fix doesn't attempt to check the type
  * of `expr` and so doesn't check if adding the function call will produce a valid expression. The conversion trait
  * [traitName] and resulting type [tyName] are used only for messaging.
  */
-abstract class ConvertToTyUsingTraitFix(
-    expr: PsiElement,
-    private val tyName: String,
-    private val traitName: String,
-    private val methodName: String) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
+abstract class ConvertToTyUsingTraitMethodFix : ConvertToTyUsingTraitFix {
 
-    constructor(expr: PsiElement, ty: Ty, traitName: String, methodName: String) : this(expr, ty.toString(), traitName, methodName)
+    private val methodName: String
 
-    override fun getFamilyName(): String = "Convert to type"
+    constructor(expr: PsiElement, tyName: String, traitName: String, methodName: String) : super(expr, tyName, traitName) {
+        this.methodName = methodName
+    }
 
-    override fun getText(): String = "Convert to $tyName using `$traitName` trait"
+    constructor(expr: PsiElement, ty: Ty, traitName: String, methodName: String) : super(expr, ty, traitName) {
+        this.methodName = methodName
+    }
 
     override fun invoke(project: Project, file: PsiFile, editor: Editor?, startElement: PsiElement, endElement: PsiElement) {
         if (startElement !is RsExpr) return
@@ -40,30 +44,30 @@ abstract class ConvertToTyUsingTraitFix(
 /**
  * For the given `expr` converts it to the borrowed type with `borrow()` method.
  */
-class ConvertToBorrowedTyFix(expr: PsiElement, ty: Ty) : ConvertToTyUsingTraitFix(expr, ty, "Borrow", "borrow")
+class ConvertToBorrowedTyFix(expr: PsiElement, ty: Ty) : ConvertToTyUsingTraitMethodFix(expr, ty, "Borrow", "borrow")
 
 /**
  * For the given `expr` converts it to the borrowed type with `borrow_mut()` method.
  */
-class ConvertToBorrowedTyWithMutFix(expr: PsiElement, ty: Ty) : ConvertToTyUsingTraitFix(expr, ty, "BorrowMut", "borrow_mut")
+class ConvertToBorrowedTyWithMutFix(expr: PsiElement, ty: Ty) : ConvertToTyUsingTraitMethodFix(expr, ty, "BorrowMut", "borrow_mut")
 
 /**
  * For the given `expr` converts it to the borrowed type with `as_mut()` method.
  */
-class ConvertToMutTyFix(expr: PsiElement, ty: Ty) : ConvertToTyUsingTraitFix(expr, ty, "AsMut", "as_mut")
+class ConvertToMutTyFix(expr: PsiElement, ty: Ty) : ConvertToTyUsingTraitMethodFix(expr, ty, "AsMut", "as_mut")
 
 /**
  * For the given `expr` converts it to the reference type with `as_ref()` method.
  */
-class ConvertToRefTyFix(expr: PsiElement, ty: Ty) : ConvertToTyUsingTraitFix(expr, ty, "AsRef", "as_ref")
+class ConvertToRefTyFix(expr: PsiElement, ty: Ty) : ConvertToTyUsingTraitMethodFix(expr, ty, "AsRef", "as_ref")
 
 /**
  * For the given `expr` converts it to the owned type with `to_owned()` method.
  */
-class ConvertToOwnedTyFix(expr: PsiElement, ty: Ty): ConvertToTyUsingTraitFix(expr, ty, "ToOwned", "to_owned")
+class ConvertToOwnedTyFix(expr: PsiElement, ty: Ty): ConvertToTyUsingTraitMethodFix(expr, ty, "ToOwned", "to_owned")
 
 /**
  * For the given `expr` adds `to_string()` call. Note the fix doesn't attempt to check if adding the function call
  * will produce a valid expression.
  */
-class ConvertToStringFix(expr: PsiElement) : ConvertToTyUsingTraitFix(expr, "String", "ToString", "to_string")
+class ConvertToStringFix(expr: PsiElement) : ConvertToTyUsingTraitMethodFix(expr, "String", "ToString", "to_string")

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyUsingTryFromTraitFix.kt
@@ -25,7 +25,7 @@ import org.rust.lang.core.types.type
  * [fromCallMaker] is also not checked.
  */
 abstract class ConvertToTyUsingTryTraitFix(
-    expr: PsiElement,
+    expr: RsExpr,
     private val ty: Ty,
     traitName: String,
     private val fromCallMaker: ConvertToTyUsingTryTraitFix.(RsPsiFactory, RsExpr, Ty) -> RsExpr
@@ -47,7 +47,7 @@ abstract class ConvertToTyUsingTryTraitFix(
  * Similar to [ConvertToTyUsingTryTraitFix], but also "unwraps" the result with `unwrap()` or `?`.
  */
 abstract class ConvertToTyUsingTryTraitAndUnpackFix(
-    expr: PsiElement,
+    expr: RsExpr,
     ty: Ty,
     private val errTy: Ty,
     traitName: String,
@@ -93,14 +93,14 @@ private val TRY_FROM_CALL_MAKER: ConvertToTyUsingTryTraitFix.(RsPsiFactory, RsEx
 /**
  * For the given `expr` converts it to the type `Result<ty, _>` with `ty::try_from(expr)`.
  */
-class ConvertToTyUsingTryFromTraitFix(expr: PsiElement, ty: Ty) :
+class ConvertToTyUsingTryFromTraitFix(expr: RsExpr, ty: Ty) :
     ConvertToTyUsingTryTraitFix(expr, ty, TRY_FROM_TRAIT, TRY_FROM_CALL_MAKER)
 
 /**
  * For the given `expr` converts it to the type [ty] with `ty::try_from(expr).unwrap()` or `ty::try_from(expr)?` if
  * possible.
  */
-class ConvertToTyUsingTryFromTraitAndUnpackFix(expr: PsiElement, ty: Ty, errTy: Ty) :
+class ConvertToTyUsingTryFromTraitAndUnpackFix(expr: RsExpr, ty: Ty, errTy: Ty) :
     ConvertToTyUsingTryTraitAndUnpackFix(expr, ty, errTy, TRY_FROM_TRAIT, TRY_FROM_CALL_MAKER)
 
 private const val FROM_STR_TRAIT = "FromStr"
@@ -110,12 +110,12 @@ private val PARSE_CALL_MAKER: ConvertToTyUsingTryTraitFix.(RsPsiFactory, RsExpr,
 /**
  * For the given `strExpr` converts it to the type `Result<ty, _>` with `strExpr.parse()`.
  */
-class ConvertToTyUsingFromStrFix(strExpr: PsiElement, ty: Ty):
+class ConvertToTyUsingFromStrFix(strExpr: RsExpr, ty: Ty):
     ConvertToTyUsingTryTraitFix(strExpr, ty, FROM_STR_TRAIT, PARSE_CALL_MAKER)
 
 /**
  * For the given `strExpr` converts it to the type [ty] with `strExpr.parse().unwrap()` or
  * `strExpr.parse()?` if possible.
  */
-class ConvertToTyUsingFromStrAndUnpackFix(strExpr: PsiElement, ty: Ty, errTy: Ty) :
+class ConvertToTyUsingFromStrAndUnpackFix(strExpr: RsExpr, ty: Ty, errTy: Ty) :
     ConvertToTyUsingTryTraitAndUnpackFix(strExpr, ty, errTy, FROM_STR_TRAIT, PARSE_CALL_MAKER)

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFix.kt
@@ -26,7 +26,7 @@ data class DerefRefPath(val derefs: Int, val refs: List<Mutability>)
  * `path.refs`. Note that correctness of the generated code is not verified.
  */
 class ConvertToTyWithDerefsRefsFix(
-    expr: PsiElement,
+    expr: RsExpr,
     ty: Ty,
     val path: DerefRefPath
 ) : ConvertToTyFix(expr, ty, formatRefs(path)) {

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ConvertToTyWithDerefsRefsFix.kt
@@ -5,7 +5,6 @@
 
 package org.rust.ide.annotator.fixes
 
-import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
@@ -28,13 +27,9 @@ data class DerefRefPath(val derefs: Int, val refs: List<Mutability>)
  */
 class ConvertToTyWithDerefsRefsFix(
     expr: PsiElement,
-    val ty: Ty,
+    ty: Ty,
     val path: DerefRefPath
-) : LocalQuickFixAndIntentionActionOnPsiElement(expr) {
-    override fun getFamilyName(): String = "Convert to type"
-
-    override fun getText(): String = "Convert to $ty using ${formatRefs(path)}"
-
+) : ConvertToTyFix(expr, ty, formatRefs(path)) {
     override fun invoke(
         project: Project,
         file: PsiFile,

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToBorrowedTyFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToBorrowedTyFixTest.kt
@@ -5,6 +5,5 @@
 
 package org.rust.ide.inspections.typecheck
 
-class ConvertToBorrowedTyFixTest : ConvertToTyUsingTraitFixTestBase(
+class ConvertToBorrowedTyFixTest : ConvertToTyUsingTraitMethodFixTestBase(
     false, "Borrow", "borrow", "use std::borrow::Borrow;")
-

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToBorrowedTyWithMutFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToBorrowedTyWithMutFixTest.kt
@@ -6,7 +6,7 @@
 package org.rust.ide.inspections.typecheck
 
 
-class ConvertToBorrowedTyWithMutFixTest : ConvertToTyUsingTraitFixTestBase(
+class ConvertToBorrowedTyWithMutFixTest : ConvertToTyUsingTraitMethodFixTestBase(
     true, "BorrowMut", "borrow_mut", "use std::borrow::BorrowMut;") {
 
     fun `test &String to &mut String`() = checkFixIsUnavailable("Convert to &mut String using `BorrowMut` trait", """

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToMutTyFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToMutTyFixTest.kt
@@ -5,4 +5,4 @@
 
 package org.rust.ide.inspections.typecheck
 
-class ConvertToMutTyFixTest : ConvertToTyUsingTraitFixTestBase(true, "AsMut", "as_mut")
+class ConvertToMutTyFixTest : ConvertToTyUsingTraitMethodFixTestBase(true, "AsMut", "as_mut")

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToRefTyFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToRefTyFixTest.kt
@@ -6,4 +6,4 @@
 package org.rust.ide.inspections.typecheck
 
 
-class ConvertToRefTyFixTest : ConvertToTyUsingTraitFixTestBase(false, "AsRef", "as_ref")
+class ConvertToRefTyFixTest : ConvertToTyUsingTraitMethodFixTestBase(false, "AsRef", "as_ref")

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyUsingFromTraitFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyUsingFromTraitFixTest.kt
@@ -54,7 +54,7 @@ class ConvertToTyUsingFromTraitFixTest : RsInspectionsTestBase(RsTypeCheckInspec
         }
     """)
 
-    fun `test From impl for generic type`() = checkFixByText ("Convert to Vec<u8> using `From` trait", """
+    fun `test From impl for generic type`() = checkFixByText("Convert to Vec<u8> using `From` trait", """
         fn main () {
             let v: Vec<u8> = <error>String::new()<caret></error>;
         }
@@ -64,43 +64,39 @@ class ConvertToTyUsingFromTraitFixTest : RsInspectionsTestBase(RsTypeCheckInspec
         }
     """)
 
-    fun `test From impl for reference type`() = checkFixByText(
-        "Convert to &[u8] using `From` trait", """
+    fun `test From impl for reference type`() = checkFixByText("Convert to &[u8] using `From` trait", """
         struct A;
-        
+
         impl From<A> for &[u8] { fn from(item: A) -> Self { &[] } }
-        
+
         fn main() {
             let b: &[u8] = <error>A<caret></error>;
         }
     """, """
         struct A;
-        
+
         impl From<A> for &[u8] { fn from(item: A) -> Self { &[] } }
-        
+
         fn main() {
             let b: &[u8] = <&[u8]>::from(A);
         }
-    """
-    )
+    """)
 
-    fun `test From impl for tuple type`() = checkFixByText(
-        "Convert to (i32, i32) using `From` trait", """
+    fun `test From impl for tuple type`() = checkFixByText("Convert to (i32, i32) using `From` trait", """
         struct A;
-        
+
         impl From<A> for (i32, i32) { fn from(item: A) -> Self { (0, 0) } }
-        
+
         fn main() {
             let b: (i32, i32) = <error>A<caret></error>;
         }
     """, """
         struct A;
-        
+
         impl From<A> for (i32, i32) { fn from(item: A) -> Self { (0, 0) } }
-        
+
         fn main() {
             let b: (i32, i32) = <(i32, i32)>::from(A);
         }
-    """
-    )
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyUsingFromTraitFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyUsingFromTraitFixTest.kt
@@ -64,6 +64,26 @@ class ConvertToTyUsingFromTraitFixTest : RsInspectionsTestBase(RsTypeCheckInspec
         }
     """)
 
+    fun `test From impl for generic type with default type params`() = checkFixByText("Convert to B using `From` trait", """
+        struct A;
+        struct B<T = i32>(T);
+
+        impl<T> From<A> for B<T> { fn from(item: A) -> Self { todo!() } }
+
+        fn foo(a: A) {
+            let b: B = <error>a/*caret*/</error>;
+        }
+    """, """
+        struct A;
+        struct B<T = i32>(T);
+
+        impl<T> From<A> for B<T> { fn from(item: A) -> Self { todo!() } }
+
+        fn foo(a: A) {
+            let b: B = B::from(a);
+        }
+    """)
+
     fun `test From impl for reference type`() = checkFixByText("Convert to &[u8] using `From` trait", """
         struct A;
 

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyUsingTraitMethodFixTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/ConvertToTyUsingTraitMethodFixTestBase.kt
@@ -11,7 +11,7 @@ import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.ide.inspections.RsTypeCheckInspection
 
 @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-abstract class ConvertToTyUsingTraitFixTestBase(
+abstract class ConvertToTyUsingTraitMethodFixTestBase(
     isExpectedMut: Boolean, private val trait: String, private val method: String, protected val imports: String = ""
 ) : RsInspectionsTestBase(RsTypeCheckInspection::class) {
     private val ref = if (isExpectedMut) "&mut " else "&"


### PR DESCRIPTION
These changes:
- refactor `Convert to type` quick-fixes. All common code is extracted into a single place, new base `ConvertToTyFix` class.
Also, now you can only pass `RsExpr` to the corresponding quick-fixes instead of any psi object
- omit default type parameters in a quick-fix text

changelog: Omit default type parameters in a `Convert to type` quick-fix text