### PR TITLE
RES: Fix resolve of macros with absolute paths in new resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -290,12 +290,19 @@ private fun getMacroIndexInParent(item: PsiElement, parent: PsiElement): Int {
 
 private val RsMacroCall.pathSegments: List<String>?
     get() {
-        val segments = generateSequence(path) { it.path }
-            .map { it.referenceName }
-            .toMutableList()
-        if (segments.any { it == null }) return null
+        val segments = mutableListOf<String>()
+        var path: RsPath? = path
+        while (path != null) {
+            segments += path.referenceName ?: return null
+            val qualifier = path.path
+            if (qualifier == null && path.hasColonColon) {
+                // ::crate_name::macro!()
+                segments += ""
+            }
+            path = qualifier
+        }
         segments.reverse()
-        return segments.requireNoNulls()
+        return segments
     }
 
 /**

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -356,6 +356,19 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
         }
     """)
 
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test macro with absolute path`() = stubOnlyResolve("""
+    //- main.rs
+        mod test_package {}
+        ::test_package::foo!();
+                      //^ lib.rs
+        fn main() {}
+    //- lib.rs
+        #[macro_export]
+        macro_rules! foo { () => {} }
+                   //X
+    """)
+
     // Issue https://github.com/intellij-rust/intellij-rust/issues/3642
     fun `test issue 3642 1`() = stubOnlyResolve("""
     //- lib.rs


### PR DESCRIPTION
Fix resolve of macros with absolute paths, e.g. `::test_package::foo!()`
Fixes #7010

changelog: Fix resolve of macros with absolute paths with new name resolution engine