### PR TITLE
INT: considers siblings near caret in FlattenUseStatementsIntention

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/FlattenUseStatementsIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/FlattenUseStatementsIntention.kt
@@ -45,7 +45,13 @@ class FlattenUseStatementsIntention : RsElementBaseIntentionAction<FlattenUseSta
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
         val useGroupOnCursor = element.ancestorStrict<RsUseGroup>() ?: return null
         val isNested = useGroupOnCursor.ancestorStrict<RsUseGroup>() != null
-        val useSpeckOnCursor = element.ancestorStrict<RsUseSpeck>() ?: return null
+        val useSpeckOnCursor = when (element) {
+            is RsUseSpeck -> element
+            else -> {
+                val sibling = (element.leftSiblings + element.rightSiblings).firstOrNull { it is RsUseSpeck }
+                sibling ?: element.ancestorStrict<RsUseSpeck>() ?: return null
+            }
+        } as RsUseSpeck
 
         val useSpeckList = mutableListOf<RsUseSpeck>()
         val basePath = useGroupOnCursor.parentUseSpeck.path?.text ?: return null

--- a/src/test/kotlin/org/rust/ide/intentions/FlattenUseStatementsIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/FlattenUseStatementsIntentionTest.kt
@@ -112,6 +112,22 @@ class FlattenUseStatementsIntentionTest : RsIntentionTestBase(FlattenUseStatemen
         use quux::eggs;
     """)
 
+    fun `test inner path caret after comma`() = doAvailableTest("""
+        use std::{
+            sync::{
+                mpsc,/*caret*/
+                Arc
+            },
+            fmt
+        };
+    """, """
+        use std::{
+            /*caret*/sync::mpsc,
+            sync::Arc,
+            fmt
+        };
+    """)
+
     fun `test inner path without last comma`() = doAvailableTest("""
         use std::{
             sync::{


### PR DESCRIPTION
This PR changes `FlattenUseStatementsInspection` so that it works properly on all places inside a use group.

Before, the intention was looking for the use speck to flatten using `ancestorStrict`. That meant that if you have invoked the intention on some element that wasn't a use speck inside a use group, e.g. here:
```rust
use self::{
    foo::{
        a,/*caret*/
        b
    },
    bar::baz,
};
```
the `useSpeckOnCursor` variable was set to `foo::` instead of `a` or `b`. Therefore the intention produced invalid code. Now the intention first looks for siblings located at caret to find the proper use speck to replace.

I suppose that the same thing should be done for `NestUseStatementsIntention`, I can do it in another PR.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/7396

changelog: The intention to flatten use imports now works properly on all places inside a use group.