### PR TITLE
FIX: AddRemainingArms intention incorrectly prints enum names and variants if they are escaped rust keywords

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -105,6 +105,7 @@ sgift
 sgrif
 shevtsiv
 Shiroy
+shocoman
 shssoichiro
 sirgl
 slavam2605

--- a/src/main/kotlin/org/rust/ide/utils/checkMatch/Pattern.kt
+++ b/src/main/kotlin/org/rust/ide/utils/checkMatch/Pattern.kt
@@ -21,17 +21,17 @@ data class Pattern(val ty: Ty, val kind: PatternKind) {
             is PatternKind.Binding -> kind.name
 
             is PatternKind.Variant -> {
-                val variantName = kind.variant.name.orEmpty().escapeIdentifierIfNeeded()
-                val itemName = kind.item.name.orEmpty().escapeIdentifierIfNeeded()
+                val variantName = kind.variant.name.orEmpty()
+                val itemName = kind.item.name.orEmpty()
 
-                val variantInScope = ctx?.findInScope(variantName.unescapeIdentifier(), VALUES)
+                val variantInScope = ctx?.findInScope(variantName, VALUES)
                     ?.takeIf { (it as? RsEnumVariant)?.parentEnum == kind.item }
 
                 // if the variant is already in scope, it can be used as just `A` instead of full `MyEnum::A`
                 val name = if (variantInScope != null) {
-                    variantName
+                    variantName.escapeIdentifierIfNeeded()
                 } else {
-                    "$itemName::$variantName"
+                    "${itemName.escapeIdentifierIfNeeded()}::${variantName.escapeIdentifierIfNeeded()}"
                 }
                 val initializer = kind.variant.initializer(kind.subPatterns, ctx)
                 "$name$initializer"
@@ -99,7 +99,7 @@ private fun RsFieldsOwner.initializer(subPatterns: List<Pattern>, ctx: RsElement
             "{ .. }"
         } else {
             subPatterns.withIndex().joinToString(",", "{", "}") { (index, pattern) ->
-                "${blockFields!!.namedFieldDeclList[index].name}: ${pattern.text(ctx)}"
+                "${blockFields!!.namedFieldDeclList[index].name.orEmpty().escapeIdentifierIfNeeded()}: ${pattern.text(ctx)}"
             }
         }
     }

--- a/src/test/kotlin/org/rust/ide/intentions/AddRemainingArmsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddRemainingArmsIntentionTest.kt
@@ -77,7 +77,7 @@ class AddRemainingArmsIntentionTest : RsIntentionTestBase(AddRemainingArmsIntent
         }
     """)
 
-    fun `test match with raw identifier-keyword as name and variant`() = doAvailableTest("""
+    fun `test match with escaped keyword as enum name and variant`() = doAvailableTest("""
         enum r#type { A, r#if, r#fn }
         fn main() {
             let a = r#type::A;
@@ -93,6 +93,45 @@ class AddRemainingArmsIntentionTest : RsIntentionTestBase(AddRemainingArmsIntent
                 r#type::A => {}
                 r#type::r#if => {}
                 r#type::r#fn => {}
+            }
+        }
+    """)
+
+    fun `test match with imported escaped keyword as enum name and variant`() = doAvailableTest("""
+        enum r#type { A, r#if, r#fn }
+        fn main() {
+            use r#type::*;
+            let a = A;
+            match a/*caret*/ {
+
+            }
+        }
+    """, """
+        enum r#type { A, r#if, r#fn }
+        fn main() {
+            use r#type::*;
+            let a = A;
+            match a/*caret*/ {
+                A => {}
+                r#if => {}
+                r#fn => {}
+            }
+        }
+    """)
+
+    fun `test match with escaped keyword as struct name and field`() = doAvailableTest("""
+        struct r#type { r#if: bool }
+        fn foo(s: r#type) {
+            match s/*caret*/ {
+                r#type { r#if: true } => {}
+            }
+        }
+    """, """
+        struct r#type { r#if: bool }
+        fn foo(s: r#type) {
+            match s/*caret*/ {
+                r#type { r#if: true } => {}
+                r#type { r#if: false } => {}
             }
         }
     """)

--- a/src/test/kotlin/org/rust/ide/intentions/AddRemainingArmsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddRemainingArmsIntentionTest.kt
@@ -76,4 +76,24 @@ class AddRemainingArmsIntentionTest : RsIntentionTestBase(AddRemainingArmsIntent
             }
         }
     """)
+
+    fun `test match with raw identifier-keyword as name and variant`() = doAvailableTest("""
+        enum r#type { A, r#if, r#fn }
+        fn main() {
+            let a = r#type::A;
+            match a/*caret*/ {
+
+            }
+        }
+    """, """
+        enum r#type { A, r#if, r#fn }
+        fn main() {
+            let a = r#type::A;
+            match a {
+                r#type::A => {}
+                r#type::r#if => {}
+                r#type::r#fn => {}
+            }
+        }
+    """)
 }


### PR DESCRIPTION
`AddRemainingArmsIntention` doesn't print enum names and variants correctly when they are escaped reserved Rust keywords. 
Here is example after activating `AddRemainingArmsFix`. And after that goes the same example with my tiny fix

Before: 
![image](https://user-images.githubusercontent.com/8329446/119379928-428f7880-bcea-11eb-8cde-a6735b5e1074.png)

After:
![image](https://user-images.githubusercontent.com/8329446/119379943-47ecc300-bcea-11eb-9ee4-230a6d9a625c.png)
