### PR TITLE
REF: add suggested refactoring support for function change signature

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureConfig.kt
@@ -22,7 +22,10 @@ import org.rust.lang.core.types.type
  * This class just holds [config].
  * It is required by [com.intellij.refactoring.changeSignature.ChangeSignatureProcessorBase].
  */
-class RsSignatureChangeInfo(val config: RsChangeFunctionSignatureConfig) : ChangeInfo {
+class RsSignatureChangeInfo(
+    val config: RsChangeFunctionSignatureConfig,
+    val changeSignature: Boolean
+) : ChangeInfo {
     override fun getNewParameters(): Array<ParameterInfo> = arrayOf()
     override fun isParameterSetOrOrderChanged(): Boolean = config.parameterSetOrOrderChanged()
     override fun isParameterTypesChanged(): Boolean = false
@@ -65,9 +68,6 @@ sealed class ParameterProperty<T: RsElement> {
     }
 }
 
-/**
- * This type needs to be comparable by identity, not value.
- */
 class Parameter(
     val factory: RsPsiFactory,
     var patText: String,
@@ -139,7 +139,7 @@ class RsChangeFunctionSignatureConfig private constructor(
         append(whereClausesText)
     }
 
-    fun createChangeInfo(): ChangeInfo = RsSignatureChangeInfo(this)
+    fun createChangeInfo(changeSignature: Boolean = true): ChangeInfo = RsSignatureChangeInfo(this, changeSignature)
     fun nameChanged(): Boolean = name != originalName
     fun parameterSetOrOrderChanged(): Boolean = parameters.map { it.index } != originalParameters.indices.toList()
 

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureHandler.kt
@@ -72,11 +72,17 @@ class RsChangeSignatureHandler : ChangeSignatureHandler {
         )
     }
 
-    private fun checkFunction(function: RsFunction): String? {
-        if (function.valueParameters != function.rawValueParameters) {
-            return RsBundle.message("refactoring.change.signature.error.cfg.disabled.parameters")
+    companion object {
+        fun isChangeSignatureAvailable(function: RsFunction): Boolean {
+            return checkFunction(function) == null
         }
-        return null
+
+        private fun checkFunction(function: RsFunction): String? {
+            if (function.valueParameters != function.rawValueParameters) {
+                return RsBundle.message("refactoring.change.signature.error.cfg.disabled.parameters")
+            }
+            return null
+        }
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureUsageProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureUsageProcessor.kt
@@ -60,7 +60,7 @@ class RsChangeSignatureUsageProcessor : ChangeSignatureUsageProcessor {
         if (usageInfo !is RsFunctionUsage) return false
         val config = changeInfo.config
         if (usageInfo is RsFunctionUsage.MethodImplementation) {
-            processFunction(config.function.project, config, usageInfo.overriddenMethod)
+            processFunction(config.function.project, config, usageInfo.overriddenMethod, true)
         } else {
             processFunctionUsage(config, usageInfo)
         }
@@ -74,7 +74,7 @@ class RsChangeSignatureUsageProcessor : ChangeSignatureUsageProcessor {
         val function = config.function
         val project = function.project
 
-        processFunction(project, config, function)
+        processFunction(project, config, function, changeInfo.changeSignature)
         return true
     }
 

--- a/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSignaturePresentationBuilder.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSignaturePresentationBuilder.kt
@@ -1,0 +1,31 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.suggested
+
+import com.intellij.refactoring.suggested.SignatureChangePresentationModel.TextFragment.Leaf
+import com.intellij.refactoring.suggested.SignaturePresentationBuilder
+import com.intellij.refactoring.suggested.SuggestedRefactoringSupport
+
+class RsSignaturePresentationBuilder(
+    signature: SuggestedRefactoringSupport.Signature,
+    otherSignature: SuggestedRefactoringSupport.Signature,
+    isOldSignature: Boolean
+) : SignaturePresentationBuilder(signature, otherSignature, isOldSignature) {
+    override fun buildPresentation() {
+        val additionalData = signature.additionalData as? RsSignatureAdditionalData ?: return
+
+        val name = signature.name
+        fragments += Leaf(name, effect(signature.name, otherSignature.name))
+
+        if (additionalData.isFunction) {
+            buildParameterList { fragments, parameter, correspondingParameter ->
+                fragments += leaf(parameter.name, correspondingParameter?.name ?: parameter.name)
+                fragments += Leaf(": ")
+                fragments += leaf(parameter.type, correspondingParameter?.type ?: parameter.type)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringAvailability.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringAvailability.kt
@@ -1,0 +1,68 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.suggested
+
+import com.intellij.psi.PsiNamedElement
+import com.intellij.refactoring.suggested.*
+import org.rust.ide.refactoring.changeSignature.RsChangeSignatureHandler
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsPatBinding
+import org.rust.lang.core.psi.ext.isReferenceToConstant
+
+class RsSuggestedRefactoringAvailability(
+    support: RsSuggestedRefactoringSupport
+) : SuggestedRefactoringAvailability(support) {
+    override fun detectAvailableRefactoring(state: SuggestedRefactoringState): SuggestedRefactoringData? {
+        val function = state.declaration as? RsFunction
+        if (function != null && hasComplexChanges(state.oldSignature, state.newSignature)) {
+            return SuggestedChangeSignatureData.create(state, function.name.orEmpty())
+        }
+        val namedElement = state.declaration as? PsiNamedElement ?: return null
+        return SuggestedRenameData(namedElement, state.oldSignature.name)
+    }
+
+    override fun shouldSuppressRefactoringForDeclaration(state: SuggestedRefactoringState): Boolean {
+        return when (state.declaration) {
+            is RsFunction -> {
+                val function = state.restoredDeclarationCopy() as? RsFunction ?: return false
+                !RsChangeSignatureHandler.isChangeSignatureAvailable(function)
+            }
+            is RsPatBinding -> {
+                val binding = state.restoredDeclarationCopy() as? RsPatBinding ?: return false
+                binding.isReferenceToConstant
+            }
+            else -> false
+        }
+    }
+
+    private fun hasComplexChanges(
+        oldSignature: SuggestedRefactoringSupport.Signature,
+        newSignature: SuggestedRefactoringSupport.Signature
+    ): Boolean = hasParameterAddedRemovedOrReordered(oldSignature, newSignature) ||
+        hasTypeChanges(oldSignature, newSignature) ||
+        hasNameChanges(oldSignature, newSignature)
+}
+
+
+/**
+ * Find if any parameter with a simple identifier was renamed.
+ */
+private fun hasNameChanges(
+    oldSignature: SuggestedRefactoringSupport.Signature,
+    newSignature: SuggestedRefactoringSupport.Signature
+): Boolean {
+    for (parameter in newSignature.parameters) {
+        val oldParam = oldSignature.parameterById(parameter.id) ?: continue
+        val oldData = oldParam.additionalData as? RsParameterAdditionalData ?: continue
+        val newData = parameter.additionalData as? RsParameterAdditionalData ?: continue
+
+        if (oldData.isPatIdent && newData.isPatIdent && oldParam.name != parameter.name) {
+            return true
+        }
+    }
+
+    return false
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringExecution.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringExecution.kt
@@ -1,0 +1,64 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.suggested
+
+import com.intellij.refactoring.changeSignature.ParameterInfo.NEW_PARAMETER
+import com.intellij.refactoring.suggested.SuggestedChangeSignatureData
+import com.intellij.refactoring.suggested.SuggestedRefactoringExecution
+import org.rust.ide.refactoring.changeSignature.Parameter
+import org.rust.ide.refactoring.changeSignature.ParameterProperty
+import org.rust.ide.refactoring.changeSignature.RsChangeFunctionSignatureConfig
+import org.rust.ide.refactoring.changeSignature.RsChangeSignatureProcessor
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsFunction
+
+class RsSuggestedRefactoringExecution(support: RsSuggestedRefactoringSupport) : SuggestedRefactoringExecution(support) {
+    override fun prepareChangeSignature(data: SuggestedChangeSignatureData): Any? {
+        val function = data.declaration as? RsFunction ?: return null
+        return RsChangeFunctionSignatureConfig.create(function)
+    }
+
+    override fun performChangeSignature(
+        data: SuggestedChangeSignatureData,
+        newParameterValues: List<NewParameterValue>,
+        preparedData: Any?
+    ) {
+        // config holds the modified configuration changed by the user
+        val config = preparedData as? RsChangeFunctionSignatureConfig ?: return
+        val function = data.declaration as? RsFunction ?: return
+        val project = function.project
+
+        // At this point, function is restored to its old state
+        // We need to create a new config which contains the original function,
+        // but which has other attributes set to the modified configuration.
+        val originalConfig = RsChangeFunctionSignatureConfig.create(function)
+
+        // We only care about attributes which change triggers the suggested refactoring dialog.
+        // Currently it is name and parameters.
+        originalConfig.name = config.name
+
+        val oldSignature = data.oldSignature
+        val newSignature = data.newSignature
+
+        var newParameterIndex = 0
+        // We need to mark "new" parameters with the new parameter index and find parameters swaps.
+        val parameters = newSignature.parameters.zip(config.parameters).map { (signatureParameter, parameter) ->
+            val oldParameter = oldSignature.parameterById(signatureParameter.id)
+            val isNewParameter = oldParameter == null
+
+            val index = when (oldParameter) {
+                null -> NEW_PARAMETER
+                else -> oldSignature.parameterIndex(oldParameter)
+            }
+
+            Parameter(parameter.factory, parameter.patText, parameter.type, index)
+        }
+        originalConfig.parameters.clear()
+        originalConfig.parameters.addAll(parameters)
+
+        RsChangeSignatureProcessor(project, originalConfig.createChangeInfo(changeSignature = false)).run()
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringStateChanges.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringStateChanges.kt
@@ -1,0 +1,70 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.suggested
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
+import com.intellij.refactoring.suggested.SuggestedRefactoringState
+import com.intellij.refactoring.suggested.SuggestedRefactoringStateChanges
+import com.intellij.refactoring.suggested.SuggestedRefactoringSupport
+import org.rust.lang.core.psi.RsElementTypes.COLON
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.RsPatIdent
+import org.rust.lang.core.psi.ext.*
+
+data class RsSignatureAdditionalData(val isFunction: Boolean) : SuggestedRefactoringSupport.SignatureAdditionalData
+data class RsParameterAdditionalData(val isPatIdent: Boolean) : SuggestedRefactoringSupport.ParameterAdditionalData
+
+class RsSuggestedRefactoringStateChanges(
+    support: RsSuggestedRefactoringSupport
+) : SuggestedRefactoringStateChanges(support) {
+    override fun parameterMarkerRanges(declaration: PsiElement): List<TextRange?> {
+        val function = declaration as? RsFunction ?: return emptyList()
+        val parameterColons: List<PsiElement?> = listOf(function.selfParameter?.colon) +
+            function.rawValueParameters.map { parameter ->
+                parameter.childrenWithLeaves.firstOrNull { it.elementType == COLON }
+            }
+        return parameterColons.mapNotNull { it?.textRange }
+    }
+
+    override fun signature(
+        declaration: PsiElement,
+        prevState: SuggestedRefactoringState?
+    ): SuggestedRefactoringSupport.Signature? {
+        val function = declaration as? RsFunction
+        if (function != null) {
+            val name = function.name ?: return null
+            val returnType = function.retType?.text
+
+            val functionParameters = function.rawValueParameters
+            // Ignore signatures with invalid parameters
+            if (functionParameters.any { it.pat == null || it.typeReference == null }) return null
+
+            val parameters = functionParameters.map { param ->
+                SuggestedRefactoringSupport.Parameter(
+                    Any(),
+                    param.pat?.text.orEmpty(),
+                    param.typeReference?.text.orEmpty(),
+                    RsParameterAdditionalData(param.pat is RsPatIdent)
+                )
+            }
+            val signature = SuggestedRefactoringSupport.Signature.create(
+                name, returnType, parameters, RsSignatureAdditionalData(true)
+            ) ?: return null
+            return if (prevState == null) {
+                signature
+            } else {
+                matchParametersWithPrevState(signature, declaration, prevState)
+            }
+        } else {
+            val name = (declaration as? PsiNamedElement)?.name ?: return null
+            return SuggestedRefactoringSupport.Signature.create(
+                name, null, emptyList(), RsSignatureAdditionalData(false)
+            )
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringSupport.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringSupport.kt
@@ -8,29 +8,31 @@ package org.rust.ide.refactoring.suggested
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.util.parentOfType
 import com.intellij.refactoring.suggested.*
+import org.rust.lang.core.psi.RsFunction
 import org.rust.lang.core.psi.RsPatBinding
 import org.rust.lang.core.psi.RsPatIdent
+import org.rust.lang.core.psi.RsValueParameterList
 import org.rust.lang.core.psi.ext.RsNameIdentifierOwner
-import org.rust.lang.core.psi.ext.isReferenceToConstant
 
 class RsSuggestedRefactoringSupport : SuggestedRefactoringSupport {
     override val availability: SuggestedRefactoringAvailability
         get() = RsSuggestedRefactoringAvailability(this)
     override val execution: SuggestedRefactoringExecution
-        get() = SuggestedRefactoringExecution.RenameOnly(this)
+        get() = RsSuggestedRefactoringExecution(this)
     override val stateChanges: SuggestedRefactoringStateChanges
-        get() = SuggestedRefactoringStateChanges.RenameOnly(this)
+        get() = RsSuggestedRefactoringStateChanges(this)
     override val ui: SuggestedRefactoringUI
-        get() = SuggestedRefactoringUI.RenameOnly
+        get() = RsSuggestedRefactoringUI()
 
     override fun importsRange(psiFile: PsiFile): TextRange? = null
 
     override fun isDeclaration(psiElement: PsiElement): Boolean = when (psiElement) {
         // May return true for const pat binding since we can't distinguish them
-        // without name resolution that forbidden here.
-        // Refactoring for constants is suppressed by `RsSuggestedRefactoringAvailability`
-        is RsPatBinding -> psiElement.parent is RsPatIdent
+        // without name resolution, which is forbidden here.
+        // Refactoring for constants is suppressed by `RsSuggestedRefactoringAvailability`.
+        is RsPatBinding -> psiElement.parent is RsPatIdent && psiElement.parentOfType<RsValueParameterList>() == null
         is RsNameIdentifierOwner -> true
         else -> false
     }
@@ -38,20 +40,13 @@ class RsSuggestedRefactoringSupport : SuggestedRefactoringSupport {
     override fun isIdentifierPart(c: Char): Boolean = Character.isUnicodeIdentifierStart(c)
     override fun isIdentifierStart(c: Char): Boolean = Character.isUnicodeIdentifierPart(c)
 
-    override fun nameRange(declaration: PsiElement): TextRange? = getRange(declaration)
-    override fun signatureRange(declaration: PsiElement): TextRange? = getRange(declaration)
-
-    private fun getRange(declaration: PsiElement): TextRange? =
-        (declaration as? RsNameIdentifierOwner)?.nameIdentifier?.textRange
-}
-
-private class RsSuggestedRefactoringAvailability(
-    refactoringSupport: SuggestedRefactoringSupport
-) : SuggestedRefactoringAvailability.RenameOnly(refactoringSupport) {
-
-    override fun shouldSuppressRefactoringForDeclaration(state: SuggestedRefactoringState): Boolean {
-        if (state.declaration !is RsPatBinding) return false
-        val restoredDeclaration = state.restoredDeclarationCopy() as? RsPatBinding ?: return false
-        return restoredDeclaration.isReferenceToConstant
+    override fun nameRange(declaration: PsiElement): TextRange? = (declaration as? RsNameIdentifierOwner)?.nameIdentifier?.textRange
+    override fun signatureRange(declaration: PsiElement): TextRange? {
+        if (declaration is RsFunction) {
+            val start = declaration.identifier
+            val end = declaration.valueParameterList?.lastChild ?: declaration.identifier
+            return TextRange(start.startOffset, end.endOffset)
+        }
+        return (declaration as? RsNameIdentifierOwner)?.nameIdentifier?.textRange
     }
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringUI.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/suggested/RsSuggestedRefactoringUI.kt
@@ -1,0 +1,24 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.suggested
+
+import com.intellij.psi.PsiCodeFragment
+import com.intellij.refactoring.suggested.*
+import org.rust.lang.core.psi.RsExpressionCodeFragment
+import org.rust.lang.core.psi.ext.RsElement
+
+class RsSuggestedRefactoringUI : SuggestedRefactoringUI() {
+    override fun createSignaturePresentationBuilder(
+        signature: SuggestedRefactoringSupport.Signature,
+        otherSignature: SuggestedRefactoringSupport.Signature,
+        isOldSignature: Boolean
+    ): SignaturePresentationBuilder = RsSignaturePresentationBuilder(signature, otherSignature, isOldSignature)
+
+    override fun extractNewParameterData(data: SuggestedChangeSignatureData): List<NewParameterData> = emptyList()
+
+    override fun extractValue(fragment: PsiCodeFragment): SuggestedRefactoringExecution.NewParameterValue.Expression? =
+        (fragment as RsExpressionCodeFragment).expr?.let { SuggestedRefactoringExecution.NewParameterValue.Expression(it) }
+}

--- a/src/test/kotlin/org/rust/ide/refactoring/suggested/RsChangeSignatureSuggestedRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/suggested/RsChangeSignatureSuggestedRefactoringTest.kt
@@ -1,0 +1,529 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.refactoring.suggested
+
+import com.intellij.openapi.actionSystem.IdeActions
+
+class RsChangeSignatureSuggestedRefactoringTest : RsSuggestedRefactoringTestBase() {
+    fun `test unavailable when changing function modifiers`() = doUnavailableTest("""
+        /*caret*/fn foo() {}
+    """) { myFixture.type("async ") }
+
+    fun `test unavailable when changing return type`() = doUnavailableTest("""
+        fn foo()/*caret*/ {}
+    """) { myFixture.type(" -> u32") }
+
+    fun `test unavailable on inner binding change`() = doUnavailableTest("""
+        struct S {
+            a: u32
+        }
+
+        fn foo(S { a/*caret*/ }: S) {}
+    """) {
+        myFixture.type(": b")
+    }
+
+    fun `test unavailable when changing a parameter without a binding`() = doUnavailableTest("""
+        struct S {}
+
+        fn foo(/*caret*/s: S) {}
+
+        fn bar() {
+            foo(S {});
+        }
+    """) {
+        myFixture.performEditorAction(IdeActions.ACTION_EDITOR_DELETE)
+        myFixture.type("S {}")
+    }
+
+    fun `test unavailable on function with cfg-disabled parameters`() = doUnavailableTest("""
+        fn foo(#[cfg(feature = "foo")] a: u32, /*caret*/) {}
+    """) { myFixture.type("b: u32") }
+
+    fun `test rename and modify signature`() = doTestChangeSignature("""
+        fn foo/*caret*/() {}
+
+        fn bar() {
+            foo();
+        }
+    """, """
+        fn foox(a: u32) {}
+
+        fn bar() {
+            foox();
+        }
+    """, "foox", {
+        myFixture.type("x")
+        myFixture.performEditorAction(IdeActions.ACTION_EDITOR_MOVE_CARET_RIGHT)
+        myFixture.type("a: u32")
+    }, """
+Old:
+  'foo' (modified)
+  '('
+  LineBreak('', false)
+  ')'
+New:
+  'foox' (modified)
+  '('
+  LineBreak('', true)
+  Group (added):
+    'a'
+    ': '
+    'u32'
+  LineBreak('', false)
+  ')'
+  """.trimIndent())
+
+    fun `test add parameter`() = doTestChangeSignature("""
+        fn foo(/*caret*/) {}
+
+        fn bar() {
+            foo();
+        }
+    """, """
+        fn foo(a: u32) {}
+
+        fn bar() {
+            foo();
+        }
+    """, "foo", { myFixture.type("a: u32") }, """
+Old:
+  'foo'
+  '('
+  LineBreak('', false)
+  ')'
+New:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group (added):
+    'a'
+    ': '
+    'u32'
+  LineBreak('', false)
+  ')'
+    """.trimIndent())
+
+    fun `test add two parameters`() = doTestChangeSignature("""
+        fn foo(/*caret*/) {}
+
+        fn bar() {
+            foo();
+        }
+    """, """
+        fn foo(a: u32, b: u32) {}
+
+        fn bar() {
+            foo(, );
+        }
+    """, "foo", { myFixture.type("a: u32, b: u32") }, """
+Old:
+  'foo'
+  '('
+  LineBreak('', false)
+  ')'
+New:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group (added):
+    'a'
+    ': '
+    'u32'
+  ','
+  LineBreak(' ', true)
+  Group (added):
+    'b'
+    ': '
+    'u32'
+  LineBreak('', false)
+  ')'
+    """.trimIndent())
+
+    fun `test prepend parameter`() = doTestChangeSignature("""
+        fn foo(/*caret*/b: &str) {}
+
+        fn bar() {
+            foo("");
+        }
+    """, """
+        fn foo(a: u32, b: &str) {}
+
+        fn bar() {
+            foo(, "");
+        }
+    """, "foo", {
+        myFixture.type("a: u32, ")
+    }, """
+Old:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group:
+    'b'
+    ': '
+    '&str'
+  LineBreak('', false)
+  ')'
+New:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group (added):
+    'a'
+    ': '
+    'u32'
+  ','
+  LineBreak(' ', true)
+  Group:
+    'b'
+    ': '
+    '&str'
+  LineBreak('', false)
+  ')'
+    """.trimIndent())
+
+    fun `test rename parameter`() = doTestChangeSignature("""
+        fn foo(a/*caret*/: u32) {
+            let b = a;
+        }
+    """, """
+        fn foo(ax: u32) {
+            let b = ax;
+        }
+    """, "foo", { myFixture.type("x") }, """
+Old:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group:
+    'a' (modified)
+    ': '
+    'u32'
+  LineBreak('', false)
+  ')'
+New:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group:
+    'ax' (modified)
+    ': '
+    'u32'
+  LineBreak('', false)
+  ')'
+    """.trimIndent())
+
+    fun `test rename parameter while other parameter has no binding`() = doTestChangeSignature("""
+        struct S {}
+
+        fn foo(a/*caret*/: u32, S {}: S) {
+            let b = a;
+        }
+    """, """
+        struct S {}
+
+        fn foo(ax: u32, S {}: S) {
+            let b = ax;
+        }
+    """, "foo", { myFixture.type("x") }, """
+Old:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group:
+    'a' (modified)
+    ': '
+    'u32'
+  ','
+  LineBreak(' ', true)
+  Group:
+    'S {}'
+    ': '
+    'S'
+  LineBreak('', false)
+  ')'
+New:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group:
+    'ax' (modified)
+    ': '
+    'u32'
+  ','
+  LineBreak(' ', true)
+  Group:
+    'S {}'
+    ': '
+    'S'
+  LineBreak('', false)
+  ')'
+    """.trimIndent())
+
+    fun `test remove parameter`() = doTestChangeSignature("""
+        fn foo(/*caret*/a: u32) {}
+
+        fn bar() {
+            foo(0);
+        }
+    """, """
+        fn foo() {}
+
+        fn bar() {
+            foo();
+        }
+    """, "foo", {
+        repeat(6) {
+            myFixture.performEditorAction(IdeActions.ACTION_EDITOR_DELETE)
+        }
+    }, """
+Old:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group (removed):
+    'a'
+    ': '
+    'u32'
+  LineBreak('', false)
+  ')'
+New:
+  'foo'
+  '('
+  LineBreak('', false)
+  ')'
+    """.trimIndent())
+
+    fun `test remove and swap parameters`() = doTestChangeSignature("""
+        fn foo(a: u32, /*caret*/b: u32, c: u32) {}
+
+        fn bar() {
+            foo(1, 2, 3);
+        }
+    """, """
+        fn foo(c: u32, a: u32) {}
+
+        fn bar() {
+            foo(3, 1);
+        }
+    """, "foo", {
+        repeat(8) {
+            myFixture.performEditorAction(IdeActions.ACTION_EDITOR_DELETE)
+        }
+        myFixture.performEditorAction(IdeActions.MOVE_ELEMENT_LEFT)
+    }, """
+Old:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group (moved):
+    'a'
+    ': '
+    'u32'
+  ','
+  LineBreak(' ', true)
+  Group (removed):
+    'b'
+    ': '
+    'u32'
+  ','
+  LineBreak(' ', true)
+  Group:
+    'c'
+    ': '
+    'u32'
+  LineBreak('', false)
+  ')'
+New:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group:
+    'c'
+    ': '
+    'u32'
+  ','
+  LineBreak(' ', true)
+  Group (moved):
+    'a'
+    ': '
+    'u32'
+  LineBreak('', false)
+  ')'
+    """.trimIndent())
+
+    fun `test swap parameters`() = doTestChangeSignature("""
+        fn foo(/*caret*/a: u32, b: u32) {}
+
+        fn bar() {
+            foo(0, 1);
+        }
+    """, """
+        fn foo(b: u32, a: u32) {}
+
+        fn bar() {
+            foo(1, 0);
+        }
+    """, "foo", {
+        myFixture.performEditorAction(IdeActions.MOVE_ELEMENT_RIGHT)
+    }, """
+Old:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group (moved):
+    'a'
+    ': '
+    'u32'
+  ','
+  LineBreak(' ', true)
+  Group:
+    'b'
+    ': '
+    'u32'
+  LineBreak('', false)
+  ')'
+New:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group:
+    'b'
+    ': '
+    'u32'
+  ','
+  LineBreak(' ', true)
+  Group (moved):
+    'a'
+    ': '
+    'u32'
+  LineBreak('', false)
+  ')'
+    """.trimIndent())
+
+    fun `test swap and rename parameters`() = doTestChangeSignature("""
+        fn foo(/*caret*/a: u32, b: u32) {}
+
+        fn bar() {
+            foo(0, 1);
+        }
+    """, """
+        fn foo(b: u32, xa: u32) {}
+
+        fn bar() {
+            foo(1, 0);
+        }
+    """, "foo", {
+        myFixture.performEditorAction(IdeActions.MOVE_ELEMENT_RIGHT)
+        myFixture.type("x")
+    }, """
+Old:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group (moved):
+    'a' (modified)
+    ': '
+    'u32'
+  ','
+  LineBreak(' ', true)
+  Group:
+    'b'
+    ': '
+    'u32'
+  LineBreak('', false)
+  ')'
+New:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group:
+    'b'
+    ': '
+    'u32'
+  ','
+  LineBreak(' ', true)
+  Group (moved):
+    'xa' (modified)
+    ': '
+    'u32'
+  LineBreak('', false)
+  ')'
+    """.trimIndent())
+
+    fun `test add lifetime`() = doTestChangeSignature("""
+        fn foo/*caret*/() {}
+
+        fn bar() {
+            foo();
+        }
+    """, """
+        fn foo<'a>(a: &'a str) {}
+
+        fn bar() {
+            foo();
+        }
+    """, "foo", {
+        myFixture.type("<'a>")
+        myFixture.performEditorAction(IdeActions.ACTION_EDITOR_MOVE_CARET_RIGHT)
+        myFixture.type("a: &'a str")
+    }, """
+Old:
+  'foo'
+  '('
+  LineBreak('', false)
+  ')'
+New:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group (added):
+    'a'
+    ': '
+    '&'a str'
+  LineBreak('', false)
+  ')'
+    """.trimIndent())
+
+    fun `test change method impl`() = doTestChangeSignature("""
+        trait Trait {
+            fn foo(&self/*caret*/);
+        }
+
+        struct S;
+        impl Trait for S {
+            fn foo(&self) {}
+        }
+    """, """
+        trait Trait {
+            fn foo(&self, a: u32);
+        }
+
+        struct S;
+        impl Trait for S {
+            fn foo(&self, a: u32) {}
+        }
+    """, "foo", {
+        myFixture.type(", a: u32")
+    }, """
+Old:
+  'foo'
+  '('
+  LineBreak('', false)
+  ')'
+New:
+  'foo'
+  '('
+  LineBreak('', true)
+  Group (added):
+    'a'
+    ': '
+    'u32'
+  LineBreak('', false)
+  ')'
+    """.trimIndent())
+}

--- a/src/test/kotlin/org/rust/ide/refactoring/suggested/RsRenameSuggestedRefactoringTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/suggested/RsRenameSuggestedRefactoringTest.kt
@@ -89,15 +89,19 @@ class RsRenameSuggestedRefactoringTest : RsSuggestedRefactoringTestBase() {
         fn foo/*caret*/() {
             let a = 5;
         }
+        fn baz<T>(t: T) {}
         fn bar() {
             foo();
+            baz(foo);
         }
     """, """
         fn foox/*caret*/() {
             let a = 5;
         }
+        fn baz<T>(t: T) {}
         fn bar() {
             foox();
+            baz(foox);
         }
     """, "foo", "foox"
     ) { myFixture.type("x") }


### PR DESCRIPTION
This PR adds support for the suggested refactoring for function signature changes. Originally it was added in https://github.com/intellij-rust/intellij-rust/pull/5913 just for simple binding renames.

I took inspiration from the Kotlin implementation and tried to reduce it to be as small as possible. So for example default values for parameters are not implemented in this PR.

![suggested-refactoring](https://user-images.githubusercontent.com/4539057/115121622-feef7380-9fb3-11eb-9d06-468fb08d0310.gif)

changelog: Add suggested refactoring support for changing function signatures.