### PR TITLE
ANN: annotate unknown cfg predicates [E0537]

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -109,9 +109,36 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
             override fun visitPatTupleStruct(o: RsPatTupleStruct) = checkRsPatTupleStruct(rsHolder, o)
             override fun visitPatTup(o: RsPatTup) = checkRsPatTup(rsHolder, o)
             override fun visitStructLiteralField(o: RsStructLiteralField) = checkReferenceIsPublic(o, o, rsHolder)
+            override fun visitMetaItem(o: RsMetaItem) = checkMetaItem(rsHolder, o)
         }
 
         element.accept(visitor)
+    }
+
+    private fun checkMetaItem(holder: RsAnnotationHolder, metaItem: RsMetaItem) {
+        val args = metaItem.metaItemArgs
+        val name = metaItem.name
+        if (metaItem.isRootMetaItem() && args != null && name in listOf("cfg", "cfg_attr")) {
+            val item = args.metaItemList.getOrNull(0) ?: return
+            checkCfgPredicate(holder, item)
+        }
+    }
+
+    private fun checkCfgPredicate(holder: RsAnnotationHolder, item: RsMetaItem) {
+        val itemName = item.name ?: return
+        val args = item.metaItemArgs ?: return
+        when (itemName) {
+            "all", "any" -> args.metaItemList.forEach { checkCfgPredicate(holder, it) }
+            "not" -> {
+                val parameter = args.metaItemList.getOrNull(0) ?: return
+                checkCfgPredicate(holder, parameter)
+            }
+            "version" -> { /* version is currently experimental */ }
+            else -> {
+                val path = item.path ?: return
+                RsDiagnostic.UnknownCfgPredicate(path, itemName).addToHolder(holder, checkCfg = false)
+            }
+        }
     }
 
     private fun checkRsPatTup(holder: RsAnnotationHolder, pattern: RsPatTup) {

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1375,6 +1375,14 @@ sealed class RsDiagnostic(
             "Only traits defined in the current crate can be implemented for arbitrary types"
         )
     }
+
+    class UnknownCfgPredicate(element: PsiElement, private val name: String) : RsDiagnostic(element) {
+        override fun prepare() = PreparedAnnotation(
+            ERROR,
+            E0537,
+            "Invalid predicate `$name`"
+        )
+    }
 }
 
 enum class RsErrorCode {
@@ -1383,7 +1391,7 @@ enum class RsErrorCode {
     E0200, E0201, E0202, E0252, E0261, E0262, E0263, E0267, E0268, E0277,
     E0308, E0322, E0328, E0364, E0365, E0379, E0384,
     E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0433, E0435, E0449, E0451, E0463,
-    E0517, E0518, E0552, E0562, E0569, E0583, E0586, E0594,
+    E0517, E0518, E0537, E0552, E0562, E0569, E0583, E0586, E0594,
     E0601, E0603, E0614, E0616, E0618, E0624, E0658, E0666, E0667, E0688, E0695,
     E0704, E0732;
 
@@ -1405,8 +1413,8 @@ class PreparedAnnotation(
     val fixes: List<LocalQuickFix> = emptyList()
 )
 
-fun RsDiagnostic.addToHolder(holder: RsAnnotationHolder) {
-    if (element.isEnabledByCfg) {
+fun RsDiagnostic.addToHolder(holder: RsAnnotationHolder, checkCfg: Boolean = true) {
+    if (!checkCfg || element.isEnabledByCfg) {
         addToHolder(holder.holder)
     }
 }


### PR DESCRIPTION
This PR adds error annotations for unknown `cfg` predicates.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/7096

changelog: Annotate unknown cfg attributes. This corresponds to the E0537 compiler error.