### PR TITLE
CI: properly push changes in repository

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,8 @@ jobs:
         runs-on: ubuntu-18.04
         steps:
             - uses: actions/checkout@v2
+              with:
+                  token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
 
             - name: Set up Python
               uses: actions/setup-python@v1
@@ -28,7 +30,7 @@ jobs:
 
             - name: Make release branch
               if: github.event_name != 'schedule' || fromJSON(steps.check-date.outputs.result).create_release_branch
-              run: python scripts/make_release_branch.py --token ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
+              run: python scripts/make_release_branch.py
 
             - name: Create new milestone
               if: github.event_name != 'schedule' || fromJSON(steps.check-date.outputs.result).create_release_branch

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -20,8 +20,8 @@ jobs:
 
             - name: Set up git user
               run: |
-                  git config --local user.email "action@github.com"
-                  git config --local user.name "GitHub Action"
+                  git config --local user.email "intellij.rust@gmail.com"
+                  git config --local user.name "intellij-rust-bot"
 
             - name: Check date
               if: github.event_name == 'schedule'

--- a/.github/workflows/rust-nightly.yml
+++ b/.github/workflows/rust-nightly.yml
@@ -163,6 +163,7 @@ jobs:
               uses: actions/checkout@v2
               with:
                   fetch-depth: 0
+                  token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
 
             - name: Set up Python
               uses: actions/setup-python@v1
@@ -171,5 +172,5 @@ jobs:
 
             - name: Save commits
               run: |
-                  python scripts/save_tag.py --token ${{ secrets.WORKFLOW_GITHUB_TOKEN }} --tag rust-nightly --commit ${{ needs.fetch-latest-changes.outputs.rust-commit }}
-                  python scripts/save_tag.py --token ${{ secrets.WORKFLOW_GITHUB_TOKEN }} --tag toml-nightly --commit ${{ needs.fetch-latest-changes.outputs.toml-commit }}
+                  python scripts/save_tag.py --tag rust-nightly --commit ${{ needs.fetch-latest-changes.outputs.rust-commit }}
+                  python scripts/save_tag.py --tag toml-nightly --commit ${{ needs.fetch-latest-changes.outputs.toml-commit }}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -61,8 +61,8 @@ jobs:
 
             - name: Set up git user
               run: |
-                  git config --local user.email "action@github.com"
-                  git config --local user.name "GitHub Action"
+                  git config --local user.email "intellij.rust@gmail.com"
+                  git config --local user.name "intellij-rust-bot"
 
             - name: Update changelog link
               if: github.event_name == 'workflow_dispatch' && github.event.inputs.type == 'stable' && github.event.inputs.update_changelog != 'false'

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -49,6 +49,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
+              with:
+                  token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
 
             - run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
 
@@ -64,7 +66,7 @@ jobs:
 
             - name: Update changelog link
               if: github.event_name == 'workflow_dispatch' && github.event.inputs.type == 'stable' && github.event.inputs.update_changelog != 'false'
-              run: python scripts/update-changelog-link.py --token ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
+              run: python scripts/update_changelog_link.py
 
     get-channel:
         runs-on: ubuntu-18.04
@@ -228,6 +230,7 @@ jobs:
               uses: actions/checkout@v2
               with:
                   fetch-depth: 0
+                  token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
 
             - name: Set up Python
               uses: actions/setup-python@v1
@@ -236,5 +239,5 @@ jobs:
 
             - name: Save commits
               run: |
-                  python scripts/save_tag.py --token ${{ secrets.WORKFLOW_GITHUB_TOKEN }} --tag rust-${{ needs.get-channel.outputs.channel }} --commit ${{ needs.fetch-latest-changes.outputs.rust-commit }}
-                  python scripts/save_tag.py --token ${{ secrets.WORKFLOW_GITHUB_TOKEN }} --tag toml-${{ needs.get-channel.outputs.channel }} --commit ${{ needs.fetch-latest-changes.outputs.toml-commit }}
+                  python scripts/save_tag.py --tag rust-${{ needs.get-channel.outputs.channel }} --commit ${{ needs.fetch-latest-changes.outputs.rust-commit }}
+                  python scripts/save_tag.py --tag toml-${{ needs.get-channel.outputs.channel }} --commit ${{ needs.fetch-latest-changes.outputs.toml-commit }}

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -52,9 +52,3 @@ def env(key: str) -> str:
     if value is None:
         raise Exception(f"{key} is not set")
     return value
-
-
-def construct_repository_url(token: str) -> str:
-    actor = env("GITHUB_ACTOR")
-    repo = env("GITHUB_REPOSITORY")
-    return f"https://{actor}:{token}@github.com/{repo}.git"

--- a/scripts/make_release_branch.py
+++ b/scripts/make_release_branch.py
@@ -1,23 +1,14 @@
-import argparse
-
-from common import get_patch_version, inc_patch_version, GRADLE_PROPERTIES, git_command, construct_repository_url
+from common import get_patch_version, inc_patch_version, GRADLE_PROPERTIES, git_command
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--token", type=str, help="github token")
-
-    args = parser.parse_args()
-
-    repo_url = construct_repository_url(args.token)
-
     patch_version = get_patch_version()
 
     release_branch = f"release-{patch_version}"
     git_command("branch", release_branch)
-    git_command("push", repo_url, release_branch)
+    git_command("push", "origin", release_branch)
 
     inc_patch_version()
 
     git_command("add", GRADLE_PROPERTIES)
     git_command("commit", "-m", ":arrow_up: patch version")
-    git_command("push", repo_url, "master")
+    git_command("push", "origin", "master")

--- a/scripts/save_tag.py
+++ b/scripts/save_tag.py
@@ -1,17 +1,14 @@
 import argparse
 
-from common import construct_repository_url, git_command
+from common import git_command
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("--token", type=str, help="github token", required=True)
     parser.add_argument("--tag", type=str, help="tag name", required=True)
     parser.add_argument("--commit", type=str, help="commit hash", required=True)
 
     args = parser.parse_args()
 
-    repo_url = construct_repository_url(args.token)
-
     git_command("tag", "-d", args.tag, check=False)
     git_command("tag", args.tag, args.commit)
-    git_command("push", "-f", repo_url, args.tag)
+    git_command("push", "-f", "origin", args.tag)

--- a/scripts/update_changelog_link.py
+++ b/scripts/update_changelog_link.py
@@ -1,18 +1,11 @@
 import re
 from datetime import date
 
-import argparse
-
-from common import get_patch_version, git_command, construct_repository_url
+from common import get_patch_version, git_command
 
 PLUGIN_XML = "plugin/src/main/resources/META-INF/plugin.xml"
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--token", type=str, help="github token")
-
-    args = parser.parse_args()
-
     with open(PLUGIN_XML) as f:
         text = f.read()
     today = date.today()
@@ -23,8 +16,6 @@ if __name__ == '__main__':
     with (open(PLUGIN_XML, mode="w")) as f:
         f.write(new_text)
 
-    repo_url = construct_repository_url(args.token)
-
     git_command("add", PLUGIN_XML)
     git_command("commit", "-m", "Changelog")
 
@@ -33,5 +24,5 @@ if __name__ == '__main__':
     git_command("checkout", release_branch)
     git_command("cherry-pick", head)
 
-    git_command("push", repo_url, "master")
-    git_command("push", repo_url, release_branch)
+    git_command("push", "origin", "master")
+    git_command("push", "origin", release_branch)


### PR DESCRIPTION
Previously, we tried to push into repo via `https://{actor}:{token}@github.com/{repo}.git` url. Found out that it doesn't work as expected and token provided in `actions/checkout` is used instead.
Now we:
- set proper token during checkout
- use [intellij-rust-bot](https://github.com/intellij-rust-bot) [machine account](https://docs.github.com/en/github/site-policy/github-terms-of-service#3-account-requirements) to generate PAT and push such changes into repo