### PR TITLE
ANN: Add a quick fix to add missing trait definitions

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -106,6 +106,7 @@ rrevenantt
 saaryogev
 sanmai-NL
 SeekingMeaning
+Sejsel
 sgift
 sgrif
 shevtsiv

--- a/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsSortImplTraitMembersInspection.kt
@@ -20,7 +20,7 @@ class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
         override fun visitImplItem(impl: RsImplItem) {
             val trait = impl.traitRef?.resolveToTrait() ?: return
             val typeRef = impl.typeReference ?: return
-            if (sortedImplItems(impl.items(), trait.items()) == null) return
+            if (sortedImplItems(impl.explicitMembers, trait.explicitMembers) == null) return
             val textRange = TextRange(
                 (impl.vis ?: impl.default ?: impl.unsafe ?: impl.impl).startOffsetInParent,
                 typeRef.startOffsetInParent + typeRef.textLength
@@ -52,8 +52,8 @@ class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
             val impl = descriptor.psiElement as? RsImplItem ?: return
             val trait = impl.traitRef?.resolveToTrait() ?: return
-            val implItems = impl.items()
-            val traitItems = trait.items()
+            val implItems = impl.explicitMembers
+            val traitItems = trait.explicitMembers
 
             // As we're applying the fix, this will be non-null.
             val sortedImplItems = sortedImplItems(implItems, traitItems) ?: return
@@ -67,10 +67,6 @@ class RsSortImplTraitMembersInspection : RsLocalInspectionTool() {
     object Testmarks {
         object ImplMemberNotInTrait : Testmark()
     }
-}
-
-private fun RsTraitOrImpl.items(): List<RsAbstractable> {
-    return members?.stubChildrenOfType<RsAbstractable>().orEmpty()
 }
 
 private fun RsAbstractable.key(): Pair<String?, IElementType> = name to elementType

--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AddDefinitionToTraitFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AddDefinitionToTraitFix.kt
@@ -1,0 +1,112 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.ide.refactoring.extractTrait.makeAbstract
+import org.rust.ide.utils.import.RsImportHelper
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+
+class AddDefinitionToTraitFix(member: RsAbstractable) : LocalQuickFixAndIntentionActionOnPsiElement(member) {
+
+    override fun getText() = "Add definition to trait"
+    override fun getFamilyName(): String = text
+
+    override fun invoke(
+        project: Project,
+        file: PsiFile,
+        editor: Editor?,
+        startElement: PsiElement,
+        endElement: PsiElement
+    ) {
+        val member = startElement as? RsAbstractable ?: return
+        val impl = member.parent?.parent as? RsImplItem ?: return
+        val traitRef = impl.traitRef ?: return
+        val trait = traitRef.resolveToTrait() ?: return
+
+        val factory = RsPsiFactory(project)
+        val newMember = member.copy().makeAbstract(factory) as RsAbstractable
+        val traitMembers = trait.members ?: return
+
+        val anchor = findAnchor(impl, trait, member)
+            ?: traitMembers.rbrace?.prevSibling
+            ?: return
+        traitMembers.addAfter(newMember, anchor)
+        if (anchor == traitMembers.lbrace) {
+            traitMembers.addAfter(factory.createNewline(), traitMembers.lbrace)
+        }
+
+        if (trait.containingMod != impl.containingMod) {
+            RsImportHelper.importTypeReferencesFromElement(trait, member)
+        }
+    }
+
+    // If trait members and impl members have the same order, we insert the new member
+    // into the corresponding place. Otherwise, we add the new member to the end of the trait.
+    private fun findAnchor(impl: RsImplItem, trait: RsTraitItem, member: RsAbstractable): RsAbstractable? {
+        val traitMembers = trait.explicitMembers
+        val mapping = impl.explicitMembers.associateWith { implMember ->
+            traitMembers.find { traitMember ->
+                implMember.elementType == traitMember.elementType && implMember.name == traitMember.name
+            }
+        }
+        val areMembersInOrder = mapping.values.filterNotNull() == traitMembers
+        if (!areMembersInOrder) return null
+
+        return mapping.entries
+            .takeWhile { (implMember, _) -> implMember != member }
+            .mapNotNull { (_, traitMember) -> traitMember }
+            .lastOrNull()
+    }
+
+    companion object {
+        fun createIfCompatible(member: RsAbstractable): AddDefinitionToTraitFix? {
+            val impl = member.parent?.parent as? RsImplItem ?: return null
+            val traitRef = impl.traitRef ?: return null
+            if (!checkTraitRef(traitRef)) return null
+            if (!checkMember(member)) return null
+            return AddDefinitionToTraitFix(member)
+        }
+
+        // `impl Trait<T> for ...` - OK
+        // `impl Trait<i32> for ...` - not OK
+        private fun checkTraitRef(traitRef: RsTraitRef): Boolean {
+            val typeArgumentList = traitRef.path.typeArgumentList ?: return true
+            val generics = typeArgumentList.stubChildrenOfType<RsElement>()
+            return generics.all { generic ->
+                generic is RsLifetime || generic is RsPathType && generic.path.isGeneric()
+            }
+        }
+
+        // `type Foo = T` - OK, T will be removed
+        // `fn foo() { ... T ... }` - OK, T will be removed
+        // `fn foo(_: T) { ... }` - not OK
+        // `const FOO: T = 0` - not OK
+        private fun checkMember(member: RsAbstractable): Boolean {
+            val elementsToCheck = when (member) {
+                is RsTypeAlias -> return true
+                is RsFunction -> member.valueParameters + listOfNotNull(member.retType)
+                is RsConstant -> listOfNotNull(member.typeReference)
+                else -> error("unreachable")
+            }
+            return elementsToCheck.all { element ->
+                element.stubDescendantsOfTypeOrSelf<RsPath>().all { path ->
+                    path.hasColonColon || !path.isGeneric()
+                }
+            }
+        }
+
+        private fun RsPath.isGeneric(): Boolean {
+            val target = reference?.resolve() ?: return false
+            return target is RsTypeParameter || target is RsConstParameter
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/extractTrait/RsExtractTraitProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractTrait/RsExtractTraitProcessor.kt
@@ -104,7 +104,7 @@ class RsExtractTraitProcessor(
                 RsImportHelper.importElement(newImpl, newTrait)
             }
 
-            if (impl.traitRef == null && impl.members?.childrenOfType<RsItemElement>()?.isEmpty() == true) {
+            if (impl.traitRef == null && impl.explicitMembers.isEmpty()) {
                 impl.delete()
             }
         }

--- a/src/main/kotlin/org/rust/ide/refactoring/extractTrait/RsExtractTraitProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/extractTrait/RsExtractTraitProcessor.kt
@@ -223,7 +223,7 @@ private fun RsImplItem.getMembersWithNames(names: Set<String>): List<RsItemEleme
     }
 }
 
-private fun PsiElement.makeAbstract(psiFactory: RsPsiFactory): PsiElement {
+fun PsiElement.makeAbstract(psiFactory: RsPsiFactory): PsiElement {
     if (this is RsVisibilityOwner) vis?.delete()
     when (this) {
         is RsFunction -> {

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitOrImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitOrImpl.kt
@@ -20,3 +20,6 @@ interface RsTraitOrImpl : RsItemElement, RsGenericDeclaration, RsAttrProcMacroOw
 
 val RsTraitOrImpl.expandedMembers: List<RsAbstractable>
     get() = members?.expandedMembers.orEmpty()
+
+val RsTraitOrImpl.explicitMembers: List<RsAbstractable>
+    get() = members?.stubChildrenOfType<RsAbstractable>().orEmpty()

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -464,7 +464,8 @@ sealed class RsDiagnostic(
         override fun prepare() = PreparedAnnotation(
             ERROR,
             errorCode(),
-            errorText()
+            errorText(),
+            fixes = listOfNotNull(AddDefinitionToTraitFix.createIfCompatible(member))
         )
 
         private fun errorCode(): RsErrorCode =

--- a/src/test/kotlin/org/rust/ide/inspections/fixes/AddDefinitionToTraitFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/fixes/AddDefinitionToTraitFixTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.RsTraitImplementationInspection
+
+class AddDefinitionToTraitFixTest : RsInspectionsTestBase(RsTraitImplementationInspection::class) {
+
+    fun `test simple method`() = checkFixByText("Add definition to trait", """
+        struct Struct {}
+        trait Trait {}
+        impl Trait for Struct {
+            fn /*error descr="Method `func` is not a member of trait `Trait` [E0407]"*//*caret*/func/*error**/() {}
+        }
+    """, """
+        struct Struct {}
+        trait Trait {
+            fn func();
+        }
+        impl Trait for Struct {
+            fn func() {}
+        }
+    """)
+
+    fun `test simple assoc constant`() = checkFixByText("Add definition to trait", """
+        struct Struct {}
+        trait Trait {}
+        impl Trait for Struct {
+            const /*error descr="Const `FOO` is not a member of trait `Trait` [E0438]"*//*caret*/FOO/*error**/: i32 = 0;
+        }
+    """, """
+        struct Struct {}
+        trait Trait {
+            const FOO: i32;
+        }
+        impl Trait for Struct {
+            const FOO: i32 = 0;
+        }
+    """)
+
+    fun `test simple assoc type`() = checkFixByText("Add definition to trait", """
+        struct Struct {}
+        trait Trait {}
+        impl Trait for Struct {
+            type /*error descr="Type `T` is not a member of trait `Trait` [E0437]"*//*caret*/T/*error**/ = i32;
+        }
+    """, """
+        struct Struct {}
+        trait Trait {
+            type T;
+        }
+        impl Trait for Struct {
+            type T = i32;
+        }
+    """)
+
+    fun `test insert at correct position if members are in order`() = checkFixByText("Add definition to trait", """
+        struct Struct {}
+        trait Trait {
+            fn a();
+            fn b();
+        }
+        impl Trait for Struct {
+            fn a() {}
+            fn /*error descr="Method `c` is not a member of trait `Trait` [E0407]"*//*caret*/c/*error**/() {}
+            fn b() {}
+        }
+    """, """
+        struct Struct {}
+        trait Trait {
+            fn a();
+            fn c();
+            fn b();
+        }
+        impl Trait for Struct {
+            fn a() {}
+            fn c() {}
+            fn b() {}
+        }
+    """)
+
+    fun `test insert at the end if members are out of order`() = checkFixByText("Add definition to trait", """
+        struct Struct {}
+        trait Trait {
+            fn a();
+            fn b();
+        }
+        impl Trait for Struct {
+            fn b() {}
+            fn /*error descr="Method `c` is not a member of trait `Trait` [E0407]"*//*caret*/c/*error**/() {}
+            fn a() {}
+        }
+    """, """
+        struct Struct {}
+        trait Trait {
+            fn a();
+            fn b();
+            fn c();
+        }
+        impl Trait for Struct {
+            fn b() {}
+            fn c() {}
+            fn a() {}
+        }
+    """)
+
+    fun `test assoc type with generics`() = checkFixByText("Add definition to trait", """
+        struct Struct {}
+        trait Trait<A> {}
+        impl<A> Trait<A> for Struct {
+            type /*error descr="Type `T` is not a member of trait `Trait` [E0437]"*//*caret*/T/*error**/ = A;
+        }
+    """, """
+        struct Struct {}
+        trait Trait<A> {
+            type T;
+        }
+        impl<A> Trait<A> for Struct {
+            type T = A;
+        }
+    """)
+
+    fun `test not available if member contains generics`() = checkFixIsUnavailable("Add definition to trait", """
+        struct Struct {}
+        trait Trait<A, B> {}
+        impl<C> Trait<C, C> for Struct {
+            // Can't substitute back from C - is it A or B?
+            const /*error descr="Const `FOO` is not a member of trait `Trait` [E0438]"*//*caret*/FOO/*error**/: C = 0;
+        }
+    """)
+
+    fun `test not available when implement trait with substitution`() = checkFixIsUnavailable("Add definition to trait", """
+        struct Struct {}
+        trait Trait<A> {
+            // const FOO: A;
+        }
+        impl Trait<i32> for Struct {
+            // Can't substitute back from i32 to A
+            const /*error descr="Const `FOO` is not a member of trait `Trait` [E0438]"*//*caret*/FOO/*error**/: i32 = 0;
+        }
+    """)
+
+    fun `test generics`() = checkFixByText("Add definition to trait", """
+        struct Struct<'a, A, const CA: i32> { field: &'a A }
+        trait Trait<'b, B, const CB: i32> {}
+        impl<'c, C, const CC: i32> Trait<'c, C, CC> for Struct<'c, C, CC> {
+            fn /*error descr="Method `func` is not a member of trait `Trait` [E0407]"*//*caret*/func/*error**/() {}
+        }
+    """, """
+        struct Struct<'a, A, const CA: i32> { field: &'a A }
+        trait Trait<'b, B, const CB: i32> {
+            fn func();
+        }
+        impl<'c, C, const CC: i32> Trait<'c, C, CC> for Struct<'c, C, CC> {
+            fn func() {}
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds one of the quick fixes listed under E0407 in #886 (the most useful one that I have missed a couple of times already). Generates trait members with no default implementation, which is the behavior I would expect from this. Maintains the member order if the order of existing trait and impl members matches.

https://user-images.githubusercontent.com/998408/115119582-7370e500-9fa9-11eb-84b8-c4046ab98938.mp4

Currently, the E0437 and E0438 (the `type` and `const` versions of E0407, respectively) rustc errors are also classified as E0407 by the plugin, and this quick fix solves all three of them.

The current implementation duplicates `RsFunction.getSignatureText()` from the "implement members" fix/refactor. I am not sure what is the best place to move this (if it's even a good idea). The duplicated implementation includes a comment about anonymous parameters preventing simply using a substring of the original signature - if I understand that correctly, this should not be an issue for the impl->trait direction (regardless of Rust edition), but I am not 100% sure. I would appreciate some insight from someone who's not touching the codebase for the first time like me :)

**TODO**
- [x] Solve duplication of `RsFunction.getSignatureText()`
- [x] Add tests (mostly adapted from implement members - the opposite action)

changelog: Add a quickfix to generate missing trait member definitions in trait implementations.