### PR TITLE
Take into account `pub(crate)` visibility in auto-import

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/ImportCandidatesCollector.kt
@@ -167,9 +167,10 @@ object ImportCandidatesCollector {
         // we need to do it because we can use direct child items of any super mod with any visibility
         val lca = ourSuperMods.find { it.modItem in superMods }
         val crateRelativePath = crateRelativePath ?: return null
+        val targetMod = superMods.first()
 
         val (shouldBePublicMods, importInfo) = if (lca == null && ourCrateAsDependency != null) {
-            if (!isPublic) return null
+            if (!isVisibleFrom(targetMod)) return null
             val externCrateMod = ourSuperMods.last().modItem
 
             val externCrateWithDepth = superMods.withIndex().mapNotNull { (index, superMod) ->
@@ -190,7 +191,6 @@ object ImportCandidatesCollector {
                 needInsertExternCrateItem, depth, crateRelativePath)
             ourSuperMods to importInfo
         } else {
-            val targetMod = superMods.first()
             val relativePath = if (targetMod.isAtLeastEdition2018) {
                 "crate::$crateRelativePath"
             } else {
@@ -198,10 +198,10 @@ object ImportCandidatesCollector {
             }
             // if current item is direct child of some ancestor of `mod` then it can be not public
             if (parentMod == lca) return ImportInfo.LocalImportInfo(relativePath)
-            if (!isPublic) return null
+            if (!isVisibleFrom(targetMod)) return null
             ourSuperMods.takeWhile { it != lca }.dropLast(1) to ImportInfo.LocalImportInfo(relativePath)
         }
-        return if (shouldBePublicMods.all { it.modItem.isPublic }) return importInfo else null
+        return if (shouldBePublicMods.all { it.modItem.isVisibleFrom(targetMod) }) return importInfo else null
     }
 
     private fun canBeResolvedToSuitableItem(

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsQualifiedNamedElement.kt
@@ -506,7 +506,7 @@ data class RsQualifiedName private constructor(
 sealed class QualifiedNamedItem(val item: RsQualifiedNamedElement) {
 
     abstract val itemName: String?
-    abstract val isPublic: Boolean
+    abstract fun isVisibleFrom(mod: RsMod): Boolean
     abstract val superMods: List<ModWithName>?
     abstract val containingCrate: Crate?
 
@@ -534,7 +534,7 @@ sealed class QualifiedNamedItem(val item: RsQualifiedNamedElement) {
 
     class ExplicitItem(item: RsQualifiedNamedElement) : QualifiedNamedItem(item) {
         override val itemName: String? get() = item.name
-        override val isPublic: Boolean get() = (item as? RsVisible)?.isPublic == true
+        override fun isVisibleFrom(mod: RsMod): Boolean = (item as? RsVisible)?.isVisibleFrom(mod) == true
         override val superMods: List<ModWithName>?
             get() = (if (item is RsMod) item.`super` else item.containingMod)?.superMods?.map { ModWithName(it) }
         override val containingCrate: Crate? get() = item.containingCrate
@@ -546,7 +546,16 @@ sealed class QualifiedNamedItem(val item: RsQualifiedNamedElement) {
         item: RsQualifiedNamedElement
     ) : QualifiedNamedItem(item) {
 
-        override val isPublic: Boolean get() = true
+        override fun isVisibleFrom(mod: RsMod): Boolean {
+            if ((item as? RsVisible)?.isVisibleFrom(mod) != true) return false
+
+            return when (reexportItem) {
+                is RsUseSpeck -> reexportItem.ancestorStrict<RsUseItem>()?.isVisibleFrom(mod) == true
+                is RsExternCrateItem -> reexportItem.isVisibleFrom(mod)
+                else -> error("unreachable")
+            }
+        }
+
         override val superMods: List<ModWithName> get() = reexportItem.containingMod.superMods.map { ModWithName(it) }
         override val containingCrate: Crate? get() = reexportItem.containingCrate
 
@@ -563,11 +572,15 @@ sealed class QualifiedNamedItem(val item: RsQualifiedNamedElement) {
 
     class CompositeItem(
         override val itemName: String?,
-        override val isPublic: Boolean,
+        private val originalItem: QualifiedNamedItem,
         private val reexportedModItem: QualifiedNamedItem,
         private val explicitSuperMods: List<ModWithName>,
         item: RsQualifiedNamedElement
     ) : QualifiedNamedItem(item) {
+
+        override fun isVisibleFrom(mod: RsMod): Boolean {
+            return originalItem.isVisibleFrom(mod) && reexportedModItem.isVisibleFrom(mod)
+        }
 
         override val superMods: List<ModWithName>
             get() {
@@ -681,7 +694,7 @@ private fun QualifiedNamedItem.collectImportItems(
                 }
                 val items = QualifiedNamedItem.ReexportedItem.from(useSpeck, mod).collectImportItems(project, visited)
                 importItems += items.map {
-                    QualifiedNamedItem.CompositeItem(itemName, isPublic, it, explicitSuperMods, item)
+                    QualifiedNamedItem.CompositeItem(itemName, this, it, explicitSuperMods, item)
                 }
                 visited -= useSpeck
             }
@@ -699,7 +712,7 @@ private fun QualifiedNamedItem.withExternCrateReexports(project: Project): List<
         val items = QualifiedNamedItem.ReexportedItem.from(externCrateItem, root).collectImportItems(project)
         importItems += items.map {
             val explicitSuperMods = superMods.dropLast(1) + QualifiedNamedItem.ModWithName(root, externCrateItem.nameWithAlias)
-            QualifiedNamedItem.CompositeItem(itemName, isPublic, it, explicitSuperMods, item)
+            QualifiedNamedItem.CompositeItem(itemName, this, it, explicitSuperMods, item)
         }
     }
     return importItems

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -2339,4 +2339,121 @@ class AutoImportFixTest : AutoImportFixTestBase() {
 
         fn foo(t: Bar/*caret*/) {}
     """)
+
+    fun `test import 'pub(crate)' from the same crate`() = checkAutoImportFixByText("""
+        mod foo {
+            pub(crate) struct Foo;
+        }
+
+        fn main() {
+            let f = <error descr="Unresolved reference: `Foo`">Foo/*caret*/</error>;
+        }
+    """, """
+        use foo::Foo;
+
+        mod foo {
+            pub(crate) struct Foo;
+        }
+
+        fn main() {
+            let f = Foo/*caret*/;
+        }
+    """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test do not try to import 'pub(crate)' item from dependency crate`() = checkAutoImportFixIsUnavailableByFileTree("""
+        //- dep-lib/lib.rs
+        pub mod foo {
+            pub(crate) struct Bar;
+        }
+        //- main.rs
+        fn foo(t: <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>) {}
+    """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test do not try to import an item from 'pub(crate)' mod in dependency crate`() = checkAutoImportFixIsUnavailableByFileTree("""
+        //- dep-lib/lib.rs
+        pub(crate) mod foo {
+            pub struct Bar;
+        }
+        //- main.rs
+        fn foo(t: <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>) {}
+    """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test do not try to import an item reexported from 'pub(crate)' mod in dependency crate`() = checkAutoImportFixIsUnavailableByFileTree("""
+        //- dep-lib/lib.rs
+        mod foo {
+            pub struct Bar;
+        }
+        pub(crate) mod baz {
+            pub use crate::foo::Bar;
+        }
+        //- main.rs
+        fn foo(t: <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>) {}
+    """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test do not try to import 'pub(crate)' item reexported from dependency crate`() = checkAutoImportFixIsUnavailableByFileTree("""
+        //- dep-lib/lib.rs
+        mod foo {
+            pub(crate) struct Bar;
+        }
+        pub mod baz {
+            pub use crate::foo::Bar;
+        }
+        //- main.rs
+        fn foo(t: <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>) {}
+    """)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test do not try to import an item reexported by 'pub(crate) use' in dependency crate`() = checkAutoImportFixIsUnavailableByFileTree("""
+        //- dep-lib/lib.rs
+        mod foo {
+            pub struct Bar;
+        }
+        pub mod baz {
+            pub(crate) use crate::foo::Bar;
+        }
+        //- main.rs
+        fn foo(t: <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>) {}
+    """)
+
+    // TODO the fix should not be available if an intermediate use is not public
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test do not try to import an item reexported by intermediate 'pub(crate) use' in dependency crate`() = expect<IllegalStateException> {
+    checkAutoImportFixIsUnavailableByFileTree("""
+        //- dep-lib/lib.rs
+        mod foo {
+            pub struct Bar;
+        }
+        mod baz {
+            pub(crate) use crate::foo::Bar;
+        }
+        pub mod quux {
+            pub use crate::baz::Bar;
+        }
+        //- main.rs
+        fn foo(t: <error descr="Unresolved reference: `Bar`">Bar/*caret*/</error>) {}
+    """)
+    }
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test do not try to import an item reexported by 'pub(crate) extern crate' in dependency crate`() = checkAutoImportFixIsUnavailableByFileTree("""
+        //- trans-lib/lib.rs
+        pub struct FooBar;
+        //- dep-lib/lib.rs
+        pub(crate) extern crate trans_lib;
+        //- lib.rs
+        extern crate dep_lib_target;
+
+        fn foo(x: <error descr="Unresolved reference: `FooBar`">FooBar/*caret*/</error>) {}
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTestBase.kt
@@ -16,6 +16,9 @@ abstract class AutoImportFixTestBase : RsInspectionsTestBase(RsUnresolvedReferen
     protected fun checkAutoImportFixIsUnavailable(@Language("Rust") text: String, testmark: Testmark? = null) =
         doTest { checkFixIsUnavailable(AutoImportFix.NAME, text, testmark = testmark) }
 
+    protected fun checkAutoImportFixIsUnavailableByFileTree(@Language("Rust") text: String, testmark: Testmark? = null) =
+        doTest { checkFixIsUnavailableByFileTree(AutoImportFix.NAME, text, testmark = testmark) }
+
     protected fun checkAutoImportFixByText(
         @Language("Rust") before: String,
         @Language("Rust") after: String,


### PR DESCRIPTION
Now auto-import should not suggest importing `pub(crate)` items from other crates
