### PR TITLE
PRJ: Don't reset project toolchain after project creation

### DIFF
--- a/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
+++ b/src/main/kotlin/org/rust/ide/newProject/RsDirectoryProjectGenerator.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.wm.impl.welcomeScreen.AbstractActionWithPanel
 import com.intellij.platform.DirectoryProjectGenerator
 import com.intellij.platform.DirectoryProjectGeneratorBase
 import com.intellij.platform.ProjectGeneratorPeer
+import org.rust.cargo.project.settings.rustSettings
 import org.rust.cargo.toolchain.tools.cargo
 import org.rust.ide.icons.RsIcons
 import org.rust.openapiext.computeWithCancelableProgress
@@ -46,6 +47,11 @@ class RsDirectoryProjectGenerator : DirectoryProjectGeneratorBase<ConfigurationD
         val generatedFiles = project.computeWithCancelableProgress("Generating Cargo project...") {
             cargo.makeProject(project, module, baseDir, name, template)
         } ?: return
+
+        project.rustSettings.modify {
+            it.toolchain = settings.toolchain
+            it.explicitPathToStdlib = settings.explicitPathToStdlib
+        }
 
         project.makeDefaultRunConfiguration(template)
         project.openFiles(generatedFiles)


### PR DESCRIPTION
FIxes #4709
Fixes #5030
Fixes https://github.com/intellij-rust/intellij-rust/issues/7204

changelog: Don't reset project toolchain after project creation
