### PR TITLE
CI: speed up check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,16 @@ jobs:
               with:
                   access_token: ${{ github.token }}
 
+    calculate-git-info:
+        needs: [ cancel-previous ]
+        runs-on: ubuntu-18.04
+        outputs:
+            is_bors_branch: ${{ steps.calculate-git-info.outputs.is_bors_branch }}
+        steps:
+            - name: Calculate git info
+              id: calculate-git-info
+              run: echo "::set-output name=is_bors_branch::${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/trying' }}"
+
     check-license:
         needs: [ cancel-previous ]
         runs-on: ubuntu-18.04
@@ -85,9 +95,10 @@ jobs:
                   path: ${{ matrix.config.artifact_path }}
 
     check-plugin:
-        needs: [ cancel-previous, build-native-code ]
+        needs: [ cancel-previous, calculate-git-info, build-native-code ]
         strategy:
-            fail-fast: false
+            # `fromJSON` is used here to convert string output to boolean
+            fail-fast: ${{ fromJSON(needs.calculate-git-info.outputs.is_bors_branch) }}
             matrix:
                 os: [ ubuntu-18.04, windows-latest ]
                 rust-version: [ 1.51.0, nightly-2021-03-24 ]

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,11 +14,12 @@ jobs:
         runs-on: ubuntu-18.04
         steps:
             - name: Cancel Previous Runs
-              uses: styfle/cancel-workflow-action@0.4.1
+              uses: styfle/cancel-workflow-action@0.9.0
               with:
                   access_token: ${{ github.token }}
 
     check-license:
+        needs: [ cancel-previous ]
         runs-on: ubuntu-18.04
         steps:
             - uses: actions/checkout@v2
@@ -27,6 +28,7 @@ jobs:
               run: ./check-license.sh
 
     build-native-code:
+        needs: [ cancel-previous ]
         strategy:
             fail-fast: true
             matrix:
@@ -83,7 +85,7 @@ jobs:
                   path: ${{ matrix.config.artifact_path }}
 
     check-plugin:
-        needs: [ build-native-code ]
+        needs: [ cancel-previous, build-native-code ]
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,10 +23,30 @@ jobs:
         runs-on: ubuntu-18.04
         outputs:
             is_bors_branch: ${{ steps.calculate-git-info.outputs.is_bors_branch }}
+            is_master_branch: ${{ steps.calculate-git-info.outputs.is_master_branch }}
+            is_merge_commit: ${{ steps.calculate-git-info.outputs.is_merge_commit }}
         steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
             - name: Calculate git info
               id: calculate-git-info
-              run: echo "::set-output name=is_bors_branch::${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/trying' }}"
+              run: |
+                  echo "::set-output name=is_bors_branch::${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/trying' }}"
+                  echo "::set-output name=is_master_branch::${{ github.ref == 'refs/heads/master'}}"
+                  if git rev-parse HEAD^2 >/dev/null 2>/dev/null
+                  then
+                      echo "::set-output name=is_merge_commit::true"
+                  else
+                      echo "::set-output name=is_merge_commit::false"
+                  fi
+
+            - name: Check git info
+              run: |
+                  echo "is_bors_branch: ${{ steps.calculate-git-info.outputs.is_bors_branch }}"
+                  echo "is_master_branch: ${{ steps.calculate-git-info.outputs.is_master_branch }}"
+                  echo "is_merge_commit: ${{ steps.calculate-git-info.outputs.is_merge_commit }}"
 
     check-license:
         needs: [ cancel-previous ]
@@ -38,7 +58,9 @@ jobs:
               run: ./check-license.sh
 
     build-native-code:
-        needs: [ cancel-previous ]
+        needs: [ cancel-previous, calculate-git-info ]
+        # `fromJSON` is used here to convert string output to boolean
+        if: ${{ !(fromJSON(needs.calculate-git-info.outputs.is_master_branch) && fromJSON(needs.calculate-git-info.outputs.is_merge_commit)) }}
         strategy:
             fail-fast: true
             matrix:


### PR DESCRIPTION
These changes:
- prevent running checks before `cancel-previous` job
- ask GitHub to fail the whole `check-plugin` job if at least one step fails during merging. Implemented as check of `staging` and `trying` branches
- prevent running checks merge commits in `master` branch. We assume that they are already checked in `staging` branch