### PR TITLE
COMP:  Fix single match arm postfix completion for `println!`

### DIFF
--- a/src/main/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplate.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplate.kt
@@ -82,7 +82,7 @@ class PrintlnPostfixTemplate(provider: RsPostfixTemplateProvider, private val ma
             }
             is RsMatchArm -> {
                 val matchBody = parent.ancestorStrict<RsMatchBody>() ?: return
-                if (matchBody.containsUnitArm) {
+                if (matchBody.matchArmList.size == 1 || matchBody.containsUnitArm) {
                     val newElement = macroCreator.replaceWithMacro(expression)
                     val caretAnchor = if (parent.comma == null) {
                         parent.addAfter(psiFactory.createComma(), newElement)

--- a/src/test/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/PrintlnPostfixTemplateTest.kt
@@ -353,4 +353,22 @@ class PrintlnPostfixTemplateTests : RsPostfixTemplateTest(PrintlnPostfixTemplate
             println!("{}", variable);/*caret*/
         }
     """)
+
+    fun `test match arm with a single arm`() = doTest("""
+        enum E<T> { A(T), B }
+
+        fn main() {
+            match E::A(22) {
+                E::A(value) => value.println/*caret*/
+            };
+        }
+    """, """
+        enum E<T> { A(T), B }
+
+        fn main() {
+            match E::A(22) {
+                E::A(value) => println!("{:?}", value),/*caret*/
+            };
+        }
+    """)
 }


### PR DESCRIPTION
Fixed #7117
