### PR TITLE
INSP: add quick fix to remove an unused import

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveImportFix.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/fixes/RemoveImportFix.kt
@@ -1,0 +1,38 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.rust.ide.intentions.RemoveCurlyBracesIntention
+import org.rust.lang.core.psi.RsUseGroup
+import org.rust.lang.core.psi.ext.RsElement
+import org.rust.lang.core.psi.ext.deleteWithSurroundingCommaAndWhitespace
+import org.rust.lang.core.psi.ext.parentUseSpeck
+
+
+/**
+ * Fix that removes a use speck or a whole use item.
+ */
+class RemoveImportFix(element: PsiElement) : LocalQuickFixOnPsiElement(element) {
+    override fun getText() = "Remove unused import"
+    override fun getFamilyName() = text
+
+    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+        val element = startElement as? RsElement ?: return
+
+        val parent = element.parent
+        element.deleteWithSurroundingCommaAndWhitespace()
+
+        if (parent is RsUseGroup) {
+            val parentSpeck = parent.parentUseSpeck
+            val ctx = RemoveCurlyBracesIntention.createContextIfCompatible(parentSpeck) ?: return
+            RemoveCurlyBracesIntention.removeCurlyBracesFromUseSpeck(ctx)
+        }
+    }
+}

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -18,31 +18,72 @@ class RsUnusedImportInspection : RsLintInspection() {
     override fun getLint(element: PsiElement): RsLint = RsLint.UnusedImports
 
     override fun buildVisitor(holder: RsProblemsHolder, isOnTheFly: Boolean) = object : RsVisitor() {
-        override fun visitUseSpeck(o: RsUseSpeck) {
+        override fun visitUseItem(item: RsUseItem) {
             if (!holder.project.isNewResolveEnabled) return
-            val item = o.ancestorStrict<RsUseItem>() ?: return
             if (item.isReexport) return
-            if (o.path?.resolveStatus != PathResolveStatus.RESOLVED) return
 
             // Do not check uses if there is a child mod inside the current mod
-            val parentMod = o.containingMod
+            val parentMod = item.containingMod
             val hasChildMods = parentMod.expandedItemsExceptImplsAndUses.any {
                 it is RsModItem || it is RsModDeclItem
             }
-            if (o.parentOfType<RsFunction>() == null && hasChildMods) return
+            if (item.parentOfType<RsFunction>() == null && hasChildMods) return
 
-            checkUseSpeck(o, holder)
+            val owner = item.parent as? RsItemsOwner ?: return
+            val usage = owner.pathUsage
+
+            val speck = item.useSpeck ?: return
+
+            val unusedSpeckSet = HashSet<RsUseSpeck>()
+            storeUseSpeckUsage(speck, usage, unusedSpeckSet)
+            markUnusedSpecks(speck, unusedSpeckSet, holder)
         }
     }
 
-    private fun checkUseSpeck(useSpeck: RsUseSpeck, holder: RsProblemsHolder) {
-        if (!useSpeck.isUsed()) {
-            val element = getHighlightElement(useSpeck)
-            holder.registerLintProblem(
-                element,
-                "Unused import: `${useSpeck.text}`"
-            )
+    /**
+     * Traverse all use specks recursively and store information about their usage.
+     */
+    private fun storeUseSpeckUsage(
+        useSpeck: RsUseSpeck,
+        usage: PathUsageMap,
+        unusedSpeckSet: MutableSet<RsUseSpeck>
+    ) {
+        val group = useSpeck.useGroup
+        val isUsed = if (group == null) {
+            isUseSpeckUsed(useSpeck, usage)
+        } else {
+            group.useSpeckList.forEach {
+                storeUseSpeckUsage(it, usage, unusedSpeckSet)
+            }
+            group.useSpeckList.any { it !in unusedSpeckSet }
         }
+        if (!isUsed) {
+            unusedSpeckSet.add(useSpeck)
+        }
+    }
+
+    private fun markUnusedSpecks(
+        useSpeck: RsUseSpeck,
+        unusedSpeckSet: Set<RsUseSpeck>,
+        holder: RsProblemsHolder
+    ) {
+        val used = useSpeck !in unusedSpeckSet
+
+        if (!used) {
+            markAsUnused(useSpeck, holder)
+        } else {
+            useSpeck.useGroup?.useSpeckList?.forEach {
+                markUnusedSpecks(it, unusedSpeckSet, holder)
+            }
+        }
+    }
+
+    private fun markAsUnused(useSpeck: RsUseSpeck, holder: RsProblemsHolder) {
+        val element = getHighlightElement(useSpeck)
+        holder.registerLintProblem(
+            element,
+            "Unused import: `${useSpeck.text}`"
+        )
     }
 }
 
@@ -58,16 +99,8 @@ private fun getHighlightElement(useSpeck: RsUseSpeck): PsiElement {
  * A usage can be either a path that uses the import of the use speck or a method call/associated item available through
  * a trait that is imported by this use speck.
  */
-private fun RsUseSpeck.isUsed(): Boolean {
-    val owner = this.parentOfType<RsUseItem>()?.parent as? RsItemsOwner ?: return true
-    val usage = owner.pathUsage
-    return isUseSpeckUsed(this, usage)
-}
-
 private fun isUseSpeckUsed(useSpeck: RsUseSpeck, usage: PathUsageMap): Boolean {
-    // Use speck with an empty group is always unused
-    val useGroup = useSpeck.useGroup
-    if (useGroup != null && useGroup.useSpeckList.isEmpty()) return false
+    if (useSpeck.path?.resolveStatus != PathResolveStatus.RESOLVED) return true
 
     val items = if (useSpeck.isStarImport) {
         val module = useSpeck.path?.reference?.resolve() as? RsMod ?: return true

--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -8,6 +8,7 @@ package org.rust.ide.inspections.lints
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.parentOfType
 import org.rust.ide.inspections.RsProblemsHolder
+import org.rust.ide.inspections.fixes.RemoveImportFix
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
 import org.rust.lang.core.resolve2.NamedItem
@@ -82,7 +83,8 @@ class RsUnusedImportInspection : RsLintInspection() {
         val element = getHighlightElement(useSpeck)
         holder.registerLintProblem(
             element,
-            "Unused import: `${useSpeck.text}`"
+            "Unused import: `${useSpeck.text}`",
+            RemoveImportFix(element)
         )
     }
 }

--- a/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseGroup.kt
+++ b/src/main/kotlin/org/rust/lang/core/psi/ext/RsUseGroup.kt
@@ -16,7 +16,8 @@ val RsUseGroup.parentUseSpeck: RsUseSpeck get() = parent as RsUseSpeck
 val RsUseGroup.asTrivial: RsUseSpeck?
     get() {
         val speck = useSpeckList.singleOrNull() ?: return null
-        if (speck.alias == null && !speck.isIdentifier) return null
+        // Do not collapse {self}
+        if (speck.alias == null && !speck.isIdentifier && speck.path?.path == null) return null
         // Do not change use-groups with comments
         if (SyntaxTraverser.psiTraverser(this).traverse().any { it is PsiComment }) return null
         return speck

--- a/src/test/kotlin/org/rust/ide/inspections/fixes/RemoveImportFixTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/fixes/RemoveImportFixTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.inspections.fixes
+
+import org.rust.UseNewResolve
+import org.rust.ide.inspections.RsInspectionsTestBase
+import org.rust.ide.inspections.lints.RsUnusedImportInspection
+
+@UseNewResolve
+class RemoveImportFixTest : RsInspectionsTestBase(RsUnusedImportInspection::class) {
+    fun `test remove use item in the middle`() = checkFixByText("Remove unused import", """
+        struct A;
+
+        mod foo {
+            use crate::FOO;
+            <warning>use crate::A/*caret*/;</warning>
+            use crate::BAR;
+        }
+    """, """
+        struct A;
+
+        mod foo {
+            use crate::FOO;
+            use crate::BAR;
+        }
+    """)
+
+    fun `test remove use speck at the beginning`() = checkFixByText("Remove unused import", """
+        struct A;
+
+        mod foo {
+            use crate::{<warning>A/*caret*/</warning>, FOO, BAR};
+        }
+    """, """
+        struct A;
+
+        mod foo {
+            use crate::{FOO, BAR};
+        }
+    """)
+
+    fun `test remove use speck in the middle`() = checkFixByText("Remove unused import", """
+        struct A;
+
+        mod foo {
+            use crate::{FOO, <warning>A/*caret*/</warning>, BAR};
+        }
+    """, """
+        struct A;
+
+        mod foo {
+            use crate::{FOO, BAR};
+        }
+    """)
+
+    fun `test remove use speck at the end`() = checkFixByText("Remove unused import", """
+        struct A;
+
+        mod foo {
+            use crate::{FOO, BAR, <warning>A/*caret*/</warning>};
+        }
+    """, """
+        struct A;
+
+        mod foo {
+            use crate::{FOO, BAR};
+        }
+    """)
+
+    fun `test collapse parent group with single item`() = checkFixByText("Remove unused import", """
+        struct A;
+
+        mod foo {
+            use crate::{FOO, <warning>A/*caret*/</warning>};
+        }
+    """, """
+        struct A;
+
+        mod foo {
+            use crate::FOO;
+        }
+    """)
+
+    fun `test collapse parent group with single qualified item`() = checkFixByText("Remove unused import", """
+        struct A;
+        mod inner {
+            pub struct B;
+        }
+
+        mod foo {
+            use crate::{<warning>A/*caret*/</warning>, inner::B};
+            fn foo(b: B) {}
+        }
+    """, """
+        struct A;
+        mod inner {
+            pub struct B;
+        }
+
+        mod foo {
+            use crate::inner::B;
+            fn foo(b: B) {}
+        }
+    """)
+}

--- a/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
+++ b/src/test/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspectionTest.kt
@@ -34,6 +34,32 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
     """)
 
+    fun `test annotate whole unused group`() = checkByText("""
+        mod foo {
+            pub struct S;
+            pub struct T1;
+            pub struct T2;
+        }
+
+        mod bar {
+            use super::foo::{S, <warning descr="Unused import: `{T1, T2}`">{T1, T2}</warning>};
+
+            fn bar(_: S) {}
+        }
+    """)
+
+    fun `test annotate whole unused use item`() = checkByText("""
+        mod foo {
+            pub struct S;
+            pub struct T1;
+            pub struct T2;
+        }
+
+        mod bar {
+            <warning descr="Unused import: `super::foo::{S, {T1, T2}}`">use super::foo::{S, {T1, T2}};</warning>
+        }
+    """)
+
     fun `test unused import with nested path in group`() = checkByText("""
         mod foo {
             pub struct R;
@@ -247,7 +273,7 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
         }
 
         mod bar {
-            use super::foo::bar::{<warning descr="Unused import: `self`">self</warning>};
+            <warning descr="Unused import: `super::foo::bar::{self}`">use super::foo::bar::{self};</warning>
         }
     """)
 
@@ -637,7 +663,7 @@ class RsUnusedImportInspectionTest : RsInspectionsTestBase(RsUnusedImportInspect
 
     @MockEdition(CargoWorkspace.Edition.EDITION_2018)
     @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
-    fun `test wrtieln macro`() = checkByText("""
+    fun `test writeln macro`() = checkByText("""
         use std::io::Write;
         fn main() {
             let mut w = Vec::new();

--- a/src/test/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntentionTest.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RemoveCurlyBracesIntentionTest.kt
@@ -6,6 +6,13 @@
 package org.rust.ide.intentions
 
 class RemoveCurlyBracesIntentionTest : RsIntentionTestBase(RemoveCurlyBracesIntention::class) {
+    fun `test unavailable on groups with more than one element`() = doUnavailableTest(
+        "use std::{f/*caret*/oo, bar};"
+    )
+
+    fun `test unavailable on speck without a group`() = doUnavailableTest(
+        "use std::f/*caret*/oo;"
+    )
 
     fun `test remove curly braces simple`() = doAvailableTest(
         "use std::{m/*caret*/em};",
@@ -25,5 +32,15 @@ class RemoveCurlyBracesIntentionTest : RsIntentionTestBase(RemoveCurlyBracesInte
     fun `test remove curly braces extra`() = doAvailableTest(
         "#[macro_use] pub use /*comment*/ std::{me/*caret*/m};",
         "#[macro_use] pub use /*comment*/ std::me/*caret*/m;"
+    )
+
+    fun `test nested`() = doAvailableTest(
+        "use foo::{bar::{baz/*caret*/}};",
+        "use foo::{bar::baz/*caret*/};",
+    )
+
+    fun `test qualified path`() = doAvailableTest(
+        "use foo::{bar::baz/*caret*/};",
+        "use foo::bar::baz/*caret*/;",
     )
 }


### PR DESCRIPTION
This PR adds a quick fix to remove an unused import. To make this fix more usable, I first changed the warning annotation range of `RsUnusedImportInspection`. This slightly deviates form the text displayed by `rustc`, but I think that it's more obvious for the user to see what is actually unused. And it will also allow the user to remove multiple unused use specks with a single quick fix.

The annotation is now checked only once per each use item, so some of the checks will not be performed per each use speck. This new annotation works in two steps. First I collect the usage (used/unused) of each use speck, and then I traverse them from the top and try to mark as large ranges as possible (i.e. if a group has two unused children, the group itself will also be marked as unused).

Before:
![before](https://user-images.githubusercontent.com/4539057/125036213-0a25dd00-e093-11eb-93f8-8e171911fa86.png)

After:
![after](https://user-images.githubusercontent.com/4539057/125036224-0db96400-e093-11eb-865a-2d4f66cc98dc.png)

In the quickfix it made sense to me to normalize the resulting use speck and flatten it if a group was reduced to a single element after removing an unused child of the group. To avoid duplicating code here, I reused `RemoveCurlyBracesIntention`. But before I had to update it a bit, since it's quite old and was unnecessarily strict. Now it's more general and can be also reused from other parts of the plugin.

The changes were relevant to each other and it's not too much code, but if you want, I can split this into multiple PRs.

changelog: Add a quick fix to remove an unused import.