### PR TITLE
ANN: Add quick fix to correct invalid cfg predicates

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -135,7 +135,13 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
             "version" -> { /* version is currently experimental */ }
             else -> {
                 val path = item.path ?: return
-                RsDiagnostic.UnknownCfgPredicate(path, itemName).addToHolder(holder, checkExistsAfterExpansion = false)
+                val fixes = NameSuggestionFix.createApplicable(path, itemName, listOf("all", "any", "not"), 1) { name ->
+                    RsPsiFactory(path.project).tryCreatePath(name) ?: error("Cannot create path out of $name")
+                }
+                RsDiagnostic.UnknownCfgPredicate(path, itemName, fixes).addToHolder(
+                    holder,
+                    checkExistsAfterExpansion = false
+                )
             }
         }
     }

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/NameSuggestionFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/NameSuggestionFix.kt
@@ -1,0 +1,44 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.util.text.EditDistance
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+
+/**
+ * Changes the text of some element to the suggested name using the provided function.
+ */
+class NameSuggestionFix<T : PsiElement>(
+    element: T,
+    private val newName: String,
+    private val elementFactory: (name: String) -> T
+): LocalQuickFixOnPsiElement(element) {
+    override fun getFamilyName(): String = "Change name of element"
+    override fun getText(): String = "Change to `$newName`"
+
+    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+        val newElement = elementFactory(newName)
+        startElement.replace(newElement)
+    }
+
+    companion object {
+        fun <T : PsiElement> createApplicable(
+            element: T,
+            name: String,
+            validNames: List<String>,
+            maxDistance: Int,
+            elementFactory: (name: String) -> T,
+        ): List<NameSuggestionFix<T>> {
+            val applicableNames = validNames.filter {
+                name != it && EditDistance.levenshtein(it, name, true) <= maxDistance
+            }
+            return applicableNames.map { NameSuggestionFix(element, it, elementFactory) }
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1376,11 +1376,16 @@ sealed class RsDiagnostic(
         )
     }
 
-    class UnknownCfgPredicate(element: PsiElement, private val name: String) : RsDiagnostic(element) {
+    class UnknownCfgPredicate(
+        element: PsiElement,
+        private val name: String,
+        private val fixes: List<LocalQuickFix> = emptyList()
+    ) : RsDiagnostic(element) {
         override fun prepare() = PreparedAnnotation(
             ERROR,
             E0537,
-            "Invalid predicate `$name`"
+            "Invalid predicate `$name`",
+            fixes = fixes
         )
     }
 }

--- a/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsErrorAnnotatorTest.kt
@@ -4209,4 +4209,33 @@ class RsErrorAnnotatorTest : RsAnnotatorTestBase(RsErrorAnnotator::class) {
         #[cfg(version())]
         fn foo() {}
     """)
+
+    fun `test E0537 quick fix any`() = checkFixByText("Change to `any`", """
+        #[cfg(<error descr="Invalid predicate `an` [E0537]">an/*caret*/</error>(foo))]
+        fn foo() {}
+    """, """
+        #[cfg(any(foo))]
+        fn foo() {}
+    """)
+
+    fun `test E0537 quick fix all`() = checkFixByText("Change to `all`", """
+        #[cfg(<error descr="Invalid predicate `allx` [E0537]">allx/*caret*/</error>(foo))]
+        fn foo() {}
+    """, """
+        #[cfg(all(foo))]
+        fn foo() {}
+    """)
+
+    fun `test E0537 quick fix not`() = checkFixByText("Change to `not`", """
+        #[cfg(<error descr="Invalid predicate `noo` [E0537]">noo/*caret*/</error>(foo))]
+        fn foo() {}
+    """, """
+        #[cfg(not(foo))]
+        fn foo() {}
+    """)
+
+    fun `test E0537 no quick fix high distance`() = checkFixIsUnavailable("Change to", """
+        #[cfg(<error descr="Invalid predicate `a` [E0537]">a/*caret*/</error>(foo))]
+        fn foo() {}
+    """)
 }


### PR DESCRIPTION
Improves https://github.com/intellij-rust/intellij-rust/pull/7102 by adding a quick fix to correct invalid cfg name.

Note that I couldn't just use `RenameFix`, because this fix has to work on `RsPath` in the case of `cfg` predicates. And in this way the fix is general and it can be used in more places.

changelog: Add quick fix to correct the name of an invalid cfg predicate.