### PR TITLE
DBG: Treat `str*` as `&str` in pretty-printers

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
@@ -159,7 +159,7 @@ class RsDebugProcessConfigurationHelper(
          */
         private val RUST_STD_TYPES: List<String> = listOf(
             "^(alloc::([a-z_]+::)+)String$",
-            "^&str$",
+            "^[&*]?(const |mut )?str\\*?$",
             "^(std::ffi::([a-z_]+::)+)OsString$",
             "^(alloc::([a-z_]+::)+)Vec<.+>$",
             "^(alloc::([a-z_]+::)+)VecDeque<.+>$",

--- a/prettyPrinters/rust_types.py
+++ b/prettyPrinters/rust_types.py
@@ -35,7 +35,8 @@ class RustType(object):
 
 # Should be synchronized with `RsDebugProcessConfigurationHelper.RUST_STD_TYPES`
 STD_STRING_REGEX = re.compile(r"^(alloc::([a-z_]+::)+)String$")
-STD_STR_REGEX = re.compile(r"^&str$")
+# str, mut str, const str*, mut str* (vanilla LLDB); &str, &mut str, *const str, *mut str (Rust-enabled LLDB)
+STD_STR_REGEX = re.compile(r"^[&*]?(const |mut )?str\*?$")
 STD_OS_STRING_REGEX = re.compile(r"^(std::ffi::([a-z_]+::)+)OsString$")
 STD_VEC_REGEX = re.compile(r"^(alloc::([a-z_]+::)+)Vec<.+>$")
 STD_VEC_DEQUE_REGEX = re.compile(r"^(alloc::([a-z_]+::)+)VecDeque<.+>$")

--- a/pretty_printers_tests/tests/string.rs
+++ b/pretty_printers_tests/tests/string.rs
@@ -6,10 +6,22 @@
 // lldbg-check:[...]s1 = "A∆й中" [...]
 // lldb-command:print s2
 // lldbg-check:[...]s2 = "A∆й中" [...]
+// lldb-command:print s3
+// lldbg-check:[...]s3 = "A∆й中" [...]
+// lldb-command:print s4
+// lldbg-check:[...]s4 = "A∆й中" [...]
+// lldb-command:print s5
+// lldbg-check:[...]s5 = "A∆й中" [...]
 // lldb-command:print empty_s1
 // lldbg-check:[...]empty_s1 = "" [...]
 // lldb-command:print empty_s2
 // lldbg-check:[...]empty_s2 = "" [...]
+// lldb-command:print empty_s3
+// lldbg-check:[...]empty_s3 = "" [...]
+// lldb-command:print empty_s4
+// lldbg-check:[...]empty_s4 = "" [...]
+// lldb-command:print empty_s5
+// lldbg-check:[...]empty_s5 = "" [...]
 
 // === GDB TESTS ==================================================================================
 
@@ -26,9 +38,17 @@
 
 
 fn main() {
-    let s1 = "A∆й中";
-    let s2 = String::from(s1);
-    let empty_s1 = "";
-    let empty_s2 = String::from(empty_s1);
+    let mut s1 = "A∆й中";
+    let mut s2 = String::from(s1);
+    let s3 = s2.as_mut_str();
+    let s4 = s3 as *mut str;
+    let s5 = s1 as *const str;
+
+    let mut empty_s1 = "";
+    let mut empty_s2 = String::from(empty_s1);
+    let empty_s3 = empty_s2.as_mut_str();
+    let empty_s4 = empty_s3 as *mut str;
+    let empty_s5 = empty_s1 as *const str;
+
     print!(""); // #break
 }


### PR DESCRIPTION
In LLDB without native Rust support (e.g. MSVC LLDB currently), `&str` type is represented as `str*`.
Both `&str` and `str*` are now treated as string slices by the pretty-printers.

Part of #5632.

Fixes #7331

changelog: Render `&str` string slices content when debugging using MSVC toolchain on Windows