### PR TITLE
RES: Filter out cfg-disabled items during resolve and completion in new resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -119,7 +119,7 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
                                 addProcessedPathName(processor, processedPathNames),
                                 lookup
                             ),
-                            element.containingMod
+                            element
                         )
                     )
                 )
@@ -149,7 +149,7 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
             element,
             filterCompletionVariantsByVisibility(
                 filterMethodCompletionVariantsByTraitBounds(processor, lookup, receiverTy),
-                receiver.containingMod
+                receiver
             )
         )
     }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -1297,4 +1297,39 @@ class RsCompletionTest : RsCompletionTestBase() {
         struct FnOnceStruct;
         fn foo(f: FnOnce(/*caret*/)) {}
     """, completionChar = '(', testmark = Testmarks.doNotAddOpenParenCompletionChar)
+
+    @MockEdition(Edition.EDITION_2018)
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test completion cfg-disabled item 1`() = checkNoCompletionByFileTree("""
+    //- main.rs
+        #[cfg(not(intellij_rust))]
+        mod foo;
+        fn main() {
+            foo::/*caret*/
+        }
+    //- foo.rs
+        pub fn func() {}
+    """)
+
+    @UseNewResolve
+    @MockEdition(Edition.EDITION_2018)
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test completion cfg-disabled item 2`() = doSingleCompletionByFileTree("""
+    //- main.rs
+        #[cfg(not(intellij_rust))]
+        mod foo;
+        #[cfg(not(intellij_rust))]
+        fn main() {
+            foo::/*caret*/
+        }
+    //- foo.rs
+        pub fn func() {}
+    """, """
+        #[cfg(not(intellij_rust))]
+        mod foo;
+        #[cfg(not(intellij_rust))]
+        fn main() {
+            foo::func()
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsCfgAttrResolveTest.kt
@@ -946,4 +946,45 @@ class RsCfgAttrResolveTest : RsResolveTestBase() {
             func();
         } //^
      """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test cfg-disabled item is unresolved 1`() = stubOnlyResolve("""
+    //- main.rs
+        #[cfg(not(intellij_rust))]
+        mod foo;
+        fn main() {
+            foo::func();
+        } //^ unresolved
+    //- foo.rs
+        pub fn func() {}
+     """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @MockAdditionalCfgOptions("intellij_rust")
+    fun `test cfg-disabled item is unresolved 2`() = stubOnlyResolve("""
+    //- main.rs
+        #[cfg(not(intellij_rust))]
+        mod foo;
+        fn main() {
+            foo::func();
+        }      //^ unresolved
+    //- foo.rs
+        pub fn func() {}
+     """)
+
+    @UseNewResolve
+    @MockAdditionalCfgOptions("intellij_rust")
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test cfg-disabled item is resolved from cfg-disabled function 1`() = stubOnlyResolve("""
+    //- main.rs
+        #[cfg(not(intellij_rust))]
+        mod foo;
+        #[cfg(not(intellij_rust))]
+        fn main() {
+            foo::func();
+        }      //^ foo.rs
+    //- foo.rs
+        pub fn func() {}
+    """)
 }


### PR DESCRIPTION
Filters out cfg-disabled items in completion and ignores them in resolve. Note that it currently doesn't apply to out-of-scope items added to completion using auto-import

changelog: Exclude some cfg-disabled items from completion when using new name resolution engine