### PR TITLE
INT: prioritize `ToggleFeatureIntention` and extend its availability range

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/ToggleFeatureIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/ToggleFeatureIntention.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.intentions
 
+import com.intellij.codeInsight.intention.HighPriorityAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
@@ -19,7 +20,7 @@ import org.rust.lang.core.psi.ext.cargoProject
 import org.rust.lang.core.psi.ext.containingCargoPackage
 import org.rust.lang.core.psi.ext.stringValue
 
-class ToggleFeatureIntention : RsElementBaseIntentionAction<ToggleFeatureIntention.Context>() {
+class ToggleFeatureIntention : RsElementBaseIntentionAction<ToggleFeatureIntention.Context>(), HighPriorityAction {
     private val matcher = insideAnyCfgFeature
 
     data class Context(val featureName: String, val element: RsElement)


### PR DESCRIPTION
Some improvements to #6845

1. make `ToggleFeatureIntention` a high priority action. Since the intention has a lower availability scope (a feature meta item only) I think it should have a higher priority than intentions with wider scope:
![image](https://user-images.githubusercontent.com/3221931/114852763-c00ec180-9deb-11eb-967b-7b6129c98562.png)

2. extend availability range of `ToggleFeatureIntention`
The intention is now available in the entire meta item, not only in the feature name:
```
#[cfg(feature = "foo")]
//    ~~~~~~~~~~~~~~~
```

changelog: should not be mentioned in the changelog if placed in the same release as #6845
