### PR TITLE
RES: Fix exception when removing crate from workspace in new resolve

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefMapService.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefMapService.kt
@@ -66,7 +66,7 @@ class DefMapHolder(private val structureModificationTracker: ModificationTracker
     }
 
     fun checkHasLatestStamp() {
-        if (!hasLatestStamp()) {
+        if (defMap != null && !hasLatestStamp()) {
             RESOLVE_LOG.error(
                 "DefMapHolder must have latest stamp right after DefMap($defMap) was updated. " +
                     "$defMapStamp vs ${structureModificationTracker.modificationCount}"
@@ -186,6 +186,8 @@ class DefMapService(val project: Project) : Disposable {
     fun getDefMapHolder(crate: CratePersistentId): DefMapHolder {
         return defMaps.computeIfAbsent(crate) { DefMapHolder(structureModificationTracker) }
     }
+
+    fun hasDefMapFor(crate: CratePersistentId): Boolean = defMaps[crate] != null
 
     fun setDefMap(crate: CratePersistentId, defMap: CrateDefMap?) {
         updateFilesMaps(crate, defMap)


### PR DESCRIPTION
Fixes exception in new resolve after removing crate from workspace:

```java
java.lang.Throwable: DefMapHolder must have latest stamp right after DefMap(baz(bin)) was updated. 5 vs 90
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:161)
	at org.rust.lang.core.resolve2.DefMapHolder.checkHasLatestStamp(DefMapService.kt:70)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt$getOrUpdateIfNeeded$1.invoke(FacadeUpdateDefMap.kt:49)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt$getOrUpdateIfNeeded$1.invoke(FacadeUpdateDefMap.kt)
	at org.rust.stdext.ConcurrencyKt$sam$com_intellij_openapi_util_ThrowableComputable$0.compute(Concurrency.kt)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.computeWithLockAndCheckingCanceled(ProgressIndicatorUtils.java:330)
	at org.rust.stdext.ConcurrencyKt.withLockAndCheckingCancelled(Concurrency.kt:114)
	at org.rust.lang.core.resolve2.FacadeUpdateDefMapKt.getOrUpdateIfNeeded(FacadeUpdateDefMap.kt:40)
	at org.rust.lang.core.resolve2.FacadeResolveKt.findModDataFor(FacadeResolve.kt:568)
	at org.rust.lang.core.psi.RsFile.doGetCachedData(RsFile.kt:103)
```

changelog: Fix exception when removing crate from workspace when using new name resolution engine