### PR TITLE
CARGO: drop `org.rust.cargo.fetch.out.dir` feature

### DIFF
--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -8,7 +8,6 @@ package org.rust.ide.experiments
 object RsExperiments {
     const val BUILD_TOOL_WINDOW = "org.rust.cargo.build.tool.window"
     const val TEST_TOOL_WINDOW = "org.rust.cargo.test.tool.window"
-    const val FETCH_OUT_DIR = "org.rust.cargo.fetch.out.dir"
     const val EVALUATE_BUILD_SCRIPTS = "org.rust.cargo.evaluate.build.scripts"
     const val CARGO_FEATURES_SETTINGS_GUTTER = "org.rust.cargo.features.settings.gutter"
     const val MACROS_NEW_ENGINE = "org.rust.macros.new.engine"

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -6,9 +6,6 @@
         <experimentalFeature id="org.rust.cargo.test.tool.window" percentOfUsers="100">
             <description>Show test results in Test Tool Window</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.cargo.fetch.out.dir" percentOfUsers="0">
-            <description>Fetch `OUT_DIR` environment variable value. It's needed to make proper name resolution for code included via `include` macro</description>
-        </experimentalFeature>
         <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="0">
             <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
         </experimentalFeature>

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -6,9 +6,6 @@
         <experimentalFeature id="org.rust.cargo.test.tool.window" percentOfUsers="100">
             <description>Show test results in Test Tool Window</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.cargo.fetch.out.dir" percentOfUsers="0">
-            <description>Fetch `OUT_DIR` environment variable value. It's needed to make proper name resolution for code included via `include` macro</description>
-        </experimentalFeature>
         <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="0">
             <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
         </experimentalFeature>


### PR DESCRIPTION
The feature was an initial attempt to support `include` macro with `OUT_DIR` variable.
It has two major issues:
- invocation of Cargo with `--build-plan` option forces Cargo to recompile everything from the scratch next time
- the option is supposed to be [removed](https://github.com/rust-lang/cargo/issues/7614).

Also, there is a more powerful feature - `org.rust.cargo.evaluate.build.scripts` that allows plugin to know about all generated `cfg` options and environment variables (including `OUT_DIR`).

So I think we can drop `--build-plan` support since it has major cons and can be superseded by `org.rust.cargo.evaluate.build.scripts` feature

changelog: Drop support of `org.rust.cargo.evaluate.build.scripts` experimental feature. Use `org.rust.cargo.evaluate.build.scripts` instead if you need to evaluate `env!("OUT_DIR")` in your `include!` macro calls
