### PR TITLE
COMP: complete possible options inside visibility restriction

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCommonCompletionProvider.kt
@@ -98,10 +98,13 @@ object RsCommonCompletionProvider : RsCompletionProvider() {
         processedPathNames: MutableSet<String>,
         processor: RsResolveProcessor
     ) {
-        when (element.parent) {
-            is RsMacroCall -> processMacroCallPathResolveVariants(element, true, processor)
+        val parent = element.parent
+        when {
+            parent is RsMacroCall -> processMacroCallPathResolveVariants(element, true, processor)
             // Handled by [RsDeriveCompletionProvider]
-            is RsMetaItem -> return
+            parent is RsMetaItem -> return
+            // Handled by [RsVisRestrictionCompletionProvider]
+            parent is RsVisRestriction && parent.`in` == null -> return
             else -> {
                 val lookup = ImplLookup.relativeTo(element)
                 processPathResolveVariants(

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
@@ -32,6 +32,7 @@ class RsCompletionContributor : CompletionContributor() {
         extend(CompletionType.BASIC, RsClippyLintCompletionProvider)
         extend(CompletionType.BASIC, RsRustcLintCompletionProvider)
         extend(CompletionType.BASIC, RsImplTraitMemberCompletionProvider)
+        extend(CompletionType.BASIC, RsVisRestrictionCompletionProvider)
     }
 
     fun extend(type: CompletionType?, provider: RsCompletionProvider) {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsVisRestrictionCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsVisRestrictionCompletionProvider.kt
@@ -1,0 +1,57 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.patterns.PlatformPatterns.psiElement
+import com.intellij.patterns.PsiElementPattern
+import com.intellij.psi.PsiElement
+import com.intellij.util.ProcessingContext
+import org.rust.ide.icons.RsIcons
+import org.rust.lang.core.psi.RsElementTypes
+import org.rust.lang.core.psi.RsPath
+import org.rust.lang.core.psi.RsVisRestriction
+import org.rust.lang.core.psi.ext.qualifier
+import org.rust.lang.core.psiElement
+import org.rust.lang.core.with
+
+/**
+ * Provides completion inside visibility restriction:
+ * `pub(<here>)`
+ */
+object RsVisRestrictionCompletionProvider : RsCompletionProvider() {
+    override val elementPattern: PsiElementPattern.Capture<PsiElement>
+        get() = psiElement(RsElementTypes.IDENTIFIER)
+            .withParent(
+                psiElement<RsPath>()
+                    .with("hasOneSegment") { item, _ ->
+                        item.qualifier == null && item.typeQual == null && !item.hasColonColon
+                    }
+            )
+            .withSuperParent(2,
+                psiElement<RsVisRestriction>()
+                    .with("hasNoIn") { item, _ -> item.`in` == null }
+            )
+
+    override fun addCompletions(
+        parameters: CompletionParameters,
+        context: ProcessingContext,
+        result: CompletionResultSet
+    ) {
+        for (name in listOf("crate", "super", "self")) {
+            result.addElement(
+                LookupElementBuilder
+                    .create(name)
+                    .withIcon(RsIcons.MODULE)
+                    .bold()
+                    .withPriority(KEYWORD_PRIORITY)
+            )
+        }
+        result.addElement(LookupElementBuilder.create("in ").withPresentableText("in"))
+    }
+}

--- a/src/test/kotlin/org/rust/lang/core/completion/RsVisRestrictionCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsVisRestrictionCompletionTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+class RsVisRestrictionCompletionTest : RsCompletionTestBase() {
+    fun `test complete vis restriction without in keyword`() = checkContainsCompletion(listOf("super", "crate", "self", "in "), """
+        pub mod foo {
+            pub(/*caret*/) struct S;
+        }
+    """)
+
+    fun `test complete in keyword`() = doFirstCompletion("""
+        pub mod foo {
+            pub(i/*caret*/) struct S;
+        }
+    """, """
+        pub mod foo {
+            pub(in /*caret*/) struct S;
+        }
+    """)
+
+    fun `test do not add colon colon after module insertion`() = doFirstCompletion("""
+        pub mod foo {
+            pub(c/*caret*/) struct S;
+        }
+    """, """
+        pub mod foo {
+            pub(crate/*caret*/) struct S;
+        }
+    """)
+
+    fun `test do not complete general paths in vis restriction path without in`() = checkNoCompletion("""
+        pub mod foo {
+            pub(crate::f/*caret*/) struct S;
+        }
+    """)
+}


### PR DESCRIPTION
This PR adds completion for things that can be put inside a visibility restriction (`self`, `super`, `crate` or `in`).
![complete-vis-restriction](https://user-images.githubusercontent.com/4539057/124453968-35a18280-dd88-11eb-9b5f-669b8f463c8e.gif)

Partially resolves https://github.com/intellij-rust/intellij-rust/issues/5025

changelog: Add completion for items inside visibility restrictions (`pub(<...>)`).