### PR TITLE
DBG: automatically break on panic inside debugger

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
@@ -51,12 +51,24 @@ class RsDebugProcessConfigurationHelper(
             try {
                 driver.loadRustcSources()
                 driver.loadPrettyPrinters()
+                driver.setBreakOnPanic()
             } catch (e: DebuggerCommandException) {
                 process.printlnToConsole(e.message)
                 LOG.warn(e)
             } catch (e: InvalidPathException) {
                 LOG.warn(e)
             }
+        }
+    }
+
+    private fun DebuggerDriver.setBreakOnPanic() {
+        val commands = when (this) {
+            is LLDBDriver -> listOf("breakpoint set -n rust_panic")
+            is GDBDriver -> listOf("set breakpoint pending on", "break rust_panic")
+            else -> return
+        }
+        for (command in commands) {
+            executeInterpreterCommand(threadId, frameIndex, command)
         }
     }
 

--- a/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/runconfig/RsDebugProcessConfigurationHelper.kt
@@ -51,7 +51,9 @@ class RsDebugProcessConfigurationHelper(
             try {
                 driver.loadRustcSources()
                 driver.loadPrettyPrinters()
-                driver.setBreakOnPanic()
+                if (settings.breakOnPanic) {
+                    driver.setBreakOnPanic()
+                }
             } catch (e: DebuggerCommandException) {
                 process.printlnToConsole(e.message)
                 LOG.warn(e)

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsBreakOnPanicConfigurableUi.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsBreakOnPanicConfigurableUi.kt
@@ -1,0 +1,31 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger.settings
+
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.layout.LayoutBuilder
+
+class RsBreakOnPanicConfigurableUi : RsDebuggerUiComponent() {
+    private val breakOnPanicCheckBox: JBCheckBox
+        = JBCheckBox("Break on panic", RsDebuggerSettings.getInstance().breakOnPanic)
+
+    override fun reset(settings: RsDebuggerSettings) {
+        breakOnPanicCheckBox.isSelected = settings.breakOnPanic
+    }
+
+    override fun isModified(settings: RsDebuggerSettings): Boolean
+        = settings.breakOnPanic != breakOnPanicCheckBox.isSelected
+
+    override fun apply(settings: RsDebuggerSettings) {
+        settings.breakOnPanic = breakOnPanicCheckBox.isSelected
+    }
+
+    override fun buildUi(builder: LayoutBuilder) {
+        with(builder) {
+            row { breakOnPanicCheckBox() }
+        }
+    }
+}

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerGeneralSettingsConfigurableUi.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerGeneralSettingsConfigurableUi.kt
@@ -1,0 +1,56 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger.settings
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.options.ConfigurableUi
+import com.intellij.ui.layout.panel
+import com.intellij.util.PlatformUtils
+import org.rust.debugger.RsDebuggerToolchainService
+import org.rust.debugger.RsDebuggerToolchainService.LLDBStatus
+import javax.swing.JComponent
+
+class RsDebuggerGeneralSettingsConfigurableUi : ConfigurableUi<RsDebuggerSettings>, Disposable {
+    private val needsToolchainSettings: Boolean
+        get() {
+            // CLion has own Toolchain settings
+            if (PlatformUtils.isCLion()) return false
+            val status = RsDebuggerToolchainService.getInstance().getBundledLLDBStatus()
+            // If there is bundled LLDB, no need to show this toolchain settings
+            return status !is LLDBStatus.Binaries
+        }
+
+    private val components: List<RsDebuggerUiComponent> = run {
+        val components = mutableListOf<RsDebuggerUiComponent>()
+        if (needsToolchainSettings) {
+            components.add(RsDebuggerToolchainConfigurableUi())
+        }
+        components.add(RsBreakOnPanicConfigurableUi())
+        components
+    }
+
+    override fun isModified(settings: RsDebuggerSettings): Boolean = components.any { it.isModified(settings) }
+
+    override fun reset(settings: RsDebuggerSettings) {
+        components.forEach { it.reset(settings) }
+    }
+
+    override fun apply(settings: RsDebuggerSettings) {
+        components.forEach { it.apply(settings) }
+    }
+
+    override fun getComponent(): JComponent {
+        return panel {
+            for (component in components) {
+                component.buildUi(this)
+            }
+        }
+    }
+
+    override fun dispose() {
+        components.forEach { it.dispose() }
+    }
+}

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerToolchainConfigurableUi.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerToolchainConfigurableUi.kt
@@ -5,11 +5,9 @@
 
 package org.rust.debugger.settings
 
-import com.intellij.openapi.Disposable
-import com.intellij.openapi.options.ConfigurableUi
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.Link
-import com.intellij.ui.layout.panel
+import com.intellij.ui.layout.LayoutBuilder
 import org.rust.debugger.RsDebuggerToolchainService
 import org.rust.debugger.RsDebuggerToolchainService.LLDBStatus
 import org.rust.openapiext.pathToDirectoryTextField
@@ -17,7 +15,7 @@ import javax.swing.AbstractButton
 import javax.swing.JComponent
 import javax.swing.JLabel
 
-class RsDebuggerToolchainConfigurableUi : ConfigurableUi<RsDebuggerSettings>, Disposable {
+class RsDebuggerToolchainConfigurableUi : RsDebuggerUiComponent() {
 
     private val downloadLink: JComponent = Link("Download") {
         val result = RsDebuggerToolchainService.getInstance().downloadDebugger()
@@ -39,7 +37,7 @@ class RsDebuggerToolchainConfigurableUi : ConfigurableUi<RsDebuggerSettings>, Di
 
     override fun isModified(settings: RsDebuggerSettings): Boolean {
         return settings.lldbPath != lldbPathField.text &&
-               settings.downloadAutomatically != downloadAutomaticallyCheckBox.isSelected
+            settings.downloadAutomatically != downloadAutomaticallyCheckBox.isSelected
     }
 
     override fun reset(settings: RsDebuggerSettings) {
@@ -52,17 +50,15 @@ class RsDebuggerToolchainConfigurableUi : ConfigurableUi<RsDebuggerSettings>, Di
         settings.downloadAutomatically = downloadAutomaticallyCheckBox.isSelected
     }
 
-    override fun getComponent(): JComponent {
+    override fun buildUi(builder: LayoutBuilder) {
         lldbPathField.text = RsDebuggerSettings.getInstance().lldbPath.orEmpty()
         update()
-        return panel {
+        with(builder) {
             row("LLDB path:") { lldbPathField() }
             row("") { downloadLink() }
             row { downloadAutomaticallyCheckBox() }
         }
     }
-
-    override fun dispose() {}
 
     private fun update() {
         @Suppress("MoveVariableDeclarationIntoWhen")

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerUiComponent.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerUiComponent.kt
@@ -1,0 +1,24 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger.settings
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.options.ConfigurableUi
+import com.intellij.ui.layout.LayoutBuilder
+import com.intellij.ui.layout.panel
+import javax.swing.JComponent
+
+abstract class RsDebuggerUiComponent: ConfigurableUi<RsDebuggerSettings>, Disposable {
+    abstract fun buildUi(builder: LayoutBuilder)
+
+    override fun getComponent(): JComponent {
+        return panel {
+            buildUi(this)
+        }
+    }
+
+    override fun dispose() {}
+}


### PR DESCRIPTION
This PR adds the option to break the debugger on any rust panic.

I had to slightly modify the debugger configurable implementation. Previously, only the toolchain options were inside the general debugger settings. I could not add another configurable, because it would have a duplicated `Rust` header, so I had to add the `break on panic` setting to the existing configurable that is used inside the general settings.

To keep the individual settings separate, I split them into separate classes so that they are not all mixed up. I also created a new base class (`RsDebuggerUiComponent`), because I didn't know how to compose `JComponent`s of multiple objects inside a single `panel` in the `getComponent` method in `RsDebuggerGeneralSettingsConfigurableUi`.

Fixes: https://github.com/intellij-rust/intellij-rust/issues/4763

changelog: Add debugger option to break on panic (enabled by default).