### PR TITLE
FIX: check namespaces in ChangeSignature name conflict detection

### DIFF
--- a/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/RsChangeSignatureTest.kt
@@ -1012,6 +1012,14 @@ Cannot change signature of function with cfg-disabled parameters""")
         visibility = null
     }
 
+    fun `test no visibility conflict module`() = doTest("""
+        mod foo {}
+        fn foo/*caret*/() {}
+    """, """
+        mod foo {}
+        fn foo/*caret*/() {}
+    """) {}
+
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test no visibility conflict disabled function`() = doTest("""
         fn bar/*caret*/() {}


### PR DESCRIPTION
`ChangeSignature` had a bug where it was incorrectly producing a name conflict between e.g. modules and the refactored function, which is incorrect. I found out about it randomly while testing it.

I was aware of this imperfection while implementing the refactoring, but I thought that because functions and types (like structs) have different naming conventions, it should not be a big deal. Well, turns out that modules kind of break that assumption :) Now it should be working properly.

```rust
mod foo {}
fn foo/*caret*/() {}
```
Running the refactoring on this function should not produce name visibility conflicts after this PR.

changelog: Fix some false positives in name conflict detection in ChangeSignature refactoring.