### PR TITLE
FIX: create structs outside if invoked from inside an impl block

### DIFF
--- a/src/main/kotlin/org/rust/ide/intentions/createFromUsage/utils.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/createFromUsage/utils.kt
@@ -67,7 +67,8 @@ fun getTargetItemForFunctionCall(path: RsPath): CallableInsertionTarget? {
 
 fun insertStruct(targetModule: RsMod, struct: RsStructItem, sourceFunction: RsElement): RsStructItem {
     if (targetModule == sourceFunction.containingMod) {
-        return sourceFunction.parent.addBefore(struct, sourceFunction) as RsStructItem
+        val anchor = sourceFunction.ancestors.firstOrNull { it.parent == targetModule } ?: sourceFunction
+        return anchor.parent.addBefore(struct, anchor) as RsStructItem
     }
     return addToModule(targetModule, struct)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/CreateStructIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateStructIntentionTest.kt
@@ -102,4 +102,30 @@ class CreateStructIntentionTest : RsIntentionTestBase(CreateStructIntention::cla
             foo::Foo { a: 0 };
         }
     """)
+
+    fun `test invoke inside impl`() = doAvailableTest("""
+        struct Foo {
+            bar: i32,
+        }
+
+        impl Foo {
+            fn foo() {
+                /*caret*/Baz { a: true }
+            }
+        }
+    """, """
+        struct Foo {
+            bar: i32,
+        }
+
+        struct Baz {
+            a: bool
+        }
+
+        impl Foo {
+            fn foo() {
+                Baz { a: true }
+            }
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/ide/intentions/CreateTupleStructIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/CreateTupleStructIntentionTest.kt
@@ -87,4 +87,28 @@ class CreateTupleStructIntentionTest : RsIntentionTestBase(CreateTupleStructInte
             foo::Foo(0);
         }
     """)
+
+    fun `test invoke inside impl`() = doAvailableTest("""
+        struct Foo {
+            bar: i32,
+        }
+
+        impl Foo {
+            fn foo() {
+                /*caret*/Baz(true);
+            }
+        }
+    """, """
+        struct Foo {
+            bar: i32,
+        }
+
+        struct Baz(bool);
+
+        impl Foo {
+            fn foo() {
+                Baz(true);
+            }
+        }
+    """)
 }


### PR DESCRIPTION
Fixes: https://github.com/intellij-rust/intellij-rust/issues/7419

changelog: The intention to create structs from unresolved usage now creates the structs outside if invoked from inside an impl block.