### PR TITLE
T: Enable move directory tests for 212 platform

### DIFF
--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveFileTest.kt
@@ -7,7 +7,6 @@ package org.rust.ide.refactoring.move
 
 import com.intellij.openapi.ui.TestDialog
 import com.intellij.util.IncorrectOperationException
-import org.rust.IgnoreInPlatform
 import org.rust.MockEdition
 import org.rust.cargo.project.workspace.CargoWorkspace
 import org.rust.withTestDialog
@@ -404,7 +403,6 @@ class RsMoveFileTest : RsMoveFileTestBase() {
         pub fn func2() {}
     """)
 
-    @IgnoreInPlatform(212)
     fun `test move directory containing one file`() = doTest(
         "foo",
         "mod2",
@@ -424,7 +422,6 @@ class RsMoveFileTest : RsMoveFileTestBase() {
         fn func() {}
     """)
 
-    @IgnoreInPlatform(212)
     fun `test move directory containing two files`() = doTest(
         "foo",
         "mod2",

--- a/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveMultipleFilesTest.kt
+++ b/src/test/kotlin/org/rust/ide/refactoring/move/RsMoveMultipleFilesTest.kt
@@ -6,7 +6,6 @@
 package org.rust.ide.refactoring.move
 
 import org.intellij.lang.annotations.Language
-import org.rust.IgnoreInPlatform
 import org.rust.fileTreeFromText
 
 class RsMoveMultipleFilesTest : RsMoveFileTestBase() {
@@ -40,7 +39,6 @@ class RsMoveMultipleFilesTest : RsMoveFileTestBase() {
         fn func2() {}
     """)
 
-    @IgnoreInPlatform(212)
     fun `test move directory and file`() = doTest(
         arrayOf("mod1/foo1", "mod1/foo2.rs"),
         "mod2",


### PR DESCRIPTION
Moving directory was not working in 212 platform, because of change in method `PsiTreeUtil#filterAncestors` behaviour. This [was fixed](https://upsource.jetbrains.com/intellij/revision/c31b8b4707e12c18c295dfab6b08d723ae56eabd) in platform in 212.4535
