### PR TITLE
T: Fix pretty printers tests on 2021.2

### DIFF
--- a/pretty_printers_tests/src/test_runner.rs
+++ b/pretty_printers_tests/src/test_runner.rs
@@ -256,7 +256,7 @@ impl<'test> TestRunner<'test> for LLDBTestRunner<'test> {
         script_str.push_str(&format!("{}\n", ENABLE_RUST));
 
         // Set breakpoints on every line that contains the string "#break"
-        let source_file_name = self.src_path.file_name().unwrap().to_string_lossy();
+        let source_file_name = self.src_path.to_string_lossy();
         for line in &breakpoint_lines {
             script_str.push_str(&format!(
                 "breakpoint set --file '{}' --line {}\n",

--- a/pretty_printers_tests/tests/nonzero.rs
+++ b/pretty_printers_tests/tests/nonzero.rs
@@ -1,7 +1,3 @@
-// fixme: find out why this test fail on CI and work in CLion
-// min-version: 1.34.0
-// max-version: 1.33.0
-
 // === LLDB TESTS ==================================================================================
 
 // lldb-command:run

--- a/pretty_printers_tests/tests/string.rs
+++ b/pretty_printers_tests/tests/string.rs
@@ -1,7 +1,3 @@
-// fixme: find out why this test fail on CI and work in CLion
-// min-version: 1.34.0
-// max-version: 1.33.0
-
 // === LLDB TESTS ==================================================================================
 
 // lldb-command:run

--- a/pretty_printers_tests/tests/vec.rs
+++ b/pretty_printers_tests/tests/vec.rs
@@ -1,7 +1,3 @@
-// fixme: find out why this test fail on CI and work in CLion
-// min-version: 1.37.0
-// max-version: 1.36.0
-
 // === LLDB TESTS ==================================================================================
 
 // lldb-command:run


### PR DESCRIPTION
Fix pretty-printers tests on 2021.2 platform.

After updating LLDB bundle to version 12 (since CLion 212.4535-EAP), LLDB is unable to resolve a breakpoint location by a file name. Fortunately, breakpoints configured with (full or relative) file paths seem to work fine. So now pretty-printers tests provide a path instead of just a file name.

For example, a previously used command
```
(lldb) breakpoint set --file 'nonzero.rs' --line 27
```
is now replaced with
```
(lldb) breakpoint set --file './tests/nonzero.rs' --line 27
```

Fixes #4527
Fixes #7453
Fixes #7454