### PR TITLE
Enable by default crates local index for nightly users

### DIFF
--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -21,7 +21,7 @@
         <experimentalFeature id="org.rust.resolve.new.engine" percentOfUsers="100">
             <description>Enables experimental resolve engine</description>
         </experimentalFeature>
-        <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="0">
+        <experimentalFeature id="org.rust.crates.local.index" percentOfUsers="100">
             <description>Enables crates local index</description>
         </experimentalFeature>
     </extensions>

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -145,6 +145,10 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
         for (feature in findAnnotationInstance<WithExperimentalFeatures>()?.features.orEmpty()) {
             setExperimentalFeatureEnabled(feature, true, testRootDisposable)
         }
+
+        for (feature in findAnnotationInstance<WithoutExperimentalFeatures>()?.features.orEmpty()) {
+            setExperimentalFeatureEnabled(feature, false, testRootDisposable)
+        }
     }
 
     private fun parse(version: String): Pair<SemVer, RustChannel> {

--- a/src/test/kotlin/org/rust/WithoutExperimentalFeatures.kt
+++ b/src/test/kotlin/org/rust/WithoutExperimentalFeatures.kt
@@ -1,0 +1,18 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust
+
+import java.lang.annotation.Inherited
+
+/**
+ * @see org.rust.ide.experiments.RsExperiments
+ * @see org.rust.openapiext.runWithEnabledFeatures
+ * @see org.rust.WithExperimentalFeatures
+ */
+@Inherited
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class WithoutExperimentalFeatures(vararg val features: String)

--- a/toml/src/test/kotlin/org/rust/toml/completion/CargoTomlDependenciesCompletionTest.kt
+++ b/toml/src/test/kotlin/org/rust/toml/completion/CargoTomlDependenciesCompletionTest.kt
@@ -6,7 +6,10 @@
 package org.rust.toml.completion
 
 import org.intellij.lang.annotations.Language
+import org.rust.WithoutExperimentalFeatures
+import org.rust.ide.experiments.RsExperiments
 
+@WithoutExperimentalFeatures(RsExperiments.CRATES_LOCAL_INDEX)
 class CargoTomlDependenciesCompletionTest : CargoTomlCompletionTestBase() {
     fun `test empty key`() = doTest("""
         [dependencies]


### PR DESCRIPTION
changelog: Crates local index feature is now enabled on nightly by default