### PR TITLE
ANN: Take into account enum's lifetimes in `Needless Lifetimes` inspection

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspection.kt
@@ -154,7 +154,7 @@ private class LifetimesCollector(val isForInputParams: Boolean = false) : RsRecu
     private fun collectAnonymousLifetimes(path: RsPath) {
         if (path.lifetimeArguments.isNotEmpty()) return
         when (val resolved = path.reference?.resolve()) {
-            is RsStructItem, is RsTraitItem, is RsTypeAlias -> {
+            is RsStructItem, is RsEnumItem, is RsTraitItem, is RsTypeAlias -> {
                 val declaration = resolved as RsGenericDeclaration
                 repeat(declaration.lifetimeParameters.size) {
                     record(null)

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsNeedlessLifetimesInspectionTest.kt
@@ -54,6 +54,18 @@ class RsNeedlessLifetimesInspectionTest : RsInspectionsTestBase(RsNeedlessLifeti
         fn <caret>foo(x: &str) -> Box<Iterator<Item=&str>> { unimplemented!() }
     """)
 
+    fun `test check struct, enum, trait, alias`() = checkByText("""
+        struct S<'a>;
+        enum E<'a> {}
+        trait T<'a> {}
+        type A<'a> = S<'a>;
+
+        fn foo1<'a>(d: &'a S) -> &'a () { unimplemented!() }
+        fn foo2<'a>(d: &'a E) -> &'a () { unimplemented!() }
+        fn foo3<'a>(d: &'a T) -> &'a () { unimplemented!() }
+        fn foo4<'a>(d: &'a A) -> &'a () { unimplemented!() }
+    """, checkWeakWarn = true)
+
     fun `test two input lifetimes no output lifetimes 1`() = doTest("""
         <weak_warning>fn <caret>foo<'a>(a: &'a str, b: &str)</weak_warning> { unimplemented!() }
     """, """


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/7155.

changelog: Take into account enum's lifetimes in `Needless Lifetimes` inspection
