### PR TITLE
RES: Enable new name resolution engine by default

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
+++ b/src/main/kotlin/org/rust/cargo/project/configurable/RsProjectConfigurable.kt
@@ -41,7 +41,7 @@ class RsProjectConfigurable(
             )
         }
         row {
-            checkBox("Use experimental name resolution engine", state::newResolveEnabled)
+            checkBox("Use new name resolution engine", state::newResolveEnabled)
         }
         row {
             checkBox("Inject Rust language into documentation comments", state::doctestInjectionEnabled)

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -21,7 +21,7 @@
         <experimentalFeature id="org.rust.macros.proc" percentOfUsers="0">
             <description>Enables procedural macro expansion</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.resolve.new.engine" percentOfUsers="0">
+        <experimentalFeature id="org.rust.resolve.new.engine" percentOfUsers="100">
             <description>Enables experimental resolve engine</description>
         </experimentalFeature>
         <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="0">

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -49,7 +49,7 @@ action.Rust.ShareInPlayground.text=Share in Playground
 
 action.Rust.ShowRecursiveMacroExpansionAction.text=Show Recursively Expanded Macro
 action.Rust.ShowSingleStepMacroExpansionAction.text=Show Expanded Macro
-action.Rust.ToggleNewResolve.text=Rust: Toggle experimental name resolution engine
+action.Rust.ToggleNewResolve.text=Rust: Toggle new name resolution engine
 
 group.Rust.MacroExpansionActions.text=Show Macro Expansion
 group.Rust.Tools.text=Rust


### PR DESCRIPTION
Enable [new name resolution engine](https://github.com/intellij-rust/intellij-rust/issues/6217) by default. There are still some corner cases unsupported, but I think that overall improvement from new resolve is big enough to enable it by default

Here is regressions tests comparison: [with build scripts evaulation](https://github.com/dima74/intellij-rust/actions/runs/745483458), [without build scripts](https://github.com/dima74/intellij-rust/actions/runs/745549334)

changelog: Enable new name resolution engine by default

Fixes #4093
Fixes #4811
Fixes #4887
Fixes #5007
Fixes #5146
Fixes #6236
Fixes #6243
Fixes #6270
Fixes #6302
Fixes #6355
Fixes #6452
Fixes #6486
Fixes #6863

