### PR TITLE
COMP: add special case for String in MatchPostfixTemplate

### DIFF
--- a/src/test/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplateTest.kt
@@ -5,6 +5,9 @@
 
 package org.rust.ide.template.postfix
 
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+
 class MatchPostfixTemplateTest : RsPostfixTemplateTest(MatchPostfixTemplate(RsPostfixTemplateProvider())) {
     fun `test simple`() = doTest("""
         enum Message {
@@ -90,6 +93,33 @@ class MatchPostfixTemplateTest : RsPostfixTemplateTest(MatchPostfixTemplate(RsPo
     """, """
         fn main() {
             let x = match 1 + 2 { _/*caret*/ => {} };
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test string`() = doTest("""
+        fn foo(s: String) {
+            s.match/*caret*/
+        }
+    """, """
+        fn foo(s: String) {
+            match s.as_str() {
+                ""/*caret*/ => {}
+                _ => {}
+            }
+        }
+    """)
+
+    fun `test str ref`() = doTest("""
+        fn foo(s: &str) {
+            s.match/*caret*/
+        }
+    """, """
+        fn foo(s: &str) {
+            match s {
+                ""/*caret*/ => {}
+                _ => {}
+            }
         }
     """)
 }


### PR DESCRIPTION
This PR adds a special case for `String` in `MatchPostfixTemplate`,  as mentioned [here](https://github.com/intellij-rust/intellij-rust/pull/6825#issuecomment-858592723), because the default is not very useful. This could possibly be applied to other types too, for example `&str`.

It also adds simple infrastructure for adding custom match generation for selected types.

changelog: Add special case for Strings in MatchPostfixTemplate.