### PR TITLE
RUN: Provide an registry key to add `--nocapture` flag to `cargo test` command

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/command/CargoCommandConfiguration.kt
@@ -32,6 +32,7 @@ import org.rust.cargo.toolchain.BacktraceMode
 import org.rust.cargo.toolchain.CargoCommandLine
 import org.rust.cargo.toolchain.RsToolchainBase
 import org.rust.cargo.toolchain.RustChannel
+import org.rust.cargo.toolchain.tools.Cargo
 import org.rust.cargo.toolchain.tools.isRustupAvailable
 import org.rust.ide.experiments.RsExperiments
 import org.rust.openapiext.isFeatureEnabled
@@ -151,6 +152,7 @@ open class CargoCommandConfiguration(
 
     private fun showTestToolWindow(): Boolean = command.startsWith("test") &&
         isFeatureEnabled(RsExperiments.TEST_TOOL_WINDOW) &&
+        !Cargo.TEST_NOCAPTURE_ENABLED_KEY.asBoolean() &&
         !command.contains("--nocapture")
 
 

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -18,6 +18,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.util.registry.RegistryValue
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapiext.isDispatchThread
 import com.intellij.util.execution.ParametersListUtil
@@ -436,6 +437,9 @@ class Cargo(toolchain: RsToolchainBase, useWrapper: Boolean = false)
     companion object {
         private val LOG: Logger = logger<Cargo>()
 
+        @JvmStatic
+        val TEST_NOCAPTURE_ENABLED_KEY: RegistryValue = Registry.get("org.rust.cargo.test.nocapture")
+
         const val NAME: String = "cargo"
         const val WRAPPER_NAME: String = "xargo"
 
@@ -455,8 +459,13 @@ class Cargo(toolchain: RsToolchainBase, useWrapper: Boolean = false)
             val (pre, post) = splitOnDoubleDash()
                 .let { (pre, post) -> pre.toMutableList() to post.toMutableList() }
 
-            if (command == "test" && allFeatures && !pre.contains("--all-features")) {
-                pre.add("--all-features")
+            if (command == "test") {
+                if (allFeatures && !pre.contains("--all-features")) {
+                    pre.add("--all-features")
+                }
+                if (TEST_NOCAPTURE_ENABLED_KEY.asBoolean() && !post.contains("--nocapture")) {
+                    post.add(0, "--nocapture")
+                }
             }
 
             if (requiredFeatures && command in FEATURES_ACCEPTING_COMMANDS) {

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -1074,6 +1074,9 @@
         <registryKey key="org.rust.cargo.evaluate.build.scripts.wrapper" defaultValue="true" restartRequired="false"
                      description="Use RUSTC_WRAPPER when fetching build script info (if experimental feature
                      `org.rust.cargo.evaluate.build.scripts` is enabled)"/>
+        <registryKey key="org.rust.cargo.test.nocapture" defaultValue="false" restartRequired="false"
+                     description="Add `--nocapture` flag to the test command line and show test results in
+                     Run Tool Window instead of raw console"/>
         <registryKey key="org.rust.macros.proc.timeout" defaultValue="5000" restartRequired="false"
                      description="The maximum time (in milliseconds) allotted to one procedural macro expansion"/>
 


### PR DESCRIPTION
Relates to https://github.com/intellij-rust/intellij-rust/issues/6505#issuecomment-853227324.

changelog: Provide an experimental feature to add `--nocapture` flag to `cargo test` command
