### PR TITLE
Don't throw exception on invalid user-created paths

### DIFF
--- a/src/211/main/kotlin/org/rust/cargo/toolchain/wsl/RsWslToolchainFlavor.kt
+++ b/src/211/main/kotlin/org/rust/cargo/toolchain/wsl/RsWslToolchainFlavor.kt
@@ -13,6 +13,7 @@ import com.intellij.util.io.isDirectory
 import org.rust.cargo.toolchain.flavors.RsToolchainFlavor
 import org.rust.openapiext.computeWithCancelableProgress
 import org.rust.openapiext.isFeatureEnabled
+import org.rust.stdext.resolveOrNull
 import java.nio.file.Path
 
 class RsWslToolchainFlavor : RsToolchainFlavor() {
@@ -44,7 +45,7 @@ class RsWslToolchainFlavor : RsToolchainFlavor() {
             val sysPath = environment["PATH"]
             for (remotePath in sysPath.orEmpty().split(":")) {
                 if (remotePath.isEmpty()) continue
-                val localPath = root.resolve(remotePath)
+                val localPath = root.resolveOrNull(remotePath) ?: continue
                 if (!localPath.isDirectory()) continue
                 yield(localPath)
             }

--- a/src/main/kotlin/org/rust/cargo/toolchain/flavors/RsSysPathToolchainFlavor.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/flavors/RsSysPathToolchainFlavor.kt
@@ -6,7 +6,7 @@
 package org.rust.cargo.toolchain.flavors
 
 import com.intellij.util.io.isDirectory
-import org.rust.stdext.toPath
+import org.rust.stdext.toPathOrNull
 import java.io.File
 import java.nio.file.Path
 
@@ -17,6 +17,6 @@ class RsSysPathToolchainFlavor : RsToolchainFlavor() {
             .split(File.pathSeparator)
             .asSequence()
             .filter { it.isNotEmpty() }
-            .map { it.toPath() }
+            .mapNotNull { it.toPathOrNull() }
             .filter { it.isDirectory() }
 }

--- a/src/main/kotlin/org/rust/stdext/Utils.kt
+++ b/src/main/kotlin/org/rust/stdext/Utils.kt
@@ -6,15 +6,19 @@
 
 package org.rust.stdext
 
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VirtualFile
 import org.apache.commons.lang.RandomStringUtils
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.file.Files
+import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.streams.asSequence
+
+private val LOG = Logger.getInstance("#org.rust.stdext")
 
 /**
  * Just a way to nudge Kotlin's type checker in the right direction
@@ -41,6 +45,19 @@ inline fun <T> VirtualFile.applyWithSymlink(f: (VirtualFile) -> T?): T? {
 }
 
 fun String.toPath(): Path = Paths.get(this)
+
+fun String.toPathOrNull(): Path? = pathOrNull(this::toPath)
+
+fun Path.resolveOrNull(other: String): Path? = pathOrNull { resolve(other) }
+
+private inline fun pathOrNull(block: () -> Path): Path? {
+    return try {
+        block()
+    } catch (e: InvalidPathException) {
+        LOG.warn(e)
+        null
+    }
+}
 
 fun Path.isExecutable(): Boolean = Files.isExecutable(this)
 


### PR DESCRIPTION
During toolchain detection, the plugin checks `PATH` variable and tries to convert its parts to `java.nio.file.Path`.
But if a user appended something illegal into the variable, the conversion fails with `InvalidPathException` exception.
Previously, we did nothing with it and it broke the UI. Now, we log such cases and skip illegal paths

Fixes #7202
Fixes #7264

changelog: Don't throw exceptions on illegal paths in `PATH` environment variable during toolchain detection
