### PR TITLE
COMP: use template builder to fill wild pats in MatchPostfixTemplate

### DIFF
--- a/src/test/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplateTest.kt
@@ -29,8 +29,8 @@ class MatchPostfixTemplateTest : RsPostfixTemplateTest(MatchPostfixTemplate(RsPo
         fn process_message() {
             let msg = Message::ChangeColor(255, 255, 255);
             match msg {
-                Message::Quit => {/*caret*/}
-                Message::ChangeColor(_, _, _) => {}
+                Message::Quit => {}
+                Message::ChangeColor(_/*caret*/, _, _) => {}
                 Message::Move { .. } => {}
                 Message::Write(_) => {}
             }
@@ -47,7 +47,7 @@ class MatchPostfixTemplateTest : RsPostfixTemplateTest(MatchPostfixTemplate(RsPo
         const THE_ANSWER: i32 = 42;
 
         fn check(x: i32) {
-            match x { _ => {/*caret*/} }
+            match x { _/*caret*/ => {} }
         }
     """)
 
@@ -78,7 +78,7 @@ class MatchPostfixTemplateTest : RsPostfixTemplateTest(MatchPostfixTemplate(RsPo
     """, """
         fn main() {
             match a {
-                _ => match b { _ => {/*caret*/} }
+                _ => match b { _/*caret*/ => {} }
             }
         }
     """)
@@ -89,7 +89,7 @@ class MatchPostfixTemplateTest : RsPostfixTemplateTest(MatchPostfixTemplate(RsPo
         }
     """, """
         fn main() {
-            let x = match 1 + 2 { _ => {/*caret*/} };
+            let x = match 1 + 2 { _/*caret*/ => {} };
         }
     """)
 }


### PR DESCRIPTION
This PR improves https://github.com/intellij-rust/intellij-rust/pull/6825 by letting the user change the generated wild patterns (`_`) with a template builder. Based on a suggestion by @Sherlock-Holo (https://github.com/intellij-rust/intellij-rust/pull/6825#issuecomment-858216675).

changelog: Allow filling pats after generating match arms with `.match` postfix template.