### PR TITLE
RUN: Add Cargo commands logging

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/CargoRunStateBase.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/CargoRunStateBase.kt
@@ -9,6 +9,8 @@ import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.logger
 import org.rust.cargo.project.model.CargoProject
 import org.rust.cargo.runconfig.buildtool.CargoPatch
 import org.rust.cargo.runconfig.buildtool.cargoPatches
@@ -64,8 +66,13 @@ abstract class CargoRunStateBase(
      */
     fun startProcess(processColors: Boolean): ProcessHandler {
         val commandLine = cargo().toColoredCommandLine(environment.project, prepareCommandLine())
+        LOG.debug("Executing Cargo command: `${commandLine.commandLineString}`")
         val handler = RsProcessHandler(commandLine, processColors)
         ProcessTerminatedListener.attach(handler) // shows exit code upon termination
         return handler
+    }
+
+    companion object {
+        private val LOG: Logger = logger<CargoRunStateBase>()
     }
 }

--- a/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/legacy/RsAsyncRunner.kt
@@ -18,6 +18,8 @@ import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.showRunContent
 import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.openapi.application.invokeLater
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
@@ -131,7 +133,9 @@ abstract class RsAsyncRunner(
         val cargo = state.cargo()
 
         val processForUserOutput = ProcessOutput()
-        val processForUser = RsProcessHandler(cargo.toColoredCommandLine(project, command))
+        val commandLine = cargo.toColoredCommandLine(project, command)
+        LOG.debug("Executing Cargo command: `${commandLine.commandLineString}`")
+        val processForUser = RsProcessHandler(commandLine)
 
         processForUser.addProcessListener(CapturingProcessAdapter(processForUserOutput))
 
@@ -227,5 +231,7 @@ abstract class RsAsyncRunner(
 
     companion object {
         class Binary(val path: Path)
+
+        private val LOG: Logger = logger<RsAsyncRunner>()
     }
 }


### PR DESCRIPTION
Now plugin logs every Cargo command executed through Cargo run configurations (including Build, Run, Debug, Test).
This might be useful when investigating a reported problem related to building, running, and debugging Rust code.

Note, to enable this _debug-level_ logging in IDE, `#org.rust.cargo.runconfig` should be entered into `Help | Diagnostic Tools | Debug Log Settings`.