### PR TITLE
INT: add intention to create a tuple struct

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNamingInspection.kt
@@ -91,18 +91,15 @@ open class RsCamelCaseNamingInspection(
     }
 
     private val Char.canStartWord: Boolean get() = isUpperCase() || isDigit()
-
-    companion object {
-
-        private val Char.hasCase: Boolean get() = isLowerCase() || isUpperCase()
-
-        private fun String.isCamelCase(): Boolean =
-            isNotEmpty()
-                && !first().isLowerCase()
-                && !contains("__")
-                && !zipWithNext().any { (fst, snd) -> (fst.hasCase && snd == '_') || (snd.hasCase && fst == '_') }
-    }
 }
+
+val Char.hasCase: Boolean get() = isLowerCase() || isUpperCase()
+
+fun String.isCamelCase(): Boolean =
+    isNotEmpty()
+        && !first().isLowerCase()
+        && !contains("__")
+        && !zipWithNext().any { (fst, snd) -> (fst.hasCase && snd == '_') || (snd.hasCase && fst == '_') }
 
 /**
  * Checks if the name is snake_case.

--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateStructIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateStructIntention.kt
@@ -23,7 +23,7 @@ import org.rust.openapiext.createSmartPointer
 class CreateStructIntention : RsElementBaseIntentionAction<CreateStructIntention.Context>() {
     override fun getFamilyName() = "Create struct"
 
-    class Context(val name: String, val literalElement: RsStructLiteral, val target: RsMod) {}
+    class Context(val name: String, val literalElement: RsStructLiteral, val target: RsMod)
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
         val path = element.parentOfType<RsPath>()
@@ -79,13 +79,6 @@ class CreateStructIntention : RsElementBaseIntentionAction<CreateStructIntention
         }
 
         return factory.tryCreateStruct("${visibility}struct ${ctx.name}$suffix")
-    }
-
-    private fun insertStruct(targetModule: RsMod, struct: RsStructItem, sourceFunction: RsElement): RsStructItem {
-        if (targetModule == sourceFunction.containingMod) {
-            return sourceFunction.parent.addBefore(struct, sourceFunction) as RsStructItem
-        }
-        return addToModule(targetModule, struct)
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateTupleStructIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/CreateTupleStructIntention.kt
@@ -1,0 +1,76 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions.createFromUsage
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import org.rust.ide.inspections.lints.isCamelCase
+import org.rust.ide.intentions.RsElementBaseIntentionAction
+import org.rust.ide.presentation.renderInsertionSafe
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.PathResolveStatus
+import org.rust.lang.core.psi.ext.RsMod
+import org.rust.lang.core.psi.ext.isAncestorOf
+import org.rust.lang.core.psi.ext.resolveStatus
+import org.rust.lang.core.types.expectedType
+import org.rust.lang.core.types.ty.TyUnknown
+import org.rust.lang.core.types.type
+
+class CreateTupleStructIntention : RsElementBaseIntentionAction<CreateTupleStructIntention.Context>() {
+    override fun getFamilyName() = "Create tuple struct"
+
+    class Context(val name: String, val call: RsCallExpr, val target: RsMod)
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val path = element.parentOfType<RsPath>()
+        val functionCall = path?.parentOfType<RsCallExpr>()
+        if (functionCall != null) {
+            if (!functionCall.expr.isAncestorOf(path)) return null
+            if (path.resolveStatus != PathResolveStatus.UNRESOLVED) return null
+
+            val target = getTargetItemForFunctionCall(path) ?: return null
+            if (target !is CallableInsertionTarget.Module) return null
+
+            val name = path.referenceName ?: return null
+            if (!name.isCamelCase()) return null
+
+            val expectedType = functionCall.expectedType ?: TyUnknown
+            // Do not offer the intention if the expected type is known
+            if (expectedType !is TyUnknown) return null
+
+            text = "Create tuple struct `$name`"
+            return Context(name, functionCall, target.module)
+        }
+        return null
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val struct = buildStruct(project, ctx) ?: return
+        val containingFunction = ctx.call.parentOfType<RsFunction>() ?: return
+        val inserted = insertStruct(ctx.target, struct, containingFunction)
+
+        PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(editor.document)
+
+        val fields = inserted.tupleFields?.tupleFieldDeclList.orEmpty()
+        if (inserted.containingFile == ctx.call.containingFile && fields.isNotEmpty()) {
+            editor.caretModel.moveToOffset(fields[0].textOffset)
+        } else {
+            inserted.navigate(true)
+        }
+    }
+
+    private fun buildStruct(project: Project, ctx: Context): RsStructItem? {
+        val factory = RsPsiFactory(project)
+        val visibility = getVisibility(ctx.target, ctx.call.containingMod)
+        val fields = ctx.call.valueArgumentList.exprList.joinToString(separator = ", ") {
+            "$visibility${it.type.renderInsertionSafe(includeLifetimeArguments = true)}"
+        }
+        return factory.tryCreateStruct("${visibility}struct ${ctx.name}($fields);")
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -893,6 +893,10 @@
             <className>org.rust.ide.intentions.createFromUsage.CreateStructIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.createFromUsage.CreateTupleStructIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 

--- a/src/main/resources/intentionDescriptions/CreateTupleStructIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/CreateTupleStructIntention/after.rs.template
@@ -1,0 +1,5 @@
+struct Foo(i32, bool);
+
+fn bar() {
+    let x = Foo(0, true);
+}

--- a/src/main/resources/intentionDescriptions/CreateTupleStructIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/CreateTupleStructIntention/before.rs.template
@@ -1,0 +1,3 @@
+fn bar() {
+    let x = <spot>Foo</spot>(0, true);
+}

--- a/src/main/resources/intentionDescriptions/CreateTupleStructIntention/description.html
+++ b/src/main/resources/intentionDescriptions/CreateTupleStructIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention creates a tuple struct from an unresolved function call.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/CreateTupleStructIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateTupleStructIntentionTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import org.rust.ide.intentions.createFromUsage.CreateTupleStructIntention
+
+class CreateTupleStructIntentionTest : RsIntentionTestBase(CreateTupleStructIntention::class) {
+    fun `test tuple struct availability range`() = checkAvailableInSelectionOnly("""
+        fn main() {
+            <selection>Foo</selection>(0);
+        }
+    """)
+
+    fun `test require camel case`() = doUnavailableTest("""
+        fn main() {
+            foo/*caret*/(0);
+        }
+    """)
+
+    fun `test different expected type`() = doUnavailableTest("""
+        fn main() {
+            let x: u32 = Foo/*caret*/(0);
+        }
+    """)
+
+    fun `test simple`() = doAvailableTest("""
+        fn main() {
+            Foo/*caret*/(0);
+        }
+    """, """
+        struct Foo(i32);
+
+        fn main() {
+            Foo(0);
+        }
+    """)
+
+    fun `test no fields`() = doAvailableTest("""
+        fn main() {
+            Foo/*caret*/();
+        }
+    """, """
+        struct Foo();
+
+        fn main() {
+            Foo();
+        }
+    """)
+
+    fun `test multiple fields`() = doAvailableTest("""
+        fn main() {
+            Foo/*caret*/(true, "foo");
+        }
+    """, """
+        struct Foo(bool, &'static str);
+
+        fn main() {
+            Foo(true, "foo");
+        }
+    """)
+
+    fun `test unknown type`() = doAvailableTest("""
+        fn main() {
+            Foo/*caret*/(Bar);
+        }
+    """, """
+        struct Foo(_);
+
+        fn main() {
+            Foo(Bar);
+        }
+    """)
+
+    fun `test create in a module`() = doAvailableTest("""
+        mod foo {}
+
+        fn main() {
+            foo::Foo/*caret*/(0);
+        }
+    """, """
+        mod foo { pub(crate) struct Foo(pub(crate) i32); }
+
+        fn main() {
+            foo::Foo(0);
+        }
+    """)
+}


### PR DESCRIPTION
This PR extends https://github.com/intellij-rust/intellij-rust/pull/6837. It adds a new intention which allows creating tuple structs from unresolved usage.

I decided to use a simple heuristic to offer the intention. It is offered for an unresolved function call if:
1) The target of the call is a module (so associated function calls are ignored).
2) The name of the called function is in CamelCase.
3) The expected return type of the function call is unknown or missing. i.e. the intention is not offered in this case:
```rust
let x: u32 = Foo/*caret*/(1, 2);
```
Because the code would not compile after the tuple struct would be created and it seems like its not what the user wants.
I'm not sure if 3) is needed, we can also skip it.

changelog: Add an intention to create a tuple struct from an unresolved function call.