### PR TITLE
Add API to get inferred method type and substitution

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/ref/RsPathReferenceImpl.kt
@@ -93,7 +93,7 @@ class RsPathReferenceImpl(
     private fun advancedMultiresolveUsingInferenceCache(): List<BoundElementWithVisibility<RsElement>>? {
         val path = element.parent as? RsPathExpr ?: return null
         return path.inference?.getResolvedPath(path)?.map { result ->
-            val element = BoundElement(result.element)
+            val element = BoundElement(result.element, result.subst)
             val isVisible = (result as? ResolvedPath.Item)?.isVisible ?: true
             BoundElementWithVisibility(element, isVisible)
         }

--- a/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/BoundElement.kt
@@ -55,10 +55,7 @@ data class BoundElement<out E : RsElement>(
         )
 
     override fun superVisitWith(visitor: TypeVisitor): Boolean =
-        assoc.values.any { visitor.visitTy(it) } ||
-            subst.types.any { it.visitWith(visitor) } ||
-            subst.regions.any { it.visitWith(visitor) } ||
-            subst.consts.any { it.visitWith(visitor) }
+        assoc.values.any { visitor.visitTy(it) } || subst.visitValues(visitor)
 }
 
 val BoundElement<RsGenericDeclaration>.positionalTypeArguments: List<Ty>

--- a/src/main/kotlin/org/rust/lang/core/types/Substitution.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/Substitution.kt
@@ -11,6 +11,7 @@ import org.rust.lang.core.psi.RsTypeParameter
 import org.rust.lang.core.types.consts.Const
 import org.rust.lang.core.types.consts.CtConstParameter
 import org.rust.lang.core.types.infer.TypeFolder
+import org.rust.lang.core.types.infer.TypeVisitor
 import org.rust.lang.core.types.infer.substitute
 import org.rust.lang.core.types.regions.ReEarlyBound
 import org.rust.lang.core.types.regions.Region
@@ -76,6 +77,11 @@ open class Substitution(
 
     fun mapConstValues(transform: (Map.Entry<CtConstParameter, Const>) -> Const): Substitution =
         Substitution(typeSubst, regionSubst, constSubst.mapValues(transform))
+
+    fun visitValues(visitor: TypeVisitor): Boolean =
+            types.any { it.visitWith(visitor) } ||
+            regions.any { it.visitWith(visitor) } ||
+            consts.any { it.visitWith(visitor) }
 
     override fun equals(other: Any?): Boolean = when {
         this === other -> true

--- a/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/rust/lang/core/types/infer/TypeInferenceWalker.kt
@@ -476,6 +476,8 @@ class RsTypeInferenceWalker(
 
         unifySubst(subst, typeParameters)
 
+        ctx.writePathSubst(pathExpr, typeParameters)
+
         val type = when (element) {
             is RsPatBinding -> ctx.getBindingType(element)
             is RsTypeDeclarationElement -> element.declaredType
@@ -666,6 +668,7 @@ class RsTypeInferenceWalker(
         // drop first element of paramTypes because it's `self` param
         // and it doesn't have value in `methodCall.valueArgumentList.exprList`
         inferArgumentTypes(methodType.paramTypes.drop(1), argExprs)
+        ctx.writeResolvedMethodSubst(methodCall, newSubst, methodType)
 
         return methodType.retType
     }


### PR DESCRIPTION
Internal. It's now possible to get `Substotution` of `RsMethodCall` or `RsPathExpr`.

I promised that [here](https://github.com/intellij-rust/intellij-rust/pull/5644#issuecomment-683338917) :)

Note that this doesn't work correctly for `refined` paths (see `test infer method arg with multiple impls of the same trait` or `test resolve UFCS method call with multiple impls of the same trait`). I'll fix it later