### PR TITLE
INSP: add lint inspection that annotates unnecessarily qualified paths

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RemovePathPrefixFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RemovePathPrefixFix.kt
@@ -1,0 +1,37 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiFile
+import com.intellij.psi.SmartPointerManager
+import org.rust.openapiext.document
+
+/**
+ * Fix that removes a prefix of a certain path.
+ *
+ * E.g. `foo::bar::baz` -> `baz`.
+ */
+class RemovePathPrefixFix(
+    file: PsiFile,
+    range: TextRange,
+) : LocalQuickFix {
+    private val fileWithRange = SmartPointerManager.getInstance(file.project)
+        .createSmartPsiFileRangePointer(file, range)
+
+    override fun getName(): String = "Remove unnecessary path prefix"
+    override fun getFamilyName(): String = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val file = fileWithRange.containingFile ?: return
+        val range = fileWithRange.range ?: return
+        val document = file.document
+        document?.deleteString(range.startOffset, range.endOffset)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsLint.kt
@@ -73,7 +73,15 @@ enum class RsLint(
             }
     },
 
-    UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY);
+    UnknownCrateTypes("unknown_crate_types", defaultLevel = DENY),
+
+    UnusedQualifications("unused_qualifications", listOf("unused")) {
+        override fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
+            when (level) {
+                WARN -> ProblemHighlightType.LIKE_UNUSED_SYMBOL
+                else -> super.toHighlightingType(level)
+            }
+    };
 
     protected open fun toHighlightingType(level: RsLintLevel): ProblemHighlightType =
         when (level) {

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnnecessaryQualificationsInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnnecessaryQualificationsInspection.kt
@@ -1,0 +1,85 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.fixes.RemovePathPrefixFix
+import org.rust.lang.core.parser.RustParserUtil
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.RsPathCodeFragment
+import org.rust.lang.core.psi.RsUseItem
+import org.rust.lang.core.psi.RsVisitor
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve.TYPES_N_VALUES_N_MACROS
+
+class RsUnnecessaryQualificationsInspection : RsLintInspection() {
+    override fun getLint(element: PsiElement): RsLint = RsLint.UnusedQualifications
+
+    override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean): RsVisitor = object : RsVisitor() {
+        override fun visitPath(path: RsPath) {
+            val root = path.rootPath()
+            val useItem = path.parentOfType<RsUseItem>()
+
+            if (useItem == null && root == path && root.canBeShortened()) {
+                val target = getUnnecessarilyQualifiedPath(path)
+                if (target != null) {
+                    val unnecessaryPart = target.fullQualifier()
+                    val range = TextRange(0, unnecessaryPart.length)
+
+                    val fix = RemovePathPrefixFix(path.containingFile,
+                        TextRange(root.startOffset, root.startOffset + unnecessaryPart.length)
+                    )
+                    holder.registerLintProblem(root, "Unnecessary qualification", range, fix)
+                }
+            }
+            super.visitPath(path)
+        }
+    }
+
+    private fun getUnnecessarilyQualifiedPath(path: RsPath): RsPath? {
+        if (path.resolveStatus == PathResolveStatus.UNRESOLVED) return null
+
+        val target = path.reference?.resolve() ?: return null
+
+        var pathText = path.referenceName ?: return null
+        var currentPath = path
+        val basePath = path.basePath()
+
+        while (true) {
+            val fragment = RsPathCodeFragment(
+                path.project, pathText, false, path, RustParserUtil.PathParsingMode.TYPE,
+                TYPES_N_VALUES_N_MACROS
+            )
+            if (fragment.path?.reference?.resolve() == target) {
+                return currentPath
+            }
+            currentPath = path.qualifier ?: break
+            if (currentPath == basePath) {
+                break
+            }
+            val currentName = currentPath.referenceName ?: break
+            pathText = "$currentName::$pathText"
+        }
+
+        return null
+    }
+}
+
+private fun RsPath.canBeShortened(): Boolean {
+    return path != null || coloncolon != null
+}
+
+/**
+ * Returns the full qualifier of a path.
+ * `foo::bar::baz` -> `foo::bar::`
+ */
+private fun RsPath.fullQualifier(): String {
+    val qualPath = qualifier ?: return coloncolon?.text ?: ""
+    return "${qualPath.fullQualifier()}${qualPath.referenceName}::"
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -608,6 +608,11 @@
                          enabledByDefault="true" level="ERROR"
                          implementationClass="org.rust.ide.inspections.lints.RsUnknownCrateTypesInspection"/>
 
+        <localInspection language="Rust" groupPath="Rust" groupName="Lints"
+                         displayName="Unnecessarily qualified path"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.rust.ide.inspections.lints.RsUnnecessaryQualificationsInspection"/>
+
         <!-- Surrounders -->
 
         <lang.surroundDescriptor language="Rust"

--- a/src/main/resources/inspectionDescriptions/RsUnnecessaryQualifications.html
+++ b/src/main/resources/inspectionDescriptions/RsUnnecessaryQualifications.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Detects unnecessarily qualificated paths.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnnecessaryQualificationsInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnnecessaryQualificationsInspectionTest.kt
@@ -1,0 +1,220 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.lints
+
+import org.rust.ide.inspections.RsInspectionsTestBase
+
+class RsUnnecessaryQualificationsInspectionTest : RsInspectionsTestBase(RsUnnecessaryQualificationsInspection::class) {
+    fun `test unavailable for single segment path`() = checkWarnings("""
+        struct S;
+
+        fn foo() {
+            let _: S;
+        }
+    """)
+
+    fun `test simple segment`() = checkFixByText("Remove unnecessary path prefix", """
+        mod bar {
+            pub struct S;
+        }
+
+        use bar::S;
+
+        fn foo() {
+            let _: <warning descr="Unnecessary qualification">bar::/*caret*/</warning>S;
+        }
+    """, """
+        mod bar {
+            pub struct S;
+        }
+
+        use bar::S;
+
+        fn foo() {
+            let _: S;
+        }
+    """)
+
+    fun `test multiple segments whole path`() = checkFixByText("Remove unnecessary path prefix", """
+        mod bar {
+            pub mod baz {
+                pub struct S;
+            }
+        }
+
+        use bar::baz::S;
+
+        fn foo() {
+            let _: <warning descr="Unnecessary qualification">bar::baz::/*caret*/</warning>S;
+        }
+    """, """
+        mod bar {
+            pub mod baz {
+                pub struct S;
+            }
+        }
+
+        use bar::baz::S;
+
+        fn foo() {
+            let _: S;
+        }
+    """)
+
+    fun `test multiple segments partial path`() = checkFixByText("Remove unnecessary path prefix", """
+        mod bar {
+            pub mod baz {
+                pub struct S;
+            }
+        }
+
+        use bar::baz;
+
+        fn foo() {
+            let _: <warning descr="Unnecessary qualification">bar::/*caret*/</warning>baz::S;
+        }
+    """, """
+        mod bar {
+            pub mod baz {
+                pub struct S;
+            }
+        }
+
+        use bar::baz;
+
+        fn foo() {
+            let _: baz::S;
+        }
+    """)
+
+    fun `test associated method`() = checkFixByText("Remove unnecessary path prefix", """
+        mod bar {
+            pub struct S;
+            impl S {
+                fn new() -> S { S }
+            }
+        }
+
+        use bar::S;
+
+        fn foo() {
+            let _ = <warning descr="Unnecessary qualification">bar::/*caret*/</warning>S::new();
+        }
+    """, """
+        mod bar {
+            pub struct S;
+            impl S {
+                fn new() -> S { S }
+            }
+        }
+
+        use bar::S;
+
+        fn foo() {
+            let _ = S::new();
+        }
+    """)
+
+    fun `test expression context with generics`() = checkFixByText("Remove unnecessary path prefix", """
+        mod bar {
+            pub struct S<T>(T);
+            impl <T> S<T> {
+                fn new(t: T) -> S<T> { S(t) }
+            }
+        }
+
+        use bar::S;
+
+        fn foo() {
+            let _ = <warning descr="Unnecessary qualification">bar::/*caret*/</warning>S::<u32>::new(0);
+        }
+    """, """
+        mod bar {
+            pub struct S<T>(T);
+            impl <T> S<T> {
+                fn new(t: T) -> S<T> { S(t) }
+            }
+        }
+
+        use bar::S;
+
+        fn foo() {
+            let _ = S::<u32>::new(0);
+        }
+    """)
+
+    fun `test crate prefix`() = checkFixByText("Remove unnecessary path prefix", """
+        mod bar {
+            pub struct S;
+        }
+
+        use bar::S;
+
+        fn foo() {
+            let _: <warning descr="Unnecessary qualification">crate::/*caret*/</warning>S;
+        }
+    """, """
+        mod bar {
+            pub struct S;
+        }
+
+        use bar::S;
+
+        fn foo() {
+            let _: S;
+        }
+    """)
+
+    fun `test bare colon colon`() = checkFixByText("Remove unnecessary path prefix", """
+        mod bar {
+            pub struct S;
+        }
+
+        use bar::S;
+
+        fn foo() {
+            let _: <warning descr="Unnecessary qualification">::/*caret*/</warning>S;
+        }
+    """, """
+        mod bar {
+            pub struct S;
+        }
+
+        use bar::S;
+
+        fn foo() {
+            let _: S;
+        }
+    """)
+
+    fun `test allow`() = checkWarnings("""
+        #![allow(unused_qualifications)]
+
+        mod bar {
+            pub struct S;
+        }
+
+        use bar::S;
+
+        fn foo() {
+            let _: bar::S;
+        }
+    """)
+
+    fun `test deny`() = checkWarnings("""
+        #![deny(unused_qualifications)]
+
+        mod bar {
+            pub struct S;
+        }
+
+        use bar::S;
+
+        fn foo() {
+            let _: <error descr="Unnecessary qualification">bar::/*caret*/</error>S;
+        }
+    """)
+}


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/5608

Related issue: https://github.com/intellij-rust/intellij-rust/issues/5888

changelog: Add inspection that finds unnecessarily qualified paths. It corresponds to the `unused_qualifications` lint.