### PR TITLE
TYPE: added filter for items expanded from macros to Structure View

### DIFF
--- a/src/main/kotlin/org/rust/ide/icons/RsIcons.kt
+++ b/src/main/kotlin/org/rust/ide/icons/RsIcons.kt
@@ -82,6 +82,10 @@ object RsIcons {
     val FIELD = load("/icons/nodes/field.svg")
     val ENUM_VARIANT = load("/icons/nodes/enumVariant.svg")
 
+    // Structure view
+
+    val MACRO_EXPANSION = AllIcons.Nodes.ErrorIntroduction
+
     // Gutter
 
     val IMPLEMENTED = AllIcons.Gutter.ImplementedMethod

--- a/src/main/kotlin/org/rust/ide/structure/RsMacroExpandedFilter.kt
+++ b/src/main/kotlin/org/rust/ide/structure/RsMacroExpandedFilter.kt
@@ -1,0 +1,40 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.structure
+
+import com.intellij.ide.util.treeView.smartTree.ActionPresentation
+import com.intellij.ide.util.treeView.smartTree.ActionPresentationData
+import com.intellij.ide.util.treeView.smartTree.Filter
+import com.intellij.ide.util.treeView.smartTree.TreeElement
+import org.rust.RsBundle
+import org.rust.ide.icons.RsIcons
+import org.rust.lang.core.macros.isExpandedFromMacro
+
+class RsMacroExpandedFilter : Filter {
+    override fun getPresentation(): ActionPresentation = ActionPresentationData(
+        RsBundle.message("structure.view.show.macro.expanded"),
+        null,
+        RsIcons.MACRO_EXPANSION,
+    )
+
+    override fun getName(): String = ID
+
+    override fun isVisible(treeNode: TreeElement?): Boolean {
+        val psi = (treeNode as? RsStructureViewElement)?.value ?: return true
+        return !psi.isExpandedFromMacro
+    }
+
+    override fun isReverted(): Boolean = true
+
+    companion object {
+        const val ID = "STRUCTURE_VIEW_MACRO_EXPANDED_FILTER"
+    }
+}

--- a/src/main/kotlin/org/rust/ide/structure/RsStructureViewModel.kt
+++ b/src/main/kotlin/org/rust/ide/structure/RsStructureViewModel.kt
@@ -39,11 +39,9 @@ class RsStructureViewModel(editor: Editor?, file: RsFileBase) :
         )
     }
 
-    override fun getFilters(): Array<Filter> {
-        return arrayOf(
-
-        )
-    }
+    override fun getFilters(): Array<Filter> = arrayOf(
+        RsMacroExpandedFilter()
+    )
 
     override fun isAlwaysShowsPlus(element: StructureViewTreeElement): Boolean = element.value is RsFile
 

--- a/src/main/resources/messages/RsBundle.properties
+++ b/src/main/resources/messages/RsBundle.properties
@@ -74,6 +74,8 @@ refactoring.change.signature.name=Change Signature
 refactoring.change.signature.refactor.super.function=Method {0} implements base method of trait {1}.\nDo you want to refactor the base method?
 refactoring.change.signature.visibility.conflict=The function will not be visible from {0} after the refactoring
 
+structure.view.show.macro.expanded=Show Items from Macro Expansions
+
 intention.Rust.ToggleFeatureIntention.enable=Enable feature `{0}`
 intention.Rust.ToggleFeatureIntention.disable=Disable feature `{0}`
 intention.Rust.ToggleFeatureIntention.family.name=Toggle feature state

--- a/src/test/kotlin/org/rust/ide/structure/RsMacroExpandedFilterTest.kt
+++ b/src/test/kotlin/org/rust/ide/structure/RsMacroExpandedFilterTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.structure
+
+import org.intellij.lang.annotations.Language
+
+class RsMacroExpandedFilterTest : RsStructureViewToggleableActionTest() {
+
+    fun `test macro expanded filter`() = doTest("""
+        pub enum Enum { One, Two }
+
+        macro_rules! foo {
+            () => {
+                pub struct Struct {
+                    field: bool,
+                }
+
+                pub trait Trait {
+                    fn func(&self);
+                }
+
+                impl Trait for Struct {
+                    fn func(&self) {}
+                }
+            };
+        }
+
+        foo! {}
+
+        struct Persistent;
+    """, """
+        |-main.rs visibility=none
+        | -Enum visibility=public
+        |  One visibility=none
+        |  Two visibility=none
+        | foo visibility=none
+        | -Struct visibility=public
+        |  field: bool visibility=private
+        | -Trait visibility=public
+        |  func() visibility=none
+        | -Trait for Struct visibility=none
+        |  func() visibility=none
+        | Persistent visibility=private
+    """, """
+        |-main.rs visibility=none
+        | -Enum visibility=public
+        |  One visibility=none
+        |  Two visibility=none
+        | foo visibility=none
+        | Persistent visibility=private
+    """)
+
+    fun `test filter macro expanded nested functions`() = doTest("""
+        macro_rules! nested {
+            () => {
+                fn first() {
+                    pub fn second() {}
+
+                    pub struct Inner(bool);
+                }
+            };
+        }
+
+        nested!();
+
+        fn external() {
+            nested!();
+        }
+    """, """
+        |-main.rs visibility=none
+        | nested visibility=none
+        | -first() visibility=private
+        |  second() visibility=public
+        |  Inner visibility=public
+        | -external() visibility=private
+        |  -first() visibility=private
+        |   second() visibility=public
+        |   Inner visibility=public
+    """, """
+        |-main.rs visibility=none
+        | nested visibility=none
+        | external() visibility=private
+    """)
+
+    fun `test filter on macro expanded type definitions has no effect`() = doTest("""
+        macro_rules! typemacro {
+            ($ t: ty) => {Option<$ t>};
+        }
+
+        type X = typemacro!(u64);
+
+        fn f(x: typemacro!(bool)) -> typemacro!(bool) { x }
+
+        trait Trait {
+            type T = typemacro!(bool);
+        }
+
+        struct Foo(typemacro!(bool));
+
+        impl Trait for Foo {
+            type T = typemacro!(bool);
+        }
+    """, """
+        |-main.rs visibility=none
+        | typemacro visibility=none
+        | X visibility=private
+        | f(typemacro!(bool)) -> typemacro!(bool) visibility=private
+        | -Trait visibility=private
+        |  T visibility=none
+        | Foo visibility=private
+        | -Trait for Foo visibility=none
+        |  T visibility=none
+    """, """
+        |-main.rs visibility=none
+        | typemacro visibility=none
+        | X visibility=private
+        | f(typemacro!(bool)) -> typemacro!(bool) visibility=private
+        | -Trait visibility=private
+        |  T visibility=none
+        | Foo visibility=private
+        | -Trait for Foo visibility=none
+        |  T visibility=none
+    """)
+
+    fun `test macro expanded expressions are always invisible`() = doTest("""
+        macro_rules! expr {
+            ($ b: expr) => {if $ b {
+                struct Foo;
+
+                2
+            } else {
+                pub trait Bar {}
+
+                3
+            }};
+        }
+
+        fn f(b: bool) {
+            let _x = expr!(b);
+        }
+
+        const C: u32 = {
+            expr!(true)
+        };
+
+        type Ty = [u8; expr!(false)];
+    """, """
+        |-main.rs visibility=none
+        | expr visibility=none
+        | f(bool) visibility=private
+        | C: u32 visibility=private
+        | Ty visibility=private
+    """, """
+        |-main.rs visibility=none
+        | expr visibility=none
+        | f(bool) visibility=private
+        | C: u32 visibility=private
+        | Ty visibility=private
+    """)
+
+    override val actionId: String = RsMacroExpandedFilter.ID
+}

--- a/src/test/kotlin/org/rust/ide/structure/RsStructureViewModelTest.kt
+++ b/src/test/kotlin/org/rust/ide/structure/RsStructureViewModelTest.kt
@@ -450,7 +450,7 @@ class RsStructureViewModelTest : RsStructureViewTestBase() {
     """)
 
     private fun doTest(@Language("Rust") code: String, expected: String, fileName: String = "main.rs") {
-        doTestWithActions(code, expected, fileName) {}
+        doTestSingleAction(code, expected, fileName) {}
     }
 
     private fun doTestForREPL(code: String, expected: String) = doTest(code, expected, RsConsoleView.VIRTUAL_FILE_NAME)

--- a/src/test/kotlin/org/rust/ide/structure/RsStructureViewTestBase.kt
+++ b/src/test/kotlin/org/rust/ide/structure/RsStructureViewTestBase.kt
@@ -14,26 +14,34 @@ import javax.swing.JTree
 import javax.swing.tree.TreePath
 
 abstract class RsStructureViewTestBase : RsTestBase() {
-    protected fun doTestWithActions(
+    protected fun doTestSingleAction(
         @Language("Rust") code: String,
         expected: String,
         fileName: String = "main.rs",
         actions: StructureViewComponent.() -> Unit,
-    ) {
+    ) = doTestStructureView(code, fileName) {
         val normExpected = expected.trimMargin()
+        actions()
+        assertTreeEqual(tree, normExpected)
+    }
+
+    protected fun doTestStructureView(
+        @Language("Rust") code: String,
+        fileName: String = "main.rs",
+        actions: StructureViewComponent.() -> Unit,
+    ) {
         myFixture.configureByText(fileName, code)
         myFixture.testStructureView {
             it.actions()
-            PlatformTestUtil.expandAll(it.tree)
-            assertTreeEqual(it.tree, normExpected)
         }
     }
 
-    private fun assertTreeEqual(tree: JTree, expected: String) {
+    protected fun assertTreeEqual(tree: JTree, expected: String) {
         val printInfo = Queryable.PrintInfo(
             arrayOf(RsStructureViewElement.NAME_KEY),
             arrayOf(RsStructureViewElement.VISIBILITY_KEY)
         )
+        PlatformTestUtil.expandAll(tree)
         val treeStringPresentation = PlatformTestUtil.print(tree, TreePath(tree.model.root), printInfo, false)
         assertEquals(expected.trim(), treeStringPresentation.trim())
     }

--- a/src/test/kotlin/org/rust/ide/structure/RsStructureViewToggleableActionTest.kt
+++ b/src/test/kotlin/org/rust/ide/structure/RsStructureViewToggleableActionTest.kt
@@ -1,0 +1,20 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.rust.ide.structure
+
+import org.intellij.lang.annotations.Language
+
+abstract class RsStructureViewToggleableActionTest : RsStructureViewTestBase() {
+    protected abstract val actionId: String
+
+    protected fun doTest(@Language("Rust") code: String, disabled: String, enabled: String) =
+        doTestStructureView(code) {
+            setActionActive(actionId, false)
+            assertTreeEqual(tree, disabled.trimMargin())
+            setActionActive(actionId, true)
+            assertTreeEqual(tree, enabled.trimMargin())
+        }
+}


### PR DESCRIPTION
changelog: added a new filter to the Structure View panel, which toggles whether macro-generated items should be included in the Structure View.

The reason to add this filter is that it is common to produce boilerplate structures and trait implementations using macros. For example, if we introduce a new trait which should be implemented for all primitive numbers, then there will likely be 12 implementations which are derived by a single macro (signed and unsigned with 8, 16, 32, 64, 128, and `size` bits). Similarly, it is common in crates which don't use const generics to implement traits for 32 or more different array sizes separately, and crates which need generically sized tuples (like `itertools` or `warp`) often implement traits for all tuples up to a certain size.

Such boilerplate impls clutter the structure view, making it hard to find the actual types and functions.