### PR TITLE
PERF: optimize local crate index parsing

### DIFF
--- a/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexServiceImpl.kt
+++ b/toml/src/main/kotlin/org/rust/toml/crates/local/CratesLocalIndexServiceImpl.kt
@@ -215,6 +215,9 @@ class CratesLocalIndexServiceImpl
         }
 
         val revTree = RevWalk(repository).parseCommit(ObjectId.fromString(currentHeadHash)).tree
+        val mapper = JsonMapper()
+            .registerKotlinModule()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 
         TreeWalk(repository).use { treeWalk ->
             treeWalk.addTree(revTree)
@@ -342,11 +345,8 @@ data class ParsedVersion(
     val features: HashMap<String, List<String>>
 )
 
-private fun crateFromJson(json: String): CargoRegistryCrateVersion {
-    val parsedVersion = JsonMapper()
-        .registerKotlinModule()
-        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-        .readValue<ParsedVersion>(json)
+private fun crateFromJson(json: String, mapper: ObjectMapper): CargoRegistryCrateVersion {
+    val parsedVersion = mapper.readValue<ParsedVersion>(json)
 
     return CargoRegistryCrateVersion(
         parsedVersion.vers,


### PR DESCRIPTION
I noticed that the local crate index takes a while to load, so I tried to profile it to see what's going on. I made two changes in two separate commits:

1) The object mapper for deserializing JSON was being created time and time again. It takes some instructions to initialize it and (most importantly), if it's created from scratch each time, it cannot leverage any proper caching of deserializers. This change reduces the time to run the `test tokio features` test from ~45s to ~22s on my notebook.

Before:
![before](https://user-images.githubusercontent.com/4539057/124237892-5499dd80-db18-11eb-9f65-22fe3a6259d3.png)

After:
![after](https://user-images.githubusercontent.com/4539057/124237913-5794ce00-db18-11eb-9342-779e3812724a.png)

2) Since loading and deserializing the versions take a lot of time, I tried to parallelize it, by first walking the tree to collect all object IDs, then deserializing them in parallel. This cut the time further from ~22s to ~10s on my notebook with 4 cores (8 hyper-threads). It used the default parallel pool, which uses 7 threads on my notebook (number of virtual cores - 1), if I'm not mistaken.
Without the first commit (with only parallelization), the test takes around 22s.

The parallelization might be a bit overkill and probably isn't really needed, but I think that 1) is a net win and should be changed.

Btw, `VFileEvent.pathEndsWith` seems to be unused.

changelog: Optimize creation of local crate index.