### PR TITLE
RES: Fix completion of derive proc macro in imports

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -212,7 +212,7 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
         for (candidate in candidates) {
             val item = candidate.item
             if (item is RsOuterAttributeOwner) {
-                val isHidden = item.shouldHideElementInCompletion(contextMod)
+                val isHidden = item.shouldHideElementInCompletion(path, contextMod)
                 if (isHidden) continue
             }
             val scopeEntry = SimpleScopeEntry(candidate.itemName, item, TYPES_N_VALUES_N_MACROS)
@@ -538,12 +538,13 @@ fun collectVariantsForEnumCompletion(
     candidate: ImportCandidate? = null
 ): List<LookupElement> {
     val enumName = element.name ?: return emptyList()
-    val contextMod = context.context?.containingMod
+    val contextElement = context.context
+    val contextMod = contextElement?.containingMod
 
     return element.enumBody?.childrenOfType<RsEnumVariant>().orEmpty().mapNotNull { enumVariant ->
         val variantName = enumVariant.name ?: return@mapNotNull null
 
-        if (contextMod != null && enumVariant.shouldHideElementInCompletion(contextMod)) return@mapNotNull null
+        if (contextMod != null && enumVariant.shouldHideElementInCompletion(contextElement, contextMod)) return@mapNotNull null
 
         return@mapNotNull createLookupElement(
             scopeEntry = SimpleScopeEntry("${enumName}::${variantName}", enumVariant, ENUM_VARIANT_NS, substitution),

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTest.kt
@@ -730,14 +730,18 @@ class RsCompletionTest : RsCompletionTestBase() {
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test complete proc macro in use item`() = checkContainsCompletionByFileTree(
-        listOf("macro_function", "macro_attr", "macro_derive"), """
+        listOf("macro_function", "macro_attr", "MacroDerive", "MacroDeriveHidden"), """
     //- dep-proc-macro/lib.rs
         #[proc_macro]
         pub fn macro_function(input: TokenStream) -> TokenStream { input }
         #[proc_macro_attribute]
         pub fn macro_attr(_attr: TokenStream, item: TokenStream) -> TokenStream { item }
-        #[proc_macro_derive(macro_derive)]
+        #[proc_macro_derive(MacroDerive)]
         pub fn macro_derive(_item: TokenStream) -> TokenStream { "".parse().unwrap() }
+
+        #[doc(hidden)]
+        #[proc_macro_derive(MacroDeriveHidden)]
+        pub fn macro_derive_hidden(_item: TokenStream) -> TokenStream { "".parse().unwrap() }
     //- lib.rs
         use dep_proc_macro::/*caret*/
     """)


### PR DESCRIPTION
Fixes #7062

changelog: Fix completion of derive proc macro with `doc(hidden)` attribute in imports