### PR TITLE
GRD: update psi viewer plugin version

### DIFF
--- a/gradle-211.properties
+++ b/gradle-211.properties
@@ -9,7 +9,7 @@ nativeDebugPluginVersion=211.7442.9
 # https://plugins.jetbrains.com/plugin/12175-grazie/versions
 graziePluginVersion=211.7442.4
 # https://plugins.jetbrains.com/plugin/227-psiviewer/versions
-psiViewerPluginVersion=211.6305.21-EAP-SNAPSHOT
+psiViewerPluginVersion=211-SNAPSHOT
 
 # please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
 sinceBuild=211.6693


### PR DESCRIPTION
`211.6305.21-EAP-SNAPSHOT` doesn't exist anymore in marketplace for some reason

bors r+