### PR TITLE
CI: cancel previous ci runs via native `concurrency` feature

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,18 +8,14 @@ on:
             - trying
     pull_request:
 
-jobs:
-    # TODO: drop it when GitHub supports its by itself
-    cancel-previous:
-        runs-on: ubuntu-18.04
-        steps:
-            - name: Cancel Previous Runs
-              uses: styfle/cancel-workflow-action@0.9.0
-              with:
-                  access_token: ${{ github.token }}
+# Allow cancelling all previous runs for the same branch
+# See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
+jobs:
     calculate-git-info:
-        needs: [ cancel-previous ]
         runs-on: ubuntu-18.04
         outputs:
             is_bors_branch: ${{ steps.calculate-git-info.outputs.is_bors_branch }}
@@ -49,7 +45,6 @@ jobs:
                   echo "checked: ${{ steps.calculate-git-info.outputs.checked }}"
 
     check-license:
-        needs: [ cancel-previous ]
         runs-on: ubuntu-18.04
         steps:
             - uses: actions/checkout@v2
@@ -58,7 +53,7 @@ jobs:
               run: ./check-license.sh
 
     build-native-code:
-        needs: [ cancel-previous, calculate-git-info ]
+        needs: [ calculate-git-info ]
         # `fromJSON` is used here to convert string output to boolean
         if: ${{ !(fromJSON(needs.calculate-git-info.outputs.is_master_branch) && fromJSON(needs.calculate-git-info.outputs.checked)) }}
         strategy:
@@ -117,7 +112,7 @@ jobs:
                   path: ${{ matrix.config.artifact_path }}
 
     check-plugin:
-        needs: [ cancel-previous, calculate-git-info, build-native-code ]
+        needs: [ calculate-git-info, build-native-code ]
         strategy:
             # `fromJSON` is used here to convert string output to boolean
             fail-fast: ${{ fromJSON(needs.calculate-git-info.outputs.is_bors_branch) }}

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -2,6 +2,12 @@ name: regressions
 
 on: [ workflow_dispatch, pull_request ]
 
+# Allow cancelling all previous runs for the same branch
+# See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     calculate-base-commit:
         runs-on: ubuntu-18.04


### PR DESCRIPTION
Recently, GitHub [announced](https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/) a `concurrency` [feature](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency) to run only single workflow/job for provided concurrency group. In combination with the `cancel-in-progress: true` flag, it also allows canceling already running tasks for the same concurrency group via builtin GitHub feature.
As a result, we can replace hacky `styfle/cancel-workflow-action` action that we used before to cancel outdated workflow runs (that actually worked not quite well when all available GitHub runners were busy) with the native GitHub feature.

changelog: Improve cancellation of outdated CI runs
