### PR TITLE
RES: Fix macro with `local_inner_macros` expanded to `extern crate`

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
@@ -119,7 +119,11 @@ private class ModCollector(
     }
 
     override fun collectImport(import: ImportLight) {
-        val usePath = dollarCrateHelper?.convertPath(import.usePath, import.offsetInExpansion) ?: import.usePath
+        val usePath = if (dollarCrateHelper != null && !import.isExternCrate) {
+            dollarCrateHelper.convertPath(import.usePath, import.offsetInExpansion)
+        } else {
+            import.usePath
+        }
         context.context.imports += Import(
             containingMod = modData,
             usePath = usePath,

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsMacroExpansionResolveTest.kt
@@ -881,6 +881,24 @@ class RsMacroExpansionResolveTest : RsResolveTestBase() {
         }
     """)
 
+    // we only test that there are no exception with new resolve
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test local_inner_macros expanded to extern crate`() = stubOnlyResolve("""
+    //- main.rs
+        use test_package::foo;
+        foo!();
+        //^ lib.rs
+        fn main() {}
+    //- lib.rs
+        #[macro_export(local_inner_macros)]
+        macro_rules! foo {
+            () => {
+                extern crate foo;
+            };
+        }
+    """)
+
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test expand macro with incomplete path`() = stubOnlyResolve("""
     //- main.rs


### PR DESCRIPTION
Fix exception when macro with `local_inner_macros` expands to `extern crate`

```
java.lang.IllegalArgumentException: Array has more than one element.
	at kotlin.collections.ArraysKt___ArraysKt.single(_Arrays.kt:2775)
	at org.rust.lang.core.resolve2.DefCollector.resolveImport(DefCollector.kt:112)
	at org.rust.lang.core.resolve2.DefCollector.resolveImports(DefCollector.kt:84)
	at org.rust.lang.core.resolve2.DefCollector.collect(DefCollector.kt:69)
	at org.rust.lang.core.resolve2.FacadeBuildDefMapKt.buildDefMap(FacadeBuildDefMap.kt:31)
```

No entry in changelog since it is a hotfix for #7014