### PR TITLE
IDE: add callee hierarchy

### DIFF
--- a/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
+++ b/src/main/kotlin/org/rust/ide/experiments/RsExperiments.kt
@@ -29,6 +29,8 @@ object RsExperiments {
     const val WSL_TOOLCHAIN = "org.rust.wsl"
 
     const val EMULATE_TERMINAL = "org.rust.cargo.emulate.terminal"
+
+    const val CALL_HIERARCHY = "org.rust.ide.call.hierarchy"
 }
 
 /**

--- a/src/main/kotlin/org/rust/ide/hierarchy/RsCallHierarchyBrowser.kt
+++ b/src/main/kotlin/org/rust/ide/hierarchy/RsCallHierarchyBrowser.kt
@@ -1,0 +1,64 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hierarchy
+
+import com.intellij.ide.hierarchy.CallHierarchyBrowserBase
+import com.intellij.ide.hierarchy.HierarchyBrowserManager
+import com.intellij.ide.hierarchy.HierarchyNodeDescriptor
+import com.intellij.ide.hierarchy.HierarchyTreeStructure
+import com.intellij.ide.util.treeView.AlphaComparator
+import com.intellij.ide.util.treeView.NodeDescriptor
+import com.intellij.openapi.actionSystem.ActionGroup
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.IdeActions
+import com.intellij.psi.PsiElement
+import com.intellij.ui.PopupHandler
+import org.rust.ide.experiments.RsExperiments.CALL_HIERARCHY
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.ext.RsQualifiedNamedElement
+import org.rust.openapiext.isFeatureEnabled
+import javax.swing.JTree
+
+class RsCallHierarchyBrowser(element: PsiElement) :
+    CallHierarchyBrowserBase(element.project, element) {
+    override fun createTrees(trees: MutableMap<in String, in JTree>) {
+        val group = ActionManager.getInstance().getAction(IdeActions.GROUP_CALL_HIERARCHY_POPUP) as ActionGroup
+        val baseOnThisMethodAction = BaseOnThisMethodAction()
+
+        val tree = createTree(false)
+        PopupHandler.installPopupMenu(
+            tree,
+            group,
+            ActionPlaces.CALL_HIERARCHY_VIEW_POPUP
+        )
+        baseOnThisMethodAction.registerCustomShortcutSet(
+            ActionManager.getInstance().getAction(IdeActions.ACTION_CALL_HIERARCHY).shortcutSet,
+            tree
+        )
+        trees[getCalleeType()] = tree
+    }
+
+    override fun getElementFromDescriptor(descriptor: HierarchyNodeDescriptor): PsiElement? = descriptor.psiElement
+
+    override fun isApplicableElement(element: PsiElement): Boolean {
+        if (!isFeatureEnabled(CALL_HIERARCHY)) return false
+        return element is RsFunction
+    }
+
+    override fun createHierarchyTreeStructure(type: String, psiElement: PsiElement): HierarchyTreeStructure? {
+        if (psiElement !is RsQualifiedNamedElement) return null
+        return when (type) {
+            getCalleeType() -> RsCalleeTreeStructure(psiElement)
+            else -> null
+        }
+    }
+
+    override fun getComparator(): Comparator<NodeDescriptor<*>> {
+        val state = HierarchyBrowserManager.getInstance(myProject).state
+        return if (state != null && state.SORT_ALPHABETICALLY) AlphaComparator.INSTANCE else SourceComparator.INSTANCE
+    }
+}

--- a/src/main/kotlin/org/rust/ide/hierarchy/RsCallHierarchyNodeDescriptor.kt
+++ b/src/main/kotlin/org/rust/ide/hierarchy/RsCallHierarchyNodeDescriptor.kt
@@ -1,0 +1,116 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hierarchy
+
+import com.intellij.icons.AllIcons
+import com.intellij.ide.IdeBundle
+import com.intellij.ide.hierarchy.HierarchyNodeDescriptor
+import com.intellij.ide.util.treeView.NodeDescriptor
+import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.openapi.roots.ui.util.CompositeAppearance
+import com.intellij.openapi.util.Comparing
+import com.intellij.openapi.util.Iconable
+import com.intellij.ui.LayeredIcon
+import org.rust.lang.core.psi.RsEnumVariant
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.substAndGetText
+import org.rust.lang.core.types.emptySubstitution
+
+class RsCallHierarchyNodeDescriptor(
+    parentDescriptor: HierarchyNodeDescriptor?,
+    element: RsQualifiedNamedElement,
+    isBase: Boolean
+) : HierarchyNodeDescriptor(element.project, parentDescriptor, element, isBase) {
+    private var usageCount = 1
+
+    fun incrementUsageCount() {
+        usageCount += 1
+    }
+
+    override fun update(): Boolean {
+        val oldText = myHighlightedText
+        val oldIcon = icon
+
+        var changes = super.update()
+
+        val element = psiElement as RsQualifiedNamedElement
+        val text = renderElement(element)
+
+        val attributes: TextAttributes? = null
+        myHighlightedText = CompositeAppearance()
+        myHighlightedText.ending.addText(text, attributes)
+
+        if (usageCount > 1) {
+            myHighlightedText.ending.addText(
+                " ${IdeBundle.message("node.call.hierarchy.N.usages", usageCount)}",
+                getUsageCountPrefixAttributes(),
+            )
+        }
+
+        val flags: Int = if (isMarkReadOnly) {
+            Iconable.ICON_FLAG_VISIBILITY or Iconable.ICON_FLAG_READ_STATUS
+        } else {
+            Iconable.ICON_FLAG_VISIBILITY
+        }
+
+        val elementIcon = element.getIcon(flags)
+        icon = if (changes && myIsBase) {
+            LayeredIcon(2).apply {
+                setIcon(elementIcon, 0)
+                setIcon(AllIcons.General.Modified, 1, -AllIcons.General.Modified.iconWidth / 2, 0)
+            }
+        } else {
+            elementIcon
+        }
+
+        val packageName = element.containingMod.qualifiedName
+        if (packageName != null) {
+            myHighlightedText.ending.addText("  ($packageName)", getPackageNameAttributes())
+        }
+
+        myName = myHighlightedText.text
+
+        if (!(Comparing.equal(myHighlightedText, oldText) && Comparing.equal(icon, oldIcon))) {
+            changes = true
+        }
+
+        return changes
+    }
+}
+
+private fun renderElement(element: RsQualifiedNamedElement): String {
+    return when (element) {
+        is RsEnumVariant -> "${element.parentEnum.name}::${element.name}()"
+        is RsMacroDefinitionBase -> "${element.name}!()"
+        is RsFunction -> {
+            when (val owner = element.owner) {
+                is RsAbstractableOwner.Trait -> "${owner.trait.name}::${element.name}()"
+                is RsAbstractableOwner.Impl -> {
+                    val impl = owner.impl
+                    val traitRef = impl.traitRef
+                    var ownerName = impl.typeReference?.substAndGetText(emptySubstitution)
+
+                    if (traitRef != null) {
+                        ownerName = "<$ownerName as ${traitRef.resolveToTrait()?.name}>"
+                    }
+                    "${ownerName}::${element.name}()"
+                }
+                else -> "${element.name}()"
+            }
+        }
+        else -> "${element.name}()"
+    }
+}
+
+class SourceComparator private constructor() : Comparator<NodeDescriptor<*>> {
+    override fun compare(nodeDescriptor1: NodeDescriptor<*>, nodeDescriptor2: NodeDescriptor<*>): Int =
+        nodeDescriptor1.index.compareTo(nodeDescriptor2.index)
+
+    companion object {
+        val INSTANCE = SourceComparator()
+    }
+}

--- a/src/main/kotlin/org/rust/ide/hierarchy/RsCallHierarchyProvider.kt
+++ b/src/main/kotlin/org/rust/ide/hierarchy/RsCallHierarchyProvider.kt
@@ -1,0 +1,26 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hierarchy
+
+import com.intellij.ide.hierarchy.CallHierarchyBrowserBase
+import com.intellij.ide.hierarchy.HierarchyBrowser
+import com.intellij.ide.hierarchy.HierarchyProvider
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.psi.PsiElement
+import org.rust.lang.core.psi.RsFunction
+import org.rust.lang.core.psi.ext.RsElement
+
+class RsCallHierarchyProvider : HierarchyProvider {
+    override fun getTarget(dataContext: DataContext): RsElement? =
+        dataContext.getData(CommonDataKeys.PSI_ELEMENT) as? RsFunction
+
+    override fun createHierarchyBrowser(target: PsiElement) = RsCallHierarchyBrowser(target)
+
+    override fun browserActivated(hierarchyBrowser: HierarchyBrowser) {
+        (hierarchyBrowser as RsCallHierarchyBrowser).changeView(CallHierarchyBrowserBase.CALLEE_TYPE)
+    }
+}

--- a/src/main/kotlin/org/rust/ide/hierarchy/RsCalleeTreeStructure.kt
+++ b/src/main/kotlin/org/rust/ide/hierarchy/RsCalleeTreeStructure.kt
@@ -1,0 +1,107 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hierarchy
+
+import com.intellij.ide.hierarchy.HierarchyNodeDescriptor
+import com.intellij.ide.hierarchy.HierarchyTreeStructure
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+
+class RsCalleeTreeStructure(
+    element: RsQualifiedNamedElement
+) : HierarchyTreeStructure(element.project, RsCallHierarchyNodeDescriptor(null, element, true)) {
+    override fun buildChildren(descriptor: HierarchyNodeDescriptor): Array<Any> {
+        return when (val element = descriptor.psiElement) {
+            is RsFunction -> {
+                val ctx = createCalleeContext(element)
+                ctx.descriptors.toTypedArray()
+            }
+            else -> emptyArray()
+        }
+    }
+}
+
+private sealed class FunctionCall(val element: RsQualifiedNamedElement) {
+    class Function(val function: RsFunction): FunctionCall(function)
+    class Method(val function: RsFunction): FunctionCall(function)
+    class TupleStruct(val struct: RsStructOrEnumItemElement): FunctionCall(struct)
+    class TupleEnumVariant(val variant: RsEnumVariant) : FunctionCall(variant)
+    class Macro(val target: RsMacroDefinitionBase) : FunctionCall(target)
+}
+
+private class CalleeContext {
+    private val elementToDescriptorMap: MutableMap<RsElement, RsCallHierarchyNodeDescriptor> = mutableMapOf()
+
+    val descriptors: List<RsCallHierarchyNodeDescriptor>
+        get() = elementToDescriptorMap.values.toList()
+
+    fun add(call: FunctionCall) {
+        val element = call.element
+        val entry = elementToDescriptorMap[element]
+        if (entry != null) {
+            entry.incrementUsageCount()
+        } else {
+            elementToDescriptorMap[element] = RsCallHierarchyNodeDescriptor(null, element, false)
+        }
+    }
+}
+
+private fun createCalleeContext(function: RsFunction): CalleeContext {
+    val ctx = CalleeContext()
+    val block = function.block ?: return ctx
+    val elements = block.children
+
+    val visitor = object: RsRecursiveVisitor() {
+        override fun visitCallExpr(o: RsCallExpr) {
+            when (val target = (o.expr as? RsPathExpr)?.path?.reference?.resolve()) {
+                is RsFunction -> ctx.add(FunctionCall.Function(target))
+                is RsStructItem -> ctx.add(FunctionCall.TupleStruct(target))
+                is RsEnumVariant -> ctx.add(FunctionCall.TupleEnumVariant(target))
+            }
+            super.visitCallExpr(o)
+        }
+
+        override fun visitMethodCall(o: RsMethodCall) {
+            val target = o.reference.resolve() as? RsFunction
+            if (target != null) {
+                ctx.add(FunctionCall.Method(target))
+            }
+            super.visitMethodCall(o)
+        }
+
+        override fun visitMacroCall(o: RsMacroCall) {
+            val target = o.path.reference?.resolve() as? RsMacroDefinitionBase
+            if (target != null) {
+                ctx.add(FunctionCall.Macro(target))
+            }
+            super.visitMacroCall(o)
+        }
+
+        override fun visitFunction(o: RsFunction) {
+            // Ignore functions
+        }
+
+        override fun visitTraitOrImpl(o: RsTraitOrImpl) {
+            // Ignore impls and traits
+        }
+
+        override fun visitBlockExpr(o: RsBlockExpr) {
+            // Ignore async blocks
+            if (!o.isAsync) {
+                super.visitBlockExpr(o)
+            }
+        }
+
+        override fun visitLambdaExpr(o: RsLambdaExpr) {
+            // Ignore lambdas
+        }
+    }
+    for (element in elements) {
+        element.accept(visitor)
+    }
+
+    return ctx
+}

--- a/src/main/resources-nightly/META-INF/experiments.xml
+++ b/src/main/resources-nightly/META-INF/experiments.xml
@@ -21,5 +21,8 @@
         <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="100">
             <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.ide.call.hierarchy" percentOfUsers="0">
+            <description>Enables caller and callee hierarchy view</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>

--- a/src/main/resources-stable/META-INF/experiments.xml
+++ b/src/main/resources-stable/META-INF/experiments.xml
@@ -21,5 +21,8 @@
         <experimentalFeature id="org.rust.cargo.evaluate.build.scripts" percentOfUsers="100">
             <description>Run build scripts while project refresh. It allows collecting information about generated items like `cfg` options, environment variables, etc</description>
         </experimentalFeature>
+        <experimentalFeature id="org.rust.ide.call.hierarchy" percentOfUsers="0">
+            <description>Enables caller and callee hierarchy view</description>
+        </experimentalFeature>
     </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -109,6 +109,10 @@
         <lang.psiStructureViewFactory language="Rust"
                                       implementationClass="org.rust.ide.structure.RsPsiStructureViewFactory"/>
 
+        <callHierarchyProvider
+            language="Rust"
+            implementationClass="org.rust.ide.hierarchy.RsCallHierarchyProvider" />
+
         <treeStructureProvider implementation="org.rust.ide.projectView.RsTreeStructureProvider"/>
 
         <!-- Usages Provider -->

--- a/src/test/kotlin/org/rust/ide/hierarchy/RsCallHierarchyTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/hierarchy/RsCallHierarchyTestBase.kt
@@ -1,0 +1,37 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hierarchy
+
+import com.intellij.ide.hierarchy.HierarchyTreeStructure
+import com.intellij.testFramework.codeInsight.hierarchy.HierarchyViewTestFixture
+import org.intellij.lang.annotations.Language
+import org.rust.RsTestBase
+import org.rust.lang.core.psi.ext.RsQualifiedNamedElement
+
+abstract class RsCallHierarchyTestBase : RsTestBase() {
+    protected abstract val type: HierarchyType
+
+    protected fun doTest(@Language("Rust") code: String, expected: String) {
+        InlineFile(code).withCaret()
+        val hierarchy = createHierarchy(type)
+        checkHierarchy(hierarchy, expected)
+    }
+
+    private fun checkHierarchy(structure: HierarchyTreeStructure, expectedStructure: String) {
+        HierarchyViewTestFixture.doHierarchyTest(structure, expectedStructure.trimIndent())
+    }
+
+    private fun createHierarchy(type: HierarchyType): HierarchyTreeStructure {
+        val element = myFixture.elementAtCaret as RsQualifiedNamedElement
+        return when (type) {
+            HierarchyType.Callee -> RsCalleeTreeStructure(element)
+        }
+    }
+
+    protected enum class HierarchyType {
+        Callee
+    }
+}

--- a/src/test/kotlin/org/rust/ide/hierarchy/RsCalleeHierarchyTest.kt
+++ b/src/test/kotlin/org/rust/ide/hierarchy/RsCalleeHierarchyTest.kt
@@ -1,0 +1,234 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.hierarchy
+
+import org.rust.MockEdition
+import org.rust.cargo.project.workspace.CargoWorkspace
+
+class RsCalleeHierarchyTest : RsCallHierarchyTestBase() {
+    override val type: HierarchyType = HierarchyType.Callee
+
+    fun `test no call`() = doTest("""
+        fn /*caret*/foo() {}
+    """, """
+<node text="foo()  (test_package)" base="true"></node>
+    """)
+
+    fun `test function`() = doTest("""
+        fn /*caret*/foo() {
+            bar()
+        }
+        fn bar() {}
+    """, """
+<node text="foo()  (test_package)" base="true">
+  <node text="bar()  (test_package)"/>
+</node>
+    """)
+
+    fun `test multiple calls`() = doTest("""
+        fn /*caret*/foo() {
+            bar();
+            bar()
+        }
+        fn bar() {}
+    """, """
+<node text="foo()  (test_package)" base="true">
+  <node text="bar() (2 usages)  (test_package)"/>
+</node>
+    """)
+
+    fun `test multiple functions`() = doTest("""
+        fn /*caret*/foo() {
+            c();
+            b();
+            a();
+        }
+        fn a() {}
+        fn b() {}
+        fn c() {}
+    """, """
+<node text="foo()  (test_package)" base="true">
+  <node text="c()  (test_package)"/>
+  <node text="b()  (test_package)"/>
+  <node text="a()  (test_package)"/>
+</node>
+    """)
+
+    fun `test tuple struct`() = doTest("""
+        struct S(u32);
+
+        fn /*caret*/foo() {
+            S(0)
+        }
+    """, """
+<node text="foo()  (test_package)" base="true">
+  <node text="S()  (test_package)"/>
+</node>
+    """)
+
+    fun `test enum variant`() = doTest("""
+        enum E {
+            A(u32)
+        }
+
+        fn /*caret*/foo() {
+            E::A(0)
+        }
+    """, """
+<node text="foo()  (test_package)" base="true">
+  <node text="E::A()  (test_package)"/>
+</node>
+    """)
+
+    fun `test macro`() = doTest("""
+        macro_rules! mac {
+            () => {}
+        }
+
+        fn /*caret*/foo() {
+            mac!();
+        }
+    """, """
+<node text="foo()  (test_package)" base="true">
+  <node text="mac!()  (test_package)"/>
+</node>
+    """)
+
+    fun `test method`() = doTest("""
+        struct S;
+
+        impl S {
+            fn foo(&self) {}
+        }
+
+        fn /*caret*/foo(s: S) {
+            s.foo();
+        }
+    """, """
+<node text="foo()  (test_package)" base="true">
+  <node text="S::foo()  (test_package)"/>
+</node>
+    """)
+
+    fun `test associated method`() = doTest("""
+        struct S;
+
+        impl S {
+            fn foo() {}
+        }
+
+        fn /*caret*/foo() {
+            S::foo();
+        }
+    """, """
+<node text="foo()  (test_package)" base="true">
+  <node text="S::foo()  (test_package)"/>
+</node>
+    """)
+
+    fun `test impl trait method`() = doTest("""
+        struct S;
+
+        trait Trait {
+            fn foo(&self);
+        }
+
+        impl Trait for S {
+            fn foo(&self) {}
+        }
+
+        fn /*caret*/foo(s: S) {
+            s.foo();
+        }
+    """, """
+<node text="foo()  (test_package)" base="true">
+  <node text="&lt;S as Trait&gt;::foo()  (test_package)"/>
+</node>
+    """)
+
+    fun `test generic trait method`() = doTest("""
+        struct S;
+
+        trait Trait {
+            fn foo(&self) {}
+        }
+
+        fn /*caret*/foo<T: Trait>(t: T) {
+            t.foo();
+        }
+    """, """
+<node text="foo()  (test_package)" base="true">
+  <node text="Trait::foo()  (test_package)"/>
+</node>
+    """)
+
+    fun `test ignore nested function`() = doTest("""
+        fn /*caret*/foo() {
+            fn baz() {
+                bar()
+            }
+        }
+
+        fn bar() {}
+    """, """
+<node text="foo()  (test_package)" base="true"></node>
+    """)
+
+    fun `test ignore nested impl`() = doTest("""
+        fn /*caret*/foo() {
+            struct S;
+
+            impl S {
+                fn baz() {
+                    bar()
+                }
+            }
+        }
+
+        fn bar() {}
+    """, """
+<node text="foo()  (test_package)" base="true"></node>
+    """)
+
+    fun `test ignore nested trait`() = doTest("""
+        fn /*caret*/foo() {
+            trait Trait {
+                fn foo() {
+                    bar()
+                }
+            }
+        }
+
+        fn bar() {}
+    """, """
+<node text="foo()  (test_package)" base="true"></node>
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    fun `test ignore nested async block`() = doTest("""
+        async fn /*caret*/foo() {
+            let x = async {
+                bar()
+            };
+        }
+
+        fn bar() {}
+    """, """
+<node text="foo()  (test_package)" base="true"></node>
+    """)
+
+    fun `test ignore nested lambda`() = doTest("""
+        fn /*caret*/foo() {
+            let x = |a| {
+                bar()
+            };
+        }
+
+        fn bar() {}
+    """, """
+<node text="foo()  (test_package)" base="true"></node>
+    """)
+}


### PR DESCRIPTION
This PR adds support for call hierarchy. Currently, only callee (not caller) hierarchy is supported, to keep the PR size smaller. I'll add caller hierarchy in a follow-up PR.

![callee-hierarchy](https://user-images.githubusercontent.com/4539057/124350623-e9bed400-dbf5-11eb-8cd9-1cc0d71912b3.png)

I'm not sure how detailed should the function call descriptions be with regard to substitutions, generic types, etc. in methods. Currently I just ignore them, but I can also try to resolve them properly so that we show proper substituted types of called methods and the types that implement them.

Related issues: https://github.com/intellij-rust/intellij-rust/issues/1545, https://github.com/intellij-rust/intellij-rust/issues/7323

changelog: Add support for callee hierarchy.