### PR TITLE
REF: add support for type aliases in getter/setter generation

### DIFF
--- a/src/main/kotlin/org/rust/ide/refactoring/generate/setter/GenerateSetterHandler.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/generate/setter/GenerateSetterHandler.kt
@@ -12,10 +12,7 @@ import org.rust.ide.refactoring.generate.BaseGenerateAction
 import org.rust.ide.refactoring.generate.BaseGenerateHandler
 import org.rust.ide.refactoring.generate.GenerateAccessorHandler
 import org.rust.ide.refactoring.generate.StructMember
-import org.rust.lang.core.psi.RsFunction
-import org.rust.lang.core.psi.RsImplItem
-import org.rust.lang.core.psi.RsPsiFactory
-import org.rust.lang.core.psi.RsStructItem
+import org.rust.lang.core.psi.*
 import org.rust.lang.core.types.Substitution
 import org.rust.lang.core.types.infer.substitute
 import org.rust.lang.core.types.ty.TyUnit
@@ -42,10 +39,10 @@ class GenerateSetterHandler : GenerateAccessorHandler() {
         val psiFactory = RsPsiFactory(project)
         val impl = getOrCreateImplBlock(implBlock, psiFactory, structName, struct)
 
-        return chosenFields.map {
+        return chosenFields.mapNotNull {
             val fieldName = it.argumentIdentifier
-            val fieldType = it.field.typeReference?.type?.substitute(substitution) ?: TyUnit
-            val typeStr = fieldType.renderInsertionSafe(useAliasNames = true, includeLifetimeArguments = true)
+            val typeRef = it.field.typeReference ?: return@mapNotNull null
+            val typeStr = typeRef.substAndGetText(substitution)
 
             val fnSignature = "pub fn ${methodName(it)}(&mut self, $fieldName: $typeStr)"
             val fnBody = "self.$fieldName = $fieldName;"

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateGetterActionTest.kt
@@ -388,7 +388,7 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
         }
     """)
 
-    fun `test type alias`() = doTest("""
+    fun `test type alias 1`() = doTest("""
         struct T;
         type Alias = T;
         struct S {
@@ -399,6 +399,26 @@ class GenerateGetterActionTest : RsGenerateBaseTest() {
     """, listOf(MemberSelection("a: Alias")), """
         struct T;
         type Alias = T;
+        struct S {
+            a: Alias
+        }
+
+        impl S {
+            pub fn a(&self) -> &Alias {
+                &self.a
+            }
+        }
+    """)
+
+    fun `test type alias 2`() = doTest("""
+        type Alias = (u32, u32);
+        struct S {
+            a: Alias
+        }
+
+        impl S/*caret*/ {}
+    """, listOf(MemberSelection("a: Alias")), """
+        type Alias = (u32, u32);
         struct S {
             a: Alias
         }

--- a/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateSetterActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/generate/GenerateSetterActionTest.kt
@@ -203,7 +203,7 @@ class GenerateSetterActionTest : RsGenerateBaseTest() {
         }
     """)
 
-    fun `test type alias`() = doTest("""
+    fun `test type alias 1`() = doTest("""
         struct T;
         type Alias = T;
         struct S {
@@ -214,6 +214,26 @@ class GenerateSetterActionTest : RsGenerateBaseTest() {
     """, listOf(MemberSelection("a: Alias")), """
         struct T;
         type Alias = T;
+        struct S {
+            a: Alias
+        }
+
+        impl S {
+            pub fn set_a(&mut self, a: Alias) {
+                self.a = a;
+            }
+        }
+    """)
+
+    fun `test type alias 2`() = doTest("""
+        type Alias = (u32, u32);
+        struct S {
+            a: Alias
+        }
+
+        impl S/*caret*/ {}
+    """, listOf(MemberSelection("a: Alias")), """
+        type Alias = (u32, u32);
         struct S {
             a: Alias
         }


### PR DESCRIPTION
changelog: Do not expand type aliases when generating getters and setters.