### PR TITLE
ANN: add inspection that checks private type leakage in public interface

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -73,7 +73,9 @@ enum class RsLint(
             }
     },
 
-    UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY);
+    UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY),
+
+    PrivateTypeInPublicInterface("private_in_public", defaultLevel = WARN);
 
     protected open fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
         when (level) {

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsPrivateTypeLeakedInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsPrivateTypeLeakedInspection.kt
@@ -1,0 +1,111 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.types.ty.TyAdt
+import org.rust.lang.core.types.type
+import org.rust.lang.utils.RsDiagnostic
+import org.rust.lang.utils.Severity
+import org.rust.lang.utils.addToHolder
+
+class RsPrivateTypeLeakedInspection : RsLintInspection() {
+    override fun getLint(element: PsiElement): RsLint = RsLint.PrivateTypeInPublicInterface
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor =
+        object : RsVisitor() {
+            override fun visitTypeReference(o: RsTypeReference) {
+                val ctx = getContext(o)
+                if (ctx != null) {
+                    val target = when (val type = o.type) {
+                        is TyAdt -> type.item
+                        else -> null
+                    }
+                    if (target != null) {
+                        checkTypeLeakage(holder, ctx, o, listOf(target))
+                    }
+                }
+
+                super.visitTypeReference(o)
+            }
+
+            override fun visitTraitRef(o: RsTraitRef) {
+                val ctx = getContext(o)
+                if (ctx != null) {
+                    val trait = o.resolveToTrait()
+                    if (trait != null) {
+                        checkTypeLeakage(holder, ctx, o, listOf(trait))
+                    }
+                }
+
+                super.visitTraitRef(o)
+            }
+        }
+}
+
+private data class Context(
+    val owner: RsItemElement,
+    val severity: Severity
+)
+
+private fun getContext(element: PsiElement): Context? {
+    val owner = element.parentOfType<RsItemElement>() ?: return null
+    if (owner !is RsAbstractable &&
+        owner !is RsStructOrEnumItemElement &&
+        owner !is RsTraitItem) return null
+
+    // Ignore private fields
+    val fieldParent = element.parentOfType<RsFieldDecl>()
+    if (fieldParent?.visibility == RsVisibility.Private) return null
+
+    // Ignore types inside functions
+    if (owner is RsFunction && owner.block?.isAncestorOf(element) == true) return null
+
+    val (realOwner, severity) = when {
+        owner is RsEnumVariant && owner.blockFields?.isAncestorOf(element) == true -> owner to Severity.WARN
+        owner is RsAbstractable && owner.owner is RsAbstractableOwner.Trait ->
+            (owner.owner as RsAbstractableOwner.Trait).trait to Severity.WARN
+        owner is RsTypeAlias -> owner to Severity.WARN
+        else -> owner to Severity.ERROR
+    }
+
+    if (realOwner.visibility == RsVisibility.Private) return null
+    if (realOwner.parent !is RsMod) return null
+
+    return Context(realOwner, severity)
+}
+
+private fun checkTypeLeakage(
+    holder: RsProblemsHolder,
+    context: Context,
+    reference: RsElement,
+    targets: List<RsVisibilityOwner>
+) {
+    // This will produce E0603
+    if (targets.any { !it.isVisibleFrom(reference.containingMod) }) return
+
+    for (target in targets) {
+        val isLeaked = when (val visibility = context.owner.visibility) {
+            is RsVisibility.Public -> target.visibility != RsVisibility.Public
+            is RsVisibility.Restricted -> !target.isVisibleFrom(visibility.inMod)
+            else -> false
+        }
+        if (isLeaked) {
+            // TODO: handle error/warning disparity in lint inspections
+            RsDiagnostic.PrivateTypeLeaked(
+                Severity.ERROR,
+                target,
+                reference,
+                (target as? RsNamedElement)?.name ?: error("Missing name")
+            )
+            .addToHolder(holder)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
+++ b/src/main/kotlin/org/rust/lang/utils/RsDiagnostic.kt
@@ -1390,6 +1390,39 @@ sealed class RsDiagnostic(
             fixes = fixes
         )
     }
+
+    class PrivateTypeLeaked(
+        private val severity: Severity,
+        private val target: RsVisibilityOwner,
+        element: RsElement,
+        private val name: String,
+    ) : RsDiagnostic(element) {
+        private val isTrait: Boolean = target is RsTraitItem
+
+        private val visibilityText: String = run {
+            if (isTrait) {
+                "private"
+            } else {
+                when (val visibility = target.visibility) {
+                    is RsVisibility.Restricted -> {
+                        if (visibility.inMod == (element.containingCrate?.rootMod ?: element.containingMod)) {
+                            "crate-restricted"
+                        } else {
+                            "restricted"
+                        }
+                    }
+                    else -> "private"
+                }
+            }
+        }
+
+        override fun prepare() = PreparedAnnotation(
+            severity,
+            if (isTrait) { E0445 } else { E0446 },
+            "$visibilityText ${if (isTrait) { "trait" } else { "type" }} `$name` leaked in public interface",
+            fixes = listOfNotNull(MakePublicFix.createIfCompatible(target, name, false))
+        )
+    }
 }
 
 enum class RsErrorCode {
@@ -1397,7 +1430,7 @@ enum class RsErrorCode {
     E0106, E0107, E0116, E0117, E0118, E0120, E0121, E0124, E0132, E0133, E0184, E0185, E0186, E0198, E0199,
     E0200, E0201, E0202, E0252, E0261, E0262, E0263, E0267, E0268, E0277,
     E0308, E0322, E0328, E0364, E0365, E0379, E0384,
-    E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0433, E0435, E0449, E0451, E0463,
+    E0403, E0404, E0407, E0415, E0416, E0424, E0426, E0428, E0433, E0435, E0445, E0446, E0449, E0451, E0463,
     E0517, E0518, E0537, E0552, E0562, E0569, E0583, E0586, E0594,
     E0601, E0603, E0614, E0616, E0618, E0624, E0658, E0666, E0667, E0688, E0695,
     E0704, E0732;

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -607,6 +607,11 @@
                          enabledByDefault="true" level="ERROR"
                          implementationClass="org.rust.ide.inspections.lints.RsUnknownCrateTypesInspection"/>
 
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
+                         displayName="Private type used in public interface"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.lints.RsPrivateTypeLeakedInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsPrivateTypeLeaked.html
+++ b/src/main/resources/inspectionDescriptions/RsPrivateTypeLeaked.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Detects private types used in public interfaces.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsPrivateTypeLeakedInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsPrivateTypeLeakedInspectionTest.kt
@@ -1,0 +1,245 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import org.rust.MockEdition
+import org.rust.cargo.project.workspace.CargoWorkspace
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+@MockEdition(CargoWorkspace.Edition.EDITION_2018)
+class RsPrivateTypeLeakedInspectionTest : RsInspectionsTestBase(RsPrivateTypeLeakedInspection::class) {
+    fun `test ignore leak of item that is not accessible`() = checkByText("""
+        mod foo {
+            mod bar {
+                struct Bar;
+            }
+
+            pub fn foo(_: bar::Bar) {}
+        }
+    """)
+
+    fun `test ignore leak in items that are not direct children of some mod`() = checkByText("""
+        fn foo() {
+            struct Bar;
+            pub fn bar() -> Bar { Bar }
+        }
+    """)
+
+    fun `test ignore private type usage inside function`() = checkByText("""
+        mod foo {
+            struct Bar;
+            fn bar() {
+                let _ = Bar;
+            }
+        }
+    """)
+
+    fun `test ignore leak in public field of private struct`() = checkByText("""
+        mod foo {
+            struct Baz;
+            struct Bar {
+                pub a: Baz
+            }
+        }
+    """)
+
+    fun `test ignore private type in field of public struct`() = checkByText("""
+        mod foo {
+            struct Baz;
+            pub struct Bar {
+                a: Baz
+            }
+        }
+    """)
+
+    fun `test leak in trait function`() = checkByText("""
+        mod foo {
+            struct Bar;
+
+            pub trait Trait {
+                fn foo() -> <warning descr="private type `Bar` leaked in public interface [E0446]">Bar</warning>;
+            }
+        }
+    """)
+
+    fun `test leak in struct named field`() = checkByText("""
+        mod foo {
+            struct Baz;
+            pub struct Bar {
+                pub a: <warning descr="private type `Baz` leaked in public interface [E0446]">Baz</warning>
+            }
+        }
+    """)
+
+    fun `test leak in struct tuple field`() = checkByText("""
+        mod foo {
+            struct Baz;
+            pub struct Bar(pub <warning descr="private type `Baz` leaked in public interface [E0446]">Baz</warning>);
+        }
+    """)
+
+    fun `test leak in enum named field`() = checkByText("""
+        mod foo {
+            struct Baz;
+
+            pub enum E {
+                Bar {
+                    a: <warning descr="private type `Baz` leaked in public interface [E0446]">Baz</warning>
+                }
+            }
+        }
+    """)
+
+    fun `test leak in enum tuple field`() = checkByText("""
+        mod foo {
+            struct Baz;
+            pub struct Bar(pub <warning descr="private type `Baz` leaked in public interface [E0446]">Baz</warning>);
+        }
+    """)
+
+    fun `test leak in function return type`() = checkByText("""
+        mod foo {
+            struct Bar;
+            pub fn bar() -> <warning descr="private type `Bar` leaked in public interface [E0446]">Bar</warning> { Bar }
+        }
+    """)
+
+    fun `test leak in function parameter`() = checkByText("""
+        mod foo {
+            struct Bar;
+            pub fn bar(a: <warning descr="private type `Bar` leaked in public interface [E0446]">Bar</warning>) {}
+        }
+    """)
+
+    fun `test leak in constant type`() = checkByText("""
+        mod foo {
+            struct Bar;
+            pub const BAR: <warning descr="private type `Bar` leaked in public interface [E0446]">Bar</warning> = Bar;
+        }
+    """)
+
+    fun `test private visibility`() = checkByText("""
+        mod bar {
+            struct Bar;
+            pub fn foo(_: <warning descr="private type `Bar` leaked in public interface [E0446]">Bar</warning>) {}
+        }
+    """)
+
+    fun `test crate restricted visibility`() = checkByText("""
+        mod bar {
+            pub(crate) struct Bar;
+            pub fn foo(_: <warning descr="crate-restricted type `Bar` leaked in public interface [E0446]">Bar</warning>) {}
+        }
+    """)
+
+    fun `test mod restricted visibility`() = checkByText("""
+        mod bar {
+            mod foo {
+                pub(in super) struct Bar;
+                pub fn foo(_: <warning descr="restricted type `Bar` leaked in public interface [E0446]">Bar</warning>) {}
+            }
+        }
+    """)
+
+    fun `test imported type`() = checkByText("""
+        struct Bar(u32);
+
+        mod foo {
+            use crate::Bar;
+            pub fn bar() -> <warning descr="private type `Bar` leaked in public interface [E0446]">Bar</warning> { Bar(0) }
+        }
+    """)
+
+    fun `test leak in type alias`() = checkByText("""
+        mod foo {
+            struct Bar;
+            pub type Foo = <warning descr="private type `Bar` leaked in public interface [E0446]">Bar</warning>;
+        }
+    """)
+
+    fun `test leak in supertrait`() = checkByText("""
+        mod foo {
+            trait Bar {}
+            pub trait Foo: <warning descr="private trait `Bar` leaked in public interface [E0445]">Bar</warning> {}
+        }
+    """)
+
+    fun `test leak in type parameters`() = checkByText("""
+        mod foo {
+            trait Bar {}
+            pub fn foo<T: <warning descr="private trait `Bar` leaked in public interface [E0445]">Bar</warning>>(_: T) {}
+        }
+    """)
+
+    fun `test leak in where clause`() = checkByText("""
+        mod foo {
+            trait Bar {}
+            pub fn foo<T>(_: T)
+                where T: <warning descr="private trait `Bar` leaked in public interface [E0445]">Bar</warning>
+            {}
+        }
+    """)
+
+    fun `test leak in generic parameter`() = checkByText("""
+        mod foo {
+            struct Bar;
+
+            pub struct S<T>(T);
+            pub fn foo(_: S<<warning descr="private type `Bar` leaked in public interface [E0446]">Bar</warning>>) {}
+        }
+    """)
+
+    fun `test multiple namespaces`() = checkByText("""
+        mod foo {
+            struct Bar {}
+            const Bar: u32 = 0;
+
+            pub fn foo() -> <warning descr="private type `Bar` leaked in public interface [E0446]">Bar</warning> { Bar {} }
+        }
+    """)
+
+    fun `test allow soft error`() = checkByText("""
+        #![allow(private_in_public)]
+
+        mod foo {
+            struct Bar;
+
+            trait Foo {
+                fn foo() -> Bar;
+            }
+        }
+    """)
+
+    fun `test allow hard error`() = checkByText("""
+        #![allow(private_in_public)]
+
+        mod foo {
+            struct Bar;
+            pub fn foo() -> Bar { Bar }
+        }
+    """)
+
+    fun `test deny`() = checkByText("""
+        #![deny(private_in_public)]
+
+        mod foo {
+            struct Bar;
+            pub fn foo() -> <warning descr="private type `Bar` leaked in public interface [E0446]">Bar</warning> { Bar }
+        }
+    """)
+
+    fun `test fix`() = checkFixByText("Make `Bar` public", """
+        mod foo {
+            struct Bar;
+            pub fn foo() -> <warning descr="private type `Bar` leaked in public interface [E0446]">Bar/*caret*/</warning> { Bar }
+        }
+    """, """
+        mod foo {
+            pub struct Bar;
+            pub fn foo() -> Bar { Bar }
+        }
+    """)
+}


### PR DESCRIPTION
Corresponding errors: https://doc.rust-lang.org/stable/error-index.html#E0446

This lint is a bit special. On one hand, in some cases it behaves like a normal lint that can be partially turned off by `#![allow()]`. On the other hand, in other cases, it is a hard compiler error that cannot be turned off (E0445, E0446).
First I implemented it as a part of the error annotator, but then I changed the implementation so that it is an inspection that can be turned off.

I want to be able to make the lint warn in specific situations, and a hard error in others. But I'm having trouble, because the current lint infrastructure is not prepared for something like this.

I'm using `RsDiagnostic` to create the annotations, but for some reason inside inspection tests if I use error, it gets converted to a warning, and if I use a warning, no annotation is produced. Should I use `registerLintProblem` instead? But I don't know how to make it produce an error/warning in different situations. Maybe the lint infrastructure will need some changes to support this use case.

Related issue: https://github.com/intellij-rust/intellij-rust/issues/5888

changelog: Add inspection that checks private types leaked in public interfaces.