### PR TITLE
ANN: Don't annotate `async` as a reserved keyword in attributes

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotator.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
 import org.rust.ide.colors.RsColor
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.IDENTIFIER
@@ -63,7 +64,7 @@ class RsEdition2018KeywordsAnnotator : AnnotatorBase() {
                 element.parent !is RsMacro && element.parent?.parent !is RsMacroCall &&
                 element.parent !is RsFieldLookup ||
                 element.elementType in RS_EDITION_2018_KEYWORDS) &&
-                element.ancestorStrict<RsUseItem>() == null
+                PsiTreeUtil.getParentOfType(element, RsUseItem::class.java, RsMetaItemArgs::class.java) == null
 
         fun isNameIdentifier(element: PsiElement): Boolean {
             val parent = element.parent

--- a/src/test/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsEdition2018KeywordsAnnotatorTest.kt
@@ -85,7 +85,7 @@ class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018Keyw
     """)
 
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
-    fun `test don't analyze macro def-call bodies and use items`() = checkErrors("""
+    fun `test don't analyze macro def-call bodies, attributes and use items`() = checkErrors("""
         use dummy::async;
         use dummy::await;
         use dummy::{async, await};
@@ -94,8 +94,23 @@ class RsEdition2018KeywordsAnnotatorTest : RsAnnotatorTestBase(RsEdition2018Keyw
             () => { async };
         }
 
+        #[<error descr="`async` is reserved keyword in Edition 2018">async</error>]
+        fn foo1() {
+            #![<error descr="`async` is reserved keyword in Edition 2018">async</error>]
+        }
+
+        #[foo::<error descr="`async` is reserved keyword in Edition 2018">async</error>]
+        fn foo2() {
+            #![foo::<error descr="`async` is reserved keyword in Edition 2018">async</error>]
+        }
+
+        #[bar(async)]
+        fn foo3() {
+            #![bar(async)]
+        }
+
         fn main() {
-            foo!(async)
+            foo!(async);
         }
     """)
 


### PR DESCRIPTION
Fixes https://github.com/intellij-rust/intellij-rust/issues/7214.

changelog: Don't annotate `async` as a reserved keyword in attributes
