### PR TITLE
T: check urls for crate documentation line markers

### DIFF
--- a/src/test/kotlin/org/rust/ide/MockBrowserLauncher.kt
+++ b/src/test/kotlin/org/rust/ide/MockBrowserLauncher.kt
@@ -1,0 +1,49 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide
+
+import com.intellij.ide.browsers.BrowserLauncher
+import com.intellij.ide.browsers.WebBrowser
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.replaceService
+import java.io.File
+import java.nio.file.Path
+
+class MockBrowserLauncher : BrowserLauncher() {
+
+    var lastFile: File? = null
+    var lastPath: Path? = null
+    var lastUrl: String? = null
+
+    override fun browse(file: File) {
+        lastFile = file
+    }
+
+    override fun browse(file: Path) {
+        lastPath = file
+    }
+
+    override fun browse(url: String, browser: WebBrowser?, project: Project?) {
+        lastUrl = url
+    }
+
+    override fun browseUsingPath(
+        url: String?,
+        browserPath: String?,
+        browser: WebBrowser?,
+        project: Project?,
+        openInNewWindow: Boolean,
+        additionalParameters: Array<String>
+    ): Boolean = false
+
+    override fun open(url: String) {}
+
+    fun replaceService(disposable: Disposable) {
+        ApplicationManager.getApplication().replaceService(BrowserLauncher::class.java, this, disposable)
+    }
+}

--- a/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
@@ -5,69 +5,96 @@
 
 package org.rust.toml
 
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl
+import com.intellij.psi.PsiElement
+import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibAndDependencyRustProjectDescriptor
+import org.rust.ide.MockBrowserLauncher
+import org.rust.ide.lineMarkers.invokeNavigationHandler
 
 @ProjectDescriptor(WithStdlibAndDependencyRustProjectDescriptor::class)
 class CargoCrateDocLineMarkerProviderTest : CargoTomlLineMarkerProviderTestBase() {
-    fun `test standard version`() = doTestByText("""
+    fun `test standard version`() = doTest("""
         [dependencies]
         base64 = "0.8.0"  # - Open documentation for `base64@^0.8.0`
 
         [target.'cfg(unix)'.dependencies]
         base64 = "0.8.0"  # - Open documentation for `base64@^0.8.0`
-    """)
+    """, "https://docs.rs/base64/^0.8.0", "https://docs.rs/base64/^0.8.0")
 
-    fun `test platform specific`() = doTestByText("""
+    fun `test platform specific`() = doTest("""
         [target.'cfg(unix)'.dependencies]
         base64 = "0.8.0"  # - Open documentation for `base64@^0.8.0`
-    """)
+    """, "https://docs.rs/base64/^0.8.0")
 
-    fun `test standard detailed`() = doTestByText("""
+    fun `test standard detailed`() = doTest("""
         [dependencies]
         jquery = { version = "1.0.2", optional = true }  # - Open documentation for `jquery@^1.0.2`
-    """)
+    """, "https://docs.rs/jquery/^1.0.2")
 
-    fun `test standard dev`() = doTestByText("""
+    fun `test standard dev`() = doTest("""
         [dev-dependencies]
         libc = "0.2.33"  # - Open documentation for `libc@^0.2.33`
-    """)
+    """, "https://docs.rs/libc/^0.2.33")
 
-    fun `test standard build`() = doTestByText("""
+    fun `test standard build`() = doTest("""
         [build-dependencies]
         libc = "0.2.33"  # - Open documentation for `libc@^0.2.33`
-    """)
+    """, "https://docs.rs/libc/^0.2.33")
 
-    fun `test specific crate`() = doTestByText("""
+    fun `test specific crate`() = doTest("""
         [dependencies.clap]  # - Open documentation for `clap@^2.27.1`
         version = "2.27.1"
-    """)
+    """, "https://docs.rs/clap/^2.27.1")
 
-    fun `test no link to doc`() = doTestByText("""
+    fun `test no link to doc`() = doTest("""
         [dependencies]
         hello_utils = { path = "hello_utils" }
     """)
 
-    fun `test renamed dependencies`() = doTestByText("""
+    fun `test renamed dependencies`() = doTest("""
         [dependencies]
         config_rs = { package = "config", version = "0.9" }  # - Open documentation for `config@^0.9`
-    """)
+    """, "https://docs.rs/config/^0.9")
 
-    fun `test unescape string literals`() = doTestByText("""
+    fun `test unescape string literals`() = doTest("""
         [dependencies]
         serde = '1.0.104'  # - Open documentation for `serde@^1.0.104`
         serde_json = { version = '''1.0.104''' }  # - Open documentation for `serde_json@^1.0.104`
         serde_yaml_rs = { package = 'serde_yaml', version = '''0.8.11''' }  # - Open documentation for `serde_yaml@^0.8.11`
         serde_derive_rs = { package = "serde\u005Fderive", version ="1\u002E0\u002E104" }  # - Open documentation for `serde_derive@^1.0.104`
-    """)
+    """, "https://docs.rs/serde/^1.0.104",
+        "https://docs.rs/serde_json/^1.0.104",
+        "https://docs.rs/serde_yaml/^0.8.11",
+        "https://docs.rs/serde_derive/^1.0.104"
+    )
 
-    fun `test empty version`() = doTestByText("""
+    fun `test empty version`() = doTest("""
         [dependencies]
         base64 = ""  # - Open documentation for `base64@*`
-    """)
+    """, "https://docs.rs/base64/*")
 
-    fun `test exact version`() = doTestByText("""
+    fun `test exact version`() = doTest("""
         [dependencies]
         base64 = "=0.8.0"  # - Open documentation for `base64@=0.8.0`
-    """)
+    """, "https://docs.rs/base64/=0.8.0")
+
+    private fun doTest(@Language("Toml") source: String, vararg expectedUrls: String) {
+        doTestByText(source)
+
+        val launcher = MockBrowserLauncher()
+        launcher.replaceService(testRootDisposable)
+
+        @Suppress("UNCHECKED_CAST")
+        val markers = DaemonCodeAnalyzerImpl.getLineMarkers(myFixture.editor.document, project) as List<LineMarkerInfo<PsiElement>>
+
+        val actualUrls = mutableListOf<String>()
+        for (marker in markers) {
+            marker.invokeNavigationHandler(marker.element)
+            actualUrls += launcher.lastUrl!!
+        }
+        assertEquals(expectedUrls.toList(), actualUrls)
+    }
 }


### PR DESCRIPTION
These changes provide test infrastructure (including `MockBrowserLauncher`) to check documentation url that the plugin uses to open in browser.
Required for #7224