### PR TITLE
REPL: Fix for Evcxr 0.10.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -200,9 +200,7 @@ jobs:
               uses: actions-rs/cargo@v1
               with:
                   command: install
-                  # REPL doesn't work with 0.10.0 version
-                  # See https://github.com/intellij-rust/intellij-rust/issues/7295
-                  args: evcxr_repl --version 0.9.0
+                  args: evcxr_repl
 
             - name: Check environment
               run: |

--- a/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
+++ b/src/main/kotlin/org/rust/cargo/toolchain/tools/Cargo.kt
@@ -515,7 +515,7 @@ class Cargo(toolchain: RsToolchainBase, useWrapper: Boolean = false)
 
         fun checkNeedInstallEvcxr(project: Project): Boolean {
             val crateName = "evcxr_repl"
-            val minVersion = SemVer("v0.5.1", 0, 5, 1)
+            val minVersion = SemVer("v0.10.0", 0, 10, 0)
             return checkNeedInstallBinaryCrate(
                 project,
                 crateName,

--- a/src/main/kotlin/org/rust/ide/console/RsConsoleCommunication.kt
+++ b/src/main/kotlin/org/rust/ide/console/RsConsoleCommunication.kt
@@ -9,7 +9,7 @@ class RsConsoleCommunication(private val consoleView: RsConsoleView) {
 
     var isExecuting: Boolean = false
         private set
-    private var receivedInitialPrompt: Boolean = false
+    private var receivedInitialPrompt: Boolean = true
     private var lastCommandContext: RsConsoleOneCommandContext? = null
 
     fun onExecutionBegin() {

--- a/src/test/kotlin/org/rustSlowTests/console/RsEvcxrTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/console/RsEvcxrTest.kt
@@ -31,12 +31,18 @@ class RsEvcxrTest : RsWithToolchainTestBase() {
 
         try {
             scanner.nextLine()  // "Welcome to evcxr. For help, type :help"
-            expectPrompt(scanner, true)
+            expectPrompt(scanner, true, withMarker = false)
 
             // success command
             writer.println("1 + 2")
             writer.flush()
             assertEquals(scanner.nextLine(), "3")
+            expectPrompt(scanner, true)
+
+            // success command
+            writer.println("1 + 3")
+            writer.flush()
+            assertEquals(scanner.nextLine(), "4")
             expectPrompt(scanner, true)
 
             // fail command
@@ -56,18 +62,19 @@ class RsEvcxrTest : RsWithToolchainTestBase() {
         return commandLine.createProcess()
     }
 
-    private fun expectPrompt(scanner: Scanner, success: Boolean) {
+    private fun expectPrompt(scanner: Scanner, success: Boolean, withMarker: Boolean = true) {
+        if (withMarker) {
+            val markerExpected = if (success) {
+                RsConsoleCommunication.SUCCESS_EXECUTION_MARKER
+            } else {
+                RsConsoleCommunication.FAILED_EXECUTION_MARKER
+            }
+            val markerReceived = scanner.nextChar().toString()
+            assertEquals(markerExpected, markerReceived)
+        }
+
         val prompt = ">> "
         val promptColored = "\u001B[33m$prompt\u001B[0m"
-
-        val markerExpected = if (success) {
-            RsConsoleCommunication.SUCCESS_EXECUTION_MARKER
-        } else {
-            RsConsoleCommunication.FAILED_EXECUTION_MARKER
-        }
-        val markerReceived = scanner.nextChar().toString()
-        assertEquals(markerExpected, markerReceived)
-
         expectInput(scanner, promptColored)
     }
 


### PR DESCRIPTION
Evcxr prints special markers `\u0091` and `\u0092` after each command, so that we can distinguish successful and failed commands. Evcxr executes special hidden command `:load_config` at startup, so in version 0.9 such marker was printed also after startup. In version 0.10 they reworked config loading, so such marker is no longer printed after startup

Fixes #7295

changelog: Fix [Rust REPL](https://plugins.jetbrains.com/plugin/8182-rust/docs/rust-repl-console.html) for latest [evcxr](https://github.com/google/evcxr) version 0.10.0