### PR TITLE
CI: create changelog pull request automatically

### DIFF
--- a/.github/workflows/create-changelog.yml
+++ b/.github/workflows/create-changelog.yml
@@ -1,0 +1,35 @@
+name: create changelog
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: '0 3 * * *' # try everyday
+
+jobs:
+    create-changelog:
+        runs-on: ubuntu-18.04
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Checkout intellij-rust.github.io repo
+              uses: actions/checkout@v2
+              with:
+                  token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
+                  repository: ${{ github.repository_owner }}/intellij-rust.github.io
+                  path: intellij-rust.github.io
+
+            - name: Set up Python
+              uses: actions/setup-python@v1
+              with:
+                  python-version: 3.9
+
+            - name: Install python packages
+              run: pip install -r intellij-rust.github.io/requirements.txt
+
+            - name: Set up git user
+              run: |
+                  (cd intellij-rust.github.io; git config --local user.email "intellij.rust@gmail.com")
+                  (cd intellij-rust.github.io; git config --local user.name "intellij-rust-bot")
+
+            - name: Make pull request
+              run: python scripts/make_changelog_pull_request.py --token ${{ secrets.WORKFLOW_GITHUB_TOKEN }} --repo_owner ${{ github.repository_owner }} --repo_name intellij-rust.github.io

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -2,7 +2,7 @@ import os
 import re
 import subprocess
 
-from typing import Tuple
+from typing import Tuple, Optional
 
 GRADLE_PROPERTIES: str = "gradle.properties"
 PATCH_VERSION_RE: str = r"patchVersion=(\d+)"
@@ -30,12 +30,16 @@ def inc_patch_version():
         properties.write(new_text)
 
 
-def execute_command(*args, print_stdout=True, check=True) -> str:
+def execute_command(*args, print_stdout=True, check=True, cwd: Optional[str] = None) -> str:
     if print_stdout:
         print(list(args))
 
     try:
-        result = subprocess.run(list(args), check=check, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        result = subprocess.run(list(args),
+                                check=check,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                                cwd=cwd)
     except subprocess.CalledProcessError as e:
         if print_stdout:
             print(e.output)

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -30,12 +30,12 @@ def inc_patch_version():
         properties.write(new_text)
 
 
-def git_command(*args, print_stdout=True, check=True) -> str:
+def execute_command(*args, print_stdout=True, check=True) -> str:
     if print_stdout:
-        print(["git"] + list(args))
+        print(list(args))
 
     try:
-        result = subprocess.run(["git"] + list(args), check=check, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        result = subprocess.run(list(args), check=check, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         if print_stdout:
             print(e.output)

--- a/scripts/fetch_projects.py
+++ b/scripts/fetch_projects.py
@@ -3,7 +3,7 @@ import json
 import subprocess
 from typing import List, Dict
 
-from common import git_command
+from git import git_command
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/scripts/get_tag_commit.py
+++ b/scripts/get_tag_commit.py
@@ -1,7 +1,7 @@
 import argparse
 from subprocess import CalledProcessError
 
-from common import git_command
+from git import git_command
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/scripts/git.py
+++ b/scripts/git.py
@@ -1,0 +1,5 @@
+from common import execute_command
+
+
+def git_command(*args, print_stdout=True, check=True) -> str:
+    return execute_command("git", *args, print_stdout=print_stdout, check=check)

--- a/scripts/git.py
+++ b/scripts/git.py
@@ -1,5 +1,7 @@
+from typing import Optional
+
 from common import execute_command
 
 
-def git_command(*args, print_stdout=True, check=True) -> str:
-    return execute_command("git", *args, print_stdout=print_stdout, check=check)
+def git_command(*args, print_stdout=True, check=True, cwd: Optional[str] = None) -> str:
+    return execute_command("git", *args, print_stdout=print_stdout, check=check, cwd=cwd)

--- a/scripts/github.py
+++ b/scripts/github.py
@@ -41,11 +41,38 @@ def create_milestone(repo: str, token: str, title: str, description: str = "", d
     urlopen(request)
 
 
+def create_pull_request(repo: str, token: str, branch: str, title: str, draft: bool = True) -> Dict:
+    headers = {"Authorization": f"token {token}",
+               "Accept": "application/vnd.github.v3+json"}
+    params = {"base": "master", "head": branch, "title": title, "draft": draft}
+    data = json.dumps(params).encode()
+    request = Request(f"https://api.github.com/repos/{repo}/pulls", data, headers, method="POST")
+    response = urlopen(request)
+    return json.load(response)
+
+
+def add_assignee(repo: str, token: str, id: int, assignee: str):
+    headers = {"Authorization": f"token {token}",
+               "Accept": "application/vnd.github.v3+json"}
+    params = {"assignees": [assignee]}
+    data = json.dumps(params).encode()
+    request = Request(f"https://api.github.com/repos/{repo}/issues/{id}", data, headers, method="POST")
+    urlopen(request)
+
+
 def get_check_statuses(repo: str, token: str, ref: str, check_name: str) -> Dict[str, List[Dict]]:
     headers = {"Authorization": f"token {token}",
                "Accept": "application/vnd.github.v3+json"}
     request = Request(
         f"https://api.github.com/repos/{repo}/commits/{ref}/check-runs?check_name={check_name}&status=completed",
         headers=headers)
+    response = urlopen(request)
+    return json.load(response)
+
+
+def get_all_branches(repo: str, token: str) -> List[Dict]:
+    headers = {"Authorization": f"token {token}",
+               "Accept": "application/vnd.github.v3+json"}
+    request = Request(f"https://api.github.com/repos/{repo}/branches", headers=headers)
     response = urlopen(request)
     return json.load(response)

--- a/scripts/make_changelog_pull_request.py
+++ b/scripts/make_changelog_pull_request.py
@@ -1,0 +1,76 @@
+import re
+from datetime import datetime, date, timedelta
+from typing import Dict
+
+import argparse
+
+from common import env, get_patch_version, execute_command
+from git import git_command
+from github import get_current_milestone, create_pull_request, get_all_branches, add_assignee
+
+
+def changelog_branch_name(patch_version: int) -> str:
+    return f"release-{patch_version}"
+
+
+def add_changelog_template(token: str, patch_version: int, cwd: str):
+    branch_name = changelog_branch_name(patch_version)
+    git_command("checkout", "-b", branch_name, cwd=cwd)
+    execute_command("python", "changelog.py", "--token", token, cwd=cwd)
+    git_command("add", "_posts", cwd=cwd)
+    git_command("commit", "-m", f"Changelog {patch_version}", cwd=cwd)
+    git_command("push", "origin", branch_name, cwd=cwd)
+
+
+def create_changelog_pull_request(changelog_repo: str, token: str, patch_version: int, milestone: Dict):
+    description = milestone["description"]
+    result = re.search("Release manager: @(\\w+)", description)
+    if result is None:
+        title = milestone["title"]
+        raise Exception(f"Failed to find release manager for {title} milestone")
+    release_manager = result.group(1)
+    pr = create_pull_request(changelog_repo, token, changelog_branch_name(patch_version), f"Changelog {patch_version}")
+    add_assignee(changelog_repo, token, pr["number"], release_manager)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--token", type=str, required=True)
+    parser.add_argument("--repo_owner", type=str, required=True)
+    parser.add_argument("--repo_name", type=str, required=True)
+    args = parser.parse_args()
+
+    repo = env("GITHUB_REPOSITORY")
+    # the script is supposed to be invoked only after release branch creation
+    # so we need previous patch version
+    release_patch_version = get_patch_version() - 1
+    changelog_repo = f"{args.repo_owner}/{args.repo_name}"
+    branch_name = changelog_branch_name(release_patch_version)
+
+    branches = get_all_branches(changelog_repo, args.token)
+    existing_branch = next((branch["name"] for branch in branches if branch["name"].endswith(branch_name)), None)
+    if existing_branch is not None:
+        print(f"Branch for v{release_patch_version} release already exists: `{existing_branch}`")
+        return
+
+    milestone = get_current_milestone(repo, release_patch_version)
+
+    # TODO: find out more correct way to parse data
+    release_date = datetime.strptime(milestone["due_on"], "%Y-%m-%dT%H:%M:%SZ").date()
+    today = date.today()
+    if today >= release_date or milestone["state"] == "closed":
+        print(f"Milestone v{release_patch_version} is over")
+
+    delta = release_date - today
+    five_days = timedelta(5)
+
+    if delta > five_days:
+        print("Too early to create release changelog")
+        return
+
+    add_changelog_template(args.token, release_patch_version, args.repo_name)
+    create_changelog_pull_request(changelog_repo, args.token, release_patch_version, milestone)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/make_release_branch.py
+++ b/scripts/make_release_branch.py
@@ -1,4 +1,5 @@
-from common import get_patch_version, inc_patch_version, GRADLE_PROPERTIES, git_command
+from common import get_patch_version, inc_patch_version, GRADLE_PROPERTIES
+from git import git_command
 
 if __name__ == '__main__':
     patch_version = get_patch_version()

--- a/scripts/save_tag.py
+++ b/scripts/save_tag.py
@@ -1,6 +1,6 @@
 import argparse
 
-from common import git_command
+from git import git_command
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/scripts/update_changelog_link.py
+++ b/scripts/update_changelog_link.py
@@ -1,7 +1,8 @@
 import re
 from datetime import date
 
-from common import get_patch_version, git_command
+from common import get_patch_version
+from git import git_command
 
 PLUGIN_XML = "plugin/src/main/resources/META-INF/plugin.xml"
 


### PR DESCRIPTION
These changes introduce a new `create changelog` workflow that should create a pull request with release changelog template in https://github.com/intellij-rust/intellij-rust.github.io repo and assign it to the corresponding release manager (according to the corresponding milestone). The workflow creates a changelog template by running `changelog.py` script from `intellij-rust.github.io` repo sometime before the release (currently, it's 5 days, i.e. usually on Wednesday morning).
The goals of this change are to remind release managers about changelog creation and automate some of their routine work.
