### PR TITLE
TOML: ignore path references with wildcards to avoid false positives

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlFileReferenceProvider.kt
+++ b/toml/src/main/kotlin/org/rust/toml/resolve/CargoTomlFileReferenceProvider.kt
@@ -6,6 +6,7 @@
 package org.rust.toml.resolve
 
 import com.intellij.openapi.util.Condition
+import com.intellij.openapi.util.TextRange
 import com.intellij.patterns.PsiElementPattern
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiElement
@@ -13,6 +14,7 @@ import com.intellij.psi.PsiFileSystemItem
 import com.intellij.psi.PsiReferenceProvider
 import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReference
 import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReferenceSet
+import com.intellij.psi.util.parentOfType
 import com.intellij.util.ProcessingContext
 import org.rust.lang.core.or
 import org.rust.lang.core.psi.RsFile
@@ -20,6 +22,7 @@ import org.rust.lang.core.psi.ext.ancestorStrict
 import org.rust.toml.CargoTomlPsiPattern
 import org.rust.toml.resolve.PathPatternType.*
 import org.toml.lang.psi.TomlHeaderOwner
+import org.toml.lang.psi.TomlKeyValue
 import org.toml.lang.psi.TomlLiteral
 import org.toml.lang.psi.ext.TomlLiteralKind
 import org.toml.lang.psi.ext.kind
@@ -28,6 +31,8 @@ import org.toml.lang.psi.ext.name
 class CargoTomlFileReferenceProvider(private val patternType: PathPatternType) : PsiReferenceProvider() {
     override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<FileReference> {
         val kind = (element as? TomlLiteral)?.kind ?: return emptyArray()
+        if (kind !is TomlLiteralKind.String) return emptyArray()
+
         val (completeDirs, completeRustFiles) = when (patternType) {
             WORKSPACE -> true to false
             GENERAL -> {
@@ -38,12 +43,21 @@ class CargoTomlFileReferenceProvider(private val patternType: PathPatternType) :
             BUILD -> false to true
         }
 
-        if (kind !is TomlLiteralKind.String) return emptyArray()
-        return CargoTomlFileReferenceSet(element, completeDirs, completeRustFiles).allReferences
+        val ignoreGlobs = patternType == WORKSPACE &&
+            element.parentOfType<TomlKeyValue>()?.key?.segments?.firstOrNull()?.name in KEYS_SUPPORTING_GLOB
+
+        val referenceSet: FileReferenceSet = if (ignoreGlobs) {
+            GlobIgnoringFileReferenceSet(element, completeDirs, completeRustFiles)
+        } else {
+            CargoTomlFileReferenceSet(element, completeDirs, completeRustFiles)
+        }
+
+        return referenceSet.allReferences
     }
 
     companion object {
         private val TARGET_TABLE_NAMES = listOf("lib", "bin", "test", "bench", "example")
+        private val KEYS_SUPPORTING_GLOB = listOf("members", "default-members")
     }
 }
 
@@ -53,7 +67,7 @@ enum class PathPatternType(val pattern: PsiElementPattern.Capture<out PsiElement
     BUILD(CargoTomlPsiPattern.buildPath)
 }
 
-private class CargoTomlFileReferenceSet(
+private open class CargoTomlFileReferenceSet(
     element: TomlLiteral,
     private val completeDirs: Boolean,
     private val completeRustFiles: Boolean
@@ -67,4 +81,30 @@ private class CargoTomlFileReferenceSet(
             }
         }
     }
+}
+
+private class GlobIgnoringFileReferenceSet(
+    element: TomlLiteral,
+    completeDirs: Boolean,
+    completeRustFiles: Boolean
+) : CargoTomlFileReferenceSet(element, completeDirs, completeRustFiles) {
+    private var globPatternFound: Boolean = false
+
+    override fun reparse() {
+        globPatternFound = false
+        super.reparse()
+    }
+
+    override fun createFileReference(range: TextRange, index: Int, text: String): FileReference? {
+        if (!globPatternFound && isGlobPathFragment(text)) {
+            globPatternFound = true
+        }
+        if (globPatternFound) return null
+        return super.createFileReference(range, index, text)
+    }
+}
+
+private fun isGlobPathFragment(text: String?): Boolean {
+    if (text == null) return false
+    return text.contains("?") || text.contains("*") || text.contains("[") || text.contains("]")
 }

--- a/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlUnresolvedPathReferenceInspectionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/inspections/CargoTomlUnresolvedPathReferenceInspectionTest.kt
@@ -100,4 +100,80 @@ class CargoTomlUnresolvedPathReferenceInspectionTest : RsInspectionsTestBase(Tom
         [dependencies]
         foo = { path = "foo.rs" }/*caret*/
     """)
+
+    fun `test wildcard inside path`() = checkByFileTree("""
+        //- foo/Cargo.toml
+        [package]
+        name = "foo"
+
+        //- Cargo.toml
+        [dependencies]
+        foo = { path = "foo/<warning descr="Cannot resolve directory '*'">*</warning>/<warning descr="Cannot resolve file 'main.rs'">main.rs</warning>" }/*caret*/
+    """)
+
+    fun `test wildcard inside workspace members path`() = checkByFileTree("""
+        //- foo/bar.rs
+        fn foo() {}
+
+        //- Cargo.toml
+        [workspace]
+        members = [
+            "foo/*/bar.rs"/*caret*/,
+        ]
+    """)
+
+    fun `test multiple wildcards`() = checkByFileTree("""
+        //- foo/bar.rs
+        fn foo() {}
+
+        //- Cargo.toml
+        [workspace]
+        members = [
+            "foo/*/*/bar.rs"/*caret*/,
+        ]
+    """)
+
+    fun `test wildcard inside workspace default members path`() = checkByFileTree("""
+        //- foo/bar.rs
+        fn foo() {}
+
+        //- Cargo.toml
+        [workspace]
+        default-members = [
+            "foo/*/bar.rs"/*caret*/,
+        ]
+    """)
+
+    fun `test question mark wildcard`() = checkByFileTree("""
+        //- foo/bar.rs
+        fn foo() {}
+
+        //- Cargo.toml
+        [workspace]
+        members = [
+            "foo/?/bar.rs"/*caret*/,
+        ]
+    """)
+
+    fun `test brackets wildcard`() = checkByFileTree("""
+        //- foo/bar.rs
+        fn foo() {}
+
+        //- Cargo.toml
+        [workspace]
+        members = [
+            "foo/[a-z]/bar.rs"/*caret*/,
+        ]
+    """)
+
+    fun `test wildcard inside workspace exclude path`() = checkByFileTree("""
+        //- foo/bar.rs
+        fn foo() {}
+
+        //- Cargo.toml
+        [workspace]
+        exclude = [
+            "foo/<warning descr="Cannot resolve directory '*'">*</warning>/<warning descr="Cannot resolve file 'bar.rs'">bar.rs</warning>"/*caret*/,
+        ]
+    """)
 }


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/7402

changelog: Ignore paths with wildcards in TOML to avoid false positives.