### PR TITLE
Confirm loading untrusted Cargo project

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -205,10 +205,10 @@ jobs:
               # see https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
               # BACKCOMPAT: 1.45.0. Don't redefine `compileNativeCode` property
               run: |
-                  echo "ORG_GRADLE_PROJECT_ideaVersion=IU-2021.1" >> $GITHUB_ENV
-                  echo "ORG_GRADLE_PROJECT_clionVersion=CL-2021.1" >> $GITHUB_ENV
-                  echo "ORG_GRADLE_PROJECT_nativeDebugPluginVersion=211.6693.65" >> $GITHUB_ENV
-                  echo "ORG_GRADLE_PROJECT_graziePluginVersion=211.6693.118" >> $GITHUB_ENV
+                  echo "ORG_GRADLE_PROJECT_ideaVersion=IU-2021.1.1" >> $GITHUB_ENV
+                  echo "ORG_GRADLE_PROJECT_clionVersion=CL-2021.1.1" >> $GITHUB_ENV
+                  echo "ORG_GRADLE_PROJECT_nativeDebugPluginVersion=211.7142.13" >> $GITHUB_ENV
+                  echo "ORG_GRADLE_PROJECT_graziePluginVersion=211.7142.14" >> $GITHUB_ENV
 
             - name: Set up env variable for old resolve
               if: matrix.resolve-engine == 'resolve-old'

--- a/gradle-211.properties
+++ b/gradle-211.properties
@@ -12,5 +12,5 @@ graziePluginVersion=211.7442.4
 psiViewerPluginVersion=211-SNAPSHOT
 
 # please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description
-sinceBuild=211.6693
+sinceBuild=211.7142
 untilBuild=211.*

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -7,6 +7,7 @@ package org.rust.cargo.project.model.impl
 
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.execution.RunManager
+import com.intellij.ide.impl.isTrusted
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.invokeAndWaitIfNeeded
@@ -543,6 +544,8 @@ private fun isExistingProject(projects: Collection<CargoProject>, manifest: Path
 }
 
 private fun doRefresh(project: Project, projects: List<CargoProjectImpl>): CompletableFuture<List<CargoProjectImpl>> {
+    @Suppress("UnstableApiUsage")
+    if (!project.isTrusted()) return CompletableFuture.completedFuture(projects)
     // TODO: get rid of `result` here
     val result = if (projects.isEmpty()) {
         CompletableFuture.completedFuture(emptyList())

--- a/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectsAction.kt
+++ b/src/main/kotlin/org/rust/ide/actions/RefreshCargoProjectsAction.kt
@@ -11,6 +11,7 @@ import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.project.model.guessAndSetupRustProject
 import org.rust.cargo.project.settings.toolchain
 import org.rust.cargo.runconfig.hasCargoProject
+import org.rust.ide.notifications.confirmLoadingUntrustedProject
 import org.rust.openapiext.saveAllDocuments
 
 class RefreshCargoProjectsAction : CargoProjectActionBase() {
@@ -22,6 +23,9 @@ class RefreshCargoProjectsAction : CargoProjectActionBase() {
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
+
+        if (!project.confirmLoadingUntrustedProject()) return
+
         saveAllDocuments()
         if (project.toolchain == null || !project.hasCargoProject) {
             guessAndSetupRustProject(project, explicitRequest = true)

--- a/src/main/kotlin/org/rust/ide/inspections/RsDetachedFileInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/RsDetachedFileInspection.kt
@@ -29,7 +29,8 @@ class RsDetachedFileInspection : RsLocalInspectionTool() {
         if (!cargoProjects.initialized) return null
 
         // Handled by [NoCargoProjectNotificationProvider]
-        if (cargoProjects.findProjectForFile(file.virtualFile) == null) return null
+        val cargoProject = cargoProjects.findProjectForFile(file.virtualFile) ?: return null
+        if (cargoProject.workspace == null) return null
 
         if (rsFile.crateRoot == null) {
             val availableModules = AttachFileToModuleFix.findAvailableModulesForFile(project, rsFile)

--- a/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/MissingToolchainNotificationProvider.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.notifications
 
+import com.intellij.ide.impl.isTrusted
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.fileChooser.FileChooser
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
@@ -61,6 +62,8 @@ class MissingToolchainNotificationProvider(project: Project) : RsNotificationPro
     ): RsEditorNotificationPanel? {
         if (isUnitTestMode) return null
         if (!(file.isRustFile || file.isCargoToml) || isNotificationDisabled(file)) return null
+        @Suppress("UnstableApiUsage")
+        if (!project.isTrusted()) return null
         if (guessAndSetupRustProject(project)) return null
 
         val toolchain = project.toolchain

--- a/src/main/kotlin/org/rust/ide/notifications/NoCargoProjectNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/NoCargoProjectNotificationProvider.kt
@@ -5,6 +5,7 @@
 
 package org.rust.ide.notifications
 
+import com.intellij.ide.impl.isTrusted
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
@@ -41,6 +42,8 @@ class NoCargoProjectNotificationProvider(project: Project) : RsNotificationProvi
     ): RsEditorNotificationPanel? {
         if (isUnitTestMode && !isDispatchThread) return null
         if (!(file.isRustFile || file.isCargoToml) || isNotificationDisabled(file)) return null
+        @Suppress("UnstableApiUsage")
+        if (!project.isTrusted()) return null
 
         val cargoProjects = project.cargoProjects
         if (!cargoProjects.initialized) return null

--- a/src/main/kotlin/org/rust/ide/notifications/RsUntrustedNotificationProvider.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/RsUntrustedNotificationProvider.kt
@@ -1,0 +1,42 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.notifications
+
+import com.intellij.ide.impl.UntrustedProjectEditorNotificationPanel
+import com.intellij.ide.impl.isTrusted
+import com.intellij.ide.impl.setTrusted
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.EditorNotificationPanel
+import com.intellij.ui.EditorNotifications
+import org.rust.cargo.project.model.cargoProjects
+import org.rust.cargo.project.model.isCargoToml
+import org.rust.lang.core.psi.isRustFile
+
+class RsUntrustedNotificationProvider : EditorNotifications.Provider<EditorNotificationPanel>(), DumbAware {
+
+    override fun getKey(): Key<EditorNotificationPanel> = PROVIDER_KEY
+
+    @Suppress("UnstableApiUsage")
+    override fun createNotificationPanel(file: VirtualFile, fileEditor: FileEditor, project: Project): EditorNotificationPanel? {
+        if (project.isTrusted()) return null
+        if (!(file.isRustFile || file.isCargoToml)) return null
+
+        val cargoProjects = project.cargoProjects
+        if (!cargoProjects.initialized) return null
+
+        return UntrustedProjectEditorNotificationPanel(project, fileEditor) {
+            project.setTrusted(true)
+        }
+    }
+
+    companion object {
+        private val PROVIDER_KEY: Key<EditorNotificationPanel> = Key.create("Untrusted Rust project")
+    }
+}

--- a/src/main/kotlin/org/rust/ide/notifications/Utils.kt
+++ b/src/main/kotlin/org/rust/ide/notifications/Utils.kt
@@ -5,12 +5,16 @@
 
 package org.rust.ide.notifications
 
+import com.intellij.ide.IdeBundle
+import com.intellij.ide.impl.confirmLoadingUntrustedProject
+import com.intellij.ide.impl.isTrusted
 import com.intellij.notification.NotificationListener
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.WindowManager
+import org.rust.RsBundle
 
 fun Project.showBalloon(content: String, type: NotificationType, action: AnAction? = null) {
     showBalloon("", content, type, action)
@@ -38,4 +42,15 @@ fun showBalloonWithoutProject(content: String, type: NotificationType) {
 fun Project.setStatusBarText(text: String) {
     val statusBar = WindowManager.getInstance().getStatusBar(this)
     statusBar?.info = text
+}
+
+@Suppress("UnstableApiUsage")
+fun Project.confirmLoadingUntrustedProject(): Boolean {
+    return isTrusted() || confirmLoadingUntrustedProject(
+        this,
+        title = IdeBundle.message("untrusted.project.dialog.title", RsBundle.message("cargo"), 1),
+        message = IdeBundle.message("untrusted.project.dialog.text", RsBundle.message("cargo"), 1),
+        trustButtonText = IdeBundle.message("untrusted.project.dialog.trust.button"),
+        distrustButtonText = IdeBundle.message("untrusted.project.dialog.distrust.button")
+    )
 }

--- a/src/main/kotlin/org/rust/ide/security/RsTrustChangeNotifier.kt
+++ b/src/main/kotlin/org/rust/ide/security/RsTrustChangeNotifier.kt
@@ -1,0 +1,21 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.security
+
+import com.intellij.ide.impl.TrustChangeNotifier
+import com.intellij.openapi.project.Project
+import com.intellij.ui.EditorNotifications
+import org.rust.cargo.project.model.cargoProjects
+
+@Suppress("UnstableApiUsage")
+class RsTrustChangeNotifier : TrustChangeNotifier {
+    override fun projectTrusted(project: Project) {
+        // Update notification provided by `RsUntrustedNotificationProvider`
+        EditorNotifications.getInstance(project).updateAllNotifications()
+        // Load project model that wasn't load before because project wasn't trusted
+        project.cargoProjects.refreshAllProjects()
+    }
+}

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -999,6 +999,7 @@
 
         <editorNotificationProvider implementation="org.rust.ide.notifications.MissingToolchainNotificationProvider"/>
         <editorNotificationProvider implementation="org.rust.ide.notifications.NoCargoProjectNotificationProvider"/>
+        <editorNotificationProvider implementation="org.rust.ide.notifications.RsUntrustedNotificationProvider"/>
 
         <notificationGroup id="Rust Plugin" displayType="BALLOON"/>
         <notificationGroup id="Rust Build Log" displayType="NONE"/>
@@ -1174,6 +1175,8 @@
     <projectListeners>
         <listener class="org.rust.lang.core.macros.MacroExpansionManagerWaker"
                   topic="org.rust.cargo.project.model.CargoProjectsService$CargoProjectsListener" />
+        <listener class="org.rust.ide.security.RsTrustChangeNotifier"
+                  topic="com.intellij.ide.impl.TrustChangeNotifier"/>
     </projectListeners>
 
     <actions>

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -77,3 +77,6 @@ refactoring.change.signature.visibility.conflict=The function will not be visibl
 intention.Rust.ToggleFeatureIntention.enable=Enable feature `{0}`
 intention.Rust.ToggleFeatureIntention.disable=Disable feature `{0}`
 intention.Rust.ToggleFeatureIntention.family.name=Toggle feature state
+
+# copy of `untrusted.project.notification.execution.error` from `ExternalSystemBundle.properties`
+untrusted.project.notification.execution.error=Cargo project is untrusted, so its task cannot be executed.

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -51,6 +51,8 @@ action.Rust.ShowRecursiveMacroExpansionAction.text=Show Recursively Expanded Mac
 action.Rust.ShowSingleStepMacroExpansionAction.text=Show Expanded Macro
 action.Rust.ToggleNewResolve.text=Rust: Toggle new name resolution engine
 
+cargo=Cargo
+
 group.Rust.MacroExpansionActions.text=Show Macro Expansion
 group.Rust.Tools.text=Rust
 


### PR DESCRIPTION
Show [untrusted project](https://www.jetbrains.com/help/idea/2021.1/project-security.html) dialog to ensure that project is safe to invoke rust tools like `cargo`/`rustc`/`rustfmt` that can be overridden to execute arbitrary (probably malicious) code and execute build scripts/procedural macros that also can contain arbitrary code

<img width="540" alt="Screen Shot 2021-06-30 at 23 36 41" src="https://user-images.githubusercontent.com/2539310/124028066-3ccd3700-d9fc-11eb-959d-ebfaa5e9d222.png">


In the case of "Preview in Safe Mode" choice, the plugin won't load any info about a project by default like `cargo metadata`, `rustc -V`, `rustc --cfg`, etc.
The plugin shows editor notification in Rust and Cargo.toml files
<img width="740" alt="Screen Shot 2021-06-30 at 23 47 43" src="https://user-images.githubusercontent.com/2539310/124029301-ac8ff180-d9fd-11eb-812b-225f78dc3b3b.png">

Also, for some dangerous actions (not all) the plugin now shows the following dialog to continue execution
<img width="414" alt="Screen Shot 2021-06-30 at 23 58 08" src="https://user-images.githubusercontent.com/2539310/124030754-2c6a8b80-d9ff-11eb-8820-e65726d66ae2.png">
Currently, it's implemented only for `Build` and `Refresh Cargo Projects` actions. For other actions it will be implemented in separate PR

See https://github.com/jonas-schievink/mallory as an example of Rust project that can "steal" your private information in various way

changelog: Confirm loading untrusted Cargo project
