### PR TITLE
TY: infer expression type of log-like macros

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/type/RsMacroTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsMacroTypeInferenceTest.kt
@@ -134,4 +134,17 @@ class RsMacroTypeInferenceTest : RsTypificationTestBase() {
             a;
         } //^ <unknown>
     """, TypeInferenceMarks.macroExprDepthLimitReached)
+
+    fun `test custom log-like macro`() = testExpr("""
+        enum Data {
+            Value
+        }
+
+        macro_rules! error { () => { Data::Value } }
+
+        fn main() {
+            let a = error!();
+            a;
+        } //^ Data
+    """)
 }


### PR DESCRIPTION
Previously, log-like macros were hardcoded in type inference to have type `TyUnit`. This PR changes it so that they are inferred properly.

Some notes:
1) I included some code that special cases the inference for `log` macros. However, with the new macro engine, it seems that they are correctly inferred as-is. Is it even worth it to keep the special case?
2) If yes, the commented code is not completely correct, since I use the name of the crate (not the name of the crate as a dependency), so it might not work correctly for renamed `log` dependency. But that should be rare and the macro is inferred properly in any case...
3) I didn't find any (macro) type inference tests that would use toolchain so that I could test this with the `log` crate. It it worth it? I think that the main point is that custom "log-like" macros are resolved. I included a test for that.

changelog: The type of custom macros that have log-like names (like `error!`, `warn!` or `debug!`) is now correctly inferred.
