### PR TITLE
RES: Basic resolve of macros 2.0 with new resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/RsMacroDataWithHash.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsMacroDataWithHash.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.macros
 import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve2.DeclMacro2DefInfo
 import org.rust.lang.core.resolve2.DeclMacroDefInfo
 import org.rust.lang.core.resolve2.MacroDefInfo
 import org.rust.lang.core.resolve2.ProcMacroDefInfo
@@ -52,6 +53,7 @@ class RsMacroDataWithHash<T : RsMacroData>(
                 } else {
                     RsMacroDataWithHash(RsDeclMacroData(def.body), def.bodyHash)
                 }
+                is DeclMacro2DefInfo -> null  // TODO
                 is ProcMacroDefInfo -> {
                     val name = def.path.name
                     val procMacroArtifact = def.procMacroArtifact ?: return null

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
@@ -129,7 +129,8 @@ val RsItemsOwner.expandedItemsCached: RsCachedItems
 class RsCachedItems(
     val namedImports: List<CachedNamedImport>,
     val starImports: List<CachedStarImport>,
-    val macros: List<RsMacro>,
+    /** [RsMacro2] are stored in [named] */
+    val legacyMacros: List<RsMacro>,
     val named: Map<String, List<RsItemElement>>,
     val namedCfgDisabled: Map<String, List<RsItemElement>>,
 ) {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMetaItem.kt
@@ -12,6 +12,7 @@ import org.rust.lang.core.RsPsiPattern
 import org.rust.lang.core.psi.RsMetaItem
 import org.rust.lang.core.psi.RsMetaItemArgs
 import org.rust.lang.core.psi.RsTraitItem
+import org.rust.lang.core.resolve.KNOWN_DERIVABLE_TRAITS
 import org.rust.lang.core.stubs.RsMetaItemStub
 import org.rust.lang.core.stubs.common.RsMetaItemPsiOrStub
 
@@ -33,6 +34,7 @@ val RsMetaItem.id: String?
         ?.map { it.referenceName ?: return null }
         ?.joinToString("::")
 
+/** Works only for [KNOWN_DERIVABLE_TRAITS] */
 fun RsMetaItem.resolveToDerivedTrait(): RsTraitItem? =
     path?.reference?.multiResolve()?.filterIsInstance<RsTraitItem>()?.singleOrNull()
 

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -795,11 +795,11 @@ fun processMacroReferenceVariants(ref: RsMacroReference, processor: RsResolvePro
     return simple.any { processor(it) }
 }
 
-fun processAttributeProcMacroResolveVariants(path: RsPath, originalProcessor: RsResolveProcessor): Boolean {
+fun processProcMacroResolveVariants(path: RsPath, originalProcessor: RsResolveProcessor): Boolean {
     val qualifier = path.qualifier
 
     val processor = createProcessor(originalProcessor.name) {
-        if (it.element !is RsMacro) {
+        if (it.element !is RsMacroDefinitionBase) {
             originalProcessor(it)
         } else {
             false

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsAttributeProcMacroReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsAttributeProcMacroReferenceImpl.kt
@@ -10,7 +10,7 @@ import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.ext.RsElement
 import org.rust.lang.core.resolve.collectResolveVariants
-import org.rust.lang.core.resolve.processAttributeProcMacroResolveVariants
+import org.rust.lang.core.resolve.processProcMacroResolveVariants
 
 class RsAttributeProcMacroReferenceImpl(
     element: RsPath
@@ -18,7 +18,7 @@ class RsAttributeProcMacroReferenceImpl(
     RsPathReference {
 
     override fun resolveInner(): List<RsElement> =
-        collectResolveVariants(element.referenceName) { processAttributeProcMacroResolveVariants(element, it) }
+        collectResolveVariants(element.referenceName) { processProcMacroResolveVariants(element, it) }
 
     override fun isReferenceTo(element: PsiElement): Boolean =
         element is RsFunction && super.isReferenceTo(element)

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsDeriveTraitReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsDeriveTraitReferenceImpl.kt
@@ -10,8 +10,10 @@ import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.RsTraitItem
 import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.isKnownDerivable
 import org.rust.lang.core.resolve.collectResolveVariants
 import org.rust.lang.core.resolve.processDeriveTraitResolveVariants
+import org.rust.lang.core.resolve.processProcMacroResolveVariants
 
 class RsDeriveTraitReferenceImpl(
     element: RsPath
@@ -19,10 +21,32 @@ class RsDeriveTraitReferenceImpl(
     RsPathReference {
 
     override fun resolveInner(): List<RsElement> {
-        val traitName = element.referenceName ?: return emptyList()
-        return collectResolveVariants(traitName) { processDeriveTraitResolveVariants(element, traitName, it) }
+        // We resolve standard derive proc macros, such as Derive or Display,
+        // to their corresponding traits,
+        // because resolving them to macros makes little sense to users (these macros are empty)
+        element.resolveToDerivedTrait()
+            .filter { it.isKnownDerivable }
+            .takeIf { it.isNotEmpty() }
+            ?.let { return it }
+
+        return element.resolveToProcMacro()
     }
 
     override fun isReferenceTo(element: PsiElement): Boolean =
         (element is RsTraitItem || element is RsFunction) && super.isReferenceTo(element)
+}
+
+private fun RsPath.resolveToDerivedTrait(): List<RsTraitItem> {
+    val traitName = referenceName ?: return emptyList()
+    val variants = collectResolveVariants(traitName) {
+        processDeriveTraitResolveVariants(this, traitName, it)
+    }
+    return variants.filterIsInstance<RsTraitItem>()
+}
+
+private fun RsPath.resolveToProcMacro(): List<RsElement> {
+    val traitName = referenceName ?: return emptyList()
+    return collectResolveVariants(traitName) {
+        processProcMacroResolveVariants(this, it)
+    }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsMacroPathReferenceImpl.kt
@@ -9,8 +9,8 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.ResolveResult
 import org.rust.lang.core.psi.RsFunction
-import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.ext.RsMacroDefinitionBase
 import org.rust.lang.core.psi.ext.RsNamedElement
 import org.rust.lang.core.resolve.pickFirstResolveVariant
 import org.rust.lang.core.resolve.processMacroCallPathResolveVariants
@@ -41,7 +41,7 @@ class RsMacroPathReferenceImpl(
     RsPathReference {
 
     override fun isReferenceTo(element: PsiElement): Boolean =
-        (element is RsMacro || element is RsFunction /* proc macro */) && super.isReferenceTo(element)
+        (element is RsMacroDefinitionBase || element is RsFunction /* proc macro */) && super.isReferenceTo(element)
 
     override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> {
         return resolve()?.let { arrayOf(PsiElementResolveResult(it)) } ?: ResolveResult.EMPTY_ARRAY

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -403,6 +403,11 @@ class DeclMacroDefInfo(
     }
 }
 
+class DeclMacro2DefInfo(
+    override val crate: CratePersistentId,
+    override val path: ModPath,
+) : MacroDefInfo()
+
 class ProcMacroDefInfo(
     override val crate: CratePersistentId,
     override val path: ModPath,

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.vfs.newvfs.persistent.PersistentFS
 import com.intellij.psi.PsiElement
 import com.intellij.psi.StubBasedPsiElement
 import org.rust.cargo.project.settings.rustSettings
+import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.refactoring.move.common.RsMoveUtil.containingModOrSelf
 import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.completion.RsMacroCompletionProvider
@@ -478,9 +479,11 @@ private fun VisItem.scopedMacroToPsi(containingMod: RsMod): RsNamedElement? {
         .filter { it.name == name && matchesIsEnabledByCfg(it, this) }
     if (legacyMacros.isNotEmpty()) return legacyMacros.singlePublicOrFirst()
 
-    items.named[name]
-        ?.singleOrNull { it is RsMacro2 && matchesIsEnabledByCfg(it, this) }
-        ?.let { return it as RsMacro2 }
+    if (name !in KNOWN_DERIVABLE_TRAITS || containingMod.containingCrate?.origin != PackageOrigin.STDLIB) {
+        items.named[name]
+            ?.singleOrNull { it is RsMacro2 && matchesIsEnabledByCfg(it, this) }
+            ?.let { return it as RsMacro2 }
+    }
 
     return items.named.values
         .flatten()

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FileModificationTracker.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FileModificationTracker.kt
@@ -66,6 +66,7 @@ private fun calculateModHash(modData: ModDataLight): HashCode {
     data.writeElements(modData.imports)
     data.writeElements(modData.macroCalls)
     data.writeElements(modData.macroDefs)
+    data.writeElements(modData.macro2Defs)
     data.writeByte(modData.attributes?.ordinal ?: RsFile.Attributes.values().size)
 
     return HashCode.fromByteArray(digest.digest())
@@ -77,13 +78,14 @@ private class ModDataLight {
     val imports: MutableList<ImportLight> = mutableListOf()
     val macroCalls: MutableList<MacroCallLight> = mutableListOf()
     val macroDefs: MutableList<MacroDefLight> = mutableListOf()
+    val macro2Defs: MutableList<Macro2DefLight> = mutableListOf()
     var attributes: RsFile.Attributes? = null  // not null only for crate root
 
     fun sort() {
         items.sortBy { it.name }
         enums.sortBy { it.item.name }
         imports.sortWith(compareBy(Arrays::compare) { it.usePath })
-        // TODO: Smart sort for macro calls & defs
+        macro2Defs.sortBy { it.name }
     }
 }
 
@@ -158,6 +160,10 @@ private class ModLightCollector(
 
     override fun collectMacroDef(def: MacroDefLight) {
         modData.macroDefs += def
+    }
+
+    override fun collectMacro2Def(def: Macro2DefLight) {
+        modData.macro2Defs += def
     }
 
     override fun afterCollectMod() {

--- a/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/ModCollector.kt
@@ -323,6 +323,20 @@ private class ModCollector(
         }
     }
 
+    override fun collectMacro2Def(def: Macro2DefLight) {
+        // save macro body for later use
+        modData.macros2[def.name] = DeclMacro2DefInfo(
+            crate = modData.crate,
+            path = modData.path.append(def.name)
+        )
+
+        // add macro to scope
+        val visibility = convertVisibility(def.visibility, isDeeplyEnabledByCfg = true)
+        val visItem = VisItem(modData.path.append(def.name), visibility)
+        val perNs = PerNs.macros(visItem)
+        onAddItem(modData, def.name, perNs, visibility)
+    }
+
     /**
      * Propagates macro defs expanded from `foo!()` to `mod2`:
      * ```

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -1495,7 +1495,7 @@ class RsMacro2Stub(
     RsNamedStub {
 
     object Type : RsStubElementType<RsMacro2Stub, RsMacro2>("MACRO_2") {
-        override fun shouldCreateStub(node: ASTNode): Boolean = node.elementType in RS_MOD_OR_FILE
+        override fun shouldCreateStub(node: ASTNode): Boolean = node.treeParent.elementType in RS_MOD_OR_FILE
 
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
             RsMacro2Stub(

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateChangeSingleFileTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsDefMapUpdateChangeSingleFileTest.kt
@@ -325,6 +325,26 @@ class RsDefMapUpdateChangeSingleFileTest : RsDefMapUpdateTestBase() {
         }
     """)
 
+    fun `test change macro 2 def name`() = doTestChanged("""
+        macro foo() {}
+    """, """
+        macro bar() {}
+    """)
+
+    fun `test change macro 2 def visibility`() = doTestChanged("""
+        macro foo() {}
+    """, """
+        pub macro foo() {}
+    """)
+
+    fun `test swap macro 2 defs`() = doTestNotChanged("""
+        macro foo() {}
+        macro bar() {}
+    """, """
+        macro bar() {}
+        macro foo() {}
+    """)
+
     @MockAdditionalCfgOptions("intellij_rust")
     fun `test add file level cfg attribute`() = doTestChanged("""
     """, """


### PR DESCRIPTION
Support basic resolve of macros 2.0:
```rust
pub macro foo() {
    ...
}
```

Rust 1.51 added two such macros, `addr_of` and `addr_of_mut`.
Note that importing macros 2.0 using `#[macro_use] extern crate ...` is not supported by this PR.

changelog: Support basic resolve of macros 2.0 (`pub macro name() { ... }`) with new name resolution engine
