### PR TITLE
INT: Generate documentation stub

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -2,6 +2,7 @@
 # If you are wondering, how to sort lines in IDEA, then the answer is
 # https://plugins.jetbrains.com/plugin/2162
 
+0x7CA
 abn
 akozlova
 alexeykudinkin

--- a/src/main/kotlin/org/rust/ide/intentions/GenerateDocStubIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/GenerateDocStubIntention.kt
@@ -14,6 +14,7 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psi.impl.RsFunctionImpl
 import org.rust.lang.core.types.ty.Ty
+import java.lang.Math.max
 
 class GenerateDocStubIntention : RsElementBaseIntentionAction<GenerateDocStubIntention.Context>() {
     override fun getText() = "Generate documentation stub"
@@ -42,9 +43,9 @@ class GenerateDocStubIntention : RsElementBaseIntentionAction<GenerateDocStubInt
         val document = editor.document
         var commentStartOffset: Int = targetFunc.textRange.startOffset
         val lineStartOffset = document.getLineStartOffset(document.getLineNumber(commentStartOffset))
-        if (lineStartOffset > 0 && lineStartOffset < commentStartOffset) {
+        if (lineStartOffset in 1 until commentStartOffset) {
             val nonWhiteSpaceOffset = CharArrayUtil.shiftBackward(document.charsSequence, commentStartOffset - 1, " \t")
-            commentStartOffset = Math.max(nonWhiteSpaceOffset, lineStartOffset)
+            commentStartOffset = max(nonWhiteSpaceOffset, lineStartOffset)
         }
         val buffer = StringBuilder()
         var commentBodyRelativeOffset = 0
@@ -66,26 +67,25 @@ class GenerateDocStubIntention : RsElementBaseIntentionAction<GenerateDocStubInt
     }
 }
 
-
-private fun generateDocumentStub(indentation: String, params: List<RsValueParameter>, returnType: Ty): String {
-    val builder = StringBuilder()
-    builder.append("$indentation/// \n")
-    builder.append("$indentation/// # Arguments \n")
-    builder.append("$indentation/// \n")
-    var paramName: String?
+private fun generateDocumentStub(
+    indentation: String,
+    params: List<RsValueParameter>,
+    returnType: Ty
+): String = buildString {
+    append("$indentation/// \n")
+    append("$indentation/// # Arguments \n")
+    append("$indentation/// \n")
     for (param in params) {
-        paramName = param.patText
-        builder.append("$indentation/// * `$paramName`: \n")
+        append("$indentation/// * `${param.patText}`: \n")
     }
-    builder.append("$indentation/// \n")
-    if (returnType != null) {
-        builder.append("$indentation/// returns: $returnType \n")
-    }
-    builder.append("$indentation/// \n")
-    builder.append("$indentation/// # Examples \n")
-    builder.append("$indentation/// \n")
-    builder.append("$indentation/// ```\n")
-    builder.append("$indentation/// \n")
-    builder.append("$indentation/// ```\n")
-    return builder.toString()
+    append("$indentation/// \n")
+
+    append("$indentation/// returns: $returnType \n")
+
+    append("$indentation/// \n")
+    append("$indentation/// # Examples \n")
+    append("$indentation/// \n")
+    append("$indentation/// ```\n")
+    append("$indentation/// \n")
+    append("$indentation/// ```\n")
 }

--- a/src/main/kotlin/org/rust/ide/intentions/GenerateDocstringStubIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/GenerateDocstringStubIntention.kt
@@ -15,7 +15,7 @@ import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.psi.impl.RsFunctionImpl
 import org.rust.lang.core.types.ty.Ty
 
-class GenerateDocStubIntention : RsElementBaseIntentionAction<GenerateDocStubIntention.Context>(){
+class GenerateDocStubIntention : RsElementBaseIntentionAction<GenerateDocStubIntention.Context>() {
     override fun getText() = "Generate documentation stub"
     override fun getFamilyName() = text
     data class Context(
@@ -30,7 +30,7 @@ class GenerateDocStubIntention : RsElementBaseIntentionAction<GenerateDocStubInt
         if (targetFunc.name != element.text) return null
         if (targetFunc.text.startsWith("///")) return null
         val params = targetFunc.valueParameters
-        if (params.isEmpty()){
+        if (params.isEmpty()) {
             return null
         }
         val returnType = targetFunc.returnType
@@ -72,8 +72,8 @@ private fun generateDocumentStub(indentation: String, params: List<RsValueParame
     builder.append("$indentation/// \n")
     builder.append("$indentation/// # Arguments \n")
     builder.append("$indentation/// \n")
-    var paramName : String?
-    for (param in params){
+    var paramName: String?
+    for (param in params) {
         paramName = param.patText
         builder.append("$indentation/// * `$paramName`: \n")
     }

--- a/src/main/kotlin/org/rust/ide/intentions/GenerateDocstringStubIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/GenerateDocstringStubIntention.kt
@@ -1,0 +1,91 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.util.text.CharArrayUtil
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.impl.RsFunctionImpl
+import org.rust.lang.core.types.ty.Ty
+
+class GenerateDocStubIntention : RsElementBaseIntentionAction<GenerateDocStubIntention.Context>(){
+    override fun getText() = "Generate documentation stub"
+    override fun getFamilyName() = text
+    data class Context(
+        val func: RsElement,
+        val params: List<RsValueParameter>,
+        val returnType: Ty
+    )
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val targetFunc = element.ancestorOrSelf<RsGenericDeclaration>() ?: return null
+        if (targetFunc !is RsFunctionImpl) return null
+        if (targetFunc.name != element.text) return null
+        if (targetFunc.text.startsWith("///")) return null
+        val params = targetFunc.valueParameters
+        if (params.isEmpty()){
+            return null
+        }
+        val returnType = targetFunc.returnType
+        return Context(targetFunc, params, returnType)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val (targetFunc, params, returnType) = ctx
+        val document = editor.document
+        var commentStartOffset: Int = targetFunc.textRange.startOffset
+        val lineStartOffset = document.getLineStartOffset(document.getLineNumber(commentStartOffset))
+        if (lineStartOffset > 0 && lineStartOffset < commentStartOffset) {
+            val nonWhiteSpaceOffset = CharArrayUtil.shiftBackward(document.charsSequence, commentStartOffset - 1, " \t")
+            commentStartOffset = Math.max(nonWhiteSpaceOffset, lineStartOffset)
+        }
+        val buffer = StringBuilder()
+        var commentBodyRelativeOffset = 0
+        val indentOffset = targetFunc.startOffset - lineStartOffset
+        val indentation = " ".repeat(indentOffset)
+        buffer.append("$indentation/// \n")
+        commentBodyRelativeOffset += buffer.length
+
+        document.insertString(commentStartOffset, buffer)
+        val docManager = PsiDocumentManager.getInstance(project)
+        docManager.commitDocument(document)
+        val stub = generateDocumentStub(indentation, params, returnType)
+        if (stub.isNotEmpty()) {
+            val insertionOffset = commentStartOffset + commentBodyRelativeOffset
+            document.insertString(insertionOffset, stub)
+            docManager.commitDocument(document)
+        }
+        editor.caretModel.moveToOffset(targetFunc.startOffset + buffer.length - indentOffset - 1)
+    }
+}
+
+
+private fun generateDocumentStub(indentation: String, params: List<RsValueParameter>, returnType: Ty): String {
+    val builder = StringBuilder()
+    builder.append("$indentation/// \n")
+    builder.append("$indentation/// # Arguments \n")
+    builder.append("$indentation/// \n")
+    var paramName : String?
+    for (param in params){
+        paramName = param.patText
+        builder.append("$indentation/// * `$paramName`: \n")
+    }
+    builder.append("$indentation/// \n")
+    if (returnType != null) {
+        builder.append("$indentation/// returns: $returnType \n")
+    }
+    builder.append("$indentation/// \n")
+    builder.append("$indentation/// # Examples \n")
+    builder.append("$indentation/// \n")
+    builder.append("$indentation/// ```\n")
+    builder.append("$indentation/// \n")
+    builder.append("$indentation/// ```\n")
+    return builder.toString()
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -754,6 +754,10 @@
             <category>Rust</category>
         </intentionAction>
         <intentionAction>
+            <className>org.rust.ide.intentions.GenerateDocStubIntention</className>
+            <category>Rust</category>
+        </intentionAction>
+        <intentionAction>
             <className>org.rust.ide.intentions.NestUseStatementsIntention</className>
             <category>Rust</category>
         </intentionAction>

--- a/src/main/resources/intentionDescriptions/GenerateDocStubIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/GenerateDocStubIntention/after.rs.template
@@ -1,0 +1,17 @@
+///
+///
+/// # Arguments
+///
+/// * `param1`:
+/// * `param2`:
+///
+/// returns: &str
+///
+/// # Examples
+///
+/// ```
+///
+/// ```
+fn foo(param1: &str, param2: u8) -> &str {
+    return "bar"
+}

--- a/src/main/resources/intentionDescriptions/GenerateDocStubIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/GenerateDocStubIntention/before.rs.template
@@ -1,0 +1,3 @@
+fn foo(param1: &str, param2: u8) -> &str {
+    return "bar"
+}

--- a/src/main/resources/intentionDescriptions/GenerateDocStubIntention/description.html
+++ b/src/main/resources/intentionDescriptions/GenerateDocStubIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention generates documentation stub.
+</body>
+</html>


### PR DESCRIPTION
changelog: Added an editor intention that generates a documentation stub as demonstrated in: https://doc.rust-lang.org/beta/rust-by-example/meta/doc.html and https://github.com/rust-lang/rust/issues/57525


![oKw9t3X](https://user-images.githubusercontent.com/12113428/113785446-7103c500-9737-11eb-963b-0deda81a1052.gif)

I'm not sure if the current implementation is robust enough, as the RustCommenter lacks the functionality that was used for IntelliJ Javadocs and Pycharm docstring implementations. So this implementation has to manually create the comments by inserting strings.  I was also not able to parse the function context like in intellij to see whether a function was being declared or just being referenced, or already had a doc, so I had to implement it. 
Feedback is very welcome