### PR TITLE
MACRO: improve macro expansion errors, show them if `show macro expansion` action fails

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -8,6 +8,7 @@ package org.rust.lang.core.macros
 import com.intellij.openapi.project.Project
 import org.rust.lang.core.macros.builtin.BuiltinMacroExpander
 import org.rust.lang.core.macros.decl.DeclMacroExpander
+import org.rust.lang.core.macros.errors.MacroExpansionError
 import org.rust.lang.core.macros.proc.ProcMacroExpander
 import org.rust.stdext.RsResult
 

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpander.kt
@@ -12,12 +12,8 @@ import org.rust.lang.core.macros.errors.MacroExpansionError
 import org.rust.lang.core.macros.proc.ProcMacroExpander
 import org.rust.stdext.RsResult
 
-abstract class MacroExpander<in T: RsMacroData, out E> {
-    open fun expandMacroAsText(def: T, call: RsMacroCallData): Pair<CharSequence, RangeMap>? {
-        return expandMacroAsTextWithErr(def, call).ok()
-    }
-
-    abstract fun expandMacroAsTextWithErr(def: T, call: RsMacroCallData): RsResult<Pair<CharSequence, RangeMap>, out E>
+abstract class MacroExpander<in T: RsMacroData, out E: MacroExpansionError> {
+    abstract fun expandMacroAsTextWithErr(def: T, call: RsMacroCallData): RsResult<Pair<CharSequence, RangeMap>, E>
 }
 
 /** A macro expander for macro calls like `foo!()` */
@@ -26,18 +22,10 @@ class FunctionLikeMacroExpander(
     private val proc: ProcMacroExpander,
     private val builtin: BuiltinMacroExpander
 ) : MacroExpander<RsMacroData, MacroExpansionError>() {
-    override fun expandMacroAsText(def: RsMacroData, call: RsMacroCallData): Pair<CharSequence, RangeMap>? {
-        return when (def) {
-            is RsDeclMacroData -> decl.expandMacroAsText(def, call)
-            is RsProcMacroData -> proc.expandMacroAsText(def, call)
-            is RsBuiltinMacroData -> builtin.expandMacroAsText(def, call)
-        }
-    }
-
     override fun expandMacroAsTextWithErr(
         def: RsMacroData,
         call: RsMacroCallData
-    ): RsResult<Pair<CharSequence, RangeMap>, out MacroExpansionError> {
+    ): RsResult<Pair<CharSequence, RangeMap>, MacroExpansionError> {
         return when (def) {
             is RsDeclMacroData -> decl.expandMacroAsTextWithErr(def, call)
             is RsProcMacroData -> proc.expandMacroAsTextWithErr(def, call)

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansion.kt
@@ -7,8 +7,9 @@ package org.rust.lang.core.macros
 
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VirtualFileWithId
-import org.rust.lang.core.macros.MacroExpansionAndParsingError.ExpansionError
-import org.rust.lang.core.macros.MacroExpansionAndParsingError.ParsingError
+import org.rust.lang.core.macros.errors.MacroExpansionAndParsingError
+import org.rust.lang.core.macros.errors.MacroExpansionAndParsingError.ExpansionError
+import org.rust.lang.core.macros.errors.MacroExpansionAndParsingError.ParsingError
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.stdext.RsResult

--- a/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystem.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/MacroExpansionFileSystem.kt
@@ -178,7 +178,7 @@ class MacroExpansionFileSystem : NewVirtualFileSystem() {
         if (fsItem !is FSFile) throw FileNotFoundException(file.path + " (Is a directory)")
         return fsItem.fetchAndRemoveContent() ?: run {
             val cachedExpansion = file.loadMixHash()?.let {
-                MacroExpansionSharedCache.getInstance().getExpansionIfCached(it)
+                MacroExpansionSharedCache.getInstance().getExpansionIfCached(it)?.ok()
             }
             if (cachedExpansion != null) {
                 cachedExpansion.text.toByteArray()

--- a/src/main/kotlin/org/rust/lang/core/macros/RsMacroCallData.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/RsMacroCallData.kt
@@ -10,14 +10,17 @@ import org.rust.lang.core.psi.ext.containingCargoPackage
 import org.rust.lang.core.psi.ext.macroBody
 
 class RsMacroCallData(
-    val macroBody: String?,
+    val macroBody: String,
     val packageEnv: Map<String, String>
 ) {
 
     companion object {
-        fun fromPsi(call: RsPossibleMacroCall): RsMacroCallData = RsMacroCallData(
-            call.macroBody,
-            call.containingCargoPackage?.env.orEmpty()
-        )
+        fun fromPsi(call: RsPossibleMacroCall): RsMacroCallData? {
+            val macroBody = call.macroBody ?: return null
+            return RsMacroCallData(
+                macroBody,
+                call.containingCargoPackage?.env.orEmpty()
+            )
+        }
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/macros/builtin/BuiltinMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/builtin/BuiltinMacroExpander.kt
@@ -10,20 +10,19 @@ import org.rust.lang.core.macros.MacroExpander
 import org.rust.lang.core.macros.RangeMap
 import org.rust.lang.core.macros.RsBuiltinMacroData
 import org.rust.lang.core.macros.RsMacroCallData
-import org.rust.lang.core.macros.errors.DeclMacroExpansionError
+import org.rust.lang.core.macros.errors.BuiltinMacroExpansionError
 import org.rust.stdext.RsResult
 import org.rust.stdext.RsResult.Err
 
 /**
  * A macro expander for built-in macros like `concat!()` and `stringify!()`
  */
-class BuiltinMacroExpander(val project: Project) : MacroExpander<RsBuiltinMacroData, DeclMacroExpansionError>() {
+class BuiltinMacroExpander(val project: Project) : MacroExpander<RsBuiltinMacroData, BuiltinMacroExpansionError>() {
     override fun expandMacroAsTextWithErr(
         def: RsBuiltinMacroData,
         call: RsMacroCallData
-    ): RsResult<Pair<CharSequence, RangeMap>, out DeclMacroExpansionError> {
-        val macroCallBodyText = call.macroBody ?: return Err(DeclMacroExpansionError.DefSyntax)
-        return Err(DeclMacroExpansionError.DefSyntax)
+    ): RsResult<Pair<CharSequence, RangeMap>, BuiltinMacroExpansionError> {
+        return Err(BuiltinMacroExpansionError)
     }
 
     companion object {

--- a/src/main/kotlin/org/rust/lang/core/macros/builtin/BuiltinMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/builtin/BuiltinMacroExpander.kt
@@ -6,7 +6,11 @@
 package org.rust.lang.core.macros.builtin
 
 import com.intellij.openapi.project.Project
-import org.rust.lang.core.macros.*
+import org.rust.lang.core.macros.MacroExpander
+import org.rust.lang.core.macros.RangeMap
+import org.rust.lang.core.macros.RsBuiltinMacroData
+import org.rust.lang.core.macros.RsMacroCallData
+import org.rust.lang.core.macros.errors.DeclMacroExpansionError
 import org.rust.stdext.RsResult
 import org.rust.stdext.RsResult.Err
 

--- a/src/main/kotlin/org/rust/lang/core/macros/decl/DeclMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/decl/DeclMacroExpander.kt
@@ -19,7 +19,9 @@ import com.intellij.psi.tree.IElementType
 import com.intellij.psi.tree.TokenSet
 import com.intellij.util.SmartList
 import org.rust.lang.core.macros.*
-import org.rust.lang.core.macros.MacroMatchingError.*
+import org.rust.lang.core.macros.errors.DeclMacroExpansionError
+import org.rust.lang.core.macros.errors.MacroMatchingError
+import org.rust.lang.core.macros.errors.MacroMatchingError.*
 import org.rust.lang.core.parser.RustParserUtil.collapsedTokenType
 import org.rust.lang.core.parser.createAdaptedRustPsiBuilder
 import org.rust.lang.core.psi.*
@@ -28,10 +30,10 @@ import org.rust.lang.core.psi.ext.descendantsOfType
 import org.rust.lang.core.psi.ext.fragmentSpecifier
 import org.rust.openapiext.forEachChild
 import org.rust.stdext.RsResult
-import org.rust.stdext.RsResult.*
+import org.rust.stdext.RsResult.Err
+import org.rust.stdext.RsResult.Ok
 import org.rust.stdext.mapNotNullToSet
 import org.rust.stdext.removeLast
-import java.util.*
 import java.util.Collections.singletonMap
 
 /**

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
@@ -1,0 +1,109 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros.errors
+
+import org.rust.lang.core.macros.MacroExpansionContext
+import org.rust.lang.core.psi.RsProcMacroKind
+import org.rust.stdext.readEnum
+import org.rust.stdext.writeEnum
+import java.io.DataInput
+import java.io.DataOutput
+import java.io.IOException
+
+/**
+ * An error type for [org.rust.lang.core.psi.ext.expansionResult]
+ */
+sealed class GetMacroExpansionError {
+    object MacroExpansionIsDisabled : GetMacroExpansionError()
+    object MacroExpansionEngineIsNotReady : GetMacroExpansionError()
+    object IncludingFileNotFound : GetMacroExpansionError()
+    object OldEngineStd : GetMacroExpansionError()
+
+    object MemExpDuringMacroExpansion : GetMacroExpansionError()
+    object MemExpAttrMacro : GetMacroExpansionError()
+    data class MemExpParsingError(
+        val expansionText: CharSequence,
+        val context: MacroExpansionContext
+    ) : GetMacroExpansionError()
+
+    object NextStepMacroAccess : GetMacroExpansionError()
+    object ExpandedInfoNotFound : GetMacroExpansionError()
+
+    override fun toString(): String = "${GetMacroExpansionError::class.simpleName}.${javaClass.simpleName}"
+}
+
+sealed class EMIGetExpansionError : GetMacroExpansionError() {
+    object InvalidExpansionFile : EMIGetExpansionError()
+
+    override fun toString(): String = "${EMIGetExpansionError::class.simpleName}.${javaClass.simpleName}"
+}
+
+sealed class ExpansionPipelineError : EMIGetExpansionError() {
+    object NotYetExpanded : ExpansionPipelineError()
+    object CfgDisabled : ExpansionPipelineError()
+    object Skipped : ExpansionPipelineError()
+    object Unresolved : ExpansionPipelineError()
+    object NoProcMacroArtifact : ExpansionPipelineError()
+    data class UnmatchedProcMacroKind(
+        val callKind: RsProcMacroKind,
+        val defKind: RsProcMacroKind,
+    ) : ExpansionPipelineError()
+    object Macro2IsNotSupported : ExpansionPipelineError()
+    object MacroCallSyntax : ExpansionPipelineError()
+    object MacroDefSyntax : ExpansionPipelineError()
+    data class ExpansionError(val e: MacroExpansionError) : ExpansionPipelineError()
+
+    override fun toString(): String = "${ExpansionPipelineError::class.simpleName}.${javaClass.simpleName}"
+}
+
+fun ResolveMacroWithoutPsiError.toExpansionPipelineError(): ExpansionPipelineError = when (this) {
+    ResolveMacroWithoutPsiError.Unresolved -> ExpansionPipelineError.Unresolved
+    ResolveMacroWithoutPsiError.NoProcMacroArtifact -> ExpansionPipelineError.NoProcMacroArtifact
+    is ResolveMacroWithoutPsiError.UnmatchedProcMacroKind ->
+        ExpansionPipelineError.UnmatchedProcMacroKind(callKind, defKind)
+    ResolveMacroWithoutPsiError.Macro2IsNotSupported -> ExpansionPipelineError.Macro2IsNotSupported
+}
+
+@Throws(IOException::class)
+fun DataOutput.writeExpansionPipelineError(err: ExpansionPipelineError) {
+    val ordinal = when (err) {
+        ExpansionPipelineError.NotYetExpanded -> 0
+        ExpansionPipelineError.CfgDisabled -> 1
+        ExpansionPipelineError.Skipped -> 2
+        ExpansionPipelineError.Unresolved -> 3
+        ExpansionPipelineError.NoProcMacroArtifact -> 4
+        is ExpansionPipelineError.UnmatchedProcMacroKind -> 5
+        ExpansionPipelineError.Macro2IsNotSupported -> 6
+        ExpansionPipelineError.MacroCallSyntax -> 7
+        ExpansionPipelineError.MacroDefSyntax -> 8
+        is ExpansionPipelineError.ExpansionError -> 9
+    }
+    writeByte(ordinal)
+
+    when (err) {
+        is ExpansionPipelineError.UnmatchedProcMacroKind -> {
+            writeEnum(err.callKind)
+            writeEnum(err.defKind)
+        }
+        is ExpansionPipelineError.ExpansionError -> writeMacroExpansionError(err.e)
+        else -> Unit
+    }
+}
+
+@Throws(IOException::class)
+fun DataInput.readExpansionPipelineError(): ExpansionPipelineError = when (val ordinal = readUnsignedByte()) {
+    0 -> ExpansionPipelineError.NotYetExpanded
+    1 -> ExpansionPipelineError.CfgDisabled
+    2 -> ExpansionPipelineError.Skipped
+    3 -> ExpansionPipelineError.Unresolved
+    4 -> ExpansionPipelineError.NoProcMacroArtifact
+    5 -> ExpansionPipelineError.UnmatchedProcMacroKind(readEnum(), readEnum())
+    6 -> ExpansionPipelineError.Macro2IsNotSupported
+    7 -> ExpansionPipelineError.MacroCallSyntax
+    8 -> ExpansionPipelineError.MacroDefSyntax
+    9 -> ExpansionPipelineError.ExpansionError(readMacroExpansionError())
+    else -> throw IOException("Unknown expansion pipeline error code $ordinal")
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/GetMacroExpansionError.kt
@@ -5,8 +5,11 @@
 
 package org.rust.lang.core.macros.errors
 
+import org.rust.ide.experiments.RsExperiments
 import org.rust.lang.core.macros.MacroExpansionContext
 import org.rust.lang.core.psi.RsProcMacroKind
+import org.rust.openapiext.RsPathManager
+import org.rust.openapiext.isFeatureEnabled
 import org.rust.stdext.readEnum
 import org.rust.stdext.writeEnum
 import java.io.DataInput
@@ -31,6 +34,54 @@ sealed class GetMacroExpansionError {
 
     object NextStepMacroAccess : GetMacroExpansionError()
     object ExpandedInfoNotFound : GetMacroExpansionError()
+
+    // Can't expand the macro because ...
+    // Failed to expand the macro because ...
+    fun toUserViewableMessage(): String = when(this) {
+        MacroExpansionIsDisabled -> "macro expansion is disabled in project settings"
+        MacroExpansionEngineIsNotReady -> "macro expansion engine is not ready"
+        IncludingFileNotFound -> "including file is not found"
+        OldEngineStd -> "the old macro expansion engine can't expand macros in Rust stdlib"
+        MemExpDuringMacroExpansion -> "internal error: in-memory macro expansion is requested during other " +
+            "macro expansion"
+        MemExpAttrMacro -> "internal error: can't do in-memory expansion of an attribute or derive macro"
+        is MemExpParsingError -> "can't parse `$expansionText` as `$context`"
+        NextStepMacroAccess -> "internal error: the expansion from a next expansion step is accessed during " +
+            "a previous expansion step"
+        ExpandedInfoNotFound -> "the macro is not yet expanded (1)"
+        EMIGetExpansionError.InvalidExpansionFile -> "internal error: the expansion file has been invalidated"
+        ExpansionPipelineError.CfgDisabled -> "the macro call is conditionally disabled with a `#[cfg()]` attribute"
+        ExpansionPipelineError.MacroCallSyntax -> "there is an error in the macro call syntax"
+        ExpansionPipelineError.MacroDefSyntax -> "there is an error in the macro definition syntax"
+        ExpansionPipelineError.NotYetExpanded -> "the macro is not yet expanded (2)"
+        ExpansionPipelineError.Skipped -> "expansion of this procedural macro is skipped by IntelliJ-Rust"
+        ExpansionPipelineError.Unresolved -> "the macro is not resolved"
+        ExpansionPipelineError.NoProcMacroArtifact -> if (!isFeatureEnabled(RsExperiments.EVALUATE_BUILD_SCRIPTS)) {
+            "the procedural macro is not compiled because experimental feature " +
+                "`${RsExperiments.EVALUATE_BUILD_SCRIPTS}` is not enabled"
+        } else {
+            "the procedural macro is not compiled successfully"
+        }
+        is ExpansionPipelineError.UnmatchedProcMacroKind -> "`$defKind` proc macro can't be called as `$callKind`"
+        is ExpansionPipelineError.Macro2IsNotSupported -> "macros 2.0 are not supported by IntelliJ-Rust"
+        is ExpansionPipelineError.ExpansionError -> when (e) {
+            BuiltinMacroExpansionError -> "built-in macro expansion is not supported"
+            DeclMacroExpansionError.DefSyntax -> "there is an error in the macro definition syntax"
+            is DeclMacroExpansionError.Matching -> "can't match the macro call body against the " +
+                "macro definition pattern(s)"
+            is ProcMacroExpansionError.ServerSideError -> "a procedural macro error occurred:\n${e.message}"
+            is ProcMacroExpansionError.Timeout -> "procedural macro expansion timeout exceeded (${e.timeout} ms)"
+            is ProcMacroExpansionError.ProcessAborted -> "the procedural macro expander process unexpectedly exited " +
+                "with code ${e.exitCode}"
+            is ProcMacroExpansionError.IOExceptionThrown -> "an exception thrown during communicating with proc " +
+                "macro expansion server; see logs for more details"
+            ProcMacroExpansionError.CantRunExpander -> "error occurred during `${RsPathManager.INTELLIJ_RUST_NATIVE_HELPER}` " +
+                "process creation; see logs for more details"
+            ProcMacroExpansionError.ExecutableNotFound -> "`${RsPathManager.INTELLIJ_RUST_NATIVE_HELPER}` executable is not found; " +
+                "(maybe it's not provided for your platform by IntelliJ-Rust)"
+            ProcMacroExpansionError.ProcMacroExpansionIsDisabled -> "procedural macro expansion is not enabled"
+        }
+    }
 
     override fun toString(): String = "${GetMacroExpansionError::class.simpleName}.${javaClass.simpleName}"
 }

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionAndParsingError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionAndParsingError.kt
@@ -1,0 +1,16 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros.errors
+
+import org.rust.lang.core.macros.MacroExpansionContext
+
+sealed class MacroExpansionAndParsingError<E> {
+    data class ExpansionError<E>(val error: E) : MacroExpansionAndParsingError<E>()
+    class ParsingError<E>(
+        val expansionText: CharSequence,
+        val context: MacroExpansionContext
+    ) : MacroExpansionAndParsingError<E>()
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionAndParsingError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionAndParsingError.kt
@@ -7,10 +7,11 @@ package org.rust.lang.core.macros.errors
 
 import org.rust.lang.core.macros.MacroExpansionContext
 
-sealed class MacroExpansionAndParsingError<E> {
+sealed class MacroExpansionAndParsingError<out E> {
     data class ExpansionError<E>(val error: E) : MacroExpansionAndParsingError<E>()
     class ParsingError<E>(
         val expansionText: CharSequence,
         val context: MacroExpansionContext
     ) : MacroExpansionAndParsingError<E>()
+    object MacroCallSyntaxError : MacroExpansionAndParsingError<Nothing>()
 }

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionError.kt
@@ -3,7 +3,7 @@
  * found in the LICENSE file.
  */
 
-package org.rust.lang.core.macros
+package org.rust.lang.core.macros.errors
 
 import com.intellij.lang.ASTNode
 import com.intellij.lang.PsiBuilder
@@ -11,14 +11,6 @@ import com.intellij.psi.tree.IElementType
 import org.rust.lang.core.macros.decl.FragmentKind
 import java.io.PrintWriter
 import java.io.StringWriter
-
-sealed class MacroExpansionAndParsingError<E> {
-    data class ExpansionError<E>(val error: E) : MacroExpansionAndParsingError<E>()
-    class ParsingError<E>(
-        val expansionText: CharSequence,
-        val context: MacroExpansionContext
-    ) : MacroExpansionAndParsingError<E>()
-}
 
 sealed class MacroExpansionError
 

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/MacroExpansionError.kt
@@ -5,13 +5,17 @@
 
 package org.rust.lang.core.macros.errors
 
-import com.intellij.lang.ASTNode
-import com.intellij.lang.PsiBuilder
-import com.intellij.psi.tree.IElementType
+import com.intellij.util.io.IOUtil
+import org.rust.lang.core.macros.MACRO_LOG
 import org.rust.lang.core.macros.decl.FragmentKind
-import java.io.PrintWriter
-import java.io.StringWriter
+import org.rust.stdext.*
+import java.io.DataInput
+import java.io.DataOutput
+import java.io.IOException
 
+/**
+ * An error type for [org.rust.lang.core.macros.MacroExpander]
+ */
 sealed class MacroExpansionError
 
 sealed class DeclMacroExpansionError : MacroExpansionError() {
@@ -19,41 +23,44 @@ sealed class DeclMacroExpansionError : MacroExpansionError() {
     object DefSyntax : DeclMacroExpansionError()
 }
 
-sealed class MacroMatchingError(macroCallBody: PsiBuilder) {
-    val offsetInCallBody: Int = macroCallBody.currentOffset
+sealed class MacroMatchingError {
+    abstract val offsetInCallBody: Int
 
-    class PatternSyntax(macroCallBody: PsiBuilder) : MacroMatchingError(macroCallBody) {
-        override fun toString(): String = "PatternSyntax"
+    data class PatternSyntax(override val offsetInCallBody: Int) : MacroMatchingError()
+
+    data class ExtraInput(override val offsetInCallBody: Int) : MacroMatchingError()
+
+    data class EndOfInput(override val offsetInCallBody: Int) : MacroMatchingError()
+
+    data class UnmatchedToken(
+        override val offsetInCallBody: Int,
+        val expectedTokenType: String,
+        val expectedTokenText: String,
+        val actualTokenType: String,
+        val actualTokenText: String
+    ) : MacroMatchingError() {
+        override fun toString(): String = "${super.toString()}(" +
+            "$expectedTokenType(`$expectedTokenText`) != $actualTokenType(`$actualTokenText`)" +
+            ")"
     }
 
-    class ExtraInput(macroCallBody: PsiBuilder) : MacroMatchingError(macroCallBody) {
-        override fun toString(): String = "ExtraInput"
+    data class FragmentIsNotParsed(
+        override val offsetInCallBody: Int,
+        val variableName: String,
+        val kind: FragmentKind
+    ) : MacroMatchingError() {
+        override fun toString(): String = "${super.toString()}($variableName, $kind)"
     }
 
-    class UnmatchedToken(macroCallBody: PsiBuilder, node: ASTNode) : MacroMatchingError(macroCallBody) {
-        private val expectedToken: IElementType = node.elementType
-        private val expectedText: String = node.text
-        private val actualToken: IElementType? = macroCallBody.tokenType
-        private val actualText: String? = macroCallBody.tokenText
+    data class EmptyGroup(override val offsetInCallBody: Int) : MacroMatchingError()
 
-        override fun toString(): String = "UnmatchedToken($expectedToken(`$expectedText`) != $actualToken(`$actualText`))"
+    data class TooFewGroupElements(override val offsetInCallBody: Int) : MacroMatchingError()
+
+    data class Nesting(override val offsetInCallBody: Int, val variableName: String) : MacroMatchingError() {
+        override fun toString(): String = "${super.toString()}($variableName)"
     }
 
-    class FragmentNotParsed(macroCallBody: PsiBuilder, val kind: FragmentKind) : MacroMatchingError(macroCallBody) {
-        override fun toString(): String = "FragmentNotParsed($kind)"
-    }
-
-    class EmptyGroup(macroCallBody: PsiBuilder) : MacroMatchingError(macroCallBody) {
-        override fun toString(): String = "EmptyGroup"
-    }
-
-    class TooFewGroupElements(macroCallBody: PsiBuilder) : MacroMatchingError(macroCallBody) {
-        override fun toString(): String = "TooFewGroupElements"
-    }
-
-    class Nesting(macroCallBody: PsiBuilder, private val variableName: String) : MacroMatchingError(macroCallBody) {
-        override fun toString(): String = "Nesting($variableName)"
-    }
+    override fun toString(): String = "${MacroMatchingError::class.simpleName}.${javaClass.simpleName}"
 }
 
 sealed class ProcMacroExpansionError : MacroExpansionError() {
@@ -64,21 +71,139 @@ sealed class ProcMacroExpansionError : MacroExpansionError() {
     }
 
     /**
-     * An exception thrown during communicating with the proc macro expander.
-     * This can means that the process was killed by a user, for example.
+     * The proc macro expander process exited before answering the request.
+     * This can indicate an issue with the procedural macro (a segfault or `std::process::exit()` call)
+     * or an issue with the proc macro expander process, for example it was killed by a user or OOM-killed.
      */
-    data class ExceptionThrown(val cause: Exception) : ProcMacroExpansionError() {
-        override fun toString(): String = StringWriter().also { writer ->
-            writer.write("${super.toString()}(\n")
-            cause.printStackTrace(PrintWriter(writer))
-            writer.write("\n)")
-        }.toString()
-    }
+    data class ProcessAborted(val exitCode: Int) : ProcMacroExpansionError()
 
-    object Timeout : ProcMacroExpansionError()
+    /**
+     * An [IOException] thrown during communicating with the proc macro expander
+     * (this includes possible OS errors and JSON serialization/deserialization errors).
+     * The stacktrace is logged to [MACRO_LOG] logger.
+     */
+    object IOExceptionThrown : ProcMacroExpansionError()
+
+    data class Timeout(val timeout: Long) : ProcMacroExpansionError()
     object CantRunExpander : ProcMacroExpansionError()
     object ExecutableNotFound : ProcMacroExpansionError()
-    object MacroCallSyntax : ProcMacroExpansionError()
+    object ProcMacroExpansionIsDisabled : ProcMacroExpansionError()
 
     override fun toString(): String = "${ProcMacroExpansionError::class.simpleName}.${javaClass.simpleName}"
+}
+
+object BuiltinMacroExpansionError : MacroExpansionError()
+
+@Throws(IOException::class)
+fun DataOutput.writeMacroExpansionError(err: MacroExpansionError) {
+    val ordinal = when (err) {
+        is DeclMacroExpansionError.Matching -> 0
+        DeclMacroExpansionError.DefSyntax -> 1
+        is ProcMacroExpansionError.ServerSideError -> 2
+        is ProcMacroExpansionError.ProcessAborted -> 3
+        is ProcMacroExpansionError.IOExceptionThrown -> 4
+        is ProcMacroExpansionError.Timeout -> 5
+        ProcMacroExpansionError.CantRunExpander -> 6
+        ProcMacroExpansionError.ExecutableNotFound -> 7
+        ProcMacroExpansionError.ProcMacroExpansionIsDisabled -> 8
+        BuiltinMacroExpansionError -> 9
+    }
+    writeByte(ordinal)
+
+    when (err) {
+        is DeclMacroExpansionError.Matching -> {
+            writeVarInt(err.errors.size)
+            for (error in err.errors) {
+                saveMatchingError(error)
+            }
+        }
+        is ProcMacroExpansionError.ServerSideError -> IOUtil.writeUTF(this, err.message)
+        is ProcMacroExpansionError.ProcessAborted -> writeInt(err.exitCode)
+        is ProcMacroExpansionError.Timeout -> writeLong(err.timeout)
+        else -> Unit
+    }.exhaustive
+}
+
+@Throws(IOException::class)
+fun DataInput.readMacroExpansionError(): MacroExpansionError = when (val ordinal = readUnsignedByte()) {
+    0 -> {
+        val size = readVarInt()
+        DeclMacroExpansionError.Matching((0 until size).map { readMatchingError() })
+    }
+    1 -> DeclMacroExpansionError.DefSyntax
+    2 -> ProcMacroExpansionError.ServerSideError(IOUtil.readUTF(this))
+    3 -> ProcMacroExpansionError.ProcessAborted(readInt())
+    5 -> ProcMacroExpansionError.Timeout(readLong())
+    6 -> ProcMacroExpansionError.CantRunExpander
+    7 -> ProcMacroExpansionError.ExecutableNotFound
+    8 -> ProcMacroExpansionError.ProcMacroExpansionIsDisabled
+    9 -> BuiltinMacroExpansionError
+    else -> throw IOException("Unknown expansion error code $ordinal")
+}
+
+@Throws(IOException::class)
+private fun DataOutput.saveMatchingError(value: MacroMatchingError) {
+    val ordinal = when (value) {
+        is MacroMatchingError.PatternSyntax -> 0
+        is MacroMatchingError.ExtraInput -> 1
+        is MacroMatchingError.EndOfInput -> 2
+        is MacroMatchingError.UnmatchedToken -> 3
+        is MacroMatchingError.FragmentIsNotParsed -> 4
+        is MacroMatchingError.EmptyGroup -> 5
+        is MacroMatchingError.TooFewGroupElements -> 6
+        is MacroMatchingError.Nesting -> 7
+    }
+    writeByte(ordinal)
+    writeVarInt(value.offsetInCallBody)
+
+    when (value) {
+        is MacroMatchingError.UnmatchedToken -> {
+            IOUtil.writeUTF(this, value.expectedTokenType)
+            IOUtil.writeUTF(this, value.expectedTokenText)
+            IOUtil.writeUTF(this, value.actualTokenType)
+            IOUtil.writeUTF(this, value.actualTokenText)
+        }
+        is MacroMatchingError.FragmentIsNotParsed -> {
+            IOUtil.writeUTF(this, value.variableName)
+            writeEnum(value.kind)
+        }
+        is MacroMatchingError.Nesting -> {
+            IOUtil.writeUTF(this, value.variableName)
+        }
+        else -> Unit
+    }.exhaustive
+}
+
+@Throws(IOException::class)
+private fun DataInput.readMatchingError(): MacroMatchingError {
+    val ordinal = readUnsignedByte()
+    val offsetInCallBody = readVarInt()
+
+    return when (ordinal) {
+        0 -> MacroMatchingError.PatternSyntax(offsetInCallBody)
+        1 -> MacroMatchingError.ExtraInput(offsetInCallBody)
+        2 -> MacroMatchingError.EndOfInput(offsetInCallBody)
+        3 -> MacroMatchingError.UnmatchedToken(
+            offsetInCallBody,
+            expectedTokenType = IOUtil.readUTF(this),
+            expectedTokenText = IOUtil.readUTF(this),
+            actualTokenType = IOUtil.readUTF(this),
+            actualTokenText = IOUtil.readUTF(this)
+        )
+        4 -> MacroMatchingError.FragmentIsNotParsed(offsetInCallBody, IOUtil.readUTF(this), readEnum())
+        5 -> MacroMatchingError.EmptyGroup(offsetInCallBody)
+        6 -> MacroMatchingError.TooFewGroupElements(offsetInCallBody)
+        7 -> MacroMatchingError.Nesting(offsetInCallBody, IOUtil.readUTF(this))
+        else -> throw IOException("Unknown matching error code $ordinal")
+    }
+}
+
+/**
+ * Some proc macro errors are not cached because they are pretty unstable
+ * (subsequent macro invocations may succeed)
+ */
+fun MacroExpansionError.canCacheError() = when (this) {
+    is DeclMacroExpansionError -> true
+    BuiltinMacroExpansionError -> true
+    is ProcMacroExpansionError -> false
 }

--- a/src/main/kotlin/org/rust/lang/core/macros/errors/ResolveMacroWithoutPsiError.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/errors/ResolveMacroWithoutPsiError.kt
@@ -1,0 +1,18 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros.errors
+
+import org.rust.lang.core.psi.RsProcMacroKind
+
+sealed class ResolveMacroWithoutPsiError {
+    object Unresolved : ResolveMacroWithoutPsiError()
+    object Macro2IsNotSupported : ResolveMacroWithoutPsiError()
+    object NoProcMacroArtifact : ResolveMacroWithoutPsiError()
+    data class UnmatchedProcMacroKind(
+        val callKind: RsProcMacroKind,
+        val defKind: RsProcMacroKind,
+    ) : ResolveMacroWithoutPsiError()
+}

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcMacroExpander.kt
@@ -7,6 +7,7 @@ package org.rust.lang.core.macros.proc
 
 import com.intellij.openapi.project.Project
 import org.rust.lang.core.macros.*
+import org.rust.lang.core.macros.errors.ProcMacroExpansionError
 import org.rust.lang.core.macros.tt.MappedSubtree
 import org.rust.lang.core.macros.tt.TokenTree
 import org.rust.lang.core.macros.tt.parseSubtree

--- a/src/main/kotlin/org/rust/lang/core/macros/proc/ProcessAbortedException.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/proc/ProcessAbortedException.kt
@@ -1,0 +1,11 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.macros.proc
+
+import java.io.IOException
+
+class ProcessAbortedException(cause: Throwable, val exitCode: Int) :
+    IOException("`intellij-rust-helper` is aborted; exit code: $exitCode", cause)

--- a/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/DefCollector.kt
@@ -287,7 +287,7 @@ class DefCollector(
     private fun tryExpandMacroCall(call: MacroCallInfo): Boolean {
         val def = defMap.resolveMacroCallToMacroDefInfo(call.containingMod, call.path, call.macroIndex)
             ?: return false
-        val defData = RsMacroDataWithHash.fromDefInfo(def)
+        val defData = RsMacroDataWithHash.fromDefInfo(def).ok()
             ?: return false
         val callData = RsMacroCallDataWithHash(RsMacroCallData(call.body, defMap.metaData.env), call.bodyHash)
         val (expandedFile, expansion) =

--- a/src/main/kotlin/org/rust/lang/core/resolve2/util/DollarCrateUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve2/util/DollarCrateUtil.kt
@@ -7,7 +7,9 @@ package org.rust.lang.core.resolve2.util
 
 import com.intellij.util.SmartList
 import org.rust.lang.core.crate.CratePersistentId
-import org.rust.lang.core.macros.*
+import org.rust.lang.core.macros.ExpansionResultOk
+import org.rust.lang.core.macros.MappedTextRange
+import org.rust.lang.core.macros.RangeMap
 import org.rust.lang.core.macros.decl.MACRO_DOLLAR_CRATE_IDENTIFIER
 import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.RsMacroCall
@@ -30,7 +32,7 @@ import org.rust.openapiext.testAssert
 fun createDollarCrateHelper(
     call: MacroCallInfo,
     def: DeclMacroDefInfo,
-    expansion: ExpansionResult
+    expansion: ExpansionResultOk
 ): DollarCrateHelper? {
     val rangesInFile = findCrateIdForEachDollarCrate(expansion, call, def)
     if (rangesInFile.isEmpty() && !def.hasLocalInnerMacros) return null
@@ -101,7 +103,7 @@ class DollarCrateHelper(
  * `expansion.text` starting from `index` contains [MACRO_DOLLAR_CRATE_IDENTIFIER] which corresponds to `crateId`
  */
 private fun findCrateIdForEachDollarCrate(
-    expansion: ExpansionResult,
+    expansion: ExpansionResultOk,
     call: MacroCallInfo,
     def: DeclMacroDefInfo
 ): Map<Int, CratePersistentId> {

--- a/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
+++ b/src/main/kotlin/org/rust/lang/core/stubs/StubImplementations.kt
@@ -38,12 +38,9 @@ import org.rust.lang.core.stubs.common.RsPathPsiOrStub
 import org.rust.lang.core.types.ty.TyFloat
 import org.rust.lang.core.types.ty.TyInteger
 import org.rust.openapiext.ancestors
-import org.rust.stdext.BitFlagsBuilder
+import org.rust.stdext.*
 import org.rust.stdext.BitFlagsBuilder.Limit.BYTE
 import org.rust.stdext.BitFlagsBuilder.Limit.INT
-import org.rust.stdext.HashCode
-import org.rust.stdext.readHashCodeNullable
-import org.rust.stdext.writeHashCodeNullable
 
 class RsFileStub(
     file: RsFile?,
@@ -2047,9 +2044,6 @@ class RsVisStub(
 private fun StubInputStream.readNameAsString(): String? = readName()?.string
 private fun StubInputStream.readUTFFastAsNullable(): String? = readNullable(this, this::readUTFFast)
 private fun StubOutputStream.writeUTFFastAsNullable(value: String?) = writeNullable(this, value, this::writeUTFFast)
-
-private fun <E : Enum<E>> StubOutputStream.writeEnum(e: E) = writeByte(e.ordinal)
-private inline fun <reified E : Enum<E>> StubInputStream.readEnum(): E = enumValues<E>()[readUnsignedByte()]
 
 private fun StubOutputStream.writeLongAsNullable(value: Long?) = writeNullable(this, value, this::writeLong)
 private fun StubInputStream.readLongAsNullable(): Long? = readNullable(this, this::readLong)

--- a/src/main/kotlin/org/rust/openapiext/RsPathManager.kt
+++ b/src/main/kotlin/org/rust/openapiext/RsPathManager.kt
@@ -13,15 +13,16 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 object RsPathManager {
+    const val INTELLIJ_RUST_NATIVE_HELPER: String = "intellij-rust-native-helper"
 
     fun prettyPrintersDir(): Path = pluginDir().resolve("prettyPrinters")
     private fun pluginDir(): Path = plugin().pluginPath
 
     fun nativeHelper(): Path? {
         val (os, binaryName) = when {
-            SystemInfo.isLinux -> "linux" to "intellij-rust-native-helper"
-            SystemInfo.isMac -> "macos" to "intellij-rust-native-helper"
-            SystemInfo.isWindows -> "windows" to "intellij-rust-native-helper.exe"
+            SystemInfo.isLinux -> "linux" to INTELLIJ_RUST_NATIVE_HELPER
+            SystemInfo.isMac -> "macos" to INTELLIJ_RUST_NATIVE_HELPER
+            SystemInfo.isWindows -> "windows" to "$INTELLIJ_RUST_NATIVE_HELPER.exe"
             else -> return null
         }
         @Suppress("UnstableApiUsage", "DEPRECATION")

--- a/src/test/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActionsTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/macroExpansion/RsShowMacroExpansionActionsTest.kt
@@ -14,6 +14,7 @@ import org.rust.ProjectDescriptor
 import org.rust.RsTestBase
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.lang.core.macros.RsExpandedElement
+import org.rust.lang.core.macros.errors.GetMacroExpansionError
 
 class RsShowMacroExpansionActionsTest : RsTestBase() {
 
@@ -175,7 +176,7 @@ class RsShowMacroExpansionActionsTest : RsTestBase() {
                 error("Expected expansion fail, but got expansion: `${expansionDetails.expansion.elements.map { it.text }}`")
             }
 
-            override fun showError(editor: Editor) {
+            override fun showError(editor: Editor, error: GetMacroExpansionError) {
                 failed = true
             }
         }

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
@@ -21,6 +21,7 @@ import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.RsPsiFactory
 import org.rust.lang.core.psi.ext.*
 import org.rust.stdext.RsResult
+import org.rust.stdext.unwrapOrElse
 import kotlin.math.min
 
 abstract class RsMacroExpansionTestBase : RsTestBase() {
@@ -135,6 +136,7 @@ abstract class RsMacroExpansionTestBase : RsTestBase() {
     private fun MacroExpansionAndParsingError<DeclMacroExpansionError>.formatError(call: RsMacroCall) = when (this) {
         is MacroExpansionAndParsingError.ExpansionError -> error.formatError(call)
         is MacroExpansionAndParsingError.ParsingError -> "can't parse expansion text `$expansionText` as $context"
+        MacroExpansionAndParsingError.MacroCallSyntaxError -> "there is a syntax error in the macro call"
     }
 
     private fun DeclMacroExpansionError.formatError(call: RsMacroCall) = when (this) {

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTestBase.kt
@@ -14,6 +14,8 @@ import org.intellij.lang.annotations.Language
 import org.rust.RsTestBase
 import org.rust.fileTreeFromText
 import org.rust.lang.core.macros.decl.DeclMacroExpander
+import org.rust.lang.core.macros.errors.DeclMacroExpansionError
+import org.rust.lang.core.macros.errors.MacroExpansionAndParsingError
 import org.rust.lang.core.psi.RsMacro
 import org.rust.lang.core.psi.RsMacroCall
 import org.rust.lang.core.psi.RsPsiFactory

--- a/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroExpanderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/proc/RsProcMacroExpanderTest.kt
@@ -9,7 +9,7 @@ import com.intellij.util.ThrowableRunnable
 import com.intellij.util.io.exists
 import org.rust.*
 import org.rust.cargo.project.model.cargoProjects
-import org.rust.lang.core.macros.ProcMacroExpansionError
+import org.rust.lang.core.macros.errors.ProcMacroExpansionError
 import org.rust.lang.core.macros.tt.TokenTree
 import org.rust.lang.core.macros.tt.parseSubtree
 import org.rust.lang.core.macros.tt.toDebugString

--- a/testData/test-proc-macros/src/lib.rs
+++ b/testData/test-proc-macros/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate proc_macro;
+
 use proc_macro::TokenStream;
 
 #[proc_macro]
@@ -46,6 +47,13 @@ pub fn function_like_process_exit(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn function_like_process_abort(input: TokenStream) -> TokenStream {
     std::process::abort()
+}
+
+// This also simulates the process killing during writing of an answer
+#[proc_macro]
+pub fn function_like_do_brace_println_and_process_exit(input: TokenStream) -> TokenStream {
+    println!("{{");
+    std::process::exit(101)
 }
 
 #[proc_macro_derive(DeriveImplForFoo)]


### PR DESCRIPTION
Improve macro expansion errors

1. Pass macro expansion errors through all our abstraction layers. Previously they were available on low levels but discarded on upper layers.
2. Cache macro expansion errors (previously, a macro expanded with an error was re-expanded every time)
2.1. Proc macro expansion errors are still not cached (because they are pretty unstable, for example, an IO or a timeout error, i.e., a subsequent macro invocation may succeed)
3. Introduce a lot of new macro expansion error types
4. `show macro expansion` actions and intentions now show a reason of the expansion failure:
![image](https://user-images.githubusercontent.com/3221931/121209639-ac2f8b00-c883-11eb-9558-707007f8ede2.png)

changelog: FEATURE: `show macro expansion` actions and intentions now show a reason of the expansion failure. INTERNAL: improve macro expansion error types & error handling
