### PR TITLE
GRD: use kotlin 1.5.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ val compileNativeCodeTaskName = "compileNativeCode"
 
 plugins {
     idea
-    kotlin("jvm") version "1.4.32"
+    kotlin("jvm") version "1.5.20"
     id("org.jetbrains.intellij") version "1.1.2"
     id("org.jetbrains.grammarkit") version "2021.1.3"
     id("net.saliman.properties") version "1.5.1"
@@ -105,7 +105,7 @@ allprojects {
         withType<KotlinCompile> {
             kotlinOptions {
                 jvmTarget = "1.8"
-                languageVersion = "1.4"
+                languageVersion = "1.5"
                 apiVersion = "1.4"
                 freeCompilerArgs = listOf("-Xjvm-default=enable")
             }


### PR DESCRIPTION
changelog: Use Kotlin 1.5 for plugin compilation. So now it's possible to use [sealed interfaces](https://kotlinlang.org/docs/whatsnew15.html#sealed-interfaces) and place subclasses of sealed classes in [different files](https://kotlinlang.org/docs/whatsnew15.html#package-wide-sealed-class-hierarchies). Note, the new stdlib API is still unavailable in the project since the plugin may be launched in IDE with 1.4 runtime
