### PR TITLE
COMP: reuse MembersGenerator in RsImplTraitMemberCompletionProvider

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProviderTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsImplTraitMemberCompletionProviderTest.kt
@@ -45,7 +45,7 @@ class RsImplTraitMemberCompletionProviderTest : RsCompletionTestBase() {
         }
 
         impl<X> Foo<X> for () {
-            const FOO: S<X> = <selection>/*caret*/S()</selection>;
+            const FOO: S<X> = <selection>/*caret*/S(())</selection>;
         }
     """)
 


### PR DESCRIPTION
Improves https://github.com/intellij-rust/intellij-rust/pull/6342 by reusing the `MembersGenerator` class.