### PR TITLE
Do not evaluate unknown cfg to false in stdlib crates

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/crate/impl/CargoBasedCrate.kt
+++ b/src/main/kotlin/org/rust/lang/core/crate/impl/CargoBasedCrate.kt
@@ -50,8 +50,9 @@ class CargoBasedCrate(
     override val cfgOptions: CfgOptions get() = cargoTarget.cfgOptions
 
     override val evaluateUnknownCfgToFalse: Boolean
-        get() = cargoTarget.pkg.cfgOptions != null   // `true` if there is `build.rs` and it is evaluated
-            || !cargoTarget.pkg.hasCustomBuildScript // `true` if there isn't `build.rs`
+        get() = origin == PackageOrigin.STDLIB || // TODO: think about it more precisely
+            cargoTarget.pkg.cfgOptions != null || // `true` if there is `build.rs` and it is evaluated
+            !cargoTarget.pkg.hasCustomBuildScript // `true` if there isn't `build.rs`
 
     override val env: Map<String, String> get() = cargoTarget.pkg.env
     override val outDir: VirtualFile? get() = cargoTarget.pkg.outDir


### PR DESCRIPTION
When `org.rust.cargo.fetch.actual.stdlib.metadata` feature is enabled, we know that stdlib crates have build scripts.

Previously, we tried to evaluate unknown cfg options that led to unresolved references in some cases.
For example, `panic!` macro has two versions with `cfg(bootstrap)` and `cfg(not(bootstrap))` on 1.51.0 and in combination with the current name resolution engine, it cannot be resolved.

Now the plugin doesn't evaluate unknown options (at least temporarily) in stdlib crates.

changelog: Fix name resolution of items in standard library with `cfg` attribute in some cases
