### PR TITLE
LI: fixed intentions and fixes running within doctests

### DIFF
--- a/src/main/kotlin/org/rust/openapiext/Template.kt
+++ b/src/main/kotlin/org/rust/openapiext/Template.kt
@@ -10,6 +10,7 @@ import com.intellij.codeInsight.template.TemplateBuilderFactory
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.SmartPsiElementPointer
+import com.intellij.psi.impl.source.tree.injected.InjectedLanguageEditorUtil
 
 fun <T : PsiElement, E : PsiElement> Editor.buildAndRunTemplate(
     owner: T,
@@ -22,5 +23,5 @@ fun <T : PsiElement, E : PsiElement> Editor.buildAndRunTemplate(
         val element = elementPointer.element ?: continue
         templateBuilder.replaceElement(element, element.text)
     }
-    templateBuilder.run(this, true)
+    templateBuilder.run(InjectedLanguageEditorUtil.getTopLevelEditor(this), true)
 }

--- a/src/test/kotlin/org/rust/ide/annotator/fixes/DoctestFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/annotator/fixes/DoctestFixTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.annotator.fixes
+
+import org.intellij.lang.annotations.Language
+import org.rust.ide.annotator.*
+
+class DoctestFixTest : RsAnnotationTestBase() {
+
+    fun `test in doctest fix const`() = doTest("Add type i32", """
+        <error descr="Missing type for `const` item">const CONST/*caret*/ = 1;</error>
+    """, """
+        const CONST:i32/*caret*/ = 1;
+    """)
+
+    fun `test in doctest add missing fields`() = doTest("Add missing fields", """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+        }
+        fn main() {
+            let <error descr="Struct pattern does not mention field `c` [E0027]">Foo { a, b, }/*caret*/</error> = foo;
+        }
+        """, """
+        struct Foo {
+            a: i32,
+            b: i32,
+            c: i32,
+        }
+        fn main() {
+            let Foo { a, b,c, }/*caret*/ = foo;
+        }
+        """
+    )
+
+    fun `test in doctest add missing tuple fields`() = doTest("Fill missing arguments", """
+        struct S(i32, i32);
+
+        fn main() {
+            let _ = S <error descr="This function takes 2 parameters but 1 parameter was supplied [E0061]">(2, <error descr="null">/*caret*/)</error></error>;
+        }
+    """, """
+        struct S(i32, i32);
+
+        fn main() {
+            let _ = S (2, 0/*caret*/);
+        }
+    """)
+
+    fun `test in doctest fill function arguments`() = doTest("Fill missing arguments", """
+        fn foo(a: u32) {}
+
+        fn main() {
+            foo<error>(<error>/*caret*/)</error></error>;
+        }
+    """, """
+        fn foo(a: u32) {}
+
+        fn main() {
+            foo(0);
+        }
+    """)
+
+    override fun createAnnotationFixture(): RsAnnotationTestFixture<Unit> {
+        val annotatorClasses = listOf(RsExpressionAnnotator::class, RsSyntaxErrorsAnnotator::class, RsErrorAnnotator::class)
+        return RsAnnotationTestFixture(this, myFixture, annotatorClasses = annotatorClasses)
+    }
+
+    fun doTest(fixName: String, @Language("Rust") before: String, @Language("Rust") after: String) {
+        val template = { text: String ->
+            """
+                //- lib.rs
+
+                /// Lorem ipsum documentali Rust epmaxle tragi. Funebar
+                /// illi _qutiden_ nekto __ulimami_.
+                ///
+                /// ```
+                %s
+                /// ```
+                ///
+                /// Nor amibal queto [tidi] oureteba.
+                ///
+                /// [tidi]: https://www.example.com
+                struct Foo;
+            """.trimIndent().format(text.prependIndent("/// "))
+        }
+        myFixture.setCaresAboutInjection(false)
+        checkFixByFileTree(
+            fixName,
+            before = template(before.trimIndent()),
+            after = template(after.trimIndent()),
+            checkWarn = false,
+            checkInfo = false,
+            checkWeakWarn = false,
+        )
+    }
+}


### PR DESCRIPTION
Closes #6790

Previously modification of injected doctest code was incorrectly handled, so that applying an fix or intention could result in corrupted code following the doctest. The reason was that modifications within a doctest run in their own injected editor, which wasn't correctly projected back into the containing file editor, but the offsets of changes were calculated relative to the whole file.

<!--
Hello and thank you for the pull request!

We don't have any strict rules about pull requests, but you might check
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md
for some hints!

Note that we need an electronic CLA for contributions:
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTING.md#cla

After you sign the CLA, please add your name to
https://github.com/intellij-rust/intellij-rust/blob/master/CONTRIBUTORS.txt

Also, please write a short description explaining your change in the following format: `changelog: %description%`
This description will help a lot to create release changelog. 
Drop these lines for internal only changes

:)
-->

changelog: fixed intentions and type fixes applied with documentation tests
