### PR TITLE
INSP: Implement `unknown_crate_types` lint

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -71,7 +71,9 @@ enum class RsLint(
                 WARN -> ProblemHighlightType.WEAK_WARNING
                 else -> super.toHighlightingType(level)
             }
-    };
+    },
+
+    UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY);
 
     protected open fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
         when (level) {

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnknownCrateTypesInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnknownCrateTypesInspection.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.psi.PsiElement
+import com.intellij.util.ProcessingContext
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.lang.core.RsPsiPattern
+import org.rust.lang.core.psi.RsInnerAttr
+import org.rust.lang.core.psi.RsLitExpr
+import org.rust.lang.core.psi.RsMetaItem
+import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.ext.isRootMetaItem
+import org.rust.lang.core.psi.ext.stringValue
+
+class RsUnknownCrateTypesInspection : RsLintInspection() {
+    override fun getLint(element: PsiElement): RsLint = RsLint.UnknownCrateTypes
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
+        object : RsVisitor() {
+            override fun visitLitExpr(o: RsLitExpr) {
+                val parent = o.parent as? RsMetaItem ?: return
+                if (parent.path?.text != "crate_type") return
+
+                val context = ProcessingContext()
+                if (!parent.isRootMetaItem(context)) return
+                if (context.get(RsPsiPattern.META_ITEM_ATTR) !is RsInnerAttr) return
+
+                if (o.stringValue !in KNOWN_CRATE_TYPES) {
+                    holder.registerLintProblem(o, "Invalid `crate_type` value")
+                }
+            }
+        }
+
+    companion object {
+        private val KNOWN_CRATE_TYPES = listOf("bin", "lib", "dylib", "staticlib", "cdylib", "rlib", "proc-macro")
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -602,6 +602,11 @@
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.rust.ide.inspections.lints.RsUnreachableCodeInspection"/>
 
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
+                         displayName="Unknown crate types"
+                         enabledByDefault="true" level="ERROR"
+                         implementationClass="org.rust.ide.inspections.lints.RsUnknownCrateTypesInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsUnknownCrateTypes.html
+++ b/src/main/resources/inspectionDescriptions/RsUnknownCrateTypes.html
@@ -1,0 +1,1 @@
+Detects an unknown crate type found in a <code>crate_type</code> attribute.

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnknownCrateTypesInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnknownCrateTypesInspectionTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class RsUnknownCrateTypesInspectionTest : RsInspectionsTestBase(RsUnknownCrateTypesInspection::class) {
+    fun `test incorrect crate type`() = checkWarnings("""
+        #![crate_type = <error descr="Invalid `crate_type` value">"foo"</error>]
+    """)
+
+    fun `test correct crate type`() = checkWarnings("""
+        #![crate_type = "cdylib"]
+    """)
+
+    fun `test ignore if outer`() = checkWarnings("""
+        #[crate_type = "foo"]
+        fn main() {}
+    """)
+
+    fun `test ignore if not root`() = checkWarnings("""
+        #![bar(crate_type = "foo")]
+    """)
+
+    fun `test warn unknown_crate_types`() = checkWarnings("""
+        #![warn(unknown_crate_types)]
+        #![crate_type = <warning descr="Invalid `crate_type` value">"foo"</warning>]
+    """)
+
+    fun `test allow unknown_crate_types`() = checkWarnings("""
+        #![allow(unknown_crate_types)]
+        #![crate_type = "foo"]
+    """)
+}


### PR DESCRIPTION
[The lint in the rustc book](https://doc.rust-lang.org/rustc/lints/listing/deny-by-default.html#unknown-crate-types)

[`Linkage` section in the Rust Reference](https://doc.rust-lang.org/reference/linkage.html)

<img width="500" src="https://user-images.githubusercontent.com/6342851/120673494-e7a11280-c49b-11eb-9983-bfca816091e2.png">


Part of https://github.com/intellij-rust/intellij-rust/issues/5888

changelog: Detect `unknown_crate_type` compiler lint
