### PR TITLE
Invoke crates local index update on on cargo registry repository changes

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexService.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexService.kt
@@ -26,6 +26,7 @@ interface CratesLocalIndexService {
      */
     @Throws(CratesLocalIndexException::class)
     fun getAllCrateNames(): List<String>
+    fun updateIfNeeded()
 
     companion object {
         fun getInstance(): CratesLocalIndexService = service()

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexStartupActivity.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexStartupActivity.kt
@@ -14,7 +14,7 @@ import org.rust.openapiext.isFeatureEnabled
 
 /**
  * [CratesLocalIndexService] initializer.
- * Only tries to get service instance, without any updates to its crates index.
+ * Tries to get and initialize a service instance and updates it if it is needed.
  */
 class CratesLocalIndexStartupActivity : StartupActivity.Background {
     override fun runActivity(project: Project) {
@@ -22,7 +22,7 @@ class CratesLocalIndexStartupActivity : StartupActivity.Background {
         if (!project.cargoProjects.hasAtLeastOneValidProject) return
 
         if (isFeatureEnabled(RsExperiments.CRATES_LOCAL_INDEX)) {
-            CratesLocalIndexService.getInstance()
+            CratesLocalIndexService.getInstance().updateIfNeeded()
         }
     }
 }

--- a/toml/src/main/kotlin/org/rust/toml/crates/local/TestCratesLocalIndexServiceImpl.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/TestCratesLocalIndexServiceImpl.kt
@@ -12,6 +12,7 @@ class TestCratesLocalIndexServiceImpl : CratesLocalIndexService {
 
     override fun getCrate(crateName: String): CargoRegistryCrate? = testCrates[crateName]
     override fun getAllCrateNames(): List<String> = testCrates.keys.toList()
+    override fun updateIfNeeded() {}
 }
 
 @TestOnly


### PR DESCRIPTION
Part of #6463

changelog: Crates local index for dependencies completion and inspections is now being updated on project changes. Note, currently this feature is experimental and can be enabled with `org.rust.crates.local.index` option in `Experimental Features` dialog.
