### PR TITLE
PERF: Fix which files are checked for modification after cargo refresh

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve2/CrateModificationTracker.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/CrateModificationTracker.kt
@@ -61,7 +61,7 @@ private fun CrateDefMap.getAllChangedFiles(project: Project, ignoredFiles: Set<R
             ?: return null  // file was deleted - should rebuilt DefMap
         file.takeIf {
             it !in ignoredFiles
-                && it.modificationStampForResolve == fileInfo.modificationStamp
+                && it.modificationStampForResolve != fileInfo.modificationStamp
         }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/resolve2/FacadeUpdateDefMap.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/FacadeUpdateDefMap.kt
@@ -108,6 +108,11 @@ fun Project.forceRebuildDefMapForCrate(crateId: CratePersistentId) {
     doUpdateDefMapForAllCrates(this, SameThreadExecutor(), EmptyProgressIndicator(), multithread = false, crateId)
 }
 
+fun Project.getAllDefMaps(): List<CrateDefMap> = crateGraph.topSortedCrates.mapNotNull {
+    val id = it.id ?: return@mapNotNull null
+    defMapService.getOrUpdateIfNeeded(id)
+}
+
 private class DefMapUpdater(
     /**
      * If null, DefMap is updated for all crates.

--- a/src/test/kotlin/org/rust/lang/core/resolve2/RsMultipleDefMapsUpdateTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve2/RsMultipleDefMapsUpdateTest.kt
@@ -22,9 +22,7 @@ class RsMultipleDefMapsUpdateTest : RsTestBase() {
     override fun setUp() {
         super.setUp()
         fileTreeFromText(codeAllCrates).create()
-        for (crate in project.crateGraph.topSortedCrates) {
-            project.defMapService.getOrUpdateIfNeeded(crate.id ?: continue)
-        }
+        project.getAllDefMaps()
     }
 
     private fun modifyCrates(vararg crates: CrateInfo) {

--- a/src/test/kotlin/org/rustPerformanceTests/RsBuildDefMapTest.kt
+++ b/src/test/kotlin/org/rustPerformanceTests/RsBuildDefMapTest.kt
@@ -8,11 +8,9 @@ package org.rustPerformanceTests
 import com.intellij.openapi.util.Disposer
 import com.sun.management.HotSpotDiagnosticMXBean
 import org.rust.UseNewResolve
-import org.rust.lang.core.crate.crateGraph
 import org.rust.lang.core.macros.MacroExpansionScope
 import org.rust.lang.core.macros.macroExpansionManager
-import org.rust.lang.core.resolve2.defMapService
-import org.rust.lang.core.resolve2.getOrUpdateIfNeeded
+import org.rust.lang.core.resolve2.getAllDefMaps
 import java.lang.management.ManagementFactory
 
 private const val DUMP_HEAP: Boolean = false
@@ -37,10 +35,7 @@ class RsBuildDefMapTest : RsRealProjectTestBase() {
         try {
             openRealProject(info)
 
-            val defMaps = project.crateGraph.topSortedCrates.mapNotNull {
-                val id = it.id ?: return@mapNotNull null
-                project.defMapService.getOrUpdateIfNeeded(id)
-            }
+            val defMaps = project.getAllDefMaps()
             if (DUMP_HEAP) {
                 dumpHeap(info.name)
             }

--- a/src/test/kotlin/org/rustPerformanceTests/RsProfileCargoRefreshTest.kt
+++ b/src/test/kotlin/org/rustPerformanceTests/RsProfileCargoRefreshTest.kt
@@ -1,0 +1,23 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rustPerformanceTests
+
+import org.rust.cargo.project.model.impl.testCargoProjects
+import org.rust.lang.core.resolve2.getAllDefMaps
+
+class RsProfileCargoRefreshTest : RsPerformanceTestBase() {
+
+    fun `test Cargo`() = profile(CARGO)
+
+    private fun profile(info: RealProjectInfo) {
+        openProject(info)
+
+        profile("Cargo refresh") {
+            project.testCargoProjects.refreshAllProjectsSync()
+            project.getAllDefMaps()
+        }
+    }
+}


### PR DESCRIPTION
Previously because of mistake we collect in new resolve unmodified files after cargo refresh. It is unneeded work and causes some performance impact. It actually works because most (if not all) of file modifications also generates PSI event which we also handle.

changelog: Slightly optimize cargo refresh when using new name resolution engine
