### PR TITLE
Cancel external linter (cargo check) on PSI any change

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterPass.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExternalLinterPass.kt
@@ -66,7 +66,7 @@ class RsExternalLinterPass(
         annotationInfo = RsExternalLinterUtils.checkLazily(
             project.toolchain ?: return,
             project,
-            moduleOrProject,
+            disposable,
             cargoTarget.pkg.workspace.contentRoot,
             args
         )

--- a/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsExternalLinterInspection.kt
@@ -38,7 +38,6 @@ import org.rust.ide.annotator.createAnnotationsForFile
 import org.rust.ide.annotator.createDisposableOnAnyPsiChange
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.ext.ancestorOrSelf
-import org.rust.lang.core.psi.ext.containingCrate
 import org.rust.stdext.buildList
 import java.util.*
 
@@ -89,7 +88,7 @@ class RsExternalLinterInspection : GlobalSimpleInspectionTool() {
             }
             val futures = cargoProjects.map {
                 ApplicationManager.getApplication().executeOnPooledThread<RsExternalLinterResult?> {
-                    checkProjectLazily(it, project)?.value
+                    checkProjectLazily(it, disposable)?.value
                 }
             }
             val annotationResults = futures.mapNotNull { it.get() }

--- a/src/main/kotlin/org/rust/openapiext/CommandLineExt.kt
+++ b/src/main/kotlin/org/rust/openapiext/CommandLineExt.kt
@@ -51,7 +51,8 @@ fun GeneralCommandLine.execute(
     listener: ProcessListener? = null
 ): ProcessOutput {
 
-    val handler = CapturingProcessHandler(this)
+    val handler = CapturingProcessHandler(this) // The OS process is started here
+
     val cargoKiller = Disposable {
         // Don't attempt a graceful termination, Cargo can be SIGKILLed safely.
         // https://github.com/rust-lang/cargo/issues/3566
@@ -68,6 +69,8 @@ fun GeneralCommandLine.execute(
     }
 
     if (alreadyDisposed) {
+        Disposer.dispose(cargoKiller) // Kill the process
+
         // On the one hand, this seems fishy,
         // on the other hand, this is isomorphic
         // to the scenario where cargoKiller triggers.

--- a/src/main/kotlin/org/rust/openapiext/CommandLineExt.kt
+++ b/src/main/kotlin/org/rust/openapiext/CommandLineExt.kt
@@ -56,7 +56,10 @@ fun GeneralCommandLine.execute(
     val cargoKiller = Disposable {
         // Don't attempt a graceful termination, Cargo can be SIGKILLed safely.
         // https://github.com/rust-lang/cargo/issues/3566
-        handler.destroyProcess()
+        if (!handler.isProcessTerminated) {
+            handler.process.destroyForcibly() // Send SIGKILL
+            handler.destroyProcess()
+        }
     }
 
     val alreadyDisposed = runReadAction {


### PR DESCRIPTION
Fixes #4283

I think we got issues with Clippy (https://github.com/rust-lang/rust-clippy/issues/3890) due to a simple reason: sometimes we miss the file descriptor to running Cargo/Clippy process, hence we never kill it and don't read its output. The result is that such missed process hangs on writing to stdout because nobody actually read its output.

The fix is that, well, now we don't miss the process. Also, now we use SIGKILL instead of SIGTERM.

changelog: Cancel external linter (cargo check) immediately when some file is changed
