### PR TITLE
INSP: improve `Can't find crate` annotations

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -1075,10 +1075,6 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     }
 
     private fun checkExternCrate(holder: RsAnnotationHolder, el: RsExternCrateItem) {
-        if (el.reference.multiResolve().isEmpty() && el.containingCrate?.origin == PackageOrigin.WORKSPACE) {
-            if (!el.isEnabledByCfg) return
-            RsDiagnostic.CrateNotFoundError(el, el.referenceName).addToHolder(holder)
-        }
         if (el.self != null) {
             EXTERN_CRATE_SELF.check(holder, el, "`extern crate self`")
             if (el.alias == null) {

--- a/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
@@ -8,14 +8,14 @@ package org.rust.ide.inspections
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ui.MultipleCheckboxOptionsPanel
+import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.inspections.import.AutoImportFix
 import org.rust.ide.inspections.import.AutoImportHintFix
 import org.rust.ide.settings.RsCodeInsightSettings
-import org.rust.lang.core.psi.RsMetaItem
-import org.rust.lang.core.psi.RsMethodCall
-import org.rust.lang.core.psi.RsPath
-import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.utils.RsDiagnostic
+import org.rust.lang.utils.addToHolder
 import javax.swing.JComponent
 
 class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
@@ -63,6 +63,13 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
 
                 if (!isMethodResolved || context != null) {
                     holder.registerProblem(methodCall, context)
+                }
+            }
+
+            override fun visitExternCrateItem(externCrate: RsExternCrateItem) {
+                if (externCrate.reference.multiResolve().isEmpty() &&
+                    externCrate.containingCrate?.origin == PackageOrigin.WORKSPACE) {
+                    RsDiagnostic.CrateNotFoundError(externCrate, externCrate.referenceName).addToHolder(holder)
                 }
             }
         }

--- a/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspection.kt
@@ -69,7 +69,8 @@ class RsUnresolvedReferenceInspection : RsLocalInspectionTool() {
             override fun visitExternCrateItem(externCrate: RsExternCrateItem) {
                 if (externCrate.reference.multiResolve().isEmpty() &&
                     externCrate.containingCrate?.origin == PackageOrigin.WORKSPACE) {
-                    RsDiagnostic.CrateNotFoundError(externCrate, externCrate.referenceName).addToHolder(holder)
+                    RsDiagnostic.CrateNotFoundError(externCrate.referenceNameElement, externCrate.referenceName)
+                        .addToHolder(holder)
                 }
             }
         }

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -930,7 +930,7 @@ sealed class RsDiagnostic(
         private val crateName: String
     ) : RsDiagnostic(startElement) {
         override fun prepare() = PreparedAnnotation(
-            ERROR,
+            UNKNOWN_SYMBOL,
             E0463,
             errorText()
         )

--- a/src/test/kotlin/org/rust/ide/annotator/RsStdlibErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsStdlibErrorAnnotatorTest.kt
@@ -18,10 +18,4 @@ class RsStdlibErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) 
         extern crate alloc;
         mod alloc {}
     """)
-
-    fun `test E0463 unknown crate`() = checkErrors("""
-        extern crate alloc;
-
-        <error descr="Can't find crate for `litarvan` [E0463]">extern crate litarvan;</error>
-    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -6,6 +6,9 @@
 package org.rust.ide.inspections
 
 import org.intellij.lang.annotations.Language
+import org.rust.MockAdditionalCfgOptions
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibAndDependencyRustProjectDescriptor
 import org.rust.ide.inspections.import.AutoImportFix
 
 class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedReferenceInspection::class) {
@@ -195,6 +198,19 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
         mod foo {}
         use foo::<error descr="identifier expected, got '::'">:</error>:bar;
     """, false)
+
+    @MockAdditionalCfgOptions("intellij_rust")
+    @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
+    fun `test unknown crate E0463`() = checkByText("""
+        extern crate alloc;
+
+        <error descr="Can't find crate for `litarvan` [E0463]">extern crate litarvan;</error>
+
+        <error descr="Can't find crate for `unknown_crate1` [E0463]">#[cfg(intellij_rust)]
+        extern crate unknown_crate1;</error>
+        #[cfg(not(intellij_rust))]
+        extern crate unknown_crate2;
+    """)
 
     private fun checkByText(@Language("Rust") text: String, ignoreWithoutQuickFix: Boolean) {
         val inspection = inspection as RsUnresolvedReferenceInspection

--- a/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/RsUnresolvedReferenceInspectionTest.kt
@@ -204,10 +204,10 @@ class RsUnresolvedReferenceInspectionTest : RsInspectionsTestBase(RsUnresolvedRe
     fun `test unknown crate E0463`() = checkByText("""
         extern crate alloc;
 
-        <error descr="Can't find crate for `litarvan` [E0463]">extern crate litarvan;</error>
+        extern crate <error descr="Can't find crate for `litarvan` [E0463]">litarvan</error>;
 
-        <error descr="Can't find crate for `unknown_crate1` [E0463]">#[cfg(intellij_rust)]
-        extern crate unknown_crate1;</error>
+        #[cfg(intellij_rust)]
+        extern crate <error descr="Can't find crate for `unknown_crate1` [E0463]">unknown_crate1</error>;
         #[cfg(not(intellij_rust))]
         extern crate unknown_crate2;
     """)


### PR DESCRIPTION
Now the corresponding annotation is provided by `Unresolved reference` inspection instead of annotator and, as a result, it can be suppressed and even turned off if the corresponding inspection is disabled.
Also, only identifier is highlighted not to highlight a lot of other code. Highlighting style was changed to "unknown symbol" to be more consistent with other unresolved references annotations

| Before| After |
| - | - |
| ![image](https://user-images.githubusercontent.com/2539310/113852675-7b5ca800-97a5-11eb-9e01-cc8279220b55.png) | ![image](https://user-images.githubusercontent.com/2539310/113853324-35ecaa80-97a6-11eb-9874-7c33a58112a5.png) |


changelog: Now `Can't find crate` annotation can be suppressed, highlights only unknown identifier and highlighting style is `unknown symbol` instead of general `error`
