### PR TITLE
QDOC: Make links that look like Rust paths work correctly in quick documentation

### DIFF
--- a/src/main/kotlin/org/rust/lang/doc/RsDocPipeline.kt
+++ b/src/main/kotlin/org/rust/lang/doc/RsDocPipeline.kt
@@ -18,12 +18,12 @@ import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.ast.findChildOfType
 import org.intellij.markdown.ast.getTextInNode
 import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
-import org.intellij.markdown.html.GeneratingProvider
-import org.intellij.markdown.html.HtmlGenerator
-import org.intellij.markdown.html.SimpleTagProvider
+import org.intellij.markdown.html.*
+import org.intellij.markdown.html.entities.EntityConverter
 import org.intellij.markdown.parser.LinkMap
 import org.intellij.markdown.parser.MarkdownParser
 import org.rust.cargo.util.AutoInjectedCrates.STD
@@ -137,6 +137,18 @@ private class RustDocMarkdownFlavourDescriptor(
         generatingProviders[MarkdownElementTypes.ATX_1] = SimpleTagProvider("h2")
         generatingProviders[MarkdownElementTypes.ATX_2] = SimpleTagProvider("h3")
         generatingProviders[MarkdownElementTypes.CODE_FENCE] = RsCodeFenceProvider(context, renderMode)
+
+        val (resolveAnchors, useSafeLinks) = true to true
+        generatingProviders[MarkdownElementTypes.SHORT_REFERENCE_LINK] = RsReferenceLinksGeneratingProvider(
+            context, linkMap, uri ?: baseURI, resolveAnchors, useSafeLinks
+        )
+        generatingProviders[MarkdownElementTypes.FULL_REFERENCE_LINK] = RsReferenceLinksGeneratingProvider(
+            context, linkMap, uri ?: baseURI, resolveAnchors, useSafeLinks
+        )
+        generatingProviders[MarkdownElementTypes.INLINE_LINK] = RsInlineLinkGeneratingProvider(
+            context, uri ?: baseURI, resolveAnchors, useSafeLinks
+        )
+
         return generatingProviders
     }
 }
@@ -240,4 +252,82 @@ private class RsCodeFenceProvider(
 enum class RsDocRenderMode {
     QUICK_DOC_POPUP,
     INLINE_DOC_COMMENT
+}
+
+
+// heavily inspired by and mostly copied from org.intellij.markdown.html.LinkGeneratingProvider
+abstract class RsLinkGeneratingProvider(val context: PsiElement, val baseURI: URI?, val resolveAnchors: Boolean = false, val useSafeLinks: Boolean = true) : GeneratingProvider {
+    final override fun processNode(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
+        var info = getRenderInfo(text, node) ?: return fallbackProvider.processNode(visitor, text, node)
+
+        // ignore safety for rust paths as `makeXssSafeDestination` may break them
+        if (useSafeLinks && !info.destination.isProbablyValidRustPath())
+            info = info.copy(destination = makeXssSafeDestination(info.destination))
+
+        renderLink(visitor, text, node, info)
+    }
+
+    fun CharSequence.isProbablyValidRustPath(): Boolean {
+        return RsPsiFactory(context.project).tryCreatePath(this.toString()) != null
+    }
+
+    private fun makeAbsoluteUrl(destination: CharSequence): CharSequence {
+        if (!resolveAnchors && destination.startsWith('#')) {
+            return destination
+        }
+
+        if (destination.isProbablyValidRustPath())
+            return "${DocumentationManagerProtocol.PSI_ELEMENT_PROTOCOL}$destination"
+
+        return baseURI?.resolveToStringSafe(destination.toString()) ?: destination
+    }
+
+    open fun renderLink(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode, info: RenderInfo) {
+        visitor.consumeTagOpen(node, "a", "href=\"${makeAbsoluteUrl(info.destination)}\"", info.title?.let { "title=\"$it\"" })
+        labelProvider.processNode(visitor, text, info.label)
+        visitor.consumeTagClose("a")
+    }
+
+    abstract fun getRenderInfo(text: String, node: ASTNode): RenderInfo?
+
+    data class RenderInfo(val label: ASTNode, val destination: CharSequence, val title: CharSequence?)
+
+    companion object {
+        val fallbackProvider = TransparentInlineHolderProvider()
+        val labelProvider = TransparentInlineHolderProvider(1, -1)
+    }
+}
+
+open class RsReferenceLinksGeneratingProvider(
+    context: PsiElement, private val linkMap: LinkMap, baseURI: URI?, resolveAnchors: Boolean = false, useSafeLinks: Boolean = true
+) : RsLinkGeneratingProvider(context, baseURI, resolveAnchors, useSafeLinks) {
+    override fun getRenderInfo(text: String, node: ASTNode): RenderInfo? {
+        val label = node.children.firstOrNull { it.type == MarkdownElementTypes.LINK_LABEL }
+            ?: return null
+        val linkInfo = linkMap.getLinkInfo(label.getTextInNode(text))
+            ?: return null
+        val linkTextNode = node.children.firstOrNull { it.type == MarkdownElementTypes.LINK_TEXT }
+
+        return RenderInfo(
+            linkTextNode ?: label,
+            EntityConverter.replaceEntities(linkInfo.destination, processEntities = true, processEscapes = true),
+            linkInfo.title?.let { EntityConverter.replaceEntities(it, processEntities = true, processEscapes = true) }
+        )
+    }
+}
+
+open class RsInlineLinkGeneratingProvider(
+    context: PsiElement, baseURI: URI?, resolveAnchors: Boolean = false, useSafeLinks: Boolean = true
+) : RsLinkGeneratingProvider(context, baseURI, resolveAnchors, useSafeLinks) {
+    override fun getRenderInfo(text: String, node: ASTNode): RenderInfo? {
+        val label = node.findChildOfType(MarkdownElementTypes.LINK_TEXT) ?: return null
+        return RenderInfo(label,
+            node.findChildOfType(MarkdownElementTypes.LINK_DESTINATION)?.getTextInNode(text)?.let {
+                LinkMap.normalizeDestination(it, true)
+            } ?: "",
+            node.findChildOfType(MarkdownElementTypes.LINK_TITLE)?.getTextInNode(text)?.let {
+                LinkMap.normalizeTitle(it)
+            }
+        )
+    }
 }

--- a/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsQuickDocumentationTest.kt
@@ -713,7 +713,7 @@ class RsQuickDocumentationTest : RsDocumentationProviderTest() {
         <div class='definition'><pre>test_package::Bar
         </pre></div>
         <div class='content'><p>Outer doc
-        <a href="psi_element://test_package/Foo">link</a></p></div>
+        <a href="psi_element://Foo">link</a></p></div>
     """)
 
     fun `test qualified name`() = doTest("""

--- a/src/test/kotlin/org/rust/ide/docs/RsRenderedDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsRenderedDocumentationTest.kt
@@ -105,6 +105,42 @@ class RsRenderedDocumentationTest : RsDocumentationProviderTest() {
         reference (eg: <code>foo.as_ref()</code> will work the same if <code>foo</code> has type <code>&amp;mut Foo</code> or <code>&amp;&amp;mut Foo</code>)</li></ul>
     """)
 
+    fun `test rust identifier as inline link`() = doTest("""
+        /// [link](Result)
+        fn main() {}
+           //^
+    """,
+        """<p><a href="psi_element://Result">link</a></p>"""
+    )
+
+    fun `test rust path as inline link`() = doTest("""
+        /// [link](caret::io::Result)
+        fn main() {}
+           //^
+    """,
+        """<p><a href="psi_element://caret::io::Result">link</a></p>"""
+    )
+
+    fun `test rust identifier as reference link`() = doTest("""
+        /// [my link][ref]
+        ///
+        /// [ref]: MyType
+        fn main() {}
+           //^
+    """,
+        """<p><a href="psi_element://MyType">my link</a></p>"""
+    )
+
+    fun `test rust path as reference link 2`() = doTest("""
+        /// [my link][ref]
+        ///
+        /// [ref]: Long::Path::For::MyType
+        fn main() {}
+           //^
+    """,
+        """<p><a href="psi_element://Long::Path::For::MyType">my link</a></p>"""
+    )
+
     private fun doTest(@Language("Rust") code: String, @Language("Html") expected: String?) {
         doTest(code, expected) { originalItem, _ ->
             (originalItem as? RsDocAndAttributeOwner)


### PR DESCRIPTION
changelog: Make links that look like Rust identifiers or paths (e.g., A, A::B, A::B::C) work correctly in quick documentation by prepending `psi_element://` to them. It fixes #7209
Now clickable links inside stdlib docs should work properly. 

![0RV6H6R3Km](https://user-images.githubusercontent.com/8329446/118520792-90453780-b764-11eb-97d7-e2fba761adef.gif)

There is just a few lines of my code, but to write them I had to copy three classes from `org.intellij.markdown.html.LinkGeneratingProvider`. I used `RsPsiFactory.tryCreatePath()` to check if a link is a valid Rust path, but I am not sure how it is performance-wise. Probably I should replace it with some quick and simple check?

Also, I had to change one test, but it was incorrect anyway (the test itself passed, but the link didn't work when I checked it manually in IDE)
