### PR TITLE
INT: generalize MatchToIfLetIntention to arbitrary arm count

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/MatchToIfLetIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/MatchToIfLetIntention.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.ancestorStrict
-import org.rust.lang.core.psi.ext.getNextNonCommentSibling
 
 class MatchToIfLetIntention : RsElementBaseIntentionAction<MatchToIfLetIntention.Context>() {
     override fun getText() = "Convert match statement to if let"
@@ -19,8 +18,7 @@ class MatchToIfLetIntention : RsElementBaseIntentionAction<MatchToIfLetIntention
     data class Context(
         val match: RsMatchExpr,
         val matchTarget: RsExpr,
-        val nonVoidArm: RsMatchArm,
-        val pat: RsPat
+        val matchBody: RsMatchBody
     )
 
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
@@ -28,29 +26,55 @@ class MatchToIfLetIntention : RsElementBaseIntentionAction<MatchToIfLetIntention
         if (element != matchExpr.match) return null
         val matchTarget = matchExpr.expr ?: return null
         val matchBody = matchExpr.matchBody ?: return null
-        val matchArmList = matchBody.matchArmList
+        if (matchBody.matchArmList.isEmpty()) return null
+        if (matchBody.matchArmList.any { it.matchArmGuard != null || it.outerAttrList.isNotEmpty() }) return null
 
-        val nonVoidArm = matchArmList.singleOrNull { it.expr?.isVoid == false } ?: return null
-        if (nonVoidArm.matchArmGuard != null || nonVoidArm.outerAttrList.isNotEmpty()) return null
-        val pat = nonVoidArm.pat
-
-        return Context(matchExpr, matchTarget, nonVoidArm, pat)
+        return Context(matchExpr, matchTarget, matchBody)
     }
 
     override fun invoke(project: Project, editor: Editor, ctx: Context) {
-        val (matchExpr, matchTarget, arm, pat) = ctx
+        val arms = ctx.matchBody.matchArmList
+        val lastArm = arms.lastOrNull() ?: return
+        val lastArmPatWild = lastArm.pat is RsPatWild
+        val lastArmExprEmpty = lastArm.expr?.let {
+            when {
+                it is RsUnitExpr -> true
+                it is RsBlockExpr && it.block.children.isEmpty() -> true
+                else -> false
+            }
+        } ?: false
 
-        var bodyText = arm.expr?.text ?: return
-        if (arm.expr !is RsBlockExpr) {
-            bodyText = "{\n$bodyText\n}"
+        val text = buildString {
+            for ((index, arm) in arms.withIndex()) {
+                var armText = "if let ${arm.pat.text} = ${ctx.matchTarget.text}"
+                if (index > 0) {
+                    val lastIndex = index == arms.size - 1
+                    armText = when {
+                        lastIndex && lastArmExprEmpty -> break
+                        lastIndex && lastArmPatWild -> " else"
+                        else -> " else $armText"
+                    }
+                }
+                append(armText)
+
+                val expr = arm.expr ?: continue
+
+                val innerExprText = if (expr is RsBlockExpr) {
+                    val text = expr.block.text
+                    val start = expr.block.lbrace.startOffsetInParent + 1
+                    val end = expr.block.rbrace?.startOffsetInParent ?: text.length
+                    text.substring(start, end)
+                } else {
+                    expr.text
+                }
+
+                val exprText = "{\n    $innerExprText\n}"
+                append(exprText)
+            }
         }
 
-        val exprText = "if let ${pat.text} = ${matchTarget.text} $bodyText"
-        val rustIfLetExprElement = RsPsiFactory(project).createExpression(exprText) as RsIfExpr
-        matchExpr.replace(rustIfLetExprElement)
+        val factory = RsPsiFactory(project)
+        val ifLetExpr = factory.createExpression(text)
+        ctx.match.replace(ifLetExpr)
     }
-
-    private val RsExpr.isVoid: Boolean
-        get() = (this is RsBlockExpr && block.lbrace.getNextNonCommentSibling() == block.rbrace)
-            || this is RsUnitExpr
 }


### PR DESCRIPTION
This PR generalizes `MatchToIfLetIntention` so that it now works for almost all match expressions.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/7409

changelog: The intention to convert a match expression to a series of if let statements is now offered in more situations.