### PR TITLE
Initial version of state collectors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -290,6 +290,9 @@ project(":plugin") {
             jvmArgs("-Dide.show.tips.on.startup.default.value=false")
             // uncomment if `unexpected exception ProcessCanceledException` prevents you from debugging a running IDE
             // jvmArgs("-Didea.ProcessCanceledException=disabled")
+
+            // Uncomment to enable FUS testing mode
+            // jvmArgs("-Dfus.internal.test.mode=true")
         }
 
         withType<PatchPluginXmlTask> {

--- a/src/main/kotlin/org/rust/ide/statistics/RsProjectUsagesCollector.kt
+++ b/src/main/kotlin/org/rust/ide/statistics/RsProjectUsagesCollector.kt
@@ -1,0 +1,82 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.statistics
+
+import com.intellij.internal.statistic.beans.MetricEvent
+import com.intellij.internal.statistic.eventLog.EventLogGroup
+import com.intellij.internal.statistic.eventLog.events.EventFields
+import com.intellij.internal.statistic.service.fus.collectors.ProjectUsagesCollector
+import com.intellij.openapi.project.Project
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.workspace.PackageOrigin
+
+@Suppress("UnstableApiUsage")
+class RsProjectUsagesCollector : ProjectUsagesCollector() {
+    override fun getGroup(): EventLogGroup = GROUP
+
+    override fun getMetrics(project: Project): Set<MetricEvent> {
+        val metrics = mutableSetOf<MetricEvent>()
+        val cargoProjects = project.cargoProjects.allProjects
+        metrics += CARGO_PROJECTS_EVENT.metric(cargoProjects.size)
+
+        val workspaceInfo = PackagesInfo()
+        val dependenciesInfo = PackagesInfo()
+        for (cargoProject in cargoProjects) {
+            for (pkg in cargoProject.workspace?.packages.orEmpty()) {
+                val info = when (pkg.origin) {
+                    PackageOrigin.WORKSPACE -> workspaceInfo
+                    PackageOrigin.DEPENDENCY -> dependenciesInfo
+                    else -> continue
+                }
+                info.packageCount += 1
+                for (target in pkg.targets) {
+                    when  {
+                        target.kind.isCustomBuild -> info.buildScriptCount += 1
+                        target.kind.isProcMacro -> info.procMacroLibCount += 1
+                    }
+                }
+            }
+        }
+
+        metrics += PACKAGES.metric(workspaceInfo.packageCount, dependenciesInfo.packageCount)
+        metrics += COMPILE_TIME_TARGETS.metric(
+            BUILD_SCRIPT_WORKSPACE.with(workspaceInfo.buildScriptCount),
+            BUILD_SCRIPT_DEPENDENCY.with(dependenciesInfo.buildScriptCount),
+            PROC_MACRO_WORKSPACE.with(workspaceInfo.procMacroLibCount),
+            PROC_MACRO_DEPENDENCY.with(dependenciesInfo.procMacroLibCount)
+        )
+        return metrics
+    }
+
+    private data class PackagesInfo(
+        var packageCount: Int = 0,
+        var buildScriptCount: Int = 0,
+        var procMacroLibCount: Int = 0
+    )
+
+    companion object {
+        private val GROUP = EventLogGroup("rust.project", 1)
+
+        private val CARGO_PROJECTS_EVENT = GROUP.registerEvent("cargo_projects", EventFields.Count)
+
+        private val PACKAGES = GROUP.registerEvent("packages",
+            EventFields.Int("workspace"),
+            EventFields.Int("dependency")
+        )
+
+        private val PROC_MACRO_WORKSPACE = EventFields.Int("proc_macro_workspace")
+        private val PROC_MACRO_DEPENDENCY = EventFields.Int("proc_macro_dependency")
+        private val BUILD_SCRIPT_WORKSPACE = EventFields.Int("build_script_workspace")
+        private val BUILD_SCRIPT_DEPENDENCY = EventFields.Int("build_script_dependency")
+
+        private val COMPILE_TIME_TARGETS = GROUP.registerVarargEvent("compile_time_targets",
+            BUILD_SCRIPT_WORKSPACE,
+            BUILD_SCRIPT_DEPENDENCY,
+            PROC_MACRO_WORKSPACE,
+            PROC_MACRO_DEPENDENCY,
+        )
+    }
+}

--- a/src/main/kotlin/org/rust/ide/statistics/RsToolchainUsagesCollector.kt
+++ b/src/main/kotlin/org/rust/ide/statistics/RsToolchainUsagesCollector.kt
@@ -1,0 +1,78 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.statistics
+
+import com.intellij.internal.statistic.beans.MetricEvent
+import com.intellij.internal.statistic.eventLog.EventLogGroup
+import com.intellij.internal.statistic.eventLog.FeatureUsageData
+import com.intellij.internal.statistic.eventLog.events.EventFields
+import com.intellij.internal.statistic.eventLog.events.PrimitiveEventField
+import com.intellij.internal.statistic.service.fus.collectors.ProjectUsagesCollector
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Version
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.settings.toolchain
+import org.rust.cargo.toolchain.RustChannel
+import org.rust.cargo.toolchain.tools.isRustupAvailable
+
+@Suppress("UnstableApiUsage")
+class RsToolchainUsagesCollector : ProjectUsagesCollector() {
+    override fun getGroup(): EventLogGroup = GROUP
+
+    override fun getMetrics(project: Project): Set<MetricEvent> {
+        val metrics = mutableSetOf<MetricEvent>()
+        val cargoProjects = project.cargoProjects.allProjects
+        val rustcVersion = cargoProjects.firstOrNull()?.rustcInfo?.version
+        if (rustcVersion != null) {
+            val version = Version(rustcVersion.semver.major, rustcVersion.semver.minor, rustcVersion.semver.patch)
+            metrics += COMPILER_EVENT.metric(
+                version,
+                rustcVersion.channel,
+                rustcVersion.host
+            )
+        }
+        metrics += RUSTUP_EVENT.metric(project.toolchain?.isRustupAvailable ?: false)
+        // TODO: check wsl toolchains
+        metrics += TYPE_EVENT.metric("local")
+
+        return metrics
+    }
+
+    companion object {
+        private val GROUP = EventLogGroup("rust.toolchain", 1)
+
+        private val VersionByObject = object : PrimitiveEventField<Version?>() {
+            override val name: String = "version"
+            override val validationRule: List<String>
+                get() = listOf("{regexp#version}")
+
+            override fun addData(fuData: FeatureUsageData, value: Version?) {
+                fuData.addVersion(value)
+            }
+        }
+
+        private val COMPILER_EVENT = GROUP.registerEvent("compiler",
+            // BACKCOMPAT: 2020.3. Use `EventFields.VersionByObject` instead and drop our copy
+            VersionByObject,
+            EventFields.Enum<RustChannel>("channel"),
+            EventFields.String("host_target", listOf(
+                "i686-pc-windows-gnu",
+                "i686-pc-windows-msvc",
+                "i686-unknown-linux-gnu",
+                "x86_64-apple-darwin",
+                "x86_64-pc-windows-gnu",
+                "x86_64-pc-windows-msvc",
+                "x86_64-unknown-linux-gnu",
+                "aarch64-unknown-linux-gnu",
+                "aarch64-apple-darwin",
+                "aarch64-pc-windows-msvc"
+            ))
+        )
+
+        private val RUSTUP_EVENT = GROUP.registerEvent("rustup", EventFields.Boolean("used"))
+        private val TYPE_EVENT = GROUP.registerEvent("type", EventFields.String("type", listOf("local", "wsl")))
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1046,6 +1046,10 @@
 
         <!-- Statistics -->
         <fileTypeStatisticProvider implementation="org.rust.ide.statistics.RsFileTypeStatisticProvider"/>
+        <!--suppress PluginXmlValidity -->
+        <statistics.projectUsagesCollector implementation="org.rust.ide.statistics.RsToolchainUsagesCollector"/>
+        <!--suppress PluginXmlValidity -->
+        <statistics.projectUsagesCollector implementation="org.rust.ide.statistics.RsProjectUsagesCollector"/>
 
         <!-- Registry keys -->
 


### PR DESCRIPTION
Provides statistic state collectors to gather info about user toolchains and some general project characteristics.
Note, the corresponding statistics are collected only if `Send usage statistics` option in `Preferences | Appearance & Behavior | System Settings | Data Sharing` settings is enabled. See more about usage statistics politic [here](https://www.jetbrains.com/help/idea/settings-usage-statistics.html)