### PR TITLE
CI&MACRO: expand proc macros on Apple Silicon machines

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -64,17 +64,22 @@ jobs:
                       arch: x86-64
                       os: ubuntu-latest
                       target: x86_64-unknown-linux-gnu
-                      artifact_path: native-helper/target/release/intellij-rust-native-helper
+                      artifact_path: native-helper/target/x86_64-unknown-linux-gnu/release/intellij-rust-native-helper
                     - name: windows
                       arch: x86-64
                       os: windows-latest
                       target: x86_64-pc-windows-msvc
-                      artifact_path: native-helper/target/release/intellij-rust-native-helper.exe
+                      artifact_path: native-helper/target/x86_64-pc-windows-msvc/release/intellij-rust-native-helper.exe
                     - name: macos
                       arch: x86-64
                       os: macos-latest
                       target: x86_64-apple-darwin
-                      artifact_path: native-helper/target/release/intellij-rust-native-helper
+                      artifact_path: native-helper/target/x86_64-apple-darwin/release/intellij-rust-native-helper
+                    - name: macos
+                      arch: arm64
+                      os: macos-11
+                      target: aarch64-apple-darwin
+                      artifact_path: native-helper/target/aarch64-apple-darwin/release/intellij-rust-native-helper
 
         name: ${{ matrix.config.name }}-${{ matrix.config.arch }}
         runs-on: ${{ matrix.config.os }}
@@ -103,7 +108,7 @@ jobs:
               uses: actions-rs/cargo@v1
               with:
                   command: build
-                  args: --manifest-path native-helper/Cargo.toml --release
+                  args: --manifest-path native-helper/Cargo.toml --target ${{ matrix.config.target }} --release
 
             - name: Publish
               uses: actions/upload-artifact@v2
@@ -233,11 +238,17 @@ jobs:
                   name: windows-x86-64
                   path: bin/windows/x86-64
 
-            - name: Load macos binaries
+            - name: Load macos x86 binaries
               uses: actions/download-artifact@v2
               with:
                   name: macos-x86-64
                   path: bin/macos/x86-64
+
+            - name: Load macos arm64 binaries
+              uses: actions/download-artifact@v2
+              with:
+                  name: macos-arm64
+                  path: bin/macos/arm64
 
             - name: Download
               uses: eskatos/gradle-command-action@v1

--- a/.github/workflows/rust-nightly.yml
+++ b/.github/workflows/rust-nightly.yml
@@ -63,17 +63,22 @@ jobs:
                       arch: x86-64
                       os: ubuntu-18.04
                       target: x86_64-unknown-linux-gnu
-                      artifact_path: native-helper/target/release/intellij-rust-native-helper
+                      artifact_path: native-helper/target/x86_64-unknown-linux-gnu/release/intellij-rust-native-helper
                     - name: windows
                       arch: x86-64
                       os: windows-latest
                       target: x86_64-pc-windows-msvc
-                      artifact_path: native-helper/target/release/intellij-rust-native-helper.exe
+                      artifact_path: native-helper/target/x86_64-pc-windows-msvc/release/intellij-rust-native-helper.exe
                     - name: macos
                       arch: x86-64
                       os: macos-latest
                       target: x86_64-apple-darwin
-                      artifact_path: native-helper/target/release/intellij-rust-native-helper
+                      artifact_path: native-helper/target/x86_64-apple-darwin/release/intellij-rust-native-helper
+                    - name: macos
+                      arch: arm64
+                      os: macos-11
+                      target: aarch64-apple-darwin
+                      artifact_path: native-helper/target/aarch64-apple-darwin/release/intellij-rust-native-helper
 
         name: ${{ matrix.config.name }}-${{ matrix.config.arch }}
         runs-on: ${{ matrix.config.os }}
@@ -93,7 +98,7 @@ jobs:
               uses: actions-rs/cargo@v1
               with:
                   command: build
-                  args: --manifest-path native-helper/Cargo.toml --release
+                  args: --manifest-path native-helper/Cargo.toml --target ${{ matrix.config.target }} --release
 
             - name: Publish
               uses: actions/upload-artifact@v2
@@ -138,11 +143,17 @@ jobs:
                   name: windows-x86-64
                   path: bin/windows/x86-64
 
-            - name: Load macos binaries
+            - name: Load macos x86 binaries
               uses: actions/download-artifact@v2
               with:
                   name: macos-x86-64
                   path: bin/macos/x86-64
+
+            - name: Load macos arm64 binaries
+              uses: actions/download-artifact@v2
+              with:
+                  name: macos-arm64
+                  path: bin/macos/arm64
 
             - name: Publish toml plugin
               if: needs.fetch-latest-changes.outputs.toml-commit != needs.fetch-latest-changes.outputs.toml-nightly

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -126,17 +126,22 @@ jobs:
                       arch: x86-64
                       os: ubuntu-18.04
                       target: x86_64-unknown-linux-gnu
-                      artifact_path: native-helper/target/release/intellij-rust-native-helper
+                      artifact_path: native-helper/target/x86_64-unknown-linux-gnu/release/intellij-rust-native-helper
                     - name: windows
                       arch: x86-64
                       os: windows-latest
                       target: x86_64-pc-windows-msvc
-                      artifact_path: native-helper/target/release/intellij-rust-native-helper.exe
+                      artifact_path: native-helper/target/x86_64-pc-windows-msvc/release/intellij-rust-native-helper.exe
                     - name: macos
                       arch: x86-64
                       os: macos-latest
                       target: x86_64-apple-darwin
-                      artifact_path: native-helper/target/release/intellij-rust-native-helper
+                      artifact_path: native-helper/target/x86_64-apple-darwin/release/intellij-rust-native-helper
+                    - name: macos
+                      arch: arm64
+                      os: macos-11
+                      target: aarch64-apple-darwin
+                      artifact_path: native-helper/target/aarch64-apple-darwin/release/intellij-rust-native-helper
 
         name: ${{ matrix.config.name }}-${{ matrix.config.arch }}
         runs-on: ${{ matrix.config.os }}
@@ -156,7 +161,7 @@ jobs:
               uses: actions-rs/cargo@v1
               with:
                   command: build
-                  args: --manifest-path native-helper/Cargo.toml --release
+                  args: --manifest-path native-helper/Cargo.toml --target ${{ matrix.config.target }} --release
 
             - name: Publish
               uses: actions/upload-artifact@v2
@@ -203,11 +208,17 @@ jobs:
                   name: windows-x86-64
                   path: bin/windows/x86-64
 
-            - name: Load macos binaries
+            - name: Load macos x86 binaries
               uses: actions/download-artifact@v2
               with:
                   name: macos-x86-64
                   path: bin/macos/x86-64
+
+            - name: Load macos arm64 binaries
+              uses: actions/download-artifact@v2
+              with:
+                  name: macos-arm64
+                  path: bin/macos/arm64
 
             - name: Publish toml plugin
               if: needs.fetch-latest-changes.outputs.toml-commit != needs.fetch-latest-changes.outputs.toml-release

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,7 +150,11 @@ allprojects {
                 environment("RUSTC_BOOTSTRAP", "1")
 
                 val hostPlatform = DefaultNativePlatform.host()
-                val outDir = "${rootDir}/bin/${hostPlatform.operatingSystem.toFamilyName()}/${hostPlatform.architecture.name}"
+                val archName = when (val archName = hostPlatform.architecture.name) {
+                    "arm-v8", "aarch64" -> "arm64"
+                    else -> archName
+                }
+                val outDir = "${rootDir}/bin/${hostPlatform.operatingSystem.toFamilyName()}/$archName"
                 args("build", "--release", "-Z", "unstable-options", "--out-dir", outDir)
 
                 // It may be useful to disable compilation of native code.

--- a/src/main/kotlin/org/rust/openapiext/RsPathManager.kt
+++ b/src/main/kotlin/org/rust/openapiext/RsPathManager.kt
@@ -27,6 +27,7 @@ object RsPathManager {
         @Suppress("UnstableApiUsage", "DEPRECATION")
         val arch = when {
             CpuArch.isIntel64() -> "x86-64"
+            SystemInfo.isMac && CpuArch.isArm64() -> "arm64"
             else -> return null
         }
 


### PR DESCRIPTION
Part of #6908

changelog: Support [procedural macro](https://doc.rust-lang.org/reference/procedural-macros.html) expansion on Apple Silicon machines. Note:
- you should use `aarch64-apple-darwin` toolchain to make procedural macro expansion work
- the proc macro expansion is still disabled by default. To turn it on, enable `org.rust.cargo.evaluate.build.scripts` and `org.rust.macros.proc` [experimental features](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-faq.html#experimental-features)