### PR TITLE
IDE: allow moving up/down in block expressions in comma-separated lists

### DIFF
--- a/src/main/kotlin/org/rust/ide/actions/mover/RsCommaListElementUpDownMover.kt
+++ b/src/main/kotlin/org/rust/ide/actions/mover/RsCommaListElementUpDownMover.kt
@@ -13,6 +13,7 @@ import org.rust.ide.actions.mover.RsLineMover.Companion.RangeEndpoint
 import org.rust.ide.formatter.impl.CommaList
 import org.rust.ide.formatter.processors.addTrailingCommaForElement
 import org.rust.ide.formatter.processors.isLastElement
+import org.rust.lang.core.psi.RsBlockExpr
 import org.rust.lang.core.psi.RsElementTypes.COMMA
 import org.rust.lang.core.psi.RsMatchArm
 import org.rust.lang.core.psi.ext.ancestorPairs
@@ -34,6 +35,8 @@ class RsCommaListElementUpDownMover : RsLineMover() {
 
     private fun findListElement(psi: PsiElement): PsiElement? {
         for ((child, parent) in psi.ancestorPairs) {
+            // Stop at block expressions inside comma-separated lists
+            if (parent is RsBlockExpr) return null
             val list = CommaList.forElement(parent.elementType)
             if (list != null && list.isElement(child)) return child
         }

--- a/src/main/kotlin/org/rust/ide/actions/mover/RsLineMover.kt
+++ b/src/main/kotlin/org/rust/ide/actions/mover/RsLineMover.kt
@@ -13,10 +13,8 @@ import com.intellij.openapiext.Testmark
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
-import org.rust.lang.core.psi.RsElementTypes
-import org.rust.lang.core.psi.RsFile
-import org.rust.lang.core.psi.RsFunction
-import org.rust.lang.core.psi.RsMatchArm
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.lang.core.psi.ext.elementType
 
 abstract class RsLineMover : LineMover() {
@@ -93,6 +91,12 @@ abstract class RsLineMover : LineMover() {
 
         fun isMovingOutOfMatchArmBlock(sibling: PsiElement, down: Boolean): Boolean =
             isMovingOutOfBraceBlock(sibling, down) && sibling.parent?.parent?.parent is RsMatchArm
+
+        fun isMovingOutOfBlockExprInsideArgList(sibling: PsiElement, down: Boolean): Boolean {
+            if (!isMovingOutOfBraceBlock(sibling, down)) return false
+            val blockExpr = sibling.ancestorStrict<RsBlockExpr>() ?: return false
+            return blockExpr.ancestorStrict<RsValueArgumentList>() != null
+        }
     }
 }
 

--- a/src/main/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMover.kt
+++ b/src/main/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMover.kt
@@ -36,7 +36,11 @@ class RsStatementUpDownMover : RsLineMover() {
         psi.ancestors.find(::isMovableElement)
 
     override fun findTargetElement(sibling: PsiElement, down: Boolean): PsiElement? {
-        if (isMovingOutOfFunctionBody(sibling, down) || isMovingOutOfMatchArmBlock(sibling, down)) {
+        if (
+            isMovingOutOfFunctionBody(sibling, down) ||
+            isMovingOutOfMatchArmBlock(sibling, down) ||
+            isMovingOutOfBlockExprInsideArgList(sibling, down)
+        ) {
             UpDownMoverTestMarks.moveOutOfBody.hit()
             return null
         }

--- a/src/test/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMoverTest.kt
+++ b/src/test/kotlin/org/rust/ide/actions/mover/RsStatementUpDownMoverTest.kt
@@ -620,4 +620,79 @@ class RsStatementUpDownMoverTest : RsStatementUpDownMoverTestBase() {
              };
         }
     """, testmark = UpDownMoverTestMarks.moveOutOfBody)
+
+    // https://github.com/intellij-rust/intellij-rust/issues/7376
+    fun `test move down in block inside argument list`() = moveDown("""
+        fn foo(a: u32) {}
+
+        fn main() {
+            foo({
+                println!("1");/*caret*/
+                println!("2");
+                1
+            });
+        }
+    """, """
+        fn foo(a: u32) {}
+
+        fn main() {
+            foo({
+                println!("2");
+                println!("1");/*caret*/
+                1
+            });
+        }
+    """)
+
+    fun `test move up first statement of block expr inside argument list`() = moveUp("""
+        fn foo(a: u32) {}
+
+        fn main() {
+            foo({
+                println!("1");/*caret*/
+                println!("2");
+                1
+            });
+        }
+    """, testmark = UpDownMoverTestMarks.moveOutOfBody)
+
+    fun `test move up first statement of lambda inside argument list`() = moveUp("""
+        fn foo<F: Fn() -> ()>(f: F) -> u32 { 0 }
+
+        struct S {
+            a: u32,
+            b: u32
+        }
+
+        fn main() {
+            let s = S {
+                a: 0,
+                b: foo(|| {
+                    println!("1");/*caret*/
+                    println!("2");
+                    1
+                })
+            };
+        }
+    """, testmark = UpDownMoverTestMarks.moveOutOfBody)
+
+    fun `test move up first statement of lambda ref inside argument list`() = moveUp("""
+        fn foo<F: Fn() -> ()>(f: &mut F) -> u32 { 0 }
+
+        struct S {
+            a: u32,
+            b: u32
+        }
+
+        fn main() {
+            let s = S {
+                a: 0,
+                b: foo(&mut || {
+                    println!("1");/*caret*/
+                    println!("2");
+                    1
+                })
+            };
+        }
+    """, testmark = UpDownMoverTestMarks.moveOutOfBody)
 }


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/7376

changelog: Allow moving up/down in block expressions inside comma-separated lists.