### PR TITLE
ANN: highlight emphasis and strong emphasis in rustdocs

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsDocHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsDocHighlightingAnnotator.kt
@@ -38,6 +38,8 @@ class RsDocHighlightingAnnotator : AnnotatorBase() {
                 is RsDocCodeBlock -> RsColor.DOC_CODE
                 else -> null
             }
+            element is RsDocEmphasis -> RsColor.DOC_EMPHASIS
+            element is RsDocStrong -> RsColor.DOC_STRONG
             element is RsDocAtxHeading -> RsColor.DOC_HEADING
             element is RsDocLink && element.descendantOfTypeStrict<RsDocGap>() == null -> RsColor.DOC_LINK
             else -> null

--- a/src/main/kotlin/org/rust/ide/colors/RsColors.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RsColors.kt
@@ -60,6 +60,8 @@ enum class RsColor(humanName: String, default: TextAttributesKey? = null) {
     DOC_COMMENT("Rustdoc//Comment", Default.DOC_COMMENT),
     DOC_HEADING("Rustdoc//Heading", Default.DOC_COMMENT_TAG),
     DOC_LINK("Rustdoc//Link", Default.DOC_COMMENT_TAG_VALUE),
+    DOC_EMPHASIS("Rustdoc//Italic text"),
+    DOC_STRONG("Rustdoc//Bold text"),
     DOC_CODE("Rustdoc//Code", Default.DOC_COMMENT_MARKUP),
 
     BRACES("Braces and Operators//Braces", Default.BRACES),

--- a/src/main/resources/org/rust/ide/colors/RustDarcula.xml
+++ b/src/main/resources/org/rust/ide/colors/RustDarcula.xml
@@ -28,6 +28,16 @@
             <option name="EFFECT_TYPE" value="1" />
         </value>
     </option>
+    <option name="org.rust.DOC_EMPHASIS">
+        <value>
+            <option name="FONT_TYPE" value="3"/>
+        </value>
+    </option>
+    <option name="org.rust.DOC_STRONG">
+        <value>
+            <option name="FONT_TYPE" value="1" />
+        </value>
+    </option>
     <option name="org.rust.DIMMED_TEXT">
         <value>
             <option name="FOREGROUND" value="606060" />

--- a/src/main/resources/org/rust/ide/colors/RustDefault.xml
+++ b/src/main/resources/org/rust/ide/colors/RustDefault.xml
@@ -28,6 +28,16 @@
             <option name="EFFECT_TYPE" value="1" />
         </value>
     </option>
+    <option name="org.rust.DOC_EMPHASIS">
+        <value>
+            <option name="FONT_TYPE" value="3"/>
+        </value>
+    </option>
+    <option name="org.rust.DOC_STRONG">
+        <value>
+            <option name="FONT_TYPE" value="1" />
+        </value>
+    </option>
     <option name="org.rust.DOC_CODE">
         <value>
             <option name="FOREGROUND" value="404040"/>

--- a/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
+++ b/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
@@ -71,9 +71,10 @@ fn <FUNCTION>main</FUNCTION>() {
              program, <MUT_BINDING>accumulator</MUT_BINDING>);
 }
 
-/// Some documentation `with code`
-/// # Heading
-/// [Rust](https://www.rust-lang.org/)
+<DOC_COMMENT>/// Some documentation <DOC_CODE>`with a code`</DOC_CODE>, <DOC_EMPHASIS>*an italic text*</DOC_EMPHASIS>
+/// and <DOC_STRONG>**a bold text**</DOC_STRONG>
+/// <DOC_HEADING># Heading</DOC_HEADING>
+/// <DOC_LINK>[Rust](https://www.rust-lang.org/)</DOC_LINK></DOC_COMMENT>
 <ATTRIBUTE>#[cfg(target_os=</ATTRIBUTE>"linux"<ATTRIBUTE>)]</ATTRIBUTE>
 <KEYWORD_UNSAFE>unsafe</KEYWORD_UNSAFE> fn <FUNCTION>a_function</FUNCTION><<TYPE_PARAMETER>T</TYPE_PARAMETER>: <LIFETIME>'lifetime</LIFETIME>>(<MUT_PARAMETER>count</MUT_PARAMETER>: &mut i64) -> ! {
     <MUT_PARAMETER>count</MUT_PARAMETER> += 1;

--- a/src/test/kotlin/org/rust/ide/annotator/RsDocHighlightingAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsDocHighlightingAnnotatorTest.kt
@@ -152,12 +152,12 @@ class RsDocHighlightingAnnotatorTest : RsAnnotatorTestBase(RsDocHighlightingAnno
         /// <DOC_LINK>[link](/url "title \"&quot;")</DOC_LINK>
         /// <DOC_LINK>[link](/url 'title "and" title')</DOC_LINK>
         /// <DOC_LINK>[link \[bar](/uri)</DOC_LINK>
-        /// <DOC_LINK>[link *foo **bar** `#`*](/uri)</DOC_LINK>
+        /// <DOC_LINK>[link <DOC_EMPHASIS>*foo <DOC_STRONG>**bar**</DOC_STRONG> `#`*</DOC_EMPHASIS>](/uri)</DOC_LINK>
         /// *<DOC_LINK>[foo*](/uri)</DOC_LINK>
         /// <DOC_LINK>[foo *bar](baz*)</DOC_LINK>
         /// <DOC_LINK>[foo][bar]</DOC_LINK>
         /// <DOC_LINK>[link \[bar][ref]</DOC_LINK>
-        /// <DOC_LINK>[link *foo **bar** `#`*][ref]</DOC_LINK>
+        /// <DOC_LINK>[link <DOC_EMPHASIS>*foo <DOC_STRONG>**bar**</DOC_STRONG> `#`*</DOC_EMPHASIS>][ref]</DOC_LINK>
         /// *<DOC_LINK>[foo*][ref]</DOC_LINK>
         /// <DOC_LINK>[foo][]</DOC_LINK>
         /// <DOC_LINK>[foo]</DOC_LINK>
@@ -210,7 +210,12 @@ class RsDocHighlightingAnnotatorTest : RsAnnotatorTestBase(RsDocHighlightingAnno
     """)
 
     fun `test heading with formatting`() = checkHighlightingStrict("""
-        /// <DOC_HEADING># header <DOC_CODE>`code`</DOC_CODE> *emphasis*</DOC_HEADING>
+        /// <DOC_HEADING># header <DOC_CODE>`code`</DOC_CODE> <DOC_EMPHASIS>*emphasis*</DOC_EMPHASIS></DOC_HEADING>
+    """)
+
+    fun `test emphasis and strong emphasis`() = checkHighlightingStrict("""
+        /// <DOC_EMPHASIS>*emphasis*</DOC_EMPHASIS>, and <DOC_EMPHASIS>_also emphasis_</DOC_EMPHASIS>
+        /// <DOC_STRONG>**strong emphasis**</DOC_STRONG>, and <DOC_STRONG>__also strong emphasis__</DOC_STRONG>
     """)
 
     private fun checkHighlightingStrict(@Language("Rust") text: String) =


### PR DESCRIPTION
Depends on #6502

highlight *\*emphasis\** and **\*\*strong emphasis\*\*** text in rustdocs.
I'm not sure what color scheme should be used by default for *\*emphasis\** text. It's assumed to be *italic*, but both default Light and Darcula themes highlight all doc comments as italic, hence plain italic *\*emphasis\** would be indistinguishable from a regular doc text. I've used a scheme from #3739 where **\*strong emphasis\*** is highlighted as **bold** and *\*emphasis\** is highlighted as _italic and **bold**_ simultaneously.

![image](https://user-images.githubusercontent.com/3221931/122029644-b72f7180-cdd5-11eb-9a12-a0fa0bd28c47.png)

Closes #3739

changelog: highlight *\*emphasis\** and **\*\*strong emphasis\*\*** text in rustdocs
