### PR TITLE
CI: fix `create changelog` workflow

### DIFF
--- a/scripts/github.py
+++ b/scripts/github.py
@@ -51,7 +51,7 @@ def create_pull_request(repo: str, token: str, branch: str, title: str, draft: b
     return json.load(response)
 
 
-def add_assignee(repo: str, token: str, id: int, assignee: str):
+def add_assignee(repo: str, token: str, id: int, assignee: str) -> None:
     headers = {"Authorization": f"token {token}",
                "Accept": "application/vnd.github.v3+json"}
     params = {"assignees": [assignee]}

--- a/scripts/github.py
+++ b/scripts/github.py
@@ -25,7 +25,7 @@ def set_milestone(token: str, repo: str, issue_number: int, milestone_number: in
     urlopen(request)
 
 
-def get_latest_milestones(repo: str, state: str = "open") -> List[Dict]:
+def get_latest_milestones(repo: str, state: str = "all") -> List[Dict]:
     response = urlopen(f"https://api.github.com/repos/{repo}/milestones?state={state}&sort=due_on&direction=desc")
     return json.load(response)
 

--- a/scripts/make_changelog_pull_request.py
+++ b/scripts/make_changelog_pull_request.py
@@ -1,8 +1,7 @@
+import argparse
 import re
 from datetime import datetime, date, timedelta
 from typing import Dict
-
-import argparse
 
 from common import env, get_patch_version, execute_command
 from git import git_command
@@ -13,7 +12,7 @@ def changelog_branch_name(patch_version: int) -> str:
     return f"release-{patch_version}"
 
 
-def add_changelog_template(token: str, patch_version: int, cwd: str):
+def add_changelog_template(token: str, patch_version: int, cwd: str) -> None:
     branch_name = changelog_branch_name(patch_version)
     git_command("checkout", "-b", branch_name, cwd=cwd)
     execute_command("python", "changelog.py", "--token", token, cwd=cwd)
@@ -22,7 +21,7 @@ def add_changelog_template(token: str, patch_version: int, cwd: str):
     git_command("push", "origin", branch_name, cwd=cwd)
 
 
-def create_changelog_pull_request(changelog_repo: str, token: str, patch_version: int, milestone: Dict):
+def create_changelog_pull_request(changelog_repo: str, token: str, patch_version: int, milestone: Dict) -> None:
     description = milestone["description"]
     result = re.search("Release manager: @(\\w+)", description)
     if result is None:
@@ -33,7 +32,7 @@ def create_changelog_pull_request(changelog_repo: str, token: str, patch_version
     add_assignee(changelog_repo, token, pr["number"], release_manager)
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--token", type=str, required=True)
     parser.add_argument("--repo_owner", type=str, required=True)

--- a/scripts/make_next_milestone.py
+++ b/scripts/make_next_milestone.py
@@ -15,7 +15,7 @@ def main():
     args = parser.parse_args()
 
     repo = env("GITHUB_REPOSITORY")
-    milestones = get_latest_milestones(repo, state="all")
+    milestones = get_latest_milestones(repo)
     milestones.sort(key=lambda milestone: milestone["title"], reverse=True)
 
     patch_version = get_patch_version()


### PR DESCRIPTION
Previously, it failed if previous milestone was closed (i.e. workflow was invoked after release but before new release branch creation)

Also, applied some suggestions from https://github.com/intellij-rust/intellij-rust/pull/7377#issuecomment-868684096