### PR TITLE
INT: make `Show the result of macro expansion` intention low priority

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/RunCargoExpandIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/RunCargoExpandIntention.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.intentions
 
+import com.intellij.codeInsight.intention.LowPriorityAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
@@ -15,9 +16,11 @@ import org.rust.cargo.toolchain.tools.Cargo.Companion.checkNeedInstallCargoExpan
 import org.rust.lang.core.psi.ext.*
 import org.rust.stdext.buildList
 
-class RunCargoExpandIntention : RsElementBaseIntentionAction<RunCargoExpandIntention.Context>() {
-    override fun getText() = "Show the result of macro expansion (cargo expand)"
-    override fun getFamilyName() = text
+class RunCargoExpandIntention : RsElementBaseIntentionAction<RunCargoExpandIntention.Context>(), LowPriorityAction {
+    override fun getText(): String = "Show the result of macro expansion (cargo expand)"
+    override fun getFamilyName(): String = text
+
+    override fun startInWriteAction(): Boolean = false
 
     data class Context(
         val cargoProject: CargoProject,


### PR DESCRIPTION
The change makes IDE place the intention below other general intentions in the intention list.
Also, now the intention isn't launched under write action because it doesn't change code


| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2539310/114149005-175fee00-9923-11eb-8baa-ad9176934d5e.png) | ![](https://user-images.githubusercontent.com/2539310/114149032-1fb82900-9923-11eb-8d14-957392021716.png) |

changelog: place `Show the result of macro expansion` intention lower in the intention list
