### PR TITLE
Complete "tests" to cfg test mod tests

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -112,6 +112,7 @@ snpefk
 sohich
 SomeoneToIgnore
 srjek
+stepancheg
 stigger
 Stzx
 t-kameyama

--- a/src/main/resources/org/rust/ide/liveTemplates/test.xml
+++ b/src/main/resources/org/rust/ide/liveTemplates/test.xml
@@ -18,6 +18,17 @@
     </template>
 
     <!-- TODO: Convert this to Generate... action -->
+    <template name="tests" description="test module" toReformat="false" toShortenFQNames="true"
+              value="#[cfg(test)]&#10;mod tests {&#10;    $END$&#10;}">
+        <context>
+            <option name="RUST_STATEMENT" value="false"/>
+            <option name="RUST_ITEM" value="false"/>
+            <option name="RUST_STATEMENT" value="false"/>
+            <option name="RUST_MOD" value="true"/>
+        </context>
+    </template>
+
+    <!-- TODO: Convert this to Generate... action -->
     <template name="tfn" description="test function" toReformat="false" toShortenFQNames="true"
               value="#[test]&#10;fn $NAME$() {&#10;    $END$&#10;}">
         <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true"/>

--- a/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/RsLiveTemplatesTest.kt
@@ -119,6 +119,15 @@ class RsLiveTemplatesTest : RsTestBase() {
         }
     """)
 
+    fun `test test available in file`() = expandSnippet("""
+        tests/*caret*/
+    """, """
+        #[cfg(test)]
+        mod tests {
+        $indent/*caret*/
+        }
+    """)
+
     fun `test module level context not available in function`() = noSnippet("""
         fn foo() {
             x.tfn/*caret*/


### PR DESCRIPTION
Expand `tests` as:

```
#[cfg(test)]
mod tests {
}
```

There's no convention to place tests into `tests` module, but Rust
by Example book uses it:
https://doc.rust-lang.org/stable/rust-by-example/testing/unit_testing.html

changelog: complete `test` to `#[cfg(test)] mod tests {}`
