### PR TITLE
INT: add intention to implement a trait for an ADT type

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/AddTypeArguments.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/AddTypeArguments.kt
@@ -16,6 +16,10 @@ import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.RsElementTypes.COMMA
 import org.rust.lang.core.psi.RsElementTypes.LT
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.elementType
+import org.rust.lang.core.psi.ext.getNextNonCommentSibling
+import org.rust.lang.core.psi.ext.requiredGenericParameters
 import org.rust.openapiext.createSmartPointer
 
 class AddTypeArguments(element: RsElement) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
@@ -30,53 +34,57 @@ class AddTypeArguments(element: RsElement) : LocalQuickFixAndIntentionActionOnPs
         endElement: PsiElement
     ) {
         val element = startElement as? RsElement ?: return
-        val (typeArguments, declaration) = getTypeArgumentsAndDeclaration(element) ?: return
-
-        val requiredParameters = declaration.requiredGenericParameters
-        if (requiredParameters.isEmpty()) return
-
-        val argumentCount = typeArguments?.typeReferenceList?.size ?: 0
-        if (argumentCount >= requiredParameters.size) return
-
-        val factory = RsPsiFactory(project)
-        val missingTypes = requiredParameters.drop(argumentCount).map { it.name ?: "_" }
-
-        val replaced = if (typeArguments != null) {
-            var anchor = with(typeArguments) {
-                typeReferenceList.lastOrNull() ?: lifetimeList.lastOrNull() ?: lt
-            }
-            val nextSibling = anchor.getNextNonCommentSibling()
-            val addCommaAfter = nextSibling?.isComma == true
-            if (addCommaAfter && nextSibling != null) {
-                anchor = nextSibling
-            }
-
-            for (type in missingTypes) {
-                if (anchor.elementType != LT && !anchor.isComma) {
-                    anchor = typeArguments.addAfter(factory.createComma(), anchor)
-                }
-                anchor = typeArguments.addAfter(factory.createType(type), anchor)
-            }
-
-            if (addCommaAfter) {
-                typeArguments.addAfter(factory.createComma(), anchor)
-            }
-
-            typeArguments
-        } else {
-            val newArgumentList = factory.createTypeArgumentList(missingTypes)
-
-            // this can only happen for type references (base types/trait refs)
-            val path = getPath(element) ?: return
-            path.addAfter(newArgumentList, path.identifier) as RsTypeArgumentList
-        }
-
-        editor?.buildAndRunTemplate(element, replaced.typeReferenceList.drop(argumentCount).map { it.createSmartPointer() })
+        val inserted = insertTypeArgumentsIfNeeded(element) ?: return
+        editor?.buildAndRunTemplate(element, inserted.map { it.createSmartPointer() })
     }
 }
 
-private val RsGenericDeclaration.requiredGenericParameters: List<RsTypeParameter>
-    get() = typeParameters.filter { it.typeReference == null }
+/**
+ * Inserts type arguments if they are needed and returns a list of inserted type arguments.
+ */
+fun insertTypeArgumentsIfNeeded(element: RsElement): List<RsTypeReference>? {
+    val (typeArguments, declaration) = getTypeArgumentsAndDeclaration(element) ?: return null
+
+    val requiredParameters = declaration.requiredGenericParameters
+    if (requiredParameters.isEmpty()) return null
+
+    val argumentCount = typeArguments?.typeReferenceList?.size ?: 0
+    if (argumentCount >= requiredParameters.size) return null
+
+    val factory = RsPsiFactory(element.project)
+    val missingTypes = requiredParameters.drop(argumentCount).map { it.name ?: "_" }
+
+    val replaced = if (typeArguments != null) {
+        var anchor = with(typeArguments) {
+            typeReferenceList.lastOrNull() ?: lifetimeList.lastOrNull() ?: lt
+        }
+        val nextSibling = anchor.getNextNonCommentSibling()
+        val addCommaAfter = nextSibling?.isComma == true
+        if (addCommaAfter && nextSibling != null) {
+            anchor = nextSibling
+        }
+
+        for (type in missingTypes) {
+            if (anchor.elementType != LT && !anchor.isComma) {
+                anchor = typeArguments.addAfter(factory.createComma(), anchor)
+            }
+            anchor = typeArguments.addAfter(factory.createType(type), anchor)
+        }
+
+        if (addCommaAfter) {
+            typeArguments.addAfter(factory.createComma(), anchor)
+        }
+
+        typeArguments
+    } else {
+        val newArgumentList = factory.createTypeArgumentList(missingTypes)
+
+        // this can only happen for type references (base types/trait refs)
+        val path = getPath(element) ?: return null
+        path.addAfter(newArgumentList, path.identifier) as RsTypeArgumentList
+    }
+    return replaced.typeReferenceList.drop(argumentCount)
+}
 
 private fun getPath(element: PsiElement): RsPath? = when (element) {
     is RsBaseType -> element.path

--- a/src/main/kotlin/org/rust/ide/intentions/AddImplTraitIntention.kt
+++ b/src/main/kotlin/org/rust/ide/intentions/AddImplTraitIntention.kt
@@ -1,0 +1,108 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+import com.intellij.codeInsight.CodeInsightUtilCore
+import com.intellij.codeInsight.template.impl.MacroCallNode
+import com.intellij.codeInsight.template.macro.CompleteMacro
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.SmartPsiElementPointer
+import org.rust.ide.inspections.fixes.insertTypeArgumentsIfNeeded
+import org.rust.ide.refactoring.implementMembers.generateMissingTraitMembers
+import org.rust.ide.utils.template.newTemplateBuilder
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.ext.*
+import org.rust.openapiext.createSmartPointer
+
+class AddImplTraitIntention : RsElementBaseIntentionAction<AddImplTraitIntention.Context>() {
+    override fun getText() = "Implement trait"
+    override fun getFamilyName() = text
+
+    class Context(val type: RsStructOrEnumItemElement, val name: String)
+
+    override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
+        val struct = element.ancestorStrict<RsStructOrEnumItemElement>() ?: return null
+        val name = struct.name ?: return null
+        return Context(struct, name)
+    }
+
+    override fun invoke(project: Project, editor: Editor, ctx: Context) {
+        val impl = RsPsiFactory(project).createTraitImplItem(
+            ctx.name,
+            "T",
+            ctx.type.typeParameterList,
+            ctx.type.whereClause
+        )
+
+        val inserted = ctx.type.parent.addAfter(impl, ctx.type) as RsImplItem
+        val traitName = inserted.traitRef?.path ?: return
+
+        val implPtr = inserted.createSmartPointer()
+        val traitNamePtr = traitName.createSmartPointer()
+        val tpl = editor.newTemplateBuilder(inserted) ?: return
+        tpl.replaceElement(traitNamePtr.element ?: return, MacroCallNode(CompleteMacro()))
+        tpl.withFinishResultListener {
+            val implCurrent = implPtr.element
+            if (implCurrent != null) {
+                runWriteAction {
+                    afterTraitNameEntered(implCurrent, editor)
+                }
+            }
+        }
+        tpl.withDisabledDaemonHighlighting()
+        tpl.runInline()
+    }
+
+    private fun afterTraitNameEntered(impl: RsImplItem, editor: Editor) {
+        val traitRef = impl.traitRef ?: return
+        val trait = traitRef.resolveToBoundTrait() ?: return
+
+        val insertedTypeArgumentsPtr = if (trait.element.requiredGenericParameters.isNotEmpty()) {
+            insertTypeArgumentsIfNeeded(traitRef)?.map { it.createSmartPointer() }
+        } else {
+            null
+        }
+
+        generateMissingTraitMembers(impl)
+
+        showTypeArgumentsTemplate(
+            editor,
+            CodeInsightUtilCore.forcePsiPostprocessAndRestoreElement(impl) ?: return,
+            insertedTypeArgumentsPtr
+        )
+    }
+
+    private fun showTypeArgumentsTemplate(
+        editor: Editor,
+        impl: RsImplItem,
+        insertedTypeArgumentsPtr: List<SmartPsiElementPointer<RsTypeReference>>?
+    ) {
+        val insertedTypeArguments = insertedTypeArgumentsPtr?.mapNotNull { it.element }?.filterIsInstance<RsBaseType>()
+        if (insertedTypeArguments != null && insertedTypeArguments.isNotEmpty()) {
+            val members = impl.members ?: return
+            val baseTypes = members.descendantsOfType<RsPath>()
+                .filter { it.parent is RsBaseType && !it.hasColonColon && it.path == null && it.typeQual == null }
+                .groupBy { it.referenceName }
+            val typeToUsage = insertedTypeArguments.associateWith {
+                it.path?.referenceName?.let { baseTypes[it] } ?: emptyList()
+            }
+            val tmp = editor.newTemplateBuilder(impl) ?: return
+            for ((type, usages) in typeToUsage) {
+                tmp.introduceVariable(type).apply {
+                    for (usage in usages) {
+                        replaceElementWithVariable(usage)
+                    }
+                }
+            }
+            tmp.withExpressionsHighlighting()
+            tmp.withDisabledDaemonHighlighting()
+            tmp.runInline()
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/implementMembers/impl.kt
@@ -49,6 +49,17 @@ fun generateTraitMembers(impl: RsImplItem, editor: Editor?) {
     }
 }
 
+/**
+ * Generates missing trait members in a non-interactive way.
+ */
+fun generateMissingTraitMembers(impl: RsImplItem) {
+    val (implInfo, trait) = findMembersToImplement(impl) ?: return
+
+    runWriteAction {
+        insertNewTraitMembers(implInfo.missingImplementations, impl, trait, null)
+    }
+}
+
 private fun findMembersToImplement(impl: RsImplItem): Pair<TraitImplementationInfo, BoundElement<RsTraitItem>>? {
     checkReadAccessAllowed()
 

--- a/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/RsPsiFactory.kt
@@ -254,7 +254,24 @@ class RsPsiFactory(
         return createFromText("impl T for S {$text}") ?: error("Failed to create members from text: `$text`")
     }
 
-    fun createInherentImplItem(name: String, typeParameterList: RsTypeParameterList?, whereClause: RsWhereClause?): RsImplItem {
+    fun createInherentImplItem(
+        name: String,
+        typeParameterList: RsTypeParameterList? = null,
+        whereClause: RsWhereClause? = null
+    ): RsImplItem = createImplTemplate(name, typeParameterList, whereClause)
+
+    fun createTraitImplItem(
+        type: String,
+        trait: String,
+        typeParameterList: RsTypeParameterList? = null,
+        whereClause: RsWhereClause? = null
+    ): RsImplItem = createImplTemplate("$trait for $type", typeParameterList, whereClause)
+
+    private fun createImplTemplate(
+        text: String,
+        typeParameterList: RsTypeParameterList?,
+        whereClause: RsWhereClause?
+    ): RsImplItem {
         val whereText = whereClause?.text ?: ""
         val typeParameterListText = typeParameterList?.text ?: ""
         val typeArgumentListText = if (typeParameterList == null) {
@@ -266,8 +283,8 @@ class RsPsiFactory(
             parameterNames.joinToString(", ", "<", ">")
         }
 
-        return createFromText("impl $typeParameterListText $name $typeArgumentListText $whereText {  }")
-            ?: error("Failed to create an inherent impl with name: `$name`")
+        return createFromText("impl $typeParameterListText $text $typeArgumentListText $whereText {  }")
+            ?: error("Failed to create an trait impl with text: `$text`")
     }
 
     fun createWhereClause(

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsGenericDeclaration.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsGenericDeclaration.kt
@@ -23,3 +23,6 @@ val RsGenericDeclaration.lifetimeParameters: List<RsLifetimeParameter>
 
 val RsGenericDeclaration.constParameters: List<RsConstParameter>
     get() = typeParameterList?.constParameterList.orEmpty()
+
+val RsGenericDeclaration.requiredGenericParameters: List<RsTypeParameter>
+    get() = typeParameters.filter { it.typeReference == null }

--- a/src/main/resources/META-INF/rust-core.xml
+++ b/src/main/resources/META-INF/rust-core.xml
@@ -918,6 +918,10 @@
             <className>org.rust.ide.intentions.createFromUsage.CreateTupleStructIntention</className>
             <category>Rust</category>
         </intentionAction>
+        <intentionAction>
+            <className>org.rust.ide.intentions.AddImplTraitIntention</className>
+            <category>Rust</category>
+        </intentionAction>
 
         <!-- Run Configurations -->
 

--- a/src/main/resources/intentionDescriptions/AddImplTraitIntention/after.rs.template
+++ b/src/main/resources/intentionDescriptions/AddImplTraitIntention/after.rs.template
@@ -1,0 +1,10 @@
+trait Trait {
+    fun foo(&self) {}
+}
+struct MyStruct;
+
+impl Trait for MyStruct {
+    fun foo(&self) {
+        todo!()
+    }
+}

--- a/src/main/resources/intentionDescriptions/AddImplTraitIntention/before.rs.template
+++ b/src/main/resources/intentionDescriptions/AddImplTraitIntention/before.rs.template
@@ -1,0 +1,4 @@
+trait Trait {
+    fun foo(&self) {}
+}
+struct <spot>MyStruct</spot>;

--- a/src/main/resources/intentionDescriptions/AddImplTraitIntention/description.html
+++ b/src/main/resources/intentionDescriptions/AddImplTraitIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This intention implements a trait for a struct.
+</body>
+</html>

--- a/src/test/kotlin/org/rust/ide/intentions/AddImplTraitIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/AddImplTraitIntentionTest.kt
@@ -1,0 +1,237 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.intentions
+
+class AddImplTraitIntentionTest : RsIntentionTestBase(AddImplTraitIntention::class) {
+    fun `test empty trait`() = doAvailableTestWithLiveTemplate("""
+        trait Foo {}
+
+        struct S/*caret*/;
+    """, "Foo\t\t", """
+        trait Foo {}
+
+        struct S;
+
+        impl Foo/*caret*/ for S {}
+    """)
+
+    fun `test ignore method with default implementation`() = doAvailableTestWithLiveTemplate("""
+        trait Foo {
+            fn foo(&self) {}
+        }
+
+        struct S/*caret*/;
+    """, "Foo\t\t", """
+        trait Foo {
+            fn foo(&self) {}
+        }
+
+        struct S;
+
+        impl Foo/*caret*/ for S {}
+    """)
+
+    fun `test trait with method`() = doAvailableTestWithLiveTemplate("""
+        trait Foo {
+            fn foo(&self);
+        }
+
+        struct S/*caret*/;
+    """, "Foo\t\t", """
+        trait Foo {
+            fn foo(&self);
+        }
+
+        struct S;
+
+        impl Foo/*caret*/ for S {
+            fn foo(&self) {
+                todo!()
+            }
+        }
+    """)
+
+    fun `test trait with const`() = doAvailableTestWithLiveTemplate("""
+        trait Foo {
+            const FOO: u32;
+        }
+
+        struct S/*caret*/;
+    """, "Foo\t\t", """
+        trait Foo {
+            const FOO: u32;
+        }
+
+        struct S;
+
+        impl Foo/*caret*/ for S { const FOO: u32 = 0; }
+    """)
+
+    fun `test trait with associated type`() = doAvailableTestWithLiveTemplate("""
+        trait Foo {
+            type Type;
+        }
+
+        struct S/*caret*/;
+    """, "Foo\t\t", """
+        trait Foo {
+            type Type;
+        }
+
+        struct S;
+
+        impl Foo for S { type Type = (); }
+    """)
+
+    fun `test trait with multiple items`() = doAvailableTestWithLiveTemplate("""
+        trait Foo {
+            type Type;
+
+            const FOO: u32;
+
+            fn foo(&self);
+        }
+
+        struct S/*caret*/;
+    """, "Foo\t\t", """
+        trait Foo {
+            type Type;
+
+            const FOO: u32;
+
+            fn foo(&self);
+        }
+
+        struct S;
+
+        impl Foo/*caret*/ for S {
+            type Type = ();
+            const FOO: u32 = 0;
+
+            fn foo(&self) {
+                todo!()
+            }
+        }
+    """)
+
+    fun `test trait with method and 1 type parameter`() = doAvailableTestWithLiveTemplate("""
+        trait Foo<T> {
+            fn foo(&self) -> T;
+        }
+
+        struct S/*caret*/;
+    """, "Foo\t\ti32\t", """
+        trait Foo<T> {
+            fn foo(&self) -> T;
+        }
+
+        struct S;
+
+        impl Foo<i32/*caret*/> for S {
+            fn foo(&self) -> i32 {
+                todo!()
+            }
+        }
+    """)
+
+    fun `test trait with method and 2 type parameters`() = doAvailableTestWithLiveTemplate("""
+        trait Foo<A, B> {
+            fn foo(&self) -> (A, B);
+        }
+
+        struct S/*caret*/;
+    """, "Foo\t\ti32\tu8\t", """
+        trait Foo<A, B> {
+            fn foo(&self) -> (A, B);
+        }
+
+        struct S;
+
+        impl Foo<i32, u8/*caret*/> for S {
+            fn foo(&self) -> (i32, u8) {
+                todo!()
+            }
+        }
+    """)
+
+    fun `test generic struct`() = doAvailableTestWithLiveTemplate("""
+        trait Foo {
+            fn foo(&self) -> u32;
+        }
+
+        struct S<'a, R, T>(R, &'a T)/*caret*/;
+    """, "Foo\t\t", """
+        trait Foo {
+            fn foo(&self) -> u32;
+        }
+
+        struct S<'a, R, T>(R, &'a T);
+
+        impl<'a, R, T> Foo/*caret*/ for S<'a, R, T> {
+            fn foo(&self) -> u32 {
+                todo!()
+            }
+        }
+    """)
+
+    fun `test generic struct with where clause`() = doAvailableTestWithLiveTemplate("""
+        trait Foo {
+            fn foo(&self) -> u32;
+        }
+
+        struct S<'a, R, T>(R, &'a T) where R: Foo/*caret*/;
+    """, "Foo\t\t", """
+        trait Foo {
+            fn foo(&self) -> u32;
+        }
+
+        struct S<'a, R, T>(R, &'a T) where R: Foo;
+
+        impl<'a, R, T> Foo/*caret*/ for S<'a, R, T> where R: Foo {
+            fn foo(&self) -> u32 {
+                todo!()
+            }
+        }
+    """)
+
+    fun `test import trait from module`() = doAvailableTestWithLiveTemplate("""
+        mod foo {
+            pub trait Foo {
+                fn foo(&self) -> u32;
+            }
+        }
+
+        struct S/*caret*/;
+    """, "Foo\t\t", """
+        use foo::Foo;
+
+        mod foo {
+            pub trait Foo {
+                fn foo(&self) -> u32;
+            }
+        }
+
+        struct S;
+
+        impl Foo/*caret*/ for S {
+            fn foo(&self) -> u32 {
+                todo!()
+            }
+        }
+    """)
+
+    fun `test invalid trait name`() = doAvailableTestWithLiveTemplate("""
+        struct Foo;
+
+        struct S/*caret*/;
+    """, "Foo\t", """
+        struct Foo;
+
+        struct S;
+
+        impl Foo/*caret*/ for S {}
+    """)
+}


### PR DESCRIPTION
This PR attempts to implement (a part of) https://github.com/intellij-rust/intellij-rust/pull/5339 in a more "atomic" way. The idea is to create an intention that will generate an impl block for a given type, let the user type a trait name and then automatically implement all members of that trait. Dealing with required supertraits will be left for another quick fix.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/4123
Fixes: https://github.com/intellij-rust/intellij-rust/issues/7342

Closes: https://github.com/intellij-rust/intellij-rust/pull/5339

changelog: Add intention to implement a trait for a struct or enum.