### PR TITLE
CARGO: escape keywords in cargo test command invocations

### DIFF
--- a/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestLocator.kt
+++ b/src/main/kotlin/org/rust/cargo/runconfig/test/CargoTestLocator.kt
@@ -27,6 +27,8 @@ object CargoTestLocator : SMTestLocator {
     private const val NAME_SEPARATOR: String = "::"
     private const val TEST_PROTOCOL: String = "cargo:test"
 
+    private val LINE_NUM_REGEX = Regex("""(.*?)(#\d+)?$""")
+
     override fun getLocation(
         protocol: String,
         path: String,
@@ -83,8 +85,10 @@ object CargoTestLocator : SMTestLocator {
     private fun toQualifiedName(path: String): Pair<String, Int?> {
         val targetName = path.substringBefore(NAME_SEPARATOR).substringBeforeLast("-")
         if (NAME_SEPARATOR !in path) return targetName to null
-        val qualifiedName = path.substringAfter(NAME_SEPARATOR).substringBefore("#")
-        val lineNum = if ("#" in path) path.substringAfterLast("#").toInt() else null
+        val match = LINE_NUM_REGEX.matchEntire(path) ?: return targetName to null
+        val qualifiedName = match.groups[1]?.value?.substringAfter(NAME_SEPARATOR)
+        val lineNum = match.groups[2]?.value?.substring(1)?.toInt()
+
         return "$targetName$NAME_SEPARATOR$qualifiedName" to lineNum
     }
 }

--- a/src/main/kotlin/org/rust/ide/refactoring/RsNamesValidator.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsNamesValidator.kt
@@ -15,9 +15,7 @@ import org.rust.lang.core.psi.RsElementTypes.QUOTE_IDENTIFIER
 
 class RsNamesValidator : NamesValidator {
 
-    override fun isKeyword(name: String, project: Project?): Boolean {
-        return getLexerType(name) in RS_KEYWORDS
-    }
+    override fun isKeyword(name: String, project: Project?): Boolean = isKeyword(name)
 
     override fun isIdentifier(name: String, project: Project?): Boolean = isIdentifier(name)
 
@@ -28,6 +26,8 @@ class RsNamesValidator : NamesValidator {
             IDENTIFIER, QUOTE_IDENTIFIER -> true
             else -> false
         }
+
+        fun isKeyword(name: String): Boolean = getLexerType(name) in RS_KEYWORDS
     }
 }
 

--- a/src/test/kotlin/org/rust/cargo/runconfig/producers/TestRunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/producers/TestRunConfigurationProducerTest.kt
@@ -341,4 +341,12 @@ class TestRunConfigurationProducerTest : RunConfigurationProducerTestBase() {
         }
         checkOnLeaf()
     }
+
+    fun `test use raw identifier for module named with keyword`() {
+        testProject {
+            lib("foo", "src/lib.rs", """mod r#struct;""")
+            file("src/struct.rs", "#[test] fn test_foo() { /*caret*/assert!(true); }").open()
+        }
+        checkOnTopLevel<RsFunction>()
+    }
 }

--- a/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/use_raw_identifier_for_module_named_with_keyword.xml
+++ b/src/test/resources/org/rust/cargo/runconfig/producers/fixtures/use_raw_identifier_for_module_named_with_keyword.xml
@@ -1,0 +1,18 @@
+<configurations>
+  <configuration name="Test r#struct::test_foo" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="test --package test-package --lib r#struct::test_foo -- --exact" />
+    <option name="workingDirectory" value="file:///my-crate" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="emulateTerminal" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="backtrace" value="SHORT" />
+    <envs />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</configurations>


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/7387

changelog: Support modules named after Rust keywords in `cargo test` configurations.