### PR TITLE
STUB: stub macro definitions and stub macro calls in code blocks if the block is stubbed 

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -70,7 +70,7 @@ class RsFileStub(
     override fun getType() = Type
 
     object Type : IStubFileElementType<RsFileStub>(RsLanguage) {
-        private const val STUB_VERSION = 212
+        private const val STUB_VERSION = 213
 
         // Bump this number if Stub structure changes
         override fun getStubVersion(): Int = RustParserDefinition.PARSER_VERSION + STUB_VERSION
@@ -1535,7 +1535,8 @@ class RsMacroCallStub(
     object Type : RsStubElementType<RsMacroCallStub, RsMacroCall>("MACRO_CALL") {
         override fun shouldCreateStub(node: ASTNode): Boolean {
             val parent = node.treeParent.elementType
-            return parent in RS_MOD_OR_FILE || parent == MEMBERS || parent == MACRO_EXPR && createStubIfParentIsStub(node)
+            return parent in RS_MOD_OR_FILE || parent == MEMBERS ||
+                (parent == MACRO_EXPR || parent == BLOCK) && createStubIfParentIsStub(node)
         }
 
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =

--- a/src/test/kotlin/org/rust/lang/core/stubs/RsLazyBlockStubCreationTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/stubs/RsLazyBlockStubCreationTest.kt
@@ -26,6 +26,22 @@ class RsLazyBlockStubCreationTest : RsLazyBlockStubCreationTestBase() {
         }
     """)
 
+    fun `test macro_rules`() = doTest("""
+    //- main.rs
+        fn main() {
+            macro_rules! foo {}
+        }
+    """)
+
+    fun `test nested macro_rules`() = doTest("""
+    //- main.rs
+        fn main() {
+            {
+                macro_rules! foo {}
+            };
+        }
+    """)
+
     private fun doTest(@Language("Rust") fileTreeText: String) {
         fileTreeFromText(fileTreeText).create()
         checkRustFiles(myFixture.findFileInTempDir("."), emptyList())

--- a/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt
@@ -234,7 +234,32 @@ class RsStubTest : RsTestBase() {
                 STRUCT_ITEM:RsStructItemStub
     """)
 
-    fun `test expressions are stubbed inside function local module`() = doTest("""
+    fun `test macro call is not stubbed inside a code block without items`() = doTest("""
+        fn foo() {
+            bar!();
+        }
+    """, """
+        RsFileStub
+          FUNCTION:RsFunctionStub
+            VALUE_PARAMETER_LIST:RsPlaceholderStub
+    """)
+
+    fun `test macro call is stubbed inside a stubbed code block`() = doTest("""
+        fn foo() {
+            bar!();
+            struct S;
+        }
+    """, """
+        RsFileStub
+          FUNCTION:RsFunctionStub
+            VALUE_PARAMETER_LIST:RsPlaceholderStub
+            BLOCK:RsPlaceholderStub
+              MACRO_CALL:RsMacroCallStub
+                PATH:RsPathStub
+              STRUCT_ITEM:RsStructItemStub
+    """)
+
+    fun `test macro call is stubbed inside function local module`() = doTest("""
         fn foo() {
             mod bar {
                 include!("a.rs");
@@ -252,7 +277,7 @@ class RsStubTest : RsTestBase() {
                     LIT_EXPR:RsLitExprStub
     """)
 
-    fun `test expressions are stubs inside file`() = doTest("""
+    fun `test macro call is stubbed inside a file`() = doTest("""
         include!("foo.rs");
     """, """
         RsFileStub

--- a/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/stubs/RsStubTest.kt
@@ -303,6 +303,32 @@ class RsStubTest : RsTestBase() {
                   PATH:RsPathStub
     """)
 
+    fun `test local macro definition is stubbed`() = doTest("""
+        fn foo() {
+            macro_rules! foo {}
+        }
+    """, """
+        RsFileStub
+          FUNCTION:RsFunctionStub
+            VALUE_PARAMETER_LIST:RsPlaceholderStub
+            BLOCK:RsPlaceholderStub
+              MACRO:RsMacroStub
+    """)
+
+    fun `test local macro definition is stubbed in a nested block, but the block is not stubbed`() = doTest("""
+        fn foo() {
+            {
+                macro_rules! foo {}
+            };
+        }
+    """, """
+        RsFileStub
+          FUNCTION:RsFunctionStub
+            VALUE_PARAMETER_LIST:RsPlaceholderStub
+            BLOCK:RsPlaceholderStub
+              MACRO:RsMacroStub
+    """)
+
     private fun doTest(@Language("Rust") code: String, expectedStubText: String) {
         val fileName = "main.rs"
         fileTreeFromText("//- $fileName\n$code").create()


### PR DESCRIPTION
We need this because `RsItemsOwner.itemsAndMacros` should
behave identically on stubs and on AST. Otherwise, it leads to
weird flaky bugs. This fixes the regression in #7194

Also, macro definitions should be available in symbol search as well as other
items. So they should be stubbed and indexed, even local ones

changelog: FEATURE: Add local macro definitions to `symbol search`. FIX: Fix possible flaky false positives around local macro calls
