### PR TITLE
Implement stub-only `QueryAttributes` API

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -148,7 +148,9 @@ private AttrUpper ::= MetaItemWithoutTT ']' |  MetaItemWithTT ']'
 private OuterAttr_first ::= '#'
 
 fake MetaItem ::= Path [ '=' LitExpr | MetaItemArgs ] | CompactTT {
-  extends = "org.rust.lang.core.psi.ext.RsStubbedElementImpl<?>"
+  implements = [ "org.rust.lang.core.psi.ext.RsElement"
+                 "org.rust.lang.core.stubs.common.RsMetaItemPsiOrStub" ]
+  mixin = "org.rust.lang.core.psi.ext.RsMetaItemImplMixin"
   stubClass = "org.rust.lang.core.stubs.RsMetaItemStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
@@ -172,8 +174,10 @@ MetaItemWithoutTT ::= PathWithoutTypeArgs [ '=' LitExprWithoutAttrs | MetaItemAr
 MetaItemWithTT ::= CompactTT { elementType = MetaItem }
 
 MetaItemArgs ::= '(' ( [ <<comma_separated_list (LitExprWithoutAttrs | MetaItemWithoutTT )>> ] ')' |  MetaItemWithTT ')' ) {
+  implements = [ "org.rust.lang.core.psi.ext.RsElement"
+                 "org.rust.lang.core.stubs.common.RsMetaItemArgsPsiOrStub" ]
   extends = "org.rust.lang.core.psi.ext.RsStubbedElementImpl<?>"
-  stubClass = "org.rust.lang.core.stubs.RsPlaceholderStub"
+  stubClass = "org.rust.lang.core.stubs.RsMetaItemArgsStub"
   elementTypeFactory = "org.rust.lang.core.stubs.StubImplementationsKt.factory"
 }
 

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -81,7 +81,7 @@ enum class RsLint(
 
     private fun explicitLevel(el: PsiElement): RsLintLevel? = el.ancestors
         .filterIsInstance<RsDocAndAttributeOwner>()
-        .flatMap { it.queryAttributes.metaItems }
+        .flatMap { it.queryAttributes.metaItems.toList().asReversed().asSequence() }
         .filter { it.metaItemArgs?.metaItemList.orEmpty().any { item -> item.id == id || item.id in groupIds } }
         .mapNotNull { it.name?.let { name -> RsLintLevel.valueForId(name) } }
         .firstOrNull()

--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -63,9 +63,6 @@ abstract class RsFileBase(fileViewProvider: FileViewProvider) : PsiFileBase(file
     override fun getFileType(): FileType = RsFileType
 
     override fun getStub(): RsFileStub? = super.getStub() as RsFileStub?
-
-    override val innerAttrList: List<RsInnerAttr>
-        get() = stubChildrenOfType()
 }
 
 class RsFile(

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/PsiElement.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.*
 import com.intellij.psi.impl.source.PsiFileImpl
+import com.intellij.psi.stubs.IStubElementType
 import com.intellij.psi.stubs.StubElement
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
@@ -210,6 +211,16 @@ fun <T : PsiElement> getStubDescendantOfType(
 
 inline fun <reified T : PsiElement> PsiElement.descendantsWithMacrosOfType(): Collection<T> =
     findDescendantsWithMacrosOfAnyType(this, true, T::class.java)
+
+fun PsiElement.stubChildOfElementType(elementType: IElementType): PsiElement? {
+    val stub = (this as? StubBasedPsiElement<*>)?.stub
+    return if (stub != null) {
+        @Suppress("UNCHECKED_CAST")
+        stub.findChildStubByType(elementType as IStubElementType<StubElement<PsiElement>, PsiElement>)?.psi
+    } else {
+        node.findChildByType(elementType)?.psi
+    }
+}
 
 /**
  * Same as [PsiElement.getContainingFile], but return a "fake" file. See [org.rust.lang.core.macros.RsExpandedElement].

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -11,16 +11,27 @@ import com.intellij.openapi.util.registry.Registry
 import com.intellij.psi.NavigatablePsiElement
 import com.intellij.psi.PsiElement
 import com.intellij.psi.StubBasedPsiElement
+import com.intellij.psi.stubs.StubBase
 import com.intellij.psi.stubs.StubElement
+import com.intellij.psi.tree.IElementType
 import org.rust.lang.core.crate.Crate
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.stubs.RsAttributeOwnerStub
+import org.rust.lang.core.stubs.RsFileStub
+import org.rust.lang.core.stubs.RsInnerAttrStub
+import org.rust.lang.core.stubs.RsMetaItemStub
+import org.rust.lang.core.stubs.common.RsAttributeOwnerPsiOrStub
+import org.rust.lang.core.stubs.common.RsMetaItemPsiOrStub
 import org.rust.lang.utils.evaluation.CfgEvaluator
 import org.rust.lang.utils.evaluation.ThreeValuedLogic
 import org.rust.openapiext.testAssert
 import org.rust.stdext.nextOrNull
 
-interface RsDocAndAttributeOwner : RsElement, NavigatablePsiElement
+interface RsDocAndAttributeOwner : RsElement, NavigatablePsiElement, RsAttributeOwnerPsiOrStub<RsMetaItem> {
+    @JvmDefault
+    override val rawMetaItems: Sequence<RsMetaItem>
+        get() = RsInnerAttributeOwnerRegistry.rawMetaItemsForPsi(this)
+}
 
 interface RsInnerAttributeOwner : RsDocAndAttributeOwner {
     /**
@@ -28,7 +39,9 @@ interface RsInnerAttributeOwner : RsDocAndAttributeOwner {
      * In contrast, inner attributes can be either direct
      * children or grandchildren.
      */
+    @JvmDefault
     val innerAttrList: List<RsInnerAttr>
+        get() = RsInnerAttributeOwnerRegistry.innerAttrsForPsi(this)
 }
 
 /**
@@ -53,6 +66,69 @@ interface RsOuterAttributeOwner : RsDocAndAttributeOwner {
     @JvmDefault
     val outerAttrList: List<RsOuterAttr>
         get() = stubChildrenOfType()
+}
+
+object RsInnerAttributeOwnerRegistry {
+    private val reg: Map<IElementType, AttrInfo> = hashMapOf(
+        RsElementTypes.FOREIGN_MOD_ITEM to AttrInfo.Direct,
+        RsElementTypes.MOD_ITEM to AttrInfo.Direct,
+        RsFileStub.Type to AttrInfo.Direct,
+        RsElementTypes.FUNCTION to AttrInfo.Nested(RsElementTypes.BLOCK),
+        RsElementTypes.IMPL_ITEM to AttrInfo.Nested(RsElementTypes.MEMBERS),
+        RsElementTypes.TRAIT_ITEM to AttrInfo.Nested(RsElementTypes.MEMBERS),
+    )
+
+    private val attrsElementSet = tokenSetOf(RsElementTypes.OUTER_ATTR, RsElementTypes.INNER_ATTR)
+
+    fun innerAttrsForPsi(psi: RsInnerAttributeOwner): List<RsInnerAttr> = when (val info = reg[psi.elementType]) {
+        AttrInfo.Direct -> psi.stubChildrenOfType()
+        is AttrInfo.Nested -> psi.stubChildOfElementType(info.elementType)?.stubChildrenOfType<RsInnerAttr>().orEmpty()
+        null -> error("Inner attributes for type $psi are not registered")
+    }
+
+    private fun allAttrsForPsi(psi: RsDocAndAttributeOwner): Sequence<RsAttr> = when (reg[psi.elementType]) {
+        null, AttrInfo.Direct -> {
+            psi.stubChildrenOfType<RsAttr>().asSequence()
+        }
+        is AttrInfo.Nested -> {
+            (psi as? RsOuterAttributeOwner)?.outerAttrList.orEmpty().asSequence() +
+                (psi as? RsInnerAttributeOwner)?.innerAttrList.orEmpty().asSequence()
+        }
+    }
+
+    fun rawMetaItemsForPsi(psi: RsDocAndAttributeOwner): Sequence<RsMetaItem> =
+        allAttrsForPsi(psi).map { it.metaItem }
+
+    private fun <S> allAttrsForStub(stub: S): Sequence<StubElement<*>> where S : StubBase<*>,
+                                                                             S : RsAttributeOwnerStub {
+        return when (val info = reg[stub.stubType]) {
+            null, AttrInfo.Direct -> {
+                stub.childrenStubs.asSequence().filter { it.stubType in attrsElementSet }
+            }
+            is AttrInfo.Nested -> {
+                val childrenStubs = stub.childrenStubs
+                val outer = childrenStubs.asSequence().filter { it.stubType == RsElementTypes.OUTER_ATTR }
+                val inner = childrenStubs
+                    .find { it.stubType == info.elementType }
+                    ?.childrenStubs
+                    ?.asSequence()
+                    ?.filterIsInstance<RsInnerAttrStub>()
+                    ?: emptySequence()
+                outer + inner
+            }
+        }
+    }
+
+    fun <S> rawMetaItemsForStub(stub: S): Sequence<RsMetaItemStub> where S : StubBase<*>,
+                                                                         S : RsAttributeOwnerStub {
+        val attrs = allAttrsForStub(stub)
+        return attrs.mapNotNull { it.findChildStubByType(RsMetaItemStub.Type) }
+    }
+
+    private sealed class AttrInfo {
+        object Direct : AttrInfo()
+        class Nested(val elementType: IElementType) : AttrInfo()
+    }
 }
 
 /**
@@ -86,21 +162,32 @@ inline val RsDocAndAttributeOwner.attributeStub: RsAttributeOwnerStub?
 /**
  * Returns [QueryAttributes] for given PSI element after `#[cfg_attr()]` expansion
  */
-val RsDocAndAttributeOwner.queryAttributes: QueryAttributes
+val RsDocAndAttributeOwner.queryAttributes: QueryAttributes<RsMetaItem>
     get() = getQueryAttributes(null)
 
 /** [explicitCrate] is passed to avoid resolve triggering */
 fun RsDocAndAttributeOwner.getQueryAttributes(
     explicitCrate: Crate?,
     stub: RsAttributeOwnerStub? = attributeStub
-): QueryAttributes {
+): QueryAttributes<RsMetaItem> {
     testAssert { !DumbService.isDumb(project) }
+    return if (stub != null) {
+        QueryAttributes(stub.getQueryAttributes(explicitCrate).metaItems.map { it.psi })
+    } else {
+        getExpandedAttributesNoStub(explicitCrate)
+    }
+}
+
+/** [explicitCrate] is passed to avoid resolve triggering */
+fun RsAttributeOwnerStub.getQueryAttributes(
+    explicitCrate: Crate?
+): QueryAttributes<RsMetaItemStub> {
     return when {
         // No attributes - return empty sequence
-        stub?.hasAttrs == false -> QueryAttributes.EMPTY
+        !hasAttrs -> QueryAttributes.empty()
 
         // No `#[cfg_attr()]` attributes - return attributes without `cfg_attr` expansion
-        stub?.hasCfgAttr == false -> rawAttributes
+        !hasCfgAttr -> rawAttributes
 
         // Slow path. There are `#[cfg_attr()]` attributes - expand them and return expanded attributes
         else -> getExpandedAttributesNoStub(explicitCrate)
@@ -108,17 +195,18 @@ fun RsDocAndAttributeOwner.getQueryAttributes(
 }
 
 /** [explicitCrate] is passed to avoid resolve triggering */
-private fun RsDocAndAttributeOwner.getExpandedAttributesNoStub(explicitCrate: Crate?): QueryAttributes {
+private fun <T : RsMetaItemPsiOrStub> RsAttributeOwnerPsiOrStub<T>.getExpandedAttributesNoStub(explicitCrate: Crate?): QueryAttributes<T> {
     if (!CFG_ATTRIBUTES_ENABLED_KEY.asBoolean()) return rawAttributes
     val crate = explicitCrate ?: containingCrate ?: return rawAttributes
     val evaluator = CfgEvaluator.forCrate(crate)
     return QueryAttributes(evaluator.expandCfgAttrs(rawMetaItems))
 }
 
-fun CfgEvaluator.expandCfgAttrs(rawMetaItems: Sequence<RsMetaItem>): Sequence<RsMetaItem> {
+fun <T : RsMetaItemPsiOrStub> CfgEvaluator.expandCfgAttrs(rawMetaItems: Sequence<T>): Sequence<T> {
     return rawMetaItems.flatMap {
         if (it.name == "cfg_attr") {
-            val list = it.metaItemArgs?.metaItemList?.iterator() ?: return@flatMap emptySequence()
+            @Suppress("UNCHECKED_CAST")
+            val list = it.metaItemArgsList.iterator() as Iterator<T>
             val condition = list.nextOrNull() ?: return@flatMap emptySequence()
             if (evaluateCondition(condition) != ThreeValuedLogic.False) {
                 expandCfgAttrs(list.asSequence())
@@ -131,15 +219,16 @@ fun CfgEvaluator.expandCfgAttrs(rawMetaItems: Sequence<RsMetaItem>): Sequence<Rs
     }
 }
 
-fun RsDocAndAttributeOwner.getTraversedRawAttributes(withCfgAttrAttribute: Boolean = false): QueryAttributes {
+fun RsDocAndAttributeOwner.getTraversedRawAttributes(withCfgAttrAttribute: Boolean = false): QueryAttributes<RsMetaItem> {
     return QueryAttributes(rawMetaItems.withFlattenCfgAttrsAttributes(withCfgAttrAttribute))
 }
 
-fun Sequence<RsMetaItem>.withFlattenCfgAttrsAttributes(withCfgAttrAttribute: Boolean): Sequence<RsMetaItem> =
+fun <T : RsMetaItemPsiOrStub> Sequence<T>.withFlattenCfgAttrsAttributes(withCfgAttrAttribute: Boolean): Sequence<T> =
     flatMap {
         if (it.name == "cfg_attr") {
-            val metaItems = it.metaItemArgs?.metaItemList ?: return@flatMap emptySequence()
-            val nested = metaItems.asSequence().drop(1)
+            val metaItems = it.metaItemArgsList
+            @Suppress("UNCHECKED_CAST")
+            val nested = metaItems.asSequence().drop(1) as Sequence<T>
             if (withCfgAttrAttribute) {
                 sequenceOf(it) + nested
             } else {
@@ -150,18 +239,11 @@ fun Sequence<RsMetaItem>.withFlattenCfgAttrsAttributes(withCfgAttrAttribute: Boo
         }
     }
 
-private val RsDocAndAttributeOwner.rawAttributes: QueryAttributes
+private val <T : RsMetaItemPsiOrStub> RsAttributeOwnerPsiOrStub<T>.rawAttributes: QueryAttributes<T>
     get() = QueryAttributes(rawMetaItems)
 
-private val RsDocAndAttributeOwner.rawMetaItems: Sequence<RsMetaItem>
-    get() {
-        val attributes: Sequence<RsAttr> = (this as? RsInnerAttributeOwner)?.innerAttrList.orEmpty().asSequence() +
-            (this as? RsOuterAttributeOwner)?.outerAttrList.orEmpty().asSequence()
-        return attributes.map { it.metaItem }
-    }
-
 class StubbedAttributeProperty<P, S>(
-    private val fromQuery: (QueryAttributes) -> Boolean,
+    private val fromQuery: (QueryAttributes<*>) -> Boolean,
     private val mayHave: (S) -> Boolean
 ) where P : RsDocAndAttributeOwner,
         P : StubBasedPsiElement<out S>,
@@ -180,7 +262,7 @@ class StubbedAttributeProperty<P, S>(
                 true
             } else {
                 // Slow path. There are `#[cfg_attr()]` attributes, so we should expand them
-                fromQuery(stub.psi.getExpandedAttributesNoStub(crate))
+                fromQuery(stub.getExpandedAttributesNoStub(crate))
             }
         }
     }
@@ -203,8 +285,8 @@ class StubbedAttributeProperty<P, S>(
  *
  * **Do not instantiate directly**, use [RsDocAndAttributeOwner.queryAttributes] instead.
  */
-class QueryAttributes(
-    val metaItems: Sequence<RsMetaItem>
+class QueryAttributes<out T: RsMetaItemPsiOrStub>(
+    val metaItems: Sequence<T>
 ) {
     // #[doc(hidden)]
     val isDocHidden: Boolean get() = hasAttributeWithArg("doc", "hidden")
@@ -231,13 +313,13 @@ class QueryAttributes(
     // `#[attributeName(arg)]`
     fun hasAttributeWithArg(attributeName: String, arg: String): Boolean {
         val attrs = attrsByName(attributeName)
-        return attrs.any { it.metaItemArgs?.metaItemList?.any { item -> item.name == arg } ?: false }
+        return attrs.any { it.metaItemArgsList.any { item -> item.name == arg } }
     }
 
     // `#[attributeName(arg)]`
     fun getFirstArgOfSingularAttribute(attributeName: String): String? {
         return attrsByName(attributeName).singleOrNull()
-            ?.metaItemArgs?.metaItemList?.firstOrNull()
+            ?.metaItemArgsList?.firstOrNull()
             ?.name
     }
 
@@ -245,7 +327,7 @@ class QueryAttributes(
     fun hasAttributeWithKeyValue(attributeName: String, key: String, value: String): Boolean {
         val attrs = attrsByName(attributeName)
         return attrs.any {
-            it.metaItemArgs?.metaItemList?.any { item -> item.name == key && item.value == value } ?: false
+            it.metaItemArgsList.any { item -> item.name == key && item.value == value }
         }
     }
 
@@ -264,21 +346,21 @@ class QueryAttributes(
         get() = getStringAttributes("lang")
 
     // #[derive(Clone)], #[derive(Copy, Clone, Debug)]
-    val deriveAttributes: Sequence<RsMetaItem>
+    val deriveAttributes: Sequence<T>
         get() = attrsByName("derive")
 
     // #[repr(u16)], #[repr(C, packed)], #[repr(simd)], #[repr(align(8))]
-    val reprAttributes: Sequence<RsMetaItem>
+    val reprAttributes: Sequence<T>
         get() = attrsByName("repr")
 
     // #[deprecated(since, note)], #[rustc_deprecated(since, reason)]
-    val deprecatedAttribute: RsMetaItem?
+    val deprecatedAttribute: T?
         get() = (attrsByName("deprecated") + attrsByName("rustc_deprecated")).firstOrNull()
 
-    val cfgAttributes: Sequence<RsMetaItem>
+    val cfgAttributes: Sequence<T>
         get() = attrsByName("cfg")
 
-    val unstableAttributes: Sequence<RsMetaItem>
+    val unstableAttributes: Sequence<T>
         get() = attrsByName("unstable")
 
     // `#[attributeName = "Xxx"]`
@@ -288,13 +370,22 @@ class QueryAttributes(
     /**
      * Get a sequence of all attributes named [name]
      */
-    fun attrsByName(name: String): Sequence<RsMetaItem> = metaItems.filter { it.name == name }
+    fun attrsByName(name: String): Sequence<T> = metaItems.filter { it.name == name }
 
     override fun toString(): String =
-        "QueryAttributes(${metaItems.joinToString { it.text }})"
+        "QueryAttributes(${metaItems.joinToString {
+            when (it) {
+                is RsMetaItem -> it.text
+                is RsMetaItemStub -> it.psi.text
+                else -> error("unreachable")
+            }
+        }})"
 
     companion object {
-        val EMPTY: QueryAttributes = QueryAttributes(emptySequence())
+        private val EMPTY: QueryAttributes<*> = QueryAttributes(emptySequence())
+
+        @Suppress("UNCHECKED_CAST")
+        fun <T : RsMetaItemPsiOrStub> empty(): QueryAttributes<T> = EMPTY as QueryAttributes<T>
     }
 }
 
@@ -315,13 +406,11 @@ val RsDocAndAttributeOwner.isCfgUnknownSelf: Boolean
 /** [crate] is passed to avoid trigger resolve */
 fun RsAttributeOwnerStub.isEnabledByCfgSelf(crate: Crate): Boolean {
     if (!mayHaveCfg) return true
-    // TODO: Don't use psi
-    val psi = (this as StubElement<*>).psi as RsDocAndAttributeOwner
-    return psi.evaluateCfg(crate) != ThreeValuedLogic.False
+    return evaluateCfg(crate) != ThreeValuedLogic.False
 }
 
 /** [crateOrNull] is passed to avoid trigger resolve */
-private fun RsDocAndAttributeOwner.evaluateCfg(crateOrNull: Crate? = null): ThreeValuedLogic {
+private fun RsAttributeOwnerPsiOrStub<*>.evaluateCfg(crateOrNull: Crate? = null): ThreeValuedLogic {
     if (!CFG_ATTRIBUTES_ENABLED_KEY.asBoolean()) return ThreeValuedLogic.True
 
     // We return true because otherwise we have recursion cycle:
@@ -329,11 +418,13 @@ private fun RsDocAndAttributeOwner.evaluateCfg(crateOrNull: Crate? = null): Thre
     //  -> [RsModDeclItem.resolve] -> [RsFile.isEnabledByCfg] -> [RsFile.crate]
     if (crateOrNull == null && this is RsFile) return ThreeValuedLogic.True
 
-    val attributeStub = attributeStub
+    val attributeStub = if (this is RsDocAndAttributeOwner) attributeStub else this as RsAttributeOwnerStub
     if (attributeStub?.mayHaveCfg == false) return ThreeValuedLogic.True
 
     val crate = crateOrNull ?: containingCrate ?: return ThreeValuedLogic.True // TODO: maybe unknown?
     val evaluator = CfgEvaluator.forCrate(crate)
+
+    val rawMetaItems = attributeStub?.rawMetaItems ?: rawMetaItems
 
     val cfgAttributes = QueryAttributes(
         if (attributeStub?.hasCfgAttr == false) {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsForeignModItem.kt
@@ -10,7 +10,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.RsForeignModItem
-import org.rust.lang.core.psi.RsInnerAttr
 import org.rust.lang.core.stubs.RsForeignModStub
 
 abstract class RsForeignModItemImplMixin : RsStubbedElementImpl<RsForeignModStub>,
@@ -19,9 +18,6 @@ abstract class RsForeignModItemImplMixin : RsStubbedElementImpl<RsForeignModStub
     constructor(node: ASTNode) : super(node)
 
     constructor(stub: RsForeignModStub, elementType: IStubElementType<*, *>) : super(stub, elementType)
-
-    override val innerAttrList: List<RsInnerAttr>
-        get() = stubChildrenOfType()
 
     override val visibility: RsVisibility get() = RsVisibility.Private // visibility does not affect foreign mods
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -34,7 +34,7 @@ val RsFunction.isMethod: Boolean get() = hasSelfParameters && owner.isImplOrTrai
 val RsFunction.isTest: Boolean
     get() = queryAttributes.isTest
 
-private val QueryAttributes.isTest
+private val QueryAttributes<*>.isTest
     get() = metaItems.mapNotNull { it.path?.referenceName }.any { it.contains("test") } || hasAtomAttribute("quickcheck")
 
 val RsFunction.isBench: Boolean
@@ -155,14 +155,14 @@ val RsFunction.isAttributeProcMacroDef: Boolean
 val RsFunction.isCustomDeriveProcMacroDef: Boolean
     get() = queryAttributes.isCustomDeriveProcMacroDef
 
-val QueryAttributes.isCustomDeriveProcMacroDef: Boolean
+val QueryAttributes<*>.isCustomDeriveProcMacroDef: Boolean
     get() = hasAttribute("proc_macro_derive")
 
 val RsFunction.isProcMacroDef: Boolean
     get() = IS_PROC_MACRO_DEF_PROP.getByPsi(this)
 
 val IS_PROC_MACRO_DEF_PROP: StubbedAttributeProperty<RsFunction, RsFunctionStub> =
-    StubbedAttributeProperty(QueryAttributes::isProcMacroDef, RsFunctionStub::mayBeProcMacroDef)
+    StubbedAttributeProperty(QueryAttributes<*>::isProcMacroDef, RsFunctionStub::mayBeProcMacroDef)
 
 val RsFunction.procMacroName: String?
     get() = when {
@@ -175,7 +175,7 @@ val RsFunction.procMacroName: String?
         else -> null
     }
 
-val QueryAttributes.isProcMacroDef
+val QueryAttributes<*>.isProcMacroDef
     get() = hasAnyOfAttributes(
         "proc_macro",
         "proc_macro_attribute",
@@ -248,9 +248,6 @@ abstract class RsFunctionImplMixin : RsStubbedNamedElementImpl<RsFunctionStub>, 
     override val isUnsafe: Boolean get() = this.greenStub?.isUnsafe ?: (unsafe != null)
 
     override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
-
-    final override val innerAttrList: List<RsInnerAttr>
-        get() = stubOnlyBlock?.innerAttrList.orEmpty()
 
     override fun getIcon(flags: Int): Icon {
         val baseIcon = when (val owner = owner) {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsImplItem.kt
@@ -58,9 +58,6 @@ abstract class RsImplItemImplMixin : RsStubbedElementImpl<RsImplItemStub>, RsImp
         return BoundElement(trait, subst)
     }
 
-    override val innerAttrList: List<RsInnerAttr>
-        get() = members?.innerAttrList ?: emptyList()
-
     override val associatedTypesTransitively: Collection<RsTypeAlias>
         get() = CachedValuesManager.getCachedValue(this) {
             CachedValueProvider.Result.create(

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
@@ -55,35 +55,35 @@ val RsMacro.macroBody: RsMacroBody?
     get() = childOfType()
 
 val HAS_MACRO_EXPORT_PROP: StubbedAttributeProperty<RsMacro, RsMacroStub> =
-    StubbedAttributeProperty(QueryAttributes::hasMacroExport, RsMacroStub::mayHaveMacroExport)
+    StubbedAttributeProperty(QueryAttributes<*>::hasMacroExport, RsMacroStub::mayHaveMacroExport)
 val HAS_MACRO_EXPORT_LOCAL_INNER_MACROS_PROP: StubbedAttributeProperty<RsMacro, RsMacroStub> =
-    StubbedAttributeProperty(QueryAttributes::hasMacroExportLocalInnerMacros, RsMacroStub::mayHaveMacroExportLocalInnerMacros)
+    StubbedAttributeProperty(QueryAttributes<*>::hasMacroExportLocalInnerMacros, RsMacroStub::mayHaveMacroExportLocalInnerMacros)
 val HAS_RUSTC_BUILTIN_MACRO_PROP: StubbedAttributeProperty<RsMacro, RsMacroStub> =
-    StubbedAttributeProperty(QueryAttributes::hasRustcBuiltinMacro, RsMacroStub::mayHaveRustcBuiltinMacro)
+    StubbedAttributeProperty(QueryAttributes<*>::hasRustcBuiltinMacro, RsMacroStub::mayHaveRustcBuiltinMacro)
 
 val RsMacro.hasMacroExport: Boolean
     get() = HAS_MACRO_EXPORT_PROP.getByPsi(this)
 
-val QueryAttributes.hasMacroExport: Boolean
+val QueryAttributes<*>.hasMacroExport: Boolean
     get() = hasAttribute("macro_export")
 
 /** `#[macro_export(local_inner_macros)]` */
 val RsMacro.hasMacroExportLocalInnerMacros: Boolean
     get() = HAS_MACRO_EXPORT_LOCAL_INNER_MACROS_PROP.getByPsi(this)
 
-val QueryAttributes.hasMacroExportLocalInnerMacros: Boolean
+val QueryAttributes<*>.hasMacroExportLocalInnerMacros: Boolean
     get() = hasAttributeWithArg("macro_export", "local_inner_macros")
 
 val RsMacro.hasRustcBuiltinMacro: Boolean
     get() = HAS_RUSTC_BUILTIN_MACRO_PROP.getByPsi(this)
 
-val QueryAttributes.hasRustcBuiltinMacro: Boolean
+val QueryAttributes<*>.hasRustcBuiltinMacro: Boolean
     get() = hasAttribute("rustc_builtin_macro")
 
 val RsMacro.isRustcDocOnlyMacro: Boolean
     get() = queryAttributes.isRustcDocOnlyMacro
 
-val QueryAttributes.isRustcDocOnlyMacro: Boolean
+val QueryAttributes<*>.isRustcDocOnlyMacro: Boolean
     get() = hasAttribute("rustc_doc_only_macro")
 
 val RsMacro.macroBodyStubbed: RsMacroBody?

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsModItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsModItem.kt
@@ -11,7 +11,6 @@ import com.intellij.psi.search.SearchScope
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
 import org.rust.lang.core.macros.RsExpandedElement
-import org.rust.lang.core.psi.RsInnerAttr
 import org.rust.lang.core.psi.RsModItem
 import org.rust.lang.core.psi.RsPsiImplUtil
 import org.rust.lang.core.stubs.RsModItemStub
@@ -43,9 +42,6 @@ abstract class RsModItemImplMixin : RsStubbedNamedElementImpl<RsModItemStub>,
     override val ownsDirectory: Boolean = true // Any inline nested mod owns a directory
 
     override val isCrateRoot: Boolean = false
-
-    override val innerAttrList: List<RsInnerAttr>
-        get() = stubChildrenOfType()
 
     override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPathReferenceElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPathReferenceElement.kt
@@ -8,8 +8,9 @@ package org.rust.lang.core.psi.ext
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.unescapedText
 import org.rust.lang.core.resolve.ref.RsPathReference
+import org.rust.lang.core.stubs.common.RsPathPsiOrStub
 
-interface RsPathReferenceElement : RsReferenceElement {
+interface RsPathReferenceElement : RsReferenceElement, RsPathPsiOrStub {
     override fun getReference(): RsPathReference?
 
     override val referenceNameElement: PsiElement?

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -148,9 +148,6 @@ abstract class RsTraitItemImplMixin : RsStubbedNamedElementImpl<RsTraitItemStub>
     override val associatedTypesTransitively: Collection<RsTypeAlias>
         get() = BoundElement(this).associatedTypesTransitively
 
-    override val innerAttrList: List<RsInnerAttr>
-        get() = members?.innerAttrList ?: emptyList()
-
     override val isUnsafe: Boolean
         get() {
             val stub = greenStub

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollectorBase.kt
@@ -181,14 +181,14 @@ class ModCollectorBase private constructor(
         get() = MOD_DECL_HAS_MACRO_USE_PROP.getByStub(this, crate)
 
     private val RsAttributeOwnerStubBase<out RsDocAndAttributeOwner>.pathAttribute: String?
-        get() = psi.getQueryAttributes(crate, this).lookupStringValueForKey("path")
+        get() = getQueryAttributes(crate).lookupStringValueForKey("path")
 
     private val RsFunctionStub.isProcMacroDef: Boolean
         get() = IS_PROC_MACRO_DEF_PROP.getByStub(this, crate)
 
     private val RsFunctionStub.procMacroName: String?
         get() {
-            val attributes = psi.getQueryAttributes(crate, this)
+            val attributes = getQueryAttributes(crate)
             return attributes.getFirstArgOfSingularAttribute("proc_macro_derive") ?: name
         }
 

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubInterfaces.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubInterfaces.kt
@@ -10,6 +10,7 @@ import org.rust.lang.core.psi.ext.QueryAttributes
 import org.rust.lang.core.psi.ext.RsDocAndAttributeOwner
 import org.rust.lang.core.psi.ext.getTraversedRawAttributes
 import org.rust.lang.core.psi.ext.name
+import org.rust.lang.core.stubs.common.RsAttributeOwnerPsiOrStub
 import org.rust.stdext.BitFlagsBuilder
 
 interface RsNamedStub {
@@ -20,7 +21,7 @@ interface RsNamedStub {
  * These properties are stored in stubs for performance reasons: it's much cheaper to check
  * a flag in a stub then traverse a PSI
  */
-interface RsAttributeOwnerStub {
+interface RsAttributeOwnerStub : RsAttributeOwnerPsiOrStub<RsMetaItemStub> {
     val hasAttrs: Boolean
 
     // #[cfg()]
@@ -41,7 +42,7 @@ interface RsAttributeOwnerStub {
         fun extractFlags(element: RsDocAndAttributeOwner): Int =
             extractFlags(element.getTraversedRawAttributes(withCfgAttrAttribute = true))
 
-        fun extractFlags(attrs: QueryAttributes): Int {
+        fun extractFlags(attrs: QueryAttributes<*>): Int {
             var hasAttrs = false
             var hasCfg = false
             var hasCfgAttr = false

--- a/src/main/kotlin/org/rust/lang/core/stubs/common/PsiOrStubInterfaces.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/common/PsiOrStubInterfaces.kt
@@ -1,0 +1,49 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.stubs.common
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.StubElement
+import org.rust.lang.core.crate.Crate
+import org.rust.lang.core.psi.ext.PathKind
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.containingCrate
+
+interface RsPathPsiOrStub {
+    val path: RsPathPsiOrStub?
+    val referenceName: String?
+    val hasColonColon: Boolean
+    val kind: PathKind
+}
+
+interface RsMetaItemPsiOrStub {
+    val path: RsPathPsiOrStub?
+    val metaItemArgs: RsMetaItemArgsPsiOrStub?
+
+    @JvmDefault
+    val metaItemArgsList: List<RsMetaItemPsiOrStub>
+        get() = metaItemArgs?.metaItemList.orEmpty()
+
+    val hasEq: Boolean
+    val value: String?
+}
+
+interface RsMetaItemArgsPsiOrStub {
+    // The list is `Mutable` in order to match types with java implementation
+    val metaItemList: MutableList<out RsMetaItemPsiOrStub>
+}
+
+interface RsAttributeOwnerPsiOrStub<T : RsMetaItemPsiOrStub> {
+    val rawMetaItems: Sequence<T>
+
+    @JvmDefault
+    val containingCrate: Crate?
+        get() = when (this) {
+            is PsiElement -> (this as RsElement).containingCrate
+            is StubElement<*> -> (psi as RsElement).containingCrate
+            else -> error("unreachable")
+        }
+}

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsLintLevelTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsLintLevelTest.kt
@@ -62,6 +62,19 @@ class RsLintLevelStructTest : RsInspectionsTestBase(RsStructNamingInspection::cl
         }
     """)
 
+    fun `test last takes precedence`() = checkByText("""
+        #[warn(non_camel_case_types)]
+        #[allow(non_camel_case_types)]
+        mod space {
+            struct planet;
+        }
+        #[allow(non_camel_case_types)]
+        #[warn(non_camel_case_types)]
+        mod science {
+            struct <warning>section</warning>;
+        }
+    """)
+
     fun `test inner takes precedence`() = checkByText("""
         #[warn(non_camel_case_types)]
         mod space {
@@ -70,6 +83,19 @@ class RsLintLevelStructTest : RsInspectionsTestBase(RsStructNamingInspection::cl
         }
         #[allow(non_camel_case_types)]
         mod science {
+            #![warn(non_camel_case_types)]
+            struct <warning>section</warning>;
+        }
+    """)
+
+    fun `test inner takes precedence 2`() = checkByText("""
+        #[warn(non_camel_case_types)]
+        fn space() {
+            #![allow(non_camel_case_types)]
+            struct planet;
+        }
+        #[allow(non_camel_case_types)]
+        fn science() {
             #![warn(non_camel_case_types)]
             struct <warning>section</warning>;
         }


### PR DESCRIPTION
Internal. Now `QueryAttributes` can be used without PSI