### PR TITLE
INT: provide `Share in Playground` action as intention for selected Rust code

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/ShareInPlaygroundAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/ShareInPlaygroundAction.kt
@@ -18,6 +18,7 @@ import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapiext.isUnitTestMode
@@ -52,89 +53,97 @@ class ShareInPlaygroundAction : DumbAwareAction() {
             }
         }
 
-        if (!confirmShare(file, hasSelection)) return
-
-        val channel = file.cargoProject?.rustcInfo?.version?.channel?.channel ?: "stable"
-        val edition = (file.crate?.edition ?: CargoWorkspace.Edition.EDITION_2018).presentation
-
-        object : Task.Backgroundable(project, RsBundle.message("action.Rust.ShareInPlayground.progress.title")) {
-
-            @Volatile
-            private var gistId: String? = null
-
-            override fun shouldStartInBackground(): Boolean = true
-            override fun run(indicator: ProgressIndicator) {
-                val json = Gson().toJson(PlaygroundCode(text))
-                val response = HttpRequests.post("$playgroundHost/meta/gist/", "application/json")
-                    .userAgent(USER_AGENT)
-                    .connect {
-                        it.write(json)
-                        it.readString(indicator)
-                    }
-
-                gistId = JsonUtils.parseJsonObject(response).getAsJsonPrimitive("id").asString
-            }
-
-            override fun onSuccess() {
-                val url = "https://play.rust-lang.org/?version=$channel&edition=$edition&gist=$gistId"
-                val copyUrlAction = NotificationAction.createSimple(RsBundle.message("action.Rust.ShareInPlayground.notification.copy.url.text")) {
-                    CopyPasteManager.getInstance().setContents(StringSelection(url))
-                }
-                project.showBalloon(
-                    RsBundle.message("action.Rust.ShareInPlayground.notification.title"),
-                    RsBundle.message("action.Rust.ShareInPlayground.notification.text", url),
-                    NotificationType.INFORMATION,
-                    copyUrlAction,
-                    NotificationListener.URL_OPENING_LISTENER
-                )
-            }
-
-            override fun onThrowable(error: Throwable) {
-                if (!isUnitTestMode) {
-                    super.onThrowable(error)
-                }
-                project.showBalloon(
-                    RsBundle.message("action.Rust.ShareInPlayground.notification.title"),
-                    RsBundle.message("action.Rust.ShareInPlayground.notification.error"),
-                    NotificationType.ERROR
-                )
-            }
-        }.queue()
-    }
-
-    private fun confirmShare(file: RsFile, hasSelection: Boolean): Boolean {
-        val showConfirmation = PropertiesComponent.getInstance().getBoolean(SHOW_SHARE_IN_PLAYGROUND_CONFIRMATION, true)
-        if (!showConfirmation) {
-            return true
-        }
-        val doNotAskOption = object : DialogWrapper.DoNotAskOption.Adapter() {
-            override fun rememberChoice(isSelected: Boolean, exitCode: Int) {
-                if (isSelected && exitCode == Messages.OK) {
-                    PropertiesComponent.getInstance().setValue(SHOW_SHARE_IN_PLAYGROUND_CONFIRMATION, false, true)
-                }
-            }
-        }
-
-        val message = if (hasSelection) {
-            RsBundle.message("action.Rust.ShareInPlayground.confirmation.selected.text")
-        } else {
-            RsBundle.message("action.Rust.ShareInPlayground.confirmation", file.name)
-        }
-
-        val answer = Messages.showOkCancelDialog(
-            message,
-            RsBundle.message("action.Rust.ShareInPlayground.text"),
-            Messages.getOkButton(),
-            Messages.getCancelButton(),
-            Messages.getQuestionIcon(),
-            doNotAskOption
-        )
-        return answer == Messages.OK
+        val context = Context(file, text, hasSelection)
+        performAction(project, context)
     }
 
     companion object {
         private const val SHOW_SHARE_IN_PLAYGROUND_CONFIRMATION = "rs.show.share.in.playground.confirmation"
+
+        fun performAction(project: Project, context: Context) {
+            val (file, text, hasSelection) = context
+            if (!confirmShare(file, hasSelection)) return
+
+            val channel = file.cargoProject?.rustcInfo?.version?.channel?.channel ?: "stable"
+            val edition = (file.crate?.edition ?: CargoWorkspace.Edition.EDITION_2018).presentation
+
+            object : Task.Backgroundable(project, RsBundle.message("action.Rust.ShareInPlayground.progress.title")) {
+
+                @Volatile
+                private var gistId: String? = null
+
+                override fun shouldStartInBackground(): Boolean = true
+                override fun run(indicator: ProgressIndicator) {
+                    val json = Gson().toJson(PlaygroundCode(text))
+                    val response = HttpRequests.post("$playgroundHost/meta/gist/", "application/json")
+                        .userAgent(USER_AGENT)
+                        .connect {
+                            it.write(json)
+                            it.readString(indicator)
+                        }
+
+                    gistId = JsonUtils.parseJsonObject(response).getAsJsonPrimitive("id").asString
+                }
+
+                override fun onSuccess() {
+                    val url = "https://play.rust-lang.org/?version=$channel&edition=$edition&gist=$gistId"
+                    val copyUrlAction = NotificationAction.createSimple(RsBundle.message("action.Rust.ShareInPlayground.notification.copy.url.text")) {
+                        CopyPasteManager.getInstance().setContents(StringSelection(url))
+                    }
+                    project.showBalloon(
+                        RsBundle.message("action.Rust.ShareInPlayground.notification.title"),
+                        RsBundle.message("action.Rust.ShareInPlayground.notification.text", url),
+                        NotificationType.INFORMATION,
+                        copyUrlAction,
+                        NotificationListener.URL_OPENING_LISTENER
+                    )
+                }
+
+                override fun onThrowable(error: Throwable) {
+                    if (!isUnitTestMode) {
+                        super.onThrowable(error)
+                    }
+                    project.showBalloon(
+                        RsBundle.message("action.Rust.ShareInPlayground.notification.title"),
+                        RsBundle.message("action.Rust.ShareInPlayground.notification.error"),
+                        NotificationType.ERROR
+                    )
+                }
+            }.queue()
+        }
+
+        private fun confirmShare(file: RsFile, hasSelection: Boolean): Boolean {
+            val showConfirmation = PropertiesComponent.getInstance().getBoolean(SHOW_SHARE_IN_PLAYGROUND_CONFIRMATION, true)
+            if (!showConfirmation) {
+                return true
+            }
+            val doNotAskOption = object : DialogWrapper.DoNotAskOption.Adapter() {
+                override fun rememberChoice(isSelected: Boolean, exitCode: Int) {
+                    if (isSelected && exitCode == Messages.OK) {
+                        PropertiesComponent.getInstance().setValue(SHOW_SHARE_IN_PLAYGROUND_CONFIRMATION, false, true)
+                    }
+                }
+            }
+
+            val message = if (hasSelection) {
+                RsBundle.message("action.Rust.ShareInPlayground.confirmation.selected.text")
+            } else {
+                RsBundle.message("action.Rust.ShareInPlayground.confirmation", file.name)
+            }
+
+            val answer = Messages.showOkCancelDialog(
+                message,
+                RsBundle.message("action.Rust.ShareInPlayground.text"),
+                Messages.getOkButton(),
+                Messages.getCancelButton(),
+                Messages.getQuestionIcon(),
+                doNotAskOption
+            )
+            return answer == Messages.OK
+        }
     }
+
+    data class Context(val file: RsFile, val text: String, val hasSelection: Boolean)
 
     @VisibleForTesting
     data class PlaygroundCode(val code: String)

--- a/src/main/kotlin/org/rust/ide/intentions/ShareInPlaygroundIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ShareInPlaygroundIntention.kt
@@ -1,0 +1,33 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.codeInsight.intention.LowPriorityAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.rust.RsBundle
+import org.rust.ide.actions.ShareInPlaygroundAction
+import org.rust.ide.actions.ShareInPlaygroundAction.Context
+import org.rust.lang.core.psi.RsFile
+
+class ShareInPlaygroundIntention : RsElementBaseIntentionAction<Context>(), LowPriorityAction {
+
+    override fun startInWriteAction(): Boolean = false
+
+    override fun getText(): String = familyName
+    override fun getFamilyName(): String = RsBundle.message("action.Rust.ShareInPlayground.text")
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val file = element.containingFile as? RsFile ?: return null
+        val selectedText = editor.selectionModel.selectedText ?: return null
+        return Context(file, selectedText, true)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        ShareInPlaygroundAction.performAction(project, ctx)
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -879,6 +879,10 @@
             <className>org.rust.ide.intentions.visibility.MakePrivateIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.ShareInPlaygroundIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 

--- a/src/main/resources/intentionDescriptions/ShareInPlaygroundIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/ShareInPlaygroundIntention/after.rs.template
@@ -1,0 +1,1 @@
+Posts code to Rust Playground and shows notification with the corresponding url

--- a/src/main/resources/intentionDescriptions/ShareInPlaygroundIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/ShareInPlaygroundIntention/before.rs.template
@@ -1,0 +1,1 @@
+Select Rust code you want to share in the editor

--- a/src/main/resources/intentionDescriptions/ShareInPlaygroundIntention/description.html
+++ b/src/main/resources/intentionDescriptions/ShareInPlaygroundIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Shares code in Rust Playground (https://play.rust-lang.org/).
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
@@ -63,7 +63,7 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
         fileTreeFromText(replaceCaretMarker(fileStructureAfter)).check(myFixture)
     }
 
-    private fun launchAction() {
+    protected fun launchAction() {
         UIUtil.dispatchAllInvocationEvents()
         myFixture.launchAction(intention)
     }

--- a/src/test/kotlin/org/rust/ide/intentions/ShareInPlaygroundIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/ShareInPlaygroundIntentionTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import org.intellij.lang.annotations.Language
+import org.rust.MockServerFixture
+import org.rust.cargo.project.workspace.CargoWorkspace.Edition.EDITION_2015
+import org.rust.ide.actions.ShareInPlaygroundActionTest
+
+class ShareInPlaygroundIntentionTest : RsIntentionTestBase(ShareInPlaygroundIntention::class) {
+
+    private val mockServerFixture: MockServerFixture = MockServerFixture()
+
+    override fun setUp() {
+        super.setUp()
+        mockServerFixture.setUp()
+    }
+
+    override fun tearDown() {
+        mockServerFixture.tearDown()
+        super.tearDown()
+    }
+
+    fun `test unavailable without selection`() = doUnavailableTest("""
+        fn main() {/*caret*/
+            println("Hello!")
+        }
+    """)
+
+    fun `test with selection`() = doTest("""
+        <selection>fn main() {
+            println("Hello!")
+        }</selection>
+    """, """
+        fn main() {
+            println("Hello!")
+        }
+    """)
+
+    private fun doTest(@Language("Rust") code: String, @Language("Rust") codeToShare: String) {
+        InlineFile(code.trimIndent())
+        ShareInPlaygroundActionTest.doTest(project, mockServerFixture, codeToShare, EDITION_2015, "stable", ::launchAction)
+    }
+}


### PR DESCRIPTION
It should promote the corresponding feature because `Alt`+`Enter` is one of the most popular shortcuts in IntelliJ IDEs

![2021-04-09 10 43 29](https://user-images.githubusercontent.com/2539310/114146613-7b34e780-9920-11eb-9697-623c441a1472.gif)


changelog: provide `Share in Playground` intention to share selected Rust code on [Rust Playground](https://play.rust-lang.org)
