### PR TITLE
IDE: remove unused imports in import optimizer

### DIFF
--- a/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
+++ b/src/main/kotlin/org/rust/ide/inspections/lints/RsUnusedImportInspection.kt
@@ -22,7 +22,6 @@ class RsUnusedImportInspection : RsLintInspection() {
             if (!holder.project.isNewResolveEnabled) return
             val item = o.ancestorStrict<RsUseItem>() ?: return
             if (item.isReexport) return
-            if (o.path?.resolveStatus != PathResolveStatus.RESOLVED) return
 
             // Do not check uses if there is a child mod inside the current mod
             val parentMod = o.containingMod
@@ -58,7 +57,7 @@ private fun getHighlightElement(useSpeck: RsUseSpeck): PsiElement {
  * A usage can be either a path that uses the import of the use speck or a method call/associated item available through
  * a trait that is imported by this use speck.
  */
-private fun RsUseSpeck.isUsed(): Boolean {
+fun RsUseSpeck.isUsed(): Boolean {
     val owner = this.parentOfType<RsUseItem>()?.parent as? RsItemsOwner ?: return true
     val usage = owner.pathUsage
     return isUseSpeckUsed(this, usage)
@@ -68,6 +67,8 @@ private fun isUseSpeckUsed(useSpeck: RsUseSpeck, usage: PathUsageMap): Boolean {
     // Use speck with an empty group is always unused
     val useGroup = useSpeck.useGroup
     if (useGroup != null && useGroup.useSpeckList.isEmpty()) return false
+
+    if (useSpeck.path?.resolveStatus != PathResolveStatus.RESOLVED) return true
 
     val items = if (useSpeck.isStarImport) {
         val module = useSpeck.path?.reference?.resolve() as? RsMod ?: return true

--- a/src/main/kotlin/org/rust/ide/refactoring/RsImportOptimizer.kt
+++ b/src/main/kotlin/org/rust/ide/refactoring/RsImportOptimizer.kt
@@ -10,9 +10,12 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.util.parentOfType
 import org.rust.cargo.project.workspace.PackageOrigin
+import org.rust.ide.inspections.lints.isUsed
 import org.rust.lang.core.psi.*
 import org.rust.lang.core.psi.ext.*
+import org.rust.lang.core.resolve2.isNewResolveEnabled
 
 class RsImportOptimizer : ImportOptimizer {
     override fun supports(file: PsiFile): Boolean = file is RsFile
@@ -52,16 +55,44 @@ class RsImportOptimizer : ImportOptimizer {
 
         /** Returns false if [useSpeck] is empty and should be removed */
         fun optimizeUseSpeck(psiFactory: RsPsiFactory, useSpeck: RsUseSpeck): Boolean {
-            val useGroup = useSpeck.useGroup ?: return true
-            useGroup.useSpeckList.forEach { optimizeUseSpeck(psiFactory, it) }
-            if (removeUseSpeckIfEmpty(useSpeck)) return false
-            if (removeCurlyBracesIfPossible(psiFactory, useSpeck)) return true
+            val checkUnused = run {
+                val item = useSpeck.ancestorStrict<RsUseItem>() ?: return true
+                if (!useSpeck.project.isNewResolveEnabled) return@run false
+                if (item.isReexport) return@run false
 
-            val sortedList = useGroup.useSpeckList
-                .sortedWith(compareBy<RsUseSpeck> { it.path?.self == null }.thenBy { it.pathText })
-                .map { it.copy() }
-            useGroup.useSpeckList.zip(sortedList).forEach { it.first.replace(it.second) }
-            return true
+                val parentMod = item.containingMod
+                val hasChildMods = parentMod.expandedItemsExceptImplsAndUses.any {
+                    it is RsModItem || it is RsModDeclItem
+                }
+                if (item.parentOfType<RsFunction>() == null && hasChildMods) return@run false
+
+                return@run true
+            }
+            return optimizeUseSpeck(psiFactory, useSpeck, checkUnused)
+        }
+
+        private fun optimizeUseSpeck(psiFactory: RsPsiFactory, useSpeck: RsUseSpeck, checkUnused: Boolean): Boolean {
+            val useGroup = useSpeck.useGroup
+            if (useGroup == null) {
+                if (!checkUnused) return true
+
+                return if (!useSpeck.isUsed()) {
+                    useSpeck.deleteWithSurroundingComma()
+                    false
+                } else {
+                    true
+                }
+            } else {
+                useGroup.useSpeckList.forEach { optimizeUseSpeck(psiFactory, it, checkUnused) }
+                if (removeUseSpeckIfEmpty(useSpeck)) return false
+                if (removeCurlyBracesIfPossible(psiFactory, useSpeck)) return true
+
+                val sortedList = useGroup.useSpeckList
+                    .sortedWith(compareBy<RsUseSpeck> { it.path?.self == null }.thenBy { it.pathText })
+                    .map { it.copy() }
+                useGroup.useSpeckList.zip(sortedList).forEach { it.first.replace(it.second) }
+                return true
+            }
         }
 
         /** Returns true if successfully removed, e.g. `use aaa::{bbb};` -> `use aaa::bbb;` */


### PR DESCRIPTION
This PR modifies import optimizer so that it now removes unused imports.

![optimize-imports](https://user-images.githubusercontent.com/4539057/125095198-39107300-e0d4-11eb-8e81-54e61ce9bf47.gif)

First I thought that we might need to introduce an experimental feature for this, but I think that we can simply remove the unused imports that we find with the current implementation and in the future, once the implementation improves, just relax the checks performed by the import optimizer (these correspond to the same checks that are in `RsUnusedImportInspection`, these should be probably merged, it should be easier after https://github.com/intellij-rust/intellij-rust/pull/7492 gets merged).

Fixes: https://github.com/intellij-rust/intellij-rust/issues/5774
Fixes: https://github.com/intellij-rust/intellij-rust/issues/2158

Related issue: https://github.com/intellij-rust/intellij-rust/issues/2259

changelog: The import optimizer will now remove unused imports.