### PR TITLE
INSP: Fix handling `writeln!` macro in unused import inspection

### DIFF
--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserDefinition.kt
@@ -104,6 +104,6 @@ class RustParserDefinition : ParserDefinition {
         /**
          * Should be increased after any change of parser rules
          */
-        const val PARSER_VERSION: Int = LEXER_VERSION + 26
+        const val PARSER_VERSION: Int = LEXER_VERSION + 27
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
+++ b/src/main/kotlin/org/rust/lang/core/parser/RustParserUtil.kt
@@ -406,8 +406,8 @@ object RustParserUtil : GeneratedParserUtilBase() {
 
         put(RustParser::ExprMacroArgument, true, "try", "await", "dbg")
         put(
-            RustParser::FormatMacroArgument, true, "format", "format_args", "write", "writeln", "print", "println",
-            "eprint", "eprintln", "panic", "unimplemented", "unreachable", "todo"
+            RustParser::FormatMacroArgument, true, "format", "format_args", "format_args_nl", "write", "writeln",
+            "print", "println", "eprint", "eprintln", "panic", "unimplemented", "unreachable", "todo"
         )
         put(
             RustParser::AssertMacroArgument, true, "assert", "debug_assert", "assert_eq", "assert_ne",

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
@@ -616,4 +616,49 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
             }
         }
     """)*/
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test wrtieln macro`() = checkByText("""
+        use std::io::Write;
+        fn main() {
+            let mut w = Vec::new();
+            writeln!(&mut w, "test").unwrap();
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test println macro`() = checkByText("""
+        use std::collections::HashSet;
+        fn main() {
+            println!("{:?}", HashSet::new());
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test format macro`() = checkByText("""
+        use std::collections::HashSet;
+        fn main() {
+            format!("{:?}", HashSet::new());
+        }
+    """)
+
+    @MockEdition(CargoWorkspace.Edition.EDITION_2018)
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test format macro with trait method call`() = checkByText("""
+        struct S;
+        trait Trait {
+            fn method(&self) {}
+        }
+        impl Trait for S {}
+
+        mod inner {
+            use crate::Trait;
+            fn foo(s: crate::S) {
+                format!("{:?}", s.method());
+            }
+        }
+    """)
 }


### PR DESCRIPTION
Expand format macros like `writeln` in `RsWithMacrosRecursiveElementWalkingVisitor`, so that unused import inspection can correctly handle needed imports (`std::io::Write`) for them

changelog: Correctly handle `writeln!` macro in unused import inspection