### PR TITLE
Properly escape crate urls produced by line markers in Cargo.toml

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/CargoCrateDocLineMarkerProvider.kt
@@ -10,6 +10,7 @@ import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.psi.PsiElement
+import com.intellij.util.io.URLUtil
 import org.rust.cargo.CargoConstants
 import org.rust.ide.icons.RsIcons
 import org.rust.ide.lineMarkers.RsLineMarkerInfoUtils
@@ -57,7 +58,7 @@ class CargoCrateDocLineMarkerProvider : LineMarkerProvider {
             anchor,
             anchor.textRange,
             RsIcons.DOCS_MARK,
-            { _, _ -> BrowserUtil.browse("https://docs.rs/$name/$urlVersion") },
+            { _, _ -> BrowserUtil.browse("https://docs.rs/$name/${URLUtil.encodeURIComponent(urlVersion)}") },
             GutterIconRenderer.Alignment.LEFT
         ) { "Open documentation for `$name@$urlVersion`" }
     }

--- a/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/CargoCrateDocLineMarkerProviderTest.kt
@@ -22,32 +22,32 @@ class CargoCrateDocLineMarkerProviderTest : CargoTomlLineMarkerProviderTestBase(
 
         [target.'cfg(unix)'.dependencies]
         base64 = "0.8.0"  # - Open documentation for `base64@^0.8.0`
-    """, "https://docs.rs/base64/^0.8.0", "https://docs.rs/base64/^0.8.0")
+    """, "https://docs.rs/base64/%5E0.8.0", "https://docs.rs/base64/%5E0.8.0")
 
     fun `test platform specific`() = doTest("""
         [target.'cfg(unix)'.dependencies]
         base64 = "0.8.0"  # - Open documentation for `base64@^0.8.0`
-    """, "https://docs.rs/base64/^0.8.0")
+    """, "https://docs.rs/base64/%5E0.8.0")
 
     fun `test standard detailed`() = doTest("""
         [dependencies]
         jquery = { version = "1.0.2", optional = true }  # - Open documentation for `jquery@^1.0.2`
-    """, "https://docs.rs/jquery/^1.0.2")
+    """, "https://docs.rs/jquery/%5E1.0.2")
 
     fun `test standard dev`() = doTest("""
         [dev-dependencies]
         libc = "0.2.33"  # - Open documentation for `libc@^0.2.33`
-    """, "https://docs.rs/libc/^0.2.33")
+    """, "https://docs.rs/libc/%5E0.2.33")
 
     fun `test standard build`() = doTest("""
         [build-dependencies]
         libc = "0.2.33"  # - Open documentation for `libc@^0.2.33`
-    """, "https://docs.rs/libc/^0.2.33")
+    """, "https://docs.rs/libc/%5E0.2.33")
 
     fun `test specific crate`() = doTest("""
         [dependencies.clap]  # - Open documentation for `clap@^2.27.1`
         version = "2.27.1"
-    """, "https://docs.rs/clap/^2.27.1")
+    """, "https://docs.rs/clap/%5E2.27.1")
 
     fun `test no link to doc`() = doTest("""
         [dependencies]
@@ -57,7 +57,7 @@ class CargoCrateDocLineMarkerProviderTest : CargoTomlLineMarkerProviderTestBase(
     fun `test renamed dependencies`() = doTest("""
         [dependencies]
         config_rs = { package = "config", version = "0.9" }  # - Open documentation for `config@^0.9`
-    """, "https://docs.rs/config/^0.9")
+    """, "https://docs.rs/config/%5E0.9")
 
     fun `test unescape string literals`() = doTest("""
         [dependencies]
@@ -65,10 +65,10 @@ class CargoCrateDocLineMarkerProviderTest : CargoTomlLineMarkerProviderTestBase(
         serde_json = { version = '''1.0.104''' }  # - Open documentation for `serde_json@^1.0.104`
         serde_yaml_rs = { package = 'serde_yaml', version = '''0.8.11''' }  # - Open documentation for `serde_yaml@^0.8.11`
         serde_derive_rs = { package = "serde\u005Fderive", version ="1\u002E0\u002E104" }  # - Open documentation for `serde_derive@^1.0.104`
-    """, "https://docs.rs/serde/^1.0.104",
-        "https://docs.rs/serde_json/^1.0.104",
-        "https://docs.rs/serde_yaml/^0.8.11",
-        "https://docs.rs/serde_derive/^1.0.104"
+    """, "https://docs.rs/serde/%5E1.0.104",
+        "https://docs.rs/serde_json/%5E1.0.104",
+        "https://docs.rs/serde_yaml/%5E0.8.11",
+        "https://docs.rs/serde_derive/%5E1.0.104"
     )
 
     fun `test empty version`() = doTest("""
@@ -79,7 +79,7 @@ class CargoCrateDocLineMarkerProviderTest : CargoTomlLineMarkerProviderTestBase(
     fun `test exact version`() = doTest("""
         [dependencies]
         base64 = "=0.8.0"  # - Open documentation for `base64@=0.8.0`
-    """, "https://docs.rs/base64/=0.8.0")
+    """, "https://docs.rs/base64/%3D0.8.0")
 
     private fun doTest(@Language("Toml") source: String, vararg expectedUrls: String) {
         doTestByText(source)


### PR DESCRIPTION
Fixes #7223
Closes #7224

changelog: Properly escape crate urls produced by line markers in Cargo.toml. should fix exception by clicking on the corresponding icon if you use [IntelliJ Projector](https://blog.jetbrains.com/blog/2021/03/11/projector-is-out/) with IntelliJ Rust plugin on backend
