### PR TITLE
COMP: always place caret into the first arm in MatchPostfixTemplate

### DIFF
--- a/src/main/kotlin/org/rust/openapiext/Template.kt
+++ b/src/main/kotlin/org/rust/openapiext/Template.kt
@@ -7,13 +7,18 @@ package org.rust.openapiext
 
 import com.intellij.codeInsight.CodeInsightUtilCore
 import com.intellij.codeInsight.template.TemplateBuilderFactory
+import com.intellij.codeInsight.template.TemplateBuilderImpl
+import com.intellij.codeInsight.template.TemplateEditingListener
+import com.intellij.codeInsight.template.TemplateManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.SmartPsiElementPointer
+import org.rust.lang.core.psi.ext.startOffset
 
-fun <T : PsiElement, E : PsiElement> Editor.buildAndRunTemplate(
-    owner: T,
-    elementsToReplace: List<SmartPsiElementPointer<E>>
+fun Editor.buildAndRunTemplate(
+    owner: PsiElement,
+    elementsToReplace: List<SmartPsiElementPointer<out PsiElement>>,
+    listener: TemplateEditingListener? = null,
 ) {
     checkWriteAccessAllowed()
     val restoredOwner = CodeInsightUtilCore.forcePsiPostprocessAndRestoreElement(owner) ?: return
@@ -22,5 +27,13 @@ fun <T : PsiElement, E : PsiElement> Editor.buildAndRunTemplate(
         val element = elementPointer.element ?: continue
         templateBuilder.replaceElement(element, element.text)
     }
-    templateBuilder.run(this, true)
+    if (listener == null) {
+        templateBuilder.run(this, true)
+    } else {
+        val templateBuilderImpl = templateBuilder as TemplateBuilderImpl
+        // From TemplateBuilderImpl.run()
+        val template = templateBuilderImpl.buildInlineTemplate()
+        caretModel.moveToOffset(restoredOwner.startOffset)
+        TemplateManager.getInstance(owner.project).startTemplate(this, template, listener)
+    }
 }

--- a/src/test/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplateTest.kt
+++ b/src/test/kotlin/org/rust/ide/template/postfix/MatchPostfixTemplateTest.kt
@@ -32,8 +32,8 @@ class MatchPostfixTemplateTest : RsPostfixTemplateTest(MatchPostfixTemplate(RsPo
         fn process_message() {
             let msg = Message::ChangeColor(255, 255, 255);
             match msg {
-                Message::Quit => {}
-                Message::ChangeColor(_/*caret*/, _, _) => {}
+                Message::Quit => {/*caret*/}
+                Message::ChangeColor(_, _, _) => {}
                 Message::Move { .. } => {}
                 Message::Write(_) => {}
             }
@@ -50,7 +50,7 @@ class MatchPostfixTemplateTest : RsPostfixTemplateTest(MatchPostfixTemplate(RsPo
         const THE_ANSWER: i32 = 42;
 
         fn check(x: i32) {
-            match x { _/*caret*/ => {} }
+            match x { _ => {/*caret*/} }
         }
     """)
 
@@ -81,7 +81,7 @@ class MatchPostfixTemplateTest : RsPostfixTemplateTest(MatchPostfixTemplate(RsPo
     """, """
         fn main() {
             match a {
-                _ => match b { _/*caret*/ => {} }
+                _ => match b { _ => {/*caret*/} }
             }
         }
     """)
@@ -92,7 +92,7 @@ class MatchPostfixTemplateTest : RsPostfixTemplateTest(MatchPostfixTemplate(RsPo
         }
     """, """
         fn main() {
-            let x = match 1 + 2 { _/*caret*/ => {} };
+            let x = match 1 + 2 { _ => {/*caret*/} };
         }
     """)
 
@@ -104,7 +104,7 @@ class MatchPostfixTemplateTest : RsPostfixTemplateTest(MatchPostfixTemplate(RsPo
     """, """
         fn foo(s: String) {
             match s.as_str() {
-                ""/*caret*/ => {}
+                "" => {/*caret*/}
                 _ => {}
             }
         }
@@ -117,7 +117,7 @@ class MatchPostfixTemplateTest : RsPostfixTemplateTest(MatchPostfixTemplate(RsPo
     """, """
         fn foo(s: &str) {
             match s {
-                ""/*caret*/ => {}
+                "" => {/*caret*/}
                 _ => {}
             }
         }


### PR DESCRIPTION
An improvement to #7328: place the caret to the first arm after finishing the template

https://user-images.githubusercontent.com/3221931/124749393-d630a780-df2c-11eb-8f2d-ee0c3f282a35.mp4

