### PR TITLE
INT: keep existing comments in NestUseStatementsIntention

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/NestUseStatementsIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/NestUseStatementsIntention.kt
@@ -7,6 +7,7 @@ package org.rust.ide.intentions
 
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
@@ -60,6 +61,10 @@ class NestUseStatementsIntention : RsElementBaseIntentionAction<NestUseStatement
         val inserted = ctx.root.addAfter(ctx.createElement(path, project), ctx.firstOldElement)
 
         for (prevElement in ctx.oldElements) {
+            val existingComment = prevElement.childrenWithLeaves.firstOrNull() as? PsiComment
+            if (existingComment != null) {
+                ctx.root.addBefore(existingComment, inserted)
+            }
             prevElement.delete()
         }
 

--- a/src/test/kotlin/org/rust/ide/intentions/NestUseStatementsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/NestUseStatementsIntentionTest.kt
@@ -292,4 +292,47 @@ class NestUseStatementsIntentionTest : RsIntentionTestBase(NestUseStatementsInte
         pub use a::b4;
 
     """)
+
+    fun `test keep outer doc comment`() = doAvailableTest("""
+        /// My doc comment
+        use a/*caret*/::b::c;
+        use a::b::d;
+    """, """
+        /// My doc comment
+        use a::{
+            b::c,
+            b::d
+        };
+
+    """)
+
+    fun `test keep middle doc comment`() = doAvailableTest("""
+        /// My doc comment
+        use a/*caret*/::b::c;
+        /// My doc comment 2
+        use a::b::d;
+    """, """
+        /// My doc comment
+        /// My doc comment 2
+        use a::{
+            b::c,
+            b::d
+        };
+
+    """)
+
+    fun `test keep middle comment`() = doAvailableTest("""
+        // My comment
+        use a/*caret*/::b::c;
+        // My comment 2
+        use a::b::d;
+    """, """
+        // My comment
+        // My comment 2
+        use a::{
+            b::c,
+            b::d
+        };
+
+    """)
 }


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/3181

changelog: Keep existing comments when using `Nest use statements` intention.