### PR TITLE
FIX: do not import default type arguments in ChangeSignature refactoring

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/impl.kt
@@ -108,7 +108,8 @@ private fun changeReturnType(factory: RsPsiFactory, function: RsFunction, config
         if (config.returnType !is TyUnit) {
             val ret = factory.createRetType(config.returnTypeReference.text)
             function.addAfter(ret, function.valueParameterList) as RsRetType
-            RsImportHelper.importTypeReferencesFromTy(function, config.returnType, useAliases = true)
+            RsImportHelper.importTypeReferencesFromTy(function, config.returnType,
+                useAliases = true, skipUnchangedDefaultTypeArguments = true)
         }
     }
 }
@@ -126,7 +127,8 @@ private fun changeArguments(
     }
     for (parameter in config.parameters) {
         val defaultValue = parameter.defaultValue.item ?: continue
-        RsImportHelper.importTypeReferencesFromElements(arguments, setOf(defaultValue), useAliases = true)
+        RsImportHelper.importTypeReferencesFromElements(arguments, setOf(defaultValue),
+            useAliases = true, skipUnchangedDefaultTypeArguments = true)
     }
     val argumentsCopy = arguments.copy() as RsValueArgumentList
     val argumentsList = argumentsCopy.exprList
@@ -244,7 +246,8 @@ private fun PsiElement.collectSurroundingWhiteSpaceAndComments(): List<PsiElemen
 
 private fun importParameterTypes(descriptors: List<Parameter>, context: RsElement) {
     for (descriptor in descriptors) {
-        RsImportHelper.importTypeReferencesFromElements(context, setOf(descriptor.typeReference), useAliases = true)
+        RsImportHelper.importTypeReferencesFromElements(context, setOf(descriptor.typeReference),
+            useAliases = true, skipUnchangedDefaultTypeArguments = true)
     }
 }
 

--- a/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
@@ -7,13 +7,12 @@ package org.rust.ide.refactoring
 
 import com.intellij.refactoring.BaseRefactoringProcessor
 import org.intellij.lang.annotations.Language
-import org.rust.MockAdditionalCfgOptions
-import org.rust.MockEdition
-import org.rust.RsTestBase
+import org.rust.*
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.ide.refactoring.changeSignature.*
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.types.type
 import org.rust.stdext.removeLast
 
 class RsChangeSignatureTest : RsTestBase() {
@@ -1157,6 +1156,34 @@ Cannot change signature of function with cfg-disabled parameters""")
         }
     """) {
         name = "foo2"
+    }
+
+    fun `test do not import default type arguments`() = doTest("""
+        mod foo {
+            pub struct S;
+            pub struct Vec<T = S>(T);
+
+            fn bar(t: Vec) {}
+                      //^
+        }
+
+        fn bar/*caret*/() {}
+    """, """
+        use foo::Vec;
+
+        mod foo {
+            pub struct S;
+            pub struct Vec<T = S>(T);
+
+            fn bar(t: Vec) {}
+                      //^
+        }
+
+        fn bar/*caret*/(a: Vec) -> Vec {}
+    """) {
+        val vec = findElementInEditor<RsTypeReference>()
+        parameters.add(parameter("a", vec))
+        returnTypeDisplay = vec
     }
 
     private fun RsChangeFunctionSignatureConfig.swapParameters(a: Int, b: Int) {


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/7077

changelog: Do not needlessly import default type arguments in ChangeSignature refactoring