### PR TITLE
TY: introduce TyAlias to allow aliasing for any type

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/TypeRendering.kt
@@ -164,11 +164,14 @@ private data class TypeRenderer(
             is TyTraitObject -> ty.traits.joinToString("+", "dyn ") { formatTrait(it, render) }
             is TyAnon -> ty.traits.joinToString("+", "impl ") { formatTrait(it, render) }
             is TyAdt -> buildString {
-                if (useAliasNames && ty.aliasedBy != null) {
-                    append(formatBoundElement(ty.aliasedBy, render))
+                append(getName(ty.item) ?: return anonymous)
+                if (includeTypeArguments) append(formatAdtGenerics(ty, render))
+            }
+            is TyAlias -> buildString {
+                if (useAliasNames && ty.typeAlias != null) {
+                    append(formatBoundElement(ty.typeAlias, render))
                 } else {
-                    append(getName(ty.item) ?: return anonymous)
-                    if (includeTypeArguments) append(formatAdtGenerics(ty, render))
+                    append(render(ty.aliases, level))
                 }
             }
             is TyInfer -> when (ty) {

--- a/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
+++ b/src/main/kotlin/org/rust/ide/utils/import/RsImportHelper.kt
@@ -150,13 +150,16 @@ object RsImportHelper {
         ty.substitute(subst).visitWith(object : TypeVisitor {
             override fun visitTy(ty: Ty): Boolean {
                 when (ty) {
-                    is TyAdt -> {
-                        val alias = ty.aliasedBy?.element.takeIf { useAliases } as? RsQualifiedNamedElement
-                        result += alias ?: ty.item
+                    is TyAlias -> {
+                        val alias = ty.typeAlias?.element.takeIf { useAliases } as? RsQualifiedNamedElement
                         if (alias != null) {
+                            result += alias
                             return true
+                        } else {
+                            visitTy(ty.aliases)
                         }
-
+                    }
+                    is TyAdt -> {
                         if (skipUnchangedDefaultTypeArguments) {
                             val filteredTypeArguments = ty.typeArguments
                                 .zip(ty.item.typeParameters)

--- a/src/main/kotlin/org/rust/lang/core/types/RsPsiTypeImplUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/RsPsiTypeImplUtil.kt
@@ -21,7 +21,7 @@ object RsPsiTypeImplUtil {
     fun declaredType(psi: RsImplItem): Ty = TyTypeParameter.self(psi)
     fun declaredType(psi: RsTypeAlias): Ty {
         val typeReference = psi.typeReference
-        if (typeReference != null) return typeReference.typeWithRecursionGuard
+        if (typeReference != null) return TyAlias.valueOf(typeReference.typeWithRecursionGuard)
         return when (psi.owner) {
             is RsAbstractableOwner.Free -> TyUnknown
             is RsAbstractableOwner.Trait -> TyProjection.valueOf(psi)

--- a/src/main/kotlin/org/rust/lang/core/types/TyFingerprint.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/TyFingerprint.kt
@@ -77,6 +77,7 @@ data class TyFingerprint constructor(
             is TyTraitObject -> TyFingerprint("dyn T")
             is TyInfer.IntVar -> ANY_INTEGER_FINGERPRINT
             is TyInfer.FloatVar -> ANY_FLOAT_FINGERPRINT
+            is TyAlias -> create(type.aliases)
             else -> null
         }
     }

--- a/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/Declarations.kt
@@ -61,7 +61,7 @@ fun inferTypeReferenceType(type: RsTypeReference, defaultTraitObjectRegion: Regi
                     target is RsTypeDeclarationElement -> {
                         val ty = target.declaredType
                             .substituteWithTraitObjectRegion(subst, defaultTraitObjectRegion ?: ReStatic)
-                        if (ty is TyAdt && ty.item != target && target is RsTypeAlias) {
+                        if (ty is TyAlias) {
                             ty.withAlias(boundElement.downcast()!!)
                         } else {
                             ty

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -552,6 +552,7 @@ class RsTypeInferenceWalker(
         val type = when (element) {
             is RsStructItem -> element.declaredType
             is RsEnumVariant -> element.parentEnum.declaredType
+            is RsTypeAlias -> element.declaredType
             else -> TyUnknown
         }.substitute(typeParameters)
 

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyAdt.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyAdt.kt
@@ -6,12 +6,10 @@
 package org.rust.lang.core.types.ty
 
 import com.intellij.codeInsight.completion.CompletionUtil
-import org.rust.lang.core.psi.RsTypeAlias
 import org.rust.lang.core.psi.ext.RsStructOrEnumItemElement
 import org.rust.lang.core.psi.ext.constParameters
 import org.rust.lang.core.psi.ext.lifetimeParameters
 import org.rust.lang.core.psi.ext.typeParameters
-import org.rust.lang.core.types.BoundElement
 import org.rust.lang.core.types.Substitution
 import org.rust.lang.core.types.consts.Const
 import org.rust.lang.core.types.consts.CtConstParameter
@@ -33,8 +31,7 @@ data class TyAdt private constructor(
     val item: RsStructOrEnumItemElement,
     val typeArguments: List<Ty>,
     val regionArguments: List<Region>,
-    val constArguments: List<Const>,
-    val aliasedBy: BoundElement<RsTypeAlias>?
+    val constArguments: List<Const>
 ) : Ty(mergeFlags(typeArguments) or mergeFlags(regionArguments) or mergeFlags(constArguments)) {
 
     // This method is rarely called (in comparison with folding), so we can implement it in a such inefficient way.
@@ -57,8 +54,7 @@ data class TyAdt private constructor(
             item,
             typeArguments.map { it.foldWith(folder) },
             regionArguments.map { it.foldWith(folder) },
-            constArguments.map { it.foldWith(folder) },
-            aliasedBy?.foldWith(folder)
+            constArguments.map { it.foldWith(folder) }
         )
 
     override fun superVisitWith(visitor: TypeVisitor): Boolean =
@@ -66,17 +62,13 @@ data class TyAdt private constructor(
             regionArguments.any { it.visitWith(visitor) } ||
             constArguments.any { it.visitWith(visitor) }
 
-    fun withAlias(aliasedBy: BoundElement<RsTypeAlias>?): TyAdt =
-        copy(aliasedBy = aliasedBy)
-
     companion object {
         fun valueOf(struct: RsStructOrEnumItemElement): TyAdt =
             TyAdt(
                 CompletionUtil.getOriginalOrSelf(struct),
                 defaultTypeArguments(struct),
                 defaultRegionArguments(struct),
-                defaultConstArguments(struct),
-                null
+                defaultConstArguments(struct)
             )
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/types/ty/TyAlias.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/ty/TyAlias.kt
@@ -1,0 +1,41 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.types.ty
+
+import org.rust.lang.core.psi.RsTypeAlias
+import org.rust.lang.core.types.BoundElement
+import org.rust.lang.core.types.infer.TypeFolder
+import org.rust.lang.core.types.infer.TypeVisitor
+
+/*tailrec fun Ty.followAliases(): Ty {
+    return if (this !is TyAlias) this
+    else aliases.followAliases()
+}*/
+
+/**
+ * Represents a type that aliases another type via a type alias.
+ */
+@Suppress("DataClassPrivateConstructor")
+data class TyAlias private constructor(
+    val aliases: Ty,
+    val typeAlias: BoundElement<RsTypeAlias>? = null
+) : Ty(aliases.flags) {
+
+    override fun superFoldWith(folder: TypeFolder): Ty =
+        TyAlias(aliases.foldWith(folder), typeAlias?.foldWith(folder))
+
+    override fun superVisitWith(visitor: TypeVisitor): Boolean =
+        aliases.visitWith(visitor)
+
+    fun withAlias(typeAlias: BoundElement<RsTypeAlias>?): TyAlias =
+        copy(typeAlias = typeAlias)
+
+    companion object {
+        fun valueOf(aliases: Ty): TyAlias {
+            return TyAlias(aliases)
+        }
+    }
+}

--- a/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsExpressionTypeInferenceTest.kt
@@ -1173,6 +1173,14 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
         } //^ S
     """)
 
+    fun `test primitive with alias`() = testExpr("""
+        type T1 = u32;
+        type T2 = T1;
+        fn main() {
+            T2 { };
+        } //^ u32
+    """)
+
     fun `test cyclic type aliases`() = testExpr("""
         type Foo = Bar;
         type Bar = Foo;
@@ -1182,7 +1190,7 @@ class RsExpressionTypeInferenceTest : RsTypificationTestBase() {
           //^ <unknown>
         }
     """)
-    // More struct alias tests in [RsGenericExpressionTypeInferenceTest]
+    // More alias tests in [RsGenericExpressionTypeInferenceTest]
 
     fun `test struct update syntax`() = testExpr("""
         struct S {

--- a/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsTypeResolvingTest.kt
@@ -416,6 +416,12 @@ class RsTypeResolvingTest : RsTypificationTestBase() {
                  //^ Foo
     """, WITH_ALIAS_NAMES)
 
+    fun `test render alias name for primitive`() = testType("""
+        type Foo = u32;
+        type Bar = Foo;
+                 //^ Foo
+    """, WITH_ALIAS_NAMES)
+
     fun `test render alias name with generics`() = testType("""
         struct S<A, B>(A, B);
         type Foo<T> = S<T, u8>;


### PR DESCRIPTION
This PR attempts to introduce a new type called `TyAlias`, which represents an alias of an arbitrary type. This removes the previous special case that only supported type aliases for ADT types (structs, enums, etc.).

This should (eventually) help resolve several issues with type aliases, mainly in code generation, auto import and type rendering/hinting. Some of them are mentioned in https://github.com/intellij-rust/intellij-rust/issues/5080.

I have **literally** no idea what am I doing, so I would be glad for some feedback, if this is the way to go or if I should go back to the drawing board :) Thanks!