### PR TITLE
Introduce `existsAfterExpansion`, use it instead of `isEnabledByCfg`

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsAnnotationHolder.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsAnnotationHolder.kt
@@ -11,7 +11,7 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.AnnotationSession
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.psi.PsiElement
-import org.rust.ide.utils.isEnabledByCfg
+import org.rust.ide.utils.existsAfterExpansion
 
 class RsAnnotationHolder(val holder: AnnotationHolder) {
 
@@ -42,7 +42,7 @@ class RsAnnotationHolder(val holder: AnnotationHolder) {
         message: String?,
         vararg fixes: IntentionAction
     ): AnnotationBuilder? {
-        if (!element.isEnabledByCfg) return null
+        if (!element.existsAfterExpansion) return null
         val builder = if (message == null) {
             holder.newSilentAnnotation(severity)
         } else {

--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -22,8 +22,8 @@ import org.rust.ide.annotator.fixes.*
 import org.rust.ide.presentation.getStubOnlyText
 import org.rust.ide.refactoring.RsNamesValidator.Companion.RESERVED_LIFETIME_NAMES
 import org.rust.ide.refactoring.findBinding
+import org.rust.ide.utils.existsAfterExpansion
 import org.rust.ide.utils.isCfgUnknown
-import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.*
 import org.rust.lang.core.FeatureAvailability.*
 import org.rust.lang.core.macros.MacroExpansionMode
@@ -135,7 +135,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
             "version" -> { /* version is currently experimental */ }
             else -> {
                 val path = item.path ?: return
-                RsDiagnostic.UnknownCfgPredicate(path, itemName).addToHolder(holder, checkCfg = false)
+                RsDiagnostic.UnknownCfgPredicate(path, itemName).addToHolder(holder, checkExistsAfterExpansion = false)
             }
         }
     }
@@ -1363,7 +1363,7 @@ private fun AnnotationSession.duplicatesByNamespace(
                 val name = it.nameOrImportedName()
                 name != null && name != "_"
             }
-            .filter { it.isEnabledByCfg && !it.isCfgUnknown }
+            .filter { it.existsAfterExpansion && !it.isCfgUnknown }
             .flatMap { it.namespaced() }
             .groupBy { it.first }       // Group by namespace
             .map { entry ->

--- a/src/main/kotlin/org/rust/ide/annotator/RsExpressionAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsExpressionAnnotator.kt
@@ -15,11 +15,10 @@ import com.intellij.util.SmartList
 import org.rust.ide.annotator.fixes.AddStructFieldsFix
 import org.rust.ide.annotator.fixes.CreateStructFieldFromConstructorFix
 import org.rust.ide.annotator.fixes.RemoveRedundantParenthesesFix
-import org.rust.ide.utils.isEnabledByCfg
+import org.rust.ide.utils.existsAfterExpansion
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve.ref.deepResolve
-import java.util.*
 
 class RsExpressionAnnotator : AnnotatorBase() {
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
@@ -63,7 +62,7 @@ class RsExpressionAnnotator : AnnotatorBase() {
             }
         } else {
             if (calculateMissingFields(body, decl).isNotEmpty()) {
-                if (!literal.isEnabledByCfg) return
+                if (!literal.existsAfterExpansion) return
 
                 val structNameRange = literal.descendantOfTypeStrict<RsPath>()?.textRange
                 if (structNameRange != null) {

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -19,8 +19,8 @@ import com.intellij.psi.search.PsiTodoSearchHelper
 import org.rust.ide.colors.RsColor
 import org.rust.ide.highlight.RsHighlighter
 import org.rust.ide.todo.isTodoPattern
+import org.rust.ide.utils.existsAfterExpansion
 import org.rust.ide.utils.isDisabledCfgAttrAttribute
-import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.*
 import org.rust.lang.core.psi.ext.*
@@ -37,7 +37,7 @@ class RsHighlightingAnnotator : AnnotatorBase() {
             else -> null
         } ?: return
 
-        if (!element.isEnabledByCfg) return
+        if (!element.existsAfterExpansion) return
         if (element.ancestors.any { it is RsAttr && it.isDisabledCfgAttrAttribute }) return
 
         val severity = if (isUnitTestMode) color.testSeverity else HighlightSeverity.INFORMATION

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingMutableAnnotator.kt
@@ -11,7 +11,7 @@ import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
 import org.rust.ide.colors.RsColor
-import org.rust.ide.utils.isEnabledByCfg
+import org.rust.ide.utils.existsAfterExpansion
 import org.rust.lang.core.psi.RsPatBinding
 import org.rust.lang.core.psi.RsPath
 import org.rust.lang.core.psi.RsSelfParameter
@@ -46,7 +46,7 @@ class RsHighlightingMutableAnnotator : AnnotatorBase() {
     }
 
     private fun distinctAnnotation(element: PsiElement, ref: RsElement, holder: AnnotationHolder) {
-        if (!element.isEnabledByCfg) return
+        if (!element.existsAfterExpansion) return
         val color = annotationFor(ref) ?: return
         if (ref.isMut) {
             @Suppress("NAME_SHADOWING")

--- a/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
@@ -21,7 +21,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import org.rust.ide.utils.isEnabledByCfg
+import org.rust.ide.utils.existsAfterExpansion
 import org.rust.lang.core.macros.*
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.ext.descendantsOfType
@@ -124,7 +124,7 @@ class RsMacroExpansionHighlightingPass(
 
 private fun RsMacroCall.prepare(): PreparedMacroCall? {
     if (macroArgument == null) return null // special macros should not be highlighted
-    if (!isEnabledByCfg) return null
+    if (!existsAfterExpansion) return null
     val expansion = expansion ?: return null
     return PreparedMacroCall(this, expansion)
 }

--- a/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsUnsafeExpressionAnnotator.kt
@@ -12,7 +12,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
 import org.rust.ide.colors.RsColor
-import org.rust.ide.utils.isEnabledByCfg
+import org.rust.ide.utils.existsAfterExpansion
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.ty.TyPointer
@@ -34,7 +34,7 @@ class RsUnsafeExpressionAnnotator : AnnotatorBase() {
     }
 
     private fun annotateUnsafeCall(expr: RsExpr, holder: RsAnnotationHolder) {
-        if (!expr.isEnabledByCfg) return
+        if (!expr.existsAfterExpansion) return
 
         if (expr.isInUnsafeBlockOrFn(/* skip the expression itself*/ 1)) {
             val textRange = when (expr) {

--- a/src/main/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHints.kt
+++ b/src/main/kotlin/org/rust/ide/hints/parameter/RsInlayParameterHints.kt
@@ -9,7 +9,7 @@ import com.intellij.codeInsight.hints.InlayInfo
 import com.intellij.codeInsight.hints.Option
 import com.intellij.psi.PsiElement
 import org.rust.ide.utils.CallInfo
-import org.rust.ide.utils.isEnabledByCfg
+import org.rust.ide.utils.existsAfterExpansion
 import org.rust.lang.core.psi.RsCallExpr
 import org.rust.lang.core.psi.RsExpr
 import org.rust.lang.core.psi.RsLambdaExpr
@@ -31,7 +31,7 @@ object RsInlayParameterHints {
             is RsMethodCall -> (CallInfo.resolve(elem) to elem.valueArgumentList)
             else -> return emptyList()
         }
-        if (!elem.isEnabledByCfg) return emptyList()
+        if (!elem.existsAfterExpansion) return emptyList()
         if (callInfo == null) return emptyList()
 
         val hints = buildList<String> {

--- a/src/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsChainMethodTypeHintsProvider.kt
@@ -18,7 +18,7 @@ import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
-import org.rust.ide.utils.isEnabledByCfg
+import org.rust.ide.utils.existsAfterExpansion
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.RsDotExpr
 import org.rust.lang.core.psi.RsFile
@@ -77,7 +77,7 @@ class RsChainMethodTypeHintsProvider : InlayHintsProvider<RsChainMethodTypeHints
                 if (DumbService.isDumb(element.project)) return true
                 if (element !is RsMethodCall) return true
                 if (!element.isLastInChain) return true
-                if (!element.isEnabledByCfg) return true
+                if (!element.existsAfterExpansion) return true
 
                 val (lookup, iterator) = lookupAndIteratorTrait
 

--- a/src/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hints/type/RsInlayTypeHintsProvider.kt
@@ -16,7 +16,7 @@ import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import org.rust.ide.utils.isEnabledByCfg
+import org.rust.ide.utils.existsAfterExpansion
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -68,7 +68,7 @@ class RsInlayTypeHintsProvider : InlayHintsProvider<RsInlayTypeHintsProvider.Set
             override fun collect(element: PsiElement, editor: Editor, sink: InlayHintsSink): Boolean {
                 if (file.project.service<DumbService>().isDumb) return true
                 if (element !is RsElement) return true
-                if (!element.isEnabledByCfg) return true
+                if (!element.existsAfterExpansion) return true
 
                 if (settings.showForVariables) {
                     presentVariable(element)

--- a/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsLocalInspectionTool.kt
@@ -13,7 +13,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
 import org.rust.cargo.project.settings.toolchain
-import org.rust.ide.utils.isEnabledByCfg
+import org.rust.ide.utils.existsAfterExpansion
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.RsVisitor
 
@@ -63,7 +63,7 @@ class RsProblemsHolder(private val holder: ProblemsHolder) {
     val isOnTheFly: Boolean get() = holder.isOnTheFly
 
     fun registerProblem(element: PsiElement, descriptionTemplate: String, vararg fixes: LocalQuickFix?) {
-        if (element.isEnabledByCfg) {
+        if (element.existsAfterExpansion) {
             holder.registerProblem(element, descriptionTemplate, *fixes)
         }
     }
@@ -74,19 +74,19 @@ class RsProblemsHolder(private val holder: ProblemsHolder) {
         highlightType: ProblemHighlightType,
         vararg fixes: LocalQuickFix
     ) {
-        if (element.isEnabledByCfg) {
+        if (element.existsAfterExpansion) {
             holder.registerProblem(element, descriptionTemplate, highlightType, *fixes)
         }
     }
 
     fun registerProblem(problemDescriptor: ProblemDescriptor) {
-        if (problemDescriptor.psiElement.isEnabledByCfg) {
+        if (problemDescriptor.psiElement.existsAfterExpansion) {
             holder.registerProblem(problemDescriptor)
         }
     }
 
     fun registerProblem(element: PsiElement, rangeInElement: TextRange, message: String, vararg fixes: LocalQuickFix?) {
-        if (element.isEnabledByCfg) {
+        if (element.existsAfterExpansion) {
             holder.registerProblem(element, rangeInElement, message, *fixes)
         }
     }
@@ -98,7 +98,7 @@ class RsProblemsHolder(private val holder: ProblemsHolder) {
         rangeInElement: TextRange,
         vararg fixes: LocalQuickFix?
     ) {
-        if (element.isEnabledByCfg) {
+        if (element.existsAfterExpansion) {
             holder.registerProblem(element, message, highlightType, rangeInElement, *fixes)
         }
     }

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureUsageProcessor.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureUsageProcessor.kt
@@ -132,7 +132,7 @@ private fun findNameConflicts(
     }
     for (item in items) {
         if (item == function) continue
-        if (!item.isEnabledByCfgSelf) continue
+        if (!item.existsAfterExpansionSelf) continue
 
         val namedItem = item as? RsNamedElement ?: continue
 

--- a/src/main/kotlin/org/rust/lang/core/dfa/CFGBuilder.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/CFGBuilder.kt
@@ -158,7 +158,7 @@ class CFGBuilder(
 
         // Conditionally disabled code should be ignored since it does not affect the execution
         // https://doc.rust-lang.org/reference/expressions.html#expression-attributes
-        if (element is RsOuterAttributeOwner && !element.isEnabledByCfgSelf) {
+        if (element is RsOuterAttributeOwner && !element.existsAfterExpansionSelf) {
             return pred
         }
 

--- a/src/main/kotlin/org/rust/lang/core/dfa/ControlFlowGraph.kt
+++ b/src/main/kotlin/org/rust/lang/core/dfa/ControlFlowGraph.kt
@@ -6,7 +6,7 @@
 package org.rust.lang.core.dfa
 
 import com.intellij.psi.PsiElement
-import org.rust.ide.utils.isEnabledByCfg
+import org.rust.ide.utils.existsAfterExpansion
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.types.regions.ScopeTree
@@ -139,10 +139,10 @@ class ControlFlowGraph private constructor(
              */
             fun isUnreachable(unexecuted: RsElement, innerExpr: RsExpr?): Boolean {
                 // Ignore conditionally disabled elements
-                if (!unexecuted.isEnabledByCfg) {
+                if (!unexecuted.existsAfterExpansion) {
                     return false
                 }
-                if (innerExpr != null && !innerExpr.isEnabledByCfg) {
+                if (innerExpr != null && !innerExpr.existsAfterExpansion) {
                     return false
                 }
 

--- a/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsFile.kt
@@ -286,10 +286,10 @@ private val CACHED_DATA_KEY: Key<CachedValue<CachedData>> = Key.create("CACHED_D
 private val CACHED_DATA_MACROS_KEY: Key<CachedValue<CachedData>> = Key.create("CACHED_DATA_MACROS_KEY")
 
 private tailrec fun PsiElement.contextualFileAndIsEnabledByCfgOnThisWay(): Pair<PsiFile, Boolean> {
-    if (this is RsDocAndAttributeOwner && !isEnabledByCfgSelf) return contextualFile to false
+    if (this is RsDocAndAttributeOwner && !existsAfterExpansionSelf) return contextualFile to false
     val contextOrMacro = (this as? RsExpandedElement)?.expandedFrom ?: context!!
     return if (contextOrMacro is PsiFile) {
-        contextOrMacro to (contextOrMacro !is RsDocAndAttributeOwner || contextOrMacro.isEnabledByCfgSelf)
+        contextOrMacro to (contextOrMacro !is RsDocAndAttributeOwner || contextOrMacro.existsAfterExpansionSelf)
     } else {
         contextOrMacro.contextualFileAndIsEnabledByCfgOnThisWay()
     }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/CfgUtils.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/CfgUtils.kt
@@ -14,6 +14,20 @@ import org.rust.lang.utils.evaluation.ThreeValuedLogic
 
 val PsiElement.isEnabledByCfg: Boolean get() = isEnabledByCfgInner(null)
 
+/**
+ * TODO at the moment it's equivalent to [isEnabledByCfg]
+ *
+ * Returns `true` if it [isEnabledByCfg] and not inside an element under attribute procedural macro.
+ *
+ * A one exception is that it returns `true` for attribute macro itself:
+ *
+ * ```
+ * #[a_macro]  // `true` for the attribute
+ * fn foo() {} // `false` for the function
+ * ```
+ */
+val PsiElement.existsAfterExpansion: Boolean get() = isEnabledByCfg
+
 fun PsiElement.isEnabledByCfg(crate: Crate): Boolean = isEnabledByCfgInner(crate)
 
 private fun PsiElement.isEnabledByCfgInner(crate: Crate?): Boolean =

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsDocAndAttributeOwner.kt
@@ -397,6 +397,14 @@ class QueryAttributes<out T: RsMetaItemPsiOrStub>(
 val RsDocAndAttributeOwner.isEnabledByCfgSelf: Boolean
     get() = evaluateCfg() != ThreeValuedLogic.False
 
+/**
+ * TODO at the moment it's equivalent to [isEnabledByCfgSelf]
+ *
+ * Returns `true` if it [isEnabledByCfgSelf] and is not under attribute procedural macro
+ */
+val RsDocAndAttributeOwner.existsAfterExpansionSelf: Boolean
+    get() = isEnabledByCfgSelf
+
 fun RsDocAndAttributeOwner.isEnabledByCfgSelf(crate: Crate): Boolean =
     isEnabledByCfgSelfInner(crate)
 

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFieldsOwner.kt
@@ -22,11 +22,11 @@ val RsFieldsOwner.fields: List<RsFieldDecl>
 
 /** Returns those named fields that are not disabled by cfg attributes */
 val RsFieldsOwner.namedFields: List<RsNamedFieldDecl>
-    get() = blockFields?.namedFieldDeclList?.filter { it.isEnabledByCfgSelf }.orEmpty()
+    get() = blockFields?.namedFieldDeclList?.filter { it.existsAfterExpansionSelf }.orEmpty()
 
 /** Returns those positional (tuple) fields that are not disabled by cfg attributes */
 val RsFieldsOwner.positionalFields: List<RsTupleFieldDecl>
-    get() = tupleFields?.tupleFieldDeclList?.filter { it.isEnabledByCfgSelf }.orEmpty()
+    get() = tupleFields?.tupleFieldDeclList?.filter { it.existsAfterExpansionSelf }.orEmpty()
 
 /**
  * If some field of a struct is private (not visible from [mod]),
@@ -46,7 +46,7 @@ fun RsFieldsOwner.canBeInstantiatedIn(mod: RsMod): Boolean =
     fields.all { it.isVisibleFrom(mod) }
 
 val RsFieldsOwner.fieldTypes: List<Ty>
-    get() = fields.filter { it.isEnabledByCfgSelf }.mapNotNull { it.typeReference?.type }
+    get() = fields.filter { it.existsAfterExpansionSelf }.mapNotNull { it.typeReference?.type }
 
 /**
  * True for:

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsFunction.kt
@@ -70,7 +70,7 @@ val RsFunction.abiName: String?
  * Should be used in code analysis: name resolution, type inference, inspections, annotations, etc.
  */
 val RsFunction.valueParameters: List<RsValueParameter>
-    get() = rawValueParameters.filter { it.isEnabledByCfgSelf }
+    get() = rawValueParameters.filter { it.existsAfterExpansionSelf }
 
 /**
  * All function parameters.

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsItemsOwner.kt
@@ -149,13 +149,13 @@ private fun RsItemsOwner.processExpandedItemsInternal(processor: (RsElement, Boo
 }
 
 private fun RsElement.processItem(processor: (RsElement, Boolean) -> Boolean): Boolean {
-    val isEnabledByCfgSelf = this !is RsDocAndAttributeOwner || this.isEnabledByCfgSelf
+    val isEnabledByCfgSelf = this !is RsDocAndAttributeOwner || this.existsAfterExpansionSelf
 
     return when (this) {
         is RsMacroCall -> {
             if (!isEnabledByCfgSelf) return false
             processExpansionRecursively {
-                it is RsDocAndAttributeOwner && processor(it, it.isEnabledByCfgSelf)
+                it is RsDocAndAttributeOwner && processor(it, it.existsAfterExpansionSelf)
             }
         }
         is RsItemElement, is RsMacro -> processor(this, isEnabledByCfgSelf)

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacroCall.kt
@@ -172,7 +172,7 @@ private fun RsMacroCall.processExpansionRecursively(processor: (RsExpandedElemen
 
 private fun RsExpandedElement.processRecursively(processor: (RsExpandedElement) -> Boolean, depth: Int): Boolean {
     return when (this) {
-        is RsMacroCall -> isEnabledByCfgSelf && processExpansionRecursively(processor, depth + 1)
+        is RsMacroCall -> existsAfterExpansionSelf && processExpansionRecursively(processor, depth + 1)
         else -> processor(this)
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsTraitItem.kt
@@ -168,7 +168,7 @@ class TraitImplementationInfo private constructor(
     traitMembers: RsMembers,
     implMembers: RsMembers
 ) {
-    val declared = traitMembers.abstractable().filter { it.isEnabledByCfgSelf }
+    val declared = traitMembers.abstractable().filter { it.existsAfterExpansionSelf }
     private val implemented = implMembers.abstractable()
     private val declaredByName = declared.associateBy { it.name!! }
     private val implementedByNameAndType = implemented.associateBy { it.name!! to it.elementType }

--- a/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/NameResolution.kt
@@ -1090,14 +1090,14 @@ private class MacroResolvingVisitor(
     }
 
     override fun visitModItem(item: RsModItem) {
-        if (missingMacroUse.hitOnFalse(item.hasMacroUse) && item.isEnabledByCfgSelf) {
+        if (missingMacroUse.hitOnFalse(item.hasMacroUse) && item.existsAfterExpansionSelf) {
             val elements = visibleMacros(item)
             visitorResult = processAll(if (reverse) elements.asReversed() else elements, processor)
         }
     }
 
     override fun visitModDeclItem(item: RsModDeclItem) {
-        if (missingMacroUse.hitOnFalse(item.hasMacroUse) && item.isEnabledByCfgSelf) {
+        if (missingMacroUse.hitOnFalse(item.hasMacroUse) && item.existsAfterExpansionSelf) {
             val mod = item.reference.resolve() as? RsMod ?: return
             val elements = visibleMacros(mod)
             visitorResult = processAll(if (reverse) elements.asReversed() else elements, processor)
@@ -1105,7 +1105,7 @@ private class MacroResolvingVisitor(
     }
 
     override fun visitExternCrateItem(item: RsExternCrateItem) {
-        if (!item.isEnabledByCfgSelf) return
+        if (!item.existsAfterExpansionSelf) return
         val mod = item.reference.resolve() as? RsFile ?: return
         if (missingMacroUse.hitOnFalse(item.hasMacroUse)) {
             // If extern crate has `#[macro_use]` attribute
@@ -1193,7 +1193,7 @@ private fun exportedMacrosInternal(scope: RsFile): List<ScopeEntry> {
 
         val externCrates = scope.stubChildrenOfType<RsExternCrateItem>()
         for (item in externCrates) {
-            if (!item.isEnabledByCfgSelf) continue
+            if (!item.existsAfterExpansionSelf) continue
             val reexportedMacros = reexportedMacros(item)
             if (reexportedMacros != null) {
                 addAll(reexportedMacros.toScopeEntries())
@@ -1259,7 +1259,7 @@ private fun collectMacrosImportedWithUseItem(
     val twoSegmentPaths = collect2segmentPaths(root)
 
     // Check cfg only if there are paths we interested in
-    if (twoSegmentPaths.isEmpty() || !useItem.isEnabledByCfgSelf) return emptyList()
+    if (twoSegmentPaths.isEmpty() || !useItem.existsAfterExpansionSelf) return emptyList()
 
     return buildList {
         for ((crateName, macroName) in twoSegmentPaths) {

--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -95,7 +95,7 @@ fun collectPathResolveVariants(
 
         if (e.name == referenceName) {
             val element = e.element ?: return@createProcessor false
-            if (element !is RsDocAndAttributeOwner || element.isEnabledByCfgSelf) {
+            if (element !is RsDocAndAttributeOwner || element.existsAfterExpansionSelf) {
                 val boundElement = BoundElement(element, e.subst)
                 val visibilityStatus = e.getVisibilityStatusFrom(path)
                 if (visibilityStatus != VisibilityStatus.CfgDisabled) {
@@ -118,7 +118,7 @@ fun collectResolveVariants(referenceName: String?, f: (RsResolveProcessor) -> Un
 
         if (e.name == referenceName) {
             val element = e.element ?: return@createProcessor false
-            if (element !is RsDocAndAttributeOwner || element.isEnabledByCfgSelf) {
+            if (element !is RsDocAndAttributeOwner || element.existsAfterExpansionSelf) {
                 result += element
             }
         }
@@ -142,7 +142,7 @@ fun <T : ScopeEntry> collectResolveVariantsAsScopeEntries(
         if (e.name == referenceName) {
             // de-lazying. See `RsResolveProcessor.lazy`
             val element = e.element ?: return@createProcessorGeneric false
-            if (element !is RsDocAndAttributeOwner || element.isEnabledByCfgSelf) {
+            if (element !is RsDocAndAttributeOwner || element.existsAfterExpansionSelf) {
                 result += e
             }
         }
@@ -161,7 +161,7 @@ fun pickFirstResolveEntry(referenceName: String?, f: (RsResolveProcessor) -> Uni
     val processor = createProcessor(referenceName) { e ->
         if (e.name == referenceName) {
             val element = e.element
-            if (element != null && (element !is RsDocAndAttributeOwner || element.isEnabledByCfgSelf)) {
+            if (element != null && (element !is RsDocAndAttributeOwner || element.existsAfterExpansionSelf)) {
                 result = e
                 return@createProcessor true
             }
@@ -180,7 +180,7 @@ fun collectCompletionVariants(
     val processor = createProcessor { e ->
         val element = e.element ?: return@createProcessor false
         if (element is RsFunction && element.isTest) return@createProcessor false
-        if (element !is RsDocAndAttributeOwner || element.isEnabledByCfgSelf) {
+        if (element !is RsDocAndAttributeOwner || element.existsAfterExpansionSelf) {
             result.addElement(createLookupElement(
                 scopeEntry = e,
                 context = context

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -34,8 +34,8 @@ import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.presentation.shortPresentableText
 import org.rust.ide.refactoring.implementMembers.ImplementMembersFix
 import org.rust.ide.utils.checkMatch.Pattern
+import org.rust.ide.utils.existsAfterExpansion
 import org.rust.ide.utils.import.RsImportHelper.getTypeReferencesInfoFromTys
-import org.rust.ide.utils.isEnabledByCfg
 import org.rust.lang.core.CONST_GENERICS
 import org.rust.lang.core.CompilerFeature
 import org.rust.lang.core.MIN_CONST_GENERICS
@@ -1413,8 +1413,8 @@ class PreparedAnnotation(
     val fixes: List<LocalQuickFix> = emptyList()
 )
 
-fun RsDiagnostic.addToHolder(holder: RsAnnotationHolder, checkCfg: Boolean = true) {
-    if (!checkCfg || element.isEnabledByCfg) {
+fun RsDiagnostic.addToHolder(holder: RsAnnotationHolder, checkExistsAfterExpansion: Boolean = true) {
+    if (!checkExistsAfterExpansion || element.existsAfterExpansion) {
         addToHolder(holder.holder)
     }
 }


### PR DESCRIPTION
At the moment, `existsAfterExpansion` is equivalent to `isEnabledByCfg`,
so this commit is just a rename. In the future, `existsAfterExpansion`
will return `false` for elements under attribute procedural macros