### PR TITLE
DBG: add option to not step into stdlib sources

### DIFF
--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettings.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSettings.kt
@@ -24,6 +24,7 @@ class RsDebuggerSettings : XDebuggerSettings<RsDebuggerSettings>("Rust") {
     var downloadAutomatically: Boolean = false
 
     var breakOnPanic: Boolean = true
+    var stepSettings: RsStepFilterSettings = RsStepFilterSettings(filterStdlib = false)
 
     var decorateMsvcTypeNames: Boolean = true
 
@@ -37,6 +38,7 @@ class RsDebuggerSettings : XDebuggerSettings<RsDebuggerSettings>("Rust") {
         val configurable = when (category) {
             DebuggerSettingsCategory.DATA_VIEWS -> createDataViewConfigurable()
             DebuggerSettingsCategory.GENERAL -> createGeneralSettingsConfigurable()
+            DebuggerSettingsCategory.STEPPING -> createSteppingConfigurable()
             else -> null
         }
         return listOfNotNull(configurable)
@@ -60,10 +62,19 @@ class RsDebuggerSettings : XDebuggerSettings<RsDebuggerSettings>("Rust") {
         )
     }
 
+    private fun createSteppingConfigurable(): Configurable {
+        return SimpleConfigurable.create(
+            STEPPING_ID,
+            RsDebuggerBundle.message("settings.rust.debugger.title"),
+            RsDebuggerSteppingSettingsConfigurableUi::class.java,
+            Companion::getInstance
+        )
+    }
+
     override fun isTargetedToProduct(configurable: Configurable): Boolean {
         if (configurable !is SearchableConfigurable) return false
         return when (configurable.id) {
-            GENERAL_SETTINGS_ID, DATA_VIEW_ID -> true
+            GENERAL_SETTINGS_ID, DATA_VIEW_ID, STEPPING_ID -> true
             else -> false
         }
     }
@@ -74,5 +85,6 @@ class RsDebuggerSettings : XDebuggerSettings<RsDebuggerSettings>("Rust") {
 
         const val GENERAL_SETTINGS_ID: String = "Debugger.Rust.General"
         const val DATA_VIEW_ID: String = "Debugger.Rust.DataView"
+        const val STEPPING_ID: String = "Debugger.Rust.Stepping"
     }
 }

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSteppingSettingsConfigurableUi.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsDebuggerSteppingSettingsConfigurableUi.kt
@@ -1,0 +1,37 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger.settings
+
+import com.intellij.openapi.options.ConfigurableUi
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.layout.panel
+import org.rust.debugger.RsDebuggerBundle
+import javax.swing.JComponent
+
+class RsDebuggerSteppingSettingsConfigurableUi : ConfigurableUi<RsDebuggerSettings> {
+    private val filterStdlib = JBCheckBox(
+        RsDebuggerBundle.message("settings.rust.debugger.do.not.step.into.stdlib.checkbox"),
+        RsDebuggerSettings.getInstance().stepSettings.filterStdlib
+    )
+
+    override fun isModified(settings: RsDebuggerSettings): Boolean {
+        return filterStdlib.isSelected != settings.stepSettings.filterStdlib
+    }
+
+    override fun reset(settings: RsDebuggerSettings) {
+        filterStdlib.isSelected = settings.stepSettings.filterStdlib
+    }
+
+    override fun apply(settings: RsDebuggerSettings) {
+        settings.stepSettings = RsStepFilterSettings(filterStdlib.isSelected)
+    }
+
+    override fun getComponent(): JComponent {
+        return panel {
+            row { filterStdlib() }
+        }
+    }
+}

--- a/debugger/src/main/kotlin/org/rust/debugger/settings/RsStepFilterSettings.kt
+++ b/debugger/src/main/kotlin/org/rust/debugger/settings/RsStepFilterSettings.kt
@@ -1,0 +1,10 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.debugger.settings
+
+data class RsStepFilterSettings(
+    val filterStdlib: Boolean
+)

--- a/debugger/src/main/resources/messages/RsDebuggerBundle.properties
+++ b/debugger/src/main/resources/messages/RsDebuggerBundle.properties
@@ -8,6 +8,7 @@ settings.rust.debugger.data.view.gdb.renderers.label=GDB renderers:
 settings.rust.debugger.data.view.lldb.renderers.label=LLDB renderers:
 settings.rust.debugger.data.view.name=Rust
 settings.rust.debugger.decorate.msvc.type.names.checkbox=Decorate MSVC type names
+settings.rust.debugger.do.not.step.into.stdlib.checkbox=Do not step into stdlib (std, core, alloc)
 settings.rust.debugger.title=Rust
 settings.rust.debugger.toolchain.download.debugger.automatically.checkbox=Download and update the debugger automatically
 settings.rust.debugger.toolchain.download.label=Download


### PR DESCRIPTION
This PR adds an option to not step into stdlib sources. In the future, it could be extended with a table for adding custom paths to be ignored (like what e.g. Python offers).

Currently, it doesn't work inside LLDB, because it does not use full paths for functions (e.g. `Vec::clear` is `example_project'clear<i32,alloc::alloc::Global>` instead of `alloc::vec::Vec::clear`). @ortem Do you have an idea how this could be fixed?

Fixes: https://github.com/intellij-rust/intellij-rust/issues/4764


https://user-images.githubusercontent.com/4854600/216394673-4292c396-1dd3-4531-b608-368cd592c8ad.mov

For QA: this feature is supposed to work
* with GDB on Linux and Windows
* with LLDB on macOS and Linux since CLion 2023.1 EAP 231.6471.1
* with MSVC LLDB on Windows

changelog: Add debugger option to not step into stdlib sources.