### PR TITLE
Support 2021.2 EAPs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -138,6 +138,19 @@ jobs:
                       platform-version: 211
                       resolve-engine: resolve-old
                       verify-plugin: true
+                    # BACKCOMPAT: 2020.3
+                    - os: windows-latest
+                      rust-version: 1.52.1
+                      base-ide: idea
+                      platform-version: 212
+                      resolve-engine: resolve-new
+                      verify-plugin: false
+                    - os: ubuntu-18.04
+                      rust-version: 1.52.1
+                      base-ide: clion
+                      platform-version: 212
+                      resolve-engine: resolve-new
+                      verify-plugin: false
 
         runs-on: ${{ matrix.os }}
         timeout-minutes: 120

--- a/.github/workflows/rust-nightly.yml
+++ b/.github/workflows/rust-nightly.yml
@@ -108,7 +108,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                platform-version: [ 203, 211 ]
+                platform-version: [ 203, 211, 212 ]
         env:
             ORG_GRADLE_PROJECT_buildNumber: ${{ needs.generate-build-number.outputs.build_number }}
             ORG_GRADLE_PROJECT_platformVersion: ${{ matrix.platform-version }}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -171,7 +171,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                platform-version: [ 203, 211 ]
+                platform-version: [ 203, 211, 212 ]
         env:
             ORG_GRADLE_PROJECT_buildNumber: ${{ needs.generate-build-number.outputs.build_number }}
             ORG_GRADLE_PROJECT_platformVersion: ${{ matrix.platform-version }}

--- a/.idea/runConfigurations/RunCLion.xml
+++ b/.idea/runConfigurations/RunCLion.xml
@@ -2,6 +2,7 @@
   <configuration default="false" name="RunCLion" type="GradleRunConfiguration" factoryName="Gradle">
     <log_file alias="idea-203.log" path="$PROJECT_DIR$/plugin/build/clion-sandbox-203/system/log/idea.log" />
     <log_file alias="idea-211.log" path="$PROJECT_DIR$/plugin/build/clion-sandbox-211/system/log/idea.log" />
+    <log_file alias="idea-212.log" path="$PROJECT_DIR$/plugin/build/clion-sandbox-212/system/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.idea/runConfigurations/RunIDEA.xml
+++ b/.idea/runConfigurations/RunIDEA.xml
@@ -2,6 +2,7 @@
   <configuration default="false" name="RunIDEA" type="GradleRunConfiguration" factoryName="Gradle" singleton="true">
     <log_file alias="idea-203.log" path="$PROJECT_DIR$/plugin/build/idea-sandbox-203/system/log/idea.log" />
     <log_file alias="idea-211.log" path="$PROJECT_DIR$/plugin/build/idea-sandbox-211/system/log/idea.log" />
+    <log_file alias="idea-212.log" path="$PROJECT_DIR$/plugin/build/idea-sandbox-212/system/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,12 @@ val baseVersion = when (baseIDE) {
 }
 
 val nativeDebugPlugin = "com.intellij.nativeDebug:${prop("nativeDebugPluginVersion")}"
-val graziePlugin = if (baseIDE == "idea") "tanvd.grazi" else "tanvd.grazi:${prop("graziePluginVersion")}"
+// BACKCOMAPT: 2021.1
+val graziePlugin = if (platformVersion >= 212 || baseIDE == "idea") {
+    "tanvd.grazi"
+} else {
+    "tanvd.grazi:${prop("graziePluginVersion")}"
+}
 val psiViewerPlugin = "PsiViewer:${prop("psiViewerPluginVersion")}"
 val intelliLangPlugin = "org.intellij.intelliLang"
 val copyrightPlugin = "com.intellij.copyright"
@@ -52,7 +57,7 @@ plugins {
     idea
     kotlin("jvm") version "1.4.32"
     id("org.jetbrains.intellij") version "0.7.2"
-    id("org.jetbrains.grammarkit") version "2021.1.2"
+    id("org.jetbrains.grammarkit") version "2021.1.3"
     id("net.saliman.properties") version "1.5.1"
     id("org.gradle.test-retry") version "1.2.0"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -236,9 +236,11 @@ project(":plugin") {
             intelliLangPlugin,
             graziePlugin,
             psiViewerPlugin,
-            javaScriptPlugin,
             mlCompletionPlugin
         )
+        if (platformVersion < 212) {
+            plugins += javaScriptPlugin
+        }
         if (baseIDE == "idea") {
             plugins += listOf(
                 copyrightPlugin,
@@ -260,7 +262,9 @@ project(":plugin") {
         implementation(project(":intelliLang"))
         implementation(project(":duplicates"))
         implementation(project(":grazie"))
-        implementation(project(":js"))
+        if (platformVersion < 212) {
+            implementation(project(":js"))
+        }
         implementation(project(":ml-completion"))
     }
 
@@ -521,15 +525,17 @@ project(":grazie") {
     }
 }
 
-project(":js") {
-    intellij {
-        setPlugins(javaScriptPlugin)
-    }
-    dependencies {
-        implementation(project(":"))
-        implementation(project(":common"))
-        testImplementation(project(":", "testOutput"))
-        testImplementation(project(":common", "testOutput"))
+if (platformVersion < 212) {
+    project(":js") {
+        intellij {
+            setPlugins(javaScriptPlugin)
+        }
+        dependencies {
+            implementation(project(":"))
+            implementation(project(":common"))
+            testImplementation(project(":", "testOutput"))
+            testImplementation(project(":common", "testOutput"))
+        }
     }
 }
 

--- a/clion/src/203/main/kotlin/org/rust/clion/profiler/perf/RsPerfConfigurationExtension.kt
+++ b/clion/src/203/main/kotlin/org/rust/clion/profiler/perf/RsPerfConfigurationExtension.kt
@@ -1,0 +1,97 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.profiler.perf
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.BaseProcessHandler
+import com.intellij.execution.process.KillableProcessHandler
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.profiler.*
+import com.intellij.profiler.clion.CPPProfilerSettings
+import com.intellij.profiler.clion.perf.PerfProfilerProcess
+import com.intellij.profiler.clion.perf.PerfUtils
+import com.intellij.profiler.clion.profilerConfigurable
+import com.intellij.profiler.linux.HasInvalidVariables
+import com.intellij.profiler.linux.KernelVariable
+import com.intellij.profiler.linux.KernelVariablesChangeRequiredException
+import com.intellij.profiler.linux.checkKernelVariables
+import com.intellij.profiler.statistics.ProfilerUsageTriggerCollector
+import com.intellij.util.text.nullize
+import com.jetbrains.cidr.lang.toolchains.CidrToolEnvironment
+import org.rust.cargo.runconfig.ConfigurationExtensionContext
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.lang.core.psi.RsFunction
+import java.io.File
+import java.nio.file.Path
+
+class RsPerfConfigurationExtension : RsPerfConfigurationExtensionBase() {
+
+    override fun patchCommandLine(
+        configuration: CargoCommandConfiguration,
+        environment: ExecutionEnvironment,
+        cmdLine: GeneralCommandLine,
+        context: ConfigurationExtensionContext
+    ) {
+        if (environment.runner.runnerId !in PROFILER_RUNNER_IDS) return
+        val project = configuration.project
+        val settings = CPPProfilerSettings.instance.state
+        val perfPath = settings.executablePath.orEmpty()
+        validatePerfSettings(project)
+        val validationResult = checkKernelVariables(REQUIRED_KERNEL_VARIABLES)
+        if (validationResult is HasInvalidVariables) {
+            throw KernelVariablesChangeRequiredException(validationResult, project)
+        }
+        val outputFile = FileUtil.createTempFile("perf", null, !keepTempProfilerFiles())
+        cmdLine.addPerfStarter(perfPath, settings.samplingFrequency, settings.defaultCmdArgs, outputFile.absolutePath)
+        context.putUserData(PERF_OUTPUT_FILE_KEY, outputFile)
+    }
+
+    override fun attachToProcess(
+        configuration: CargoCommandConfiguration,
+        handler: ProcessHandler,
+        environment: ExecutionEnvironment,
+        context: ConfigurationExtensionContext
+    ) {
+        if (environment.runner.runnerId !in PROFILER_RUNNER_IDS) return
+        if (handler !is BaseProcessHandler<*>)
+            throw ExecutionException("Can't detect target process id")
+        val outputFile = context.getUserData(PERF_OUTPUT_FILE_KEY)
+            ?: throw ExecutionException("Can't get output perf data file")
+
+        val project = configuration.project
+        val profilerProcess = PerfProfilerProcess(
+            handler,
+            outputFile,
+            configuration.name,
+            project,
+            System.currentTimeMillis(),
+            RsFunction::class.java
+        )
+        ProfilerToolWindowManager.getInstance(project).addProfilerProcessTab(profilerProcess)
+    }
+
+    @Throws(MisConfiguredException::class)
+    private fun validatePerfSettings(project: Project) {
+        val state = CPPProfilerSettings.instance.state
+        throw validateLocalPath(state.executablePath.orEmpty(), "Perf executable", project, profilerConfigurable::class.java)
+            ?: validateFrequency(state.samplingFrequency, project, profilerConfigurable::class.java)
+            ?: validateOutputDirectory(state.outputDirectory.orEmpty(), project, profilerConfigurable::class.java)
+            ?: return
+    }
+
+    companion object {
+        private val REQUIRED_KERNEL_VARIABLES = listOf(
+            KernelVariable("perf_event_paranoid", "1") { it.toInt() <= 1 }, //required, error otherwise
+            KernelVariable("kptr_restrict", "0") { it == "0" } //useful, warning otherwise
+        )
+        private val PERF_OUTPUT_FILE_KEY = Key.create<File>("perf.output")
+    }
+}

--- a/clion/src/211/main/kotlin/org/rust/clion/profiler/perf/RsPerfConfigurationExtension.kt
+++ b/clion/src/211/main/kotlin/org/rust/clion/profiler/perf/RsPerfConfigurationExtension.kt
@@ -1,0 +1,97 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.profiler.perf
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.BaseProcessHandler
+import com.intellij.execution.process.KillableProcessHandler
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.profiler.*
+import com.intellij.profiler.clion.CPPProfilerSettings
+import com.intellij.profiler.clion.perf.PerfProfilerProcess
+import com.intellij.profiler.clion.perf.PerfUtils
+import com.intellij.profiler.clion.profilerConfigurable
+import com.intellij.profiler.linux.HasInvalidVariables
+import com.intellij.profiler.linux.KernelVariable
+import com.intellij.profiler.linux.KernelVariablesChangeRequiredException
+import com.intellij.profiler.linux.checkKernelVariables
+import com.intellij.profiler.statistics.ProfilerUsageTriggerCollector
+import com.intellij.util.text.nullize
+import com.jetbrains.cidr.lang.toolchains.CidrToolEnvironment
+import org.rust.cargo.runconfig.ConfigurationExtensionContext
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.lang.core.psi.RsFunction
+import java.io.File
+import java.nio.file.Path
+
+class RsPerfConfigurationExtension : RsPerfConfigurationExtensionBase() {
+
+    override fun patchCommandLine(
+        configuration: CargoCommandConfiguration,
+        environment: ExecutionEnvironment,
+        cmdLine: GeneralCommandLine,
+        context: ConfigurationExtensionContext
+    ) {
+        if (environment.runner.runnerId !in PROFILER_RUNNER_IDS) return
+        val project = configuration.project
+        val settings = CPPProfilerSettings.instance.state
+        val perfPath = settings.executablePath.orEmpty()
+        validatePerfSettings(project)
+        val validationResult = checkKernelVariables(REQUIRED_KERNEL_VARIABLES)
+        if (validationResult is HasInvalidVariables) {
+            throw KernelVariablesChangeRequiredException(validationResult, project)
+        }
+        val outputFile = FileUtil.createTempFile("perf", null, !keepTempProfilerFiles())
+        cmdLine.addPerfStarter(perfPath, settings.samplingFrequency, settings.defaultCmdArgs, outputFile.absolutePath)
+        context.putUserData(PERF_OUTPUT_FILE_KEY, outputFile)
+    }
+
+    override fun attachToProcess(
+        configuration: CargoCommandConfiguration,
+        handler: ProcessHandler,
+        environment: ExecutionEnvironment,
+        context: ConfigurationExtensionContext
+    ) {
+        if (environment.runner.runnerId !in PROFILER_RUNNER_IDS) return
+        if (handler !is BaseProcessHandler<*>)
+            throw ExecutionException("Can't detect target process id")
+        val outputFile = context.getUserData(PERF_OUTPUT_FILE_KEY)
+            ?: throw ExecutionException("Can't get output perf data file")
+
+        val project = configuration.project
+        val profilerProcess = PerfProfilerProcess(
+            handler,
+            outputFile,
+            configuration.name,
+            project,
+            System.currentTimeMillis(),
+            RsFunction::class.java
+        )
+        ProfilerToolWindowManager.getInstance(project).addProfilerProcessTab(profilerProcess)
+    }
+
+    @Throws(MisConfiguredException::class)
+    private fun validatePerfSettings(project: Project) {
+        val state = CPPProfilerSettings.instance.state
+        throw validateLocalPath(state.executablePath.orEmpty(), "Perf executable", project, profilerConfigurable::class.java)
+            ?: validateFrequency(state.samplingFrequency, project, profilerConfigurable::class.java)
+            ?: validateOutputDirectory(state.outputDirectory.orEmpty(), project, profilerConfigurable::class.java)
+            ?: return
+    }
+
+    companion object {
+        private val REQUIRED_KERNEL_VARIABLES = listOf(
+            KernelVariable("perf_event_paranoid", "1") { it.toInt() <= 1 }, //required, error otherwise
+            KernelVariable("kptr_restrict", "0") { it == "0" } //useful, warning otherwise
+        )
+        private val PERF_OUTPUT_FILE_KEY = Key.create<File>("perf.output")
+    }
+}

--- a/clion/src/212/main/kotlin/org/rust/clion/profiler/perf/RsPerfConfigurationExtension.kt
+++ b/clion/src/212/main/kotlin/org/rust/clion/profiler/perf/RsPerfConfigurationExtension.kt
@@ -1,0 +1,83 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.clion.profiler.perf
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.BaseProcessHandler
+import com.intellij.execution.process.KillableProcessHandler
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.util.Key
+import com.intellij.profiler.ProfilerToolWindowManager
+import com.intellij.profiler.clion.CPPProfilerSettings
+import com.intellij.profiler.clion.perf.PerfProfilerProcess
+import com.intellij.profiler.clion.perf.PerfUtils
+import com.intellij.profiler.statistics.ProfilerUsageTriggerCollector
+import com.intellij.util.text.nullize
+import com.jetbrains.cidr.lang.toolchains.CidrToolEnvironment
+import org.rust.cargo.runconfig.ConfigurationExtensionContext
+import org.rust.cargo.runconfig.command.CargoCommandConfiguration
+import org.rust.lang.core.psi.RsFunction
+import java.nio.file.Path
+
+class RsPerfConfigurationExtension : RsPerfConfigurationExtensionBase() {
+
+    override fun patchCommandLine(
+        configuration: CargoCommandConfiguration,
+        environment: ExecutionEnvironment,
+        cmdLine: GeneralCommandLine,
+        context: ConfigurationExtensionContext
+    ) {
+        if (environment.runner.runnerId !in PROFILER_RUNNER_IDS) return
+        val project = configuration.project
+        val settings = CPPProfilerSettings.instance.state
+        val perfPath = settings.executablePath.orEmpty()
+        PerfUtils.validatePerfSettings(TOOL_ENVIRONMENT, project)?.let { throw it }
+        PerfUtils.validateKernelVariables(project)?.let { throw it }
+        val outputFilePath = PerfUtils.createOutputFilePath(TOOL_ENVIRONMENT, settings.outputDirectory.nullize())
+        cmdLine.addPerfStarter(perfPath, settings.samplingFrequency, settings.defaultCmdArgs, outputFilePath.toString())
+        context.putUserData(PERF_OUTPUT_FILE_KEY, outputFilePath)
+    }
+
+    override fun attachToProcess(
+        configuration: CargoCommandConfiguration,
+        handler: ProcessHandler,
+        environment: ExecutionEnvironment,
+        context: ConfigurationExtensionContext
+    ) {
+        if (environment.runner.runnerId !in PROFILER_RUNNER_IDS) return
+        if (handler !is BaseProcessHandler<*>)
+            throw ExecutionException("Can't detect target process id")
+        //since we executing `perf record` instead of original app, we should kill it softly to be able finish correctly
+        if (handler is KillableProcessHandler) {
+            handler.setShouldKillProcessSoftly(true)
+        }
+        val outputFile = context.getUserData(PERF_OUTPUT_FILE_KEY)
+            ?: throw ExecutionException("Can't get output perf data file")
+
+        val project = configuration.project
+        val profilerProcess = PerfProfilerProcess(
+            handler,
+            false,
+            outputFile,
+            configuration.name,
+            project,
+            System.currentTimeMillis(),
+            TOOL_ENVIRONMENT,
+            RsFunction::class.java
+        )
+        ProfilerUsageTriggerCollector.reportStart(project, profilerProcess.profilerConfiguration.configurationTypeId, configuration.type.id)
+        ProfilerToolWindowManager.getInstance(project).addProfilerProcessTab(profilerProcess)
+    }
+
+    companion object {
+        private val PERF_OUTPUT_FILE_KEY = Key.create<Path>("perf.output")
+
+        // TODO: works only for local profiling
+        private val TOOL_ENVIRONMENT = CidrToolEnvironment()
+    }
+}

--- a/clion/src/main/kotlin/org/rust/clion/profiler/perf/RsPerfConfigurationExtension.kt
+++ b/clion/src/main/kotlin/org/rust/clion/profiler/perf/RsPerfConfigurationExtension.kt
@@ -5,102 +5,25 @@
 
 package org.rust.clion.profiler.perf
 
-import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.RunnerSettings
-import com.intellij.execution.process.BaseProcessHandler
-import com.intellij.execution.process.ProcessHandler
-import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.SystemInfo
-import com.intellij.openapi.util.io.FileUtil
-import com.intellij.profiler.*
-import com.intellij.profiler.clion.CPPProfilerSettings
-import com.intellij.profiler.clion.perf.PerfProfilerProcess
-import com.intellij.profiler.clion.profilerConfigurable
-import com.intellij.profiler.linux.HasInvalidVariables
-import com.intellij.profiler.linux.KernelVariable
-import com.intellij.profiler.linux.KernelVariablesChangeRequiredException
-import com.intellij.profiler.linux.checkKernelVariables
 import org.rust.cargo.runconfig.CargoCommandConfigurationExtension
-import org.rust.cargo.runconfig.ConfigurationExtensionContext
 import org.rust.cargo.runconfig.command.CargoCommandConfiguration
 import org.rust.clion.profiler.RsProfilerRunner
 import org.rust.clion.profiler.legacy.RsProfilerRunnerLegacy
-import org.rust.lang.core.psi.RsFunction
-import java.io.File
 
-class RsPerfConfigurationExtension : CargoCommandConfigurationExtension() {
+abstract class RsPerfConfigurationExtensionBase : CargoCommandConfigurationExtension() {
 
     override fun isApplicableFor(configuration: CargoCommandConfiguration): Boolean = true
 
     override fun isEnabledFor(applicableConfiguration: CargoCommandConfiguration, runnerSettings: RunnerSettings?): Boolean =
         SystemInfo.isLinux
 
-    override fun patchCommandLine(
-        configuration: CargoCommandConfiguration,
-        environment: ExecutionEnvironment,
-        cmdLine: GeneralCommandLine,
-        context: ConfigurationExtensionContext
-    ) {
-        if (environment.runner.runnerId !in PROFILER_RUNNER_IDS) return
-        val project = configuration.project
-        val settings = CPPProfilerSettings.instance.state
-        val perfPath = settings.executablePath.orEmpty()
-        validatePerfSettings(project)
-        val validationResult = checkKernelVariables(REQUIRED_KERNEL_VARIABLES)
-        if (validationResult is HasInvalidVariables) {
-            throw KernelVariablesChangeRequiredException(validationResult, project)
-        }
-        val outputFile = FileUtil.createTempFile("perf", null, !keepTempProfilerFiles())
-        cmdLine.addPerfStarter(perfPath, settings.samplingFrequency, settings.defaultCmdArgs, outputFile.absolutePath)
-        context.putUserData(PERF_OUTPUT_FILE_KEY, outputFile)
-    }
-
-    override fun attachToProcess(
-        configuration: CargoCommandConfiguration,
-        handler: ProcessHandler,
-        environment: ExecutionEnvironment,
-        context: ConfigurationExtensionContext
-    ) {
-        if (environment.runner.runnerId !in PROFILER_RUNNER_IDS) return
-        if (handler !is BaseProcessHandler<*>)
-            throw ExecutionException("Can't detect target process id")
-        val outputFile = context.getUserData(PERF_OUTPUT_FILE_KEY)
-            ?: throw ExecutionException("Can't get output perf data file")
-
-        val project = configuration.project
-        val profilerProcess = PerfProfilerProcess(
-            handler,
-            outputFile,
-            configuration.name,
-            project,
-            System.currentTimeMillis(),
-            RsFunction::class.java
-        )
-        ProfilerToolWindowManager.getInstance(project).addProfilerProcessTab(profilerProcess)
-    }
-
-    @Throws(MisConfiguredException::class)
-    private fun validatePerfSettings(project: Project) {
-        val state = CPPProfilerSettings.instance.state
-        throw validateLocalPath(state.executablePath.orEmpty(), "Perf executable", project, profilerConfigurable::class.java)
-            ?: validateFrequency(state.samplingFrequency, project, profilerConfigurable::class.java)
-            ?: validateOutputDirectory(state.outputDirectory.orEmpty(), project, profilerConfigurable::class.java)
-            ?: return
-    }
-
     companion object {
-        private val PERF_OUTPUT_FILE_KEY = Key.create<File>("perf.output")
-        private val PROFILER_RUNNER_IDS = listOf(RsProfilerRunner.RUNNER_ID, RsProfilerRunnerLegacy.RUNNER_ID)
+        val PROFILER_RUNNER_IDS = listOf(RsProfilerRunner.RUNNER_ID, RsProfilerRunnerLegacy.RUNNER_ID)
 
-        private val REQUIRED_KERNEL_VARIABLES = listOf(
-            KernelVariable("perf_event_paranoid", "1") { it.toInt() <= 1 }, //required, error otherwise
-            KernelVariable("kptr_restrict", "0") { it == "0" } //useful, warning otherwise
-        )
-
-        private fun GeneralCommandLine.addPerfStarter(
+        fun GeneralCommandLine.addPerfStarter(
             perfPath: String,
             samplingFrequency: Int,
             defaultArgs: List<String>,

--- a/gradle-212.properties
+++ b/gradle-212.properties
@@ -1,16 +1,14 @@
 # Existent IDE versions can be found in the following repos:
 # https://www.jetbrains.com/intellij-repository/releases/
 # https://www.jetbrains.com/intellij-repository/snapshots/
-ideaVersion=IU-2021.1.1
-clionVersion=CL-2021.1.1
+ideaVersion=IU-212.3116-EAP-CANDIDATE-SNAPSHOT
+clionVersion=CL-212.3116-EAP-CANDIDATE-SNAPSHOT
 
 # https://plugins.jetbrains.com/plugin/12775-native-debugging-support/versions
-nativeDebugPluginVersion=211.7142.13
-# https://plugins.jetbrains.com/plugin/12175-grazie/versions
-graziePluginVersion=211.7142.14
+nativeDebugPluginVersion=212.3116.29
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions
-psiViewerPluginVersion=211.6305.21-EAP-SNAPSHOT
+psiViewerPluginVersion=212-SNAPSHOT
 
 # please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
-sinceBuild=211.6693
-untilBuild=211.*
+sinceBuild=212.3116
+untilBuild=213.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 propertiesPluginEnvironmentNameProperty=platformVersion
-# Supported platforms: 203, 211
+# Supported platforms: 203, 211, 212
 platformVersion=211
 # Supported IDEs: idea, clion
 baseIDE=idea

--- a/intellij-toml/src/main/kotlin/org/toml/lang/parse/TomlParserDefinition.kt
+++ b/intellij-toml/src/main/kotlin/org/toml/lang/parse/TomlParserDefinition.kt
@@ -27,7 +27,7 @@ class TomlParserDefinition : ParserDefinition {
 
     override fun createFile(viewProvider: FileViewProvider): PsiFile = TomlFile(viewProvider)
 
-    override fun spaceExistenceTypeBetweenTokens(left: ASTNode?, right: ASTNode?): ParserDefinition.SpaceRequirements =
+    override fun spaceExistenceTypeBetweenTokens(left: ASTNode, right: ASTNode): ParserDefinition.SpaceRequirements =
         LanguageUtil.canStickTokensTogetherByLexer(left, right, TomlLexer())
 
     override fun getStringLiteralElements(): TokenSet = TokenSet.EMPTY

--- a/ml-completion/src/212/main/kotlin/org/rust/ml/RsMLRankingProvider.kt
+++ b/ml-completion/src/212/main/kotlin/org/rust/ml/RsMLRankingProvider.kt
@@ -1,0 +1,20 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ml
+
+import com.intellij.internal.ml.catboost.CatBoostJarCompletionModelProvider
+import com.intellij.internal.ml.completion.DecoratingItemsPolicy
+import com.intellij.lang.Language
+import org.rust.lang.RsLanguage
+
+@Suppress("UnstableApiUsage")
+class RsMLRankingProvider : CatBoostJarCompletionModelProvider("Rust", "rust_features", "rust_model") {
+    override fun isLanguageSupported(language: Language): Boolean = language == RsLanguage
+    override fun getDecoratingPolicy(): DecoratingItemsPolicy = DecoratingItemsPolicy.Composite(
+        DecoratingItemsPolicy.ByAbsoluteThreshold(3.0),
+        DecoratingItemsPolicy.ByRelativeThreshold(2.5)
+    )
+}

--- a/ml-completion/src/test/kotlin/org/rust/ml/RsElementFeatureProviderTest.kt
+++ b/ml-completion/src/test/kotlin/org/rust/ml/RsElementFeatureProviderTest.kt
@@ -8,6 +8,8 @@ package org.rust.ml
 import com.intellij.codeInsight.lookup.LookupManager
 import com.intellij.codeInsight.lookup.impl.LookupImpl
 import com.intellij.completion.ml.util.RelevanceUtil.asRelevanceMaps
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.util.BuildNumber
 import com.intellij.testFramework.UsefulTestCase
 import org.intellij.lang.annotations.Language
 import org.rust.ProjectDescriptor
@@ -78,8 +80,8 @@ class RsElementFeatureProviderTest : RsTestBase() {
             prin/*caret*/
         }
     """, mapOf(
-        "println" to "1",
-        "my_print" to "0",
+        "println" to true.toMLValue(),
+        "my_print" to false.toMLValue(),
     ))
 
     fun `test all keywords are covered`() {
@@ -124,5 +126,16 @@ class RsElementFeatureProviderTest : RsTestBase() {
         val featuresMap = asRelevanceMaps(relevanceObjects).second
         val actualValue = featuresMap[feature]
         assertEquals("Invalid value for `$feature` of `$lookupString`", expectedValue, actualValue)
+    }
+
+    companion object {
+
+        private val BUILD_212: BuildNumber = BuildNumber.fromString("212")!!
+
+        // BACKCOMPAT: 2021.1. Use 0 or 1 integer values
+        private fun Boolean.toMLValue(): Any {
+            val value = if (this) 1 else 0
+            return if (ApplicationInfo.getInstance().build < BUILD_212) value.toString() else value
+        }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,10 +12,15 @@ include(
     "intelliLang",
     "duplicates",
     "grazie",
-    "js",
     "ml-completion",
     "intellij-toml"
 )
+
+val platformVersion: String by extra
+
+if (platformVersion.toInt() < 212) {
+    include("js")
+}
 
 // Configure Gradle Build Cache. It is enabled in `gradle.properties` via `org.gradle.caching`.
 // Also, `gradle clean` task is configured to delete `build-cache` directory.

--- a/src/203/main/kotlin/org/rust/debugger/runconfig/compatUtils.kt
+++ b/src/203/main/kotlin/org/rust/debugger/runconfig/compatUtils.kt
@@ -1,0 +1,19 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger.runconfig
+
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.updateSettings.impl.pluginsAdvertisement.PluginsAdvertiser
+
+fun installPluginsAndEnable(
+    project: Project?,
+    pluginIds: Set<PluginId>,
+    showDialog: Boolean = false,
+    onSuccess: Runnable
+) {
+    PluginsAdvertiser.installAndEnable(project, pluginIds, showDialog, onSuccess)
+}

--- a/src/203/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
+++ b/src/203/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
@@ -1,0 +1,17 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.indexing.FileContent
+import com.intellij.util.indexing.FileContentImpl
+
+fun createFileContentByText(file: VirtualFile, contentAsText: CharSequence, project: Project): FileContent {
+    return FileContentImpl.createByText(file, contentAsText).also {
+        (it as FileContentImpl).project = project
+    }
+}

--- a/src/211/main/kotlin/org/rust/debugger/runconfig/compatUtils.kt
+++ b/src/211/main/kotlin/org/rust/debugger/runconfig/compatUtils.kt
@@ -1,0 +1,19 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger.runconfig
+
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.updateSettings.impl.pluginsAdvertisement.PluginsAdvertiser
+
+fun installPluginsAndEnable(
+    project: Project?,
+    pluginIds: Set<PluginId>,
+    showDialog: Boolean = false,
+    onSuccess: Runnable
+) {
+    PluginsAdvertiser.installAndEnable(project, pluginIds, showDialog, onSuccess)
+}

--- a/src/211/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
+++ b/src/211/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
@@ -1,0 +1,17 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.indexing.FileContent
+import com.intellij.util.indexing.FileContentImpl
+
+fun createFileContentByText(file: VirtualFile, contentAsText: CharSequence, project: Project): FileContent {
+    return FileContentImpl.createByText(file, contentAsText).also {
+        (it as FileContentImpl).project = project
+    }
+}

--- a/src/212/main/kotlin/org/rust/cargo/toolchain/wsl/RsWslToolchain.kt
+++ b/src/212/main/kotlin/org/rust/cargo/toolchain/wsl/RsWslToolchain.kt
@@ -1,0 +1,76 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.toolchain.wsl
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.wsl.WSLCommandLineOptions
+import com.intellij.execution.wsl.WSLDistribution
+import com.intellij.execution.wsl.WslPath
+import com.intellij.util.io.isFile
+import com.intellij.util.io.systemIndependentPath
+import org.rust.cargo.toolchain.RsRemoteToolchain
+import org.rust.stdext.toPath
+import java.io.File
+import java.nio.file.Path
+
+class RsWslToolchain(
+    private val wslPath: WslPath
+) : RsRemoteToolchain(wslPath.distribution.getWindowsPath(wslPath.linuxPath)?.toPath() ?: wslPath.linuxPath.toPath()) {
+    private val distribution: WSLDistribution get() = wslPath.distribution
+    private val linuxPath: Path = wslPath.linuxPath.toPath()
+
+    override val fileSeparator: String = "/"
+
+    override val executionTimeoutInMilliseconds: Int = 5000
+
+    override fun patchCommandLine(commandLine: GeneralCommandLine): GeneralCommandLine {
+        val parameters = commandLine.parametersList.list.map { toRemotePath(it) }
+        commandLine.parametersList.clearAll()
+        commandLine.parametersList.addAll(parameters)
+
+        commandLine.environment.forEach { (k, v) ->
+            val paths = v.split(File.pathSeparatorChar)
+            commandLine.environment[k] = paths.joinToString(":") { toRemotePath(it) }
+        }
+
+        commandLine.workDirectory?.let {
+            if (it.path.startsWith(fileSeparator)) {
+                commandLine.workDirectory = File(toLocalPath(it.path))
+            }
+        }
+
+        val remoteWorkDir = commandLine.workDirectory?.absolutePath
+            ?.let { toRemotePath(it) }
+        val options = WSLCommandLineOptions()
+            .setRemoteWorkingDirectory(remoteWorkDir)
+            .addInitCommand("export PATH=\"${linuxPath.systemIndependentPath}:\$PATH\"")
+        return distribution.patchCommandLine(commandLine, null, options)
+    }
+
+    override fun toLocalPath(remotePath: String): String =
+        distribution.getWindowsPath(remotePath) ?: remotePath
+
+    override fun toRemotePath(localPath: String): String =
+        distribution.getWslPath(localPath) ?: localPath
+
+    override fun expandUserHome(remotePath: String): String =
+        distribution.expandUserHome(remotePath)
+
+    override fun getExecutableName(toolName: String): String = toolName
+
+    override fun pathToExecutable(toolName: String): Path = linuxPath.pathToExecutableOnWsl(toolName)
+
+    override fun hasExecutable(exec: String): Boolean =
+        distribution.getWindowsPath(pathToExecutable(exec))?.isFile() == true
+
+    override fun hasCargoExecutable(exec: String): Boolean =
+        distribution.getWindowsPath(pathToCargoExecutable(exec))?.isFile() == true
+
+    companion object {
+        private fun WSLDistribution.getWindowsPath(wslPath: Path): Path? =
+            getWindowsPath(wslPath.toString())?.toPath()
+    }
+}

--- a/src/212/main/kotlin/org/rust/cargo/toolchain/wsl/RsWslToolchainFlavor.kt
+++ b/src/212/main/kotlin/org/rust/cargo/toolchain/wsl/RsWslToolchainFlavor.kt
@@ -1,0 +1,69 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.toolchain.wsl
+
+import com.intellij.execution.wsl.WSLUtil
+import com.intellij.execution.wsl.WslDistributionManager
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapiext.isDispatchThread
+import com.intellij.util.io.isDirectory
+import org.rust.cargo.toolchain.flavors.RsToolchainFlavor
+import org.rust.openapiext.computeWithCancelableProgress
+import org.rust.openapiext.isFeatureEnabled
+import java.nio.file.Path
+
+class RsWslToolchainFlavor : RsToolchainFlavor() {
+
+    override fun getHomePathCandidates(): Sequence<Path> = sequence {
+
+        fun <T> compute(title: String, getter: () -> T): T = if (isDispatchThread) {
+            val project = ProjectManager.getInstance().defaultProject
+            project.computeWithCancelableProgress(title, getter)
+        } else {
+            getter()
+        }
+
+        val distributions = compute("Getting installed distributions...") {
+            WslDistributionManager.getInstance().installedDistributions
+        }
+        for (distro in distributions) {
+            @Suppress("UnstableApiUsage")
+            val root = distro.uncRootPath
+            val environment = compute("Getting environment variables...") { distro.environment }
+
+            val home = environment["HOME"]
+            val remoteCargoPath = home?.let { "$it/.cargo/bin" }
+            val localCargoPath = remoteCargoPath?.let { root.resolve(it) }
+            if (localCargoPath?.isDirectory() == true) {
+                yield(localCargoPath)
+            }
+
+            val sysPath = environment["PATH"]
+            for (remotePath in sysPath.orEmpty().split(":")) {
+                if (remotePath.isEmpty()) continue
+                val localPath = root.resolve(remotePath)
+                if (!localPath.isDirectory()) continue
+                yield(localPath)
+            }
+
+            for (remotePath in listOf("/usr/local/bin", "/usr/bin")) {
+                val localPath = root.resolve(remotePath)
+                if (!localPath.isDirectory()) continue
+                yield(localPath)
+            }
+        }
+    }
+
+    override fun isApplicable(): Boolean =
+        WSLUtil.isSystemCompatible() && isFeatureEnabled(WSL_TOOLCHAIN)
+
+    override fun isValidToolchainPath(path: Path): Boolean =
+        WslDistributionManager.isWslPath(path.toString()) && super.isValidToolchainPath(path)
+
+    override fun hasExecutable(path: Path, toolName: String): Boolean = path.hasExecutableOnWsl(toolName)
+
+    override fun pathToExecutable(path: Path, toolName: String): Path = path.pathToExecutableOnWsl(toolName)
+}

--- a/src/212/main/kotlin/org/rust/cargo/toolchain/wsl/RsWslToolchainProvider.kt
+++ b/src/212/main/kotlin/org/rust/cargo/toolchain/wsl/RsWslToolchainProvider.kt
@@ -1,0 +1,18 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.toolchain.wsl
+
+import com.intellij.execution.wsl.WslPath
+import org.rust.cargo.toolchain.RsToolchainBase
+import org.rust.cargo.toolchain.RsToolchainProvider
+import java.nio.file.Path
+
+class RsWslToolchainProvider : RsToolchainProvider {
+    override fun getToolchain(homePath: Path): RsToolchainBase? {
+        val wslPath = WslPath.parseWindowsUncPath(homePath.toString()) ?: return null
+        return RsWslToolchain(wslPath)
+    }
+}

--- a/src/212/main/kotlin/org/rust/cargo/toolchain/wsl/Utils.kt
+++ b/src/212/main/kotlin/org/rust/cargo/toolchain/wsl/Utils.kt
@@ -1,0 +1,22 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.cargo.toolchain.wsl
+
+import com.intellij.execution.wsl.WSLDistribution
+import com.intellij.util.io.isFile
+import java.nio.file.Path
+
+const val WSL_TOOLCHAIN: String = "org.rust.wsl"
+
+fun WSLDistribution.expandUserHome(path: String): String {
+    if (!path.startsWith("~/")) return path
+    val userHome = userHome ?: return path
+    return "$userHome${path.substring(1)}"
+}
+
+fun Path.hasExecutableOnWsl(toolName: String): Boolean = pathToExecutableOnWsl(toolName).isFile()
+
+fun Path.pathToExecutableOnWsl(toolName: String): Path = resolve(toolName)

--- a/src/212/main/kotlin/org/rust/debugger/runconfig/compatUtils.kt
+++ b/src/212/main/kotlin/org/rust/debugger/runconfig/compatUtils.kt
@@ -1,0 +1,19 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger.runconfig
+
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.updateSettings.impl.pluginsAdvertisement.installAndEnable
+
+fun installPluginsAndEnable(
+    project: Project?,
+    pluginIds: Set<PluginId>,
+    showDialog: Boolean = false,
+    onSuccess: Runnable
+) {
+    installAndEnable(project, pluginIds, showDialog, onSuccess)
+}

--- a/src/212/main/kotlin/org/rust/ide/formatter/RustfmtExternalFormatProcessor.kt
+++ b/src/212/main/kotlin/org/rust/ide/formatter/RustfmtExternalFormatProcessor.kt
@@ -1,0 +1,20 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.formatter
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiFile
+
+class RustfmtExternalFormatProcessor : RustfmtExternalFormatProcessorBase() {
+    @Suppress("UnstableApiUsage")
+    override fun format(
+        source: PsiFile,
+        range: TextRange,
+        canChangeWhiteSpacesOnly: Boolean,
+        keepLineBreaks: Boolean, // Always `false`?
+        enableBulkUpdate: Boolean
+    ): TextRange = formatWithRustfmtOrBuiltinFormatter(source, range, canChangeWhiteSpacesOnly)
+}

--- a/src/212/main/kotlin/org/rust/ide/structure/compatUtils.kt
+++ b/src/212/main/kotlin/org/rust/ide/structure/compatUtils.kt
@@ -1,0 +1,8 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.structure
+
+typealias QueryableInfo = MutableMap<in String, in String>

--- a/src/212/main/kotlin/org/rust/ide/wordSelection/compatUtils.kt
+++ b/src/212/main/kotlin/org/rust/ide/wordSelection/compatUtils.kt
@@ -1,0 +1,11 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.wordSelection
+
+import com.intellij.openapi.editor.LineExtensionInfo
+import java.util.function.IntFunction
+
+typealias LineExtensionPainter = IntFunction<out MutableCollection<out LineExtensionInfo>>

--- a/src/212/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
+++ b/src/212/main/kotlin/org/rust/lang/core/macros/compatUtils.kt
@@ -1,0 +1,16 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.indexing.FileContent
+import com.intellij.util.indexing.FileContentImpl
+
+// BACKCOMPAT: 2021.1. Inline it
+fun createFileContentByText(file: VirtualFile, contentAsText: CharSequence, project: Project): FileContent {
+    return FileContentImpl.createByText(file, contentAsText, project)
+}

--- a/src/212/main/kotlin/org/rust/lang/core/psi/ext/compatUtils.kt
+++ b/src/212/main/kotlin/org/rust/lang/core/psi/ext/compatUtils.kt
@@ -1,0 +1,17 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.psi.ext
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.descendantsOfType
+
+inline fun <reified T : PsiElement> PsiElement.descendantOfType(predicate: (T) -> Boolean): T? {
+    return descendantsOfType<T>().firstOrNull(predicate)
+}
+
+inline fun <reified T : PsiElement> PsiElement.anyDescendantOfType(predicate: (T) -> Boolean): Boolean {
+    return descendantOfType(predicate) != null
+}

--- a/src/212/main/resources/META-INF/platform-core.xml
+++ b/src/212/main/resources/META-INF/platform-core.xml
@@ -1,0 +1,12 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <experimentalFeature id="org.rust.wsl" percentOfUsers="0">
+            <description>Enables WSL toolchains</description>
+        </experimentalFeature>
+    </extensions>
+    <extensions defaultExtensionNs="org.rust">
+        <toolchainProvider implementation="org.rust.cargo.toolchain.wsl.RsWslToolchainProvider"/>
+        <toolchainFlavor id="rust.wslToolchainFlavor"
+                         implementation="org.rust.cargo.toolchain.wsl.RsWslToolchainFlavor"/>
+    </extensions>
+</idea-plugin>

--- a/src/212/test/kotlin/org/rust/ide/search/RsUsageViewTreeTest.kt
+++ b/src/212/test/kotlin/org/rust/ide/search/RsUsageViewTreeTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.search
+
+class RsUsageViewTreeTest : RsUsageViewTreeTestBase() {
+
+    fun `test grouping function usages`() = doTestByText("""
+        fn foo() {}
+          //^
+
+        fn bar() {
+            foo();
+        }
+
+        fn baz() {
+            foo();
+        }
+    """, """
+        <root> (2)
+         Function
+          foo
+         Found usages (2)
+          function call (2)
+           main.rs (2)
+            6foo();
+            10foo();
+    """)
+
+    fun `test grouping struct usages`() = doTestByText("""
+        struct S {
+             //^
+            a: usize,
+        }
+
+        impl S {}
+        impl S {}
+
+        fn foo(s1: &S) {}
+
+        fn bar() {
+            let s1 = S { a: 1 };
+            let a = 1;
+            let s2 = S { a };
+        }
+    """, """
+        <root> (5)
+         Struct
+          S
+         Found usages (5)
+          impl (2)
+           main.rs (2)
+            7impl S {}
+            8impl S {}
+          init struct (2)
+           main.rs (2)
+            13let s1 = S { a: 1 };
+            15let s2 = S { a };
+          type reference (1)
+           main.rs (1)
+            10fn foo(s1: &S) {}
+    """)
+}

--- a/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildTaskRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/buildtool/CargoBuildTaskRunner.kt
@@ -13,10 +13,14 @@ import com.intellij.execution.RunManager
 import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.progress.*
+import com.intellij.openapi.progress.EmptyProgressIndicator
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapiext.isHeadlessEnvironment
 import com.intellij.task.*
@@ -73,7 +77,7 @@ class CargoBuildTaskRunner : ProjectTaskRunner() {
 
         CargoBuildSessionsQueueManager.getInstance(project)
             .buildSessionsQueue
-            .run(queuedTask, null, EmptyProgressIndicator())
+            .run(queuedTask, ModalityState.defaultModalityState(), EmptyProgressIndicator())
 
         return resultPromise
     }

--- a/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
+++ b/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
@@ -17,7 +17,6 @@ import com.intellij.openapi.application.ex.ApplicationManagerEx
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
-import com.intellij.openapi.updateSettings.impl.pluginsAdvertisement.PluginsAdvertiser
 import com.intellij.openapi.util.BuildNumber
 import com.intellij.util.PlatformUtils.*
 import org.rust.cargo.runconfig.RsDefaultProgramRunnerBase
@@ -89,7 +88,7 @@ class RsDebugAdvertisingRunner : RsDefaultProgramRunnerBase() {
                 get() = "Install"
 
             override fun doOkAction(project: Project, pluginId: PluginId) {
-                PluginsAdvertiser.installAndEnable(project, setOf(pluginId), false) {}
+                installPluginsAndEnable(project, setOf(pluginId), false) {}
             }
         },
         ENABLE {
@@ -99,7 +98,7 @@ class RsDebugAdvertisingRunner : RsDefaultProgramRunnerBase() {
                 get() = "Enable"
 
             override fun doOkAction(project: Project, pluginId: PluginId) {
-                PluginsAdvertiser.installAndEnable(project, setOf(pluginId), false) {}
+                installPluginsAndEnable(project, setOf(pluginId), false) {}
             }
         },
         RESTART {

--- a/src/main/kotlin/org/rust/ide/actions/InstallComponentAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/InstallComponentAction.kt
@@ -28,8 +28,8 @@ class InstallComponentAction(
         object : Task.Backgroundable(project, "Installing $componentName...") {
             override fun shouldStartInBackground(): Boolean = false
             override fun run(indicator: ProgressIndicator) {
-                val result = rustup.downloadComponent(myProject, componentName) as? DownloadResult.Err ?: return
-                myProject.showBalloon(result.error, NotificationType.ERROR)
+                val result = rustup.downloadComponent(project, componentName) as? DownloadResult.Err ?: return
+                project.showBalloon(result.error, NotificationType.ERROR)
             }
         }.queue()
     }

--- a/src/main/kotlin/org/rust/ide/actions/InstallTargetAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/InstallTargetAction.kt
@@ -31,10 +31,10 @@ class InstallTargetAction(
             override fun shouldStartInBackground(): Boolean = false
 
             override fun run(indicator: ProgressIndicator) {
-                val result = rustup.downloadTarget(myProject, targetName)
+                val result = rustup.downloadTarget(project, targetName)
 
                 if (result is DownloadResult.Err) {
-                    myProject.showBalloon(result.error, NotificationType.ERROR)
+                    project.showBalloon(result.error, NotificationType.ERROR)
                 }
             }
         }.queue()

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionManager.kt
@@ -270,8 +270,15 @@ class MacroExpansionManagerImpl(
         this.dirs = dir
         this.inner = impl
         impl.macroExpansionMode = mode
+
+        runWriteAction {
+            ProjectRootManagerEx.getInstanceEx(project)
+                .makeRootsChange(EmptyRunnable.getInstance(), false, true)
+        }
+
         val saveCacheOnDispose = cacheDirectory.isNotEmpty()
         val disposable = impl.setupForUnitTests(saveCacheOnDispose)
+
         Disposer.register(disposable) {
             this.inner = null
             this.dirs = null

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionSharedCache.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionSharedCache.kt
@@ -16,11 +16,12 @@ import com.intellij.openapi.util.registry.RegistryValueListener
 import com.intellij.psi.stubs.*
 import com.intellij.testFramework.ReadOnlyLightVirtualFile
 import com.intellij.util.indexing.FileContent
-import com.intellij.util.indexing.FileContentImpl
 import com.intellij.util.io.*
 import org.rust.lang.RsLanguage
 import org.rust.lang.core.macros.MacroExpansionSharedCache.Companion.CACHE_ENABLED
-import org.rust.lang.core.macros.decl.*
+import org.rust.lang.core.macros.decl.DeclMacroExpander
+import org.rust.lang.core.macros.decl.MACRO_DOLLAR_CRATE_IDENTIFIER
+import org.rust.lang.core.macros.decl.MACRO_DOLLAR_CRATE_IDENTIFIER_REGEX
 import org.rust.lang.core.macros.proc.ProcMacroExpander
 import org.rust.lang.core.parser.RustParserDefinition
 import org.rust.lang.core.stubs.RsFileStub
@@ -177,9 +178,7 @@ class MacroExpansionSharedCache : Disposable {
         val result = cachedExpand(expander, def.data, call.data, hash) ?: return null
         val serializedStub = cachedBuildStub(hash) {
             val file = ReadOnlyLightVirtualFile("macro.rs", RsLanguage, result.text)
-            FileContentImpl.createByText(file, result.text).also {
-                (it as FileContentImpl).project = project
-            }
+            createFileContentByText(file, result.text, project)
         } ?: return null
 
         val stub = try {

--- a/src/test/kotlin/org/rust/lang/core/stubs/RsStubAccessTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/stubs/RsStubAccessTest.kt
@@ -13,8 +13,6 @@ import com.intellij.openapi.vfs.VirtualFileVisitor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.PsiFileImpl
 import com.intellij.psi.stubs.StubElement
-import com.intellij.testFramework.LoggedErrorProcessor
-import org.apache.log4j.Logger
 import org.rust.RsTestBase
 import org.rust.lang.core.psi.RsFile
 import org.rust.lang.core.psi.ext.RsElement
@@ -61,25 +59,15 @@ class RsStubAccessTest : RsTestBase() {
 
     fun `test parent works correctly for stubbed elements`() {
         val parentsByStub: MutableMap<PsiElement, PsiElement> = HashMap()
-        try {
-            LoggedErrorProcessor.setNewInstance(object : LoggedErrorProcessor() {
-                override fun processError(message: String?, t: Throwable?, details: Array<out String>?, logger: Logger) {
-                    logger.info(message, t)
-                    throw AssertionError(message)
-                }
-            })
-            processStubsWithoutAstAccess<RsElement> {
-                val parent = try {
-                    it.parent
-                } catch (e: AssertionError) {
-                    null
-                }
-                if (parent != null) {
-                    parentsByStub += it to it.parent
-                }
+        processStubsWithoutAstAccess<RsElement> {
+            val parent = try {
+                it.parent
+            } catch (e: AssertionError) {
+                null
             }
-        } finally {
-            LoggedErrorProcessor.restoreDefaultProcessor()
+            if (parent != null) {
+                parentsByStub += it to it.parent
+            }
         }
 
         checkAstNotLoaded(VirtualFileFilter.NONE)


### PR DESCRIPTION
Note, `js` module won't be included in 212 build because of https://github.com/JetBrains/gradle-intellij-plugin/issues/674

changelog: Support 2021.2 EAPs
