### PR TITLE
ANN: introduce a color for `std::fmt` format specifiers

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotator.kt
@@ -19,7 +19,6 @@ import org.rust.ide.presentation.render
 import org.rust.lang.core.macros.MacroExpansionMode
 import org.rust.lang.core.macros.macroExpansionManager
 import org.rust.lang.core.psi.*
-import org.rust.lang.core.psi.ext.containingCrate
 import org.rust.lang.core.psi.ext.startOffset
 import org.rust.lang.core.psi.ext.withSubst
 import org.rust.lang.core.resolve.KnownItems
@@ -256,7 +255,7 @@ private fun checkSyntaxErrors(ctx: ParseContext): List<ErrorAnnotation> {
 }
 
 private fun highlightParametersOutside(ctx: ParseContext, holder: AnnotationHolder) {
-    val key = RsColor.FORMAT_SPECIFIER
+    val key = RsColor.FORMAT_PARAMETER
     val highlightSeverity = if (isUnitTestMode) key.testSeverity else HighlightSeverity.INFORMATION
 
     for (parameter in ctx.parameters) {
@@ -265,7 +264,7 @@ private fun highlightParametersOutside(ctx: ParseContext, holder: AnnotationHold
 }
 
 private fun highlightParametersInside(ctx: ParseContext, holder: AnnotationHolder) {
-    fun highlight(range: IntRange?, offset: Int, color: RsColor = RsColor.IDENTIFIER) {
+    fun highlight(range: IntRange?, offset: Int, color: RsColor = RsColor.FORMAT_SPECIFIER) {
         if (range != null && !range.isEmpty()) {
             val highlightSeverity = if (isUnitTestMode) color.testSeverity else HighlightSeverity.INFORMATION
             holder.newSilentAnnotation(highlightSeverity)

--- a/src/main/kotlin/org/rust/ide/colors/RsColors.kt
+++ b/src/main/kotlin/org/rust/ide/colors/RsColors.kt
@@ -6,6 +6,7 @@
 package org.rust.ide.colors
 
 import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.editor.HighlighterColors
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.options.colors.AttributesDescriptor
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Default
@@ -52,7 +53,8 @@ enum class RsColor(humanName: String, default: TextAttributesKey? = null) {
     STRING("Literals//Strings//String", Default.STRING),
     VALID_STRING_ESCAPE("Literals//Strings//Escape sequence//Valid", Default.VALID_STRING_ESCAPE),
     INVALID_STRING_ESCAPE("Literals//Strings//Escape sequence//Invalid", Default.INVALID_STRING_ESCAPE),
-    FORMAT_SPECIFIER("Literals//Strings//Format specifier in string argument", Default.VALID_STRING_ESCAPE),
+    FORMAT_PARAMETER("Literals//Strings//Format parameter", Default.VALID_STRING_ESCAPE),
+    FORMAT_SPECIFIER("Literals//Strings//Format specifier inside format parameter", HighlighterColors.TEXT),
 
     BLOCK_COMMENT("Comments//Block comment", Default.BLOCK_COMMENT),
     EOL_COMMENT("Comments//Line comment", Default.LINE_COMMENT),

--- a/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
+++ b/src/main/resources/org/rust/ide/colors/highlighterDemoText.rs
@@ -78,7 +78,8 @@ fn <FUNCTION>main</FUNCTION>() {
 <KEYWORD_UNSAFE>unsafe</KEYWORD_UNSAFE> fn <FUNCTION>a_function</FUNCTION><<TYPE_PARAMETER>T</TYPE_PARAMETER>: <LIFETIME>'lifetime</LIFETIME>>(<MUT_PARAMETER>count</MUT_PARAMETER>: &mut i64) -> ! {
     <MUT_PARAMETER>count</MUT_PARAMETER> += 1;
     'label: loop {
-        <MACRO>println!</MACRO>("Hello\x20W\u{f3}rld!\u{abcdef}");
+        let str_with_escapes = "Hello\x20W\u{f3}rld!\u{abcdef}";
+        <MACRO>println!</MACRO>("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER> <FORMAT_PARAMETER>{<FORMAT_SPECIFIER>foo</FORMAT_SPECIFIER>:<<FORMAT_SPECIFIER>4</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", str_with_escapes, foo = 42);
     }
 }
 

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorTest.kt
@@ -30,11 +30,11 @@ class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::c
 
         fn main() {
             println!("<error descr="Invalid reference to positional argument 0 (no arguments were given)">{}</error>");
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<error descr="Invalid reference to positional argument 1 (there is 1 argument)">1</error>}</FORMAT_SPECIFIER>", 1);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<IDENTIFIER>1</IDENTIFIER>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<error descr="Invalid reference to positional argument 3 (there are 2 arguments)">3</error>}</FORMAT_SPECIFIER>", 1, 1);
-            println!("Hello <FORMAT_SPECIFIER>{:<error descr="Invalid reference to positional argument 1 (there is 1 argument)">1${'$'}</error>}</FORMAT_SPECIFIER>", 1);
-            println!("<FORMAT_SPECIFIER>{<error descr="There is no argument named `foo`">foo</error>}</FORMAT_SPECIFIER>");
-            println!("Hello <FORMAT_SPECIFIER>{:<error descr="There is no argument named `foo`">foo${'$'}</error>}</FORMAT_SPECIFIER>", 1);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>}</FORMAT_PARAMETER><FORMAT_PARAMETER>{<error descr="Invalid reference to positional argument 1 (there is 1 argument)">1</error>}</FORMAT_PARAMETER>", 1);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>}</FORMAT_PARAMETER><FORMAT_PARAMETER>{<FORMAT_SPECIFIER>1</FORMAT_SPECIFIER>}</FORMAT_PARAMETER><FORMAT_PARAMETER>{<error descr="Invalid reference to positional argument 3 (there are 2 arguments)">3</error>}</FORMAT_PARAMETER>", 1, 1);
+            println!("Hello <FORMAT_PARAMETER>{:<error descr="Invalid reference to positional argument 1 (there is 1 argument)">1${'$'}</error>}</FORMAT_PARAMETER>", 1);
+            println!("<FORMAT_PARAMETER>{<error descr="There is no argument named `foo`">foo</error>}</FORMAT_PARAMETER>");
+            println!("Hello <FORMAT_PARAMETER>{:<error descr="There is no argument named `foo`">foo${'$'}</error>}</FORMAT_PARAMETER>", 1);
         }
     """)
 
@@ -43,14 +43,14 @@ class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::c
 
         fn main() {
             println!("", <error descr="Argument never used">1.2</error>);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER>", 1, <error descr="Argument never used">1.2</error>);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", 1, <error descr="Argument never used">1.2</error>);
             println!("", <error descr="Named argument never used">foo=1.2</error>);
         }
     """)
 
     fun `test invalid parameter type`() = checkErrors("""
         fn main() {
-            println!("<FORMAT_SPECIFIER>{:<error descr="Unknown format trait `u`">u</error>}</FORMAT_SPECIFIER>", 1);
+            println!("<FORMAT_PARAMETER>{:<error descr="Unknown format trait `u`">u</error>}</FORMAT_PARAMETER>", 1);
         }
     """)
 
@@ -63,18 +63,18 @@ class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::c
         }
 
         fn main() {
-            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", 1);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", 1);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>foo</IDENTIFIER>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", foo=1);
-            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", 1, 1);
-            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", foo=1);
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", 1);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>}</FORMAT_PARAMETER><FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", 1);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>foo</FORMAT_SPECIFIER>}</FORMAT_PARAMETER><FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", foo=1);
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER><FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", 1, 1);
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", foo=1);
 
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER>", foo=1);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<IDENTIFIER>1</IDENTIFIER>:<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER>", 1, Debug);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", foo=1);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>}</FORMAT_PARAMETER><FORMAT_PARAMETER>{<FORMAT_SPECIFIER>1</FORMAT_SPECIFIER>:<FUNCTION>?</FUNCTION>}</FORMAT_PARAMETER><FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", 1, Debug);
 
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>foo</IDENTIFIER>}</FORMAT_SPECIFIER>", foo=1);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>bar</IDENTIFIER>:<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<IDENTIFIER>foo</IDENTIFIER>}</FORMAT_SPECIFIER>", foo=1, bar=Debug);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<IDENTIFIER>foo</IDENTIFIER>}</FORMAT_SPECIFIER>", foo=1);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>foo</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", foo=1);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>bar</FORMAT_SPECIFIER>:<FUNCTION>?</FUNCTION>}</FORMAT_PARAMETER><FORMAT_PARAMETER>{<FORMAT_SPECIFIER>foo</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", foo=1, bar=Debug);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>}</FORMAT_PARAMETER><FORMAT_PARAMETER>{<FORMAT_SPECIFIER>foo</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", foo=1);
         }
     """)
 
@@ -83,7 +83,7 @@ class RsFormatMacroAnnotatorTest : RsAnnotatorTestBase(RsFormatMacroAnnotator::c
             println!("<error descr="Invalid format string: } expected.
 If you intended to print `{` symbol, you can escape it using `{{`">{</error>");
             //~^ ERROR invalid format string: expected `'}'` but string was terminated
-            println!("<FORMAT_SPECIFIER>{{</FORMAT_SPECIFIER><FORMAT_SPECIFIER>}}</FORMAT_SPECIFIER>");
+            println!("<FORMAT_PARAMETER>{{</FORMAT_PARAMETER><FORMAT_PARAMETER>}}</FORMAT_PARAMETER>");
             println!("<error descr="Invalid format string: unmatched '}'">}</error>");
             //~^ ERROR invalid format string: unmatched `}` found
 //            let _ = format!("{_foo}", _foo = 6usize);
@@ -95,10 +95,10 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>");
             //~^ ERROR invalid format string: expected `'}'` but string was terminated
             let _ = format!("<error descr="Invalid format string: unmatched '}'">}</error>");
             //~^ ERROR invalid format string: unmatched `}` found
-            let _ = format!("<FORMAT_SPECIFIER>{<error descr="Invalid format string">\</error>\}</FORMAT_SPECIFIER>");
+            let _ = format!("<FORMAT_PARAMETER>{<error descr="Invalid format string">\</error>\}</FORMAT_PARAMETER>");
             //~^ ERROR invalid format string: expected `'}'`, found `'\\'`
-            let _ = format!("\n\n\n<FORMAT_SPECIFIER>{\n\n<error descr="Invalid format string: } expected.
-If you intended to print `{` symbol, you can escape it using `{{`">\</error></FORMAT_SPECIFIER>n");
+            let _ = format!("\n\n\n<FORMAT_PARAMETER>{\n\n<error descr="Invalid format string: } expected.
+If you intended to print `{` symbol, you can escape it using `{{`">\</error></FORMAT_PARAMETER>n");
             //~^ ERROR invalid format string
             let _ = format!(r###"
             <error descr="Invalid format string: } expected.
@@ -114,78 +114,78 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         $implDisplayI32
 
         fn main() {
-            format!("<FORMAT_SPECIFIER>{
+            format!("<FORMAT_PARAMETER>{
            <error descr="Invalid format string: } expected.
-        If you intended to print `{` symbol, you can escape it using `{{`"> </error>a</FORMAT_SPECIFIER>");
+        If you intended to print `{` symbol, you can escape it using `{{`"> </error>a</FORMAT_PARAMETER>");
             //~^ ERROR invalid format string
-            format!("<FORMAT_SPECIFIER>{<error descr="Invalid format string: } expected.
+            format!("<FORMAT_PARAMETER>{<error descr="Invalid format string: } expected.
         If you intended to print `{` symbol, you can escape it using `{{`"> </error>\
-            b</FORMAT_SPECIFIER>");
+            b</FORMAT_PARAMETER>");
             //~^ ERROR invalid format string
-            format!(r#"<FORMAT_SPECIFIER>{<error descr="Invalid format string: } expected.
+            format!(r#"<FORMAT_PARAMETER>{<error descr="Invalid format string: } expected.
         If you intended to print `{` symbol, you can escape it using `{{`"> </error>\
-            rawc</FORMAT_SPECIFIER>"#);
+            rawc</FORMAT_PARAMETER>"#);
             //~^^^ ERROR invalid format string
-            format!(r#"<FORMAT_SPECIFIER>{<error descr="Invalid format string: } expected.
+            format!(r#"<FORMAT_PARAMETER>{<error descr="Invalid format string: } expected.
         If you intended to print `{` symbol, you can escape it using `{{`"> </error>\n
         \n
-           rawd</FORMAT_SPECIFIER>"#);
+           rawd</FORMAT_PARAMETER>"#);
             //~^^^ ERROR invalid format string
-            format!("<FORMAT_SPECIFIER>{ \n
+            format!("<FORMAT_PARAMETER>{ \n
         \n
            <error descr="Invalid format string: } expected.
-        If you intended to print `{` symbol, you can escape it using `{{`"> </error>e</FORMAT_SPECIFIER>");
+        If you intended to print `{` symbol, you can escape it using `{{`"> </error>e</FORMAT_PARAMETER>");
             //~^ ERROR invalid format string
             format!("
-            <FORMAT_SPECIFIER>{
+            <FORMAT_PARAMETER>{
            <error descr="Invalid format string: } expected.
-        If you intended to print `{` symbol, you can escape it using `{{`"> </error>a</FORMAT_SPECIFIER>");
+        If you intended to print `{` symbol, you can escape it using `{{`"> </error>a</FORMAT_PARAMETER>");
             //~^ ERROR invalid format string
             format!("
-            <FORMAT_SPECIFIER>{
+            <FORMAT_PARAMETER>{
            <error descr="Invalid format string: } expected.
         If you intended to print `{` symbol, you can escape it using `{{`"> </error>a
-            </FORMAT_SPECIFIER>");
+            </FORMAT_PARAMETER>");
             //~^^ ERROR invalid format string
             format!(r#"
-        raw  <FORMAT_SPECIFIER>{<error descr="Invalid format string: } expected.
+        raw  <FORMAT_PARAMETER>{<error descr="Invalid format string: } expected.
         If you intended to print `{` symbol, you can escape it using `{{`"> </error>\
-            c</FORMAT_SPECIFIER>"#);
+            c</FORMAT_PARAMETER>"#);
             //~^^^ ERROR invalid format string
             format!(r#"
-        raw  <FORMAT_SPECIFIER>{<error descr="Invalid format string: } expected.
+        raw  <FORMAT_PARAMETER>{<error descr="Invalid format string: } expected.
         If you intended to print `{` symbol, you can escape it using `{{`"> </error>\n
         \n
-           d</FORMAT_SPECIFIER>"#);
+           d</FORMAT_PARAMETER>"#);
             //~^^^ ERROR invalid format string
             format!("
-          <FORMAT_SPECIFIER>{ \n
+          <FORMAT_PARAMETER>{ \n
         \n
            <error descr="Invalid format string: } expected.
-        If you intended to print `{` symbol, you can escape it using `{{`"> </error>e</FORMAT_SPECIFIER>");
+        If you intended to print `{` symbol, you can escape it using `{{`"> </error>e</FORMAT_PARAMETER>");
             //~^ ERROR invalid format string
 
             format!("
-            <FORMAT_SPECIFIER>{<IDENTIFIER>asdf</IDENTIFIER>
-            }</FORMAT_SPECIFIER>
+            <FORMAT_PARAMETER>{<FORMAT_SPECIFIER>asdf</FORMAT_SPECIFIER>
+            }</FORMAT_PARAMETER>
             ", asdf=1);
             // ok - this is supported
             format!("
-            <FORMAT_SPECIFIER>{
-            <error descr="Invalid format string">asdf</error>}</FORMAT_SPECIFIER>
+            <FORMAT_PARAMETER>{
+            <error descr="Invalid format string">asdf</error>}</FORMAT_PARAMETER>
             ", asdf=1);
             //~^^ ERROR invalid format string
 
             // note: `\x7B` is `{`
-            println!("<FORMAT_SPECIFIER>\x7B}</FORMAT_SPECIFIER>\u{8} <error descr="Invalid format string: } expected.
+            println!("<FORMAT_PARAMETER>\x7B}</FORMAT_PARAMETER>\u{8} <error descr="Invalid format string: } expected.
         If you intended to print `{` symbol, you can escape it using `{{`">{</error>", 1);
             //~^ ERROR invalid format string: expected `'}'` but string was terminated
 
-            println!("<FORMAT_SPECIFIER>\x7B}</FORMAT_SPECIFIER>\u8 {", 1);
+            println!("<FORMAT_PARAMETER>\x7B}</FORMAT_PARAMETER>\u8 {", 1);
             //~^ ERROR incorrect unicode escape sequence
 
             // note: raw strings don't escape `\xFF` and `\u{FF}` sequences
-            println!(r#"\x7B<error descr="Invalid format string: unmatched '}'">}</error>\u<FORMAT_SPECIFIER>{8}</FORMAT_SPECIFIER> <error descr="Invalid format string: } expected.
+            println!(r#"\x7B<error descr="Invalid format string: unmatched '}'">}</error>\u<FORMAT_PARAMETER>{8}</FORMAT_PARAMETER> <error descr="Invalid format string: } expected.
         If you intended to print `{` symbol, you can escape it using `{{`">{</error>"#, 1);
             //~^ ERROR invalid format string: unmatched `}` found
         }
@@ -193,11 +193,11 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
 
     fun `test invalid inner syntax`() = checkErrors("""
         fn main() {
-            println!("<FORMAT_SPECIFIER>{3<error descr="Invalid format string">a</error>}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{:<error descr="Invalid format string">|</error>}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{:>><error descr="Invalid format string">></error>}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{<error descr="Invalid format string">!:?</error>}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{:?<error descr="Invalid format string">?</error>}</FORMAT_SPECIFIER>");
+            println!("<FORMAT_PARAMETER>{3<error descr="Invalid format string">a</error>}</FORMAT_PARAMETER>");
+            println!("<FORMAT_PARAMETER>{:<error descr="Invalid format string">|</error>}</FORMAT_PARAMETER>");
+            println!("<FORMAT_PARAMETER>{:>><error descr="Invalid format string">></error>}</FORMAT_PARAMETER>");
+            println!("<FORMAT_PARAMETER>{<error descr="Invalid format string">!:?</error>}</FORMAT_PARAMETER>");
+            println!("<FORMAT_PARAMETER>{:?<error descr="Invalid format string">?</error>}</FORMAT_PARAMETER>");
         }
     """)
 
@@ -219,28 +219,28 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         }
 
         fn main(){
-            println!("<FORMAT_SPECIFIER>{{</FORMAT_SPECIFIER><FORMAT_SPECIFIER>}}</FORMAT_SPECIFIER>");
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:#<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>e</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>x</IDENTIFIER>:}</FORMAT_SPECIFIER>", x=S);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:<FUNCTION>x</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:<FUNCTION>x?</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:0<}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>1</IDENTIFIER>:<IDENTIFIER>0${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>", 1, S);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>1</IDENTIFIER>:0<IDENTIFIER>0${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>", 1, S);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:<IDENTIFIER>10</IDENTIFIER><FUNCTION>x</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:<IDENTIFIER>1${'$'}</IDENTIFIER>.<IDENTIFIER>10</IDENTIFIER><FUNCTION>x</FUNCTION>}</FORMAT_SPECIFIER>", S, 1);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:<IDENTIFIER>a${'$'}</IDENTIFIER>.<IDENTIFIER>b${'$'}</IDENTIFIER><FUNCTION>x</FUNCTION>}</FORMAT_SPECIFIER>", S, a=2, b=3);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>number</IDENTIFIER>:*>+#0<IDENTIFIER>width${'$'}</IDENTIFIER>.<IDENTIFIER>10</IDENTIFIER><FUNCTION>x?</FUNCTION>}</FORMAT_SPECIFIER>", number=S, width=1);
-            println!("<FORMAT_SPECIFIER>{:-}</FORMAT_SPECIFIER> <FORMAT_SPECIFIER>{:#}</FORMAT_SPECIFIER> <FORMAT_SPECIFIER>{:+#}</FORMAT_SPECIFIER>", S, S, S);
+            println!("<FORMAT_PARAMETER>{{</FORMAT_PARAMETER><FORMAT_PARAMETER>}}</FORMAT_PARAMETER>");
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>:}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>?</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{:#<FUNCTION>?</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>e</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>x</FORMAT_SPECIFIER>:}</FORMAT_PARAMETER>", x=S);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>:<FUNCTION>x</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>:<FUNCTION>x?</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>:0<}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>1</FORMAT_SPECIFIER>:<FORMAT_SPECIFIER>0${'$'}</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", 1, S);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>1</FORMAT_SPECIFIER>:0<FORMAT_SPECIFIER>0${'$'}</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", 1, S);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>:<FORMAT_SPECIFIER>10</FORMAT_SPECIFIER><FUNCTION>x</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>:<FORMAT_SPECIFIER>1${'$'}</FORMAT_SPECIFIER>.<FORMAT_SPECIFIER>10</FORMAT_SPECIFIER><FUNCTION>x</FUNCTION>}</FORMAT_PARAMETER>", S, 1);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>:<FORMAT_SPECIFIER>a${'$'}</FORMAT_SPECIFIER>.<FORMAT_SPECIFIER>b${'$'}</FORMAT_SPECIFIER><FUNCTION>x</FUNCTION>}</FORMAT_PARAMETER>", S, a=2, b=3);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>number</FORMAT_SPECIFIER>:*>+#0<FORMAT_SPECIFIER>width${'$'}</FORMAT_SPECIFIER>.<FORMAT_SPECIFIER>10</FORMAT_SPECIFIER><FUNCTION>x?</FUNCTION>}</FORMAT_PARAMETER>", number=S, width=1);
+            println!("<FORMAT_PARAMETER>{:-}</FORMAT_PARAMETER> <FORMAT_PARAMETER>{:#}</FORMAT_PARAMETER> <FORMAT_PARAMETER>{:+#}</FORMAT_PARAMETER>", S, S, S);
             println!("");
-            println!("<FORMAT_SPECIFIER>\x7B}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_PARAMETER>\x7B}</FORMAT_PARAMETER>", S);
             let mut w = Vec::new();
-            write!(&mut w, "<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
-            format_args!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
+            write!(&mut w, "<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S);
+            format_args!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S);
         }
     """)
 
@@ -249,18 +249,18 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
 
         fn main() {
             let s = S;
-            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Display` (required by {})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:?})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>x?</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:x?})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>X?</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:X?})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:#<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Debug` (required by {:#?})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>o</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Octal` (required by {:o})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>x</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `LowerHex` (required by {:x})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>X</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `UpperHex` (required by {:X})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>p</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Pointer` (required by {:p})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>b</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `Binary` (required by {:b})">s</error>);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>e</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `LowerExp` (required by {:e})">s</error>);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:<FUNCTION>E</FUNCTION>}</FORMAT_SPECIFIER>", <error descr="`S` doesn't implement `UpperExp` (required by {0:E})">s</error>);
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", <error descr="`S` doesn't implement `Display` (required by {})">s</error>);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>?</FUNCTION>}</FORMAT_PARAMETER>", <error descr="`S` doesn't implement `Debug` (required by {:?})">s</error>);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>x?</FUNCTION>}</FORMAT_PARAMETER>", <error descr="`S` doesn't implement `Debug` (required by {:x?})">s</error>);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>X?</FUNCTION>}</FORMAT_PARAMETER>", <error descr="`S` doesn't implement `Debug` (required by {:X?})">s</error>);
+            println!("<FORMAT_PARAMETER>{:#<FUNCTION>?</FUNCTION>}</FORMAT_PARAMETER>", <error descr="`S` doesn't implement `Debug` (required by {:#?})">s</error>);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>o</FUNCTION>}</FORMAT_PARAMETER>", <error descr="`S` doesn't implement `Octal` (required by {:o})">s</error>);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>x</FUNCTION>}</FORMAT_PARAMETER>", <error descr="`S` doesn't implement `LowerHex` (required by {:x})">s</error>);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>X</FUNCTION>}</FORMAT_PARAMETER>", <error descr="`S` doesn't implement `UpperHex` (required by {:X})">s</error>);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>p</FUNCTION>}</FORMAT_PARAMETER>", <error descr="`S` doesn't implement `Pointer` (required by {:p})">s</error>);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>b</FUNCTION>}</FORMAT_PARAMETER>", <error descr="`S` doesn't implement `Binary` (required by {:b})">s</error>);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>e</FUNCTION>}</FORMAT_PARAMETER>", <error descr="`S` doesn't implement `LowerExp` (required by {:e})">s</error>);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>:<FUNCTION>E</FUNCTION>}</FORMAT_PARAMETER>", <error descr="`S` doesn't implement `UpperExp` (required by {0:E})">s</error>);
         }
     """)
 
@@ -297,18 +297,18 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         }
 
         fn main() {
-            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>x?</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>X?</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:#<FUNCTION>?</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>o</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>x</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>X</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>p</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>b</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>e</FUNCTION>}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{:<FUNCTION>E</FUNCTION>}</FORMAT_SPECIFIER>", S);
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>?</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>x?</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>X?</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{:#<FUNCTION>?</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>o</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>x</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>X</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>p</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>b</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>e</FUNCTION>}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{:<FUNCTION>E</FUNCTION>}</FORMAT_PARAMETER>", S);
         }
     """)
 
@@ -329,7 +329,7 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         }
 
         fn main() {
-            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", *W { s: S });
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", *W { s: S });
         }
     """)
 
@@ -338,7 +338,7 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
 
         fn main() {
             let s = S;
-            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", &1);
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", &1);
         }
     """)
 
@@ -347,12 +347,12 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
 
         fn main() {
             let a = 5;
-            println!("Hello <FORMAT_SPECIFIER>{:<IDENTIFIER>1${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 1, a);
+            println!("Hello <FORMAT_PARAMETER>{:<FORMAT_SPECIFIER>1${'$'}</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>!", 1, a);
 
-            println!("Hello <FORMAT_SPECIFIER>{:<IDENTIFIER>1${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 1, 5);
-            println!("Hello <FORMAT_SPECIFIER>{<IDENTIFIER>1</IDENTIFIER>:<IDENTIFIER>0${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 5, 1);
-            println!("Hello <FORMAT_SPECIFIER>{<IDENTIFIER>1</IDENTIFIER>:<IDENTIFIER>0${'$'}</IDENTIFIER>.<IDENTIFIER>2${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 1, 1, 4);
-            println!("Hello <FORMAT_SPECIFIER>{:<IDENTIFIER>width${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 1, width = 5);
+            println!("Hello <FORMAT_PARAMETER>{:<FORMAT_SPECIFIER>1${'$'}</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>!", 1, 5);
+            println!("Hello <FORMAT_PARAMETER>{<FORMAT_SPECIFIER>1</FORMAT_SPECIFIER>:<FORMAT_SPECIFIER>0${'$'}</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>!", 5, 1);
+            println!("Hello <FORMAT_PARAMETER>{<FORMAT_SPECIFIER>1</FORMAT_SPECIFIER>:<FORMAT_SPECIFIER>0${'$'}</FORMAT_SPECIFIER>.<FORMAT_SPECIFIER>2${'$'}</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>!", 1, 1, 4);
+            println!("Hello <FORMAT_PARAMETER>{:<FORMAT_SPECIFIER>width${'$'}</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>!", 1, width = 5);
         }
     """)
 
@@ -360,9 +360,9 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         $implDisplayI32
 
         fn main() {
-            println!("Hello <FORMAT_SPECIFIER>{:<IDENTIFIER>1${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 1, <error descr="Width specifier must be of type `usize`">"asd"</error>);
-            println!("Hello <FORMAT_SPECIFIER>{:.<IDENTIFIER>1${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 1, <error descr="Precision specifier must be of type `usize`">2.0</error>);
-            println!("Hello <FORMAT_SPECIFIER>{:<IDENTIFIER>1${'$'}</IDENTIFIER>.<IDENTIFIER>1${'$'}</IDENTIFIER>}</FORMAT_SPECIFIER>!", 1, <error descr="Precision specifier must be of type `usize`"><error descr="Width specifier must be of type `usize`">2.0</error></error>);
+            println!("Hello <FORMAT_PARAMETER>{:<FORMAT_SPECIFIER>1${'$'}</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>!", 1, <error descr="Width specifier must be of type `usize`">"asd"</error>);
+            println!("Hello <FORMAT_PARAMETER>{:.<FORMAT_SPECIFIER>1${'$'}</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>!", 1, <error descr="Precision specifier must be of type `usize`">2.0</error>);
+            println!("Hello <FORMAT_PARAMETER>{:<FORMAT_SPECIFIER>1${'$'}</FORMAT_SPECIFIER>.<FORMAT_SPECIFIER>1${'$'}</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>!", 1, <error descr="Precision specifier must be of type `usize`"><error descr="Width specifier must be of type `usize`">2.0</error></error>);
         }
     """)
 
@@ -370,11 +370,11 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         $implDisplayI32
 
         fn main() {
-            println!("<FORMAT_SPECIFIER>{:.<IDENTIFIER>*</IDENTIFIER>}</FORMAT_SPECIFIER>", 1, 2);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:.<IDENTIFIER>*</IDENTIFIER>}</FORMAT_SPECIFIER>", 1);
-            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<IDENTIFIER>name</IDENTIFIER>:.<IDENTIFIER>*</IDENTIFIER>}</FORMAT_SPECIFIER>", 1, 3, name=2);
-            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER><FORMAT_SPECIFIER>{<IDENTIFIER>2</IDENTIFIER>:.<IDENTIFIER>*</IDENTIFIER>}</FORMAT_SPECIFIER>", 1, 5, 2);
-            println!("<FORMAT_SPECIFIER>{:<IDENTIFIER>a${'$'}</IDENTIFIER>.<IDENTIFIER>*</IDENTIFIER>}</FORMAT_SPECIFIER>!", 5, 1, a=3);
+            println!("<FORMAT_PARAMETER>{:.<FORMAT_SPECIFIER>*</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", 1, 2);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>:.<FORMAT_SPECIFIER>*</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", 1);
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER><FORMAT_PARAMETER>{<FORMAT_SPECIFIER>name</FORMAT_SPECIFIER>:.<FORMAT_SPECIFIER>*</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", 1, 3, name=2);
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER><FORMAT_PARAMETER>{<FORMAT_SPECIFIER>2</FORMAT_SPECIFIER>:.<FORMAT_SPECIFIER>*</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>", 1, 5, 2);
+            println!("<FORMAT_PARAMETER>{:<FORMAT_SPECIFIER>a${'$'}</FORMAT_SPECIFIER>.<FORMAT_SPECIFIER>*</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>!", 5, 1, a=3);
         }
     """)
 
@@ -387,8 +387,8 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         }
 
         fn main() {
-            println!("<FORMAT_SPECIFIER>{:.<IDENTIFIER>*</IDENTIFIER>}</FORMAT_SPECIFIER>!", <error descr="Precision specifier must be of type `usize`">"asd"</error>, S);
-            println!("<FORMAT_SPECIFIER>{<IDENTIFIER>0</IDENTIFIER>:.<IDENTIFIER>*</IDENTIFIER>}</FORMAT_SPECIFIER>!", <error descr="Precision specifier must be of type `usize`">S</error>);
+            println!("<FORMAT_PARAMETER>{:.<FORMAT_SPECIFIER>*</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>!", <error descr="Precision specifier must be of type `usize`">"asd"</error>, S);
+            println!("<FORMAT_PARAMETER>{<FORMAT_SPECIFIER>0</FORMAT_SPECIFIER>:.<FORMAT_SPECIFIER>*</FORMAT_SPECIFIER>}</FORMAT_PARAMETER>!", <error descr="Precision specifier must be of type `usize`">S</error>);
         }
     """)
 
@@ -400,8 +400,8 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
 
         fn main() {
             let g: G<S> = G(S);
-            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
-            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", g);
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S);
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", g);
         }
     """)
 
@@ -409,7 +409,7 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         fn never() -> ! { unimplemented!() }
 
         fn main() {
-            println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", never());
+            println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", never());
         }
     """)
 
@@ -427,9 +427,9 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         $implDisplayI32
 
         fn main() {
-            println!(r"\<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>!", 1);
-            println!(r"\u<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>!", 1);
-            println!(r##"<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>
+            println!(r"\<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>!", 1);
+            println!(r"\u<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>!", 1);
+            println!(r##"<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>
 
             <error descr="Invalid reference to positional argument 1 (there is 1 argument)">{}</error>"##, 1);
         }
@@ -479,9 +479,9 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { unimplemented!() }
         }
         fn main() {
-            std::println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
-            std::println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER> <error descr="Invalid reference to positional argument 1 (there is 1 argument)">{}</error>", S);
-            std::println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S, <error descr="Argument never used">S</error>);
+            std::println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S);
+            std::println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER> <error descr="Invalid reference to positional argument 1 (there is 1 argument)">{}</error>", S);
+            std::println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S, <error descr="Argument never used">S</error>);
         }
     """)
 
@@ -504,9 +504,9 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         }
 
         fn main() {
-            panic!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
-            panic!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER> <error descr="Invalid reference to positional argument 1 (there is 1 argument)">{}</error>", S);
-            panic!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S, <error descr="Argument never used">S</error>);
+            panic!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S);
+            panic!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER> <error descr="Invalid reference to positional argument 1 (there is 1 argument)">{}</error>", S);
+            panic!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S, <error descr="Argument never used">S</error>);
         }
     """)
 
@@ -523,7 +523,7 @@ If you intended to print `{` symbol, you can escape it using `{{`">{</error>"###
         macro_rules! as_is { ($($ t:tt)*) => {$($ t)*}; }
         fn main() {
             as_is! {
-                println!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", 1);
+                println!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", 1);
                 println!("", <error descr="Argument never used">1</error>);
             }
         }

--- a/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorToolchainTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsFormatMacroAnnotatorToolchainTest.kt
@@ -35,12 +35,12 @@ class RsFormatMacroAnnotatorToolchainTest : RsWithToolchainAnnotatorTestBase<Uni
 
                 /*caret*/
                 fn main() {
-                    log::trace!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
-                    log::debug!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
-                    log::info!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
-                    log::warn!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
-                    log::error!("<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
-                    log::log!(log::Level::Warn, "<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
+                    log::trace!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S);
+                    log::debug!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S);
+                    log::info!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S);
+                    log::warn!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S);
+                    log::error!("<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S);
+                    log::log!(log::Level::Warn, "<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S);
                 }
             """)
         }
@@ -67,8 +67,8 @@ class RsFormatMacroAnnotatorToolchainTest : RsWithToolchainAnnotatorTestBase<Uni
 
                 /*caret*/
                 fn main() {
-                    log::debug!(target: "events", "<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
-                    log::log!(target: "events", log::Level::Warn, "<FORMAT_SPECIFIER>{}</FORMAT_SPECIFIER>", S);
+                    log::debug!(target: "events", "<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S);
+                    log::log!(target: "events", log::Level::Warn, "<FORMAT_PARAMETER>{}</FORMAT_PARAMETER>", S);
                 }
             """)
         }


### PR DESCRIPTION
As discussed in https://github.com/intellij-rust/intellij-rust/pull/7243#issuecomment-863359497, rename `FORMAT_SPECIFIER` color to `FORMAT_PARAMETER` and introduce `FORMAT_SPECIFIER` color

https://user-images.githubusercontent.com/3221931/122535107-e63f2080-d02b-11eb-9554-b525f69b9690.mp4