### PR TITLE
Fix URL encoding of docs.rs links

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -97,6 +97,7 @@ pasa
 pavel-v-chernykh
 pcholakov
 pocket7878
+punkeel
 rrevenantt
 saaryogev
 sanmai-NL

--- a/toml/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt
@@ -15,8 +15,21 @@ import org.rust.ide.icons.RsIcons
 import org.rust.ide.lineMarkers.RsLineMarkerInfoUtils
 import org.rust.lang.core.psi.ext.elementType
 import org.toml.lang.psi.*
+import java.net.URLEncoder
 
 class CargoCrateDocLineMarkerProvider : LineMarkerProvider {
+    companion object {
+        fun prepareDocsLink(name: String, version: String): String {
+            val urlEncodedVersion = URLEncoder.encode(version, "utf-8");
+            val urlVersion = when {
+                version.isEmpty() -> "*"
+                version.first().isDigit() -> "%5E${urlEncodedVersion}"
+                else -> urlEncodedVersion
+            }
+            return "https://docs.rs/$name/$urlVersion";
+        }
+    }
+
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? = null
 
     override fun collectSlowLineMarkers(elements: List<PsiElement>, result: MutableCollection<in LineMarkerInfo<*>>) {
@@ -47,19 +60,21 @@ class CargoCrateDocLineMarkerProvider : LineMarkerProvider {
     }
 
     private fun genLineMarkerInfo(anchor: PsiElement, name: String, version: String): LineMarkerInfo<PsiElement> {
-        val urlVersion = when {
+        val prettyVersion = when {
             version.isEmpty() -> "*"
             version.first().isDigit() -> "^${version}"
             else -> version
         }
 
+        val docsLink = prepareDocsLink(name, version);
+
         return RsLineMarkerInfoUtils.create(
             anchor,
             anchor.textRange,
             RsIcons.DOCS_MARK,
-            { _, _ -> BrowserUtil.browse("https://docs.rs/$name/$urlVersion") },
+            { _, _ -> BrowserUtil.browse(docsLink) },
             GutterIconRenderer.Alignment.LEFT
-        ) { "Open documentation for `$name@$urlVersion`" }
+        ) { "Open documentation for `$name@$prettyVersion`" }
     }
 }
 

--- a/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
@@ -7,6 +7,7 @@ package org.rust.toml
 
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibAndDependencyRustProjectDescriptor
+import java.net.URL
 
 @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
 class CargoCrateDocLineMarkerProviderTest : CargoTomlLineMarkerProviderTestBase() {
@@ -70,4 +71,28 @@ class CargoCrateDocLineMarkerProviderTest : CargoTomlLineMarkerProviderTestBase(
         [dependencies]
         base64 = "=0.8.0"  # - Open documentation for `base64@=0.8.0`
     """)
+
+    fun `test docs link with semver major`() {
+        val link = CargoCrateDocLineMarkerProvider.prepareDocsLink("abc", "1");
+        assertEquals("https://docs.rs/abc/%5E1", link);
+        assertNotNull(URL(link));
+    }
+
+    fun `test docs link with exact version`() {
+        val link = CargoCrateDocLineMarkerProvider.prepareDocsLink("abc", "=1.2.3");
+        assertEquals("https://docs.rs/abc/%3D1.2.3", link);
+        assertNotNull(URL(link));
+    }
+
+    fun `test docs link with non-semver version`() {
+        val link = CargoCrateDocLineMarkerProvider.prepareDocsLink("abc", "latest");
+        assertEquals("https://docs.rs/abc/latest", link);
+        assertNotNull(URL(link));
+    }
+
+    fun `test docs link with wildcard`() {
+        val link = CargoCrateDocLineMarkerProvider.prepareDocsLink("abc", "*");
+        assertEquals("https://docs.rs/abc/*", link);
+        assertNotNull(URL(link));
+    }
 }


### PR DESCRIPTION
Fixes #7223. Properly encode the `docs.rs` links. Without this fix, the created URL would be passed to BrowserUtil#browse, which _may_ try to parse the URL and fail. This happens for instance when using IntelliJ Projector.

changelog: Fix docs.rs links in IntelliJ Projector (Cargo.toml gutter icon)
