### PR TITLE
Implement Run/Debug as root

### DIFF
--- a/clion/src/main/kotlin/org/rust/clion/debugger/RsCLionDebuggerDriverConfigurationProvider.kt
+++ b/clion/src/main/kotlin/org/rust/clion/debugger/RsCLionDebuggerDriverConfigurationProvider.kt
@@ -13,8 +13,8 @@ import com.jetbrains.cidr.execution.debugger.backend.DebuggerDriverConfiguration
 import org.rust.debugger.RsDebuggerDriverConfigurationProvider
 
 class RsCLionDebuggerDriverConfigurationProvider : RsDebuggerDriverConfigurationProvider {
-    override fun getDebuggerDriverConfiguration(project: Project): DebuggerDriverConfiguration? {
+    override fun getDebuggerDriverConfiguration(project: Project, isElevated: Boolean): DebuggerDriverConfiguration? {
         val toolchain = CPPToolchains.getInstance().defaultToolchain ?: return null
-        return createDriverConfiguration(project, CPPEnvironment(toolchain))
+        return createDriverConfiguration(project, CPPEnvironment(toolchain), isElevated)
     }
 }

--- a/debugger/src/main/kotlin/org/rust/debugger/RsDebuggerDriverConfigurationProvider.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/RsDebuggerDriverConfigurationProvider.kt
@@ -11,7 +11,7 @@ import com.jetbrains.cidr.execution.debugger.backend.DebuggerDriverConfiguration
 
 interface RsDebuggerDriverConfigurationProvider {
 
-    fun getDebuggerDriverConfiguration(project: Project): DebuggerDriverConfiguration?
+    fun getDebuggerDriverConfiguration(project: Project, isElevated: Boolean): DebuggerDriverConfiguration?
 
     companion object {
         @JvmField

--- a/debugger/src/main/kotlin/org/rust/debugger/RsDebuggerDriverConfigurationProviderImpl.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/RsDebuggerDriverConfigurationProviderImpl.kt
@@ -13,21 +13,23 @@ import org.rust.debugger.RsDebuggerToolchainService.LLDBStatus
 import java.io.File
 
 class RsDebuggerDriverConfigurationProviderImpl : RsDebuggerDriverConfigurationProvider {
-    override fun getDebuggerDriverConfiguration(project: Project): DebuggerDriverConfiguration? {
+    override fun getDebuggerDriverConfiguration(project: Project, isElevated: Boolean): DebuggerDriverConfiguration? {
         @Suppress("MoveVariableDeclarationIntoWhen")
         val lldbStatus = RsDebuggerToolchainService.getInstance().getLLDBStatus()
         return when (lldbStatus) {
-            is LLDBStatus.Binaries -> RsLLDBDriverConfiguration(lldbStatus)
+            is LLDBStatus.Binaries -> RsLLDBDriverConfiguration(lldbStatus, isElevated)
             else -> null
         }
     }
 }
 
 private class RsLLDBDriverConfiguration(
-    private val binaries: LLDBStatus.Binaries
+    private val binaries: LLDBStatus.Binaries,
+    private val isElevated: Boolean
 ) : LLDBDriverConfiguration() {
     override fun getDriverName(): String = "Rust LLDB"
     override fun useSTLRenderers(): Boolean = false
     override fun getLLDBFrameworkFile(architectureType: ArchitectureType): File = binaries.frameworkFile
     override fun getLLDBFrontendFile(architectureType: ArchitectureType): File = binaries.frontendFile
+    override fun isElevated(): Boolean = isElevated
 }

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunParameters.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunParameters.kt
@@ -18,7 +18,8 @@ import org.rust.debugger.RsDebuggerDriverConfigurationProvider
 class RsDebugRunParameters(
     val project: Project,
     private val cmd: GeneralCommandLine,
-    val cargoProject: CargoProject?
+    val cargoProject: CargoProject?,
+    private val isElevated: Boolean
 ) : RunParameters() {
 
     override fun getInstaller(): Installer = TrivialInstaller(cmd)
@@ -26,8 +27,10 @@ class RsDebugRunParameters(
 
     override fun getDebuggerDriverConfiguration(): DebuggerDriverConfiguration {
         for (provider in RsDebuggerDriverConfigurationProvider.EP_NAME.extensionList) {
-            return provider.getDebuggerDriverConfiguration(project) ?: continue
+            return provider.getDebuggerDriverConfiguration(project, isElevated) ?: continue
         }
-        return LLDBDriverConfiguration()
+        return object : LLDBDriverConfiguration() {
+            override fun isElevated(): Boolean = isElevated
+        }
     }
 }

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtils.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtils.kt
@@ -34,7 +34,12 @@ object RsDebugRunnerUtils {
         environment: ExecutionEnvironment,
         runExecutable: GeneralCommandLine
     ): RunContentDescriptor {
-        val runParameters = RsDebugRunParameters(environment.project, runExecutable, state.cargoProject)
+        val runParameters = RsDebugRunParameters(
+            environment.project,
+            runExecutable,
+            state.cargoProject,
+            state.runConfiguration.withSudo
+        )
         return XDebuggerManager.getInstance(environment.project)
             .startSession(environment, object : XDebugProcessStarter() {
                 override fun start(session: XDebugSession): XDebugProcess =

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtils.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugRunnerUtils.kt
@@ -20,6 +20,7 @@ import com.intellij.xdebugger.XDebuggerManager
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.runconfig.BuildResult
 import org.rust.cargo.runconfig.CargoRunStateBase
+import org.rust.cargo.runconfig.CargoTestRunState
 import org.rust.cargo.toolchain.wsl.RsWslToolchain
 import org.rust.debugger.RsDebuggerToolchainService
 import org.rust.debugger.settings.RsDebuggerSettings
@@ -38,7 +39,9 @@ object RsDebugRunnerUtils {
             environment.project,
             runExecutable,
             state.cargoProject,
-            state.runConfiguration.withSudo
+            // TODO: always pass `withSudo` when `com.intellij.execution.process.ElevationService` supports error stream redirection
+            // https://github.com/intellij-rust/intellij-rust/issues/7320
+            if (state is CargoTestRunState) false else state.runConfiguration.withSudo
         )
         return XDebuggerManager.getInstance(environment.project)
             .startSession(environment, object : XDebugProcessStarter() {

--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoTestCommandRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoTestCommandRunner.kt
@@ -51,7 +51,9 @@ class CargoTestCommandRunner : AsyncProgramRunner<RunnerSettings>() {
 
         private fun buildTests(environment: ExecutionEnvironment, state: CargoRunStateBase, cmdHasNoRun: Boolean): Promise<Int?> {
             val buildProcessHandler = run {
-                val buildCmd = if (cmdHasNoRun) state.commandLine else state.commandLine.prependArgument("--no-run")
+                val buildCmd = state.commandLine.copy(withSudo = false).run {
+                    if (cmdHasNoRun) this else prependArgument("--no-run")
+                }
                 val buildConfig = CargoCommandConfiguration.CleanConfiguration.Ok(buildCmd, state.config.toolchain)
                 val buildState = CargoRunState(state.environment, state.runConfiguration, buildConfig)
                 buildState.startProcess(processColors = true)

--- a/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/RsExecutableRunner.kt
@@ -86,6 +86,7 @@ abstract class RsExecutableRunner(
             runCargoCommand.environmentVariables,
             executableArguments,
             runCargoCommand.emulateTerminal,
+            runCargoCommand.withSudo,
             patchToRemote = false // patching is performed for debugger/profiler/valgrind on CLion side if needed
         )
         return showRunContent(state, environment, runExecutable)

--- a/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/Utils.kt
@@ -42,7 +42,8 @@ fun CargoCommandLine.mergeWithDefault(default: CargoCommandConfiguration): Cargo
         environmentVariables = default.env,
         requiredFeatures = default.requiredFeatures,
         allFeatures = default.allFeatures,
-        emulateTerminal = default.emulateTerminal
+        emulateTerminal = default.emulateTerminal,
+        withSudo = default.withSudo,
     )
 
 fun RunManager.createCargoCommandRunConfiguration(cargoCommandLine: CargoCommandLine, name: String? = null): RunnerAndConfigurationSettings {

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildManager.kt
@@ -228,6 +228,9 @@ object CargoBuildManager {
             "test" -> ParametersListUtil.join("test", "--no-run", *commandArguments.toTypedArray())
             else -> return null
         }
+        // building does not require root privileges anyway
+        buildConfiguration.withSudo = false
+
         return buildConfiguration
     }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -56,6 +56,7 @@ open class CargoCommandConfiguration(
     var requiredFeatures: Boolean = true
     var allFeatures: Boolean = false
     var emulateTerminal: Boolean = false
+    var withSudo: Boolean = false
     var backtrace: BacktraceMode = BacktraceMode.SHORT
     var env: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
 
@@ -89,6 +90,7 @@ open class CargoCommandConfiguration(
         element.writeBool("requiredFeatures", requiredFeatures)
         element.writeBool("allFeatures", allFeatures)
         element.writeBool("emulateTerminal", emulateTerminal)
+        element.writeBool("withSudo", withSudo)
         element.writeEnum("backtrace", backtrace)
         env.writeExternal(element)
         element.writeBool("isRedirectInput", isRedirectInput)
@@ -105,6 +107,7 @@ open class CargoCommandConfiguration(
         element.readBool("requiredFeatures")?.let { requiredFeatures = it }
         element.readBool("allFeatures")?.let { allFeatures = it }
         element.readBool("emulateTerminal")?.let { emulateTerminal = it }
+        element.readBool("withSudo")?.let { withSudo = it }
         element.readEnum<BacktraceMode>("backtrace")?.let { backtrace = it }
         env = EnvironmentVariablesData.readExternal(element)
         element.readBool("isRedirectInput")?.let { isRedirectInput = it }
@@ -117,6 +120,7 @@ open class CargoCommandConfiguration(
         requiredFeatures = cmd.requiredFeatures
         allFeatures = cmd.allFeatures
         emulateTerminal = cmd.emulateTerminal
+        withSudo = cmd.withSudo
         backtrace = cmd.backtraceMode
         workingDirectory = cmd.workingDirectory
         env = cmd.environmentVariables
@@ -199,7 +203,8 @@ open class CargoCommandConfiguration(
                 env,
                 requiredFeatures,
                 allFeatures,
-                emulateTerminal
+                emulateTerminal,
+                withSudo
             )
         }
 

--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -15,10 +15,12 @@ import com.intellij.execution.testframework.actions.ConsolePropertiesProvider
 import com.intellij.execution.testframework.sm.runner.SMTRunnerConsoleProperties
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.util.execution.ParametersListUtil
 import com.intellij.util.io.exists
 import org.jdom.Element
+import org.rust.RsBundle
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.settings.toolchain
@@ -139,7 +141,16 @@ open class CargoCommandConfiguration(
                 path?.exists() != true -> throw RuntimeConfigurationWarning("Input file doesn't exist")
                 !path.toFile().isFile -> throw RuntimeConfigurationWarning("Input file is not valid")
             }
-
+        }
+        // TODO: remove when `com.intellij.execution.process.ElevationService` supports error stream redirection
+        // https://github.com/intellij-rust/intellij-rust/issues/7320
+        if (withSudo && showTestToolWindow()) {
+            val message = if (SystemInfo.isWindows) {
+                RsBundle.message("notification.run.tests.as.root.windows")
+            } else {
+                RsBundle.message("notification.run.tests.as.root.unix")
+            }
+            throw RuntimeConfigurationWarning(message)
         }
 
         val config = clean()

--- a/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
@@ -83,6 +83,7 @@ abstract class RsAsyncRunner(
                     environmentVariables,
                     executableArguments,
                     emulateTerminal,
+                    withSudo,
                     patchToRemote = false // patching is performed for debugger/profiler/valgrind on CLion side if needed
                 )
             }

--- a/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
@@ -71,7 +71,7 @@ abstract class RsAsyncRunner(
             if (cmdHasNoRun) commandLine else commandLine.prependArgument("--no-run")
         } else {
             commandLine.copy(command = "build", additionalArguments = commandArguments)
-        }.copy(emulateTerminal = false)
+        }.copy(emulateTerminal = false, withSudo = false) // building does not require root privileges
 
         val getRunCommand = { executablePath: Path ->
             with(commandLine) {

--- a/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
@@ -91,6 +91,10 @@ class CargoCommandConfigurationEditor(project: Project)
     private val requiredFeatures = CheckBox("Implicitly add required features if possible", true)
     private val allFeatures = CheckBox("Use all features in tests", false)
     private val emulateTerminal = CheckBox("Emulate terminal in output console", false)
+    private val withSudo = CheckBox(
+        if (SystemInfo.isWindows) "Run with Administrator privileges" else "Run with root privileges",
+        false
+    )
 
     override fun resetEditorFrom(configuration: CargoCommandConfiguration) {
         super.resetEditorFrom(configuration)
@@ -99,6 +103,7 @@ class CargoCommandConfigurationEditor(project: Project)
         requiredFeatures.isSelected = configuration.requiredFeatures
         allFeatures.isSelected = configuration.allFeatures
         emulateTerminal.isSelected = configuration.emulateTerminal
+        withSudo.isSelected = configuration.withSudo
         backtraceMode.selectedIndex = configuration.backtrace.index
         environmentVariables.envData = configuration.env
 
@@ -124,6 +129,7 @@ class CargoCommandConfigurationEditor(project: Project)
         configuration.requiredFeatures = requiredFeatures.isSelected
         configuration.allFeatures = allFeatures.isSelected
         configuration.emulateTerminal = emulateTerminal.isSelected && !SystemInfo.isWindows
+        configuration.withSudo = withSudo.isSelected
         configuration.backtrace = BacktraceMode.fromIndex(backtraceMode.selectedIndex)
         configuration.env = environmentVariables.envData
 
@@ -151,6 +157,7 @@ class CargoCommandConfigurationEditor(project: Project)
         if (!SystemInfo.isWindows) {
             row { emulateTerminal() }
         }
+        row { withSudo() }
 
         row(environmentVariables.label) {
             environmentVariables(growX)

--- a/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/ui/CargoCommandConfigurationEditor.kt
@@ -33,6 +33,8 @@ import org.rust.cargo.toolchain.RustChannel
 import org.rust.cargo.toolchain.tools.isRustupAvailable
 import org.rust.cargo.util.CargoCommandCompletionProvider
 import org.rust.cargo.util.RsCommandLineEditor
+import org.rust.ide.experiments.RsExperiments
+import org.rust.openapiext.isFeatureEnabled
 import org.rust.openapiext.pathTextField
 import javax.swing.JCheckBox
 import javax.swing.JComponent
@@ -94,7 +96,11 @@ class CargoCommandConfigurationEditor(project: Project)
     private val withSudo = CheckBox(
         if (SystemInfo.isWindows) "Run with Administrator privileges" else "Run with root privileges",
         false
-    )
+    ).apply {
+        // TODO: remove when `com.intellij.execution.process.ElevationService` supports error stream redirection
+        // https://github.com/intellij-rust/intellij-rust/issues/7320
+        isEnabled = isFeatureEnabled(RsExperiments.BUILD_TOOL_WINDOW)
+    }
 
     override fun resetEditorFrom(configuration: CargoCommandConfiguration) {
         super.resetEditorFrom(configuration)

--- a/src/main/kotlin/org/rust/cargo/toolchain/CommandLine.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/CommandLine.kt
@@ -56,7 +56,8 @@ data class CargoCommandLine(
     val environmentVariables: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT,
     val requiredFeatures: Boolean = true,
     val allFeatures: Boolean = false,
-    val emulateTerminal: Boolean = false
+    val emulateTerminal: Boolean = false,
+    val withSudo: Boolean = false
 ) : RsCommandLineBase() {
 
     override fun createRunConfiguration(runManager: RunManagerEx, name: String?): RunnerAndConfigurationSettings =

--- a/src/main/kotlin/org/rust/cargo/toolchain/RsToolchainBase.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/RsToolchainBase.kt
@@ -81,10 +81,11 @@ abstract class RsToolchainBase(val location: Path) {
         environmentVariables: EnvironmentVariablesData,
         parameters: List<String>,
         emulateTerminal: Boolean,
+        withSudo: Boolean,
         patchToRemote: Boolean = true,
         http: HttpConfigurable = HttpConfigurable.getInstance()
     ): GeneralCommandLine {
-        var commandLine = GeneralCommandLine(executable)
+        var commandLine = GeneralCommandLine(executable, withSudo)
             .withWorkDirectory(workingDirectory)
             .withInput(redirectInputFrom)
             .withEnvironment("TERM", "ansi")

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -33,6 +33,7 @@ import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.cargo.project.workspace.CargoWorkspaceData
 import org.rust.cargo.project.workspace.PackageId
+import org.rust.cargo.runconfig.buildtool.CargoBuildManager.isBuildToolWindowEnabled
 import org.rust.cargo.runconfig.buildtool.CargoPatch
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration.Companion.findCargoPackage
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration.Companion.findCargoProject
@@ -394,7 +395,9 @@ class Cargo(toolchain: RsToolchainBase, useWrapper: Boolean = false)
                 environmentVariables,
                 parameters,
                 emulateTerminal,
-                withSudo,
+                // TODO: always pass `withSudo` when `com.intellij.execution.process.ElevationService` supports error stream redirection
+                // https://github.com/intellij-rust/intellij-rust/issues/7320
+                if (project.isBuildToolWindowEnabled) withSudo else false,
                 http = http
             ).withEnvironment("RUSTC", rustcExecutable)
         }

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -394,6 +394,7 @@ class Cargo(toolchain: RsToolchainBase, useWrapper: Boolean = false)
                 environmentVariables,
                 parameters,
                 emulateTerminal,
+                withSudo,
                 http = http
             ).withEnvironment("RUSTC", rustcExecutable)
         }

--- a/src/main/kotlin/org/rust/openapiext/CommandLineExt.kt
+++ b/src/main/kotlin/org/rust/openapiext/CommandLineExt.kt
@@ -8,6 +8,7 @@ package org.rust.openapiext
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.execution.process.ElevationService
 import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.process.ProcessOutput
 import com.intellij.openapi.Disposable
@@ -22,8 +23,15 @@ import java.nio.file.Path
 
 private val LOG: Logger = Logger.getInstance("org.rust.openapiext.CommandLineExt")
 
-@Suppress("FunctionName")
-fun GeneralCommandLine(path: Path, vararg args: String) = GeneralCommandLine(path.systemIndependentPath, *args)
+@Suppress("FunctionName", "UnstableApiUsage")
+fun GeneralCommandLine(path: Path, withSudo: Boolean = false, vararg args: String) =
+    object : GeneralCommandLine(path.systemIndependentPath, *args) {
+        override fun createProcess(): Process = if (withSudo) {
+            ElevationService.getInstance().createProcess(this)
+        } else {
+            super.createProcess()
+        }
+    }
 
 fun GeneralCommandLine.withWorkDirectory(path: Path?) = withWorkDirectory(path?.systemIndependentPath)
 

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -63,6 +63,8 @@ notification.file.not.belong.to.cargo.project=File does not belong to any known 
 notification.invalid.stdlib.source.path="Invalid Rust standard library source path: `{0}`
 notification.no.cargo.projects.found=No Cargo projects found
 notification.no.toolchain.configured=No Rust toolchain configured
+notification.run.tests.as.root.windows=Running tests with Administrator privileges is not yet supported
+notification.run.tests.as.root.unix=Running tests with root privileges is not yet supported
 
 refactoring.change.signature.error.cfg.disabled.parameters=Cannot change signature of function with cfg-disabled parameters
 refactoring.change.signature.name.conflict=The name {0} conflicts with an existing item in {1}

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/BenchRunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/BenchRunConfigurationProducerTest.kt
@@ -204,6 +204,7 @@ class BenchRunConfigurationProducerTest : RunConfigurationProducerTestBase() {
             requiredFeatures = false
             allFeatures = true
             emulateTerminal = true
+            withSudo = true
             isRedirectInput = true
             backtrace = BacktraceMode.FULL
             env = EnvironmentVariablesData.create(mapOf("FOO" to "BAR"), true)

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/ExecutableRunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/ExecutableRunConfigurationProducerTest.kt
@@ -56,6 +56,7 @@ class ExecutableRunConfigurationProducerTest : RunConfigurationProducerTestBase(
             requiredFeatures = false
             allFeatures = true
             emulateTerminal = true
+            withSudo = true
             isRedirectInput = true
             backtrace = BacktraceMode.FULL
             env = EnvironmentVariablesData.create(mapOf("FOO" to "BAR"), true)

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/TestRunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/TestRunConfigurationProducerTest.kt
@@ -222,6 +222,7 @@ class TestRunConfigurationProducerTest : RunConfigurationProducerTestBase() {
             requiredFeatures = false
             allFeatures = true
             emulateTerminal = true
+            withSudo = true
             isRedirectInput = true
             backtrace = BacktraceMode.FULL
             env = EnvironmentVariablesData.create(mapOf("FOO" to "BAR"), true)

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_configuration_uses_default_environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_configuration_uses_default_environment.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="false" />
     <option name="allFeatures" value="true" />
     <option name="emulateTerminal" value="true" />
+    <option name="withSudo" value="true" />
     <option name="backtrace" value="FULL" />
     <envs>
       <env name="FOO" value="BAR" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_fn_is_more_specific_than_main_or_test_mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_fn_is_more_specific_than_main_or_test_mod.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_adds_bin_name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_adds_bin_name.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_ignores_selected_files_that_contain_no_benches.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_ignores_selected_files_that_contain_no_benches.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_uses_complete_function_path.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_uses_complete_function_path.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_annotated_functions.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_annotated_functions.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_benches_source_root.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_benches_source_root.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_directories_inside_benches_source_root.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_directories_inside_benches_source_root.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_files.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_module_declarations.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_module_declarations.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_modules.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_modules.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_multiple_files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_multiple_files.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_nested_modules_1.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_nested_modules_1.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_nested_modules_2.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_nested_modules_2.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_root_module.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/bench_producer_works_for_root_module.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executable_configuration_uses_default_environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executable_configuration_uses_default_environment.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="false" />
     <option name="allFeatures" value="true" />
     <option name="emulateTerminal" value="true" />
+    <option name="withSudo" value="true" />
     <option name="backtrace" value="FULL" />
     <envs>
       <env name="FOO" value="BAR" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executable_producer_works_for_bin.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executable_producer_works_for_bin.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executable_producer_works_for_example.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/executable_producer_works_for_example.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/hyphen_in_name_works.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/hyphen_in_name_works.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ignored_test_is_run_with_ignored_option.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/ignored_test_is_run_with_ignored_option.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_bench_fn.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_bench_fn.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_bench_mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_bench_mod.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_test_fn.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_test_fn.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_test_mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_fn_is_more_specific_than_test_mod.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_mod_is_more_specific_than_test_mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/main_mod_is_more_specific_than_test_mod.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/meaningful_bench_configuration_name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/meaningful_bench_configuration_name.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/meaningful_test_configuration_name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/meaningful_test_configuration_name.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/take_into_account_path_attribute.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/take_into_account_path_attribute.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_configuration_uses_default_environment.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_configuration_uses_default_environment.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="false" />
     <option name="allFeatures" value="true" />
     <option name="emulateTerminal" value="true" />
+    <option name="withSudo" value="true" />
     <option name="backtrace" value="FULL" />
     <envs>
       <env name="FOO" value="BAR" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_fn_is_more_specific_than_main_mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_fn_is_more_specific_than_main_mod.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_mod_decl_is_more_specific_than_main_mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_mod_decl_is_more_specific_than_main_mod.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_mod_is_more_specific_than_bench_mod.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_mod_is_more_specific_than_bench_mod.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_adds_bin_name.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_adds_bin_name.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_ignores_selected_files_that_contain_no_tests.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_ignores_selected_files_that_contain_no_tests.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_uses_complete_function_path.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_uses_complete_function_path.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_annotated_functions.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_annotated_functions.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_directories_inside_tests_source_root.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_directories_inside_tests_source_root.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_files.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_module_declarations.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_module_declarations.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_modules.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_modules.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_multiple_files.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_multiple_files.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_nested_modules_1.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_nested_modules_1.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_nested_modules_2.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_nested_modules_2.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_project_root.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_project_root.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_root_module.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_root_module.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_tests_source_root.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/test_producer_works_for_tests_source_root.xml
@@ -6,6 +6,7 @@
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />
     <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
     <option name="backtrace" value="SHORT" />
     <envs />
     <option name="isRedirectInput" value="false" />


### PR DESCRIPTION
The implementation is based on `com.intellij.execution.process.ElevationService` API introduced in 2020.3.

Fixes #7048

changelog: Implement Run/Debug as root. The new `Run with root privileges`/`Run with Administrator privileges` option is now available for any Cargo configurations. 
Current restrictions:
* Requires `Build` tool window, which is enabled by default via `org.rust.cargo.build.window` option in `Experimental Features`
* When using with `cargo test` configuration, only Debug (but not Run) actually gives root privileges to the process

Check [CLion blog](https://blog.jetbrains.com/clion/2020/11/clion-2020-3-goes-beta-debug/#run_debug_as_root) for more information about this feature.