### PR TITLE
COMP: fix RsCompletionTestFixtureBase::checkCompletion

### DIFF
--- a/src/test/kotlin/org/rust/lang/core/completion/RsAwaitCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsAwaitCompletionTest.kt
@@ -11,14 +11,7 @@ import org.rust.cargo.project.workspace.CargoWorkspace
 class RsAwaitCompletionTest : RsCompletionTestBase() {
 
     @MockEdition(CargoWorkspace.Edition.EDITION_2015)
-    fun `test postfix await 2015 (anon)`() = checkCompletion("await", """
-        #[lang = "core::future::future::Future"]
-        trait Future { type Output; }
-        fn foo() -> impl Future<Output=i32> { unimplemented!() }
-        fn main() {
-            foo()./*caret*/;
-        }
-    """, """
+    fun `test postfix await 2015 (anon)`() = checkNotContainsCompletion("await", """
         #[lang = "core::future::future::Future"]
         trait Future { type Output; }
         fn foo() -> impl Future<Output=i32> { unimplemented!() }
@@ -28,16 +21,7 @@ class RsAwaitCompletionTest : RsCompletionTestBase() {
     """)
 
     @MockEdition(CargoWorkspace.Edition.EDITION_2015)
-    fun `test postfix await 2015 (adt)`() = checkCompletion("await", """
-        #[lang = "core::future::future::Future"]
-        trait Future { type Output; }
-        struct S;
-        impl Future for S { type Output = i32; }
-        fn foo() -> S { unimplemented!() }
-        fn main() {
-            foo()./*caret*/;
-        }
-    """, """
+    fun `test postfix await 2015 (adt)`() = checkNotContainsCompletion("await", """
         #[lang = "core::future::future::Future"]
         trait Future { type Output; }
         struct S;

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
@@ -106,6 +106,16 @@ abstract class RsCompletionTestBase : RsTestBase() {
         render: LookupElement.() -> String = { lookupString }
     ) = completionFixture.checkNotContainsCompletion(code, variant, render)
 
+    protected fun checkNotContainsCompletion(
+        variants: List<String>,
+        @Language("Rust") code: String,
+        render: LookupElement.() -> String = { lookupString }
+    ) {
+        for (variant in variants) {
+            completionFixture.checkNotContainsCompletion(code, variant, render)
+        }
+    }
+
     protected open fun checkNoCompletion(@Language("Rust") code: String) = completionFixture.checkNoCompletion(code)
 
     protected fun checkNoCompletionByFileTree(@Language("Rust") code: String) =

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixtureBase.kt
@@ -61,12 +61,16 @@ abstract class RsCompletionTestFixtureBase<IN>(
             checkByText(before, after.trimIndent()) {
                 val items = myFixture.completeBasic()
                     ?: return@checkByText // single completion was inserted
-                val lookupItem = items.find { it.lookupString == lookupString } ?: return@checkByText
+                val lookupItem = items.find { it.lookupString == lookupString } ?: error("Lookup string $lookupString not found")
                 myFixture.lookup.currentItem = lookupItem
                 myFixture.type(completionChar)
             }
         }
-        testmark?.checkHit(action)
+        if (testmark != null) {
+            testmark.checkHit(action)
+        } else {
+            action()
+        }
     }
 
     fun checkNoCompletion(code: IN) {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsKeywordCompletionContributorTest.kt
@@ -691,13 +691,7 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         }
     """)
 
-    fun `test no if|match after path segment`() = checkCompletion(CONDITION_KEYWORDS, """
-        struct Foo;
-
-        fn foo() {
-            Foo::/*caret*/
-        }
-    """, """
+    fun `test no if|match after path segment`() = checkNotContainsCompletion(CONDITION_KEYWORDS, """
         struct Foo;
 
         fn foo() {
@@ -705,9 +699,7 @@ class RsKeywordCompletionContributorTest : RsCompletionTestBase() {
         }
     """)
 
-    fun `test no if|match out of function`() = checkCompletion(CONDITION_KEYWORDS, """
-        const FOO: &str = /*caret*/
-    """, """
+    fun `test no if|match out of function`() = checkNotContainsCompletion(CONDITION_KEYWORDS, """
         const FOO: &str = /*caret*/
     """)
 

--- a/src/test/kotlin/org/rust/lang/core/completion/RsVisibilityCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsVisibilityCompletionTest.kt
@@ -15,7 +15,7 @@ class RsVisibilityCompletionTest : RsCompletionTestBase() {
         }
     """, """
         struct S {
-            pub/*caret*/ a: u32
+            pub /*caret*/a: u32
         }
     """)
 
@@ -52,7 +52,7 @@ class RsVisibilityCompletionTest : RsCompletionTestBase() {
     fun `test tuple field decl`() = checkCompletion("pub", """
         struct S(/*caret*/u32);
     """, """
-        struct S(pub/*caret*/ u32);
+        struct S(pub /*caret*/u32);
     """)
 
     fun `test inside struct tuple fields`() = checkContainsCompletion("pub", """


### PR DESCRIPTION
While working on https://github.com/intellij-rust/intellij-rust/issues/3830, I noticed that the function `RsCompletionTestBase::checkCompletion` does not behave correctly. If no testmark is passed to the function, it basically won't do anything, therefore the test will always succeed.

I changed `checkCompletion` so that it actually does something even without a testmark. It now also throws an error if the passed lookup string is not found.

There were a few tests that used `checkCompletion` without a testmark, so they passed even though they were actually failing. I tried to fix them.