### PR TITLE
TOML: add intention to add unresolved crate to dependencies

### DIFF
--- a/intellij-toml/core/src/main/kotlin/org/toml/lang/psi/TomlPsiFactory.kt
+++ b/intellij-toml/core/src/main/kotlin/org/toml/lang/psi/TomlPsiFactory.kt
@@ -8,6 +8,7 @@ package org.toml.lang.psi
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.PsiParserFacade
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.LocalTimeCounter
 
@@ -30,6 +31,11 @@ class TomlPsiFactory(private val project: Project, private val markGenerated: Bo
     // Copied from org.rust.lang.core.psi.ext as it's not available here
     private inline fun <reified T : PsiElement> PsiElement.descendantOfTypeStrict(): T? =
         PsiTreeUtil.findChildOfType(this, T::class.java, /* strict */ true)
+
+    fun createNewline(): PsiElement = createWhitespace("\n")
+
+    fun createWhitespace(ws: String): PsiElement =
+        PsiParserFacade.SERVICE.getInstance(project).createWhiteSpaceFromText(ws)
 
     fun createLiteral(value: String): TomlLiteral =
         // If you're creating a string value, like `serde = "1.0.90"` make sure that the `value` parameter actually

--- a/toml/src/main/kotlin/org/rust/toml/intentions/AddCrateDependencyIntention.kt
+++ b/toml/src/main/kotlin/org/rust/toml/intentions/AddCrateDependencyIntention.kt
@@ -1,0 +1,129 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.intentions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.ide.experiments.RsExperiments
+import org.rust.lang.core.psi.RsExternCrateItem
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.RsUseItem
+import org.rust.lang.core.psi.ext.*
+import org.rust.openapiext.isFeatureEnabled
+import org.rust.openapiext.toPsiFile
+import org.rust.toml.crates.local.CargoRegistryCrate
+import org.rust.toml.crates.local.CratesLocalIndexException
+import org.rust.toml.crates.local.CratesLocalIndexService
+import org.toml.lang.psi.*
+
+class AddCrateDependencyIntention : TomlElementBaseIntentionAction<Context>() {
+    override fun getText(): String = "Add crate to dependencies"
+    override fun getFamilyName(): String = text
+
+    override fun findApplicableContextInternal(project: Project, editor: Editor, element: PsiElement): Context? {
+        if (!isFeatureEnabled(RsExperiments.CRATES_LOCAL_INDEX)) return null
+
+        val externCrateItem = element.parentOfType<RsExternCrateItem>(true)
+        val path = element.parentOfType<RsPath>(true)
+
+        val target: RsElement = when {
+            externCrateItem != null -> {
+                if (externCrateItem.reference.multiResolve().isNotEmpty()) return null
+                externCrateItem
+            }
+            path != null -> {
+                if (path.reference == null) return null
+                if (path.parentOfType<RsUseItem>() == null) return null
+
+                val isPathUnresolved = path.resolveStatus != PathResolveStatus.RESOLVED
+                if (!isPathUnresolved) return null
+
+                val qualifier = path.qualifier
+                if (qualifier != null) return null
+                path
+            }
+            else -> null
+        } ?: return null
+
+        if (target.containingCrate?.origin != PackageOrigin.WORKSPACE) return null
+
+        val (crateName, crate) = getAvailableCrate(target) ?: return null
+        return Context(target, crateName, crate)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val element = ctx.element
+        val pkg = element.containingCargoPackage ?: return
+        val manifest = pkg.contentRoot?.findChild("Cargo.toml") ?: return
+        val tomlManifest = manifest.toPsiFile(project) as? TomlFile ?: return
+
+        val version = ctx.crate.sortedVersions.reversed().firstOrNull { !it.isYanked } ?: return
+
+        val factory = TomlPsiFactory(project)
+        val dependencies = findOrCreateDependencies(tomlManifest, factory)
+
+        val dependency = factory.createKeyValue(ctx.crateName, "\"${version.version}\"")
+
+        val lastChild = dependencies.entries.lastOrNull()
+        val inserted = if (lastChild != null) {
+            dependencies.addAfter(dependency, lastChild)
+        } else {
+            dependencies.add(dependency)
+        }
+        dependencies.addBefore(factory.createNewline(), inserted)
+
+        tomlManifest.navigate(true)
+    }
+}
+
+data class Context(val element: RsElement, val crateName: String, val crate: CargoRegistryCrate)
+
+private fun getAvailableCrate(element: PsiElement): Pair<String, CargoRegistryCrate>? {
+    val crateName = when (element) {
+        is RsPath -> {
+            val path = element.basePath()
+            path.referenceName
+        }
+        is RsExternCrateItem -> element.identifier?.text
+        else -> null
+    } ?: return null
+
+    val crate = try {
+        CratesLocalIndexService.getInstance().getCrate(crateName)
+    } catch (e: CratesLocalIndexException) {
+        null
+    } ?: return null
+    return crateName to crate
+}
+
+private fun findOrCreateDependencies(manifest: TomlFile, factory: TomlPsiFactory): TomlTable {
+    val tables = mutableMapOf<String, MutableList<TomlTable>>()
+    val visitor = object : TomlVisitor() {
+        override fun visitTable(element: TomlTable) {
+            val key = element.header.key?.segments?.getOrNull(0)?.name ?: return
+            tables.getOrPut(key) { mutableListOf() }.add(element)
+        }
+    }
+    manifest.acceptChildren(visitor)
+
+    val dependencyTable = tables["dependencies"]?.getOrNull(0)
+    if (dependencyTable != null) return dependencyTable
+
+    val anchor = tables["package"]?.getOrNull(0)
+    val newTable = factory.createTable("dependencies")
+
+    return if (anchor != null) {
+        val table = manifest.addAfter(newTable, anchor)
+        val whitespace = factory.createWhitespace("\n\n")
+        manifest.addBefore(whitespace, table)
+        table
+    } else {
+        manifest.add(newTable)
+    } as TomlTable
+}

--- a/toml/src/main/resources/META-INF/toml-only.xml
+++ b/toml/src/main/resources/META-INF/toml-only.xml
@@ -55,6 +55,11 @@
             <category>Rust/Cargo.toml</category>
         </intentionAction>
 
+        <intentionAction>
+            <className>org.rust.toml.intentions.AddCrateDependencyIntention</className>
+            <category>Rust</category>
+        </intentionAction>
+
         <applicationService serviceInterface="org.rust.toml.crates.local.CratesLocalIndexService"
                             serviceImplementation="org.rust.toml.crates.local.CratesLocalIndexServiceImpl"
                             testServiceImplementation="org.rust.toml.crates.local.TestCratesLocalIndexServiceImpl"/>

--- a/toml/src/main/resources/intentionDescriptions/AddCrateDependencyIntention/after.rs.template
+++ b/toml/src/main/resources/intentionDescriptions/AddCrateDependencyIntention/after.rs.template
@@ -1,0 +1,6 @@
+// src/lib.rs
+use foo;
+
+// Cargo.toml
+[dependencies]
+foo = "1.0.0"

--- a/toml/src/main/resources/intentionDescriptions/AddCrateDependencyIntention/before.rs.template
+++ b/toml/src/main/resources/intentionDescriptions/AddCrateDependencyIntention/before.rs.template
@@ -1,0 +1,5 @@
+// src/lib.rs
+use foo;
+
+// Cargo.toml
+[dependencies]

--- a/toml/src/main/resources/intentionDescriptions/AddCrateDependencyIntention/description.html
+++ b/toml/src/main/resources/intentionDescriptions/AddCrateDependencyIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Add a crate dependency to Cargo.toml from an unresolved import or extern crate item.
+</body>
+</html>

--- a/toml/src/test/kotlin/org/rust/toml/intentions/AddCrateDependencyIntentionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/intentions/AddCrateDependencyIntentionTest.kt
@@ -1,0 +1,302 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.toml.intentions
+
+import com.intellij.codeInsight.intention.IntentionActionDelegate
+import org.intellij.lang.annotations.Language
+import org.rust.FileTree
+import org.rust.cargo.RsWithToolchainTestBase
+import org.rust.fileTree
+import org.rust.ide.experiments.RsExperiments
+import org.rust.openapiext.runWithEnabledFeatures
+import org.rust.toml.crates.local.CargoRegistryCrate
+import org.rust.toml.crates.local.CargoRegistryCrateVersion
+import org.rust.toml.crates.local.withMockedCrates
+
+class AddCrateDependencyIntentionTest : RsWithToolchainTestBase() {
+    fun `test unavailable if crate is not found`() = doUnavailableTest(fileTree {
+        toml("Cargo.toml", """
+            [package]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+        """)
+
+        dir("src") {
+            rust("lib.rs", """
+                use foo/*caret*/;
+            """)
+        }
+    })
+
+    fun `test unavailable if import is resolved`() = doUnavailableTest(fileTree {
+        toml(
+            "Cargo.toml", """
+            [package]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+        """
+        )
+
+        dir("src") {
+            rust(
+                "lib.rs", """
+                mod foo;
+
+                use foo/*caret*/::S;
+            """
+            )
+            rust("foo.rs", """pub struct S;""")
+        }
+    }, "foo" to CargoRegistryCrate.of("1"))
+
+    fun `test add crate from use item`() = doAvailableTest(fileTree {
+        toml("Cargo.toml", """
+            [package]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+        """)
+
+        dir("src") {
+            rust("lib.rs", """
+                use foo/*caret*/;
+            """)
+        }
+    }, """
+        [package]
+        name = "bar"
+        version = "0.1.0"
+        authors = []
+        edition = "2018"
+
+        [dependencies]
+        foo = "1"
+    """, "foo" to CargoRegistryCrate.of("1"))
+
+    fun `test add crate from extern crate item`() = doAvailableTest(fileTree {
+        toml("Cargo.toml", """
+            [package]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+
+            [dependencies]
+        """)
+
+        dir("src") {
+            rust("lib.rs", """
+                extern crate foo/*caret*/;
+            """)
+        }
+    }, """
+        [package]
+        name = "bar"
+        version = "0.1.0"
+        authors = []
+
+        [dependencies]
+        foo = "1"
+    """, "foo" to CargoRegistryCrate.of("1"))
+
+    fun `test add last version`() = doAvailableTest(fileTree {
+        toml("Cargo.toml", """
+            [package]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+        """)
+
+        dir("src") {
+            rust("lib.rs", """
+                use foo/*caret*/;
+            """)
+        }
+    }, """
+        [package]
+        name = "bar"
+        version = "0.1.0"
+        authors = []
+        edition = "2018"
+
+        [dependencies]
+        foo = "3"
+    """, "foo" to CargoRegistryCrate.of("1", "2", "3"))
+
+    fun `test ignore yanked versions`() = doAvailableTest(fileTree {
+        toml("Cargo.toml", """
+            [package]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+        """)
+
+        dir("src") {
+            rust("lib.rs", """
+                use foo/*caret*/;
+            """)
+        }
+    }, """
+        [package]
+        name = "bar"
+        version = "0.1.0"
+        authors = []
+        edition = "2018"
+
+        [dependencies]
+        foo = "1"
+    """, "foo" to CargoRegistryCrate(listOf(
+        CargoRegistryCrateVersion("1", false, listOf()),
+        CargoRegistryCrateVersion("1.1", true, listOf()),
+        CargoRegistryCrateVersion("1.2", true, listOf())
+    )))
+
+    fun `test create dependencies if missing`() = doAvailableTest(fileTree {
+        toml("Cargo.toml", """
+            [package]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+        """)
+
+        dir("src") {
+            rust("lib.rs", """
+                use foo/*caret*/;
+            """)
+        }
+    }, """
+        [package]
+        name = "bar"
+        version = "0.1.0"
+        authors = []
+        edition = "2018"
+
+        [dependencies]
+        foo = "1"
+    """, "foo" to CargoRegistryCrate.of("1"))
+
+    fun `test append to existing dependencies`() = doAvailableTest(fileTree {
+        toml("Cargo.toml", """
+            [package]
+            name = "bar"
+            version = "0.1.0"
+            authors = []
+            edition = "2018"
+
+            [dependencies]
+            log = ""
+        """)
+
+        dir("src") {
+            rust("lib.rs", """
+                use foo/*caret*/;
+            """)
+        }
+    }, """
+        [package]
+        name = "bar"
+        version = "0.1.0"
+        authors = []
+        edition = "2018"
+
+        [dependencies]
+        log = ""
+        foo = "1"
+    """, "foo" to CargoRegistryCrate.of("1"))
+
+    fun `test workspace`() = doAvailableTest("bar", fileTree {
+        toml("Cargo.toml", """
+            [workspace]
+            members = ["bar"]
+        """)
+        dir("bar") {
+            toml("Cargo.toml", """
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+                edition = "2018"
+
+                [dependencies]
+            """)
+
+            dir("src") {
+                rust("lib.rs", """
+                    use foo/*caret*/;
+                """)
+            }
+        }
+    }, """
+        [package]
+        name = "bar"
+        version = "0.1.0"
+        authors = []
+        edition = "2018"
+
+        [dependencies]
+        foo = "1"
+    """, "foo" to CargoRegistryCrate.of("1"))
+
+    private fun doUnavailableTest(
+        fileTree: FileTree,
+        vararg crates: Pair<String, CargoRegistryCrate>
+    ) {
+        doTest(crates.toList()) {
+            val project = fileTree.create()
+            myFixture.configureFromExistingVirtualFile(project.file("src/lib.rs"))
+            val intention = myFixture.availableIntentions.firstOrNull {
+                val originalIntention = IntentionActionDelegate.unwrap(it)
+                AddCrateDependencyIntention::class == originalIntention::class
+            }
+            assertNull(intention)
+        }
+    }
+
+    private fun doAvailableTest(
+        directory: String,
+        fileTree: FileTree,
+        @Language("TOML") after: String,
+        vararg crates: Pair<String, CargoRegistryCrate>
+    ) {
+        doTest(crates.toList()) {
+            val project = fileTree.create()
+            myFixture.configureFromExistingVirtualFile(project.file("${directory}/src/lib.rs"))
+            val intention = myFixture.availableIntentions.firstOrNull {
+                val originalIntention = IntentionActionDelegate.unwrap(it)
+                AddCrateDependencyIntention::class == originalIntention::class
+            }!!
+            myFixture.launchAction(intention)
+            myFixture.openFileInEditor(project.file("${directory}/Cargo.toml"))
+            myFixture.checkResult(after.trimIndent())
+        }
+    }
+
+    private fun doAvailableTest(
+        fileTree: FileTree,
+        @Language("TOML") after: String,
+        vararg crates: Pair<String, CargoRegistryCrate>
+    ) = doAvailableTest(".", fileTree, after, *crates)
+
+    private fun doTest(crates: List<Pair<String, CargoRegistryCrate>>, action: () -> Unit) {
+        runWithEnabledFeatures(RsExperiments.CRATES_LOCAL_INDEX) {
+            withMockedCrates(crates.toMap()) {
+                action()
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an intention that let's you quickly add a dependency to Cargo.toml from an unresolved `use` import or `extern crate` item. Since we still do not highlight unresolved imports by default (https://github.com/intellij-rust/intellij-rust/issues/3837), it is modeled as an intention (same as e.g. `CreateFunctionIntention`).

![add-crate-to-dependencies](https://user-images.githubusercontent.com/4539057/123395188-34aa6d00-d5a0-11eb-9f70-2a1513598fbf.gif)

Related issues: https://github.com/intellij-rust/intellij-rust/issues/3837, https://github.com/intellij-rust/intellij-rust/issues/4092

changelog:
