### PR TITLE
Associate `poetry.lock` files with TOML file type

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -2,6 +2,7 @@
 # If you are wondering, how to sort lines in IDEA, then the answer is
 # https://plugins.jetbrains.com/plugin/2162
 
+abn
 akozlova
 alexeykudinkin
 alexpana

--- a/intellij-toml/src/main/resources/META-INF/plugin.xml
+++ b/intellij-toml/src/main/resources/META-INF/plugin.xml
@@ -24,7 +24,7 @@
                   implementationClass="org.toml.lang.psi.TomlFileType"
                   fieldName="INSTANCE"
                   extensions="toml"
-                  fileNames="Cargo.lock;Cargo.toml.orig;Gopkg.lock;Pipfile"/>
+                  fileNames="Cargo.lock;Cargo.toml.orig;Gopkg.lock;Pipfile;poetry.lock"/>
         <lang.parserDefinition language="TOML" implementationClass="org.toml.lang.parse.TomlParserDefinition"/>
         <lang.ast.factory language="TOML" implementationClass="org.toml.lang.psi.impl.TomlASTFactory"/>
         <lang.syntaxHighlighter language="TOML" implementationClass="org.toml.ide.TomlHighlighter"/>

--- a/intellij-toml/src/test/kotlin/org/toml/lang/TomlFileTypeTest.kt
+++ b/intellij-toml/src/test/kotlin/org/toml/lang/TomlFileTypeTest.kt
@@ -17,6 +17,7 @@ class TomlFileTypeTest : TomlTestBase() {
     fun `test Cargo toml orig`() = doTest("Cargo.toml.orig")
     fun `test Gopkg lock`() = doTest("Gopkg.lock")
     fun `test Pipfile`() = doTest("Pipfile")
+    fun `test Poetry lock file`() = doTest("poetry.lock")
     fun `test Cargo config`() = doTest(".cargo/config")
 
     private fun doTest(path: String) {


### PR DESCRIPTION
changelog: Consider poetry.lock as TOML file
