### PR TITLE
MACRO: support `:pat_param` `macro_rules!` matcher, fix `:pat` matcher

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/macros/decl/DeclMacroExpander.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/decl/DeclMacroExpander.kt
@@ -284,7 +284,7 @@ class DeclMacroExpander(val project: Project): MacroExpander<RsDeclMacroData, De
     }
 
     companion object {
-        const val EXPANDER_VERSION = 14
+        const val EXPANDER_VERSION = 15
         private val USELESS_PARENS_EXPRS = tokenSetOf(
             LIT_EXPR, MACRO_EXPR, PATH_EXPR, PAREN_EXPR, TUPLE_EXPR, ARRAY_EXPR, UNIT_EXPR
         )

--- a/src/main/kotlin/org/rust/lang/core/macros/decl/FragmentKind.kt
+++ b/src/main/kotlin/org/rust/lang/core/macros/decl/FragmentKind.kt
@@ -21,6 +21,7 @@ enum class FragmentKind(private val kind: String) {
     Expr("expr"),
     Ty("ty"),
     Pat("pat"),
+    PatParam("pat_param"),
     Stmt("stmt"),
     Block("block"),
     Item("item"),
@@ -37,7 +38,8 @@ enum class FragmentKind(private val kind: String) {
             Path -> RustParser.TypePathGenericArgsNoTypeQual(builder, 0)
             Expr -> RustParser.Expr(builder, 0, -1)
             Ty -> RustParser.TypeReference(builder, 0)
-            Pat -> RustParser.Pat(builder, 0)
+            Pat -> RustParserUtil.parseSimplePat(builder) // TODO `RustParser.Pat(builder, 0)` on 2021 edition
+            PatParam -> RustParserUtil.parseSimplePat(builder)
             Stmt -> parseStatement(builder)
             Block -> RustParserUtil.parseCodeBlockLazy(builder, 0)
             Item -> RustParser.Item(builder, 0)

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
@@ -726,4 +726,9 @@ object RustParserUtil : GeneratedParserUtilBase() {
     fun parseCodeBlockLazy(builder: PsiBuilder, level: Int): Boolean {
         return PsiBuilderUtil.parseBlockLazy(builder, LBRACE, RBRACE, BLOCK) != null
     }
+
+    @JvmStatic
+    fun parseSimplePat(builder: PsiBuilder): Boolean {
+        return RustParser.SimplePat(builder, 0)
+    }
 }


### PR DESCRIPTION
Fixes #7372

Support [`:pat_param`](https://blog.rust-lang.org/2021/05/11/edition-2021.html#or-patterns-in-macro_rules) `macro_rules!` matcher (from Rust 1.53.0)

Fix `:pat` matcher - now it should not parse `or patterns` (this behavior should be changed on [2021 edition](https://blog.rust-lang.org/2021/05/11/edition-2021.html#or-patterns-in-macro_rules))

changelog: FEATURE: Support [`:pat_param`](https://blog.rust-lang.org/2021/05/11/edition-2021.html#or-patterns-in-macro_rules) `macro_rules!` matcher (from Rust 1.53.0), FIX: Fix `:pat` matcher - now it should not parse `or patterns`