### PR TITLE
INSP: Introduce non-shorthand field patterns lint

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -63,7 +63,15 @@ enum class RsLint(
             }
     },
 
-    BareTraitObjects("bare_trait_objects", listOf("rust_2018_idioms"));
+    BareTraitObjects("bare_trait_objects", listOf("rust_2018_idioms")),
+
+    NonShorthandFieldPatterns("non_shorthand_field_patterns") {
+        override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
+            when (level) {
+                WARN -> ProblemHighlightType.WEAK_WARNING
+                else -> super.toHighlightingType(level)
+            }
+    };
 
     protected open fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
         when (level) {

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsNonShorthandFieldPatternsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsNonShorthandFieldPatternsInspection.kt
@@ -1,0 +1,43 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.lang.core.psi.RsPatFieldFull
+import org.rust.lang.core.psi.RsPsiFactory
+import org.rust.lang.core.psi.RsVisitor
+
+class RsNonShorthandFieldPatternsInspection : RsLintInspection() {
+    override fun getLint(element: PsiElement): RsLint = RsLint.NonShorthandFieldPatterns
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
+        override fun visitPatFieldFull(o: RsPatFieldFull) {
+            val identifier = o.identifier?.text ?: return
+            val binding = o.pat.text
+            if (identifier != binding) return
+
+            holder.registerLintProblem(
+                o,
+                "The `$identifier:` in this pattern is redundant",
+                object : LocalQuickFix {
+                    override fun getFamilyName(): String = "Use shorthand field pattern: `$identifier`"
+
+                    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+                        val field = descriptor.psiElement as RsPatFieldFull
+                        val patBinding = RsPsiFactory(field.project).createPatBinding(field.pat.text)
+                        field.parent.addBefore(patBinding, field)
+                        field.delete()
+                    }
+                }
+            )
+        }
+    }
+
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -507,6 +507,11 @@
                          enabledByDefault="true" level="WEAK WARNING"
                          implementationClass="org.rust.ide.inspections.RsFieldInitShorthandInspection"/>
 
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
+                         displayName="Non-shorthand field patterns"
+                         enabledByDefault="true" level="WEAK WARNING"
+                         implementationClass="org.rust.ide.inspections.lints.RsNonShorthandFieldPatternsInspection"/>
+
         <localInspection language="Rust" groupName="Rust"
                          displayName="Assert Equal"
                          enabledByDefault="true" level="WEAK WARNING"

--- a/src/main/resources/inspectionDescriptions/RsNonShorthandFieldPatterns.html
+++ b/src/main/resources/inspectionDescriptions/RsNonShorthandFieldPatterns.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Detects using <code>Struct { x: x }</code> instead of <code>Struct { x }</code> in a pattern.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsBareTraitObjectsInspectionTest.kt
@@ -3,11 +3,11 @@
  * found in the LICENSE file.
  */
 
-package org.rust.ide.inspections
+package org.rust.ide.inspections.lints
 
 import org.rust.MockEdition
 import org.rust.cargo.project.workspace.CargoWorkspace
-import org.rust.ide.inspections.lints.RsBareTraitObjectsInspection
+import org.rust.ide.inspections.RsInspectionsTestBase
 
 @MockEdition(CargoWorkspace.Edition.EDITION_2018)
 class RsBareTraitObjectsInspectionTest : RsInspectionsTestBase(RsBareTraitObjectsInspection::class) {

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsNonShorthandFieldPatternsInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsNonShorthandFieldPatternsInspectionTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class RsNonShorthandFieldPatternsInspectionTest : RsInspectionsTestBase(RsNonShorthandFieldPatternsInspection::class) {
+    fun `test not applicable`() = checkFixIsUnavailable("Use shorthand field pattern: `foo`", """
+        fn main() {
+            match foo {
+                S { foo: bar/*caret*/, baz: &baz } => (),
+            }
+        }
+    """, checkWeakWarn = true)
+
+    fun `test allow non_shorthand_field_patterns`() = checkWarnings("""
+        #[allow(non_shorthand_field_patterns)]
+        fn main() {
+            match foo {
+                S { foo: foo/*caret*/, baz: quux } => (),
+            }
+        }
+    """)
+
+    fun `test deny non_shorthand_field_patterns`() = checkWarnings("""
+        #[deny(non_shorthand_field_patterns)]
+        fn main() {
+            match foo {
+                S { <error descr="The `foo:` in this pattern is redundant">foo: foo/*caret*/</error>, baz: quux } => (),
+            }
+        }
+    """)
+
+    fun `test fix`() = checkFixByText("Use shorthand field pattern: `foo`", """
+        fn main() {
+            match foo {
+                S { <weak_warning descr="The `foo:` in this pattern is redundant">foo: foo/*caret*/</weak_warning>, baz: quux } => (),
+            }
+        }
+    """, """
+        fn main() {
+            match foo {
+                S { foo/*caret*/, baz: quux } => (),
+            }
+        }
+    """, checkWeakWarn = true)
+}


### PR DESCRIPTION
Part of #5888

![image](https://user-images.githubusercontent.com/6342851/117564890-130c2980-b0b7-11eb-9930-c0c62a5d70a4.png)

changelog: Detect and provide quick-fix for [non-shorthand-field-patterns](https://doc.bccnsoft.com/docs/rust-1.36.0-docs-html/rustc/lints/listing/warn-by-default.html#non-shorthand-field-patterns) compiler lint
