### PR TITLE
PSI: implement missed getContext() for macro definitions

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import org.rust.ide.icons.RsIcons
+import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.macros.decl.MacroGraph
 import org.rust.lang.core.macros.decl.MacroGraphBuilder
 import org.rust.lang.core.psi.*
@@ -45,6 +46,8 @@ abstract class RsMacroImplMixin : RsStubbedNamedElementImpl<RsMacroStub>,
         modificationTracker.incModificationCount()
         return false // force rustStructureModificationTracker to be incremented
     }
+
+    override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 }
 
 /** "macro_rules" identifier of `macro_rules! foo {}`; guaranteed to be non-null by the grammar */

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro2.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsMacro2.kt
@@ -6,8 +6,10 @@
 package org.rust.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
 import org.rust.ide.icons.RsIcons
+import org.rust.lang.core.macros.RsExpandedElement
 import org.rust.lang.core.psi.RsMacro2
 import org.rust.lang.core.psi.RsPsiImplUtil
 import org.rust.lang.core.stubs.RsMacro2Stub
@@ -23,4 +25,6 @@ abstract class RsMacro2ImplMixin : RsStubbedNamedElementImpl<RsMacro2Stub>,
     override fun getIcon(flags: Int): Icon? = RsIcons.MACRO
 
     override val crateRelativePath: String? get() = RsPsiImplUtil.crateRelativePath(this)
+
+    override fun getContext(): PsiElement? = RsExpandedElement.getContextImpl(this)
 }


### PR DESCRIPTION
I'm not sure what this fixes for uses, but obviously this method was just missed