### PR TITLE
T&PERF: improve tests performance

### DIFF
--- a/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/CargoProjectService.kt
@@ -51,6 +51,7 @@ interface CargoProjectsService {
      * @param manifest a path to `Cargo.toml` file of the project that should be attached
      */
     fun attachCargoProject(manifest: Path): Boolean
+    fun attachCargoProjects(vararg manifests: Path)
     fun detachCargoProject(cargoProject: CargoProject)
     fun refreshAllProjects(): CompletableFuture<out List<CargoProject>>
     fun discoverAndRefresh(): CompletableFuture<out List<CargoProject>>

--- a/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
+++ b/src/main/kotlin/org/rust/cargo/project/model/impl/CargoProjectImpl.kt
@@ -191,6 +191,18 @@ open class CargoProjectsServiceImpl(
         return true
     }
 
+    override fun attachCargoProjects(vararg manifests: Path) {
+        val manifests2 = manifests.filter { !isExistingProject(allProjects, it) }
+        if (manifests2.isEmpty()) return
+        modifyProjects { projects ->
+            val newManifests3 = manifests2.filter { !isExistingProject(projects, it) }
+            if (newManifests3.isEmpty())
+                CompletableFuture.completedFuture(projects)
+            else
+                doRefresh(project, projects + newManifests3.map { CargoProjectImpl(it, this) })
+        }
+    }
+
     override fun detachCargoProject(cargoProject: CargoProject) {
         modifyProjects { projects ->
             CompletableFuture.completedFuture(projects.filter { it.manifest != cargoProject.manifest })

--- a/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
+++ b/src/main/kotlin/org/rust/cargo/project/workspace/CargoWorkspace.kt
@@ -507,8 +507,7 @@ private class WorkspaceImpl(
         manifestPath,
         workspaceRootUrl,
         packages.map { pkg ->
-            // Currently, stdlib doesn't use 2018 edition
-            val packageEdition = if (pkg.origin == STDLIB) pkg.edition else edition
+            val packageEdition = if (pkg.origin == STDLIB || pkg.origin == STDLIB_DEPENDENCY) pkg.edition else edition
             pkg.asPackageData(packageEdition)
         },
         cfgOptions,

--- a/src/test/kotlin/org/rust/MockCargoFeatures.kt
+++ b/src/test/kotlin/org/rust/MockCargoFeatures.kt
@@ -10,7 +10,15 @@ import java.lang.annotation.Inherited
 /**
  * Allows setting cargo features for a specific test ([RsTestBase]).
  *
- * Use it like `@MockCargoFeatures("package_name/feature_name")`.
+ * Examples:
+ *
+ * ```
+ * @MockCargoFeatures("foo", "bar")
+ * @MockCargoFeatures("foo=[dep]", "dep")
+ * @MockCargoFeatures("package_name/feature_name")
+ * @MockCargoFeatures("package_name/foo=[package_name/dep]", "package_name/dep")
+ * ```
+ *
  * `package_name` can be omitted. In this case "test-package" assumed.
  *
  * @see RsTestBase.setupMockCfgOptions

--- a/src/test/kotlin/org/rust/cargo/project/model/impl/CargoProjectDeduplicationTest.kt
+++ b/src/test/kotlin/org/rust/cargo/project/model/impl/CargoProjectDeduplicationTest.kt
@@ -41,8 +41,10 @@ class CargoProjectDeduplicationTest : RsWithToolchainTestBase() {
     }.run {
         create(project, cargoProjectDirectory)
         val rootProjectManifest = cargoProjectDirectory.findFileByRelativePath("root-project/Cargo.toml")!!
-        project.testCargoProjects.attachCargoProject(rootProjectManifest.pathAsPath)
-        project.testCargoProjects.attachCargoProject(cargoProjectDirectory.pathAsPath.resolve("root-project/subproject/Cargo.toml"))
+        project.testCargoProjects.attachCargoProjects(
+            rootProjectManifest.pathAsPath,
+            cargoProjectDirectory.pathAsPath.resolve("root-project/subproject/Cargo.toml")
+        )
         assertEquals(2, project.testCargoProjects.allProjects.size)
         runWriteAction {
             VfsUtil.saveText(rootProjectManifest, VfsUtil.loadText(rootProjectManifest).replace("#", ""))
@@ -82,15 +84,16 @@ class CargoProjectDeduplicationTest : RsWithToolchainTestBase() {
         }
     }.run {
         create(project, cargoProjectDirectory)
-        project.testCargoProjects.attachCargoProject(cargoProjectDirectory.pathAsPath.resolve("root-project/subproject_1/Cargo.toml"))
-        project.testCargoProjects.attachCargoProject(cargoProjectDirectory.pathAsPath.resolve("root-project/subproject_2/Cargo.toml"))
+        project.testCargoProjects.attachCargoProjects(
+            cargoProjectDirectory.pathAsPath.resolve("root-project/subproject_1/Cargo.toml"),
+            cargoProjectDirectory.pathAsPath.resolve("root-project/subproject_2/Cargo.toml")
+        )
         assertEquals(2, project.testCargoProjects.allProjects.size)
         val rootProjectManifest = cargoProjectDirectory.findFileByRelativePath("root-project/__Cargo.toml")!!
         runWriteAction {
             rootProjectManifest.rename(null, "Cargo.toml")
         }
         project.testCargoProjects.attachCargoProject(rootProjectManifest.pathAsPath)
-        project.testCargoProjects.refreshAllProjectsSync()
         assertEquals(rootProjectManifest.pathAsPath, project.testCargoProjects.singleProject().manifest)
     }
 
@@ -136,14 +139,12 @@ class CargoProjectDeduplicationTest : RsWithToolchainTestBase() {
         val rootProjectManifest = cargoProjectDirectory.findFileByRelativePath("root-project/Cargo.toml")!!
         val includedProjectManifest = cargoProjectDirectory.pathAsPath.resolve("root-project/subproject_1/Cargo.toml")
         val excludedProjectManifest = cargoProjectDirectory.pathAsPath.resolve("root-project/subproject_2/Cargo.toml")
-        project.testCargoProjects.attachCargoProject(includedProjectManifest)
-        project.testCargoProjects.attachCargoProject(excludedProjectManifest)
+        project.testCargoProjects.attachCargoProjects(includedProjectManifest, excludedProjectManifest)
         assertEquals(2, project.testCargoProjects.allProjects.size)
         runWriteAction {
             VfsUtil.saveText(rootProjectManifest, VfsUtil.loadText(rootProjectManifest).replace("#", ""))
         }
         project.testCargoProjects.attachCargoProject(rootProjectManifest.pathAsPath)
-        project.testCargoProjects.refreshAllProjectsSync()
         assertEquals(
             listOf(
                 rootProjectManifest.pathAsPath,
@@ -181,8 +182,10 @@ class CargoProjectDeduplicationTest : RsWithToolchainTestBase() {
     }.run {
         create(project, cargoProjectDirectory)
         val rootProjectManifest = cargoProjectDirectory.findFileByRelativePath("root-project/Cargo.toml")!!
-        project.testCargoProjects.attachCargoProject(rootProjectManifest.pathAsPath)
-        project.testCargoProjects.attachCargoProject(cargoProjectDirectory.pathAsPath.resolve("root-project/subproject/Cargo.toml"))
+        project.testCargoProjects.attachCargoProjects(
+            rootProjectManifest.pathAsPath,
+            cargoProjectDirectory.pathAsPath.resolve("root-project/subproject/Cargo.toml")
+        )
         assertEquals(2, project.testCargoProjects.allProjects.size)
         runWriteAction {
             VfsUtil.saveText(rootProjectManifest, VfsUtil.loadText(rootProjectManifest).replace("#", ""))

--- a/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterCargoTest.kt
+++ b/src/test/kotlin/org/rust/cargo/runconfig/filters/RsBacktraceFilterCargoTest.kt
@@ -5,8 +5,6 @@
 
 package org.rust.cargo.runconfig.filters
 
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibRustProjectDescriptor
 import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.cargo.runconfig.filters.HighlightFilterTestBase.Companion.checkHighlights
@@ -16,7 +14,6 @@ import org.rust.singleWorkspace
 /**
  * Cargo tests for [RsBacktraceFilter]
  */
-@ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
 class RsBacktraceFilterCargoTest : RsWithToolchainTestBase() {
     private val filter: RsBacktraceFilter
         get() = RsBacktraceFilter(project, cargoProjectDirectory, project.cargoProjects.singleWorkspace())

--- a/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/intentions/RsIntentionTestBase.kt
@@ -103,10 +103,10 @@ abstract class RsIntentionTestBase(private val intentionClass: KClass<out Intent
     }
 
     private fun findIntention(): IntentionAction? {
-        return myFixture.availableIntentions.firstOrNull {
+        return IntentionManager.getInstance().intentionActions.firstOrNull {
             val originalIntention = IntentionActionDelegate.unwrap(it)
             intentionClass == originalIntention::class
-        }
+        }?.takeIf { it.isAvailable(project, myFixture.editor, myFixture.file) }
     }
 
     protected fun checkAvailableInSelectionOnly(@Language("Rust") code: String, fileName: String = "main.rs") {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestBase.kt
@@ -104,16 +104,20 @@ abstract class RsCompletionTestBase : RsTestBase() {
         variant: String,
         @Language("Rust") code: String,
         render: LookupElement.() -> String = { lookupString }
-    ) = completionFixture.checkNotContainsCompletion(code, variant, render)
+    ) = completionFixture.checkNotContainsCompletion(code, setOf(variant), render)
+
+    protected fun checkNotContainsCompletion(
+        variants: Set<String>,
+        @Language("Rust") code: String,
+        render: LookupElement.() -> String = { lookupString }
+    ) = completionFixture.checkNotContainsCompletion(code, variants, render)
 
     protected fun checkNotContainsCompletion(
         variants: List<String>,
         @Language("Rust") code: String,
         render: LookupElement.() -> String = { lookupString }
     ) {
-        for (variant in variants) {
-            completionFixture.checkNotContainsCompletion(code, variant, render)
-        }
+        completionFixture.checkNotContainsCompletion(code, variants.toSet(), render)
     }
 
     protected open fun checkNoCompletion(@Language("Rust") code: String) = completionFixture.checkNoCompletion(code)

--- a/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixture.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsCompletionTestFixture.kt
@@ -48,7 +48,7 @@ class RsCompletionTestFixture(
         render: LookupElement.() -> String = { lookupString }
     ) {
         fileTreeFromText(code).createAndOpenFileWithCaretMarker(myFixture)
-        doContainsCompletion(variants, render)
+        doContainsCompletion(variants.toSet(), render)
     }
 
     private fun checkAstNotLoaded(fileFilter: VirtualFileFilter) {

--- a/src/test/kotlin/org/rust/lang/core/completion/RsFragmentSpecifierCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsFragmentSpecifierCompletionTest.kt
@@ -29,14 +29,10 @@ class RsFragmentSpecifierCompletionTest : RsCompletionTestBase() {
 
     @Suppress("SameParameterValue")
     private fun checkContains(@Language("Rust") text: String) {
-        for (fragmentKind in FragmentKind.kinds) {
-            checkContainsCompletion(fragmentKind, text)
-        }
+        checkContainsCompletion(FragmentKind.kinds.toList(), text)
     }
 
     private fun checkNotContains(@Language("Rust") text: String) {
-        for (fragmentKind in FragmentKind.kinds) {
-            checkNotContainsCompletion(fragmentKind, text)
-        }
+        checkNotContainsCompletion(FragmentKind.kinds.toSet(), text)
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPartialMacroArgumentCompletionTest.kt
@@ -6,8 +6,6 @@
 package org.rust.lang.core.completion
 
 import org.intellij.lang.annotations.Language
-import org.rust.ProjectDescriptor
-import org.rust.WithStdlibRustProjectDescriptor
 
 class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
     fun `test expr 1`() = doTest("""
@@ -84,7 +82,6 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
         }
     """, setOf("iii", "i32"))
 
-    @ProjectDescriptor(WithStdlibRustProjectDescriptor::class)
     fun `test no completion from index`() = doTest("""
         macro_rules! my_macro {
             ($ e:expr, foo) => (1);
@@ -94,6 +91,10 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
         fn main() {
             my_macro!(Hash/*caret*/);
         }
+
+        pub mod collections {
+            pub struct HashMap;
+        }
     """, setOf(), setOf("HashMap"))
 
     fun `test different fragment offsets`() = doTest("""
@@ -101,7 +102,7 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
             (foo * $ e:ty, b) => (1);
             ($ e:expr, a) => (1);
         }
-        
+
         fn main() {
             let iii = 1;
             my_macro!(foo * i/*caret*/);
@@ -111,11 +112,11 @@ class RsPartialMacroArgumentCompletionTest : RsCompletionTestBase() {
     private fun doTest(@Language("Rust") code: String, contains: Set<String>, notContains: Set<String> = emptySet()) {
         RsPartialMacroArgumentCompletionProvider.Testmarks.touched.checkHit {
             RsFullMacroArgumentCompletionProvider.Testmarks.touched.checkNotHit {
-                for (variant in contains) {
-                    checkContainsCompletion(variant, code)
+                if (contains.isNotEmpty()) {
+                    checkContainsCompletion(contains.toList(), code)
                 }
-                for (variant in notContains) {
-                    checkNotContainsCompletion(variant, code)
+                if (notContains.isNotEmpty()) {
+                    checkNotContainsCompletion(notContains, code)
                 }
             }
         }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsPrimitiveTypeCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsPrimitiveTypeCompletionTest.kt
@@ -22,8 +22,7 @@ class RsPrimitiveTypeCompletionTest : RsCompletionTestBase() {
 
     private fun doTest(@Language("Rust") text: String) {
         val primitiveTypes = TyInteger.VALUES + TyFloat.VALUES + TyBool.INSTANCE + TyStr.INSTANCE + TyChar.INSTANCE
-        for (ty in primitiveTypes) {
-            checkContainsCompletion(ty.name, text)
-        }
+        val primitiveTypeNames = primitiveTypes.map { it.name }
+        checkContainsCompletion(primitiveTypeNames, text)
     }
 }

--- a/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/completion/RsStdlibCompletionTest.kt
@@ -89,7 +89,7 @@ class RsStdlibCompletionTest : RsCompletionTestBase() {
         use std::/*caret*/;
     """)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
+    @ExpandMacros(MacroExpansionScope.ALL, "actual_std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test complete items from 'os' module unix`() {
         if (!SystemInfo.isUnix) return
@@ -100,7 +100,7 @@ class RsStdlibCompletionTest : RsCompletionTestBase() {
         """)
     }
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
+    @ExpandMacros(MacroExpansionScope.ALL, "actual_std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test complete items from 'os' module windows`() {
         if (!SystemInfo.isWindows) return

--- a/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachingToolchainTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionCachingToolchainTest.kt
@@ -6,7 +6,6 @@
 package org.rust.lang.core.macros
 
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.impl.LaterInvocator
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VfsUtil
@@ -117,11 +116,6 @@ class RsMacroExpansionCachingToolchainTest : RsWithToolchainTestBase() {
     private fun attachCargoProjectAndExpandMacros(p: TestProject) {
         macroExpansionServiceDisposable = project.macroExpansionManager.setUnitTestExpansionModeAndDirectory(MacroExpansionScope.WORKSPACE, "mocked")
         check(project.cargoProjects.attachCargoProject(p.file("Cargo.toml").pathAsPath))
-        val future = project.cargoProjects.refreshAllProjects()
-        while (!future.isDone) {
-            Thread.sleep(10)
-            LaterInvocator.dispatchPendingFlushes()
-        }
     }
 
     fun `test re-open project without changes`() = stubBasedRefMatch.checkReExpanded(doNothing(), """

--- a/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/resolve/RsStdlibResolveTest.kt
@@ -712,7 +712,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
                         //^ ...libcore/macros/mod.rs|...core/src/macros/mod.rs
     """)
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
+    @ExpandMacros(MacroExpansionScope.ALL, "actual_std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test resolve in os module unix`() {
         if (!SystemInfo.isUnix) return
@@ -723,7 +723,7 @@ class RsStdlibResolveTest : RsResolveTestBase() {
         """)
     }
 
-    @ExpandMacros(MacroExpansionScope.ALL, "std")
+    @ExpandMacros(MacroExpansionScope.ALL, "actual_std")
     @ProjectDescriptor(WithActualStdlibRustProjectDescriptor::class)
     fun `test resolve in os module windows`() {
         if (!SystemInfo.isWindows) return

--- a/src/test/kotlin/org/rustSlowTests/CargoProjectServiceTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/CargoProjectServiceTest.kt
@@ -9,7 +9,6 @@ import org.rust.cargo.RsWithToolchainTestBase
 import org.rust.cargo.project.model.cargoProjects
 import org.rust.fileTree
 import org.rust.openapiext.pathAsPath
-import java.util.concurrent.TimeUnit
 
 
 class CargoProjectServiceTest : RsWithToolchainTestBase() {
@@ -75,10 +74,11 @@ class CargoProjectServiceTest : RsWithToolchainTestBase() {
 
         val rootPath = testProject.root.pathAsPath
         val projects = project.cargoProjects.apply {
-            attachCargoProject(rootPath.resolve("a/Cargo.toml"))
-            attachCargoProject(rootPath.resolve("b/Cargo.toml"))
-            attachCargoProject(rootPath.resolve("d/Cargo.toml"))
-            refreshAllProjects().get(1, TimeUnit.MINUTES)
+            attachCargoProjects(
+                rootPath.resolve("a/Cargo.toml"),
+                rootPath.resolve("b/Cargo.toml"),
+                rootPath.resolve("d/Cargo.toml"),
+            )
         }
 
         fun checkFile(relpath: String, projectName: String?) {

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoProjectResolveTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/CargoProjectResolveTest.kt
@@ -875,8 +875,10 @@ class CargoProjectResolveTest : RsWithToolchainTestBase() {
         }
     }.run {
         val prj = create(project, cargoProjectDirectory)
-        project.testCargoProjects.attachCargoProject(cargoProjectDirectory.pathAsPath.resolve("project_1/Cargo.toml"))
-        project.testCargoProjects.attachCargoProject(cargoProjectDirectory.pathAsPath.resolve("project_2/Cargo.toml"))
+        project.testCargoProjects.attachCargoProjects(
+            cargoProjectDirectory.pathAsPath.resolve("project_1/Cargo.toml"),
+            cargoProjectDirectory.pathAsPath.resolve("project_2/Cargo.toml"),
+        )
         prj.checkReferenceIsResolved<RsPath>("project_1/src/main.rs")
         prj.checkReferenceIsResolved<RsPath>("project_2/src/main.rs")
     }

--- a/src/test/kotlin/org/rustSlowTests/lang/resolve/RsProcMacroExpansionResolveIntegrationTest.kt
+++ b/src/test/kotlin/org/rustSlowTests/lang/resolve/RsProcMacroExpansionResolveIntegrationTest.kt
@@ -78,8 +78,10 @@ class RsProcMacroExpansionResolveIntegrationTest : RsWithToolchainTestBase() {
             }
         }.run {
             val prj = create(project, cargoProjectDirectory)
-            project.testCargoProjects.attachCargoProject(cargoProjectDirectory.pathAsPath.resolve("my_proc_macro/Cargo.toml"))
-            project.testCargoProjects.attachCargoProject(cargoProjectDirectory.pathAsPath.resolve("mylib/Cargo.toml"))
+            project.testCargoProjects.attachCargoProjects(
+                cargoProjectDirectory.pathAsPath.resolve("my_proc_macro/Cargo.toml"),
+                cargoProjectDirectory.pathAsPath.resolve("mylib/Cargo.toml")
+            )
             prj.checkReferenceIsResolved<RsMethodCall>("mylib/src/lib.rs")
         }
     }


### PR DESCRIPTION
1. Cache `RustcInfo` and `StandardLibrary` instances in rust project descriptors.
2. Don't change rust edition for stdlib dependencies by `@MockEdition` (this makes sense only for `WithActualStdlibRustProjectDescriptor`)
3. Use a different macro expansion caching key for `WithActualStdlibRustProjectDescriptor` tests. Now macros in stdlib dependencies will not be re-expanded every time.
4. Some optimization here and there

Points 1-3 make `WithActualStdlibRustProjectDescriptor` tests almost as cheap as `WithStdlibRustProjectDescriptor`.