### PR TITLE
GRD: enable Gradle Build Cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 out/
 bin/
 build/
+build-cache
 gen/
 deps/
 exampleProject

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ plugins {
 idea {
     module {
         // https://github.com/gradle/kotlin-dsl/issues/537/
-        excludeDirs = excludeDirs + file("testData") + file("deps") + file("bin")
+        excludeDirs = excludeDirs + file("testData") + file("deps") + file("bin") + file("build-cache")
     }
 }
 
@@ -380,6 +380,10 @@ project(":") {
                 into("bin")
                 include("**")
             }
+        }
+
+        clean {
+            delete(*(File("${rootDir}/build-cache").listFiles() ?: emptyArray()))
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,9 @@ compileNativeCode=true
 
 org.gradle.jvmargs=-Xmx2g
 
+# Enable Gradle Build Cache. It is also configured in settings.gradle.kts.
+org.gradle.caching=true
+
 # Since kotlin 1.4, stdlib dependency is added by default by kotlib gradle plugin.
 # But we don't need it because all necessary kotlin libraries are already bundled into IDE.
 # See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for more details

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,3 +16,13 @@ include(
     "ml-completion",
     "intellij-toml"
 )
+
+// Configure Gradle Build Cache. It is enabled in `gradle.properties` via `org.gradle.caching`.
+// Also, `gradle clean` task is configured to delete `build-cache` directory.
+buildCache {
+    local {
+        isEnabled = System.getenv("CI") == null
+        directory = File(rootDir, "build-cache")
+        removeUnusedEntriesAfterDays = 30
+    }
+}


### PR DESCRIPTION
From [Gradle docs](https://docs.gradle.org/current/userguide/build_cache.html):

> The Gradle build cache is a cache mechanism that aims to save time by reusing
> outputs produced by other builds. The build cache works by storing build outputs
> and allowing builds to fetch these outputs from the cache when it is determined
> that inputs have not changed, avoiding the expensive work of regenerating them.

In short, now we have a directory `build-cache` where Gradle puts all
(intermediate) build outputs it ever produces and reuses them if possible, 
so frequent git branch switching or IntelliJ platform version switching 
does not cause long build times.

In order to prevent constant growth of `build-cache` there is a mechanism that
removes cached entries that have not been accessed for 30 days (the value is
configured in `settings.gradle.kts`). My `build-cache` directory size is less than
150 Mb after a week of usage.

Now you can mention these messages in a build log:

```
> Task :compileKotlin FROM-CACHE
> Task :compileJava FROM-CACHE
```

Such `FROM-CACHE` records (instead of the usual `UP-TO-DATE`) means that the task
was not `UP-TO-DATE`, but it was **not** re-launched. Instead, the build output
was fetched from the build cache.

For me, this drastically improves the build time in the case of the platform version
switching.