### PR TITLE
CI: speed up check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,16 @@ jobs:
               with:
                   access_token: ${{ github.token }}
 
+    calculate-git-info:
+        needs: [ cancel-previous ]
+        runs-on: ubuntu-18.04
+        outputs:
+            is_bors_branch: ${{ steps.calculate-git-info.outputs.is_bors_branch }}
+        steps:
+            - name: Calculate git info
+              id: calculate-git-info
+              run: echo "::set-output name=is_bors_branch::${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/trying' }}"
+
     check-license:
         needs: [ cancel-previous ]
         runs-on: ubuntu-18.04
@@ -85,9 +95,10 @@ jobs:
                   path: ${{ matrix.config.artifact_path }}
 
     check-plugin:
-        needs: [ cancel-previous, build-native-code ]
+        needs: [ cancel-previous, calculate-git-info, build-native-code ]
         strategy:
-            fail-fast: false
+            # `fromJSON` is used here to convert string output to boolean
+            fail-fast: ${{ fromJSON(needs.calculate-git-info.outputs.is_bors_branch) }}
             matrix:
                 os: [ ubuntu-18.04, windows-latest ]
                 rust-version: [ 1.51.0, nightly-2021-03-24 ]

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,11 +14,12 @@ jobs:
         runs-on: ubuntu-18.04
         steps:
             - name: Cancel Previous Runs
-              uses: styfle/cancel-workflow-action@0.4.1
+              uses: styfle/cancel-workflow-action@0.9.0
               with:
                   access_token: ${{ github.token }}
 
     check-license:
+        needs: [ cancel-previous ]
         runs-on: ubuntu-18.04
         steps:
             - uses: actions/checkout@v2
@@ -27,6 +28,7 @@ jobs:
               run: ./check-license.sh
 
     build-native-code:
+        needs: [ cancel-previous ]
         strategy:
             fail-fast: true
             matrix:
@@ -83,7 +85,7 @@ jobs:
                   path: ${{ matrix.config.artifact_path }}
 
     check-plugin:
-        needs: [ build-native-code ]
+        needs: [ cancel-previous, build-native-code ]
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,10 +23,30 @@ jobs:
         runs-on: ubuntu-18.04
         outputs:
             is_bors_branch: ${{ steps.calculate-git-info.outputs.is_bors_branch }}
+            is_master_branch: ${{ steps.calculate-git-info.outputs.is_master_branch }}
+            checked: ${{ steps.calculate-git-info.outputs.checked }}
         steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
+            - name: Set up Python
+              uses: actions/setup-python@v1
+              with:
+                  python-version: 3.7
+
             - name: Calculate git info
               id: calculate-git-info
-              run: echo "::set-output name=is_bors_branch::${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/trying' }}"
+              run: |
+                  echo "::set-output name=is_bors_branch::${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/trying' }}"
+                  echo "::set-output name=is_master_branch::${{ github.ref == 'refs/heads/master'}}"
+                  echo "::set-output name=checked::$(python scripts/has_successful_status.py --token ${{ github.token }} --ref ${{ github.sha }} --check_name check)"
+
+            - name: Check git info
+              run: |
+                  echo "is_bors_branch: ${{ steps.calculate-git-info.outputs.is_bors_branch }}"
+                  echo "is_master_branch: ${{ steps.calculate-git-info.outputs.is_master_branch }}"
+                  echo "checked: ${{ steps.calculate-git-info.outputs.checked }}"
 
     check-license:
         needs: [ cancel-previous ]
@@ -38,7 +58,9 @@ jobs:
               run: ./check-license.sh
 
     build-native-code:
-        needs: [ cancel-previous ]
+        needs: [ cancel-previous, calculate-git-info ]
+        # `fromJSON` is used here to convert string output to boolean
+        if: ${{ !(fromJSON(needs.calculate-git-info.outputs.is_master_branch) && fromJSON(needs.calculate-git-info.outputs.checked)) }}
         strategy:
             fail-fast: true
             matrix:

--- a/scripts/github.py
+++ b/scripts/github.py
@@ -39,3 +39,13 @@ def create_milestone(repo: str, token: str, title: str, description: str = "", d
     data = json.dumps(params).encode()
     request = Request(f"https://api.github.com/repos/{repo}/milestones", data, headers, method="POST")
     urlopen(request)
+
+
+def get_check_statuses(repo: str, token: str, ref: str, check_name: str) -> Dict[str, List[Dict]]:
+    headers = {"Authorization": f"token {token}",
+               "Accept": "application/vnd.github.v3+json"}
+    request = Request(
+        f"https://api.github.com/repos/{repo}/commits/{ref}/check-runs?check_name={check_name}&status=completed",
+        headers=headers)
+    response = urlopen(request)
+    return json.load(response)

--- a/scripts/has_successful_status.py
+++ b/scripts/has_successful_status.py
@@ -1,0 +1,22 @@
+import argparse
+import json
+
+from common import env
+from github import get_check_statuses
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--token", type=str, required=True)
+    parser.add_argument("--ref", type=str, required=True)
+    parser.add_argument("--check_name", type=str, required=True)
+
+    args = parser.parse_args()
+
+    repo = env("GITHUB_REPOSITORY")
+    try:
+        statuses = get_check_statuses(repo, args.token, args.ref, args.check_name)
+        has_successful_check = any(s["conclusion"] == "success" for s in statuses["check_runs"])
+    except:
+        has_successful_check = False
+
+    print(json.dumps(has_successful_check))


### PR DESCRIPTION
These changes:
- prevent running checks before `cancel-previous` job
- ask GitHub to fail the whole `check-plugin` job if at least one step fails during merging. Implemented as check of `staging` and `trying` branches
- run checks in `master` branch only once, i.e. don't run `check` workflow for changes merged by bors because they are already checked in `staging` branch