### PR TITLE
CARGO: fetch cfg options according to Cargo config

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
@@ -222,7 +222,13 @@ private fun fetchCargoWorkspace(context: CargoSyncTask.SyncContext): TaskResult<
             })
             val manifestPath = projectDirectory.resolve("Cargo.toml")
 
-            val cfgOptions = toolchain.rustc().getCfgOptions(projectDirectory)
+            val cfgOptions = try {
+                cargo.getCfgOption(childContext.project, projectDirectory)
+            } catch (e: ExecutionException) {
+                // BACKCOMPAT: Rust 1.51. Drop fallback `rustc --print cfg` call
+                toolchain.rustc().getCfgOptions(projectDirectory)
+            }
+
             val ws = CargoWorkspace.deserialize(manifestPath, projectDescriptionData, cfgOptions)
             TaskResult.Ok(ws)
         } catch (e: ExecutionException) {

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoSyncTask.kt
@@ -28,6 +28,7 @@ import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import com.intellij.util.io.exists
+import com.intellij.util.text.SemVer
 import org.rust.RsTask
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.RustcInfo
@@ -109,9 +110,10 @@ class CargoSyncTask(
                         } else {
                             val context = SyncContext(project, cargoProject, toolchain, indicator, childProgress)
                             val rustcInfoResult = fetchRustcInfo(context)
+                            val rustcInfo = (rustcInfoResult as? TaskResult.Ok)?.value
                             cargoProject.withRustcInfo(rustcInfoResult)
-                                .withWorkspace(fetchCargoWorkspace(context))
-                                .withStdlib(fetchStdlib(context, (rustcInfoResult as? TaskResult.Ok)?.value))
+                                .withWorkspace(fetchCargoWorkspace(context, rustcInfo))
+                                .withStdlib(fetchStdlib(context, rustcInfo))
                         }
                     }
                 )
@@ -157,7 +159,7 @@ class CargoSyncTask(
         val oldCargoProject: CargoProjectImpl,
         val toolchain: RsToolchain,
         val progress: ProgressIndicator,
-        private val syncProgress: BuildProgress<BuildProgressDescriptor>
+        val syncProgress: BuildProgress<BuildProgressDescriptor>
     ) {
         fun <T> runWithChildProgress(
             title: String,
@@ -200,7 +202,7 @@ private fun fetchRustcInfo(context: CargoSyncTask.SyncContext): TaskResult<Rustc
     }
 }
 
-private fun fetchCargoWorkspace(context: CargoSyncTask.SyncContext): TaskResult<CargoWorkspace> {
+private fun fetchCargoWorkspace(context: CargoSyncTask.SyncContext, rustcInfo: RustcInfo?): TaskResult<CargoWorkspace> {
     return context.runWithChildProgress("Updating workspace info") { childContext ->
 
         val toolchain = childContext.toolchain
@@ -225,7 +227,17 @@ private fun fetchCargoWorkspace(context: CargoSyncTask.SyncContext): TaskResult<
             val cfgOptions = try {
                 cargo.getCfgOption(childContext.project, projectDirectory)
             } catch (e: ExecutionException) {
-                // BACKCOMPAT: Rust 1.51. Drop fallback `rustc --print cfg` call
+                val rustcVersion = rustcInfo?.version?.semver
+                if (rustcVersion == null || rustcVersion > RUST_1_51) {
+                    val message = "Fetching target specific `cfg` options failed. Fallback to host options.\n\n${e.message.orEmpty()}"
+                    @Suppress("DialogTitleCapitalization")
+                    childContext.syncProgress.message(
+                        "Fetching target specific `cfg` options",
+                        message,
+                        MessageEvent.Kind.WARNING,
+                        null
+                    )
+                }
                 toolchain.rustc().getCfgOptions(projectDirectory)
             }
 
@@ -306,3 +318,5 @@ private fun <T, R> BuildProgress<BuildProgressDescriptor>.runWithChildProgress(
         throw e
     }
 }
+
+private val RUST_1_51: SemVer = SemVer.parseFromText("1.51.0")!!

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -26,6 +26,7 @@ import com.intellij.util.net.HttpConfigurable
 import com.intellij.util.text.SemVer
 import org.jetbrains.annotations.TestOnly
 import org.rust.cargo.CargoConstants
+import org.rust.cargo.CfgOptions
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.rustSettings
@@ -165,6 +166,22 @@ open class Cargo(toolchain: RsToolchain, useWrapper: Boolean = false)
     ) {
         val commandLine = CargoCommandLine("vendor", projectDirectory, listOf(dstPath.toString()))
         commandLine.execute(owner)
+    }
+
+    /**
+     * Execute `cargo rustc --print cfg` and parse output as [CfgOptions].
+     * Available since Rust 1.52
+     */
+    @Throws(ExecutionException::class)
+    fun getCfgOption(
+        owner: Project,
+        projectDirectory: Path?
+    ): CfgOptions {
+        val output = createBaseCommandLine(
+            listOf("rustc", "-Z", "unstable-options", "--print", "cfg"),
+            workingDirectory = projectDirectory,
+        ).withEnvironment(RUSTC_BOOTSTRAP, "1").execute(owner, ignoreExitCode = false)
+        return CfgOptions.parse(output.stdoutLines)
     }
 
     private fun fetchBuildScriptsInfo(

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/CustomTargetCfgResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/CustomTargetCfgResolveTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rustSlowTests.lang.resolve
+
+import com.intellij.util.text.SemVer
+import org.rust.MinRustcVersion
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.cargo.toolchain.tools.rustc
+import org.rust.lang.core.psi.RsPath
+
+class CustomTargetCfgResolveTest : RsWithToolchainTestBase() {
+
+    @MinRustcVersion("1.52.0")
+    fun `test custom build-in compiler target`() {
+        buildProject {
+            toml("Cargo.toml", """
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+            """)
+            dir(".cargo") {
+                toml("config", """
+                    [build]
+                    target = "wasm32-unknown-unknown"
+                """)
+            }
+            dir("src") {
+                rust("main.rs", """
+                    #[cfg(not(target_arch = "wasm32"))]
+                    mod disabled;
+                    #[cfg(target_arch = "wasm32")]
+                    mod enabled;
+
+                    #[cfg(not(target_arch = "wasm32"))]
+                    pub use disabled::function_under_cfg;
+                    #[cfg(target_arch = "wasm32")]
+                    pub use enabled::function_under_cfg;
+
+                    fn main() {
+                        function_under_cfg();
+                            //^
+                    }
+                """)
+                rust("disabled.rs", """
+                    pub fn function_under_cfg() {}
+                """)
+                rust("enabled.rs", """
+                    pub fn function_under_cfg() {}
+                """)
+            }
+        }.checkReferenceIsResolved<RsPath>("src/main.rs", toFile = ".../src/enabled.rs")
+    }
+
+    @MinRustcVersion("1.52.0")
+    fun `test custom json target`() {
+        buildProject {
+            toml("Cargo.toml", """
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+            """)
+            dir(".cargo") {
+                toml("config", """
+                    [build]
+                    target = "custom-target.json"
+                """)
+            }
+            file("custom-target.json", """
+                {
+                    "llvm-target": "aarch64-unknown-none",
+                    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+                    "arch": "aarch64",
+                    "target-endian": "little",
+                    "target-pointer-width": "64",
+                    "target-c-int-width": "32",
+                    "os": "none",
+                    "executables": true,
+                    "linker-flavor": "ld.lld",
+                    "linker": "rust-lld",
+                    "panic-strategy": "abort",
+                    "disable-redzone": true,
+                    "features": "-mmx,-sse,+soft-float"
+                }
+            """)
+            dir("src") {
+                rust("main.rs", """
+                    #[cfg(not(target_arch = "aarch64"))]
+                    mod disabled;
+                    #[cfg(target_arch = "aarch64")]
+                    mod enabled;
+
+                    #[cfg(not(target_arch = "aarch64"))]
+                    pub use disabled::function_under_cfg;
+                    #[cfg(target_arch = "aarch64")]
+                    pub use enabled::function_under_cfg;
+
+                    fn main() {
+                        function_under_cfg();
+                            //^
+                    }
+                """)
+                rust("disabled.rs", """
+                    pub fn function_under_cfg() {}
+                """)
+                rust("enabled.rs", """
+                    pub fn function_under_cfg() {}
+                """)
+            }
+        }.checkReferenceIsResolved<RsPath>("src/main.rs", toFile = ".../src/enabled.rs")
+    }
+
+    // BACKCOMPAT: Rust 1.51. Drop it
+    // Checks that our integration doesn't fail for Rust below 1.52
+    fun `test custom compiler target with rust below 1_52`() {
+        val rustcVersion = rustupFixture.toolchain!!.rustc().queryVersion() ?: return
+        if (rustcVersion.semver > SemVer.parseFromText("1.51.0")) return
+        buildProject {
+            toml("Cargo.toml", """
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+            """)
+            dir(".cargo") {
+                toml("config", """
+                    [build]
+                    target = "wasm32-unknown-unknown"
+                """)
+            }
+            dir("src") {
+                rust("main.rs", """
+                    #[cfg(not(target_arch = "wasm32"))]
+                    mod disabled;
+                    #[cfg(target_arch = "wasm32")]
+                    mod enabled;
+
+                    #[cfg(not(target_arch = "wasm32"))]
+                    pub use disabled::function_under_cfg;
+                    #[cfg(target_arch = "wasm32")]
+                    pub use enabled::function_under_cfg;
+
+                    fn main() {
+                        function_under_cfg();
+                            //^
+                    }
+                """)
+                rust("disabled.rs", """
+                    pub fn function_under_cfg() {}
+                """)
+                rust("enabled.rs", """
+                    pub fn function_under_cfg() {}
+                """)
+            }
+        }.checkReferenceIsResolved<RsPath>("src/main.rs", toFile = ".../src/disabled.rs")
+    }
+}


### PR DESCRIPTION
Now the plugin use `cargo rustc --print cfg` instead of raw `rustc --print cfg` that allows taking [Cargo config](https://doc.rust-lang.org/cargo/reference/config.html) into account, i.e. fetch cfg options for custom build target, `RUSTFLAGS`, etc.
As a result, evaluation of `cfg` attributes also takes such custom options into account and users can set up them.

Note, `cargo rustc --print cfg` option is available only since Rust 1.52. With older toolchain, the plugin uses host `cfg` options

Fixes #5183
Part of #6104
Related to https://github.com/rust-lang/cargo/issues/9342

<img width="358" src="https://user-images.githubusercontent.com/2539310/114613416-fba27200-9cab-11eb-9b41-97457858ec54.png"/>

<img width="358" alt="Screen Shot 2021-04-12 at 15 12 51" src="https://user-images.githubusercontent.com/2539310/114392523-95312d00-9ba1-11eb-849a-827bae53f69a.png">



changelog: Now the plugin takes [Cargo config](https://doc.rust-lang.org/cargo/reference/config.html) into account during evaluation of `cfg` conditions. Note, it works since Rust 1.52.0
