### PR TITLE
ANN: improve Change function signature fix 

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsErrorAnnotator.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.annotator
 
 import com.intellij.codeInsight.daemon.impl.HighlightRangeExtension
-import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.AnnotationSession
@@ -18,7 +17,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.parentOfType
-import com.intellij.util.containers.addIfNotNull
 import org.rust.cargo.project.workspace.CargoWorkspace.Edition
 import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.annotator.fixes.*
@@ -947,13 +945,15 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
     }
 
     private fun checkValueArgumentList(holder: RsAnnotationHolder, args: RsValueArgumentList) {
-        val (expectedCount, functionType, function) = when (val parent = args.parent) {
-            is RsCallExpr -> parent.getFunctionCallContext()
-            is RsMethodCall -> parent.getFunctionCallContext()
-            else -> null
-        } ?: return
+        val (expectedCount, functionType, function) = args.getFunctionCallContext() ?: return
 
         val realCount = args.exprList.size
+        val fixes = if (function != null) {
+            ChangeFunctionSignatureFix.createIfCompatible(args, function)
+        } else {
+            emptyList()
+        }
+
         if (realCount < expectedCount) {
             // Mark only the right parenthesis
             val rparen = args.rparen
@@ -964,7 +964,7 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
             // But enable the quick fix on the whole argument range
             RsDiagnostic.IncorrectFunctionArgumentCountError(
                 args, expectedCount, realCount, functionType,
-                listOf(FillFunctionArgumentsFix(args)),
+                listOf(FillFunctionArgumentsFix(args)) + fixes,
                 textAttributes = TextAttributesKey.createTextAttributesKey("DEFAULT_TEXT_ATTRIBUTES")
             ).addToHolder(holder)
         } else if (!functionType.variadic && realCount > expectedCount) {
@@ -972,24 +972,22 @@ class RsErrorAnnotator : AnnotatorBase(), HighlightRangeExtension {
                 holder.newErrorAnnotation(it, null)?.create()
             }
 
-            val fixes = mutableListOf<LocalQuickFix>(RemoveRedundantFunctionArgumentsFix(args, expectedCount))
-            if (function != null) {
-                fixes.addIfNotNull(ChangeFunctionSignatureFix.createIfCompatible(
-                    args, function,
-                    ChangeFunctionSignatureFix.ArgumentScanDirection.Forward
-                ))
-                fixes.addIfNotNull(ChangeFunctionSignatureFix.createIfCompatible(
-                    args, function,
-                    ChangeFunctionSignatureFix.ArgumentScanDirection.Backward
-                ))
-            }
-
             RsDiagnostic.IncorrectFunctionArgumentCountError(
                 args, expectedCount, realCount, functionType,
-                fixes = fixes,
+                fixes = listOf(RemoveRedundantFunctionArgumentsFix(args, expectedCount)) + fixes,
                 textAttributes = TextAttributesKey.createTextAttributesKey("DEFAULT_TEXT_ATTRIBUTES")
             )
-            .addToHolder(holder)
+                .addToHolder(holder)
+        }
+
+        if (realCount == expectedCount && fixes.isNotEmpty()) {
+            val builder = holder.holder.newSilentAnnotation(HighlightSeverity.ERROR)
+                .textAttributes(TextAttributesKey.createTextAttributesKey("DEFAULT_TEXT_ATTRIBUTES"))
+                .range(args.textRange)
+            for (fix in fixes) {
+                builder.withFix(fix)
+            }
+            builder.create()
         }
     }
 
@@ -1515,6 +1513,14 @@ data class FunctionCallContext(
     val functionType: FunctionType,
     val function: RsFunction? = null
 )
+
+fun RsValueArgumentList.getFunctionCallContext(): FunctionCallContext? {
+    return when (val parent = parent) {
+        is RsCallExpr -> parent.getFunctionCallContext()
+        is RsMethodCall -> parent.getFunctionCallContext()
+        else -> null
+    }
+}
 
 fun RsCallExpr.getFunctionCallContext(): FunctionCallContext? {
     val path = (expr as? RsPathExpr)?.path ?: return null

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/ChangeFunctionSignatureFix.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.ide.annotator.getFunctionCallContext
 import org.rust.ide.presentation.renderInsertionSafe
 import org.rust.ide.refactoring.changeSignature.*
@@ -20,51 +19,71 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.isMethod
 import org.rust.lang.core.psi.ext.valueParameters
 import org.rust.lang.core.types.implLookup
+import org.rust.lang.core.types.inference
 import org.rust.lang.core.types.ty.Ty
 import org.rust.lang.core.types.ty.TyUnknown
 import org.rust.lang.core.types.type
+import org.rust.lang.utils.RsDiagnostic
+import org.rust.stdext.mapToSet
+import org.rust.stdext.numberSuffix
+import kotlin.math.max
 
 /**
- * Requires that the number of arguments is larger than the number of parameters.
+ * This fix can add, remove or change the type of parameters of a function.
  */
 class ChangeFunctionSignatureFix private constructor(
-    arguments: RsValueArgumentList,
+    argumentList: RsValueArgumentList,
     function: RsFunction,
-    private val direction: ArgumentScanDirection,
-) : LocalQuickFixAndIntentionActionOnPsiElement(arguments), PriorityAction {
+    private val signature: Signature,
+    private val priority: PriorityAction.Priority? = null
+) : LocalQuickFixAndIntentionActionOnPsiElement(argumentList), PriorityAction {
     private val fixText: String = run {
-        val signature = calculateSignature(function, arguments, direction)
-        val argumentInsertions = signature.withIndex().filter { (_, item) -> item is SignatureMember.Argument }
-
         val callableType = if (function.isMethod) "method" else "function"
         val name = function.name
-        if (argumentInsertions.size == 1) {
-            val index = argumentInsertions[0].index + 1
-            val argument = argumentInsertions[0].value as SignatureMember.Argument
+        val changes = signature.actions.withIndex().filter { (_, item) -> item !is SignatureAction.KeepParameter }
+        val arguments = getEffectiveArguments(argumentList, function)
 
-            val ordinal = "${index}${suffix(index)}"
-            "Add `${renderType(argument.expr.type)}` as `$ordinal` parameter to $callableType `$name`"
+        if (changes.size == 1) {
+            val (index, action) = changes[0]
+            val indexOffset = index + 1
+            val ordinal = "$indexOffset${numberSuffix(indexOffset)}"
+            val parameterFormat = function.valueParameters.getOrNull(index)?.pat?.formatParameter(index)
+
+            when (action) {
+                is SignatureAction.ChangeParameterType -> {
+                    val argument = arguments[action.argumentIndex]
+                    "Change type of $parameterFormat of $callableType `$name` to `${renderType(argument.type)}`"
+                }
+                is SignatureAction.InsertArgument -> {
+                    val argument = arguments[action.argumentIndex]
+                    "Add `${renderType(argument.type)}` as `$ordinal` parameter to $callableType `$name`"
+                }
+                SignatureAction.RemoveParameter -> "Remove $parameterFormat from $callableType `$name`"
+                is SignatureAction.KeepParameter -> error("unreachable")
+            }
         } else {
-            val signatureText = signature.joinToString(", ") {
-                when (it) {
-                    is SignatureMember.Argument -> "<b>${renderType(it.expr.type)}</b>"
-                    is SignatureMember.Parameter -> it.parameter.typeReference?.text.orEmpty()
+            val actions = signature.actions.filter { it !is SignatureAction.RemoveParameter }
+            val signatureText = actions.joinToString(", ") { action ->
+                when (action) {
+                    is SignatureAction.InsertArgument -> "<b>${renderType(arguments[action.argumentIndex].type)}</b>"
+                    is SignatureAction.KeepParameter -> renderType(
+                        function.valueParameters[action.parameterIndex].typeReference?.type ?: TyUnknown
+                    )
+                    is SignatureAction.ChangeParameterType -> "<b>${renderType(arguments[action.argumentIndex].type)}</b>"
+                    SignatureAction.RemoveParameter -> error("unreachable")
                 }
             }
 
-            "<html>Change signature of $name($signatureText)</html>"
+            "<html>Change signature to $name($signatureText)</html>"
         }
     }
 
     override fun getText(): String = fixText
-    override fun getFamilyName(): String = "Add parameter to function"
+    override fun getFamilyName(): String = "Change function signature"
 
     override fun startInWriteAction(): Boolean = false
 
-    override fun getPriority(): PriorityAction.Priority = when (direction) {
-        ArgumentScanDirection.Forward -> PriorityAction.Priority.HIGH
-        ArgumentScanDirection.Backward -> PriorityAction.Priority.NORMAL
-    }
+    override fun getPriority(): PriorityAction.Priority = priority ?: PriorityAction.Priority.NORMAL
 
     override fun invoke(
         project: Project,
@@ -74,30 +93,45 @@ class ChangeFunctionSignatureFix private constructor(
         endElement: PsiElement
     ) {
         val args = startElement as? RsValueArgumentList ?: return
-        val context = when (val parent = args.parent) {
-            is RsCallExpr -> parent.getFunctionCallContext()
-            is RsMethodCall -> parent.getFunctionCallContext()
-            else -> null
-        } ?: return
+        val context = args.getFunctionCallContext() ?: return
         val function = context.function ?: return
 
         val usedNames = mutableSetOf<String>()
         getExistingParameterNames(usedNames, function)
 
         val config = RsChangeFunctionSignatureConfig.create(function)
-        val signature = calculateSignature(function, args, direction)
         val factory = RsPsiFactory(project)
 
-        for ((index, item) in signature.withIndex()) {
-            if (item is SignatureMember.Argument) {
-                val expr = item.expr
-                val typeText = renderType(expr.type)
-                val fragment = RsTypeReferenceCodeFragment(project, typeText, context = args)
-                val typeReference = fragment.typeReference ?: factory.createType("()")
-                val name = generateName(suggestName(expr), usedNames)
+        val arguments = getEffectiveArguments(args, function)
+        var parameterIndex = 0
+        for ((index, item) in signature.actions.withIndex()) {
+            when (item) {
+                is SignatureAction.InsertArgument -> {
+                    val expr = arguments.getOrNull(item.argumentIndex) ?: continue
+                    val typeText = renderType(expr.type)
+                    val typeReference = factory.tryCreateType(typeText) ?: factory.createType("()")
+                    val name = generateName(suggestName(expr), usedNames)
 
-                config.parameters.add(index, Parameter(factory, name, ParameterProperty.fromItem(typeReference)))
-                config.additionalTypesToImport.add(expr.type)
+                    config.parameters.add(index, Parameter(factory, name, ParameterProperty.fromItem(typeReference)))
+                    config.additionalTypesToImport.add(expr.type)
+                    parameterIndex++
+                }
+                is SignatureAction.RemoveParameter -> config.parameters.removeAt(parameterIndex)
+                is SignatureAction.ChangeParameterType -> {
+                    val original = config.parameters[parameterIndex]
+                    val expr = arguments.getOrNull(item.argumentIndex) ?: continue
+                    val typeText = renderType(expr.type)
+                    val typeReference = factory.tryCreateType(typeText) ?: factory.createType("()")
+                    config.parameters[parameterIndex] = Parameter(
+                        factory,
+                        original.patText,
+                        ParameterProperty.fromItem(typeReference),
+                        original.index
+                    )
+                    config.additionalTypesToImport.add(expr.type)
+                    parameterIndex++
+                }
+                else -> parameterIndex++
             }
         }
 
@@ -107,20 +141,46 @@ class ChangeFunctionSignatureFix private constructor(
     companion object {
         fun createIfCompatible(
             arguments: RsValueArgumentList,
-            function: RsFunction,
-            direction: ArgumentScanDirection
-        ): ChangeFunctionSignatureFix? {
-            if (function.containingCrate?.origin != PackageOrigin.WORKSPACE) return null
+            function: RsFunction
+        ): List<ChangeFunctionSignatureFix> {
+            if (!RsChangeSignatureHandler.isChangeSignatureAvailable(function)) return emptyList()
+            val context = arguments.getFunctionCallContext() ?: return emptyList()
 
-            val signature = calculateSignature(function, arguments, direction)
-            val parameterInsertions = signature.filterIsInstance<SignatureMember.Parameter>()
+            val errorArguments = arguments.inference?.diagnostics
+                .orEmpty()
+                .filter { it is RsDiagnostic.TypeError && it.element in arguments.exprList }
+                .mapToSet { it.element }
 
-            // There are parameters that were not matched by any argument
-            if (function.valueParameters.size < parameterInsertions.size) {
-                return null
+            // Map is used to make sure that there is only a single fix for a given signature
+            val signatureToFix = mutableMapOf<Signature, ChangeFunctionSignatureFix>()
+
+            val argumentCount = arguments.exprList.size
+            if (context.expectedParameterCount < argumentCount) {
+                val effectiveArgumentCount = getEffectiveArguments(arguments, function).size
+
+                for ((direction, priority) in listOf(
+                    ArgumentScanDirection.Forward to PriorityAction.Priority.HIGH,
+                    ArgumentScanDirection.Backward to PriorityAction.Priority.NORMAL
+                )) {
+                    val signature = calculateSignatureWithInsertion(function, arguments, direction)
+
+                    // Check if parameter count would match the current argument count
+                    if (signature.getActualParameterCount() != effectiveArgumentCount) {
+                        continue
+                    }
+
+                    signatureToFix[signature] = ChangeFunctionSignatureFix(arguments, function, signature, priority)
+                }
             }
 
-            return ChangeFunctionSignatureFix(arguments, function, direction)
+            if (signatureToFix.isEmpty()) {
+                val simpleSignature = calculateSignatureWithoutInsertion(function, arguments, errorArguments)
+                if (!simpleSignature.actions.all { it is SignatureAction.KeepParameter }) {
+                    signatureToFix[simpleSignature] = ChangeFunctionSignatureFix(arguments, function, simpleSignature)
+                }
+            }
+
+            return signatureToFix.values.toList()
         }
     }
 
@@ -131,6 +191,15 @@ class ChangeFunctionSignatureFix private constructor(
         object Backward : ArgumentScanDirection() {
             override fun <T> map(iterable: Iterable<T>): Iterable<T> = iterable.reversed()
         }
+    }
+}
+
+private fun RsPat.formatParameter(index: Int): String {
+    return if (this is RsPatIdent) {
+        "parameter `${patBinding.name}`"
+    } else {
+        val num = index + 1
+        "`$num${numberSuffix(num)}` parameter"
     }
 }
 
@@ -160,18 +229,19 @@ private fun generateName(defaultName: String, usedNames: MutableSet<String>): St
 
 /**
  * Calculates a possible new signature in the specified direction.
+ * This method tries to insert new parameters into the signature (possibly in the middle).
  * Assumes that there are more arguments than parameters.
  */
-private fun calculateSignature(
+private fun calculateSignatureWithInsertion(
     function: RsFunction,
     argumentList: RsValueArgumentList,
     direction: ChangeFunctionSignatureFix.ArgumentScanDirection
-): List<SignatureMember> {
+): Signature {
     val parameters = function.valueParameters
-    val arguments = argumentList.exprList
+    val arguments = getEffectiveArguments(argumentList, function)
 
     if (parameters.isEmpty()) {
-        return arguments.map { SignatureMember.Argument(it) }
+        return Signature(arguments.indices.map { SignatureAction.InsertArgument(it) })
     }
 
     val ctx = function.implLookup.ctx
@@ -181,31 +251,80 @@ private fun calculateSignature(
     val parameterIterator = createIterator(parameters)
     val argumentIterator = createIterator(arguments)
 
-    val insertions = mutableListOf<SignatureMember>()
+    val insertions = mutableListOf<SignatureAction>()
     while (true) {
         val parameter = parameterIterator.value
         val argument = argumentIterator.value ?: break
 
         if (parameter != null && ctx.combineTypes(parameter.typeReference?.type ?: TyUnknown, argument.type).isOk) {
-            insertions.add(SignatureMember.Parameter(parameter))
+            insertions.add(SignatureAction.KeepParameter(parameters.indexOf(parameter)))
             parameterIterator.advance()
             argumentIterator.advance()
         } else {
-            insertions.add(SignatureMember.Argument(argument))
+            insertions.add(SignatureAction.InsertArgument(arguments.indexOf(argument)))
             argumentIterator.advance()
         }
     }
 
-    return direction.map(insertions).toList()
+    while (true) {
+        val parameter = parameterIterator.value ?: break
+        insertions.add(SignatureAction.KeepParameter(parameters.indexOf(parameter)))
+        parameterIterator.advance()
+    }
+
+    return Signature(direction.map(insertions).toList())
+}
+
+/**
+ * Calculates a possible new signature without shuffling new parameters into the signature.
+ * New parameters can only be added to the end.
+ * Goes linearly through parameter/argument pairs and calculates actions that should be performed to parameters to match
+ * the arguments.
+ */
+private fun calculateSignatureWithoutInsertion(
+    function: RsFunction,
+    args: RsValueArgumentList,
+    errorArguments: Set<PsiElement>
+): Signature {
+    val actions = mutableListOf<SignatureAction>()
+
+    val parameters = function.valueParameters
+    val arguments = getEffectiveArguments(args, function)
+
+    val length = max(arguments.size, parameters.size)
+    for (index in 0 until length) {
+        val action = when {
+            index >= arguments.size -> SignatureAction.RemoveParameter
+            index >= parameters.size -> SignatureAction.InsertArgument(index)
+            arguments[index] in errorArguments -> SignatureAction.ChangeParameterType(index)
+            else -> SignatureAction.KeepParameter(index)
+        }
+        actions.add(action)
+    }
+
+    return Signature(actions)
+}
+
+/**
+ * Returns argument expressions.
+ * If the call is UFCS, removes self argument from the argument list.
+ */
+private fun getEffectiveArguments(args: RsValueArgumentList, function: RsFunction): List<RsExpr> {
+    val arguments = args.exprList
+
+    val isUFCS = function.isMethod && args.parent is RsCallExpr
+    return if (isUFCS) {
+        arguments.drop(1)
+    } else {
+        arguments
+    }
 }
 
 private class PeekableIterator<T>(private val iterator: Iterator<T>) {
     var value: T? = null
 
     init {
-        if (iterator.hasNext()) {
-            value = iterator.next()
-        }
+        advance()
     }
 
     fun advance() {
@@ -217,25 +336,29 @@ private class PeekableIterator<T>(private val iterator: Iterator<T>) {
     }
 }
 
-private sealed class SignatureMember {
-    data class Parameter(val parameter: RsValueParameter) : SignatureMember()
-    data class Argument(val expr: RsExpr) : SignatureMember()
-}
-
-private fun suffix(number: Int): String {
-    if ((number % 100) in 11..13) {
-        return "th"
-    }
-    return when (number % 10) {
-        1 -> "st"
-        2 -> "nd"
-        3 -> "rd"
-        else -> "th"
+private data class Signature(val actions: List<SignatureAction>) {
+    /**
+     * Calculates how many parameters would a function had if these actions were applied to its signature.
+     */
+    fun getActualParameterCount(): Int = actions.sumOf {
+        val count = when (it) {
+            is SignatureAction.RemoveParameter -> -1
+            else -> 1
+        }
+        count
     }
 }
 
-private fun renderType(ty: Ty): String =
-    ty.renderInsertionSafe(includeLifetimeArguments = true)
+private sealed class SignatureAction {
+    data class KeepParameter(val parameterIndex: Int) : SignatureAction()
+    data class InsertArgument(val argumentIndex: Int) : SignatureAction()
+
+    // Parameters may only be removed at the end
+    object RemoveParameter : SignatureAction()
+    data class ChangeParameterType(val argumentIndex: Int) : SignatureAction()
+}
+
+private fun renderType(ty: Ty): String = ty.renderInsertionSafe()
 
 private fun getExistingParameterNames(usedNames: MutableSet<String>, function: RsFunction) {
     val visitor = object : RsRecursiveVisitor() {

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/FillFunctionArgumentsFix.kt
@@ -42,11 +42,7 @@ class FillFunctionArgumentsFix(element: PsiElement) : LocalQuickFixAndIntentionA
         val arguments = startElement.parentOfType<RsValueArgumentList>(true) ?: return
         val parent = arguments.parent as? RsElement ?: return
 
-        val requiredParameterCount = when (parent) {
-            is RsCallExpr -> parent.getFunctionCallContext()?.expectedParameterCount
-            is RsMethodCall -> parent.getFunctionCallContext()?.expectedParameterCount
-            else -> null
-        } ?: return
+        val requiredParameterCount = arguments.getFunctionCallContext()?.expectedParameterCount ?: return
         val parameters = getParameterTypes(parent)?.take(requiredParameterCount) ?: return
 
         val factory = RsPsiFactory(project)

--- a/src/main/kotlin/org/rust/ide/annotator/fixes/RemoveRedundantFunctionArgumentsFix.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/fixes/RemoveRedundantFunctionArgumentsFix.kt
@@ -19,6 +19,7 @@ class RemoveRedundantFunctionArgumentsFix(
 ) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
     override fun getText(): String = "Remove redundant arguments"
     override fun getFamilyName(): String = text
+
     override fun invoke(
         project: Project,
         file: PsiFile,

--- a/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/changeSignature/RsChangeSignatureHandler.kt
@@ -15,6 +15,7 @@ import com.intellij.refactoring.RefactoringBundle
 import com.intellij.refactoring.changeSignature.ChangeSignatureHandler
 import com.intellij.refactoring.util.CommonRefactoringUtil
 import org.rust.RsBundle
+import org.rust.cargo.project.workspace.PackageOrigin
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.openapiext.editor
@@ -78,6 +79,9 @@ class RsChangeSignatureHandler : ChangeSignatureHandler {
         }
 
         private fun checkFunction(function: RsFunction): String? {
+            if (function.containingCrate?.origin != PackageOrigin.WORKSPACE) {
+                return "Cannot change signature of function in a foreign crate"
+            }
             if (function.valueParameters != function.rawValueParameters) {
                 return RsBundle.message("refactoring.change.signature.error.cfg.disabled.parameters")
             }

--- a/src/main/kotlin/org/rust/stdext/Utils.kt
+++ b/src/main/kotlin/org/rust/stdext/Utils.kt
@@ -64,3 +64,15 @@ fun randomLowercaseAlphabetic(length: Int): String =
 
 fun ByteArray.getLeading64bits(): Long =
     ByteBuffer.wrap(this).also { it.order(ByteOrder.BIG_ENDIAN) }.getLong(0)
+
+fun numberSuffix(number: Int): String {
+    if ((number % 100) in 11..13) {
+        return "th"
+    }
+    return when (number % 10) {
+        1 -> "st"
+        2 -> "nd"
+        3 -> "rd"
+        else -> "th"
+    }
+}


### PR DESCRIPTION
This PR improve the `Change signature` quick fix. It now also allows changing parameter types and removing extraneous parameters at the end of the signature (in addition to adding new parameters, which it could do before. A discussion of this feature is present [here](https://github.com/intellij-rust/intellij-rust/pull/6745#issuecomment-858554947).

![change-parameter](https://user-images.githubusercontent.com/4539057/121543918-95b33c00-ca09-11eb-8e56-086037ded0bd.gif)

changelog: Improve the `Change signature` quick fix. It can now also change parameter types and remove extraneous parameters from the end of the signature.