### PR TITLE
ANN: highlight format templates in custom macros

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsMacroExpansionHighlightingPass.kt
@@ -67,7 +67,8 @@ class RsMacroExpansionHighlightingPass(
         RsEdition2018KeywordsAnnotator(),
         RsHighlightingAnnotator(),
         RsHighlightingMutableAnnotator(),
-        RsCfgDisabledCodeAnnotator()
+        RsCfgDisabledCodeAnnotator(),
+        RsFormatMacroAnnotator(),
     )
 
     @Suppress("UnstableApiUsage")

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.annotator
 
 import com.intellij.ide.annotator.BatchMode
+import org.rust.ExpandMacros
 import org.rust.ProjectDescriptor
 import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.ide.colors.RsColor
@@ -512,6 +513,19 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
     fun `test panic with single literal`() = checkErrors("""
         fn main() {
             panic!("{}");
+        }
+    """)
+
+    @ExpandMacros
+    fun `test custom macro`() = checkErrors("""
+        $implDisplayI32
+
+        macro_rules! as_is { ($($ t:tt)*) => {$($ t)*}; }
+        fn main() {
+            as_is! {
+                println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", 1);
+                println!("", <error descr="Argument never used">1</error>);
+            }
         }
     """)
 }


### PR DESCRIPTION
Apply highlighting from #3869 and #4969 to custom macro bodies (#4640)

![image](https://user-images.githubusercontent.com/3221931/122242962-68b0ce80-cecc-11eb-9ddb-5848fbe9e3af.png)

changelog: Provide highlighting of [format string literals](https://doc.rust-lang.org/std/fmt/) in any macros that expand to macros like println, write, format, etc