### PR TITLE
fix highlighting variables//default to actually highlight variables only

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -62,6 +62,7 @@ king6cong
 Kobzol
 kumbayo
 la10736
+LastExceed
 LiamClark
 Litarvan
 lundibundi

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -181,7 +181,7 @@ private fun colorFor(element: RsElement): RsColor? = when (element) {
     is RsModDeclItem -> RsColor.MODULE
     is RsMod -> if (element.isCrateRoot) RsColor.CRATE else RsColor.MODULE
     is RsPatBinding -> {
-        if (element.ancestorStrict<RsValueParameter>() != null) RsColor.PARAMETER else RsColor.IDENTIFIER
+        if (element.ancestorStrict<RsValueParameter>() != null) RsColor.PARAMETER else RsColor.VARIABLE
     }
     is RsStructItem -> when (element.kind) {
         RsStructKind.STRUCT -> RsColor.STRUCT

--- a/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsHighlightingAnnotator.kt
@@ -181,7 +181,7 @@ private fun colorFor(element: RsElement): RsColor? = when (element) {
     is RsModDeclItem -> RsColor.MODULE
     is RsMod -> if (element.isCrateRoot) RsColor.CRATE else RsColor.MODULE
     is RsPatBinding -> {
-        if (element.ancestorStrict<RsValueParameter>() != null) RsColor.PARAMETER else null
+        if (element.ancestorStrict<RsValueParameter>() != null) RsColor.PARAMETER else RsColor.IDENTIFIER
     }
     is RsStructItem -> when (element.kind) {
         RsStructKind.STRUCT -> RsColor.STRUCT

--- a/src/main/kotlin/org/rust/ide/colors/RsColors.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RsColors.kt
@@ -15,7 +15,7 @@ import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Default
  * See [RsColorSettingsPage] and [org.rust.ide.highlight.RsHighlighter]
  */
 enum class RsColor(humanName: String, default: TextAttributesKey? = null) {
-    IDENTIFIER("Variables//Default", Default.IDENTIFIER),
+    VARIABLE("Variables//Default", Default.IDENTIFIER),
     MUT_BINDING("Variables//Mutable binding", Default.IDENTIFIER),
     FIELD("Variables//Field", Default.INSTANCE_FIELD),
     CONSTANT("Variables//Constant", Default.CONSTANT),

--- a/src/main/kotlin/org/rust/ide/highlight/RsHighlighter.kt
+++ b/src/main/kotlin/org/rust/ide/highlight/RsHighlighter.kt
@@ -27,9 +27,6 @@ class RsHighlighter : SyntaxHighlighterBase() {
 
     companion object {
         fun map(tokenType: IElementType): RsColor? = when (tokenType) {
-            IDENTIFIER -> RsColor.IDENTIFIER
-            UNDERSCORE -> RsColor.IDENTIFIER
-
             QUOTE_IDENTIFIER -> RsColor.LIFETIME
 
             CHAR_LITERAL -> RsColor.CHAR

--- a/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsHighlightingAnnotatorTest.kt
@@ -153,12 +153,12 @@ class RsHighlightingAnnotatorTest : RsAnnotatorTestBase(RsHighlightingAnnotator:
 
     fun `test primitive`() = checkByText("""
         fn <FUNCTION>main</FUNCTION>() -> <PRIMITIVE_TYPE>bool</PRIMITIVE_TYPE> {
-            let a: <PRIMITIVE_TYPE>u8</PRIMITIVE_TYPE> = 42;
-            let b: <PRIMITIVE_TYPE>f32</PRIMITIVE_TYPE> = <NUMBER>10.0</NUMBER>;
-            let c: &<PRIMITIVE_TYPE>str</PRIMITIVE_TYPE> = "example";
+            let <VARIABLE>a</VARIABLE>: <PRIMITIVE_TYPE>u8</PRIMITIVE_TYPE> = 42;
+            let <VARIABLE>b</VARIABLE>: <PRIMITIVE_TYPE>f32</PRIMITIVE_TYPE> = <NUMBER>10.0</NUMBER>;
+            let <VARIABLE>c</VARIABLE>: &<PRIMITIVE_TYPE>str</PRIMITIVE_TYPE> = "example";
             <PRIMITIVE_TYPE>char</PRIMITIVE_TYPE>::is_lowercase('a');
-            let mut i32 = 1;
-            i32 = 2;
+            let mut <VARIABLE>i32</VARIABLE> = 1;
+            <VARIABLE>i32</VARIABLE> = 2;
             true
         }
     """)

--- a/src/test/kotlin/org/rust/ide/docs/RsCodeHighlightingInQuickDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsCodeHighlightingInQuickDocumentationTest.kt
@@ -32,9 +32,9 @@ class RsCodeHighlightingInQuickDocumentationTest : RsDocumentationProviderTest()
     """, """
         <div class='definition'><pre>test_package
         fn <b>add_one</b>(x: i32) -&gt; i32</pre></div>
-        <div class='content'><p>Adds one to the number given.</p><h2>Examples</h2><pre style="..."><span style="...">let </span><span style="...">five </span><span style="...">= </span><span style="...">5</span><span style="...">;</span>
+        <div class='content'><p>Adds one to the number given.</p><h2>Examples</h2><pre style="..."><span style="...">let </span><span style="...">five = </span><span style="...">5</span><span style="...">;</span>
 
-        <span style="...">assert_eq</span><span style="...">!(</span><span style="...">6</span><span style="...">, </span><span style="...">add_one</span><span style="...">(</span><span style="...">5</span><span style="...">));</span>
+        <span style="...">assert_eq!(</span><span style="...">6</span><span style="...">, add_one(</span><span style="...">5</span><span style="...">));</span>
         </pre>
         </div>
     """)
@@ -87,15 +87,15 @@ class RsCodeHighlightingInQuickDocumentationTest : RsDocumentationProviderTest()
         pub trait <b>AsRef</b>&lt;T: ?<a href="psi_element://Sized">Sized</a>&gt;</pre></div>
         <div class='content'><p>A cheap, reference-to-reference conversion.</p><p><code>AsRef</code> is very similar to, but different than, <code>Borrow</code>. See
         <a href="psi_element://../book/borrow-and-asref.html">the book</a> for more.</p><p><strong>Note: this trait must not fail</strong>. If the conversion can fail, use a dedicated method which
-        returns an <code>Option&lt;T&gt;</code> or a <code>Result&lt;T, E&gt;</code>.</p><h2>Examples</h2><p>Both <code>String</code> and <code>&amp;str</code> implement <code>AsRef&lt;str&gt;</code>:</p><pre style="..."><span style="...">fn </span><span style="...">is_hello</span><span style="...">&lt;</span><span style="...">T</span><span style="...">: </span><span style="...">AsRef</span><span style="...">&lt;</span><span style="...">str</span><span style="...">&gt;&gt;(</span><span style="...">s</span><span style="...">: </span><span style="...">T</span><span style="...">) {</span>
-           <span style="...">assert_eq</span><span style="...">!(</span><span style="...">&quot;hello&quot;</span><span style="...">, </span><span style="...">s</span><span style="...">.</span><span style="...">as_ref</span><span style="...">());</span>
+        returns an <code>Option&lt;T&gt;</code> or a <code>Result&lt;T, E&gt;</code>.</p><h2>Examples</h2><p>Both <code>String</code> and <code>&amp;str</code> implement <code>AsRef&lt;str&gt;</code>:</p><pre style="..."><span style="...">fn </span><span style="...">is_hello&lt;T: AsRef&lt;str&gt;&gt;(s: T) {</span>
+           <span style="...">assert_eq!(</span><span style="...">&quot;hello&quot;</span><span style="...">, s.as_ref());</span>
         <span style="...">}</span>
 
-        <span style="...">let </span><span style="...">s </span><span style="...">= </span><span style="...">&quot;hello&quot;</span><span style="...">;</span>
-        <span style="...">is_hello</span><span style="...">(</span><span style="...">s</span><span style="...">);</span>
+        <span style="...">let </span><span style="...">s = </span><span style="...">&quot;hello&quot;</span><span style="...">;</span>
+        <span style="...">is_hello(s);</span>
 
-        <span style="...">let </span><span style="...">s </span><span style="...">= </span><span style="...">&quot;hello&quot;</span><span style="...">.</span><span style="...">to_string</span><span style="...">();</span>
-        <span style="...">is_hello</span><span style="...">(</span><span style="...">s</span><span style="...">);</span>
+        <span style="...">let </span><span style="...">s = </span><span style="...">&quot;hello&quot;</span><span style="...">.to_string();</span>
+        <span style="...">is_hello(s);</span>
         </pre>
         <h2>Generic Impls</h2><ul><li><code>AsRef</code> auto-dereference if the inner type is a reference or a mutable
         reference (eg: <code>foo.as_ref()</code> will work the same if <code>foo</code> has type <code>&amp;mut Foo</code> or <code>&amp;&amp;mut Foo</code>)</li></ul></div>
@@ -122,11 +122,11 @@ class RsCodeHighlightingInQuickDocumentationTest : RsDocumentationProviderTest()
     """, """
         <div class='definition'><pre>test_package
         struct <b>Foo</b></pre></div>
-        <div class='content'><p>Some doc.</p><h2>Example</h2><pre style="..."><span style="...">#[</span><span style="...">attr1</span><span style="...">]</span>
-        <span style="...">#[</span><span style="...">attr2</span><span style="...">]</span>
-        <span style="...">#[</span><span style="...">attr3</span><span style="...">]</span>
-        <span style="...">let </span><span style="...">foo </span><span style="...">= </span><span style="...">Foo</span><span style="...">;</span>
-           <span style="...">let </span><span style="...">foo4 </span><span style="...">= </span><span style="...">Foo</span><span style="...">;</span>
+        <div class='content'><p>Some doc.</p><h2>Example</h2><pre style="..."><span style="...">#[attr1]</span>
+        <span style="...">#[attr2]</span>
+        <span style="...">#[attr3]</span>
+        <span style="...">let </span><span style="...">foo = Foo;</span>
+           <span style="...">let </span><span style="...">foo4 = Foo;</span>
         </pre>
         </div>
     """)

--- a/src/test/kotlin/org/rust/ide/docs/RsRenderedDocumentationTest.kt
+++ b/src/test/kotlin/org/rust/ide/docs/RsRenderedDocumentationTest.kt
@@ -91,15 +91,15 @@ class RsRenderedDocumentationTest : RsDocumentationProviderTest() {
     """, """
         <p>A cheap, reference-to-reference conversion.</p><p><code>AsRef</code> is very similar to, but different than, <code>Borrow</code>. See
         <a href="psi_element://../book/borrow-and-asref.html">the book</a> for more.</p><p><strong>Note: this trait must not fail</strong>. If the conversion can fail, use a dedicated method which
-        returns an <code>Option&lt;T&gt;</code> or a <code>Result&lt;T, E&gt;</code>.</p><h2>Examples</h2><p>Both <code>String</code> and <code>&amp;str</code> implement <code>AsRef&lt;str&gt;</code>:</p><pre style="..."><span style="...">fn </span><span style="...">is_hello</span><span style="...">&lt;</span><span style="...">T</span><span style="...">: </span><span style="...">AsRef</span><span style="...">&lt;</span><span style="...">str</span><span style="...">&gt;&gt;(</span><span style="...">s</span><span style="...">: </span><span style="...">T</span><span style="...">) {</span>
-           <span style="...">assert_eq</span><span style="...">!(</span><span style="...">&quot;hello&quot;</span><span style="...">, </span><span style="...">s</span><span style="...">.</span><span style="...">as_ref</span><span style="...">());</span>
+        returns an <code>Option&lt;T&gt;</code> or a <code>Result&lt;T, E&gt;</code>.</p><h2>Examples</h2><p>Both <code>String</code> and <code>&amp;str</code> implement <code>AsRef&lt;str&gt;</code>:</p><pre style="..."><span style="...">fn </span><span style="...">is_hello&lt;T: AsRef&lt;str&gt;&gt;(s: T) {</span>
+           <span style="...">assert_eq!(</span><span style="...">&quot;hello&quot;</span><span style="...">, s.as_ref());</span>
         <span style="...">}</span>
 
-        <span style="...">let </span><span style="...">s </span><span style="...">= </span><span style="...">&quot;hello&quot;</span><span style="...">;</span>
-        <span style="...">is_hello</span><span style="...">(</span><span style="...">s</span><span style="...">);</span>
+        <span style="...">let </span><span style="...">s = </span><span style="...">&quot;hello&quot;</span><span style="...">;</span>
+        <span style="...">is_hello(s);</span>
 
-        <span style="...">let </span><span style="...">s </span><span style="...">= </span><span style="...">&quot;hello&quot;</span><span style="...">.</span><span style="...">to_string</span><span style="...">();</span>
-        <span style="...">is_hello</span><span style="...">(</span><span style="...">s</span><span style="...">);</span>
+        <span style="...">let </span><span style="...">s = </span><span style="...">&quot;hello&quot;</span><span style="...">.to_string();</span>
+        <span style="...">is_hello(s);</span>
         </pre>
         <h2>Generic Impls</h2><ul><li><code>AsRef</code> auto-dereference if the inner type is a reference or a mutable
         reference (eg: <code>foo.as_ref()</code> will work the same if <code>foo</code> has type <code>&amp;mut Foo</code> or <code>&amp;&amp;mut Foo</code>)</li></ul>


### PR DESCRIPTION
step1 for #5397, can't figure out how to do step2 (implementing the missing option)

changelog: rename syntax highlighting option "variables -> default" to "identifier" since that's what the option has been doing the whole time (the actual option for default variables has yet to be implemented)