### PR TITLE
FIX: better check where clause in RsNeedlessLifetimesInspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
@@ -98,7 +98,7 @@ private fun couldUseElision(fn: RsFunction): Boolean {
     }
 }
 
-private class LifetimesCollector(val isForInputParams: Boolean = false) : RsVisitor() {
+private class LifetimesCollector(val isForInputParams: Boolean = false) : RsRecursiveVisitor() {
     var abort: Boolean = false
     val lifetimes = mutableListOf<ReferenceLifetime>()
 
@@ -230,7 +230,7 @@ private fun hasWhereLifetimes(whereClause: RsWhereClause?): Boolean {
         // now walk the bounds
         predicate.typeParamBounds?.polyboundList?.map { it.bound }?.forEach { it.accept(collector) }
         // and check that all lifetimes are allowed
-        if (!allowedLifetimes.containsAll(collector.lifetimes)) return false
+        if (!allowedLifetimes.containsAll(collector.lifetimes)) return true
     }
     return false
 }

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspectionTest.kt
@@ -248,6 +248,17 @@ class RsNeedlessLifetimesInspectionTest : RsInspectionsTestBase(RsNeedlessLifeti
         fn foo<'a, T>(s: &'a str, t: T) where T: S<'a> { unimplemented!() }
     """)
 
+    // https://github.com/intellij-rust/intellij-rust/issues/7092
+    fun `test no elision when lifetime in where 3`() = doTest("""
+        trait A<'b> {}
+
+        struct C<T>(T);
+
+        impl<T> C<T> {
+            fn d<'e>(&'e self) where T: A<'e> {}
+        }
+    """)
+
     fun `test no elision when lifetime in body`() = doTest("""
         fn foo<'a>(s: &'a str) { let x: &'a str = unimplemented!(); }
     """)


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/7092

changelog: Remove false positive in RsNeedlessLifetimesInspection when the lifetime is used in where clause.