### PR TITLE
RES2: Fix resolve crate when importing private module with same name

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeResolve.kt
@@ -59,6 +59,7 @@ fun processItemDeclarations2(
             if (namespace !in ns) continue
             for (visItem in visItems) {
                 if (ipm == WITHOUT_PRIVATE_IMPORTS && visItem.visibility == Visibility.Invisible) continue
+                if (namespace == Namespace.Types && visItem.visibility.isInvisible && name in defMap.externPrelude) continue
                 val visibilityFilter = visItem.visibility.createFilter(project)
                 for (element in visItem.toPsi(defMap, project, namespace)) {
                     if (!elements.add(element)) continue
@@ -81,7 +82,7 @@ fun processItemDeclarations2(
     if (ipm.withExternCrates && Namespace.Types in ns) {
         for ((name, externCrateDefMap) in defMap.externPrelude.entriesWithName(processor.name)) {
             val existingItemInScope = modData.visibleItems[name]
-            if (existingItemInScope != null && existingItemInScope.types.isNotEmpty()) continue
+            if (existingItemInScope != null && existingItemInScope.types.any { !it.visibility.isInvisible }) continue
 
             val externCrateRoot = externCrateDefMap.root.toRsMod(project)
                 // crate root can't multiresolve

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsPackageLibraryResolveTest.kt
@@ -830,6 +830,17 @@ class RsPackageLibraryResolveTest : RsResolveTestBase() {
                            //^ dep-lib/lib.rs
     """)
 
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test import the same name as a crate name 2`() = stubOnlyResolve("""
+    //- dep-lib/lib.rs
+        mod dep_lib_target;
+        pub fn dep_lib_target() {}
+    //- dep-lib/dep_lib_target.rs
+    //- lib.rs
+        use dep_lib_target::dep_lib_target;
+          //^ dep-lib/lib.rs
+    """)
+
     // Issue https://github.com/intellij-rust/intellij-rust/issues/3912
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     fun `test star import of item with the same name as extern crate`() = stubOnlyResolve("""


### PR DESCRIPTION
Fixes #7124

changelog: Fix false-positive [E0603](https://doc.rust-lang.org/error-index.html#E0603) "Module is private" when using new name resolution engine
