### PR TITLE
IDE: Add support for navbar breadcrumbs

### DIFF
--- a/src/main/kotlin/org/rust/ide/miscExtensions/RsBreadcrumbsInfoProvider.kt
+++ b/src/main/kotlin/org/rust/ide/miscExtensions/RsBreadcrumbsInfoProvider.kt
@@ -38,7 +38,8 @@ class RsBreadcrumbsInfoProvider : BreadcrumbsProvider {
     private object RsNamedHandler : RsElementHandler<RsNamedElement> {
         override fun accepts(e: PsiElement): Boolean =
             e is RsModItem || e is RsStructOrEnumItemElement || e is RsTraitItem
-                || e is RsConstant || e is RsTypeAlias
+            || e is RsConstant || e is RsTypeAlias || e is RsNamedFieldDecl
+            || e is RsEnumVariant || e is RsModDeclItem || e is RsExternCrateItem
 
         override fun elementInfo(e: RsNamedElement): String = e.name.let { "$it" }
     }
@@ -75,10 +76,10 @@ class RsBreadcrumbsInfoProvider : BreadcrumbsProvider {
         }
     }
 
-    private object RsMacroHandler : RsElementHandler<RsMacro> {
-        override fun accepts(e: PsiElement): Boolean = e is RsMacro
+    private object RsMacroHandler : RsElementHandler<RsMacroDefinitionBase> {
+        override fun accepts(e: PsiElement): Boolean = e is RsMacroDefinitionBase
 
-        override fun elementInfo(e: RsMacro): String = e.name.let { "$it!" }
+        override fun elementInfo(e: RsMacroDefinitionBase): String = e.name.let { "$it!" }
     }
 
     private object RsFunctionHandler : RsElementHandler<RsFunction> {
@@ -214,6 +215,8 @@ class RsBreadcrumbsInfoProvider : BreadcrumbsProvider {
     override fun getElementInfo(e: PsiElement): String = handler(e)!!.elementInfo(e as RsElement)
 
     override fun getElementTooltip(e: PsiElement): String? = null
+
+    fun getBreadcrumb(e: RsElement): String? = handler(e)?.elementInfo(e)
 
     companion object {
         @Suppress("unused")

--- a/src/main/kotlin/org/rust/ide/navigationToolbar/RsNavBarModelExtension.kt
+++ b/src/main/kotlin/org/rust/ide/navigationToolbar/RsNavBarModelExtension.kt
@@ -22,9 +22,6 @@ class RsNavBarModelExtension : StructureAwareNavBarModelExtension() {
         }
 
         val provider = RsBreadcrumbsInfoProvider()
-        if (provider.acceptElement(element)) {
-            return provider.getElementInfo(element)
-        }
-        return null
+        return provider.getBreadcrumb(element)
     }
 }

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -264,8 +264,7 @@
         <elementDescriptionProvider implementation="org.rust.ide.presentation.RsDescriptionProvider"/>
         <breadcrumbsInfoProvider implementation="org.rust.ide.miscExtensions.RsBreadcrumbsInfoProvider"/>
 
-        <!-- Disabled because of https://github.com/intellij-rust/intellij-rust/issues/7153 -->
-        <!-- <navbar implementation="org.rust.ide.navigationToolbar.RsNavBarModelExtension" order="first"/>-->
+        <navbar implementation="org.rust.ide.navigationToolbar.RsNavBarModelExtension" order="first"/>
 
         <!-- Spell-checker -->
 

--- a/src/test/kotlin/org/rust/ide/miscExtensions/RsNavBarTest.kt
+++ b/src/test/kotlin/org/rust/ide/miscExtensions/RsNavBarTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.miscExtensions
+
+import com.intellij.ide.navigationToolbar.NavBarModel
+import com.intellij.ide.navigationToolbar.NavBarPresentation
+import com.intellij.openapi.editor.ex.EditorEx
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+
+class RsNavBarTest : RsTestBase() {
+    fun `test struct`() = doTest("""
+        struct /*caret*/S;
+    """, "S")
+
+    fun `test struct field`() = doTest("""
+        struct S {
+            a/*caret*/: u32
+        }
+    """, "S", "a")
+
+    fun `test enum`() = doTest("""
+        enum E/*caret*/ {}
+    """, "E")
+
+    fun `test enum variant`() = doTest("""
+        enum E {
+            V1/*caret*/
+        }
+    """, "E", "V1")
+
+    fun `test trait`() = doTest("""
+        trait T/*caret*/ {}
+    """, "T")
+
+    fun `test trait constant`() = doTest("""
+        trait T/*caret*/ {
+            const C/*caret*/: u32;
+        }
+    """, "T", "C")
+
+    fun `test trait function`() = doTest("""
+        trait T/*caret*/ {
+            fn foo/*caret*/();
+        }
+    """, "T", "foo()")
+
+    fun `test trait type`() = doTest("""
+        trait T {
+            type FOO/*caret*/;
+        }
+    """, "T", "FOO")
+
+    fun `test constant`() = doTest("""
+        const C/*caret*/: u32 = 0;
+    """, "C")
+
+    fun `test function`() = doTest("""
+        fn foo/*caret*/() {}
+    """, "foo()")
+
+    fun `test type`() = doTest("""
+        type T/*caret*/ = u32;
+    """, "T")
+
+    fun `test block`() = doTest("""
+        fn foo() {
+            let x = {/*caret*/
+                42
+            };
+        }
+    """, "foo()")
+
+    fun `test macro`() = doTest("""
+        macro_rules! foo/*caret*/ {}
+    """, "foo!")
+
+    fun `test macro 2`() = doTest("""
+        macro foo/*caret*/ {}
+    """, "foo!")
+
+    fun `test nested function`() = doTest("""
+        fn foo() {
+            fn bar() {
+                /*caret*/
+            }
+        }
+    """, "foo()", "bar()")
+
+    fun `test mod`() = doTest("""
+        mod foo {
+            /*caret*/
+        }
+    """, "foo")
+
+    fun `test nested mod`() = doTest("""
+        mod foo {
+            mod bar {
+                fn baz() {
+                    /*caret*/
+                }
+            }
+        }
+    """, "foo", "bar", "baz()")
+
+    fun `test mod decl`() = doTest("""
+        mod foo/*caret*/;
+    """, "foo")
+
+    fun `test use item`() = doTest("""
+        use foo::bar/*caret*/;
+    """)
+
+    fun `test use item alias`() = doTest("""
+        use foo::bar as baz/*caret*/;
+    """)
+
+    fun `test use extern crate`() = doTest("""
+        extern crate foo/*caret*/;
+    """, "foo")
+
+    fun doTest(@Language("Rust") code: String, vararg items: String) {
+        InlineFile(code).withCaret()
+
+        val model = NavBarModel(myFixture.project)
+        model.updateModel((myFixture.editor as EditorEx).dataContext)
+
+        val actualItems = (0 until model.size()).map {
+            NavBarPresentation.calcPresentableText(model[it], false)
+        }
+        val expected = listOf("src", "main.rs", *items)
+        assertEquals(expected, actualItems)
+    }
+}


### PR DESCRIPTION
This PR adds tests for the new navbar navigation (#6581), and enables it by default.

While writing the tests, I realized that when `StructureAwareNavBarModelExtension::getPresentableText` returns null, the element is rendered with `toString`, which is less than ideal.

I tried to find the missing cases not handled by the breadcrumbs provider, and added them to `RsBreadcrumbsInfoProvider::RsNamedHandler`. I'm not sure if that's the ideal solution though. Maybe I should only add them to the navbar model? Or somehow unify the navbar model with the breadcrumbs provider?

There is also some issue in tests, when a macro 2.0 or an extern crate is rendered by the navbar, the rendered path does not contain the name of the containing file for some reason.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/7153

changelog: Introduce navigation bar breadcrumbs