### PR TITLE
RES: fix resolve of field shorthand in unknown struct literal

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -133,9 +133,8 @@ fun processStructLiteralFieldResolveVariants(
     isCompletion: Boolean,
     processor: RsResolveProcessor
 ): Boolean {
-    val resolved = field.parentStructLiteral.path.reference?.deepResolve()
-    val structOrEnumVariant = resolved as? RsFieldsOwner ?: return false
-    if (processFieldDeclarations(structOrEnumVariant, processor)) return true
+    val resolved = field.parentStructLiteral.path.reference?.deepResolve() as? RsFieldsOwner
+    if (resolved != null && processFieldDeclarations(resolved, processor)) return true
     if (!isCompletion && field.expr == null) {
         processNestedScopesUpwards(field, VALUES, processor)
     }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsResolveTest.kt
@@ -689,7 +689,7 @@ class RsResolveTest : RsResolveTestBase() {
     """)
 
     fun `test struct field positional`() = checkByCodeGeneric<RsFieldDecl>("""
-        struct S(i32, i32)
+        struct S(i32, i32);
                      //X
         fn main() {
             let _ = S { 1: 92 };
@@ -704,6 +704,14 @@ class RsResolveTest : RsResolveTestBase() {
         fn main() {
             let _ = T2 { foo: 92 };
         }              //^
+    """)
+
+    fun `test unknown struct field shorthand`() = checkByCode("""
+        fn main() {
+            let foo = 62;
+              //X
+            let _ = UnknownStruct { foo };
+        }                          //^
     """)
 
     fun `test cyclic type aliases`() = checkByCode("""


### PR DESCRIPTION
Fixes this case:

```
fn main() {
    let foo = 62;
      //X
    let _ = UnknownStruct { foo };
}                          //^
```

changelog: fix name resolution of field shorthand to a local variable in the case of unresolved struct literal
