### PR TITLE
LI: Use the new RsDoc PSI for doctest injections

### DIFF
--- a/src/main/kotlin/org/rust/ide/annotator/RsDocHighlightingAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsDocHighlightingAnnotator.kt
@@ -10,9 +10,8 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapiext.isUnitTestMode
 import com.intellij.psi.PsiElement
-import org.rust.cargo.project.settings.rustSettings
 import org.rust.ide.colors.RsColor
-import org.rust.ide.injected.findDoctestInjectableRanges
+import org.rust.ide.injected.doctestInfo
 import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psi.ext.descendantOfTypeStrict
 import org.rust.lang.core.psi.ext.elementType
@@ -51,9 +50,5 @@ class RsDocHighlightingAnnotator : AnnotatorBase() {
     }
 
     private val RsDocCodeFence.isDoctestInjected: Boolean
-        get() {
-            if (!project.rustSettings.doctestInjectionEnabled) return false
-            if (containingDoc.owner?.containingCrate?.areDoctestsEnabled != true) return false
-            return findDoctestInjectableRanges(this).isNotEmpty()
-        }
+        get() = doctestInfo() != null
 }

--- a/src/main/kotlin/org/rust/ide/annotator/RsDoctestAnnotator.kt
+++ b/src/main/kotlin/org/rust/ide/annotator/RsDoctestAnnotator.kt
@@ -11,12 +11,8 @@ import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.colors.EditorColors
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.tree.injected.InjectionBackgroundSuppressor
-import org.rust.cargo.project.settings.rustSettings
 import org.rust.ide.injected.RsDoctestLanguageInjector
-import org.rust.ide.injected.findDoctestInjectableRanges
-import org.rust.lang.core.psi.ext.RsElement
-import org.rust.lang.core.psi.ext.ancestorStrict
-import org.rust.lang.core.psi.ext.containingCrate
+import org.rust.ide.injected.doctestInfo
 import org.rust.lang.core.psi.ext.startOffset
 import org.rust.lang.doc.psi.RsDocCodeFence
 
@@ -31,12 +27,10 @@ class RsDoctestAnnotator : AnnotatorBase() {
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         if (holder.isBatchMode) return
         if (element !is RsDocCodeFence) return
-        if (!element.project.rustSettings.doctestInjectionEnabled) return
-        // only library targets can have doctests
-        if (element.ancestorStrict<RsElement>()?.containingCrate?.areDoctestsEnabled != true) return
+        val doctest = element.doctestInfo() ?: return
 
         val startOffset = element.startOffset
-        findDoctestInjectableRanges(element).forEach {
+        doctest.rangesForBackgroundHighlighting.forEach {
             holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
                 .range(it.shiftRight(startOffset))
                 .textAttributes(EditorColors.INJECTED_LANGUAGE_FRAGMENT)

--- a/src/main/kotlin/org/rust/lang/doc/psi/Psi.kt
+++ b/src/main/kotlin/org/rust/lang/doc/psi/Psi.kt
@@ -168,7 +168,10 @@ interface RsDocLinkDestination : RsDocElement
  * [InjectionBackgroundSuppressor] is used to disable builtin background highlighting for injection.
  * We create such background manually by [RsDoctestAnnotator] (see the class docs)
  */
-interface RsDocCodeFence : RsDocElement, PsiLanguageInjectionHost, InjectionBackgroundSuppressor
+interface RsDocCodeFence : RsDocElement, PsiLanguageInjectionHost, InjectionBackgroundSuppressor {
+    val start: RsDocCodeFenceStartEnd
+    val lang: RsDocCodeFenceLang?
+}
 
 // TODO should be `PsiLanguageInjectionHost` too
 interface RsDocCodeBlock : RsDocElement

--- a/src/main/kotlin/org/rust/lang/doc/psi/impl/Psi.kt
+++ b/src/main/kotlin/org/rust/lang/doc/psi/impl/Psi.kt
@@ -91,6 +91,12 @@ class RsDocLinkDestinationImpl(type: IElementType) : RsDocElementImpl(type), RsD
 class RsDocCodeFenceImpl(type: IElementType) : RsDocElementImpl(type), RsDocCodeFence {
     override fun isValidHost(): Boolean = true
 
+    override val start: RsDocCodeFenceStartEnd
+        get() = notNullChild(childOfType())
+
+    override val lang: RsDocCodeFenceLang?
+        get() = childOfType()
+
     /**
      * Handles changes in PSI injected to the comment (see [RsDoctestLanguageInjector]).
      * It is not used on typing. Instead, it's used on direct PSI changes (performed by

--- a/src/test/kotlin/org/rust/ide/annotator/RsDoctestAnnotatorTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/RsDoctestAnnotatorTest.kt
@@ -120,6 +120,65 @@ class RsDoctestAnnotatorTest : RsAnnotatorTestBase(RsDoctestAnnotator::class) {
         |fn foo() {}
         |""")
 
+    fun `test indented code fence`() = doTest("""
+        |/// foo
+        |///  ```
+        |///<info>  <inject>let a = 0;
+        |</inject></info>///<info>
+        |</info>///<info>  <inject>let a = 0;
+        |</inject></info>///  ```
+        |fn foo() {}
+        |""")
+
+    fun `test indented code fence 2`() = doTest("""
+        |/// foo
+        |///  ```
+        |///<info>  <inject>let a = 0;
+        |</inject></info>///<info> <caret>
+        |</info>///<info>  <inject>let a = 0;
+        |</inject></info>///  ```
+        |fn foo() {}
+        |""")
+
+    fun `test indented code fence 3`() = doTest("""
+        |/// foo
+        |///    ```
+        |///<info>    <inject>let a = 0;
+        |</inject></info>///<info>  <caret>
+        |</info>///<info>    <inject>let a = 0;
+        |</inject></info>///  ```
+        |fn foo() {}
+        |""")
+
+    fun `test code fence with 4 backticks`() = doTest("""
+        |/// ````
+        |///<info> <inject>let a = 0;
+        |</inject></info>/// ````
+        |fn foo() {}
+        |""")
+
+    fun `test code fence with tildes`() = doTest("""
+        |/// ~~~
+        |///<info> <inject>let a = 0;
+        |</inject></info>/// ~~~
+        |fn foo() {}
+        |""")
+
+    fun `test incomplete code fence`() = doTest("""
+        |/// ```
+        |///<info>
+        |</info>///<info> <error>`</error></info>
+        |fn foo() {}
+        |""")
+
+    fun `test code before indent`() = doTest("""
+        |///  ```
+        |///<info>  <inject>let a = 0;
+        |</inject></info>///<info> <inject>let b = 0;
+        |</inject></info>///  ```
+        |fn foo() {}
+        |""")
+
     fun doTest(code: String) = checkByFileTree(
         "//- lib.rs\n/*caret*/${code.trimMargin()}",
         checkWarn = false,

--- a/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/import/AutoImportFixTest.kt
@@ -2173,6 +2173,22 @@ class AutoImportFixTest : AutoImportFixTestBase() {
     """, Testmarks.doctestInjectionImport)
 
     @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
+    fun `test import outer item in doctest injection with tildes`() = checkAutoImportFixByFileTreeWithouHighlighting("""
+    //- lib.rs
+        /// ~~~
+        /// foo/*caret*/();
+        /// ~~~
+        pub fn foo() {}
+    """, """
+    //- lib.rs
+        /// ~~~
+        /// use test_package::foo;
+        /// foo();
+        /// ~~~
+        pub fn foo() {}
+    """, Testmarks.doctestInjectionImport)
+
+    @ProjectDescriptor(WithDependencyRustProjectDescriptor::class)
     fun `test import outer item in doctest injection in star comment`() = checkAutoImportFixByFileTreeWithouHighlighting("""
     //- lib.rs
         /**


### PR DESCRIPTION
This fixes several issues with doctests:

1. The plugin now understands doctests in markdown
  code fences with more than 3 backticks ("`````")
  or with tildes ("~~~")
2. Apply correct indentation for indented code fence

![image](https://user-images.githubusercontent.com/3221931/122642571-cbe07200-d113-11eb-99f1-5ef076d2bd48.png)


changelog: Support [doctests](https://doc.rust-lang.org/rustdoc/documentation-tests.html) in code fences wrapped in different number of backticks or tildes