### PR TITLE
TY&RES: support const arguments that looks like type arguments

### DIFF
--- a/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
+++ b/src/main/kotlin/org/rust/ide/presentation/RsPsiRenderer.kt
@@ -610,7 +610,10 @@ open class PsiSubstitutingPsiRenderer(
             }
             is RsConstParameter -> when (val s = subst.constSubst[resolved]) {
                 is RsPsiSubstitution.Value.Present -> {
-                    appendConstExpr(sb, s.value)
+                    when (s.value) {
+                        is RsExpr -> appendConstExpr(sb, s.value)
+                        is RsTypeReference -> appendTypeReference(sb, s.value)
+                    }
                     true
                 }
                 else -> false

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsPath.kt
@@ -69,7 +69,16 @@ val RsPath.qualifier: RsPath?
     }
 
 fun RsPath.allowedNamespaces(isCompletion: Boolean = false): Set<Namespace> = when (val parent = parent) {
-    is RsPath, is RsTypeReference, is RsTraitRef, is RsStructLiteral, is RsPatStruct -> TYPES
+    is RsPath, is RsTraitRef, is RsStructLiteral, is RsPatStruct -> TYPES
+    is RsTypeReference -> when (parent.parent) {
+        is RsTypeArgumentList -> when {
+            // type A = Foo<T>
+            //              ~ `T` can be either type or const argument
+            typeArgumentList == null && valueParameterList == null -> TYPES_N_VALUES
+            else -> TYPES
+        }
+        else -> TYPES
+    }
     is RsUseSpeck -> when {
         // use foo::bar::{self, baz};
         //     ~~~~~~~~

--- a/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
+++ b/src/main/kotlin/org/rust/lang/core/resolve/Namespace.kt
@@ -38,6 +38,7 @@ val RsNamedElement.namespaces: Set<Namespace> get() = when (this) {
     is RsTypeAlias -> TYPES
 
     is RsPatBinding,
+    is RsConstParameter,
     is RsConstant -> VALUES
     is RsFunction -> if (this.isProcMacroDef) MACROS else VALUES
 

--- a/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/typecheck/RsTypeCheckInspectionTest.kt
@@ -354,4 +354,14 @@ class RsTypeCheckInspectionTest : RsInspectionsTestBase(RsTypeCheckInspection::c
             foo(<error>&s</error>);
         }
     """)
+
+    // Issue https://github.com/intellij-rust/intellij-rust/issues/7420
+    fun `test correctly match const arguments with const parameters`() = checkErrors("""
+        struct Foo<const N: u8, const S: bool>(u32);
+
+        impl<const N: u8> From<u32> for Foo<N, true> {
+                                            // ^^^^ the error should not appear here
+            fn from(val: u32) -> Self { Foo(val) }
+        }
+    """)
 }

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsConstArgumentResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsConstArgumentResolveTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.resolve
+
+class RsConstArgumentResolveTest : RsResolveTestBase() {
+    // Type path arguments:
+
+    fun `test disambiguate type argument`() = checkByCode("""
+        const A: i32 = 0;
+        type A = i32;
+           //X
+        struct Foo<T>(T);
+        type T = Foo<A>;
+                   //^
+    """)
+
+    fun `test disambiguate type argument when parent path is unresolved`() = checkByCode("""
+        const A: i32 = 0;
+        type A = i32;
+           //X
+        type T = Unknown<A>;
+                       //^
+    """)
+
+    fun `test resolve const parameter that looks like a type parameter`() = checkByCode("""
+        const A: i32 = 0;
+            //X
+        struct Foo<const S: i32>();
+        type T = Foo<A>;
+                   //^
+    """)
+
+    fun `test in the case of ambiguity const argument is resolved to a type`() = checkByCode("""
+        const A: i32 = 0;
+        type A = i32;
+           //X
+        struct Foo<const S: i32>();
+        type T = Foo<A>;
+                   //^
+    """)
+
+    // Expression path arguments:
+
+    fun `test disambiguate type argument in expr path`() = checkByCode("""
+        const A: i32 = 0;
+        type A = i32;
+           //X
+        fn foo<T>() {}
+        fn main() {
+            foo::<A>();
+                //^
+        }
+    """)
+
+    fun `test disambiguate type argument in expr path when parent path is unresolved`() = checkByCode("""
+        const A: i32 = 0;
+        type A = i32;
+           //X
+        fn main() {
+            unknown::<A>();
+                    //^
+        }
+    """)
+
+    fun `test resolve const parameter that looks like a type parameter in expr path`() = checkByCode("""
+        const A: i32 = 0;
+            //X
+        fn foo<const S: i32>() {}
+        fn main() {
+            foo::<A>();
+                //^
+        }
+    """)
+
+    fun `test in the case of ambiguity const argument is resolved to a type in expr path`() = checkByCode("""
+        const A: i32 = 0;
+        type A = i32;
+           //X
+        fn foo<const S: i32>() {}
+        fn main() {
+            foo::<A>();
+                //^
+        }
+    """)
+
+    fun `test type is preferred in an upper scope`() = checkByCode("""
+        struct N { f: i32 }
+             //X
+        fn foo<const N: i32>() {
+            foo::<N>();
+        }       //^
+    """)
+
+    // Method call arguments:
+
+    fun `test disambiguate type argument in method call`() = checkByCode("""
+        const A: i32 = 0;
+        type A = i32;
+           //X
+        struct S;
+        impl S {
+            fn foo<const S: i32>(&self) {}
+        }
+        fn main() {
+            S.foo::<A>();
+                  //^
+        }
+    """)
+
+    fun `test disambiguate type argument in method call when parent path is unresolved`() = checkByCode("""
+        const A: i32 = 0;
+        type A = i32;
+           //X
+        struct S;
+        fn main() {
+            S.unknown::<A>();
+                      //^
+        }
+    """)
+
+    fun `test resolve const parameter that looks like a type parameter in method call`() = checkByCode("""
+        const A: i32 = 0;
+            //X
+        struct S;
+        impl S {
+            fn foo<const S: i32>(&self) {}
+        }
+        fn main() {
+            s.foo::<A>();
+                  //^
+        }
+    """)
+
+    fun `test in the case of ambiguity const argument is resolved to a type in method call`() = checkByCode("""
+        const A: i32 = 0;
+        type A = i32;
+           //X
+        struct S;
+        impl S {
+            fn foo<const S: i32>(&self) {}
+        }
+        fn main() {
+            s.foo::<A>();
+                  //^
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStubOnlyTypeInferenceTest.kt
@@ -282,4 +282,18 @@ class RsStubOnlyTypeInferenceTest : RsTypificationTestBase() {
         }
 
     """)
+
+    fun `test const argument that looks like a type argument`() = stubOnlyTypeInfer("""
+    //- foo.rs
+        #![feature(const_generics)]
+        pub struct S<const N1: usize>;
+        pub fn bar<const N2: usize>() -> S<N2> { S }
+    //- mod.rs
+        mod foo;
+        const C: usize = 42;
+        fn main() {
+            let a = foo::bar::<C>();
+            a;
+        } //^ S<42>
+    """)
 }


### PR DESCRIPTION
Related to #3985, fixes (partially, except `Extra error` case) #7420

