### PR TITLE
CI: use evcxr_repl 0.9 in tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -200,7 +200,9 @@ jobs:
               uses: actions-rs/cargo@v1
               with:
                   command: install
-                  args: evcxr_repl
+                  # REPL doesn't work with 0.10.0 version
+                  # See https://github.com/intellij-rust/intellij-rust/issues/7295
+                  args: evcxr_repl --version 0.9.0
 
             - name: Check environment
               run: |


### PR DESCRIPTION
Recent 0.10.0 version doesn't work with IDE integration.
https://github.com/intellij-rust/intellij-rust/issues/7295