### PR TITLE
ANN: Annotate trailing comma in toml inline table

### DIFF
--- a/intellij-toml/core/src/main/kotlin/org/toml/ide/annotator/TomlAnnotator.kt
+++ b/intellij-toml/core/src/main/kotlin/org/toml/ide/annotator/TomlAnnotator.kt
@@ -5,14 +5,21 @@
 
 package org.toml.ide.annotator
 
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.ide.annotator.AnnotatorBase
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.SyntaxTraverser
 import org.toml.lang.psi.TomlArray
+import org.toml.lang.psi.TomlElementTypes
 import org.toml.lang.psi.TomlInlineTable
+import org.toml.lang.psi.ext.elementType
 
 class TomlAnnotator : AnnotatorBase() {
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
@@ -23,6 +30,27 @@ class TomlAnnotator : AnnotatorBase() {
             if (whiteSpaces.any { it.textContains('\n') }) {
                 holder.newAnnotation(HighlightSeverity.ERROR, "Inline tables are intended to appear on a single line").create()
             }
+        }
+
+        val parent = element.parent
+        if (element.elementType == TomlElementTypes.COMMA && parent is TomlInlineTable &&
+            element.textOffset > parent.entries.lastOrNull()?.textOffset ?: 0) {
+            val message = "Remove trailing comma"
+
+            val fix = object : LocalQuickFix {
+                override fun getFamilyName(): String = message
+                override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+                    descriptor.psiElement?.delete()
+                }
+            }
+
+            val problemDescriptor = InspectionManager.getInstance(element.project)
+                .createProblemDescriptor(element, message, fix, ProblemHighlightType.ERROR, true)
+
+            holder.newAnnotation(HighlightSeverity.ERROR, "Trailing commas are not allowed in inline tables")
+                .newLocalQuickFix(fix, problemDescriptor)
+                .registerFix()
+                .create()
         }
     }
 }

--- a/intellij-toml/core/src/test/kotlin/org/toml/ide/annotator/TomlAnnotatorTest.kt
+++ b/intellij-toml/core/src/test/kotlin/org/toml/ide/annotator/TomlAnnotatorTest.kt
@@ -15,4 +15,15 @@ class TomlAnnotatorTest : TomlAnnotatorTestBase(TomlAnnotator::class) {
                 "foo", "bar"
             ]}
     """)
+
+    fun `test trailing comma in inline table`() = checkByText("""
+        foo = { bar = "", baz = ""<error>,</error> }
+        foo = [ "bar", "baz", ]
+    """)
+
+    fun `test trailing comma in inline table fix`() = checkFixByText("Remove trailing comma", """
+        foo = { bar = "", baz = ""<error>,/*caret*/</error> }
+    """, """
+        foo = { bar = "", baz = "" }
+    """)
 }

--- a/intellij-toml/src/main/resources/META-INF/plugin.xml
+++ b/intellij-toml/src/main/resources/META-INF/plugin.xml
@@ -11,6 +11,7 @@
     <!-- TODO: create normal change note list -->
     <change-notes><![CDATA[
         <ul>
+            <li>Annotate and provide quick-fix for trailing commas in inline tables</li>
             <li>Restore missing icon for TOML files</li>
         </ul>
     ]]>


### PR DESCRIPTION
<img width="600" src="https://user-images.githubusercontent.com/6342851/124483241-c5f4bd00-ddb2-11eb-9d20-ff3dcfa20332.png">

changelog: Annotate trailing commas in TOML inline tables as errors