### PR TITLE
COMP: deduplicate method completion variants by name and trait

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Processors.kt
@@ -289,7 +289,7 @@ fun processAllWithSubst(
     return false
 }
 
-fun filterCompletionVariantsByVisibility(processor: RsResolveProcessor, context: RsElement): RsResolveProcessor {
+fun filterCompletionVariantsByVisibility(context: RsElement, processor: RsResolveProcessor): RsResolveProcessor {
     val mod = context.containingMod
     return createProcessor(processor.name) {
         val element = it.element

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionFilteringTest.kt
@@ -282,4 +282,26 @@ class RsCompletionFilteringTest: RsCompletionTestBase() {
             <S<X>>::cl/*caret*/;
         }
     """)
+
+    fun `test trait implementation on multiple dereference levels`() = doSingleCompletion("""
+        struct S;
+        trait T { fn foo(&self); }
+
+        impl T for S { fn foo(&self) {} }
+        impl T for &S { fn foo(&self) {} }
+
+        fn main(a: &S) {
+            a.f/*caret*/
+        }
+    """, """
+        struct S;
+        trait T { fn foo(&self); }
+
+        impl T for S { fn foo(&self) {} }
+        impl T for &S { fn foo(&self) {} }
+
+        fn main(a: &S) {
+            a.foo()/*caret*/
+        }
+    """)
 }


### PR DESCRIPTION
Fixes #7238

changelog: Fix method duplication issue in completion list
