### PR TITLE
TOML: add inspection that offers an update to a newer dependency version

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CrateVersionRequirement.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CrateVersionRequirement.kt
@@ -7,9 +7,10 @@ package org.rust.toml.crates.local
 
 import com.vdurmont.semver4j.Requirement
 import com.vdurmont.semver4j.Semver
-import com.vdurmont.semver4j.SemverException
 
 class CrateVersionRequirement private constructor(private val requirements: List<Requirement>) {
+    val isPinned: Boolean = requirements.any { it.toString().startsWith("=") }
+
     fun matches(version: Semver): Boolean = requirements.all {
         it.isSatisfiedBy(version)
     }

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CrateVersionInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CrateVersionInspection.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import com.intellij.codeInspection.ProblemsHolder
+import org.rust.toml.crates.local.CargoRegistryCrate
+import org.rust.toml.crates.local.CratesLocalIndexException
+import org.rust.toml.crates.local.CratesLocalIndexService
+import org.toml.lang.psi.TomlValue
+import org.toml.lang.psi.TomlVisitor
+
+abstract class CrateVersionInspection : CargoTomlInspectionToolBase() {
+    override val requiresLocalCrateIndex: Boolean = true
+
+    abstract fun handleCrateVersion(
+        dependency: DependencyCrate,
+        crate: CargoRegistryCrate,
+        versionElement: TomlValue,
+        holder: ProblemsHolder
+    )
+
+    override fun buildCargoTomlVisitor(holder: ProblemsHolder): TomlVisitor {
+        return object : CargoDependencyCrateVisitor() {
+            override fun visitDependency(dependency: DependencyCrate) {
+                if (dependency.isForeign()) return
+
+                val crate = try {
+                    CratesLocalIndexService.getInstance().getCrate(dependency.crateName) ?: return
+                } catch (e: CratesLocalIndexException) {
+                    return
+                }
+
+                val versionElement = dependency.properties["version"] ?: return
+                handleCrateVersion(dependency, crate, versionElement, holder)
+            }
+        }
+    }
+}

--- a/toml/src/main/kotlin/org/rust/toml/inspections/CrateVersionInvalidInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/CrateVersionInvalidInspection.kt
@@ -7,50 +7,39 @@ package org.rust.toml.inspections
 
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
+import org.rust.toml.crates.local.CargoRegistryCrate
 import org.rust.toml.crates.local.CrateVersionRequirement
-import org.rust.toml.crates.local.CratesLocalIndexException
-import org.rust.toml.crates.local.CratesLocalIndexService
 import org.rust.toml.stringValue
-import org.toml.lang.psi.TomlVisitor
+import org.toml.lang.psi.TomlValue
 
-class CrateVersionInvalidInspection : CargoTomlInspectionToolBase() {
-    override val requiresLocalCrateIndex: Boolean = true
+class CrateVersionInvalidInspection : CrateVersionInspection() {
+    override fun handleCrateVersion(
+        dependency: DependencyCrate,
+        crate: CargoRegistryCrate,
+        versionElement: TomlValue,
+        holder: ProblemsHolder
+    ) {
+        val versionText = versionElement.stringValue ?: return
 
-    override fun buildCargoTomlVisitor(holder: ProblemsHolder): TomlVisitor {
-        return object : CargoDependencyCrateVisitor() {
-            override fun visitDependency(dependency: DependencyCrate) {
-                if (dependency.isForeign()) return
+        val versionReq = CrateVersionRequirement.build(versionText)
+        if (versionReq == null) {
+            holder.registerProblem(
+                versionElement,
+                "Invalid version requirement $versionText",
+                ProblemHighlightType.WEAK_WARNING
+            )
+            return
+        }
 
-                val crate = try {
-                    CratesLocalIndexService.getInstance().getCrate(dependency.crateName) ?: return
-                } catch (e: CratesLocalIndexException) {
-                    return
-                }
+        val compatibleVersions = crate.versions.filter {
+            val version = it.semanticVersion ?: return@filter false
+            versionReq.matches(version)
+        }
 
-                val versionElement = dependency.properties["version"] ?: return
-                val versionText = versionElement.stringValue ?: return
-
-                val versionReq = CrateVersionRequirement.build(versionText)
-                if (versionReq == null) {
-                    holder.registerProblem(
-                        versionElement,
-                        "Invalid version requirement $versionText",
-                        ProblemHighlightType.WEAK_WARNING
-                    )
-                    return
-                }
-
-                val compatibleVersions = crate.versions.filter {
-                    val version = it.semanticVersion ?: return@filter false
-                    versionReq.matches(version)
-                }
-
-                if (compatibleVersions.isEmpty()) {
-                    holder.registerProblem(versionElement, "No version matching $versionText found for crate ${dependency.crateName}")
-                } else if (compatibleVersions.all { it.isYanked }) {
-                    holder.registerProblem(versionElement, "All versions matching $versionText for crate ${dependency.crateName} are yanked")
-                }
-            }
+        if (compatibleVersions.isEmpty()) {
+            holder.registerProblem(versionElement, "No version matching $versionText found for crate ${dependency.crateName}")
+        } else if (compatibleVersions.all { it.isYanked }) {
+            holder.registerProblem(versionElement, "All versions matching $versionText for crate ${dependency.crateName} are yanked")
         }
     }
 }

--- a/toml/src/main/kotlin/org/rust/toml/inspections/NewCrateVersionAvailableInspection.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/NewCrateVersionAvailableInspection.kt
@@ -1,0 +1,48 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.vdurmont.semver4j.Semver
+import org.rust.toml.crates.local.CargoRegistryCrate
+import org.rust.toml.crates.local.CrateVersionRequirement
+import org.rust.toml.stringValue
+import org.toml.lang.psi.TomlValue
+
+class NewCrateVersionAvailableInspection : CrateVersionInspection() {
+    override fun handleCrateVersion(
+        dependency: DependencyCrate,
+        crate: CargoRegistryCrate,
+        versionElement: TomlValue,
+        holder: ProblemsHolder
+    ) {
+        val versionText = versionElement.stringValue ?: return
+        val versionReq = CrateVersionRequirement.build(versionText) ?: return
+        if (versionReq.isPinned) return
+
+        val versions = crate.versions
+            .filter { !it.isYanked }
+            .mapNotNull { it.semanticVersion }
+            .sortedDescending()
+
+        val highestMatchingVersion = versions.firstOrNull { versionReq.matches(it) } ?: return
+        val newerVersion = versions.firstOrNull { it.isRustStable && it > highestMatchingVersion } ?: return
+
+        holder.registerProblem(
+            versionElement,
+            "A newer version is available for crate ${dependency.crateName}: ${newerVersion.value}",
+            ProblemHighlightType.WEAK_WARNING,
+            UpdateCrateVersionFix(versionElement, newerVersion.value)
+        )
+    }
+}
+
+/**
+ * A lot of Rust crates stay at 0.x.y for a long time, so we consider even major versions 0 to be stable.
+ */
+private val Semver.isRustStable: Boolean
+    get() = suffixTokens.isEmpty()

--- a/toml/src/main/kotlin/org/rust/toml/inspections/UpdateCrateVersionFix.kt
+++ b/toml/src/main/kotlin/org/rust/toml/inspections/UpdateCrateVersionFix.kt
@@ -1,0 +1,27 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.toml.lang.psi.TomlPsiFactory
+import org.toml.lang.psi.TomlValue
+
+class UpdateCrateVersionFix(
+    versionElement: TomlValue,
+    private val version: String
+): LocalQuickFixOnPsiElement(versionElement) {
+    override fun getFamilyName(): String = "Update dependency version"
+    override fun getText(): String = "Update version to $version"
+
+    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+        val factory = TomlPsiFactory(project)
+        val newValue = factory.createLiteral("\"$version\"")
+        startElement.replace(newValue)
+    }
+}

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -44,6 +44,13 @@
                          enabledByDefault="true"
                          level="WARNING"
                          implementationClass="org.rust.toml.inspections.CrateVersionInvalidInspection"/>
+        <localInspection language="TOML"
+                         displayName="New crate version available"
+                         groupPath="Rust"
+                         groupName="Cargo.toml"
+                         enabledByDefault="true"
+                         level="WARNING"
+                         implementationClass="org.rust.toml.inspections.NewCrateVersionAvailableInspection"/>
 
         <intentionAction>
             <className>org.rust.toml.intentions.ExpandDependencySpecificationIntention</className>

--- a/toml/src/main/resources/inspectionDescriptions/NewCrateVersionAvailable.html
+++ b/toml/src/main/resources/inspectionDescriptions/NewCrateVersionAvailable.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Detects dependency crates with outdated versions in Cargo.toml
+</body>
+</html>

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlCrateInspectionTestBase.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlCrateInspectionTestBase.kt
@@ -8,23 +8,47 @@ package org.rust.toml.inspections
 import com.intellij.codeInspection.InspectionProfileEntry
 import org.intellij.lang.annotations.Language
 import org.rust.cargo.CargoConstants
+import org.rust.ide.annotator.RsAnnotationTestFixture
 import org.rust.ide.experiments.RsExperiments
 import org.rust.ide.inspections.RsInspectionsTestBase
 import org.rust.openapiext.runWithEnabledFeatures
 import org.rust.toml.crates.local.CargoRegistryCrate
-import org.rust.toml.crates.local.CargoRegistryCrateVersion
 import org.rust.toml.crates.local.withMockedCrates
 import kotlin.reflect.KClass
 
 abstract class CargoTomlCrateInspectionTestBase(
     inspectionClass: KClass<out InspectionProfileEntry>
 ) : RsInspectionsTestBase(inspectionClass) {
-    protected fun doTest(@Language("TOML") code: String, vararg crates: Pair<String, CargoRegistryCrate>) {
-        myFixture.configureByText(CargoConstants.MANIFEST_FILE, code)
+    override fun createAnnotationFixture(): RsAnnotationTestFixture<Unit> =
+        RsAnnotationTestFixture(
+            this,
+            myFixture,
+            inspectionClasses = listOf(inspectionClass),
+            baseFileName = CargoConstants.MANIFEST_FILE
+        )
 
+    protected fun doTest(@Language("TOML") code: String, vararg crates: Pair<String, CargoRegistryCrate>) {
+        runTest(crates.toList()) {
+            myFixture.configureByText(CargoConstants.MANIFEST_FILE, code)
+            myFixture.checkHighlighting()
+        }
+    }
+
+    protected fun checkFix(
+        fixName: String,
+        @Language("TOML") before: String,
+        @Language("TOML") after: String,
+        vararg crates: Pair<String, CargoRegistryCrate>
+    ) {
+        runTest(crates.toList()) {
+            checkFixByText(fixName, before, after, checkWeakWarn = true)
+        }
+    }
+
+    private fun runTest(crates: List<Pair<String, CargoRegistryCrate>>, action: () -> Unit) {
         runWithEnabledFeatures(RsExperiments.CRATES_LOCAL_INDEX) {
             withMockedCrates(crates.toMap()) {
-                myFixture.checkHighlighting()
+                action()
             }
         }
     }

--- a/toml/src/test/kotlin/org/rust/toml/inspections/NewCrateVersionAvailableInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/NewCrateVersionAvailableInspectionTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.inspections
+
+import org.rust.toml.crates.local.CargoRegistryCrate
+import org.rust.toml.crates.local.CargoRegistryCrateVersion
+
+class NewCrateVersionAvailableInspectionTest : CargoTomlCrateInspectionTestBase(NewCrateVersionAvailableInspection::class) {
+    fun `test do not warn about missing crate`() = doTest("""
+        [dependencies]
+        foo = "1"
+    """)
+
+    fun `test do not warn about invalid version`() = doTest("""
+        [dependencies]
+        foo = "=2.3.4"
+    """,
+        "foo1" to CargoRegistryCrate.of("1.2.3"),
+    )
+
+    fun `test newer version available`() = doTest("""
+        [dependencies]
+        foo1 = <weak_warning descr="A newer version is available for crate foo1: 2.1.0">"1.2.3"</weak_warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("1.1.0", "1.2.3", "2.1.0"),
+    )
+
+    fun `test newer version available with major version 0`() = doTest("""
+        [dependencies]
+        foo1 = <weak_warning descr="A newer version is available for crate foo1: 0.2.0">"0.1.1"</weak_warning>
+    """,
+        "foo1" to CargoRegistryCrate.of("0.1.1", "0.2.0"),
+    )
+
+    fun `test major version required`() = doTest("""
+        [dependencies]
+        foo1 = "2"
+    """,
+        "foo1" to CargoRegistryCrate.of("2.0.0", "2.1.0", "2.2.0"),
+    )
+
+    fun `test ignore yanked higher version`() = doTest("""
+        [dependencies]
+        foo1 = "1.2"
+    """,
+        "foo1" to CargoRegistryCrate(listOf(
+            CargoRegistryCrateVersion("1.2.0", false, emptyList()),
+            CargoRegistryCrateVersion("2.0.0", true, emptyList())
+        )),
+    )
+
+    fun `test ignore yanked same version`() = doTest("""
+        [dependencies]
+        foo1 = "2.0.0"
+    """,
+        "foo1" to CargoRegistryCrate(listOf(
+            CargoRegistryCrateVersion("1.2.0", false, emptyList()),
+            CargoRegistryCrateVersion("2.0.0", true, emptyList())
+        )),
+    )
+
+    fun `test ignore pinned version`() = doTest("""
+        [dependencies]
+        foo1 = "=1.2"
+    """,
+        "foo1" to CargoRegistryCrate.of("1.2.0", "2.0.0"),
+    )
+
+    fun `test ignore unstable version`() = doTest("""
+        [dependencies]
+        foo1 = "1.2"
+    """,
+        "foo1" to CargoRegistryCrate.of("1.2.0", "2.0.0-beta3"),
+    )
+
+    fun `test unstable version required`() = doTest("""
+        [dependencies]
+        foo1 = "2.0.0-beta3"
+    """,
+        "foo1" to CargoRegistryCrate.of("1.2.0", "2.0.0-beta3"),
+    )
+
+    fun `test fix update to new version inline`() = checkFix("Update version to 2.0.0", """
+        [dependencies]
+        foo1 = <weak_warning descr="A newer version is available for crate foo1: 2.0.0">"1.2<caret>"</weak_warning>
+    """, """
+        [dependencies]
+        foo1 = "2.0.0"
+    """,
+        "foo1" to CargoRegistryCrate.of("1.2.0", "2.0.0"),
+    )
+
+    fun `test fix update to new version expanded`() = checkFix("Update version to 2.0.0", """
+        [dependencies]
+        foo1 = { version = <weak_warning descr="A newer version is available for crate foo1: 2.0.0">"1.2<caret>"</weak_warning> }
+    """, """
+        [dependencies]
+        foo1 = { version = "2.0.0" }
+    """,
+        "foo1" to CargoRegistryCrate.of("1.2.0", "2.0.0"),
+    )
+}


### PR DESCRIPTION
This PR adds a TOML inspection that uses a weak warning to notify the user that there might be a more recent version of a dependency available (inspired by https://github.com/mibac138/intellij-rust/commit/c8960b23adeb70deac77aab3d5b6a4edbb7fa700). It also provides a quick fix that replaces the version requirement with the newest crate version.

Currently, the inspection is only offered if there is a non-yanked, stable version of the dependency which is not matched by the provided version requirement. This means that if the maximum version is e.g. `3` and the user requires `4`, the inspection will trigger, which might be a bit weird, but this situation should be very rare. I didn't know how else to implement it, since I didn't find a way how to compare versions with version requirements.

Also, I'm not sure if we should disable the inspection in some situations, like when the version requirement is exact (`=1.2.3`) or when it's empty/wildcard (`*`)?

Related issue: https://github.com/intellij-rust/intellij-rust/issues/7126

changelog: Add an inspection that warns about possibly outdated dependency versions in Cargo.toml.