### PR TITLE
ANN: fix false-positive highlighting on implicit named arguments in format macro annotations

### DIFF
--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.annotator
 
 import com.intellij.ide.annotator.BatchMode
+import org.rust.MockRustcVersion
 import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
@@ -35,6 +36,16 @@ class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::c
             println!("Hello <FORMAT_PARAMETER>{:<error descr="Invalid reference to positional argument 1 (there is 1 argument)">1${'$'}</error>}</FORMAT_PARAMETER>", 1);
             println!("<FORMAT_PARAMETER>{<error descr="There is no argument named `foo`">foo</error>}</FORMAT_PARAMETER>");
             println!("Hello <FORMAT_PARAMETER>{:<error descr="There is no argument named `foo`">foo${'$'}</error>}</FORMAT_PARAMETER>", 1);
+        }
+    """)
+
+    @MockRustcVersion("1.50.0-nightly")
+    fun `test implicit named arguments`() = checkErrors("""
+        #![feature(format_args_capture)]
+
+        fn main() {
+            let foo = 1;
+            println!("Hello <FORMAT_PARAMETER>{<FORMAT_SPECIFIER>foo</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>");
         }
     """)
 


### PR DESCRIPTION
This PR adds basic support for the `format_args_capture` unstable feature, just so that we avoid false positives.

Later we can add proper support for resolving format macro arguments with a reference contributor that would resolve arguments either to named parameters or to local bindings. It would also display unresolved reference errors if no argument is found when `format_args_capture` is enabled.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/7332

changelog: Do not warn about missing format macro arguments if `format_args_capture` feature is enabled.