### PR TITLE
Fix interop with `rainbow-brackets` plugin

### DIFF
--- a/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
+++ b/src/main/kotlin/org/rust/ide/injected/RsDoctestLanguageInjector.kt
@@ -143,10 +143,10 @@ class RsDoctestLanguageInjector : MultiHostInjector {
             }
             if (index == cratesEndIndex && !alreadyHasMain) {
                 if (prefix == null) prefix = StringBuilder()
-                prefix.append("fn $INJECTED_MAIN_NAME() {")
+                prefix.append("fn $INJECTED_MAIN_NAME() {\n")
             }
 
-            val suffix = if (isLastIteration && !alreadyHasMain) "}" else null
+            val suffix = if (isLastIteration && !alreadyHasMain) "\n}" else null
 
             inj.addPlace(prefix?.toString(), suffix, context, range)
         }


### PR DESCRIPTION
Fixes the issue with doctests:
https://github.com/izhangzhihao/intellij-rainbow-brackets/issues/483

(see the conversation in #6100)


changelog: Fix weird highlighting of doctests if [rainbow-brackets](https://plugins.jetbrains.com/plugin/10080-rainbow-brackets) plugin is installed
