### PR TITLE
COMP: complete lambdas in function expression position

### DIFF
--- a/src/main/kotlin/org/rust/ide/utils/template/EditorExt.kt
+++ b/src/main/kotlin/org/rust/ide/utils/template/EditorExt.kt
@@ -24,7 +24,7 @@ fun Editor.buildAndRunTemplate(
     val tbl = newTemplateBuilder(owner) ?: return
     for (elementPointer in elementsToReplace) {
         val element = elementPointer.element ?: continue
-        tbl.replaceElement(element, element.text)
+        tbl.replaceElement(element)
     }
     if (listener != null) {
         tbl.withListener(listener)

--- a/src/main/kotlin/org/rust/ide/utils/template/RsTemplateBuilder.kt
+++ b/src/main/kotlin/org/rust/ide/utils/template/RsTemplateBuilder.kt
@@ -38,8 +38,8 @@ class RsTemplateBuilder(
     private var disableDaemonHighlighting: Boolean = false
     private val listeners: MutableList<TemplateEditingListener> = mutableListOf()
 
-    fun replaceElement(element: PsiElement, replacementText: String): RsTemplateBuilder {
-        delegate.replaceElement(element, replacementText)
+    fun replaceElement(element: PsiElement, replacementText: String? = null): RsTemplateBuilder {
+        delegate.replaceElement(element, replacementText ?: element.text)
         return this
     }
 

--- a/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsCompletionContributor.kt
@@ -33,6 +33,7 @@ class RsCompletionContributor : CompletionContributor() {
         extend(CompletionType.BASIC, RsRustcLintCompletionProvider)
         extend(CompletionType.BASIC, RsImplTraitMemberCompletionProvider)
         extend(CompletionType.BASIC, RsVisRestrictionCompletionProvider)
+        extend(CompletionType.BASIC, RsLambdaExprCompletionProvider)
     }
 
     fun extend(type: CompletionType?, provider: RsCompletionProvider) {

--- a/src/main/kotlin/org/rust/lang/core/completion/RsLambdaExprCompletionProvider.kt
+++ b/src/main/kotlin/org/rust/lang/core/completion/RsLambdaExprCompletionProvider.kt
@@ -1,0 +1,98 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.patterns.ElementPattern
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiErrorElement
+import com.intellij.psi.util.descendantsOfType
+import com.intellij.psi.util.parentOfType
+import com.intellij.util.ProcessingContext
+import org.rust.ide.utils.template.newTemplateBuilder
+import org.rust.lang.core.psi.*
+import org.rust.lang.core.psi.RsElementTypes.OR
+import org.rust.lang.core.psi.ext.elementType
+import org.rust.lang.core.psi.ext.getNextNonWhitespaceSibling
+import org.rust.lang.core.psi.ext.leftSiblings
+import org.rust.lang.core.psi.ext.startOffset
+import org.rust.lang.core.psiElement
+import org.rust.lang.core.types.expectedType
+import org.rust.lang.core.types.implLookup
+import org.rust.openapiext.createSmartPointer
+
+object RsLambdaExprCompletionProvider : RsCompletionProvider() {
+
+    override val elementPattern: ElementPattern<PsiElement>
+        get() = psiElement<PsiElement>()
+            .withSuperParent(2, psiElement<RsPathExpr>())
+
+    override fun addCompletions(
+        parameters: CompletionParameters,
+        context: ProcessingContext,
+        result: CompletionResultSet
+    ) {
+        val element = parameters.position.safeGetOriginalOrSelf()
+        val expr = element.parentOfType<RsExpr>() ?: return
+
+        val paramCount = getParameterCount(expr) ?: return
+        val params = (0 until paramCount).joinToString(", ") { "p${it}" }
+
+        val start = if (expr.leftSiblings.filter { it !is PsiErrorElement }.firstOrNull()?.elementType == OR) {
+            ""
+        } else {
+            "|"
+        }
+        val text = "$start$params| {}"
+
+        result.addElement(
+            LookupElementBuilder
+                .create(text)
+                .bold()
+                .withPresentableText("|| {}")
+                .withInsertHandler { ctx, _ -> handleInsert(ctx) }
+                .withPriority(KEYWORD_PRIORITY * 1.01)
+        )
+    }
+}
+
+private fun handleInsert(ctx: InsertionContext) {
+    val lambda = ctx.getElementOfType<RsLambdaExpr>() ?: return
+    val pats = lambda.descendantsOfType<RsPatIdent>().toList()
+
+    val lambdaPtr = lambda.createSmartPointer()
+
+    val template = ctx.editor.newTemplateBuilder(lambda) ?: return
+    for (pat in pats) {
+        template.replaceElement(pat)
+    }
+
+    val expr = lambda.expr
+    if (expr != null) {
+        template.replaceElement(expr)
+    }
+    template.withFinishResultListener {
+        val element = lambdaPtr.element
+        if (element != null) {
+            val blockExpr = element.expr as? RsBlockExpr ?: return@withFinishResultListener
+            if (blockExpr.block.lbrace.getNextNonWhitespaceSibling() != blockExpr.block.rbrace) {
+                return@withFinishResultListener
+            }
+
+            val offset = blockExpr.block.lbrace.startOffset
+            ctx.editor.caretModel.moveToOffset(offset + 1)
+        }
+    }
+    template.runInline()
+}
+
+private fun getParameterCount(expr: RsExpr): Int? {
+    val type = expr.expectedType ?: return null
+    return expr.implLookup.asTyFunction(type)?.value?.paramTypes?.size
+}

--- a/src/test/kotlin/org/rust/RsTestBase.kt
+++ b/src/test/kotlin/org/rust/RsTestBase.kt
@@ -6,6 +6,7 @@
 package org.rust
 
 import com.intellij.TestCase
+import com.intellij.codeInsight.template.impl.TemplateManagerImpl
 import com.intellij.findAnnotationInstance
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.runWriteAction
@@ -275,6 +276,23 @@ abstract class RsTestBase : BasePlatformTestCase(), RsTestCase {
         action()
         PsiTestUtil.checkPsiStructureWithCommit(myFixture.file, PsiTestUtil::checkPsiMatchesTextIgnoringNonCode)
         myFixture.checkResult(replaceCaretMarker(after))
+    }
+
+    protected fun checkByTextWithLiveTemplate(
+        @Language("Rust") before: String,
+        @Language("Rust") after: String,
+        toType: String,
+        fileName: String = "main.rs",
+        action: () -> Unit
+    ) {
+        val actionWithTemplate = {
+            action()
+            assertNotNull(TemplateManagerImpl.getTemplateState(myFixture.editor))
+            myFixture.type(toType)
+            assertNull(TemplateManagerImpl.getTemplateState(myFixture.editor))
+        }
+        TemplateManagerImpl.setTemplateTesting(testRootDisposable)
+        checkByText(before, after, fileName, actionWithTemplate)
     }
 
     protected fun checkCaretMove(

--- a/src/test/kotlin/org/rust/lang/core/completion/RsLambdaExprCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsLambdaExprCompletionTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.lang.core.completion
+
+import com.intellij.codeInsight.lookup.LookupElementPresentation
+import org.intellij.lang.annotations.Language
+import org.rust.ProjectDescriptor
+import org.rust.WithStdlibRustProjectDescriptor
+
+class RsLambdaExprCompletionTest : RsCompletionTestBase() {
+    fun `test complete after pipe`() = doTest("""
+        fn foo(f: fn(u32) -> ()) {}
+
+        fn main() {
+            foo(|/*caret*/);
+        }
+    """, """
+        fn foo(f: fn(u32) -> ()) {}
+
+        fn main() {
+            foo(|p0| {/*caret*/});
+        }
+    """)
+
+    fun `test no arguments`() = doTest("""
+        fn foo(f: fn() -> ()) {}
+
+        fn main() {
+            foo(/*caret*/);
+        }
+    """, """
+        fn foo(f: fn() -> ()) {}
+
+        fn main() {
+            foo(|| {/*caret*/});
+        }
+    """)
+
+    fun `test multiple arguments`() = doTest("""
+        fn foo(f: fn(u32, bool) -> ()) {}
+
+        fn main() {
+            foo(/*caret*/);
+        }
+    """, """
+        fn foo(f: fn(u32, bool) -> ()) {}
+
+        fn main() {
+            foo(|p0/*caret*/, p1| {});
+        }
+    """)
+
+    fun `test template`() = doTestWithTemplate("""
+        fn foo(f: fn(u32, bool) -> ()) {}
+
+        fn main() {
+            foo(/*caret*/);
+        }
+    """, "foo\tbar\t1 + 2\t", """
+        fn foo(f: fn(u32, bool) -> ()) {}
+
+        fn main() {
+            foo(|foo, bar| 1 + 2/*caret*/);
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test impl Fn`() = doTest("""
+        fn foo(f: impl Fn(u32, bool) -> ()) {}
+
+        fn main() {
+            foo(/*caret*/);
+        }
+    """, """
+        fn foo(f: impl Fn(u32, bool) -> ()) {}
+
+        fn main() {
+            foo(|p0/*caret*/, p1| {});
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test dyn Fn`() = doTest("""
+        fn foo(f: &dyn Fn(u32, bool) -> ()) {}
+
+        fn main() {
+            foo(/*caret*/);
+        }
+    """, """
+        fn foo(f: &dyn Fn(u32, bool) -> ()) {}
+
+        fn main() {
+            foo(|p0/*caret*/, p1| {});
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test generic Fn`() = doTest("""
+        fn foo<F: Fn(u32, bool) -> ()>(f: F) {}
+
+        fn main() {
+            foo(/*caret*/);
+        }
+    """, """
+        fn foo<F: Fn(u32, bool) -> ()>(f: F) {}
+
+        fn main() {
+            foo(|p0/*caret*/, p1| {});
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test generic FnMut`() = doTest("""
+        fn foo<F: FnMut(u32, bool) -> ()>(f: F) {}
+
+        fn main() {
+            foo(/*caret*/);
+        }
+    """, """
+        fn foo<F: FnMut(u32, bool) -> ()>(f: F) {}
+
+        fn main() {
+            foo(|p0/*caret*/, p1| {});
+        }
+    """)
+
+    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
+    fun `test generic FnOnce`() = doTest("""
+        fn foo<F: FnOnce(u32, bool) -> ()>(f: F) {}
+
+        fn main() {
+            foo(/*caret*/);
+        }
+    """, """
+        fn foo<F: FnOnce(u32, bool) -> ()>(f: F) {}
+
+        fn main() {
+            foo(|p0/*caret*/, p1| {});
+        }
+    """)
+
+    private fun doTest(@Language("Rust") before: String, @Language("Rust") after: String) {
+        checkByText(before.trimIndent(), after.trimIndent()) {
+            checkCompletion()
+        }
+    }
+
+    private fun doTestWithTemplate(@Language("Rust") before: String, toType: String, @Language("Rust") after: String) {
+        checkByTextWithLiveTemplate(before.trimIndent(), after.trimIndent(), toType) {
+            checkCompletion()
+        }
+    }
+
+    private fun checkCompletion() {
+        val items = myFixture.completeBasic()
+        val item = items.find {
+            val presentation = LookupElementPresentation()
+            it.renderElement(presentation)
+            presentation.itemText == "|| {}"
+        } ?: error("No lambda completion found")
+        myFixture.lookup.currentItem = item
+        myFixture.type('\n')
+    }
+}


### PR DESCRIPTION
This PR adds completion for lambds in expression positions that expect a function (`&dyn Fn`, `F: Fn`, `impl Fn`, `fn`). The check for `|` already being present is quite hacky, but I didn't know how else to do it, since the `|` in e.g. `foo(|)` is not parsed as an expression nor as an identifier.

![closure-completion](https://user-images.githubusercontent.com/4539057/124951149-60ebd200-e013-11eb-994f-741dd2a497fd.gif)

Fixes: https://github.com/intellij-rust/intellij-rust/issues/3830

changelog: Add completion for lambdas in expression positions that expect a function.