### PR TITLE
Fix NPE in debugger advertising runner in 2021.2 IDEs

### DIFF
--- a/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
+++ b/src/main/kotlin/org/rust/debugger/runconfig/RsDebugAdvertisingRunner.kt
@@ -28,9 +28,9 @@ class RsDebugAdvertisingRunner : RsDefaultProgramRunnerBase() {
         if (executorId != DefaultDebugExecutor.EXECUTOR_ID) return false
         if (profile !is CargoCommandConfiguration) return false
         if (!isSupportedPlatform()) return false
-        val plugin = nativeDebuggingSupportPlugin()
+        val plugin = nativeDebuggingSupportPlugin() ?: return true
         val loadedPlugins = PluginManagerCore.getLoadedPlugins()
-        return plugin !in loadedPlugins || plugin?.isEnabled != true
+        return plugin !in loadedPlugins || !plugin.isEnabled
     }
 
     override fun execute(environment: ExecutionEnvironment) {


### PR DESCRIPTION
Fixes exception mentioned in https://github.com/intellij-rust/intellij-rust/issues/7280#issuecomment-859505965

changelog: Fix exception in debugger advertiser in 2021.2 versions of IntelliJ IDEA Ultimate, GoLand and PyCharm Pro
