### PR TITLE
COMP: add custom postfix templates

### DIFF
--- a/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/RsPostfixTemplateProvider.kt
@@ -5,13 +5,22 @@
 
 package org.rust.ide.template.postfix
 
+import com.intellij.codeInsight.template.impl.TemplateSettings
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplate
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateProvider
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateWithExpressionSelector
+import com.intellij.codeInsight.template.postfix.templates.PostfixTemplatesUtils
+import com.intellij.codeInsight.template.postfix.templates.editable.DefaultPostfixTemplateEditor
+import com.intellij.codeInsight.template.postfix.templates.editable.PostfixTemplateEditor
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import org.jdom.Element
 import org.rust.ide.refactoring.introduceVariable.extractExpression
+import org.rust.ide.template.postfix.editable.RsEditablePostfixTemplate
+import org.rust.ide.template.postfix.editable.RsPostfixTemplateEditor
+import org.rust.ide.template.postfix.editable.RsPostfixTemplateExpressionCondition
+import org.rust.lang.RsLanguage
 import org.rust.lang.core.psi.RsExpr
 
 class RsPostfixTemplateProvider : PostfixTemplateProvider {
@@ -51,6 +60,38 @@ class RsPostfixTemplateProvider : PostfixTemplateProvider {
     override fun preCheck(copyFile: PsiFile, realEditor: Editor, currentOffset: Int) = copyFile
 
     override fun preExpand(file: PsiFile, editor: Editor) {
+    }
+
+    override fun getPresentableName(): String = RsLanguage.displayName
+
+    override fun createEditor(templateToEdit: PostfixTemplate?): PostfixTemplateEditor {
+        // forbid editing (overwriting) of built-in templates; default editor allows only renaming
+        if (templateToEdit !is RsEditablePostfixTemplate && templateToEdit != null)
+            return DefaultPostfixTemplateEditor(this, templateToEdit)
+
+        val editor = RsPostfixTemplateEditor(this)
+        editor.setTemplate(templateToEdit)
+        return editor
+    }
+
+    override fun readExternalTemplate(id: String, name: String, template: Element): PostfixTemplate? {
+        val liveTemplate = template.getChild(TemplateSettings.TEMPLATE)?.let {
+            TemplateSettings.readTemplateFromElement("", it, this.javaClass.classLoader)
+        } ?: return null
+
+        val conditions = PostfixTemplatesUtils.readExternalConditions(template) { param ->
+            param?.let { RsPostfixTemplateExpressionCondition.readExternal(it) }
+        }.filterNotNull().toSet()
+
+        val useTopmostExpression = template.getAttributeValue(PostfixTemplatesUtils.TOPMOST_ATTR).toBoolean()
+
+        return RsEditablePostfixTemplate(id, name, liveTemplate.string, "", conditions, useTopmostExpression, this)
+    }
+
+    override fun writeExternalTemplate(template: PostfixTemplate, parentElement: Element) {
+        if (template is RsEditablePostfixTemplate) {
+            PostfixTemplatesUtils.writeExternalTemplate(template, parentElement)
+        }
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/template/postfix/editable/RsEditablePostfixTemplate.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/editable/RsEditablePostfixTemplate.kt
@@ -1,0 +1,81 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.template.postfix.editable
+
+import com.intellij.codeInsight.template.impl.TemplateImpl
+import com.intellij.codeInsight.template.impl.TextExpression
+import com.intellij.codeInsight.template.postfix.templates.PostfixTemplateProvider
+import com.intellij.codeInsight.template.postfix.templates.editable.EditablePostfixTemplateWithMultipleExpressions
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.util.Condition
+import com.intellij.openapi.util.Conditions
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.containers.ContainerUtil
+import org.rust.ide.template.postfix.RsExprParentsSelector
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.psi.RsExprStmt
+
+class RsEditablePostfixTemplate(
+    templateId: String,
+    templateName: String,
+    templateText: String,
+    example: String,
+    expressionTypes: Set<RsPostfixTemplateExpressionCondition>,
+    useTopmostExpression: Boolean,
+    provider: PostfixTemplateProvider
+) : EditablePostfixTemplateWithMultipleExpressions<RsPostfixTemplateExpressionCondition>(
+    templateId, templateName, createTemplate(templateText), example, expressionTypes,
+    useTopmostExpression, provider
+) {
+    override fun getExpressions(context: PsiElement, document: Document, offset: Int): MutableList<PsiElement> {
+        if (DumbService.getInstance(context.project).isDumb) return mutableListOf()
+
+        val allExpressions = RsExprParentsSelector().getExpressions(context, document, offset)
+        val expressions = if (myUseTopmostExpression) {
+            val topmostExpr = allExpressions.maxByOrNull { it.textLength } ?: return mutableListOf()
+            mutableListOf(topmostExpr)
+        } else {
+            allExpressions
+        }
+
+        // accept expression of any type if list is empty (it's default state)
+        if (myExpressionConditions.isEmpty() && context is RsExpr)
+            return expressions.toMutableList()
+
+        return ContainerUtil.filter(expressions, Conditions.and({ e: PsiElement ->
+            (PSI_ERROR_FILTER.value(e) && e is RsExpr && e.textRange.endOffset == offset)
+        }, expressionCompositeCondition))
+    }
+
+    override fun getTopmostExpression(element: PsiElement): PsiElement {
+        return if (element.parent is RsExprStmt) element.parent else element
+    }
+
+    override fun isBuiltin(): Boolean = false
+
+    companion object {
+        private val PSI_ERROR_FILTER =
+            Condition { element: PsiElement? -> element != null && !PsiTreeUtil.hasErrorElements(element) }
+
+        fun createTemplate(templateText: String): TemplateImpl {
+            val template = TemplateImpl("fakeKey", templateText, "")
+            template.isToReformat = false
+            template.parseSegments()
+
+            // turn segments (words surrounded by '$' char) into variables
+            for (i in 0 until template.segmentsCount) {
+                val segmentName = template.getSegmentName(i)
+                val internalName = segmentName == "EXPR" || segmentName == TemplateImpl.ARG || segmentName in TemplateImpl.INTERNAL_VARS_SET
+                if (!internalName)
+                    template.addVariable(segmentName, TextExpression(segmentName), true)
+            }
+
+            return template
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/template/postfix/editable/RsPostfixTemplateEditor.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/editable/RsPostfixTemplateEditor.kt
@@ -1,0 +1,64 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.template.postfix.editable
+
+import com.intellij.codeInsight.template.impl.TemplateEditorUtil
+import com.intellij.codeInsight.template.postfix.settings.PostfixTemplateEditorBase
+import com.intellij.codeInsight.template.postfix.templates.PostfixTemplate
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.ui.Messages
+import com.intellij.util.ui.FormBuilder
+import com.intellij.util.ui.UIUtil
+import org.rust.ide.template.postfix.RsPostfixTemplateProvider
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+open class RsPostfixTemplateEditor(provider: RsPostfixTemplateProvider) :
+    PostfixTemplateEditorBase<RsPostfixTemplateExpressionCondition>(provider, createEditor(), true) {
+
+    var myPanel: JPanel = FormBuilder.createFormBuilder()
+        .addComponentFillVertically(myEditTemplateAndConditionsPanel, UIUtil.DEFAULT_VGAP)
+        .panel
+
+    override fun createTemplate(templateId: String, templateName: String): PostfixTemplate {
+        val types = myExpressionTypesListModel.elements().asSequence().toSet()
+        val templateText = myTemplateEditor.document.text
+        val useTopmostExpression = myApplyToTheTopmostJBCheckBox.isSelected
+
+        return RsEditablePostfixTemplate(templateId, templateName, templateText, "", types, useTopmostExpression, myProvider)
+    }
+
+    override fun getComponent(): JComponent = myPanel
+
+    override fun fillConditions(group: DefaultActionGroup) {
+        for (type in RsPostfixTemplateExpressionCondition.Type.values().filter { it != RsPostfixTemplateExpressionCondition.Type.UserEntered })
+            group.add(AddConditionAction(RsPostfixTemplateExpressionCondition(type)))
+        group.add(EnterCustomTypeNameAction())
+    }
+
+    private inner class EnterCustomTypeNameAction : DumbAwareAction("Enter Type Name...") {
+        override fun actionPerformed(e: AnActionEvent) {
+            val typeName = Messages.showInputDialog(myPanel, "Enter custom type name. Type parameters are not supported.", "Enter Type Name", null)
+            if (typeName != null) {
+                val userEnteredType = RsPostfixTemplateExpressionCondition(RsPostfixTemplateExpressionCondition.Type.UserEntered, typeName)
+                myExpressionTypesListModel.addElement(userEnteredType)
+            }
+        }
+    }
+
+    companion object {
+        fun createEditor(): Editor {
+            val project = ProjectManager.getInstance().defaultProject
+            val document = EditorFactory.getInstance().createDocument("")
+            return TemplateEditorUtil.createEditor(false, document, project)!!
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/template/postfix/editable/RsPostfixTemplateExpressionCondition.kt
+++ b/src/main/kotlin/org/rust/ide/template/postfix/editable/RsPostfixTemplateExpressionCondition.kt
@@ -1,0 +1,110 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.template.postfix.editable
+
+import com.intellij.codeInsight.template.postfix.templates.editable.PostfixTemplateExpressionCondition
+import com.intellij.openapi.util.text.StringUtil
+import org.jdom.Element
+import org.rust.ide.presentation.renderInsertionSafe
+import org.rust.lang.core.psi.RsExpr
+import org.rust.lang.core.types.ty.*
+import org.rust.lang.core.types.type
+import java.util.*
+
+class RsPostfixTemplateExpressionCondition(private val expressionType: Type, private val userEnteredTypeName: String = "") : PostfixTemplateExpressionCondition<RsExpr> {
+    enum class Type {
+        Ref, Slice, Bool, Number, ADT, Array, Tuple, Unit, UserEntered;
+
+        val id: String get() = toString()
+    }
+
+    override fun value(element: RsExpr): Boolean {
+        return when (expressionType) {
+            Type.Ref -> element.type is TyReference
+            Type.Slice -> element.type.stripReferences() is TySlice
+            Type.Bool -> element.type.stripReferences() is TyBool
+            Type.Number -> element.type.stripReferences() is TyNumeric
+            Type.ADT -> element.type.stripReferences() is TyAdt
+            Type.Array -> element.type.stripReferences() is TyArray
+            Type.Tuple -> element.type.stripReferences() is TyTuple
+            Type.Unit -> element.type.stripReferences() is TyUnit
+            Type.UserEntered -> isUserEnteredType(element)
+        }
+    }
+
+    private fun CharSequence.withoutTypeParameters(): String {
+        val sb = StringBuilder(this.length)
+        var depth = 0
+        for (ch in this) {
+            when {
+                ch == '<' -> depth++
+                ch == '>' -> depth--
+                depth == 0 -> sb.append(ch)
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun isUserEnteredType(element: RsExpr): Boolean {
+        val typePathWithoutParams = userEnteredTypeName.withoutTypeParameters()
+        val typePath = typePathWithoutParams.substringBeforeLast("::", "")
+        val typeName = typePathWithoutParams.substringAfterLast("::").filter { !it.isWhitespace() }
+
+        return if (element.type.stripReferences() is TyAdt) {
+            val adtItem = (element.type.stripReferences() as TyAdt).item
+            val adtFullPath = adtItem.containingCrate?.presentableName + adtItem.crateRelativePath
+
+            val useFullPath = typePath.isNotEmpty()
+            if (useFullPath)
+                "$typePath::$typeName" == adtFullPath
+            else
+                typeName == adtItem.name
+        } else {
+            typeName == element.type.renderInsertionSafe(includeTypeArguments = false).filter { !it.isWhitespace() }
+        }
+    }
+
+    override fun getPresentableName(): String {
+        return when (expressionType) {
+            Type.UserEntered -> "Type: $userEnteredTypeName"
+            else -> expressionType.id
+        }
+    }
+
+    override fun getId(): String = expressionType.id
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as RsPostfixTemplateExpressionCondition
+        return expressionType == other.expressionType && userEnteredTypeName == other.userEnteredTypeName
+    }
+
+    override fun hashCode(): Int = Objects.hash(id, userEnteredTypeName)
+
+    override fun serializeTo(element: Element) {
+        super.serializeTo(element) // serialize ID_ATTR
+        element.setAttribute(USER_ENTERED_TYPE_NAME_ATTRIBUTE, userEnteredTypeName)
+    }
+
+    companion object {
+        const val USER_ENTERED_TYPE_NAME_ATTRIBUTE = "Aetna"
+
+        // deserialize expression type
+        fun readExternal(condition: Element): RsPostfixTemplateExpressionCondition? {
+            val id = condition.getAttributeValue(PostfixTemplateExpressionCondition.ID_ATTR)
+            val externalType = Type.values().find { id == it.id } ?: return null
+
+            if (externalType == Type.UserEntered) {
+                val userTypeName = condition.getAttributeValue(USER_ENTERED_TYPE_NAME_ATTRIBUTE)
+                if (StringUtil.isNotEmpty(userTypeName))
+                    return RsPostfixTemplateExpressionCondition(externalType, userTypeName)
+            } else
+                return RsPostfixTemplateExpressionCondition(externalType)
+
+            return null
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/ide/template/postfix/editable/RsEditablePostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/editable/RsEditablePostfixTemplateTest.kt
@@ -1,0 +1,273 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.template.postfix.editable
+
+import com.intellij.codeInsight.template.postfix.settings.PostfixTemplateStorage
+import com.intellij.codeInsight.template.postfix.templates.PostfixLiveTemplate
+import com.intellij.codeInsight.template.postfix.templates.PostfixTemplate
+import com.intellij.codeInsight.template.postfix.templates.editable.PostfixChangedBuiltinTemplate
+import com.intellij.openapi.application.runReadAction
+import com.intellij.util.containers.ContainerUtil
+import org.rust.RsTestBase
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.ide.template.postfix.AssertPostfixTemplate
+import org.rust.ide.template.postfix.RsPostfixTemplateProvider
+import org.rust.singleProject
+import org.rust.ide.template.postfix.editable.RsPostfixTemplateExpressionCondition as TemplateCondition
+
+
+class RsEditablePostfixTemplateTest : RsTestBase() {
+    private val myProvider: RsPostfixTemplateProvider = RsPostfixTemplateProvider()
+
+    fun `test 'template id' after reload`() {
+        val template = RsEditablePostfixTemplate(
+            "myId", "myKey", "", "",
+            emptySet(), true, myProvider
+        )
+        assertEquals("myId", reloadRustTemplate(template).id)
+    }
+
+    fun `test 'template key' after reload`() {
+        val template = RsEditablePostfixTemplate(
+            "myId", "myKey", "", "", emptySet(), true, myProvider
+        )
+        assertEquals(".myKey", reloadRustTemplate(template).key)
+    }
+
+    fun `test attribute 'topmost' after reload`() {
+        var template = RsEditablePostfixTemplate(
+            "myId", "myKey", "", "", emptySet(),
+            true, myProvider
+        )
+        assertTrue(reloadRustTemplate(template).isUseTopmostExpression)
+        template = RsEditablePostfixTemplate("myId", "myKey", "", "", emptySet(), false, myProvider)
+        assertFalse(reloadRustTemplate(template).isUseTopmostExpression)
+    }
+
+    fun `test changed builtin template`() {
+        val customTemplate = RsEditablePostfixTemplate(
+            "myId", "myKey", "", "", emptySet(), true, myProvider
+        )
+
+        val builtinTemplate = AssertPostfixTemplate(myProvider)
+        val template = PostfixChangedBuiltinTemplate(customTemplate, builtinTemplate)
+
+        val reloaded = reloadTemplate(template)
+        assertInstanceOf(reloaded, PostfixChangedBuiltinTemplate::class.java)
+        assertEquals("myId", reloaded.id)
+        assertEquals(template.builtinTemplate.id, (reloaded as PostfixChangedBuiltinTemplate).builtinTemplate.id)
+        assertTrue(reloaded.isBuiltin())
+    }
+
+    fun `test type conditions after reload`() {
+        for (type in TemplateCondition.Type.values().filter { it != TemplateCondition.Type.UserEntered }) {
+            val condition = TemplateCondition(type)
+            assertSameElements(reloadConditions(templateWithCondition(condition)), condition)
+        }
+    }
+
+    fun `test user entered type name condition after reload`() {
+        val condition = TemplateCondition(TemplateCondition.Type.UserEntered, "Test::TypeName")
+        val reloadedConditions = reloadConditions(templateWithCondition(condition))
+        assertSameElements(reloadedConditions, condition)
+    }
+
+    fun `test reload several type conditions at once`() {
+        val conditions = TemplateCondition.Type.values().filter { it != TemplateCondition.Type.UserEntered }
+            .map { TemplateCondition(it) }.toSet()
+        val template = RsEditablePostfixTemplate(
+            "myId", "myKey", "", "", conditions, true, myProvider
+        )
+        assertSameElements(reloadConditions(template), conditions)
+    }
+
+    fun `test $EXPR$ variable marks expression position`() = doTest(
+        """
+            fn main() {
+                let x = 0;
+                x.key<caret>
+            }
+        """, """
+            fn main() {
+                let x = 0;
+                x * xx
+            }
+        """, "key", "\$EXPR\$ * \$EXPR\$\$EXPR\$"
+    )
+
+    fun `test $END$ variable marks last caret position`() = doTest(
+        """
+                fn main() {
+                    10.add<caret>
+                }
+            """, """
+                fn main() {
+                    (10 + <caret>)
+                }
+            """, "add", "(\$EXPR\$ + \$END\$)"
+    )
+
+    fun `test if let template`() = doTest(
+        """
+                fn main() {
+                    enum MyEnum {A, B(i32), C}
+                    let value = MyEnum::B(10);
+                    value.myiflet<caret>
+                }
+            """, """
+                fn main() {
+                    enum MyEnum {A, B(i32), C}
+                    let value = MyEnum::B(10);
+                    if let PAT = value {}
+                }
+            """, "myiflet", "if let \$PAT\$ = \$EXPR\$ {\$END\$}"
+    )
+
+    fun `test template without selected type will work with any type`() {
+        val values = listOf(
+            "true", "123", "\"test string\"", "(1,2,3)", "()", "struct S; S{}", "[1,2,3]",
+            "let s: &[i32] = &[1,2,3][..]; s"
+        )
+
+        for (v in values)
+            checkApplicability(
+                true, "key", """
+                fn main() {
+                    let i = {$v};
+                    i.key<caret>
+                }
+            """, setOf()
+            )
+    }
+
+    fun `test template with one specific type is not applicable to other types`() {
+        val valuesAndTypes = listOf(
+            "true" to TemplateCondition(TemplateCondition.Type.Bool),
+            "123" to TemplateCondition(TemplateCondition.Type.Number),
+            "(1,2,3)" to TemplateCondition(TemplateCondition.Type.Tuple),
+            "()" to TemplateCondition(TemplateCondition.Type.Unit),
+            "struct S; S{}" to TemplateCondition(TemplateCondition.Type.ADT),
+            "[1,2,3]" to TemplateCondition(TemplateCondition.Type.Array),
+            "let s: &[i32] = &[1,2,3][..]; s" to TemplateCondition(TemplateCondition.Type.Slice)
+        )
+
+        for (a in valuesAndTypes)
+            for (b in valuesAndTypes)
+                checkApplicability(
+                    a == b, "key", """
+                    fn main() {
+                        let i = {${b.first}};
+                        i.key<caret>
+                    }
+                """, setOf(a.second)
+                )
+    }
+
+    fun `test template applicable to user entered type`() {
+        val type = TemplateCondition(TemplateCondition.Type.UserEntered, "MyEnum")
+        checkApplicability(
+            true, "key", """
+                enum MyEnum { A, B, C }
+                fn main() {
+                    let e = MyEnum::A;
+                    e.key<caret>
+                }
+            """, setOf(type)
+        )
+        checkApplicability(
+            false, "key", """
+                enum MyEnum2 { A, B, C }
+                fn main() {
+                    let e = MyEnum2::A;
+                    e.key<caret>
+                }
+            """, setOf(type)
+        )
+    }
+
+    fun `test template user entered type with full path`() {
+        val projectName = myFixture.project.cargoProjects.singleProject().presentableName
+        val type = TemplateCondition(TemplateCondition.Type.UserEntered, "${projectName}::myMod::MyEnum")
+        checkApplicability(
+            true, "key", """
+                mod myMod { enum MyEnum { A, B, C } }
+                enum MyEnum { C, B, A }
+
+                fn main() {
+                    let e = myMod::MyEnum::A;
+                    e.key<caret>
+                }
+            """, setOf(type)
+        )
+        checkApplicability(
+            false, "key", """
+                mod myMod { enum MyEnum { A, B, C } }
+                enum MyEnum { C, B, A }
+
+                fn main() {
+                    let e = MyEnum::A;
+                    e.key<caret>
+                }
+            """, setOf(type)
+        )
+    }
+
+    private fun checkApplicability(
+        isApplicable: Boolean, templateName: String, testCase: String,
+        conditions: Set<TemplateCondition> = setOf()
+    ) {
+        InlineFile(testCase).withCaret()
+        createAndRegisterTemplate(templateName, "", conditions)
+
+        val result = runReadAction {
+            PostfixLiveTemplate.isApplicableTemplate(myProvider, ".$templateName", myFixture.file, myFixture.editor)
+        }
+
+        val types = conditions.joinToString { it.presentableName }
+        check(result == isApplicable) {
+            "custom postfix template ${if (types.isNotEmpty()) "with types: '$types' " else ""} " +
+                "${if (isApplicable) "should" else "shouldn't"} be applicable to given case:\n$testCase"
+        }
+    }
+
+    private fun doTest(
+        before: String, after: String, templateName: String, templateText: String,
+        conditions: Set<TemplateCondition> = setOf()
+    ) {
+        createAndRegisterTemplate(templateName, templateText, conditions)
+        checkByText(before.trimIndent(), after.trimIndent()) { myFixture.type("\t") }
+    }
+
+    private fun templateWithCondition(condition: TemplateCondition): RsEditablePostfixTemplate {
+        return RsEditablePostfixTemplate(
+            "myId", "myKey", "", "", setOf(condition), true, myProvider
+        )
+    }
+
+    private fun reloadTemplate(template: PostfixTemplate): PostfixTemplate {
+        val saveStorage = PostfixTemplateStorage()
+        saveStorage.setTemplates(myProvider, listOf(template))
+        val loadStorage = PostfixTemplateStorage.getInstance()
+        loadStorage.loadState(saveStorage.state!!)
+        return ContainerUtil.getFirstItem(loadStorage.getTemplates(myProvider))
+    }
+
+    private fun reloadRustTemplate(template: RsEditablePostfixTemplate): RsEditablePostfixTemplate {
+        return reloadTemplate(template) as RsEditablePostfixTemplate
+    }
+
+    private fun reloadConditions(template: RsEditablePostfixTemplate): Set<TemplateCondition> {
+        return reloadRustTemplate(template).expressionConditions
+    }
+
+    private fun createAndRegisterTemplate(
+        templateName: String, templateText: String,
+        conditions: Set<TemplateCondition> = setOf()
+    ) {
+        val template = RsEditablePostfixTemplate("myId", templateName, templateText, "", conditions, true, myProvider)
+        PostfixTemplateStorage.getInstance().setTemplates(myProvider, setOf(template))
+    }
+}


### PR DESCRIPTION
Short demonstration:
![custom_template_1](https://user-images.githubusercontent.com/8329446/119675803-8e1b6100-be67-11eb-836e-0bd63f25fa99.gif)


Basically, it's the same as custom postfix templates in IDEA for Java or in Goland for Go. You can select several types (bool, number, reference, etc) for an expression which the template would be applicable to. You can also enter the type yourself (like "Vec", "String", or with full path "sdl2::event::Event" ("sdl2" is a crate name). Type parameters are ignored so "Vec" type would be the same as "Vec\<String\>" or "Vec\<Vec\<u32\>\>". In addition, if the type list is empty (it is by default), the template will be applicable to an expression of any type.

There is a limited support for user variables ($val$ in the gif) inside the template text. You can simply 'tab' through them but cannot choose the order. 

Unfortunately, there are no such nice things as "Live Template macros" or "TemplateContext" familiar from regular live templates. And I am not really sure we need them now.

Closes #6823

changelog: Allow users to create their own postfix templates
